### PR TITLE
feat: add tenure selection components and gallery management

### DIFF
--- a/frontend/src/components/MyTenureSelect.tsx
+++ b/frontend/src/components/MyTenureSelect.tsx
@@ -1,0 +1,41 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+
+interface Props {
+  value: number | null;
+  onChange: (value: number | null) => void;
+  label?: string;
+}
+
+export function MyTenureSelect({ value, onChange, label = 'Sender' }: Props) {
+  const { data: entries } = useMyRosterEntriesQuery();
+
+  return (
+    <div className="w-64 space-y-1">
+      <label className="text-sm font-medium">{label}</label>
+      <Select
+        value={value ? String(value) : ''}
+        onValueChange={(val) => onChange(val ? Number(val) : null)}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="Select tenure" />
+        </SelectTrigger>
+        <SelectContent>
+          {entries?.map((e) => (
+            <SelectItem key={e.id} value={String(e.id)}>
+              {e.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+export default MyTenureSelect;

--- a/frontend/src/components/TenureSearch.tsx
+++ b/frontend/src/components/TenureSearch.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useTenureSearch } from '@/mail/queries';
+
+interface Props {
+  value: number | null;
+  onChange: (value: number | null, display?: string) => void;
+  label?: string;
+}
+
+export function TenureSearch({ value, onChange, label = 'Recipient' }: Props) {
+  const [search, setSearch] = useState('');
+  const { data: results } = useTenureSearch(search);
+
+  return (
+    <div className="w-64 space-y-1">
+      <label className="text-sm font-medium">{label}</label>
+      <Input
+        placeholder="Search character"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      {results?.results.length ? (
+        <ul className="rounded border">
+          {results.results.map((opt) => (
+            <li key={opt.id}>
+              <Button
+                type="button"
+                variant={value === opt.id ? 'default' : 'ghost'}
+                className="w-full justify-start"
+                onClick={() => {
+                  onChange(opt.id, opt.display_name);
+                  setSearch(opt.display_name);
+                }}
+              >
+                {opt.display_name}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+export default TenureSearch;

--- a/frontend/src/mail/components/ComposeMailForm.tsx
+++ b/frontend/src/mail/components/ComposeMailForm.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
-import { useSendMail, useTenureSearch } from '../queries';
+import { useSendMail } from '../queries';
 import type { PlayerMail } from '../types';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { useQueryClient } from '@tanstack/react-query';
+import TenureSearch from '@/components/TenureSearch';
+import MyTenureSelect from '@/components/MyTenureSelect';
 
 interface Props {
   replyTo?: PlayerMail | null;
@@ -13,16 +15,16 @@ interface Props {
 
 export function ComposeMailForm({ replyTo, onSent }: Props) {
   const [recipient, setRecipient] = useState<number | null>(null);
+  const [senderTenure, setSenderTenure] = useState<number | null>(null);
   const [subject, setSubject] = useState('');
   const [message, setMessage] = useState('');
-  const [search, setSearch] = useState('');
-  const { data: results } = useTenureSearch(search);
   const sendMail = useSendMail();
   const queryClient = useQueryClient();
 
   useEffect(() => {
     if (replyTo) {
       setRecipient(replyTo.sender_tenure);
+      setSenderTenure(replyTo.recipient_tenure);
       const subj = replyTo.subject.startsWith('Re:') ? replyTo.subject : `Re: ${replyTo.subject}`;
       setSubject(subj);
       const quoted = replyTo.message
@@ -30,18 +32,16 @@ export function ComposeMailForm({ replyTo, onSent }: Props) {
         .map((line) => `> ${line}`)
         .join('\n');
       setMessage(`\n\n${quoted}`);
-      if (replyTo.sender_display) {
-        setSearch(replyTo.sender_display);
-      }
     }
   }, [replyTo]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!recipient) return;
+    if (!recipient || !senderTenure) return;
     sendMail.mutate(
       {
         recipient_tenure: recipient,
+        sender_tenure: senderTenure,
         subject,
         message,
         in_reply_to: replyTo?.id,
@@ -50,9 +50,9 @@ export function ComposeMailForm({ replyTo, onSent }: Props) {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ['mail'] });
           setRecipient(null);
+          setSenderTenure(null);
           setSubject('');
           setMessage('');
-          setSearch('');
           onSent?.();
         },
       }
@@ -61,37 +61,17 @@ export function ComposeMailForm({ replyTo, onSent }: Props) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
-      <Input
-        placeholder="Search character"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-      />
-      {results?.results.length ? (
-        <ul className="rounded border">
-          {results.results.map((opt) => (
-            <li key={opt.id}>
-              <Button
-                type="button"
-                variant={recipient === opt.id ? 'default' : 'ghost'}
-                className="w-full justify-start"
-                onClick={() => {
-                  setRecipient(opt.id);
-                  setSearch(opt.display_name);
-                }}
-              >
-                {opt.display_name}
-              </Button>
-            </li>
-          ))}
-        </ul>
-      ) : null}
+      <div className="flex gap-2">
+        <TenureSearch value={recipient} onChange={(id) => setRecipient(id)} />
+        <MyTenureSelect value={senderTenure} onChange={setSenderTenure} />
+      </div>
       <Input placeholder="Subject" value={subject} onChange={(e) => setSubject(e.target.value)} />
       <Textarea
         placeholder="Message (Markdown supported)"
         value={message}
         onChange={(e) => setMessage(e.target.value)}
       />
-      <Button type="submit" disabled={!recipient}>
+      <Button type="submit" disabled={!recipient || !senderTenure}>
         Send
       </Button>
     </form>

--- a/frontend/src/mail/types.ts
+++ b/frontend/src/mail/types.ts
@@ -7,14 +7,13 @@ export interface PlayerMail {
   in_reply_to: number | null;
   sent_date: string;
   read_date: string | null;
-  sender_account: string;
-  sender_character: string | null;
   sender_tenure: number | null;
   sender_display: string;
 }
 
 export interface MailFormData {
   recipient_tenure: number;
+  sender_tenure: number;
   subject: string;
   message: string;
   in_reply_to?: number;

--- a/frontend/src/roster/api.ts
+++ b/frontend/src/roster/api.ts
@@ -71,6 +71,20 @@ export async function fetchTenureGalleries(tenureId: number): Promise<TenureGall
   return res.json();
 }
 
+export async function createTenureGallery(
+  tenureId: number,
+  data: Pick<TenureGallery, 'name' | 'is_public' | 'allowed_viewers'>
+): Promise<TenureGallery> {
+  const res = await apiFetch(`/api/roster/galleries/`, {
+    method: 'POST',
+    body: JSON.stringify({ ...data, tenure_id: tenureId }),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to create gallery');
+  }
+  return res.json();
+}
+
 export async function updateTenureGallery(
   galleryId: TenureGallery['id'],
   data: Partial<Pick<TenureGallery, 'is_public' | 'allowed_viewers' | 'name'>>

--- a/frontend/src/roster/components/GalleryManagement.tsx
+++ b/frontend/src/roster/components/GalleryManagement.tsx
@@ -1,8 +1,8 @@
 import { Controller, useForm } from 'react-hook-form';
-import Select from 'react-select';
 import CreatableSelect from 'react-select/creatable';
-import { useMyRosterEntriesQuery, useTenureGalleriesQuery, useUpdateGallery } from '../queries';
+import { useTenureGalleriesQuery, useUpdateGallery, useCreateGallery } from '../queries';
 import type { TenureGallery } from '../types';
+import MyTenureSelect from '@/components/MyTenureSelect';
 
 interface Option {
   value: number;
@@ -55,15 +55,60 @@ function GalleryForm({ gallery, onSave }: { gallery: TenureGallery; onSave: () =
   );
 }
 
+interface NewGalleryValues {
+  name: string;
+  is_public: boolean;
+  viewers: Option[];
+}
+
+function NewGalleryForm({ tenureId, onCreate }: { tenureId: number; onCreate: () => void }) {
+  const { register, control, handleSubmit, reset } = useForm<NewGalleryValues>({
+    defaultValues: { name: '', is_public: true, viewers: [] },
+  });
+  const createGallery = useCreateGallery();
+  const onSubmit = async (data: NewGalleryValues) => {
+    await createGallery.mutateAsync({
+      tenureId,
+      data: {
+        name: data.name,
+        is_public: data.is_public,
+        allowed_viewers: data.viewers.map((v) => v.value),
+      },
+    });
+    reset();
+    onCreate();
+  };
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-1">
+      <input type="text" placeholder="New gallery name" {...register('name', { required: true })} />
+      <label className="flex items-center space-x-2">
+        <input type="checkbox" {...register('is_public')} /> <span>Public</span>
+      </label>
+      <Controller
+        name="viewers"
+        control={control}
+        render={({ field }) => (
+          <CreatableSelect
+            {...field}
+            isMulti
+            placeholder="Allowed viewer tenure IDs"
+            formatCreateLabel={(val) => `Add ${val}`}
+          />
+        )}
+      />
+      <button type="submit" className="rounded bg-blue-500 px-2 py-1 text-white">
+        Create
+      </button>
+    </form>
+  );
+}
+
 export function GalleryManagement() {
-  const { data: myEntries } = useMyRosterEntriesQuery();
-  const { control, watch } = useForm<{ tenure: Option | null }>({
+  const { control, watch } = useForm<{ tenure: number | null }>({
     defaultValues: { tenure: null },
   });
-  const tenureId = watch('tenure')?.value;
+  const tenureId = watch('tenure');
   const { data: galleries, refetch } = useTenureGalleriesQuery(tenureId);
-
-  const tenureOptions = myEntries?.map((e) => ({ value: e.id, label: e.name })) ?? [];
 
   return (
     <section className="space-y-2">
@@ -71,10 +116,9 @@ export function GalleryManagement() {
       <Controller
         name="tenure"
         control={control}
-        render={({ field }) => (
-          <Select {...field} options={tenureOptions} isClearable placeholder="Select Tenure" />
-        )}
+        render={({ field }) => <MyTenureSelect value={field.value} onChange={field.onChange} />}
       />
+      {tenureId && <NewGalleryForm tenureId={tenureId} onCreate={() => refetch()} />}
       <ul className="space-y-2">
         {galleries?.map((g) => (
           <li key={g.id} className="border p-2">

--- a/frontend/src/roster/components/MediaUploadForm.tsx
+++ b/frontend/src/roster/components/MediaUploadForm.tsx
@@ -1,11 +1,7 @@
 import { Controller, useForm } from 'react-hook-form';
 import Select from 'react-select';
-import {
-  useMyRosterEntriesQuery,
-  useTenureGalleriesQuery,
-  useUploadPlayerMedia,
-  useAssociateMedia,
-} from '../queries';
+import { useTenureGalleriesQuery, useUploadPlayerMedia, useAssociateMedia } from '../queries';
+import MyTenureSelect from '@/components/MyTenureSelect';
 
 interface Option {
   value: number;
@@ -16,12 +12,11 @@ interface UploadFormValues {
   image_file: FileList;
   title: string;
   description: string;
-  tenure: Option | null;
+  tenure: number | null;
   gallery: Option | null;
 }
 
 export function MediaUploadForm({ onUploadComplete }: { onUploadComplete?: () => void }) {
-  const { data: myEntries } = useMyRosterEntriesQuery();
   const uploadMutation = useUploadPlayerMedia();
   const associateMutation = useAssociateMedia();
 
@@ -29,7 +24,7 @@ export function MediaUploadForm({ onUploadComplete }: { onUploadComplete?: () =>
     defaultValues: { tenure: null, gallery: null },
   });
 
-  const tenureId = watch('tenure')?.value;
+  const tenureId = watch('tenure');
   const { data: galleries } = useTenureGalleriesQuery(tenureId);
 
   const onSubmit = async (data: UploadFormValues) => {
@@ -41,7 +36,7 @@ export function MediaUploadForm({ onUploadComplete }: { onUploadComplete?: () =>
     if (data.tenure) {
       await associateMutation.mutateAsync({
         mediaId: result.id,
-        tenureId: data.tenure.value,
+        tenureId: data.tenure,
         galleryId: data.gallery?.value,
       });
     }
@@ -49,7 +44,6 @@ export function MediaUploadForm({ onUploadComplete }: { onUploadComplete?: () =>
     onUploadComplete?.();
   };
 
-  const tenureOptions = myEntries?.map((e) => ({ value: e.id, label: e.name })) ?? [];
   const galleryOptions = galleries?.map((g) => ({ value: g.id, label: g.name })) ?? [];
 
   return (
@@ -62,9 +56,7 @@ export function MediaUploadForm({ onUploadComplete }: { onUploadComplete?: () =>
         <Controller
           name="tenure"
           control={control}
-          render={({ field }) => (
-            <Select {...field} options={tenureOptions} isClearable placeholder="Select Tenure" />
-          )}
+          render={({ field }) => <MyTenureSelect value={field.value} onChange={field.onChange} />}
         />
         {tenureId && (
           <Controller

--- a/frontend/src/roster/queries.ts
+++ b/frontend/src/roster/queries.ts
@@ -9,6 +9,7 @@ import {
   uploadPlayerMedia,
   associateMedia,
   fetchTenureGalleries,
+  createTenureGallery,
   updateTenureGallery,
 } from './api';
 import type {
@@ -109,5 +110,17 @@ export function useUpdateGallery() {
   return useMutation({
     mutationFn: ({ galleryId, data }: { galleryId: number; data: Partial<TenureGallery> }) =>
       updateTenureGallery(galleryId, data),
+  });
+}
+
+export function useCreateGallery() {
+  return useMutation({
+    mutationFn: ({
+      tenureId,
+      data,
+    }: {
+      tenureId: number;
+      data: Pick<TenureGallery, 'name' | 'is_public' | 'allowed_viewers'>;
+    }) => createTenureGallery(tenureId, data),
   });
 }

--- a/src/world/roster/admin.py
+++ b/src/world/roster/admin.py
@@ -232,7 +232,7 @@ class TenureMediaAdmin(admin.ModelAdmin):
 @admin.register(PlayerMail)
 class PlayerMailAdmin(admin.ModelAdmin):
     list_display = [
-        "sender_account",
+        "sender_tenure",
         "recipient_tenure",
         "subject",
         "sent_date",
@@ -241,7 +241,8 @@ class PlayerMailAdmin(admin.ModelAdmin):
     ]
     list_filter = ["sent_date", "read_date", "archived"]
     search_fields = [
-        "sender_account__username",
+        "sender_tenure__player_data__account__username",
+        "sender_tenure__roster_entry__character__name",
         "recipient_tenure__roster_entry__character__name",
         "subject",
     ]
@@ -250,8 +251,7 @@ class PlayerMailAdmin(admin.ModelAdmin):
 
     # Use autocomplete for user-populated tables
     autocomplete_fields = [
-        "sender_account",
-        "sender_character",
+        "sender_tenure",
         "recipient_tenure",
         "in_reply_to",
     ]
@@ -261,8 +261,7 @@ class PlayerMailAdmin(admin.ModelAdmin):
             "Message Info",
             {
                 "fields": (
-                    "sender_account",
-                    "sender_character",
+                    "sender_tenure",
                     "recipient_tenure",
                     "subject",
                 )

--- a/src/world/roster/factories.py
+++ b/src/world/roster/factories.py
@@ -129,8 +129,7 @@ class PlayerMailFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = PlayerMail
 
-    sender_account = factory.SubFactory(AccountFactory)
-    sender_character = factory.SubFactory(CharacterFactory)
+    sender_tenure = factory.SubFactory(RosterTenureFactory)
     recipient_tenure = factory.SubFactory(RosterTenureFactory)
     subject = factory.Sequence(lambda n: f"Subject {n}")
     message = factory.Sequence(lambda n: f"Message body {n}")

--- a/src/world/roster/migrations/0002_playermail_sender_tenure.py
+++ b/src/world/roster/migrations/0002_playermail_sender_tenure.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("roster", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="playermail",
+            name="sender_tenure",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="sent_mail",
+                to="roster.rostertenure",
+                help_text="Tenure used when sending the mail",
+            ),
+        ),
+    ]

--- a/src/world/roster/migrations/0003_remove_sender_account_and_character.py
+++ b/src/world/roster/migrations/0003_remove_sender_account_and_character.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("roster", "0002_playermail_sender_tenure"),
+    ]
+
+    operations = [
+        migrations.RemoveIndex(
+            model_name="playermail",
+            name="roster_play_sender__2c3255_idx",
+        ),
+        migrations.RemoveField(
+            model_name="playermail",
+            name="sender_account",
+        ),
+        migrations.RemoveField(
+            model_name="playermail",
+            name="sender_character",
+        ),
+        migrations.AddIndex(
+            model_name="playermail",
+            index=models.Index(
+                fields=["sender_tenure", "sent_date"],
+                name="roster_playermail_sender_tenure_sent_date_idx",
+            ),
+        ),
+    ]

--- a/src/world/roster/serializers/mail.py
+++ b/src/world/roster/serializers/mail.py
@@ -8,20 +8,18 @@ from world.roster.models import PlayerMail, RosterTenure
 class PlayerMailSerializer(serializers.ModelSerializer):
     """Serialize player mail messages."""
 
-    sender_account = serializers.CharField(
-        source="sender_account.username", read_only=True
-    )
-    sender_character = serializers.CharField(
-        source="sender_character.name", read_only=True, allow_null=True
-    )
     recipient_tenure = serializers.PrimaryKeyRelatedField(
         queryset=RosterTenure.objects.all()
     )
     recipient_display = serializers.CharField(
         source="recipient_tenure.display_name", read_only=True
     )
-    sender_tenure = serializers.SerializerMethodField()
-    sender_display = serializers.SerializerMethodField()
+    sender_tenure = serializers.PrimaryKeyRelatedField(
+        queryset=RosterTenure.objects.all()
+    )
+    sender_display = serializers.CharField(
+        source="sender_tenure.display_name", read_only=True
+    )
     in_reply_to = serializers.PrimaryKeyRelatedField(
         queryset=PlayerMail.objects.all(), required=False, allow_null=True
     )
@@ -37,35 +35,12 @@ class PlayerMailSerializer(serializers.ModelSerializer):
             "in_reply_to",
             "sent_date",
             "read_date",
-            "sender_account",
-            "sender_character",
             "sender_tenure",
             "sender_display",
         ]
         read_only_fields = [
             "sent_date",
             "read_date",
-            "sender_account",
-            "sender_character",
-            "sender_tenure",
             "sender_display",
             "recipient_display",
         ]
-
-    def get_sender_tenure(self, obj):
-        """Return the sender's current roster tenure for their character."""
-        if not obj.sender_character:
-            return None
-        tenure = RosterTenure.objects.filter(
-            roster_entry__character=obj.sender_character, end_date__isnull=True
-        ).first()
-        return tenure.id if tenure else None
-
-    def get_sender_display(self, obj):
-        """Return display name for the sender's tenure if available."""
-        if not obj.sender_character:
-            return obj.sender_account.username
-        tenure = RosterTenure.objects.filter(
-            roster_entry__character=obj.sender_character, end_date__isnull=True
-        ).first()
-        return tenure.display_name if tenure else obj.sender_account.username

--- a/src/world/roster/tests/test_mail_viewset.py
+++ b/src/world/roster/tests/test_mail_viewset.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 from rest_framework.test import APIClient
 
 from world.roster.factories import (
-    AccountFactory,
     PlayerDataFactory,
     PlayerMailFactory,
     RosterTenureFactory,
@@ -25,16 +24,18 @@ class PlayerMailViewSetTestCase(TestCase):
         self.recipient = PlayerDataFactory()
         self.tenure = RosterTenureFactory(player_data=self.recipient)
         self.client.force_authenticate(user=self.recipient.account)
-        self.sender_account = AccountFactory()
+        self.sender_player = PlayerDataFactory()
+        self.sender_account = self.sender_player.account
+        self.sender_tenure = RosterTenureFactory(player_data=self.sender_player)
         PlayerMailFactory(
             recipient_tenure=self.tenure,
-            sender_account=self.sender_account,
+            sender_tenure=self.sender_tenure,
             sent_date=timezone.now() - timedelta(days=1),
             subject="Old",
         )
         PlayerMailFactory(
             recipient_tenure=self.tenure,
-            sender_account=self.sender_account,
+            sender_tenure=self.sender_tenure,
             subject="New",
         )
 
@@ -57,6 +58,7 @@ class PlayerMailViewSetTestCase(TestCase):
         url = reverse("roster:mail-list")
         payload = {
             "recipient_tenure": self.tenure.id,
+            "sender_tenure": self.sender_tenure.id,
             "subject": "Hello",
             "message": "Test message",
         }
@@ -75,6 +77,7 @@ class PlayerMailViewSetTestCase(TestCase):
         url = reverse("roster:mail-list")
         payload = {
             "recipient_tenure": self.tenure.id,
+            "sender_tenure": self.sender_tenure.id,
             "subject": "Re: Old",
             "message": "Reply",
             "in_reply_to": original.id,


### PR DESCRIPTION
## Summary
- add reusable tenure search and my-tenure select components
- require selecting sender tenure when composing mail
- support creating and managing galleries with new API hooks
- derive mail sender from tenure, removing redundant account/character fields

## Testing
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689fb0778bf48331bf8f039b018a8906