### PR TITLE
feat: add status endpoint

### DIFF
--- a/frontend/src/evennia_replacements/HomePage.tsx
+++ b/frontend/src/evennia_replacements/HomePage.tsx
@@ -9,10 +9,10 @@ import { QuickActions } from '../components/QuickActions';
 import { StatsCard } from './StatsCard';
 import { RecentConnected } from './RecentConnected';
 import { NewsTeaser } from './NewsTeaser';
-import { useServerStatus } from './queries';
+import { useStatusQuery } from './queries';
 
 export function HomePage() {
-  const { data, isLoading } = useServerStatus();
+  const { data, isLoading } = useStatusQuery();
 
   return (
     <>
@@ -30,8 +30,19 @@ export function HomePage() {
         <StatusBlock />
       </section>
       <div className="container mx-auto grid gap-4 py-8 md:grid-cols-3">
-        <StatsCard stats={data?.stats} isLoading={isLoading} />
-        <RecentConnected accounts={data?.recent_connected} isLoading={isLoading} />
+        <StatsCard
+          stats={
+            data
+              ? {
+                  accounts: data.accounts,
+                  characters: data.characters,
+                  rooms: data.rooms,
+                }
+              : undefined
+          }
+          isLoading={isLoading}
+        />
+        <RecentConnected accounts={data?.recentPlayers} isLoading={isLoading} />
         <NewsTeaser news={data?.news} isLoading={isLoading} />
       </div>
       <QuickActions />

--- a/frontend/src/evennia_replacements/StatusBlock.tsx
+++ b/frontend/src/evennia_replacements/StatusBlock.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 
-import { useServerStatus } from './queries';
+import { useStatusQuery } from './queries';
 
 export function StatusBlock() {
-  const { data } = useServerStatus();
+  const { data } = useStatusQuery();
 
   if (!data) {
     return null;
@@ -14,7 +14,7 @@ export function StatusBlock() {
     <Card className="w-fit">
       <CardContent className="flex items-center gap-2 p-4">
         <Badge>{data.online} online</Badge>
-        <span className="text-sm text-muted-foreground">{data.total} total players</span>
+        <span className="text-sm text-muted-foreground">{data.accounts} total accounts</span>
       </CardContent>
     </Card>
   );

--- a/frontend/src/evennia_replacements/api.ts
+++ b/frontend/src/evennia_replacements/api.ts
@@ -1,4 +1,4 @@
-import type { AccountData, HomeStats, ServerStatus } from './types';
+import type { AccountData, StatusData } from './types';
 import { getCookie } from '../lib/utils';
 
 function getCSRFToken(): string {
@@ -21,15 +21,7 @@ export function apiFetch(url: string, options: RequestInit = {}) {
   });
 }
 
-export async function fetchHomeStats(): Promise<HomeStats> {
-  const res = await apiFetch('/api/homepage/');
-  if (!res.ok) {
-    throw new Error('Failed to load stats');
-  }
-  return res.json();
-}
-
-export async function fetchServerStatus(): Promise<ServerStatus> {
+export async function fetchStatus(): Promise<StatusData> {
   const res = await apiFetch('/api/status/');
   if (!res.ok) {
     throw new Error('Failed to load status');

--- a/frontend/src/evennia_replacements/queries.tsx
+++ b/frontend/src/evennia_replacements/queries.tsx
@@ -1,23 +1,15 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchHomeStats, fetchAccount, postLogin, postLogout, fetchServerStatus } from './api';
+import { fetchStatus, fetchAccount, postLogin, postLogout } from './api';
 import { useAppDispatch } from '../store/hooks';
 import { setAccount } from '../store/authSlice';
 import { resetGame } from '../store/gameSlice';
 import { useGameSocket } from '../hooks/useGameSocket';
 import { useEffect } from 'react';
 
-export function useHomeStatsQuery() {
+export function useStatusQuery() {
   return useQuery({
-    queryKey: ['homepage'],
-    queryFn: fetchHomeStats,
-    throwOnError: true,
-  });
-}
-
-export function useServerStatus() {
-  return useQuery({
-    queryKey: ['server-status'],
-    queryFn: fetchServerStatus,
+    queryKey: ['status'],
+    queryFn: fetchStatus,
     refetchInterval: 30000,
     throwOnError: true,
   });

--- a/frontend/src/evennia_replacements/types.ts
+++ b/frontend/src/evennia_replacements/types.ts
@@ -1,16 +1,3 @@
-export interface HomeStats {
-  num_accounts_connected: number;
-  num_accounts_registered: number;
-  num_accounts_registered_recent: number;
-  num_accounts_connected_recent: number;
-  num_characters: number;
-  num_rooms: number;
-  num_exits: number;
-  num_others: number;
-  page_title: string;
-  accounts_connected_recent: Array<{ username: string; last_login: string }>;
-}
-
 export interface AccountData {
   id: number;
   username: string;
@@ -19,10 +6,11 @@ export interface AccountData {
   avatar_url?: string;
 }
 
-export interface ServerStatus {
+export interface StatusData {
   online: number;
-  total: number;
-  stats?: Record<string, number>;
-  recent_connected?: Array<{ username: string; avatar_url?: string }>;
-  news?: Array<{ id: number; title: string }>;
+  accounts: number;
+  characters: number;
+  rooms: number;
+  recentPlayers: Array<{ username: string; avatar_url?: string }>;
+  news: Array<{ id: number; title: string }>;
 }

--- a/src/web/tests/test_api.py
+++ b/src/web/tests/test_api.py
@@ -31,12 +31,22 @@ class WebAPITests(TestCase):
     @patch("web.api.views.SESSION_HANDLER")
     def test_status_api_returns_counts(self, mock_session_handler):
         mock_session_handler.account_count.return_value = 2
+        ObjectDB.objects.create(
+            db_key="Char", db_typeclass_path="typeclasses.characters.Character"
+        )
+        ObjectDB.objects.create(
+            db_key="Room", db_typeclass_path="typeclasses.rooms.Room"
+        )
         url = reverse("api-status")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["online"], 2)
-        self.assertEqual(data["total"], AccountDB.objects.count())
+        self.assertEqual(data["accounts"], AccountDB.objects.count())
+        self.assertEqual(data["characters"], 1)
+        self.assertEqual(data["rooms"], 1)
+        self.assertIsInstance(data["recentPlayers"], list)
+        self.assertIsInstance(data["news"], list)
 
     def test_login_api_returns_user_on_post(self):
         url = reverse("api-login")


### PR DESCRIPTION
## Summary
- add `/api/status` endpoint with counts and recent player info
- replace frontend home stats calls with new status query
- show online counts, recent players, and news on home page

## Testing
- `uv run pre-commit run --files frontend/src/evennia_replacements/api.ts frontend/src/evennia_replacements/queries.tsx frontend/src/evennia_replacements/HomePage.tsx frontend/src/evennia_replacements/StatusBlock.tsx frontend/src/evennia_replacements/types.ts src/web/api/views.py src/web/tests/test_api.py`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_68991bd8944083318dcd4e29af22a610