### PR TITLE
Fix outdated play links to game route

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -13,7 +13,7 @@ import { Sheet, SheetTrigger, SheetContent } from './ui/sheet';
 import { Button } from './ui/button';
 
 const links = [
-  { to: '/play', label: 'Play' },
+  { to: '/game', label: 'Play' },
   { to: '/roster', label: 'Roster' },
   { to: '/scenes', label: 'Scenes' },
   { to: '/news', label: 'News' },

--- a/frontend/src/components/QuickActions.tsx
+++ b/frontend/src/components/QuickActions.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { Card } from './ui/card';
 
 const actions = [
-  { to: '/play', label: 'Play' },
+  { to: '/game', label: 'Play' },
   { to: '/roster', label: 'Roster' },
   { to: '/scenes', label: 'Scenes' },
   { to: '/lore', label: 'Lore' },


### PR DESCRIPTION
## Summary
- point Play navigation links to `/game`

## Testing
- `pnpm exec prettier src/components/Header.tsx src/components/QuickActions.tsx --write`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689b87727cb483319fa6c2f69496458a