### PR TITLE
Fix minor typo in command docstring

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -20,7 +20,7 @@ class ArxCommand(Command):
     Base command we'll use for all Arx II commands. We'll take a different approach
     than Evennia. Evennia has very 'fat' commands that contain all the business logic
     for any given action a player wishes to take. By contrast, we want our commands
-    to be very thing - the only thing a command should be responsible for is to try to
+    to be very thin - the only thing a command should be responsible for is to try to
     help determine what a player is attempting to do and to what, fetch whatever object
     the player is targeting if they can, then call whatever method or service function
     is appropriate for processing that action. We'll catch any exception raised by the


### PR DESCRIPTION
## Summary
- fix thin/thing typo in ArxCommand class docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687d26c2acbc8331a9ed4cbdfc806ec9


> Note - I was trying out codex to see how it'd handle a trivial typo fix. We can see that it'll need guidance for how to run tests, or that we'll need some sort of env setup that would add pretty massive overhead to some tasks.