### PR TITLE
Add character-based sessions to game window

### DIFF
--- a/frontend/src/components/character/GalleriesSection.tsx
+++ b/frontend/src/components/character/GalleriesSection.tsx
@@ -1,4 +1,5 @@
 import type { CharacterGallery } from '../../evennia_replacements/types';
+import { Link } from 'react-router-dom';
 
 interface GalleriesSectionProps {
   galleries: CharacterGallery[];
@@ -11,9 +12,9 @@ export function GalleriesSection({ galleries }: GalleriesSectionProps) {
       <ul className="list-disc pl-5">
         {galleries.map((g) => (
           <li key={g.name}>
-            <a href={g.url} className="text-primary underline">
+            <Link to={g.url} className="text-primary underline">
               {g.name}
-            </a>
+            </Link>
           </li>
         ))}
       </ul>

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -1,16 +1,18 @@
 import { GameWindow } from './components/GameWindow';
 import { CharacterPanel } from './components/CharacterPanel';
 import { QuickActions } from './components/QuickActions';
+import { useMyRosterEntriesQuery } from '../evennia_replacements/queries';
 
 export function GamePage() {
+  const { data: characters = [] } = useMyRosterEntriesQuery();
   return (
     <div className="mx-auto max-w-4xl">
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <div className="lg:col-span-2">
-          <GameWindow />
+          <GameWindow characters={characters} />
         </div>
         <div className="space-y-6">
-          <CharacterPanel />
+          <CharacterPanel characters={characters} />
           <QuickActions />
         </div>
       </div>

--- a/frontend/src/game/components/CharacterPanel.tsx
+++ b/frontend/src/game/components/CharacterPanel.tsx
@@ -1,15 +1,45 @@
-import { useAppSelector } from '../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import { startSession } from '../../store/gameSlice';
+import { useGameSocket } from '../../hooks/useGameSocket';
+import type { MyRosterEntry } from '../../evennia_replacements/types';
 
-export function CharacterPanel() {
-  const currentCharacter = useAppSelector((state) => state.game.currentCharacter);
+interface CharacterPanelProps {
+  characters: MyRosterEntry[];
+}
+
+export function CharacterPanel({ characters }: CharacterPanelProps) {
+  const dispatch = useAppDispatch();
+  const { connect } = useGameSocket();
+  const sessions = useAppSelector((state) => state.game.sessions);
+  const active = useAppSelector((state) => state.game.active);
+
+  const handleSelect = (name: string) => {
+    dispatch(startSession(name));
+    if (!sessions[name]?.isConnected) {
+      connect(name);
+    }
+  };
 
   return (
     <div className="rounded-lg border bg-card p-4">
-      <h3 className="mb-2 font-semibold">Character</h3>
-      {currentCharacter ? (
-        <p className="text-sm">{currentCharacter}</p>
+      <h3 className="mb-2 font-semibold">Characters</h3>
+      {characters.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No characters available</p>
       ) : (
-        <p className="text-sm text-muted-foreground">No character selected</p>
+        <ul className="space-y-1">
+          {characters.map((char) => (
+            <li key={char.id}>
+              <button
+                className={`w-full rounded px-2 py-1 text-left text-sm hover:bg-accent ${
+                  active === char.name ? 'bg-accent' : ''
+                }`}
+                onClick={() => handleSelect(char.name)}
+              >
+                {char.name}
+              </button>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/frontend/src/game/components/ChatWindow.tsx
+++ b/frontend/src/game/components/ChatWindow.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
-import { useAppSelector } from '../../store/hooks';
+import type { GameMessage } from '../../hooks/types';
 import { EvenniaMessage } from './EvenniaMessage';
 import { GAME_MESSAGE_TYPE } from '../../hooks/types';
 
-export function ChatWindow() {
-  const { messages, isConnected } = useAppSelector((state) => state.game);
+interface ChatWindowProps {
+  messages: Array<GameMessage & { id: string }>;
+  isConnected: boolean;
+}
+
+export function ChatWindow({ messages, isConnected }: ChatWindowProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
 

--- a/frontend/src/game/components/CommandInput.tsx
+++ b/frontend/src/game/components/CommandInput.tsx
@@ -2,7 +2,11 @@ import { useState } from 'react';
 import { useGameSocket } from '../../hooks/useGameSocket';
 import { Input } from '../../components/ui/input';
 
-export function CommandInput() {
+interface CommandInputProps {
+  character: string;
+}
+
+export function CommandInput({ character }: CommandInputProps) {
   const [command, setCommand] = useState('');
   const { send } = useGameSocket();
 
@@ -10,7 +14,7 @@ export function CommandInput() {
     e.preventDefault();
     const trimmed = command.trim();
     if (trimmed) {
-      send(trimmed);
+      send(character, trimmed);
       setCommand('');
     }
   };

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -1,13 +1,77 @@
 import { ChatWindow } from './ChatWindow';
 import { CommandInput } from './CommandInput';
 import { Card, CardContent } from '../../components/ui/card';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import { setActiveSession } from '../../store/gameSlice';
+import { useGameSocket } from '../../hooks/useGameSocket';
+import { Link } from 'react-router-dom';
+import type { MyRosterEntry } from '../../evennia_replacements/types';
 
-export function GameWindow() {
+interface GameWindowProps {
+  characters: MyRosterEntry[];
+}
+
+export function GameWindow({ characters }: GameWindowProps) {
+  const dispatch = useAppDispatch();
+  const { connect } = useGameSocket();
+  const { sessions, active } = useAppSelector((state) => state.game);
+
+  if (characters.length === 0) {
+    return (
+      <Card className="w-full max-w-[calc(88ch+2rem)]">
+        <CardContent className="p-4">
+          <p className="text-sm">
+            You have no active characters. Visit the{' '}
+            <Link to="/roster" className="underline">
+              roster
+            </Link>{' '}
+            to apply for one.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!active) {
+    return (
+      <Card className="w-full max-w-[calc(88ch+2rem)]">
+        <CardContent className="p-4">
+          <p className="text-sm text-muted-foreground">Select a character to begin.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const session = sessions[active];
+
+  const handleTabClick = (name: string) => {
+    dispatch(setActiveSession(name));
+    if (!sessions[name].isConnected) {
+      connect(name);
+    }
+  };
+
   return (
     <Card className="w-full max-w-[calc(88ch+2rem)]">
       <CardContent className="p-4">
-        <ChatWindow />
-        <CommandInput />
+        <div className="mb-4 flex gap-2 border-b">
+          {Object.keys(sessions).map((name) => (
+            <button
+              key={name}
+              onClick={() => handleTabClick(name)}
+              className={`relative rounded-t px-2 py-1 text-sm ${
+                active === name ? 'border-b-2 border-primary' : ''
+              }`}
+            >
+              {name}
+              {sessions[name].unread > 0 && (
+                <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-red-500" />
+              )}
+            </button>
+          ))}
+        </div>
+        <ChatWindow messages={session.messages} isConnected={session.isConnected} />
+        <CommandInput character={active} />
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- Support multiple character sessions with per-character message history
- Connect to the game only after selecting a character
- Show tabs for active sessions with unread indicators and roster link when none
- Use React Router Link components for internal navigation

## Testing
- `uv run pre-commit run --files frontend/src/components/character/GalleriesSection.tsx frontend/src/game/components/GameWindow.tsx`
- `cd frontend && pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6894d2a110e48331a3aa18097c25b3da