### PR TITLE
docs: explain CommandDescriptor format

### DIFF
--- a/docs/frontend/command_descriptor.md
+++ b/docs/frontend/command_descriptor.md
@@ -1,0 +1,64 @@
+# CommandDescriptor Format
+
+`CommandDescriptor` objects describe actions the webclient can present to the player. They appear in command payloads from the server and drive UI elements such as context menus, toolbar icons, and prompts. The format matches the dataclass defined on the backend and includes the following fields:
+
+| field  | type | purpose |
+|--------|------|---------|
+| `label` | string | Human readable label shown to the player |
+| `action` | string | Command verb sent back to the server |
+| `params` | object | Additional parameters for the action |
+| `icon` | string \| null | Optional icon identifier used by the UI |
+
+## Examples
+
+### Context menu
+
+A list of descriptors can populate a right‑click menu for an object:
+
+```json
+[
+  {
+    "label": "Examine",
+    "action": "look",
+    "params": { "target": 42 },
+    "icon": "search"
+  },
+  {
+    "label": "Get",
+    "action": "get",
+    "params": { "target": 42 },
+    "icon": "hand"
+  }
+]
+```
+
+### Icon action
+
+Icons hint at the intent of quick‑access commands, such as toolbar buttons:
+
+```json
+{
+  "label": "Inventory",
+  "action": "open_panel",
+  "params": { "target": "inventory" },
+  "icon": "briefcase"
+}
+```
+
+### Prompt
+
+Descriptors can trigger a client‑side prompt before sending a command back to the server:
+
+```json
+{
+  "label": "Rename",
+  "action": "prompt",
+  "params": {
+    "command": "rename",
+    "prompt": "Enter a new name"
+  },
+  "icon": "edit"
+}
+```
+
+The webclient consumes these descriptors to build interactive elements, as outlined in the [Webclient Game Plan](./game_client_plan.md). Each descriptor supplied in a command payload maps directly to a UI component that collects any needed parameters and dispatches the chosen `action` back to the server.

--- a/docs/frontend/message_types.md
+++ b/docs/frontend/message_types.md
@@ -66,3 +66,5 @@ args array.
   {}
 ]
 ```
+
+For the structure of each command object, refer to [CommandDescriptor Format](./command_descriptor.md), which shows how these descriptors power context menus, icon buttons, and prompts.


### PR DESCRIPTION
## Summary
- document CommandDescriptor fields and provide examples for context menus, icon actions, and prompts
- link message type documentation to CommandDescriptor details

## Testing
- `uv run pre-commit run --files docs/frontend/command_descriptor.md docs/frontend/message_types.md`


------
https://chatgpt.com/codex/tasks/task_e_689ab0b4cf68833191032dc434f77538