### PR TITLE
Add FlowState const and command error messaging test

### DIFF
--- a/docs/commands_overview.md
+++ b/docs/commands_overview.md
@@ -1,0 +1,13 @@
+# Command System Overview
+
+Arx II keeps command classes intentionally simple. A command only interprets player
+input and hands control to the flow engine. Every command declares one or more
+**dispatchers** that pair a regular expression with a handler instance. The dispatcher
+parses the text, resolves any referenced objects and then calls its handler.
+
+Handlers perform permission checks and kick off flows. They can emit prerequisite
+events before the main flow runs. Game rules and messaging belong in flows,
+triggers or service functions—not in commands or handlers.
+
+Because commands only glue these pieces together we test dispatchers, handlers
+and flows rather than individual command classes.

--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -179,7 +179,7 @@ class ArxCommand(Command):
                     caller=self.caller,
                     cmdset=self.cmdset)}"
             )
-        self.selected_dispatcher.execute_event()
+        self.selected_dispatcher.execute()
 
     def get_syntax_display(
         self, caller=None, cmdset=None, mode: HelpFileViewMode = HelpFileViewMode.TEXT

--- a/src/commands/handlers/base.py
+++ b/src/commands/handlers/base.py
@@ -21,8 +21,8 @@ from typing import Any, Mapping, Sequence
 from evennia.objects.models import ObjectDB
 
 from commands.exceptions import CommandError
+from flows.consts import FlowState
 from flows.context_data import ContextData
-from flows.flow_execution import FlowState
 from flows.flow_stack import FlowStack
 from flows.models import FlowDefinition
 

--- a/src/commands/tests/test_dispatchers.py
+++ b/src/commands/tests/test_dispatchers.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.dispatchers import BaseDispatcher, LocationDispatcher, TargetDispatcher
+from commands.exceptions import CommandError
+from evennia_extensions.factories import ObjectDBFactory
+
+
+class DummyHandler:
+    def __init__(self):
+        self.kwargs = None
+
+    def run(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class DummyCommand:
+    def __init__(self, caller, args, raw_string=None):
+        self.caller = caller
+        self.args = args
+        self.raw_string = raw_string or args
+
+
+class BaseDispatcherTests(TestCase):
+    def test_execute_passes_kwargs_to_handler(self):
+        caller = ObjectDBFactory(db_key="caller")
+        handler = DummyHandler()
+        cmd = DummyCommand(caller, "")
+        disp = BaseDispatcher(r"^$", handler)
+        disp.bind(cmd)
+        self.assertTrue(disp.is_match())
+        disp.execute()
+        self.assertEqual(handler.kwargs["caller"], caller)
+
+
+class TargetDispatcherTests(TestCase):
+    def test_target_resolved_and_passed(self):
+        caller = ObjectDBFactory(db_key="caller")
+        target = ObjectDBFactory(db_key="target")
+        caller.search = MagicMock(return_value=target)
+        handler = DummyHandler()
+        cmd = DummyCommand(caller, "target")
+        disp = TargetDispatcher(r"^(?P<target>.+)$", handler)
+        disp.bind(cmd)
+        disp.execute()
+        self.assertEqual(handler.kwargs["target"], target)
+
+    def test_missing_target_raises(self):
+        caller = ObjectDBFactory(db_key="caller")
+        caller.search = MagicMock(return_value=None)
+        handler = DummyHandler()
+        cmd = DummyCommand(caller, "nobody")
+        disp = TargetDispatcher(r"^(?P<target>.+)$", handler)
+        disp.bind(cmd)
+        with self.assertRaises(CommandError):
+            disp.execute()
+
+
+class LocationDispatcherTests(TestCase):
+    def test_location_passed(self):
+        location = ObjectDBFactory(db_key="room")
+        caller = ObjectDBFactory(db_key="caller", location=location)
+        handler = DummyHandler()
+        cmd = DummyCommand(caller, "look")
+        disp = LocationDispatcher(r"^look$", handler)
+        disp.bind(cmd)
+        disp.execute()
+        self.assertEqual(handler.kwargs["target"], location)

--- a/src/commands/tests/test_handlers.py
+++ b/src/commands/tests/test_handlers.py
@@ -1,0 +1,80 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from commands.command import ArxCommand
+from commands.dispatchers import BaseDispatcher
+from commands.exceptions import CommandError
+from commands.handlers.base import BaseHandler
+from evennia_extensions.factories import ObjectDBFactory
+from flows.consts import FlowState
+from flows.factories import FlowDefinitionFactory
+from flows.flow_stack import FlowStack
+from flows.models import FlowDefinition
+
+
+class BaseHandlerTests(TestCase):
+    def test_run_primes_context_and_executes_flow(self):
+        caller = ObjectDBFactory(db_key="caller")
+        target = ObjectDBFactory(db_key="target")
+        flow_def = FlowDefinitionFactory(name="main")
+        handler = BaseHandler(flow_name=flow_def.name)
+        with patch.object(FlowDefinition.objects, "get", return_value=flow_def):
+            with patch.object(
+                FlowStack,
+                "create_and_execute_flow",
+                return_value=MagicMock(state=FlowState.RUNNING),
+            ) as mock_exec:
+                handler.run(caller=caller, target=target)
+                self.assertIn(caller.pk, handler.context.states)
+                self.assertIn(target.pk, handler.context.states)
+                mock_exec.assert_called_once()
+
+    def test_prerequisite_stop_raises_error(self):
+        caller = ObjectDBFactory(db_key="caller")
+        flow_def = FlowDefinitionFactory(name="main")
+        handler = BaseHandler(flow_name=flow_def.name, prerequisite_events=["pre"])
+        with (
+            patch.object(FlowDefinition.objects, "get", return_value=flow_def),
+            patch.object(
+                FlowDefinition,
+                "emit_event_definition",
+                return_value=MagicMock(steps=MagicMock(all=lambda: [])),
+            ),
+            patch.object(
+                FlowStack,
+                "create_and_execute_flow",
+                return_value=MagicMock(state=FlowState.STOP, stop_reason="blocked"),
+            ),
+        ):
+            with self.assertRaises(CommandError):
+                handler.run(caller=caller)
+
+
+class CommandErrorMessageTests(TestCase):
+    def test_caller_receives_error_message(self):
+        class FailingHandler:
+            def run(self, **kwargs):
+                raise CommandError("bad")
+
+        dispatcher = BaseDispatcher(r"^$", FailingHandler())
+
+        class TestCmd(ArxCommand):
+            key = "fail"
+            dispatchers = [dispatcher]
+
+        caller = ObjectDBFactory(db_key="caller")
+        caller.msg = MagicMock()
+
+        cmd = TestCmd()
+        cmd.caller = caller
+        cmd.args = ""
+        cmd.raw_string = ""
+        dispatcher.bind(cmd)
+        cmd.selected_dispatcher = dispatcher
+
+        cmd.func()
+
+        caller.msg.assert_called_once()
+        sent = caller.msg.call_args.kwargs["text"]
+        self.assertEqual(str(sent), "bad")

--- a/src/flows/consts.py
+++ b/src/flows/consts.py
@@ -1,3 +1,4 @@
+from enum import Enum, auto
 import operator
 
 from django.db import models
@@ -57,6 +58,13 @@ OPERATOR_MAP = {
     FlowActionChoices.EVALUATE_LESS_THAN_OR_EQUALS: operator.le,
     FlowActionChoices.EVALUATE_GREATER_THAN_OR_EQUALS: operator.ge,
 }
+
+
+class FlowState(Enum):
+    """Simple execution state used by handlers."""
+
+    RUNNING = auto()
+    STOP = auto()
 
 
 class DefaultEvents(models.TextChoices):

--- a/src/flows/flow_execution.py
+++ b/src/flows/flow_execution.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Callable, Optional
 
-from flows import service_functions
+from flows.consts import FlowState
 from flows.context_data import ContextData
 from flows.models import FlowDefinition, FlowStepDefinition
 from flows.object_states.base_state import BaseState
@@ -48,6 +48,8 @@ class FlowExecution:
         self.context = context
         self.flow_stack = flow_stack
         self.origin = origin
+        self.state: FlowState = FlowState.RUNNING
+        self.stop_reason: str | None = None
         self.variable_mapping = (
             variable_mapping or {}
         )  # Maps flow variable names to their values
@@ -144,6 +146,8 @@ class FlowExecution:
 
     def get_service_function(self, function_name: str) -> Callable:
         """Return a service function by name."""
+        from flows import service_functions
+
         return service_functions.get_service_function(function_name)
 
     def get_next_child(

--- a/src/flows/models.py
+++ b/src/flows/models.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import operator
+from types import SimpleNamespace
 from typing import List
 
 from django.db import models
@@ -46,6 +47,20 @@ class FlowDefinition(models.Model):
 
     def __str__(self):
         return self.name
+
+    @staticmethod
+    def emit_event_definition(event_name: str) -> "FlowDefinition":
+        """Create an unsaved FlowDefinition that emits ``event_name``."""
+        flow_def = FlowDefinition(name=f"_emit_{event_name}")
+        step = FlowStepDefinition(
+            flow=flow_def,
+            action=FlowActionChoices.EMIT_FLOW_EVENT,
+            variable_name="emit_event",
+            parameters={"event_type": event_name},
+        )
+        flow_def._unsaved_steps = [step]
+        flow_def.steps = SimpleNamespace(all=lambda: flow_def._unsaved_steps)
+        return flow_def
 
 
 class FlowStepDefinition(models.Model):


### PR DESCRIPTION
## Summary
- move `FlowState` enum to `flows.consts`
- update imports after moving `FlowState`
- verify CommandError messages reach the caller

## Testing
- `uv run arx test commands.tests.test_dispatchers commands.tests.test_handlers`

------
https://chatgpt.com/codex/tasks/task_e_6880224ec82483318858849bd5b39ef1