### PR TITLE
feat(frontend): improve game window and socket types

### DIFF
--- a/frontend/src/game/components/ChatWindow.tsx
+++ b/frontend/src/game/components/ChatWindow.tsx
@@ -1,5 +1,6 @@
 import { useAppSelector } from '../../store/hooks';
 import { EvenniaMessage } from './EvenniaMessage';
+import { GAME_MESSAGE_TYPE } from '../../hooks/types';
 
 export function ChatWindow() {
   const { messages, isConnected } = useAppSelector((state) => state.game);
@@ -15,7 +16,7 @@ export function ChatWindow() {
           </span>
         </div>
       </div>
-      <div className="mb-4 h-96 overflow-y-auto rounded bg-muted/30 p-4">
+      <div className="mb-4 h-96 overflow-y-auto rounded bg-black p-4 font-mono text-white">
         {messages.length === 0 ? (
           <p className="text-muted-foreground">No messages yet...</p>
         ) : (
@@ -27,15 +28,15 @@ export function ChatWindow() {
               <EvenniaMessage
                 content={message.content}
                 className={
-                  message.type === 'system'
-                    ? 'text-blue-600'
-                    : message.type === 'action'
-                      ? 'text-green-600'
-                      : message.type === 'channel'
-                        ? 'text-purple-600'
-                        : message.type === 'error'
-                          ? 'text-red-600'
-                          : 'text-foreground'
+                  message.type === GAME_MESSAGE_TYPE.SYSTEM
+                    ? 'text-blue-400'
+                    : message.type === GAME_MESSAGE_TYPE.ACTION
+                      ? 'text-green-400'
+                      : message.type === GAME_MESSAGE_TYPE.CHANNEL
+                        ? 'text-purple-400'
+                        : message.type === GAME_MESSAGE_TYPE.ERROR
+                          ? 'text-red-400'
+                          : 'text-white'
                 }
               />
             </div>

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -3,7 +3,7 @@ import { CommandInput } from './CommandInput';
 
 export function GameWindow() {
   return (
-    <div className="rounded-lg border bg-card p-4">
+    <div className="w-[calc(88ch+2rem)] rounded-lg border bg-card p-4">
       <ChatWindow />
       <CommandInput />
     </div>

--- a/frontend/src/hooks/parseGameMessage.ts
+++ b/frontend/src/hooks/parseGameMessage.ts
@@ -1,0 +1,30 @@
+import type { GameMessage, GameMessageType, IncomingMessage } from './types';
+import { GAME_MESSAGE_TYPE, WS_MESSAGE_TYPE } from './types';
+
+export function parseGameMessage(data: string): GameMessage {
+  try {
+    const parsed: IncomingMessage = JSON.parse(data);
+    if (Array.isArray(parsed) && parsed.length >= 2) {
+      const [msgType, args, kwargs = {}] = parsed;
+      let content = '';
+      let messageType: GameMessageType = GAME_MESSAGE_TYPE.SYSTEM;
+
+      if (msgType === WS_MESSAGE_TYPE.TEXT && Array.isArray(args) && args.length > 0) {
+        content = String(args[0]);
+        messageType = (kwargs as Record<string, unknown>).from_channel
+          ? GAME_MESSAGE_TYPE.CHANNEL
+          : GAME_MESSAGE_TYPE.TEXT;
+      } else if (msgType === WS_MESSAGE_TYPE.LOGGED_IN) {
+        content = 'Successfully logged in!';
+      } else {
+        content = JSON.stringify(parsed);
+      }
+
+      return { content, timestamp: Date.now(), type: messageType };
+    }
+  } catch {
+    // fall through to error case
+  }
+
+  return { content: data, timestamp: Date.now(), type: GAME_MESSAGE_TYPE.ERROR };
+}

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -1,0 +1,27 @@
+export const GAME_MESSAGE_TYPE = {
+  SYSTEM: 'system',
+  CHAT: 'chat',
+  ACTION: 'action',
+  TEXT: 'text',
+  CHANNEL: 'channel',
+  ERROR: 'error',
+} as const;
+
+export type GameMessageType = (typeof GAME_MESSAGE_TYPE)[keyof typeof GAME_MESSAGE_TYPE];
+
+export const WS_MESSAGE_TYPE = {
+  TEXT: 'text',
+  LOGGED_IN: 'logged_in',
+} as const;
+
+export type SocketMessageType = (typeof WS_MESSAGE_TYPE)[keyof typeof WS_MESSAGE_TYPE];
+
+export interface GameMessage {
+  content: string;
+  timestamp: number;
+  type: GameMessageType;
+}
+
+export type IncomingMessage = [SocketMessageType, unknown[], Record<string, unknown>?];
+
+export type OutgoingMessage = [typeof WS_MESSAGE_TYPE.TEXT, [string], Record<string, unknown>];

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -1,14 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { GameMessage } from '../hooks/types';
 
 interface GameState {
   isConnected: boolean;
   currentCharacter: string | null;
-  messages: Array<{
-    id: string;
-    content: string;
-    timestamp: number;
-    type: 'system' | 'chat' | 'action' | 'text' | 'channel' | 'error';
-  }>;
+  messages: Array<GameMessage & { id: string }>;
 }
 
 const initialState: GameState = {
@@ -27,11 +23,8 @@ export const gameSlice = createSlice({
     setCurrentCharacter: (state, action: PayloadAction<string | null>) => {
       state.currentCharacter = action.payload;
     },
-    addMessage: (state, action: PayloadAction<Omit<GameState['messages'][0], 'id'>>) => {
-      state.messages.push({
-        ...action.payload,
-        id: Date.now().toString(),
-      });
+    addMessage: (state, action: PayloadAction<GameMessage>) => {
+      state.messages.push({ ...action.payload, id: Date.now().toString() });
     },
     clearMessages: (state) => {
       state.messages = [];


### PR DESCRIPTION
## Summary
- ensure game window width matches Evennia expectations and uses a black background for white text
- split websocket message parsing and type definitions from useGameSocket
- lighten message colors for dark theme
- centralize message type constants to avoid string literal comparisons

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_6890c8bb0b488331ab2633d12cdd8240