### PR TITLE
feat: add roster list page with filtering

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.2",
     "@reduxjs/toolkit": "^2.3.0",
     "@tanstack/react-query": "^5.62.2",
     "class-variance-authority": "^0.7.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.2
+        version: 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@reduxjs/toolkit':
         specifier: ^2.3.0
         version: 2.8.2(react-redux@9.2.0(@types/react@18.3.23)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
@@ -661,6 +664,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.12':
+    resolution: {integrity: sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -2531,6 +2547,22 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.23
+
+  '@radix-ui/react-tabs@1.1.12(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.23)(react@18.3.1)':
     dependencies:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,8 @@ import { GamePage } from './game/GamePage';
 import { LoginPage } from './evennia_replacements/LoginPage';
 import { ProfilePage } from './pages/ProfilePage';
 import { NotFoundPage } from './pages/NotFoundPage';
-import { CharacterSheetPage } from './pages/CharacterSheetPage';
+import { CharacterSheetPage } from './roster/pages/CharacterSheetPage';
+import { RosterListPage } from './roster/pages/RosterListPage';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/roster" element={<RosterListPage />} />
         <Route path="/characters/:id" element={<CharacterSheetPage />} />
         <Route path="/game" element={<GamePage />} />
         <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/components/ProfileDropdown.tsx
+++ b/frontend/src/components/ProfileDropdown.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
-import { useLogout, useMyRosterEntriesQuery } from '../evennia_replacements/queries';
+import { useLogout } from '../evennia_replacements/queries';
+import { useMyRosterEntriesQuery } from '../roster/queries';
 import type { AccountData } from '../evennia_replacements/types';
 import {
   DropdownMenu,

--- a/frontend/src/components/character/CharacterApplicationForm.tsx
+++ b/frontend/src/components/character/CharacterApplicationForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSendRosterApplication } from '../../evennia_replacements/queries';
+import { useSendRosterApplication } from '../../roster/queries';
 import { Button } from '../ui/button';
 import { Textarea } from '../ui/textarea';
 

--- a/frontend/src/components/character/CharacterPortrait.tsx
+++ b/frontend/src/components/character/CharacterPortrait.tsx
@@ -1,4 +1,4 @@
-import type { CharacterData } from '../../evennia_replacements/types';
+import type { CharacterData } from '../../roster/types';
 
 interface CharacterPortraitProps {
   character: CharacterData;

--- a/frontend/src/components/character/GalleriesSection.tsx
+++ b/frontend/src/components/character/GalleriesSection.tsx
@@ -1,4 +1,4 @@
-import type { CharacterGallery } from '../../evennia_replacements/types';
+import type { CharacterGallery } from '../../roster/types';
 import { Link } from 'react-router-dom';
 
 interface GalleriesSectionProps {

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  )
+);
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+));
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn('bg-primary font-medium text-primary-foreground', className)}
+    {...props}
+  />
+));
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    {...props}
+  />
+));
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+));
+TableCaption.displayName = 'TableCaption';
+
+export { Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, TableCaption };

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { cn } from '../../lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/frontend/src/evennia_replacements/api.ts
+++ b/frontend/src/evennia_replacements/api.ts
@@ -1,11 +1,11 @@
-import type { AccountData, HomeStats, RosterEntryData, MyRosterEntry } from './types';
+import type { AccountData, HomeStats } from './types';
 import { getCookie } from '../lib/utils';
 
 function getCSRFToken(): string {
   return getCookie('csrftoken') || '';
 }
 
-function apiFetch(url: string, options: RequestInit = {}) {
+export function apiFetch(url: string, options: RequestInit = {}) {
   const method = options.method?.toUpperCase() ?? 'GET';
   const headers = new Headers(options.headers);
 
@@ -53,30 +53,4 @@ export async function postLogin(data: {
 
 export async function postLogout(): Promise<void> {
   await apiFetch('/api/logout/', { method: 'POST' });
-}
-
-export async function fetchRosterEntry(id: number): Promise<RosterEntryData> {
-  const res = await apiFetch(`/api/roster/${id}/`);
-  if (!res.ok) {
-    throw new Error('Failed to load roster entry');
-  }
-  return res.json();
-}
-
-export async function fetchMyRosterEntries(): Promise<MyRosterEntry[]> {
-  const res = await apiFetch('/api/roster/mine/');
-  if (!res.ok) {
-    throw new Error('Failed to load characters');
-  }
-  return res.json();
-}
-
-export async function postRosterApplication(id: number, message: string): Promise<void> {
-  const res = await apiFetch(`/api/roster/${id}/apply/`, {
-    method: 'POST',
-    body: JSON.stringify({ message }),
-  });
-  if (!res.ok) {
-    throw new Error(`Failed to send application for character ${id}`);
-  }
 }

--- a/frontend/src/evennia_replacements/queries.tsx
+++ b/frontend/src/evennia_replacements/queries.tsx
@@ -1,13 +1,5 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
-import {
-  fetchHomeStats,
-  fetchAccount,
-  postLogin,
-  postLogout,
-  fetchRosterEntry,
-  fetchMyRosterEntries,
-  postRosterApplication,
-} from './api';
+import { fetchHomeStats, fetchAccount, postLogin, postLogout } from './api';
 import { useAppDispatch } from '../store/hooks';
 import { setAccount } from '../store/authSlice';
 import { useEffect } from 'react';
@@ -56,29 +48,5 @@ export function useLogout(onSuccess?: () => void) {
       dispatch(setAccount(null));
       onSuccess?.();
     },
-  });
-}
-
-export function useRosterEntryQuery(id: number) {
-  return useQuery({
-    queryKey: ['roster-entry', id],
-    queryFn: () => fetchRosterEntry(id),
-    enabled: !!id,
-    throwOnError: true,
-  });
-}
-
-export function useMyRosterEntriesQuery(enabled = true) {
-  return useQuery({
-    queryKey: ['my-roster-entries'],
-    queryFn: fetchMyRosterEntries,
-    enabled,
-    throwOnError: true,
-  });
-}
-
-export function useSendRosterApplication(id: number) {
-  return useMutation({
-    mutationFn: (message: string) => postRosterApplication(id, message),
   });
 }

--- a/frontend/src/evennia_replacements/types.ts
+++ b/frontend/src/evennia_replacements/types.ts
@@ -18,29 +18,3 @@ export interface AccountData {
   last_login: string | null;
   avatar_url?: string;
 }
-
-export interface MyRosterEntry {
-  id: number;
-  name: string;
-}
-
-export interface CharacterGallery {
-  name: string;
-  url: string;
-}
-
-export interface CharacterData {
-  id: number;
-  name: string;
-  portrait: string;
-  background?: string;
-  stats?: Record<string, number>;
-  relationships?: string[];
-  galleries: CharacterGallery[];
-}
-
-export interface RosterEntryData {
-  id: number;
-  character: CharacterData;
-  can_apply: boolean;
-}

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -1,7 +1,7 @@
 import { GameWindow } from './components/GameWindow';
 import { CharacterPanel } from './components/CharacterPanel';
 import { QuickActions } from './components/QuickActions';
-import { useMyRosterEntriesQuery } from '../evennia_replacements/queries';
+import { useMyRosterEntriesQuery } from '../roster/queries';
 
 export function GamePage() {
   const { data: characters = [] } = useMyRosterEntriesQuery();

--- a/frontend/src/game/components/CharacterPanel.tsx
+++ b/frontend/src/game/components/CharacterPanel.tsx
@@ -1,7 +1,7 @@
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { startSession } from '../../store/gameSlice';
 import { useGameSocket } from '../../hooks/useGameSocket';
-import type { MyRosterEntry } from '../../evennia_replacements/types';
+import type { MyRosterEntry } from '../../roster/types';
 
 interface CharacterPanelProps {
   characters: MyRosterEntry[];

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { setActiveSession } from '../../store/gameSlice';
 import { useGameSocket } from '../../hooks/useGameSocket';
 import { Link } from 'react-router-dom';
-import type { MyRosterEntry } from '../../evennia_replacements/types';
+import type { MyRosterEntry } from '../../roster/types';
 
 interface GameWindowProps {
   characters: MyRosterEntry[];

--- a/frontend/src/roster/api.ts
+++ b/frontend/src/roster/api.ts
@@ -1,0 +1,53 @@
+import type { RosterEntryData, MyRosterEntry, RosterData } from './types';
+import type { PaginatedResponse } from '@/shared/types';
+import { apiFetch } from '../evennia_replacements/api';
+
+export async function fetchRosterEntry(id: number): Promise<RosterEntryData> {
+  const res = await apiFetch(`/api/roster/${id}/`);
+  if (!res.ok) {
+    throw new Error('Failed to load roster entry');
+  }
+  return res.json();
+}
+
+export async function fetchMyRosterEntries(): Promise<MyRosterEntry[]> {
+  const res = await apiFetch('/api/roster/mine/');
+  if (!res.ok) {
+    throw new Error('Failed to load characters');
+  }
+  return res.json();
+}
+
+export async function fetchRosters(): Promise<RosterData[]> {
+  const res = await apiFetch('/api/roster/rosters/');
+  if (!res.ok) {
+    throw new Error('Failed to load rosters');
+  }
+  return res.json();
+}
+
+export async function fetchRosterEntries(
+  rosterId: number,
+  page = 1,
+  filters: { name?: string; class?: string; gender?: string } = {}
+): Promise<PaginatedResponse<RosterEntryData>> {
+  const params = new URLSearchParams({ roster: String(rosterId), page: String(page) });
+  if (filters.name) params.set('name', filters.name);
+  if (filters.class) params.set('class', filters.class);
+  if (filters.gender) params.set('gender', filters.gender);
+  const res = await apiFetch(`/api/roster/?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error('Failed to load roster entries');
+  }
+  return res.json();
+}
+
+export async function postRosterApplication(id: number, message: string): Promise<void> {
+  const res = await apiFetch(`/api/roster/${id}/apply/`, {
+    method: 'POST',
+    body: JSON.stringify({ message }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to send application for character ${id}`);
+  }
+}

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { useRosterEntryQuery } from '../evennia_replacements/queries';
+import { useRosterEntryQuery } from '../queries';
 import {
   CharacterPortrait,
   BackgroundSection,
@@ -7,7 +7,7 @@ import {
   RelationshipsSection,
   GalleriesSection,
   CharacterApplicationForm,
-} from '../components/character';
+} from '../../components/character';
 
 export function CharacterSheetPage() {
   const { id } = useParams();

--- a/frontend/src/roster/pages/RosterListPage.tsx
+++ b/frontend/src/roster/pages/RosterListPage.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useRostersQuery, useRosterEntriesQuery } from '../queries';
+import type { RosterEntryData } from '../types';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../components/ui/tabs';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '../../components/ui/table';
+import { Input } from '../../components/ui/input';
+import { Button } from '../../components/ui/button';
+
+export function RosterListPage() {
+  const { data: rosters, isLoading: rostersLoading } = useRostersQuery();
+  const [activeRoster, setActiveRoster] = useState<number | undefined>(undefined);
+  const [page, setPage] = useState(1);
+  const [filters, setFilters] = useState({ name: '', class: '', gender: '' });
+
+  useEffect(() => {
+    if (rosters && activeRoster === undefined) {
+      const available = rosters.find((r) => r.name === 'Available') ?? rosters[0];
+      setActiveRoster(available?.id);
+    }
+  }, [rosters, activeRoster]);
+
+  const { data: entryPage, isLoading: entriesLoading } = useRosterEntriesQuery(
+    activeRoster,
+    page,
+    filters
+  );
+
+  if (rostersLoading) return <p className="p-4">Loading...</p>;
+  if (!rosters || rosters.length === 0) return <p className="p-4">No rosters found.</p>;
+
+  const handleFilterChange = (key: 'name' | 'class' | 'gender', value: string) => {
+    setPage(1);
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div className="container mx-auto space-y-4 p-4">
+      <Tabs
+        value={activeRoster ? String(activeRoster) : undefined}
+        onValueChange={(v: string) => {
+          setActiveRoster(Number(v));
+          setPage(1);
+        }}
+      >
+        <TabsList>
+          {rosters.map((r) => (
+            <TabsTrigger key={r.id} value={String(r.id)}>
+              {r.name}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {rosters.map((r) => (
+          <TabsContent key={r.id} value={String(r.id)}>
+            <div className="mb-4 flex gap-2">
+              <Input
+                placeholder="Name"
+                value={filters.name}
+                onChange={(e) => handleFilterChange('name', e.target.value)}
+              />
+              <Input
+                placeholder="Class"
+                value={filters.class}
+                onChange={(e) => handleFilterChange('class', e.target.value)}
+              />
+              <Input
+                placeholder="Gender"
+                value={filters.gender}
+                onChange={(e) => handleFilterChange('gender', e.target.value)}
+              />
+            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Portrait</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Gender</TableHead>
+                  <TableHead>Class</TableHead>
+                  <TableHead>Level</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {entriesLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={5}>Loading...</TableCell>
+                  </TableRow>
+                ) : (
+                  entryPage?.results?.map((entry: RosterEntryData) => (
+                    <TableRow key={entry.id}>
+                      <TableCell>
+                        <Link to={`/characters/${entry.character.id}`}>
+                          {entry.character.portrait ? (
+                            <img
+                              src={entry.character.portrait}
+                              alt={entry.character.name}
+                              className="h-16 w-16 object-cover"
+                            />
+                          ) : (
+                            <div className="h-16 w-16 bg-gray-200" />
+                          )}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <Link to={`/characters/${entry.character.id}`} className="underline">
+                          {entry.character.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell>{entry.character.gender ?? '—'}</TableCell>
+                      <TableCell>{entry.character.class ?? '—'}</TableCell>
+                      <TableCell>{entry.character.level ?? '—'}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+            <div className="mt-4 flex justify-between">
+              <Button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={!entryPage?.previous}
+              >
+                Previous
+              </Button>
+              <Button onClick={() => setPage((p) => p + 1)} disabled={!entryPage?.next}>
+                Next
+              </Button>
+            </div>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/roster/queries.ts
+++ b/frontend/src/roster/queries.ts
@@ -1,0 +1,55 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import {
+  fetchRosterEntry,
+  fetchMyRosterEntries,
+  fetchRosters,
+  fetchRosterEntries,
+  postRosterApplication,
+} from './api';
+import type { RosterEntryData } from './types';
+import type { PaginatedResponse } from '@/shared/types';
+
+export function useRosterEntryQuery(id: number) {
+  return useQuery({
+    queryKey: ['roster-entry', id],
+    queryFn: () => fetchRosterEntry(id),
+    enabled: !!id,
+    throwOnError: true,
+  });
+}
+
+export function useMyRosterEntriesQuery(enabled = true) {
+  return useQuery({
+    queryKey: ['my-roster-entries'],
+    queryFn: fetchMyRosterEntries,
+    enabled,
+    throwOnError: true,
+  });
+}
+
+export function useRostersQuery() {
+  return useQuery({
+    queryKey: ['rosters'],
+    queryFn: fetchRosters,
+    throwOnError: true,
+  });
+}
+
+export function useRosterEntriesQuery(
+  rosterId: number | undefined,
+  page: number,
+  filters: { name?: string; class?: string; gender?: string }
+) {
+  return useQuery<PaginatedResponse<RosterEntryData>>({
+    queryKey: ['roster-entries', rosterId, page, filters],
+    queryFn: () => fetchRosterEntries(rosterId!, page, filters),
+    enabled: !!rosterId,
+    throwOnError: true,
+  });
+}
+
+export function useSendRosterApplication(id: number) {
+  return useMutation({
+    mutationFn: (message: string) => postRosterApplication(id, message),
+  });
+}

--- a/frontend/src/roster/types.ts
+++ b/frontend/src/roster/types.ts
@@ -1,0 +1,36 @@
+export interface MyRosterEntry {
+  id: number;
+  name: string;
+}
+
+export interface CharacterGallery {
+  name: string;
+  url: string;
+}
+
+export interface CharacterData {
+  id: number;
+  name: string;
+  portrait: string;
+  gender?: string | null;
+  class?: string | null;
+  level?: number | null;
+  background?: string;
+  stats?: Record<string, number>;
+  relationships?: string[];
+  galleries: CharacterGallery[];
+}
+
+export interface RosterEntryData {
+  id: number;
+  character: CharacterData;
+  can_apply: boolean;
+}
+
+export interface RosterData {
+  id: number;
+  name: string;
+  description: string;
+  is_active: boolean;
+  available_count: number;
+}

--- a/frontend/src/shared/types.ts
+++ b/frontend/src/shared/types.ts
@@ -1,0 +1,6 @@
+export interface PaginatedResponse<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}


### PR DESCRIPTION
## Summary
- add optional gender, class, and level fields to character type
- implement roster list page with roster tabs, filtering, and pagination
- add API helpers and hooks to load rosters and roster entries
- group roster-related API, types, queries, and pages under src/roster
- centralize reusable PaginatedResponse type under src/shared for broader use

## Testing
- `pnpm build`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689578f115c08331b1dcbfb180ae95aa