### PR TITLE
feat(submissions): player forms for feedback and bug reports (Phase 5b)

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -85,8 +85,8 @@ broken regardless of technical correctness.
 | [Tooling](tooling.md) | in-progress | Player building tools, GM tools (level-gated), staff tools |
 | Covenants | skeleton | Covenant roles (stub), speed ranks — needs party model, rituals, bonuses, API |
 | Vitals | skeleton | CharacterStatus, CharacterVitals model — needs non-combat integration, API, frontend |
-| [GM System](gm-system.md) | not-started | GM identity, tables, levels, rewards — depends on Staff Inbox prerequisite |
-| [Staff Inbox & Player Submissions](staff-inbox.md) | not-started | Feedback, bug reports, player reports, and triage aggregator for staff |
+| [GM System](gm-system.md) | in-progress | Phases 0-3 complete: identity, tables, roster/invites. Phase 4 dissolved into Stories; Phase 5 UI deferred until after Stories |
+| [Staff Inbox & Player Submissions](staff-inbox.md) | in-progress | Staff frontend complete; player-facing submission forms pending (Phase 5b) |
 
 ### Recent Infrastructure Changes
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,8 @@ import { EventDetailPage } from '@/events/pages/EventDetailPage';
 import { EventCreatePage } from '@/events/pages/EventCreatePage';
 import { EventEditPage } from '@/events/pages/EventEditPage';
 import { CodexPage } from './codex/pages/CodexPage';
+import { FeedbackPage } from './submissions/pages/FeedbackPage';
+import { BugReportPage } from './submissions/pages/BugReportPage';
 import { StaffHubPage } from './staff/pages/StaffHubPage';
 import { StaffInboxPage } from './staff/pages/StaffInboxPage';
 import { StaffApplicationsPage } from './staff/pages/StaffApplicationsPage';
@@ -101,6 +103,22 @@ function App() {
           element={
             <ProtectedRoute>
               <XpKudosPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/feedback"
+          element={
+            <ProtectedRoute>
+              <FeedbackPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/bug-report"
+          element={
+            <ProtectedRoute>
+              <BugReportPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/ProfileDropdown.tsx
+++ b/frontend/src/components/ProfileDropdown.tsx
@@ -12,7 +12,7 @@ import {
 } from './ui/dropdown-menu';
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import { CharacterLink } from './character';
-import { PlusCircle, Shield, Sparkles } from 'lucide-react';
+import { Bug, MessageSquare, PlusCircle, Shield, Sparkles } from 'lucide-react';
 
 interface ProfileDropdownProps {
   account: AccountData;
@@ -68,6 +68,20 @@ export function ProfileDropdown({ account }: ProfileDropdownProps) {
           <Link to="/xp-kudos" className="flex items-center gap-2">
             <Sparkles className="h-4 w-4" />
             XP / Kudos
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>Help / Contact</DropdownMenuLabel>
+        <DropdownMenuItem asChild>
+          <Link to="/feedback" className="flex items-center gap-2">
+            <MessageSquare className="h-4 w-4" />
+            Send Feedback
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link to="/bug-report" className="flex items-center gap-2">
+            <Bug className="h-4 w-4" />
+            Report a Bug
           </Link>
         </DropdownMenuItem>
         {account.is_staff && (

--- a/frontend/src/roster/types.ts
+++ b/frontend/src/roster/types.ts
@@ -4,6 +4,7 @@ export interface MyRosterEntry {
   id: number;
   name: CharacterData['name'];
   profile_picture_url: string | null;
+  primary_persona_id: number | null;
 }
 
 export interface CharacterGallery {

--- a/frontend/src/submissions/SubmissionForm.tsx
+++ b/frontend/src/submissions/SubmissionForm.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+
+type SubmissionFn = (data: {
+  reporter_persona: number;
+  description: string;
+}) => Promise<{ id: number }>;
+
+interface SubmissionFormProps {
+  title: string;
+  intro: string;
+  placeholder: string;
+  successMessage: string;
+  submitFn: SubmissionFn;
+}
+
+/**
+ * Generic player-submission form used by both Feedback and Bug Report pages.
+ *
+ * Auto-selects the user's first character's primary persona as the
+ * reporter_persona. If the user has no character with a primary persona,
+ * shows an error state directing them to create a character first.
+ */
+export function SubmissionForm({
+  title,
+  intro,
+  placeholder,
+  successMessage,
+  submitFn,
+}: SubmissionFormProps) {
+  const navigate = useNavigate();
+  const [description, setDescription] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const { data: characters, isLoading } = useMyRosterEntriesQuery(true);
+
+  const personaId =
+    characters?.find((c) => c.primary_persona_id !== null)?.primary_persona_id ?? null;
+
+  const mutation = useMutation({
+    mutationFn: submitFn,
+    onSuccess: () => setSubmitted(true),
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!personaId || !description.trim()) return;
+    mutation.mutate({
+      reporter_persona: personaId,
+      description: description.trim(),
+    });
+  }
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto max-w-2xl px-4 py-8">
+        <p className="text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  if (personaId === null) {
+    return (
+      <div className="container mx-auto max-w-2xl px-4 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>{title}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground">
+              You need at least one character before you can submit.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (submitted) {
+    return (
+      <div className="container mx-auto max-w-2xl px-4 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Thank you</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p>{successMessage}</p>
+            <Button onClick={() => navigate('/')}>Return home</Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">{intro}</p>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={placeholder}
+              rows={8}
+              disabled={mutation.isPending}
+            />
+            {mutation.isError ? (
+              <p className="text-sm text-destructive">Submission failed. Please try again later.</p>
+            ) : null}
+            <div className="flex justify-end">
+              <Button type="submit" disabled={mutation.isPending || !description.trim()}>
+                {mutation.isPending ? 'Submitting...' : 'Submit'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/submissions/api.ts
+++ b/frontend/src/submissions/api.ts
@@ -1,0 +1,44 @@
+/**
+ * Player submission API — feedback and bug reports.
+ *
+ * Player reports (reporting problematic behavior from another player) are
+ * intentionally NOT exposed here. That flow requires a dedicated safety-
+ * focused design pass (wording, block/mute integration, evidence handling)
+ * and lives in the roadmap under Phase 5b-followup.
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+
+export interface SubmitFeedbackRequest {
+  reporter_persona: number;
+  description: string;
+}
+
+export interface SubmitBugReportRequest {
+  reporter_persona: number;
+  description: string;
+}
+
+export async function submitFeedback(data: SubmitFeedbackRequest): Promise<{ id: number }> {
+  const res = await apiFetch('/api/player-submissions/feedback/', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(detail || 'Failed to submit feedback.');
+  }
+  return res.json();
+}
+
+export async function submitBugReport(data: SubmitBugReportRequest): Promise<{ id: number }> {
+  const res = await apiFetch('/api/player-submissions/bug-reports/', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(detail || 'Failed to submit bug report.');
+  }
+  return res.json();
+}

--- a/frontend/src/submissions/pages/BugReportPage.tsx
+++ b/frontend/src/submissions/pages/BugReportPage.tsx
@@ -1,0 +1,14 @@
+import { submitBugReport } from '@/submissions/api';
+import { SubmissionForm } from '@/submissions/SubmissionForm';
+
+export function BugReportPage() {
+  return (
+    <SubmissionForm
+      title="Report a Bug"
+      intro="Describe what you were doing, what you expected to happen, and what actually happened. Include any error messages."
+      placeholder="Steps to reproduce, expected behavior, actual behavior..."
+      successMessage="Thanks — staff will investigate."
+      submitFn={submitBugReport}
+    />
+  );
+}

--- a/frontend/src/submissions/pages/FeedbackPage.tsx
+++ b/frontend/src/submissions/pages/FeedbackPage.tsx
@@ -1,0 +1,14 @@
+import { submitFeedback } from '@/submissions/api';
+import { SubmissionForm } from '@/submissions/SubmissionForm';
+
+export function FeedbackPage() {
+  return (
+    <SubmissionForm
+      title="Send Feedback"
+      intro="Have thoughts on the game, a suggestion, or something you'd like us to know? Let us know below. Staff reviews all feedback."
+      placeholder="What's on your mind?"
+      successMessage="Thanks for your feedback — staff will review it."
+      submitFn={submitFeedback}
+    />
+  );
+}

--- a/src/world/roster/serializers/roster_core.py
+++ b/src/world/roster/serializers/roster_core.py
@@ -75,10 +75,16 @@ class MyRosterEntrySerializer(serializers.ModelSerializer):
 
     name = serializers.CharField(source="character_sheet.character.db_key")
     profile_picture_url = serializers.SerializerMethodField()
+    primary_persona_id = serializers.SerializerMethodField()
 
     class Meta:
         model = RosterEntry
-        fields: ClassVar[tuple[str, ...]] = ("id", "name", "profile_picture_url")
+        fields: ClassVar[tuple[str, ...]] = (
+            "id",
+            "name",
+            "profile_picture_url",
+            "primary_persona_id",
+        )
         read_only_fields: ClassVar[tuple[str, ...]] = fields
 
     def get_profile_picture_url(self, obj: RosterEntry) -> str | None:
@@ -86,6 +92,18 @@ class MyRosterEntrySerializer(serializers.ModelSerializer):
         try:
             return obj.profile_picture.media.cloudinary_url
         except AttributeError:
+            return None
+
+    def get_primary_persona_id(self, obj: RosterEntry) -> int | None:
+        """Return the PRIMARY persona's id, or None if none exists.
+
+        Used by player-submission forms to attach a reporter_persona.
+        """
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        try:
+            return obj.character_sheet.primary_persona.pk
+        except ObjectDoesNotExist:
             return None
 
 

--- a/src/world/roster/tests/test_serializers.py
+++ b/src/world/roster/tests/test_serializers.py
@@ -471,3 +471,17 @@ class MyRosterEntrySerializerTestCase(TestCase):
         assert data["id"] == self.entry.id
         assert "name" in data
         assert data["name"] == self.entry.character_sheet.character.db_key
+
+    def test_primary_persona_id_returns_pk_when_present(self):
+        """primary_persona_id returns the PRIMARY persona's pk."""
+        data = MyRosterEntrySerializer(self.entry).data
+        # CharacterSheetFactory.post_generation creates a PRIMARY persona.
+        primary = self.entry.character_sheet.primary_persona
+        assert data["primary_persona_id"] == primary.pk
+
+    def test_primary_persona_id_none_when_missing(self):
+        """primary_persona_id is None if the sheet has no PRIMARY persona."""
+        # Build a sheet without the post_generation PRIMARY persona
+        entry = RosterEntryFactory(character_sheet__primary_persona=False)
+        data = MyRosterEntrySerializer(entry).data
+        assert data["primary_persona_id"] is None


### PR DESCRIPTION
Adds player-facing UI for the two low-risk submission types from the staff inbox backend. Player reports (problematic behavior) remain deferred for a dedicated safety-focused design pass.

Backend:
- MyRosterEntrySerializer exposes primary_persona_id so the frontend can attach the reporter_persona without a separate lookup

Frontend:
- /feedback and /bug-report routes (ProtectedRoute)
- Shared SubmissionForm component: auto-picks the user's first character with a PRIMARY persona; shows a helpful empty state if the user has no character yet
- Help / Contact entries in the account dropdown

Also marks the ROADMAP.md index current: GM System and Staff Inbox are in-progress, not not-started.