### PR TITLE
feat: add user registration flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Layout } from './components/Layout';
 import { HomePage } from './evennia_replacements/HomePage';
 import { GamePage } from './game/GamePage';
 import { LoginPage } from './evennia_replacements/LoginPage';
+import { RegisterPage } from './evennia_replacements/RegisterPage';
 import { ProfilePage } from './pages/ProfilePage';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { CharacterSheetPage } from './roster/pages/CharacterSheetPage';
@@ -18,6 +19,7 @@ function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
         <Route path="/profile/*" element={<ProfilePage />}>
           <Route path="mail" element={<MailPage />} />
           <Route path="media" element={<PlayerMediaPage />} />

--- a/frontend/src/components/SubmitButton.tsx
+++ b/frontend/src/components/SubmitButton.tsx
@@ -1,0 +1,24 @@
+import { Button, type ButtonProps } from './ui/button';
+import { Loader2 } from 'lucide-react';
+
+interface SubmitButtonProps extends ButtonProps {
+  isLoading?: boolean;
+  disabled?: boolean;
+}
+
+export function SubmitButton({
+  isLoading = false,
+  disabled = false,
+  children,
+  type = 'submit',
+  ...props
+}: SubmitButtonProps) {
+  return (
+    <Button type={type} disabled={disabled || isLoading} {...props}>
+      {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+      {children}
+    </Button>
+  );
+}
+
+export default SubmitButton;

--- a/frontend/src/components/character/CharacterApplicationForm.tsx
+++ b/frontend/src/components/character/CharacterApplicationForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useSendRosterApplication } from '../../roster/queries';
-import { Button } from '../ui/button';
 import { Textarea } from '../ui/textarea';
+import { SubmitButton } from '../SubmitButton';
 import type { RosterEntryData } from '../../roster/types';
 
 interface CharacterApplicationFormProps {
@@ -28,7 +28,9 @@ export function CharacterApplicationForm({ entryId }: CharacterApplicationFormPr
           onChange={(e) => setMessage(e.target.value)}
           placeholder="Why do you want to play this character?"
         />
-        <Button type="submit">Send Application</Button>
+        <SubmitButton isLoading={mutation.isPending} disabled={!message}>
+          Send Application
+        </SubmitButton>
       </form>
       {mutation.isError && <p className="text-red-600">Failed to send application.</p>}
     </section>

--- a/frontend/src/evennia_replacements/LoginPage.tsx
+++ b/frontend/src/evennia_replacements/LoginPage.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLogin } from './queries';
 import { SITE_NAME } from '../config';
-import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
+import { SubmitButton } from '../components/SubmitButton';
 
 export function LoginPage() {
   const navigate = useNavigate();
@@ -34,9 +34,13 @@ export function LoginPage() {
           onChange={(e) => setPassword(e.target.value)}
           placeholder="Password"
         />
-        <Button type="submit" className="w-full">
+        <SubmitButton
+          className="w-full"
+          isLoading={mutation.isPending}
+          disabled={!username || !password}
+        >
           Log In
-        </Button>
+        </SubmitButton>
       </form>
       {mutation.isError && <p className="mt-4 text-red-600">Login failed. Please try again.</p>}
     </div>

--- a/frontend/src/evennia_replacements/RegisterPage.test.tsx
+++ b/frontend/src/evennia_replacements/RegisterPage.test.tsx
@@ -1,0 +1,106 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RegisterPage } from './RegisterPage';
+import { vi } from 'vitest';
+import * as api from './api';
+import { mockAccount } from '@/test/mocks/account';
+import { store } from '@/store/store';
+import { setAccount } from '@/store/authSlice';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+
+vi.mock('./api');
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    store.dispatch(setAccount(null));
+  });
+
+  it('registers and stores account data', async () => {
+    vi.mocked(api.checkUsername).mockResolvedValue(true);
+    vi.mocked(api.checkEmail).mockResolvedValue(true);
+    vi.mocked(api.postRegister).mockResolvedValue(mockAccount);
+    renderWithProviders(<RegisterPage />);
+
+    await userEvent.type(screen.getByPlaceholderText('Username'), 'tester');
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText('Email'), 'test@test.com');
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText('Password'), 'secret');
+    await userEvent.tab();
+    await userEvent.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() => {
+      expect(api.postRegister).toHaveBeenCalledWith({
+        username: 'tester',
+        email: 'test@test.com',
+        password: 'secret',
+      });
+      expect(store.getState().auth.account).toEqual(mockAccount);
+    });
+  });
+
+  it('shows error when username already taken', async () => {
+    vi.mocked(api.checkUsername).mockResolvedValue(false);
+    vi.mocked(api.checkEmail).mockResolvedValue(true);
+    renderWithProviders(<RegisterPage />);
+
+    await userEvent.type(screen.getByPlaceholderText('Username'), 'tester');
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText('Email'), 'test@test.com');
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText('Password'), 'secret');
+    await userEvent.tab();
+    await userEvent.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/username already taken/i)).toBeInTheDocument();
+      expect(api.postRegister).not.toHaveBeenCalled();
+    });
+  });
+
+  it('shows error when email already taken', async () => {
+    vi.mocked(api.checkUsername).mockResolvedValue(true);
+    vi.mocked(api.checkEmail).mockResolvedValue(false);
+    renderWithProviders(<RegisterPage />);
+
+    await userEvent.type(screen.getByPlaceholderText('Username'), 'tester');
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText('Email'), 'test@test.com');
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText('Password'), 'secret');
+    await userEvent.tab();
+    await userEvent.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/email already taken/i)).toBeInTheDocument();
+      expect(api.postRegister).not.toHaveBeenCalled();
+    });
+  });
+
+  it('disables submit while registering', async () => {
+    vi.mocked(api.checkUsername).mockResolvedValue(true);
+    vi.mocked(api.checkEmail).mockResolvedValue(true);
+    let resolve: (value: unknown) => void;
+    vi.mocked(api.postRegister).mockImplementation(
+      () =>
+        new Promise((res) => {
+          resolve = res;
+        })
+    );
+    renderWithProviders(<RegisterPage />);
+
+    await userEvent.type(screen.getByPlaceholderText('Username'), 'tester');
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText('Email'), 'test@test.com');
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText('Password'), 'secret');
+    await userEvent.tab();
+    const button = screen.getByRole('button', { name: /register/i });
+    await userEvent.click(button);
+
+    expect(button).toBeDisabled();
+
+    resolve(mockAccount);
+  });
+});

--- a/frontend/src/evennia_replacements/RegisterPage.tsx
+++ b/frontend/src/evennia_replacements/RegisterPage.tsx
@@ -1,0 +1,80 @@
+import { useNavigate } from 'react-router-dom';
+import { useRegister } from './queries';
+import { SITE_NAME } from '../config';
+import { Input } from '../components/ui/input';
+import { SubmitButton } from '../components/SubmitButton';
+import { Button } from '../components/ui/button';
+import { useForm } from 'react-hook-form';
+import { checkUsername, checkEmail } from './api';
+
+const providers = ['Google', 'Facebook', 'Instagram', 'TikTok', 'Discord'];
+
+type FormValues = {
+  username: string;
+  email: string;
+  password: string;
+};
+
+export function RegisterPage() {
+  const navigate = useNavigate();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<FormValues>({ mode: 'onBlur' });
+  const mutation = useRegister(() => {
+    navigate('/');
+  });
+  const onSubmit = handleSubmit((data) => mutation.mutate(data));
+
+  return (
+    <div className="mx-auto max-w-sm">
+      <h1 className="mb-6 text-2xl font-bold">Register for {SITE_NAME}</h1>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <Input
+          placeholder="Username"
+          {...register('username', {
+            required: 'Username is required',
+            validate: async (value) => (await checkUsername(value)) || 'Username already taken',
+          })}
+        />
+        {errors.username && <p className="text-sm text-red-600">{errors.username.message}</p>}
+        <Input
+          placeholder="Email"
+          type="email"
+          {...register('email', {
+            required: 'Email is required',
+            validate: async (value) => (await checkEmail(value)) || 'Email already taken',
+          })}
+        />
+        {errors.email && <p className="text-sm text-red-600">{errors.email.message}</p>}
+        <Input
+          type="password"
+          placeholder="Password"
+          {...register('password', {
+            required: 'Password is required',
+          })}
+        />
+        {errors.password && <p className="text-sm text-red-600">{errors.password.message}</p>}
+        <SubmitButton className="w-full" isLoading={mutation.isPending} disabled={!isValid}>
+          Register
+        </SubmitButton>
+      </form>
+      {mutation.isError && (
+        <p className="mt-4 text-red-600">Registration failed. Please try again.</p>
+      )}
+      <div className="mt-6 space-y-2">
+        {providers.map((name) => (
+          <Button
+            key={name}
+            variant="outline"
+            className="w-full"
+            onClick={() => alert('Coming soon')}
+          >
+            Sign up with {name}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/evennia_replacements/api.ts
+++ b/frontend/src/evennia_replacements/api.ts
@@ -65,3 +65,38 @@ export async function postLogin(data: {
 export async function postLogout(): Promise<void> {
   await apiFetch('/api/logout/', { method: 'POST' });
 }
+
+export async function postRegister(data: {
+  username: string;
+  password: string;
+  email: string;
+}): Promise<AccountData> {
+  const res = await apiFetch('/api/register/', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error('Registration failed');
+  }
+  return res.json();
+}
+
+export async function checkUsername(username: string): Promise<boolean> {
+  const res = await apiFetch(
+    `/api/register/availability/?username=${encodeURIComponent(username)}`
+  );
+  if (!res.ok) {
+    throw new Error('Username check failed');
+  }
+  const data = await res.json();
+  return data.username;
+}
+
+export async function checkEmail(email: string): Promise<boolean> {
+  const res = await apiFetch(`/api/register/availability/?email=${encodeURIComponent(email)}`);
+  if (!res.ok) {
+    throw new Error('Email check failed');
+  }
+  const data = await res.json();
+  return data.email;
+}

--- a/frontend/src/evennia_replacements/queries.tsx
+++ b/frontend/src/evennia_replacements/queries.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchStatus, fetchAccount, postLogin, postLogout } from './api';
+import { fetchStatus, fetchAccount, postLogin, postLogout, postRegister } from './api';
 import { useAppDispatch } from '../store/hooks';
 import { setAccount } from '../store/authSlice';
 import { resetGame } from '../store/gameSlice';
@@ -36,6 +36,17 @@ export function useLogin(onSuccess?: () => void) {
   const dispatch = useAppDispatch();
   return useMutation({
     mutationFn: postLogin,
+    onSuccess: (data) => {
+      dispatch(setAccount(data));
+      onSuccess?.();
+    },
+  });
+}
+
+export function useRegister(onSuccess?: () => void) {
+  const dispatch = useAppDispatch();
+  return useMutation({
+    mutationFn: postRegister,
     onSuccess: (data) => {
       dispatch(setAccount(data));
       onSuccess?.();

--- a/frontend/src/mail/components/ComposeMailForm.tsx
+++ b/frontend/src/mail/components/ComposeMailForm.tsx
@@ -3,7 +3,7 @@ import { useSendMail } from '../queries';
 import type { PlayerMail } from '../types';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { Button } from '@/components/ui/button';
+import { SubmitButton } from '@/components/SubmitButton';
 import { useQueryClient } from '@tanstack/react-query';
 import TenureSearch from '@/components/TenureSearch';
 import MyTenureSelect from '@/components/MyTenureSelect';
@@ -71,9 +71,9 @@ export function ComposeMailForm({ replyTo, onSent }: Props) {
         value={message}
         onChange={(e) => setMessage(e.target.value)}
       />
-      <Button type="submit" disabled={!recipient || !senderTenure}>
+      <SubmitButton disabled={!recipient || !senderTenure} isLoading={sendMail.isPending}>
         Send
-      </Button>
+      </SubmitButton>
     </form>
   );
 }

--- a/frontend/src/roster/components/GalleryManagement.tsx
+++ b/frontend/src/roster/components/GalleryManagement.tsx
@@ -3,6 +3,7 @@ import { useTenureGalleriesQuery, useUpdateGallery, useCreateGallery } from '../
 import type { TenureGallery } from '../types';
 import MyTenureSelect from '@/components/MyTenureSelect';
 import TenureMultiSearch from '@/components/TenureMultiSearch';
+import { SubmitButton } from '@/components/SubmitButton';
 
 interface Option {
   value: number;
@@ -50,9 +51,12 @@ function GalleryForm({ gallery, onSave }: { gallery: TenureGallery; onSave: () =
           )}
         />
       )}
-      <button type="submit" className="rounded bg-blue-500 px-2 py-1 text-white">
+      <SubmitButton
+        className="rounded bg-blue-500 px-2 py-1 text-white"
+        isLoading={updateGallery.isPending}
+      >
         Save
-      </button>
+      </SubmitButton>
     </form>
   );
 }
@@ -64,8 +68,16 @@ interface NewGalleryValues {
 }
 
 function NewGalleryForm({ tenureId, onCreate }: { tenureId: number; onCreate: () => void }) {
-  const { register, control, handleSubmit, reset, watch } = useForm<NewGalleryValues>({
+  const {
+    register,
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { isValid },
+  } = useForm<NewGalleryValues>({
     defaultValues: { name: '', is_public: true, viewers: [] },
+    mode: 'onChange',
   });
   const createGallery = useCreateGallery();
   const isPublic = watch('is_public');
@@ -100,9 +112,13 @@ function NewGalleryForm({ tenureId, onCreate }: { tenureId: number; onCreate: ()
           )}
         />
       )}
-      <button type="submit" className="rounded bg-blue-500 px-2 py-1 text-white">
+      <SubmitButton
+        className="rounded bg-blue-500 px-2 py-1 text-white"
+        isLoading={createGallery.isPending}
+        disabled={!isValid}
+      >
         Create
-      </button>
+      </SubmitButton>
     </form>
   );
 }

--- a/frontend/src/roster/components/MediaUploadForm.tsx
+++ b/frontend/src/roster/components/MediaUploadForm.tsx
@@ -3,6 +3,7 @@ import Select from 'react-select';
 import { useEffect, useState } from 'react';
 import { useTenureGalleriesQuery, useUploadPlayerMedia, useAssociateMedia } from '../queries';
 import MyTenureSelect from '@/components/MyTenureSelect';
+import { SubmitButton } from '@/components/SubmitButton';
 
 interface Option {
   value: number;
@@ -21,8 +22,16 @@ export function MediaUploadForm({ onUploadComplete }: { onUploadComplete?: () =>
   const uploadMutation = useUploadPlayerMedia();
   const associateMutation = useAssociateMedia();
 
-  const { register, control, handleSubmit, reset, watch } = useForm<UploadFormValues>({
+  const {
+    register,
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { isValid },
+  } = useForm<UploadFormValues>({
     defaultValues: { tenure: null, gallery: null },
+    mode: 'onChange',
   });
 
   const tenureId = watch('tenure');
@@ -100,9 +109,13 @@ export function MediaUploadForm({ onUploadComplete }: { onUploadComplete?: () =>
             )}
           />
         )}
-        <button type="submit" className="rounded bg-blue-500 px-2 py-1 text-white">
+        <SubmitButton
+          className="rounded bg-blue-500 px-2 py-1 text-white"
+          isLoading={uploadMutation.isPending || associateMutation.isPending}
+          disabled={!isValid}
+        >
           Upload
-        </button>
+        </SubmitButton>
       </form>
     </section>
   );

--- a/frontend/src/scenes/components/SceneHeader.tsx
+++ b/frontend/src/scenes/components/SceneHeader.tsx
@@ -5,6 +5,7 @@ import { SceneDetail, updateScene, finishScene } from '../queries';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Textarea } from '../../components/ui/textarea';
+import { SubmitButton } from '../../components/SubmitButton';
 
 interface Props {
   scene?: SceneDetail;
@@ -54,9 +55,9 @@ export function SceneHeader({ scene, onRefresh }: Props) {
           <Textarea id="description" {...register('description')} />
         </div>
         <div className="flex gap-2">
-          <Button size="sm" type="submit" disabled={save.isPending}>
+          <SubmitButton size="sm" isLoading={save.isPending}>
             Save
-          </Button>
+          </SubmitButton>
           <Button size="sm" variant="secondary" onClick={() => setEditing(false)}>
             Cancel
           </Button>
@@ -77,14 +78,15 @@ export function SceneHeader({ scene, onRefresh }: Props) {
                 Edit
               </Button>
               {scene.is_active && (
-                <Button
+                <SubmitButton
                   size="sm"
                   variant="destructive"
                   onClick={() => end.mutate()}
-                  disabled={end.isPending}
+                  isLoading={end.isPending}
+                  type="button"
                 >
                   End Scene
-                </Button>
+                </SubmitButton>
               )}
             </>
           )}

--- a/src/web/api/urls.py
+++ b/src/web/api/urls.py
@@ -4,12 +4,20 @@ from web.api.views import (
     HomePageAPIView,
     LoginAPIView,
     LogoutAPIView,
+    RegisterAPIView,
+    RegisterAvailabilityAPIView,
     ServerStatusAPIView,
 )
 
 urlpatterns = [
     path("homepage/", HomePageAPIView.as_view(), name="api-homepage"),
     path("status/", ServerStatusAPIView.as_view(), name="api-status"),
+    path("register/", RegisterAPIView.as_view(), name="api-register"),
+    path(
+        "register/availability/",
+        RegisterAvailabilityAPIView.as_view(),
+        name="api-register-availability",
+    ),
     path("login/", LoginAPIView.as_view(), name="api-login"),
     path("logout/", LogoutAPIView.as_view(), name="api-logout"),
 ]


### PR DESCRIPTION
## Summary
- add API endpoint to check username and email availability
- validate registration form fields with react-hook-form and availability checks
- expand backend and frontend tests for registration validation
- centralize submit button logic with loading/disabled states across forms

## Testing
- `uv run arx test`
- `pnpm test --run src/evennia_replacements/RegisterPage.test.tsx src/evennia_replacements/LoginPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689fcf5c30788331a8f21ac5ee1409e1