### PR TITLE
Add frontend architecture docs

### DIFF
--- a/docs/frontend/architecture.md
+++ b/docs/frontend/architecture.md
@@ -1,0 +1,27 @@
+# Frontend Architecture
+
+Arx II is migrating from server-rendered templates to a modern React application. The frontend uses Vite for bundling, React Router for routing, React Query for API access, Redux Toolkit for state management and the shadcn/ui component library styled with Tailwind CSS. All code is written in TypeScript.
+
+## Local development
+
+Nginx is not required when developing locally. Run the Vite dev server to serve the application and proxy API requests to Django running at `http://localhost:8000`:
+
+```bash
+pnpm dev
+```
+
+## Build process
+
+Production builds output static files to `src/web/static/dist/` so Django or nginx can serve them:
+
+```bash
+pnpm build
+```
+
+## Setup with mise
+
+The `mise.toml` file manages our binary dependencies. Node and pnpm versions are defined so everyone uses the same tooling. After cloning the repository, install the tools with:
+
+```bash
+mise install
+```

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS
+
+This directory contains the React frontend. Development is tracked in this file.
+
+## Plan
+- Use Vite with React and TypeScript.
+- Handle routing with React Router.
+- Fetch data through React Query hitting the Django REST API.
+- Use Redux Toolkit for shared state and websocket integration.
+- Style components with shadcn/ui and Tailwind CSS.
+
+## Progress
+- Docs directory created with initial architecture notes.
+- Configuration of Node and pnpm managed via `mise`.
+- Frontend bootstrap not yet implemented.

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ idiomatic_version_file_enable_tools = ["python"]
 [tools]
 python = "3.13.0"
 node = "24.4.1"
+pnpm = "latest"
 uv = "latest"
 
 [env]


### PR DESCRIPTION
## Summary
- document frontend architecture and local dev workflow
- track progress for Vite/React client in frontend/AGENTS.md
- manage pnpm via `mise.toml`

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68884f54f2a483318422be46561e92af