### PR TITLE
chore: build frontend on push and clarify hook policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
-default_stages: [commit]
+default_stages: [pre-commit]
+default_install_hook_types: [pre-commit, pre-push]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -71,3 +72,14 @@ repos:
         language: system
         pass_filenames: true
         files: ^frontend/.*\.(ts|tsx|js|jsx|json|css|md)$
+      - id: frontend-build
+        name: Frontend Build
+        entry: bash
+        args:
+          - -c
+          - |
+            cd frontend
+            pnpm build
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 This repository contains **Arx II**, a sequel to the Arx MUD. It is built on the Evennia framework and Django.
 
 - **Testing**: always run the suite with `uv run arx test` to ensure the correct environment and dependencies. Using `python` directly can miss packages like `typer`.
+- **Git hooks**: do not bypass pre-commit or pre-push hooks with `--no-verify`. The pre-push hook runs `pnpm build` for the frontend; ensure the build succeeds before pushing.
 - **Design goals**: gameplay rules should live in the database. Avoid hardcoding specific mechanics in code. The `flows` system under `src/flows` allows designers to create data-driven tasks. Flows emit events that triggers can listen to and spawn additional flows.
 - **Service functions** should be generic utilities. They must not embed hardcoded gameplay logic. Use flows and triggers with data to implement specific rules.
 - We want extensive automation to support a narrative driven game world. Player choices should drive automated reactions defined via data.


### PR DESCRIPTION
## Summary
- build frontend during `pre-push` to catch bundling errors
- document that `--no-verify` is not allowed for hooks

## Testing
- `pre-commit run --files AGENTS.md .pre-commit-config.yaml`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6894ae28bd188331af8462650d018adf