### PR TITLE
Fix reaction toggling on scene messages

### DIFF
--- a/src/world/scenes/tests/test_views.py
+++ b/src/world/scenes/tests/test_views.py
@@ -434,6 +434,24 @@ class SceneMessageViewSetTestCase(APITestCase):
         self.assertEqual(reactions[0]["emoji"], "👍")
         self.assertEqual(reactions[0]["count"], 2)
 
+    def test_reaction_toggle_off(self):
+        """Posting the same reaction twice removes it."""
+        scene = SceneFactory(participants=[self.account])
+        participation = scene.participations.get(account=self.account)
+        persona = PersonaFactory(participation=participation)
+        message = SceneMessageFactory(scene=scene, persona=persona)
+        url = reverse("scenemessagereaction-list")
+        response = self.client.post(
+            url, {"message": message.pk, "emoji": "👍"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(SceneMessageReaction.objects.count(), 1)
+        response = self.client.post(
+            url, {"message": message.pk, "emoji": "👍"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(SceneMessageReaction.objects.count(), 0)
+
     def test_message_sequence_numbers(self):
         """Test messages have proper sequence numbers"""
         scene = SceneFactory(participants=[self.account])

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -227,3 +227,21 @@ class SceneMessageReactionViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return SceneMessageReaction.objects.filter(account=self.request.user)
+
+    def create(self, request, *args, **kwargs):
+        """Toggle a reaction on or off for the authenticated user."""
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        deleted, _ = SceneMessageReaction.objects.filter(
+            message=data["message"],
+            account=request.user,
+            emoji=data["emoji"],
+        ).delete()
+        if deleted:
+            return Response({"detail": "Reaction removed."}, status=status.HTTP_200_OK)
+        serializer.save()
+        headers = self.get_success_headers(serializer.data)
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )


### PR DESCRIPTION
## Summary
- allow duplicate reaction posts to remove existing reaction instead of error
- add test for reaction toggling

## Testing
- `uv run pre-commit run --files src/world/scenes/views.py src/world/scenes/tests/test_views.py`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689c15a3b6288331b88927035e2ced53