### PR TITLE
feat: add online character search to page command

### DIFF
--- a/frontend/src/components/SearchSelect.tsx
+++ b/frontend/src/components/SearchSelect.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+import AsyncSelect from 'react-select/async';
+import type { OptionsOrGroups, GroupBase } from 'react-select';
+import { apiFetch } from '@/evennia_replacements/api';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import type { Option } from '@/shared/types';
+
+interface SearchSelectProps {
+  endpoint: string;
+  value: string;
+  onChange: (val: string) => void;
+}
+
+export function SearchSelect({ endpoint, value, onChange }: SearchSelectProps) {
+  const [input, setInput] = useState('');
+  const debounced = useDebouncedValue(input);
+  const [options, setOptions] = useState<Option[]>([]);
+
+  useEffect(() => {
+    const url = `${endpoint}?search=${encodeURIComponent(debounced)}`;
+    apiFetch(url)
+      .then((res) => res.json())
+      .then((data: OptionsOrGroups<Option, GroupBase<Option>>) => {
+        setOptions(data as Option[]);
+      });
+  }, [endpoint, debounced]);
+
+  return (
+    <AsyncSelect
+      cacheOptions
+      defaultOptions
+      loadOptions={() => Promise.resolve(options)}
+      value={value ? { value, label: value } : null}
+      onInputChange={(val) => {
+        setInput(val);
+        return val;
+      }}
+      onChange={(opt) => onChange((opt as Option | null)?.value ?? '')}
+      classNames={{
+        control: () => 'bg-white text-black dark:bg-slate-800 dark:text-white',
+        menu: () => 'bg-white text-black dark:bg-slate-800 dark:text-white',
+        option: (state) =>
+          state.isFocused
+            ? 'bg-slate-100 dark:bg-slate-700 text-black dark:text-white'
+            : 'text-black dark:text-white',
+      }}
+    />
+  );
+}
+
+export default SearchSelect;

--- a/frontend/src/game/components/CommandForm.tsx
+++ b/frontend/src/game/components/CommandForm.tsx
@@ -3,6 +3,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { SheetFooter } from '@/components/ui/sheet';
 import type { CommandSpec } from '@/game/types';
+import SearchSelect from '@/components/SearchSelect';
 
 interface CommandFormProps {
   params_schema: CommandSpec['params_schema'];
@@ -31,18 +32,30 @@ export function CommandForm({
 
   return (
     <form onSubmit={handleSubmit} className="mt-4 space-y-4">
-      {Object.keys(params_schema).map((param) => (
-        <div key={param} className="grid gap-2">
-          <Label htmlFor={param}>{param}</Label>
-          <input
-            id={param}
-            type="text"
-            value={fields[param] ?? ''}
-            onChange={handleChange(param)}
-            className="w-full rounded border p-2"
-          />
-        </div>
-      ))}
+      {Object.keys(params_schema).map((param) => {
+        const schema = params_schema[param];
+        const isSelect = schema.widget === 'character-search' && schema.options_endpoint;
+        return (
+          <div key={param} className="grid gap-2">
+            <Label htmlFor={param}>{param}</Label>
+            {isSelect ? (
+              <SearchSelect
+                endpoint={schema.options_endpoint!}
+                value={fields[param] ?? ''}
+                onChange={(val) => setFields({ ...fields, [param]: val })}
+              />
+            ) : (
+              <input
+                id={param}
+                type="text"
+                value={fields[param] ?? ''}
+                onChange={handleChange(param)}
+                className="w-full rounded border p-2"
+              />
+            )}
+          </div>
+        );
+      })}
       <div className="flex items-center space-x-2">
         <input
           id="close-on-submit"

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -2,6 +2,8 @@ export interface ParamSchema {
   type: string;
   required?: boolean;
   match?: string;
+  widget?: string;
+  options_endpoint?: string;
 }
 
 export interface CommandSpec {

--- a/frontend/src/roster/components/GalleryManagement.tsx
+++ b/frontend/src/roster/components/GalleryManagement.tsx
@@ -4,15 +4,11 @@ import type { TenureGallery } from '../types';
 import MyTenureSelect from '@/components/MyTenureSelect';
 import TenureMultiSearch from '@/components/TenureMultiSearch';
 import { SubmitButton } from '@/components/SubmitButton';
-
-interface Option {
-  value: number;
-  label: string;
-}
+import type { Option } from '@/shared/types';
 
 interface GalleryFormValues {
   is_public: boolean;
-  viewers: Option[];
+  viewers: Option<number>[];
 }
 
 function GalleryForm({ gallery, onSave }: { gallery: TenureGallery; onSave: () => void }) {
@@ -64,7 +60,7 @@ function GalleryForm({ gallery, onSave }: { gallery: TenureGallery; onSave: () =
 interface NewGalleryValues {
   name: string;
   is_public: boolean;
-  viewers: Option[];
+  viewers: Option<number>[];
 }
 
 function NewGalleryForm({ tenureId, onCreate }: { tenureId: number; onCreate: () => void }) {

--- a/frontend/src/roster/components/MediaUploadForm.tsx
+++ b/frontend/src/roster/components/MediaUploadForm.tsx
@@ -4,18 +4,14 @@ import { useEffect, useState } from 'react';
 import { useTenureGalleriesQuery, useUploadPlayerMedia, useAssociateMedia } from '../queries';
 import MyTenureSelect from '@/components/MyTenureSelect';
 import { SubmitButton } from '@/components/SubmitButton';
-
-interface Option {
-  value: number;
-  label: string;
-}
+import type { Option } from '@/shared/types';
 
 interface UploadFormValues {
   image_file: FileList;
   title: string;
   description: string;
   tenure: number | null;
-  gallery: Option | null;
+  gallery: Option<number> | null;
 }
 
 export function MediaUploadForm({ onUploadComplete }: { onUploadComplete?: () => void }) {

--- a/frontend/src/shared/types.ts
+++ b/frontend/src/shared/types.ts
@@ -4,3 +4,8 @@ export interface PaginatedResponse<T> {
   previous: string | null;
   results: T[];
 }
+
+export interface Option<T = string> {
+  value: T;
+  label: string;
+}

--- a/src/commands/evennia_overrides/communication.py
+++ b/src/commands/evennia_overrides/communication.py
@@ -38,7 +38,11 @@ class CmdPage(FrontendMetadataMixin, Command):
         {
             "prompt": "page character=message",
             "params_schema": {
-                "character": {"type": "string"},
+                "character": {
+                    "type": "string",
+                    "widget": "character-search",
+                    "options_endpoint": "/api/characters/online/",
+                },
                 "message": {"type": "string"},
             },
         }

--- a/src/commands/frontend_types.py
+++ b/src/commands/frontend_types.py
@@ -9,6 +9,8 @@ class ParamSchema(TypedDict, total=False):
     type: str
     required: bool
     match: str
+    widget: str
+    options_endpoint: str
 
 
 class UsageEntry(TypedDict, total=False):

--- a/src/commands/tests/test_cmd_page.py
+++ b/src/commands/tests/test_cmd_page.py
@@ -84,5 +84,12 @@ class CmdPageTests(TestCase):
         self.assertEqual(descriptor["prompt"], "page character=message")
         self.assertEqual(
             descriptor["params_schema"],
-            {"character": {"type": "string"}, "message": {"type": "string"}},
+            {
+                "character": {
+                    "type": "string",
+                    "widget": "character-search",
+                    "options_endpoint": "/api/characters/online/",
+                },
+                "message": {"type": "string"},
+            },
         )

--- a/src/web/api/urls.py
+++ b/src/web/api/urls.py
@@ -4,6 +4,7 @@ from web.api.views import (
     CurrentUserAPIView,
     HomePageAPIView,
     LogoutAPIView,
+    OnlineCharacterSearchAPIView,
     RegisterAvailabilityAPIView,
     ServerStatusAPIView,
 )
@@ -19,6 +20,11 @@ urlpatterns = [
     ),
     # Custom logout endpoint (allauth headless doesn't provide one)
     path("auth/browser/v1/auth/logout", LogoutAPIView.as_view(), name="api-logout"),
+    path(
+        "characters/online/",
+        OnlineCharacterSearchAPIView.as_view(),
+        name="api-online-characters",
+    ),
     # Django-allauth headless API endpoints
     path("auth/", include("allauth.headless.urls")),
 ]

--- a/src/web/api/views.py
+++ b/src/web/api/views.py
@@ -155,3 +155,26 @@ class LogoutAPIView(APIView):
         """Log out the current user."""
         logout(request)
         return Response({"status": "success"})
+
+
+class OnlineCharacterSearchAPIView(APIView):
+    """Return characters online and visible to the request user."""
+
+    def get(self, request, *args, **kwargs):
+        """Return list of online characters matching search term."""
+        term = request.query_params.get("search", "")
+        connected = AccountDB.objects.get_connected_accounts()
+        names = (
+            RosterEntry.objects.filter(
+                tenures__end_date__isnull=True,
+                tenures__player_data__account__in=connected,
+                tenures__display_settings__allow_pages=True,
+                tenures__display_settings__show_online_status=True,
+                character__db_key__icontains=term,
+            )
+            .values_list("character__db_key", flat=True)
+            .distinct()
+            .order_by("character__db_key")
+        )
+        data = [{"value": name, "label": name} for name in names]
+        return Response(data)


### PR DESCRIPTION
## Summary
- expose Page target as a searchable character widget
- add API endpoint for online character lookup
- render character search in frontend CmdPage forms
- debounce search calls and reuse a shared Option type
- extract search select into a standalone component

## Testing
- `pnpm typecheck`
- `uv run arx test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f31dd578833184b9b06827176f5a