### PR TITLE
docs: revise webclient plan and mark stale docs

### DIFF
--- a/docs/frontend/command_descriptor.md
+++ b/docs/frontend/command_descriptor.md
@@ -7,6 +7,7 @@
 | `label` | string | Human readable label shown to the player |
 | `action` | string | Command verb sent back to the server |
 | `params` | object | Additional parameters for the action |
+| `params_schema` | object \| null | Description of arguments the client must collect |
 | `icon` | string \| null | Optional icon identifier used by the UI |
 
 ## Examples
@@ -60,5 +61,11 @@ Descriptors can trigger a client‑side prompt before sending a command back to 
   "icon": "edit"
 }
 ```
+
+### Collecting parameters
+
+Descriptors with a `params_schema` tell the client which inputs to gather before dispatching the command. If the schema defines one or two simple text fields, the webclient opens a modal dialog. More complex schemas open a side drawer with a form. The collected values merge into `params` when the `action` is sent back to the server.
+
+When `icon` is omitted, the frontend should supply a generic placeholder.
 
 The webclient consumes these descriptors to build interactive elements, as outlined in the [Webclient Game Plan](./game_client_plan.md). Each descriptor supplied in a command payload maps directly to a UI component that collects any needed parameters and dispatches the chosen `action` back to the server.

--- a/docs/frontend/game_client_plan.md
+++ b/docs/frontend/game_client_plan.md
@@ -1,19 +1,34 @@
 # Webclient Game Plan
 
-The `/game` endpoint will evolve into a full-featured webclient built on the new frontend stack. This document outlines desired features and backend support.
+The `/game` endpoint will evolve into a full-featured webclient built on the new frontend stack. This document outlines desired
+features, current progress, and remaining work.
+
+## Progress
+
+- Out-of-band messaging hooks are in place using Evennia's websocket payloads.
+- Backend tasks send available command descriptors and contextual room/object data.
+- Early client parsing exists for these payloads.
 
 ## Core features
 
 - Large chat-centric interface where most interactions happen via text.
 - Messages include contextual data about the sender so the UI can show thumbnails and link to character sheets.
-- UI components such as who list, map, inventory and others can be moved around or toggled within the chat window.
-- Filters allowing players to separate channels, private messages, out-of-character messages and room chatter into different views.
-- Notifications when the player is mentioned or directly addressed.
+- Location panel lists objects, exits, and characters with context-based commands.
+- Right-clicking commands that require additional text opens a modal for one or two fields, or a side drawer for more complex forms.
+- Placeholder icons appear when an object or character lacks a thumbnail.
+- Rich message window displays avatars and supports reactions.
+- Scene window shows active scene information and can convert recent room conversation into scene messages.
 
 ## Technical notes
 
 - Communication continues over the existing websocket system.
-- Backend endpoints may require expansion to deliver the additional context for messages.
+- Backend flows and service functions must emit context updates at appropriate times.
 - Redux Toolkit manages websocket state and chat history on the client.
+
+## Possibly stale
+
+- UI components such as who list, map, inventory and others can be moved around or toggled within the chat window.
+- Filters allowing players to separate channels, private messages, out-of-character messages and room chatter into different views.
+- Notifications when the player is mentioned or directly addressed.
 
 This plan will expand as the modern webclient progresses.

--- a/docs/frontend/message_types.md
+++ b/docs/frontend/message_types.md
@@ -14,6 +14,8 @@ Standard text messages. The payload contains the text and optional channel infor
 
 Sent by the server after a successful login.
 
+> **Possibly stale:** future clients may rely solely on HTTP session state and drop this message.
+
 ```json
 ["logged_in", [], {}]
 ```
@@ -68,3 +70,22 @@ args array.
 ```
 
 For the structure of each command object, refer to [CommandDescriptor Format](./command_descriptor.md), which shows how these descriptors power context menus, icon buttons, and prompts.
+
+## `room_state`
+
+Describes the player's current location. The payload currently includes the room and nearby objects; exits and characters will be added later.
+
+```json
+[
+  "room_state",
+  [],
+  {
+    "room": { "dbref": "#1", "name": "Courtyard", "thumbnail_url": null, "commands": [] },
+    "objects": [
+      { "dbref": "#2", "name": "Bench", "thumbnail_url": null, "commands": ["sit"] }
+    ]
+  }
+]
+```
+
+Clients should display placeholder icons when `thumbnail_url` is null.

--- a/docs/frontend/migration_plan.md
+++ b/docs/frontend/migration_plan.md
@@ -1,5 +1,7 @@
 # Frontend Migration Plan
 
+> **Status:** Login and home page migration is complete. The remaining steps here may be stale and should be reviewed for removal.
+
 These notes outline the process for replacing Evennia's server-rendered pages with a modern React application. The project uses Vite, TypeScript, and Tailwind CSS.
 
 ## Goals

--- a/src/web/WEBCLIENT_METADATA.md
+++ b/src/web/WEBCLIENT_METADATA.md
@@ -1,5 +1,7 @@
 # Websocket Metadata Submission for Visual Novel UI
 
+> **Status:** Basic OOB messaging is now in place and tasks can send command descriptors and room context. The remaining notes capture exploratory work and may be partially stale. See [docs/frontend/game_client_plan.md](../docs/frontend/game_client_plan.md) for current goals.
+
 ## Overview
 
 This document outlines the approach for sending rich metadata through Evennia's websocket connection to support an advanced visual novel-style UI. The system allows us to attach images, avatar thumbnails, emotional states, and interactive elements like message reactions while maintaining compatibility with traditional telnet clients.

--- a/src/web/webclient/README.md
+++ b/src/web/webclient/README.md
@@ -1,5 +1,7 @@
 # Webclient Views
 
+> **Note:** This document describes Evennia's legacy webclient views and is likely stale. The modern React client replaces this system and may remove these views entirely.
+
 The webclient is mainly controlled by Javascript directly in the browser, so
 you usually customize it via `mygame/web/static/webclient/js/` - files instead.
 


### PR DESCRIPTION
## Summary
- document current progress on OOB command descriptors and context payloads
- lay out next steps for location panels, context menus, and scene integration
- flag outdated frontend docs as potentially stale for future cleanup

## Testing
- `uv run pre-commit run --files docs/frontend/command_descriptor.md docs/frontend/game_client_plan.md docs/frontend/message_types.md docs/frontend/migration_plan.md src/web/WEBCLIENT_METADATA.md src/web/webclient/README.md`

------
https://chatgpt.com/codex/tasks/task_e_689b845ca3d483318f8f8c5c61461d23