### PR TITLE
Add movement service function

### DIFF
--- a/docs/flows_examples.md
+++ b/docs/flows_examples.md
@@ -86,3 +86,17 @@ TriggerDefinition(
 
 Each trigger based on this definition will fire only when the event's
 ``target`` matches the object hosting the trigger.
+
+## Moving Objects
+
+Use the ``move_object`` service function to relocate an item within a flow:
+
+```python
+FlowStepDefinition(
+    action=FlowActionChoices.CALL_SERVICE_FUNCTION,
+    variable_name="move_object",
+    parameters={"obj": "$item", "destination": "$room"},
+)
+```
+
+This moves the object stored in ``$item`` to the ``$room`` location.

--- a/src/flows/service_functions/__init__.py
+++ b/src/flows/service_functions/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import Callable
 
-from flows.service_functions import communication, perception
+from flows.service_functions import communication, movement, perception
 
 # Mapping of available service functions.
 SERVICE_FUNCTIONS: dict[str, Callable] = {
@@ -11,6 +11,7 @@ SERVICE_FUNCTIONS: dict[str, Callable] = {
     "message_location": communication.message_location,
     "object_has_tag": perception.object_has_tag,
     "append_to_attribute": perception.append_to_attribute,
+    "move_object": movement.move_object,
 }
 
 

--- a/src/flows/service_functions/movement.py
+++ b/src/flows/service_functions/movement.py
@@ -1,0 +1,48 @@
+"""Movement-related service functions."""
+
+from commands.exceptions import CommandError
+from flows.flow_execution import FlowExecution
+
+
+def move_object(
+    flow_execution: FlowExecution,
+    obj: str,
+    destination: str,
+    quiet: bool = True,
+    **kwargs: object,
+) -> None:
+    """Move an object to ``destination``.
+
+    Args:
+        flow_execution: Current execution context.
+        obj: Name of the flow variable referencing the object to move.
+        destination: Name of the flow variable referencing the destination.
+        quiet: Passed to ``move_to`` to suppress hooks and messages.
+        **kwargs: Additional keyword arguments for ``move_to``.
+
+    Raises:
+        CommandError: If the move cannot be completed.
+
+    Example:
+        ````python
+        FlowStepDefinition(
+            action=FlowActionChoices.CALL_SERVICE_FUNCTION,
+            variable_name="move_object",
+            parameters={"obj": "$item", "destination": "$room"},
+        )
+        ````
+    """
+
+    obj_state = flow_execution.get_object_state(obj)
+    dest_state = flow_execution.get_object_state(destination)
+
+    if obj_state is None or dest_state is None:
+        raise CommandError("Invalid object or destination.")
+
+    if not obj_state.can_move(obj_state, dest_state):
+        raise CommandError("Move not permitted.")
+
+    success = obj_state.obj.move_to(dest_state.obj, quiet=quiet, **kwargs)
+
+    if not success:
+        raise CommandError("Could not move object.")

--- a/src/flows/tests/test_movement.py
+++ b/src/flows/tests/test_movement.py
@@ -1,0 +1,90 @@
+from django.test import TestCase
+
+from commands.exceptions import CommandError
+from evennia_extensions.factories import ObjectDBFactory
+from flows.consts import FlowActionChoices
+from flows.factories import (
+    FlowDefinitionFactory,
+    FlowExecutionFactory,
+    FlowStepDefinitionFactory,
+)
+from flows.service_functions.movement import move_object
+
+
+class MoveObjectServiceFunctionTests(TestCase):
+    def test_move_object_updates_location(self):
+        room1 = ObjectDBFactory(
+            db_key="room1", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        room2 = ObjectDBFactory(
+            db_key="room2", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        item = ObjectDBFactory(db_key="rock", location=room1)
+
+        fx = FlowExecutionFactory(variable_mapping={"item": item, "dest": room2})
+        for obj in (room1, room2, item):
+            fx.context.initialize_state_for_object(obj)
+
+        move_object(fx, "$item", "$dest")
+
+        item.refresh_from_db()
+        self.assertEqual(item.location, room2)
+
+    def test_invalid_destination_raises(self):
+        room = ObjectDBFactory(
+            db_key="room", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        item = ObjectDBFactory(db_key="rock", location=room)
+
+        fx = FlowExecutionFactory(variable_mapping={"item": item})
+        fx.context.initialize_state_for_object(item)
+
+        with self.assertRaises(CommandError):
+            move_object(fx, "$item", None)
+
+    def test_can_move_is_checked(self):
+        room1 = ObjectDBFactory(
+            db_key="r1",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        room2 = ObjectDBFactory(
+            db_key="r2",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        fx = FlowExecutionFactory(variable_mapping={"room": room1, "dest": room2})
+        for obj in (room1, room2):
+            fx.context.initialize_state_for_object(obj)
+
+        with self.assertRaises(CommandError):
+            move_object(fx, "$room", "$dest")
+
+    def test_flowstep_moves_object(self):
+        room1 = ObjectDBFactory(
+            db_key="start",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        room2 = ObjectDBFactory(
+            db_key="end",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        item = ObjectDBFactory(db_key="rock", location=room1)
+
+        flow_def = FlowDefinitionFactory()
+        FlowStepDefinitionFactory(
+            flow=flow_def,
+            action=FlowActionChoices.CALL_SERVICE_FUNCTION,
+            variable_name="move_object",
+            parameters={"obj": "$item", "destination": "$dest"},
+        )
+
+        fx = FlowExecutionFactory(
+            flow_definition=flow_def,
+            variable_mapping={"item": item, "dest": room2},
+        )
+        for obj in (room1, room2, item):
+            fx.context.initialize_state_for_object(obj)
+
+        fx.flow_stack.execute_flow(fx)
+
+        item.refresh_from_db()
+        self.assertEqual(item.location, room2)


### PR DESCRIPTION
## Summary
- add `move_object` service function to support moving objects via flows
- register the new service function
- cover `move_object` with tests
- fix move_object to check can_move permissions before moving
- refine implementation to directly use object states and avoid isinstance checks
- document FlowStep usage of move_object
- add a flow-based test for move_object

## Testing
- `PATH="$(pwd)/.venv/bin:$PATH" .venv/bin/arx test`

------
https://chatgpt.com/codex/tasks/task_e_6883f177fb688331a3ee3810190c7c3d