### PR TITLE
feat(frontend): add character sheet page

### DIFF
--- a/docs/frontend/character_sheets_plan.md
+++ b/docs/frontend/character_sheets_plan.md
@@ -14,9 +14,9 @@ The roster and character sheet system will let players browse available characte
 ## Backend requirements
 
 - `GET /api/roster/` returns active rosters and each character's public summary, portrait URL, roster type, and availability status. Endpoint supports pagination and django-filter query parameters for searching or filtering by availability, gender, class, and other fields that may be stubbed until full data exists.
-- `GET /api/characters/<id>/` returns a full character sheet. Response includes secret sections only if the viewer controls the character or has staff permission.
-- `POST /api/characters/<id>/apply/` submits an application to play a roster character.
-- `GET /api/accounts/me/characters/` lists the viewer's characters, providing ids and names so the frontend can link to sheets.
+- `GET /api/roster/<id>/` returns a full character sheet. Response includes secret sections only if the viewer controls the character or has staff permission.
+- `POST /api/roster/<id>/apply/` submits an application to play a roster character.
+- `GET /api/roster/mine/` lists the viewer's characters, providing ids and names so the frontend can link to sheets.
 - `GET /api/accounts/me/applications/` lists the viewer's unprocessed applications. `PUT` or `PATCH` updates an application, and `DELETE` removes it as long as it has not yet been processed.
 - API responses expose Cloudinary image data for portraits and gallery images.
 
@@ -30,6 +30,7 @@ The roster and character sheet system will let players browse available characte
 - Character sheet page displays portrait, summary, hooks, and other sections returned by the API. When the viewer owns the character, private fields render in an "Owner" tab.
 - From the game client, clicking a character name opens the sheet in a side panel using the same route.
 - Profile page lists pending applications with options to edit or delete.
+- Profile dropdown lists the viewer's characters for quick access.
 
 ## Prototyping steps
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { GamePage } from './game/GamePage';
 import { LoginPage } from './evennia_replacements/LoginPage';
 import { ProfilePage } from './pages/ProfilePage';
 import { NotFoundPage } from './pages/NotFoundPage';
+import { CharacterSheetPage } from './pages/CharacterSheetPage';
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/characters/:id" element={<CharacterSheetPage />} />
         <Route path="/game" element={<GamePage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,56 +1,12 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import { useAccount } from '../store/hooks';
-import { useLogout } from '../evennia_replacements/queries';
-import { SITE_NAME } from '../config';
+import { SiteTitle } from './SiteTitle';
+import { UserNav } from './UserNav';
 
 export function Header() {
-  const account = useAccount();
-  const [open, setOpen] = useState(false);
-  const logout = useLogout(() => setOpen(false));
-
   return (
     <header className="border-b">
       <div className="container mx-auto flex items-center justify-between px-4 py-4">
-        <h1 className="text-2xl font-bold">
-          <Link to="/">{SITE_NAME}</Link>
-        </h1>
-        {account ? (
-          <div className="relative">
-            <button onClick={() => setOpen(!open)} className="font-medium">
-              {account.display_name}
-            </button>
-            {open && (
-              <nav className="absolute right-0 mt-2 w-40 rounded border bg-background shadow-md">
-                <ul className="flex flex-col">
-                  <li>
-                    <Link
-                      to="/profile"
-                      className="block px-4 py-2 hover:bg-accent hover:text-accent-foreground"
-                      onClick={() => setOpen(false)}
-                    >
-                      Profile
-                    </Link>
-                  </li>
-                  <li>
-                    <button
-                      onClick={() => logout.mutate()}
-                      className="block w-full px-4 py-2 text-left hover:bg-accent hover:text-accent-foreground"
-                    >
-                      Logout
-                    </button>
-                  </li>
-                </ul>
-              </nav>
-            )}
-          </div>
-        ) : (
-          <nav>
-            <Link to="/login" className="text-primary hover:underline">
-              Log in
-            </Link>
-          </nav>
-        )}
+        <SiteTitle />
+        <UserNav />
       </div>
     </header>
   );

--- a/frontend/src/components/ProfileDropdown.tsx
+++ b/frontend/src/components/ProfileDropdown.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useLogout, useMyRosterEntriesQuery } from '../evennia_replacements/queries';
+import type { AccountData } from '../evennia_replacements/types';
+
+interface ProfileDropdownProps {
+  account: AccountData;
+}
+
+export function ProfileDropdown({ account }: ProfileDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const logout = useLogout(() => setOpen(false));
+  const { data: characters } = useMyRosterEntriesQuery(true);
+
+  return (
+    <div className="relative">
+      <button onClick={() => setOpen(!open)} className="font-medium">
+        {account.display_name}
+      </button>
+      {open && (
+        <nav className="absolute right-0 mt-2 w-40 rounded border bg-background shadow-md">
+          <ul className="flex flex-col">
+            {characters?.map((c) => (
+              <li key={c.id}>
+                <Link
+                  to={`/characters/${c.id}`}
+                  className="block px-4 py-2 hover:bg-accent hover:text-accent-foreground"
+                  onClick={() => setOpen(false)}
+                >
+                  {c.name}
+                </Link>
+              </li>
+            ))}
+            <li>
+              <Link
+                to="/profile"
+                className="block px-4 py-2 hover:bg-accent hover:text-accent-foreground"
+                onClick={() => setOpen(false)}
+              >
+                Profile
+              </Link>
+            </li>
+            <li>
+              <button
+                onClick={() => logout.mutate()}
+                className="block w-full px-4 py-2 text-left hover:bg-accent hover:text-accent-foreground"
+              >
+                Logout
+              </button>
+            </li>
+          </ul>
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SiteTitle.tsx
+++ b/frontend/src/components/SiteTitle.tsx
@@ -1,0 +1,10 @@
+import { Link } from 'react-router-dom';
+import { SITE_NAME } from '../config';
+
+export function SiteTitle() {
+  return (
+    <h1 className="text-2xl font-bold">
+      <Link to="/">{SITE_NAME}</Link>
+    </h1>
+  );
+}

--- a/frontend/src/components/UserNav.tsx
+++ b/frontend/src/components/UserNav.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+import { useAccount } from '../store/hooks';
+import { ProfileDropdown } from './ProfileDropdown';
+
+export function UserNav() {
+  const account = useAccount();
+  if (account) {
+    return <ProfileDropdown account={account} />;
+  }
+  return (
+    <nav>
+      <Link to="/login" className="text-primary hover:underline">
+        Log in
+      </Link>
+    </nav>
+  );
+}

--- a/frontend/src/components/character/BackgroundSection.tsx
+++ b/frontend/src/components/character/BackgroundSection.tsx
@@ -1,0 +1,12 @@
+interface BackgroundSectionProps {
+  background?: string;
+}
+
+export function BackgroundSection({ background }: BackgroundSectionProps) {
+  return (
+    <section>
+      <h3 className="text-xl font-semibold">Background</h3>
+      <p>{background || 'TBD'}</p>
+    </section>
+  );
+}

--- a/frontend/src/components/character/CharacterApplicationForm.tsx
+++ b/frontend/src/components/character/CharacterApplicationForm.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { useSendRosterApplication } from '../../evennia_replacements/queries';
+
+interface CharacterApplicationFormProps {
+  entryId: number;
+}
+
+export function CharacterApplicationForm({ entryId }: CharacterApplicationFormProps) {
+  const [message, setMessage] = useState('');
+  const mutation = useSendRosterApplication(entryId);
+
+  return (
+    <section>
+      <h3 className="text-xl font-semibold">Apply to Play</h3>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mutation.mutate(message);
+          setMessage('');
+        }}
+        className="space-y-2"
+      >
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          className="w-full rounded border p-2"
+          placeholder="Why do you want to play this character?"
+        />
+        <button type="submit" className="rounded bg-primary px-4 py-2 text-primary-foreground">
+          Send Application
+        </button>
+      </form>
+      {mutation.isError && <p className="text-red-600">Failed to send application.</p>}
+    </section>
+  );
+}

--- a/frontend/src/components/character/CharacterPortrait.tsx
+++ b/frontend/src/components/character/CharacterPortrait.tsx
@@ -1,0 +1,18 @@
+import type { CharacterData } from '../../evennia_replacements/types';
+
+interface CharacterPortraitProps {
+  character: CharacterData;
+}
+
+export function CharacterPortrait({ character }: CharacterPortraitProps) {
+  return (
+    <div className="flex flex-col items-start gap-4 sm:flex-row">
+      <img
+        src={character.portrait}
+        alt={`${character.name} portrait`}
+        className="h-48 w-48 rounded object-cover"
+      />
+      <h2 className="text-2xl font-bold">{character.name}</h2>
+    </div>
+  );
+}

--- a/frontend/src/components/character/GalleriesSection.tsx
+++ b/frontend/src/components/character/GalleriesSection.tsx
@@ -1,0 +1,22 @@
+import type { CharacterGallery } from '../../evennia_replacements/types';
+
+interface GalleriesSectionProps {
+  galleries: CharacterGallery[];
+}
+
+export function GalleriesSection({ galleries }: GalleriesSectionProps) {
+  return (
+    <section>
+      <h3 className="text-xl font-semibold">Galleries</h3>
+      <ul className="list-disc pl-5">
+        {galleries.map((g) => (
+          <li key={g.name}>
+            <a href={g.url} className="text-primary underline">
+              {g.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/character/RelationshipsSection.tsx
+++ b/frontend/src/components/character/RelationshipsSection.tsx
@@ -1,0 +1,18 @@
+interface RelationshipsSectionProps {
+  relationships?: string[];
+}
+
+export function RelationshipsSection({ relationships }: RelationshipsSectionProps) {
+  return (
+    <section>
+      <h3 className="text-xl font-semibold">Relationships</h3>
+      <ul className="list-disc pl-5">
+        {relationships?.length ? (
+          relationships.map((rel) => <li key={rel}>{rel}</li>)
+        ) : (
+          <li>TBD</li>
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/character/StatsSection.tsx
+++ b/frontend/src/components/character/StatsSection.tsx
@@ -1,0 +1,12 @@
+interface StatsSectionProps {
+  stats?: Record<string, number>;
+}
+
+export function StatsSection({ stats }: StatsSectionProps) {
+  return (
+    <section>
+      <h3 className="text-xl font-semibold">Stats</h3>
+      <p>{stats ? JSON.stringify(stats) : 'TBD'}</p>
+    </section>
+  );
+}

--- a/frontend/src/components/character/index.ts
+++ b/frontend/src/components/character/index.ts
@@ -1,0 +1,6 @@
+export { CharacterPortrait } from './CharacterPortrait';
+export { BackgroundSection } from './BackgroundSection';
+export { StatsSection } from './StatsSection';
+export { RelationshipsSection } from './RelationshipsSection';
+export { GalleriesSection } from './GalleriesSection';
+export { CharacterApplicationForm } from './CharacterApplicationForm';

--- a/frontend/src/evennia_replacements/HomePage.tsx
+++ b/frontend/src/evennia_replacements/HomePage.tsx
@@ -1,9 +1,9 @@
 import { Link } from 'react-router-dom';
-import { useHomeStats } from './queries';
+import { useHomeStatsQuery } from './queries';
 import { SITE_NAME } from '../config';
 
 export function HomePage() {
-  const { data, isLoading, error } = useHomeStats();
+  const { data, isLoading, error } = useHomeStatsQuery();
 
   if (isLoading) {
     return (

--- a/frontend/src/evennia_replacements/queries.tsx
+++ b/frontend/src/evennia_replacements/queries.tsx
@@ -1,10 +1,18 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { fetchHomeStats, fetchAccount, postLogin, postLogout } from './api';
+import {
+  fetchHomeStats,
+  fetchAccount,
+  postLogin,
+  postLogout,
+  fetchRosterEntry,
+  fetchMyRosterEntries,
+  postRosterApplication,
+} from './api';
 import { useAppDispatch } from '../store/hooks';
 import { setAccount } from '../store/authSlice';
 import { useEffect } from 'react';
 
-export function useHomeStats() {
+export function useHomeStatsQuery() {
   return useQuery({ queryKey: ['homepage'], queryFn: fetchHomeStats });
 }
 
@@ -43,5 +51,27 @@ export function useLogout(onSuccess?: () => void) {
       dispatch(setAccount(null));
       onSuccess?.();
     },
+  });
+}
+
+export function useRosterEntryQuery(id: number) {
+  return useQuery({
+    queryKey: ['roster-entry', id],
+    queryFn: () => fetchRosterEntry(id),
+    enabled: !!id,
+  });
+}
+
+export function useMyRosterEntriesQuery(enabled = true) {
+  return useQuery({
+    queryKey: ['my-roster-entries'],
+    queryFn: fetchMyRosterEntries,
+    enabled,
+  });
+}
+
+export function useSendRosterApplication(id: number) {
+  return useMutation({
+    mutationFn: (message: string) => postRosterApplication(id, message),
   });
 }

--- a/frontend/src/evennia_replacements/types.ts
+++ b/frontend/src/evennia_replacements/types.ts
@@ -17,3 +17,29 @@ export interface AccountData {
   display_name: string;
   last_login: string | null;
 }
+
+export interface MyRosterEntry {
+  id: number;
+  name: string;
+}
+
+export interface CharacterGallery {
+  name: string;
+  url: string;
+}
+
+export interface CharacterData {
+  id: number;
+  name: string;
+  portrait: string;
+  background?: string;
+  stats?: Record<string, number>;
+  relationships?: string[];
+  galleries: CharacterGallery[];
+}
+
+export interface RosterEntryData {
+  id: number;
+  character: CharacterData;
+  can_apply: boolean;
+}

--- a/frontend/src/pages/CharacterSheetPage.tsx
+++ b/frontend/src/pages/CharacterSheetPage.tsx
@@ -1,0 +1,30 @@
+import { useParams } from 'react-router-dom';
+import { useRosterEntryQuery } from '../evennia_replacements/queries';
+import {
+  CharacterPortrait,
+  BackgroundSection,
+  StatsSection,
+  RelationshipsSection,
+  GalleriesSection,
+  CharacterApplicationForm,
+} from '../components/character';
+
+export function CharacterSheetPage() {
+  const { id } = useParams();
+  const entryId = Number(id);
+  const { data: entry, isLoading, error } = useRosterEntryQuery(entryId);
+
+  if (isLoading) return <p className="p-4">Loading...</p>;
+  if (error || !entry) return <p className="p-4">Character not found.</p>;
+
+  return (
+    <div className="container mx-auto space-y-4 p-4">
+      <CharacterPortrait character={entry.character} />
+      <BackgroundSection background={entry.character.background} />
+      <StatsSection stats={entry.character.stats} />
+      <RelationshipsSection relationships={entry.character.relationships} />
+      <GalleriesSection galleries={entry.character.galleries} />
+      {entry.can_apply && <CharacterApplicationForm entryId={entry.id} />}
+    </div>
+  );
+}

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -8,6 +8,7 @@ creation commands.
 
 """
 
+from django.utils.functional import cached_property
 from evennia.objects.objects import DefaultCharacter
 from evennia.utils.utils import lazy_property
 
@@ -52,6 +53,15 @@ class Character(ObjectParent, DefaultCharacter):
         from world.traits.handlers import TraitHandler
 
         return TraitHandler(self)
+
+    @cached_property
+    def cached_tenures(self):
+        """Prefetched active tenures for this character.
+
+        Returns:
+            list: Tenures with no end date.
+        """
+        return list(self.tenures.filter(end_date__isnull=True))
 
     def do_look(self, target):
         desc = self.at_look(target)

--- a/src/web/api/urls.py
+++ b/src/web/api/urls.py
@@ -1,9 +1,16 @@
 from django.urls import path
+from rest_framework.routers import DefaultRouter
 
 from web.api.views import HomePageAPIView, LoginAPIView, LogoutAPIView
+from world.roster.views import RosterEntryViewSet
+
+router = DefaultRouter()
+router.register("roster", RosterEntryViewSet, basename="roster")
 
 urlpatterns = [
     path("homepage/", HomePageAPIView.as_view(), name="api-homepage"),
     path("login/", LoginAPIView.as_view(), name="api-login"),
     path("logout/", LogoutAPIView.as_view(), name="api-logout"),
 ]
+
+urlpatterns += router.urls

--- a/src/world/roster/models.py
+++ b/src/world/roster/models.py
@@ -3,6 +3,8 @@ Roster system models for character management.
 Handles character rosters, player tenures, applications, and tenure-specific settings.
 """
 
+from functools import cached_property
+
 from django.db import models
 from django.utils import timezone
 from evennia.accounts.models import AccountDB
@@ -241,6 +243,11 @@ class RosterTenure(models.Model):
         account = self.player_data.account
         super().delete(*args, **kwargs)
         account.__dict__.pop("characters", None)
+
+    @cached_property
+    def cached_media(self):
+        """Prefetched media for this tenure."""
+        return list(self.media.all())
 
     @property
     def display_name(self):


### PR DESCRIPTION
## Summary
- break header into reusable pieces and surface character links in profile dropdown
- compose character sheet from dedicated sections with an application form
- rename query hooks for clarity and support sending application messages
- centralize API headers to avoid repetition and clarify error messages
- host character-related serializers and API views within the roster app to keep web/api lean
- expose roster entries through a dedicated viewset and model serializer
- nest character details under roster entries and prefetch tenure media for portraits
- cache roster tenures on the Character typeclass instead of monkeypatching ObjectDB

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689147ebc3cc8331bbae52734e124d4c