### PR TITLE
feat(frontend): add command history

### DIFF
--- a/frontend/src/game/components/CommandInput.tsx
+++ b/frontend/src/game/components/CommandInput.tsx
@@ -9,6 +9,8 @@ interface CommandInputProps {
 
 export function CommandInput({ character }: CommandInputProps) {
   const [command, setCommand] = useState('');
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState<number>(-1);
   const { send } = useGameSocket();
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -16,7 +18,27 @@ export function CommandInput({ character }: CommandInputProps) {
     const trimmed = command.trim();
     if (trimmed) {
       send(character, trimmed);
+      setHistory((prev) => [...prev, trimmed]);
+      setHistoryIndex(-1);
       setCommand('');
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (history.length > 0) {
+        const newIndex = historyIndex <= 0 ? history.length - 1 : historyIndex - 1;
+        setHistoryIndex(newIndex);
+        setCommand(history[newIndex]);
+      }
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (history.length > 0) {
+        const newIndex = historyIndex >= history.length - 1 ? -1 : historyIndex + 1;
+        setHistoryIndex(newIndex);
+        setCommand(newIndex === -1 ? '' : history[newIndex]);
+      }
     }
   };
 
@@ -27,6 +49,7 @@ export function CommandInput({ character }: CommandInputProps) {
         placeholder="Enter command..."
         value={command}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCommand(e.target.value)}
+        onKeyDown={handleKeyDown}
       />
     </form>
   );


### PR DESCRIPTION
## Summary
- add history navigation with up/down arrows in game command input

## Testing
- `pre-commit run --files frontend/src/game/components/CommandInput.tsx`
- `pnpm typecheck`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac32415c833186b343e66a357349