### PR TITLE
Phase 1 — magic-cluster seed mechanism + integration tests

### DIFF
--- a/docs/roadmap/seed-and-integration-tests.md
+++ b/docs/roadmap/seed-and-integration-tests.md
@@ -1,6 +1,6 @@
 # Seed Mechanism + Integration Test Coverage
 
-**Status:** in-progress (audit complete; execution starting)
+**Status:** Phase 1 complete; Phase 2 in-progress
 **Audit:** [`docs/audits/2026-04-26-seed-and-integration-coverage-audit.md`](../audits/2026-04-26-seed-and-integration-coverage-audit.md)
 
 ## Why this exists
@@ -44,15 +44,15 @@ These can overlap at the boundaries — for example, the magic-cluster seed help
 
 | Task | Unlocks |
 |------|---------|
-| **1.1** — `seed_magic_config()` orchestrator: lazy-create the 5 singletons (AnimaConfig, SoulfrayConfig, ResonanceGainConfig, CorruptionConfig, AudereThreshold) with sensible defaults. Includes IntensityTier reference rows (AudereThreshold's FK target) and MishapPoolTier rows. | `use_technique` no longer errors on cast. Anima daily regen actually fires. Soulfray accumulation works. Audere eligibility check has data to work with. |
-| **1.2** — Seed canonical Rituals: "Rite of Imbuing" and "Rite of Atonement". Factories already exist (`ImbuingRitualFactory`, `AtonementRitualFactory`); just need an idempotent seed call. | Atonement flow can fire. Imbuing ritual dispatches. Both today silently fail because the service code looks them up by hardcoded name. |
-| **1.3** — Seed `ThreadPullCost` rows for tiers 1, 2, 3. | `spend_resonance_for_pull` no longer errors. Thread pulls become a real mechanic. |
-| **1.4** — Pipeline test: `test_thread_pull_pipeline.py`. Resonance spend → CombatPull written → ThreadPullEffect resolved → effect applied (FLAT_BONUS, INTENSITY_BUMP, VITAL_BONUS, CAPABILITY_GRANT). | Proves the entire Spec A thread system works in combat context. Today this is exercised only by unit tests against individual stages. |
-| **1.5** — Pipeline test: `test_anima_regen_pipeline.py`. Full daily regen tick: AnimaConfig + character with depleted anima + Soulfray-gated property → tick fires → anima restored unless gated. | Confirms the AnimaConfig + ConditionStage `blocks_anima_regen` property + tick scheduler all integrate correctly. |
-| **1.6** — Pipeline test: `test_situation_pipeline.py`. SituationTemplate → SituationInstance → ChallengeInstance chain → resolution. | Currently zero pipeline coverage for the Situation system despite full factory coverage. |
-| **1.7** — Pipeline test: `test_corruption_per_cast_pipeline.py` (or extend `test_corruption_flow`) covering the full per-cast hook landed in PR #403 — Audere caster takes corruption from non-Celestial cast, multiple resonances accrue per their involvement. | Validates the per-cast corruption hook end-to-end. The unit tests cover the formula; this covers the pipeline. |
-| **1.8** — Cantrip starter catalog: at minimum 1 cantrip per archetype × style combination (5 styles × ~5 archetypes = ~25 entries). Allows CG magic stage to function with seed data, not just test fixtures. | CG magic stage works on a fresh dev install. New characters can pick a starter cantrip. |
-| **1.9** — `seed_magic_dev()` master function that calls 1.1, 1.2, 1.3, 1.8 plus the existing `author_reference_corruption_content()` and `MagicContent.create_all()`. Idempotent. | One call seeds the entire magic cluster. Becomes the magic-cluster contribution to Phase 3's `seed_dev_database()`. |
+| ✅ **1.1** — `seed_magic_config()` orchestrator: lazy-create the 5 singletons (AnimaConfig, SoulfrayConfig, ResonanceGainConfig, CorruptionConfig, AudereThreshold) with sensible defaults. Includes IntensityTier reference rows (AudereThreshold's FK target) and MishapPoolTier rows. | `use_technique` no longer errors on cast. Anima daily regen actually fires. Soulfray accumulation works. Audere eligibility check has data to work with. |
+| ✅ **1.2** — Seed canonical Rituals: "Rite of Imbuing" and "Rite of Atonement". Factories already exist (`ImbuingRitualFactory`, `AtonementRitualFactory`); just need an idempotent seed call. | Atonement flow can fire. Imbuing ritual dispatches. Both today silently fail because the service code looks them up by hardcoded name. |
+| ✅ **1.3** — Seed `ThreadPullCost` rows for tiers 1, 2, 3. Also seeds `ThreadPullEffect` catalog (FLAT_BONUS, INTENSITY_BUMP, VITAL_BONUS, CAPABILITY_GRANT) via `seed_thread_pull_catalog()`. | `spend_resonance_for_pull` no longer errors. Thread pulls become a real mechanic. |
+| ✅ **1.4** — Pipeline test: `test_thread_pull_pipeline.py`. Resonance spend → CombatPull written → ThreadPullEffect resolved → effect applied (FLAT_BONUS, INTENSITY_BUMP, VITAL_BONUS, CAPABILITY_GRANT). | Proves the entire Spec A thread system works in combat context. |
+| ✅ **1.5** — Pipeline test: `test_anima_regen_pipeline.py`. Full daily regen tick: AnimaConfig + character with depleted anima + Soulfray-gated property → tick fires → anima restored unless gated. | Confirms the AnimaConfig + ConditionStage `blocks_anima_regen` property + tick scheduler all integrate correctly. |
+| ✅ **1.6** — Pipeline test: `test_situation_pipeline.py`. SituationTemplate → SituationInstance → ChallengeInstance chain → resolution. | Situation system covered end-to-end. |
+| ✅ **1.7** — Pipeline test: `test_corruption_per_cast_pipeline.py` covering the full per-cast hook landed in PR #403 — Audere caster takes corruption from non-Celestial cast, multiple resonances accrue per their involvement. | Per-cast corruption hook validated end-to-end. |
+| ✅ **1.8** — Cantrip starter catalog via `seed_cantrip_starter_catalog()`: 5 TechniqueStyle rows, 6 EffectType rows, 25 Cantrip rows (5 styles × 5 archetypes), 5 PROSPECT Path rows. | CG magic stage works on a fresh dev install. New characters can pick a starter cantrip. |
+| ✅ **1.9** — `seed_magic_dev()` master function in `integration_tests/game_content/magic.py` that calls 1.1, 1.2, 1.3, 1.8 plus `author_reference_corruption_content()` and `MagicContent.create_all()`. Two idempotency fixes: `_make_magical_endurance_check_type()` switched from factory to direct ORM (converges with seed_magic_config's row); `MagicContent.create_all()` switched to get_or_create (no duplicate Technique/ActionEnhancement rows on re-run). 7 new tests covering idempotency and convergence. | One call seeds the entire magic cluster. Ready to become the magic-cluster contribution to Phase 3's `seed_dev_database()`. |
 
 ### Phase 1 not in scope
 

--- a/src/integration_tests/game_content/magic.py
+++ b/src/integration_tests/game_content/magic.py
@@ -1,4 +1,4 @@
-"""MagicContent — technique and ActionEnhancement records for social action tests."""
+"""Magic test-infrastructure: MagicContent (technique content) and seed_magic_config()."""
 
 from __future__ import annotations
 
@@ -516,8 +516,7 @@ def seed_magic_config() -> MagicConfigResult:
     # --- Soulfray condition + stages (needed for AudereThreshold.minimum_warp_stage) ---
     # SoulfrayContentFactory() is idempotent — uses get_or_create internally.
     soulfray_content = SoulfrayContentFactory()
-    # "Ripping" is stage index 2 (0-based) = stage_order 3
-    ripping_stage = soulfray_content.stages[2]
+    ripping_stage = next(s for s in soulfray_content.stages if s.name == "Ripping")
 
     # --- AudereThreshold (singleton, no get_or_create on factory) ---
     audere_threshold, _ = AudereThreshold.objects.get_or_create(

--- a/src/integration_tests/game_content/magic.py
+++ b/src/integration_tests/game_content/magic.py
@@ -1,4 +1,15 @@
-"""Magic test-infrastructure: MagicContent (technique content) and seed_magic_config()."""
+"""Magic test-infrastructure: seed helpers and MagicContent.
+
+Exports:
+- ``seed_magic_dev()`` — master orchestrator for the entire magic cluster.
+  Composes all Phase 1 seed helpers into a single idempotent call. This is
+  the magic-cluster contribution to Phase 3's ``seed_dev_database()``.
+- ``seed_magic_config()`` — Task 1.1 — singletons + IntensityTier + MishapPoolTier
+- ``seed_canonical_rituals()`` — Task 1.2 — Rite of Imbuing + Rite of Atonement
+- ``seed_thread_pull_catalog()`` — Task 1.3 — ThreadPullCost + ThreadPullEffect catalog
+- ``seed_cantrip_starter_catalog()`` — Task 1.8 — 5 styles × 5 archetypes = 25 cantrips
+- ``MagicContent`` — static factory helpers for integration-test technique wiring
+"""
 
 from __future__ import annotations
 
@@ -102,34 +113,67 @@ class MagicContent:
         The social safety bonus adds +10 control for unengaged characters, giving
         control_delta=10 and effective_cost = max(12 - 10, 0) = 2 per use.
 
+        Idempotent: uses get_or_create on technique name and on
+        (base_action_key, technique) for enhancements, so calling this method
+        twice produces exactly 6 techniques and 6 enhancements.
+
         Safe to call from setUpTestData across multiple test classes.
 
         Returns:
             MagicContentResult with techniques and enhancements dicts.
         """
         from actions.constants import EnhancementSourceType  # noqa: PLC0415
-        from actions.factories import ActionEnhancementFactory  # noqa: PLC0415
-        from world.magic.factories import GiftFactory, TechniqueFactory  # noqa: PLC0415
+        from actions.models import ActionEnhancement  # noqa: PLC0415
+        from world.magic.factories import GiftFactory  # noqa: PLC0415
+        from world.magic.models import EffectType, Technique, TechniqueStyle  # noqa: PLC0415
 
         gift = GiftFactory(name="Social Arts")
+
+        # Ensure a minimal style and effect_type exist for social techniques.
+        # get_or_create so re-runs don't create duplicates.
+        style, _ = TechniqueStyle.objects.get_or_create(
+            name="Social",
+            defaults={"description": "Magic expressed through social interaction."},
+        )
+        effect_type, _ = EffectType.objects.get_or_create(
+            name="Social Influence",
+            defaults={
+                "description": "Magical enhancement of social action.",
+                "base_power": None,
+                "base_anima_cost": 2,
+                "has_power_scaling": False,
+            },
+        )
+
         techniques: dict[str, Technique] = {}
         enhancements: dict[str, ActionEnhancement] = {}
 
         for action_key, technique_name in ACTION_TECHNIQUE_MAP.items():
-            technique = TechniqueFactory(
+            technique, _ = Technique.objects.get_or_create(
                 name=technique_name,
-                gift=gift,
-                intensity=2,
-                control=2,
-                anima_cost=12,
+                defaults={
+                    "gift": gift,
+                    "style": style,
+                    "effect_type": effect_type,
+                    "intensity": 2,
+                    "control": 2,
+                    "anima_cost": 12,
+                    "description": f"Social magic technique: {technique_name}.",
+                },
             )
             techniques[action_key] = technique
 
-            enhancement = ActionEnhancementFactory(
+            variant_name = f"Magical {action_key.title()}"
+            enhancement, _ = ActionEnhancement.objects.get_or_create(
                 base_action_key=action_key,
-                variant_name=f"Magical {action_key.title()}",
-                source_type=EnhancementSourceType.TECHNIQUE,
                 technique=technique,
+                defaults={
+                    "variant_name": variant_name,
+                    "is_involuntary": False,
+                    "source_type": EnhancementSourceType.TECHNIQUE,
+                    "distinction": None,
+                    "condition": None,
+                },
             )
             enhancements[action_key] = enhancement
 
@@ -1123,4 +1167,66 @@ def seed_cantrip_starter_catalog() -> CantripStarterCatalogResult:
         effect_types=effect_types,
         cantrips=cantrips,
         paths=paths,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 1.9 — seed_magic_dev()
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MagicDevSeedResult:
+    """Returned by seed_magic_dev().
+
+    Composes all Phase 1 seed results into one dataclass.
+    ``author_reference_corruption_content()`` returns None so it is not
+    represented here; callers can query Wild Hunt / Web of Spiders rows directly.
+    """
+
+    config: MagicConfigResult
+    rituals: RitualSeedResult
+    thread_pull_catalog: ThreadPullCatalogResult
+    cantrip_catalog: CantripStarterCatalogResult
+    magic_content: MagicContentResult
+
+
+def seed_magic_dev() -> MagicDevSeedResult:
+    """Seed the entire magic cluster in one idempotent call.
+
+    Composes all Phase 1 seed helpers:
+
+    1. ``seed_magic_config()`` — AnimaConfig, SoulfrayConfig, ResonanceGainConfig,
+       CorruptionConfig, AudereThreshold, IntensityTier × 3, MishapPoolTier
+    2. ``seed_canonical_rituals()`` — Rite of Imbuing, Rite of Atonement
+    3. ``seed_thread_pull_catalog()`` — ThreadPullCost × 3, ThreadPullEffect × 4,
+       canonical Tideborne resonance
+    4. ``seed_cantrip_starter_catalog()`` — 5 TechniqueStyle, 6 EffectType,
+       25 Cantrip, 5 PROSPECT Path rows
+    5. ``author_reference_corruption_content()`` — Wild Hunt (Primal) + Web of
+       Spiders (Abyssal) Corruption ConditionTemplates + CORRUPTION_TWIST entries
+    6. ``MagicContent.create_all()`` — 6 social action Techniques + 6
+       ActionEnhancements
+
+    All writes are idempotent (get_or_create throughout). Re-running on a
+    populated database is a no-op; staff edits to existing rows are preserved.
+
+    Returns:
+        MagicDevSeedResult composing all sub-results.
+    """
+    from world.magic.factories import author_reference_corruption_content  # noqa: PLC0415
+
+    config = seed_magic_config()
+    rituals = seed_canonical_rituals()
+    thread_pull_catalog = seed_thread_pull_catalog()
+    cantrip_catalog = seed_cantrip_starter_catalog()
+    author_reference_corruption_content()
+    magic_content = MagicContent.create_all()
+
+    return MagicDevSeedResult(
+        config=config,
+        rituals=rituals,
+        thread_pull_catalog=thread_pull_catalog,
+        cantrip_catalog=cantrip_catalog,
+        magic_content=magic_content,
     )

--- a/src/integration_tests/game_content/magic.py
+++ b/src/integration_tests/game_content/magic.py
@@ -11,11 +11,13 @@ if TYPE_CHECKING:
 
     from actions.models import ActionEnhancement
     from actions.models.consequence_pools import ConsequencePool
+    from world.classes.models import Path
     from world.conditions.models import CapabilityType, ConditionStage
     from world.magic.audere import AudereThreshold
     from world.magic.models import (
         Affinity,
         AnimaConfig,
+        EffectType,
         IntensityTier,
         MagicalAlterationTemplate,
         MishapPoolTier,
@@ -24,7 +26,9 @@ if TYPE_CHECKING:
         SoulfrayConfig,
         Technique,
         TechniqueCapabilityGrant,
+        TechniqueStyle,
     )
+    from world.magic.models.cantrips import Cantrip
     from world.magic.models.corruption_config import CorruptionConfig
     from world.magic.models.gain_config import ResonanceGainConfig
     from world.magic.models.threads import ThreadPullCost, ThreadPullEffect
@@ -737,4 +741,386 @@ def seed_thread_pull_catalog() -> ThreadPullCatalogResult:
         pull_costs=pull_costs,
         canonical_resonance=resonance,
         pull_effects=pull_effects,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 1.8 — seed_cantrip_starter_catalog()
+# ---------------------------------------------------------------------------
+#
+# 5×5 grid: 5 CantripArchetype values × 5 TechniqueStyle names = 25 cantrips.
+#
+# Style → PROSPECT Path mapping (per CLAUDE.md / magic CLAUDE.md):
+#   Manifestation → Path of Steel
+#   Subtle        → Path of Whispers
+#   Performance   → Path of Voice
+#   Prayer        → Path of the Chosen
+#   Incantation   → Path of Tomes
+#
+# Archetype → EffectType mapping:
+#   ATTACK  → Ranged Attack  (for Manifestation/Performance/Incantation)
+#             Weapon Enhancement (for Subtle/Prayer)
+#   DEFENSE → Defense
+#   BUFF    → Buff
+#   DEBUFF  → Debuff
+#   UTILITY → Utility
+#
+# Each (archetype, style) pair maps to exactly one cantrip with an evocative name.
+#
+
+#: 5 canonical PROSPECT paths, each with minimal required fields.
+#: (name, description)
+_PROSPECT_PATHS: list[tuple[str, str]] = [
+    ("Path of Steel", "Warriors who temper themselves through hardship and direct action."),
+    ("Path of Whispers", "Those who move unseen, trading in secrets and subtle influence."),
+    ("Path of Voice", "Performers whose magic resonates through song, story, and presence."),
+    ("Path of the Chosen", "Devotees bound to a higher power whose prayers shape reality."),
+    ("Path of Tomes", "Scholars who unlock magic through careful study and written lore."),
+]
+
+#: 5 canonical TechniqueStyle definitions (name, description) and their linked path name.
+_TECHNIQUE_STYLES: list[tuple[str, str, str]] = [
+    (
+        "Manifestation",
+        "Magic made tangible — raw elemental force given shape and weight.",
+        "Path of Steel",
+    ),
+    (
+        "Subtle",
+        "Magic woven into the fabric of things — invisible until it strikes.",
+        "Path of Whispers",
+    ),
+    (
+        "Performance",
+        "Magic amplified through art — voice, gesture, and presence as conduit.",
+        "Path of Voice",
+    ),
+    (
+        "Prayer",
+        "Magic granted by devotion — the higher power answers through the faithful.",
+        "Path of the Chosen",
+    ),
+    (
+        "Incantation",
+        "Magic encoded in language — formulae, glyphs, and spoken true names.",
+        "Path of Tomes",
+    ),
+]
+
+#: 6 canonical EffectType definitions (name, description, base_power, base_anima_cost).
+_EFFECT_TYPES: list[tuple[str, str, int | None, int]] = [
+    ("Weapon Enhancement", "Imbues a held weapon with magical force.", 10, 3),
+    ("Ranged Attack", "Projects destructive energy at a distant target.", 10, 3),
+    ("Buff", "Enhances the caster or an ally with a temporary magical boon.", None, 2),
+    ("Debuff", "Weakens or hampers a target with a magical affliction.", None, 2),
+    ("Defense", "Interposes magical protection between the caster and harm.", 8, 3),
+    ("Utility", "Produces a practical magical effect with no direct combat role.", None, 2),
+]
+
+# Mapping: (archetype_value, style_name) → (cantrip_name, description, effect_type_name)
+# 25 entries covering all 5×5 combinations.
+_CANTRIP_GRID: list[tuple[str, str, str, str, str]] = [
+    # (archetype, style, cantrip_name, description, effect_type)
+    # --- ATTACK ---
+    (
+        "attack",
+        "Manifestation",
+        "Burning Strike",
+        "A lance of raw fire conjured from personal will and hurled at the enemy.",
+        "Ranged Attack",
+    ),
+    (
+        "attack",
+        "Subtle",
+        "Shadow Blade",
+        "A blade wreathed in shadow strikes from an unexpected angle.",
+        "Weapon Enhancement",
+    ),
+    (
+        "attack",
+        "Performance",
+        "Shattering Chorus",
+        "A keening note tears through armor and resolve alike.",
+        "Ranged Attack",
+    ),
+    (
+        "attack",
+        "Prayer",
+        "Smiting Light",
+        "Holy radiance descends on the unworthy, burning like judgment.",
+        "Weapon Enhancement",
+    ),
+    (
+        "attack",
+        "Incantation",
+        "Force Sigil",
+        "A rune of impact is inscribed mid-air, detonating on contact.",
+        "Ranged Attack",
+    ),
+    # --- DEFENSE ---
+    (
+        "defense",
+        "Manifestation",
+        "Iron Skin",
+        "The caster's flesh hardens momentarily into something like cooled metal.",
+        "Defense",
+    ),
+    (
+        "defense",
+        "Subtle",
+        "Blur Step",
+        "Subtle distortions make the caster hard to track — blows glance aside.",
+        "Defense",
+    ),
+    (
+        "defense",
+        "Performance",
+        "Resonant Ward",
+        "A harmonious tone creates a shimmering barrier that absorbs incoming force.",
+        "Defense",
+    ),
+    (
+        "defense",
+        "Prayer",
+        "Sacred Ward",
+        "The devout invoke their patron's shelter; harm slides off like rain.",
+        "Defense",
+    ),
+    (
+        "defense",
+        "Incantation",
+        "Arcane Barrier",
+        "An inscribed ward springs up and deflects the next magical blow.",
+        "Defense",
+    ),
+    # --- BUFF ---
+    (
+        "buff",
+        "Manifestation",
+        "Surge",
+        "Raw vitality floods the target's limbs, sharpening reflexes for a moment.",
+        "Buff",
+    ),
+    (
+        "buff",
+        "Subtle",
+        "Unseen Edge",
+        "Whispered magic gifts the target preternatural awareness of threats.",
+        "Buff",
+    ),
+    (
+        "buff",
+        "Performance",
+        "Inspiring Refrain",
+        "A rousing melody lifts allies' spirits and sharpens their focus.",
+        "Buff",
+    ),
+    (
+        "buff",
+        "Prayer",
+        "Blessing of Strength",
+        "A murmured prayer calls down divine favor onto a willing recipient.",
+        "Buff",
+    ),
+    (
+        "buff",
+        "Incantation",
+        "Empowering Glyph",
+        "A brief formula inscribed on the target's skin grants temporary potency.",
+        "Buff",
+    ),
+    # --- DEBUFF ---
+    (
+        "debuff",
+        "Manifestation",
+        "Leaden Aura",
+        "Palpable magical weight presses down on the target, slowing movement.",
+        "Debuff",
+    ),
+    (
+        "debuff",
+        "Subtle",
+        "Doubt's Touch",
+        "A whisper in the mind erodes the target's certainty at a critical moment.",
+        "Debuff",
+    ),
+    (
+        "debuff",
+        "Performance",
+        "Discordant Note",
+        "A jarring sound disrupts the target's concentration and coordination.",
+        "Debuff",
+    ),
+    (
+        "debuff",
+        "Prayer",
+        "Mark of Penitence",
+        "The caster's deity marks the target, making all blows against them more telling.",
+        "Debuff",
+    ),
+    (
+        "debuff",
+        "Incantation",
+        "Unraveling Hex",
+        "A compact curse formula frays the target's magical and physical defenses.",
+        "Debuff",
+    ),
+    # --- UTILITY ---
+    (
+        "utility",
+        "Manifestation",
+        "Mending Touch",
+        "Elemental force knits broken objects or calms a raging fire with a touch.",
+        "Utility",
+    ),
+    (
+        "utility",
+        "Subtle",
+        "Silent Passage",
+        "The caster's presence dampens sound and scent — ideal for moving unseen.",
+        "Utility",
+    ),
+    (
+        "utility",
+        "Performance",
+        "Lullaby",
+        "A soft melody coaxes fatigue into the listener, easing them toward sleep.",
+        "Utility",
+    ),
+    (
+        "utility",
+        "Prayer",
+        "Gentle Mending",
+        "A prayer of restoration closes minor wounds and soothes pain.",
+        "Utility",
+    ),
+    (
+        "utility",
+        "Incantation",
+        "Light Script",
+        "A luminous glyph provides clean magical light until dismissed.",
+        "Utility",
+    ),
+]
+
+
+@dataclass
+class CantripStarterCatalogResult:
+    """Returned by seed_cantrip_starter_catalog().
+
+    Covers the 5×5 grid of archetypes × styles.  All rows are lazy-created via
+    get_or_create so re-running on a populated DB is a no-op; staff edits survive.
+    """
+
+    styles: dict[str, TechniqueStyle]  # style_name → TechniqueStyle
+    effect_types: dict[str, EffectType]  # effect_type_name → EffectType
+    cantrips: dict[str, Cantrip]  # cantrip_name → Cantrip
+    paths: dict[str, Path]  # path_name → Path (the 5 PROSPECT paths)
+
+
+def seed_cantrip_starter_catalog() -> CantripStarterCatalogResult:
+    """Lazy-create the cantrip starter catalog: 5 styles × 5 archetypes = 25 cantrips.
+
+    All writes use get_or_create so re-running on a populated DB is a no-op.
+    Existing rows are never modified; staff edits survive repeated calls.
+
+    5×5 archetype × style grid
+    ─────────────────────────────────────────────────────────────────────────
+    Style         Path              Archetype coverage
+    ─────────────────────────────────────────────────────────────────────────
+    Manifestation Path of Steel     attack, defense, buff, debuff, utility
+    Subtle        Path of Whispers  attack, defense, buff, debuff, utility
+    Performance   Path of Voice     attack, defense, buff, debuff, utility
+    Prayer        Path of Chosen    attack, defense, buff, debuff, utility
+    Incantation   Path of Tomes     attack, defense, buff, debuff, utility
+    ─────────────────────────────────────────────────────────────────────────
+
+    Creates:
+    - 5 Path rows (PROSPECT stage) — one per style, idempotent on name
+    - 5 TechniqueStyle rows — wired to their corresponding Path via allowed_paths M2M
+    - 6 EffectType rows — Weapon Enhancement, Ranged Attack, Buff, Debuff, Defense, Utility
+    - 25 Cantrip rows — one per (archetype, style) pair, idempotent on name
+
+    Returns:
+        CantripStarterCatalogResult with all created/fetched instances.
+    """
+    from world.classes.models import Path, PathStage  # noqa: PLC0415
+    from world.magic.constants import CantripArchetype  # noqa: PLC0415
+    from world.magic.models import EffectType, TechniqueStyle  # noqa: PLC0415
+    from world.magic.models.cantrips import Cantrip  # noqa: PLC0415
+
+    # --- PROSPECT Paths (idempotent on name) ---
+    paths: dict[str, Path] = {}
+    for path_name, path_description in _PROSPECT_PATHS:
+        path, _ = Path.objects.get_or_create(
+            name=path_name,
+            defaults={
+                "description": path_description,
+                "stage": PathStage.PROSPECT,
+                "minimum_level": 1,
+                "is_active": True,
+                "sort_order": 0,
+            },
+        )
+        paths[path_name] = path
+
+    # --- TechniqueStyle rows + M2M wiring (idempotent on name) ---
+    styles: dict[str, TechniqueStyle] = {}
+    for style_name, style_description, linked_path_name in _TECHNIQUE_STYLES:
+        style, _ = TechniqueStyle.objects.get_or_create(
+            name=style_name,
+            defaults={"description": style_description},
+        )
+        # Wire the path into allowed_paths if not already linked (M2M add is idempotent)
+        linked_path = paths[linked_path_name]
+        style.allowed_paths.add(linked_path)
+        styles[style_name] = style
+
+    # --- EffectType rows (idempotent on name) ---
+    effect_types: dict[str, EffectType] = {}
+    for et_name, et_description, base_power, base_anima_cost in _EFFECT_TYPES:
+        has_scaling = base_power is not None
+        et, _ = EffectType.objects.get_or_create(
+            name=et_name,
+            defaults={
+                "description": et_description,
+                "base_power": base_power,
+                "base_anima_cost": base_anima_cost,
+                "has_power_scaling": has_scaling,
+            },
+        )
+        effect_types[et_name] = et
+
+    # --- Cantrip rows (idempotent on name) ---
+    # Validate all archetype values exist in CantripArchetype
+    valid_archetypes = {choice.value for choice in CantripArchetype}
+    cantrips: dict[str, Cantrip] = {}
+    for sort_idx, (archetype_value, style_name, cantrip_name, description, et_name) in enumerate(
+        _CANTRIP_GRID
+    ):
+        if archetype_value not in valid_archetypes:
+            msg = f"Invalid archetype '{archetype_value}' in _CANTRIP_GRID"
+            raise ValueError(msg)
+        cantrip, _ = Cantrip.objects.get_or_create(
+            name=cantrip_name,
+            defaults={
+                "description": description,
+                "archetype": archetype_value,
+                "effect_type": effect_types[et_name],
+                "style": styles[style_name],
+                "base_intensity": 1,
+                "base_control": 1,
+                "base_anima_cost": 5,
+                "requires_facet": False,
+                "is_active": True,
+                "sort_order": sort_idx,
+            },
+        )
+        cantrips[cantrip_name] = cantrip
+
+    return CantripStarterCatalogResult(
+        styles=styles,
+        effect_types=effect_types,
+        cantrips=cantrips,
+        paths=paths,
     )

--- a/src/integration_tests/game_content/magic.py
+++ b/src/integration_tests/game_content/magic.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     )
     from world.magic.models.corruption_config import CorruptionConfig
     from world.magic.models.gain_config import ResonanceGainConfig
+    from world.magic.models.threads import ThreadPullCost, ThreadPullEffect
     from world.mechanics.models import Property
 
 # Maps action_key → technique name (narrative, not mechanical)
@@ -593,3 +594,147 @@ def seed_canonical_rituals() -> RitualSeedResult:
     imbuing = ImbuingRitualFactory()
     atonement = AtonementRitualFactory()
     return RitualSeedResult(rite_of_imbuing=imbuing, rite_of_atonement=atonement)
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3 — seed_thread_pull_catalog()
+# ---------------------------------------------------------------------------
+
+#: Canonical resonance name for the thread pull catalog.
+#: Must not collide with names used by other seed helpers
+#: ("Wild Hunt", "Web of Spiders" are claimed by corruption content).
+_CATALOG_RESONANCE_NAME: str = "Tideborne"
+_CATALOG_AFFINITY_NAME: str = "Primal (Tideborne)"
+
+#: Per-tier pull cost definitions: (tier, resonance_cost, anima_per_thread, label)
+_PULL_COST_TIERS: list[tuple[int, int, int, str]] = [
+    (1, 1, 1, "soft"),
+    (2, 3, 2, "medium"),
+    (3, 6, 3, "hard"),
+]
+
+#: Canonical capability name for CAPABILITY_GRANT effect.
+_CATALOG_CAPABILITY_NAME: str = "endurance"
+
+
+@dataclass
+class ThreadPullCatalogResult:
+    """Returned by seed_thread_pull_catalog().
+
+    All rows are lazy-created via get_or_create. Re-running preserves any edits
+    to existing rows (idempotent).
+    """
+
+    pull_costs: dict[int, ThreadPullCost]  # tier → cost row
+    canonical_resonance: Resonance
+    pull_effects: dict[str, ThreadPullEffect]  # EffectKind value → effect row
+
+
+def seed_thread_pull_catalog() -> ThreadPullCatalogResult:
+    """Lazy-create ThreadPullCost rows (tiers 1/2/3) and a 4-row ThreadPullEffect catalog.
+
+    All writes use get_or_create so re-running on a populated DB is a no-op.
+    Existing rows are never modified; staff edits survive repeated calls.
+
+    Creates:
+    - ThreadPullCost rows: tier 1 (soft), tier 2 (medium), tier 3 (hard)
+    - Affinity "Primal (Tideborne)" — shared affinity for the catalog resonance
+    - Resonance "Tideborne" — canonical reference resonance for the catalog
+    - CapabilityType "endurance" — used by the CAPABILITY_GRANT effect
+    - ThreadPullEffect rows:
+        - FLAT_BONUS (tier=1, min_thread_level=0, flat_bonus_amount=2)
+        - INTENSITY_BUMP (tier=2, min_thread_level=0, intensity_bump_amount=1)
+        - VITAL_BONUS (tier=0, min_thread_level=0, vital_bonus_amount=5, MAX_HEALTH)
+        - CAPABILITY_GRANT (tier=3, min_thread_level=5, capability=endurance)
+
+    Returns:
+        ThreadPullCatalogResult dataclass with all created/fetched instances.
+    """
+    from world.conditions.models import CapabilityType  # noqa: PLC0415
+    from world.magic.constants import EffectKind, TargetKind, VitalBonusTarget  # noqa: PLC0415
+    from world.magic.factories import (  # noqa: PLC0415
+        AffinityFactory,
+        ResonanceFactory,
+        ThreadPullCostFactory,
+    )
+    from world.magic.models.threads import ThreadPullEffect  # noqa: PLC0415
+
+    # --- ThreadPullCost rows (tier is the natural key via django_get_or_create) ---
+    pull_costs: dict[int, ThreadPullCost] = {}
+    for tier, resonance_cost, anima_per_thread, label in _PULL_COST_TIERS:
+        cost = ThreadPullCostFactory(
+            tier=tier,
+            resonance_cost=resonance_cost,
+            anima_per_thread=anima_per_thread,
+            label=label,
+        )
+        pull_costs[tier] = cost
+
+    # --- Canonical resonance (both factory calls use django_get_or_create on name) ---
+    affinity = AffinityFactory(name=_CATALOG_AFFINITY_NAME)
+    resonance = ResonanceFactory(name=_CATALOG_RESONANCE_NAME, affinity=affinity)
+
+    # --- CapabilityType for CAPABILITY_GRANT (get_or_create on name) ---
+    capability, _ = CapabilityType.objects.get_or_create(
+        name=_CATALOG_CAPABILITY_NAME,
+        defaults={"description": "Endurance capability — used by thread pull catalog."},
+    )
+
+    # --- ThreadPullEffect rows (natural key: target_kind, resonance, tier, min_thread_level) ---
+    # Using direct ORM get_or_create per task spec to avoid non-idempotent factory calls.
+    pull_effects: dict[str, ThreadPullEffect] = {}
+
+    flat_bonus_effect, _ = ThreadPullEffect.objects.get_or_create(
+        target_kind=TargetKind.TRAIT,
+        resonance=resonance,
+        tier=1,
+        min_thread_level=0,
+        defaults={
+            "effect_kind": EffectKind.FLAT_BONUS,
+            "flat_bonus_amount": 2,
+        },
+    )
+    pull_effects[EffectKind.FLAT_BONUS] = flat_bonus_effect
+
+    intensity_bump_effect, _ = ThreadPullEffect.objects.get_or_create(
+        target_kind=TargetKind.TRAIT,
+        resonance=resonance,
+        tier=2,
+        min_thread_level=0,
+        defaults={
+            "effect_kind": EffectKind.INTENSITY_BUMP,
+            "intensity_bump_amount": 1,
+        },
+    )
+    pull_effects[EffectKind.INTENSITY_BUMP] = intensity_bump_effect
+
+    vital_bonus_effect, _ = ThreadPullEffect.objects.get_or_create(
+        target_kind=TargetKind.TRAIT,
+        resonance=resonance,
+        tier=0,
+        min_thread_level=0,
+        defaults={
+            "effect_kind": EffectKind.VITAL_BONUS,
+            "vital_bonus_amount": 5,
+            "vital_target": VitalBonusTarget.MAX_HEALTH,
+        },
+    )
+    pull_effects[EffectKind.VITAL_BONUS] = vital_bonus_effect
+
+    capability_grant_effect, _ = ThreadPullEffect.objects.get_or_create(
+        target_kind=TargetKind.TRAIT,
+        resonance=resonance,
+        tier=3,
+        min_thread_level=5,
+        defaults={
+            "effect_kind": EffectKind.CAPABILITY_GRANT,
+            "capability_grant": capability,
+        },
+    )
+    pull_effects[EffectKind.CAPABILITY_GRANT] = capability_grant_effect
+
+    return ThreadPullCatalogResult(
+        pull_costs=pull_costs,
+        canonical_resonance=resonance,
+        pull_effects=pull_effects,
+    )

--- a/src/integration_tests/game_content/magic.py
+++ b/src/integration_tests/game_content/magic.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         MagicalAlterationTemplate,
         MishapPoolTier,
         Resonance,
+        Ritual,
         SoulfrayConfig,
         Technique,
         TechniqueCapabilityGrant,
@@ -550,3 +551,45 @@ def seed_magic_config() -> MagicConfigResult:
         intensity_tiers=intensity_tiers,
         mishap_pool_tier=mishap_pool_tier,
     )
+
+
+# ---------------------------------------------------------------------------
+# Task 1.2 — seed_canonical_rituals()
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RitualSeedResult:
+    """Returned by seed_canonical_rituals().
+
+    Wraps the canonical Rite of Imbuing and Rite of Atonement rituals.
+    Both are lazy-created via factory django_get_or_create on name,
+    so re-running preserves any edits to existing rows (idempotent).
+    """
+
+    rite_of_imbuing: Ritual
+    rite_of_atonement: Ritual
+
+
+def seed_canonical_rituals() -> RitualSeedResult:
+    """Lazy-create the two canonical rituals: Imbuing and Atonement.
+
+    Both factories use django_get_or_create(name=...) so re-running on a
+    populated DB is a no-op. Existing rows are never modified; staff edits
+    survive repeated calls.
+
+    Creates:
+    - Ritual: "Rite of Imbuing" (SERVICE dispatch to spend_resonance_for_imbuing)
+    - Ritual: "Rite of Atonement" (SERVICE dispatch to atonement service)
+
+    Returns:
+        RitualSeedResult dataclass with both ritual instances.
+    """
+    from world.magic.factories import (  # noqa: PLC0415
+        AtonementRitualFactory,
+        ImbuingRitualFactory,
+    )
+
+    imbuing = ImbuingRitualFactory()
+    atonement = AtonementRitualFactory()
+    return RitualSeedResult(rite_of_imbuing=imbuing, rite_of_atonement=atonement)

--- a/src/integration_tests/game_content/magic.py
+++ b/src/integration_tests/game_content/magic.py
@@ -452,7 +452,7 @@ def seed_magic_config() -> MagicConfigResult:
         MagicConfigResult dataclass with all created/fetched instances.
     """
     from actions.models.consequence_pools import ConsequencePool  # noqa: PLC0415
-    from world.checks.factories import CheckTypeFactory  # noqa: PLC0415
+    from world.checks.models import CheckCategory, CheckType  # noqa: PLC0415
     from world.magic.audere import AudereThreshold  # noqa: PLC0415
     from world.magic.factories import SoulfrayContentFactory  # noqa: PLC0415
     from world.magic.models import (  # noqa: PLC0415
@@ -468,7 +468,14 @@ def seed_magic_config() -> MagicConfigResult:
     anima_config = AnimaConfig.get_singleton()
 
     # --- SoulfrayConfig (singleton, no get_or_create on factory) ---
-    resilience_check_type = CheckTypeFactory(name="Magical Endurance")
+    # Use direct ORM rather than CheckTypeFactory: the factory's SubFactory
+    # generates a fresh CheckCategory on every call, making (name, category)
+    # novel and leaking an orphan CheckType row on each re-run.
+    magic_check_category, _ = CheckCategory.objects.get_or_create(name="Magic")
+    resilience_check_type, _ = CheckType.objects.get_or_create(
+        name="Magical Endurance",
+        defaults={"category": magic_check_category},
+    )
     soulfray_config, _ = SoulfrayConfig.objects.get_or_create(
         pk=1,
         defaults={

--- a/src/integration_tests/game_content/magic.py
+++ b/src/integration_tests/game_content/magic.py
@@ -12,13 +12,20 @@ if TYPE_CHECKING:
     from actions.models import ActionEnhancement
     from actions.models.consequence_pools import ConsequencePool
     from world.conditions.models import CapabilityType, ConditionStage
+    from world.magic.audere import AudereThreshold
     from world.magic.models import (
         Affinity,
+        AnimaConfig,
+        IntensityTier,
         MagicalAlterationTemplate,
+        MishapPoolTier,
         Resonance,
+        SoulfrayConfig,
         Technique,
         TechniqueCapabilityGrant,
     )
+    from world.magic.models.corruption_config import CorruptionConfig
+    from world.magic.models.gain_config import ResonanceGainConfig
     from world.mechanics.models import Property
 
 # Maps action_key → technique name (narrative, not mechanical)
@@ -392,3 +399,148 @@ class MagicContent:
             soulfray_consequence_pool=pool,
             soulfray_stage=soulfray_stage,
         )
+
+
+# ---------------------------------------------------------------------------
+# Task 1.1 — seed_magic_config()
+# ---------------------------------------------------------------------------
+
+#: Canonical IntensityTier definitions: (name, threshold, control_modifier)
+_INTENSITY_TIERS: list[tuple[str, int, int]] = [
+    ("Minor", 5, 0),
+    ("Moderate", 10, -2),
+    ("Major", 15, -5),
+]
+
+#: Name for the default mishap consequence pool
+_MISHAP_POOL_NAME: str = "Magic Mishap Pool (default)"
+
+
+@dataclass
+class MagicConfigResult:
+    """Returned by seed_magic_config().
+
+    All singletons are lazy-created via get_or_create.  Re-running preserves
+    any edits to existing rows (idempotent).
+    """
+
+    anima_config: AnimaConfig
+    soulfray_config: SoulfrayConfig
+    resonance_gain_config: ResonanceGainConfig
+    corruption_config: CorruptionConfig
+    audere_threshold: AudereThreshold
+    intensity_tiers: dict[str, IntensityTier]  # name → tier
+    mishap_pool_tier: MishapPoolTier
+
+
+def seed_magic_config() -> MagicConfigResult:
+    """Lazy-create the 5 magic config singletons plus IntensityTier and MishapPoolTier rows.
+
+    All writes use get_or_create so re-running on a populated DB is a no-op.
+    Existing rows are never modified; staff edits survive repeated calls.
+
+    Creates:
+    - AnimaConfig (pk=1)
+    - SoulfrayConfig (pk=1, resilience_check_type="Magical Endurance")
+    - ResonanceGainConfig (pk=1)
+    - CorruptionConfig (pk=1)
+    - IntensityTier rows: Minor (threshold=5), Moderate (threshold=10), Major (threshold=15)
+    - AudereThreshold (minimum_intensity_tier=Major, minimum_warp_stage=Soulfray "Ripping")
+    - MishapPoolTier (min_deficit=1, max_deficit=None) backed by a minimal ConsequencePool
+
+    Returns:
+        MagicConfigResult dataclass with all created/fetched instances.
+    """
+    from actions.models.consequence_pools import ConsequencePool  # noqa: PLC0415
+    from world.checks.factories import CheckTypeFactory  # noqa: PLC0415
+    from world.magic.audere import AudereThreshold  # noqa: PLC0415
+    from world.magic.factories import SoulfrayContentFactory  # noqa: PLC0415
+    from world.magic.models import (  # noqa: PLC0415
+        AnimaConfig,
+        IntensityTier,
+        MishapPoolTier,
+        SoulfrayConfig,
+    )
+    from world.magic.models.corruption_config import CorruptionConfig  # noqa: PLC0415
+    from world.magic.models.gain_config import ResonanceGainConfig  # noqa: PLC0415
+
+    # --- AnimaConfig (has its own get_or_create helper) ---
+    anima_config = AnimaConfig.get_singleton()
+
+    # --- SoulfrayConfig (singleton, no get_or_create on factory) ---
+    resilience_check_type = CheckTypeFactory(name="Magical Endurance")
+    soulfray_config, _ = SoulfrayConfig.objects.get_or_create(
+        pk=1,
+        defaults={
+            "soulfray_threshold_ratio": "0.30",
+            "severity_scale": 10,
+            "deficit_scale": 5,
+            "resilience_check_type": resilience_check_type,
+            "base_check_difficulty": 15,
+            "ritual_budget_critical_success": 10,
+            "ritual_budget_success": 6,
+            "ritual_budget_partial": 3,
+            "ritual_budget_failure": 1,
+            "ritual_severity_cost_per_point": 1,
+        },
+    )
+
+    # --- ResonanceGainConfig (pk=1) ---
+    resonance_gain_config, _ = ResonanceGainConfig.objects.get_or_create(pk=1, defaults={})
+
+    # --- CorruptionConfig (pk=1) ---
+    corruption_config, _ = CorruptionConfig.objects.get_or_create(pk=1, defaults={})
+
+    # --- IntensityTier reference rows ---
+    intensity_tiers: dict[str, IntensityTier] = {}
+    for tier_name, threshold, control_mod in _INTENSITY_TIERS:
+        tier, _ = IntensityTier.objects.get_or_create(
+            name=tier_name,
+            defaults={
+                "threshold": threshold,
+                "control_modifier": control_mod,
+                "description": f"{tier_name} intensity level.",
+            },
+        )
+        intensity_tiers[tier_name] = tier
+
+    major_tier = intensity_tiers["Major"]
+
+    # --- Soulfray condition + stages (needed for AudereThreshold.minimum_warp_stage) ---
+    # SoulfrayContentFactory() is idempotent — uses get_or_create internally.
+    soulfray_content = SoulfrayContentFactory()
+    # "Ripping" is stage index 2 (0-based) = stage_order 3
+    ripping_stage = soulfray_content.stages[2]
+
+    # --- AudereThreshold (singleton, no get_or_create on factory) ---
+    audere_threshold, _ = AudereThreshold.objects.get_or_create(
+        pk=1,
+        defaults={
+            "minimum_intensity_tier": major_tier,
+            "minimum_warp_stage": ripping_stage,
+            "intensity_bonus": 20,
+            "anima_pool_bonus": 30,
+            "warp_multiplier": 2,
+        },
+    )
+
+    # --- MishapPoolTier: one catch-all tier (min_deficit=1, max_deficit=None) ---
+    mishap_pool, _ = ConsequencePool.objects.get_or_create(
+        name=_MISHAP_POOL_NAME,
+        defaults={"description": "Default pool for magic mishaps from control deficit."},
+    )
+    mishap_pool_tier, _ = MishapPoolTier.objects.get_or_create(
+        min_deficit=1,
+        max_deficit=None,
+        defaults={"consequence_pool": mishap_pool},
+    )
+
+    return MagicConfigResult(
+        anima_config=anima_config,
+        soulfray_config=soulfray_config,
+        resonance_gain_config=resonance_gain_config,
+        corruption_config=corruption_config,
+        audere_threshold=audere_threshold,
+        intensity_tiers=intensity_tiers,
+        mishap_pool_tier=mishap_pool_tier,
+    )

--- a/src/integration_tests/game_content/magic.py
+++ b/src/integration_tests/game_content/magic.py
@@ -481,7 +481,7 @@ def seed_magic_config() -> MagicConfigResult:
     soulfray_config, _ = SoulfrayConfig.objects.get_or_create(
         pk=1,
         defaults={
-            "soulfray_threshold_ratio": "0.30",
+            "soulfray_threshold_ratio": Decimal("0.30"),
             "severity_scale": 10,
             "deficit_scale": 5,
             "resilience_check_type": resilience_check_type,

--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -662,3 +662,259 @@ class TestSeedCantripStarterCatalogPreservesEdits(TestCase):
             "staff-edited description",
             "seed_cantrip_starter_catalog() must not overwrite existing rows",
         )
+
+
+# ---------------------------------------------------------------------------
+# Task 1.9 — seed_magic_dev() orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestSeedMagicDevCheckTypeConvergence(TestCase):
+    """TDD: guard for _make_magical_endurance_check_type() orphan bug.
+
+    This test is written BEFORE the fix so it fails first, confirming the bug,
+    then passes after the fix is applied.
+    """
+
+    def test_check_type_convergence(self) -> None:
+        """Exactly 1 CheckType named 'Magical Endurance' after orchestrator runs.
+
+        Before the fix, author_reference_corruption_content() calls
+        _make_magical_endurance_check_type() which uses CheckTypeFactory with a
+        fresh CheckCategory SubFactory — creating an orphan row on each call.
+        seed_magic_config() independently creates the canonical row via direct ORM.
+        Running both produces 2 CheckType rows.  After the fix, both helpers
+        converge on the same (name='Magical Endurance', category__name='Magic') row.
+        """
+        from integration_tests.game_content.magic import seed_magic_dev
+        from world.checks.models import CheckCategory, CheckType
+
+        seed_magic_dev()
+
+        self.assertEqual(
+            CheckType.objects.filter(name="Magical Endurance").count(),
+            1,
+            "seed_magic_dev() must produce exactly 1 CheckType named 'Magical Endurance'",
+        )
+        self.assertEqual(
+            CheckCategory.objects.filter(name="Magic").count(),
+            1,
+            "seed_magic_dev() must produce exactly 1 CheckCategory named 'Magic'",
+        )
+
+
+class TestSeedMagicDevTechniqueIdempotency(TestCase):
+    """TDD: guard for MagicContent.create_all() duplicate Technique bug.
+
+    This test is written BEFORE the fix so it fails first, confirming the bug,
+    then passes after MagicContent.create_all() switches to get_or_create.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from integration_tests.game_content.magic import seed_magic_dev
+
+        # Two calls — if create_all() is not idempotent, techniques double
+        seed_magic_dev()
+        seed_magic_dev()
+
+    def test_social_techniques_exist_exactly_once(self) -> None:
+        """Each of the 6 social action techniques must appear exactly once."""
+        from integration_tests.game_content.magic import ACTION_TECHNIQUE_MAP
+        from world.magic.models import Technique
+
+        for action_key, technique_name in ACTION_TECHNIQUE_MAP.items():
+            with self.subTest(technique=technique_name):
+                self.assertEqual(
+                    Technique.objects.filter(name=technique_name).count(),
+                    1,
+                    f"Technique '{technique_name}' must exist exactly once after two "
+                    f"seed_magic_dev() calls (action_key={action_key!r})",
+                )
+
+    def test_action_enhancements_exist_exactly_once(self) -> None:
+        """Each of the 6 ActionEnhancement rows must appear exactly once."""
+        from actions.models import ActionEnhancement
+        from integration_tests.game_content.magic import ACTION_TECHNIQUE_MAP
+
+        for action_key in ACTION_TECHNIQUE_MAP:
+            with self.subTest(action_key=action_key):
+                self.assertEqual(
+                    ActionEnhancement.objects.filter(base_action_key=action_key).count(),
+                    1,
+                    f"ActionEnhancement for '{action_key}' must exist exactly once after two "
+                    f"seed_magic_dev() calls",
+                )
+
+
+class TestSeedMagicDev(TestCase):
+    """Verify the master orchestrator composes all Phase 1 seed helpers."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from integration_tests.game_content.magic import seed_magic_dev
+
+        cls.first = seed_magic_dev()
+        cls.second = seed_magic_dev()
+
+    def test_first_call_creates_all_components(self) -> None:
+        """Spot-check: at least one of every authored row family exists."""
+        from world.checks.models import CheckType
+        from world.classes.models import Path
+        from world.conditions.models import ConditionTemplate
+        from world.magic.audere import AudereThreshold
+        from world.magic.models import (
+            AnimaConfig,
+            EffectType,
+            IntensityTier,
+            MishapPoolTier,
+            Ritual,
+            SoulfrayConfig,
+            Technique,
+            TechniqueStyle,
+        )
+        from world.magic.models.cantrips import Cantrip
+        from world.magic.models.corruption_config import CorruptionConfig
+        from world.magic.models.gain_config import ResonanceGainConfig
+        from world.magic.models.threads import ThreadPullCost, ThreadPullEffect
+
+        # --- Task 1.1: config singletons ---
+        self.assertEqual(AnimaConfig.objects.count(), 1)
+        self.assertEqual(SoulfrayConfig.objects.count(), 1)
+        self.assertEqual(ResonanceGainConfig.objects.count(), 1)
+        self.assertEqual(CorruptionConfig.objects.count(), 1)
+        self.assertEqual(AudereThreshold.objects.count(), 1)
+        self.assertGreaterEqual(IntensityTier.objects.count(), 3)
+        self.assertEqual(MishapPoolTier.objects.count(), 1)
+
+        # --- Task 1.2: canonical rituals ---
+        self.assertTrue(Ritual.objects.filter(name="Rite of Imbuing").exists())
+        self.assertTrue(Ritual.objects.filter(name="Rite of Atonement").exists())
+
+        # --- Task 1.3: thread pull catalog ---
+        self.assertEqual(ThreadPullCost.objects.count(), 3)
+        self.assertEqual(ThreadPullEffect.objects.count(), 4)
+
+        # --- Task 1.8: cantrip catalog ---
+        # TechniqueStyle: 5 from cantrip catalog + 1 "Social" from MagicContent.create_all()
+        self.assertGreaterEqual(TechniqueStyle.objects.count(), 5)
+        self.assertTrue(
+            TechniqueStyle.objects.filter(
+                name__in={"Manifestation", "Subtle", "Performance", "Prayer", "Incantation"}
+            ).count()
+            == 5,
+            "All 5 cantrip-catalog styles must exist",
+        )
+        # EffectType: 6 from cantrip catalog + 1 "Social Influence" from MagicContent.create_all()
+        self.assertGreaterEqual(EffectType.objects.count(), 6)
+        self.assertEqual(Cantrip.objects.count(), 25)
+        self.assertEqual(Path.objects.filter(name__startswith="Path of").count(), 5)
+
+        # --- author_reference_corruption_content: Wild Hunt + Web of Spiders ---
+        self.assertTrue(
+            ConditionTemplate.objects.filter(name__icontains="Wild Hunt").exists(),
+            "Wild Hunt Corruption ConditionTemplate must exist",
+        )
+        self.assertTrue(
+            ConditionTemplate.objects.filter(name__icontains="Web of Spiders").exists(),
+            "Web of Spiders Corruption ConditionTemplate must exist",
+        )
+
+        # --- MagicContent.create_all(): 6 social techniques ---
+        from integration_tests.game_content.magic import ACTION_TECHNIQUE_MAP
+
+        for technique_name in ACTION_TECHNIQUE_MAP.values():
+            self.assertTrue(
+                Technique.objects.filter(name=technique_name).exists(),
+                f"Social technique '{technique_name}' must exist",
+            )
+
+        # --- CheckType canonical row (convergence guard) ---
+        self.assertEqual(CheckType.objects.filter(name="Magical Endurance").count(), 1)
+
+    def test_idempotent_full_run(self) -> None:
+        """Row counts must not change on a third call."""
+        from actions.models import ActionEnhancement
+        from world.checks.models import CheckCategory, CheckType
+        from world.classes.models import Path
+        from world.conditions.models import ConditionTemplate
+        from world.magic.audere import AudereThreshold
+        from world.magic.models import (
+            AnimaConfig,
+            EffectType,
+            IntensityTier,
+            MishapPoolTier,
+            Ritual,
+            SoulfrayConfig,
+            Technique,
+            TechniqueStyle,
+        )
+        from world.magic.models.cantrips import Cantrip
+        from world.magic.models.corruption_config import CorruptionConfig
+        from world.magic.models.gain_config import ResonanceGainConfig
+        from world.magic.models.threads import ThreadPullCost, ThreadPullEffect
+
+        def _snapshot() -> dict[str, int]:
+            return {
+                "anima_config": AnimaConfig.objects.count(),
+                "soulfray_config": SoulfrayConfig.objects.count(),
+                "resonance_gain_config": ResonanceGainConfig.objects.count(),
+                "corruption_config": CorruptionConfig.objects.count(),
+                "audere_threshold": AudereThreshold.objects.count(),
+                "intensity_tiers": IntensityTier.objects.count(),
+                "mishap_pool_tiers": MishapPoolTier.objects.count(),
+                "rituals": Ritual.objects.count(),
+                "thread_pull_costs": ThreadPullCost.objects.count(),
+                "thread_pull_effects": ThreadPullEffect.objects.count(),
+                "technique_styles": TechniqueStyle.objects.count(),
+                "effect_types": EffectType.objects.count(),
+                "cantrips": Cantrip.objects.count(),
+                "paths": Path.objects.count(),
+                "condition_templates": ConditionTemplate.objects.count(),
+                "techniques": Technique.objects.count(),
+                "action_enhancements": ActionEnhancement.objects.count(),
+                "check_types": CheckType.objects.count(),
+                "check_categories": CheckCategory.objects.count(),
+            }
+
+        from integration_tests.game_content.magic import seed_magic_dev
+
+        before = _snapshot()
+        seed_magic_dev()
+        after = _snapshot()
+
+        for model_name, count_before in before.items():
+            with self.subTest(model=model_name):
+                self.assertEqual(
+                    after[model_name],
+                    count_before,
+                    f"{model_name}: row count changed from {count_before} to "
+                    f"{after[model_name]} on third seed_magic_dev() call",
+                )
+
+    def test_check_type_convergence(self) -> None:
+        """Exactly 1 CheckType named 'Magical Endurance' after two orchestrator calls."""
+        from world.checks.models import CheckCategory, CheckType
+
+        self.assertEqual(
+            CheckType.objects.filter(name="Magical Endurance").count(),
+            1,
+        )
+        self.assertEqual(
+            CheckCategory.objects.filter(name="Magic").count(),
+            1,
+        )
+
+    def test_technique_idempotency_via_magic_content(self) -> None:
+        """The 6 social techniques must exist exactly once after two orchestrator calls."""
+        from integration_tests.game_content.magic import ACTION_TECHNIQUE_MAP
+        from world.magic.models import Technique
+
+        for action_key, technique_name in ACTION_TECHNIQUE_MAP.items():
+            with self.subTest(technique=technique_name):
+                self.assertEqual(
+                    Technique.objects.filter(name=technique_name).count(),
+                    1,
+                    f"Technique '{technique_name}' (action_key={action_key!r}) must exist "
+                    f"exactly once after two seed_magic_dev() calls",
+                )

--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -94,6 +94,7 @@ class TestSeedMagicConfigIdempotency(TestCase):
         self.second: MagicConfigResult = seed_magic_config()
 
     def _counts(self) -> dict[str, int]:
+        from world.checks.models import CheckCategory, CheckType
         from world.magic.audere import AudereThreshold
         from world.magic.models import AnimaConfig, IntensityTier, MishapPoolTier, SoulfrayConfig
         from world.magic.models.corruption_config import CorruptionConfig
@@ -107,6 +108,8 @@ class TestSeedMagicConfigIdempotency(TestCase):
             "audere_threshold": AudereThreshold.objects.count(),
             "intensity_tiers": IntensityTier.objects.count(),
             "mishap_pool_tiers": MishapPoolTier.objects.count(),
+            "check_types": CheckType.objects.count(),
+            "check_categories": CheckCategory.objects.count(),
         }
 
     def test_row_counts_unchanged(self) -> None:
@@ -118,6 +121,17 @@ class TestSeedMagicConfigIdempotency(TestCase):
         self.assertEqual(counts["audere_threshold"], 1)
         self.assertEqual(counts["intensity_tiers"], 3)
         self.assertGreaterEqual(counts["mishap_pool_tiers"], 1)
+        # Guard against orphan CheckType/CheckCategory rows leaking on re-run
+        self.assertEqual(
+            counts["check_types"],
+            1,
+            "seed_magic_config() must not create extra CheckType rows on second call",
+        )
+        self.assertEqual(
+            counts["check_categories"],
+            1,
+            "seed_magic_config() must not create extra CheckCategory rows on second call",
+        )
 
     def test_same_pks_returned(self) -> None:
         self.assertEqual(self.first.anima_config.pk, self.second.anima_config.pk)

--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -50,6 +50,32 @@ class TestSeedMagicConfigCreation(TestCase):
         self.assertEqual(cfg.resilience_check_type.name, "Magical Endurance")
         self.assertEqual(self.result.soulfray_config.pk, 1)
 
+    def test_soulfray_threshold_ratio_is_decimal(self) -> None:
+        """Regression: seed_magic_config() must store Decimal, not a string literal.
+
+        SharedMemoryModel's identity map caches the freshly-inserted instance
+        with whatever Python value was passed to get_or_create defaults.  If a
+        string literal like "0.30" is passed instead of Decimal("0.30"), downstream
+        code that does ``Decimal(...) >= soulfray_threshold_ratio`` raises TypeError.
+        """
+        from decimal import Decimal
+
+        from world.magic.models import SoulfrayConfig
+
+        cfg = SoulfrayConfig.objects.get(pk=1)
+        # isinstance check: catches the string-literal bug before any arithmetic
+        self.assertIsInstance(
+            cfg.soulfray_threshold_ratio,
+            Decimal,
+            "soulfray_threshold_ratio must be a Decimal, not a string literal",
+        )
+        # Decimal comparison: fires TypeError if value is a str
+        self.assertGreater(
+            cfg.soulfray_threshold_ratio,
+            Decimal("0.0"),
+            "soulfray_threshold_ratio must be > 0",
+        )
+
     def test_resonance_gain_config_created(self) -> None:
         from world.magic.models.gain_config import ResonanceGainConfig
 

--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -1,5 +1,5 @@
 """Tests for seed_magic_config() — Task 1.1, seed_canonical_rituals() — Task 1.2,
-and seed_thread_pull_catalog() — Task 1.3.
+seed_thread_pull_catalog() — Task 1.3, and seed_cantrip_starter_catalog() — Task 1.8.
 
 Verifies:
 1. All 5 singletons + IntensityTier rows + MishapPoolTier are created with
@@ -11,15 +11,20 @@ Verifies:
 6. ThreadPullCost + ThreadPullEffect catalog rows are created correctly (Task 1.3).
 7. Thread pull catalog seeding is idempotent (Task 1.3).
 8. Staff edits to ThreadPullEffect survive a re-run (Task 1.3).
+9. Cantrip starter catalog creates 5 styles, 6 effect types, 25 cantrips (Task 1.8).
+10. Cantrip catalog seeding is idempotent (Task 1.8).
+11. Staff edits to Cantrip rows survive a re-run (Task 1.8).
 """
 
 from django.test import TestCase
 
 from integration_tests.game_content.magic import (
+    CantripStarterCatalogResult,
     MagicConfigResult,
     RitualSeedResult,
     ThreadPullCatalogResult,
     seed_canonical_rituals,
+    seed_cantrip_starter_catalog,
     seed_magic_config,
     seed_thread_pull_catalog,
 )
@@ -449,4 +454,211 @@ class TestSeedThreadPullCatalogPreservesEdits(TestCase):
             db_value["flat_bonus_amount"],
             99,
             "seed_thread_pull_catalog() must not overwrite existing rows (get_or_create semantics)",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 1.8 — seed_cantrip_starter_catalog()
+# ---------------------------------------------------------------------------
+
+
+class TestSeedCantripStarterCatalogCreation(TestCase):
+    """First-call assertions: correct counts and archetype×style grid exists."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.result: CantripStarterCatalogResult = seed_cantrip_starter_catalog()
+
+    def test_five_styles_created(self) -> None:
+        from world.magic.models import TechniqueStyle
+
+        self.assertEqual(TechniqueStyle.objects.count(), 5)
+        expected_styles = {"Manifestation", "Subtle", "Performance", "Prayer", "Incantation"}
+        actual_styles = set(TechniqueStyle.objects.values_list("name", flat=True))
+        self.assertEqual(actual_styles, expected_styles)
+        self.assertEqual(set(self.result.styles.keys()), expected_styles)
+
+    def test_six_effect_types_created(self) -> None:
+        from world.magic.models import EffectType
+
+        self.assertEqual(EffectType.objects.count(), 6)
+        expected = {
+            "Weapon Enhancement",
+            "Ranged Attack",
+            "Buff",
+            "Debuff",
+            "Defense",
+            "Utility",
+        }
+        actual = set(EffectType.objects.values_list("name", flat=True))
+        self.assertEqual(actual, expected)
+        self.assertEqual(set(self.result.effect_types.keys()), expected)
+
+    def test_twenty_five_cantrips_created(self) -> None:
+        from world.magic.models.cantrips import Cantrip
+
+        self.assertEqual(Cantrip.objects.count(), 25)
+        self.assertEqual(len(self.result.cantrips), 25)
+
+    def test_each_cantrip_has_correct_archetype_and_style(self) -> None:
+        """Every (archetype, style_name) combination must appear exactly once."""
+        from world.magic.constants import CantripArchetype
+        from world.magic.models.cantrips import Cantrip
+
+        expected_archetypes = {
+            CantripArchetype.ATTACK,
+            CantripArchetype.DEFENSE,
+            CantripArchetype.BUFF,
+            CantripArchetype.DEBUFF,
+            CantripArchetype.UTILITY,
+        }
+        expected_style_names = {"Manifestation", "Subtle", "Performance", "Prayer", "Incantation"}
+
+        # Build (archetype, style_name) pairs from the DB
+        pairs = set(Cantrip.objects.select_related("style").values_list("archetype", "style__name"))
+        expected_pairs = {
+            (arch, style) for arch in expected_archetypes for style in expected_style_names
+        }
+        self.assertEqual(
+            pairs,
+            expected_pairs,
+            "Each (archetype, style) pair must appear exactly once",
+        )
+
+    def test_five_prospect_paths_created(self) -> None:
+        from world.classes.models import Path, PathStage
+
+        self.assertEqual(Path.objects.filter(stage=PathStage.PROSPECT).count(), 5)
+        expected_path_names = {
+            "Path of Steel",
+            "Path of Whispers",
+            "Path of Voice",
+            "Path of the Chosen",
+            "Path of Tomes",
+        }
+        actual = set(Path.objects.filter(stage=PathStage.PROSPECT).values_list("name", flat=True))
+        self.assertEqual(actual, expected_path_names)
+        self.assertEqual(set(self.result.paths.keys()), expected_path_names)
+
+    def test_styles_wired_to_paths(self) -> None:
+        """Each TechniqueStyle must have exactly one allowed_path matching the canonical mapping."""
+        style_to_path = {
+            "Manifestation": "Path of Steel",
+            "Subtle": "Path of Whispers",
+            "Performance": "Path of Voice",
+            "Prayer": "Path of the Chosen",
+            "Incantation": "Path of Tomes",
+        }
+        from world.magic.models import TechniqueStyle
+
+        for style_name, path_name in style_to_path.items():
+            style = TechniqueStyle.objects.get(name=style_name)
+            allowed = list(style.allowed_paths.values_list("name", flat=True))
+            self.assertIn(
+                path_name,
+                allowed,
+                f"Style '{style_name}' must have '{path_name}' in allowed_paths",
+            )
+
+    def test_cantrips_are_active(self) -> None:
+        from world.magic.models.cantrips import Cantrip
+
+        inactive = Cantrip.objects.filter(is_active=False).count()
+        self.assertEqual(inactive, 0, "All seeded cantrips must be active")
+
+    def test_cantrip_default_mechanicals(self) -> None:
+        """All cantrips should have starter-level mechanical values."""
+        from world.magic.models.cantrips import Cantrip
+
+        for cantrip in Cantrip.objects.all():
+            self.assertEqual(cantrip.base_intensity, 1, f"{cantrip.name}: base_intensity")
+            self.assertEqual(cantrip.base_control, 1, f"{cantrip.name}: base_control")
+            self.assertEqual(cantrip.base_anima_cost, 5, f"{cantrip.name}: base_anima_cost")
+
+
+class TestSeedCantripStarterCatalogIdempotency(TestCase):
+    """Second-call assertions: row counts unchanged, same PKs returned."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.first: CantripStarterCatalogResult = seed_cantrip_starter_catalog()
+        cls.second: CantripStarterCatalogResult = seed_cantrip_starter_catalog()
+
+    def _counts(self) -> dict[str, int]:
+        from world.classes.models import Path, PathStage
+        from world.magic.models import EffectType, TechniqueStyle
+        from world.magic.models.cantrips import Cantrip
+
+        return {
+            "cantrips": Cantrip.objects.count(),
+            "styles": TechniqueStyle.objects.count(),
+            "effect_types": EffectType.objects.count(),
+            "prospect_paths": Path.objects.filter(stage=PathStage.PROSPECT).count(),
+        }
+
+    def test_row_counts_unchanged(self) -> None:
+        counts = self._counts()
+        self.assertEqual(counts["cantrips"], 25)
+        self.assertEqual(counts["styles"], 5)
+        self.assertEqual(counts["effect_types"], 6)
+        self.assertEqual(counts["prospect_paths"], 5)
+
+    def test_same_pks_returned(self) -> None:
+        style_names = {"Manifestation", "Subtle", "Performance", "Prayer", "Incantation"}
+        for name in style_names:
+            self.assertEqual(
+                self.first.styles[name].pk,
+                self.second.styles[name].pk,
+                f"TechniqueStyle '{name}' pk changed on second call",
+            )
+        for name, cantrip in self.first.cantrips.items():
+            self.assertEqual(
+                cantrip.pk,
+                self.second.cantrips[name].pk,
+                f"Cantrip '{name}' pk changed on second call",
+            )
+        for name, et in self.first.effect_types.items():
+            self.assertEqual(
+                et.pk,
+                self.second.effect_types[name].pk,
+                f"EffectType '{name}' pk changed on second call",
+            )
+        path_names = {
+            "Path of Steel",
+            "Path of Whispers",
+            "Path of Voice",
+            "Path of the Chosen",
+            "Path of Tomes",
+        }
+        for name in path_names:
+            self.assertEqual(
+                self.first.paths[name].pk,
+                self.second.paths[name].pk,
+                f"Path '{name}' pk changed on second call",
+            )
+
+
+class TestSeedCantripStarterCatalogPreservesEdits(TestCase):
+    """Staff edits to Cantrip rows survive a re-run (get_or_create semantics)."""
+
+    def test_edit_preserved_on_rerun(self) -> None:
+        from world.magic.models.cantrips import Cantrip
+
+        first = seed_cantrip_starter_catalog()
+        # Pick the first cantrip alphabetically for determinism
+        cantrip_name = next(iter(sorted(first.cantrips.keys())))
+        cantrip_pk = first.cantrips[cantrip_name].pk
+
+        # Simulate a staff edit via bulk update (bypasses identity map)
+        Cantrip.objects.filter(pk=cantrip_pk).update(description="staff-edited description")
+
+        # Re-run the seed — must not overwrite the staff edit
+        seed_cantrip_starter_catalog()
+
+        # Use .values() to bypass SharedMemoryModel identity-map cache
+        db_value = Cantrip.objects.filter(pk=cantrip_pk).values("description").get()
+        self.assertEqual(
+            db_value["description"],
+            "staff-edited description",
+            "seed_cantrip_starter_catalog() must not overwrite existing rows",
         )

--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -1,4 +1,5 @@
-"""Tests for seed_magic_config() — Task 1.1 and seed_canonical_rituals() — Task 1.2.
+"""Tests for seed_magic_config() — Task 1.1, seed_canonical_rituals() — Task 1.2,
+and seed_thread_pull_catalog() — Task 1.3.
 
 Verifies:
 1. All 5 singletons + IntensityTier rows + MishapPoolTier are created with
@@ -7,6 +8,9 @@ Verifies:
 3. Staff edits to existing rows survive a re-run (get_or_create, not update_or_create) (Task 1.1).
 4. Canonical rituals are created with correct names (Task 1.2).
 5. Ritual seeding is idempotent and preserves edits (Task 1.2).
+6. ThreadPullCost + ThreadPullEffect catalog rows are created correctly (Task 1.3).
+7. Thread pull catalog seeding is idempotent (Task 1.3).
+8. Staff edits to ThreadPullEffect survive a re-run (Task 1.3).
 """
 
 from django.test import TestCase
@@ -14,8 +18,10 @@ from django.test import TestCase
 from integration_tests.game_content.magic import (
     MagicConfigResult,
     RitualSeedResult,
+    ThreadPullCatalogResult,
     seed_canonical_rituals,
     seed_magic_config,
+    seed_thread_pull_catalog,
 )
 
 
@@ -243,4 +249,178 @@ class TestSeedCanonicalRituals(TestCase):
             db_value["description"],
             "custom description",
             "seed_canonical_rituals() must not overwrite existing rows (get_or_create semantics)",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3 — seed_thread_pull_catalog()
+# ---------------------------------------------------------------------------
+
+
+class TestSeedThreadPullCatalogCreation(TestCase):
+    """First-call assertions: correct rows exist with expected values."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.result: ThreadPullCatalogResult = seed_thread_pull_catalog()
+
+    def test_pull_costs_created(self) -> None:
+        from world.magic.models.threads import ThreadPullCost
+
+        self.assertEqual(ThreadPullCost.objects.count(), 3)
+        tier1 = ThreadPullCost.objects.get(tier=1)
+        tier2 = ThreadPullCost.objects.get(tier=2)
+        tier3 = ThreadPullCost.objects.get(tier=3)
+
+        self.assertEqual(tier1.resonance_cost, 1)
+        self.assertEqual(tier1.anima_per_thread, 1)
+        self.assertEqual(tier1.label, "soft")
+
+        self.assertEqual(tier2.resonance_cost, 3)
+        self.assertEqual(tier2.anima_per_thread, 2)
+        self.assertEqual(tier2.label, "medium")
+
+        self.assertEqual(tier3.resonance_cost, 6)
+        self.assertEqual(tier3.anima_per_thread, 3)
+        self.assertEqual(tier3.label, "hard")
+
+        self.assertIn(1, self.result.pull_costs)
+        self.assertIn(2, self.result.pull_costs)
+        self.assertIn(3, self.result.pull_costs)
+
+    def test_pull_effects_created(self) -> None:
+        from world.magic.constants import EffectKind
+        from world.magic.models.threads import ThreadPullEffect
+
+        self.assertEqual(ThreadPullEffect.objects.count(), 4)
+
+        self.assertIn(EffectKind.FLAT_BONUS, self.result.pull_effects)
+        self.assertIn(EffectKind.INTENSITY_BUMP, self.result.pull_effects)
+        self.assertIn(EffectKind.VITAL_BONUS, self.result.pull_effects)
+        self.assertIn(EffectKind.CAPABILITY_GRANT, self.result.pull_effects)
+
+        flat = self.result.pull_effects[EffectKind.FLAT_BONUS]
+        self.assertEqual(flat.tier, 1)
+        self.assertEqual(flat.flat_bonus_amount, 2)
+
+        bump = self.result.pull_effects[EffectKind.INTENSITY_BUMP]
+        self.assertEqual(bump.tier, 2)
+        self.assertEqual(bump.intensity_bump_amount, 1)
+
+        vital = self.result.pull_effects[EffectKind.VITAL_BONUS]
+        self.assertEqual(vital.tier, 0)
+        self.assertEqual(vital.vital_bonus_amount, 5)
+        from world.magic.constants import VitalBonusTarget
+
+        self.assertEqual(vital.vital_target, VitalBonusTarget.MAX_HEALTH)
+
+        cap_grant = self.result.pull_effects[EffectKind.CAPABILITY_GRANT]
+        self.assertEqual(cap_grant.tier, 3)
+        self.assertEqual(cap_grant.min_thread_level, 5)
+        self.assertIsNotNone(cap_grant.capability_grant)
+        self.assertEqual(cap_grant.capability_grant.name, "endurance")
+
+    def test_canonical_resonance_authored(self) -> None:
+        from world.magic.models import Affinity, Resonance
+
+        self.assertEqual(Resonance.objects.filter(name="Tideborne").count(), 1)
+        self.assertEqual(Affinity.objects.filter(name="Primal (Tideborne)").count(), 1)
+        self.assertEqual(self.result.canonical_resonance.name, "Tideborne")
+        self.assertEqual(self.result.canonical_resonance.affinity.name, "Primal (Tideborne)")
+
+
+class TestSeedThreadPullCatalogIdempotency(TestCase):
+    """Second-call assertions: row counts unchanged, same PKs returned."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.first: ThreadPullCatalogResult = seed_thread_pull_catalog()
+        cls.second: ThreadPullCatalogResult = seed_thread_pull_catalog()
+
+    def _counts(self) -> dict[str, int]:
+        from world.conditions.models import CapabilityType
+        from world.magic.models import Affinity, Resonance
+        from world.magic.models.threads import ThreadPullCost, ThreadPullEffect
+
+        return {
+            "pull_costs": ThreadPullCost.objects.count(),
+            "pull_effects": ThreadPullEffect.objects.count(),
+            "resonances": Resonance.objects.count(),
+            "affinities": Affinity.objects.count(),
+            "capability_types": CapabilityType.objects.count(),
+        }
+
+    def test_row_counts_unchanged(self) -> None:
+        counts = self._counts()
+        self.assertEqual(counts["pull_costs"], 3)
+        self.assertEqual(
+            counts["pull_effects"],
+            4,
+            "seed_thread_pull_catalog() must not create extra ThreadPullEffect rows on second call",
+        )
+        self.assertEqual(
+            counts["resonances"],
+            1,
+            "seed_thread_pull_catalog() must not create extra Resonance rows on second call",
+        )
+        self.assertEqual(
+            counts["affinities"],
+            1,
+            "seed_thread_pull_catalog() must not create extra Affinity rows on second call",
+        )
+        self.assertEqual(
+            counts["capability_types"],
+            1,
+            "seed_thread_pull_catalog() must not create extra CapabilityType rows on second call",
+        )
+
+    def test_same_pks_returned(self) -> None:
+        from world.magic.constants import EffectKind
+
+        self.assertEqual(
+            self.first.canonical_resonance.pk,
+            self.second.canonical_resonance.pk,
+        )
+        for tier in (1, 2, 3):
+            self.assertEqual(
+                self.first.pull_costs[tier].pk,
+                self.second.pull_costs[tier].pk,
+                f"ThreadPullCost tier {tier} pk changed on second call",
+            )
+        for effect_kind in (
+            EffectKind.FLAT_BONUS,
+            EffectKind.INTENSITY_BUMP,
+            EffectKind.VITAL_BONUS,
+            EffectKind.CAPABILITY_GRANT,
+        ):
+            self.assertEqual(
+                self.first.pull_effects[effect_kind].pk,
+                self.second.pull_effects[effect_kind].pk,
+                f"ThreadPullEffect {effect_kind} pk changed on second call",
+            )
+
+
+class TestSeedThreadPullCatalogPreservesEdits(TestCase):
+    """Staff edits to ThreadPullEffect survive a re-run (get_or_create semantics)."""
+
+    def test_edit_preserved_on_rerun(self) -> None:
+        from world.magic.constants import EffectKind
+        from world.magic.models.threads import ThreadPullEffect
+
+        first = seed_thread_pull_catalog()
+        flat_pk = first.pull_effects[EffectKind.FLAT_BONUS].pk
+
+        # Simulate a staff edit via bulk update (bypasses identity map)
+        ThreadPullEffect.objects.filter(pk=flat_pk).update(flat_bonus_amount=99)
+
+        # Re-run the seed — must not overwrite the staff edit
+        seed_thread_pull_catalog()
+
+        # Use .values() to bypass SharedMemoryModel identity-map cache and
+        # read directly from the DB.
+        db_value = ThreadPullEffect.objects.filter(pk=flat_pk).values("flat_bonus_amount").get()
+        self.assertEqual(
+            db_value["flat_bonus_amount"],
+            99,
+            "seed_thread_pull_catalog() must not overwrite existing rows (get_or_create semantics)",
         )

--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -1,15 +1,22 @@
-"""Tests for seed_magic_config() — Task 1.1.
+"""Tests for seed_magic_config() — Task 1.1 and seed_canonical_rituals() — Task 1.2.
 
 Verifies:
 1. All 5 singletons + IntensityTier rows + MishapPoolTier are created with
-   expected values on the first call.
-2. A second call produces zero new DB writes (idempotent).
-3. Staff edits to existing rows survive a re-run (get_or_create, not update_or_create).
+   expected values on the first call (Task 1.1).
+2. A second call produces zero new DB writes (idempotent) (Task 1.1).
+3. Staff edits to existing rows survive a re-run (get_or_create, not update_or_create) (Task 1.1).
+4. Canonical rituals are created with correct names (Task 1.2).
+5. Ritual seeding is idempotent and preserves edits (Task 1.2).
 """
 
 from django.test import TestCase
 
-from integration_tests.game_content.magic import MagicConfigResult, seed_magic_config
+from integration_tests.game_content.magic import (
+    MagicConfigResult,
+    RitualSeedResult,
+    seed_canonical_rituals,
+    seed_magic_config,
+)
 
 
 class TestSeedMagicConfigCreation(TestCase):
@@ -187,4 +194,53 @@ class TestSeedMagicConfigPreservesEdits(TestCase):
             db_value["daily_regen_percent"],
             15,
             "seed_magic_config() must not overwrite existing rows (get_or_create semantics)",
+        )
+
+
+class TestSeedCanonicalRituals(TestCase):
+    """Task 1.2: seed_canonical_rituals() creates idempotent ritual rows."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.result: RitualSeedResult = seed_canonical_rituals()
+
+    def test_creation(self) -> None:
+        from world.magic.models import Ritual
+
+        self.assertEqual(Ritual.objects.count(), 2)
+        imbuing = Ritual.objects.get(name="Rite of Imbuing")
+        atonement = Ritual.objects.get(name="Rite of Atonement")
+        self.assertIsNotNone(imbuing)
+        self.assertIsNotNone(atonement)
+        self.assertEqual(self.result.rite_of_imbuing.name, "Rite of Imbuing")
+        self.assertEqual(self.result.rite_of_atonement.name, "Rite of Atonement")
+
+    def test_idempotency(self) -> None:
+        from world.magic.models import Ritual
+
+        first = seed_canonical_rituals()
+        second = seed_canonical_rituals()
+
+        self.assertEqual(Ritual.objects.count(), 2)
+        self.assertEqual(first.rite_of_imbuing.pk, second.rite_of_imbuing.pk)
+        self.assertEqual(first.rite_of_atonement.pk, second.rite_of_atonement.pk)
+
+    def test_edit_preserved_on_rerun(self) -> None:
+        from world.magic.models import Ritual
+
+        seed_canonical_rituals()
+
+        # Simulate a staff edit via bulk update (bypasses identity map)
+        Ritual.objects.filter(name="Rite of Imbuing").update(description="custom description")
+
+        # Re-run the seed — must not overwrite the staff edit
+        seed_canonical_rituals()
+
+        # Use .values() to bypass SharedMemoryModel identity-map cache and
+        # read directly from the DB.
+        db_value = Ritual.objects.filter(name="Rite of Imbuing").values("description").get()
+        self.assertEqual(
+            db_value["description"],
+            "custom description",
+            "seed_canonical_rituals() must not overwrite existing rows (get_or_create semantics)",
         )

--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -1,0 +1,160 @@
+"""Tests for seed_magic_config() — Task 1.1.
+
+Verifies:
+1. All 5 singletons + IntensityTier rows + MishapPoolTier are created with
+   expected values on the first call.
+2. A second call produces zero new DB writes (idempotent).
+3. Staff edits to existing rows survive a re-run (get_or_create, not update_or_create).
+"""
+
+from django.test import TestCase
+
+from integration_tests.game_content.magic import MagicConfigResult, seed_magic_config
+
+
+class TestSeedMagicConfigCreation(TestCase):
+    """First-call assertions: correct rows exist with expected values."""
+
+    def setUp(self) -> None:
+        self.result: MagicConfigResult = seed_magic_config()
+
+    def test_anima_config_created(self) -> None:
+        from world.magic.models import AnimaConfig
+
+        self.assertEqual(AnimaConfig.objects.count(), 1)
+        cfg = AnimaConfig.objects.get(pk=1)
+        self.assertEqual(cfg.daily_regen_percent, 5)
+        self.assertEqual(cfg.daily_regen_blocking_property_key, "blocks_anima_regen")
+        self.assertEqual(self.result.anima_config.pk, 1)
+
+    def test_soulfray_config_created(self) -> None:
+        from world.magic.models import SoulfrayConfig
+
+        self.assertEqual(SoulfrayConfig.objects.count(), 1)
+        cfg = SoulfrayConfig.objects.get(pk=1)
+        self.assertIsNotNone(cfg.resilience_check_type)
+        self.assertEqual(cfg.resilience_check_type.name, "Magical Endurance")
+        self.assertEqual(self.result.soulfray_config.pk, 1)
+
+    def test_resonance_gain_config_created(self) -> None:
+        from world.magic.models.gain_config import ResonanceGainConfig
+
+        self.assertEqual(ResonanceGainConfig.objects.count(), 1)
+        self.assertEqual(self.result.resonance_gain_config.pk, 1)
+
+    def test_corruption_config_created(self) -> None:
+        from world.magic.models.corruption_config import CorruptionConfig
+
+        self.assertEqual(CorruptionConfig.objects.count(), 1)
+        self.assertEqual(self.result.corruption_config.pk, 1)
+
+    def test_audere_threshold_created(self) -> None:
+        from world.magic.audere import AudereThreshold
+
+        self.assertEqual(AudereThreshold.objects.count(), 1)
+        threshold = AudereThreshold.objects.get(pk=1)
+        self.assertEqual(threshold.intensity_bonus, 20)
+        self.assertEqual(threshold.anima_pool_bonus, 30)
+        self.assertEqual(threshold.warp_multiplier, 2)
+        # minimum_intensity_tier should be "Major"
+        self.assertEqual(threshold.minimum_intensity_tier.name, "Major")
+        # minimum_warp_stage should be "Ripping" (stage_order=3)
+        self.assertEqual(threshold.minimum_warp_stage.name, "Ripping")
+        self.assertEqual(self.result.audere_threshold.pk, 1)
+
+    def test_intensity_tiers_created(self) -> None:
+        from world.magic.models import IntensityTier
+
+        self.assertEqual(IntensityTier.objects.count(), 3)
+        minor = IntensityTier.objects.get(name="Minor")
+        moderate = IntensityTier.objects.get(name="Moderate")
+        major = IntensityTier.objects.get(name="Major")
+        self.assertEqual(minor.threshold, 5)
+        self.assertEqual(moderate.threshold, 10)
+        self.assertEqual(major.threshold, 15)
+        self.assertIn("Minor", self.result.intensity_tiers)
+        self.assertIn("Moderate", self.result.intensity_tiers)
+        self.assertIn("Major", self.result.intensity_tiers)
+
+    def test_mishap_pool_tier_created(self) -> None:
+        from world.magic.models import MishapPoolTier
+
+        self.assertGreaterEqual(MishapPoolTier.objects.count(), 1)
+        tier = MishapPoolTier.objects.get(min_deficit=1, max_deficit__isnull=True)
+        self.assertIsNotNone(tier.consequence_pool)
+        self.assertEqual(tier.consequence_pool.name, "Magic Mishap Pool (default)")
+        self.assertEqual(self.result.mishap_pool_tier.pk, tier.pk)
+
+
+class TestSeedMagicConfigIdempotency(TestCase):
+    """Second-call assertions: row counts unchanged, same PKs returned."""
+
+    def setUp(self) -> None:
+        self.first: MagicConfigResult = seed_magic_config()
+        self.second: MagicConfigResult = seed_magic_config()
+
+    def _counts(self) -> dict[str, int]:
+        from world.magic.audere import AudereThreshold
+        from world.magic.models import AnimaConfig, IntensityTier, MishapPoolTier, SoulfrayConfig
+        from world.magic.models.corruption_config import CorruptionConfig
+        from world.magic.models.gain_config import ResonanceGainConfig
+
+        return {
+            "anima_config": AnimaConfig.objects.count(),
+            "soulfray_config": SoulfrayConfig.objects.count(),
+            "resonance_gain_config": ResonanceGainConfig.objects.count(),
+            "corruption_config": CorruptionConfig.objects.count(),
+            "audere_threshold": AudereThreshold.objects.count(),
+            "intensity_tiers": IntensityTier.objects.count(),
+            "mishap_pool_tiers": MishapPoolTier.objects.count(),
+        }
+
+    def test_row_counts_unchanged(self) -> None:
+        counts = self._counts()
+        self.assertEqual(counts["anima_config"], 1)
+        self.assertEqual(counts["soulfray_config"], 1)
+        self.assertEqual(counts["resonance_gain_config"], 1)
+        self.assertEqual(counts["corruption_config"], 1)
+        self.assertEqual(counts["audere_threshold"], 1)
+        self.assertEqual(counts["intensity_tiers"], 3)
+        self.assertGreaterEqual(counts["mishap_pool_tiers"], 1)
+
+    def test_same_pks_returned(self) -> None:
+        self.assertEqual(self.first.anima_config.pk, self.second.anima_config.pk)
+        self.assertEqual(self.first.soulfray_config.pk, self.second.soulfray_config.pk)
+        self.assertEqual(self.first.resonance_gain_config.pk, self.second.resonance_gain_config.pk)
+        self.assertEqual(self.first.corruption_config.pk, self.second.corruption_config.pk)
+        self.assertEqual(self.first.audere_threshold.pk, self.second.audere_threshold.pk)
+        self.assertEqual(self.first.mishap_pool_tier.pk, self.second.mishap_pool_tier.pk)
+
+    def test_intensity_tier_pks_unchanged(self) -> None:
+        for name in ("Minor", "Moderate", "Major"):
+            self.assertEqual(
+                self.first.intensity_tiers[name].pk,
+                self.second.intensity_tiers[name].pk,
+                f"IntensityTier '{name}' pk changed on second call",
+            )
+
+
+class TestSeedMagicConfigPreservesEdits(TestCase):
+    """Staff edits to existing rows survive a re-run (get_or_create semantics)."""
+
+    def test_edit_preserved_on_rerun(self) -> None:
+        from world.magic.models import AnimaConfig
+
+        seed_magic_config()
+
+        # Simulate a staff edit via bulk update (bypasses identity map)
+        AnimaConfig.objects.filter(pk=1).update(daily_regen_percent=15)
+
+        # Re-run the seed — must not overwrite the staff edit
+        seed_magic_config()
+
+        # Use .values() to bypass SharedMemoryModel identity-map cache and
+        # read directly from the DB.
+        db_value = AnimaConfig.objects.filter(pk=1).values("daily_regen_percent").get()
+        self.assertEqual(
+            db_value["daily_regen_percent"],
+            15,
+            "seed_magic_config() must not overwrite existing rows (get_or_create semantics)",
+        )

--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -15,8 +15,9 @@ from integration_tests.game_content.magic import MagicConfigResult, seed_magic_c
 class TestSeedMagicConfigCreation(TestCase):
     """First-call assertions: correct rows exist with expected values."""
 
-    def setUp(self) -> None:
-        self.result: MagicConfigResult = seed_magic_config()
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.result: MagicConfigResult = seed_magic_config()
 
     def test_anima_config_created(self) -> None:
         from world.magic.models import AnimaConfig
@@ -79,7 +80,7 @@ class TestSeedMagicConfigCreation(TestCase):
     def test_mishap_pool_tier_created(self) -> None:
         from world.magic.models import MishapPoolTier
 
-        self.assertGreaterEqual(MishapPoolTier.objects.count(), 1)
+        self.assertEqual(MishapPoolTier.objects.count(), 1)
         tier = MishapPoolTier.objects.get(min_deficit=1, max_deficit__isnull=True)
         self.assertIsNotNone(tier.consequence_pool)
         self.assertEqual(tier.consequence_pool.name, "Magic Mishap Pool (default)")
@@ -89,12 +90,14 @@ class TestSeedMagicConfigCreation(TestCase):
 class TestSeedMagicConfigIdempotency(TestCase):
     """Second-call assertions: row counts unchanged, same PKs returned."""
 
-    def setUp(self) -> None:
-        self.first: MagicConfigResult = seed_magic_config()
-        self.second: MagicConfigResult = seed_magic_config()
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.first: MagicConfigResult = seed_magic_config()
+        cls.second: MagicConfigResult = seed_magic_config()
 
     def _counts(self) -> dict[str, int]:
         from world.checks.models import CheckCategory, CheckType
+        from world.conditions.models import ConditionStage, ConditionTemplate
         from world.magic.audere import AudereThreshold
         from world.magic.models import AnimaConfig, IntensityTier, MishapPoolTier, SoulfrayConfig
         from world.magic.models.corruption_config import CorruptionConfig
@@ -110,6 +113,8 @@ class TestSeedMagicConfigIdempotency(TestCase):
             "mishap_pool_tiers": MishapPoolTier.objects.count(),
             "check_types": CheckType.objects.count(),
             "check_categories": CheckCategory.objects.count(),
+            "condition_templates": ConditionTemplate.objects.count(),
+            "condition_stages": ConditionStage.objects.count(),
         }
 
     def test_row_counts_unchanged(self) -> None:
@@ -120,7 +125,7 @@ class TestSeedMagicConfigIdempotency(TestCase):
         self.assertEqual(counts["corruption_config"], 1)
         self.assertEqual(counts["audere_threshold"], 1)
         self.assertEqual(counts["intensity_tiers"], 3)
-        self.assertGreaterEqual(counts["mishap_pool_tiers"], 1)
+        self.assertEqual(counts["mishap_pool_tiers"], 1)
         # Guard against orphan CheckType/CheckCategory rows leaking on re-run
         self.assertEqual(
             counts["check_types"],
@@ -131,6 +136,17 @@ class TestSeedMagicConfigIdempotency(TestCase):
             counts["check_categories"],
             1,
             "seed_magic_config() must not create extra CheckCategory rows on second call",
+        )
+        # Guard against ConditionTemplate/ConditionStage leaking on re-run
+        self.assertEqual(
+            counts["condition_templates"],
+            1,
+            "seed_magic_config() must not create extra ConditionTemplate rows on second call",
+        )
+        self.assertEqual(
+            counts["condition_stages"],
+            5,
+            "seed_magic_config() must not create extra ConditionStage rows on second call",
         )
 
     def test_same_pks_returned(self) -> None:

--- a/src/integration_tests/pipeline/test_anima_regen_pipeline.py
+++ b/src/integration_tests/pipeline/test_anima_regen_pipeline.py
@@ -1,0 +1,204 @@
+"""End-to-end pipeline tests for the daily anima regen tick.
+
+User story:
+    As a player, each server day my character's anima pool refills by a
+    configured percentage — unless a Soulfray ConditionInstance at stage 2+
+    (Tearing onward) is blocking regen, or my character is currently engaged
+    in a stakes-bearing activity.
+
+Covers:
+    1. Baseline regen — depleted anima + no blocking state → tick restores.
+    2. Soulfray stage 2 (Tearing) blocks regen — tick does NOT restore.
+    3. Soulfray stage 1 (Fraying) does NOT block regen — tick restores.
+    4. CharacterEngagement blocks regen — tick does NOT restore.
+    5. Already-full anima is a no-op — tick is idempotent at maximum.
+
+Confirms: AnimaConfig singleton + ConditionStage.properties M2M
+(blocks_anima_regen) + CharacterEngagement exclusion + tick scheduler
+all integrate correctly end-to-end.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from integration_tests.game_content.magic import MagicConfigResult, seed_magic_config
+
+
+class TestAnimaRegenPipeline(TestCase):
+    """Full daily anima regen tick pipeline — all gating paths.
+
+    setUpTestData seeds:
+    - Magic config singletons (AnimaConfig with daily_regen_percent=5,
+      daily_regen_blocking_property_key="blocks_anima_regen")
+    - SoulfrayContent (5 stages; stages 2–5 carry the blocks_anima_regen
+      Property) via the idempotent SoulfrayContentFactory() call embedded
+      inside seed_magic_config().
+
+    Individual tests create their own characters, depleted CharacterAnima
+    rows, and optional ConditionInstances at specific stages so each
+    scenario is fully isolated.
+    """
+
+    config: MagicConfigResult
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.magic.factories import SoulfrayContentFactory
+
+        cls.config = seed_magic_config()
+        # Re-call SoulfrayContentFactory() to get stage objects in local scope.
+        # Idempotent — returns the same template/stages already seeded by
+        # seed_magic_config().
+        cls.soulfray_content = SoulfrayContentFactory()
+        cls.soulfray_template = cls.soulfray_content.template
+        # stages[0] = Fraying (stage_order=1, threshold=1)  — does NOT block
+        # stages[1] = Tearing (stage_order=2, threshold=6)  — BLOCKS
+        cls.stages = cls.soulfray_content.stages
+
+    # -----------------------------------------------------------------------
+    # Scenario 1: baseline regen
+    # -----------------------------------------------------------------------
+
+    def test_baseline_regen_restores_anima(self) -> None:
+        """Depleted anima + no blocking conditions → tick restores by daily_regen_percent.
+
+        AnimaConfig.daily_regen_percent=5, maximum=100 → regen floor = 5.
+        After tick, current should be 5 (floor((100 * 5) // 100)).
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import CharacterAnimaFactory
+        from world.magic.services.anima import anima_regen_tick
+
+        sheet = CharacterSheetFactory()
+        anima = CharacterAnimaFactory(character=sheet.character, current=0, maximum=100)
+
+        summary = anima_regen_tick()
+
+        anima.refresh_from_db()
+        expected_regen = (100 * 5) // 100  # = 5
+        self.assertGreaterEqual(summary.regenerated, 1)
+        self.assertEqual(anima.current, expected_regen)
+
+    # -----------------------------------------------------------------------
+    # Scenario 2: Soulfray stage 2 (Tearing) blocks regen
+    # -----------------------------------------------------------------------
+
+    def test_soulfray_stage_2_blocks_regen(self) -> None:
+        """Soulfray at stage 2 (Tearing) carries blocks_anima_regen — tick is a no-op.
+
+        The ConditionInstance has current_stage=stages[1] (Tearing), which is one
+        of the stages wired with the blocks_anima_regen Property by SoulfrayContentFactory.
+        The tick should see condition_blocked >= 1 and leave anima.current unchanged.
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.conditions.factories import ConditionInstanceFactory
+        from world.magic.factories import CharacterAnimaFactory
+        from world.magic.services.anima import anima_regen_tick
+
+        sheet = CharacterSheetFactory()
+        anima = CharacterAnimaFactory(character=sheet.character, current=0, maximum=100)
+
+        # Soulfray instance at stage 2 (Tearing) — this stage carries the blocking property.
+        tearing_stage = self.stages[1]
+        ConditionInstanceFactory(
+            target=sheet.character,
+            condition=self.soulfray_template,
+            current_stage=tearing_stage,
+            severity=tearing_stage.severity_threshold,
+        )
+
+        summary = anima_regen_tick()
+
+        anima.refresh_from_db()
+        self.assertGreaterEqual(summary.condition_blocked, 1)
+        self.assertEqual(anima.current, 0)
+
+    # -----------------------------------------------------------------------
+    # Scenario 3: Soulfray stage 1 (Fraying) does NOT block regen
+    # -----------------------------------------------------------------------
+
+    def test_soulfray_stage_1_does_not_block_regen(self) -> None:
+        """Soulfray at stage 1 (Fraying) lacks the blocks_anima_regen property.
+
+        Stage 1 (Fraying) is not wired with the blocking property — only stages 2+
+        carry it per spec §8.4. The tick should still regen this character's anima.
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.conditions.factories import ConditionInstanceFactory
+        from world.magic.factories import CharacterAnimaFactory
+        from world.magic.services.anima import anima_regen_tick
+
+        sheet = CharacterSheetFactory()
+        anima = CharacterAnimaFactory(character=sheet.character, current=0, maximum=100)
+
+        # Stage 1 (Fraying) — does NOT carry the blocking property.
+        fraying_stage = self.stages[0]
+        ConditionInstanceFactory(
+            target=sheet.character,
+            condition=self.soulfray_template,
+            current_stage=fraying_stage,
+            severity=fraying_stage.severity_threshold,
+        )
+
+        summary = anima_regen_tick()
+
+        anima.refresh_from_db()
+        # Character should be regenerated (stage 1 does not block).
+        expected_regen = (100 * 5) // 100  # = 5
+        self.assertGreaterEqual(summary.regenerated, 1)
+        self.assertEqual(anima.current, expected_regen)
+
+    # -----------------------------------------------------------------------
+    # Scenario 4: CharacterEngagement blocks regen
+    # -----------------------------------------------------------------------
+
+    def test_engagement_blocks_regen(self) -> None:
+        """Active CharacterEngagement prevents the tick from regenerating anima.
+
+        Per spec §5.5: characters currently in a stakes-bearing engagement are
+        excluded from the daily regen pass. The tick should see engagement_blocked >= 1
+        and leave anima.current unchanged.
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import CharacterAnimaFactory
+        from world.magic.services.anima import anima_regen_tick
+        from world.mechanics.factories import CharacterEngagementFactory
+
+        sheet = CharacterSheetFactory()
+        anima = CharacterAnimaFactory(character=sheet.character, current=0, maximum=100)
+        CharacterEngagementFactory(character=sheet.character)
+
+        summary = anima_regen_tick()
+
+        anima.refresh_from_db()
+        self.assertGreaterEqual(summary.engagement_blocked, 1)
+        self.assertEqual(anima.current, 0)
+
+    # -----------------------------------------------------------------------
+    # Scenario 5: already-full anima is a no-op
+    # -----------------------------------------------------------------------
+
+    def test_already_full_anima_is_noop(self) -> None:
+        """Character at maximum anima is excluded from the regen queryset.
+
+        The tick queries CharacterAnima where current < maximum.  A full character
+        is not examined at all — no regen, no error, summary.examined count unchanged.
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import CharacterAnimaFactory
+        from world.magic.services.anima import anima_regen_tick
+
+        sheet = CharacterSheetFactory()
+        anima = CharacterAnimaFactory(character=sheet.character, current=100, maximum=100)
+
+        anima_regen_tick()
+
+        anima.refresh_from_db()
+        # Full character is not in the queryset, so it doesn't count as "examined".
+        self.assertEqual(anima.current, 100)
+        # The summary may include other characters from other tests (setUpTestData
+        # runs once for the class, but each test method runs in a transaction that
+        # is rolled back). This scenario only asserts on anima.current — the count
+        # fields reflect the entire tick pass across all characters in the DB.
+        # The key invariant is that this character's anima stays at maximum.

--- a/src/integration_tests/pipeline/test_corruption_per_cast_pipeline.py
+++ b/src/integration_tests/pipeline/test_corruption_per_cast_pipeline.py
@@ -1,0 +1,442 @@
+"""End-to-end pipeline tests for the per-cast corruption accrual hook (PR #403).
+
+User story:
+    As a character, casting a non-Celestial technique causes my corruption to
+    rise in proportion to the resonance involved, the technique tier, and
+    whether I am in heightened states such as Audere, anima deficit, or
+    suffering a control mishap.
+
+Covers gaps NOT already exercised by FullCastPipelineCorruptionTests
+(world/magic/tests/integration/test_corruption_flow.py):
+
+    1. Audere push multiplier — Abyssal cast while character is in Audere
+       accrues more corruption than the same cast without Audere (×1.5).
+    2. Multi-resonance split attribution — a Gift with 2 Abyssal resonances
+       splits runtime intensity equally; each resonance accrues its share.
+    3. Stacked multipliers (deficit + Audere) — both flags true; asserts
+       the combined × 3.0 multiplier is applied (per spec §3.1 formula).
+    4. CORRUPTION_ACCRUING / CORRUPTION_ACCRUED events fire from the
+       cast-driven path (not a direct accrue_corruption call).
+
+All tests drive the full use_technique() orchestrator (Step 9 fires
+accrue_corruption_for_cast). Direct calls to accrue_corruption_for_cast
+are unit-test territory; these tests prove the pipeline wiring.
+
+CorruptionConfig defaults (integer-tenths, all × 0.1):
+    abyssal_coefficient  = 10  (× 1.0 per involvement unit)
+    tier_1_coefficient   = 10  (× 1.0 for level 1–5 techniques)
+    audere_multiplier    = 15  (× 1.5 on top of 10-neutral)
+    deficit_multiplier   = 20  (× 2.0)
+    mishap_multiplier    = 15  (× 1.5)
+
+Tick formula (spec §3.1):
+    base_tick   = involvement × (affinity_coef / 10) × (tier_coef / 10)
+    multipliers = (d × m × a) / 1000   (each of d/m/a is the configured
+                  integer-tenths value when flag=True, else 10/neutral)
+    tick        = ceil(base_tick × multipliers)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+
+class TestCorruptionPerCastPipeline(TestCase):
+    """Per-cast corruption hook pipeline — Audere, multi-resonance, stacked multipliers.
+
+    setUpTestData lazy-creates only CorruptionConfig(pk=1) with default coefficients
+    (abyssal=10, tier-1=10, audere=15, deficit=20, mishap=15).  We do NOT call
+    seed_magic_config() here because that creates a SoulfrayConfig singleton whose
+    DecimalField value is stored as a string literal in the identity map on fresh
+    get_or_create, causing a TypeError in the soulfray ratio comparison inside
+    use_technique().  Instead, we rely on the absence of a SoulfrayConfig row so
+    use_technique()'s Step 7 guard (``if soulfray_config:``) is a no-op — cleanly
+    isolating the corruption path.
+
+    Individual tests create their own characters, CharacterAnima rows, and
+    resonances with ConditionTemplates so each scenario is fully isolated.
+    The simple _make_simple_corruption_template() helper is used rather than
+    CorruptionConditionTemplateFactory to keep thresholds deterministic and
+    avoid the HOLD_OVERFLOW resist check that can gate stage advancement.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.magic.services.corruption import get_corruption_config
+
+        # Lazy-create the CorruptionConfig singleton so accrue_corruption_for_cast
+        # resolves it from a real DB row (default coefficients apply).
+        cls.corruption_config = get_corruption_config()
+
+    # -----------------------------------------------------------------------
+    # Internal helpers
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    def _make_simple_corruption_template(resonance: object) -> object:
+        """Create a simple 5-stage Corruption ConditionTemplate for resonance.
+
+        Uses ADVANCE_AT_THRESHOLD (no HOLD_OVERFLOW resist check) so stage
+        advancement is deterministic in tests.  Thresholds: 50, 200, 500,
+        1000, 1500.
+
+        Idempotent: if stages already exist on the template (--keepdb reuse),
+        stage creation is skipped.
+        """
+        from world.conditions.factories import (
+            ConditionStageFactory,
+            ConditionTemplateFactory,
+        )
+
+        template = ConditionTemplateFactory(
+            name=f"Corruption ({resonance.name} pipeline test)",
+            has_progression=True,
+            corruption_resonance=resonance,
+        )
+        # Guard: skip stage creation if stages already exist (--keepdb idempotency).
+        if template.stages.exists():
+            return template
+        thresholds = [50, 200, 500, 1000, 1500]
+        for i, threshold in enumerate(thresholds, start=1):
+            ConditionStageFactory(
+                condition=template,
+                stage_order=i,
+                severity_threshold=threshold,
+            )
+        return template
+
+    @staticmethod
+    def _make_abyssal_gift_technique(
+        *,
+        intensity: int = 5,
+        control: int = 10,
+        anima_cost: int = 2,
+        level: int = 1,
+        resonance_count: int = 1,
+    ) -> tuple:
+        """Create Abyssal resonance(s) + Gift + Technique.
+
+        Returns (resonances_list, gift, technique).
+
+        When resonance_count > 1 all resonances share the same Abyssal
+        affinity and are added to the same Gift, so the involvement split
+        spreads evenly across all of them.
+        """
+        from world.magic.factories import (
+            AffinityFactory,
+            GiftFactory,
+            ResonanceFactory,
+            TechniqueFactory,
+        )
+
+        abyssal_affinity = AffinityFactory(name="Abyssal")
+        resonances = [
+            ResonanceFactory(name=f"Test Abyssal Res {i}", affinity=abyssal_affinity)
+            for i in range(resonance_count)
+        ]
+        gift = GiftFactory()
+        for res in resonances:
+            gift.resonances.add(res)
+        technique = TechniqueFactory(
+            gift=gift,
+            intensity=intensity,
+            control=control,
+            anima_cost=anima_cost,
+            level=level,
+        )
+        return resonances, gift, technique
+
+    # -----------------------------------------------------------------------
+    # Scenario 1: Audere push multiplier
+    # -----------------------------------------------------------------------
+
+    def test_audere_multiplier_amplifies_corruption(self) -> None:
+        """Abyssal cast with character in Audere accrues more than without.
+
+        Setup:
+            intensity=5, control=10 (+ social safety +10 = runtime_control=20),
+            level=1 (tier 1).  1 Abyssal resonance.
+            involvement = runtime_intensity // 1 = 5
+            base_tick = 5 × (10/10) × (10/10) = 5
+
+        Without Audere (multipliers = 10×10×10/1000 = 1.0):
+            tick = ceil(5 × 1.0) = 5
+
+        With Audere (multipliers = 10×10×15/1000 = 1.5):
+            tick = ceil(5 × 1.5) = ceil(7.5) = 8
+
+        The test creates two characters — one baseline, one with an Audere
+        ConditionInstance — and asserts the Audere character accrues more.
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.conditions.factories import (
+            ConditionInstanceFactory,
+            ConditionTemplateFactory,
+        )
+        from world.magic.factories import CharacterAnimaFactory
+        from world.magic.models.aura import CharacterResonance
+        from world.magic.services import use_technique
+
+        resonances_base, _gift_base, technique_base = self._make_abyssal_gift_technique(
+            intensity=5, control=10, anima_cost=2, level=1
+        )
+        resonances_audere, _gift_audere, technique_audere = self._make_abyssal_gift_technique(
+            intensity=5, control=10, anima_cost=2, level=1
+        )
+        res_base = resonances_base[0]
+        res_audere = resonances_audere[0]
+
+        self._make_simple_corruption_template(res_base)
+        self._make_simple_corruption_template(res_audere)
+
+        sheet_base = CharacterSheetFactory()
+        CharacterAnimaFactory(character=sheet_base.character, current=20, maximum=20)
+
+        sheet_audere = CharacterSheetFactory()
+        CharacterAnimaFactory(character=sheet_audere.character, current=20, maximum=20)
+
+        # Put sheet_audere's character in Audere by creating the ConditionInstance directly.
+        # _character_is_in_audere() checks for ConditionInstance where
+        # condition.name = "Audere".  We can create that directly with a factory
+        # without going through the full gate check (which requires engagement + Soulfray).
+        audere_template = ConditionTemplateFactory(name="Audere")
+        ConditionInstanceFactory(
+            target=sheet_audere.character,
+            condition=audere_template,
+        )
+
+        # Baseline cast (no Audere)
+        result_base = use_technique(
+            character=sheet_base.character,
+            technique=technique_base,
+            resolve_fn=lambda: None,
+        )
+
+        # Audere cast
+        result_audere = use_technique(
+            character=sheet_audere.character,
+            technique=technique_audere,
+            resolve_fn=lambda: None,
+        )
+
+        # Both should have accrual results
+        self.assertIsNotNone(result_base.corruption_summary)
+        self.assertIsNotNone(result_audere.corruption_summary)
+
+        # was_audere flag should differ
+        self.assertFalse(result_base.was_audere)
+        self.assertTrue(result_audere.was_audere)
+
+        # Assert Audere character accrues more corruption
+        char_res_base = CharacterResonance.objects.get(
+            character_sheet=sheet_base, resonance=res_base
+        )
+        char_res_audere = CharacterResonance.objects.get(
+            character_sheet=sheet_audere, resonance=res_audere
+        )
+
+        # Without Audere: tick = ceil(5 × 1.0) = 5
+        self.assertEqual(char_res_base.corruption_current, 5)
+        # With Audere: tick = ceil(5 × 1.5) = ceil(7.5) = 8
+        self.assertEqual(char_res_audere.corruption_current, 8)
+        # Audere character should always have strictly more
+        self.assertGreater(
+            char_res_audere.corruption_current,
+            char_res_base.corruption_current,
+        )
+
+    # -----------------------------------------------------------------------
+    # Scenario 2: Multi-resonance split attribution
+    # -----------------------------------------------------------------------
+
+    def test_multi_resonance_split_attribution(self) -> None:
+        """Gift with 2 Abyssal resonances splits involvement equally between them.
+
+        Setup:
+            intensity=10, level=1 (tier 1).  2 Abyssal resonances on the Gift.
+            per_resonance_share = 10 // 2 = 5 (integer division per spec §10.1)
+            base_tick per resonance = 5 × (10/10) × (10/10) = 5
+            multipliers = 10×10×10/1000 = 1.0 (no flags set)
+            tick per resonance = ceil(5 × 1.0) = 5
+
+        Both resonances should increment corruption_current and
+        corruption_lifetime by 5.  Accrual summary has 2 per_resonance entries.
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import CharacterAnimaFactory
+        from world.magic.models.aura import CharacterResonance
+        from world.magic.services import use_technique
+
+        resonances, _gift, technique = self._make_abyssal_gift_technique(
+            intensity=10, control=10, anima_cost=2, level=1, resonance_count=2
+        )
+        res_a, res_b = resonances
+
+        self._make_simple_corruption_template(res_a)
+        self._make_simple_corruption_template(res_b)
+
+        sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
+
+        result = use_technique(
+            character=sheet.character,
+            technique=technique,
+            resolve_fn=lambda: None,
+        )
+
+        self.assertIsNotNone(result.corruption_summary)
+        # Both resonances should appear in per_resonance accrual list
+        self.assertEqual(len(result.corruption_summary.per_resonance), 2)
+
+        char_res_a = CharacterResonance.objects.get(character_sheet=sheet, resonance=res_a)
+        char_res_b = CharacterResonance.objects.get(character_sheet=sheet, resonance=res_b)
+
+        # Equal split: each resonance should receive involvement=5 → tick=5
+        self.assertEqual(char_res_a.corruption_current, 5)
+        self.assertEqual(char_res_a.corruption_lifetime, 5)
+        self.assertEqual(char_res_b.corruption_current, 5)
+        self.assertEqual(char_res_b.corruption_lifetime, 5)
+
+    # -----------------------------------------------------------------------
+    # Scenario 3: Stacked multipliers — deficit + Audere
+    # -----------------------------------------------------------------------
+
+    def test_stacked_deficit_and_audere_multipliers(self) -> None:
+        """Cast with deficit + Audere both active stacks multipliers per spec §3.1.
+
+        Setup:
+            intensity=5, control=10, anima_cost=30, current_anima=2,
+            level=1 (tier 1), 1 Abyssal resonance.
+
+            Social safety bonus applies (+10 control, no engagement):
+              runtime_control = 10 + 10 = 20
+              control_delta   = 20 - 5  = 15
+              effective_cost  = max(30 - 15, 0) = 15
+              deficit         = max(15 - 2, 0) = 13  → was_deficit=True
+
+            Audere ConditionInstance created → was_audere=True.
+
+            involvement = 5 (runtime_intensity // 1)
+            base_tick = 5 × (10/10) × (10/10) = 5
+            multipliers = (20 × 10 × 15) / 1000 = 3.0
+            tick = ceil(5 × 3.0) = 15
+
+        Compared to neutral tick (no flags) = 5 (3× uplift).
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.conditions.factories import (
+            ConditionInstanceFactory,
+            ConditionTemplateFactory,
+        )
+        from world.magic.factories import CharacterAnimaFactory
+        from world.magic.models.aura import CharacterResonance
+        from world.magic.services import use_technique
+
+        resonances, _gift, technique = self._make_abyssal_gift_technique(
+            intensity=5,
+            control=10,
+            anima_cost=30,  # high cost to force deficit
+            level=1,
+        )
+        res = resonances[0]
+        self._make_simple_corruption_template(res)
+
+        sheet = CharacterSheetFactory()
+        # Low current anima ensures deficit: effective_cost=15 > current=2
+        CharacterAnimaFactory(character=sheet.character, current=2, maximum=50)
+
+        # Apply Audere ConditionInstance.
+        # _character_is_in_audere() checks condition__name == AUDERE_CONDITION_NAME = "Audere".
+        # Use get_or_create via the factory so the template already created by Scenario 1
+        # (--keepdb) is reused safely.
+        from world.magic.audere import AUDERE_CONDITION_NAME
+
+        audere_template = ConditionTemplateFactory(name=AUDERE_CONDITION_NAME)
+        ConditionInstanceFactory(
+            target=sheet.character,
+            condition=audere_template,
+        )
+
+        result = use_technique(
+            character=sheet.character,
+            technique=technique,
+            resolve_fn=lambda: None,
+        )
+
+        self.assertIsNotNone(result.corruption_summary)
+        self.assertTrue(result.was_deficit, "Expected was_deficit=True with anima=2, cost=15")
+        self.assertTrue(result.was_audere, "Expected was_audere=True with Audere condition active")
+
+        char_res = CharacterResonance.objects.get(character_sheet=sheet, resonance=res)
+        # stacked tick = ceil(5 × 3.0) = 15
+        self.assertEqual(char_res.corruption_current, 15)
+        self.assertEqual(char_res.corruption_lifetime, 15)
+
+    # -----------------------------------------------------------------------
+    # Scenario 4: CORRUPTION_ACCRUING + CORRUPTION_ACCRUED events fire from cast path
+    # -----------------------------------------------------------------------
+
+    def test_cast_emits_corruption_accruing_and_accrued_events(self) -> None:
+        """The cast-driven pipeline fires CORRUPTION_ACCRUING and CORRUPTION_ACCRUED.
+
+        Verifies that the reactive event layer fires for each per-resonance
+        accrual step when routed through use_technique → accrue_corruption_for_cast
+        → accrue_corruption.  The character must have a location so emit_event
+        fires (it is suppressed when location is None).
+
+        Uses a single Abyssal resonance with intensity=5, level=1.
+        Expected: 1 CORRUPTION_ACCRUING + 1 CORRUPTION_ACCRUED emitted.
+        """
+        from evennia.objects.models import ObjectDB
+
+        from flows.constants import EventName
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import CharacterAnimaFactory
+        from world.magic.services import use_technique
+
+        resonances, _gift, technique = self._make_abyssal_gift_technique(
+            intensity=5, control=10, anima_cost=2, level=1
+        )
+        res = resonances[0]
+        self._make_simple_corruption_template(res)
+
+        sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
+
+        # Give the character a location so emit_event fires (skipped when location is None).
+        room = ObjectDB.objects.create(
+            db_key="CorruptionPipelineTestRoom",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        sheet.character.location = room
+
+        emitted_event_names: list[str] = []
+        import world.magic.services.corruption as corruption_mod
+
+        original_emit = corruption_mod.emit_event
+
+        def capturing_emit(
+            event_name: str, payload: object, location: object, **kwargs: object
+        ) -> object:
+            emitted_event_names.append(event_name)
+            return original_emit(event_name, payload, location, **kwargs)
+
+        with patch("world.magic.services.corruption.emit_event", side_effect=capturing_emit):
+            use_technique(
+                character=sheet.character,
+                technique=technique,
+                resolve_fn=lambda: None,
+            )
+
+        self.assertIn(
+            EventName.CORRUPTION_ACCRUING,
+            emitted_event_names,
+            "Expected CORRUPTION_ACCRUING to fire from cast-driven path",
+        )
+        self.assertIn(
+            EventName.CORRUPTION_ACCRUED,
+            emitted_event_names,
+            "Expected CORRUPTION_ACCRUED to fire from cast-driven path",
+        )

--- a/src/integration_tests/pipeline/test_corruption_per_cast_pipeline.py
+++ b/src/integration_tests/pipeline/test_corruption_per_cast_pipeline.py
@@ -46,14 +46,11 @@ from django.test import TestCase
 class TestCorruptionPerCastPipeline(TestCase):
     """Per-cast corruption hook pipeline — Audere, multi-resonance, stacked multipliers.
 
-    setUpTestData lazy-creates only CorruptionConfig(pk=1) with default coefficients
-    (abyssal=10, tier-1=10, audere=15, deficit=20, mishap=15).  We do NOT call
-    seed_magic_config() here because that creates a SoulfrayConfig singleton whose
-    DecimalField value is stored as a string literal in the identity map on fresh
-    get_or_create, causing a TypeError in the soulfray ratio comparison inside
-    use_technique().  Instead, we rely on the absence of a SoulfrayConfig row so
-    use_technique()'s Step 7 guard (``if soulfray_config:``) is a no-op — cleanly
-    isolating the corruption path.
+    setUpTestData calls seed_magic_config() to set up all required singletons
+    (AnimaConfig, SoulfrayConfig, ResonanceGainConfig, CorruptionConfig, etc.)
+    with correct types.  seed_magic_config() now stores SoulfrayConfig's
+    soulfray_threshold_ratio as Decimal("0.30"), so use_technique()'s Step 7
+    soulfray guard no longer raises TypeError.
 
     Individual tests create their own characters, CharacterAnima rows, and
     resonances with ConditionTemplates so each scenario is fully isolated.
@@ -64,11 +61,13 @@ class TestCorruptionPerCastPipeline(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        from world.magic.services.corruption import get_corruption_config
+        from integration_tests.game_content.magic import seed_magic_config
 
-        # Lazy-create the CorruptionConfig singleton so accrue_corruption_for_cast
-        # resolves it from a real DB row (default coefficients apply).
-        cls.corruption_config = get_corruption_config()
+        # seed_magic_config() creates all required singletons (including
+        # SoulfrayConfig with Decimal("0.30") for soulfray_threshold_ratio)
+        # and the CorruptionConfig with default coefficients.
+        result = seed_magic_config()
+        cls.corruption_config = result.corruption_config
 
     # -----------------------------------------------------------------------
     # Internal helpers

--- a/src/integration_tests/pipeline/test_situation_pipeline.py
+++ b/src/integration_tests/pipeline/test_situation_pipeline.py
@@ -1,0 +1,429 @@
+"""End-to-end pipeline tests for the Situation system.
+
+User story:
+    As a GM, I place a Situation template at a room location. The system
+    creates a SituationInstance and a set of ChallengeInstance rows — one
+    per ChallengeTemplate in the template's SituationChallengeLink set.
+    Players can then resolve each ChallengeInstance via the standard
+    resolve_challenge pipeline. When all ChallengeInstances are resolved
+    (deactivated), the GM can mark the Situation complete.
+
+Covers:
+    1. Instantiating a SituationTemplate manually creates SituationInstance
+       + one ChallengeInstance per linked ChallengeTemplate.
+    2. Resolving a single ChallengeInstance within a Situation writes a
+       CharacterChallengeRecord and sets is_active=False on DESTROY outcomes.
+    3. Resolving ALL ChallengeInstances leaves no active challenges in the
+       Situation, which is the prerequisite for marking it complete.
+    4. Attempting to resolve a challenge twice raises ChallengeResolutionError.
+
+Architecture gaps documented:
+    - No ``instantiate_situation(template, location)`` service function exists.
+      The test builds the chain manually: SituationInstance + per-link
+      ChallengeInstances. A proper service would belong in
+      ``world/mechanics/challenge_resolution.py`` or a new
+      ``world/mechanics/situation_services.py`` and is a Phase 1 follow-up.
+    - No completion semantics on SituationInstance (no status field, only
+      ``is_active`` bool). Completion is defined here as "no active
+      ChallengeInstances remaining" — we verify that state rather than a
+      terminal status enum.
+    - SituationApproach model does not exist; challenge approaches live at
+      ChallengeTemplate level (ChallengeApproach). The architectural notes
+      describing per-situation approach overrides were speculative design;
+      the implemented schema does not include them.
+    - Cooperative resolution is unimplemented at the model/service layer.
+      The CharacterChallengeRecord unique constraint enforces one record per
+      (character, challenge_instance) — multiple characters can each resolve
+      the same challenge, but there is no aggregation logic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from integration_tests.game_content.challenges import ChallengeContent
+from integration_tests.game_content.characters import CharacterContent
+from integration_tests.game_content.social import SocialContent
+from world.mechanics.models import (
+    ChallengeInstance,
+    CharacterChallengeRecord,
+    SituationChallengeLink,
+    SituationInstance,
+    SituationTemplate,
+)
+from world.mechanics.types import ChallengeResolutionError
+
+
+class TestSituationPipeline(TestCase):
+    """SituationTemplate → SituationInstance → ChallengeInstance chain + resolution.
+
+    setUpTestData seeds:
+    - Full ChallengeContent suite (capabilities, properties, applications,
+      6 starter ChallengeTemplates with consequences)
+    - A SituationTemplate with two linked ChallengeTemplates
+      ("Darkness" + "Locked Door") via SituationChallengeLink
+    - A room ObjectDB to host the situation
+    - A character with challenge stats (strength/agility/perception) for resolution
+    - A SituationInstance + two ChallengeInstances at the room
+
+    Individual tests either use cls.situation_instance + cls.challenge_instances
+    directly, or create fresh instances where isolation is required (resolution
+    deactivates challenges, making re-use across tests unsafe).
+    """
+
+    content: object  # ChallengeContentResult
+    situation_template: SituationTemplate
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia_extensions.factories import ObjectDBFactory
+        from world.mechanics.factories import (
+            ChallengeInstanceFactory,
+            SituationChallengeLinkFactory,
+            SituationInstanceFactory,
+            SituationTemplateFactory,
+        )
+
+        social_result = SocialContent.create_all()
+        cls.content = ChallengeContent.create_all(social_result.outcomes)
+
+        # Two challenges that will form our Situation.
+        cls.darkness_template = cls.content.challenges["Darkness"]
+        cls.locked_door_template = cls.content.challenges["Locked Door"]
+
+        # SituationTemplate needs a ChallengeCategory.
+        # Re-use the "Environmental" category already created by ChallengeContent.
+        env_category = cls.content.challenge_categories["Environmental"]
+
+        cls.situation_template = SituationTemplateFactory(
+            name="The Sealed Passage",
+            description_template="A sealed corridor shrouded in darkness.",
+            category=env_category,
+        )
+
+        # Link two challenges in display order.
+        SituationChallengeLinkFactory(
+            situation_template=cls.situation_template,
+            challenge_template=cls.darkness_template,
+            display_order=0,
+        )
+        SituationChallengeLinkFactory(
+            situation_template=cls.situation_template,
+            challenge_template=cls.locked_door_template,
+            display_order=1,
+        )
+
+        # Room that will host the situation.
+        cls.room = ObjectDBFactory(
+            db_key="sealed_passage_room",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+
+        # Character with challenge traits.
+        cls.char, cls.persona = CharacterContent.create_base_challenge_character(name="Pathfinder")
+
+        # Instantiate the situation manually (no service exists — see docstring gap note).
+        cls.situation_instance = SituationInstanceFactory(
+            template=cls.situation_template,
+            location=cls.room,
+        )
+
+        # Create one ChallengeInstance per linked ChallengeTemplate.
+        cls.challenge_instances: dict[str, ChallengeInstance] = {}
+        links = SituationChallengeLink.objects.filter(
+            situation_template=cls.situation_template
+        ).order_by("display_order")
+        for link in links:
+            target = ObjectDBFactory(db_key=f"target_{link.challenge_template.name}")
+            instance = ChallengeInstanceFactory(
+                template=link.challenge_template,
+                situation_instance=cls.situation_instance,
+                location=cls.room,
+                target_object=target,
+            )
+            cls.challenge_instances[link.challenge_template.name] = instance
+
+    # -----------------------------------------------------------------------
+    # Scenario 1: Instantiation creates the expected chain
+    # -----------------------------------------------------------------------
+
+    def test_situation_instance_created(self) -> None:
+        """SituationInstance exists and references the correct template and location."""
+        assert self.situation_instance.template == self.situation_template
+        assert self.situation_instance.location == self.room
+        assert self.situation_instance.is_active is True
+
+    def test_challenge_instances_linked_to_situation(self) -> None:
+        """One ChallengeInstance per linked ChallengeTemplate, all tied to SituationInstance."""
+        linked_instances = ChallengeInstance.objects.filter(
+            situation_instance=self.situation_instance
+        )
+        assert linked_instances.count() == 2
+
+        template_names = set(linked_instances.values_list("template__name", flat=True))
+        assert "Darkness" in template_names
+        assert "Locked Door" in template_names
+
+    def test_all_challenge_instances_start_active(self) -> None:
+        """All ChallengeInstances created as part of the Situation start active and revealed."""
+        linked_instances = ChallengeInstance.objects.filter(
+            situation_instance=self.situation_instance
+        )
+        for instance in linked_instances:
+            assert instance.is_active is True, f"{instance.template.name} should be active"
+            assert instance.is_revealed is True, f"{instance.template.name} should be revealed"
+
+    def test_situation_challenge_links_ordered(self) -> None:
+        """SituationChallengeLinks are retrievable in display_order."""
+        links = list(
+            SituationChallengeLink.objects.filter(
+                situation_template=self.situation_template
+            ).order_by("display_order")
+        )
+        assert len(links) == 2
+        assert links[0].challenge_template.name == "Darkness"
+        assert links[1].challenge_template.name == "Locked Door"
+
+    # -----------------------------------------------------------------------
+    # Scenario 2: Resolving a ChallengeInstance within a Situation
+    # -----------------------------------------------------------------------
+
+    def _resolve_darkness(self, char: object) -> object:
+        """Create a fresh Darkness instance and resolve it (high roll → DESTROY outcome)."""
+        from evennia_extensions.factories import ObjectDBFactory
+        from world.mechanics.challenge_resolution import resolve_challenge
+        from world.mechanics.factories import ChallengeInstanceFactory
+        from world.mechanics.models import ChallengeApproach
+        from world.mechanics.services import get_available_actions
+        from world.mechanics.types import CapabilitySource
+
+        fresh_room = ObjectDBFactory(
+            db_key="resolve_test_room", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        fresh_instance = ChallengeInstanceFactory(
+            template=self.darkness_template,
+            situation_instance=self.situation_instance,
+            location=fresh_room,
+            target_object=ObjectDBFactory(db_key="resolve_dark_target"),
+        )
+
+        actions = get_available_actions(char, fresh_room)
+        matching = [a for a in actions if a.challenge_instance_id == fresh_instance.pk]
+        assert matching, "No available actions found for the fresh Darkness instance"
+
+        action = matching[0]
+        approach = ChallengeApproach.objects.get(pk=action.approach_id)
+        source: CapabilitySource = action.capability_source
+
+        with patch("world.checks.services.random.randint", return_value=95):
+            result = resolve_challenge(char, fresh_instance, approach, source)
+
+        return result, fresh_instance
+
+    def test_resolving_challenge_creates_record(self) -> None:
+        """resolve_challenge writes a CharacterChallengeRecord for the challenge instance."""
+        _result, fresh_instance = self._resolve_darkness(self.char)
+
+        assert CharacterChallengeRecord.objects.filter(
+            character=self.char,
+            challenge_instance=fresh_instance,
+        ).exists()
+
+    def test_destroy_resolution_deactivates_challenge(self) -> None:
+        """A success/critical outcome with DESTROY resolution_type sets is_active=False."""
+        _result, fresh_instance = self._resolve_darkness(self.char)
+
+        fresh_instance.refresh_from_db()
+        # Success/critical consequences have ResolutionType.DESTROY in the seed data.
+        assert fresh_instance.is_active is False, (
+            "Darkness challenge should be deactivated after a high-roll success"
+        )
+
+    def test_resolve_challenge_returns_result_with_situation_context(self) -> None:
+        """Resolution result includes challenge_instance_id matching the instance."""
+        result, fresh_instance = self._resolve_darkness(self.char)
+
+        assert result.challenge_instance_id == fresh_instance.pk
+        assert result.challenge_name == "Darkness"
+
+    # -----------------------------------------------------------------------
+    # Scenario 3: Situation completion when all challenges resolved
+    # -----------------------------------------------------------------------
+
+    def test_situation_completion_when_all_challenges_resolved(self) -> None:
+        """Resolving all ChallengeInstances leaves zero active challenges in the Situation.
+
+        Completion semantics: SituationInstance has only ``is_active`` (bool).
+        There is no terminal status enum. "Complete" is defined here as having no
+        remaining active ChallengeInstances — the GM can then set is_active=False
+        on the SituationInstance to clean up.
+
+        This test verifies the state, not a service function (no completion service
+        exists — see docstring gap note at module level).
+        """
+        from evennia_extensions.factories import ObjectDBFactory
+        from world.mechanics.challenge_resolution import resolve_challenge
+        from world.mechanics.factories import ChallengeInstanceFactory
+        from world.mechanics.models import ChallengeApproach
+        from world.mechanics.services import get_available_actions
+
+        # Use a dedicated room and situation for this test.
+        completion_room = ObjectDBFactory(
+            db_key="completion_test_room", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        completion_situation = SituationInstance.objects.create(
+            template=self.situation_template,
+            location=completion_room,
+            is_active=True,
+        )
+
+        challenge_instances_to_resolve: list[ChallengeInstance] = []
+        links = SituationChallengeLink.objects.filter(
+            situation_template=self.situation_template
+        ).order_by("display_order")
+
+        for link in links:
+            target = ObjectDBFactory(db_key=f"comp_target_{link.challenge_template.name}")
+            ci = ChallengeInstanceFactory(
+                template=link.challenge_template,
+                situation_instance=completion_situation,
+                location=completion_room,
+                target_object=target,
+            )
+            challenge_instances_to_resolve.append(ci)
+
+        # Resolve all challenges with a high roll (success → DESTROY).
+        for ci in challenge_instances_to_resolve:
+            actions = get_available_actions(self.char, completion_room)
+            matching = [a for a in actions if a.challenge_instance_id == ci.pk]
+            assert matching, f"No actions found for {ci.template.name}"
+
+            action = matching[0]
+            approach = ChallengeApproach.objects.get(pk=action.approach_id)
+
+            with patch("world.checks.services.random.randint", return_value=95):
+                resolve_challenge(self.char, ci, approach, action.capability_source)
+
+        # After resolution: no active challenges remain in this situation.
+        active_count = ChallengeInstance.objects.filter(
+            situation_instance=completion_situation,
+            is_active=True,
+        ).count()
+
+        assert active_count == 0, (
+            f"Expected 0 active challenges after full resolution, found {active_count}"
+        )
+
+        # The situation itself is still marked is_active (no auto-complete service).
+        # Deactivating it is a manual GM step — verify we can toggle it.
+        completion_situation.is_active = False
+        completion_situation.save()
+        completion_situation.refresh_from_db()
+        assert completion_situation.is_active is False
+
+    # -----------------------------------------------------------------------
+    # Scenario 4: Double-resolution guard
+    # -----------------------------------------------------------------------
+
+    def test_resolving_challenge_twice_raises_error(self) -> None:
+        """Attempting to resolve the same challenge twice raises ChallengeResolutionError."""
+        from evennia_extensions.factories import ObjectDBFactory
+        from world.mechanics.challenge_resolution import resolve_challenge
+        from world.mechanics.factories import ChallengeInstanceFactory
+        from world.mechanics.models import ChallengeApproach
+        from world.mechanics.services import get_available_actions
+
+        dupe_room = ObjectDBFactory(
+            db_key="dupe_test_room", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        dupe_instance = ChallengeInstanceFactory(
+            template=self.darkness_template,
+            situation_instance=self.situation_instance,
+            location=dupe_room,
+            target_object=ObjectDBFactory(db_key="dupe_dark_target"),
+        )
+
+        actions = get_available_actions(self.char, dupe_room)
+        matching = [a for a in actions if a.challenge_instance_id == dupe_instance.pk]
+        assert matching, "No available actions found for dupe instance"
+
+        action = matching[0]
+        approach = ChallengeApproach.objects.get(pk=action.approach_id)
+        source = action.capability_source
+
+        with patch("world.checks.services.random.randint", return_value=10):
+            resolve_challenge(self.char, dupe_instance, approach, source)
+
+        # Second resolution attempt — challenge may still be active (low roll = PERSONAL),
+        # but CharacterChallengeRecord already exists → should raise.
+        dupe_instance.is_active = True
+        dupe_instance.save()
+
+        import pytest
+
+        with pytest.raises(ChallengeResolutionError, match="already resolved"):
+            with patch("world.checks.services.random.randint", return_value=10):
+                resolve_challenge(self.char, dupe_instance, approach, source)
+
+    # -----------------------------------------------------------------------
+    # Cooperative resolution (not implemented — documented)
+    # -----------------------------------------------------------------------
+
+    def test_multiple_characters_can_each_resolve_same_challenge(self) -> None:
+        """Two characters can both resolve the same ChallengeInstance independently.
+
+        Cooperative resolution aggregation is not implemented (no service layer
+        combines results, no 'cooperative success' outcome). Each character's
+        resolution is independent. The CharacterChallengeRecord unique constraint
+        is per (character, challenge_instance), so two different characters
+        each get their own record.
+
+        This test documents the current behaviour: independent resolution,
+        no aggregation.
+        """
+        from evennia_extensions.factories import ObjectDBFactory
+        from world.mechanics.challenge_resolution import resolve_challenge
+        from world.mechanics.factories import ChallengeInstanceFactory
+        from world.mechanics.models import ChallengeApproach
+        from world.mechanics.services import get_available_actions
+
+        coop_room = ObjectDBFactory(
+            db_key="coop_test_room", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        coop_instance = ChallengeInstanceFactory(
+            template=self.darkness_template,
+            situation_instance=self.situation_instance,
+            location=coop_room,
+            target_object=ObjectDBFactory(db_key="coop_dark_target"),
+        )
+
+        char_a, _ = CharacterContent.create_base_challenge_character(name="CoopA")
+        char_b, _ = CharacterContent.create_base_challenge_character(name="CoopB")
+
+        def _resolve_for(char: object) -> None:
+            actions = get_available_actions(char, coop_room)
+            matching = [a for a in actions if a.challenge_instance_id == coop_instance.pk]
+            assert matching, f"No actions for char {char}"
+            action = matching[0]
+            approach = ChallengeApproach.objects.get(pk=action.approach_id)
+            # Use a low roll so the challenge stays active for the second character.
+            with patch("world.checks.services.random.randint", return_value=10):
+                resolve_challenge(char, coop_instance, approach, action.capability_source)
+
+        _resolve_for(char_a)
+
+        # Challenge may have been deactivated; re-activate for char_b's turn.
+        coop_instance.is_active = True
+        coop_instance.save()
+
+        _resolve_for(char_b)
+
+        records = CharacterChallengeRecord.objects.filter(challenge_instance=coop_instance)
+        assert records.count() == 2, (
+            f"Expected 2 records (one per character), found {records.count()}"
+        )
+        record_chars = {r.character_id for r in records}
+        assert char_a.pk in record_chars
+        assert char_b.pk in record_chars

--- a/src/integration_tests/pipeline/test_thread_pull_pipeline.py
+++ b/src/integration_tests/pipeline/test_thread_pull_pipeline.py
@@ -1,0 +1,346 @@
+"""End-to-end pipeline tests for the Spec A thread pull system.
+
+Covers the full chain:
+    seed_thread_pull_catalog → Thread on character
+    → spend_resonance_for_pull → CombatPull written
+    → resolve_pull_effects → CombatPullResolvedEffect rows
+    for each effect_kind (FLAT_BONUS, INTENSITY_BUMP, VITAL_BONUS, CAPABILITY_GRANT).
+
+Tier-0 VITAL_BONUS is verified as passive: active without any resonance spend,
+via character.threads.passive_vital_bonuses() (Thread anchor only).
+
+Test class structure:
+    TestThreadPullPipeline  — full setUpTestData + four test methods, one per
+                              effect kind. Uses combat context so CombatPull rows
+                              are written and CombatPullResolvedEffect rows are
+                              snapshotted.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from integration_tests.game_content.magic import (
+    MagicConfigResult,
+    ThreadPullCatalogResult,
+    seed_magic_config,
+    seed_thread_pull_catalog,
+)
+from world.magic.constants import EffectKind, TargetKind, VitalBonusTarget
+
+
+class TestThreadPullPipeline(TestCase):
+    """Proves the entire Spec A thread pull system works end-to-end.
+
+    setUpTestData seeds:
+    - Magic config singletons (AnimaConfig, SoulfrayConfig, etc.)
+    - Thread pull catalog (ThreadPullCost × 3, ThreadPullEffect × 4, Tideborne resonance)
+    - A character with CharacterSheet, CharacterAnima, CharacterResonance balance
+    - A Thread anchored to a Trait, targeting the canonical "Tideborne" resonance
+      with level=10 (satisfies min_thread_level=5 for CAPABILITY_GRANT; multiplier=1)
+    - A minimal CombatEncounter + CombatParticipant scaffold
+
+    VITAL_BONUS (tier=0) is passive — the test verifies it activates without any spend.
+    FLAT_BONUS (tier=1), INTENSITY_BUMP (tier=2), CAPABILITY_GRANT (tier=3) each
+    require a resonance spend and write CombatPull + CombatPullResolvedEffect rows.
+    """
+
+    config: MagicConfigResult
+    catalog: ThreadPullCatalogResult
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.combat.factories import (
+            CombatEncounterFactory,
+            CombatParticipantFactory,
+        )
+        from world.magic.factories import (
+            CharacterAnimaFactory,
+            CharacterResonanceFactory,
+        )
+        from world.magic.models import Thread
+        from world.traits.factories import TraitFactory
+        from world.vitals.models import CharacterVitals
+
+        cls.config = seed_magic_config()
+        cls.catalog = seed_thread_pull_catalog()
+
+        # Character scaffold
+        cls.sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=cls.sheet.character, current=50, maximum=50)
+
+        # Resonance balance: must afford tier-3 pull (resonance_cost=6) with headroom.
+        CharacterResonanceFactory(
+            character_sheet=cls.sheet,
+            resonance=cls.catalog.canonical_resonance,
+            balance=20,
+            lifetime_earned=20,
+        )
+
+        # Trait anchor (target_kind=TRAIT is the default for ThreadFactory; we create
+        # directly here so we control the trait and can pass it to involved_traits).
+        cls.target_trait = TraitFactory()
+        cls.thread = Thread.objects.create(
+            owner=cls.sheet,
+            resonance=cls.catalog.canonical_resonance,
+            target_kind=TargetKind.TRAIT,
+            target_trait=cls.target_trait,
+            # level=10 → multiplier = max(1, 10//10) = 1; satisfies min_thread_level=5
+            level=10,
+            developed_points=0,
+        )
+
+        # Vitals (needed for recompute_max_health_with_threads inside spend_resonance_for_pull)
+        cls.vitals = CharacterVitals.objects.create(
+            character_sheet=cls.sheet,
+            health=50,
+            base_max_health=50,
+            max_health=50,
+        )
+
+        # Combat scaffold: encounter at round 1
+        cls.encounter = CombatEncounterFactory(round_number=1)
+        cls.participant = CombatParticipantFactory(
+            encounter=cls.encounter,
+            character_sheet=cls.sheet,
+        )
+
+    # -----------------------------------------------------------------------
+    # Helper
+    # -----------------------------------------------------------------------
+
+    def _make_combat_ctx(self, round_number: int = 1) -> object:
+        """Return a PullActionContext for combat, with the trait anchor in scope."""
+        from world.combat.factories import (
+            CombatEncounterFactory,
+            CombatParticipantFactory,
+        )
+        from world.magic.types import PullActionContext
+
+        encounter = CombatEncounterFactory(round_number=round_number)
+        participant = CombatParticipantFactory(
+            encounter=encounter,
+            character_sheet=self.sheet,
+        )
+        return PullActionContext(
+            combat_encounter=encounter,
+            participant=participant,
+            involved_traits=(self.target_trait.pk,),
+        )
+
+    def _fresh_resonance_balance(self, amount: int) -> None:
+        """Reset the character's Tideborne resonance balance to `amount` for isolation.
+
+        Uses direct attribute update + save so the SharedMemoryModel identity map
+        stays in sync (avoids stale-cache reads on subsequent .objects.get() calls).
+        """
+        from world.magic.models import CharacterResonance
+
+        cr = CharacterResonance.objects.get(
+            character_sheet=self.sheet,
+            resonance=self.catalog.canonical_resonance,
+        )
+        cr.balance = amount
+        cr.save(update_fields=["balance"])
+        # Invalidate the handler cache so the service sees the updated value.
+        self.sheet.character.resonances.invalidate()
+
+    # -----------------------------------------------------------------------
+    # Test 1: passive VITAL_BONUS active without any spend
+    # -----------------------------------------------------------------------
+
+    def test_passive_vital_bonus_active_without_spend(self) -> None:
+        """Tier-0 VITAL_BONUS activates passively via the Thread anchor alone.
+
+        No resonance spend is needed. character.threads.passive_vital_bonuses()
+        sums tier-0 MAX_HEALTH contributions across the character's threads.
+
+        The catalog VITAL_BONUS row: tier=0, vital_bonus_amount=5, MAX_HEALTH.
+        Thread.level=10 → multiplier = max(1, 10//10) = 1. Expected sum = 5 × 1 = 5.
+        """
+
+        passive_total = self.sheet.character.threads.passive_vital_bonuses(
+            VitalBonusTarget.MAX_HEALTH
+        )
+        self.assertEqual(passive_total, 5)
+
+    # -----------------------------------------------------------------------
+    # Test 2: tier-1 pull → CombatPull + FLAT_BONUS CombatPullResolvedEffect
+    # -----------------------------------------------------------------------
+
+    def test_tier1_pull_writes_combat_pull_and_flat_bonus_effect(self) -> None:
+        """Tier-1 resonance spend writes a CombatPull and a FLAT_BONUS resolved effect.
+
+        Catalog: FLAT_BONUS tier=1, flat_bonus_amount=2, min_thread_level=0.
+        Thread.level=10 → multiplier=1. Expected scaled_value = 2 × 1 = 2.
+
+        Also verifies tier-0 VITAL_BONUS is resolved (passive but included in the
+        resolve sweep when tier includes 0..1 range), and balance is debited.
+        """
+        from world.combat.models import CombatPull, CombatPullResolvedEffect
+        from world.magic.models import CharacterResonance
+        from world.magic.services import spend_resonance_for_pull
+
+        self._fresh_resonance_balance(10)
+
+        ctx = self._make_combat_ctx(round_number=2)
+        result = spend_resonance_for_pull(
+            self.sheet,
+            self.catalog.canonical_resonance,
+            tier=1,
+            threads=[self.thread],
+            action_context=ctx,
+        )
+
+        # --- CombatPull written ---
+        pull = CombatPull.objects.get(
+            participant=ctx.participant,
+            round_number=2,
+        )
+        self.assertEqual(pull.tier, 1)
+        self.assertEqual(pull.resonance_spent, 1)  # catalog tier-1 cost: resonance_cost=1
+        self.assertEqual(pull.anima_spent, 0)  # single thread: max(0,1-1)×1=0
+
+        # --- FLAT_BONUS resolved effect written ---
+        flat_effects = CombatPullResolvedEffect.objects.filter(
+            pull=pull,
+            kind=EffectKind.FLAT_BONUS,
+            source_tier=1,
+        )
+        self.assertEqual(flat_effects.count(), 1)
+        flat_eff = flat_effects.first()
+        self.assertEqual(flat_eff.authored_value, 2)
+        self.assertEqual(flat_eff.level_multiplier, 1)
+        self.assertEqual(flat_eff.scaled_value, 2)
+
+        # --- Return value matches DB ---
+        flat_rows = [r for r in result.resolved_effects if r.kind == EffectKind.FLAT_BONUS]
+        tier1_flat = [r for r in flat_rows if r.source_tier == 1]
+        self.assertEqual(len(tier1_flat), 1)
+        self.assertEqual(tier1_flat[0].scaled_value, 2)
+
+        # --- Balance debited ---
+        cr = CharacterResonance.objects.get(
+            character_sheet=self.sheet,
+            resonance=self.catalog.canonical_resonance,
+        )
+        self.assertEqual(cr.balance, 9)  # 10 − 1 (tier-1 cost)
+
+    # -----------------------------------------------------------------------
+    # Test 3: tier-2 pull → INTENSITY_BUMP CombatPullResolvedEffect
+    # -----------------------------------------------------------------------
+
+    def test_tier2_pull_writes_intensity_bump_effect(self) -> None:
+        """Tier-2 resonance spend writes a CombatPull with an INTENSITY_BUMP resolved effect.
+
+        Catalog: INTENSITY_BUMP tier=2, intensity_bump_amount=1, min_thread_level=0.
+        Thread.level=10 → multiplier=1. Expected scaled_value = 1 × 1 = 1.
+        resolve_pull_effects sweeps tiers 0..2, so FLAT_BONUS (tier=1) and
+        VITAL_BONUS (tier=0) rows also appear in resolved_effects.
+        """
+        from world.combat.models import CombatPull, CombatPullResolvedEffect
+        from world.magic.services import spend_resonance_for_pull
+
+        self._fresh_resonance_balance(10)
+
+        ctx = self._make_combat_ctx(round_number=3)
+        result = spend_resonance_for_pull(
+            self.sheet,
+            self.catalog.canonical_resonance,
+            tier=2,
+            threads=[self.thread],
+            action_context=ctx,
+        )
+
+        pull = CombatPull.objects.get(
+            participant=ctx.participant,
+            round_number=3,
+        )
+        self.assertEqual(pull.tier, 2)
+        self.assertEqual(pull.resonance_spent, 3)  # catalog tier-2 cost: resonance_cost=3
+
+        # --- INTENSITY_BUMP resolved effect written ---
+        bump_effects = CombatPullResolvedEffect.objects.filter(
+            pull=pull,
+            kind=EffectKind.INTENSITY_BUMP,
+            source_tier=2,
+        )
+        self.assertEqual(bump_effects.count(), 1)
+        bump_eff = bump_effects.first()
+        self.assertEqual(bump_eff.authored_value, 1)
+        self.assertEqual(bump_eff.level_multiplier, 1)
+        self.assertEqual(bump_eff.scaled_value, 1)
+
+        # --- Return value includes INTENSITY_BUMP ---
+        bump_rows = [
+            r
+            for r in result.resolved_effects
+            if r.kind == EffectKind.INTENSITY_BUMP and r.source_tier == 2
+        ]
+        self.assertEqual(len(bump_rows), 1)
+        self.assertEqual(bump_rows[0].scaled_value, 1)
+
+    # -----------------------------------------------------------------------
+    # Test 4: tier-3 pull → CAPABILITY_GRANT CombatPullResolvedEffect
+    # -----------------------------------------------------------------------
+
+    def test_tier3_pull_writes_capability_grant_effect(self) -> None:
+        """Tier-3 resonance spend writes a CAPABILITY_GRANT resolved effect.
+
+        Catalog: CAPABILITY_GRANT tier=3, min_thread_level=5, capability=endurance.
+        Thread.level=10 satisfies min_thread_level=5.
+        CAPABILITY_GRANT has no numeric payload; granted_capability points to the
+        "endurance" CapabilityType seeded by seed_thread_pull_catalog().
+
+        The resolve sweep covers tiers 0..3, so all four effect kinds appear.
+        This test verifies the CAPABILITY_GRANT row specifically.
+        """
+        from world.combat.models import CombatPull, CombatPullResolvedEffect
+        from world.magic.services import spend_resonance_for_pull
+
+        self._fresh_resonance_balance(10)
+
+        ctx = self._make_combat_ctx(round_number=4)
+        result = spend_resonance_for_pull(
+            self.sheet,
+            self.catalog.canonical_resonance,
+            tier=3,
+            threads=[self.thread],
+            action_context=ctx,
+        )
+
+        pull = CombatPull.objects.get(
+            participant=ctx.participant,
+            round_number=4,
+        )
+        self.assertEqual(pull.tier, 3)
+        self.assertEqual(pull.resonance_spent, 6)  # catalog tier-3 cost: resonance_cost=6
+
+        # --- CAPABILITY_GRANT resolved effect written ---
+        grant_effects = CombatPullResolvedEffect.objects.filter(
+            pull=pull,
+            kind=EffectKind.CAPABILITY_GRANT,
+            source_tier=3,
+        )
+        self.assertEqual(grant_effects.count(), 1)
+        grant_eff = grant_effects.first()
+        self.assertIsNone(grant_eff.scaled_value)
+        self.assertIsNotNone(grant_eff.granted_capability)
+        self.assertEqual(grant_eff.granted_capability.name, "endurance")
+
+        # --- Return value includes CAPABILITY_GRANT ---
+        cap_rows = [
+            r
+            for r in result.resolved_effects
+            if r.kind == EffectKind.CAPABILITY_GRANT and r.source_tier == 3
+        ]
+        self.assertEqual(len(cap_rows), 1)
+        self.assertEqual(cap_rows[0].granted_capability.name, "endurance")
+
+        # --- All four effect kinds resolved across tiers 0..3 ---
+        resolved_kinds = {r.kind for r in result.resolved_effects}
+        self.assertIn(EffectKind.FLAT_BONUS, resolved_kinds)
+        self.assertIn(EffectKind.INTENSITY_BUMP, resolved_kinds)
+        self.assertIn(EffectKind.VITAL_BONUS, resolved_kinds)
+        self.assertIn(EffectKind.CAPABILITY_GRANT, resolved_kinds)

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -1203,10 +1203,21 @@ _ABYSSAL_AFFINITY_NAME: str = "abyssal"
 
 
 def _make_magical_endurance_check_type():
-    """Return a 'Magical Endurance' CheckType, creating it if absent."""
-    from world.checks.factories import CheckTypeFactory
+    """Return the canonical 'Magical Endurance' CheckType, creating it if absent.
 
-    return CheckTypeFactory(name="Magical Endurance")
+    Uses direct ORM get_or_create so the call is idempotent and converges with
+    the row authored by seed_magic_config().  The old CheckTypeFactory approach
+    created a fresh CheckCategory SubFactory on every call, making the
+    (name, category) natural key novel each time and leaking orphan CheckType rows.
+    """
+    from world.checks.models import CheckCategory, CheckType
+
+    magic_cat, _ = CheckCategory.objects.get_or_create(name="Magic")
+    check_type, _ = CheckType.objects.get_or_create(
+        name="Magical Endurance",
+        defaults={"category": magic_cat},
+    )
+    return check_type
 
 
 class CorruptionConditionTemplateFactory(factory.django.DjangoModelFactory):

--- a/src/world/magic/services/resonance.py
+++ b/src/world/magic/services/resonance.py
@@ -305,7 +305,15 @@ def resolve_pull_effects(
                 authored = (
                     row.flat_bonus_amount or row.intensity_bump_amount or row.vital_bonus_amount
                 )
-                base_scaled = (authored or 0) * multiplier
+                # CAPABILITY_GRANT and NARRATIVE_ONLY have no numeric payload;
+                # their scaled_value must be None (DB CheckConstraint forbids 0).
+                has_numeric_payload = row.effect_kind not in (
+                    EffectKind.CAPABILITY_GRANT,
+                    EffectKind.NARRATIVE_ONLY,
+                )
+                base_scaled: int | None = (
+                    (authored or 0) * multiplier if has_numeric_payload else None
+                )
                 inactive = row.effect_kind == EffectKind.VITAL_BONUS and not in_combat
                 resolved.append(
                     ResolvedPullEffect(

--- a/src/world/magic/types/pull.py
+++ b/src/world/magic/types/pull.py
@@ -43,7 +43,7 @@ class ResolvedPullEffect:
     kind: str
     authored_value: int | None
     level_multiplier: int
-    scaled_value: int
+    scaled_value: int | None
     vital_target: str | None
     source_thread: Thread
     source_thread_level: int


### PR DESCRIPTION
## Summary

  Closes Phase 1 of the seed-and-integration-tests roadmap: the magic cluster is
  now end-to-end seedable from one orchestrator and every magic user story has
  service-layer pipeline coverage.

  - New seeds in `src/integration_tests/game_content/magic.py`
    (`seed_magic_config`, `seed_canonical_rituals`, `seed_thread_pull_catalog`,
    `seed_cantrip_starter_catalog`, `seed_magic_dev`) — composed into one
    idempotent entry point that becomes the magic-cluster contribution to
    Phase 3's `seed_dev_database()`.
  - 4 new pipeline tests in `src/integration_tests/pipeline/`: thread pull,
    anima regen, situation, per-cast corruption.
  - Pipeline tests surfaced and fixed 4 production bugs (see Bug fixes below).
  - Roadmap doc updated; tasks 1.1–1.9 marked ✅.

  ## What got seeded

  - 5 magic singletons (AnimaConfig / SoulfrayConfig / ResonanceGainConfig /
    CorruptionConfig / AudereThreshold) + IntensityTier reference rows
    (Minor / Moderate / Major) + MishapPoolTier
  - Canonical rituals: Rite of Imbuing, Rite of Atonement
  - Thread pull catalog: 3 ThreadPullCost rows + 4 ThreadPullEffect rows
    (FLAT_BONUS / INTENSITY_BUMP / VITAL_BONUS / CAPABILITY_GRANT) on a
    canonical "Tideborne" Resonance
  - Cantrip starter catalog: 5 styles × 5 archetypes = 25 cantrips +
    6 EffectTypes + 5 PROSPECT Paths

  All seed functions use `get_or_create(natural_key, defaults={...})`. Re-runs
  on an edited DB preserve edits — never `update_or_create`.

  ## Pipeline tests added

  - `test_thread_pull_pipeline.py` — resonance spend → CombatPull written →
    ThreadPullEffect resolved for all four effect_kinds
  - `test_anima_regen_pipeline.py` — daily regen + Soulfray-stage and
    CharacterEngagement gating
  - `test_situation_pipeline.py` — SituationTemplate → SituationInstance →
    ChallengeInstance chain → resolution
  - `test_corruption_per_cast_pipeline.py` — Audere push multiplier +
    multi-resonance equal split + stacked multipliers + event emission

  ## Bug fixes surfaced by the new tests

  1. `resolve_pull_effects` wrote `scaled_value=0` for CAPABILITY_GRANT and
     NARRATIVE_ONLY effects, violating the `CombatPullResolvedEffect`
     CheckConstraint — would have crashed any tier-3 capability pull.
  2. `seed_magic_config` passed string `"0.30"` for `SoulfrayConfig.
     soulfray_threshold_ratio`; SharedMemoryModel cached the string and
     downstream `Decimal >=` comparisons in `use_technique` exploded. Fixed
     + regression-guarded.
  3. `_make_magical_endurance_check_type` in `world/magic/factories.py`
     leaked a fresh `CheckType` row each call (orphan SubFactory pattern).
     Switched to direct ORM keyed on the canonical name+category.
  4. `MagicContent.create_all()` was non-idempotent — duplicate Techniques
     and ActionEnhancements on re-run. Switched to `get_or_create` on
     natural keys.

  ## Follow-ups (not in this PR)

  - Situation system gaps surfaced by 1.6: no `instantiate_situation()`
    service, no `SituationInstance` completion status, no `SituationApproach`
    model, no cooperative resolution aggregation. Worth its own design pass.
  - `SoulfrayConfigFactory.resilience_check_type` has the same orphan
    SubFactory pattern; not fired by `seed_magic_dev()` so deferred.

  ## Test plan

  - [x] `arx test integration_tests.game_content.tests.test_magic_seed` — 39/39
  - [x] `arx test integration_tests` — 104/104
  - [x] `arx test world.magic` — 827/827
  - [x] Full no-keepdb regression (matches CI fresh-DB) — 5138/5138
