### PR TITLE
Add location window with room exits and occupants

### DIFF
--- a/docs/frontend/message_types.md
+++ b/docs/frontend/message_types.md
@@ -73,7 +73,7 @@ For the structure of each command object, refer to [CommandDescriptor Format](./
 
 ## `room_state`
 
-Describes the player's current location. The payload currently includes the room and nearby objects; exits and characters will be added later.
+Describes the player's current location. The payload includes the room, nearby objects and characters, and exits.
 
 ```json
 [
@@ -83,6 +83,9 @@ Describes the player's current location. The payload currently includes the room
     "room": { "dbref": "#1", "name": "Courtyard", "thumbnail_url": null, "commands": [] },
     "objects": [
       { "dbref": "#2", "name": "Bench", "thumbnail_url": null, "commands": ["sit"] }
+    ],
+    "exits": [
+      { "dbref": "#3", "name": "North", "thumbnail_url": null, "commands": ["north"] }
     ]
   }
 ]

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -7,6 +7,7 @@ import { useGameSocket } from '../../hooks/useGameSocket';
 import { Link } from 'react-router-dom';
 import type { MyRosterEntry } from '../../roster/types';
 import { SceneWindow } from './SceneWindow';
+import { LocationWindow } from './LocationWindow';
 
 interface GameWindowProps {
   characters: MyRosterEntry[];
@@ -71,7 +72,12 @@ export function GameWindow({ characters }: GameWindowProps) {
             </button>
           ))}
         </div>
-        <SceneWindow character={active} scene={session.scene} room={session.room} />
+        <LocationWindow character={active} room={session.room} />
+        <SceneWindow
+          character={active}
+          scene={session.scene}
+          room={session.room ? { id: session.room.id, name: session.room.name } : null}
+        />
         <ChatWindow messages={session.messages} isConnected={session.isConnected} />
         <CommandInput character={active} />
       </CardContent>

--- a/frontend/src/game/components/LocationWindow.tsx
+++ b/frontend/src/game/components/LocationWindow.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent } from '../../components/ui/card';
+import { Button } from '../../components/ui/button';
+import { useGameSocket } from '../../hooks/useGameSocket';
+import type { RoomStateObject } from '../../hooks/types';
+import type { MyRosterEntry } from '../../roster/types';
+
+interface LocationWindowProps {
+  character: MyRosterEntry['name'];
+  room: {
+    id: number;
+    name: string;
+    thumbnail_url: string | null;
+    objects: RoomStateObject[];
+    exits: RoomStateObject[];
+  } | null;
+}
+
+export function LocationWindow({ character, room }: LocationWindowProps) {
+  const { send } = useGameSocket();
+  if (!room) return null;
+
+  const handleExit = (exit: RoomStateObject) => {
+    const cmd = exit.commands[0] ?? exit.name;
+    send(character, cmd);
+  };
+
+  return (
+    <Card className="mb-4">
+      <CardContent className="p-4">
+        <h2 className="mb-2 text-lg font-semibold">{room.name}</h2>
+        {room.thumbnail_url && (
+          <img src={room.thumbnail_url} alt={room.name} className="mb-4 w-full rounded" />
+        )}
+        {room.objects.length > 0 && (
+          <div className="mb-4">
+            <h3 className="mb-2 text-sm font-semibold">Here</h3>
+            <div className="flex flex-wrap gap-2">
+              {room.objects.map((obj) => (
+                <div key={obj.dbref} className="flex items-center gap-1 text-sm">
+                  {obj.thumbnail_url ? (
+                    <img src={obj.thumbnail_url} alt={obj.name} className="h-6 w-6 rounded" />
+                  ) : (
+                    <div className="h-6 w-6 rounded bg-muted" />
+                  )}
+                  <span>{obj.name}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        <div>
+          <h3 className="mb-2 text-sm font-semibold">Exits</h3>
+          {room.exits.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {room.exits.map((exit) => (
+                <Button key={exit.dbref} size="sm" onClick={() => handleExit(exit)}>
+                  {exit.name}
+                </Button>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No obvious exits.</p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/handleRoomStatePayload.ts
+++ b/frontend/src/hooks/handleRoomStatePayload.ts
@@ -8,6 +8,17 @@ export function handleRoomStatePayload(
   dispatch: AppDispatch
 ) {
   const roomId = parseInt(payload.room.dbref.replace('#', ''), 10);
-  dispatch(setSessionRoom({ character, room: { id: roomId, name: payload.room.name } }));
+  dispatch(
+    setSessionRoom({
+      character,
+      room: {
+        id: roomId,
+        name: payload.room.name,
+        thumbnail_url: payload.room.thumbnail_url,
+        objects: payload.objects,
+        exits: payload.exits,
+      },
+    })
+  );
   dispatch(setSessionScene({ character, scene: payload.scene ?? null }));
 }

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -63,6 +63,7 @@ export interface RoomStateObject {
 export interface RoomStatePayload {
   room: RoomStateObject;
   objects: RoomStateObject[];
+  exits: RoomStateObject[];
   scene?: SceneSummary | null;
 }
 

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -1,14 +1,22 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import type { GameMessage, SceneSummary } from '../hooks/types';
+import type { GameMessage, RoomStateObject, SceneSummary } from '../hooks/types';
 import type { MyRosterEntry } from '../roster/types';
 import type { CommandSpec } from '../game/types';
+
+interface RoomData {
+  id: number;
+  name: string;
+  thumbnail_url: string | null;
+  objects: RoomStateObject[];
+  exits: RoomStateObject[];
+}
 
 interface Session {
   isConnected: boolean;
   messages: Array<GameMessage & { id: string }>;
   unread: number;
   commands: CommandSpec[];
-  room: { id: number; name: string } | null;
+  room: RoomData | null;
   scene: SceneSummary | null;
 }
 
@@ -89,10 +97,7 @@ export const gameSlice = createSlice({
     },
     setSessionRoom: (
       state,
-      action: PayloadAction<{
-        character: MyRosterEntry['name'];
-        room: { id: number; name: string } | null;
-      }>
+      action: PayloadAction<{ character: MyRosterEntry['name']; room: RoomData | null }>
     ) => {
       const { character, room } = action.payload;
       const session = state.sessions[character];

--- a/src/flows/helpers/payloads.py
+++ b/src/flows/helpers/payloads.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from flows.object_states.base_state import BaseState
+from flows.object_states.exit_state import ExitState
 
 
 def serialize_state(
@@ -57,15 +58,20 @@ def build_room_state_payload(caller: BaseState, room: BaseState) -> Dict[str, An
         room: Room state to describe.
 
     Returns:
-        Structured payload describing the room and present objects.
+        Structured payload describing the room, present objects, exits, and active scene.
     """
     room_data = serialize_state(room, looker=caller)
 
     objects: List[Dict[str, Any]] = []
+    exits: List[Dict[str, Any]] = []
     for obj in room.contents:
         if obj is caller:
             continue
-        objects.append(serialize_state(obj, looker=caller))
+        serialized = serialize_state(obj, looker=caller)
+        if isinstance(obj, ExitState):
+            exits.append(serialized)
+        else:
+            objects.append(serialized)
 
     active_scene = room.active_scene
     scene_data: Dict[str, Any] | None = None
@@ -78,4 +84,4 @@ def build_room_state_payload(caller: BaseState, room: BaseState) -> Dict[str, An
             "is_owner": is_owner,
         }
 
-    return {"room": room_data, "objects": objects, "scene": scene_data}
+    return {"room": room_data, "objects": objects, "exits": exits, "scene": scene_data}

--- a/src/flows/tests/test_room_state.py
+++ b/src/flows/tests/test_room_state.py
@@ -23,6 +23,11 @@ class RoomStateTests(TestCase):
             location=self.room,
         )
         self.item = ObjectDBFactory(db_key="rock", location=self.room)
+        self.exit = ObjectDBFactory(
+            db_key="north",
+            db_typeclass_path="typeclasses.exits.Exit",
+            location=self.room,
+        )
 
         room_media = PlayerMediaFactory()
         ObjectDisplayData.objects.create(object=self.room, thumbnail=room_media)
@@ -30,26 +35,32 @@ class RoomStateTests(TestCase):
         ObjectDisplayData.objects.create(object=self.caller, thumbnail=char_media)
         item_media = PlayerMediaFactory()
         ObjectDisplayData.objects.create(object=self.item, thumbnail=item_media)
+        exit_media = PlayerMediaFactory()
+        ObjectDisplayData.objects.create(object=self.exit, thumbnail=exit_media)
 
         self.context = SceneDataManagerFactory()
         self.room_state = self.context.initialize_state_for_object(self.room)
         self.char_state = self.context.initialize_state_for_object(self.caller)
         self.item_state = self.context.initialize_state_for_object(self.item)
+        self.exit_state = self.context.initialize_state_for_object(self.exit)
 
         self.room_state.dispatcher_tags = ["look"]
         self.item_state.dispatcher_tags = ["look", "get"]
+        self.exit_state.dispatcher_tags = ["north"]
 
         look_cmd = SimpleNamespace(key="look")
         get_cmd = SimpleNamespace(key="get")
         say_cmd = SimpleNamespace(key="say")
+        north_cmd = SimpleNamespace(key="north")
         self.caller.cmdset.current = SimpleNamespace(
-            commands=[look_cmd, get_cmd, say_cmd]
+            commands=[look_cmd, get_cmd, say_cmd, north_cmd]
         )
 
     def test_build_room_state_payload(self):
         payload = build_room_state_payload(self.char_state, self.room_state)
         self.assertEqual(payload["room"]["commands"], ["look"])
         self.assertEqual(payload["objects"][0]["commands"], ["look", "get"])
+        self.assertEqual(payload["exits"][0]["commands"], ["north"])
         self.assertIsNone(payload["scene"])
 
     def test_build_room_state_payload_uses_cached_scene(self):
@@ -71,4 +82,5 @@ class RoomStateTests(TestCase):
             payload = md.call_args.kwargs["payload"]
             self.assertEqual(payload["room"]["commands"], ["look"])
             self.assertEqual(payload["objects"][0]["commands"], ["look", "get"])
+            self.assertEqual(payload["exits"][0]["commands"], ["north"])
             self.assertIsNone(payload["scene"])

--- a/src/web/webclient/message_types.py
+++ b/src/web/webclient/message_types.py
@@ -82,6 +82,7 @@ class RoomStatePayload:
 
     room: RoomStateObject
     objects: List[RoomStateObject]
+    exits: List[RoomStateObject]
     scene: Optional["SceneSummary"] = None
 
 


### PR DESCRIPTION
## Summary
- add a location window showing room image, occupants, and exits
- include exits in room_state payloads and store
- document room_state exits in websocket message docs

## Testing
- `uv run pre-commit run --files src/flows/helpers/payloads.py src/flows/tests/test_room_state.py docs/frontend/message_types.md frontend/src/hooks/types.ts frontend/src/hooks/handleRoomStatePayload.ts frontend/src/store/gameSlice.ts frontend/src/game/components/GameWindow.tsx frontend/src/game/components/LocationWindow.tsx src/web/webclient/message_types.py`
- `uv run arx test`

------
https://chatgpt.com/codex/tasks/task_e_689beaf69a3883318068ccc4f92d01ed