### PR TITLE
feat: add websocket message type definitions

### DIFF
--- a/docs/frontend/message_types.md
+++ b/docs/frontend/message_types.md
@@ -1,0 +1,68 @@
+# Websocket Message Types
+
+This document describes the payload structure for messages exchanged between the frontend client and the backend over the websocket connection.
+
+## `text`
+
+Standard text messages. The payload contains the text and optional channel information.
+
+```json
+["text", ["<content>"], { "from_channel": "<channel>?" }]
+```
+
+## `logged_in`
+
+Sent by the server after a successful login.
+
+```json
+["logged_in", [], {}]
+```
+
+## `vn_message`
+
+Visual-novel style message with rich metadata.
+
+```json
+[
+  "vn_message",
+  [],
+  {
+    "text": "Hello there!",
+    "speaker": { "key": "Alice", "id": 1, "avatar_url": null, "display_name": "Alice" },
+    "presentation": { "side": "left", "tone": "normal", "emotion": "neutral", "background": null },
+    "interaction": { "message_id": "abc123", "allow_reactions": true, "tags": [] },
+    "timing": { "timestamp": "2024-01-01T00:00:00Z", "typing_speed": "normal" }
+  }
+]
+```
+
+## `message_reaction`
+
+Represents a reaction to a previous message.
+
+```json
+[
+  "message_reaction",
+  [],
+  {
+    "message_id": "abc123",
+    "reaction": "\uD83D\uDC4D",
+    "actor": { "id": 1, "key": "Alice" },
+    "counts": { "\uD83D\uDC4D": 3 }
+  }
+]
+```
+
+## `commands`
+
+Sends one or more commands for the frontend client to execute. Each command
+object contains the command name and optional parameters and is provided in the
+args array.
+
+```json
+[
+  "commands",
+  [{ "command": "open_panel", "params": { "target": "inventory" } }],
+  {}
+]
+```

--- a/frontend/src/hooks/parseGameMessage.ts
+++ b/frontend/src/hooks/parseGameMessage.ts
@@ -16,6 +16,15 @@ export function parseGameMessage(data: string): GameMessage {
           : GAME_MESSAGE_TYPE.TEXT;
       } else if (msgType === WS_MESSAGE_TYPE.LOGGED_IN) {
         content = 'Successfully logged in!';
+      } else if (msgType === WS_MESSAGE_TYPE.VN_MESSAGE) {
+        content = String((kwargs as Record<string, unknown>).text ?? '');
+        messageType = GAME_MESSAGE_TYPE.ACTION;
+      } else if (msgType === WS_MESSAGE_TYPE.MESSAGE_REACTION) {
+        content = JSON.stringify(kwargs);
+        messageType = GAME_MESSAGE_TYPE.SYSTEM;
+      } else if (msgType === WS_MESSAGE_TYPE.COMMANDS) {
+        content = JSON.stringify({ commands: args });
+        messageType = GAME_MESSAGE_TYPE.SYSTEM;
       } else {
         content = JSON.stringify(parsed);
       }

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -12,6 +12,9 @@ export type GameMessageType = (typeof GAME_MESSAGE_TYPE)[keyof typeof GAME_MESSA
 export const WS_MESSAGE_TYPE = {
   TEXT: 'text',
   LOGGED_IN: 'logged_in',
+  VN_MESSAGE: 'vn_message',
+  MESSAGE_REACTION: 'message_reaction',
+  COMMANDS: 'commands',
 } as const;
 
 export type SocketMessageType = (typeof WS_MESSAGE_TYPE)[keyof typeof WS_MESSAGE_TYPE];
@@ -25,3 +28,23 @@ export interface GameMessage {
 export type IncomingMessage = [SocketMessageType, unknown[], Record<string, unknown>?];
 
 export type OutgoingMessage = [typeof WS_MESSAGE_TYPE.TEXT, [string], Record<string, unknown>];
+
+export interface VnMessagePayload {
+  text: string;
+  speaker: Record<string, unknown>;
+  presentation: Record<string, unknown>;
+  interaction: Record<string, unknown>;
+  timing: Record<string, unknown>;
+}
+
+export interface MessageReactionPayload {
+  message_id: string;
+  reaction: string;
+  actor: Record<string, unknown>;
+  counts?: Record<string, number>;
+}
+
+export interface CommandPayload {
+  command: string;
+  params?: Record<string, unknown>;
+}

--- a/src/web/webclient/message_types.py
+++ b/src/web/webclient/message_types.py
@@ -1,0 +1,79 @@
+"""Websocket message type definitions."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class WebsocketMessageType(str, Enum):
+    """Supported websocket message types."""
+
+    TEXT = "text"
+    LOGGED_IN = "logged_in"
+    VN_MESSAGE = "vn_message"
+    MESSAGE_REACTION = "message_reaction"
+    COMMANDS = "commands"
+
+
+@dataclass
+class WebsocketMessage:
+    """Message transmitted over the websocket.
+
+    Attributes:
+        type: Message type identifier.
+        args: Positional message arguments.
+        kwargs: Keyword payload.
+    """
+
+    type: WebsocketMessageType
+    args: List[Any] = field(default_factory=list)
+    kwargs: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class VnMessagePayload:
+    """Payload for ``vn_message`` messages.
+
+    Attributes:
+        text: Message content.
+        speaker: Speaker metadata.
+        presentation: Visual presentation options.
+        interaction: Interaction metadata for the message.
+        timing: Timing information for display.
+    """
+
+    text: str
+    speaker: Dict[str, Any]
+    presentation: Dict[str, Any]
+    interaction: Dict[str, Any]
+    timing: Dict[str, Any]
+
+
+@dataclass
+class MessageReactionPayload:
+    """Payload for ``message_reaction`` messages.
+
+    Attributes:
+        message_id: Identifier of the message receiving the reaction.
+        reaction: Reaction value, such as an emoji.
+        actor: Metadata about the actor reacting.
+        counts: Updated reaction counts.
+    """
+
+    message_id: str
+    reaction: str
+    actor: Dict[str, Any]
+    counts: Optional[Dict[str, int]] = None
+
+
+@dataclass
+class Command:
+    """Command object within a ``commands`` message.
+
+    Attributes:
+        command: Name of the frontend command to execute.
+        params: Optional keyword parameters for the command.
+    """
+
+    command: str
+    params: Dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- define websocket message and payload types in frontend
- mirror websocket message type enums and payload dataclasses on backend
- document websocket message payload structures

## Testing
- `uv run pre-commit run --files frontend/src/hooks/types.ts frontend/src/hooks/parseGameMessage.ts src/web/webclient/message_types.py docs/frontend/message_types.md`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689a8be5cc888331854df36c65199543