### PR TITLE
Implement message_location service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This repository contains **Arx II**, a sequel to the Arx MUD. It is built on the Evennia framework and Django.
 
-- **Testing**: run the suite with `arx test`. If you haven't activated the virtual environment, use `uv run arx test` instead.
+- **Testing**: run the suite with `arx test`. If you haven't activated the virtual environment, use `uv run arx test` instead. Running tests with the plain `python` command can miss dependencies like `typer`.
 - **Design goals**: gameplay rules should live in the database. Avoid hardcoding specific mechanics in code. The `flows` system under `src/flows` allows designers to create data-driven tasks. Flows emit events that triggers can listen to and spawn additional flows.
 - **Service functions** should be generic utilities. They must not embed hardcoded gameplay logic. Use flows and triggers with data to implement specific rules.
 - We want extensive automation to support a narrative driven game world. Player choices should drive automated reactions defined via data.

--- a/src/flows/consts.py
+++ b/src/flows/consts.py
@@ -28,6 +28,20 @@ class FlowActionChoices(models.TextChoices):
 
     SET_CONTEXT_VALUE = "set_context_value", "Set Context Value"
     MODIFY_CONTEXT_VALUE = "modify_context_value", "Modify Context Value"
+    ADD_CONTEXT_LIST_VALUE = "add_context_list_value", "Add Context List Value"
+    REMOVE_CONTEXT_LIST_VALUE = (
+        "remove_context_list_value",
+        "Remove Context List Value",
+    )
+    SET_CONTEXT_DICT_VALUE = "set_context_dict_value", "Set Context Dict Value"
+    REMOVE_CONTEXT_DICT_VALUE = (
+        "remove_context_dict_value",
+        "Remove Context Dict Value",
+    )
+    MODIFY_CONTEXT_DICT_VALUE = (
+        "modify_context_dict_value",
+        "Modify Context Dict Value",
+    )
     EVALUATE_EQUALS = "evaluate_equals", "Evaluate Equals"
     EVALUATE_NOT_EQUALS = "evaluate_not_equals", "Evaluate Not Equals"
     EVALUATE_LESS_THAN = "evaluate_less_than", "Evaluate Less Than"

--- a/src/flows/context_data.py
+++ b/src/flows/context_data.py
@@ -73,6 +73,64 @@ class ContextData:
             self.states[key] = state
         return state
 
+    def add_to_context_list(self, key, attribute, value):
+        """Append ``value`` to a list attribute on a stored state."""
+
+        state = self.get_state_by_pk(key)
+        if state is not None:
+            lst = list(getattr(state, attribute, []))
+            if value not in lst:
+                lst.append(value)
+            setattr(state, attribute, lst)
+            self.states[key] = state
+        return state
+
+    def remove_from_context_list(self, key, attribute, value):
+        """Remove ``value`` from a list attribute on a stored state."""
+
+        state = self.get_state_by_pk(key)
+        if state is not None:
+            lst = list(getattr(state, attribute, []))
+            if value in lst:
+                lst.remove(value)
+            setattr(state, attribute, lst)
+            self.states[key] = state
+        return state
+
+    def set_context_dict_value(self, key, attribute, dict_key, value):
+        """Set ``dict_key`` in a dict attribute on a stored state."""
+
+        state = self.get_state_by_pk(key)
+        if state is not None:
+            mapping = dict(getattr(state, attribute, {}))
+            mapping[dict_key] = value
+            setattr(state, attribute, mapping)
+            self.states[key] = state
+        return state
+
+    def remove_context_dict_value(self, key, attribute, dict_key):
+        """Remove ``dict_key`` from a dict attribute on a stored state."""
+
+        state = self.get_state_by_pk(key)
+        if state is not None:
+            mapping = dict(getattr(state, attribute, {}))
+            mapping.pop(dict_key, None)
+            setattr(state, attribute, mapping)
+            self.states[key] = state
+        return state
+
+    def modify_context_dict_value(self, key, attribute, dict_key, modifier):
+        """Modify ``dict_key`` in a dict attribute using ``modifier``."""
+
+        state = self.get_state_by_pk(key)
+        if state is not None:
+            mapping = dict(getattr(state, attribute, {}))
+            old_value = mapping.get(dict_key)
+            mapping[dict_key] = modifier(old_value)
+            setattr(state, attribute, mapping)
+            self.states[key] = state
+        return state
+
     def store_flow_event(self, key, flow_event):
         """Store a FlowEvent under a specific key.
 

--- a/src/flows/service_functions/__init__.py
+++ b/src/flows/service_functions/__init__.py
@@ -8,6 +8,7 @@ from flows.service_functions import communication, perception
 SERVICE_FUNCTIONS: dict[str, Callable] = {
     "get_formatted_description": perception.get_formatted_description,
     "send_message": communication.send_message,
+    "message_location": communication.message_location,
     "object_has_tag": perception.object_has_tag,
     "append_to_attribute": perception.append_to_attribute,
 }

--- a/src/flows/service_functions/communication.py
+++ b/src/flows/service_functions/communication.py
@@ -1,6 +1,7 @@
 """Communication-related service functions."""
 
 from flows.flow_execution import FlowExecution
+from flows.object_states.base_state import BaseState
 
 
 def send_message(
@@ -38,3 +39,90 @@ def send_message(
         return
 
     target_state.msg(message)
+
+
+def message_location(
+    flow_execution: FlowExecution,
+    caller: str,
+    target: str | None = None,
+    caller_message: str | None = None,
+    target_message: str | None = None,
+    bystander_message: str | None = None,
+    **kwargs: object,
+) -> None:
+    """Send formatted messages to caller, target and bystanders.
+
+    Args:
+        flow_execution: Current execution context.
+        caller: Flow variable for the caller.
+        target: Optional flow variable for the target.
+        caller_message: Template for the caller.
+        target_message: Template for the target.
+        bystander_message: Template for others in the room.
+        **kwargs: Additional keyword arguments.
+
+    Templates may use ``{caller}``, ``{target}`` and ``{location}`` which are
+    resolved per recipient using ``get_display_name``.
+
+    Example:
+        ````python
+        FlowStepDefinition(
+            action=FlowActionChoices.CALL_SERVICE_FUNCTION,
+            variable_name="message_location",
+            parameters={
+                "caller": "$caller",
+                "target": "$target",
+                "caller_message": "You poke {target}.",
+                "target_message": "{caller} pokes you.",
+                "bystander_message": "{caller} pokes {target}.",
+            },
+        )
+        ````
+    """
+
+    def _resolve(ref: str | None):
+        if ref is None:
+            return None
+        return flow_execution.get_object_state(ref)
+
+    caller_state = _resolve(caller)
+    target_state = _resolve(target)
+
+    location_state = None
+    if caller_state and caller_state.obj.location:
+        location = caller_state.obj.location
+        location_state = flow_execution.context.get_state_by_pk(location.pk)
+
+    def format_text(template: str | None, looker: "BaseState") -> str | None:
+        if not template:
+            return None
+        mapping = {
+            "caller": caller_state.get_display_name(looker) if caller_state else "",
+            "target": target_state.get_display_name(looker) if target_state else "",
+            "location": (
+                location_state.get_display_name(looker) if location_state else ""
+            ),
+        }
+        return template.format(**mapping)
+
+    recipients = []
+    if location_state:
+        recipients = [
+            st
+            for st in location_state.contents
+            if st not in (caller_state, target_state)
+        ]
+
+    def _send(recipient_state: "BaseState | None", template: str | None) -> None:
+        if recipient_state is None:
+            return
+        text = format_text(template, recipient_state)
+        if text is None:
+            return
+        recipient_state.msg(text)
+
+    _send(caller_state, caller_message)
+    _send(target_state, target_message)
+    if bystander_message:
+        for recipient in recipients:
+            _send(recipient, bystander_message)

--- a/src/flows/tests/test_message_location.py
+++ b/src/flows/tests/test_message_location.py
@@ -1,0 +1,118 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from evennia_extensions.factories import ObjectDBFactory
+from flows.factories import FlowExecutionFactory
+from flows.service_functions.communication import message_location
+
+
+class TestMessageLocation(TestCase):
+    def test_names_vary_by_looker(self):
+        room = ObjectDBFactory(
+            db_key="Hall", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        target = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        bystander = ObjectDBFactory(
+            db_key="Charlie",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+
+        fx = FlowExecutionFactory(variable_mapping={"caller": caller, "target": target})
+        for obj in (room, caller, target, bystander):
+            fx.context.initialize_state_for_object(obj)
+
+        target_state = fx.context.get_state_by_pk(target.pk)
+
+        target_state.fake_name = "Mysterious figure"
+        fx.context.add_to_context_list(
+            key=target.pk, attribute="real_name_viewers", value=caller.pk
+        )
+
+        with (
+            patch.object(caller, "msg") as caller_msg,
+            patch.object(target, "msg") as target_msg,
+            patch.object(bystander, "msg") as by_msg,
+        ):
+            message_location(
+                fx,
+                "$caller",
+                target="$target",
+                caller_message="You greet {target}.",
+                target_message="{caller} greets you.",
+                bystander_message="{caller} greets {target}.",
+            )
+
+            caller_msg.assert_called_with("You greet Bob.")
+            target_msg.assert_called_with("Alice greets you.")
+            by_msg.assert_called_with("Alice greets Mysterious figure.")
+
+    def test_modify_fake_name_for_viewer(self):
+        room = ObjectDBFactory(
+            db_key="Hall", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        target = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        bystander = ObjectDBFactory(
+            db_key="Charlie",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+
+        fx = FlowExecutionFactory(variable_mapping={"caller": caller, "target": target})
+        for obj in (room, caller, target, bystander):
+            fx.context.initialize_state_for_object(obj)
+
+        target_state = fx.context.get_state_by_pk(target.pk)
+        bystander_state = fx.context.get_state_by_pk(bystander.pk)
+
+        target_state.fake_name = "Masked stranger"
+        fx.context.add_to_context_list(
+            key=target.pk, attribute="real_name_viewers", value=caller.pk
+        )
+        fx.context.modify_context_dict_value(
+            key=target.pk,
+            attribute="display_name_map",
+            dict_key=bystander.pk,
+            modifier=lambda name: (
+                f"{target_state.get_display_name(bystander_state)} (Evil)"
+                if name is None
+                else f"{name} (Evil)"
+            ),
+        )
+
+        with (
+            patch.object(caller, "msg") as caller_msg,
+            patch.object(target, "msg") as target_msg,
+            patch.object(bystander, "msg") as by_msg,
+        ):
+            message_location(
+                fx,
+                "$caller",
+                target="$target",
+                caller_message="You glare at {target}.",
+                target_message="{caller} glares at you.",
+                bystander_message="{caller} glares at {target}.",
+            )
+
+            caller_msg.assert_called_with("You glare at Bob.")
+            target_msg.assert_called_with("Alice glares at you.")
+            by_msg.assert_called_with("Alice glares at Masked stranger (Evil).")


### PR DESCRIPTION
## Summary
- allow BaseState to handle per-looker names and disguises
- add `message_location` service function for room-style messages
- register the new service
- test location messaging
- clarify instructions on how to run tests
- support modifying per-looker display names based on fake names
- document message_location usage with a FlowStep example
- add context modifications for lists and dicts so flows can adjust fake names

## Testing
- `uv run arx test`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880482162bc83318504eba50afdb92e