### PR TITLE
Fix whisper macro substitution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This repository contains **Arx II**, a sequel to the Arx MUD. It is built on the
 - We want extensive automation to support a narrative driven game world. Player choices should drive automated reactions defined via data.
 - **Docstrings**: Use Google style docstrings for Python code. Avoid Sphinx or reStructuredText markup.
 - Prefer try/except blocks over hasattr/getattr checks when unsure if an object exposes an attribute.
+- Avoid unnecessary `hasattr` checks and only catch exceptions the call can raise.
 - Avoid Evennia's lock system for permissions.
 - Each object state class should expose small `can_<action>()` methods (e.g., `can_get`, `can_take_from`) for permission checks.
 - Commands and handlers must emit an intent event before executing actions so triggers may cancel or modify them.

--- a/src/commands/tests/test_cmd_inventory_say_whisper_pose.py
+++ b/src/commands/tests/test_cmd_inventory_say_whisper_pose.py
@@ -89,15 +89,21 @@ class CmdWhisperTests(TestCase):
         self.caller.msg = MagicMock()
         self.target.msg = MagicMock()
 
-    def test_whisper_sends_to_target_and_caller(self):
+    def test_whisper_formats_message(self):
         cmd = CmdWhisper()
         cmd.caller = self.caller
         cmd.args = "Bob=secret"
         cmd.raw_string = "whisper Bob=secret"
         cmd.parse()
         cmd.func()
-        self.target.msg.assert_called_once()
-        self.caller.msg.assert_called_once()
+        self.assertEqual(
+            self.target.msg.call_args.args[0],
+            'Alice whisper "secret"',
+        )
+        self.assertEqual(
+            self.caller.msg.call_args.args[0],
+            'You whisper "secret" to Bob.',
+        )
 
 
 class CmdPoseTests(TestCase):


### PR DESCRIPTION
## Summary
- ensure `send_message` resolves mapping variables and applies funcparser parsing
- add regression test for whisper command output
- simplify message formatting logic
- document to avoid unnecessary checks

## Testing
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_68865931adbc83318b9a380e35ee9991