### PR TITLE
Send command error messages to frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@tanstack/react-query": "^5.62.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "sonner": "^1.4.2",
     "lucide-react": "^0.536.0",
     "next-themes": "^0.4.6",
     "react": "^18.3.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       react-router-dom:
         specifier: ^6.28.0
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sonner:
+        specifier: ^1.4.2
+        version: 1.7.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -2257,6 +2260,12 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sonner@1.7.4:
+    resolution: {integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4523,6 +4532,11 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  sonner@1.7.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
 

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,0 +1,5 @@
+import { Toaster as SonnerToaster } from 'sonner';
+
+export function Toaster() {
+  return <SonnerToaster />;
+}

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -2,6 +2,7 @@ import { GameWindow } from './components/GameWindow';
 import { CharacterPanel } from './components/CharacterPanel';
 import { QuickActions } from './components/QuickActions';
 import { useMyRosterEntriesQuery } from '../roster/queries';
+import { Toaster } from '../components/ui/sonner';
 
 export function GamePage() {
   const { data: characters = [] } = useMyRosterEntriesQuery();
@@ -16,6 +17,7 @@ export function GamePage() {
           <QuickActions />
         </div>
       </div>
+      <Toaster />
     </div>
   );
 }

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -17,6 +17,7 @@ export const WS_MESSAGE_TYPE = {
   COMMANDS: 'commands',
   ROOM_STATE: 'room_state',
   SCENE: 'scene',
+  COMMAND_ERROR: 'command_error',
 } as const;
 
 export type SocketMessageType = (typeof WS_MESSAGE_TYPE)[keyof typeof WS_MESSAGE_TYPE];
@@ -77,4 +78,9 @@ export interface SceneSummary {
 export interface ScenePayload {
   action: 'start' | 'update' | 'end';
   scene: SceneSummary;
+}
+
+export interface CommandErrorPayload {
+  command: string;
+  error: string;
 }

--- a/frontend/src/hooks/useGameSocket.ts
+++ b/frontend/src/hooks/useGameSocket.ts
@@ -5,6 +5,7 @@ import { GAME_MESSAGE_TYPE, WS_MESSAGE_TYPE } from './types';
 
 import type {
   CommandsPayload,
+  CommandErrorPayload,
   GameMessage,
   IncomingMessage,
   OutgoingMessage,
@@ -18,6 +19,7 @@ import { handleCommandPayload } from './handleCommandPayload';
 import { useCallback } from 'react';
 import type { MyRosterEntry } from '../roster/types';
 import { WS_PORT } from '../config';
+import { toast } from 'sonner';
 
 const sockets: Record<string, WebSocket> = {};
 
@@ -81,6 +83,12 @@ export function useGameSocket() {
 
           if (msgType === WS_MESSAGE_TYPE.SCENE) {
             handleScenePayload(character, kwargs as unknown as ScenePayload, dispatch);
+            return;
+          }
+
+          if (msgType === WS_MESSAGE_TYPE.COMMAND_ERROR) {
+            const { error, command } = (kwargs as unknown as CommandErrorPayload) ?? {};
+            toast.error(error, { description: command });
             return;
           }
 

--- a/src/commands/tests/test_handlers.py
+++ b/src/commands/tests/test_handlers.py
@@ -80,7 +80,14 @@ class CommandErrorMessageTests(TestCase):
         cmd.selected_dispatcher = dispatcher
 
         cmd.func()
+        self.assertEqual(caller.msg.call_count, 2)
 
-        caller.msg.assert_called_once()
-        sent = caller.msg.call_args.args[0]  # First positional argument is the text
-        self.assertEqual(str(sent), "bad")
+        text_call = caller.msg.call_args_list[0]
+        self.assertEqual(str(text_call.args[0]), "bad")
+
+        oob_call = caller.msg.call_args_list[1]
+        kwargs = oob_call.kwargs
+        self.assertIn("command_error", kwargs)
+        _, payload = kwargs["command_error"]
+        self.assertEqual(payload["error"], "bad")
+        self.assertEqual(payload["command"], "")

--- a/src/web/webclient/message_types.py
+++ b/src/web/webclient/message_types.py
@@ -13,6 +13,7 @@ class WebsocketMessageType(str, Enum):
     COMMANDS = "commands"
     ROOM_STATE = "room_state"
     SCENE = "scene"
+    COMMAND_ERROR = "command_error"
 
 
 @dataclass
@@ -102,3 +103,11 @@ class ScenePayload:
 
     action: str
     scene: SceneSummary
+
+
+@dataclass
+class CommandErrorPayload:
+    """Payload for ``command_error`` messages."""
+
+    command: str
+    error: str


### PR DESCRIPTION
## Summary
- send CommandError text to caller and emit a `command_error` payload separately
- simplify `ArxCommand.msg` to just forward arguments to `caller.msg`

## Testing
- `uv run arx test`
- `uv run pre-commit run --files src/commands/command.py`


------
https://chatgpt.com/codex/tasks/task_e_689d468789a483319fbaa588038a518d