### PR TITLE
Run code review workflow only on PR creation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
## Summary
- run Claude code review workflow only when a pull request is opened

## Testing
- `uv run pre-commit run --files .github/workflows/claude-code-review.yml`

------
https://chatgpt.com/codex/tasks/task_e_68adf2a62a14833191a4e76524e138a7