### PR TITLE
Add per-cast hooks to allow for accruing abyssal corruption

### DIFF
--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -644,12 +644,14 @@ What was built:
   the casting character has any resonance at corruption stage 3+. Stage
   3+ resonances are surfaced by name so the player can make an informed
   push-or-back-off choice.
-- **Integration test suite** — 13 scenarios in
+- **Integration test suite** — 18 scenarios in
   `src/world/magic/tests/integration/test_corruption_flow.py`: lazy
   condition creation, lifetime monotonicity across accrue+reduce, no-
   template no-op, lock entry/exit, Atonement happy paths + refusal
-  paths, decay sync, risk-transparency event emission. Per-cast accrual
-  scenarios are excluded pending the deferred per-cast hook (see below).
+  paths, decay sync, risk-transparency event emission, and full per-cast
+  pipeline coverage (Abyssal accrual, Celestial skip, lazy creation
+  through the cast pipeline, CORRUPTION_WARNING emission via cast,
+  no-sheet NPC silent skip).
 - **Pre-existing factory bug fix exposed during integration testing** —
   `ConditionStageFactory.severity_multiplier` formula was tied to
   factory.Sequence's `stage_order` value, overflowing
@@ -666,20 +668,29 @@ tether-mediated resist support, `reduce_corruption` for tether-mediated
 rescue rituals, and trace-corruption-to-Sineater via the same
 `accrue_corruption` primitive.
 
-Deferred (gated on a follow-up that extends `TechniqueUseResult`):
-- **Per-cast accrual hook into `use_technique`** — `accrue_corruption_for_cast`
-  per-cast orchestrator and the wiring into the technique pipeline. Spec
-  §10.1 flagged the risk: `TechniqueUseResult` does not expose
-  per-resonance involvement (stat_bonus contribution + thread-pull
-  resonance spent). Implementing the orchestrator requires extending
-  `TechniqueUseResult` (and `use_technique` itself) to surface that
-  breakdown. The per-resonance formula is fully specified in §3.1 and
-  the service shape is sketched in the plan; just unblocks once the
-  technique pipeline exposes the inputs. No architectural changes
-  needed in the corruption foundation — just the missing input.
+Per-cast hook follow-up (DONE):
+- **`TechniqueUseResult` extended** with `technique`, `was_deficit`,
+  `was_mishap`, `was_audere`, `resonance_involvements`, and
+  `corruption_summary` fields. The per-resonance attribution splits
+  runtime intensity equally across the gift's resonances (impl-phase
+  resolution per spec §10.1 — modifier system does not track
+  per-resonance source attribution; equal split matches the §6.1
+  target curve). `thread_pull_resonance_spent` reads from active
+  `CombatPull` rows for the casting character.
+- **`accrue_corruption_for_cast` per-cast orchestrator** — implements
+  the spec §3.1 formula (affinity coefficient × tier coefficient ×
+  push multipliers, ceil-rounded). Skips Celestial, zero-involvement,
+  and zero-tick cases. Returns `CorruptionAccrualSummary`.
+- **Pipeline wiring** — Step 9 of `use_technique` calls the orchestrator
+  after Soulfray accumulation and mishap rider, before reactive event
+  emission. NPCs without a `CharacterSheet` skip silently.
+- **Cast-pipeline integration tests** in
+  `test_corruption_flow.py:FullCastPipelineCorruptionTests` (5 scenarios,
+  see test suite count above).
+
+Still deferred (gated on Spec B):
 - **Soul Tether (Spec B)** — the redirect mechanic, Sineater asymmetry,
   rescue rituals.
-- **Cast-pipeline integration tests** — wait on the per-cast hook above.
 
 Not in this scope (deferred): non-Corruption stage 3+ recovery rituals
 (Spec B authors via the same `reduce_corruption` primitive), public

--- a/src/world/magic/services/corruption.py
+++ b/src/world/magic/services/corruption.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 from django.db import transaction
 
 from flows.constants import EventName
@@ -15,6 +17,7 @@ from world.magic.models.aura import CharacterResonance
 from world.magic.models.corruption_config import CorruptionConfig
 from world.magic.types.corruption import (
     CorruptionAccrualResult,
+    CorruptionAccrualSummary,
     CorruptionAccruedPayload,
     CorruptionAccruingPayload,
     CorruptionCause,
@@ -26,16 +29,154 @@ from world.magic.types.corruption import (
     ProtagonismLockedPayload,
     ProtagonismRestoredPayload,
 )
+from world.magic.types.techniques import TechniqueUseResult
 
 # Stage constants — spec §2.1 terminal stage
 _TERMINAL_STAGE = 5
 _WARNING_STAGES = (3, 4)
+
+# Affinity name strings — used for coefficient lookup (case-insensitive)
+_AFFINITY_CELESTIAL = "celestial"
+_AFFINITY_PRIMAL = "primal"
+_AFFINITY_ABYSSAL = "abyssal"
+
+# Lookup for tier coefficient attribute names
+_TIER_COEF_ATTRS = {
+    1: "tier_1_coefficient",
+    2: "tier_2_coefficient",
+    3: "tier_3_coefficient",
+    4: "tier_4_coefficient",
+    5: "tier_5_coefficient",
+}
 
 
 def get_corruption_config() -> CorruptionConfig:
     """Lazy-create the CorruptionConfig singleton at pk=1."""
     config, _ = CorruptionConfig.objects.get_or_create(pk=1)
     return config
+
+
+def _resolve_affinity_coefficient(resonance: Resonance, config: CorruptionConfig) -> int:
+    """Return the integer-tenths affinity coefficient for a resonance (case-insensitive name match).
+
+    Celestial → config.celestial_coefficient (default 0)
+    Primal    → config.primal_coefficient    (default 2)
+    Abyssal   → config.abyssal_coefficient   (default 10)
+    Unknown   → 0 (treats unknown affinities like Celestial — no corruption)
+    """
+    affinity_name = resonance.affinity.name.lower()
+    if affinity_name == _AFFINITY_CELESTIAL:
+        return config.celestial_coefficient
+    if affinity_name == _AFFINITY_PRIMAL:
+        return config.primal_coefficient
+    if affinity_name == _AFFINITY_ABYSSAL:
+        return config.abyssal_coefficient
+    return 0
+
+
+def _resolve_tier_coefficient(tier: int, config: CorruptionConfig) -> int:
+    """Return the integer-tenths tier coefficient for a technique tier (1–5)."""
+    attr = _TIER_COEF_ATTRS.get(tier, "tier_5_coefficient")
+    return getattr(config, attr)  # noqa: GETATTR_LITERAL
+
+
+def _compute_tick(  # noqa: PLR0913
+    *,
+    involvement: int,
+    affinity_coef: int,
+    tier_coef: int,
+    deficit_multiplier: int,
+    mishap_multiplier: int,
+    audere_multiplier: int,
+    was_deficit: bool,
+    was_mishap: bool,
+    was_audere: bool,
+) -> int:
+    """Compute the per-resonance corruption tick per spec §3.1.
+
+    All coefficients are integer-tenths (× 0.1 in formula).
+    Multipliers default to 10 (× 0.1 → 1.0) when their flag is False.
+
+    base_tick   = involvement × (affinity_coef / 10) × (tier_coef / 10)
+    multipliers = (d × m × a) / 1000   where each of d/m/a is either the
+                  configured integer-tenths value or 10 (neutral)
+    tick        = ceil(base_tick × multipliers)
+    """
+    base_tick = involvement * affinity_coef / 10 * tier_coef / 10
+    d = deficit_multiplier if was_deficit else 10
+    m = mishap_multiplier if was_mishap else 10
+    a = audere_multiplier if was_audere else 10
+    multipliers = d * m * a / 1000
+    return math.ceil(base_tick * multipliers)
+
+
+def accrue_corruption_for_cast(
+    *,
+    caster_sheet: CharacterSheet,
+    technique_use_result: TechniqueUseResult,
+    config: CorruptionConfig | None = None,
+) -> CorruptionAccrualSummary:
+    """Apply per-resonance corruption ticks for one technique cast.
+
+    Walks technique_use_result.resonance_involvements; for each resonance R
+    with non-zero involvement and non-zero tick after Celestial-skip and
+    ceil-rounding, calls accrue_corruption. Returns a CorruptionAccrualSummary.
+
+    Assumption: technique_use_result.technique is not None. The defensive guard
+    for the early-exit case (technique=None) is deferred to Task 3 (the cast hook).
+    """
+    if config is None:
+        config = get_corruption_config()
+
+    per_resonance: list[CorruptionAccrualResult] = []
+
+    for inv in technique_use_result.resonance_involvements:
+        resonance = inv.resonance
+        affinity_coef = _resolve_affinity_coefficient(resonance, config)
+
+        # Celestial always has coefficient 0 — skip entirely (no accrual, no audit noise)
+        if affinity_coef == 0:
+            continue
+
+        involvement = inv.stat_bonus_contribution + inv.thread_pull_resonance_spent
+        if involvement <= 0:
+            continue
+
+        tier = technique_use_result.technique.tier  # type: ignore[union-attr]
+        tier_coef = _resolve_tier_coefficient(tier, config)
+
+        tick = _compute_tick(
+            involvement=involvement,
+            affinity_coef=affinity_coef,
+            tier_coef=tier_coef,
+            deficit_multiplier=config.deficit_multiplier,
+            mishap_multiplier=config.mishap_multiplier,
+            audere_multiplier=config.audere_multiplier,
+            was_deficit=technique_use_result.was_deficit,
+            was_mishap=technique_use_result.was_mishap,
+            was_audere=technique_use_result.was_audere,
+        )
+
+        if tick == 0:
+            continue
+
+        result = accrue_corruption(
+            character_sheet=caster_sheet,
+            resonance=resonance,
+            amount=tick,
+            source=CorruptionSource.TECHNIQUE_USE,
+            technique_use=technique_use_result,
+        )
+        per_resonance.append(result)
+
+    technique = technique_use_result.technique
+    technique_id = technique.pk if technique is not None else 0
+
+    return CorruptionAccrualSummary(
+        caster_sheet_id=caster_sheet.pk,
+        technique_id=technique_id,
+        per_resonance=tuple(per_resonance),
+    )
 
 
 def _resolve_character(character_sheet: CharacterSheet) -> object:

--- a/src/world/magic/services/techniques.py
+++ b/src/world/magic/services/techniques.py
@@ -269,6 +269,7 @@ def use_technique(  # noqa: PLR0913, C901 — kw-only args are intentional, targ
             anima_cost=cost,
             soulfray_warning=soulfray_warning,
             confirmed=False,
+            technique=technique,
         )
 
     # --- TECHNIQUE_PRE_CAST (cancellable, before anima deduction) ---
@@ -290,6 +291,7 @@ def use_technique(  # noqa: PLR0913, C901 — kw-only args are intentional, targ
             return TechniqueUseResult(
                 anima_cost=cost,
                 confirmed=False,
+                technique=technique,
             )
 
     # Step 4: Deduct anima

--- a/src/world/magic/services/techniques.py
+++ b/src/world/magic/services/techniques.py
@@ -231,7 +231,7 @@ def calculate_effective_anima_cost(
     )
 
 
-def use_technique(  # noqa: PLR0913, C901 — kw-only args are intentional, targets is new for reactive layer
+def use_technique(  # noqa: PLR0913, PLR0912, C901 — kw-only args are intentional; step 9 added a branch
     *,
     character: ObjectDB,
     technique: Technique,
@@ -354,6 +354,18 @@ def use_technique(  # noqa: PLR0913, C901 — kw-only args are intentional, targ
         was_audere=_character_is_in_audere(character),
         resonance_involvements=resonance_involvements,
     )
+
+    # Step 9: Per-cast corruption accrual (Magic Scope #7)
+    # Defensive sheet lookup: NPCs without a CharacterSheet skip corruption
+    # accrual silently (the orchestrator requires a sheet to write to).
+    sheet = _get_character_sheet(character)
+    if sheet is not None:
+        from world.magic.services.corruption import accrue_corruption_for_cast  # noqa: PLC0415
+
+        technique_result.corruption_summary = accrue_corruption_for_cast(
+            caster_sheet=sheet,
+            technique_use_result=technique_result,
+        )
 
     # --- TECHNIQUE_CAST (post-resolve, frozen) ---
     if caster_room is not None:

--- a/src/world/magic/services/techniques.py
+++ b/src/world/magic/services/techniques.py
@@ -20,7 +20,12 @@ from world.magic.services.soulfray import (
     get_soulfray_warning,
     select_mishap_pool,
 )
-from world.magic.types import AnimaCostResult, RuntimeTechniqueStats, TechniqueUseResult
+from world.magic.types import (
+    AnimaCostResult,
+    ResonanceInvolvement,
+    RuntimeTechniqueStats,
+    TechniqueUseResult,
+)
 from world.mechanics.constants import (
     TECHNIQUE_STAT_CATEGORY_NAME,
     TECHNIQUE_STAT_CONTROL,
@@ -89,6 +94,61 @@ def _get_intensity_tier_control_modifier(runtime_intensity: int) -> int:
     if tier is None:
         return 0
     return tier.control_modifier
+
+
+def _character_is_in_audere(character: ObjectDB) -> bool:
+    """Return True if the character has an active Audere ConditionInstance."""
+    from world.conditions.models import ConditionInstance  # noqa: PLC0415
+    from world.magic.audere import AUDERE_CONDITION_NAME  # noqa: PLC0415
+
+    return ConditionInstance.objects.filter(
+        target=character,
+        condition__name=AUDERE_CONDITION_NAME,
+    ).exists()
+
+
+def _build_resonance_involvements(
+    *,
+    technique: Technique,
+    character: ObjectDB,
+    runtime_intensity: int,
+) -> tuple[ResonanceInvolvement, ...]:
+    """Compute per-resonance involvement for one cast.
+
+    stat_bonus_contribution splits runtime intensity equally across the
+    technique's gift's resonances (the modifier system does not track
+    per-resonance attribution; spec §10.1 acknowledges this as an
+    impl-phase resolution).
+
+    thread_pull_resonance_spent sums CombatPull.resonance_spent for the
+    character's active pulls per resonance.
+    """
+    resonances = list(technique.gift.resonances.all())
+    if not resonances:
+        return ()
+
+    per_resonance_share = runtime_intensity // len(resonances)
+    pulls_by_resonance: dict[int, int] = {}
+    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+    try:
+        active_pulls = character.combat_pulls.active()
+    except ObjectDoesNotExist:
+        # Character has no CharacterSheet (e.g., NPCs); treat as no active pulls.
+        active_pulls = []
+    for pull in active_pulls:
+        pulls_by_resonance[pull.resonance_id] = (
+            pulls_by_resonance.get(pull.resonance_id, 0) + pull.resonance_spent
+        )
+
+    return tuple(
+        ResonanceInvolvement(
+            resonance=r,
+            stat_bonus_contribution=per_resonance_share,
+            thread_pull_resonance_spent=pulls_by_resonance.get(r.pk, 0),
+        )
+        for r in resonances
+    )
 
 
 def get_runtime_technique_stats(
@@ -273,6 +333,12 @@ def use_technique(  # noqa: PLR0913, C901 — kw-only args are intentional, targ
         if pool is not None and effective_check_result is not None:
             mishap = _resolve_mishap(character, pool, effective_check_result)
 
+    resonance_involvements = _build_resonance_involvements(
+        technique=technique,
+        character=character,
+        runtime_intensity=stats.intensity,
+    )
+
     technique_result = TechniqueUseResult(
         anima_cost=cost,
         soulfray_warning=soulfray_warning,
@@ -280,6 +346,11 @@ def use_technique(  # noqa: PLR0913, C901 — kw-only args are intentional, targ
         resolution_result=resolution_result,
         soulfray_result=soulfray_result,
         mishap=mishap,
+        technique=technique,
+        was_deficit=cost.deficit > 0,
+        was_mishap=mishap is not None,
+        was_audere=_character_is_in_audere(character),
+        resonance_involvements=resonance_involvements,
     )
 
     # --- TECHNIQUE_CAST (post-resolve, frozen) ---

--- a/src/world/magic/tests/integration/test_corruption_flow.py
+++ b/src/world/magic/tests/integration/test_corruption_flow.py
@@ -1,16 +1,8 @@
 """Integration tests for the Corruption foundation (Magic Scope #7).
 
 Each test exercises a multi-step slice of the shipped surfaces rather
-than a single function in isolation.
-
-Excluded scenarios (waiting on Phase 6.4 / 7.1 unblocking — TechniqueUseResult
-extension to expose per-resonance involvement):
-- Per-cast accrual via use_technique
-- Cast pipeline integration
-
-Those scenarios are gated on accrue_corruption_for_cast being wired into
-services/techniques.py, which depends on TechniqueUseResult exposing
-per-resonance stat bonus contributions.
+than a single function in isolation.  Full per-cast pipeline coverage
+(Scenario 11) is now included following Phase 7.1 wiring.
 
 Pattern matches src/world/magic/tests/integration/test_soulfray_recovery_flow.py.
 """
@@ -28,10 +20,15 @@ from world.conditions.models import ConditionInstance
 from world.conditions.services import decay_condition_severity
 from world.magic.exceptions import ProtagonismLockedError
 from world.magic.factories import (
+    AffinityFactory,
+    CharacterAnimaFactory,
+    GiftFactory,
     ResonanceFactory,
+    TechniqueFactory,
     with_corruption_at_stage,
 )
 from world.magic.models.aura import CharacterResonance
+from world.magic.services import use_technique
 from world.magic.services.atonement import (
     AtonementStageOutOfRange,
     perform_atonement_rite,
@@ -419,3 +416,216 @@ class RiskTransparencyEventTests(TestCase):
             )
 
         assert EventName.PROTAGONISM_LOCKED in emitted_event_names
+
+
+# ---------------------------------------------------------------------------
+# Scenario 11: Full per-cast accrual via use_technique
+# ---------------------------------------------------------------------------
+
+
+def _make_abyssal_gift_and_technique(
+    *,
+    intensity: int = 2,
+    control: int = 10,
+    anima_cost: int = 2,
+    level: int = 1,
+) -> tuple:
+    """Create an Abyssal resonance + Gift + Technique for integration tests.
+
+    Returns (resonance, gift, technique).
+    """
+    abyssal_affinity = AffinityFactory(name="Abyssal")
+    resonance = ResonanceFactory(affinity=abyssal_affinity)
+    gift = GiftFactory()
+    gift.resonances.add(resonance)
+    technique = TechniqueFactory(
+        gift=gift,
+        intensity=intensity,
+        control=control,
+        anima_cost=anima_cost,
+        level=level,
+    )
+    return resonance, gift, technique
+
+
+class FullCastPipelineCorruptionTests(TestCase):
+    """Scenario 11: full per-cast accrual via use_technique (Phase 7.1 unblock)."""
+
+    def test_abyssal_cast_increments_corruption_current_and_lifetime(self) -> None:
+        """End-to-end: Abyssal tier-1 cast → corruption_current/lifetime increment.
+
+        Uses the simple template (deterministic stage advancement) so the test
+        isn't gated on RNG.
+        """
+        resonance, _gift, technique = _make_abyssal_gift_and_technique(
+            intensity=2, control=10, anima_cost=2, level=1
+        )
+        _make_simple_template(resonance)
+
+        sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
+
+        result = use_technique(
+            character=sheet.character,
+            technique=technique,
+            resolve_fn=lambda: None,
+        )
+
+        # Summary is attached to the result
+        assert result.corruption_summary is not None
+
+        # corruption fields incremented on CharacterResonance
+        char_res = CharacterResonance.objects.get(character_sheet=sheet, resonance=resonance)
+        assert char_res.corruption_current > 0
+        assert char_res.corruption_lifetime > 0
+        assert char_res.corruption_current == char_res.corruption_lifetime
+
+    def test_celestial_cast_does_not_accrue_corruption(self) -> None:
+        """Celestial Gift → no corruption accrual, even with authored content."""
+        celestial_affinity = AffinityFactory(name="Celestial")
+        resonance = ResonanceFactory(affinity=celestial_affinity)
+        gift = GiftFactory()
+        gift.resonances.add(resonance)
+        technique = TechniqueFactory(
+            gift=gift,
+            intensity=2,
+            control=10,
+            anima_cost=2,
+            level=1,
+        )
+        # Author a template for the resonance so it would be picked up if
+        # the celestial-skip logic were absent.
+        _make_simple_template(resonance)
+
+        sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
+
+        result = use_technique(
+            character=sheet.character,
+            technique=technique,
+            resolve_fn=lambda: None,
+        )
+
+        # Summary is still attached (orchestrator ran, just skipped Celestial)
+        assert result.corruption_summary is not None
+        # No per-resonance accrual results (Celestial skipped)
+        assert len(result.corruption_summary.per_resonance) == 0
+
+        # No CharacterResonance row created at all (nothing to write)
+        assert not CharacterResonance.objects.filter(
+            character_sheet=sheet, resonance=resonance
+        ).exists()
+
+    def test_lazy_condition_creation_at_threshold(self) -> None:
+        """Repeated tier-1 casts cross stage 1 threshold → ConditionInstance created.
+
+        Pre-loads corruption_current to just below threshold=50, then casts
+        once with intensity=10 to push it over in a single cast.  Avoids a
+        long loop while still exercising the full pipeline.
+        """
+        resonance, _gift, technique = _make_abyssal_gift_and_technique(
+            intensity=10, control=10, anima_cost=2, level=1
+        )
+        _make_simple_template(resonance)
+
+        sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=sheet.character, current=50, maximum=50)
+
+        # Pre-load to 40 — below threshold=50 so no condition yet.
+        # Direct DB write bypasses the service to avoid test duplication.
+        char_res, _ = CharacterResonance.objects.get_or_create(
+            character_sheet=sheet, resonance=resonance
+        )
+        char_res.corruption_current = 40
+        char_res.corruption_lifetime = 40
+        char_res.save(update_fields=["corruption_current", "corruption_lifetime"])
+        assert not ConditionInstance.objects.filter(target=sheet.character).exists()
+
+        # A single tier-1 cast with intensity=10 gives stat_bonus_contribution=10.
+        # Abyssal default coefficient=10, tier-1 coefficient=10.
+        # tick = ceil(10 * 10/10 * 10/10 * 1.0) = ceil(10) = 10.
+        # 40 + 10 = 50 ≥ threshold → lazy-create fires.
+        result = use_technique(
+            character=sheet.character,
+            technique=technique,
+            resolve_fn=lambda: None,
+        )
+
+        assert result.corruption_summary is not None
+        char_res.refresh_from_db()
+        assert char_res.corruption_current >= 50
+        # ConditionInstance should now exist
+        assert ConditionInstance.objects.filter(target=sheet.character).exists()
+
+    def test_cast_with_authored_content_at_high_severity_fires_warning(self) -> None:
+        """At stage 2, an Abyssal cast crossing stage 3 threshold emits CORRUPTION_WARNING.
+
+        Pre-loads corruption_current to 490 (just below stage 3 threshold=500),
+        then casts with intensity=10 to cross 500.
+        """
+        from flows.constants import EventName
+
+        resonance, _gift, technique = _make_abyssal_gift_and_technique(
+            intensity=10, control=10, anima_cost=2, level=1
+        )
+        _make_simple_template(resonance)
+
+        sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=sheet.character, current=50, maximum=50)
+
+        # Give the character a location so emit_event fires.
+        room = _create_room()
+        sheet.character.location = room
+
+        # Bring to stage 2 via direct service call (threshold=200 to 499).
+        # Use the corruption service so ConditionInstance is created correctly.
+        accrue_corruption(
+            character_sheet=sheet,
+            resonance=resonance,
+            amount=490,
+            source=CorruptionSource.STAFF_GRANT,
+        )
+        char_res = CharacterResonance.objects.get(character_sheet=sheet, resonance=resonance)
+        assert char_res.corruption_current == 490
+
+        emitted_event_names: list[str] = []
+        import world.magic.services.corruption as corruption_mod
+
+        original_emit = corruption_mod.emit_event
+
+        def capturing_emit(event_name, payload, location, **kwargs):
+            emitted_event_names.append(event_name)
+            return original_emit(event_name, payload, location, **kwargs)
+
+        with patch(_EMIT_EVENT_PATH, side_effect=capturing_emit):
+            # Cast crosses 500 (490 + ≥10 tick → ≥500) → stage 3 advancement.
+            use_technique(
+                character=sheet.character,
+                technique=technique,
+                resolve_fn=lambda: None,
+            )
+
+        assert EventName.CORRUPTION_WARNING in emitted_event_names
+
+    def test_no_sheet_character_skips_corruption_silently(self) -> None:
+        """Character without a CharacterSheet → cast succeeds, no corruption attempted."""
+        # Build an ObjectDB character directly — no CharacterSheet row.
+        _resonance, _gift, technique = _make_abyssal_gift_and_technique(
+            intensity=2, control=10, anima_cost=2, level=1
+        )
+        character = ObjectDB.objects.create(
+            db_key="NPCTestChar",
+            db_typeclass_path="typeclasses.characters.Character",
+        )
+        CharacterAnimaFactory(character=character, current=20, maximum=20)
+
+        result = use_technique(
+            character=character,
+            technique=technique,
+            resolve_fn=lambda: None,
+        )
+
+        # Cast succeeded
+        assert result.confirmed is True
+        # No corruption summary (sheet lookup returned None → hook skipped)
+        assert result.corruption_summary is None

--- a/src/world/magic/tests/test_corruption_for_cast.py
+++ b/src/world/magic/tests/test_corruption_for_cast.py
@@ -1,0 +1,637 @@
+"""Tests for accrue_corruption_for_cast orchestrator (Scope #7, Task 2).
+
+Formula (spec §3.1):
+    involvement = stat_bonus_contribution + thread_pull_resonance_spent
+    base_tick   = involvement × affinity_coef/10 × tier_coef/10
+    multipliers = (deficit_mul × mishap_mul × audere_mul) / 1000
+    tick        = ceil(base_tick × multipliers)
+
+Default config coefficients (integer-tenths):
+    celestial = 0, primal = 2, abyssal = 10
+    tier 1 = 10, tier 2 = 20, tier 3 = 40, tier 4 = 80, tier 5 = 160
+    deficit_multiplier = 20, mishap_multiplier = 15, audere_multiplier = 15
+"""
+
+from unittest import mock
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.conditions.factories import ConditionStageFactory, ConditionTemplateFactory
+from world.conditions.types import AdvancementOutcome
+from world.magic.factories import AffinityFactory, ResonanceFactory, TechniqueFactory
+from world.magic.models.corruption_config import CorruptionConfig
+from world.magic.services.corruption import accrue_corruption_for_cast
+from world.magic.types.corruption import (
+    CorruptionAccrualResult,
+    CorruptionAccrualSummary,
+    CorruptionSource,
+)
+from world.magic.types.techniques import AnimaCostResult, ResonanceInvolvement, TechniqueUseResult
+
+
+def _make_anima_cost() -> AnimaCostResult:
+    """Minimal AnimaCostResult for constructing TechniqueUseResult."""
+    return AnimaCostResult(
+        base_cost=2,
+        effective_cost=2,
+        control_delta=0,
+        current_anima=10,
+        deficit=0,
+    )
+
+
+def _make_result(
+    *,
+    technique,
+    resonance_involvements=(),
+    was_deficit=False,
+    was_mishap=False,
+    was_audere=False,
+) -> TechniqueUseResult:
+    """Build a minimal TechniqueUseResult for testing."""
+    return TechniqueUseResult(
+        anima_cost=_make_anima_cost(),
+        technique=technique,
+        was_deficit=was_deficit,
+        was_mishap=was_mishap,
+        was_audere=was_audere,
+        resonance_involvements=tuple(resonance_involvements),
+    )
+
+
+def _make_corruption_template(resonance):
+    """Create a minimal Corruption ConditionTemplate wired to a resonance."""
+    template = ConditionTemplateFactory(
+        name=f"Corruption ({resonance.name})",
+        has_progression=True,
+        corruption_resonance=resonance,
+    )
+    thresholds = [50, 200, 500, 1000, 1500]
+    for i, threshold in enumerate(thresholds, start=1):
+        ConditionStageFactory(
+            condition=template,
+            stage_order=i,
+            severity_threshold=threshold,
+        )
+    return template
+
+
+class TestAccrueCorruptionForCast(TestCase):
+    """accrue_corruption_for_cast per-resonance dispatch and formula."""
+
+    def _call(self, caster_sheet=None, **kwargs) -> CorruptionAccrualSummary:
+        sheet = caster_sheet or CharacterSheetFactory()
+        return accrue_corruption_for_cast(caster_sheet=sheet, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Celestial skip
+    # ------------------------------------------------------------------
+
+    def test_celestial_resonance_zero_tick(self) -> None:
+        """Celestial resonance skipped entirely — no accrue_corruption call, empty per_resonance."""
+        celestial_affinity = AffinityFactory(name="Celestial")
+        celestial_resonance = ResonanceFactory(name="Celestial Test", affinity=celestial_affinity)
+        technique = TechniqueFactory(level=1)  # tier 1
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=celestial_resonance,
+                    stat_bonus_contribution=10,
+                    thread_pull_resonance_spent=5,
+                )
+            ],
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            summary = self._call(technique_use_result=result_obj)
+
+        mock_accrue.assert_not_called()
+        self.assertIsInstance(summary, CorruptionAccrualSummary)
+        self.assertEqual(summary.per_resonance, ())
+
+    # ------------------------------------------------------------------
+    # Abyssal baseline
+    # ------------------------------------------------------------------
+
+    def test_abyssal_tier_1_cantrip_stat_bonus_2_yields_2_ticks(self) -> None:
+        """Abyssal, tier 1, stat_bonus=2, no flags → tick = ceil(2 × 1.0 × 1.0 × 1.0) = 2."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal Test", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            self._call(technique_use_result=result_obj)
+
+        mock_accrue.assert_called_once()
+        call_kwargs = mock_accrue.call_args.kwargs
+        self.assertEqual(call_kwargs["amount"], 2)
+        self.assertEqual(call_kwargs["resonance"], resonance)
+
+    # ------------------------------------------------------------------
+    # Multiplier tests
+    # ------------------------------------------------------------------
+
+    def test_audere_multiplier_applied(self) -> None:
+        """was_audere=True → 1.5× multiplier; ceil(2 × 1.0 × 1.0 × 1.5) = 3."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal Audere", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+            was_audere=True,
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            self._call(technique_use_result=result_obj)
+
+        call_kwargs = mock_accrue.call_args.kwargs
+        self.assertEqual(call_kwargs["amount"], 3)
+
+    def test_deficit_multiplier_applied(self) -> None:
+        """was_deficit=True → 2× multiplier; ceil(2 × 1.0 × 1.0 × 2.0) = 4."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal Deficit", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+            was_deficit=True,
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            self._call(technique_use_result=result_obj)
+
+        call_kwargs = mock_accrue.call_args.kwargs
+        self.assertEqual(call_kwargs["amount"], 4)
+
+    def test_mishap_multiplier_applied(self) -> None:
+        """was_mishap=True → 1.5× multiplier; ceil(2 × 1.0 × 1.0 × 1.5) = 3."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal Mishap", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+            was_mishap=True,
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            self._call(technique_use_result=result_obj)
+
+        call_kwargs = mock_accrue.call_args.kwargs
+        self.assertEqual(call_kwargs["amount"], 3)
+
+    def test_combined_multipliers_compound(self) -> None:
+        """All three flags True → multiplier = 2.0 × 1.5 × 1.5 = 4.5; tick = ceil(2 × 4.5) = 9."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal All Flags", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+            was_deficit=True,
+            was_mishap=True,
+            was_audere=True,
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            self._call(technique_use_result=result_obj)
+
+        call_kwargs = mock_accrue.call_args.kwargs
+        self.assertEqual(call_kwargs["amount"], 9)
+
+    # ------------------------------------------------------------------
+    # involvement from thread pulls
+    # ------------------------------------------------------------------
+
+    def test_thread_pull_resonance_spent_adds_to_involvement(self) -> None:
+        """stat_bonus=2, thread_pull=3 → involvement=5; tick = ceil(5 × 1.0 × 1.0 × 1.0) = 5."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal Thread", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=3,
+                )
+            ],
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            self._call(technique_use_result=result_obj)
+
+        call_kwargs = mock_accrue.call_args.kwargs
+        self.assertEqual(call_kwargs["amount"], 5)
+
+    # ------------------------------------------------------------------
+    # Multi-resonance
+    # ------------------------------------------------------------------
+
+    def test_multi_resonance_distributes_per_resonance_ticks(self) -> None:
+        """Two non-zero involvements → two accrue_corruption calls with distinct resonances.
+
+        Primal coef=2 (×0.1→0.2), Abyssal coef=10 (×0.1→1.0), tier 1 coef=10 (×0.1→1.0).
+        Primal involvement=10: base = 10 × 0.2 × 1.0 = 2.0 → ceil(2.0) = 2
+        Abyssal involvement=10: base = 10 × 1.0 × 1.0 = 10.0 → ceil(10.0) = 10
+        """
+        primal_affinity = AffinityFactory(name="Primal")
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        primal_resonance = ResonanceFactory(name="Primal Multi", affinity=primal_affinity)
+        abyssal_resonance = ResonanceFactory(name="Abyssal Multi", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=primal_resonance,
+                    stat_bonus_contribution=10,
+                    thread_pull_resonance_spent=0,
+                ),
+                ResonanceInvolvement(
+                    resonance=abyssal_resonance,
+                    stat_bonus_contribution=10,
+                    thread_pull_resonance_spent=0,
+                ),
+            ],
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            summary = self._call(technique_use_result=result_obj)
+
+        self.assertEqual(mock_accrue.call_count, 2)
+        amounts = {
+            call.kwargs["resonance"]: call.kwargs["amount"] for call in mock_accrue.call_args_list
+        }
+        self.assertEqual(amounts[primal_resonance], 2)
+        self.assertEqual(amounts[abyssal_resonance], 10)
+        # Both results are in per_resonance
+        self.assertEqual(len(summary.per_resonance), 2)
+
+    # ------------------------------------------------------------------
+    # Zero involvement / zero tick skip
+    # ------------------------------------------------------------------
+
+    def test_zero_involvement_skips_call(self) -> None:
+        """involvement = 0 → no accrue_corruption call."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal Zero", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=0,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            summary = self._call(technique_use_result=result_obj)
+
+        mock_accrue.assert_not_called()
+        self.assertEqual(summary.per_resonance, ())
+
+    # ------------------------------------------------------------------
+    # Tier coefficient
+    # ------------------------------------------------------------------
+
+    def test_tier_3_coefficient_quadruples_baseline(self) -> None:
+        """technique.tier=3 → tier_coef=40 (4× tier 1); Abyssal, stat_bonus=2, no flags.
+
+        base = 2 × (10/10) × (40/10) = 2 × 1.0 × 4.0 = 8.0 → tick = ceil(8.0) = 8.
+        """
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal Tier3", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=11)  # level 11 → tier 3
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            self._call(technique_use_result=result_obj)
+
+        call_kwargs = mock_accrue.call_args.kwargs
+        self.assertEqual(call_kwargs["amount"], 8)
+
+    # ------------------------------------------------------------------
+    # Return type and structure
+    # ------------------------------------------------------------------
+
+    def test_returns_corruption_accrual_summary(self) -> None:
+        """Return value is a CorruptionAccrualSummary with correct fields populated."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal Summary", affinity=abyssal_affinity)
+        sheet = CharacterSheetFactory()
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            summary = self._call(caster_sheet=sheet, technique_use_result=result_obj)
+
+        self.assertIsInstance(summary, CorruptionAccrualSummary)
+        self.assertEqual(summary.caster_sheet_id, sheet.pk)
+        self.assertEqual(summary.technique_id, technique.pk)
+        self.assertEqual(len(summary.per_resonance), 1)
+
+    def test_per_resonance_tuple_contains_accrual_results(self) -> None:
+        """Each per_resonance entry is the CorruptionAccrualResult returned by accrue_corruption."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal Result", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+        )
+
+        fake_accrual_result = CorruptionAccrualResult(
+            resonance=resonance,
+            amount_applied=2,
+            current_before=0,
+            current_after=2,
+            lifetime_before=0,
+            lifetime_after=2,
+            stage_before=0,
+            stage_after=0,
+            advancement_outcome=AdvancementOutcome.NO_CHANGE,
+            condition_instance=None,
+        )
+
+        with mock.patch(
+            "world.magic.services.corruption.accrue_corruption",
+            return_value=fake_accrual_result,
+        ):
+            summary = self._call(technique_use_result=result_obj)
+
+        self.assertEqual(len(summary.per_resonance), 1)
+        self.assertIs(summary.per_resonance[0], fake_accrual_result)
+
+    # ------------------------------------------------------------------
+    # No template authored — still calls accrue_corruption (real integration)
+    # ------------------------------------------------------------------
+
+    def test_no_template_authored_still_returns_summary(self) -> None:
+        """Resonance with no ConditionTemplate → accrue_corruption is still called.
+
+        accrue_corruption returns a no-op CorruptionAccrualResult; the result
+        is added to per_resonance. corruption_current still increments.
+        """
+        from world.magic.models.aura import CharacterResonance
+
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal NoTemplate", affinity=abyssal_affinity)
+        sheet = CharacterSheetFactory()
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+        )
+
+        # No template created — accrue_corruption fires but is a no-op for conditions
+        summary = accrue_corruption_for_cast(
+            caster_sheet=sheet,
+            technique_use_result=result_obj,
+        )
+
+        self.assertIsInstance(summary, CorruptionAccrualSummary)
+        self.assertEqual(len(summary.per_resonance), 1)
+        # Field still incremented
+        row = CharacterResonance.objects.get(character_sheet=sheet, resonance=resonance)
+        self.assertEqual(row.corruption_current, 2)
+
+    # ------------------------------------------------------------------
+    # Explicit config override
+    # ------------------------------------------------------------------
+
+    def test_explicit_config_override_zeros_all_ticks(self) -> None:
+        """Config with all affinity coefs=0 produces zero ticks and empty per_resonance tuple."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal Zeroed", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=10,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+        )
+
+        # All affinity coefficients zeroed out — unsaved, used as config override
+        zero_config = CorruptionConfig(
+            celestial_coefficient=0,
+            primal_coefficient=0,
+            abyssal_coefficient=0,
+            tier_1_coefficient=10,
+            tier_2_coefficient=20,
+            tier_3_coefficient=40,
+            tier_4_coefficient=80,
+            tier_5_coefficient=160,
+            deficit_multiplier=20,
+            mishap_multiplier=15,
+            audere_multiplier=15,
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            summary = self._call(
+                technique_use_result=result_obj,
+                config=zero_config,
+            )
+
+        mock_accrue.assert_not_called()
+        self.assertEqual(summary.per_resonance, ())
+
+    # ------------------------------------------------------------------
+    # Primal coefficient
+    # ------------------------------------------------------------------
+
+    def test_primal_coefficient_applied(self) -> None:
+        """Primal coef=2, tier 1, involvement=10 → base = 10 × 0.2 × 1.0 = 2.0 → tick=2."""
+        primal_affinity = AffinityFactory(name="Primal")
+        resonance = ResonanceFactory(name="Primal Coef", affinity=primal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=10,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            self._call(technique_use_result=result_obj)
+
+        call_kwargs = mock_accrue.call_args.kwargs
+        self.assertEqual(call_kwargs["amount"], 2)
+
+    def test_primal_low_involvement_rounds_up_to_one(self) -> None:
+        """Primal coef=2, tier 1, involvement=1 → base = 1 × 0.2 × 1.0 = 0.2 → ceil(0.2) = 1."""
+        primal_affinity = AffinityFactory(name="Primal")
+        resonance = ResonanceFactory(name="Primal Ceil", affinity=primal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=1,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            self._call(technique_use_result=result_obj)
+
+        call_kwargs = mock_accrue.call_args.kwargs
+        self.assertEqual(call_kwargs["amount"], 1)
+
+    # ------------------------------------------------------------------
+    # accrue_corruption receives correct keyword args
+    # ------------------------------------------------------------------
+
+    def test_accrue_corruption_receives_technique_use_kwarg(self) -> None:
+        """accrue_corruption is called with technique_use=technique_use_result for audit trail."""
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonance = ResonanceFactory(name="Abyssal AuditArg", affinity=abyssal_affinity)
+        technique = TechniqueFactory(level=1)
+
+        result_obj = _make_result(
+            technique=technique,
+            resonance_involvements=[
+                ResonanceInvolvement(
+                    resonance=resonance,
+                    stat_bonus_contribution=2,
+                    thread_pull_resonance_spent=0,
+                )
+            ],
+        )
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            mock_accrue.return_value = mock.MagicMock()
+            self._call(technique_use_result=result_obj)
+
+        call_kwargs = mock_accrue.call_args.kwargs
+        self.assertIs(call_kwargs["technique_use"], result_obj)
+        self.assertEqual(call_kwargs["source"], CorruptionSource.TECHNIQUE_USE)
+
+    # ------------------------------------------------------------------
+    # Empty resonance_involvements
+    # ------------------------------------------------------------------
+
+    def test_empty_involvements_returns_empty_summary(self) -> None:
+        """No involvements → no accrue_corruption calls, empty per_resonance."""
+        sheet = CharacterSheetFactory()
+        technique = TechniqueFactory(level=1)
+        result_obj = _make_result(technique=technique, resonance_involvements=[])
+
+        with mock.patch("world.magic.services.corruption.accrue_corruption") as mock_accrue:
+            summary = accrue_corruption_for_cast(
+                caster_sheet=sheet,
+                technique_use_result=result_obj,
+            )
+
+        mock_accrue.assert_not_called()
+        self.assertIsInstance(summary, CorruptionAccrualSummary)
+        self.assertEqual(summary.per_resonance, ())
+        self.assertEqual(summary.technique_id, technique.pk)

--- a/src/world/magic/tests/test_technique_use_result_shape.py
+++ b/src/world/magic/tests/test_technique_use_result_shape.py
@@ -1,0 +1,265 @@
+"""Tests verifying TechniqueUseResult is populated with per-resonance involvement fields.
+
+Covers Task 1 of the corruption-per-cast-hook implementation: new fields on
+TechniqueUseResult and the two helpers (_character_is_in_audere,
+_build_resonance_involvements) wired into use_technique.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from world.conditions.factories import ConditionInstanceFactory, ConditionTemplateFactory
+from world.magic.audere import AUDERE_CONDITION_NAME
+from world.magic.factories import (
+    CharacterAnimaFactory,
+    GiftFactory,
+    ResonanceFactory,
+    TechniqueFactory,
+)
+from world.magic.services import use_technique
+from world.magic.types import ResonanceInvolvement, TechniqueUseResult
+from world.mechanics.factories import CharacterEngagementFactory
+
+
+class TechniqueUseResultFieldTests(TestCase):
+    """Verify the new fields on TechniqueUseResult are populated correctly."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.resonance = ResonanceFactory()
+        cls.gift = GiftFactory()
+        cls.gift.resonances.add(cls.resonance)
+        cls.technique = TechniqueFactory(
+            intensity=5,
+            control=10,
+            anima_cost=3,
+            gift=cls.gift,
+        )
+
+    def setUp(self) -> None:
+        self.anima = CharacterAnimaFactory(current=20, maximum=20)
+        self.character = self.anima.character
+        CharacterEngagementFactory(character=self.character)
+
+    def test_use_technique_populates_technique_field(self) -> None:
+        """result.technique is the technique passed to use_technique."""
+        result = use_technique(
+            character=self.character,
+            technique=self.technique,
+            resolve_fn=MagicMock(return_value="ok"),
+        )
+        assert isinstance(result, TechniqueUseResult)
+        assert result.technique == self.technique
+
+    def test_use_technique_populates_was_deficit_when_overburn(self) -> None:
+        """was_deficit is True when anima cost exceeds available anima."""
+        # Use a high-cost technique with very little anima
+        anima = CharacterAnimaFactory(current=1, maximum=20)
+        character = anima.character
+        CharacterEngagementFactory(character=character)
+        expensive_technique = TechniqueFactory(
+            intensity=5,
+            control=5,
+            anima_cost=10,  # will overburn with only 1 current
+            gift=self.gift,
+        )
+
+        result = use_technique(
+            character=character,
+            technique=expensive_technique,
+            resolve_fn=MagicMock(return_value="ok"),
+            confirm_soulfray_risk=True,
+        )
+
+        assert result.was_deficit is True
+        assert result.anima_cost.deficit > 0
+
+    def test_use_technique_was_deficit_false_when_no_overburn(self) -> None:
+        """was_deficit is False when the character has enough anima."""
+        result = use_technique(
+            character=self.character,
+            technique=self.technique,
+            resolve_fn=MagicMock(return_value="ok"),
+        )
+
+        assert result.was_deficit is False
+
+    @patch("world.magic.services.techniques._resolve_mishap")
+    @patch("world.magic.services.techniques.select_mishap_pool")
+    def test_use_technique_populates_was_mishap_when_mishap_resolved(
+        self,
+        mock_pool: MagicMock,
+        mock_resolve_mishap: MagicMock,
+    ) -> None:
+        """was_mishap is True when _resolve_mishap returns a non-None MishapResult."""
+        from world.magic.types import MishapResult
+
+        mishap_technique = TechniqueFactory(
+            intensity=15,
+            control=1,  # control_deficit=14 → triggers mishap path
+            anima_cost=3,
+            gift=self.gift,
+        )
+        fake_pool = MagicMock()
+        mock_pool.return_value = fake_pool
+        fake_mishap = MishapResult(consequence_label="Backlash", applied_effect_ids=[])
+        mock_resolve_mishap.return_value = fake_mishap
+
+        from world.checks.factories import CheckTypeFactory
+        from world.checks.types import CheckResult
+        from world.traits.factories import CheckOutcomeFactory
+
+        check_type = CheckTypeFactory()
+        outcome = CheckOutcomeFactory()
+        check_result = CheckResult(
+            check_type=check_type,
+            outcome=outcome,
+            chart=None,
+            roller_rank=None,
+            target_rank=None,
+            rank_difference=0,
+            trait_points=0,
+            aspect_bonus=0,
+            total_points=0,
+        )
+
+        result = use_technique(
+            character=self.character,
+            technique=mishap_technique,
+            resolve_fn=MagicMock(return_value="ok"),
+            check_result=check_result,
+        )
+
+        assert result.was_mishap is True
+        assert result.mishap is fake_mishap
+
+    def test_use_technique_was_mishap_false_when_no_mishap(self) -> None:
+        """was_mishap is False for a clean cast with no mishap."""
+        result = use_technique(
+            character=self.character,
+            technique=self.technique,  # control > intensity, no mishap
+            resolve_fn=MagicMock(return_value="ok"),
+        )
+
+        assert result.was_mishap is False
+        assert result.mishap is None
+
+    def test_use_technique_populates_was_audere_when_audere_active(self) -> None:
+        """was_audere is True when the character has an active Audere ConditionInstance."""
+        audere_template = ConditionTemplateFactory(name=AUDERE_CONDITION_NAME)
+        ConditionInstanceFactory(target=self.character, condition=audere_template)
+
+        result = use_technique(
+            character=self.character,
+            technique=self.technique,
+            resolve_fn=MagicMock(return_value="ok"),
+        )
+
+        assert result.was_audere is True
+
+    def test_use_technique_was_audere_false_when_not_in_audere(self) -> None:
+        """was_audere is False when the character has no Audere condition."""
+        result = use_technique(
+            character=self.character,
+            technique=self.technique,
+            resolve_fn=MagicMock(return_value="ok"),
+        )
+
+        assert result.was_audere is False
+
+    def test_use_technique_resonance_involvements_per_gift_resonance(self) -> None:
+        """resonance_involvements has one entry per resonance on the gift."""
+        result = use_technique(
+            character=self.character,
+            technique=self.technique,
+            resolve_fn=MagicMock(return_value="ok"),
+        )
+
+        assert len(result.resonance_involvements) == 1
+        inv = result.resonance_involvements[0]
+        assert isinstance(inv, ResonanceInvolvement)
+        assert inv.resonance == self.resonance
+
+    def test_use_technique_resonance_involvements_split_intensity_equally_for_two_resonance_gift(
+        self,
+    ) -> None:
+        """stat_bonus_contribution splits runtime intensity equally across resonances."""
+        resonance_b = ResonanceFactory()
+        two_res_gift = GiftFactory()
+        two_res_gift.resonances.add(self.resonance, resonance_b)
+        technique = TechniqueFactory(
+            intensity=6,
+            control=10,
+            anima_cost=2,
+            gift=two_res_gift,
+        )
+
+        result = use_technique(
+            character=self.character,
+            technique=technique,
+            resolve_fn=MagicMock(return_value="ok"),
+        )
+
+        assert len(result.resonance_involvements) == 2
+        for inv in result.resonance_involvements:
+            # runtime_intensity = 6 (no engagement modifiers set here, just CharacterEngagement
+            # with no modifiers); split = 6 // 2 = 3
+            assert inv.stat_bonus_contribution == 3
+
+    def test_use_technique_resonance_involvements_includes_combat_pull_spent(self) -> None:
+        """thread_pull_resonance_spent sums active CombatPull.resonance_spent per resonance."""
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.combat.factories import (
+            CombatEncounterFactory,
+            CombatParticipantFactory,
+            CombatPullFactory,
+        )
+
+        sheet = CharacterSheetFactory(character=self.character)
+        encounter = CombatEncounterFactory(round_number=1)
+        participant = CombatParticipantFactory(
+            encounter=encounter,
+            character_sheet=sheet,
+        )
+        CombatPullFactory(
+            participant=participant,
+            encounter=encounter,
+            round_number=1,
+            resonance=self.resonance,
+            resonance_spent=7,
+        )
+
+        # Invalidate cached_property so the new pull is visible
+        self.character.combat_pulls.__dict__.pop("_active", None)
+
+        result = use_technique(
+            character=self.character,
+            technique=self.technique,
+            resolve_fn=MagicMock(return_value="ok"),
+        )
+
+        assert len(result.resonance_involvements) == 1
+        assert result.resonance_involvements[0].thread_pull_resonance_spent == 7
+
+    def test_use_technique_resonance_involvements_empty_when_gift_has_no_resonances(
+        self,
+    ) -> None:
+        """resonance_involvements is empty tuple when the gift has no resonances."""
+        bare_gift = GiftFactory()  # no resonances added
+        technique = TechniqueFactory(
+            intensity=3,
+            control=5,
+            anima_cost=2,
+            gift=bare_gift,
+        )
+
+        result = use_technique(
+            character=self.character,
+            technique=technique,
+            resolve_fn=MagicMock(return_value="ok"),
+        )
+
+        assert result.resonance_involvements == ()

--- a/src/world/magic/types/__init__.py
+++ b/src/world/magic/types/__init__.py
@@ -40,6 +40,7 @@ from world.magic.types.ritual import (
 from world.magic.types.techniques import (
     AnimaCostResult,
     MishapResult,
+    ResonanceInvolvement,
     RuntimeTechniqueStats,
     SoulfrayResult,
     SoulfrayWarning,
@@ -63,6 +64,7 @@ __all__ = [
     "PullPreviewResult",
     "ResolvedPullEffect",
     "ResonanceDailyTickSummary",
+    "ResonanceInvolvement",
     "ResonancePullResult",
     "ResonanceWeeklySettlementSummary",
     "RitualOutcome",

--- a/src/world/magic/types/techniques.py
+++ b/src/world/magic/types/techniques.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from world.checks.types import CheckResult
+    from world.magic.models import Resonance, Technique
     from world.mechanics.types import AppliedEffect
 
 
@@ -67,6 +68,19 @@ class MishapResult:
     applied_effect_ids: list[int] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class ResonanceInvolvement:
+    """Per-resonance participation summary for one technique cast.
+
+    Used by the per-cast corruption hook (Task 2/3) to compute corruption
+    accrual per resonance.
+    """
+
+    resonance: Resonance
+    stat_bonus_contribution: int  # share of runtime intensity attributable to this resonance
+    thread_pull_resonance_spent: int  # sum of CombatPull.resonance_spent for active pulls
+
+
 @dataclass
 class TechniqueUseResult:
     """Complete result of using a technique."""
@@ -77,3 +91,9 @@ class TechniqueUseResult:
     mishap: MishapResult | None = None
     soulfray_result: SoulfrayResult | None = None
     soulfray_warning: SoulfrayWarning | None = None
+    technique: Technique | None = None  # The cast technique
+    was_deficit: bool = False  # True if the cast triggered anima overburn
+    was_mishap: bool = False  # True if a mishap rider was applied
+    was_audere: bool = False  # True if the character was in Audere during the cast
+    resonance_involvements: tuple[ResonanceInvolvement, ...] = ()
+    corruption_summary: object | None = None  # Placeholder for Task 3 CorruptionAccrualSummary


### PR DESCRIPTION
## Summary

  - Closes the deferred per-cast hook from Magic Scope #7 (Corruption foundation, PR #402). Non-Celestial technique use now
  accrues per-resonance corruption automatically through `use_technique`.
  - Extends `TechniqueUseResult` with per-cast context (`technique`, `was_deficit`, `was_mishap`, `was_audere`,
  `resonance_involvements`, `corruption_summary`) so the orchestrator has the inputs spec §3.1 requires.
  - Implements `accrue_corruption_for_cast` per spec §3.1 formula and wires it into `use_technique` as Step 9 (after Soulfray
  accumulation, before reactive event emission).

  ## Background

  Scope #7 shipped the corruption foundation (services, models, condition machinery, protagonism-lock plumbing, Atonement Rite)
  but deferred the cast-pipeline hook because `TechniqueUseResult` didn't expose per-resonance involvement. This PR adds that
  exposure and ships the orchestrator.

  ## Design call worth flagging

  Spec §10.1 flagged a risk: the formula assumes `get_runtime_technique_stats` returns per-resonance contributions to runtime
  intensity/control. It doesn't — the modifier system tracks distinctions and items as sources, not resonances. The agreed
  impl-phase resolution: split runtime intensity equally across the technique's gift's resonances. This matches the spec's
  example (tier-1 cantrip with stat_bonus=2 → 2 ticks) and §6.1's target curve (Prospect ≈ 1 corruption/cast, level-3 tier-3 ≈
  10–20/cast). The choice is documented inline in `_build_resonance_involvements`. If we later want true per-resonance source
  attribution, the hook is in place — extend `get_runtime_technique_stats` and the orchestrator picks it up unchanged.

  ## What's in scope

  - `TechniqueUseResult` shape extension + `ResonanceInvolvement` frozen dataclass
  - `accrue_corruption_for_cast` per-cast orchestrator (Celestial skip, zero-involvement skip, zero-tick skip, per-resonance
  dispatch to `accrue_corruption`)
  - Pipeline wiring in `use_technique` Step 9
  - NPC defensive guard (characters without a `CharacterSheet` skip silently)
  - 34 new tests (11 shape, 18 formula unit, 5 cast-pipeline integration)
  - Roadmap updated; "Excluded scenarios" docstring removed from `test_corruption_flow.py`

  ## What's still deferred (Spec B work, not this PR)

  - Soul Tether redirect mechanic, Sineater asymmetry, tether-mediated rescue rituals — all build on the foundation hooks
  (`CORRUPTION_ACCRUING` event, `CONDITION_STAGE_ADVANCE_CHECK_ABOUT_TO_FIRE` event, `reduce_corruption` primitive) which are
  already live from Scope #7.

  ## Test plan

  - [ ] `just test world.magic --keepdb` — 827 tests OK (6 skipped)
  - [ ] `just test world.conditions --keepdb` — 167 tests OK
  - [ ] No-keepdb full regression matching CI: `echo yes | uv run arx test world.magic world.conditions` — **994 tests, OK** (6
  skipped)
  - [ ] `just lint` clean
  - [ ] All pre-commit hooks pass on every commit
  - [ ] Manual verification: cast a non-Celestial technique in the dev shell, confirm `CharacterResonance.corruption_current`
  increments and `result.corruption_summary` is populated

  ## Spec / plan

  - Spec: `docs/superpowers/specs/2026-04-25-magic-scope-7-corruption-design.md` §3.1 (formula), §8.2 (integration scenarios),
  §10.1 (per-resonance attribution risk)
  - Plan: `docs/superpowers/plans/2026-04-25-magic-scope-7-corruption.md` (gitignored — local) — Tasks 6.4 + 7.1
  - Roadmap: `docs/roadmap/magic.md` "Scope #7 — Corruption" → "Per-cast hook follow-up (DONE)"