### PR TITLE
refactor: centralize character links

### DIFF
--- a/frontend/src/components/ProfileDropdown.tsx
+++ b/frontend/src/components/ProfileDropdown.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
+import { CharacterLink } from './character';
 
 interface ProfileDropdownProps {
   account: AccountData;
@@ -32,7 +33,7 @@ export function ProfileDropdown({ account }: ProfileDropdownProps) {
       <DropdownMenuContent>
         {characters?.map((c) => (
           <DropdownMenuItem key={c.id} asChild>
-            <Link to={`/characters/${c.id}`}>{c.name}</Link>
+            <CharacterLink id={c.id}>{c.name}</CharacterLink>
           </DropdownMenuItem>
         ))}
         <DropdownMenuItem asChild>

--- a/frontend/src/components/SceneListCard.tsx
+++ b/frontend/src/components/SceneListCard.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { CharacterAvatarLink } from './character';
+import { urls } from '../utils/urls';
+import type { SceneSummary } from '../scenes/types';
+
+interface SceneListCardProps {
+  title: string;
+  scenes: SceneSummary[];
+  emptyMessage: string;
+}
+
+export function SceneListCard({ title, scenes, emptyMessage }: SceneListCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        {scenes.map((scene) => (
+          <div key={scene.id} className="flex items-center gap-2">
+            <div className="flex -space-x-2">
+              {scene.participants.map((p) => (
+                <CharacterAvatarLink
+                  key={p.id}
+                  id={p.roster_entry.id}
+                  name={p.roster_entry.name}
+                  avatarUrl={p.roster_entry.profile_url}
+                  className="h-8 w-8 border hover:border-primary"
+                  fallback={p.roster_entry.name?.charAt(0) || '?'}
+                />
+              ))}
+            </div>
+            <Link to={urls.scene(scene.id)} className="font-medium hover:text-primary">
+              {scene.name}
+            </Link>
+          </div>
+        ))}
+        {!scenes.length && <p className="text-sm text-muted-foreground">{emptyMessage}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/ScenesSpotlight.tsx
+++ b/frontend/src/components/ScenesSpotlight.tsx
@@ -1,31 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
-import { Avatar, AvatarImage, AvatarFallback } from './ui/avatar';
 import { apiFetch } from '../evennia_replacements/api';
-import { urls } from '../utils/urls';
-
-interface RosterEntry {
-  id: number;
-  name: string;
-  profile_url?: string;
-}
-
-interface SceneParticipant {
-  id: number;
-  name: string;
-  roster_entry: RosterEntry;
-}
-
-interface Scene {
-  id: number;
-  name: string;
-  participants: SceneParticipant[];
-}
+import { SceneListCard } from './SceneListCard';
+import type { SceneSummary } from '../scenes/types';
 
 interface ScenesSpotlightData {
-  in_progress: Scene[];
-  recent: Scene[];
+  in_progress: SceneSummary[];
+  recent: SceneSummary[];
 }
 
 async function fetchScenesSpotlight(): Promise<ScenesSpotlightData> {
@@ -44,66 +24,16 @@ export function ScenesSpotlight() {
 
   return (
     <section className="container mx-auto grid gap-4 py-8 md:grid-cols-2">
-      <Card>
-        <CardHeader>
-          <CardTitle>In Progress</CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-4">
-          {data?.in_progress.map((scene) => (
-            <div key={scene.id} className="flex items-center gap-2">
-              <div className="flex -space-x-2">
-                {scene.participants.map((p) => (
-                  <Link key={p.id} to={urls.character(p.roster_entry.id)}>
-                    <Avatar className="h-8 w-8 border hover:border-primary">
-                      {p.roster_entry.profile_url ? (
-                        <AvatarImage src={p.roster_entry.profile_url} alt={p.roster_entry.name} />
-                      ) : (
-                        <AvatarFallback>{p.roster_entry.name?.charAt(0) || '?'}</AvatarFallback>
-                      )}
-                    </Avatar>
-                  </Link>
-                ))}
-              </div>
-              <Link to={urls.scene(scene.id)} className="font-medium hover:text-primary">
-                {scene.name}
-              </Link>
-            </div>
-          ))}
-          {!data?.in_progress?.length && (
-            <p className="text-sm text-muted-foreground">No active scenes.</p>
-          )}
-        </CardContent>
-      </Card>
-      <Card>
-        <CardHeader>
-          <CardTitle>Recently Concluded</CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-4">
-          {data?.recent.map((scene) => (
-            <div key={scene.id} className="flex items-center gap-2">
-              <div className="flex -space-x-2">
-                {scene.participants.map((p) => (
-                  <Link key={p.id} to={urls.character(p.roster_entry.id)}>
-                    <Avatar className="h-8 w-8 border hover:border-primary">
-                      {p.roster_entry.profile_url ? (
-                        <AvatarImage src={p.roster_entry.profile_url} alt={p.roster_entry.name} />
-                      ) : (
-                        <AvatarFallback>{p.roster_entry.name?.charAt(0) || '?'}</AvatarFallback>
-                      )}
-                    </Avatar>
-                  </Link>
-                ))}
-              </div>
-              <Link to={urls.scene(scene.id)} className="font-medium hover:text-primary">
-                {scene.name}
-              </Link>
-            </div>
-          ))}
-          {!data?.recent?.length && (
-            <p className="text-sm text-muted-foreground">No recently concluded scenes.</p>
-          )}
-        </CardContent>
-      </Card>
+      <SceneListCard
+        title="In Progress"
+        scenes={data?.in_progress ?? []}
+        emptyMessage="No active scenes."
+      />
+      <SceneListCard
+        title="Recently Concluded"
+        scenes={data?.recent ?? []}
+        emptyMessage="No recently concluded scenes."
+      />
     </section>
   );
 }

--- a/frontend/src/components/character/CharacterAvatarLink.tsx
+++ b/frontend/src/components/character/CharacterAvatarLink.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+import { Avatar, AvatarImage, AvatarFallback } from '../ui/avatar';
+import { cn } from '../../lib/utils';
+
+interface CharacterAvatarLinkProps {
+  id: number;
+  name?: string;
+  avatarUrl?: string;
+  className?: string;
+  fallback?: string;
+}
+
+export function CharacterAvatarLink({
+  id,
+  name,
+  avatarUrl,
+  className,
+  fallback,
+}: CharacterAvatarLinkProps) {
+  const computed = name?.slice(0, 2).toUpperCase();
+  const fallbackText = fallback ?? (computed && computed !== '' ? computed : '??');
+  return (
+    <Link to={`/characters/${id}`}>
+      <Avatar className={cn(className)}>
+        {avatarUrl ? <AvatarImage src={avatarUrl} alt={name} /> : null}
+        <AvatarFallback>{fallbackText}</AvatarFallback>
+      </Avatar>
+    </Link>
+  );
+}

--- a/frontend/src/components/character/CharacterLink.tsx
+++ b/frontend/src/components/character/CharacterLink.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { cn } from '../../lib/utils';
+
+interface CharacterLinkProps {
+  id: number;
+  children: ReactNode;
+  className?: string;
+}
+
+export function CharacterLink({ id, children, className }: CharacterLinkProps) {
+  return (
+    <Link to={`/characters/${id}`} className={cn(className)}>
+      {children}
+    </Link>
+  );
+}

--- a/frontend/src/components/character/index.ts
+++ b/frontend/src/components/character/index.ts
@@ -4,3 +4,5 @@ export { StatsSection } from './StatsSection';
 export { RelationshipsSection } from './RelationshipsSection';
 export { GalleriesSection } from './GalleriesSection';
 export { CharacterApplicationForm } from './CharacterApplicationForm';
+export { CharacterLink } from './CharacterLink';
+export { CharacterAvatarLink } from './CharacterAvatarLink';

--- a/frontend/src/evennia_replacements/RecentConnected.test.tsx
+++ b/frontend/src/evennia_replacements/RecentConnected.test.tsx
@@ -29,7 +29,11 @@ describe('RecentConnected', () => {
 
   it('handles entries with undefined names gracefully', () => {
     const entries = [
-      { id: 1, name: undefined as any, avatar_url: 'https://example.com/unknown.jpg' },
+      {
+        id: 1,
+        name: undefined as unknown as string,
+        avatar_url: 'https://example.com/unknown.jpg',
+      },
       { id: 2, name: '', avatar_url: 'https://example.com/empty.jpg' },
     ];
 

--- a/frontend/src/evennia_replacements/RecentConnected.tsx
+++ b/frontend/src/evennia_replacements/RecentConnected.tsx
@@ -1,7 +1,6 @@
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
-import { Avatar, AvatarImage, AvatarFallback } from '../components/ui/avatar';
 import { Skeleton } from '../components/ui/skeleton';
-import { Link } from 'react-router-dom';
+import { CharacterAvatarLink, CharacterLink } from '../components/character';
 
 interface RecentConnectedProps {
   entries?: Array<{ id: number; name: string; avatar_url?: string }>;
@@ -28,13 +27,15 @@ export function RecentConnected({ entries, isLoading }: RecentConnectedProps) {
           <ul className="space-y-2">
             {entries?.map((entry) => (
               <li key={entry.id} className="flex items-center gap-2">
-                <Avatar>
-                  <AvatarImage src={entry.avatar_url} />
-                  <AvatarFallback>{(entry.name || '??').slice(0, 2).toUpperCase()}</AvatarFallback>
-                </Avatar>
-                <Link to={`/characters/${entry.id}`} className="text-sm underline">
+                <CharacterAvatarLink
+                  id={entry.id}
+                  name={entry.name}
+                  avatarUrl={entry.avatar_url}
+                  className="h-8 w-8"
+                />
+                <CharacterLink id={entry.id} className="text-sm underline">
                   {entry.name}
-                </Link>
+                </CharacterLink>
               </li>
             ))}
           </ul>

--- a/frontend/src/roster/pages/RosterListPage.tsx
+++ b/frontend/src/roster/pages/RosterListPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { useRostersQuery, useRosterEntriesQuery } from '../queries';
 import type { RosterEntryData } from '../types';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../components/ui/tabs';
@@ -13,6 +12,7 @@ import {
 } from '../../components/ui/table';
 import { Input } from '../../components/ui/input';
 import { Button } from '../../components/ui/button';
+import { CharacterAvatarLink, CharacterLink } from '../../components/character';
 
 export function RosterListPage() {
   const { data: rosters, isLoading: rostersLoading } = useRostersQuery();
@@ -94,22 +94,18 @@ export function RosterListPage() {
                   entryPage?.results?.map((entry: RosterEntryData) => (
                     <TableRow key={entry.id}>
                       <TableCell>
-                        <Link to={`/characters/${entry.id}`}>
-                          {entry.profile_picture ? (
-                            <img
-                              src={entry.profile_picture.media.cloudinary_url}
-                              alt={entry.character.name}
-                              className="h-16 w-16 object-cover"
-                            />
-                          ) : (
-                            <div className="h-16 w-16 bg-gray-200" />
-                          )}
-                        </Link>
+                        <CharacterAvatarLink
+                          id={entry.id}
+                          name={entry.character.name}
+                          avatarUrl={entry.profile_picture?.media.cloudinary_url}
+                          className="h-16 w-16"
+                          fallback=""
+                        />
                       </TableCell>
                       <TableCell>
-                        <Link to={`/characters/${entry.id}`} className="underline">
+                        <CharacterLink id={entry.id} className="underline">
                           {entry.character.name}
-                        </Link>
+                        </CharacterLink>
                       </TableCell>
                       <TableCell>{entry.character.gender ?? '—'}</TableCell>
                       <TableCell>{entry.character.char_class ?? '—'}</TableCell>

--- a/frontend/src/scenes/pages/ScenesListPage.tsx
+++ b/frontend/src/scenes/pages/ScenesListPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
+import { CharacterLink } from '../../components/character';
 import { fetchScenes, SceneListItem } from '../queries';
 
 export function ScenesListPage() {
@@ -44,12 +45,12 @@ export function ScenesListPage() {
                 {scene.participants.map((p, idx) => (
                   <span key={p.id}>
                     {p.roster_entry ? (
-                      <Link
-                        to={`/characters/${p.roster_entry.id}`}
+                      <CharacterLink
+                        id={p.roster_entry.id}
                         className="text-blue-600 hover:underline"
                       >
                         {p.name}
-                      </Link>
+                      </CharacterLink>
                     ) : (
                       p.name
                     )}

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -1,43 +1,13 @@
 import { apiFetch } from '../evennia_replacements/api';
 
-export interface RosterEntryRef {
-  id: number;
-  name: string;
-}
-
-export interface SceneParticipant {
-  id: number;
-  name: string;
-  roster_entry?: RosterEntryRef | null;
-}
-
-export interface SceneLocation {
-  id: number;
-  name: string;
-}
-
-export interface SceneListItem {
-  id: number;
-  name: string;
-  description: string;
-  date_started: string;
-  location?: SceneLocation | null;
-  participants: SceneParticipant[];
-}
-
-export interface SceneDetail extends SceneListItem {
-  highlight_message: SceneMessage | null;
-  is_active: boolean;
-  is_owner: boolean;
-}
-
-export interface SceneMessage {
-  id: number;
-  persona: { id: number; name: string; thumbnail_url?: string };
-  content: string;
-  timestamp: string;
-  reactions: { emoji: string; count: number; reacted: boolean }[];
-}
+export type {
+  RosterEntryRef,
+  SceneParticipant,
+  SceneLocation,
+  SceneListItem,
+  SceneDetail,
+  SceneMessage,
+} from './types';
 
 export async function fetchScenes(params: string) {
   const res = await apiFetch(`/api/scenes/?${params}`);

--- a/frontend/src/scenes/types.ts
+++ b/frontend/src/scenes/types.ts
@@ -1,0 +1,49 @@
+export interface RosterEntryRef {
+  id: number;
+  name: string;
+  profile_url?: string;
+}
+
+export interface SceneParticipant {
+  id: number;
+  name: string;
+  roster_entry?: RosterEntryRef | null;
+}
+
+export interface SceneParticipantRef extends SceneParticipant {
+  roster_entry: RosterEntryRef;
+}
+
+export interface SceneSummary {
+  id: number;
+  name: string;
+  participants: SceneParticipantRef[];
+}
+
+export interface SceneLocation {
+  id: number;
+  name: string;
+}
+
+export interface SceneListItem {
+  id: number;
+  name: string;
+  description: string;
+  date_started: string;
+  location?: SceneLocation | null;
+  participants: SceneParticipant[];
+}
+
+export interface SceneMessage {
+  id: number;
+  persona: { id: number; name: string; thumbnail_url?: string };
+  content: string;
+  timestamp: string;
+  reactions: { emoji: string; count: number; reacted: boolean }[];
+}
+
+export interface SceneDetail extends SceneListItem {
+  highlight_message: SceneMessage | null;
+  is_active: boolean;
+  is_owner: boolean;
+}


### PR DESCRIPTION
## Summary
- add reusable `CharacterAvatarLink` and `CharacterLink` components
- replace repeated character avatar/name links with new components across the frontend
- extract `SceneListCard` to deduplicate spotlight sections
- centralize scene-related TypeScript interfaces under `scenes/types`
- adjust tests for stricter linting

## Testing
- `pnpm --dir frontend test`
- `pnpm --dir frontend build`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689d25f3c5648331b7f6c432f9fcf1d9