### PR TITLE
Add combined movement permission helper

### DIFF
--- a/src/flows/object_states/__init__.py
+++ b/src/flows/object_states/__init__.py
@@ -17,6 +17,8 @@ Modules in this package include:
   - character_state.py: Contains CharacterState, a subclass of BaseState
     designed for characters. It integrates character-specific details such as
     health status and appearance modifiers.
+  - exit_state.py: Contains ExitState, used for exits and exposing traversal
+    permissions.
 
 This structure enables a clean separation of description logic for various
 object types and ensures that default values can be overridden or modified

--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -209,3 +209,29 @@ class BaseState:
             self.obj.msg(text, **extra)
         except AttributeError:
             pass
+
+    # ------------------------------------------------------------------
+    # Permission helpers
+    # ------------------------------------------------------------------
+
+    def can_move(
+        self,
+        actor: "BaseState | None" = None,
+        dest: "BaseState | None" = None,
+    ) -> bool:
+        """Return True if ``actor`` may move this object to ``dest``.
+
+        Args:
+            actor: State attempting the move.
+            dest: Destination container state.
+
+        Returns:
+            bool: ``True`` if the move is allowed.
+
+        Notes:
+            Moving an object into itself is always disallowed.
+        """
+
+        if dest is self:
+            return False
+        return True

--- a/src/flows/object_states/character_state.py
+++ b/src/flows/object_states/character_state.py
@@ -14,3 +14,18 @@ class CharacterState(BaseState):
     def get_categories(self) -> dict:
         # For now, no extra character-specific categories.
         return {}
+
+    # ------------------------------------------------------------------
+    # Permission helpers
+    # ------------------------------------------------------------------
+
+    def can_move(
+        self,
+        actor: "BaseState | None" = None,
+        dest: "BaseState | None" = None,
+    ) -> bool:
+        """Return True only if ``actor`` is moving themselves to ``dest``."""
+
+        if actor is not self:
+            return False
+        return super().can_move(actor=actor, dest=dest)

--- a/src/flows/object_states/exit_state.py
+++ b/src/flows/object_states/exit_state.py
@@ -1,0 +1,30 @@
+from flows.object_states.base_state import BaseState
+
+
+class ExitState(BaseState):
+    """State wrapper for exit objects."""
+
+    # ------------------------------------------------------------------
+    # Permission helpers
+    # ------------------------------------------------------------------
+
+    def can_move(
+        self,
+        actor: "BaseState | None" = None,
+        dest: "BaseState | None" = None,
+    ) -> bool:
+        """Return ``False`` to prevent moving exits."""
+
+        return False
+
+    def can_traverse(self, actor: "BaseState | None" = None) -> bool:
+        """Return ``True`` if ``actor`` may traverse this exit.
+
+        Args:
+            actor: State attempting the action.
+
+        Returns:
+            bool: Always ``True``.
+        """
+
+        return True

--- a/src/flows/object_states/room_state.py
+++ b/src/flows/object_states/room_state.py
@@ -22,3 +22,16 @@ class RoomState(BaseState):
     def get_categories(self) -> dict:
         # For now, no extra room-specific categories.
         return {}
+
+    # ------------------------------------------------------------------
+    # Permission helpers
+    # ------------------------------------------------------------------
+
+    def can_move(
+        self,
+        actor: "BaseState | None" = None,
+        dest: "BaseState | None" = None,
+    ) -> bool:
+        """Return ``False`` to disallow moving rooms."""
+
+        return False

--- a/src/flows/tests/test_object_state_permissions.py
+++ b/src/flows/tests/test_object_state_permissions.py
@@ -1,0 +1,61 @@
+from django.test import TestCase
+
+from evennia_extensions.factories import ObjectDBFactory
+from flows.factories import SceneDataManagerFactory
+from flows.object_states.character_state import CharacterState
+from flows.object_states.exit_state import ExitState
+from flows.object_states.room_state import RoomState
+
+
+class ObjectStatePermissionTests(TestCase):
+    def setUp(self):
+        self.context = SceneDataManagerFactory()
+        self.room = ObjectDBFactory(
+            db_key="hall", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.char = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+        self.dest = ObjectDBFactory(
+            db_key="outside", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.exit = ObjectDBFactory(
+            db_key="out",
+            db_typeclass_path="typeclasses.exits.Exit",
+            location=self.room,
+            destination=self.dest,
+        )
+        self.item = ObjectDBFactory(db_key="rock", location=self.room)
+        for obj in (self.room, self.dest, self.exit, self.char, self.item):
+            self.context.initialize_state_for_object(obj)
+
+    def test_default_state_allows_moving_items(self):
+        item_state = self.context.get_state_by_pk(self.item.pk)
+        actor_state = self.context.get_state_by_pk(self.char.pk)
+        dest_state = self.context.get_state_by_pk(self.dest.pk)
+        self.assertTrue(item_state.can_move(actor_state, dest_state))
+
+    def test_room_and_exit_cannot_move(self):
+        room_state: RoomState = self.context.get_state_by_pk(self.room.pk)
+        exit_state: ExitState = self.context.get_state_by_pk(self.exit.pk)
+        actor_state = self.context.get_state_by_pk(self.char.pk)
+        dest_state = self.context.get_state_by_pk(self.dest.pk)
+        self.assertFalse(room_state.can_move(actor_state, dest_state))
+        self.assertFalse(exit_state.can_move(actor_state, dest_state))
+
+    def test_character_can_move_themselves(self):
+        char_state: CharacterState = self.context.get_state_by_pk(self.char.pk)
+        dest_state = self.context.get_state_by_pk(self.dest.pk)
+        self.assertTrue(char_state.can_move(char_state, dest_state))
+
+    def test_character_cannot_be_moved_by_others(self):
+        char_state: CharacterState = self.context.get_state_by_pk(self.char.pk)
+        actor_state = self.context.get_state_by_pk(self.item.pk)
+        dest_state = self.context.get_state_by_pk(self.dest.pk)
+        self.assertFalse(char_state.can_move(actor_state, dest_state))
+
+    def test_object_cannot_move_into_itself(self):
+        item_state = self.context.get_state_by_pk(self.item.pk)
+        self.assertFalse(item_state.can_move(item_state, item_state))

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -10,6 +10,7 @@ creation commands.
 
 from evennia.objects.objects import DefaultCharacter
 
+from flows.object_states.character_state import CharacterState
 from typeclasses.mixins import ObjectParent
 
 
@@ -33,6 +34,8 @@ class Character(ObjectParent, DefaultCharacter):
     at_post_puppet - Echoes "AccountName has entered the game" to the room.
 
     """
+
+    state_class = CharacterState
 
     def do_look(self, target):
         desc = self.at_look(target)

--- a/src/typeclasses/exits.py
+++ b/src/typeclasses/exits.py
@@ -9,6 +9,7 @@ for allowing Characters to traverse the exit to its destination.
 
 from evennia.objects.objects import DefaultExit
 
+from flows.object_states.exit_state import ExitState
 from typeclasses.mixins import ObjectParent
 
 
@@ -39,4 +40,4 @@ class Exit(ObjectParent, DefaultExit):
                                         defined, in which case that will simply be echoed.
     """
 
-    pass
+    state_class = ExitState

--- a/src/typeclasses/rooms.py
+++ b/src/typeclasses/rooms.py
@@ -8,6 +8,7 @@ Rooms are simple containers that has no location of their own.
 from django.utils.functional import cached_property
 from evennia.objects.objects import DefaultRoom
 
+from flows.object_states.room_state import RoomState
 from flows.scene_data_manager import SceneDataManager
 from flows.trigger_registry import TriggerRegistry
 from typeclasses.mixins import ObjectParent
@@ -23,6 +24,8 @@ class Room(ObjectParent, DefaultRoom):
     See mygame/typeclasses/objects.py for a list of
     properties and methods available on all Objects.
     """
+
+    state_class = RoomState
 
     @cached_property
     def trigger_registry(self) -> TriggerRegistry:


### PR DESCRIPTION
## Summary
- replace `can_get`/`can_drop` with a single `can_move` method
- forbid moving rooms and exits entirely
- only allow characters to move themselves
- prevent moving an object into itself
- update tests for new logic

## Testing
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_688395244db4833183d5997f65a74ac4