### PR TITLE
Feature/staff inbox frontend

### DIFF
--- a/docs/roadmap/staff-inbox.md
+++ b/docs/roadmap/staff-inbox.md
@@ -1,6 +1,6 @@
 # Staff Inbox and Player Submissions
 
-**Status:** in-progress (backend complete, frontend pending)
+**Status:** in-progress (staff frontend complete, player submission forms pending)
 **Depends on:** None (foundational infrastructure)
 
 ## Overview
@@ -132,11 +132,17 @@ For the first PR, everything is **staff-only**. Delegation tiers come later.
 - Staff-only endpoint: all submissions related to a specific account (walking persona chains)
 - Reports against, reports submitted, feedback, bug reports, character applications
 
-### Phase 5 — Frontend (separate work)
-- Staff dashboard widget showing job counts by category
-- Per-type list views
-- Account history page UI
+### Phase 5a — Staff frontend ✅
+- Staff hub cards with inbox count badge and per-type navigation
+- Inbox triage page with toggleable category filters (localStorage-persisted)
+- Per-type list views with status filters and pagination (feedback, bug reports, player reports)
+- Per-type detail views with status management (mark reviewed, dismiss)
+- Player report detail with reported player info, flags, and account history link
+- Account history page showing grouped submissions per account
+
+### Phase 5b — Player submission forms (TODO)
 - Submission forms for players (feedback, bug report)
+- Player-facing UI for submitting reports
 
 ## PlayerReport — Full Design Deferred
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ import { StaffBugReportsPage } from './staff/pages/StaffBugReportsPage';
 import { StaffBugReportDetailPage } from './staff/pages/StaffBugReportDetailPage';
 import { StaffPlayerReportsPage } from './staff/pages/StaffPlayerReportsPage';
 import { StaffPlayerReportDetailPage } from './staff/pages/StaffPlayerReportDetailPage';
+import { StaffAccountHistoryPage } from './staff/pages/StaffAccountHistoryPage';
 import { RouletteModal } from './components/roulette/RouletteModal';
 
 function App() {
@@ -179,6 +180,14 @@ function App() {
           element={
             <ProtectedRoute>
               <StaffPlayerReportDetailPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/staff/accounts/:id/history"
+          element={
+            <ProtectedRoute>
+              <StaffAccountHistoryPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { EventCreatePage } from '@/events/pages/EventCreatePage';
 import { EventEditPage } from '@/events/pages/EventEditPage';
 import { CodexPage } from './codex/pages/CodexPage';
 import { StaffHubPage } from './staff/pages/StaffHubPage';
+import { StaffInboxPage } from './staff/pages/StaffInboxPage';
 import { StaffApplicationsPage } from './staff/pages/StaffApplicationsPage';
 import { StaffApplicationDetailPage } from './staff/pages/StaffApplicationDetailPage';
 import { RouletteModal } from './components/roulette/RouletteModal';
@@ -100,6 +101,14 @@ function App() {
           element={
             <ProtectedRoute>
               <StaffHubPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/staff/inbox"
+          element={
+            <ProtectedRoute>
+              <StaffInboxPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,8 @@ import { StaffApplicationsPage } from './staff/pages/StaffApplicationsPage';
 import { StaffApplicationDetailPage } from './staff/pages/StaffApplicationDetailPage';
 import { StaffFeedbackPage } from './staff/pages/StaffFeedbackPage';
 import { StaffFeedbackDetailPage } from './staff/pages/StaffFeedbackDetailPage';
+import { StaffBugReportsPage } from './staff/pages/StaffBugReportsPage';
+import { StaffBugReportDetailPage } from './staff/pages/StaffBugReportDetailPage';
 import { RouletteModal } from './components/roulette/RouletteModal';
 
 function App() {
@@ -143,6 +145,22 @@ function App() {
           element={
             <ProtectedRoute>
               <StaffFeedbackDetailPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/staff/bug-reports"
+          element={
+            <ProtectedRoute>
+              <StaffBugReportsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/staff/bug-reports/:id"
+          element={
+            <ProtectedRoute>
+              <StaffBugReportDetailPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,8 @@ import { StaffFeedbackPage } from './staff/pages/StaffFeedbackPage';
 import { StaffFeedbackDetailPage } from './staff/pages/StaffFeedbackDetailPage';
 import { StaffBugReportsPage } from './staff/pages/StaffBugReportsPage';
 import { StaffBugReportDetailPage } from './staff/pages/StaffBugReportDetailPage';
+import { StaffPlayerReportsPage } from './staff/pages/StaffPlayerReportsPage';
+import { StaffPlayerReportDetailPage } from './staff/pages/StaffPlayerReportDetailPage';
 import { RouletteModal } from './components/roulette/RouletteModal';
 
 function App() {
@@ -161,6 +163,22 @@ function App() {
           element={
             <ProtectedRoute>
               <StaffBugReportDetailPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/staff/player-reports"
+          element={
+            <ProtectedRoute>
+              <StaffPlayerReportsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/staff/player-reports/:id"
+          element={
+            <ProtectedRoute>
+              <StaffPlayerReportDetailPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,8 @@ import { StaffHubPage } from './staff/pages/StaffHubPage';
 import { StaffInboxPage } from './staff/pages/StaffInboxPage';
 import { StaffApplicationsPage } from './staff/pages/StaffApplicationsPage';
 import { StaffApplicationDetailPage } from './staff/pages/StaffApplicationDetailPage';
+import { StaffFeedbackPage } from './staff/pages/StaffFeedbackPage';
+import { StaffFeedbackDetailPage } from './staff/pages/StaffFeedbackDetailPage';
 import { RouletteModal } from './components/roulette/RouletteModal';
 
 function App() {
@@ -125,6 +127,22 @@ function App() {
           element={
             <ProtectedRoute>
               <StaffApplicationDetailPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/staff/feedback"
+          element={
+            <ProtectedRoute>
+              <StaffFeedbackPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/staff/feedback/:id"
+          element={
+            <ProtectedRoute>
+              <StaffFeedbackDetailPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { GuestOnlyRoute } from './components/GuestOnlyRoute';
 import { ProtectedRoute } from './components/ProtectedRoute';
+import { StaffRoute } from './components/StaffRoute';
 import { HomePage } from './evennia_replacements/HomePage';
 import { GamePage } from './game/GamePage';
 import { LoginPage } from './evennia_replacements/LoginPage';
@@ -106,89 +107,89 @@ function App() {
         <Route
           path="/staff"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffHubPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route
           path="/staff/inbox"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffInboxPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route
           path="/staff/applications"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffApplicationsPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route
           path="/staff/applications/:id"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffApplicationDetailPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route
           path="/staff/feedback"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffFeedbackPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route
           path="/staff/feedback/:id"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffFeedbackDetailPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route
           path="/staff/bug-reports"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffBugReportsPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route
           path="/staff/bug-reports/:id"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffBugReportDetailPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route
           path="/staff/player-reports"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffPlayerReportsPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route
           path="/staff/player-reports/:id"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffPlayerReportDetailPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route
           path="/staff/accounts/:id/history"
           element={
-            <ProtectedRoute>
+            <StaffRoute>
               <StaffAccountHistoryPage />
-            </ProtectedRoute>
+            </StaffRoute>
           }
         />
         <Route path="/characters/create/application" element={<CharacterCreationPage />} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -9,7 +9,7 @@ import { Button } from './ui/button';
 import { Badge } from './ui/badge';
 import { navigationMenuTriggerStyle } from '@/components/ui/navigation-menu-trigger-style';
 import { useAppSelector } from '@/store/hooks';
-import { usePendingApplicationCount } from '@/staff/queries';
+import { useOpenSubmissionCount } from '@/staff/queries';
 
 const links = [
   { to: '/game', label: 'Play' },
@@ -24,8 +24,7 @@ const links = [
 export function Header() {
   const account = useAppSelector((state) => state.auth.account);
   const isStaff = account?.is_staff ?? false;
-  const pendingCountQuery = usePendingApplicationCount(isStaff);
-  const pendingCount = pendingCountQuery.data;
+  const { data: pendingCount } = useOpenSubmissionCount(isStaff);
 
   return (
     <header className="border-b">

--- a/frontend/src/components/StaffRoute.tsx
+++ b/frontend/src/components/StaffRoute.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAppSelector } from '@/store/hooks';
+
+interface StaffRouteProps {
+  children: ReactNode;
+}
+
+/**
+ * Route guard that redirects non-staff users. Checks both authentication
+ * and is_staff before rendering children, preventing unnecessary API calls.
+ */
+export function StaffRoute({ children }: StaffRouteProps) {
+  const account = useAppSelector((state) => state.auth.account);
+
+  if (!account) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!account.is_staff) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/staff/api.ts
+++ b/frontend/src/staff/api.ts
@@ -14,8 +14,8 @@ import type {
   SubmissionStatus,
 } from './types';
 
-const INBOX_URL = '/api/staff_inbox';
-const SUBMISSIONS_URL = '/api/player_submissions';
+const INBOX_URL = '/api/staff-inbox';
+const SUBMISSIONS_URL = '/api/player-submissions';
 
 // =============================================================================
 // Staff Inbox
@@ -51,7 +51,13 @@ export async function getAccountHistory(accountId: number): Promise<AccountHisto
 }
 
 export async function getOpenSubmissionCount(): Promise<number> {
-  const res = await apiFetch(`${INBOX_URL}/?page_size=1`);
+  // Exclude character_application to avoid double-counting with the separate applications badge
+  const params = new URLSearchParams();
+  params.append('categories', 'player_feedback');
+  params.append('categories', 'bug_report');
+  params.append('categories', 'player_report');
+  params.append('page_size', '1');
+  const res = await apiFetch(`${INBOX_URL}/?${params}`);
   if (!res.ok) return 0;
   const data: InboxResponse = await res.json();
   return data.count;

--- a/frontend/src/staff/api.ts
+++ b/frontend/src/staff/api.ts
@@ -1,0 +1,175 @@
+/**
+ * Staff Inbox API functions
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+import type { PaginatedResponse } from '@/shared/types';
+import type {
+  AccountHistory,
+  BugReport,
+  InboxResponse,
+  PlayerFeedback,
+  PlayerReport,
+  SubmissionCategory,
+  SubmissionStatus,
+} from './types';
+
+const INBOX_URL = '/api/staff_inbox';
+const SUBMISSIONS_URL = '/api/player_submissions';
+
+// =============================================================================
+// Staff Inbox
+// =============================================================================
+
+export async function getStaffInbox(
+  categories?: SubmissionCategory[],
+  page?: number,
+  pageSize?: number
+): Promise<InboxResponse> {
+  const params = new URLSearchParams();
+  if (categories) {
+    for (const cat of categories) {
+      params.append('categories', cat);
+    }
+  }
+  if (page) {
+    params.append('page', page.toString());
+  }
+  if (pageSize) {
+    params.append('page_size', pageSize.toString());
+  }
+  const qs = params.toString();
+  const res = await apiFetch(`${INBOX_URL}/${qs ? `?${qs}` : ''}`);
+  if (!res.ok) throw new Error('Failed to load staff inbox');
+  return res.json();
+}
+
+export async function getAccountHistory(accountId: number): Promise<AccountHistory> {
+  const res = await apiFetch(`${INBOX_URL}/accounts/${accountId}/history/`);
+  if (!res.ok) throw new Error('Failed to load account history');
+  return res.json();
+}
+
+export async function getOpenSubmissionCount(): Promise<number> {
+  const res = await apiFetch(`${INBOX_URL}/?page_size=1`);
+  if (!res.ok) return 0;
+  const data: InboxResponse = await res.json();
+  return data.count;
+}
+
+// =============================================================================
+// Player Feedback
+// =============================================================================
+
+export async function getFeedbackList(
+  status?: SubmissionStatus,
+  page?: number
+): Promise<PaginatedResponse<PlayerFeedback>> {
+  const params = new URLSearchParams();
+  if (status) {
+    params.append('status', status);
+  }
+  if (page) {
+    params.append('page', page.toString());
+  }
+  const qs = params.toString();
+  const res = await apiFetch(`${SUBMISSIONS_URL}/feedback/${qs ? `?${qs}` : ''}`);
+  if (!res.ok) throw new Error('Failed to load feedback list');
+  return res.json();
+}
+
+export async function getFeedbackDetail(id: number): Promise<PlayerFeedback> {
+  const res = await apiFetch(`${SUBMISSIONS_URL}/feedback/${id}/`);
+  if (!res.ok) throw new Error('Failed to load feedback detail');
+  return res.json();
+}
+
+export async function updateFeedbackStatus(
+  id: number,
+  status: SubmissionStatus
+): Promise<PlayerFeedback> {
+  const res = await apiFetch(`${SUBMISSIONS_URL}/feedback/${id}/`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status }),
+  });
+  if (!res.ok) throw new Error('Failed to update feedback status');
+  return res.json();
+}
+
+// =============================================================================
+// Bug Reports
+// =============================================================================
+
+export async function getBugReportList(
+  status?: SubmissionStatus,
+  page?: number
+): Promise<PaginatedResponse<BugReport>> {
+  const params = new URLSearchParams();
+  if (status) {
+    params.append('status', status);
+  }
+  if (page) {
+    params.append('page', page.toString());
+  }
+  const qs = params.toString();
+  const res = await apiFetch(`${SUBMISSIONS_URL}/bug-reports/${qs ? `?${qs}` : ''}`);
+  if (!res.ok) throw new Error('Failed to load bug report list');
+  return res.json();
+}
+
+export async function getBugReportDetail(id: number): Promise<BugReport> {
+  const res = await apiFetch(`${SUBMISSIONS_URL}/bug-reports/${id}/`);
+  if (!res.ok) throw new Error('Failed to load bug report detail');
+  return res.json();
+}
+
+export async function updateBugReportStatus(
+  id: number,
+  status: SubmissionStatus
+): Promise<BugReport> {
+  const res = await apiFetch(`${SUBMISSIONS_URL}/bug-reports/${id}/`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status }),
+  });
+  if (!res.ok) throw new Error('Failed to update bug report status');
+  return res.json();
+}
+
+// =============================================================================
+// Player Reports
+// =============================================================================
+
+export async function getPlayerReportList(
+  status?: SubmissionStatus,
+  page?: number
+): Promise<PaginatedResponse<PlayerReport>> {
+  const params = new URLSearchParams();
+  if (status) {
+    params.append('status', status);
+  }
+  if (page) {
+    params.append('page', page.toString());
+  }
+  const qs = params.toString();
+  const res = await apiFetch(`${SUBMISSIONS_URL}/player-reports/${qs ? `?${qs}` : ''}`);
+  if (!res.ok) throw new Error('Failed to load player report list');
+  return res.json();
+}
+
+export async function getPlayerReportDetail(id: number): Promise<PlayerReport> {
+  const res = await apiFetch(`${SUBMISSIONS_URL}/player-reports/${id}/`);
+  if (!res.ok) throw new Error('Failed to load player report detail');
+  return res.json();
+}
+
+export async function updatePlayerReportStatus(
+  id: number,
+  status: SubmissionStatus
+): Promise<PlayerReport> {
+  const res = await apiFetch(`${SUBMISSIONS_URL}/player-reports/${id}/`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status }),
+  });
+  if (!res.ok) throw new Error('Failed to update player report status');
+  return res.json();
+}

--- a/frontend/src/staff/api.ts
+++ b/frontend/src/staff/api.ts
@@ -32,10 +32,10 @@ export async function getStaffInbox(
       params.append('categories', cat);
     }
   }
-  if (page) {
+  if (page != null) {
     params.append('page', page.toString());
   }
-  if (pageSize) {
+  if (pageSize != null) {
     params.append('page_size', pageSize.toString());
   }
   const qs = params.toString();
@@ -75,7 +75,7 @@ export async function getFeedbackList(
   if (status) {
     params.append('status', status);
   }
-  if (page) {
+  if (page != null) {
     params.append('page', page.toString());
   }
   const qs = params.toString();
@@ -114,7 +114,7 @@ export async function getBugReportList(
   if (status) {
     params.append('status', status);
   }
-  if (page) {
+  if (page != null) {
     params.append('page', page.toString());
   }
   const qs = params.toString();
@@ -153,7 +153,7 @@ export async function getPlayerReportList(
   if (status) {
     params.append('status', status);
   }
-  if (page) {
+  if (page != null) {
     params.append('page', page.toString());
   }
   const qs = params.toString();

--- a/frontend/src/staff/pages/StaffAccountHistoryPage.tsx
+++ b/frontend/src/staff/pages/StaffAccountHistoryPage.tsx
@@ -1,0 +1,95 @@
+import { Link, Navigate, useParams } from 'react-router-dom';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAccountHistory } from '@/staff/queries';
+import { useAppSelector } from '@/store/hooks';
+import type { AccountHistoryCategory, InboxItem } from '@/staff/types';
+
+function detailPath(item: InboxItem): string {
+  switch (item.source_type) {
+    case 'player_feedback':
+      return `/staff/feedback/${item.source_pk}`;
+    case 'bug_report':
+      return `/staff/bug-reports/${item.source_pk}`;
+    case 'player_report':
+      return `/staff/player-reports/${item.source_pk}`;
+    case 'character_application':
+      return `/staff/applications/${item.source_pk}`;
+  }
+}
+
+function HistorySection({ title, category }: { title: string; category: AccountHistoryCategory }) {
+  if (category.total === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">
+          {title} ({category.total}
+          {category.truncated ? '+' : ''})
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {category.items.map((item) => (
+          <Link
+            key={`${item.source_type}-${item.source_pk}`}
+            to={detailPath(item)}
+            className="block rounded-md p-2 transition-colors hover:bg-muted/50"
+          >
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium">{item.title}</p>
+              <span className="text-xs text-muted-foreground">{item.status}</span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {new Date(item.created_at).toLocaleDateString()}
+            </p>
+          </Link>
+        ))}
+        {category.truncated && (
+          <p className="text-xs text-muted-foreground">
+            Showing first {category.items.length} of {category.total} items.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function StaffAccountHistoryPage() {
+  const account = useAppSelector((state) => state.auth.account);
+  const { id } = useParams<{ id: string }>();
+  const accountId = id ? parseInt(id, 10) : undefined;
+  const { data: history, isLoading } = useAccountHistory(accountId);
+
+  if (!account?.is_staff) return <Navigate to="/" replace />;
+  if (isLoading) return <p className="p-8 text-muted-foreground">Loading...</p>;
+  if (!history) return <p className="p-8 text-muted-foreground">Account not found.</p>;
+
+  const totalItems =
+    history.reports_against.total +
+    history.reports_submitted.total +
+    history.feedback.total +
+    history.bug_reports.total +
+    history.character_applications.total;
+
+  return (
+    <div className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
+      <h1 className="text-2xl font-bold">Account History</h1>
+
+      {totalItems === 0 ? (
+        <p className="text-muted-foreground">No submission history for this account.</p>
+      ) : (
+        <>
+          <HistorySection title="Reports Against" category={history.reports_against} />
+          <HistorySection title="Reports Submitted" category={history.reports_submitted} />
+          <HistorySection title="Feedback" category={history.feedback} />
+          <HistorySection title="Bug Reports" category={history.bug_reports} />
+          <HistorySection
+            title="Character Applications"
+            category={history.character_applications}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/staff/pages/StaffAccountHistoryPage.tsx
+++ b/frontend/src/staff/pages/StaffAccountHistoryPage.tsx
@@ -3,20 +3,8 @@ import { Link, Navigate, useParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAccountHistory } from '@/staff/queries';
 import { useAppSelector } from '@/store/hooks';
-import type { AccountHistoryCategory, InboxItem } from '@/staff/types';
-
-function detailPath(item: InboxItem): string {
-  switch (item.source_type) {
-    case 'player_feedback':
-      return `/staff/feedback/${item.source_pk}`;
-    case 'bug_report':
-      return `/staff/bug-reports/${item.source_pk}`;
-    case 'player_report':
-      return `/staff/player-reports/${item.source_pk}`;
-    case 'character_application':
-      return `/staff/applications/${item.source_pk}`;
-  }
-}
+import type { AccountHistoryCategory } from '@/staff/types';
+import { detailPath } from '@/staff/utils';
 
 function HistorySection({ title, category }: { title: string; category: AccountHistoryCategory }) {
   if (category.total === 0) return null;

--- a/frontend/src/staff/pages/StaffAccountHistoryPage.tsx
+++ b/frontend/src/staff/pages/StaffAccountHistoryPage.tsx
@@ -1,8 +1,7 @@
-import { Link, Navigate, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAccountHistory } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 import type { AccountHistoryCategory } from '@/staff/types';
 import { detailPath } from '@/staff/utils';
 
@@ -44,12 +43,10 @@ function HistorySection({ title, category }: { title: string; category: AccountH
 }
 
 export function StaffAccountHistoryPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const { id } = useParams<{ id: string }>();
   const accountId = id ? parseInt(id, 10) : undefined;
   const { data: history, isLoading } = useAccountHistory(accountId);
 
-  if (!account?.is_staff) return <Navigate to="/" replace />;
   if (isLoading) return <p className="p-8 text-muted-foreground">Loading...</p>;
   if (!history) return <p className="p-8 text-muted-foreground">Account not found.</p>;
 

--- a/frontend/src/staff/pages/StaffApplicationDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffApplicationDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -15,7 +15,6 @@ import {
   useDenyApplication,
   useRequestRevisions,
 } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 
 function InfoRow({ label, value }: { label: string; value: string }) {
   return (
@@ -27,7 +26,6 @@ function InfoRow({ label, value }: { label: string; value: string }) {
 }
 
 export function StaffApplicationDetailPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const appId = id ? parseInt(id, 10) : undefined;
@@ -41,7 +39,6 @@ export function StaffApplicationDetailPage() {
 
   const [actionComment, setActionComment] = useState('');
 
-  if (!account?.is_staff) return <Navigate to="/" replace />;
   if (isLoading) return <p className="p-8 text-muted-foreground">Loading...</p>;
   if (!application) return <p className="p-8 text-muted-foreground">Application not found.</p>;
 

--- a/frontend/src/staff/pages/StaffApplicationsPage.tsx
+++ b/frontend/src/staff/pages/StaffApplicationsPage.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react';
-import { Link, Navigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { statusLabel, statusVariant } from '@/character-creation/utils';
 import { useApplications } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 
 const STATUS_OPTIONS: { label: string; value: string | undefined }[] = [
   { label: 'All', value: undefined },
@@ -19,12 +18,9 @@ const STATUS_OPTIONS: { label: string; value: string | undefined }[] = [
 ];
 
 export function StaffApplicationsPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const [statusFilter, setStatusFilter] = useState<string | undefined>(undefined);
   const { data, isLoading } = useApplications(statusFilter);
   const applications = data?.results;
-
-  if (!account?.is_staff) return <Navigate to="/" replace />;
 
   return (
     <div className="container mx-auto max-w-6xl px-4 py-8">

--- a/frontend/src/staff/pages/StaffBugReportDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffBugReportDetailPage.tsx
@@ -59,8 +59,14 @@ export function StaffBugReportDetailPage() {
 
       {report.status === 'open' && (
         <div className="flex gap-2">
-          <Button onClick={() => handleStatusChange('reviewed')}>Mark Reviewed</Button>
-          <Button variant="outline" onClick={() => handleStatusChange('dismissed')}>
+          <Button disabled={updateStatus.isPending} onClick={() => handleStatusChange('reviewed')}>
+            Mark Reviewed
+          </Button>
+          <Button
+            variant="outline"
+            disabled={updateStatus.isPending}
+            onClick={() => handleStatusChange('dismissed')}
+          >
             Dismiss
           </Button>
         </div>

--- a/frontend/src/staff/pages/StaffBugReportDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffBugReportDetailPage.tsx
@@ -1,0 +1,70 @@
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useBugReportDetail, useUpdateBugReportStatus } from '@/staff/queries';
+import { useAppSelector } from '@/store/hooks';
+
+export function StaffBugReportDetailPage() {
+  const account = useAppSelector((state) => state.auth.account);
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const reportId = id ? parseInt(id, 10) : undefined;
+  const { data: report, isLoading } = useBugReportDetail(reportId);
+  const updateStatus = useUpdateBugReportStatus();
+
+  if (!account?.is_staff) return <Navigate to="/" replace />;
+  if (isLoading) return <p className="p-8 text-muted-foreground">Loading...</p>;
+  if (!report) return <p className="p-8 text-muted-foreground">Bug report not found.</p>;
+
+  function handleStatusChange(status: 'reviewed' | 'dismissed') {
+    if (!reportId) return;
+    updateStatus.mutate(
+      { id: reportId, status },
+      { onSuccess: () => navigate('/staff/bug-reports') }
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
+      <h1 className="text-2xl font-bold">Bug Report Detail</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>Bug Report #{report.id}</span>
+            <Badge>{report.status}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Description</p>
+            <p className="whitespace-pre-wrap">{report.description}</p>
+          </div>
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <p className="font-medium text-muted-foreground">Reporter</p>
+              <p>
+                {report.reporter_persona_name} ({report.reporter_account_username})
+              </p>
+            </div>
+            <div>
+              <p className="font-medium text-muted-foreground">Submitted</p>
+              <p>{new Date(report.created_at).toLocaleString()}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {report.status === 'open' && (
+        <div className="flex gap-2">
+          <Button onClick={() => handleStatusChange('reviewed')}>Mark Reviewed</Button>
+          <Button variant="outline" onClick={() => handleStatusChange('dismissed')}>
+            Dismiss
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/staff/pages/StaffBugReportDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffBugReportDetailPage.tsx
@@ -1,20 +1,17 @@
-import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useBugReportDetail, useUpdateBugReportStatus } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 
 export function StaffBugReportDetailPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const reportId = id ? parseInt(id, 10) : undefined;
   const { data: report, isLoading } = useBugReportDetail(reportId);
   const updateStatus = useUpdateBugReportStatus();
 
-  if (!account?.is_staff) return <Navigate to="/" replace />;
   if (isLoading) return <p className="p-8 text-muted-foreground">Loading...</p>;
   if (!report) return <p className="p-8 text-muted-foreground">Bug report not found.</p>;
 

--- a/frontend/src/staff/pages/StaffBugReportsPage.tsx
+++ b/frontend/src/staff/pages/StaffBugReportsPage.tsx
@@ -1,22 +1,18 @@
 import { useState } from 'react';
-import { Link, Navigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useBugReportList } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 import type { SubmissionStatus } from '@/staff/types';
 import { STATUS_OPTIONS, statusVariant } from '@/staff/utils';
 
 export function StaffBugReportsPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const [statusFilter, setStatusFilter] = useState<SubmissionStatus | undefined>(undefined);
   const [page, setPage] = useState(1);
   const { data, isLoading } = useBugReportList(statusFilter, page);
   const items = data?.results;
-
-  if (!account?.is_staff) return <Navigate to="/" replace />;
 
   return (
     <div className="container mx-auto max-w-6xl px-4 py-8">

--- a/frontend/src/staff/pages/StaffBugReportsPage.tsx
+++ b/frontend/src/staff/pages/StaffBugReportsPage.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { useBugReportList } from '@/staff/queries';
+import { useAppSelector } from '@/store/hooks';
+import type { SubmissionStatus } from '@/staff/types';
+
+const STATUS_OPTIONS: { label: string; value: SubmissionStatus | undefined }[] = [
+  { label: 'All', value: undefined },
+  { label: 'Open', value: 'open' },
+  { label: 'Reviewed', value: 'reviewed' },
+  { label: 'Dismissed', value: 'dismissed' },
+];
+
+function statusVariant(status: string): 'default' | 'secondary' | 'outline' {
+  switch (status) {
+    case 'open':
+      return 'default';
+    case 'reviewed':
+      return 'secondary';
+    case 'dismissed':
+      return 'outline';
+    default:
+      return 'outline';
+  }
+}
+
+export function StaffBugReportsPage() {
+  const account = useAppSelector((state) => state.auth.account);
+  const [statusFilter, setStatusFilter] = useState<SubmissionStatus | undefined>(undefined);
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useBugReportList(statusFilter, page);
+  const items = data?.results;
+
+  if (!account?.is_staff) return <Navigate to="/" replace />;
+
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold">Bug Reports</h1>
+
+      <div className="mb-6 flex flex-wrap gap-2">
+        {STATUS_OPTIONS.map((opt) => (
+          <Button
+            key={opt.label}
+            variant={statusFilter === opt.value ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => {
+              setStatusFilter(opt.value);
+              setPage(1);
+            }}
+          >
+            {opt.label}
+          </Button>
+        ))}
+      </div>
+
+      {isLoading ? (
+        <p className="text-muted-foreground">Loading...</p>
+      ) : !items?.length ? (
+        <p className="text-muted-foreground">No bug reports found.</p>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <Link key={item.id} to={`/staff/bug-reports/${item.id}`}>
+              <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+                <CardContent className="flex items-center justify-between py-4">
+                  <div>
+                    <p className="font-medium">
+                      {item.description.length > 80
+                        ? item.description.slice(0, 80) + '...'
+                        : item.description}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {item.reporter_persona_name} ({item.reporter_account_username}) &middot;{' '}
+                      {new Date(item.created_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/staff/pages/StaffBugReportsPage.tsx
+++ b/frontend/src/staff/pages/StaffBugReportsPage.tsx
@@ -7,26 +7,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { useBugReportList } from '@/staff/queries';
 import { useAppSelector } from '@/store/hooks';
 import type { SubmissionStatus } from '@/staff/types';
-
-const STATUS_OPTIONS: { label: string; value: SubmissionStatus | undefined }[] = [
-  { label: 'All', value: undefined },
-  { label: 'Open', value: 'open' },
-  { label: 'Reviewed', value: 'reviewed' },
-  { label: 'Dismissed', value: 'dismissed' },
-];
-
-function statusVariant(status: string): 'default' | 'secondary' | 'outline' {
-  switch (status) {
-    case 'open':
-      return 'default';
-    case 'reviewed':
-      return 'secondary';
-    case 'dismissed':
-      return 'outline';
-    default:
-      return 'outline';
-  }
-}
+import { STATUS_OPTIONS, statusVariant } from '@/staff/utils';
 
 export function StaffBugReportsPage() {
   const account = useAppSelector((state) => state.auth.account);
@@ -62,28 +43,52 @@ export function StaffBugReportsPage() {
       ) : !items?.length ? (
         <p className="text-muted-foreground">No bug reports found.</p>
       ) : (
-        <div className="space-y-3">
-          {items.map((item) => (
-            <Link key={item.id} to={`/staff/bug-reports/${item.id}`}>
-              <Card className="cursor-pointer transition-colors hover:bg-muted/50">
-                <CardContent className="flex items-center justify-between py-4">
-                  <div>
-                    <p className="font-medium">
-                      {item.description.length > 80
-                        ? item.description.slice(0, 80) + '...'
-                        : item.description}
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      {item.reporter_persona_name} ({item.reporter_account_username}) &middot;{' '}
-                      {new Date(item.created_at).toLocaleDateString()}
-                    </p>
-                  </div>
-                  <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
-                </CardContent>
-              </Card>
-            </Link>
-          ))}
-        </div>
+        <>
+          <div className="space-y-3">
+            {items.map((item) => (
+              <Link key={item.id} to={`/staff/bug-reports/${item.id}`}>
+                <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+                  <CardContent className="flex items-center justify-between py-4">
+                    <div>
+                      <p className="font-medium">
+                        {item.description.length > 80
+                          ? item.description.slice(0, 80) + '...'
+                          : item.description}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {item.reporter_persona_name} ({item.reporter_account_username}) &middot;{' '}
+                        {new Date(item.created_at).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+
+          {data && data.count > 0 && (data.next || data.previous) && (
+            <div className="mt-6 flex items-center justify-center gap-4">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!data.previous}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">Page {page}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!data.next}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/staff/pages/StaffFeedbackDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffFeedbackDetailPage.tsx
@@ -1,0 +1,70 @@
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useFeedbackDetail, useUpdateFeedbackStatus } from '@/staff/queries';
+import { useAppSelector } from '@/store/hooks';
+
+export function StaffFeedbackDetailPage() {
+  const account = useAppSelector((state) => state.auth.account);
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const feedbackId = id ? parseInt(id, 10) : undefined;
+  const { data: feedback, isLoading } = useFeedbackDetail(feedbackId);
+  const updateStatus = useUpdateFeedbackStatus();
+
+  if (!account?.is_staff) return <Navigate to="/" replace />;
+  if (isLoading) return <p className="p-8 text-muted-foreground">Loading...</p>;
+  if (!feedback) return <p className="p-8 text-muted-foreground">Feedback not found.</p>;
+
+  function handleStatusChange(status: 'reviewed' | 'dismissed') {
+    if (!feedbackId) return;
+    updateStatus.mutate(
+      { id: feedbackId, status },
+      { onSuccess: () => navigate('/staff/feedback') }
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
+      <h1 className="text-2xl font-bold">Feedback Detail</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>Feedback #{feedback.id}</span>
+            <Badge>{feedback.status}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Description</p>
+            <p className="whitespace-pre-wrap">{feedback.description}</p>
+          </div>
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <p className="font-medium text-muted-foreground">Reporter</p>
+              <p>
+                {feedback.reporter_persona_name} ({feedback.reporter_account_username})
+              </p>
+            </div>
+            <div>
+              <p className="font-medium text-muted-foreground">Submitted</p>
+              <p>{new Date(feedback.created_at).toLocaleString()}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {feedback.status === 'open' && (
+        <div className="flex gap-2">
+          <Button onClick={() => handleStatusChange('reviewed')}>Mark Reviewed</Button>
+          <Button variant="outline" onClick={() => handleStatusChange('dismissed')}>
+            Dismiss
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/staff/pages/StaffFeedbackDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffFeedbackDetailPage.tsx
@@ -1,20 +1,17 @@
-import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useFeedbackDetail, useUpdateFeedbackStatus } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 
 export function StaffFeedbackDetailPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const feedbackId = id ? parseInt(id, 10) : undefined;
   const { data: feedback, isLoading } = useFeedbackDetail(feedbackId);
   const updateStatus = useUpdateFeedbackStatus();
 
-  if (!account?.is_staff) return <Navigate to="/" replace />;
   if (isLoading) return <p className="p-8 text-muted-foreground">Loading...</p>;
   if (!feedback) return <p className="p-8 text-muted-foreground">Feedback not found.</p>;
 

--- a/frontend/src/staff/pages/StaffFeedbackDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffFeedbackDetailPage.tsx
@@ -59,8 +59,14 @@ export function StaffFeedbackDetailPage() {
 
       {feedback.status === 'open' && (
         <div className="flex gap-2">
-          <Button onClick={() => handleStatusChange('reviewed')}>Mark Reviewed</Button>
-          <Button variant="outline" onClick={() => handleStatusChange('dismissed')}>
+          <Button disabled={updateStatus.isPending} onClick={() => handleStatusChange('reviewed')}>
+            Mark Reviewed
+          </Button>
+          <Button
+            variant="outline"
+            disabled={updateStatus.isPending}
+            onClick={() => handleStatusChange('dismissed')}
+          >
             Dismiss
           </Button>
         </div>

--- a/frontend/src/staff/pages/StaffFeedbackPage.tsx
+++ b/frontend/src/staff/pages/StaffFeedbackPage.tsx
@@ -1,22 +1,18 @@
 import { useState } from 'react';
-import { Link, Navigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useFeedbackList } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 import type { SubmissionStatus } from '@/staff/types';
 import { STATUS_OPTIONS, statusVariant } from '@/staff/utils';
 
 export function StaffFeedbackPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const [statusFilter, setStatusFilter] = useState<SubmissionStatus | undefined>(undefined);
   const [page, setPage] = useState(1);
   const { data, isLoading } = useFeedbackList(statusFilter, page);
   const items = data?.results;
-
-  if (!account?.is_staff) return <Navigate to="/" replace />;
 
   return (
     <div className="container mx-auto max-w-6xl px-4 py-8">

--- a/frontend/src/staff/pages/StaffFeedbackPage.tsx
+++ b/frontend/src/staff/pages/StaffFeedbackPage.tsx
@@ -7,26 +7,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { useFeedbackList } from '@/staff/queries';
 import { useAppSelector } from '@/store/hooks';
 import type { SubmissionStatus } from '@/staff/types';
-
-const STATUS_OPTIONS: { label: string; value: SubmissionStatus | undefined }[] = [
-  { label: 'All', value: undefined },
-  { label: 'Open', value: 'open' },
-  { label: 'Reviewed', value: 'reviewed' },
-  { label: 'Dismissed', value: 'dismissed' },
-];
-
-function statusVariant(status: string): 'default' | 'secondary' | 'outline' {
-  switch (status) {
-    case 'open':
-      return 'default';
-    case 'reviewed':
-      return 'secondary';
-    case 'dismissed':
-      return 'outline';
-    default:
-      return 'outline';
-  }
-}
+import { STATUS_OPTIONS, statusVariant } from '@/staff/utils';
 
 export function StaffFeedbackPage() {
   const account = useAppSelector((state) => state.auth.account);
@@ -62,28 +43,52 @@ export function StaffFeedbackPage() {
       ) : !items?.length ? (
         <p className="text-muted-foreground">No feedback found.</p>
       ) : (
-        <div className="space-y-3">
-          {items.map((item) => (
-            <Link key={item.id} to={`/staff/feedback/${item.id}`}>
-              <Card className="cursor-pointer transition-colors hover:bg-muted/50">
-                <CardContent className="flex items-center justify-between py-4">
-                  <div>
-                    <p className="font-medium">
-                      {item.description.length > 80
-                        ? item.description.slice(0, 80) + '...'
-                        : item.description}
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      {item.reporter_persona_name} ({item.reporter_account_username}) &middot;{' '}
-                      {new Date(item.created_at).toLocaleDateString()}
-                    </p>
-                  </div>
-                  <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
-                </CardContent>
-              </Card>
-            </Link>
-          ))}
-        </div>
+        <>
+          <div className="space-y-3">
+            {items.map((item) => (
+              <Link key={item.id} to={`/staff/feedback/${item.id}`}>
+                <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+                  <CardContent className="flex items-center justify-between py-4">
+                    <div>
+                      <p className="font-medium">
+                        {item.description.length > 80
+                          ? item.description.slice(0, 80) + '...'
+                          : item.description}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {item.reporter_persona_name} ({item.reporter_account_username}) &middot;{' '}
+                        {new Date(item.created_at).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+
+          {data && data.count > 0 && (data.next || data.previous) && (
+            <div className="mt-6 flex items-center justify-center gap-4">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!data.previous}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">Page {page}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!data.next}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/staff/pages/StaffFeedbackPage.tsx
+++ b/frontend/src/staff/pages/StaffFeedbackPage.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { useFeedbackList } from '@/staff/queries';
+import { useAppSelector } from '@/store/hooks';
+import type { SubmissionStatus } from '@/staff/types';
+
+const STATUS_OPTIONS: { label: string; value: SubmissionStatus | undefined }[] = [
+  { label: 'All', value: undefined },
+  { label: 'Open', value: 'open' },
+  { label: 'Reviewed', value: 'reviewed' },
+  { label: 'Dismissed', value: 'dismissed' },
+];
+
+function statusVariant(status: string): 'default' | 'secondary' | 'outline' {
+  switch (status) {
+    case 'open':
+      return 'default';
+    case 'reviewed':
+      return 'secondary';
+    case 'dismissed':
+      return 'outline';
+    default:
+      return 'outline';
+  }
+}
+
+export function StaffFeedbackPage() {
+  const account = useAppSelector((state) => state.auth.account);
+  const [statusFilter, setStatusFilter] = useState<SubmissionStatus | undefined>(undefined);
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useFeedbackList(statusFilter, page);
+  const items = data?.results;
+
+  if (!account?.is_staff) return <Navigate to="/" replace />;
+
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold">Player Feedback</h1>
+
+      <div className="mb-6 flex flex-wrap gap-2">
+        {STATUS_OPTIONS.map((opt) => (
+          <Button
+            key={opt.label}
+            variant={statusFilter === opt.value ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => {
+              setStatusFilter(opt.value);
+              setPage(1);
+            }}
+          >
+            {opt.label}
+          </Button>
+        ))}
+      </div>
+
+      {isLoading ? (
+        <p className="text-muted-foreground">Loading...</p>
+      ) : !items?.length ? (
+        <p className="text-muted-foreground">No feedback found.</p>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <Link key={item.id} to={`/staff/feedback/${item.id}`}>
+              <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+                <CardContent className="flex items-center justify-between py-4">
+                  <div>
+                    <p className="font-medium">
+                      {item.description.length > 80
+                        ? item.description.slice(0, 80) + '...'
+                        : item.description}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {item.reporter_persona_name} ({item.reporter_account_username}) &middot;{' '}
+                      {new Date(item.created_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/staff/pages/StaffHubPage.tsx
+++ b/frontend/src/staff/pages/StaffHubPage.tsx
@@ -2,12 +2,13 @@ import { Link, Navigate } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { usePendingApplicationCount } from '@/staff/queries';
+import { useOpenSubmissionCount, usePendingApplicationCount } from '@/staff/queries';
 import { useAppSelector } from '@/store/hooks';
 
 export function StaffHubPage() {
   const account = useAppSelector((state) => state.auth.account);
-  const { data: pendingCount } = usePendingApplicationCount();
+  const { data: pendingAppCount } = usePendingApplicationCount();
+  const { data: openInboxCount } = useOpenSubmissionCount();
 
   if (!account?.is_staff) return <Navigate to="/" replace />;
 
@@ -15,13 +16,64 @@ export function StaffHubPage() {
     <div className="container mx-auto max-w-4xl px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold">Staff Dashboard</h1>
       <div className="grid gap-4 md:grid-cols-2">
+        <Link to="/staff/inbox">
+          <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                Inbox
+                {openInboxCount && openInboxCount > 0 ? (
+                  <Badge variant="destructive">{openInboxCount}</Badge>
+                ) : null}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Triage open submissions across all categories.
+              </p>
+            </CardContent>
+          </Card>
+        </Link>
+        <Link to="/staff/feedback">
+          <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+            <CardHeader>
+              <CardTitle>Feedback</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Review player feedback and suggestions.
+              </p>
+            </CardContent>
+          </Card>
+        </Link>
+        <Link to="/staff/bug-reports">
+          <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+            <CardHeader>
+              <CardTitle>Bug Reports</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">Review and triage bug reports.</p>
+            </CardContent>
+          </Card>
+        </Link>
+        <Link to="/staff/player-reports">
+          <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+            <CardHeader>
+              <CardTitle>Player Reports</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Review reports of problematic player behavior.
+              </p>
+            </CardContent>
+          </Card>
+        </Link>
         <Link to="/staff/applications">
           <Card className="cursor-pointer transition-colors hover:bg-muted/50">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                Applications
-                {pendingCount && pendingCount > 0 ? (
-                  <Badge variant="destructive">{pendingCount}</Badge>
+                Roster Applications
+                {pendingAppCount && pendingAppCount > 0 ? (
+                  <Badge variant="destructive">{pendingAppCount}</Badge>
                 ) : null}
               </CardTitle>
             </CardHeader>
@@ -32,7 +84,6 @@ export function StaffHubPage() {
             </CardContent>
           </Card>
         </Link>
-        {/* Future sections will go here */}
       </div>
     </div>
   );

--- a/frontend/src/staff/pages/StaffHubPage.tsx
+++ b/frontend/src/staff/pages/StaffHubPage.tsx
@@ -1,16 +1,12 @@
-import { Link, Navigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useOpenSubmissionCount, usePendingApplicationCount } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 
 export function StaffHubPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const { data: pendingAppCount } = usePendingApplicationCount();
   const { data: openInboxCount } = useOpenSubmissionCount();
-
-  if (!account?.is_staff) return <Navigate to="/" replace />;
 
   return (
     <div className="container mx-auto max-w-4xl px-4 py-8">

--- a/frontend/src/staff/pages/StaffInboxPage.tsx
+++ b/frontend/src/staff/pages/StaffInboxPage.tsx
@@ -5,7 +5,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useStaffInbox } from '@/staff/queries';
 import { useAppSelector } from '@/store/hooks';
-import type { InboxItem, SubmissionCategory } from '@/staff/types';
+import type { SubmissionCategory } from '@/staff/types';
+import { detailPath } from '@/staff/utils';
 
 const CATEGORY_OPTIONS: { label: string; value: SubmissionCategory; color: string }[] = [
   {
@@ -52,19 +53,6 @@ function categoryLabel(sourceType: string): string {
 
 function categoryColor(sourceType: string): string {
   return CATEGORY_OPTIONS.find((c) => c.value === sourceType)?.color ?? '';
-}
-
-function detailPath(item: InboxItem): string {
-  switch (item.source_type) {
-    case 'player_feedback':
-      return `/staff/feedback/${item.source_pk}`;
-    case 'bug_report':
-      return `/staff/bug-reports/${item.source_pk}`;
-    case 'player_report':
-      return `/staff/player-reports/${item.source_pk}`;
-    case 'character_application':
-      return `/staff/applications/${item.source_pk}`;
-  }
 }
 
 function timeAgo(dateString: string): string {

--- a/frontend/src/staff/pages/StaffInboxPage.tsx
+++ b/frontend/src/staff/pages/StaffInboxPage.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
-import { Link, Navigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useStaffInbox } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 import type { SubmissionCategory } from '@/staff/types';
 import { detailPath } from '@/staff/utils';
 
@@ -69,7 +68,6 @@ function timeAgo(dateString: string): string {
 }
 
 export function StaffInboxPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const [mutedCategories, setMutedCategories] =
     useState<Set<SubmissionCategory>>(loadMutedCategories);
   const [page, setPage] = useState(1);
@@ -82,8 +80,6 @@ export function StaffInboxPage() {
     activeCategories.length < CATEGORY_OPTIONS.length ? activeCategories : undefined,
     page
   );
-
-  if (!account?.is_staff) return <Navigate to="/" replace />;
 
   function toggleCategory(category: SubmissionCategory) {
     setMutedCategories((prev) => {

--- a/frontend/src/staff/pages/StaffInboxPage.tsx
+++ b/frontend/src/staff/pages/StaffInboxPage.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { useStaffInbox } from '@/staff/queries';
+import { useAppSelector } from '@/store/hooks';
+import type { InboxItem, SubmissionCategory } from '@/staff/types';
+
+const CATEGORY_OPTIONS: { label: string; value: SubmissionCategory; color: string }[] = [
+  {
+    label: 'Feedback',
+    value: 'player_feedback',
+    color: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  },
+  {
+    label: 'Bug Reports',
+    value: 'bug_report',
+    color: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+  },
+  {
+    label: 'Player Reports',
+    value: 'player_report',
+    color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  },
+  {
+    label: 'Applications',
+    value: 'character_application',
+    color: 'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200',
+  },
+];
+
+const STORAGE_KEY = 'staff-inbox-muted-categories';
+
+function loadMutedCategories(): Set<SubmissionCategory> {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return new Set(JSON.parse(stored));
+  } catch {
+    // ignore
+  }
+  return new Set();
+}
+
+function saveMutedCategories(muted: Set<SubmissionCategory>) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...muted]));
+}
+
+function categoryLabel(sourceType: string): string {
+  return CATEGORY_OPTIONS.find((c) => c.value === sourceType)?.label ?? sourceType;
+}
+
+function categoryColor(sourceType: string): string {
+  return CATEGORY_OPTIONS.find((c) => c.value === sourceType)?.color ?? '';
+}
+
+function detailPath(item: InboxItem): string {
+  switch (item.source_type) {
+    case 'player_feedback':
+      return `/staff/feedback/${item.source_pk}`;
+    case 'bug_report':
+      return `/staff/bug-reports/${item.source_pk}`;
+    case 'player_report':
+      return `/staff/player-reports/${item.source_pk}`;
+    case 'character_application':
+      return `/staff/applications/${item.source_pk}`;
+  }
+}
+
+function timeAgo(dateString: string): string {
+  const now = new Date();
+  const date = new Date(dateString);
+  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function StaffInboxPage() {
+  const account = useAppSelector((state) => state.auth.account);
+  const [mutedCategories, setMutedCategories] =
+    useState<Set<SubmissionCategory>>(loadMutedCategories);
+  const [page, setPage] = useState(1);
+
+  const activeCategories = CATEGORY_OPTIONS.map((c) => c.value).filter(
+    (c) => !mutedCategories.has(c)
+  );
+
+  const { data, isLoading } = useStaffInbox(
+    activeCategories.length < CATEGORY_OPTIONS.length ? activeCategories : undefined,
+    page
+  );
+
+  if (!account?.is_staff) return <Navigate to="/" replace />;
+
+  function toggleCategory(category: SubmissionCategory) {
+    setMutedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      saveMutedCategories(next);
+      return next;
+    });
+    setPage(1);
+  }
+
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold">Staff Inbox</h1>
+
+      {/* Category toggles */}
+      <div className="mb-6 flex flex-wrap gap-2">
+        {CATEGORY_OPTIONS.map((opt) => (
+          <Button
+            key={opt.value}
+            variant={mutedCategories.has(opt.value) ? 'outline' : 'default'}
+            size="sm"
+            onClick={() => toggleCategory(opt.value)}
+          >
+            {opt.label}
+          </Button>
+        ))}
+      </div>
+
+      {/* Items list */}
+      {isLoading ? (
+        <p className="text-muted-foreground">Loading...</p>
+      ) : !data?.results.length ? (
+        <p className="text-muted-foreground">No open items.</p>
+      ) : (
+        <>
+          <div className="space-y-3">
+            {data.results.map((item) => (
+              <Link key={`${item.source_type}-${item.source_pk}`} to={detailPath(item)}>
+                <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+                  <CardContent className="flex items-center justify-between py-4">
+                    <div className="flex items-center gap-3">
+                      <span
+                        className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-semibold ${categoryColor(item.source_type)}`}
+                      >
+                        {categoryLabel(item.source_type)}
+                      </span>
+                      <div>
+                        <p className="font-medium">{item.title}</p>
+                        <p className="text-sm text-muted-foreground">
+                          {item.reporter_summary} &middot; {timeAgo(item.created_at)}
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {data.num_pages > 1 && (
+            <div className="mt-6 flex items-center justify-center gap-4">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {data.current_page} of {data.num_pages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= data.num_pages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/staff/pages/StaffPlayerReportDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffPlayerReportDetailPage.tsx
@@ -1,20 +1,17 @@
-import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { usePlayerReportDetail, useUpdatePlayerReportStatus } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 
 export function StaffPlayerReportDetailPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const reportId = id ? parseInt(id, 10) : undefined;
   const { data: report, isLoading } = usePlayerReportDetail(reportId);
   const updateStatus = useUpdatePlayerReportStatus();
 
-  if (!account?.is_staff) return <Navigate to="/" replace />;
   if (isLoading) return <p className="p-8 text-muted-foreground">Loading...</p>;
   if (!report) return <p className="p-8 text-muted-foreground">Report not found.</p>;
 

--- a/frontend/src/staff/pages/StaffPlayerReportDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffPlayerReportDetailPage.tsx
@@ -1,0 +1,90 @@
+import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { usePlayerReportDetail, useUpdatePlayerReportStatus } from '@/staff/queries';
+import { useAppSelector } from '@/store/hooks';
+
+export function StaffPlayerReportDetailPage() {
+  const account = useAppSelector((state) => state.auth.account);
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const reportId = id ? parseInt(id, 10) : undefined;
+  const { data: report, isLoading } = usePlayerReportDetail(reportId);
+  const updateStatus = useUpdatePlayerReportStatus();
+
+  if (!account?.is_staff) return <Navigate to="/" replace />;
+  if (isLoading) return <p className="p-8 text-muted-foreground">Loading...</p>;
+  if (!report) return <p className="p-8 text-muted-foreground">Report not found.</p>;
+
+  function handleStatusChange(status: 'reviewed' | 'dismissed') {
+    if (!reportId) return;
+    updateStatus.mutate(
+      { id: reportId, status },
+      { onSuccess: () => navigate('/staff/player-reports') }
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
+      <h1 className="text-2xl font-bold">Player Report Detail</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>Player Report #{report.id}</span>
+            <Badge>{report.status}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Reported Player</p>
+            <p>
+              {report.reported_persona_name} ({report.reported_account_username}){' \u2014 '}
+              <Link
+                to={`/staff/accounts/${report.reported_account}/history`}
+                className="text-primary underline"
+              >
+                View Account History
+              </Link>
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Behavior Description</p>
+            <p className="whitespace-pre-wrap">{report.behavior_description}</p>
+          </div>
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <p className="font-medium text-muted-foreground">Reporter</p>
+              <p>
+                {report.reporter_persona_name} ({report.reporter_account_username})
+              </p>
+            </div>
+            <div>
+              <p className="font-medium text-muted-foreground">Submitted</p>
+              <p>{new Date(report.created_at).toLocaleString()}</p>
+            </div>
+            <div>
+              <p className="font-medium text-muted-foreground">Asked to Stop</p>
+              <p>{report.asked_to_stop ? 'Yes' : 'No'}</p>
+            </div>
+            <div>
+              <p className="font-medium text-muted-foreground">Blocked or Muted</p>
+              <p>{report.blocked_or_muted ? 'Yes' : 'No'}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {report.status === 'open' && (
+        <div className="flex gap-2">
+          <Button onClick={() => handleStatusChange('reviewed')}>Mark Reviewed</Button>
+          <Button variant="outline" onClick={() => handleStatusChange('dismissed')}>
+            Dismiss
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/staff/pages/StaffPlayerReportDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffPlayerReportDetailPage.tsx
@@ -79,8 +79,14 @@ export function StaffPlayerReportDetailPage() {
 
       {report.status === 'open' && (
         <div className="flex gap-2">
-          <Button onClick={() => handleStatusChange('reviewed')}>Mark Reviewed</Button>
-          <Button variant="outline" onClick={() => handleStatusChange('dismissed')}>
+          <Button disabled={updateStatus.isPending} onClick={() => handleStatusChange('reviewed')}>
+            Mark Reviewed
+          </Button>
+          <Button
+            variant="outline"
+            disabled={updateStatus.isPending}
+            onClick={() => handleStatusChange('dismissed')}
+          >
             Dismiss
           </Button>
         </div>

--- a/frontend/src/staff/pages/StaffPlayerReportsPage.tsx
+++ b/frontend/src/staff/pages/StaffPlayerReportsPage.tsx
@@ -1,22 +1,18 @@
 import { useState } from 'react';
-import { Link, Navigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { usePlayerReportList } from '@/staff/queries';
-import { useAppSelector } from '@/store/hooks';
 import type { SubmissionStatus } from '@/staff/types';
 import { STATUS_OPTIONS, statusVariant } from '@/staff/utils';
 
 export function StaffPlayerReportsPage() {
-  const account = useAppSelector((state) => state.auth.account);
   const [statusFilter, setStatusFilter] = useState<SubmissionStatus | undefined>(undefined);
   const [page, setPage] = useState(1);
   const { data, isLoading } = usePlayerReportList(statusFilter, page);
   const items = data?.results;
-
-  if (!account?.is_staff) return <Navigate to="/" replace />;
 
   return (
     <div className="container mx-auto max-w-6xl px-4 py-8">

--- a/frontend/src/staff/pages/StaffPlayerReportsPage.tsx
+++ b/frontend/src/staff/pages/StaffPlayerReportsPage.tsx
@@ -7,26 +7,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { usePlayerReportList } from '@/staff/queries';
 import { useAppSelector } from '@/store/hooks';
 import type { SubmissionStatus } from '@/staff/types';
-
-const STATUS_OPTIONS: { label: string; value: SubmissionStatus | undefined }[] = [
-  { label: 'All', value: undefined },
-  { label: 'Open', value: 'open' },
-  { label: 'Reviewed', value: 'reviewed' },
-  { label: 'Dismissed', value: 'dismissed' },
-];
-
-function statusVariant(status: string): 'default' | 'secondary' | 'outline' {
-  switch (status) {
-    case 'open':
-      return 'default';
-    case 'reviewed':
-      return 'secondary';
-    case 'dismissed':
-      return 'outline';
-    default:
-      return 'outline';
-  }
-}
+import { STATUS_OPTIONS, statusVariant } from '@/staff/utils';
 
 export function StaffPlayerReportsPage() {
   const account = useAppSelector((state) => state.auth.account);
@@ -62,31 +43,55 @@ export function StaffPlayerReportsPage() {
       ) : !items?.length ? (
         <p className="text-muted-foreground">No player reports found.</p>
       ) : (
-        <div className="space-y-3">
-          {items.map((item) => (
-            <Link key={item.id} to={`/staff/player-reports/${item.id}`}>
-              <Card className="cursor-pointer transition-colors hover:bg-muted/50">
-                <CardContent className="flex items-center justify-between py-4">
-                  <div>
-                    <p className="font-medium">
-                      {item.behavior_description.length > 80
-                        ? item.behavior_description.slice(0, 80) + '...'
-                        : item.behavior_description}
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      Reported: {item.reported_persona_name} ({item.reported_account_username})
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      {item.reporter_persona_name} ({item.reporter_account_username}) &middot;{' '}
-                      {new Date(item.created_at).toLocaleDateString()}
-                    </p>
-                  </div>
-                  <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
-                </CardContent>
-              </Card>
-            </Link>
-          ))}
-        </div>
+        <>
+          <div className="space-y-3">
+            {items.map((item) => (
+              <Link key={item.id} to={`/staff/player-reports/${item.id}`}>
+                <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+                  <CardContent className="flex items-center justify-between py-4">
+                    <div>
+                      <p className="font-medium">
+                        {item.behavior_description.length > 80
+                          ? item.behavior_description.slice(0, 80) + '...'
+                          : item.behavior_description}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        Reported: {item.reported_persona_name} ({item.reported_account_username})
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {item.reporter_persona_name} ({item.reporter_account_username}) &middot;{' '}
+                        {new Date(item.created_at).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+
+          {data && data.count > 0 && (data.next || data.previous) && (
+            <div className="mt-6 flex items-center justify-center gap-4">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!data.previous}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">Page {page}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!data.next}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/staff/pages/StaffPlayerReportsPage.tsx
+++ b/frontend/src/staff/pages/StaffPlayerReportsPage.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { usePlayerReportList } from '@/staff/queries';
+import { useAppSelector } from '@/store/hooks';
+import type { SubmissionStatus } from '@/staff/types';
+
+const STATUS_OPTIONS: { label: string; value: SubmissionStatus | undefined }[] = [
+  { label: 'All', value: undefined },
+  { label: 'Open', value: 'open' },
+  { label: 'Reviewed', value: 'reviewed' },
+  { label: 'Dismissed', value: 'dismissed' },
+];
+
+function statusVariant(status: string): 'default' | 'secondary' | 'outline' {
+  switch (status) {
+    case 'open':
+      return 'default';
+    case 'reviewed':
+      return 'secondary';
+    case 'dismissed':
+      return 'outline';
+    default:
+      return 'outline';
+  }
+}
+
+export function StaffPlayerReportsPage() {
+  const account = useAppSelector((state) => state.auth.account);
+  const [statusFilter, setStatusFilter] = useState<SubmissionStatus | undefined>(undefined);
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = usePlayerReportList(statusFilter, page);
+  const items = data?.results;
+
+  if (!account?.is_staff) return <Navigate to="/" replace />;
+
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold">Player Reports</h1>
+
+      <div className="mb-6 flex flex-wrap gap-2">
+        {STATUS_OPTIONS.map((opt) => (
+          <Button
+            key={opt.label}
+            variant={statusFilter === opt.value ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => {
+              setStatusFilter(opt.value);
+              setPage(1);
+            }}
+          >
+            {opt.label}
+          </Button>
+        ))}
+      </div>
+
+      {isLoading ? (
+        <p className="text-muted-foreground">Loading...</p>
+      ) : !items?.length ? (
+        <p className="text-muted-foreground">No player reports found.</p>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <Link key={item.id} to={`/staff/player-reports/${item.id}`}>
+              <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+                <CardContent className="flex items-center justify-between py-4">
+                  <div>
+                    <p className="font-medium">
+                      {item.behavior_description.length > 80
+                        ? item.behavior_description.slice(0, 80) + '...'
+                        : item.behavior_description}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Reported: {item.reported_persona_name} ({item.reported_account_username})
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {item.reporter_persona_name} ({item.reporter_account_username}) &middot;{' '}
+                      {new Date(item.created_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/staff/queries.ts
+++ b/frontend/src/staff/queries.ts
@@ -11,12 +11,48 @@ import {
   getPendingApplicationCount,
   requestApplicationRevisions,
 } from '@/character-creation/api';
+import type {
+  AccountHistory,
+  BugReport,
+  InboxResponse,
+  PlayerFeedback,
+  PlayerReport,
+  SubmissionCategory,
+  SubmissionStatus,
+} from './types';
+import {
+  getStaffInbox,
+  getAccountHistory,
+  getFeedbackList,
+  getFeedbackDetail,
+  updateFeedbackStatus,
+  getBugReportList,
+  getBugReportDetail,
+  updateBugReportStatus,
+  getPlayerReportList,
+  getPlayerReportDetail,
+  updatePlayerReportStatus,
+  getOpenSubmissionCount,
+} from './api';
 
 export const staffKeys = {
   all: ['staff'] as const,
   applications: (status?: string) => [...staffKeys.all, 'applications', status] as const,
   application: (id: number) => [...staffKeys.all, 'application', id] as const,
   pendingCount: () => [...staffKeys.all, 'pending-count'] as const,
+  inbox: (categories?: SubmissionCategory[], page?: number) =>
+    [...staffKeys.all, 'inbox', categories, page] as const,
+  inboxCount: () => [...staffKeys.all, 'inbox-count'] as const,
+  feedback: (status?: string, page?: number) =>
+    [...staffKeys.all, 'feedback', status, page] as const,
+  feedbackDetail: (id: number) => [...staffKeys.all, 'feedback-detail', id] as const,
+  bugReports: (status?: string, page?: number) =>
+    [...staffKeys.all, 'bug-reports', status, page] as const,
+  bugReportDetail: (id: number) => [...staffKeys.all, 'bug-report-detail', id] as const,
+  playerReports: (status?: string, page?: number) =>
+    [...staffKeys.all, 'player-reports', status, page] as const,
+  playerReportDetail: (id: number) => [...staffKeys.all, 'player-report-detail', id] as const,
+  accountHistory: (id: number) => [...staffKeys.all, 'account-history', id] as const,
 };
 
 export function useApplications(statusFilter?: string) {
@@ -92,5 +128,127 @@ export function useAddStaffComment() {
     onSuccess: (_data, { id }) => {
       queryClient.invalidateQueries({ queryKey: staffKeys.application(id) });
     },
+  });
+}
+
+// =============================================================================
+// Staff Inbox Hooks
+// =============================================================================
+
+export function useStaffInbox(categories?: SubmissionCategory[], page?: number) {
+  return useQuery<InboxResponse>({
+    queryKey: staffKeys.inbox(categories, page),
+    queryFn: () => getStaffInbox(categories, page),
+  });
+}
+
+export function useOpenSubmissionCount(enabled = true) {
+  return useQuery<number>({
+    queryKey: staffKeys.inboxCount(),
+    queryFn: getOpenSubmissionCount,
+    refetchInterval: 60_000,
+    enabled,
+  });
+}
+
+// =============================================================================
+// Player Feedback Hooks
+// =============================================================================
+
+export function useFeedbackList(status?: SubmissionStatus, page?: number) {
+  return useQuery<PaginatedResponse<PlayerFeedback>>({
+    queryKey: staffKeys.feedback(status, page),
+    queryFn: () => getFeedbackList(status, page),
+  });
+}
+
+export function useFeedbackDetail(id: number | undefined) {
+  return useQuery<PlayerFeedback>({
+    queryKey: staffKeys.feedbackDetail(id!),
+    queryFn: () => getFeedbackDetail(id!),
+    enabled: !!id,
+  });
+}
+
+export function useUpdateFeedbackStatus() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, status }: { id: number; status: SubmissionStatus }) =>
+      updateFeedbackStatus(id, status),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: staffKeys.all });
+    },
+  });
+}
+
+// =============================================================================
+// Bug Report Hooks
+// =============================================================================
+
+export function useBugReportList(status?: SubmissionStatus, page?: number) {
+  return useQuery<PaginatedResponse<BugReport>>({
+    queryKey: staffKeys.bugReports(status, page),
+    queryFn: () => getBugReportList(status, page),
+  });
+}
+
+export function useBugReportDetail(id: number | undefined) {
+  return useQuery<BugReport>({
+    queryKey: staffKeys.bugReportDetail(id!),
+    queryFn: () => getBugReportDetail(id!),
+    enabled: !!id,
+  });
+}
+
+export function useUpdateBugReportStatus() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, status }: { id: number; status: SubmissionStatus }) =>
+      updateBugReportStatus(id, status),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: staffKeys.all });
+    },
+  });
+}
+
+// =============================================================================
+// Player Report Hooks
+// =============================================================================
+
+export function usePlayerReportList(status?: SubmissionStatus, page?: number) {
+  return useQuery<PaginatedResponse<PlayerReport>>({
+    queryKey: staffKeys.playerReports(status, page),
+    queryFn: () => getPlayerReportList(status, page),
+  });
+}
+
+export function usePlayerReportDetail(id: number | undefined) {
+  return useQuery<PlayerReport>({
+    queryKey: staffKeys.playerReportDetail(id!),
+    queryFn: () => getPlayerReportDetail(id!),
+    enabled: !!id,
+  });
+}
+
+export function useUpdatePlayerReportStatus() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, status }: { id: number; status: SubmissionStatus }) =>
+      updatePlayerReportStatus(id, status),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: staffKeys.all });
+    },
+  });
+}
+
+// =============================================================================
+// Account History Hook
+// =============================================================================
+
+export function useAccountHistory(accountId: number | undefined) {
+  return useQuery<AccountHistory>({
+    queryKey: staffKeys.accountHistory(accountId!),
+    queryFn: () => getAccountHistory(accountId!),
+    enabled: !!accountId,
   });
 }

--- a/frontend/src/staff/types.ts
+++ b/frontend/src/staff/types.ts
@@ -1,0 +1,93 @@
+// Inbox item from /api/staff_inbox/
+export interface InboxItem {
+  source_type: 'player_feedback' | 'bug_report' | 'player_report' | 'character_application';
+  source_pk: number;
+  title: string;
+  reporter_summary: string;
+  created_at: string;
+  status: string;
+  detail_url: string;
+}
+
+// Paginated inbox response (extended pagination from staff_inbox)
+export interface InboxResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  page_size: number;
+  num_pages: number;
+  current_page: number;
+  results: InboxItem[];
+}
+
+// Feedback detail from /api/player_submissions/feedback/{id}/
+export interface PlayerFeedback {
+  id: number;
+  reporter_account: number;
+  reporter_account_username: string;
+  reporter_persona: number;
+  reporter_persona_name: string;
+  description: string;
+  location: number | null;
+  created_at: string;
+  status: string;
+}
+
+// Bug report detail from /api/player_submissions/bug-reports/{id}/
+export interface BugReport {
+  id: number;
+  reporter_account: number;
+  reporter_account_username: string;
+  reporter_persona: number;
+  reporter_persona_name: string;
+  description: string;
+  location: number | null;
+  created_at: string;
+  status: string;
+}
+
+// Player report detail from /api/player_submissions/player-reports/{id}/
+export interface PlayerReport {
+  id: number;
+  reporter_account: number;
+  reporter_account_username: string;
+  reporter_persona: number;
+  reporter_persona_name: string;
+  reported_account: number;
+  reported_account_username: string;
+  reported_persona: number;
+  reported_persona_name: string;
+  behavior_description: string;
+  asked_to_stop: boolean;
+  blocked_or_muted: boolean;
+  scene: number | null;
+  interaction: number | null;
+  location: number | null;
+  created_at: string;
+  status: string;
+}
+
+// Account history response from /api/staff_inbox/accounts/{id}/history/
+export interface AccountHistoryCategory {
+  items: InboxItem[];
+  total: number;
+  truncated: boolean;
+}
+
+export interface AccountHistory {
+  reports_against: AccountHistoryCategory;
+  reports_submitted: AccountHistoryCategory;
+  feedback: AccountHistoryCategory;
+  bug_reports: AccountHistoryCategory;
+  character_applications: AccountHistoryCategory;
+}
+
+// Submission status values
+export type SubmissionStatus = 'open' | 'reviewed' | 'dismissed';
+
+// Category values for inbox filtering
+export type SubmissionCategory =
+  | 'player_feedback'
+  | 'bug_report'
+  | 'player_report'
+  | 'character_application';

--- a/frontend/src/staff/utils.ts
+++ b/frontend/src/staff/utils.ts
@@ -1,0 +1,34 @@
+import type { InboxItem, SubmissionStatus } from '@/staff/types';
+
+export function detailPath(item: InboxItem): string {
+  switch (item.source_type) {
+    case 'player_feedback':
+      return `/staff/feedback/${item.source_pk}`;
+    case 'bug_report':
+      return `/staff/bug-reports/${item.source_pk}`;
+    case 'player_report':
+      return `/staff/player-reports/${item.source_pk}`;
+    case 'character_application':
+      return `/staff/applications/${item.source_pk}`;
+  }
+}
+
+export function statusVariant(status: string): 'default' | 'secondary' | 'outline' {
+  switch (status) {
+    case 'open':
+      return 'default';
+    case 'reviewed':
+      return 'secondary';
+    case 'dismissed':
+      return 'outline';
+    default:
+      return 'outline';
+  }
+}
+
+export const STATUS_OPTIONS: { label: string; value: SubmissionStatus | undefined }[] = [
+  { label: 'All', value: undefined },
+  { label: 'Open', value: 'open' },
+  { label: 'Reviewed', value: 'reviewed' },
+  { label: 'Dismissed', value: 'dismissed' },
+];


### PR DESCRIPTION
And yet more creating staff inbox stuff.

  - Staff-facing frontend for the inbox triage system and per-type submission management                                                                                              - Two-layer architecture: unified inbox for open item triage + independent per-type sections for historical browsing                                                                - New StaffRoute component checks auth + staff permissions at the route level, preventing unnecessary API calls                                                                   
                                                                                                                                                                                      
What's included
                                                                                                                                                                                    
  - Staff Hub — updated with cards for Inbox, Feedback, Bug Reports, Player Reports, and Roster Applications                                                                        
  - Inbox page — triage view with toggleable category filters (persisted in localStorage), pagination, color-coded category badges
  - Feedback list + detail — status filter tabs (All/Open/Reviewed/Dismissed), pagination, mark reviewed/dismiss actions
  - Bug Reports list + detail — same structure as feedback
  - Player Reports list + detail — includes reported player info, asked-to-stop/blocked-or-muted flags, link to account history
  - Account History page — grouped submission history per account (reports against, reports submitted, feedback, bug reports, applications)
  - Header badge — shows total open submission count (excludes applications to avoid double-counting)

  New routes

  /staff/inbox, /staff/feedback, /staff/feedback/:id, /staff/bug-reports, /staff/bug-reports/:id, /staff/player-reports, /staff/player-reports/:id, /staff/accounts/:id/history     

  Roadmap

  Completes Phase 5a of the Staff Inbox roadmap. Phase 5b (player-facing submission forms) is deferred.

  Test plan

  - Staff hub shows all cards with correct navigation
  - Inbox loads open items, category toggles work and persist across page refresh
  - Per-type list pages filter by status and paginate
  - Detail pages show full submission content with working review/dismiss buttons
  - Player report detail links to account history page
  - Non-staff authenticated users are redirected without seeing staff content or triggering API calls
  - Header badge reflects total open submissions