### PR TITLE
feat(frontend): add entity context menu

### DIFF
--- a/frontend/src/game/actions.ts
+++ b/frontend/src/game/actions.ts
@@ -1,0 +1,9 @@
+import type { LucideIcon } from 'lucide-react';
+import { Eye, Hand, MessageCircle } from 'lucide-react';
+
+// Lookup mapping action strings to icon components
+export const ACTION_ICON_MAP: Record<string, LucideIcon> = {
+  look: Eye,
+  get: Hand,
+  talk: MessageCircle,
+};

--- a/frontend/src/game/components/EntityContextMenu.test.tsx
+++ b/frontend/src/game/components/EntityContextMenu.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { EntityContextMenu } from './EntityContextMenu';
+
+const sendMock = vi.fn();
+
+vi.mock('@/hooks/useGameSocket', () => ({
+  useGameSocket: () => ({ send: sendMock }),
+}));
+
+describe('EntityContextMenu', () => {
+  it('renders icons and sends commands', async () => {
+    render(
+      <EntityContextMenu
+        character="Tester"
+        commands={[{ action: 'look', command: 'look tester' }]}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /look/i });
+    await userEvent.click(button);
+    expect(sendMock).toHaveBeenCalledWith('Tester', 'look tester');
+  });
+});

--- a/frontend/src/game/components/EntityContextMenu.tsx
+++ b/frontend/src/game/components/EntityContextMenu.tsx
@@ -1,0 +1,35 @@
+import { ACTION_ICON_MAP } from '@/game/actions';
+import { useGameSocket } from '@/hooks/useGameSocket';
+
+interface CommandSpec {
+  action: string;
+  command: string;
+}
+
+interface EntityContextMenuProps {
+  character: string;
+  commands: CommandSpec[];
+}
+
+export function EntityContextMenu({ character, commands }: EntityContextMenuProps) {
+  const { send } = useGameSocket();
+
+  return (
+    <div className="flex gap-1">
+      {commands.map(({ action, command }) => {
+        const Icon = ACTION_ICON_MAP[action];
+        if (!Icon) return null;
+        return (
+          <button
+            key={action}
+            onClick={() => send(character, command)}
+            aria-label={action}
+            className="rounded p-1 hover:bg-accent"
+          >
+            <Icon className="h-4 w-4" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- map context menu actions to icon components
- render entity context menu that dispatches websocket commands
- test context menu command dispatch

## Testing
- `pnpm test --run`
- `uv run arx test` *(partially ran: stopped after 6 tests)*

------
https://chatgpt.com/codex/tasks/task_e_689a9ae023ec83319281d88ff6633acc