### PR TITLE
Improve behavior package hook resolution

### DIFF
--- a/src/behaviors/matching_value_package.py
+++ b/src/behaviors/matching_value_package.py
@@ -1,0 +1,48 @@
+"""Generic checks for verifying access requirements."""
+
+from behaviors.models import BehaviorPackageInstance
+from commands.exceptions import CommandError
+from flows.object_states.base_state import BaseState
+
+
+def require_matching_value(
+    state: BaseState, pkg: BehaviorPackageInstance, actor: BaseState | None
+) -> None:
+    """Require a matching attribute on ``actor`` or its inventory.
+
+    The package ``data`` should define:
+        ``attribute``: Name of the attribute to look up on states.
+        ``value``: Required value for that attribute.
+        ``error``: Optional message to raise when the check fails.
+
+    Example:
+        ````python
+        lock_def = BehaviorPackageDefinition.objects.create(
+            name="locked_exit",
+            service_function_path="behaviors.matching_value_package.require_matching_value",
+        )
+        BehaviorPackageInstance.objects.create(
+            definition=lock_def,
+            obj=exit_obj,
+            hook="can_traverse",
+            data={"attribute": "key_id", "value": "silver"},
+        )
+        ````
+    """
+
+    if actor is None:
+        raise CommandError("No actor provided.")
+
+    attr = pkg.data.get("attribute")
+    required = pkg.data.get("value")
+    if attr is None or required is None:
+        raise CommandError("Lock is misconfigured.")
+
+    # Check the actor and any carried objects for the required value.
+    if actor.get_attribute(attr) == required:
+        return None
+    for item in actor.contents:
+        if item.get_attribute(attr) == required:
+            return None
+
+    raise CommandError(pkg.data.get("error", "Access denied."))

--- a/src/behaviors/migrations/0001_initial.py
+++ b/src/behaviors/migrations/0001_initial.py
@@ -54,6 +54,13 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
+                (
+                    "hook",
+                    models.CharField(
+                        help_text="Name of the hook where this package applies.",
+                        max_length=100,
+                    ),
+                ),
                 ("data", models.JSONField(blank=True, null=True)),
                 (
                     "definition",

--- a/src/behaviors/models.py
+++ b/src/behaviors/models.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 """Models for reusable behavior packages."""
 
-from typing import Callable, Dict
+from importlib import import_module
+from typing import Callable
 
 from django.db import models
 from django.utils.functional import cached_property
 from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
-
-from flows.helpers.hooks import get_package_hooks
 
 
 class BehaviorPackageDefinition(SharedMemoryModel):
@@ -19,20 +18,24 @@ class BehaviorPackageDefinition(SharedMemoryModel):
     description = models.TextField(blank=True, null=True)
     service_function_path = models.CharField(
         max_length=255,
-        help_text="Python path to the service module implementing hooks.",
+        help_text="Python path to the service function for this package.",
     )
 
     def __str__(self) -> str:
         return self.name
 
     @cached_property
-    def hooks(self) -> Dict[str, Callable]:
-        """Return hook functions provided by the service module."""
-        return get_package_hooks(self.service_function_path)
+    def service_function(self) -> Callable:
+        """Import and cache the service function."""
 
-    def get_hook(self, name: str) -> Callable | None:
-        """Return a hook function if available."""
-        return self.hooks.get(name)
+        module_path, func_name = self.service_function_path.rsplit(".", 1)
+        module = import_module(module_path)
+        return getattr(module, func_name)
+
+    def get_service_function(self) -> Callable:
+        """Return the service function for this package."""
+
+        return self.service_function
 
 
 class BehaviorPackageInstance(SharedMemoryModel):
@@ -48,11 +51,26 @@ class BehaviorPackageInstance(SharedMemoryModel):
         on_delete=models.CASCADE,
         related_name="behavior_packages",
     )
+    hook = models.CharField(
+        max_length=100,
+        help_text="Name of the hook where this package applies.",
+    )
     data = models.JSONField(blank=True, null=True)
 
     def __str__(self) -> str:
         return f"{self.definition.name} for {self.obj.key}"
 
     def get_hook(self, name: str) -> Callable | None:
-        """Return the hook function for ``name`` if available."""
-        return self.definition.get_hook(name)
+        """Return the service function for ``name`` if this instance uses it."""
+
+        if name != self.hook:
+            return None
+
+        return self.definition.get_service_function()
+
+    def get_from_data(self, key: str):
+        """Return ``key`` from ``data`` if present and ``data`` is a mapping."""
+
+        if isinstance(self.data, dict):
+            return self.data.get(key)
+        return None

--- a/src/behaviors/state_values_package.py
+++ b/src/behaviors/state_values_package.py
@@ -1,0 +1,34 @@
+"""Service helpers for setting state values from package data."""
+
+from behaviors.models import BehaviorPackageInstance
+from flows.object_states.base_state import BaseState
+
+
+def initialize_state(state: BaseState, pkg: BehaviorPackageInstance) -> None:
+    """Apply values from ``pkg.data`` to ``state``.
+
+    The package's ``data`` should contain a mapping named ``values``. Each key
+    in that mapping is assigned to the corresponding attribute on ``state``. If
+    ``values`` is omitted, all top-level keys of ``pkg.data`` are applied
+    directly.
+
+    Example:
+        ````python
+        key_def = BehaviorPackageDefinition.objects.create(
+            name="key",
+            service_function_path="behaviors.state_values_package.initialize_state",
+        )
+        BehaviorPackageInstance.objects.create(
+            definition=key_def,
+            obj=key_obj,
+            hook="initialize_state",
+            data={"values": {"key_id": "silver"}},
+        )
+        ````
+    """
+
+    values = pkg.get_from_data("values")
+    if values is None:
+        values = pkg.data or {}
+    for attr, value in values.items():
+        state.set_attribute(attr, value)

--- a/src/behaviors/tests/blocker_package.py
+++ b/src/behaviors/tests/blocker_package.py
@@ -4,12 +4,7 @@ from behaviors.models import BehaviorPackageInstance
 from flows.object_states.base_state import BaseState
 
 
-def can_traverse(
+def require_matching_value(
     state: BaseState, pkg: BehaviorPackageInstance, actor: BaseState | None
 ) -> bool:
     return False
-
-
-hooks = {
-    "can_traverse": can_traverse,
-}

--- a/src/behaviors/tests/buff_package.py
+++ b/src/behaviors/tests/buff_package.py
@@ -5,14 +5,8 @@ from flows.object_states.base_state import BaseState
 
 
 def initialize_state(state: BaseState, pkg: BehaviorPackageInstance) -> None:
-    state.bonus = pkg.data.get("bonus", 0)
+    state.set_attribute("bonus", pkg.data.get("bonus", 0))
 
 
 def modify_strength(state: BaseState, pkg: BehaviorPackageInstance, value: int) -> int:
-    return value + state.bonus
-
-
-hooks = {
-    "initialize_state": initialize_state,
-    "modify_strength": modify_strength,
-}
+    return value + state.get_attribute("bonus", 0)

--- a/src/behaviors/tests/test_locked_exit.py
+++ b/src/behaviors/tests/test_locked_exit.py
@@ -1,0 +1,68 @@
+from django.test import TestCase
+
+from behaviors.models import BehaviorPackageDefinition, BehaviorPackageInstance
+from commands.exceptions import CommandError
+from evennia_extensions.factories import ObjectDBFactory
+from flows.factories import SceneDataManagerFactory
+from flows.object_states.exit_state import ExitState
+
+
+class LockedExitTests(TestCase):
+    def setUp(self):
+        self.context = SceneDataManagerFactory()
+        self.room = ObjectDBFactory(
+            db_key="hall", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.dest = ObjectDBFactory(
+            db_key="yard", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.exit = ObjectDBFactory(
+            db_key="out",
+            db_typeclass_path="typeclasses.exits.Exit",
+            location=self.room,
+            destination=self.dest,
+        )
+        self.char = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+        self.key = ObjectDBFactory(db_key="silver key", location=self.room)
+
+        self.lock_def = BehaviorPackageDefinition.objects.create(
+            name="locked_exit",
+            service_function_path="behaviors.matching_value_package.require_matching_value",
+        )
+        self.key_def = BehaviorPackageDefinition.objects.create(
+            name="key",
+            service_function_path="behaviors.state_values_package.initialize_state",
+        )
+        BehaviorPackageInstance.objects.create(
+            definition=self.lock_def,
+            obj=self.exit,
+            hook="can_traverse",
+            data={"attribute": "key_id", "value": "silver"},
+        )
+        BehaviorPackageInstance.objects.create(
+            definition=self.key_def,
+            obj=self.key,
+            hook="initialize_state",
+            data={"values": {"key_id": "silver"}},
+        )
+
+        for obj in (self.room, self.dest, self.exit, self.char, self.key):
+            self.context.initialize_state_for_object(obj)
+
+        self.exit_state: ExitState = self.context.get_state_by_pk(self.exit.pk)
+        self.char_state = self.context.get_state_by_pk(self.char.pk)
+
+    def test_key_allows_traversal(self):
+        # Initially the key is on the ground; traversal should fail.
+        with self.assertRaises(CommandError):
+            self.exit_state.can_traverse(self.char_state)
+
+        # Give the key to the character and reinitialize its state.
+        self.key.location = self.char
+        self.context.initialize_state_for_object(self.key)
+
+        self.assertTrue(self.exit_state.can_traverse(self.char_state))

--- a/src/behaviors/tests/test_packages.py
+++ b/src/behaviors/tests/test_packages.py
@@ -30,15 +30,32 @@ class BehaviorPackageTests(TestCase):
     def test_packages_affect_state(self):
         blocker_def = BehaviorPackageDefinition.objects.create(
             name="blocker",
-            service_function_path="behaviors.tests.blocker_package",
+            service_function_path="behaviors.tests.blocker_package.require_matching_value",
         )
-        buff_def = BehaviorPackageDefinition.objects.create(
-            name="buff",
-            service_function_path="behaviors.tests.buff_package",
+        buff_init = BehaviorPackageDefinition.objects.create(
+            name="buff_init",
+            service_function_path="behaviors.tests.buff_package.initialize_state",
         )
-        BehaviorPackageInstance.objects.create(definition=blocker_def, obj=self.exit)
+        buff_mod = BehaviorPackageDefinition.objects.create(
+            name="buff_mod",
+            service_function_path="behaviors.tests.buff_package.modify_strength",
+        )
         BehaviorPackageInstance.objects.create(
-            definition=buff_def, obj=self.char, data={"bonus": 5}
+            definition=blocker_def,
+            obj=self.exit,
+            hook="can_traverse",
+        )
+        BehaviorPackageInstance.objects.create(
+            definition=buff_init,
+            obj=self.char,
+            hook="initialize_state",
+            data={"bonus": 5},
+        )
+        BehaviorPackageInstance.objects.create(
+            definition=buff_mod,
+            obj=self.char,
+            hook="modify_strength",
+            data={"bonus": 5},
         )
 
         for obj in (self.room, self.dest, self.exit, self.char):

--- a/src/commands/__init__.py
+++ b/src/commands/__init__.py
@@ -1,5 +1,6 @@
 """Expose command classes for easy import."""
 
+from commands.door import CmdLock, CmdUnlock
 from commands.evennia_overrides.communication import CmdPose, CmdSay, CmdWhisper
 from commands.evennia_overrides.movement import CmdDrop, CmdGet, CmdGive, CmdHome
 from commands.evennia_overrides.perception import CmdInventory, CmdLook
@@ -14,4 +15,6 @@ __all__ = [
     "CmdSay",
     "CmdWhisper",
     "CmdPose",
+    "CmdLock",
+    "CmdUnlock",
 ]

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -52,9 +52,11 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdGive,
             CmdHome,
             CmdInventory,
+            CmdLock,
             CmdLook,
             CmdPose,
             CmdSay,
+            CmdUnlock,
             CmdWhisper,
         )
 
@@ -67,6 +69,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdSay())
         self.add(CmdWhisper())
         self.add(CmdPose())
+        self.add(CmdLock())
+        self.add(CmdUnlock())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/src/commands/door.py
+++ b/src/commands/door.py
@@ -1,0 +1,45 @@
+from commands.command import ArxCommand
+from commands.dispatchers import TargetDispatcher
+from commands.exceptions import CommandError
+from commands.handlers.base import BaseHandler
+
+
+class LockDispatcher(TargetDispatcher):
+    """Resolve an exit target and a key object."""
+
+    def get_additional_kwargs(self):
+        match = self.pattern.match(self._input_string())
+        if not match:
+            raise CommandError("Invalid syntax.")
+        exit_obj = self._get_target(match)
+        key_name = match.group("key")
+        key_obj = self.command.caller.search(key_name)
+        if not key_obj:
+            raise CommandError(f"Could not find target '{key_name}'.")
+        return {"target": exit_obj, "key": key_obj}
+
+
+class CmdLock(ArxCommand):
+    """Lock an exit with a key."""
+
+    key = "lock"
+    locks = "cmd:all()"
+    dispatchers = [
+        LockDispatcher(
+            r"^(?P<target>.+?)\s+with\s+(?P<key>.+)$",
+            BaseHandler(flow_name="lock_exit"),
+        )
+    ]
+
+
+class CmdUnlock(ArxCommand):
+    """Unlock an exit with a key."""
+
+    key = "unlock"
+    locks = "cmd:all()"
+    dispatchers = [
+        LockDispatcher(
+            r"^(?P<target>.+?)\s+with\s+(?P<key>.+)$",
+            BaseHandler(flow_name="unlock_exit"),
+        )
+    ]

--- a/src/commands/tests/test_cmd_lock_unlock.py
+++ b/src/commands/tests/test_cmd_lock_unlock.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from behaviors.models import BehaviorPackageDefinition, BehaviorPackageInstance
+from commands.door import CmdLock, CmdUnlock
+from evennia_extensions.factories import ObjectDBFactory
+
+
+class CmdLockUnlockTests(TestCase):
+    def setUp(self):
+        self.room = ObjectDBFactory(
+            db_key="hall", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.dest = ObjectDBFactory(
+            db_key="yard", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.exit = ObjectDBFactory(
+            db_key="out",
+            db_typeclass_path="typeclasses.exits.Exit",
+            location=self.room,
+            destination=self.dest,
+        )
+        self.caller = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+        self.key = ObjectDBFactory(db_key="silver key", location=self.caller)
+        self.caller.msg = MagicMock()
+        self.lock_def = BehaviorPackageDefinition.objects.create(
+            name="locked_exit",
+            service_function_path="behaviors.matching_value_package.require_matching_value",
+        )
+        self.key_def = BehaviorPackageDefinition.objects.create(
+            name="key",
+            service_function_path="behaviors.state_values_package.initialize_state",
+        )
+        BehaviorPackageInstance.objects.create(
+            definition=self.key_def,
+            obj=self.key,
+            hook="initialize_state",
+            data={"values": {"key_id": "silver"}},
+        )
+
+    def test_unlock_removes_package(self):
+        BehaviorPackageInstance.objects.create(
+            definition=self.lock_def,
+            obj=self.exit,
+            hook="can_traverse",
+            data={"attribute": "key_id", "value": "silver"},
+        )
+        self.caller.search = MagicMock(side_effect=[self.exit, self.key])
+        cmd = CmdUnlock()
+        cmd.caller = self.caller
+        cmd.args = "out with silver key"
+        cmd.raw_string = "unlock out with silver key"
+        cmd.parse()
+        cmd.func()
+        self.assertFalse(
+            BehaviorPackageInstance.objects.filter(
+                definition=self.lock_def, obj=self.exit
+            ).exists()
+        )
+
+    def test_lock_adds_package(self):
+        self.caller.search = MagicMock(side_effect=[self.exit, self.key])
+        cmd = CmdLock()
+        cmd.caller = self.caller
+        cmd.args = "out with silver key"
+        cmd.raw_string = "lock out with silver key"
+        cmd.parse()
+        cmd.func()
+        self.assertTrue(
+            BehaviorPackageInstance.objects.filter(
+                definition=self.lock_def, obj=self.exit
+            ).exists()
+        )

--- a/src/flows/migrations/0003_add_lock_flows.py
+++ b/src/flows/migrations/0003_add_lock_flows.py
@@ -1,0 +1,58 @@
+"""Add flows for locking and unlocking exits."""
+
+from django.db import migrations
+
+
+def create_lock_flows(apps, schema_editor):
+    FlowDefinition = apps.get_model("flows", "FlowDefinition")
+    FlowStepDefinition = apps.get_model("flows", "FlowStepDefinition")
+
+    lock_flow, _ = FlowDefinition.objects.get_or_create(
+        name="lock_exit",
+        defaults={"description": "Lock an exit using a key."},
+    )
+    FlowStepDefinition.objects.get_or_create(
+        flow=lock_flow,
+        parent=None,
+        action="call_service_function",
+        variable_name="register_behavior_package",
+        defaults={
+            "parameters": {
+                "obj": "@target",
+                "package_name": "locked_exit",
+                "hook": "can_traverse",
+                "data": {
+                    "attribute": "key_id",
+                    "value": "@key.key_id",
+                },
+            }
+        },
+    )
+
+    unlock_flow, _ = FlowDefinition.objects.get_or_create(
+        name="unlock_exit",
+        defaults={"description": "Unlock an exit using a key."},
+    )
+    FlowStepDefinition.objects.get_or_create(
+        flow=unlock_flow,
+        parent=None,
+        action="call_service_function",
+        variable_name="remove_behavior_package",
+        defaults={
+            "parameters": {
+                "obj": "@target",
+                "package_name": "locked_exit",
+            }
+        },
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("flows", "0002_add_basic_flows"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_lock_flows, reverse_code=migrations.RunPython.noop),
+    ]

--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -43,6 +43,20 @@ class BaseState:
         self.name_suffix_map: dict[int, str] = {}
         self.packages = []
 
+    # ------------------------------------------------------------------
+    # Attribute access helpers
+    # ------------------------------------------------------------------
+
+    def set_attribute(self, name: str, value) -> None:
+        """Set ``name`` to ``value`` on this state."""
+
+        setattr(self, name, value)
+
+    def get_attribute(self, name: str, default=None):
+        """Return attribute ``name`` or ``default`` if missing."""
+
+        return getattr(self, name, default)
+
     def __str__(self) -> str:
         """Return the default display name."""
         return self.get_display_name()
@@ -257,6 +271,11 @@ class BaseState:
             if result is not None:
                 return result
         return None
+
+    def initialize_state(self) -> None:
+        """Call the ``initialize_state`` hook on attached packages."""
+
+        self._run_package_hook("initialize_state")
 
     def apply_attribute_modifiers(self, attr_name: str, value):
         """Return ``value`` modified by any packages."""

--- a/src/flows/scene_data_manager.py
+++ b/src/flows/scene_data_manager.py
@@ -186,11 +186,8 @@ class SceneDataManager:
             BehaviorPackageInstance.objects.select_related("definition").filter(obj=obj)
         )
         state.packages = packages
-        for pkg in packages:
-            init_func = pkg.get_hook("initialize_state")
-            if init_func is not None:
-                init_func(state, pkg)
         self.states[obj.pk] = state
+        state.initialize_state()
         return state
 
     # ------------------------------------------------------------------

--- a/src/flows/service_functions/packages.py
+++ b/src/flows/service_functions/packages.py
@@ -10,13 +10,15 @@ def register_behavior_package(
     flow_execution: FlowExecution,
     obj: str,
     package_name: str,
+    hook: str,
     data: dict | None = None,
     **kwargs: Any,
 ) -> None:
     """Attach a behavior package to an object."""
-    target = flow_execution.get_object(obj)
-    if target is None:
+    state = flow_execution.get_object_state(obj)
+    if state is None:
         raise RuntimeError("Invalid target for package registration.")
+    target = state.obj
     try:
         definition = BehaviorPackageDefinition.objects.get(name=package_name)
     except BehaviorPackageDefinition.DoesNotExist as exc:
@@ -24,6 +26,7 @@ def register_behavior_package(
     BehaviorPackageInstance.objects.create(
         definition=definition,
         obj=target,
+        hook=hook,
         data=data or {},
     )
 
@@ -35,9 +38,10 @@ def remove_behavior_package(
     **kwargs: Any,
 ) -> None:
     """Remove a behavior package from an object."""
-    target = flow_execution.get_object(obj)
-    if target is None:
+    state = flow_execution.get_object_state(obj)
+    if state is None:
         raise RuntimeError("Invalid target for package removal.")
+    target = state.obj
     try:
         definition = BehaviorPackageDefinition.objects.get(name=package_name)
     except BehaviorPackageDefinition.DoesNotExist:


### PR DESCRIPTION
## Summary
- generalize service modules for key behavior packages
- update tests and flows to work with generic state initialization and checks
- rename locked-exit hook to `require_matching_value`
- initialize state packages via `BaseState.initialize_state`

## Testing
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_68866f9566b4833194b52144547e2a4f