### PR TITLE
Add character-based page command

### DIFF
--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -19,6 +19,7 @@ from evennia import default_cmds
 from commands.account.account_info import CmdAccount
 from commands.account.character_switching import CmdCharacters, CmdIC
 from commands.account.sheet import CmdSheet
+from commands.evennia_overrides.communication import CmdPage
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -102,13 +103,14 @@ class AccountCmdSet(default_cmds.AccountCmdSet):
         Populates the cmdset
         """
         super().at_cmdset_creation()
-        for cmdname in ("ic", "characters", "account"):
+        for cmdname in ("ic", "characters", "account", "page"):
             self.remove(cmdname)
 
         self.add(CmdIC())
         self.add(CmdCharacters())
         self.add(CmdAccount())
         self.add(CmdSheet())
+        self.add(CmdPage())
 
 
 class UnloggedinCmdSet(default_cmds.UnloggedinCmdSet):

--- a/src/commands/evennia_overrides/communication.py
+++ b/src/commands/evennia_overrides/communication.py
@@ -1,8 +1,13 @@
 """Evennia command overrides for communication."""
 
+from evennia import Command
+from evennia.utils import search
+
 from commands.command import ArxCommand
 from commands.dispatchers import TargetTextDispatcher, TextDispatcher
+from commands.frontend import FrontendMetadataMixin
 from commands.handlers.base import BaseHandler
+from world.roster.models import RosterEntry
 
 
 class CmdSay(ArxCommand):
@@ -24,6 +29,58 @@ class CmdWhisper(ArxCommand):
             BaseHandler(flow_name="whisper"),
         )
     ]
+
+
+class CmdPage(FrontendMetadataMixin, Command):
+    """Send a private message to the player of a character."""
+
+    usage = [
+        {
+            "prompt": "page character=message",
+            "params_schema": {
+                "character": {"type": "string"},
+                "message": {"type": "string"},
+            },
+        }
+    ]
+
+    key = "page"
+    locks = "cmd:all()"
+    help_category = "Account"
+
+    def func(self):
+        """Execute the page command."""
+        if not self.args or "=" not in self.args:
+            self.caller.msg("Usage: page <character>=<message>")
+            return
+
+        charname, text = [part.strip() for part in self.args.split("=", 1)]
+        if not charname or not text:
+            self.caller.msg("Usage: page <character>=<message>")
+            return
+
+        characters = search.object_search(charname, exact=True)
+        if not characters:
+            self.caller.msg(f"Could not find character '{charname}'.")
+            return
+        if len(characters) > 1:
+            self.caller.msg(f"Multiple characters found matching '{charname}'.")
+            return
+
+        character = characters[0]
+        try:
+            character.roster_entry
+        except RosterEntry.DoesNotExist:
+            self.caller.msg(f"Character '{charname}' is not on the roster.")
+            return
+
+        account = character.active_account
+        if not account:
+            self.caller.msg(f"Character '{charname}' has no active player.")
+            return
+
+        character.msg(f"{self.caller.key} pages: {text}")
+        self.caller.msg(f"You page {character.key}: {text}")
 
 
 class CmdPose(ArxCommand):

--- a/src/commands/tests/test_cmd_page.py
+++ b/src/commands/tests/test_cmd_page.py
@@ -1,0 +1,88 @@
+"""Tests for the page command."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from commands.evennia_overrides.communication import CmdPage
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.roster.factories import (
+    PlayerDataFactory,
+    RosterEntryFactory,
+    RosterTenureFactory,
+)
+
+
+class CmdPageTests(TestCase):
+    """Tests for the page command."""
+
+    def setUp(self):
+        self.caller = AccountFactory(username="Alice")
+        self.caller.msg = MagicMock()
+
+        self.target_account = AccountFactory(username="BobAcc")
+        self.target_account.msg = MagicMock()
+        player_data = PlayerDataFactory(account=self.target_account)
+        self.character = CharacterFactory(db_key="Bob")
+        self.character.msg = MagicMock()
+        roster_entry = RosterEntryFactory(character=self.character)
+        RosterTenureFactory(roster_entry=roster_entry, player_data=player_data)
+
+    @patch("commands.evennia_overrides.communication.search.object_search")
+    def test_page_routes_to_character(self, mock_search):
+        """Character name should deliver the message to the target character."""
+
+        mock_search.return_value = [self.character]
+
+        cmd = CmdPage()
+        cmd.caller = self.caller
+        cmd.args = "Bob=hello"
+        cmd.func()
+
+        mock_search.assert_called_once_with("Bob", exact=True)
+        self.character.msg.assert_called_once_with("Alice pages: hello")
+        self.target_account.msg.assert_not_called()
+        self.caller.msg.assert_any_call("You page Bob: hello")
+
+    @patch("commands.evennia_overrides.communication.search.object_search")
+    def test_page_requires_active_player(self, mock_search):
+        """The command should error if the character has no active player."""
+
+        mock_search.return_value = [self.character]
+        # Remove all tenures to simulate no active player
+        self.character.roster_entry.tenures.all().delete()
+
+        cmd = CmdPage()
+        cmd.caller = self.caller
+        cmd.args = "Bob=hi"
+        cmd.func()
+
+        self.target_account.msg.assert_not_called()
+        self.character.msg.assert_not_called()
+        self.caller.msg.assert_called_with("Character 'Bob' has no active player.")
+
+    @patch("commands.evennia_overrides.communication.search.object_search")
+    def test_page_requires_rostered_character(self, mock_search):
+        """The command should error if the character is not on the roster."""
+
+        unrostered = CharacterFactory(db_key="NoRoster")
+        mock_search.return_value = [unrostered]
+
+        cmd = CmdPage()
+        cmd.caller = self.caller
+        cmd.args = "NoRoster=hey"
+        cmd.func()
+
+        self.caller.msg.assert_called_with("Character 'NoRoster' is not on the roster.")
+
+    def test_page_exposes_usage_metadata(self):
+        """CmdPage should expose usage information for the frontend."""
+
+        cmd = CmdPage()
+        payload = cmd.to_payload()
+        descriptor = payload["descriptors"][0]
+        self.assertEqual(descriptor["prompt"], "page character=message")
+        self.assertEqual(
+            descriptor["params_schema"],
+            {"character": {"type": "string"}, "message": {"type": "string"}},
+        )

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -10,6 +10,7 @@ creation commands.
 
 from functools import cached_property
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from evennia.objects.objects import DefaultCharacter
 
@@ -91,6 +92,21 @@ class Character(ObjectParent, DefaultCharacter):
         from evennia_extensions.data_handlers import CharacterItemDataHandler
 
         return CharacterItemDataHandler(self)
+
+    @property
+    def active_account(self):
+        """Return the account currently linked to this character.
+
+        Returns:
+            Account | None: The controlling account, if any.
+        """
+        try:
+            tenure = self.roster_entry.current_tenure
+        except ObjectDoesNotExist:
+            return None
+        if not tenure or not tenure.player_data:
+            return None
+        return tenure.player_data.account
 
     def do_look(self, target):
         desc = self.at_look(target)


### PR DESCRIPTION
## Summary
- keep `page` as an account command and resolve targets via roster tenure
- add `Character.active_account` property to avoid fragile `getattr` calls
- cover missing roster entry and inactive player cases with unit tests
- deliver page messages to the target character instead of the account
- expose page usage metadata for the frontend and clean up cmdset imports

## Testing
- `uv run pre-commit run --files src/commands/evennia_overrides/communication.py src/commands/default_cmdsets.py src/commands/tests/test_cmd_page.py`
- `uv run arx test commands.tests.test_cmd_page commands.tests.test_cmd_inventory_say_whisper_pose`


------
https://chatgpt.com/codex/tasks/task_e_68a7d691e2108331b7f6a85fbf1a4e21