### PR TITLE
Improve help syntax readability

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -33,7 +33,7 @@ class ArxCommand(Command):
     description = ""  # short description in help, appended after syntax
 
     # base template for in-game help
-    base_ascii_template = "{title}\n{syntax_display}\n\n{description}"
+    base_ascii_template = "{title}\n\n{syntax_display}\n\n{description}"
 
     # base template for help viewed on webpage
     base_html_template = "<h2>{title}</h2><p>{syntax_display}</p><p>{description}</p>"
@@ -192,4 +192,6 @@ class ArxCommand(Command):
         """
         newline = "\n" if mode == HelpFileViewMode.TEXT else "<br />"
         syntax_strings = self.get_syntax_strings(caller, cmdset, mode)
+        if mode == HelpFileViewMode.TEXT:
+            syntax_strings = [f"  {line}" for line in syntax_strings]
         return f"Syntax: {newline}{newline.join(syntax_strings)}"

--- a/src/commands/dispatchers.py
+++ b/src/commands/dispatchers.py
@@ -162,6 +162,13 @@ class BaseDispatcher:
             pattern = pattern[1:]
         if pattern.endswith("$"):
             pattern = pattern[:-1]
+        # normalize whitespace tokens
+        pattern = re.sub(r"\\s\+", " ", pattern)
+        # replace named groups with simple placeholders
+        pattern = re.sub(r"\(\?P<(\w+)>[^)]+\)", r"<\1>", pattern)
+        # unescape common characters
+        pattern = pattern.replace("\\'", "'").replace('\\"', '"')
+        pattern = re.sub(r"\s+", " ", pattern)
         return f"{self.command.key} {pattern}".strip()
 
 


### PR DESCRIPTION
## Summary
- show blank line after command title
- indent in-game syntax lines
- convert regex patterns to user-friendly placeholders

## Testing
- `uv run arx test`

------
https://chatgpt.com/codex/tasks/task_e_68862f527c94833193d964249a7a58f5