### PR TITLE
Enhance scene browsing with filters, reactions, and detail views

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import { ProfilePage } from './pages/ProfilePage';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { CharacterSheetPage } from './roster/pages/CharacterSheetPage';
 import { RosterListPage } from './roster/pages/RosterListPage';
+import { ScenesListPage } from './scenes/pages/ScenesListPage';
+import { SceneDetailPage } from './scenes/pages/SceneDetailPage';
 
 function App() {
   return (
@@ -17,6 +19,8 @@ function App() {
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/roster" element={<RosterListPage />} />
         <Route path="/characters/:id" element={<CharacterSheetPage />} />
+        <Route path="/scenes" element={<ScenesListPage />} />
+        <Route path="/scenes/:id" element={<SceneDetailPage />} />
         <Route path="/game" element={<GamePage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/frontend/src/scenes/components/SceneHeader.tsx
+++ b/frontend/src/scenes/components/SceneHeader.tsx
@@ -1,0 +1,21 @@
+import { SceneDetail } from '../queries';
+
+interface Props {
+  scene?: SceneDetail;
+}
+
+export function SceneHeader({ scene }: Props) {
+  if (!scene) return null;
+  return (
+    <div>
+      <h1 className="mb-2 text-xl font-bold">{scene.name}</h1>
+      <p className="mb-4">{scene.description}</p>
+      {scene.highlight_message && (
+        <div className="mb-4 border bg-muted/20 p-2">
+          <p className="font-semibold">Top Message:</p>
+          <p>{scene.highlight_message.content}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/scenes/components/SceneMessages.tsx
+++ b/frontend/src/scenes/components/SceneMessages.tsx
@@ -1,0 +1,75 @@
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRef } from 'react';
+import { fetchSceneMessages, postReaction, SceneMessage } from '../queries';
+
+interface Props {
+  sceneId: string;
+}
+
+export function SceneMessages({ sceneId }: Props) {
+  const queryClient = useQueryClient();
+  const messageIdRef = useRef<number>(0);
+  const messagesQuery = useInfiniteQuery<{
+    results: SceneMessage[];
+    next?: string;
+    nextCursor?: string;
+  }>({
+    queryKey: ['scene-messages', sceneId],
+    queryFn: ({ pageParam }) => fetchSceneMessages(sceneId, pageParam),
+    getNextPageParam: (lastPage) => lastPage.nextCursor || lastPage.next,
+  });
+
+  const reactionMutation = useMutation({
+    mutationFn: (emoji: string) => postReaction(messageIdRef.current, emoji),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] }),
+  });
+
+  return (
+    <div>
+      {messagesQuery.data?.pages
+        .flatMap((page) => page.results)
+        .map((msg: SceneMessage) => (
+          <div key={msg.id} className="border-b py-2">
+            <div className="flex items-center gap-2">
+              {msg.persona.thumbnail_url && (
+                <img src={msg.persona.thumbnail_url} alt={msg.persona.name} className="h-6 w-6" />
+              )}
+              <span className="font-medium">{msg.persona.name}</span>
+              <span className="text-xs text-muted-foreground">
+                {new Date(msg.timestamp).toLocaleString()}
+              </span>
+            </div>
+            <p>{msg.content}</p>
+            <div className="flex gap-2">
+              {msg.reactions.map((r) => (
+                <button
+                  key={r.emoji}
+                  className="text-sm"
+                  onClick={() => {
+                    messageIdRef.current = msg.id;
+                    reactionMutation.mutate(r.emoji);
+                  }}
+                >
+                  {r.emoji} {r.count}
+                </button>
+              ))}
+              <button
+                className="text-sm"
+                onClick={() => {
+                  messageIdRef.current = msg.id;
+                  reactionMutation.mutate('👍');
+                }}
+              >
+                👍
+              </button>
+            </div>
+          </div>
+        ))}
+      {messagesQuery.hasNextPage && (
+        <button onClick={() => messagesQuery.fetchNextPage()} className="mt-4">
+          Load More
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/scenes/pages/SceneDetailPage.tsx
+++ b/frontend/src/scenes/pages/SceneDetailPage.tsx
@@ -1,0 +1,19 @@
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { fetchScene, SceneDetail } from '../queries';
+import { SceneHeader } from '../components/SceneHeader';
+import { SceneMessages } from '../components/SceneMessages';
+
+export function SceneDetailPage() {
+  const { id = '' } = useParams();
+  const { data: scene } = useQuery<SceneDetail>({
+    queryKey: ['scene', id],
+    queryFn: () => fetchScene(id),
+  });
+  return (
+    <div className="container mx-auto p-4">
+      <SceneHeader scene={scene} />
+      <SceneMessages sceneId={id} />
+    </div>
+  );
+}

--- a/frontend/src/scenes/pages/ScenesListPage.tsx
+++ b/frontend/src/scenes/pages/ScenesListPage.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { fetchScenes, SceneListItem } from '../queries';
+
+export function ScenesListPage() {
+  const [status, setStatus] = useState('active');
+  const { data } = useQuery<{ results: SceneListItem[] }>({
+    queryKey: ['scenes', status],
+    queryFn: () => fetchScenes(`status=${status}`),
+  });
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="mb-4">
+        <select value={status} onChange={(e) => setStatus(e.target.value)} className="border p-2">
+          <option value="active">Active</option>
+          <option value="completed">Completed</option>
+          <option value="upcoming">Upcoming</option>
+        </select>
+      </div>
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="border p-2 text-left">Name</th>
+            <th className="border p-2 text-left">Description</th>
+            <th className="border p-2 text-left">Date</th>
+            <th className="border p-2 text-left">Location</th>
+            <th className="border p-2 text-left">Participants</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.results?.map((scene) => (
+            <tr key={scene.id}>
+              <td className="border p-2">
+                <Link to={`/scenes/${scene.id}`} className="text-blue-600 hover:underline">
+                  {scene.name}
+                </Link>
+              </td>
+              <td className="border p-2">{scene.description}</td>
+              <td className="border p-2">{new Date(scene.date_started).toLocaleDateString()}</td>
+              <td className="border p-2">{scene.location?.name || ''}</td>
+              <td className="border p-2">
+                {scene.participants.map((p, idx) => (
+                  <span key={p.id}>
+                    {p.roster_entry ? (
+                      <Link
+                        to={`/characters/${p.roster_entry.id}`}
+                        className="text-blue-600 hover:underline"
+                      >
+                        {p.name}
+                      </Link>
+                    ) : (
+                      p.name
+                    )}
+                    {idx < scene.participants.length - 1 && ', '}
+                  </span>
+                ))}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -1,0 +1,68 @@
+import { apiFetch } from '../evennia_replacements/api';
+
+export interface RosterEntryRef {
+  id: number;
+  name: string;
+}
+
+export interface SceneParticipant {
+  id: number;
+  name: string;
+  roster_entry?: RosterEntryRef | null;
+}
+
+export interface SceneLocation {
+  id: number;
+  name: string;
+}
+
+export interface SceneListItem {
+  id: number;
+  name: string;
+  description: string;
+  date_started: string;
+  location?: SceneLocation | null;
+  participants: SceneParticipant[];
+}
+
+export interface SceneDetail extends SceneListItem {
+  highlight_message: SceneMessage | null;
+}
+
+export interface SceneMessage {
+  id: number;
+  persona: { id: number; name: string; thumbnail_url?: string };
+  content: string;
+  timestamp: string;
+  reactions: { emoji: string; count: number; reacted: boolean }[];
+}
+
+export async function fetchScenes(params: string) {
+  const res = await apiFetch(`/api/scenes/?${params}`);
+  if (!res.ok) throw new Error('Failed to load scenes');
+  return res.json();
+}
+
+export async function fetchScene(id: string) {
+  const res = await apiFetch(`/api/scenes/${id}/`);
+  if (!res.ok) throw new Error('Failed to load scene');
+  return res.json();
+}
+
+export async function fetchSceneMessages(scene: string, cursor?: string) {
+  const url = new URL('/api/messages/', window.location.origin);
+  url.searchParams.set('scene', scene);
+  if (cursor) url.searchParams.set('cursor', cursor);
+  const res = await apiFetch(url.pathname + url.search);
+  if (!res.ok) throw new Error('Failed to load messages');
+  return res.json();
+}
+
+export async function postReaction(message: number, emoji: string) {
+  const res = await apiFetch('/api/reactions/', {
+    method: 'POST',
+    body: JSON.stringify({ message, emoji }),
+  });
+  if (!res.ok) throw new Error('Failed to add reaction');
+  return res.json();
+}

--- a/src/world/scenes/admin.py
+++ b/src/world/scenes/admin.py
@@ -4,6 +4,7 @@ from world.scenes.models import (
     Persona,
     Scene,
     SceneMessage,
+    SceneMessageReaction,
     SceneMessageSupplementalData,
     SceneParticipation,
 )
@@ -14,12 +15,6 @@ class SceneMessageInline(admin.TabularInline):
     extra = 0
     readonly_fields = ["timestamp", "sequence_number"]
     fields = ["persona", "content", "context", "mode", "timestamp", "sequence_number"]
-
-
-class PersonaInline(admin.TabularInline):
-    model = Persona
-    extra = 0
-    fields = ["name", "description", "character", "thumbnail_url"]
 
 
 class SceneParticipationInline(admin.TabularInline):
@@ -41,7 +36,7 @@ class SceneAdmin(admin.ModelAdmin):
     list_filter = ["is_active", "is_public", "date_started"]
     search_fields = ["name", "description"]
     readonly_fields = ["date_started"]
-    inlines = [SceneParticipationInline, PersonaInline, SceneMessageInline]
+    inlines = [SceneParticipationInline, SceneMessageInline]
 
     def participant_count(self, obj):
         return obj.participants.count()
@@ -51,9 +46,13 @@ class SceneAdmin(admin.ModelAdmin):
 
 @admin.register(Persona)
 class PersonaAdmin(admin.ModelAdmin):
-    list_display = ["name", "scene", "account", "character", "created_at"]
-    list_filter = ["created_at", "scene__is_active"]
-    search_fields = ["name", "scene__name", "account__username"]
+    list_display = ["name", "scene", "participation", "character", "created_at"]
+    list_filter = ["created_at"]
+    search_fields = [
+        "name",
+        "participation__scene__name",
+        "participation__account__username",
+    ]
     readonly_fields = ["created_at"]
 
 
@@ -75,3 +74,11 @@ class SceneMessageAdmin(admin.ModelAdmin):
 @admin.register(SceneMessageSupplementalData)
 class SceneMessageSupplementalDataAdmin(admin.ModelAdmin):
     list_display = ["message"]
+
+
+@admin.register(SceneMessageReaction)
+class SceneMessageReactionAdmin(admin.ModelAdmin):
+    list_display = ["message", "account", "emoji", "created_at"]
+    list_filter = ["emoji", "created_at"]
+    search_fields = ["message__content", "account__username"]
+    readonly_fields = ["created_at"]

--- a/src/world/scenes/filters.py
+++ b/src/world/scenes/filters.py
@@ -1,3 +1,4 @@
+from django.utils import timezone
 import django_filters
 
 from world.scenes.models import Persona, Scene, SceneMessage
@@ -8,20 +9,54 @@ class SceneFilter(django_filters.FilterSet):
     is_public = django_filters.BooleanFilter()
     location = django_filters.NumberFilter(field_name="location__id")
     participant = django_filters.NumberFilter(field_name="participants__id")
+    status = django_filters.CharFilter(method="filter_status")
+    gm = django_filters.NumberFilter(method="filter_gm")
+    player = django_filters.NumberFilter(method="filter_player")
 
     class Meta:
         model = Scene
-        fields = ["is_active", "is_public", "location", "participant"]
+        fields = [
+            "is_active",
+            "is_public",
+            "location",
+            "participant",
+            "status",
+            "gm",
+            "player",
+        ]
+
+    def filter_status(self, queryset, name, value):
+        now = timezone.now()
+        if value == "active":
+            return queryset.filter(
+                is_active=True, date_started__lte=now, date_finished__isnull=True
+            )
+        if value == "completed":
+            return queryset.filter(is_active=False, date_finished__isnull=False)
+        if value == "upcoming":
+            return queryset.filter(is_active=False, date_started__gt=now)
+        return queryset
+
+    def filter_gm(self, queryset, name, value):
+        return queryset.filter(
+            participations__account__id=value, participations__is_gm=True
+        ).distinct()
+
+    def filter_player(self, queryset, name, value):
+        return queryset.filter(
+            participations__account__id=value, participations__is_gm=False
+        ).distinct()
 
 
 class PersonaFilter(django_filters.FilterSet):
-    scene = django_filters.NumberFilter(field_name="scene__id")
-    account = django_filters.NumberFilter(field_name="account__id")
+    scene = django_filters.NumberFilter(field_name="participation__scene__id")
+    participation = django_filters.NumberFilter(field_name="participation__id")
+    account = django_filters.NumberFilter(field_name="participation__account__id")
     character = django_filters.NumberFilter(field_name="character__id")
 
     class Meta:
         model = Persona
-        fields = ["scene", "account", "character"]
+        fields = ["scene", "participation", "account", "character"]
 
 
 class SceneMessageFilter(django_filters.FilterSet):

--- a/src/world/scenes/serializers.py
+++ b/src/world/scenes/serializers.py
@@ -1,22 +1,34 @@
-from django.core.exceptions import ObjectDoesNotExist
-from evennia.accounts.models import AccountDB
+from django.db.models import Count
 from rest_framework import serializers
 
-from world.scenes.models import Persona, Scene, SceneMessage
+from world.scenes.models import Persona, Scene, SceneMessage, SceneMessageReaction
 
 
 class PersonaSerializer(serializers.ModelSerializer):
+    roster_entry = serializers.SerializerMethodField()
+
     class Meta:
         model = Persona
         fields = [
             "id",
-            "scene",
-            "account",
+            "participation",
             "name",
+            "is_fake_name",
             "description",
             "thumbnail_url",
             "character",
+            "roster_entry",
         ]
+        read_only_fields = ["roster_entry"]
+
+    def get_roster_entry(self, obj):
+        entry = getattr(obj.character, "roster_entry", None)
+        if entry:
+            return {"id": entry.id, "name": entry.character.db_key}
+        return None
+
+    def create(self, validated_data):
+        return super().create(validated_data)
 
 
 class SceneMessageSerializer(serializers.ModelSerializer):
@@ -26,6 +38,7 @@ class SceneMessageSerializer(serializers.ModelSerializer):
     supplemental_data = serializers.JSONField(
         source="supplemental_data.data", read_only=True, allow_null=True
     )
+    reactions = serializers.SerializerMethodField()
 
     class Meta:
         model = SceneMessage
@@ -40,56 +53,71 @@ class SceneMessageSerializer(serializers.ModelSerializer):
             "supplemental_data",
             "timestamp",
             "sequence_number",
+            "reactions",
         ]
         read_only_fields = ["sequence_number", "timestamp"]
+
+    def get_reactions(self, obj):
+        request = self.context.get("request")
+        reactions = obj.reactions.values("emoji").annotate(count=Count("id"))
+        user_reacted = set()
+        if request and request.user.is_authenticated:
+            user_reacted = set(
+                obj.reactions.filter(account=request.user).values_list(
+                    "emoji", flat=True
+                )
+            )
+        return [
+            {
+                "emoji": r["emoji"],
+                "count": r["count"],
+                "reacted": r["emoji"] in user_reacted,
+            }
+            for r in reactions
+        ]
 
     def create(self, validated_data):
         persona_id = validated_data.pop("persona_id", None)
         if persona_id:
-            persona = Persona.objects.select_related("scene").get(id=persona_id)
+            persona = Persona.objects.select_related("participation__scene").get(
+                id=persona_id
+            )
             validated_data["persona"] = persona
-            validated_data["scene"] = persona.scene
+            validated_data["scene"] = persona.participation.scene
+        return super().create(validated_data)
+
+
+class SceneMessageReactionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SceneMessageReaction
+        fields = ["id", "message", "emoji"]
+
+    def create(self, validated_data):
+        validated_data["account"] = self.context["request"].user
         return super().create(validated_data)
 
 
 class SceneParticipantSerializer(serializers.ModelSerializer):
-    """
-    Simplified participant representation for scene lists
-    """
+    """Simplified participant representation for scene lists"""
 
-    avatar_url = serializers.SerializerMethodField()
+    roster_entry = serializers.SerializerMethodField()
 
     class Meta:
-        model = AccountDB
-        fields = ["id", "username", "avatar_url"]
+        model = Persona
+        fields = ["id", "name", "roster_entry"]
 
-    def get_avatar_url(self, obj):
-        try:
-            return obj.player_data.avatar_url
-        except ObjectDoesNotExist:
-            return None
+    def get_roster_entry(self, obj):
+        entry = getattr(obj.character, "roster_entry", None)
+        if entry:
+            return {"id": entry.id, "name": entry.character.db_key}
+        return None
 
 
 class SceneListSerializer(serializers.ModelSerializer):
-    """
-    Simplified scene representation for lists (like spotlight)
-    """
+    """Simplified scene representation for lists"""
 
-    participants = SceneParticipantSerializer(many=True, read_only=True)
-
-    class Meta:
-        model = Scene
-        fields = ["id", "name", "participants"]
-
-
-class SceneDetailSerializer(serializers.ModelSerializer):
-    """
-    Full scene representation with messages and personas
-    """
-
-    messages = SceneMessageSerializer(many=True, read_only=True)
-    personas = PersonaSerializer(many=True, read_only=True)
-    participants = SceneParticipantSerializer(many=True, read_only=True)
+    participants = serializers.SerializerMethodField()
+    location = serializers.SerializerMethodField()
 
     class Meta:
         model = Scene
@@ -97,15 +125,59 @@ class SceneDetailSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "description",
-            "location",
             "date_started",
+            "location",
+            "participants",
+        ]
+
+    def get_location(self, obj):
+        if obj.location:
+            return {"id": obj.location.id, "name": obj.location.db_key}
+        return None
+
+    def get_participants(self, obj):
+        personas = Persona.objects.filter(
+            participation__scene=obj, is_fake_name=False, participation__is_gm=False
+        ).select_related("character__roster_entry")
+        return SceneParticipantSerializer(personas, many=True).data
+
+
+class SceneDetailSerializer(SceneListSerializer):
+    """Full scene representation with messages and personas"""
+
+    messages = SceneMessageSerializer(many=True, read_only=True)
+    personas = serializers.SerializerMethodField()
+    highlight_message = serializers.SerializerMethodField()
+
+    class Meta(SceneListSerializer.Meta):
+        model = Scene
+        fields = SceneListSerializer.Meta.fields + [
             "date_finished",
             "is_active",
             "is_public",
-            "participants",
             "personas",
             "messages",
+            "highlight_message",
         ]
+
+    def get_personas(self, obj):
+        personas = Persona.objects.filter(participation__scene=obj).select_related(
+            "participation", "character__roster_entry"
+        )
+        return PersonaSerializer(personas, many=True).data
+
+    def get_participants(self, obj):
+        return super().get_participants(obj)
+
+    def get_highlight_message(self, obj):
+        message = (
+            obj.messages.annotate(num_reactions=Count("reactions"))
+            .order_by("-num_reactions", "sequence_number")
+            .first()
+        )
+        if message:
+            return SceneMessageSerializer(message, context=self.context).data
+        return None
 
 
 class ScenesSpotlightSerializer(serializers.Serializer):

--- a/src/world/scenes/tests/test_permissions.py
+++ b/src/world/scenes/tests/test_permissions.py
@@ -3,7 +3,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from core_management.test_utils import suppress_permission_errors
-from evennia_extensions.factories import AccountFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory
 from world.scenes.factories import (
     PersonaFactory,
     SceneFactory,
@@ -143,17 +143,20 @@ class PersonaPermissionsTestCase(APITestCase):
         cls.staff = AccountFactory(username="staff", is_staff=True)
 
         cls.scene = SceneFactory()
-        SceneParticipationFactory(scene=cls.scene, account=cls.participant)
-        cls.persona = PersonaFactory(scene=cls.scene, account=cls.participant)
+        cls.participation = SceneParticipationFactory(
+            scene=cls.scene, account=cls.participant
+        )
+        cls.persona = PersonaFactory(participation=cls.participation)
 
     @suppress_permission_errors
     def test_create_persona_participant_only(self):
         """Only scene participants can create personas"""
         url = reverse("persona-list")
+        character = CharacterFactory()
         data = {
-            "scene": self.scene.id,
             "name": "Test Persona",
-            "account": self.participant.id,
+            "participation": self.participation.id,
+            "character": character.id,
         }
 
         # Outsider cannot create persona
@@ -197,12 +200,16 @@ class SceneMessagePermissionsTestCase(APITestCase):
         cls.staff = AccountFactory(username="staff", is_staff=True)
 
         cls.scene = SceneFactory()
-        SceneParticipationFactory(scene=cls.scene, account=cls.sender)
-        SceneParticipationFactory(scene=cls.scene, account=cls.participant)
-
-        cls.sender_persona = PersonaFactory(scene=cls.scene, account=cls.sender)
-        cls.participant_persona = PersonaFactory(
+        cls.sender_participation = SceneParticipationFactory(
+            scene=cls.scene, account=cls.sender
+        )
+        cls.participant_participation = SceneParticipationFactory(
             scene=cls.scene, account=cls.participant
+        )
+
+        cls.sender_persona = PersonaFactory(participation=cls.sender_participation)
+        cls.participant_persona = PersonaFactory(
+            participation=cls.participant_participation
         )
 
         cls.message = SceneMessageFactory(scene=cls.scene, persona=cls.sender_persona)

--- a/src/world/scenes/urls.py
+++ b/src/world/scenes/urls.py
@@ -1,12 +1,20 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from world.scenes.views import PersonaViewSet, SceneMessageViewSet, SceneViewSet
+from world.scenes.views import (
+    PersonaViewSet,
+    SceneMessageReactionViewSet,
+    SceneMessageViewSet,
+    SceneViewSet,
+)
 
 router = DefaultRouter()
 router.register(r"scenes", SceneViewSet)
 router.register(r"personas", PersonaViewSet, basename="persona")
 router.register(r"messages", SceneMessageViewSet, basename="scenemessage")
+router.register(
+    r"reactions", SceneMessageReactionViewSet, basename="scenemessagereaction"
+)
 
 urlpatterns = [
     path("api/", include(router.urls)),


### PR DESCRIPTION
## Summary
- remove denormalized scene foreign key from personas and require a character reference
- derive scene context via scene participation throughout serializers, filters, views, and admin
- replace previous migration with updated initial schema reflecting the streamlined persona model

## Testing
- `uv run pre-commit run --files src/world/scenes/models.py src/world/scenes/factories.py src/world/scenes/serializers.py src/world/scenes/filters.py src/world/scenes/permissions.py src/world/scenes/views.py src/world/scenes/admin.py src/world/scenes/tests/test_view_actions_permissions.py src/world/scenes/tests/test_permissions.py src/world/scenes/tests/test_views.py src/world/scenes/migrations/0001_initial.py`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689b88a89a5083318cfb730f603597ad