### PR TITLE
feat(frontend): add QuickActions component

### DIFF
--- a/frontend/src/components/QuickActions.tsx
+++ b/frontend/src/components/QuickActions.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom';
+import { Card } from './ui/card';
+
+const actions = [
+  { to: '/play', label: 'Play' },
+  { to: '/roster', label: 'Roster' },
+  { to: '/lore', label: 'Lore' },
+  { to: '/news', label: 'News' },
+  { to: '/community', label: 'Community' },
+];
+
+export function QuickActions() {
+  return (
+    <section className="container mx-auto grid gap-4 py-8 sm:grid-cols-2 md:grid-cols-3">
+      {actions.map(({ to, label }) => (
+        <Card key={to} className="hover:bg-muted">
+          <Link to={to} className="flex h-full w-full items-center justify-center p-6">
+            <span className="text-lg font-semibold">{label}</span>
+          </Link>
+        </Card>
+      ))}
+    </section>
+  );
+}

--- a/frontend/src/evennia_replacements/HomePage.tsx
+++ b/frontend/src/evennia_replacements/HomePage.tsx
@@ -4,6 +4,7 @@ import { Button } from '../components/ui/button';
 import { SITE_NAME } from '../config';
 import { StatusBlock } from './StatusBlock';
 import { NewPlayerSection } from './NewPlayerSection';
+import { QuickActions } from '../components/QuickActions';
 
 export function HomePage() {
   return (
@@ -21,6 +22,7 @@ export function HomePage() {
         </Button>
         <StatusBlock />
       </section>
+      <QuickActions />
       <NewPlayerSection />
     </>
   );


### PR DESCRIPTION
## Summary
- add QuickActions component with shadcn Card links to key sections
- render QuickActions on the home page beneath the hero

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6898f9d576b0833195f318e183611734