### PR TITLE
Update trigger registry handling

### DIFF
--- a/src/commands/handlers/base.py
+++ b/src/commands/handlers/base.py
@@ -49,13 +49,14 @@ class BaseHandler:
 
         # Independent per-handler execution context
         self.context: ContextData = ContextData()
-        self.flow_stack: FlowStack = FlowStack()
+        self.flow_stack: FlowStack | None = None
 
     # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
     def run(self, *, caller: ObjectDB, **dispatcher_vars: Any) -> None:  # noqa: D401
         """Prime context, run prerequisites, then run the main flow."""
+        self.flow_stack = FlowStack(trigger_registry=caller.trigger_registry)
         self._prime_context(caller=caller, flow_vars=dispatcher_vars)
         self._run_prerequisites()
         self._run_main_flow(caller=caller, flow_vars=dispatcher_vars)


### PR DESCRIPTION
## Summary
- update `trigger_registry` property to return `None` offscreen
- register/unregister triggers in `at_post_move`
- pass caller's trigger registry to `FlowStack`
- expand trigger registry tests

## Testing
- `uv run arx test`

------
https://chatgpt.com/codex/tasks/task_e_687ff8f5950083318da18da942beeded