### PR TITLE
feat(scenes): ephemeral scene real-time delivery without persistence

### DIFF
--- a/src/world/scenes/interaction_services.py
+++ b/src/world/scenes/interaction_services.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import itertools
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -16,10 +17,13 @@ from world.scenes.models import (
 from world.scenes.place_models import InteractionReceiver, Place
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from evennia.objects.models import ObjectDB
 
 DELETION_WINDOW_DAYS = 30
 _active_scene_attr = "active_scene"
+_ephemeral_counter = itertools.count()
 
 
 def create_interaction(  # noqa: PLR0913 - atomic creation requires all interaction fields
@@ -31,16 +35,16 @@ def create_interaction(  # noqa: PLR0913 - atomic creation requires all interact
     place: Place | None = None,
     receivers: list[Persona] | None = None,
     target_personas: list[Persona] | None = None,
-) -> Interaction | None:
+) -> Interaction:
     """Create an atomic RP interaction with optional receiver records.
-
-    For ephemeral scenes, returns None without persisting anything --
-    the interaction is delivered in real-time but never stored.
 
     Receiver logic:
     - If receivers are explicitly provided, create InteractionReceiver rows.
     - If place is provided without receivers, auto-populate from PlacePresence.
     - If neither place nor receivers, the interaction is public (no receiver rows).
+
+    Callers must handle ephemeral scenes before calling this function --
+    ephemeral interactions should never be persisted.
 
     Args:
         persona: The writer's identity (non-nullable).
@@ -52,11 +56,8 @@ def create_interaction(  # noqa: PLR0913 - atomic creation requires all interact
         target_personas: Explicit IC targets for thread derivation.
 
     Returns:
-        The created Interaction, or None for ephemeral scenes.
+        The created Interaction.
     """
-    if scene is not None and scene.privacy_mode == ScenePrivacyMode.EPHEMERAL:
-        return None
-
     interaction = Interaction.objects.create(
         persona=persona,
         content=content,
@@ -102,13 +103,48 @@ def create_interaction(  # noqa: PLR0913 - atomic creation requires all interact
     return interaction
 
 
-def _broadcast_payload(location: ObjectDB, payload: dict) -> None:
-    """Send an interaction payload to all objects in a location via WebSocket."""
-    for obj in location.contents:
+def _send_to_objects(
+    objects: Iterable[ObjectDB],
+    payload: dict[str, object],
+) -> None:
+    """Send an interaction payload to specific objects via WebSocket."""
+    for obj in objects:
         try:
             obj.msg(interaction=((), payload))
         except AttributeError:
             continue
+
+
+def _broadcast_to_location(
+    location: ObjectDB,
+    payload: dict[str, object],
+) -> None:
+    """Send an interaction payload to all objects in a location via WebSocket."""
+    _send_to_objects(location.contents, payload)
+
+
+def _build_interaction_payload(  # noqa: PLR0913 - payload needs all interaction fields
+    *,
+    interaction_id: int,
+    persona: Persona,
+    content: str,
+    mode: str,
+    timestamp: str,
+    scene_id: int | None,
+) -> dict[str, object]:
+    """Build a structured interaction payload for WebSocket delivery."""
+    return {
+        "id": interaction_id,
+        "persona": {
+            "id": persona.pk,
+            "name": persona.name,
+            "thumbnail_url": persona.thumbnail_url or "",
+        },
+        "content": content,
+        "mode": mode,
+        "timestamp": timestamp,
+        "scene_id": scene_id,
+    }
 
 
 def push_interaction(interaction: Interaction) -> None:
@@ -126,20 +162,16 @@ def push_interaction(interaction: Interaction) -> None:
     if location is None:
         return
 
-    payload = {
-        "id": interaction.pk,
-        "persona": {
-            "id": persona.pk,
-            "name": persona.name,
-            "thumbnail_url": persona.thumbnail_url or "",
-        },
-        "content": interaction.content,
-        "mode": interaction.mode,
-        "timestamp": interaction.timestamp.isoformat(),
-        "scene_id": interaction.scene_id,
-    }
+    payload = _build_interaction_payload(
+        interaction_id=interaction.pk,
+        persona=persona,
+        content=interaction.content,
+        mode=interaction.mode,
+        timestamp=interaction.timestamp.isoformat(),
+        scene_id=interaction.scene_id,
+    )
 
-    _broadcast_payload(location, payload)
+    _broadcast_to_location(location, payload)
 
 
 def push_ephemeral_interaction(
@@ -148,6 +180,7 @@ def push_ephemeral_interaction(
     content: str,
     mode: str,
     scene: Scene,
+    recipients: list[ObjectDB] | None = None,
 ) -> None:
     """Push an ephemeral interaction payload — real-time delivery without persistence.
 
@@ -155,27 +188,37 @@ def push_ephemeral_interaction(
     function builds and broadcasts a payload directly so players still see
     each other's poses in real-time. The content exists only in transit.
 
-    Uses a negative timestamp-based ID to distinguish from persisted interactions
-    on the frontend (no DB primary key exists).
+    Uses a negative timestamp-based ID (with monotonic counter) to distinguish
+    from persisted interactions on the frontend (no DB primary key exists).
+
+    Args:
+        persona: The writer's identity.
+        content: The interaction text.
+        mode: InteractionMode value.
+        scene: The ephemeral scene.
+        recipients: If provided, send only to these objects (e.g. whisper).
+            Otherwise broadcast to the full room.
     """
-    location = persona.character.location
-    if location is None:
-        return
+    now = timezone.now()
+    counter = next(_ephemeral_counter) % 1000
+    ephemeral_id = -(int(now.timestamp() * 1000) * 1000 + counter)
 
-    payload = {
-        "id": -int(timezone.now().timestamp() * 1000),
-        "persona": {
-            "id": persona.pk,
-            "name": persona.name,
-            "thumbnail_url": persona.thumbnail_url or "",
-        },
-        "content": content,
-        "mode": mode,
-        "timestamp": timezone.now().isoformat(),
-        "scene_id": scene.pk,
-    }
+    payload = _build_interaction_payload(
+        interaction_id=ephemeral_id,
+        persona=persona,
+        content=content,
+        mode=mode,
+        timestamp=now.isoformat(),
+        scene_id=scene.pk,
+    )
 
-    _broadcast_payload(location, payload)
+    if recipients is not None:
+        _send_to_objects(recipients, payload)
+    else:
+        location = persona.character.location
+        if location is None:
+            return
+        _broadcast_to_location(location, payload)
 
 
 def can_view_interaction(  # noqa: PLR0911 - visibility cascade has distinct branches
@@ -374,8 +417,7 @@ def record_interaction(  # noqa: PLR0913 - all fields needed for interaction cre
         receivers=receivers,
         target_personas=target_personas,
     )
-    if interaction is not None:
-        push_interaction(interaction)
+    push_interaction(interaction)
     return interaction
 
 
@@ -409,6 +451,7 @@ def record_whisper_interaction(
             content=content,
             mode=InteractionMode.WHISPER,
             scene=scene,
+            recipients=[character, target],
         )
         return None
 
@@ -420,6 +463,5 @@ def record_whisper_interaction(
         scene=scene,
         target_personas=[target_persona],
     )
-    if interaction is not None:
-        push_interaction(interaction)
+    push_interaction(interaction)
     return interaction

--- a/src/world/scenes/interaction_services.py
+++ b/src/world/scenes/interaction_services.py
@@ -102,8 +102,17 @@ def create_interaction(  # noqa: PLR0913 - atomic creation requires all interact
     return interaction
 
 
+def _broadcast_payload(location: ObjectDB, payload: dict) -> None:
+    """Send an interaction payload to all objects in a location via WebSocket."""
+    for obj in location.contents:
+        try:
+            obj.msg(interaction=((), payload))
+        except AttributeError:
+            continue
+
+
 def push_interaction(interaction: Interaction) -> None:
-    """Push a structured interaction payload to connected clients via WebSocket.
+    """Push a persisted interaction payload to connected clients via WebSocket.
 
     Uses Evennia's msg() which routes through the WebSocket to connected
     web clients. The message type 'interaction' will be handled by a new
@@ -130,11 +139,43 @@ def push_interaction(interaction: Interaction) -> None:
         "scene_id": interaction.scene_id,
     }
 
-    for obj in location.contents:
-        try:
-            obj.msg(interaction=((), payload))
-        except AttributeError:
-            continue
+    _broadcast_payload(location, payload)
+
+
+def push_ephemeral_interaction(
+    *,
+    persona: Persona,
+    content: str,
+    mode: str,
+    scene: Scene,
+) -> None:
+    """Push an ephemeral interaction payload — real-time delivery without persistence.
+
+    For ephemeral scenes, the content is never written to the database. This
+    function builds and broadcasts a payload directly so players still see
+    each other's poses in real-time. The content exists only in transit.
+
+    Uses a negative timestamp-based ID to distinguish from persisted interactions
+    on the frontend (no DB primary key exists).
+    """
+    location = persona.character.location
+    if location is None:
+        return
+
+    payload = {
+        "id": -int(timezone.now().timestamp() * 1000),
+        "persona": {
+            "id": persona.pk,
+            "name": persona.name,
+            "thumbnail_url": persona.thumbnail_url or "",
+        },
+        "content": content,
+        "mode": mode,
+        "timestamp": timezone.now().isoformat(),
+        "scene_id": scene.pk,
+    }
+
+    _broadcast_payload(location, payload)
 
 
 def can_view_interaction(  # noqa: PLR0911 - visibility cascade has distinct branches
@@ -314,6 +355,16 @@ def record_interaction(  # noqa: PLR0913 - all fields needed for interaction cre
     if scene is None and character.location is not None:
         scene = getattr(character.location, _active_scene_attr, None)
 
+    # Ephemeral scenes: push in real-time but never persist
+    if scene is not None and scene.privacy_mode == ScenePrivacyMode.EPHEMERAL:
+        push_ephemeral_interaction(
+            persona=persona,
+            content=content,
+            mode=mode,
+            scene=scene,
+        )
+        return None
+
     interaction = create_interaction(
         persona=persona,
         content=content,
@@ -350,6 +401,16 @@ def record_whisper_interaction(
     scene: Scene | None = None
     if character.location is not None:
         scene = getattr(character.location, _active_scene_attr, None)
+
+    # Ephemeral scenes: push in real-time but never persist
+    if scene is not None and scene.privacy_mode == ScenePrivacyMode.EPHEMERAL:
+        push_ephemeral_interaction(
+            persona=persona,
+            content=content,
+            mode=InteractionMode.WHISPER,
+            scene=scene,
+        )
+        return None
 
     interaction = create_interaction(
         persona=persona,

--- a/src/world/scenes/tests/test_interaction_services.py
+++ b/src/world/scenes/tests/test_interaction_services.py
@@ -96,18 +96,22 @@ class TestCreateInteraction(TestCase):
         assert interaction is not None
         assert interaction.scene == scene
 
-    def test_ephemeral_scene_returns_none(self) -> None:
+    def test_ephemeral_scene_still_persists_if_called_directly(self) -> None:
+        """create_interaction does not guard against ephemeral scenes.
+
+        Callers (record_interaction, record_whisper_interaction) are responsible
+        for routing ephemeral scenes to push_ephemeral_interaction instead.
+        """
         scene = SceneFactory(privacy_mode=ScenePrivacyMode.EPHEMERAL)
         interaction = create_interaction(
             persona=self.writer_persona,
-            content="secret whisper",
+            content="should persist if caller forgot ephemeral check",
             mode=InteractionMode.WHISPER,
             scene=scene,
             receivers=[self.receiver_persona_1],
         )
-        assert interaction is None
-        assert Interaction.objects.count() == 0
-        assert InteractionReceiver.objects.count() == 0
+        assert interaction is not None
+        assert Interaction.objects.count() == 1
 
     def test_creation_with_target_personas(self) -> None:
         scene = SceneFactory()
@@ -626,7 +630,7 @@ class TestEphemeralInteraction(TestCase):
 
     def test_ephemeral_scene_pushes_but_does_not_persist(self) -> None:
         """In ephemeral scenes, interactions are pushed via WebSocket but not saved."""
-        room, char_a, char_b, _identity_a, _identity_b = self._make_room_with_characters()
+        room, char_a, char_b, identity_a, _identity_b = self._make_room_with_characters()
         scene = SceneFactory(
             location=room,
             privacy_mode=ScenePrivacyMode.EPHEMERAL,
@@ -659,10 +663,15 @@ class TestEphemeralInteraction(TestCase):
         assert payload["mode"] == InteractionMode.POSE
         assert payload["scene_id"] == scene.pk
         assert payload["id"] < 0  # Negative ID for ephemeral
+        assert "persona" in payload
+        assert payload["persona"]["name"] == identity_a.active_persona.name
 
-    def test_ephemeral_whisper_pushes_but_does_not_persist(self) -> None:
-        """Whispers in ephemeral scenes are also pushed without persistence."""
+    def test_ephemeral_whisper_only_sent_to_participants(self) -> None:
+        """Whispers in ephemeral scenes are sent only to writer + target, not the room."""
         room, char_a, char_b, _identity_a, _identity_b = self._make_room_with_characters()
+        # Add a bystander who should NOT receive the whisper
+        char_c = CharacterFactory(db_key="Carol", location=room)
+        CharacterIdentityFactory(character=char_c)
         scene = SceneFactory(
             location=room,
             privacy_mode=ScenePrivacyMode.EPHEMERAL,
@@ -671,8 +680,10 @@ class TestEphemeralInteraction(TestCase):
 
         mock_a = Mock()
         mock_b = Mock()
+        mock_c = Mock()
         char_a.msg = mock_a
         char_b.msg = mock_b
+        char_c.msg = mock_c
 
         result = record_whisper_interaction(
             character=char_a,
@@ -682,8 +693,11 @@ class TestEphemeralInteraction(TestCase):
 
         assert result is None
         assert Interaction.objects.count() == 0
+        # Only writer and target receive the whisper
         assert mock_a.call_count == 1
         assert mock_b.call_count == 1
+        # Bystander does NOT receive the whisper
+        assert mock_c.call_count == 0
 
     def test_non_ephemeral_scene_still_persists(self) -> None:
         """Regular scenes still persist interactions normally."""

--- a/src/world/scenes/tests/test_interaction_services.py
+++ b/src/world/scenes/tests/test_interaction_services.py
@@ -607,3 +607,102 @@ class TestPushInteraction(TestCase):
 
         # Should not raise
         push_interaction(interaction)
+
+
+class TestEphemeralInteraction(TestCase):
+    """Tests for ephemeral scene real-time delivery without persistence."""
+
+    def _make_room_with_characters(self) -> tuple:
+        """Create a room with two characters that have identities."""
+        room = ObjectDBFactory(
+            db_key="Private Room",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        char_a = CharacterFactory(db_key="Alice", location=room)
+        char_b = CharacterFactory(db_key="Bob", location=room)
+        identity_a = CharacterIdentityFactory(character=char_a)
+        identity_b = CharacterIdentityFactory(character=char_b)
+        return room, char_a, char_b, identity_a, identity_b
+
+    def test_ephemeral_scene_pushes_but_does_not_persist(self) -> None:
+        """In ephemeral scenes, interactions are pushed via WebSocket but not saved."""
+        room, char_a, char_b, _identity_a, _identity_b = self._make_room_with_characters()
+        scene = SceneFactory(
+            location=room,
+            privacy_mode=ScenePrivacyMode.EPHEMERAL,
+        )
+
+        mock_a = Mock()
+        mock_b = Mock()
+        char_a.msg = mock_a
+        char_b.msg = mock_b
+
+        result = record_interaction(
+            character=char_a,
+            content="whispers something private.",
+            mode=InteractionMode.POSE,
+            scene=scene,
+        )
+
+        # Not persisted
+        assert result is None
+        assert Interaction.objects.count() == 0
+
+        # But pushed via WebSocket
+        assert mock_a.call_count == 1
+        assert mock_b.call_count == 1
+
+        # Check payload structure
+        call_kwargs = mock_a.call_args
+        payload = call_kwargs.kwargs["interaction"][1]
+        assert payload["content"] == "whispers something private."
+        assert payload["mode"] == InteractionMode.POSE
+        assert payload["scene_id"] == scene.pk
+        assert payload["id"] < 0  # Negative ID for ephemeral
+
+    def test_ephemeral_whisper_pushes_but_does_not_persist(self) -> None:
+        """Whispers in ephemeral scenes are also pushed without persistence."""
+        room, char_a, char_b, _identity_a, _identity_b = self._make_room_with_characters()
+        scene = SceneFactory(
+            location=room,
+            privacy_mode=ScenePrivacyMode.EPHEMERAL,
+        )
+        room.active_scene = scene
+
+        mock_a = Mock()
+        mock_b = Mock()
+        char_a.msg = mock_a
+        char_b.msg = mock_b
+
+        result = record_whisper_interaction(
+            character=char_a,
+            target=char_b,
+            content="secret words.",
+        )
+
+        assert result is None
+        assert Interaction.objects.count() == 0
+        assert mock_a.call_count == 1
+        assert mock_b.call_count == 1
+
+    def test_non_ephemeral_scene_still_persists(self) -> None:
+        """Regular scenes still persist interactions normally."""
+        room, char_a, char_b, _identity_a, _identity_b = self._make_room_with_characters()
+        scene = SceneFactory(
+            location=room,
+            privacy_mode=ScenePrivacyMode.PUBLIC,
+        )
+
+        char_a.msg = Mock()
+        char_b.msg = Mock()
+
+        result = record_interaction(
+            character=char_a,
+            content="waves to the crowd.",
+            mode=InteractionMode.POSE,
+            scene=scene,
+        )
+
+        assert result is not None
+        assert Interaction.objects.count() == 1
+        assert result.content == "waves to the crowd."


### PR DESCRIPTION
Ephemeral scenes now push interaction payloads via WebSocket without writing to the database. Players see each other's poses in real-time, but the content exists only in transit — never persisted.

- Extract _broadcast_payload helper from push_interaction
- Add push_ephemeral_interaction for non-persisted WebSocket delivery
- record_interaction and record_whisper_interaction detect ephemeral scenes and use push_ephemeral_interaction instead of create_interaction
- Ephemeral payloads use negative IDs to distinguish from DB records