### PR TITLE
Implement SceneDataManager persistence

### DIFF
--- a/src/commands/handlers/AGENTS.md
+++ b/src/commands/handlers/AGENTS.md
@@ -4,7 +4,7 @@ This folder contains command handlers. `BaseHandler` bridges the dispatcher and 
 
 - Dispatchers resolve objects before creating a handler. Handlers should not perform parsing or object searches.
 - Instantiate a handler with `flow_name` and optional `prerequisite_events`, then call `run(caller=obj, **flow_vars)`.
-- When run, the handler primes a `ContextData` and `FlowStack`, emits any prerequisite events, and executes the main flow.
+- When run, the handler uses the caller's `SceneDataManager` and a `FlowStack`, emits any prerequisite events, and executes the main flow.
 - Game rules should live in flows, triggers, or service functions. Avoid modifying Evennia objects directly inside handlers.
 - Always raise `CommandError` for user-facing failures.
 - Keep variable names descriptive and docstrings plain ASCII.

--- a/src/commands/handlers/__init__.py
+++ b/src/commands/handlers/__init__.py
@@ -5,7 +5,7 @@ Handlers are the thin, reusable bridge between a DispatcherResult and FlowExecut
 A **Handler** coordinates three jobs *only*:
 
 1.  **Context & Stack Setup**
-    • Create a fresh :class:`ContextData`.
+    • Obtain the caller's :class:`SceneDataManager`.
     • Populate it with objects/values supplied by the *dispatcher* (caller, targets,
       parsed arguments, etc.).
     • Create—or receive—an :class:`EventStack` so every flow shares recursion

--- a/src/commands/handlers/base.py
+++ b/src/commands/handlers/base.py
@@ -22,9 +22,9 @@ from evennia.objects.models import ObjectDB
 
 from commands.exceptions import CommandError
 from flows.consts import FlowState
-from flows.context_data import ContextData
 from flows.flow_stack import FlowStack
 from flows.models import FlowDefinition
+from flows.scene_data_manager import SceneDataManager
 
 __all__ = ["BaseHandler"]
 
@@ -47,8 +47,8 @@ class BaseHandler:
         self.flow_name: str = flow_name
         self.prerequisite_events: tuple[str, ...] = tuple(prerequisite_events or ())
 
-        # Independent per-handler execution context
-        self.context: ContextData = ContextData()
+        # Will be assigned in _prime_context
+        self.context: SceneDataManager | None = None
         self.flow_stack: FlowStack | None = None
 
     # ------------------------------------------------------------------
@@ -66,6 +66,7 @@ class BaseHandler:
     # ------------------------------------------------------------------
     def _prime_context(self, *, caller: ObjectDB, flow_vars: Mapping[str, Any]) -> None:
         """Add ObjectState entries for *caller* and any object-typed flow variable."""
+        self.context = caller.location.scene_data
         self.context.initialize_state_for_object(caller)
 
         for value in flow_vars.values():

--- a/src/commands/tests/test_handlers.py
+++ b/src/commands/tests/test_handlers.py
@@ -15,8 +15,11 @@ from flows.models import FlowDefinition
 
 class BaseHandlerTests(TestCase):
     def test_run_primes_context_and_executes_flow(self):
-        caller = ObjectDBFactory(db_key="caller")
-        target = ObjectDBFactory(db_key="target")
+        room = ObjectDBFactory(
+            db_key="room", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = ObjectDBFactory(db_key="caller", location=room)
+        target = ObjectDBFactory(db_key="target", location=room)
         flow_def = FlowDefinitionFactory(name="main")
         handler = BaseHandler(flow_name=flow_def.name)
         with patch.object(FlowDefinition.objects, "get", return_value=flow_def):
@@ -31,7 +34,10 @@ class BaseHandlerTests(TestCase):
                 mock_exec.assert_called_once()
 
     def test_prerequisite_stop_raises_error(self):
-        caller = ObjectDBFactory(db_key="caller")
+        room = ObjectDBFactory(
+            db_key="room", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = ObjectDBFactory(db_key="caller", location=room)
         flow_def = FlowDefinitionFactory(name="main")
         handler = BaseHandler(flow_name=flow_def.name, prerequisite_events=["pre"])
         with (

--- a/src/flows/__init__.py
+++ b/src/flows/__init__.py
@@ -5,7 +5,7 @@ is defined in database flows and triggers rather than hardcoded in
 Python.
 
 Key pieces:
- - ContextData stores object states and events for a single run.
+ - SceneDataManager stores object states and events for a scene.
  - BaseState wraps Evennia objects with temporary state.
  - FlowEvent represents in-memory events that triggers react to.
  - FlowExecution runs a FlowDefinition and resolves variables.

--- a/src/flows/factories.py
+++ b/src/flows/factories.py
@@ -5,10 +5,10 @@ import factory
 from evennia_extensions.factories import ObjectDBFactory
 from flows import models
 from flows.consts import FlowActionChoices
-from flows.context_data import ContextData
 from flows.flow_event import FlowEvent
 from flows.flow_execution import FlowExecution
 from flows.flow_stack import FlowStack
+from flows.scene_data_manager import SceneDataManager
 from flows.trigger_registry import TriggerRegistry
 
 
@@ -75,10 +75,10 @@ class TriggerFactory(factory.django.DjangoModelFactory):
     additional_filter_condition = factory.LazyFunction(dict)
 
 
-# ContextData is not a model, but we can provide a helper for tests
-class ContextDataFactory(factory.Factory):
+# SceneDataManager is not a model, but we can provide a helper for tests
+class SceneDataManagerFactory(factory.Factory):
     class Meta:
-        model = ContextData
+        model = SceneDataManager
 
 
 class FlowStackFactory(factory.Factory):
@@ -97,7 +97,7 @@ class FlowExecutionFactory(factory.Factory):
         model = FlowExecution
 
     flow_definition = factory.SubFactory(FlowDefinitionWithInitialStepFactory)
-    context = factory.SubFactory(ContextDataFactory)
+    context = factory.SubFactory(SceneDataManagerFactory)
     flow_stack = factory.SubFactory(FlowStackFactory)
     origin = factory.LazyFunction(MagicMock)
     variable_mapping = factory.LazyFunction(dict)

--- a/src/flows/factories.pyi
+++ b/src/flows/factories.pyi
@@ -3,10 +3,10 @@ from typing import Any, Dict, Optional, Type
 from evennia.objects.objects import DefaultObject
 
 from flows import models
-from flows.context_data import ContextData
 from flows.flow_event import FlowEvent
 from flows.flow_execution import FlowExecution
 from flows.flow_stack import FlowStack
+from flows.scene_data_manager import SceneDataManager
 
 class FlowDefinitionFactory:
     def __new__(cls, *args: Any, **kwargs: Any) -> models.FlowDefinition: ...
@@ -62,8 +62,8 @@ class TriggerFactory:
     obj: DefaultObject
     additional_filter_condition: Dict[str, Any]
 
-class ContextDataFactory:
-    def __new__(cls, *args: Any, **kwargs: Any) -> ContextData: ...
+class SceneDataManagerFactory:
+    def __new__(cls, *args: Any, **kwargs: Any) -> SceneDataManager: ...
 
 class FlowStackFactory:
     def __new__(cls, **kwargs: Any) -> FlowStack: ...
@@ -75,7 +75,7 @@ class FlowExecutionFactory:
     def __new__(
         cls,
         flow_definition: Optional[models.FlowDefinition] = None,
-        context: Optional[ContextData] = None,
+        context: Optional[SceneDataManager] = None,
         flow_stack: Optional[FlowStack] = None,
         origin: Optional[Any] = None,
         variable_mapping: Optional[Dict[str, Any]] = None,
@@ -86,7 +86,7 @@ class FlowExecutionFactory:
         model: Type[FlowExecution]
 
     flow_definition: Optional[models.FlowDefinition]
-    context: Optional[ContextData]
+    context: Optional[SceneDataManager]
     flow_stack: Optional[FlowStack]
     origin: Any
     variable_mapping: Dict[str, Any]

--- a/src/flows/flow_event.py
+++ b/src/flows/flow_event.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
-    from flows.context_data import ContextData
     from flows.flow_execution import FlowExecution
     from flows.flow_stack import FlowStack
+    from flows.scene_data_manager import SceneDataManager
 
 
 class FlowEvent:
@@ -11,7 +11,7 @@ class FlowEvent:
 
     FlowEvent objects are created by flow steps to mark notable moments such as
     when a character glances at another object. Events are stored on the current
-    ContextData instance and passed to triggers. Because the `data` dictionary is
+    SceneDataManager instance and passed to triggers. Because the ``data`` dictionary is
     mutable, triggered flows can update it so later conditions may react. This
     enables event chains without direct coupling in Python code.
 
@@ -45,7 +45,7 @@ class FlowEvent:
         )
 
     @property
-    def context(self) -> "ContextData":
+    def context(self) -> "SceneDataManager":
         return self.source.context
 
     @property

--- a/src/flows/flow_execution.py
+++ b/src/flows/flow_execution.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Callable, Optional
 
 from flows.consts import FlowState
-from flows.context_data import ContextData
 from flows.models import FlowDefinition, FlowStepDefinition
 from flows.object_states.base_state import BaseState
+from flows.scene_data_manager import SceneDataManager
 from flows.trigger_registry import TriggerRegistry
 from typeclasses.objects import Object
 
@@ -20,7 +20,7 @@ class FlowExecution:
     Service functions referenced by steps are resolved from the
     `service_functions` module.
 
-    FlowExecution works with ContextData to manage ephemeral object states and
+    FlowExecution works with SceneDataManager to manage ephemeral object states and
     with FlowStack to orchestrate nested flows. Keeping logic in the database
     allows designers to iterate on behavior without modifying Python code.
     """
@@ -28,7 +28,7 @@ class FlowExecution:
     def __init__(
         self,
         flow_definition: FlowDefinition,
-        context: ContextData,
+        context: SceneDataManager,
         flow_stack: "FlowStack",
         origin: Object,
         variable_mapping: Optional[dict[str, object]] = None,
@@ -38,7 +38,7 @@ class FlowExecution:
 
         Args:
             flow_definition: The flow definition to execute.
-            context: Shared ContextData for this execution.
+            context: Shared SceneDataManager for this execution.
             flow_stack: FlowStack orchestrating nested flows.
             origin: Object that initiated the flow.
             variable_mapping: Initial mapping of variable names to values.
@@ -122,7 +122,7 @@ class FlowExecution:
         ``obj_ref`` may be a flow variable reference, an Evennia object,
         a primary key, or an existing BaseState. The method resolves any
         variable references and then attempts to look up the corresponding state
-        in the current ContextData.
+        in the current SceneDataManager.
 
         Args:
             obj_ref: Reference to resolve into a state.

--- a/src/flows/flow_stack.py
+++ b/src/flows/flow_stack.py
@@ -41,7 +41,7 @@ class FlowStack:
 
         Args:
             flow_definition: The FlowDefinition to execute.
-            context: Shared ContextData instance.
+            context: Shared SceneDataManager instance.
             origin: Object that initiated the flow.
             limit: Maximum allowed executions for this `(flow, origin)` pair.
             variable_mapping: Optional initial variable mapping.

--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -5,26 +5,27 @@ from django.utils.functional import cached_property
 from evennia.utils.utils import compress_whitespace, iter_to_str
 
 if TYPE_CHECKING:
-    from flows.context_data import ContextData
+    from flows.scene_data_manager import SceneDataManager
     from typeclasses.objects import Object
 
 
 class BaseState:
     """Ephemeral wrapper around an Evennia object.
 
-    A BaseState exposes attributes such as `name` and `description` that mirror
-    the underlying object but can be modified during a flow run. Changes are
-    kept only within the current ContextData so they never touch the database.
+    A BaseState exposes attributes such as ``name`` and ``description`` that
+    mirror the underlying object but can be modified during a flow run. Changes
+    are kept only within the current ``SceneDataManager`` so they never touch
+    the database.
     Subclasses may add additional convenience properties for specific object
     types.
     """
 
-    def __init__(self, obj: "Object", context: "ContextData"):
+    def __init__(self, obj: "Object", context: "SceneDataManager"):
         """Initialize the state.
 
         Args:
             obj: The Evennia object to wrap.
-            context: ContextData this state belongs to.
+            context: SceneDataManager this state belongs to.
 
         The state can present a ``fake_name`` to observers that are not in
         ``real_name_viewers``. Optional ``name_prefix`` and ``name_suffix``

--- a/src/flows/scene_data_manager.py
+++ b/src/flows/scene_data_manager.py
@@ -1,17 +1,18 @@
 from evennia.objects.models import ObjectDB
 
 
-class ContextData:
-    """Shared state container used while executing flows.
+class SceneDataManager:
+    """Shared state container cached on a room.
 
-    ContextData maps object IDs to `BaseState` instances. These states store
-    attributes that service functions and flow steps may change. The container
-    also keeps `FlowEvent` objects emitted during execution so that later
-    steps or triggered flows can reference them.
+    A SceneDataManager maps object IDs to ``BaseState`` instances. These states
+    store attributes that service functions and flow steps may change during a
+    command. ``FlowEvent`` objects emitted while executing flows are also kept
+    here so that later steps or triggered flows can reference them.
 
     Attributes:
-        states: Mapping of object ID to state.
-        flow_events: Mapping of event key to `FlowEvent`.
+        states: Mapping of object ID to state. Persists across commands until
+            :py:meth:`reset` is called.
+        flow_events: Mapping of event key to ``FlowEvent``.
     """
 
     def __init__(self):
@@ -19,6 +20,11 @@ class ContextData:
         self.states = {}
         # Dictionary to store FlowEvent objects, keyed by a string.
         self.flow_events = {}
+
+    def reset(self) -> None:
+        """Clear stored states and events."""
+        self.states.clear()
+        self.flow_events.clear()
 
     def set_context_value(self, key, attribute, value):
         """Set an attribute on a stored state.

--- a/src/flows/tests/test_models/test_flow_steps.py
+++ b/src/flows/tests/test_models/test_flow_steps.py
@@ -4,10 +4,10 @@ from django.test import TestCase
 
 from flows.consts import FlowActionChoices
 from flows.factories import (
-    ContextDataFactory,
     FlowDefinitionFactory,
     FlowExecutionFactory,
     FlowStepDefinitionFactory,
+    SceneDataManagerFactory,
 )
 from flows.flow_stack import FlowStack
 
@@ -18,7 +18,7 @@ class FlowStepDefinitionTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.flow_def = FlowDefinitionFactory()
-        cls.context = ContextDataFactory()
+        cls.context = SceneDataManagerFactory()
 
     def setUp(self):
         self.variable_mapping = {}

--- a/src/flows/tests/test_models/test_trigger.py
+++ b/src/flows/tests/test_models/test_trigger.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase
 
 from flows.factories import (
-    ContextDataFactory,
     FlowEventFactory,
+    SceneDataManagerFactory,
     TriggerDefinitionFactory,
     TriggerFactory,
 )
@@ -15,7 +15,7 @@ class TestTrigger(TestCase):
     """Test suite for the Trigger model."""
 
     def setUp(self):
-        self.context = ContextDataFactory()
+        self.context = SceneDataManagerFactory()
         self.trigger_def = TriggerDefinitionFactory(
             event__key="test_event", base_filter_condition={"foo": "bar"}
         )

--- a/src/flows/trigger_registry.py
+++ b/src/flows/trigger_registry.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING, List
 
 if TYPE_CHECKING:
-    from flows.context_data import ContextData
     from flows.flow_event import FlowEvent
     from flows.flow_stack import FlowStack
     from flows.models import Trigger
+    from flows.scene_data_manager import SceneDataManager
 
 
 class TriggerRegistry:
@@ -40,7 +40,7 @@ class TriggerRegistry:
         self.triggers.sort(key=lambda t: t.priority, reverse=True)
 
     def process_event(
-        self, event: "FlowEvent", flow_stack: "FlowStack", context: "ContextData"
+        self, event: "FlowEvent", flow_stack: "FlowStack", context: "SceneDataManager"
     ) -> None:
         """Process an event by evaluating registered triggers in priority order.
 

--- a/src/typeclasses/mixins.py
+++ b/src/typeclasses/mixins.py
@@ -6,7 +6,7 @@ from flows.trigger_registry import TriggerRegistry
 if TYPE_CHECKING:
     from evennia.objects.objects import DefaultObject
 
-    from flows.context_data import ContextData
+    from flows.scene_data_manager import SceneDataManager
 
 
 class ObjectParent:
@@ -27,7 +27,7 @@ class ObjectParent:
         return self.db
 
     def get_object_state(
-        self: Union[Self, "DefaultObject"], context: "ContextData"
+        self: Union[Self, "DefaultObject"], context: "SceneDataManager"
     ) -> BaseState:
         return self.state_class(obj=self, context=context)
 

--- a/src/typeclasses/rooms.py
+++ b/src/typeclasses/rooms.py
@@ -8,6 +8,7 @@ Rooms are simple containers that has no location of their own.
 from django.utils.functional import cached_property
 from evennia.objects.objects import DefaultRoom
 
+from flows.scene_data_manager import SceneDataManager
 from flows.trigger_registry import TriggerRegistry
 from typeclasses.mixins import ObjectParent
 
@@ -27,3 +28,8 @@ class Room(ObjectParent, DefaultRoom):
     def trigger_registry(self) -> TriggerRegistry:
         """Return the TriggerRegistry associated with this room."""
         return TriggerRegistry()
+
+    @cached_property
+    def scene_data(self) -> SceneDataManager:
+        """Return the SceneDataManager associated with this room."""
+        return SceneDataManager()

--- a/src/typeclasses/tests/test_trigger_registry.py
+++ b/src/typeclasses/tests/test_trigger_registry.py
@@ -21,6 +21,14 @@ class TriggerRegistryPropertyTests(TestCase):
         self.assertIsInstance(room.__class__.trigger_registry, cached_property)
         self.assertNotIsInstance(char.__class__.trigger_registry, cached_property)
 
+    def test_scene_data_cached_property(self):
+        room = ObjectDBFactory(
+            db_key="hall", db_typeclass_path="typeclasses.rooms.Room"
+        )
+
+        self.assertIs(room.scene_data, room.scene_data)
+        self.assertIsInstance(room.__class__.scene_data, cached_property)
+
     def test_triggers_register_and_unregister_on_move(self):
         room1 = ObjectDBFactory(
             db_key="room1",


### PR DESCRIPTION
## Summary
- rename `flows.context_data` module to `scene_data_manager`
- keep `SceneDataManager` across commands and add a `reset` method
- expose `scene_data` cached property on rooms
- use the room's `scene_data` in command handlers
- update factories, tests and docs for the new name

## Testing
- `uv run arx test`

------
https://chatgpt.com/codex/tasks/task_e_6880e85f1df48331b2ede8d742e6ee98