### PR TITLE
Add gender property and state-based display names

### DIFF
--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -43,6 +43,11 @@ class BaseState:
         self.name_suffix_map: dict[int, str] = {}
 
     @cached_property
+    def gender(self) -> str:
+        """Gender for funcparser pronoun helpers."""
+        return self.obj.gender
+
+    @cached_property
     def name(self):
         # Compute the default name from the Evennia object.
         return self.obj.key

--- a/src/typeclasses/mixins.py
+++ b/src/typeclasses/mixins.py
@@ -1,12 +1,11 @@
 from typing import TYPE_CHECKING, Self, Union
 
 from flows.object_states.base_state import BaseState
+from flows.scene_data_manager import SceneDataManager
 from flows.trigger_registry import TriggerRegistry
 
 if TYPE_CHECKING:
     from evennia.objects.objects import DefaultObject
-
-    from flows.scene_data_manager import SceneDataManager
 
 
 class ObjectParent:
@@ -37,6 +36,30 @@ class ObjectParent:
         if self.location:
             return self.location.trigger_registry
         return None
+
+    @property
+    def scene_data(self: Union[Self, "DefaultObject"]):
+        """Return the SceneDataManager from our containing location."""
+        if self.location:
+            return self.location.scene_data
+        return None
+
+    @property
+    def gender(self: Union[Self, "DefaultObject"]) -> str:
+        """Gender used by funcparser pronoun helpers."""
+        return "neutral"
+
+    def get_display_name(
+        self: Union[Self, "DefaultObject"], looker=None, **kwargs
+    ) -> str:
+        """Return the display name using state data when available."""
+        scene_data = self.scene_data
+        if scene_data:
+            state = scene_data.get_state_by_pk(self.pk)
+            if state:
+                looker_state = scene_data.get_state_by_pk(looker.pk) if looker else None
+                return state.get_display_name(looker_state, **kwargs)
+        return super().get_display_name(looker, **kwargs)
 
     def at_post_move(self, source_location, move_type="move", **kwargs):
         """Register or unregister triggers when moving between rooms."""

--- a/src/typeclasses/tests/test_gender_display.py
+++ b/src/typeclasses/tests/test_gender_display.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+
+from evennia_extensions.factories import ObjectDBFactory
+from flows.factories import SceneDataManagerFactory
+
+
+class GenderAndDisplayNameTests(TestCase):
+    def setUp(self):
+        self.room = ObjectDBFactory(
+            db_key="room", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.char = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+        self.viewer = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+
+    def test_default_gender_is_neutral(self):
+        context = SceneDataManagerFactory()
+        state = context.initialize_state_for_object(self.char)
+        self.assertEqual(state.gender, "neutral")
+        self.assertEqual(self.char.gender, "neutral")
+
+    def test_get_display_name_uses_state(self):
+        self.assertEqual(self.char.get_display_name(self.viewer), "Alice")
+        context = SceneDataManagerFactory()
+        self.room.scene_data = context
+        for obj in (self.room, self.char, self.viewer):
+            context.initialize_state_for_object(obj)
+        char_state = context.get_state_by_pk(self.char.pk)
+        char_state.fake_name = "Mysterious figure"
+        self.assertEqual(self.char.get_display_name(self.viewer), "Mysterious figure")


### PR DESCRIPTION
## Summary
- add gender property to `ObjectParent` and `BaseState`
- expose `scene_data` on objects via `ObjectParent`
- use scene data states when returning display names
- test gender defaults and state-based display names

## Testing
- `uv run arx test`

------
https://chatgpt.com/codex/tasks/task_e_68845308af88833191113d6caf5b126d