### PR TITLE
Add CLI start command and standalone build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ arx shell
 arx manage show_urls
 ```
 
+### Build the frontend:
+
+```powershell
+arx build
+```
+
+### Start the server:
+
+```powershell
+arx start
+```
+
 ### Build frontend and start server:
 
 ```powershell


### PR DESCRIPTION
## Summary
- add `arx start` and make `arx reload` available
- allow `arx shell -c` to execute code
- split frontend build into `arx build` and reuse in `arx serve`
- document new CLI commands

## Testing
- `uv run pre-commit run --files src/cli/arx.py README.md`
- `uv run arx test`

------
https://chatgpt.com/codex/tasks/task_e_6898e36196b08331a1d16b431784f482