### PR TITLE
Implement context-driven appearance

### DIFF
--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -1,6 +1,8 @@
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from django.utils.functional import cached_property
+from evennia.utils.utils import compress_whitespace, iter_to_str
 
 if TYPE_CHECKING:
     from flows.context_data import ContextData
@@ -58,3 +60,80 @@ class BaseState:
         this method to supply extra template keys.
         """
         return {}
+
+    # ------------------------------------------------------------------
+    # Appearance helpers (inspired by Evennia's DefaultObject)
+    # ------------------------------------------------------------------
+
+    @property
+    def appearance_template(self) -> str:
+        """Template used by :meth:`return_appearance`."""
+        return "{name}\n{desc}"
+
+    # Display-component methods
+    def get_display_name(self, **kwargs) -> str:
+        return self.name
+
+    def get_extra_display_name_info(self, **kwargs) -> str:
+        return ""
+
+    def get_display_desc(self, **kwargs) -> str:
+        return self.description
+
+    def _get_contents(self, content_type: str):
+        """Return contained states of the given type that should be displayed."""
+        states = [
+            self.context.get_state_by_pk(obj.pk)
+            for obj in self.obj.contents_get(content_type=content_type)
+        ]
+        return [st for st in states if st and st.get_display_name()]
+
+    def get_display_exits(self, **kwargs) -> str:
+        exits = self._get_contents("exit")
+        names = iter_to_str(
+            (ex.get_display_name(**kwargs) for ex in exits), endsep=", and"
+        )
+        return f"|wExits:|n {names}" if names else ""
+
+    def get_display_characters(self, **kwargs) -> str:
+        characters = self._get_contents("character")
+        names = iter_to_str(
+            (ch.get_display_name(**kwargs) for ch in characters), endsep=", and"
+        )
+        return f"|wCharacters:|n {names}" if names else ""
+
+    def get_display_things(self, **kwargs) -> str:
+        things = self._get_contents("object")
+        grouped = defaultdict(list)
+        for thing in things:
+            grouped[thing.get_display_name(**kwargs)].append(thing)
+        thing_names = []
+        for name, group in sorted(grouped.items()):
+            count = len(group)
+            obj = group[0].obj
+            singular, plural = obj.get_numbered_name(count, None, key=name)
+            thing_names.append(singular if count == 1 else plural)
+        names = iter_to_str(thing_names, endsep=", and")
+        return f"|wYou see:|n {names}" if names else ""
+
+    def get_display_header(self, **kwargs) -> str:
+        return ""
+
+    def get_display_footer(self, **kwargs) -> str:
+        return ""
+
+    def format_appearance(self, appearance: str, **kwargs) -> str:
+        return compress_whitespace(appearance).strip()
+
+    def return_appearance(self, **kwargs) -> str:
+        appearance = self.appearance_template.format(
+            name=self.get_display_name(**kwargs),
+            extra_name_info=self.get_extra_display_name_info(**kwargs),
+            desc=self.get_display_desc(**kwargs),
+            header=self.get_display_header(**kwargs),
+            footer=self.get_display_footer(**kwargs),
+            exits=self.get_display_exits(**kwargs),
+            characters=self.get_display_characters(**kwargs),
+            things=self.get_display_things(**kwargs),
+        )
+        return self.format_appearance(appearance, **kwargs)

--- a/src/flows/object_states/room_state.py
+++ b/src/flows/object_states/room_state.py
@@ -6,10 +6,18 @@ class RoomState(BaseState):
     RoomState represents the state for room objects.
     """
 
+    default_description = "This is a room."
+
     @property
-    def template(self) -> str:
-        # Room-specific template.
-        return "Room: {name}\n{description}"
+    def appearance_template(self) -> str:
+        return "{name}\n" "{desc}\n" "{exits}\n" "{characters}\n" "{things}"
+
+    @property
+    def description(self) -> str:
+        try:
+            return self.obj.item_data.desc or self.default_description
+        except AttributeError:
+            return self.default_description
 
     def get_categories(self) -> dict:
         # For now, no extra room-specific categories.

--- a/src/flows/service_functions/perception.py
+++ b/src/flows/service_functions/perception.py
@@ -4,19 +4,45 @@ from __future__ import annotations
 
 from typing import Any
 
+from flows.object_states.base_state import BaseState
+
 
 def get_formatted_description(
-    flow_execution: Any, obj: Any | None = None, **kwargs: Any
+    flow_execution: Any,
+    obj: Any | None = None,
+    **kwargs: Any,
 ) -> str:
-    """Return a placeholder formatted description for ``obj``.
+    """Return a formatted description for ``obj`` using ContextData.
+
+    This helper resolves ``obj`` from flow variables and then looks up the
+    appropriate state object from ``flow_execution.context``. The state's
+    template and categories determine how the final string is produced.
+    Contained objects are summarized by name according to their own states.
 
     Parameters
     ----------
     flow_execution:
         The current :class:`~flows.flow_execution.FlowExecution`.
     obj:
-        The object to describe.
+        The target to describe. May be a flow variable reference, an Evennia
+        object, a primary key, or an existing state object.
     **kwargs:
-        Additional keyword arguments ignored for now.
+        Additional keyword arguments passed to the state's appearance helpers.
     """
-    return f"Formatted description for {obj}"
+
+    # Resolve flow variable references like "$target".
+    resolved = flow_execution.resolve_flow_reference(obj)
+
+    state: BaseState | None = None
+    if isinstance(resolved, BaseState):
+        state = resolved
+    elif hasattr(resolved, "pk"):
+        state = flow_execution.context.get_state_by_pk(resolved.pk)
+    elif resolved is not None:
+        # Attempt to treat ``resolved`` as a primary key.
+        state = flow_execution.context.get_state_by_pk(resolved)
+
+    if state is None:
+        return str(resolved)
+
+    return state.return_appearance(**kwargs)

--- a/src/flows/tests/test_flow_execution.py
+++ b/src/flows/tests/test_flow_execution.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from evennia_extensions.factories import ObjectDBFactory
 from flows.consts import FlowActionChoices
 from flows.factories import (
     FlowDefinitionFactory,
@@ -21,10 +22,64 @@ class FlowExecutionServiceFunctionTests(TestCase):
             flow=flow_def,
             action=FlowActionChoices.CALL_SERVICE_FUNCTION,
             variable_name="get_formatted_description",
-            parameters={"obj": "sword", "result_variable": "desc"},
+            parameters={
+                "obj": "$target",
+                "result_variable": "desc",
+            },
         )
 
-        fx = FlowExecutionFactory(flow_definition=flow_def)
+        sword = ObjectDBFactory(db_key="sword")
+        sword.db.desc = "A shiny sword"
+        viewer = ObjectDBFactory(db_key="viewer")
+
+        fx = FlowExecutionFactory(
+            flow_definition=flow_def,
+            variable_mapping={"target": sword},
+        )
+        fx.context.initialize_state_for_object(sword)
+        fx.context.initialize_state_for_object(viewer)
+
         fx.execute_current_step()
 
-        self.assertEqual(fx.get_variable("desc"), "Formatted description for sword")
+        expected = fx.context.get_state_by_pk(sword.pk).return_appearance()
+        self.assertEqual(fx.get_variable("desc"), expected)
+
+    def test_room_description_format(self):
+        flow_def = FlowDefinitionFactory()
+        FlowStepDefinitionFactory(
+            flow=flow_def,
+            action=FlowActionChoices.CALL_SERVICE_FUNCTION,
+            variable_name="get_formatted_description",
+            parameters={
+                "obj": "$target",
+                "result_variable": "desc",
+            },
+        )
+
+        room = ObjectDBFactory(
+            db_key="Hall", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        room.db.desc = "A simple room."
+        dest = ObjectDBFactory(
+            db_key="Outside", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        exit_obj = ObjectDBFactory(
+            db_key="out",
+            db_typeclass_path="typeclasses.exits.Exit",
+            location=room,
+            destination=dest,
+        )
+        thing = ObjectDBFactory(db_key="rock", location=room)
+        viewer = ObjectDBFactory(db_key="Bob", location=room)
+
+        fx = FlowExecutionFactory(
+            flow_definition=flow_def,
+            variable_mapping={"target": room},
+        )
+        for obj in (room, dest, exit_obj, thing, viewer):
+            fx.context.initialize_state_for_object(obj)
+
+        fx.execute_current_step()
+
+        expected = fx.context.get_state_by_pk(room.pk).return_appearance()
+        self.assertEqual(fx.get_variable("desc"), expected)


### PR DESCRIPTION
## Summary
- refine appearance helpers to rely on state data
- override room appearance template for exit/character/thing lists
- simplify perception service function interface
- update flow execution tests for new API

## Testing
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_687f00ae5ec48331b54b09770d278c62