### PR TITLE
feat: add error boundary for API queries

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,16 +1,23 @@
 import { ReactNode } from 'react';
 import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
 
 interface Props {
   children: ReactNode;
 }
 
-function ErrorFallback({ resetErrorBoundary }: { resetErrorBoundary: () => void }) {
+function ErrorFallback({
+  error,
+  resetErrorBoundary,
+}: {
+  error: Error;
+  resetErrorBoundary: () => void;
+}) {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <div className="text-center">
         <h2 className="text-2xl font-bold text-red-600">Something went wrong</h2>
-        <p className="mt-2 text-muted-foreground">Please refresh the page and try again.</p>
+        <p className="mt-2 text-muted-foreground">{error.message}</p>
         <button
           onClick={resetErrorBoundary}
           className="mt-4 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
@@ -24,13 +31,18 @@ function ErrorFallback({ resetErrorBoundary }: { resetErrorBoundary: () => void 
 
 export function ErrorBoundary({ children }: Props) {
   return (
-    <ReactErrorBoundary
-      FallbackComponent={ErrorFallback}
-      onError={(error, errorInfo) => {
-        console.error('Uncaught error:', error, errorInfo);
-      }}
-    >
-      {children}
-    </ReactErrorBoundary>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ReactErrorBoundary
+          FallbackComponent={ErrorFallback}
+          onReset={reset}
+          onError={(error, errorInfo) => {
+            console.error('Uncaught error:', error, errorInfo);
+          }}
+        >
+          {children}
+        </ReactErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   );
 }

--- a/frontend/src/evennia_replacements/HomePage.tsx
+++ b/frontend/src/evennia_replacements/HomePage.tsx
@@ -3,23 +3,12 @@ import { useHomeStatsQuery } from './queries';
 import { SITE_NAME } from '../config';
 
 export function HomePage() {
-  const { data, isLoading, error } = useHomeStatsQuery();
+  const { data, isLoading } = useHomeStatsQuery();
 
   if (isLoading) {
     return (
       <div className="flex min-h-96 items-center justify-center">
         <div className="text-lg">Loading homepage...</div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="container mx-auto mt-4">
-        <div className="text-center text-red-600">
-          <h2 className="text-xl font-bold">Failed to load homepage data</h2>
-          <p>Please try refreshing the page.</p>
-        </div>
       </div>
     );
   }

--- a/frontend/src/evennia_replacements/queries.tsx
+++ b/frontend/src/evennia_replacements/queries.tsx
@@ -13,7 +13,11 @@ import { setAccount } from '../store/authSlice';
 import { useEffect } from 'react';
 
 export function useHomeStatsQuery() {
-  return useQuery({ queryKey: ['homepage'], queryFn: fetchHomeStats });
+  return useQuery({
+    queryKey: ['homepage'],
+    queryFn: fetchHomeStats,
+    throwOnError: true,
+  });
 }
 
 export function useAccountQuery() {
@@ -21,6 +25,7 @@ export function useAccountQuery() {
   const result = useQuery({
     queryKey: ['account'],
     queryFn: fetchAccount,
+    throwOnError: true,
   });
 
   useEffect(() => {
@@ -59,6 +64,7 @@ export function useRosterEntryQuery(id: number) {
     queryKey: ['roster-entry', id],
     queryFn: () => fetchRosterEntry(id),
     enabled: !!id,
+    throwOnError: true,
   });
 }
 
@@ -67,6 +73,7 @@ export function useMyRosterEntriesQuery(enabled = true) {
     queryKey: ['my-roster-entries'],
     queryFn: fetchMyRosterEntries,
     enabled,
+    throwOnError: true,
   });
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import { store } from './store/store';
 import { AuthProvider } from './components/AuthProvider';
 import { ThemeProvider } from './components/theme-provider';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import App from './App';
 import './index.css';
 
@@ -22,18 +23,20 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <BrowserRouter>
-            <ThemeProvider
-              attribute="class"
-              defaultTheme="system"
-              enableSystem
-              disableTransitionOnChange
-            >
-              <App />
-            </ThemeProvider>
-          </BrowserRouter>
-        </AuthProvider>
+        <ErrorBoundary>
+          <AuthProvider>
+            <BrowserRouter>
+              <ThemeProvider
+                attribute="class"
+                defaultTheme="system"
+                enableSystem
+                disableTransitionOnChange
+              >
+                <App />
+              </ThemeProvider>
+            </BrowserRouter>
+          </AuthProvider>
+        </ErrorBoundary>
       </QueryClientProvider>
     </Provider>
   </StrictMode>

--- a/frontend/src/pages/CharacterSheetPage.tsx
+++ b/frontend/src/pages/CharacterSheetPage.tsx
@@ -12,10 +12,10 @@ import {
 export function CharacterSheetPage() {
   const { id } = useParams();
   const entryId = Number(id);
-  const { data: entry, isLoading, error } = useRosterEntryQuery(entryId);
+  const { data: entry, isLoading } = useRosterEntryQuery(entryId);
 
   if (isLoading) return <p className="p-4">Loading...</p>;
-  if (error || !entry) return <p className="p-4">Character not found.</p>;
+  if (!entry) return <p className="p-4">Character not found.</p>;
 
   return (
     <div className="container mx-auto space-y-4 p-4">


### PR DESCRIPTION
## Summary
- wrap API-driven pages in a reusable ErrorBoundary to surface request failures
- raise query errors to the boundary with React Query's `throwOnError`
- simplify pages now that ErrorBoundary handles API errors

## Testing
- `pnpm build`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689553516d0c8331b13738cf7e4bb711