### PR TITLE
docs: prioritize scenes on homepage

### DIFF
--- a/docs/frontend/homepage_plan.md
+++ b/docs/frontend/homepage_plan.md
@@ -2,10 +2,24 @@
 
 The homepage introduces players to the world of **Arx II** and points them toward current activity. It highlights scenes and stories players can join while giving newcomers quick orientation.
 
+## Scenes and Stories
+
+Scenes and stories are the heart of Arx II and outrank news and community content in prominence. Both the navigation bar and homepage quick actions should list **Scenes** before **News** and **Community** so players are immediately drawn toward active narrative play.
+
+### ScenesSpotlight
+
+The `ScenesSpotlight` component surfaces in-progress and recently concluded scenes, reinforcing the game's storytelling focus. It fetches data from `/api/scenes/spotlight/` and expects two arrays:
+
+- `in_progress` – scene objects with `id`, `title`, and participant info for currently running stories.
+- `recent` – recently finished scenes with the same structure.
+
+By highlighting these scenes, the spotlight invites players to jump into ongoing narratives or follow up on recent events.
+
 ## Layout Summary
 
+- **Navigation** – Global menu lists **Scenes**, **News**, and **Community** in that order to emphasize storytelling.
 - **Hero** – Tagline and call to action alongside a striking background. Optionally include a brief teaser of active stories.
-- **Quick Actions** – Buttons for logging in, creating an account, resuming the last character, or jumping into a featured scene.
+- **Quick Actions** – Buttons list a featured scene first, followed by links to News and Community, alongside login, account creation, and resume options.
 - **Live Snapshot** – Dynamic list of currently running scenes and stories so players can immediately see where action is happening.
 - **New-player Tabs** – Collapsible panels or tabs that explain basic mechanics and link to onboarding content.
 - **Lore Tabs** – Curated lore topics or featured articles to help players explore the setting.
@@ -19,7 +33,10 @@ The homepage introduces players to the world of **Arx II** and points them towar
 - **Quick Actions**
   - Authentication state for displaying login or resume options.
   - Character list for logged-in users.
-  - Linkable scene or story IDs for direct entry.
+  - Featured scene ID followed by links to News and Community.
+- **ScenesSpotlight**
+  - Endpoint `/api/scenes/spotlight/` returning `in_progress` and `recent` scenes.
+  - Each scene includes `id`, `title`, and participant list with avatar URLs.
 - **Live Snapshot**
   - Feed of active scenes with title, location, participants, and joinable flag.
   - List of ongoing stories with summary and entry points.
@@ -41,7 +58,3 @@ The homepage introduces players to the world of **Arx II** and points them towar
 - Use **shadcn/ui** components for accessible, themeable primitives.
 - Tailwind CSS provides layout, spacing, and typography utilities.
 - Keep the layout mobile-first and responsive.
-
-## Scenes and Stories Emphasis
-
-The homepage must surface active **scenes** and **stories**. These represent the core gameplay loop—players browse ongoing narratives, join scenes in progress, and engage with evolving plots. The Live Snapshot should prominently feature open scenes and story hooks to invite immediate participation.


### PR DESCRIPTION
## Summary
- Emphasize scenes and stories as the primary focus of the homepage
- Describe ScenesSpotlight component and its data needs
- Order navigation and quick actions with Scenes ahead of News and Community

## Testing
- `uv run pre-commit run --files docs/frontend/homepage_plan.md`

------
https://chatgpt.com/codex/tasks/task_e_68993a027ad88331b6b28c250379ae0d