### PR TITLE
Improve scene editing and invalidate scenes list after finishing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-error-boundary": "^6.0.0",
+    "react-hook-form": "^7.62.0",
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.28.0",
     "tailwind-merge": "^3.3.1"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       react-error-boundary:
         specifier: ^6.0.0
         version: 6.0.0(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.62.0
+        version: 7.62.0(react@18.3.1)
       react-redux:
         specifier: ^9.1.2
         version: 9.2.0(@types/react@18.3.23)(react@18.3.1)(redux@5.0.1)
@@ -2102,6 +2105,12 @@ packages:
     resolution: {integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==}
     peerDependencies:
       react: '>=16.13.1'
+
+  react-hook-form@7.62.0:
+    resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -4366,6 +4375,10 @@ snapshots:
   react-error-boundary@6.0.0(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.2
+      react: 18.3.1
+
+  react-hook-form@7.62.0(react@18.3.1):
+    dependencies:
       react: 18.3.1
 
   react-is@17.0.2: {}


### PR DESCRIPTION
## Summary
- ensure scene finishing invalidates list queries so scenes move out of active view
- convert scene edit form to react-hook-form with labeled fields and default values
- add react-hook-form dependency

## Testing
- `uv run arx test`
- `uvx pre-commit run --files frontend/src/scenes/components/SceneHeader.tsx frontend/package.json`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689c19c8bc608331b05d2b75b9226111