### PR TITLE
Send command set updates on login and puppet

### DIFF
--- a/src/typeclasses/accounts.py
+++ b/src/typeclasses/accounts.py
@@ -26,6 +26,8 @@ from functools import cached_property
 
 from evennia.accounts.accounts import DefaultAccount, DefaultGuest
 
+from commands.utils import serialize_cmdset
+
 
 class Account(DefaultAccount):
     """
@@ -110,6 +112,10 @@ class Account(DefaultAccount):
     def at_post_login(self, session=None):
         """Called after successful login."""
         super().at_post_login(session)
+
+        payload = serialize_cmdset(self)
+        for sess in self.sessions.all():
+            sess.msg(commands=(payload, {}))
 
         # Don't auto-puppet anything - let player choose via @ic command
         # Show available characters if they have any

--- a/src/typeclasses/tests/test_cmdset_updates.py
+++ b/src/typeclasses/tests/test_cmdset_updates.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from evennia_extensions.factories import AccountFactory, ObjectDBFactory
+
+
+class CommandUpdateTests(TestCase):
+    def test_at_post_login_sends_commands(self):
+        session = MagicMock()
+        account = AccountFactory(typeclass="typeclasses.accounts.Account")
+        account.sessions.all = MagicMock(return_value=[session])
+        account.get_available_characters = MagicMock(return_value=[])
+        with patch("typeclasses.accounts.serialize_cmdset", return_value=["cmd"]):
+            with patch("typeclasses.accounts.DefaultAccount.at_post_login"):
+                account.at_post_login(session=session)
+        session.msg.assert_any_call(commands=(["cmd"], {}))
+
+    def test_at_post_puppet_sends_commands(self):
+        session1 = MagicMock()
+        session2 = MagicMock()
+        char = ObjectDBFactory(db_typeclass_path="typeclasses.characters.Character")
+        char.sessions.all = MagicMock(return_value=[session1, session2])
+        with patch("typeclasses.characters.serialize_cmdset", return_value=["cmd"]):
+            with patch("typeclasses.characters.DefaultCharacter.at_post_puppet"):
+                char.at_post_puppet()
+        session1.msg.assert_called_with(commands=(["cmd"], {}))
+        session2.msg.assert_called_with(commands=(["cmd"], {}))
+
+    def test_at_post_unpuppet_clears_commands(self):
+        session = MagicMock()
+        char = ObjectDBFactory(db_typeclass_path="typeclasses.characters.Character")
+        with patch("typeclasses.characters.DefaultCharacter.at_post_unpuppet"):
+            char.at_post_unpuppet(session=session)
+        session.msg.assert_called_with(commands=([], {}))


### PR DESCRIPTION
## Summary
- push serialized command sets to sessions on account login and character puppeting
- clear client command mirror on character unpuppet
- add tests for command update hooks

## Testing
- `uv run pre-commit run --files src/typeclasses/accounts.py src/typeclasses/characters.py src/typeclasses/tests/test_cmdset_updates.py`
- `uv run arx test typeclasses.tests.test_cmdset_updates --keepdb`


------
https://chatgpt.com/codex/tasks/task_e_689ab0bd9bac8331b2738660a622493d