### PR TITLE
Show roster entries in RecentConnected

### DIFF
--- a/frontend/src/evennia_replacements/HomePage.tsx
+++ b/frontend/src/evennia_replacements/HomePage.tsx
@@ -43,7 +43,7 @@ export function HomePage() {
           }
           isLoading={isLoading}
         />
-        <RecentConnected accounts={data?.recentPlayers} isLoading={isLoading} />
+        <RecentConnected entries={data?.recentPlayers} isLoading={isLoading} />
         <NewsTeaser news={data?.news} isLoading={isLoading} />
       </div>
       <ScenesSpotlight />

--- a/frontend/src/evennia_replacements/RecentConnected.tsx
+++ b/frontend/src/evennia_replacements/RecentConnected.tsx
@@ -1,13 +1,14 @@
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
 import { Avatar, AvatarImage, AvatarFallback } from '../components/ui/avatar';
 import { Skeleton } from '../components/ui/skeleton';
+import { Link } from 'react-router-dom';
 
 interface RecentConnectedProps {
-  accounts?: Array<{ username: string; avatar_url?: string }>;
+  entries?: Array<{ id: number; name: string; avatar_url?: string }>;
   isLoading: boolean;
 }
 
-export function RecentConnected({ accounts, isLoading }: RecentConnectedProps) {
+export function RecentConnected({ entries, isLoading }: RecentConnectedProps) {
   return (
     <Card>
       <CardHeader>
@@ -25,13 +26,15 @@ export function RecentConnected({ accounts, isLoading }: RecentConnectedProps) {
           </div>
         ) : (
           <ul className="space-y-2">
-            {accounts?.map((acc) => (
-              <li key={acc.username} className="flex items-center gap-2">
+            {entries?.map((entry) => (
+              <li key={entry.id} className="flex items-center gap-2">
                 <Avatar>
-                  <AvatarImage src={acc.avatar_url} />
-                  <AvatarFallback>{acc.username.slice(0, 2).toUpperCase()}</AvatarFallback>
+                  <AvatarImage src={entry.avatar_url} />
+                  <AvatarFallback>{entry.name.slice(0, 2).toUpperCase()}</AvatarFallback>
                 </Avatar>
-                <span className="text-sm">{acc.username}</span>
+                <Link to={`/characters/${entry.id}`} className="text-sm underline">
+                  {entry.name}
+                </Link>
               </li>
             ))}
           </ul>

--- a/frontend/src/evennia_replacements/types.ts
+++ b/frontend/src/evennia_replacements/types.ts
@@ -11,6 +11,6 @@ export interface StatusData {
   accounts: number;
   characters: number;
   rooms: number;
-  recentPlayers: Array<{ username: string; avatar_url?: string }>;
+  recentPlayers: Array<{ id: number; name: string; avatar_url?: string }>;
   news: Array<{ id: number; title: string }>;
 }

--- a/src/web/api/views.py
+++ b/src/web/api/views.py
@@ -15,6 +15,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from web.api.serializers import AccountPlayerSerializer
+from world.roster.models import RosterEntry
 
 
 class HomePageAPIView(APIView):
@@ -103,8 +104,14 @@ class ServerStatusAPIView(APIView):
         )
 
         recent_accounts = list(AccountDB.objects.get_recently_connected_accounts())
+        recent_entries = (
+            RosterEntry.objects.filter(character__db_account__in=recent_accounts)
+            .select_related("character")
+            .distinct()
+        )
         recent_players = [
-            {"username": account.username} for account in recent_accounts[:4]
+            {"id": entry.id, "name": entry.character.key}
+            for entry in recent_entries[:4]
         ]
 
         data = {


### PR DESCRIPTION
## Summary
- Show roster entries instead of account usernames in RecentConnected window
- Link recent characters to their roster entries
- Update server status API and tests for roster data

## Testing
- `uv run pre-commit run --files frontend/src/evennia_replacements/HomePage.tsx frontend/src/evennia_replacements/RecentConnected.tsx frontend/src/evennia_replacements/types.ts src/web/api/views.py src/web/tests/test_api.py`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689cecab4dac8331873febadc20a8bb8