### PR TITLE
Expose command usage metadata via serializer

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -8,6 +8,7 @@ from commands.consts import HelpFileViewMode
 from commands.descriptors import CommandDescriptor, DispatcherDescriptor
 from commands.dispatchers import BaseDispatcher, TargetDispatcher, TargetTextDispatcher
 from commands.exceptions import CommandError
+from commands.frontend_types import FrontendDescriptor
 
 # from evennia import default_cmds
 
@@ -215,7 +216,7 @@ class ArxCommand(Command):
         return f"Syntax: {newline}{newline.join(syntax_strings)}"
 
     def to_payload(self, context: str | None = None) -> Dict:
-        """Serialize this command and its dispatchers.
+        """Serialize this command, its dispatchers and usage patterns.
 
         Args:
             context: Optional context filter such as ``"room"`` or ``"object"``.
@@ -225,6 +226,7 @@ class ArxCommand(Command):
         """
 
         dispatcher_descs: List[DispatcherDescriptor] = []
+        descriptors: List[FrontendDescriptor] = []
         for dispatcher in self.dispatchers:
             dispatcher.bind(self)
             disp_context = self._get_dispatcher_context(dispatcher)
@@ -235,11 +237,13 @@ class ArxCommand(Command):
                     syntax=dispatcher.get_syntax_string(), context=disp_context
                 )
             )
+            descriptors.append(dispatcher.frontend_descriptor())
 
         descriptor = CommandDescriptor(
             key=self.key,
             aliases=sorted(self.aliases),
             dispatchers=dispatcher_descs,
+            descriptors=descriptors,
         )
         return descriptor.to_dict()
 

--- a/src/commands/descriptors.py
+++ b/src/commands/descriptors.py
@@ -3,6 +3,8 @@
 from dataclasses import asdict, dataclass
 from typing import Dict, List
 
+from commands.frontend_types import FrontendDescriptor
+
 
 @dataclass
 class DispatcherDescriptor:
@@ -29,11 +31,13 @@ class CommandDescriptor:
         key: Primary command name.
         aliases: Alternate command names.
         dispatchers: Descriptors for the command's dispatchers.
+        descriptors: Frontend usage patterns for the command.
     """
 
     key: str
     aliases: List[str]
     dispatchers: List[DispatcherDescriptor]
+    descriptors: List[FrontendDescriptor]
 
     def to_dict(self) -> Dict[str, object]:
         """Serialize descriptor into a dictionary."""
@@ -41,4 +45,5 @@ class CommandDescriptor:
             "key": self.key,
             "aliases": self.aliases,
             "dispatchers": [disp.to_dict() for disp in self.dispatchers],
+            "descriptors": self.descriptors,
         }

--- a/src/commands/evennia_overrides/__init__.py
+++ b/src/commands/evennia_overrides/__init__.py
@@ -1,6 +1,17 @@
 """Evennia command overrides grouped by function."""
 
+from commands.evennia_overrides.builder import CmdDig, CmdLink, CmdOpen, CmdUnlink
 from commands.evennia_overrides.movement import CmdDrop, CmdGet, CmdGive, CmdHome
 from commands.evennia_overrides.perception import CmdLook
 
-__all__ = ["CmdLook", "CmdGet", "CmdDrop", "CmdGive", "CmdHome"]
+__all__ = [
+    "CmdLook",
+    "CmdGet",
+    "CmdDrop",
+    "CmdGive",
+    "CmdHome",
+    "CmdDig",
+    "CmdOpen",
+    "CmdLink",
+    "CmdUnlink",
+]

--- a/src/commands/evennia_overrides/builder.py
+++ b/src/commands/evennia_overrides/builder.py
@@ -1,0 +1,64 @@
+"""Evennia builder command overrides with frontend metadata."""
+
+from evennia.commands.default.building import (
+    CmdDig as EvenniaCmdDig,
+    CmdLink as EvenniaCmdLink,
+    CmdOpen as EvenniaCmdOpen,
+    CmdUnLink as EvenniaCmdUnlink,
+)
+
+from commands.frontend import FrontendMetadataMixin
+
+
+class CmdDig(FrontendMetadataMixin, EvenniaCmdDig):
+    """Create a new room and optional connecting exits."""
+
+    usage = [
+        {
+            "prompt": "@dig room_name=exit_name[:back_exit]",
+            "params_schema": {
+                "room_name": {"type": "string"},
+                "exit_name": {"type": "string"},
+                "back_exit": {"type": "string", "required": False},
+            },
+        }
+    ]
+
+
+class CmdOpen(FrontendMetadataMixin, EvenniaCmdOpen):
+    """Create an exit from the current room."""
+
+    usage = [
+        {
+            "prompt": "@open exit_name=destination",
+            "params_schema": {
+                "exit_name": {"type": "string"},
+                "destination": {"type": "string"},
+            },
+        }
+    ]
+
+
+class CmdLink(FrontendMetadataMixin, EvenniaCmdLink):
+    """Link an existing exit to a destination."""
+
+    usage = [
+        {
+            "prompt": "@link exit_name=destination",
+            "params_schema": {
+                "exit_name": {"type": "string"},
+                "destination": {"type": "string"},
+            },
+        }
+    ]
+
+
+class CmdUnlink(FrontendMetadataMixin, EvenniaCmdUnlink):
+    """Remove the destination from an exit."""
+
+    usage = [
+        {
+            "prompt": "unlink exit_name",
+            "params_schema": {"exit_name": {"type": "string"}},
+        }
+    ]

--- a/src/commands/frontend.py
+++ b/src/commands/frontend.py
@@ -1,0 +1,51 @@
+"""Helpers for exposing command usage to the frontend."""
+
+from typing import Dict, List
+
+from commands.descriptors import CommandDescriptor
+from commands.frontend_types import FrontendDescriptor, ParamSchema, UsageEntry
+
+
+class FrontendMetadataMixin:
+    """Serialize Evennia command usage without rewriting it.
+
+    Evennia's default commands don't use Arx's dispatcher system, so they lack
+    structured metadata describing how the command should be presented in the
+    client. Subclassing this mixin lets legacy commands declare a ``usage`` class
+    attribute that lists supported syntax patterns. Each entry contains a
+    ``prompt`` string and a ``params_schema`` mapping. The :meth:`to_payload`
+    method returns these entries alongside basic command information, allowing
+    the frontend to render forms or quick actions for the command without
+    converting it into the new dispatcher-based style.
+    """
+
+    # Descriptions of usage patterns; override in subclasses.
+    usage: List[UsageEntry] = []
+
+    def to_payload(self, context: str | None = None) -> Dict:
+        """Return serialized metadata for the command.
+
+        Args:
+            context: Unused context filter for API compatibility.
+
+        Returns:
+            Dict: Serialized command descriptor including usage patterns.
+        """
+        descriptors: List[FrontendDescriptor] = []
+        for entry in self.usage:
+            params: Dict[str, ParamSchema] = entry.get("params_schema", {})
+            descriptors.append(
+                FrontendDescriptor(
+                    action=self.key,
+                    prompt=entry.get("prompt", ""),
+                    params_schema=params,
+                    icon=entry.get("icon", ""),
+                )
+            )
+        descriptor = CommandDescriptor(
+            key=self.key,
+            aliases=sorted(getattr(self, "aliases", [])),
+            dispatchers=[],
+            descriptors=descriptors,
+        )
+        return descriptor.to_dict()

--- a/src/commands/frontend_types.py
+++ b/src/commands/frontend_types.py
@@ -1,0 +1,28 @@
+"""Typed definitions for frontend command metadata."""
+
+from typing import Dict, TypedDict
+
+
+class ParamSchema(TypedDict, total=False):
+    """Schema definition for a single command parameter."""
+
+    type: str
+    required: bool
+    match: str
+
+
+class UsageEntry(TypedDict, total=False):
+    """Declarative usage entry for legacy Evennia commands."""
+
+    prompt: str
+    params_schema: Dict[str, ParamSchema]
+    icon: str
+
+
+class FrontendDescriptor(TypedDict):
+    """Serialized usage descriptor consumed by the frontend."""
+
+    action: str
+    prompt: str
+    params_schema: Dict[str, ParamSchema]
+    icon: str

--- a/src/commands/serializers.py
+++ b/src/commands/serializers.py
@@ -1,5 +1,7 @@
 """Serializers for command descriptors."""
 
+from typing import Dict
+
 from rest_framework import serializers
 
 from commands.types import CommandDescriptor
@@ -22,3 +24,12 @@ class CommandDescriptorSerializer(serializers.Serializer):
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
         return instance
+
+
+class CommandSerializer(serializers.Serializer):
+    """Serialize commands into payload dictionaries."""
+
+    def to_representation(self, instance) -> Dict:
+        """Convert a command into a payload via ``to_payload``."""
+
+        return instance.to_payload()

--- a/src/commands/tests/test_builder_descriptors.py
+++ b/src/commands/tests/test_builder_descriptors.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+
+from commands.evennia_overrides.builder import CmdDig, CmdLink, CmdOpen, CmdUnlink
+
+
+class BuilderCommandDescriptorTests(TestCase):
+    """Ensure builder commands expose frontend descriptors."""
+
+    def test_dig_descriptor(self):
+        desc = CmdDig().to_payload()["descriptors"][0]
+        self.assertEqual(desc["action"], "@dig")
+        self.assertEqual(desc["prompt"], "@dig room_name=exit_name[:back_exit]")
+        self.assertIn("room_name", desc["params_schema"])
+
+    def test_open_descriptor(self):
+        desc = CmdOpen().to_payload()["descriptors"][0]
+        self.assertEqual(desc["action"], "@open")
+        self.assertEqual(desc["prompt"], "@open exit_name=destination")
+        self.assertIn("destination", desc["params_schema"])
+
+    def test_link_descriptor(self):
+        desc = CmdLink().to_payload()["descriptors"][0]
+        self.assertEqual(desc["action"], "@link")
+        self.assertIn("exit_name", desc["params_schema"])
+
+    def test_unlink_descriptor(self):
+        desc = CmdUnlink().to_payload()["descriptors"][0]
+        self.assertEqual(desc["action"], "unlink")
+        self.assertEqual(desc["prompt"], "unlink exit_name")

--- a/src/commands/tests/test_command_payload.py
+++ b/src/commands/tests/test_command_payload.py
@@ -18,6 +18,7 @@ class CommandPayloadTests(TestCase):
                 {"syntax": "look <target>", "context": "object"},
             ],
         )
+        self.assertEqual(len(payload["descriptors"]), 2)
 
     def test_filters_by_context(self):
         cmd = CmdLook()
@@ -25,8 +26,10 @@ class CommandPayloadTests(TestCase):
         self.assertEqual(
             room_payload["dispatchers"], [{"syntax": "look", "context": "room"}]
         )
+        self.assertEqual(len(room_payload["descriptors"]), 1)
         obj_payload = cmd.to_payload(context="object")
         self.assertEqual(
             obj_payload["dispatchers"],
             [{"syntax": "look <target>", "context": "object"}],
         )
+        self.assertEqual(len(obj_payload["descriptors"]), 1)

--- a/src/commands/tests/test_command_serializer.py
+++ b/src/commands/tests/test_command_serializer.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.command import ArxCommand
+from commands.dispatchers import TargetDispatcher
+from commands.evennia_overrides.builder import CmdDig
+from commands.serializers import CommandSerializer
+from commands.utils import serialize_cmdset
+
+
+class DummyHandler:
+    def run(self, **kwargs):
+        pass
+
+
+class DummyDispatcherCommand(ArxCommand):
+    key = "dummy"
+    dispatchers = [TargetDispatcher(r"^(?P<target>.+)$", DummyHandler())]
+
+
+class CommandSerializerTests(TestCase):
+    """Tests for serializing commands into payload dictionaries."""
+
+    def test_builder_command_serialization(self):
+        """Serializer should return mixin payload for builder commands."""
+        serializer = CommandSerializer(CmdDig())
+        self.assertEqual(
+            serializer.data["descriptors"], CmdDig().to_payload()["descriptors"]
+        )
+
+    def test_dispatcher_command_serialization(self):
+        """Serializer should use dispatchers to build payload."""
+        cmd = DummyDispatcherCommand()
+        serializer = CommandSerializer(cmd)
+        self.assertEqual(
+            serializer.data["descriptors"], cmd.to_payload()["descriptors"]
+        )
+        desc = serializer.data["descriptors"][0]
+        self.assertIn("target", desc["params_schema"])
+        self.assertEqual(desc["prompt"], "dummy <target>")
+
+    def test_serialize_cmdset_combines_commands(self):
+        """serialize_cmdset should aggregate descriptors from cmdset."""
+        cmdset = MagicMock()
+        cmdset.commands = [CmdDig(), DummyDispatcherCommand()]
+        obj = MagicMock()
+        obj.cmdset.current = cmdset
+        data = serialize_cmdset(obj)
+        actions = {d["action"] for d in data}
+        self.assertIn("@dig", actions)
+        self.assertIn("dummy", actions)


### PR DESCRIPTION
## Summary
- centralize frontend command metadata typed dicts in `frontend_types` and remove TYPE_CHECKING fallbacks
- update command descriptors and utilities to use these types directly
- simplify `serialize_cmdset` to return typed descriptors without redundant retries

## Testing
- `uv run pre-commit run --files src/commands/frontend_types.py src/commands/frontend.py src/commands/descriptors.py src/commands/command.py src/commands/dispatchers.py src/commands/utils.py`
- `uv run arx test commands.tests.test_builder_descriptors commands.tests.test_command_serializer commands.tests.test_dispatchers`


------
https://chatgpt.com/codex/tasks/task_e_689e099da2688331b79d5e2d2d92b999