### PR TITLE
Revamp quick actions UI with command drawer

### DIFF
--- a/frontend/src/game/components/CommandDrawer.tsx
+++ b/frontend/src/game/components/CommandDrawer.tsx
@@ -1,0 +1,79 @@
+import { useState, FormEvent } from 'react';
+import { useGameSocket } from '@/hooks/useGameSocket';
+import type { CommandSpec } from '@/game/types';
+import type { MyRosterEntry } from '@/roster/types';
+import { formatCommand } from '@/game/helpers/commandHelpers';
+import {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+} from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+
+interface CommandDrawerProps extends CommandSpec {
+  character: MyRosterEntry['name'];
+}
+
+export function CommandDrawer({
+  character,
+  action,
+  prompt,
+  params_schema,
+  name,
+  help,
+}: CommandDrawerProps) {
+  const { send } = useGameSocket();
+  const [fields, setFields] = useState<Record<string, string>>({});
+
+  const handleChange = (param: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFields({ ...fields, [param]: e.target.value });
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const cmd = formatCommand(prompt, fields);
+    send(character, cmd);
+    setFields({});
+  };
+
+  const title = name ?? action;
+  const description = help ?? prompt;
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="ghost" className="justify-start px-2 py-1">
+          {title}
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>{title}</SheetTitle>
+          {description && <SheetDescription>{description}</SheetDescription>}
+        </SheetHeader>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          {Object.keys(params_schema).map((param) => (
+            <div key={param} className="grid gap-2">
+              <Label htmlFor={param}>{param}</Label>
+              <input
+                id={param}
+                type="text"
+                value={fields[param] ?? ''}
+                onChange={handleChange(param)}
+                className="w-full rounded border p-2"
+              />
+            </div>
+          ))}
+          <SheetFooter>
+            <Button type="submit">Submit</Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/game/components/EntityContextMenu.tsx
+++ b/frontend/src/game/components/EntityContextMenu.tsx
@@ -1,8 +1,9 @@
 import type { CommandSpec } from '@/game/types';
+import type { MyRosterEntry } from '@/roster/types';
 import { QuickAction } from './QuickAction';
 
 interface EntityContextMenuProps {
-  character: string;
+  character: MyRosterEntry['name'];
   commands: CommandSpec[];
 }
 

--- a/frontend/src/game/components/QuickAction.tsx
+++ b/frontend/src/game/components/QuickAction.tsx
@@ -1,11 +1,13 @@
 import { useGameSocket } from '@/hooks/useGameSocket';
 import type { CommandSpec } from '@/game/types';
+import type { MyRosterEntry } from '@/roster/types';
+import { formatCommand } from '@/game/helpers/commandHelpers';
 import type { LucideIcon } from 'lucide-react';
 import { Eye, Hand, MessageCircle } from 'lucide-react';
 import { FormEvent, useState } from 'react';
 
 interface QuickActionProps extends CommandSpec {
-  character: string;
+  character: MyRosterEntry['name'];
 }
 
 const ICON_MAP: Record<string, LucideIcon> = {
@@ -13,35 +15,6 @@ const ICON_MAP: Record<string, LucideIcon> = {
   get: Hand,
   talk: MessageCircle,
 };
-
-/**
- * Formats a command using the prompt template and field values.
- * Handles syntax like "@dig room_name=exit_name, back_exit"
- */
-function formatCommand(prompt: string, fields: Record<string, string>): string {
-  let command = prompt;
-
-  // First, handle optional parameters by checking if they have values
-  // Remove optional comma-separated parts if the parameter is empty
-  command = command.replace(/, ([a-z_]+)/g, (match, paramName) => {
-    const hasValue = fields[paramName] && fields[paramName].trim() !== '';
-    if (!hasValue) {
-      return ''; // Remove the optional part
-    }
-    return match; // Keep the optional part
-  });
-
-  // Then replace each parameter with its value from fields
-  Object.entries(fields).forEach(([key, value]) => {
-    if (value && value.trim() !== '') {
-      // Use word boundaries to ensure we replace whole parameter names only
-      const regex = new RegExp(`\\b${key}\\b`, 'g');
-      command = command.replace(regex, value);
-    }
-  });
-
-  return command;
-}
 
 export function QuickAction({ character, action, prompt, params_schema }: QuickActionProps) {
   const { send } = useGameSocket();

--- a/frontend/src/game/components/QuickActions.tsx
+++ b/frontend/src/game/components/QuickActions.tsx
@@ -1,17 +1,30 @@
 import { useAppSelector } from '@/store/hooks';
-import { QuickAction } from './QuickAction';
+import { groupCommands } from '@/game/helpers/commandHelpers';
+import { CommandDrawer } from './CommandDrawer';
 
 export function QuickActions() {
   const { active, sessions } = useAppSelector((state) => state.game);
   if (!active) return null;
   const commands = sessions[active]?.commands ?? [];
+  const grouped = groupCommands(commands);
 
   return (
     <div className="rounded-lg border bg-card p-4">
       <h3 className="mb-2 font-semibold">Quick Actions</h3>
-      <div className="flex flex-col gap-2">
-        {commands.map((cmd, index) => (
-          <QuickAction key={`${active}-${index}-${cmd.action}`} character={active} {...cmd} />
+      <div className="flex flex-col gap-4">
+        {Object.entries(grouped).map(([category, cmds]) => (
+          <div key={category}>
+            <h4 className="mb-1 text-sm font-medium">{category}</h4>
+            <div className="flex flex-col">
+              {cmds.map((cmd, index) => (
+                <CommandDrawer
+                  key={`${active}-${index}-${cmd.action}`}
+                  character={active}
+                  {...cmd}
+                />
+              ))}
+            </div>
+          </div>
         ))}
       </div>
     </div>

--- a/frontend/src/game/components/SceneWindow.tsx
+++ b/frontend/src/game/components/SceneWindow.tsx
@@ -6,9 +6,10 @@ import { startScene, finishScene } from '@/scenes/queries';
 import type { SceneSummary } from '@/hooks/types';
 import { useAppDispatch } from '@/store/hooks';
 import { setSessionScene } from '@/store/gameSlice';
+import type { MyRosterEntry } from '@/roster/types';
 
 interface Props {
-  character: string;
+  character: MyRosterEntry['name'];
   scene: SceneSummary | null;
   room: { id: number; name: string } | null;
 }

--- a/frontend/src/game/helpers/commandHelpers.ts
+++ b/frontend/src/game/helpers/commandHelpers.ts
@@ -1,0 +1,51 @@
+import type { CommandSpec } from '../types';
+
+/**
+ * Insert field values into a command prompt template.
+ *
+ * The prompt may include parameter names that will be replaced by corresponding
+ * values from `fields`. Comma-separated segments containing a parameter are
+ * omitted if the parameter value is blank.
+ *
+ * Examples:
+ * formatCommand("say message", { message: "hello" });
+ * // -> "say hello"
+ *
+ * formatCommand("give item, target", { item: "coin", target: "bob" });
+ * // -> "give coin, bob"
+ *
+ * // When target is empty the trailing comma segment is removed
+ * formatCommand("give item, target", { item: "coin", target: "" });
+ * // -> "give coin"
+ */
+export function formatCommand(prompt: string, fields: Record<string, string>): string {
+  let command = prompt;
+
+  // Remove optional comma-separated parts if the parameter is empty
+  command = command.replace(/, ([a-z_]+)/g, (match, paramName) => {
+    const hasValue = fields[paramName] && fields[paramName].trim() !== '';
+    return hasValue ? match : '';
+  });
+
+  // Replace each parameter with its value
+  Object.entries(fields).forEach(([key, value]) => {
+    if (value && value.trim() !== '') {
+      const regex = new RegExp(`\\b${key}\\b`, 'g');
+      command = command.replace(regex, value);
+    }
+  });
+
+  return command;
+}
+
+/**
+ * Group commands by their category, defaulting to "General".
+ */
+export function groupCommands(commands: CommandSpec[]): Record<string, CommandSpec[]> {
+  return commands.reduce((acc: Record<string, CommandSpec[]>, cmd) => {
+    const category = cmd.category ?? 'General';
+    acc[category] = acc[category] || [];
+    acc[category].push(cmd);
+    return acc;
+  }, {});
+}

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -9,4 +9,10 @@ export interface CommandSpec {
   prompt: string;
   params_schema: Record<string, ParamSchema>;
   icon: string;
+  /** Human readable command name. */
+  name?: string;
+  /** Category used for grouping commands. */
+  category?: string;
+  /** Help text describing command usage. */
+  help?: string;
 }

--- a/frontend/src/hooks/handleCommandPayload.ts
+++ b/frontend/src/hooks/handleCommandPayload.ts
@@ -1,8 +1,9 @@
 import type { CommandSpec } from '@/game/types';
+import type { MyRosterEntry } from '@/roster/types';
 import { store } from '@/store/store';
 import { setSessionCommands } from '@/store/gameSlice';
 
-export function handleCommandPayload(character: string, commands: CommandSpec[]) {
+export function handleCommandPayload(character: MyRosterEntry['name'], commands: CommandSpec[]) {
   // Backend already sends CommandSpec format, no conversion needed
   store.dispatch(setSessionCommands({ character, commands }));
 }

--- a/frontend/src/hooks/handleRoomStatePayload.ts
+++ b/frontend/src/hooks/handleRoomStatePayload.ts
@@ -1,9 +1,10 @@
 import type { RoomStatePayload } from './types';
 import type { AppDispatch } from '@/store/store';
 import { setSessionRoom, setSessionScene } from '@/store/gameSlice';
+import type { MyRosterEntry } from '@/roster/types';
 
 export function handleRoomStatePayload(
-  character: string,
+  character: MyRosterEntry['name'],
   payload: RoomStatePayload,
   dispatch: AppDispatch
 ) {

--- a/frontend/src/hooks/handleScenePayload.ts
+++ b/frontend/src/hooks/handleScenePayload.ts
@@ -1,9 +1,10 @@
 import type { ScenePayload } from './types';
 import type { AppDispatch } from '@/store/store';
 import { setSessionScene } from '@/store/gameSlice';
+import type { MyRosterEntry } from '@/roster/types';
 
 export function handleScenePayload(
-  character: string,
+  character: MyRosterEntry['name'],
   payload: ScenePayload,
   dispatch: AppDispatch
 ) {


### PR DESCRIPTION
## Summary
- group quick action commands by category and trigger drawers
- introduce CommandDrawer component with labeled inputs and help text
- extend command spec with optional name, category, and help fields
- centralize command formatting and grouping helpers with usage examples
- type character props as MyRosterEntry['name'] across components and hooks

## Testing
- `pnpm typecheck`
- `pnpm exec vitest run`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ab406ad08331be65c6d2939ffd11