### PR TITLE
feat(frontend): handle backend commands

### DIFF
--- a/frontend/src/game/actions.ts
+++ b/frontend/src/game/actions.ts
@@ -1,9 +1,0 @@
-import type { LucideIcon } from 'lucide-react';
-import { Eye, Hand, MessageCircle } from 'lucide-react';
-
-// Lookup mapping action strings to icon components
-export const ACTION_ICON_MAP: Record<string, LucideIcon> = {
-  look: Eye,
-  get: Hand,
-  talk: MessageCircle,
-};

--- a/frontend/src/game/actions.tsx
+++ b/frontend/src/game/actions.tsx
@@ -1,0 +1,30 @@
+import { useGameSocket } from '@/hooks/useGameSocket';
+import type { CommandSpec } from './types';
+import type { LucideIcon } from 'lucide-react';
+import { Eye, Hand, MessageCircle } from 'lucide-react';
+import type { ComponentType } from 'react';
+
+export interface ActionComponentProps extends CommandSpec {
+  character: string;
+}
+
+const makeIconAction = (action: string, Icon: LucideIcon): ComponentType<ActionComponentProps> => {
+  return function IconAction({ character, command }: ActionComponentProps) {
+    const { send } = useGameSocket();
+    return (
+      <button
+        onClick={() => send(character, command)}
+        aria-label={action}
+        className="rounded p-1 hover:bg-accent"
+      >
+        <Icon className="h-4 w-4" />
+      </button>
+    );
+  };
+};
+
+export const ACTION_COMPONENT_MAP: Record<string, ComponentType<ActionComponentProps>> = {
+  look: makeIconAction('look', Eye),
+  get: makeIconAction('get', Hand),
+  talk: makeIconAction('talk', MessageCircle),
+};

--- a/frontend/src/game/components/EntityContextMenu.tsx
+++ b/frontend/src/game/components/EntityContextMenu.tsx
@@ -1,10 +1,5 @@
-import { ACTION_ICON_MAP } from '@/game/actions';
-import { useGameSocket } from '@/hooks/useGameSocket';
-
-interface CommandSpec {
-  action: string;
-  command: string;
-}
+import { ACTION_COMPONENT_MAP } from '@/game/actions';
+import type { CommandSpec } from '@/game/types';
 
 interface EntityContextMenuProps {
   character: string;
@@ -12,23 +7,12 @@ interface EntityContextMenuProps {
 }
 
 export function EntityContextMenu({ character, commands }: EntityContextMenuProps) {
-  const { send } = useGameSocket();
-
   return (
     <div className="flex gap-1">
       {commands.map(({ action, command }) => {
-        const Icon = ACTION_ICON_MAP[action];
-        if (!Icon) return null;
-        return (
-          <button
-            key={action}
-            onClick={() => send(character, command)}
-            aria-label={action}
-            className="rounded p-1 hover:bg-accent"
-          >
-            <Icon className="h-4 w-4" />
-          </button>
-        );
+        const Component = ACTION_COMPONENT_MAP[action];
+        if (!Component) return null;
+        return <Component key={action} character={character} action={action} command={command} />;
       })}
     </div>
   );

--- a/frontend/src/game/components/QuickActions.tsx
+++ b/frontend/src/game/components/QuickActions.tsx
@@ -1,13 +1,20 @@
+import { useAppSelector } from '@/store/hooks';
+import { ACTION_COMPONENT_MAP } from '@/game/actions';
+
 export function QuickActions() {
+  const { active, sessions } = useAppSelector((state) => state.game);
+  if (!active) return null;
+  const commands = sessions[active]?.commands ?? [];
+
   return (
     <div className="rounded-lg border bg-card p-4">
       <h3 className="mb-2 font-semibold">Quick Actions</h3>
-      <div className="space-y-2">
-        <button className="w-full rounded px-2 py-1 text-left text-sm hover:bg-accent">Look</button>
-        <button className="w-full rounded px-2 py-1 text-left text-sm hover:bg-accent">
-          Inventory
-        </button>
-        <button className="w-full rounded px-2 py-1 text-left text-sm hover:bg-accent">Who</button>
+      <div className="flex gap-1">
+        {commands.map(({ action, command }) => {
+          const Component = ACTION_COMPONENT_MAP[action];
+          if (!Component) return null;
+          return <Component key={action} character={active} action={action} command={command} />;
+        })}
       </div>
     </div>
   );

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -1,0 +1,4 @@
+export interface CommandSpec {
+  action: string;
+  command: string;
+}

--- a/frontend/src/hooks/parseGameMessage.ts
+++ b/frontend/src/hooks/parseGameMessage.ts
@@ -22,9 +22,6 @@ export function parseGameMessage(data: string): GameMessage {
       } else if (msgType === WS_MESSAGE_TYPE.MESSAGE_REACTION) {
         content = JSON.stringify(kwargs);
         messageType = GAME_MESSAGE_TYPE.SYSTEM;
-      } else if (msgType === WS_MESSAGE_TYPE.COMMANDS) {
-        content = JSON.stringify({ commands: args });
-        messageType = GAME_MESSAGE_TYPE.SYSTEM;
       } else {
         content = JSON.stringify(parsed);
       }

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -1,11 +1,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { GameMessage } from '../hooks/types';
 import type { MyRosterEntry } from '../roster/types';
+import type { CommandSpec } from '../game/types';
 
 interface Session {
   isConnected: boolean;
   messages: Array<GameMessage & { id: string }>;
   unread: number;
+  commands: CommandSpec[];
 }
 
 interface GameState {
@@ -25,7 +27,7 @@ export const gameSlice = createSlice({
     startSession: (state, action: PayloadAction<MyRosterEntry['name']>) => {
       const name = action.payload;
       if (!state.sessions[name]) {
-        state.sessions[name] = { isConnected: false, messages: [], unread: 0 };
+        state.sessions[name] = { isConnected: false, messages: [], unread: 0, commands: [] };
       }
       state.active = name;
       state.sessions[name].unread = 0;
@@ -66,6 +68,16 @@ export const gameSlice = createSlice({
         session.messages = [];
       }
     },
+    setSessionCommands: (
+      state,
+      action: PayloadAction<{ character: MyRosterEntry['name']; commands: CommandSpec[] }>
+    ) => {
+      const { character, commands } = action.payload;
+      const session = state.sessions[character];
+      if (session) {
+        session.commands = commands;
+      }
+    },
     resetGame: () => initialState,
   },
 });
@@ -76,5 +88,6 @@ export const {
   setSessionConnectionStatus,
   addSessionMessage,
   clearSessionMessages,
+  setSessionCommands,
   resetGame,
 } = gameSlice.actions;


### PR DESCRIPTION
## Summary
- store backend-provided command descriptors per character in Redux
- map command actions to React components for quick-action UI
- dispatch commands via websocket when action buttons are used

## Testing
- `pnpm test --run`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689ab0a79fcc8331b44eab5aa52f20e1