### PR TITLE
Add roster application availability controls

### DIFF
--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -54,15 +54,6 @@ class Character(ObjectParent, DefaultCharacter):
 
         return TraitHandler(self)
 
-    @cached_property
-    def cached_tenures(self):
-        """Prefetched active tenures for this character.
-
-        Returns:
-            list: Tenures with no end date.
-        """
-        return list(self.tenures.filter(end_date__isnull=True))
-
     def do_look(self, target):
         desc = self.at_look(target)
         self.msg(desc)

--- a/src/world/roster/admin.py
+++ b/src/world/roster/admin.py
@@ -17,8 +17,14 @@ from world.roster.models import (
 
 @admin.register(Roster)
 class RosterAdmin(admin.ModelAdmin):
-    list_display = ["name", "description", "is_active", "sort_order"]
-    list_filter = ["is_active"]
+    list_display = [
+        "name",
+        "description",
+        "is_active",
+        "allow_applications",
+        "sort_order",
+    ]
+    list_filter = ["is_active", "allow_applications"]
     search_fields = ["name", "description"]
     ordering = ["sort_order", "name"]
 

--- a/src/world/roster/factories.py
+++ b/src/world/roster/factories.py
@@ -47,6 +47,7 @@ class RosterFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Roster_{n}")
     description = factory.LazyAttribute(lambda obj: f"Description for {obj.name}")
     is_active = True
+    allow_applications = True
     sort_order = factory.Sequence(lambda n: n)
 
 

--- a/src/world/roster/managers.py
+++ b/src/world/roster/managers.py
@@ -13,8 +13,10 @@ class RosterEntryQuerySet(models.QuerySet):
         return self.filter(roster__is_active=True)
 
     def available_characters(self):
-        """Filter to characters without current players."""
-        return self.exclude(tenures__end_date__isnull=True)
+        """Filter to characters accepting applications."""
+        return self.filter(roster__allow_applications=True).exclude(
+            tenures__end_date__isnull=True
+        )
 
     def exclude_frozen(self):
         """Exclude frozen characters."""

--- a/src/world/roster/migrations/0001_initial.py
+++ b/src/world/roster/migrations/0001_initial.py
@@ -50,6 +50,13 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
+                    "allow_applications",
+                    models.BooleanField(
+                        default=True,
+                        help_text="Can players apply for characters in this roster?",
+                    ),
+                ),
+                (
                     "sort_order",
                     models.PositiveIntegerField(default=0, help_text="Display order"),
                 ),
@@ -364,7 +371,7 @@ class Migration(migrations.Migration):
                 "indexes": [
                     models.Index(
                         fields=["tenure", "sort_order"],
-                        name="tenuremedia_tenure_order_idx",
+                        name="roster_tenu_tenure__c3b6cf_idx",
                     )
                 ],
             },

--- a/src/world/roster/tests/test_models.py
+++ b/src/world/roster/tests/test_models.py
@@ -170,6 +170,31 @@ class RosterApplicationModelTestCase(TestCase):
                 self.assertFalse(app.withdraw())
 
 
+class RosterEntryModelTestCase(TestCase):
+    """Test RosterEntry model helpers."""
+
+    def test_current_tenure_returns_unended(self):
+        entry = RosterEntryFactory()
+        RosterTenureFactory(
+            roster_entry=entry,
+            end_date=timezone.now(),
+            player_number=1,
+        )
+        current = RosterTenureFactory(roster_entry=entry, player_number=2)
+        self.assertEqual(entry.current_tenure, current)
+
+    def test_accepts_applications_conditions(self):
+        entry = RosterEntryFactory()
+        self.assertTrue(entry.accepts_applications)
+
+        RosterTenureFactory(roster_entry=entry)
+        del entry.cached_tenures
+        self.assertFalse(entry.accepts_applications)
+
+        disallowed = RosterEntryFactory(roster__allow_applications=False)
+        self.assertFalse(disallowed.accepts_applications)
+
+
 class RosterTenureModelTestCase(TestCase):
     """Test RosterTenure model functionality"""
 

--- a/src/world/roster/tests/test_serializers.py
+++ b/src/world/roster/tests/test_serializers.py
@@ -122,6 +122,14 @@ class RosterApplicationCreateSerializerTestCase(TestCase):
                 "character_attr": "character",
                 "expected_message": "You are already playing this character",
             },
+            {
+                "name": "roster not accepting applications",
+                "setup": lambda: RosterEntryFactory(
+                    roster__allow_applications=False
+                ).character,
+                "character_attr": "setup_result",
+                "expected_message": "Player not allowed to apply to this roster type",
+            },
         ]
 
         for case in test_cases:

--- a/src/world/roster/views.py
+++ b/src/world/roster/views.py
@@ -46,16 +46,13 @@ class RosterEntryViewSet(viewsets.ReadOnlyModelViewSet):
             .prefetch_related(
                 Prefetch(
                     "tenures",
-                    queryset=RosterTenure.objects.filter(
-                        end_date__isnull=True
-                    ).prefetch_related(
+                    queryset=RosterTenure.objects.all().prefetch_related(
                         Prefetch(
                             "media",
                             queryset=TenureMedia.objects.select_related("media"),
                             to_attr="cached_media",
                         )
                     ),
-                    to_attr="cached_tenures",
                 )
             )
             .order_by("character__db_key")


### PR DESCRIPTION
## Summary
- allow individual rosters to disable play applications
- expose current tenure via roster entries with cached tenure lists
- update roster view prefetching and tests for new tenure caching

## Testing
- `uv run arx test world.roster`


------
https://chatgpt.com/codex/tasks/task_e_6897c084b6c08331ac41c335457bf1cd