### PR TITLE
feat(frontend): add status overview widgets

### DIFF
--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,6 @@
+import { cn } from '../../lib/utils';
+import type { HTMLAttributes } from 'react';
+
+export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />;
+}

--- a/frontend/src/evennia_replacements/HomePage.tsx
+++ b/frontend/src/evennia_replacements/HomePage.tsx
@@ -5,8 +5,14 @@ import { SITE_NAME } from '../config';
 import { StatusBlock } from './StatusBlock';
 import { NewPlayerSection } from './NewPlayerSection';
 import { QuickActions } from '../components/QuickActions';
+import { StatsCard } from './StatsCard';
+import { RecentConnected } from './RecentConnected';
+import { NewsTeaser } from './NewsTeaser';
+import { useServerStatus } from './queries';
 
 export function HomePage() {
+  const { data, isLoading } = useServerStatus();
+
   return (
     <>
       <section
@@ -22,6 +28,11 @@ export function HomePage() {
         </Button>
         <StatusBlock />
       </section>
+      <div className="container mx-auto grid gap-4 py-8 md:grid-cols-3">
+        <StatsCard stats={data?.stats} isLoading={isLoading} />
+        <RecentConnected accounts={data?.recent_connected} isLoading={isLoading} />
+        <NewsTeaser news={data?.news} isLoading={isLoading} />
+      </div>
       <QuickActions />
       <NewPlayerSection />
     </>

--- a/frontend/src/evennia_replacements/NewsTeaser.tsx
+++ b/frontend/src/evennia_replacements/NewsTeaser.tsx
@@ -1,0 +1,42 @@
+import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
+import { Table, TableBody, TableRow, TableCell } from '../components/ui/table';
+import { Skeleton } from '../components/ui/skeleton';
+
+interface NewsItem {
+  id: number;
+  title: string;
+}
+
+interface NewsTeaserProps {
+  news?: NewsItem[];
+  isLoading: boolean;
+}
+
+export function NewsTeaser({ news, isLoading }: NewsTeaserProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Latest News</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            {[0, 1, 2].map((i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+        ) : (
+          <Table>
+            <TableBody>
+              {news?.map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell className="p-0 py-2 text-sm">{item.title}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/evennia_replacements/RecentConnected.tsx
+++ b/frontend/src/evennia_replacements/RecentConnected.tsx
@@ -1,0 +1,42 @@
+import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
+import { Avatar, AvatarImage, AvatarFallback } from '../components/ui/avatar';
+import { Skeleton } from '../components/ui/skeleton';
+
+interface RecentConnectedProps {
+  accounts?: Array<{ username: string; avatar_url?: string }>;
+  isLoading: boolean;
+}
+
+export function RecentConnected({ accounts, isLoading }: RecentConnectedProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recently Connected</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="flex items-center gap-2">
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <Skeleton className="h-4 w-1/3" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {accounts?.map((acc) => (
+              <li key={acc.username} className="flex items-center gap-2">
+                <Avatar>
+                  <AvatarImage src={acc.avatar_url} />
+                  <AvatarFallback>{acc.username.slice(0, 2).toUpperCase()}</AvatarFallback>
+                </Avatar>
+                <span className="text-sm">{acc.username}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/evennia_replacements/StatsCard.tsx
+++ b/frontend/src/evennia_replacements/StatsCard.tsx
@@ -1,0 +1,36 @@
+import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
+import { Skeleton } from '../components/ui/skeleton';
+
+interface StatsCardProps {
+  stats?: Record<string, number>;
+  isLoading: boolean;
+}
+
+export function StatsCard({ stats, isLoading }: StatsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Stats</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-4 w-1/3" />
+            <Skeleton className="h-4 w-1/4" />
+          </div>
+        ) : (
+          <ul className="space-y-1 text-sm">
+            {stats &&
+              Object.entries(stats).map(([label, value]) => (
+                <li key={label} className="flex justify-between">
+                  <span className="capitalize">{label.replace(/_/g, ' ')}</span>
+                  <span className="font-medium">{value}</span>
+                </li>
+              ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/evennia_replacements/types.ts
+++ b/frontend/src/evennia_replacements/types.ts
@@ -22,4 +22,7 @@ export interface AccountData {
 export interface ServerStatus {
   online: number;
   total: number;
+  stats?: Record<string, number>;
+  recent_connected?: Array<{ username: string; avatar_url?: string }>;
+  news?: Array<{ id: number; title: string }>;
 }


### PR DESCRIPTION
## Summary
- show StatsCard, RecentConnected and NewsTeaser widgets on the home page
- fetch status data with React Query and display shadcn skeletons while loading
- reuse existing server status API function instead of duplicating it

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689903aebfc08331b078fee0cd7ce276