### PR TITLE
Refactor protocol-aware message dispatcher

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -57,6 +57,46 @@ class ArxCommand(Command):
     account = None
     raw_string = None
 
+    def msg(
+        self,
+        text: str | None = None,
+        from_obj=None,
+        session=None,
+        options=None,
+        *,
+        payload=None,
+        payload_key: str = "rich",
+        **kwargs,
+    ) -> None:
+        """Send a message to the caller.
+
+        Args:
+            text: Message text.
+            from_obj: Object sending the message.
+            session: Specific session to message.
+            options: Extra options for Evennia's ``msg``.
+            payload: Structured payload for webclient sessions.
+            payload_key: OOB command name used for ``payload``. Defaults to
+                ``"rich"``.
+        """
+        from web import message_dispatcher
+
+        params = {}
+        if from_obj is not None:
+            params["from_obj"] = from_obj
+        if options is not None:
+            params["options"] = options
+        params.update(kwargs)
+
+        message_dispatcher.send(
+            self.caller,
+            text,
+            payload=payload,
+            payload_key=payload_key,
+            session=session,
+            **params,
+        )
+
     def get_help(
         self, caller, cmdset, mode: HelpFileViewMode = HelpFileViewMode.TEXT
     ) -> str:

--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -235,6 +235,9 @@ class BaseState:
         from_obj: object | None = None,
         session: object | None = None,
         options: object | None = None,
+        *,
+        payload: object | None = None,
+        payload_key: str = "vn_message",
         **kwargs: object,
     ) -> None:
         """Send a message to the underlying Evennia object.
@@ -243,18 +246,24 @@ class BaseState:
         transparently with states or raw objects.
         """
 
-        try:
-            extra = {}
-            if from_obj is not None:
-                extra["from_obj"] = from_obj
-            if session is not None:
-                extra["session"] = session
-            if options is not None:
-                extra["options"] = options
-            extra.update(kwargs)
-            self.obj.msg(text, **extra)
-        except AttributeError:
-            pass
+        from web import message_dispatcher
+
+        params: dict[str, object] = {}
+        if from_obj is not None:
+            params["from_obj"] = from_obj
+        if options is not None:
+            params["options"] = options
+        params.update(kwargs)
+
+        message_dispatcher.send(
+            self.obj,
+            text,
+            payload=payload,
+            payload_key=payload_key,
+            session=session,
+            use_text_kwarg=False,
+            **params,
+        )
 
     # ------------------------------------------------------------------
     # Package hooks

--- a/src/web/message_dispatcher.py
+++ b/src/web/message_dispatcher.py
@@ -1,0 +1,66 @@
+"""Utilities for sending protocol-aware messages."""
+
+from collections.abc import Iterable
+
+
+def _iter_sessions(target, session):
+    if session is not None:
+        return [session]
+    try:
+        sessions_iter = target.sessions.all()
+        return (
+            list(sessions_iter)
+            if isinstance(sessions_iter, Iterable)
+            else sessions_iter
+        )
+    except AttributeError:
+        return [target]
+
+
+def send(
+    session_or_account,
+    text: str | None = None,
+    *,
+    payload=None,
+    payload_key: str = "rich",
+    session=None,
+    use_text_kwarg: bool = True,
+    **kwargs,
+) -> None:
+    """Send ``text`` and optional ``payload`` to the appropriate sessions.
+
+    Args:
+        session_or_account: Target session or account.
+        text: Message text.
+        payload: Structured data sent only to webclient sessions.
+        payload_key: OOB command name for ``payload``. Defaults to ``"rich"``.
+        session: Specific session to target.
+        use_text_kwarg: Use ``text=`` keyword when calling ``msg``.
+        **kwargs: Additional parameters forwarded to ``msg``.
+    """
+    if session_or_account is None:
+        return
+
+    if text is not None:
+        text_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        if session is not None:
+            text_kwargs["session"] = session
+        try:
+            if use_text_kwarg:
+                session_or_account.msg(text=text, **text_kwargs)
+            else:
+                session_or_account.msg(text, **text_kwargs)
+        except AttributeError:
+            pass
+
+    if payload is None:
+        return
+
+    for sess in _iter_sessions(session_or_account, session):
+        try:
+            if "webclient" in getattr(sess, "protocol_key", ""):
+                # Evennia's OOB system expects (args, kwargs). We have no
+                # positional args, so provide an empty tuple.
+                sess.msg(**{payload_key: ((), payload)})
+        except AttributeError:
+            continue


### PR DESCRIPTION
## Summary
- Default dispatcher and command payload keys to `rich` to differentiate command feedback from player messages
- Restore `send_message` service function to direct messaging without dispatcher coupling

## Testing
- `uv run pre-commit run --files src/commands/command.py src/flows/service_functions/communication.py src/web/message_dispatcher.py`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689a8f98a0cc83319750b6c2aeeab4ea