### PR TITLE
test(frontend): add basic page tests

### DIFF
--- a/frontend/src/pages/NotFoundPage.test.tsx
+++ b/frontend/src/pages/NotFoundPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import { NotFoundPage } from './NotFoundPage';
+import { renderWithProviders } from '../test/utils/renderWithProviders';
+
+describe('NotFoundPage', () => {
+  it('renders not found message', () => {
+    renderWithProviders(<NotFoundPage />);
+    expect(screen.getByRole('heading', { name: /404 - Page Not Found/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -1,0 +1,15 @@
+import { screen } from '@testing-library/react';
+import { ProfilePage } from './ProfilePage';
+import { renderWithProviders } from '../test/utils/renderWithProviders';
+
+describe('ProfilePage', () => {
+  it('defaults to mail tab when not on media path', () => {
+    renderWithProviders(<ProfilePage />, { initialEntries: ['/profile'] });
+    expect(screen.getByRole('tab', { name: /mail/i })).toHaveAttribute('data-state', 'active');
+  });
+
+  it('selects media tab when on media path', () => {
+    renderWithProviders(<ProfilePage />, { initialEntries: ['/profile/media'] });
+    expect(screen.getByRole('tab', { name: /media/i })).toHaveAttribute('data-state', 'active');
+  });
+});

--- a/frontend/src/roster/pages/CharacterSheetPage.test.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/react';
+import { Routes, Route } from 'react-router-dom';
+import { vi } from 'vitest';
+import { renderWithProviders } from '../../test/utils/renderWithProviders';
+import { CharacterSheetPage } from './CharacterSheetPage';
+
+vi.mock('../queries', () => ({
+  useRosterEntryQuery: vi.fn(),
+}));
+import { useRosterEntryQuery } from '../queries';
+
+const mockUseRosterEntryQuery = vi.mocked(useRosterEntryQuery);
+
+describe('CharacterSheetPage', () => {
+  it('shows loading state', () => {
+    mockUseRosterEntryQuery.mockReturnValue({ data: null, isLoading: true });
+    renderWithProviders(
+      <Routes>
+        <Route path="/:id" element={<CharacterSheetPage />} />
+      </Routes>,
+      { initialEntries: ['/1'] }
+    );
+    expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+  });
+
+  it('shows not found when no entry', () => {
+    mockUseRosterEntryQuery.mockReturnValue({ data: null, isLoading: false });
+    renderWithProviders(
+      <Routes>
+        <Route path="/:id" element={<CharacterSheetPage />} />
+      </Routes>,
+      { initialEntries: ['/1'] }
+    );
+    expect(screen.getByText(/Character not found/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/roster/pages/PlayerMediaPage.test.tsx
+++ b/frontend/src/roster/pages/PlayerMediaPage.test.tsx
@@ -1,0 +1,42 @@
+import { screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { renderWithProviders } from '../../test/utils/renderWithProviders';
+import { PlayerMediaPage } from './PlayerMediaPage';
+
+vi.mock('../queries', () => ({
+  usePlayerMediaQuery: vi.fn(),
+}));
+import { usePlayerMediaQuery } from '../queries';
+
+vi.mock('../components/MediaUploadForm', () => ({
+  MediaUploadForm: () => <div>Upload</div>,
+}));
+vi.mock('../components/GalleryManagement', () => ({
+  GalleryManagement: () => <div>Gallery</div>,
+}));
+
+const mockUsePlayerMediaQuery = vi.mocked(usePlayerMediaQuery);
+
+describe('PlayerMediaPage', () => {
+  it('renders list of media', () => {
+    mockUsePlayerMediaQuery.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          cloudinary_public_id: 'abc',
+          cloudinary_url: '',
+          media_type: 'image',
+          title: 'Test Media',
+          description: '',
+          created_by: null,
+          uploaded_date: '',
+          updated_date: '',
+        },
+      ],
+      refetch: vi.fn(),
+    });
+    renderWithProviders(<PlayerMediaPage />);
+    expect(screen.getByText('My Media')).toBeInTheDocument();
+    expect(screen.getByText('Test Media')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/utils/renderWithProviders.tsx
+++ b/frontend/src/test/utils/renderWithProviders.tsx
@@ -10,13 +10,16 @@ import { store } from '@/store/store';
  *
  * @param ui The component to render.
  */
-export function renderWithProviders(ui: ReactNode) {
+export function renderWithProviders(
+  ui: ReactNode,
+  { initialEntries }: { initialEntries?: string[] } = {}
+) {
   const queryClient = new QueryClient();
 
   return render(
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter>{ui}</MemoryRouter>
+        <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
       </QueryClientProvider>
     </Provider>
   );


### PR DESCRIPTION
## Summary
- extend renderWithProviders to accept initialEntries
- add vitest coverage for 404, profile, roster character, and media pages

## Testing
- `pnpm exec vitest run`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689fcc6a948c8331afa94ecd3d91d27d