### PR TITLE
Add labels to registration form and note frontend type checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 This repository contains **Arx II**, a sequel to the Arx MUD. It is built on the Evennia framework and Django.
 
 - **Testing**: always run the suite with `uv run arx test` to ensure the correct environment and dependencies. Using `python` directly can miss packages like `typer`.
+- **Frontend**: when working on frontend code, run `pnpm typecheck` inside `frontend` in addition to the test suite to catch TypeScript errors early.
 - **Git hooks**: do not bypass pre-commit or pre-push hooks with `--no-verify`. The pre-push hook runs `pnpm build` for the frontend; ensure the build succeeds before pushing.
 - **Prettier**: frontend files are formatted via a pre-commit hook that runs `pnpm exec prettier --write`. Run `pnpm install` inside `frontend` so required plugins like `prettier-plugin-tailwindcss` are available. The hook currently fails when only one frontend file is provided; running `pnpm exec prettier <file>` manually works until the hook can be fixed.
 - **Design goals**: gameplay rules should live in the database. Avoid hardcoding specific mechanics in code. The `flows` system under `src/flows` allows designers to create data-driven tasks. Flows emit events that triggers can listen to and spawn additional flows.

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Label = React.forwardRef<HTMLLabelElement, React.LabelHTMLAttributes<HTMLLabelElement>>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(
+        'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Label.displayName = 'Label';
+
+export { Label };

--- a/frontend/src/evennia_replacements/RegisterPage.test.tsx
+++ b/frontend/src/evennia_replacements/RegisterPage.test.tsx
@@ -22,11 +22,11 @@ describe('RegisterPage', () => {
     vi.mocked(api.postRegister).mockResolvedValue(mockAccount);
     renderWithProviders(<RegisterPage />);
 
-    await userEvent.type(screen.getByPlaceholderText('Username'), 'tester');
+    await userEvent.type(screen.getByLabelText('Username'), 'tester');
     await userEvent.tab();
-    await userEvent.type(screen.getByPlaceholderText('Email'), 'test@test.com');
+    await userEvent.type(screen.getByLabelText('Email'), 'test@test.com');
     await userEvent.tab();
-    await userEvent.type(screen.getByPlaceholderText('Password'), 'secret');
+    await userEvent.type(screen.getByLabelText('Password'), 'secret');
     await userEvent.tab();
     await userEvent.click(screen.getByRole('button', { name: /register/i }));
 
@@ -45,11 +45,11 @@ describe('RegisterPage', () => {
     vi.mocked(api.checkEmail).mockResolvedValue(true);
     renderWithProviders(<RegisterPage />);
 
-    await userEvent.type(screen.getByPlaceholderText('Username'), 'tester');
+    await userEvent.type(screen.getByLabelText('Username'), 'tester');
     await userEvent.tab();
-    await userEvent.type(screen.getByPlaceholderText('Email'), 'test@test.com');
+    await userEvent.type(screen.getByLabelText('Email'), 'test@test.com');
     await userEvent.tab();
-    await userEvent.type(screen.getByPlaceholderText('Password'), 'secret');
+    await userEvent.type(screen.getByLabelText('Password'), 'secret');
     await userEvent.tab();
     await userEvent.click(screen.getByRole('button', { name: /register/i }));
 
@@ -64,11 +64,11 @@ describe('RegisterPage', () => {
     vi.mocked(api.checkEmail).mockResolvedValue(false);
     renderWithProviders(<RegisterPage />);
 
-    await userEvent.type(screen.getByPlaceholderText('Username'), 'tester');
+    await userEvent.type(screen.getByLabelText('Username'), 'tester');
     await userEvent.tab();
-    await userEvent.type(screen.getByPlaceholderText('Email'), 'test@test.com');
+    await userEvent.type(screen.getByLabelText('Email'), 'test@test.com');
     await userEvent.tab();
-    await userEvent.type(screen.getByPlaceholderText('Password'), 'secret');
+    await userEvent.type(screen.getByLabelText('Password'), 'secret');
     await userEvent.tab();
     await userEvent.click(screen.getByRole('button', { name: /register/i }));
 
@@ -90,11 +90,11 @@ describe('RegisterPage', () => {
     );
     renderWithProviders(<RegisterPage />);
 
-    await userEvent.type(screen.getByPlaceholderText('Username'), 'tester');
+    await userEvent.type(screen.getByLabelText('Username'), 'tester');
     await userEvent.tab();
-    await userEvent.type(screen.getByPlaceholderText('Email'), 'test@test.com');
+    await userEvent.type(screen.getByLabelText('Email'), 'test@test.com');
     await userEvent.tab();
-    await userEvent.type(screen.getByPlaceholderText('Password'), 'secret');
+    await userEvent.type(screen.getByLabelText('Password'), 'secret');
     await userEvent.tab();
     const button = screen.getByRole('button', { name: /register/i });
     await userEvent.click(button);

--- a/frontend/src/evennia_replacements/RegisterPage.tsx
+++ b/frontend/src/evennia_replacements/RegisterPage.tsx
@@ -4,6 +4,7 @@ import { SITE_NAME } from '../config';
 import { Input } from '../components/ui/input';
 import { SubmitButton } from '../components/SubmitButton';
 import { Button } from '../components/ui/button';
+import { Label } from '../components/ui/label';
 import { useForm } from 'react-hook-form';
 import { checkUsername, checkEmail } from './api';
 
@@ -31,31 +32,43 @@ export function RegisterPage() {
     <div className="mx-auto max-w-sm">
       <h1 className="mb-6 text-2xl font-bold">Register for {SITE_NAME}</h1>
       <form onSubmit={onSubmit} className="space-y-4">
-        <Input
-          placeholder="Username"
-          {...register('username', {
-            required: 'Username is required',
-            validate: async (value) => (await checkUsername(value)) || 'Username already taken',
-          })}
-        />
-        {errors.username && <p className="text-sm text-red-600">{errors.username.message}</p>}
-        <Input
-          placeholder="Email"
-          type="email"
-          {...register('email', {
-            required: 'Email is required',
-            validate: async (value) => (await checkEmail(value)) || 'Email already taken',
-          })}
-        />
-        {errors.email && <p className="text-sm text-red-600">{errors.email.message}</p>}
-        <Input
-          type="password"
-          placeholder="Password"
-          {...register('password', {
-            required: 'Password is required',
-          })}
-        />
-        {errors.password && <p className="text-sm text-red-600">{errors.password.message}</p>}
+        <div className="space-y-1">
+          <Label htmlFor="username">Username</Label>
+          <Input
+            id="username"
+            placeholder="Username"
+            {...register('username', {
+              required: 'Username is required',
+              validate: async (value) => (await checkUsername(value)) || 'Username already taken',
+            })}
+          />
+          {errors.username && <p className="text-sm text-red-600">{errors.username.message}</p>}
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            placeholder="Email"
+            type="email"
+            {...register('email', {
+              required: 'Email is required',
+              validate: async (value) => (await checkEmail(value)) || 'Email already taken',
+            })}
+          />
+          {errors.email && <p className="text-sm text-red-600">{errors.email.message}</p>}
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            placeholder="Password"
+            {...register('password', {
+              required: 'Password is required',
+            })}
+          />
+          {errors.password && <p className="text-sm text-red-600">{errors.password.message}</p>}
+        </div>
         <SubmitButton className="w-full" isLoading={mutation.isPending} disabled={!isValid}>
           Register
         </SubmitButton>


### PR DESCRIPTION
## Summary
- add shadcn Label component and wire into registration page
- document running `pnpm typecheck` for frontend changes
- update registration page tests to use label-based queries

## Testing
- `pnpm typecheck`
- `pnpm test run`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_689ffb6cec408331a61e42ae2b97d62b