### PR TITLE
feat(frontend): add lore tabs section to homepage

### DIFF
--- a/frontend/src/evennia_replacements/HomePage.tsx
+++ b/frontend/src/evennia_replacements/HomePage.tsx
@@ -4,6 +4,7 @@ import { Button } from '../components/ui/button';
 import { SITE_NAME } from '../config';
 import { StatusBlock } from './StatusBlock';
 import { NewPlayerSection } from './NewPlayerSection';
+import { LoreTabs } from './LoreTabs';
 import { QuickActions } from '../components/QuickActions';
 
 export function HomePage() {
@@ -24,6 +25,7 @@ export function HomePage() {
       </section>
       <QuickActions />
       <NewPlayerSection />
+      <LoreTabs />
     </>
   );
 }

--- a/frontend/src/evennia_replacements/LoreTabs.tsx
+++ b/frontend/src/evennia_replacements/LoreTabs.tsx
@@ -1,0 +1,67 @@
+import { Link } from 'react-router-dom';
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '../components/ui/accordion';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
+
+export function LoreTabs() {
+  return (
+    <section className="container mx-auto py-12">
+      <Tabs defaultValue="setting" className="w-full">
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="setting">Setting</TabsTrigger>
+          <TabsTrigger value="factions">Houses/Factions</TabsTrigger>
+          <TabsTrigger value="timeline">Timeline</TabsTrigger>
+        </TabsList>
+        <TabsContent value="setting">
+          <Accordion type="single" collapsible>
+            <AccordionItem value="setting-item">
+              <AccordionTrigger>World Overview</AccordionTrigger>
+              <AccordionContent>
+                <p className="mb-2">
+                  Discover the basics of Arx II's setting and its central themes.
+                </p>
+                <Link className="text-primary underline" to="/lore/setting">
+                  Read more
+                </Link>
+                .
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </TabsContent>
+        <TabsContent value="factions">
+          <Accordion type="single" collapsible>
+            <AccordionItem value="factions-item">
+              <AccordionTrigger>Key Players</AccordionTrigger>
+              <AccordionContent>
+                <p className="mb-2">Meet the houses and factions competing for influence.</p>
+                <Link className="text-primary underline" to="/lore/houses">
+                  Read more
+                </Link>
+                .
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </TabsContent>
+        <TabsContent value="timeline">
+          <Accordion type="single" collapsible>
+            <AccordionItem value="timeline-item">
+              <AccordionTrigger>Historical Events</AccordionTrigger>
+              <AccordionContent>
+                <p className="mb-2">Explore the major events that shaped the realm.</p>
+                <Link className="text-primary underline" to="/lore/timeline">
+                  Read more
+                </Link>
+                .
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </TabsContent>
+      </Tabs>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add LoreTabs component with Setting, Houses/Factions, and Timeline tabs
- show LoreTabs after the New Player section on the home page

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689903b95f688331b0e1c8df26b312c5