### PR TITLE
Add look_at events and shared memory models

### DIFF
--- a/src/flows/models/flows.py
+++ b/src/flows/models/flows.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 from django.db import models
+from evennia.utils.idmapper.models import SharedMemoryModel
 
 from flows.consts import OPERATOR_MAP, FlowActionChoices
 from flows.flow_event import FlowEvent
@@ -16,7 +17,7 @@ CONDITIONAL_ACTIONS = {
 }
 
 
-class FlowDefinition(models.Model):
+class FlowDefinition(SharedMemoryModel):
     """Represents a reusable definition for a flow, consisting of multiple steps."""
 
     name = models.CharField(max_length=255, unique=True)
@@ -40,7 +41,7 @@ class FlowDefinition(models.Model):
         return flow_def
 
 
-class FlowStepDefinition(models.Model):
+class FlowStepDefinition(SharedMemoryModel):
     """Represents a single step in a flow definition.
 
     The ``variable_name`` field is a generic reference whose meaning depends on

--- a/src/flows/models/triggers.py
+++ b/src/flows/models/triggers.py
@@ -2,6 +2,7 @@ from typing import List
 
 from django.db import models
 from django.utils.functional import cached_property
+from evennia.utils.idmapper.models import SharedMemoryModel
 
 from flows.flow_event import FlowEvent
 from flows.helpers.logic import resolve_self_placeholders
@@ -9,7 +10,7 @@ from flows.models.events import Event
 from flows.models.flows import FlowDefinition
 
 
-class TriggerDefinition(models.Model):
+class TriggerDefinition(SharedMemoryModel):
     """Reusable template describing when to launch another flow.
 
     ``base_filter_condition`` allows simple equality checks against event data to
@@ -63,7 +64,7 @@ class TriggerDefinition(models.Model):
         return self.name
 
 
-class Trigger(models.Model):
+class Trigger(SharedMemoryModel):
     """Represents an active trigger on an object, based on a TriggerDefinition."""
 
     trigger_definition = models.ForeignKey(
@@ -138,7 +139,7 @@ class Trigger(models.Model):
         return f"{self.trigger_definition.name} for {self.obj.key}"
 
 
-class TriggerData(models.Model):
+class TriggerData(SharedMemoryModel):
     """Stores long-lived, arbitrary data associated with a specific Trigger."""
 
     trigger = models.ForeignKey(

--- a/src/flows/tests/test_look_flow.py
+++ b/src/flows/tests/test_look_flow.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+
+from evennia_extensions.factories import ObjectDBFactory
+from flows.factories import FlowExecutionFactory, SceneDataManagerFactory
+from flows.flow_stack import FlowStack
+from flows.models import FlowDefinition
+
+
+class LookFlowEventTests(TestCase):
+    def test_look_flow_emits_events_for_target_and_contents(self):
+        room = ObjectDBFactory(
+            db_key="Hall", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        viewer = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        target = ObjectDBFactory(db_key="Rock", location=room)
+        item1 = ObjectDBFactory(db_key="pebble", location=target)
+        item2 = ObjectDBFactory(db_key="stone", location=target)
+
+        look_flow = FlowDefinition.objects.get(name="look")
+
+        context = SceneDataManagerFactory()
+        stack = FlowStack(trigger_registry=room.trigger_registry)
+        for obj in (room, viewer, target, item1, item2):
+            context.initialize_state_for_object(obj)
+
+        fx = FlowExecutionFactory(
+            flow_definition=look_flow,
+            context=context,
+            flow_stack=stack,
+            origin=viewer,
+            variable_mapping={"caller": viewer, "target": target, "mode": "look"},
+        )
+        stack.execute_flow(fx)
+
+        self.assertIn("look_at_target", context.flow_events)
+        self.assertIn("look_at_contents_0", context.flow_events)
+        self.assertIn("look_at_contents_1", context.flow_events)
+        targets = {
+            context.flow_events["look_at_target"].data["target"],
+            context.flow_events["look_at_contents_0"].data["target"],
+            context.flow_events["look_at_contents_1"].data["target"],
+        }
+        self.assertEqual({target, item1, item2}, targets)


### PR DESCRIPTION
## Summary
- convert flow models to Evennia's `SharedMemoryModel`
- extend the look flow in the migration to emit `look_at` events for the target and its inventory
- test that the look flow stores these events

## Testing
- `printf 'yes\n' | uv run arx test`

------
https://chatgpt.com/codex/tasks/task_e_6882e3341fd08331829bd1a3adcf2c5f