### PR TITLE
Add interactive scene management

### DIFF
--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -6,6 +6,7 @@ import { setActiveSession } from '../../store/gameSlice';
 import { useGameSocket } from '../../hooks/useGameSocket';
 import { Link } from 'react-router-dom';
 import type { MyRosterEntry } from '../../roster/types';
+import { SceneWindow } from './SceneWindow';
 
 interface GameWindowProps {
   characters: MyRosterEntry[];
@@ -70,6 +71,7 @@ export function GameWindow({ characters }: GameWindowProps) {
             </button>
           ))}
         </div>
+        <SceneWindow character={active} scene={session.scene} room={session.room} />
         <ChatWindow messages={session.messages} isConnected={session.isConnected} />
         <CommandInput character={active} />
       </CardContent>

--- a/frontend/src/game/components/SceneWindow.tsx
+++ b/frontend/src/game/components/SceneWindow.tsx
@@ -1,0 +1,56 @@
+import { Card, CardContent } from '../../components/ui/card';
+import { Button } from '../../components/ui/button';
+import { Link } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { startScene, finishScene } from '../../scenes/queries';
+import type { SceneSummary } from '../../hooks/types';
+
+interface Props {
+  character: string;
+  scene: SceneSummary | null;
+  room: { id: number; name: string } | null;
+}
+
+export function SceneWindow({ character, scene, room }: Props) {
+  const start = useMutation({
+    mutationFn: () => {
+      if (!room) throw new Error('No room');
+      const name = `${character} scene at ${room.name} on ${new Date().toISOString().slice(0, 10)}`;
+      return startScene(room.id, name);
+    },
+  });
+
+  const end = useMutation({
+    mutationFn: () => finishScene(String(scene?.id)),
+  });
+
+  if (!room) return null;
+
+  return (
+    <Card className="mb-4">
+      <CardContent className="p-4">
+        {scene ? (
+          <div className="flex items-center justify-between">
+            <Link to={`/scenes/${scene.id}`} className="underline">
+              {scene.name}
+            </Link>
+            {scene.is_owner && (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => end.mutate()}
+                disabled={end.isPending}
+              >
+                End Scene
+              </Button>
+            )}
+          </div>
+        ) : (
+          <Button size="sm" onClick={() => start.mutate()} disabled={start.isPending}>
+            Start Scene
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/handleRoomStatePayload.ts
+++ b/frontend/src/hooks/handleRoomStatePayload.ts
@@ -1,6 +1,13 @@
 import type { RoomStatePayload } from './types';
+import type { AppDispatch } from '../store/store';
+import { setSessionRoom, setSessionScene } from '../store/gameSlice';
 
-export function handleRoomStatePayload(payload: RoomStatePayload) {
-  // TODO: dispatch room state to update frontend state
-  console.debug('Received room state payload', payload);
+export function handleRoomStatePayload(
+  character: string,
+  payload: RoomStatePayload,
+  dispatch: AppDispatch
+) {
+  const roomId = parseInt(payload.room.dbref.replace('#', ''), 10);
+  dispatch(setSessionRoom({ character, room: { id: roomId, name: payload.room.name } }));
+  dispatch(setSessionScene({ character, scene: payload.scene ?? null }));
 }

--- a/frontend/src/hooks/handleScenePayload.ts
+++ b/frontend/src/hooks/handleScenePayload.ts
@@ -1,0 +1,12 @@
+import type { ScenePayload } from './types';
+import type { AppDispatch } from '../store/store';
+import { setSessionScene } from '../store/gameSlice';
+
+export function handleScenePayload(
+  character: string,
+  payload: ScenePayload,
+  dispatch: AppDispatch
+) {
+  const scene = payload.action === 'end' ? null : payload.scene;
+  dispatch(setSessionScene({ character, scene }));
+}

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -16,6 +16,7 @@ export const WS_MESSAGE_TYPE = {
   MESSAGE_REACTION: 'message_reaction',
   COMMANDS: 'commands',
   ROOM_STATE: 'room_state',
+  SCENE: 'scene',
 } as const;
 
 export type SocketMessageType = (typeof WS_MESSAGE_TYPE)[keyof typeof WS_MESSAGE_TYPE];
@@ -62,4 +63,17 @@ export interface RoomStateObject {
 export interface RoomStatePayload {
   room: RoomStateObject;
   objects: RoomStateObject[];
+  scene?: SceneSummary | null;
+}
+
+export interface SceneSummary {
+  id: number;
+  name: string;
+  description: string;
+  is_owner: boolean;
+}
+
+export interface ScenePayload {
+  action: 'start' | 'update' | 'end';
+  scene: SceneSummary;
 }

--- a/frontend/src/hooks/useGameSocket.ts
+++ b/frontend/src/hooks/useGameSocket.ts
@@ -9,8 +9,10 @@ import type {
   IncomingMessage,
   OutgoingMessage,
   RoomStatePayload,
+  ScenePayload,
 } from './types';
 import { handleRoomStatePayload } from './handleRoomStatePayload';
+import { handleScenePayload } from './handleScenePayload';
 import { handleCommandPayload } from './handleCommandPayload';
 
 import { useCallback } from 'react';
@@ -73,8 +75,12 @@ export function useGameSocket() {
 
           // Control message: ROOM_STATE
           if (msgType === WS_MESSAGE_TYPE.ROOM_STATE) {
-            // codex branch expected payload in kwargs
-            handleRoomStatePayload(kwargs as unknown as RoomStatePayload);
+            handleRoomStatePayload(character, kwargs as unknown as RoomStatePayload, dispatch);
+            return;
+          }
+
+          if (msgType === WS_MESSAGE_TYPE.SCENE) {
+            handleScenePayload(character, kwargs as unknown as ScenePayload, dispatch);
             return;
           }
 

--- a/frontend/src/scenes/components/SceneHeader.tsx
+++ b/frontend/src/scenes/components/SceneHeader.tsx
@@ -1,15 +1,73 @@
-import { SceneDetail } from '../queries';
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { SceneDetail, updateScene, finishScene } from '../queries';
+import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
+import { Textarea } from '../../components/ui/textarea';
 
 interface Props {
   scene?: SceneDetail;
 }
 
 export function SceneHeader({ scene }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(scene?.name ?? '');
+  const [description, setDescription] = useState(scene?.description ?? '');
+  const qc = useQueryClient();
+  const save = useMutation({
+    mutationFn: () => updateScene(String(scene?.id), { name, description }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['scene', String(scene?.id)] });
+      setEditing(false);
+    },
+  });
+  const end = useMutation({
+    mutationFn: () => finishScene(String(scene?.id)),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['scene', String(scene?.id)] });
+    },
+  });
+
   if (!scene) return null;
+
+  if (editing) {
+    return (
+      <div className="mb-4 space-y-2">
+        <Input value={name} onChange={(e) => setName(e.target.value)} />
+        <Textarea value={description} onChange={(e) => setDescription(e.target.value)} />
+        <div className="flex gap-2">
+          <Button size="sm" onClick={() => save.mutate()} disabled={save.isPending}>
+            Save
+          </Button>
+          <Button size="sm" variant="secondary" onClick={() => setEditing(false)}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div>
       <h1 className="mb-2 text-xl font-bold">{scene.name}</h1>
       <p className="mb-4">{scene.description}</p>
+      {scene.is_owner && (
+        <div className="mb-4 flex gap-2">
+          <Button size="sm" onClick={() => setEditing(true)}>
+            Edit
+          </Button>
+          {scene.is_active && (
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => end.mutate()}
+              disabled={end.isPending}
+            >
+              End Scene
+            </Button>
+          )}
+        </div>
+      )}
       {scene.highlight_message && (
         <div className="mb-4 border bg-muted/20 p-2">
           <p className="font-semibold">Top Message:</p>

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -27,6 +27,8 @@ export interface SceneListItem {
 
 export interface SceneDetail extends SceneListItem {
   highlight_message: SceneMessage | null;
+  is_active: boolean;
+  is_owner: boolean;
 }
 
 export interface SceneMessage {
@@ -64,5 +66,29 @@ export async function postReaction(message: number, emoji: string) {
     body: JSON.stringify({ message, emoji }),
   });
   if (!res.ok) throw new Error('Failed to add reaction');
+  return res.json();
+}
+
+export async function startScene(location: number, name?: string) {
+  const res = await apiFetch('/api/scenes/', {
+    method: 'POST',
+    body: JSON.stringify({ location_id: location, name }),
+  });
+  if (!res.ok) throw new Error('Failed to start scene');
+  return res.json();
+}
+
+export async function updateScene(id: string, data: { name?: string; description?: string }) {
+  const res = await apiFetch(`/api/scenes/${id}/`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to update scene');
+  return res.json();
+}
+
+export async function finishScene(id: string) {
+  const res = await apiFetch(`/api/scenes/${id}/finish/`, { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to finish scene');
   return res.json();
 }

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import type { GameMessage } from '../hooks/types';
+import type { GameMessage, SceneSummary } from '../hooks/types';
 import type { MyRosterEntry } from '../roster/types';
 import type { CommandSpec } from '../game/types';
 
@@ -8,6 +8,8 @@ interface Session {
   messages: Array<GameMessage & { id: string }>;
   unread: number;
   commands: CommandSpec[];
+  room: { id: number; name: string } | null;
+  scene: SceneSummary | null;
 }
 
 interface GameState {
@@ -27,7 +29,14 @@ export const gameSlice = createSlice({
     startSession: (state, action: PayloadAction<MyRosterEntry['name']>) => {
       const name = action.payload;
       if (!state.sessions[name]) {
-        state.sessions[name] = { isConnected: false, messages: [], unread: 0, commands: [] };
+        state.sessions[name] = {
+          isConnected: false,
+          messages: [],
+          unread: 0,
+          commands: [],
+          room: null,
+          scene: null,
+        };
       }
       state.active = name;
       state.sessions[name].unread = 0;
@@ -78,6 +87,29 @@ export const gameSlice = createSlice({
         session.commands = commands;
       }
     },
+    setSessionRoom: (
+      state,
+      action: PayloadAction<{
+        character: MyRosterEntry['name'];
+        room: { id: number; name: string } | null;
+      }>
+    ) => {
+      const { character, room } = action.payload;
+      const session = state.sessions[character];
+      if (session) {
+        session.room = room;
+      }
+    },
+    setSessionScene: (
+      state,
+      action: PayloadAction<{ character: MyRosterEntry['name']; scene: SceneSummary | null }>
+    ) => {
+      const { character, scene } = action.payload;
+      const session = state.sessions[character];
+      if (session) {
+        session.scene = scene;
+      }
+    },
     resetGame: () => initialState,
   },
 });
@@ -89,5 +121,7 @@ export const {
   addSessionMessage,
   clearSessionMessages,
   setSessionCommands,
+  setSessionRoom,
+  setSessionScene,
   resetGame,
 } = gameSlice.actions;

--- a/src/flows/helpers/payloads.py
+++ b/src/flows/helpers/payloads.py
@@ -67,4 +67,15 @@ def build_room_state_payload(caller: BaseState, room: BaseState) -> Dict[str, An
             continue
         objects.append(serialize_state(obj, looker=caller))
 
-    return {"room": room_data, "objects": objects}
+    active_scene = room.active_scene
+    scene_data: Dict[str, Any] | None = None
+    if active_scene:
+        is_owner = active_scene.is_owner(caller.account)
+        scene_data = {
+            "id": active_scene.id,
+            "name": active_scene.name,
+            "description": active_scene.description,
+            "is_owner": is_owner,
+        }
+
+    return {"room": room_data, "objects": objects, "scene": scene_data}

--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -79,6 +79,14 @@ class BaseState:
         """Return the wrapped object's primary key."""
         return self.obj.pk
 
+    @property
+    def account(self):
+        """Return the Account associated with this object, if any."""
+        try:
+            return self.obj.account
+        except AttributeError:
+            return None
+
     @cached_property
     def gender(self) -> str:
         """Gender for funcparser pronoun helpers."""

--- a/src/flows/object_states/room_state.py
+++ b/src/flows/object_states/room_state.py
@@ -1,4 +1,5 @@
 from flows.object_states.base_state import BaseState
+from world.scenes.models import Scene
 
 
 class RoomState(BaseState):
@@ -7,6 +8,11 @@ class RoomState(BaseState):
     """
 
     default_description = "This is a room."
+
+    @property
+    def active_scene(self) -> Scene | None:
+        """Return the active scene cached on this room."""
+        return self.obj.active_scene
 
     @property
     def appearance_template(self) -> str:

--- a/src/typeclasses/rooms.py
+++ b/src/typeclasses/rooms.py
@@ -13,6 +13,7 @@ from flows.object_states.room_state import RoomState
 from flows.scene_data_manager import SceneDataManager
 from flows.trigger_registry import TriggerRegistry
 from typeclasses.mixins import ObjectParent
+from world.scenes.models import Scene
 
 
 class Room(ObjectParent, DefaultRoom):
@@ -37,3 +38,16 @@ class Room(ObjectParent, DefaultRoom):
     def scene_data(self) -> SceneDataManager:
         """Return the SceneDataManager associated with this room."""
         return SceneDataManager()
+
+    @property
+    def active_scene(self) -> Scene | None:
+        """Scene currently running in this room."""
+        try:
+            return self.ndb.active_scene
+        except AttributeError:
+            return None
+
+    @active_scene.setter
+    def active_scene(self, value: Scene | None) -> None:
+        """Cache ``value`` as the active scene for this room."""
+        self.ndb.active_scene = value

--- a/src/web/webclient/message_types.py
+++ b/src/web/webclient/message_types.py
@@ -12,6 +12,7 @@ class WebsocketMessageType(str, Enum):
     MESSAGE_REACTION = "message_reaction"
     COMMANDS = "commands"
     ROOM_STATE = "room_state"
+    SCENE = "scene"
 
 
 @dataclass
@@ -81,3 +82,22 @@ class RoomStatePayload:
 
     room: RoomStateObject
     objects: List[RoomStateObject]
+    scene: Optional["SceneSummary"] = None
+
+
+@dataclass
+class SceneSummary:
+    """Minimal scene information for websocket messages."""
+
+    id: int
+    name: str
+    description: str
+    is_owner: bool
+
+
+@dataclass
+class ScenePayload:
+    """Payload for ``scene`` messages."""
+
+    action: str
+    scene: SceneSummary

--- a/src/world/scenes/services.py
+++ b/src/world/scenes/services.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from web import message_dispatcher
+from world.scenes.models import Scene
+
+ActionType = Literal["start", "update", "end"]
+
+
+def broadcast_scene_message(scene: Scene, action: ActionType) -> None:
+    """Send scene information to all accounts in the scene's location.
+
+    The room caches its active scene when a scene starts or ends so that
+    subsequent room state payloads can avoid extra database lookups.
+
+    Args:
+        scene: Scene to announce.
+        action: Event type for the scene.
+    """
+    location = scene.location
+    if location is None:
+        return
+    if action == "start":
+        location.active_scene = scene
+    elif action == "end":
+        location.active_scene = None
+    for obj in location.contents:
+        try:
+            account = obj.account
+        except AttributeError:
+            continue
+        is_owner = scene.is_owner(account)
+        payload = {
+            "action": action,
+            "scene": {
+                "id": scene.id,
+                "name": scene.name,
+                "description": scene.description,
+                "is_owner": is_owner,
+            },
+        }
+        message_dispatcher.send(account, payload=payload, payload_key="scene")


### PR DESCRIPTION
## Summary
- cache active scenes on rooms and include them in room-state payloads
- log room messages to active scenes with automatic participant and persona setup
- broadcast scene updates and manage scenes via new SceneWindow in game UI
- cache scene participations and expose owner checks

## Testing
- `uv run pre-commit run --files src/flows/helpers/payloads.py src/flows/object_states/base_state.py src/flows/object_states/room_state.py src/flows/service_functions/communication.py src/flows/tests/test_message_location.py src/flows/tests/test_room_state.py src/typeclasses/rooms.py src/world/scenes/models.py src/world/scenes/serializers.py src/world/scenes/services.py`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689bca82ca3c8331a38f1d54b91f163e