### PR TITLE
Fix Prettier pre-commit arg handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,15 +63,16 @@ repos:
         args:
           - -c
           - |
-            cd frontend
-            cleaned=()
-            for file in "$@"; do
-              cleaned+=("${file#frontend/}")
-            done
-            pnpm exec prettier --write "${cleaned[@]}"
+              cd frontend
+              cleaned=()
+              for file in "$@"; do
+                cleaned+=("${file#frontend/}")
+              done
+              pnpm exec prettier --write --ignore-unknown "${cleaned[@]}"
+          - ""
         language: system
         pass_filenames: true
-        files: ^frontend/.*\.(ts|tsx|js|jsx|json|css|md)$
+        files: ^frontend/
       - id: frontend-build
         name: Frontend Build
         entry: bash


### PR DESCRIPTION
## Summary
- ensure Prettier hook passes a blank argument so first filename isn't swallowed by bash
- limit Prettier pre-commit hook to frontend files and ignore unknown types

## Testing
- `pnpm install`
- `uv run pre-commit run --files .pre-commit-config.yaml frontend/package.json`


------
https://chatgpt.com/codex/tasks/task_e_68956ec18c708331a85490e030672748