### PR TITLE
Broadcast room state updates on room movement

### DIFF
--- a/src/typeclasses/mixins.py
+++ b/src/typeclasses/mixins.py
@@ -48,6 +48,14 @@ class ObjectParent:
         return None
 
     @property
+    def scene_state(self: Union[Self, "DefaultObject"]) -> BaseState | None:
+        """Return the state object representing this entity in the scene."""
+        scene_data = self.scene_data
+        if scene_data:
+            return scene_data.get_state_by_pk(self.pk)
+        return None
+
+    @property
     def gender(self: Union[Self, "DefaultObject"]) -> str:
         """Gender used by funcparser pronoun helpers."""
         return "neutral"
@@ -56,12 +64,10 @@ class ObjectParent:
         self: Union[Self, "DefaultObject"], looker=None, **kwargs
     ) -> str:
         """Return the display name using state data when available."""
-        scene_data = self.scene_data
-        if scene_data:
-            state = scene_data.get_state_by_pk(self.pk)
-            if state:
-                looker_state = scene_data.get_state_by_pk(looker.pk) if looker else None
-                return state.get_display_name(looker_state, **kwargs)
+        state = self.scene_state
+        if state:
+            looker_state = looker.scene_state if looker else None
+            return state.get_display_name(looker_state, **kwargs)
         return super().get_display_name(looker, **kwargs)
 
     def at_post_move(self, source_location, move_type="move", **kwargs):


### PR DESCRIPTION
## Summary
- Broadcast `room_state` updates when an object enters or leaves a room
- Add helper to rooms for accessing session-aware contents
- Expose `scene_state` on the object parent and reuse it for state lookups

## Testing
- `uv run arx test`

------
https://chatgpt.com/codex/tasks/task_e_689d43f45b808331ab5dc703ac01dce8