### PR TITLE
Update send_message to use object state

### DIFF
--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -139,3 +139,30 @@ class BaseState:
             things=self.get_display_things(**kwargs),
         )
         return self.format_appearance(appearance, **kwargs)
+
+    def msg(
+        self,
+        text: str | None = None,
+        from_obj: object | None = None,
+        session: object | None = None,
+        options: object | None = None,
+        **kwargs: object,
+    ) -> None:
+        """Send a message to the underlying Evennia object.
+
+        This mirrors ``DefaultObject.msg`` so that service functions can work
+        transparently with states or raw objects.
+        """
+
+        try:
+            extra = {}
+            if from_obj is not None:
+                extra["from_obj"] = from_obj
+            if session is not None:
+                extra["session"] = session
+            if options is not None:
+                extra["options"] = options
+            extra.update(kwargs)
+            self.obj.msg(text, **extra)
+        except AttributeError:
+            pass

--- a/src/flows/service_functions/communication.py
+++ b/src/flows/service_functions/communication.py
@@ -26,9 +26,15 @@ def send_message(
         )
         ````
     """
-    target = flow_execution.resolve_flow_reference(recipient)
+    target_state = flow_execution.get_object_state(recipient)
     message = flow_execution.resolve_flow_reference(text)
-    try:
-        target.msg(message)
-    except AttributeError:
-        pass
+
+    if target_state is None:
+        target = flow_execution.resolve_flow_reference(recipient)
+        try:
+            target.msg(message)
+        except AttributeError:
+            pass
+        return
+
+    target_state.msg(message)


### PR DESCRIPTION
## Summary
- support msg passthrough on BaseState
- deliver send_message via FlowExecution.get_object_state
- verify send_message works when a state is provided
- resolve text references for send_message
- test variable text resolution

## Testing
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_687fe28a78b08331be68f1b2c547ea06