### PR TITLE
Add auth links for login and game pages

### DIFF
--- a/frontend/src/evennia_replacements/LoginPage.test.tsx
+++ b/frontend/src/evennia_replacements/LoginPage.test.tsx
@@ -3,9 +3,9 @@ import userEvent from '@testing-library/user-event';
 import { LoginPage } from './LoginPage';
 import { vi } from 'vitest';
 import * as api from './api';
-import { mockAccount } from '@/test/mocks/account';
-import { store } from '@/store/store';
-import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { mockAccount } from '../test/mocks/account';
+import { store } from '../store/store';
+import { renderWithProviders } from '../test/utils/renderWithProviders';
 
 vi.mock('./api');
 
@@ -25,5 +25,11 @@ describe('LoginPage', () => {
       });
       expect(store.getState().auth.account).toEqual(mockAccount);
     });
+  });
+
+  it('has a link to register', () => {
+    renderWithProviders(<LoginPage />);
+    const link = screen.getByRole('link', { name: /register/i });
+    expect(link).toHaveAttribute('href', '/register');
   });
 });

--- a/frontend/src/evennia_replacements/LoginPage.tsx
+++ b/frontend/src/evennia_replacements/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useLogin } from './queries';
 import { SITE_NAME } from '../config';
 import { Input } from '../components/ui/input';
@@ -43,6 +43,13 @@ export function LoginPage() {
         </SubmitButton>
       </form>
       {mutation.isError && <p className="mt-4 text-red-600">Login failed. Please try again.</p>}
+      <p className="mt-4 text-center text-sm">
+        Don't have an account?{' '}
+        <Link to="/register" className="text-blue-500 hover:underline">
+          Register
+        </Link>
+        .
+      </p>
     </div>
   );
 }

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from '@testing-library/react';
+import { GamePage } from './GamePage';
+import { renderWithProviders } from '../test/utils/renderWithProviders';
+import { store } from '../store/store';
+import { setAccount } from '../store/authSlice';
+import { mockAccount } from '../test/mocks/account';
+
+describe('GamePage', () => {
+  beforeEach(() => {
+    store.dispatch(setAccount(null));
+  });
+
+  it('prompts to log in when not authenticated', () => {
+    renderWithProviders(<GamePage />);
+    expect(screen.getByText(/you must be logged in/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /log in/i })).toHaveAttribute('href', '/login');
+    expect(screen.getByRole('link', { name: /register/i })).toHaveAttribute('href', '/register');
+  });
+
+  it('shows game interface when authenticated', () => {
+    store.dispatch(setAccount(mockAccount));
+    renderWithProviders(<GamePage />);
+    expect(screen.queryByText(/you must be logged in/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -3,9 +3,29 @@ import { CharacterPanel } from './components/CharacterPanel';
 import { QuickActions } from './components/QuickActions';
 import { useMyRosterEntriesQuery } from '../roster/queries';
 import { Toaster } from '../components/ui/sonner';
+import { Link } from 'react-router-dom';
+import { useAccount } from '../store/hooks';
 
 export function GamePage() {
+  const account = useAccount();
   const { data: characters = [] } = useMyRosterEntriesQuery();
+
+  if (!account) {
+    return (
+      <div className="mx-auto max-w-sm text-center">
+        <p className="mb-4">You must be logged in to access the game.</p>
+        <div className="flex justify-center gap-4">
+          <Link to="/login" className="text-blue-500 hover:underline">
+            Log in
+          </Link>
+          <Link to="/register" className="text-blue-500 hover:underline">
+            Register
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="mx-auto max-w-4xl">
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">


### PR DESCRIPTION
## Summary
- add registration link to login page
- prompt unauthenticated users on game page to log in or register
- add tests for new login and game page flows

## Testing
- `uv run pre-commit run --files frontend/src/evennia_replacements/LoginPage.tsx frontend/src/game/GamePage.tsx frontend/src/evennia_replacements/LoginPage.test.tsx frontend/src/game/GamePage.test.tsx`
- `cd frontend && pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_689ff68b8608833196658dc011054bf7