### PR TITLE
Adjust pre-commit and add more sane defaults to settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.py eol=lf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -9,20 +9,23 @@ repos:
       - id: check-ast
       - id: check-added-large-files
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.4.2
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies:
-          ["flake8-bugbear==21.4.3", "flake8-tidy-imports==4.3.0"]
+          - flake8-bugbear
+          - flake8-comprehensions
+          - flake8-logging
+          - flake8-tidy-imports
         args: [--config=./flake8.cfg]
         verbose: true

--- a/flake8.cfg
+++ b/flake8.cfg
@@ -13,4 +13,5 @@ exclude =
     docker,
     docs,
     logs,
+    settings.py,
     *migrations*

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -3,7 +3,7 @@
 This folder holds modules for implementing one's own commands and
 command sets. All the modules' classes are essentially empty and just
 imports the default implementations from Evennia; so adding anything
-to them will start overloading the defaults. 
+to them will start overloading the defaults.
 
 You can change the organisation of this directory as you see fit, just
 remember that if you change any of the default command set classes'

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1,13 +1,13 @@
-# server/ 
+# server/
 
-This directory holds files used by and configuring the Evennia server 
+This directory holds files used by and configuring the Evennia server
 itself.
 
 Out of all the subdirectories in the game directory, Evennia does
 expect this directory to exist, so you should normally not delete,
 rename or change its folder structure.
 
-When running you will find four new files appear in this directory: 
+When running you will find four new files appear in this directory:
 
  - `server.pid` and `portal.pid`: These hold the process IDs of the
    Portal and Server, so that they can be managed by the launcher. If
@@ -29,7 +29,7 @@ This subdirectory holds the configuration modules for the server. With
 them you can change how Evennia operates and also plug in your own
 functionality to replace the default. You usually need to restart the
 server to apply changes done here. The most important file is the file
-`settings.py` which is the main configuration file of Evennia. 
+`settings.py` which is the main configuration file of Evennia.
 
 ## server/logs/
 

--- a/src/server/conf/connection_screens.py
+++ b/src/server/conf/connection_screens.py
@@ -21,7 +21,6 @@ of the screen is done by the unlogged-in "look" command.
 """
 
 from django.conf import settings
-
 from evennia import utils
 
 CONNECTION_SCREEN = """

--- a/src/server/conf/settings.py
+++ b/src/server/conf/settings.py
@@ -18,11 +18,8 @@ https://www.12factor.net/
 https://github.com/joke2k/django-environ
 """
 
-# Use the defaults from Evennia unless explicitly overridden
-from evennia.settings_default import *
-
 import environ
-import os
+from evennia.settings_default import *
 
 env = environ.Env(
     # set casting, default value
@@ -30,21 +27,21 @@ env = environ.Env(
 )
 
 # Take environment variables from .env file
-environ.Env.read_env(os.path.join(GAME_DIR, '.env'))
+environ.Env.read_env(os.path.join(GAME_DIR, ".env"))
 
 # False if not in os.environ because of casting above
-DEBUG = env('DEBUG')
+DEBUG = env("DEBUG")
 
 # Raises Django's ImproperlyConfigured
 # exception if SECRET_KEY not in os.environ
-SECRET_KEY = env('SECRET_KEY')
+SECRET_KEY = env("SECRET_KEY")
 
 # Parse database connection url strings
 # like psql://user:pass@127.0.0.1:8458/db
 DATABASES = {
     # read os.environ['DATABASE_URL'] and raises
     # ImproperlyConfigured exception if not found
-    'default': env.db(),
+    "default": env.db(),
 }
 
 ######################################################################
@@ -54,3 +51,7 @@ DATABASES = {
 # This is the name of your game. Make it catchy!
 SERVERNAME = "Arx II"
 EVENNIA_ADMIN = False
+MULTISESSION_MODE = 2
+AUTO_CREATE_CHARACTER_WITH_ACCOUNT = False
+AUTO_PUPPET_ON_LOGIN = False
+IN_GAME_ERRORS = DEBUG

--- a/src/server/logs/README.md
+++ b/src/server/logs/README.md
@@ -1,15 +1,15 @@
 This directory contains Evennia's log files. The existence of this README.md file is also necessary
 to correctly include the log directory in git (since log files are ignored by git and you can't
-commit an empty directory). 
+commit an empty directory).
 
 - `server.log` - log file from the game Server.
 - `portal.log` - log file from Portal proxy (internet facing)
 
 Usually these logs are viewed together with `evennia -l`. They are also rotated every week so as not
-to be too big. Older log names will have a name appended by `_month_date`. 
- 
+to be too big. Older log names will have a name appended by `_month_date`.
+
 - `lockwarnings.log` - warnings from the lock system.
 - `http_requests.log` - this will generally be empty unless turning on debugging inside the server.
 
 - `channel_<channelname>.log` - these are channel logs for the in-game channels They are also used
-  by the `/history` flag in-game to get the latest message history. 
+  by the `/history` flag in-game to get the latest message history.

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -7,9 +7,10 @@ is setup to be the "default" character type created by the default
 creation commands.
 
 """
+
 from evennia.objects.objects import DefaultCharacter
 
-from .objects import ObjectParent
+from typeclasses.objects import ObjectParent
 
 
 class Character(ObjectParent, DefaultCharacter):

--- a/src/typeclasses/exits.py
+++ b/src/typeclasses/exits.py
@@ -6,12 +6,14 @@ set and has a single command defined on itself with the same name as its key,
 for allowing Characters to traverse the exit to its destination.
 
 """
+
 from evennia.objects.objects import DefaultExit
 
-from .objects import ObjectParent
+from typeclasses.objects import ObjectParent
 
 
 class Exit(ObjectParent, DefaultExit):
+    # flake8: noqa: B950
     """
     Exits are connectors between rooms. Exits are normal Objects except
     they defines the `destination` property. It also does work in the

--- a/src/typeclasses/objects.py
+++ b/src/typeclasses/objects.py
@@ -10,6 +10,7 @@ the other types, you can do so by adding this as a multiple
 inheritance.
 
 """
+
 from evennia.objects.objects import DefaultObject
 
 

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -1,4 +1,4 @@
-# Web 
+# Web
 
 This folder contains overriding of web assets - the website and webclient
 coming with the game.
@@ -18,9 +18,9 @@ more details):
    reroute to a view handling the main index-page of the website.  The view is
    either a function or a callable class (Evennia tends to have them as
    functions).
-3. The view-function will prepare all the data needed by the web page. For the default 
+3. The view-function will prepare all the data needed by the web page. For the default
    index page, this means gather the game statistics so you can see how many
-   are currently connected to the game etc. 
+   are currently connected to the game etc.
 4. The view will next fetch a _template_. A template is a HTML-document with special
    'placeholder' tags (written as `{{...}}` or `{% ... %}` usually). These
    placeholders allow the view to inject dynamic content into the HTML and make
@@ -29,7 +29,7 @@ more details):
    is called 'rendering' the template. The result is a complete HTML page.
 5. (The view can also pull in a _form_ to customize user-input in a similar way.)
 6. The finished HTML page is packed in a _HTTP response_ and is returned to the
-   web browser, which can now display the page! 
+   web browser, which can now display the page!
 
 ## A note on the webclient
 
@@ -43,7 +43,7 @@ require the server.
 
 In the case of the Webclient, Evennia will load the Webclient page as above,
 but the page then contains Javascript code responsible for actually displaying
-the client GUI, allows you to resize windows etc. 
+the client GUI, allows you to resize windows etc.
 
 After it starts, the webclient 'calls home' and spins up a websocket link to
 the Evennia Portal - this is how all data is then exchanged. So after the

--- a/src/web/admin/urls.py
+++ b/src/web/admin/urls.py
@@ -6,9 +6,8 @@ The main web/urls.py includes these routes for all urls starting with `admin/`
 
 """
 
-
-from django.urls import path
-
+# uncomment the import below once you're ready to add patterns
+# from django.urls import path
 from evennia.web.admin.urls import urlpatterns as evennia_admin_urlpatterns
 
 # add patterns here

--- a/src/web/static/README.md
+++ b/src/web/static/README.md
@@ -1,6 +1,6 @@
 ## Static files
 
-This is the place to put static resources you want to serve from the 
+This is the place to put static resources you want to serve from the
 Evennia server. This is usually CSS and Javascript files but you _could_ also
 serve other media like images, videos and music files from here.
 

--- a/src/web/static/rest_framework/images/README.md
+++ b/src/web/static/rest_framework/images/README.md
@@ -1,3 +1,3 @@
-# Static files for API 
+# Static files for API
 
 Override images here.

--- a/src/web/templates/README.md
+++ b/src/web/templates/README.md
@@ -5,7 +5,7 @@ markers in them to allow Evennia/Django to insert dynamic content in a web
 page. An example is listing how many users are currently online in the game.
 
 Templates are referenced by _views_ - Python functions or callable classes that
-prepare the data needed by the template and 'renders' them into a finished 
+prepare the data needed by the template and 'renders' them into a finished
 HTML page to return to the user.
 
 You can replace Evennia's default templates by overriding them in this folder.

--- a/src/web/templates/website/README.md
+++ b/src/web/templates/website/README.md
@@ -1,5 +1,5 @@
 You can replace the django templates (html files) for the website
-here. 
+here.
 
-You can find the original files under `evennia/web/templates/website/`. Just 
+You can find the original files under `evennia/web/templates/website/`. Just
 copy a template here and modify to have it override the default.

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -12,10 +12,9 @@ should modify urls.py in those sub directories.
 Search the Django documentation for "URL dispatcher" for more help.
 
 """
-from django.urls import include, path
 
-# default evennia patterns
-from evennia.web.urls import urlpatterns as evennia_default_urlpatterns
+from django.urls import include, path
+from evennia.web.urls import urlpatterns as evennia_urls
 
 # add patterns
 urlpatterns = [
@@ -30,4 +29,4 @@ urlpatterns = [
 ]
 
 # 'urlpatterns' must be named such for Django to find it.
-urlpatterns = urlpatterns + evennia_default_urlpatterns
+urlpatterns = urlpatterns + evennia_urls

--- a/src/web/webclient/urls.py
+++ b/src/web/webclient/urls.py
@@ -6,9 +6,9 @@ The main web/urls.py includes these routes for all urls starting with `webclient
 
 """
 
-from django.urls import path
-
-from evennia.web.webclient.urls import urlpatterns as evennia_webclient_urlpatterns
+# Uncomment once you need to import it
+# from django.urls import path
+from evennia.web.webclient.urls import urlpatterns as evennia_urls
 
 # add patterns here
 urlpatterns = [
@@ -17,4 +17,4 @@ urlpatterns = [
 ]
 
 # read by Django
-urlpatterns = urlpatterns + evennia_webclient_urlpatterns
+urlpatterns = urlpatterns + evennia_urls

--- a/src/web/website/urls.py
+++ b/src/web/website/urls.py
@@ -6,8 +6,8 @@ so it can reroute to all website pages.
 
 """
 
-from django.urls import path
-
+# uncomment to import once ready for use
+# from django.urls import path
 from evennia.web.website.urls import urlpatterns as evennia_website_urlpatterns
 
 # add patterns here

--- a/src/world/README.md
+++ b/src/world/README.md
@@ -2,9 +2,9 @@
 
 This folder is meant as a miscellaneous folder for all that other stuff
 related to the game. Code which are not commands or typeclasses go
-here, like custom economy systems, combat code, batch-files etc. 
+here, like custom economy systems, combat code, batch-files etc.
 
 You can restructure and even rename this folder as best fits your
 sense of organisation. Just remember that if you add new sub
 directories, you must add (optionally empty) `__init__.py` files in
-them for Python to be able to find the modules within. 
+them for Python to be able to find the modules within.

--- a/src/world/batch_cmds.ev
+++ b/src/world/batch_cmds.ev
@@ -22,5 +22,3 @@
 # an example of a batch-command code. See also the batch-code
 # system for loading python-code this way.
 #
-
-


### PR DESCRIPTION
This fixed a lot of issues with the precommit hooks on the basic files that evennia auto-generates for a new game. I also resolved dependency issues due to some pinned versions in the precommit hooks.

A particular file to note is exits. You'll see the line:
`# flake8: noqa: B950`
That's an instruction for Flake8 to not perform QA on the following lines for rule B950, which is the line-length rule. Basically it's saying "ignore the fact that this docstring ignores our regular rules for the rest of our codebase". Exclusions like that aren't necessarily a bad practice, particularly for doc strings, where people might compose little ascii diagrams or the like. Random `noqa` instructions in other places might get other reviewers to ask you wtf you are doing, however.