### PR TITLE
Store parsed text in scene messages

### DIFF
--- a/src/flows/service_functions/communication.py
+++ b/src/flows/service_functions/communication.py
@@ -184,7 +184,7 @@ def message_location(
             log_text = _PARSER.parse(
                 text,
                 caller=caller_state,
-                receiver=None,
+                receiver=location_state,
                 mapping=resolved_mapping,
                 return_string=True,
             )

--- a/src/flows/tests/test_room_state.py
+++ b/src/flows/tests/test_room_state.py
@@ -77,7 +77,7 @@ class RoomStateTests(TestCase):
             context=self.context,
         )
         with patch("web.message_dispatcher.send") as md:
-            send_room_state(fx, "@caller", "@room")
+            send_room_state(fx, "@caller")
             md.assert_called_once()
             payload = md.call_args.kwargs["payload"]
             self.assertEqual(payload["room"]["commands"], ["look"])


### PR DESCRIPTION
## Summary
- parse scene broadcast text with a neutral receiver so logged scene messages store third-person wording
- test that scene messages save parsed text instead of templates
- adjust room state test to call `send_room_state` with current signature

## Testing
- `uv run pre-commit run --files src/flows/service_functions/communication.py src/flows/tests/test_message_location.py src/flows/tests/test_room_state.py`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689c157f76bc8331a6b22b8a14d31c12