### PR TITLE
Clear frontend state and sockets on logout

### DIFF
--- a/frontend/src/evennia_replacements/queries.tsx
+++ b/frontend/src/evennia_replacements/queries.tsx
@@ -1,7 +1,9 @@
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchHomeStats, fetchAccount, postLogin, postLogout } from './api';
 import { useAppDispatch } from '../store/hooks';
 import { setAccount } from '../store/authSlice';
+import { resetGame } from '../store/gameSlice';
+import { useGameSocket } from '../hooks/useGameSocket';
 import { useEffect } from 'react';
 
 export function useHomeStatsQuery() {
@@ -42,10 +44,15 @@ export function useLogin(onSuccess?: () => void) {
 
 export function useLogout(onSuccess?: () => void) {
   const dispatch = useAppDispatch();
+  const queryClient = useQueryClient();
+  const { disconnectAll } = useGameSocket();
   return useMutation({
     mutationFn: postLogout,
     onSuccess: () => {
+      disconnectAll();
+      dispatch(resetGame());
       dispatch(setAccount(null));
+      queryClient.clear();
       onSuccess?.();
     },
   });

--- a/frontend/src/hooks/useGameSocket.ts
+++ b/frontend/src/hooks/useGameSocket.ts
@@ -58,5 +58,9 @@ export function useGameSocket() {
     }
   }, []);
 
-  return { connect, send };
+  const disconnectAll = useCallback(() => {
+    Object.values(sockets).forEach((socket) => socket.close());
+  }, []);
+
+  return { connect, send, disconnectAll };
 }

--- a/frontend/src/roster/queries.ts
+++ b/frontend/src/roster/queries.ts
@@ -8,6 +8,7 @@ import {
 } from './api';
 import type { RosterEntryData, RosterData, CharacterData } from './types';
 import type { PaginatedResponse } from '@/shared/types';
+import { useAccount } from '@/store/hooks';
 
 export function useRosterEntryQuery(id: RosterEntryData['id']) {
   return useQuery({
@@ -19,10 +20,11 @@ export function useRosterEntryQuery(id: RosterEntryData['id']) {
 }
 
 export function useMyRosterEntriesQuery(enabled = true) {
+  const account = useAccount();
   return useQuery({
     queryKey: ['my-roster-entries'],
     queryFn: fetchMyRosterEntries,
-    enabled,
+    enabled: !!account && enabled,
     throwOnError: true,
   });
 }

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -66,6 +66,7 @@ export const gameSlice = createSlice({
         session.messages = [];
       }
     },
+    resetGame: () => initialState,
   },
 });
 
@@ -75,4 +76,5 @@ export const {
   setSessionConnectionStatus,
   addSessionMessage,
   clearSessionMessages,
+  resetGame,
 } = gameSlice.actions;


### PR DESCRIPTION
## Summary
- reset game sessions and disconnect websockets when logging out
- clear query cache and auth state to remove character listings post-logout
- skip `/mine` roster calls unless authenticated

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6897ba4663688331a875ea5002a5c804