### PR TITLE
Clarify scenes and combat docs

### DIFF
--- a/docs/old_arx_migrations/README.md
+++ b/docs/old_arx_migrations/README.md
@@ -1,0 +1,11 @@
+# Porting Systems from Arx I
+
+These notes outline how Arx II will draw inspiration from the first game while moving to a fully data driven architecture. We are not importing character data or recipes. Instead we plan to capture the feel of key systems and improve on them with modern tooling.
+
+Reference documents:
+
+- `scenes.md` – Player run scenes and trust based GM tools
+- `crafting.md` – Rebuilding the crafting process
+- `combat.md` – Designing cooperative combat encounters
+- `traits.md` – Handling advantages and backgrounds
+- `progression.md` – Account XP and development based advancement

--- a/docs/old_arx_migrations/combat.md
+++ b/docs/old_arx_migrations/combat.md
@@ -1,0 +1,13 @@
+# Combat
+
+The Arx I combat system revolved around a turn queue with scripts handling abilities and damage. Arx II will take the opportunity to reinvent these mechanics. Our guiding principle is to create dramatic, cooperative moments rather than strict simulation. Combat is largely asymmetrical: player characters face enemies, large battles or boss monsters in various PvE scenarios.
+
+Planned changes:
+
+- Resolution and messaging run through the command system so modifiers can come from data tables.
+- States expose permissions like `can_attack` or `can_flee` and internal utilities execute rolls and apply damage.
+- Players are rewarded for coordinating actions; team combos confer bonuses that a lone fighter cannot achieve.
+
+PvP conflict is possible only when all participants share a high level of trust and explicitly consent. Rivalries may exist, but open antagonism between characters is prohibited unless their players are friendly with one another.
+
+We will reference Arx I only for inspiration. The new approach should feel familiar but ultimately provide a smoother and more satisfying experience.

--- a/docs/old_arx_migrations/crafting.md
+++ b/docs/old_arx_migrations/crafting.md
@@ -1,0 +1,11 @@
+# Crafting
+
+Arx I featured intricate crafting trees defined directly in code. Rather than porting every old recipe we will rebuild the system with a data first approach. Recipes and workshops live in the database so designers can iterate without changing source.
+
+Key ideas:
+
+1. Define crafting steps in data so resources can be checked and items generated without code changes.
+2. Keep the feel of skill gates and rare components but configure them in data tables.
+3. Encourage collaboration by allowing characters to combine efforts on large projects.
+
+This rewrite aims for smoother experimentation and a more social crafting experience.

--- a/docs/old_arx_migrations/progression.md
+++ b/docs/old_arx_migrations/progression.md
@@ -1,0 +1,7 @@
+# Progression
+
+Arx II introduces a two tier advancement system. Accounts earn experience points (XP) that can unlock new character slots or major abilities. Individual characters progress through many smaller "development" tracks such as skills, relationships and magic affinities.
+
+Development points accrue when a character spends time training or interacting with relevant systems. XP gates major milestones like new classes or broad power tiers. This encourages players to invest effort across multiple areas while still rewarding narrative achievements.
+
+The game will be class and level based, unlike Arx I. Levels measure overall capability but development points let characters specialize in nearly any aspect of play.

--- a/docs/old_arx_migrations/scenes.md
+++ b/docs/old_arx_migrations/scenes.md
@@ -1,0 +1,11 @@
+# Scenes
+
+Arx I used a system called "RPEvents" for player run story scenes. To avoid clashing with the engine's own event hooks we refer to them as **scenes** in Arx II. No scene logs or data need to be imported from the original game. We only care about matching the flexibility that players enjoyed.
+
+Scenes serve purely as an organizational space for roleplay. They track participants and logs in the database. Scenes are mostly driven by commands, with a story framework providing guardrails and guidance for GMs. Player GMs gain autonomy over time through a trust or level system. At higher trust levels they can run stories with the same authority that staff wielded in Arx I, but without needing access to administrative commands.
+
+Key goals:
+
+- Scenes are launched and managed via commands.
+- Trust levels gate the scope of actions a player GM may take during a scene.
+- GM commands cover administrative needs so storytelling flows smoothly.

--- a/docs/old_arx_migrations/traits.md
+++ b/docs/old_arx_migrations/traits.md
@@ -1,0 +1,11 @@
+# Traits
+
+Traits in Arx II cover advantages, backgrounds and other character defining choices. We will not import any existing trait values, but we want players to recognize the same themes.
+
+Plans:
+
+- New models describe each trait's costs and prerequisites.
+- Generic utilities replace the scattered checks used in Arx I and apply changes consistently.
+- Development occurs over time and can trigger rewards or side effects when progress is recorded.
+
+The system should feel flexible and allow new trait categories to be added without code changes.


### PR DESCRIPTION
## Summary
- trim service function and flow mentions across the old Arx migration docs
- highlight command-driven scenes
- simplify combat guidance and remove player-bickering line

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68881af2c37083319d198133b939a89c