### PR TITLE
Add FlowEvent condition tests

### DIFF
--- a/src/flows/tests/test_flow_event.py
+++ b/src/flows/tests/test_flow_event.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+
+from flows.factories import FlowEventFactory
+
+
+class FlowEventMatchesConditionsTests(TestCase):
+    """Tests for FlowEvent.matches_conditions."""
+
+    def test_matching_conditions_returns_true(self):
+        event = FlowEventFactory(data={"foo": "bar", "baz": 1})
+        self.assertTrue(event.matches_conditions({"foo": "bar", "baz": 1}))
+
+    def test_non_matching_conditions_returns_false(self):
+        event = FlowEventFactory(data={"foo": "bar", "baz": 1})
+        self.assertFalse(event.matches_conditions({"foo": "baz"}))
+        self.assertFalse(event.matches_conditions({"foo": "bar", "baz": 2}))
+
+    def test_missing_keys_handled_gracefully(self):
+        event = FlowEventFactory(data={"foo": "bar"})
+        self.assertFalse(event.matches_conditions({"missing": "value"}))


### PR DESCRIPTION
## Summary
- add a new `test_flow_event.py` module
- test success, failure and missing-key handling in `matches_conditions`

## Testing
- `pre-commit run --files src/flows/tests/test_flow_event.py` *(fails: command not found)*
- `pytest -q src/flows/tests/test_flow_event.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687d29b024688331aa19e4d8cb7b6f6a