### PR TITLE
feat: add hero section and status block

### DIFF
--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/frontend/src/evennia_replacements/HomePage.tsx
+++ b/frontend/src/evennia_replacements/HomePage.tsx
@@ -1,95 +1,23 @@
 import { Link } from 'react-router-dom';
-import { useHomeStatsQuery } from './queries';
+
+import { Button } from '../components/ui/button';
 import { SITE_NAME } from '../config';
+import { StatusBlock } from './StatusBlock';
 
 export function HomePage() {
-  const { data, isLoading } = useHomeStatsQuery();
-
-  if (isLoading) {
-    return (
-      <div className="flex min-h-96 items-center justify-center">
-        <div className="text-lg">Loading homepage...</div>
-      </div>
-    );
-  }
-
   return (
-    <div className="container mx-auto mt-4" id="main-copy">
-      <div className="row">
-        <div className="col">
-          <div className="card text-center">
-            <div className="card-body">
-              <h1 className="card-title">Welcome to {SITE_NAME}!</h1>
-              <hr />
-              <p className="lead">The Python MUD/MU* creation system.</p>
-              <p>
-                You are looking at the start of your game's website, generated out of the box by
-                Evennia.
-                <br />
-                It can be expanded into a full-fledged home for your game.
-              </p>
-              <p>
-                <Link to="/game" className="playbutton font-semibold text-blue-600 underline">
-                  Play in the browser!
-                </Link>
-              </p>
-            </div>
-          </div>
-        </div>
+    <section
+      id="hero"
+      className="container mx-auto flex flex-col items-center gap-8 py-12 text-center"
+    >
+      <div className="flex flex-col items-center gap-2">
+        <h1 className="text-4xl font-bold tracking-tight">Welcome to {SITE_NAME}!</h1>
+        <p className="text-lg text-muted-foreground">The Python MUD/MU* creation system.</p>
       </div>
-      {data && (
-        <div className="row mt-4">
-          <div className="col-12 col-md-4 mb-3">
-            <div className="card">
-              <h4 className="card-header text-center">Accounts</h4>
-              <div className="card-body">
-                <p>
-                  There's currently <strong>{data.num_accounts_connected}</strong> connected out of
-                  a total of <strong>{data.num_accounts_registered}</strong> account
-                  {data.num_accounts_registered !== 1 && 's'} registered.
-                </p>
-                <p>
-                  Of these, <strong>{data.num_accounts_registered_recent}</strong> were created this
-                  week, and <strong>{data.num_accounts_connected_recent}</strong> have connected
-                  within the last seven days.
-                </p>
-              </div>
-            </div>
-          </div>
-          <div className="col-12 col-md-4 mb-3">
-            <div className="card">
-              <h4 className="card-header text-center">Recently Connected</h4>
-              <div className="card-body px-0 py-0">
-                <ul className="list-group">
-                  {data.accounts_connected_recent.map((a) => (
-                    <li key={a.username} className="list-group-item">
-                      {a.username}&mdash;<em>{a.last_login} ago</em>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-          </div>
-          <div className="col-12 col-md-4 mb-3">
-            <div className="card">
-              <h4 className="card-header text-center">Database Stats</h4>
-              <div className="card-body px-0 py-0">
-                <ul className="list-group">
-                  <li className="list-group-item">
-                    {data.num_accounts_registered} account
-                    {data.num_accounts_registered !== 1 && 's'} (+ {data.num_characters} character
-                    {data.num_characters !== 1 && 's'})
-                  </li>
-                  <li className="list-group-item">
-                    {data.num_rooms} room{data.num_rooms !== 1 && 's'} (+ {data.num_exits} exits)
-                  </li>
-                  <li className="list-group-item">{data.num_others} other objects</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
+      <Button asChild size="lg">
+        <Link to="/game">Play in the browser</Link>
+      </Button>
+      <StatusBlock />
+    </section>
   );
 }

--- a/frontend/src/evennia_replacements/StatusBlock.tsx
+++ b/frontend/src/evennia_replacements/StatusBlock.tsx
@@ -1,0 +1,21 @@
+import { Card, CardContent } from '../components/ui/card';
+import { Badge } from '../components/ui/badge';
+
+import { useServerStatus } from './queries';
+
+export function StatusBlock() {
+  const { data } = useServerStatus();
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <Card className="w-fit">
+      <CardContent className="flex items-center gap-2 p-4">
+        <Badge>{data.online} online</Badge>
+        <span className="text-sm text-muted-foreground">{data.total} total players</span>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/evennia_replacements/api.ts
+++ b/frontend/src/evennia_replacements/api.ts
@@ -1,4 +1,4 @@
-import type { AccountData, HomeStats } from './types';
+import type { AccountData, HomeStats, ServerStatus } from './types';
 import { getCookie } from '../lib/utils';
 
 function getCSRFToken(): string {
@@ -25,6 +25,14 @@ export async function fetchHomeStats(): Promise<HomeStats> {
   const res = await apiFetch('/api/homepage/');
   if (!res.ok) {
     throw new Error('Failed to load stats');
+  }
+  return res.json();
+}
+
+export async function fetchServerStatus(): Promise<ServerStatus> {
+  const res = await apiFetch('/api/status/');
+  if (!res.ok) {
+    throw new Error('Failed to load status');
   }
   return res.json();
 }

--- a/frontend/src/evennia_replacements/queries.tsx
+++ b/frontend/src/evennia_replacements/queries.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchHomeStats, fetchAccount, postLogin, postLogout } from './api';
+import { fetchHomeStats, fetchAccount, postLogin, postLogout, fetchServerStatus } from './api';
 import { useAppDispatch } from '../store/hooks';
 import { setAccount } from '../store/authSlice';
 import { resetGame } from '../store/gameSlice';
@@ -10,6 +10,15 @@ export function useHomeStatsQuery() {
   return useQuery({
     queryKey: ['homepage'],
     queryFn: fetchHomeStats,
+    throwOnError: true,
+  });
+}
+
+export function useServerStatus() {
+  return useQuery({
+    queryKey: ['server-status'],
+    queryFn: fetchServerStatus,
+    refetchInterval: 30000,
     throwOnError: true,
   });
 }

--- a/frontend/src/evennia_replacements/types.ts
+++ b/frontend/src/evennia_replacements/types.ts
@@ -18,3 +18,8 @@ export interface AccountData {
   last_login: string | null;
   avatar_url?: string;
 }
+
+export interface ServerStatus {
+  online: number;
+  total: number;
+}

--- a/src/web/api/urls.py
+++ b/src/web/api/urls.py
@@ -1,9 +1,15 @@
 from django.urls import path
 
-from web.api.views import HomePageAPIView, LoginAPIView, LogoutAPIView
+from web.api.views import (
+    HomePageAPIView,
+    LoginAPIView,
+    LogoutAPIView,
+    ServerStatusAPIView,
+)
 
 urlpatterns = [
     path("homepage/", HomePageAPIView.as_view(), name="api-homepage"),
+    path("status/", ServerStatusAPIView.as_view(), name="api-status"),
     path("login/", LoginAPIView.as_view(), name="api-login"),
     path("logout/", LogoutAPIView.as_view(), name="api-logout"),
 ]

--- a/src/web/api/views.py
+++ b/src/web/api/views.py
@@ -78,6 +78,29 @@ class HomePageAPIView(APIView):
         return Response(context)
 
 
+class ServerStatusAPIView(APIView):
+    """Return server player counts."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, *args, **kwargs):
+        """Return online and total player counts.
+
+        Args:
+            request: DRF request.
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            Response: JSON data with ``online`` and ``total`` counts.
+        """
+        data = {
+            "online": SESSION_HANDLER.account_count(),
+            "total": AccountDB.objects.count(),
+        }
+        return Response(data)
+
+
 @method_decorator(ensure_csrf_cookie, name="dispatch")
 class LoginAPIView(APIView):
     """Return account data for the current session and handle authentication."""

--- a/src/web/tests/test_api.py
+++ b/src/web/tests/test_api.py
@@ -28,6 +28,16 @@ class WebAPITests(TestCase):
         self.assertEqual(data["num_accounts_connected_recent"], 0)
         self.assertIsInstance(data["accounts_connected_recent"], list)
 
+    @patch("web.api.views.SESSION_HANDLER")
+    def test_status_api_returns_counts(self, mock_session_handler):
+        mock_session_handler.account_count.return_value = 2
+        url = reverse("api-status")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["online"], 2)
+        self.assertEqual(data["total"], AccountDB.objects.count())
+
     def test_login_api_returns_user_on_post(self):
         url = reverse("api-login")
         response = self.client.post(url, {"username": "tester", "password": "pass"})


### PR DESCRIPTION
## Summary
- replace placeholder homepage with Tailwind hero section and webclient CTA
- implement status block that fetches player counts
- add shadcn badge component for status display
- expose `/api/status/` endpoint for server player counts

## Testing
- `uv run pre-commit run --files src/web/api/views.py src/web/api/urls.py src/web/tests/test_api.py`
- `pnpm test --run`
- `pnpm build`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_68982d93176483318cbe776137202fde