### PR TITLE
Add movement flows migration

### DIFF
--- a/src/flows/migrations/0002_add_basic_flows.py
+++ b/src/flows/migrations/0002_add_basic_flows.py
@@ -65,6 +65,181 @@ def create_basic_flows(apps, schema_editor):
         defaults={"parameters": {"recipient": "$caller", "text": "$desc"}},
     )
 
+    # Get flow
+    get_flow, _ = FlowDefinition.objects.get_or_create(
+        name="get",
+        defaults={"description": "Move an item to the caller."},
+    )
+
+    Event.objects.get_or_create(name="object_get", defaults={"label": "Object Get"})
+
+    step1, _ = FlowStepDefinition.objects.get_or_create(
+        flow=get_flow,
+        parent=None,
+        action="call_service_function",
+        variable_name="move_object",
+        defaults={"parameters": {"obj": "$target", "destination": "$caller"}},
+    )
+
+    step2, _ = FlowStepDefinition.objects.get_or_create(
+        flow=get_flow,
+        parent_id=step1.id,
+        action="emit_flow_event",
+        variable_name="object_get",
+        defaults={
+            "parameters": {
+                "event_type": "object_get",
+                "data": {"caller": "$caller", "target": "$target"},
+            }
+        },
+    )
+
+    FlowStepDefinition.objects.get_or_create(
+        flow=get_flow,
+        parent_id=step2.id,
+        action="call_service_function",
+        variable_name="message_location",
+        defaults={
+            "parameters": {
+                "caller": "$caller",
+                "target": "$target",
+                "text": ["$You() $conj(pick) up $you(target)."],
+            }
+        },
+    )
+
+    # Drop flow
+    drop_flow, _ = FlowDefinition.objects.get_or_create(
+        name="drop",
+        defaults={"description": "Drop an item into the room."},
+    )
+
+    Event.objects.get_or_create(name="object_drop", defaults={"label": "Object Drop"})
+
+    step1, _ = FlowStepDefinition.objects.get_or_create(
+        flow=drop_flow,
+        parent=None,
+        action="call_service_function",
+        variable_name="move_object",
+        defaults={"parameters": {"obj": "$target", "destination": "$caller.location"}},
+    )
+
+    step2, _ = FlowStepDefinition.objects.get_or_create(
+        flow=drop_flow,
+        parent_id=step1.id,
+        action="emit_flow_event",
+        variable_name="object_drop",
+        defaults={
+            "parameters": {
+                "event_type": "object_drop",
+                "data": {"caller": "$caller", "target": "$target"},
+            }
+        },
+    )
+
+    FlowStepDefinition.objects.get_or_create(
+        flow=drop_flow,
+        parent_id=step2.id,
+        action="call_service_function",
+        variable_name="message_location",
+        defaults={
+            "parameters": {
+                "caller": "$caller",
+                "target": "$target",
+                "text": ["$You() $conj(drop) $you(target)."],
+            }
+        },
+    )
+
+    # Give flow
+    give_flow, _ = FlowDefinition.objects.get_or_create(
+        name="give",
+        defaults={"description": "Give an item to another character."},
+    )
+
+    Event.objects.get_or_create(name="object_give", defaults={"label": "Object Give"})
+
+    step1, _ = FlowStepDefinition.objects.get_or_create(
+        flow=give_flow,
+        parent=None,
+        action="call_service_function",
+        variable_name="move_object",
+        defaults={"parameters": {"obj": "$target", "destination": "$recipient"}},
+    )
+
+    step2, _ = FlowStepDefinition.objects.get_or_create(
+        flow=give_flow,
+        parent_id=step1.id,
+        action="emit_flow_event",
+        variable_name="object_give",
+        defaults={
+            "parameters": {
+                "event_type": "object_give",
+                "data": {
+                    "caller": "$caller",
+                    "target": "$target",
+                    "recipient": "$recipient",
+                },
+            }
+        },
+    )
+
+    FlowStepDefinition.objects.get_or_create(
+        flow=give_flow,
+        parent_id=step2.id,
+        action="call_service_function",
+        variable_name="message_location",
+        defaults={
+            "parameters": {
+                "caller": "$caller",
+                "target": "$recipient",
+                "text": ["$You() $conj(give) $you(target) something."],
+            }
+        },
+    )
+
+    # Home flow
+    home_flow, _ = FlowDefinition.objects.get_or_create(
+        name="home",
+        defaults={"description": "Return the caller to their home."},
+    )
+
+    Event.objects.get_or_create(name="object_home", defaults={"label": "Object Home"})
+
+    step1, _ = FlowStepDefinition.objects.get_or_create(
+        flow=home_flow,
+        parent=None,
+        action="call_service_function",
+        variable_name="move_object",
+        defaults={"parameters": {"obj": "$caller", "destination": "$caller.home"}},
+    )
+
+    step2, _ = FlowStepDefinition.objects.get_or_create(
+        flow=home_flow,
+        parent_id=step1.id,
+        action="emit_flow_event",
+        variable_name="object_home",
+        defaults={
+            "parameters": {
+                "event_type": "object_home",
+                "data": {"caller": "$caller"},
+            }
+        },
+    )
+
+    FlowStepDefinition.objects.get_or_create(
+        flow=home_flow,
+        parent_id=step2.id,
+        action="call_service_function",
+        variable_name="message_location",
+        defaults={
+            "parameters": {
+                "caller": "$caller",
+                "text": ["$You() $conj(go) home."],
+            }
+        },
+    )
+
 
 class Migration(migrations.Migration):
 

--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -42,6 +42,23 @@ class BaseState:
         self.name_prefix_map: dict[int, str] = {}
         self.name_suffix_map: dict[int, str] = {}
 
+    def __str__(self) -> str:
+        """Return the default display name."""
+        return self.get_display_name()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, BaseState):
+            return self.obj == other.obj
+        return self.obj == other
+
+    def __hash__(self) -> int:
+        return hash(self.obj)
+
+    @property
+    def pk(self) -> int:
+        """Return the wrapped object's primary key."""
+        return self.obj.pk
+
     @cached_property
     def name(self):
         # Compute the default name from the Evennia object.
@@ -86,7 +103,9 @@ class BaseState:
         return "{name}\n{desc}"
 
     # Display-component methods
-    def get_display_name(self, looker: "BaseState | None" = None, **kwargs) -> str:
+    def get_display_name(
+        self, looker: "BaseState | object | None" = None, **kwargs
+    ) -> str:
         """Return the name visible to ``looker``.
 
         Args:
@@ -96,20 +115,27 @@ class BaseState:
         Returns:
             The display name appropriate for ``looker``.
         """
+        looker_state = looker
+        if looker is not None and not isinstance(looker, BaseState):
+            try:
+                looker_state = self.context.get_state_by_pk(looker.pk)
+            except AttributeError:
+                looker_state = None
+
         base = self.name
         if self.fake_name:
-            if looker is None:
+            if looker_state is None:
                 base = self.fake_name
             else:
-                pk = looker.obj.pk
+                pk = looker_state.obj.pk
                 if pk != self.obj.pk and pk not in self.real_name_viewers:
                     base = self.fake_name
 
         prefix = self.name_prefix
         suffix = self.name_suffix
 
-        if looker is not None:
-            pk = looker.obj.pk
+        if looker_state is not None:
+            pk = looker_state.obj.pk
             prefix = self.name_prefix_map.get(pk, prefix)
             suffix = self.name_suffix_map.get(pk, suffix)
 


### PR DESCRIPTION
## Summary
- add movement flows to existing migration
- rework `message_location` to use Evennia mapping
- update message location tests
- refine BaseState string and equality behavior
- provide example FlowStep in `message_location` docstring
- add `pk` property to BaseState

## Testing
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_6884539b0bd08331b97766d52eec40cb