### PR TITLE
Use character sheets for roster entry details

### DIFF
--- a/frontend/src/components/character/StatsSection.tsx
+++ b/frontend/src/components/character/StatsSection.tsx
@@ -1,14 +1,51 @@
 import type { CharacterData } from '../../roster/types';
 
 interface StatsSectionProps {
-  stats?: CharacterData['stats'];
+  age?: CharacterData['age'];
+  gender?: CharacterData['gender'];
+  race?: CharacterData['race'];
+  charClass?: CharacterData['char_class'];
+  level?: CharacterData['level'];
+  concept?: CharacterData['concept'];
+  family?: CharacterData['family'];
+  vocation?: CharacterData['vocation'];
+  socialRank?: CharacterData['social_rank'];
 }
 
-export function StatsSection({ stats }: StatsSectionProps) {
+export function StatsSection({
+  age,
+  gender,
+  race,
+  charClass,
+  level,
+  concept,
+  family,
+  vocation,
+  socialRank,
+}: StatsSectionProps) {
   return (
     <section>
       <h3 className="text-xl font-semibold">Stats</h3>
-      <p>{stats ? JSON.stringify(stats) : 'TBD'}</p>
+      <dl className="grid grid-cols-2 gap-x-2">
+        <dt>Age</dt>
+        <dd>{age ?? 'TBD'}</dd>
+        <dt>Gender</dt>
+        <dd>{gender ?? 'TBD'}</dd>
+        <dt>Race</dt>
+        <dd>{race ?? 'TBD'}</dd>
+        <dt>Class</dt>
+        <dd>{charClass ?? 'TBD'}</dd>
+        <dt>Level</dt>
+        <dd>{level ?? 'TBD'}</dd>
+        <dt>Concept</dt>
+        <dd>{concept || 'TBD'}</dd>
+        <dt>Family</dt>
+        <dd>{family || 'TBD'}</dd>
+        <dt>Vocation</dt>
+        <dd>{vocation || 'TBD'}</dd>
+        <dt>Social Rank</dt>
+        <dd>{socialRank ?? 'TBD'}</dd>
+      </dl>
     </section>
   );
 }

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -21,7 +21,17 @@ export function CharacterSheetPage() {
     <div className="container mx-auto space-y-4 p-4">
       <CharacterPortrait name={entry.character.name} profilePicture={entry.profile_picture} />
       <BackgroundSection background={entry.character.background} />
-      <StatsSection stats={entry.character.stats} />
+      <StatsSection
+        age={entry.character.age}
+        gender={entry.character.gender}
+        race={entry.character.race}
+        charClass={entry.character.char_class}
+        level={entry.character.level}
+        concept={entry.character.concept}
+        family={entry.character.family}
+        vocation={entry.character.vocation}
+        socialRank={entry.character.social_rank}
+      />
       <RelationshipsSection relationships={entry.character.relationships} />
       <GalleriesSection galleries={entry.character.galleries} />
       {entry.can_apply && <CharacterApplicationForm entryId={entry.id} />}

--- a/frontend/src/roster/types.ts
+++ b/frontend/src/roster/types.ts
@@ -11,11 +11,16 @@ export interface CharacterGallery {
 export interface CharacterData {
   id: number;
   name: string;
+  age?: number | null;
   gender?: string | null;
+  race?: string | null;
   char_class?: string | null;
   level?: number | null;
+  concept?: string;
+  family?: string;
+  vocation?: string;
+  social_rank?: number | null;
   background?: string;
-  stats?: Record<string, number>;
   relationships?: string[];
   galleries: CharacterGallery[];
 }

--- a/src/world/roster/serializers.py
+++ b/src/world/roster/serializers.py
@@ -33,11 +33,30 @@ class CharacterSerializer(serializers.ModelSerializer):
     """Serialize character data for roster entry views."""
 
     name = serializers.CharField(source="db_key")
-    background = serializers.SerializerMethodField()
-    gender = serializers.SerializerMethodField()
+    age = serializers.IntegerField(
+        source="item_data.age", read_only=True, allow_null=True
+    )
+    gender = serializers.CharField(
+        source="item_data.gender", read_only=True, allow_null=True, allow_blank=True
+    )
+    race = serializers.SerializerMethodField()
     char_class = serializers.SerializerMethodField()
     level = serializers.SerializerMethodField()
-    stats = serializers.DictField(child=serializers.IntegerField(), default=dict)
+    concept = serializers.CharField(
+        source="item_data.concept", read_only=True, default=""
+    )
+    family = serializers.CharField(
+        source="item_data.family", read_only=True, default=""
+    )
+    vocation = serializers.CharField(
+        source="item_data.vocation", read_only=True, default=""
+    )
+    social_rank = serializers.IntegerField(
+        source="item_data.social_rank", read_only=True, allow_null=True
+    )
+    background = serializers.CharField(
+        source="item_data.background", read_only=True, default=""
+    )
     relationships = serializers.ListField(child=serializers.CharField(), default=list)
     galleries = CharacterGallerySerializer(many=True, default=list)
 
@@ -46,31 +65,32 @@ class CharacterSerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "name",
-            "background",
+            "age",
             "gender",
+            "race",
             "char_class",
             "level",
-            "stats",
+            "concept",
+            "family",
+            "vocation",
+            "social_rank",
+            "background",
             "relationships",
             "galleries",
         )
         read_only_fields = fields
 
-    def get_background(self, obj):
-        """Return the character's background from Evennia attributes."""
-        return getattr(obj.db, "background", "")
-
-    def get_gender(self, obj):
-        """Return the character's gender from Evennia attributes."""
-        return getattr(obj.db, "gender", None)
+    def get_race(self, obj):
+        # Placeholder until race is implemented
+        return None
 
     def get_char_class(self, obj):
-        """Return the character's class from Evennia attributes."""
-        return getattr(obj.db, "class", None)
+        # Placeholder until class system is implemented
+        return None
 
     def get_level(self, obj):
-        """Return the character's level from Evennia attributes."""
-        return getattr(obj.db, "level", None)
+        # Placeholder until leveling is implemented
+        return None
 
 
 class ArtistSerializer(serializers.ModelSerializer):

--- a/src/world/roster/tests/test_views.py
+++ b/src/world/roster/tests/test_views.py
@@ -5,6 +5,7 @@ Tests for roster views and API endpoints.
 from django.test import TestCase
 from rest_framework.test import APIClient
 
+from world.character_sheets.factories import CharacterSheetFactory
 from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 
 
@@ -14,6 +15,16 @@ class RosterEntryViewSetTestCase(TestCase):
     def setUp(self):
         """Set up test data for each test"""
         self.roster_entry = RosterEntryFactory()
+        self.sheet = CharacterSheetFactory(
+            character=self.roster_entry.character,
+            age=30,
+            gender="male",
+            concept="Brave knight",
+            family="Stormwind",
+            vocation="Warrior",
+            social_rank=5,
+            background="Born into nobility",
+        )
         self.tenure = RosterTenureFactory(roster_entry=self.roster_entry)
         self.client = APIClient()
 
@@ -61,10 +72,18 @@ class RosterEntryViewSetTestCase(TestCase):
         self.assertIn("character", response.data)
         self.assertIn("profile_picture", response.data)
         self.assertIn("tenures", response.data)
-        self.assertEqual(
-            response.data["character"]["name"],
-            self.roster_entry.character.name,
-        )
+        character = response.data["character"]
+        self.assertEqual(character["name"], self.roster_entry.character.name)
+        self.assertEqual(character["age"], self.sheet.age)
+        self.assertEqual(character["gender"], self.sheet.gender)
+        self.assertEqual(character["concept"], self.sheet.concept)
+        self.assertEqual(character["family"], self.sheet.family)
+        self.assertEqual(character["vocation"], self.sheet.vocation)
+        self.assertEqual(character["social_rank"], self.sheet.social_rank)
+        self.assertEqual(character["background"], self.sheet.background)
+        self.assertIsNone(character["race"])
+        self.assertIsNone(character["char_class"])
+        self.assertIsNone(character["level"])
 
     def test_filter_by_name_returns_expected_entry(self):
         """Ensure filtering by name works."""


### PR DESCRIPTION
## Summary
- pull roster entry demographics from character sheets
- test roster entry detail response for character sheet data
- display character sheet details on roster entry page
- use character.item_data to source demographic fields in roster serializer

## Testing
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_6898b31e2d8483319c560cfb2daaa6a9