### PR TITLE
Implement iterable flow event step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This repository contains **Arx II**, a sequel to the Arx MUD. It is built on the
 
 - **Testing**: run the suite with `arx test`. If you haven't activated the virtual environment, use `uv run arx test` instead.
 - **Design goals**: gameplay rules should live in the database. Avoid hardcoding specific mechanics in code. The `flows` system under `src/flows` allows designers to create data-driven tasks. Flows emit events that triggers can listen to and spawn additional flows.
+- **Service functions** should be generic utilities. They must not embed hardcoded gameplay logic. Use flows and triggers with data to implement specific rules.
 - We want extensive automation to support a narrative driven game world. Player choices should drive automated reactions defined via data.
 
 Look for additional `AGENTS.md` files in subdirectories for directory-specific guidelines.

--- a/src/flows/consts.py
+++ b/src/flows/consts.py
@@ -41,6 +41,10 @@ class FlowActionChoices(models.TextChoices):
     )
     CALL_SERVICE_FUNCTION = "call_service_function", "Call Service Function"
     EMIT_FLOW_EVENT = "emit_flow_event", "Emit Flow Event"
+    EMIT_FLOW_EVENT_FOR_EACH = (
+        "emit_flow_event_for_each",
+        "Emit Flow Event For Each",
+    )
 
 
 # Map the comparison actions to their corresponding operator functions.

--- a/src/flows/factories.py
+++ b/src/flows/factories.py
@@ -37,6 +37,7 @@ class FlowStepDefinitionFactory(factory.django.DjangoModelFactory):
             models.FlowActionChoices.EVALUATE_EQUALS,
             models.FlowActionChoices.CALL_SERVICE_FUNCTION,
             models.FlowActionChoices.EMIT_FLOW_EVENT,
+            models.FlowActionChoices.EMIT_FLOW_EVENT_FOR_EACH,
         ]
     )
     variable_name = factory.Sequence(lambda n: f"var{n}")

--- a/src/flows/flow_execution.py
+++ b/src/flows/flow_execution.py
@@ -64,7 +64,10 @@ class FlowExecution:
                 raise RuntimeError(f"Flow variable '{path[0]}' is undefined.")
             current = base
             for attr in path[1:]:
-                current = getattr(current, attr, None)
+                if isinstance(current, dict):
+                    current = current.get(attr)
+                else:
+                    current = getattr(current, attr, None)
                 if current is None:
                     raise RuntimeError(f"Attribute '{attr}' not found on {base}.")
             return current

--- a/src/flows/service_functions/__init__.py
+++ b/src/flows/service_functions/__init__.py
@@ -2,11 +2,14 @@
 
 from typing import Callable
 
-from flows.service_functions import perception
+from flows.service_functions import communication, perception
 
 # Mapping of available service functions.
 SERVICE_FUNCTIONS: dict[str, Callable] = {
     "get_formatted_description": perception.get_formatted_description,
+    "send_message": communication.send_message,
+    "object_has_tag": perception.object_has_tag,
+    "append_to_attribute": perception.append_to_attribute,
 }
 
 

--- a/src/flows/service_functions/communication.py
+++ b/src/flows/service_functions/communication.py
@@ -1,0 +1,11 @@
+"""Communication-related service functions."""
+
+from typing import Any
+
+
+def send_message(flow_execution: Any, recipient: Any, text: Any, **kwargs: Any) -> None:
+    """Send ``text`` to ``recipient`` if it has a ``msg`` method."""
+    target = flow_execution.resolve_flow_reference(recipient)
+    message = flow_execution.resolve_flow_reference(text)
+    if hasattr(target, "msg"):
+        target.msg(message)

--- a/src/flows/service_functions/perception.py
+++ b/src/flows/service_functions/perception.py
@@ -46,3 +46,59 @@ def get_formatted_description(
         return str(resolved)
 
     return state.return_appearance(**kwargs)
+
+
+def send_formatted_description(
+    flow_execution: Any,
+    looker: Any,
+    text: Any,
+    **kwargs: Any,
+) -> None:
+    """Send formatted text to ``looker``."""
+
+    target = flow_execution.resolve_flow_reference(looker)
+    message = flow_execution.resolve_flow_reference(text)
+    if hasattr(target, "msg"):
+        target.msg(message)
+
+
+def object_has_tag(flow_execution: Any, obj: Any, tag: str, **kwargs: Any) -> bool:
+    """Return ``True`` if ``obj`` has ``tag``."""
+
+    resolved = flow_execution.resolve_flow_reference(obj)
+
+    state: BaseState | None = None
+    if isinstance(resolved, BaseState):
+        state = resolved
+    elif hasattr(resolved, "pk"):
+        state = flow_execution.context.get_state_by_pk(resolved.pk)
+    elif resolved is not None:
+        state = flow_execution.context.get_state_by_pk(resolved)
+
+    if state and hasattr(state.obj, "tags"):
+        return bool(state.obj.tags.get(tag))
+
+    if hasattr(resolved, "tags"):
+        return bool(resolved.tags.get(tag))
+
+    return False
+
+
+def append_to_attribute(
+    flow_execution: Any, obj: Any, attribute: str, append_text: str, **kwargs: Any
+) -> None:
+    """Append ``append_text`` to ``attribute`` on the state for ``obj``."""
+
+    resolved = flow_execution.resolve_flow_reference(obj)
+
+    state: BaseState | None = None
+    if isinstance(resolved, BaseState):
+        state = resolved
+    elif hasattr(resolved, "pk"):
+        state = flow_execution.context.get_state_by_pk(resolved.pk)
+    elif resolved is not None:
+        state = flow_execution.context.get_state_by_pk(resolved)
+
+    if state:
+        current = getattr(state, attribute, "")
+        setattr(state, attribute, f"{current}{append_text}")

--- a/src/flows/tests/test_emit_iterable_event.py
+++ b/src/flows/tests/test_emit_iterable_event.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from flows.consts import FlowActionChoices
+from flows.factories import (
+    FlowDefinitionFactory,
+    FlowExecutionFactory,
+    FlowStepDefinitionFactory,
+)
+
+
+class TestEmitFlowEventForEach(TestCase):
+    def test_emit_event_for_each_creates_events(self):
+        flow_def = FlowDefinitionFactory()
+        FlowStepDefinitionFactory(
+            flow=flow_def,
+            action=FlowActionChoices.EMIT_FLOW_EVENT_FOR_EACH,
+            variable_name="glance",
+            parameters={
+                "iterable": "$items",
+                "event_type": "glance",
+                "data": {"target": "$item"},
+            },
+        )
+
+        fx = FlowExecutionFactory(
+            flow_definition=flow_def,
+            variable_mapping={"items": [1, 2]},
+        )
+
+        with patch.object(fx, "get_trigger_registry") as mock_registry:
+            mock_registry.return_value = MagicMock()
+            fx.flow_stack.execute_flow(fx)
+
+        self.assertIn("glance_0", fx.context.flow_events)
+        self.assertIn("glance_1", fx.context.flow_events)
+        self.assertEqual(fx.context.flow_events["glance_0"].data["target"], 1)
+        self.assertEqual(fx.context.flow_events["glance_1"].data["target"], 2)

--- a/src/flows/tests/test_evil_tag_flow.py
+++ b/src/flows/tests/test_evil_tag_flow.py
@@ -1,0 +1,118 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from evennia_extensions.factories import ObjectDBFactory
+from flows.consts import FlowActionChoices
+from flows.factories import (
+    FlowDefinitionFactory,
+    FlowExecutionFactory,
+    FlowStepDefinitionFactory,
+)
+from flows.flow_stack import FlowStack
+
+
+class TestEvilNameFlow(TestCase):
+    def test_iterate_and_mark_evil(self):
+        room = ObjectDBFactory(
+            db_key="Hall", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        good = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        evil = ObjectDBFactory(
+            db_key="Eve",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        evil.tags.add("evil")
+        viewer = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+
+        # Flow to iterate contents and emit events
+        look_flow = FlowDefinitionFactory()
+        FlowStepDefinitionFactory(
+            flow=look_flow,
+            action=FlowActionChoices.EMIT_FLOW_EVENT_FOR_EACH,
+            variable_name="glance",
+            parameters={
+                "iterable": "$room.contents",
+                "event_type": "glance",
+                "data": {"target": "$item"},
+            },
+        )
+
+        # Flow triggered for each glance event
+        evil_flow = FlowDefinitionFactory()
+        step_check = FlowStepDefinitionFactory(
+            flow=evil_flow,
+            action=FlowActionChoices.CALL_SERVICE_FUNCTION,
+            variable_name="object_has_tag",
+            parameters={
+                "obj": "$event.data.target",
+                "tag": "evil",
+                "result_variable": "is_evil",
+            },
+        )
+        step_cond = FlowStepDefinitionFactory(
+            flow=evil_flow,
+            action=FlowActionChoices.EVALUATE_EQUALS,
+            parent_id=step_check.id,
+            variable_name="is_evil",
+            parameters={"value": "True"},
+        )
+        FlowStepDefinitionFactory(
+            flow=evil_flow,
+            action=FlowActionChoices.CALL_SERVICE_FUNCTION,
+            parent_id=step_cond.id,
+            variable_name="append_to_attribute",
+            parameters={
+                "obj": "$event.data.target",
+                "attribute": "name",
+                "append_text": " (Evil)",
+            },
+        )
+
+        fx = FlowExecutionFactory(
+            flow_definition=look_flow, variable_mapping={"room": room}
+        )
+        for obj in (room, good, evil, viewer):
+            fx.context.initialize_state_for_object(obj)
+
+        # Execute the look flow to generate events
+        flow_stack: FlowStack = fx.flow_stack
+        with patch.object(fx, "get_trigger_registry") as mock_registry:
+            mock_registry.return_value = MagicMock()
+            flow_stack.execute_flow(fx)
+
+        # Manually execute evil_flow for each emitted event
+        for event in fx.context.flow_events.values():
+            flow_stack.create_and_execute_flow(
+                flow_definition=evil_flow,
+                context=fx.context,
+                origin=event,
+                variable_mapping={"event": event},
+            )
+
+        good_state = fx.context.get_state_by_pk(good.pk)
+        evil_state = fx.context.get_state_by_pk(evil.pk)
+
+        self.assertEqual(good_state.name, good.key)
+        self.assertEqual(evil_state.name, f"{evil.key} (Evil)")
+        self.assertIn("glance_0", fx.context.flow_events)
+        self.assertIn("glance_1", fx.context.flow_events)
+
+        get_desc = fx.get_service_function("get_formatted_description")
+        send_msg = fx.get_service_function("send_message")
+        description = get_desc(fx, evil)
+
+        with patch.object(viewer, "msg") as mock_msg:
+            send_msg(fx, viewer, description)
+            mock_msg.assert_called_with(description)
+
+        self.assertIn("Eve (Evil)", description)


### PR DESCRIPTION
## Summary
- add communication service helper and register `send_message`
- expand tests with flow iterating over contents and modifying names based on tags
- extend evil tag flow test to confirm final appearance is sent

## Testing
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_687fa140e9d88331bc5eccf5600760c3