### PR TITLE
Fix cmdset OOB message structure

### DIFF
--- a/src/commands/evennia_overrides/cmdset_handler.py
+++ b/src/commands/evennia_overrides/cmdset_handler.py
@@ -18,7 +18,7 @@ class CmdSetHandler(EvenniaCmdSetHandler):
         self._update_handle = None
         payload = serialize_cmdset(self.obj)
         for session in self.obj.sessions.all():
-            session.msg(commands=payload)
+            session.msg(commands=(payload, {}))
 
     def _schedule_update(self):
         """Debounce cmdset updates to only send once."""

--- a/src/commands/tests/test_cmdset_handler.py
+++ b/src/commands/tests/test_cmdset_handler.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from commands.evennia_overrides.cmdset_handler import CmdSetHandler
+
+
+class CmdSetHandlerTests(TestCase):
+    """Tests for the command set handler sending OOB updates."""
+
+    def test_send_update_includes_empty_kwargs(self):
+        session = MagicMock()
+        obj = MagicMock()
+        obj.sessions.all.return_value = [session]
+
+        handler = CmdSetHandler.__new__(CmdSetHandler)
+        handler.obj = obj
+        handler._update_handle = None
+
+        with patch(
+            "commands.evennia_overrides.cmdset_handler.serialize_cmdset",
+            return_value=["cmd"],
+        ):
+            handler._send_update()
+
+        session.msg.assert_called_with(commands=(["cmd"], {}))


### PR DESCRIPTION
## Summary
- ensure cmdset updates send OOB args/kwargs structure
- test cmdset handler includes empty kwargs in update messages

## Testing
- `uv run arx test`

------
https://chatgpt.com/codex/tasks/task_e_689aa78f92c48331abf3fe33e5c30641