### PR TITLE
Add admin support for flows models

### DIFF
--- a/src/flows/admin.py
+++ b/src/flows/admin.py
@@ -1,3 +1,66 @@
-# from django.contrib import admin
+"""Django admin configuration for the flows app."""
 
-# Register your models here.
+from django.contrib import admin
+
+from flows.models import (
+    Event,
+    FlowDefinition,
+    FlowStepDefinition,
+    Trigger,
+    TriggerData,
+    TriggerDefinition,
+)
+
+
+class FlowStepDefinitionInline(admin.StackedInline):
+    """Inline for displaying flow steps within a FlowDefinition."""
+
+    model = FlowStepDefinition
+    extra = 1
+    fields = ["parent", "action", "variable_name", "parameters"]
+    autocomplete_fields = ["parent"]
+
+
+@admin.register(FlowDefinition)
+class FlowDefinitionAdmin(admin.ModelAdmin):
+    list_display = ["name", "description"]
+    search_fields = ["name"]
+    inlines = [FlowStepDefinitionInline]
+
+
+@admin.register(FlowStepDefinition)
+class FlowStepDefinitionAdmin(admin.ModelAdmin):
+    list_display = ["flow", "parent", "action", "variable_name"]
+    list_filter = ["flow", "action"]
+    search_fields = ["variable_name"]
+    autocomplete_fields = ["flow", "parent"]
+
+
+@admin.register(Event)
+class EventAdmin(admin.ModelAdmin):
+    list_display = ["name", "label"]
+    search_fields = ["name", "label"]
+
+
+@admin.register(TriggerDefinition)
+class TriggerDefinitionAdmin(admin.ModelAdmin):
+    list_display = ["name", "event", "flow_definition", "priority"]
+    list_filter = ["event", "priority"]
+    search_fields = ["name"]
+    autocomplete_fields = ["event", "flow_definition"]
+
+
+@admin.register(Trigger)
+class TriggerAdmin(admin.ModelAdmin):
+    list_display = ["trigger_definition", "obj"]
+    list_filter = ["trigger_definition"]
+    search_fields = ["obj__db_key", "trigger_definition__name"]
+    autocomplete_fields = ["trigger_definition"]
+    raw_id_fields = ["obj"]
+
+
+@admin.register(TriggerData)
+class TriggerDataAdmin(admin.ModelAdmin):
+    list_display = ["trigger", "key", "value"]
+    search_fields = ["key", "value"]
+    autocomplete_fields = ["trigger"]


### PR DESCRIPTION
## Summary
- set up admin classes for flows models
- show `FlowStepDefinition` inline for `FlowDefinition`
- use autocomplete widgets for FK fields that point to registered models

## Testing
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_68861a6ac0d88331950571d4850360e9