### PR TITLE
Add roster filters, pagination, and nested serializers

### DIFF
--- a/frontend/src/components/character/BackgroundSection.tsx
+++ b/frontend/src/components/character/BackgroundSection.tsx
@@ -1,5 +1,7 @@
+import type { CharacterData } from '../../roster/types';
+
 interface BackgroundSectionProps {
-  background?: string;
+  background?: CharacterData['background'];
 }
 
 export function BackgroundSection({ background }: BackgroundSectionProps) {

--- a/frontend/src/components/character/CharacterApplicationForm.tsx
+++ b/frontend/src/components/character/CharacterApplicationForm.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react';
 import { useSendRosterApplication } from '../../roster/queries';
 import { Button } from '../ui/button';
 import { Textarea } from '../ui/textarea';
+import type { RosterEntryData } from '../../roster/types';
 
 interface CharacterApplicationFormProps {
-  entryId: number;
+  entryId: RosterEntryData['id'];
 }
 
 export function CharacterApplicationForm({ entryId }: CharacterApplicationFormProps) {

--- a/frontend/src/components/character/CharacterPortrait.tsx
+++ b/frontend/src/components/character/CharacterPortrait.tsx
@@ -1,18 +1,23 @@
-import type { CharacterData } from '../../roster/types';
+import type { CharacterData, TenureMedia } from '../../roster/types';
 
 interface CharacterPortraitProps {
-  character: CharacterData;
+  name: CharacterData['name'];
+  profilePicture?: TenureMedia['cloudinary_url'] | null;
 }
 
-export function CharacterPortrait({ character }: CharacterPortraitProps) {
+export function CharacterPortrait({ name, profilePicture }: CharacterPortraitProps) {
   return (
     <div className="flex flex-col items-start gap-4 sm:flex-row">
-      <img
-        src={character.portrait}
-        alt={`${character.name} portrait`}
-        className="h-48 w-48 rounded object-cover"
-      />
-      <h2 className="text-2xl font-bold">{character.name}</h2>
+      {profilePicture ? (
+        <img
+          src={profilePicture}
+          alt={`${name} portrait`}
+          className="h-48 w-48 rounded object-cover"
+        />
+      ) : (
+        <div className="h-48 w-48 rounded bg-gray-200" />
+      )}
+      <h2 className="text-2xl font-bold">{name}</h2>
     </div>
   );
 }

--- a/frontend/src/components/character/GalleriesSection.tsx
+++ b/frontend/src/components/character/GalleriesSection.tsx
@@ -1,8 +1,8 @@
-import type { CharacterGallery } from '../../roster/types';
 import { Link } from 'react-router-dom';
+import type { CharacterData } from '../../roster/types';
 
 interface GalleriesSectionProps {
-  galleries: CharacterGallery[];
+  galleries: CharacterData['galleries'];
 }
 
 export function GalleriesSection({ galleries }: GalleriesSectionProps) {

--- a/frontend/src/components/character/RelationshipsSection.tsx
+++ b/frontend/src/components/character/RelationshipsSection.tsx
@@ -1,5 +1,7 @@
+import type { CharacterData } from '../../roster/types';
+
 interface RelationshipsSectionProps {
-  relationships?: string[];
+  relationships?: CharacterData['relationships'];
 }
 
 export function RelationshipsSection({ relationships }: RelationshipsSectionProps) {

--- a/frontend/src/components/character/StatsSection.tsx
+++ b/frontend/src/components/character/StatsSection.tsx
@@ -1,5 +1,7 @@
+import type { CharacterData } from '../../roster/types';
+
 interface StatsSectionProps {
-  stats?: Record<string, number>;
+  stats?: CharacterData['stats'];
 }
 
 export function StatsSection({ stats }: StatsSectionProps) {

--- a/frontend/src/game/components/CharacterPanel.tsx
+++ b/frontend/src/game/components/CharacterPanel.tsx
@@ -13,7 +13,7 @@ export function CharacterPanel({ characters }: CharacterPanelProps) {
   const sessions = useAppSelector((state) => state.game.sessions);
   const active = useAppSelector((state) => state.game.active);
 
-  const handleSelect = (name: string) => {
+  const handleSelect = (name: MyRosterEntry['name']) => {
     dispatch(startSession(name));
     if (!sessions[name]?.isConnected) {
       connect(name);

--- a/frontend/src/game/components/CommandInput.tsx
+++ b/frontend/src/game/components/CommandInput.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { useGameSocket } from '../../hooks/useGameSocket';
 import { Input } from '../../components/ui/input';
+import type { MyRosterEntry } from '../../roster/types';
 
 interface CommandInputProps {
-  character: string;
+  character: MyRosterEntry['name'];
 }
 
 export function CommandInput({ character }: CommandInputProps) {

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -44,7 +44,7 @@ export function GameWindow({ characters }: GameWindowProps) {
 
   const session = sessions[active];
 
-  const handleTabClick = (name: string) => {
+  const handleTabClick = (name: MyRosterEntry['name']) => {
     dispatch(setActiveSession(name));
     if (!sessions[name].isConnected) {
       connect(name);

--- a/frontend/src/hooks/useGameSocket.ts
+++ b/frontend/src/hooks/useGameSocket.ts
@@ -4,6 +4,7 @@ import { parseGameMessage } from './parseGameMessage';
 import { WS_MESSAGE_TYPE } from './types';
 import type { OutgoingMessage } from './types';
 import { useCallback } from 'react';
+import type { MyRosterEntry } from '../roster/types';
 
 const sockets: Record<string, WebSocket> = {};
 
@@ -12,7 +13,7 @@ export function useGameSocket() {
   const account = useAppSelector((state) => state.auth.account);
 
   const connect = useCallback(
-    (character: string) => {
+    (character: MyRosterEntry['name']) => {
       if (sockets[character]) return;
 
       // Check if user is authenticated
@@ -48,7 +49,7 @@ export function useGameSocket() {
     [dispatch, account]
   );
 
-  const send = useCallback((character: string, command: string) => {
+  const send = useCallback((character: MyRosterEntry['name'], command: string) => {
     const socket = sockets[character];
     if (socket && socket.readyState === WebSocket.OPEN) {
       const message: OutgoingMessage = [WS_MESSAGE_TYPE.TEXT, [command], {}];

--- a/frontend/src/roster/api.ts
+++ b/frontend/src/roster/api.ts
@@ -1,8 +1,8 @@
-import type { RosterEntryData, MyRosterEntry, RosterData } from './types';
+import type { RosterEntryData, MyRosterEntry, RosterData, CharacterData } from './types';
 import type { PaginatedResponse } from '@/shared/types';
 import { apiFetch } from '../evennia_replacements/api';
 
-export async function fetchRosterEntry(id: number): Promise<RosterEntryData> {
+export async function fetchRosterEntry(id: RosterEntryData['id']): Promise<RosterEntryData> {
   const res = await apiFetch(`/api/roster/${id}/`);
   if (!res.ok) {
     throw new Error('Failed to load roster entry');
@@ -27,13 +27,13 @@ export async function fetchRosters(): Promise<RosterData[]> {
 }
 
 export async function fetchRosterEntries(
-  rosterId: number,
+  rosterId: RosterData['id'],
   page = 1,
-  filters: { name?: string; class?: string; gender?: string } = {}
+  filters: Partial<Pick<CharacterData, 'name' | 'char_class' | 'gender'>> = {}
 ): Promise<PaginatedResponse<RosterEntryData>> {
   const params = new URLSearchParams({ roster: String(rosterId), page: String(page) });
   if (filters.name) params.set('name', filters.name);
-  if (filters.class) params.set('class', filters.class);
+  if (filters.char_class) params.set('char_class', filters.char_class);
   if (filters.gender) params.set('gender', filters.gender);
   const res = await apiFetch(`/api/roster/?${params.toString()}`);
   if (!res.ok) {
@@ -41,8 +41,10 @@ export async function fetchRosterEntries(
   }
   return res.json();
 }
-
-export async function postRosterApplication(id: number, message: string): Promise<void> {
+export async function postRosterApplication(
+  id: RosterEntryData['id'],
+  message: string
+): Promise<void> {
   const res = await apiFetch(`/api/roster/${id}/apply/`, {
     method: 'POST',
     body: JSON.stringify({ message }),

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -19,7 +19,10 @@ export function CharacterSheetPage() {
 
   return (
     <div className="container mx-auto space-y-4 p-4">
-      <CharacterPortrait character={entry.character} />
+      <CharacterPortrait
+        name={entry.character.name}
+        profilePicture={entry.profile_picture?.cloudinary_url}
+      />
       <BackgroundSection background={entry.character.background} />
       <StatsSection stats={entry.character.stats} />
       <RelationshipsSection relationships={entry.character.relationships} />

--- a/frontend/src/roster/pages/RosterListPage.tsx
+++ b/frontend/src/roster/pages/RosterListPage.tsx
@@ -18,12 +18,11 @@ export function RosterListPage() {
   const { data: rosters, isLoading: rostersLoading } = useRostersQuery();
   const [activeRoster, setActiveRoster] = useState<number | undefined>(undefined);
   const [page, setPage] = useState(1);
-  const [filters, setFilters] = useState({ name: '', class: '', gender: '' });
+  const [filters, setFilters] = useState({ name: '', char_class: '', gender: '' });
 
   useEffect(() => {
     if (rosters && activeRoster === undefined) {
-      const available = rosters.find((r) => r.name === 'Available') ?? rosters[0];
-      setActiveRoster(available?.id);
+      setActiveRoster(rosters[0]?.id);
     }
   }, [rosters, activeRoster]);
 
@@ -36,7 +35,7 @@ export function RosterListPage() {
   if (rostersLoading) return <p className="p-4">Loading...</p>;
   if (!rosters || rosters.length === 0) return <p className="p-4">No rosters found.</p>;
 
-  const handleFilterChange = (key: 'name' | 'class' | 'gender', value: string) => {
+  const handleFilterChange = (key: 'name' | 'char_class' | 'gender', value: string) => {
     setPage(1);
     setFilters((prev) => ({ ...prev, [key]: value }));
   };
@@ -67,8 +66,8 @@ export function RosterListPage() {
               />
               <Input
                 placeholder="Class"
-                value={filters.class}
-                onChange={(e) => handleFilterChange('class', e.target.value)}
+                value={filters.char_class}
+                onChange={(e) => handleFilterChange('char_class', e.target.value)}
               />
               <Input
                 placeholder="Gender"
@@ -96,9 +95,9 @@ export function RosterListPage() {
                     <TableRow key={entry.id}>
                       <TableCell>
                         <Link to={`/characters/${entry.character.id}`}>
-                          {entry.character.portrait ? (
+                          {entry.profile_picture ? (
                             <img
-                              src={entry.character.portrait}
+                              src={entry.profile_picture.cloudinary_url}
                               alt={entry.character.name}
                               className="h-16 w-16 object-cover"
                             />
@@ -113,7 +112,7 @@ export function RosterListPage() {
                         </Link>
                       </TableCell>
                       <TableCell>{entry.character.gender ?? '—'}</TableCell>
-                      <TableCell>{entry.character.class ?? '—'}</TableCell>
+                      <TableCell>{entry.character.char_class ?? '—'}</TableCell>
                       <TableCell>{entry.character.level ?? '—'}</TableCell>
                     </TableRow>
                   ))

--- a/frontend/src/roster/queries.ts
+++ b/frontend/src/roster/queries.ts
@@ -6,10 +6,10 @@ import {
   fetchRosterEntries,
   postRosterApplication,
 } from './api';
-import type { RosterEntryData } from './types';
+import type { RosterEntryData, RosterData, CharacterData } from './types';
 import type { PaginatedResponse } from '@/shared/types';
 
-export function useRosterEntryQuery(id: number) {
+export function useRosterEntryQuery(id: RosterEntryData['id']) {
   return useQuery({
     queryKey: ['roster-entry', id],
     queryFn: () => fetchRosterEntry(id),
@@ -36,9 +36,9 @@ export function useRostersQuery() {
 }
 
 export function useRosterEntriesQuery(
-  rosterId: number | undefined,
+  rosterId: RosterData['id'] | undefined,
   page: number,
-  filters: { name?: string; class?: string; gender?: string }
+  filters: Partial<Pick<CharacterData, 'name' | 'char_class' | 'gender'>>
 ) {
   return useQuery<PaginatedResponse<RosterEntryData>>({
     queryKey: ['roster-entries', rosterId, page, filters],
@@ -48,7 +48,7 @@ export function useRosterEntriesQuery(
   });
 }
 
-export function useSendRosterApplication(id: number) {
+export function useSendRosterApplication(id: RosterEntryData['id']) {
   return useMutation({
     mutationFn: (message: string) => postRosterApplication(id, message),
   });

--- a/frontend/src/roster/types.ts
+++ b/frontend/src/roster/types.ts
@@ -1,6 +1,6 @@
 export interface MyRosterEntry {
   id: number;
-  name: string;
+  name: CharacterData['name'];
 }
 
 export interface CharacterGallery {
@@ -11,9 +11,8 @@ export interface CharacterGallery {
 export interface CharacterData {
   id: number;
   name: string;
-  portrait: string;
   gender?: string | null;
-  class?: string | null;
+  char_class?: string | null;
   level?: number | null;
   background?: string;
   stats?: Record<string, number>;
@@ -24,6 +23,8 @@ export interface CharacterData {
 export interface RosterEntryData {
   id: number;
   character: CharacterData;
+  profile_picture: TenureMedia | null;
+  tenures: RosterTenure[];
   can_apply: boolean;
 }
 
@@ -33,4 +34,30 @@ export interface RosterData {
   description: string;
   is_active: boolean;
   available_count: number;
+}
+
+export interface TenureMedia {
+  id: number;
+  cloudinary_public_id: string;
+  cloudinary_url: string;
+  media_type: string;
+  title: string;
+  description: string;
+  sort_order: number;
+  is_public: boolean;
+  uploaded_date: string;
+  updated_date: string;
+}
+
+export interface RosterTenure {
+  id: number;
+  player_number: number;
+  start_date: string;
+  end_date: string | null;
+  applied_date: string;
+  approved_date: string | null;
+  approved_by: number | null;
+  tenure_notes: string;
+  photo_folder: string;
+  media: TenureMedia[];
 }

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { GameMessage } from '../hooks/types';
+import type { MyRosterEntry } from '../roster/types';
 
 interface Session {
   isConnected: boolean;
@@ -9,7 +10,7 @@ interface Session {
 
 interface GameState {
   sessions: Record<string, Session>;
-  active: string | null;
+  active: MyRosterEntry['name'] | null;
 }
 
 const initialState: GameState = {
@@ -21,7 +22,7 @@ export const gameSlice = createSlice({
   name: 'game',
   initialState,
   reducers: {
-    startSession: (state, action: PayloadAction<string>) => {
+    startSession: (state, action: PayloadAction<MyRosterEntry['name']>) => {
       const name = action.payload;
       if (!state.sessions[name]) {
         state.sessions[name] = { isConnected: false, messages: [], unread: 0 };
@@ -29,7 +30,7 @@ export const gameSlice = createSlice({
       state.active = name;
       state.sessions[name].unread = 0;
     },
-    setActiveSession: (state, action: PayloadAction<string>) => {
+    setActiveSession: (state, action: PayloadAction<MyRosterEntry['name']>) => {
       const name = action.payload;
       if (state.sessions[name]) {
         state.active = name;
@@ -38,7 +39,7 @@ export const gameSlice = createSlice({
     },
     setSessionConnectionStatus: (
       state,
-      action: PayloadAction<{ character: string; status: boolean }>,
+      action: PayloadAction<{ character: MyRosterEntry['name']; status: boolean }>
     ) => {
       const { character, status } = action.payload;
       const session = state.sessions[character];
@@ -48,7 +49,7 @@ export const gameSlice = createSlice({
     },
     addSessionMessage: (
       state,
-      action: PayloadAction<{ character: string; message: GameMessage }>,
+      action: PayloadAction<{ character: MyRosterEntry['name']; message: GameMessage }>
     ) => {
       const { character, message } = action.payload;
       const session = state.sessions[character];
@@ -59,7 +60,7 @@ export const gameSlice = createSlice({
         }
       }
     },
-    clearSessionMessages: (state, action: PayloadAction<string>) => {
+    clearSessionMessages: (state, action: PayloadAction<MyRosterEntry['name']>) => {
       const session = state.sessions[action.payload];
       if (session) {
         session.messages = [];

--- a/src/world/roster/filters.py
+++ b/src/world/roster/filters.py
@@ -1,0 +1,30 @@
+import django_filters
+
+from world.roster.models import RosterEntry
+
+
+class RosterEntryFilterSet(django_filters.FilterSet):
+    """Filter roster entries by related character attributes."""
+
+    gender = django_filters.CharFilter(method="filter_gender")
+    char_class = django_filters.CharFilter(method="filter_char_class")
+    name = django_filters.CharFilter(
+        field_name="character__db_key", lookup_expr="icontains"
+    )
+    roster = django_filters.NumberFilter(field_name="roster_id")
+
+    class Meta:
+        model = RosterEntry
+        fields = ["gender", "char_class", "name", "roster"]
+
+    def filter_gender(self, queryset, name, value):
+        return queryset.filter(
+            character__db_attributes__db_key="gender",
+            character__db_attributes__db_value__icontains=value,
+        )
+
+    def filter_char_class(self, queryset, name, value):
+        return queryset.filter(
+            character__db_attributes__db_key="class",
+            character__db_attributes__db_value__icontains=value,
+        )

--- a/src/world/roster/views.py
+++ b/src/world/roster/views.py
@@ -11,13 +11,16 @@ from django.db.models import Prefetch
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_http_methods
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
 from evennia_extensions.models import PlayerData
 from world.roster.email_service import RosterEmailService
+from world.roster.filters import RosterEntryFilterSet
 from world.roster.models import MediaType, RosterEntry, RosterTenure, TenureMedia
 from world.roster.serializers import (
     MyRosterEntrySerializer,
@@ -215,11 +218,20 @@ def roster_list(request):
     return render(request, "roster/roster_list.html", context)
 
 
+class RosterEntryPagination(PageNumberPagination):
+    """Default pagination for roster entries."""
+
+    page_size = 20
+
+
 class RosterEntryViewSet(viewsets.ReadOnlyModelViewSet):
     """Expose roster entries and related actions."""
 
     serializer_class = RosterEntrySerializer
     permission_classes = [AllowAny]
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = RosterEntryFilterSet
+    pagination_class = RosterEntryPagination
 
     def get_queryset(self):
         """Return a queryset of roster entries."""


### PR DESCRIPTION
## Summary
- expose profile pictures and tenure media in roster entry serializers
- add filterset and pagination to roster entry viewset
- align frontend types and pages with backend models and remove hardcoded roster order
- reference backend model field types in frontend props, queries, store, and hooks for consistency

## Testing
- `pnpm exec prettier src/components/character/CharacterPortrait.tsx src/components/character/BackgroundSection.tsx src/components/character/StatsSection.tsx src/components/character/RelationshipsSection.tsx src/components/character/GalleriesSection.tsx src/components/character/CharacterApplicationForm.tsx src/roster/api.ts src/roster/queries.ts src/game/components/CharacterPanel.tsx src/game/components/GameWindow.tsx src/game/components/CommandInput.tsx src/store/gameSlice.ts src/hooks/useGameSocket.ts src/roster/types.ts --write`
- `uv run pre-commit run --files frontend/src/components/character/CharacterPortrait.tsx frontend/src/components/character/BackgroundSection.tsx frontend/src/components/character/StatsSection.tsx frontend/src/components/character/RelationshipsSection.tsx frontend/src/components/character/GalleriesSection.tsx frontend/src/components/character/CharacterApplicationForm.tsx frontend/src/roster/api.ts frontend/src/roster/queries.ts frontend/src/game/components/CharacterPanel.tsx frontend/src/game/components/GameWindow.tsx frontend/src/game/components/CommandInput.tsx frontend/src/store/gameSlice.ts frontend/src/hooks/useGameSocket.ts frontend/src/roster/types.ts`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_68967cd7ddcc8331b551463e18eac92b