### PR TITLE
Combat magic pipeline integration

### DIFF
--- a/docs/superpowers/specs/2026-04-30-combat-magic-pipeline-integration-design.md
+++ b/docs/superpowers/specs/2026-04-30-combat-magic-pipeline-integration-design.md
@@ -1,0 +1,398 @@
+# Combat Magic Pipeline Integration
+
+**Date:** 2026-04-30
+**Status:** Spec — pre-implementation
+**Owner:** brann
+
+## Purpose
+
+Wire combat technique resolution through the magic system's `use_technique`
+orchestrator so a combat-cast technique exercises the same pipeline as a
+scene-cast one: anima deduction, soulfray accumulation, mishap rolls,
+TECHNIQUE_PRE_CAST / TECHNIQUE_CAST event emission, reactive scar interception,
+thread-pull bonuses, and corruption checks.
+
+Today, `_resolve_pc_action` in `src/world/combat/services.py` reads
+`technique.effect_type.base_power` directly and calls
+`apply_damage_to_opponent`. Combat bypasses the magic system entirely, so
+none of the above side effects fire on a combat-cast technique. This spec
+fixes that for the **damage path only**. Non-attack effect types
+(Defense / Buff / Movement / Debuff) are deferred to a follow-up that adds
+a conditions-from-techniques resolver.
+
+## Scope
+
+### In scope
+
+- Damage-path combat techniques route through `use_technique`.
+- Anima is deducted on combat cast (including overburn → soulfray).
+- TECHNIQUE_PRE_CAST and TECHNIQUE_CAST emit during combat rounds.
+- Reactive scars subscribed to TECHNIQUE_PRE_CAST can intercept and cancel
+  a combat cast (no damage, no anima deducted).
+- Mishap rolls fire when the technique's roll triggers them.
+- Active `CombatPull` rows for the caster contribute their **FLAT_BONUS**
+  scaled values to the offense check's `extra_modifiers` (per Resonance
+  Pivot Spec A §5.8).
+- Damage delivered to the opponent matches the magic-pipeline-derived value.
+
+### Out of scope (deferred)
+
+- **Non-attack effect types** (Defense / Buff / Movement / Debuff applying
+  conditions in combat). Needs a conditions-from-techniques resolver —
+  separate PR after this lands.
+- **`PerformRitualAction` player command.** Separate small PR.
+- **Other pull effect kinds in combat damage**:
+  - `INTENSITY_BUMP` — needs `get_runtime_technique_stats` to accept a combat
+    context so pull-driven intensity is reflected in anima cost calc. Defer.
+  - `CAPABILITY_GRANT` — tied to non-attack pipeline. Defer.
+  - `NARRATIVE_ONLY` — cosmetic; surface in narrative buffer. Defer.
+  - `VITAL_BONUS` — already wired through `recompute_max_health_with_threads`
+    and `apply_damage_reduction_from_threads`; untouched by this spec.
+- **TECHNIQUE_AFFECTED per target.** `CombatOpponent` is not an `ObjectDB`,
+  so the `targets` parameter to `use_technique` would be empty. PRE_CAST and
+  CAST still fire. AFFECTED-per-target waits until the opponent ↔ ObjectDB
+  relationship is decided.
+- **Frontend changes.** Server-only PR.
+- **Refactor of `apply_damage_to_opponent`.** Only the caller changes.
+
+### PR-size constraint
+
+Aim for ~600 lines diff total including tests. The combat-side delta in
+`_resolve_pc_action` is intentionally small (~8 lines deleted, ~4 lines
+added) so that any concurrent work on `combat/services.py` from the
+combat-iterating developer remains merge-friendly.
+
+## Architecture
+
+### Boundary
+
+```
+world/combat/services.py
+├── resolve_combat_technique(...)        ← NEW: orchestrates the adapter
+└── _resolve_pc_action(...)              ← CHANGED: damage path delegates
+
+world/combat/services.py (or sibling submodule)
+└── CombatAttackResolver                 ← NEW: dataclass resolver, __call__'d
+                                            by use_technique as resolve_fn
+
+world/combat/types.py
+└── CombatTechniqueResolution            ← NEW: returned from resolver to
+                                            use_technique; consumed by adapter
+
+world/magic/services/techniques.py
+└── use_technique                        ← MICRO-CHANGE: check_result extractor
+                                            also accepts resolution_result
+                                            .check_result directly (3 lines)
+```
+
+The adapter lives **combat-side** because combat is the consumer and knows
+about `CombatParticipant`, `CombatPull`, `apply_damage_to_opponent`, and
+offense check types. Magic stays generic — `use_technique` keeps its single
+contract: "give me a `resolve_fn`, I'll wrap the magic envelope around it."
+
+### `use_technique` micro-change
+
+The current extractor in `use_technique` reads `check_result` from
+`resolution_result.main_result.check_result` (the social-action shape from
+Scope #4). Combat's `CombatTechniqueResolution` exposes `check_result`
+directly without a `main_result` wrapper, so the extractor is generalized
+to accept either shape:
+
+```python
+# After:
+if effective_check_result is None:
+    effective_check_result = getattr(resolution_result, "check_result", None)
+    if effective_check_result is None and hasattr(resolution_result, "main_result"):
+        main = resolution_result.main_result
+        if main is not None and hasattr(main, "check_result"):
+            effective_check_result = main.check_result
+```
+
+Behavior unchanged for existing callers; combat callers pick up the new
+direct path.
+
+## Data flow
+
+```
+_resolve_pc_action(participant, action, ...)
+  │
+  ├── if combo_upgrade: existing combo path (unchanged)
+  ├── if effect_type.base_power is None: no-op (deferred — non-attack types)
+  └── else: damage path
+        │
+        v
+resolve_combat_technique(participant, action, target, fatigue_category, ...)
+  │
+  ├── pull_flat_bonus = sum FLAT_BONUS scaled_value across active pulls for
+  │       this participant in this encounter
+  │
+  ├── resolver = CombatAttackResolver(participant, action, target,
+  │       pull_flat_bonus, fatigue_category, offense_check_type,
+  │       offense_check_fn)
+  │
+  └── use_technique(
+        character=participant.character_sheet.character,
+        technique=action.focused_action,
+        resolve_fn=resolver,
+        confirm_soulfray_risk=True,
+        targets=[],   # AFFECTED deferred
+      )
+        │
+        ├─ runtime stats → effective anima cost → soulfray warning checkpoint
+        ├─ TECHNIQUE_PRE_CAST emit (cancellable)
+        │       └── on cancel: return TechniqueUseResult(confirmed=False)
+        ├─ deduct_anima
+        │
+        ├─ resolver()  ─────────────────────────────────────────┐
+        │     │                                                 │
+        │     ├─ extra_modifiers = effort_mod + pull_flat_bonus │
+        │     ├─ check_result = perform_check(...)              │
+        │     ├─ scaled = base_power if SL>=2; //2 if SL==1; 0  │
+        │     ├─ if scaled > 0: apply_damage_to_opponent(...)   │
+        │     └─ return CombatTechniqueResolution(...)          │
+        │     ◄─────────────────────────────────────────────────┘
+        │
+        ├─ soulfray accrual (uses .check_result via extractor)
+        ├─ mishap rider     (uses .check_result via extractor)
+        ├─ corruption accrual
+        └─ TECHNIQUE_CAST emit
+        ▼
+adapter unpacks TechniqueUseResult:
+  ├── if not result.confirmed: return empty damage_results (cancelled)
+  └── else: pull damage_results out of result.resolution_result
+       │
+       ▼
+_resolve_pc_action appends damage_results to ActionOutcome,
+runs apply_fatigue (unconditional — preserves existing contract)
+```
+
+### Two invariants preserved
+
+1. **PRE_CAST cancel = no observable side effects.** Damage application
+   and the offense check both live inside the resolver, which
+   `use_technique` only invokes after PRE_CAST clears. A cancelling
+   reactive scar produces `confirmed=False`, no damage, no anima deducted.
+
+2. **Soulfray and mishap see the real check result.** The resolver runs
+   the check inside the envelope, and the (extended) extractor in
+   `use_technique` hands the right `CheckResult` to soulfray accumulation
+   and mishap selection.
+
+## Component shapes
+
+### `CombatTechniqueResolution` (new — `world/combat/types.py`)
+
+```python
+@dataclass(frozen=True)
+class CombatTechniqueResolution:
+    """Returned from a combat resolver into use_technique.
+
+    Frozen — once the inner resolution is computed it cannot change.
+    Read by the adapter to populate the outer ActionOutcome.
+    """
+    check_result: CheckResult
+    damage_results: list[OpponentDamageResult]
+    pull_flat_bonus: int
+    scaled_damage: int
+```
+
+`check_result` is a top-level attribute (not nested under `main_result`)
+because combat doesn't have an action-resolution wrapper to nest under.
+`use_technique`'s extractor handles both shapes.
+
+### `CombatAttackResolver` (new — `world/combat/services.py`)
+
+```python
+@dataclass
+class CombatAttackResolver:
+    """Resolves the inner damage step of a combat-cast attack technique.
+
+    Built by resolve_combat_technique() and passed to use_technique() as
+    resolve_fn. State is inspectable at any point during/after the cast,
+    which closures don't allow. Subclassable when non-attack effect types
+    arrive (next PR): CombatBuffResolver, CombatDefenseResolver, etc.
+    """
+    participant: CombatParticipant
+    action: CombatRoundAction
+    target: CombatOpponent
+    pull_flat_bonus: int
+    fatigue_category: str
+    offense_check_type: CheckType
+    offense_check_fn: PerformCheckFn | None
+
+    def __call__(self) -> CombatTechniqueResolution:
+        check_result = self._roll_check()
+        scaled_damage = self._scale(check_result)
+        damage_results = self._apply(scaled_damage)
+        return CombatTechniqueResolution(
+            check_result=check_result,
+            damage_results=damage_results,
+            pull_flat_bonus=self.pull_flat_bonus,
+            scaled_damage=scaled_damage,
+        )
+
+    def _roll_check(self) -> CheckResult:
+        """Roll the offense check with effort + pull-bonus modifiers."""
+        ...
+
+    def _scale(self, check_result: CheckResult) -> int:
+        """Scale base_power by success_level: full / half / zero."""
+        ...
+
+    def _apply(self, scaled_damage: int) -> list[OpponentDamageResult]:
+        """Apply damage to target if alive and damage > 0."""
+        ...
+```
+
+Each step is its own method so subclasses (next PR's
+`CombatBuffResolver` etc.) can override what differs without
+re-implementing the orchestration.
+
+### `resolve_combat_technique` (new — `world/combat/services.py`)
+
+```python
+def resolve_combat_technique(
+    *,
+    participant: CombatParticipant,
+    action: CombatRoundAction,
+    target: CombatOpponent,
+    fatigue_category: str,
+    offense_check_type: CheckType,
+    offense_check_fn: PerformCheckFn | None,
+) -> CombatTechniqueResult:
+    """Route a damage-path combat technique through use_technique."""
+    encounter = participant.encounter
+    pull_flat_bonus = _sum_active_flat_bonuses(participant, encounter)
+
+    resolver = CombatAttackResolver(
+        participant=participant,
+        action=action,
+        target=target,
+        pull_flat_bonus=pull_flat_bonus,
+        fatigue_category=fatigue_category,
+        offense_check_type=offense_check_type,
+        offense_check_fn=offense_check_fn,
+    )
+
+    technique_use_result = use_technique(
+        character=participant.character_sheet.character,
+        technique=action.focused_action,
+        resolve_fn=resolver,
+        confirm_soulfray_risk=True,
+        targets=[],   # AFFECTED-per-target deferred — see spec
+    )
+
+    return _build_combat_result(technique_use_result, resolver)
+```
+
+### `_resolve_pc_action` change
+
+```python
+def _resolve_pc_action(...):
+    outcome = ActionOutcome(...)
+    technique = action.focused_action
+    if technique is None:
+        return outcome
+
+    target = action.focused_target
+    fatigue_category = _ACTION_TO_FATIGUE_CATEGORY.get(...)
+
+    if target is not None:
+        target.refresh_from_db()
+        if target.status != OpponentStatus.DEFEATED:
+            if action.combo_upgrade:
+                # combo path UNCHANGED
+                ...
+            elif technique.effect_type.base_power is not None:
+                # damage path — route through magic pipeline
+                combat_result = resolve_combat_technique(
+                    participant=participant,
+                    action=action,
+                    target=target,
+                    fatigue_category=fatigue_category,
+                    offense_check_type=offense_check_type,
+                    offense_check_fn=offense_check_fn,
+                )
+                outcome.damage_results.extend(combat_result.damage_results)
+            else:
+                # non-attack effect type — deferred PR adds the pipeline
+                # (Defense / Buff / Movement / Debuff applying conditions)
+                pass
+
+    apply_fatigue(...)   # unchanged — applies even on cancel
+    return outcome
+```
+
+## Cancel and error handling
+
+| Failure mode | Behavior |
+|---|---|
+| PRE_CAST cancelled by reactive scar | `confirmed=False`, anima not deducted, resolver never called, adapter returns empty `damage_results`. Fatigue still applied (preserves existing contract). |
+| Soulfray warning at checkpoint | Round resolution always passes `confirm_soulfray_risk=True` (frontend handles preview). If `False` is somehow passed, treated identically to cancel. |
+| Anima overburn | Existing `use_technique` semantics: anima deducts to negative/zero, soulfray severity accrues. No combat-specific handling. |
+| Missing `CharacterAnima` for caster | `use_technique` raises `DoesNotExist`. PCs always have `CharacterAnima`; raising on a missing row is the correct data-integrity signal. |
+| Resolver raises mid-cast | Anima already deducted; exception propagates. Existing transactional model of `use_technique` — combat inherits it. |
+| Target defeated mid-resolution | Preserved inside `CombatAttackResolver._apply`: `target.refresh_from_db()`, skip if `status == DEFEATED`. |
+| Non-attack effect type (`base_power is None`) | `_resolve_pc_action` checks before invoking adapter. No-op behavior preserved until next PR. |
+
+## Tests
+
+### Integration tests — `world/combat/tests/test_combat_magic_integration.py`
+
+| Test | Assertion |
+|---|---|
+| `test_combat_cast_deducts_anima` | `CharacterAnima.current` decreases by `effective_cost` after combat round resolves a technique |
+| `test_pre_cast_emitted_in_combat` | `TECHNIQUE_PRE_CAST` payload captured during round resolution |
+| `test_cast_emitted_in_combat` | `TECHNIQUE_CAST` payload captured after round resolution |
+| `test_reactive_scar_cancels_combat_cast` | `ReactiveCondition` on PRE_CAST with cancel flow → no damage, no anima deducted, no `TECHNIQUE_CAST` emitted |
+| `test_mishap_fires_on_combat_control_deficit` | technique with `intensity > control` → mishap conditions present on caster after round |
+| `test_active_flat_bonus_pulls_modify_offense_check` | participant has active `CombatPull` with FLAT_BONUS scaled_value=4 → `perform_check` called with `extra_modifiers` including +4 |
+| `test_combat_damage_routes_through_pipeline` | full happy path — anima deducted, damage applied, events emitted, `OpponentDamageResult.damage_dealt > 0` |
+
+### Unit tests — `world/combat/tests/test_combat_attack_resolver.py`
+
+| Test | Assertion |
+|---|---|
+| `test_resolver_rolls_check_with_pull_bonus` | resolver with `pull_flat_bonus=3` → `perform_check` receives `extra_modifiers` containing 3 |
+| `test_resolver_full_success_returns_full_damage` | mock `perform_check` returns `success_level=2` → `scaled_damage == base_power` |
+| `test_resolver_partial_success_returns_half_damage` | `success_level=1` → `scaled_damage == base_power // 2` |
+| `test_resolver_miss_returns_zero_damage` | `success_level=0` → `scaled_damage == 0`, no `apply_damage_to_opponent` call |
+| `test_resolver_skips_defeated_target` | target with `status=DEFEATED` → `damage_results=[]` even on hit |
+
+### Test data
+
+All factories already exist: `CombatParticipantFactory`,
+`CombatOpponentFactory`, `CombatPullFactory`,
+`CombatPullResolvedEffectFactory`, `TechniqueFactory`,
+`CharacterAnimaFactory`. No new factories needed.
+
+### Regression coverage
+
+The existing `_scale_damage_by_check` inline body is removed (logic moves
+into `CombatAttackResolver._roll_check` + `_scale`). No callers remain
+after the swap. Existing combat round-resolution tests assert observable
+damage outcomes, which the new path produces equivalently.
+
+## Anti-patterns avoided
+
+- **Inverting dependencies.** Magic does not import combat. The adapter
+  lives combat-side; magic only learns about combat through the
+  `resolve_fn` callback contract.
+- **Closure-captured state.** Resolver is a dataclass with explicit
+  attributes, not a closure. Inspectable, testable, subclassable.
+- **Speculative pull-effect routing.** Only `FLAT_BONUS` is consumed in
+  this PR, per Spec A §5.8. Other kinds are commented at the call site
+  with their deferred owners.
+- **Combat-specific failure modes for anima.** Overburn is the existing
+  `use_technique` semantic; combat inherits it without inventing a
+  combat-only rejection path.
+
+## References
+
+- `src/world/magic/services/techniques.py:use_technique`
+- `src/world/combat/services.py:_resolve_pc_action`
+- `src/world/magic/tests/test_reactive_integration.py` (cancel-path pattern)
+- `docs/superpowers/specs/2026-04-02-scope4-scene-magic-enhancement-design.md`
+  (the social-action wrapper pattern this spec mirrors for combat)
+- `docs/superpowers/specs/2026-04-18-resonance-pivot-spec-a-threads-and-currency-design.md`
+  §5.8 (FLAT_BONUS routing rule)

--- a/docs/superpowers/specs/2026-04-30-combat-magic-pipeline-integration-design.md
+++ b/docs/superpowers/specs/2026-04-30-combat-magic-pipeline-integration-design.md
@@ -200,6 +200,78 @@ class CombatTechniqueResolution:
 because combat doesn't have an action-resolution wrapper to nest under.
 `use_technique`'s extractor handles both shapes.
 
+### `CombatTechniqueResult` (new — `world/combat/types.py`)
+
+```python
+@dataclass(frozen=True)
+class CombatTechniqueResult:
+    """Adapter's return shape — what _resolve_pc_action consumes.
+
+    Wraps the magic-pipeline outcome (TechniqueUseResult) plus the
+    combat-side damage_results extracted from it. Frozen because the
+    cast is over by the time this is constructed.
+    """
+    damage_results: list[OpponentDamageResult]
+    technique_use_result: TechniqueUseResult
+```
+
+`damage_results` is the only field `_resolve_pc_action` reads to populate
+`ActionOutcome.damage_results`. `technique_use_result` is exposed for
+future consumers that want to surface mishap text, soulfray warnings, or
+overburn flags into the round narration — none of which this PR wires up,
+but keeping the field avoids re-extracting later.
+
+### `_build_combat_result` (new — `world/combat/services.py`)
+
+```python
+def _build_combat_result(
+    technique_use_result: TechniqueUseResult,
+    resolver: CombatAttackResolver,
+) -> CombatTechniqueResult:
+    """Translate use_technique's outcome into the adapter's return shape."""
+    if not technique_use_result.confirmed:
+        # PRE_CAST cancellation or unconfirmed soulfray warning —
+        # resolver was never called; no damage to report.
+        return CombatTechniqueResult(
+            damage_results=[],
+            technique_use_result=technique_use_result,
+        )
+
+    resolution = technique_use_result.resolution_result
+    # Type contract: resolver returns CombatTechniqueResolution; if
+    # use_technique passed it through unmodified, this isinstance check
+    # is a defensive assertion, not user-input validation.
+    assert isinstance(resolution, CombatTechniqueResolution)
+    return CombatTechniqueResult(
+        damage_results=list(resolution.damage_results),
+        technique_use_result=technique_use_result,
+    )
+```
+
+### `_sum_active_flat_bonuses` (new — `world/combat/services.py`)
+
+```python
+def _sum_active_flat_bonuses(
+    participant: CombatParticipant,
+    encounter: CombatEncounter,
+) -> int:
+    """Sum scaled_value across FLAT_BONUS resolved-effect rows on the
+    participant's active CombatPull rows for this encounter.
+
+    Uses the existing CharacterCombatPullHandler (cached, prefetched)
+    rather than querying directly — reads from
+    ``character.combat_pulls.active_for_encounter(encounter)`` and walks
+    each pull's ``resolved_effects_cached`` (already prefetched).
+    """
+    character = participant.character_sheet.character
+    total = 0
+    for pull in character.combat_pulls.active_for_encounter(encounter):
+        for eff in pull.resolved_effects_cached:
+            if eff.kind == EffectKind.FLAT_BONUS and eff.scaled_value:
+                total += eff.scaled_value
+    return total
+```
+
 ### `CombatAttackResolver` (new — `world/combat/services.py`)
 
 ```python

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from world.conditions.models import ConditionTemplate
     from world.covenants.models import CovenantRole
     from world.magic.models import Technique
+    from world.magic.types import TechniqueUseResult
     from world.scenes.models import Persona
 
     PerformCheckFn = Callable[..., CheckResult]
@@ -75,6 +76,7 @@ from world.combat.types import (
     ActionOutcome,
     AvailableCombo,
     CombatTechniqueResolution,
+    CombatTechniqueResult,
     ComboSlotMatch,
     DefenseResult,
     OpponentDamageResult,
@@ -183,6 +185,30 @@ def _sum_active_flat_bonuses(
             if eff.kind == EffectKind.FLAT_BONUS and eff.scaled_value:
                 total += eff.scaled_value
     return total
+
+
+def _build_combat_result(
+    technique_use_result: TechniqueUseResult,
+    resolver: CombatAttackResolver,  # noqa: ARG001 - kept for future extensibility
+) -> CombatTechniqueResult:
+    """Translate use_technique's outcome into the adapter's return shape."""
+    if not technique_use_result.confirmed:
+        return CombatTechniqueResult(
+            damage_results=[],
+            technique_use_result=technique_use_result,
+        )
+
+    resolution = technique_use_result.resolution_result
+    # Defensive assertion against programmer error — service contract
+    # is that combat resolvers return CombatTechniqueResolution.
+    if not isinstance(resolution, CombatTechniqueResolution):
+        msg = f"Expected CombatTechniqueResolution, got {type(resolution).__name__}"
+        raise TypeError(msg)
+
+    return CombatTechniqueResult(
+        damage_results=list(resolution.damage_results),
+        technique_use_result=technique_use_result,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -85,6 +85,7 @@ from world.combat.types import (
 )
 from world.fatigue.constants import EFFORT_CHECK_MODIFIER, EffortLevel, FatigueCategory
 from world.fatigue.services import apply_fatigue, get_fatigue_penalty
+from world.magic.constants import EffectKind
 from world.vitals.constants import (
     DEATH_HEALTH_THRESHOLD,
     KNOCKOUT_HEALTH_THRESHOLD,
@@ -99,7 +100,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-@dataclass
+@dataclass(frozen=True)
 class CombatAttackResolver:
     """Resolves the inner damage step of a combat-cast attack technique.
 
@@ -176,8 +177,6 @@ def _sum_active_flat_bonuses(
     Reads through CharacterCombatPullHandler so the cached/prefetched
     list is honored — avoids re-querying.
     """
-    from world.magic.constants import EffectKind  # noqa: PLC0415
-
     character = participant.character_sheet.character
     total = 0
     for pull in character.combat_pulls.active_for_encounter(encounter):
@@ -211,7 +210,7 @@ def _build_combat_result(
     )
 
 
-def resolve_combat_technique(  # noqa: PLR0913 - many args needed for resolver construction
+def resolve_combat_technique(  # noqa: PLR0913 — keyword-only orchestrator args
     *,
     participant: CombatParticipant,
     action: CombatRoundAction,
@@ -1446,9 +1445,11 @@ def _resolve_pc_action(
                     )
                     outcome.damage_results.extend(combat_result.damage_results)
                 else:
-                    # No offense check type configured — apply raw base_power
-                    # directly. Preserves existing test fixtures that don't
-                    # set up check types.
+                    # TODO(combat-magic-pipeline): Remove this bypass once all combat
+                    # tests/fixtures provide an offense_check_type. Without one, this
+                    # branch skips the magic pipeline entirely (no anima cost, no events,
+                    # no soulfray), which is a temporary test-compatibility shim, not
+                    # production behavior.
                     dmg_result = apply_damage_to_opponent(target, technique.effect_type.base_power)
                     outcome.damage_results.append(dmg_result)
 

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -74,6 +74,7 @@ from world.combat.models import (
 from world.combat.types import (
     ActionOutcome,
     AvailableCombo,
+    CombatTechniqueResolution,
     ComboSlotMatch,
     DefenseResult,
     OpponentDamageResult,
@@ -150,6 +151,17 @@ class CombatAttackResolver:
         if self.target.status == OpponentStatus.DEFEATED:
             return []
         return [apply_damage_to_opponent(self.target, scaled_damage)]
+
+    def __call__(self) -> CombatTechniqueResolution:
+        check_result = self._roll_check()
+        scaled_damage = self._scale(check_result)
+        damage_results = self._apply(scaled_damage)
+        return CombatTechniqueResolution(
+            check_result=check_result,
+            damage_results=damage_results,
+            pull_flat_bonus=self.pull_flat_bonus,
+            scaled_damage=scaled_damage,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -131,6 +131,17 @@ class CombatAttackResolver:
             fatigue_penalty=penalty,
         )
 
+    def _scale(self, check_result: CheckResult) -> int:
+        """Scale base_power by success_level: full / half / zero."""
+        base_power = self.action.focused_action.effect_type.base_power
+        if base_power is None:
+            return 0
+        if check_result.success_level >= OFFENSE_FULL_THRESHOLD:
+            return base_power
+        if check_result.success_level >= OFFENSE_HALF_THRESHOLD:
+            return base_power // 2
+        return 0
+
 
 # ---------------------------------------------------------------------------
 # ActionCategory -> FatigueCategory mapping (same values)

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -1391,35 +1391,6 @@ def check_and_advance_boss_phase(
 # ---------------------------------------------------------------------------
 
 
-def _scale_damage_by_check(  # noqa: PLR0913 - check params are all required
-    raw: int,
-    participant: CombatParticipant,
-    action: CombatRoundAction,
-    fatigue_category: str,
-    offense_check_type: CheckType,
-    offense_check_fn: PerformCheckFn | None,
-) -> int:
-    """Roll an offense check and scale raw damage by success level."""
-    check_fn = offense_check_fn
-    if check_fn is None:
-        from world.checks.services import perform_check as check_fn  # noqa: PLC0415
-
-    penalty = get_fatigue_penalty(participant.character_sheet, fatigue_category)
-    effort_mod = EFFORT_CHECK_MODIFIER.get(action.effort_level, 0)
-    character = participant.character_sheet.character
-    result = check_fn(
-        character,
-        offense_check_type,
-        extra_modifiers=effort_mod,
-        fatigue_penalty=penalty,
-    )
-    if result.success_level >= OFFENSE_FULL_THRESHOLD:
-        return raw
-    if result.success_level >= OFFENSE_HALF_THRESHOLD:
-        return raw // 2
-    return 0
-
-
 def _resolve_pc_action(
     participant: CombatParticipant,
     action: CombatRoundAction,
@@ -1460,23 +1431,26 @@ def _resolve_pc_action(
                 )
                 outcome.combo_used = combo
                 outcome.damage_results.append(dmg_result)
-            else:
-                base_power = technique.effect_type.base_power
-                if base_power is not None:
-                    if offense_check_type is not None:
-                        scaled = _scale_damage_by_check(
-                            base_power,
-                            participant,
-                            action,
-                            fatigue_category,
-                            offense_check_type,
-                            offense_check_fn,
-                        )
-                    else:
-                        scaled = base_power
-                    if scaled > 0:
-                        dmg_result = apply_damage_to_opponent(target, scaled)
-                        outcome.damage_results.append(dmg_result)
+            elif technique.effect_type.base_power is not None:
+                # Damage path — route through magic pipeline (use_technique).
+                # Non-attack effect types (base_power is None) stay no-op until
+                # the conditions-from-techniques resolver lands (next PR).
+                if offense_check_type is not None:
+                    combat_result = resolve_combat_technique(
+                        participant=participant,
+                        action=action,
+                        target=target,
+                        fatigue_category=fatigue_category,
+                        offense_check_type=offense_check_type,
+                        offense_check_fn=offense_check_fn,
+                    )
+                    outcome.damage_results.extend(combat_result.damage_results)
+                else:
+                    # No offense check type configured — apply raw base_power
+                    # directly. Preserves existing test fixtures that don't
+                    # set up check types.
+                    dmg_result = apply_damage_to_opponent(target, technique.effect_type.base_power)
+                    outcome.damage_results.append(dmg_result)
 
     # Apply fatigue after action resolves
     apply_fatigue(

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -142,6 +142,15 @@ class CombatAttackResolver:
             return base_power // 2
         return 0
 
+    def _apply(self, scaled_damage: int) -> list[OpponentDamageResult]:
+        """Apply damage to target if alive and damage > 0."""
+        if scaled_damage <= 0:
+            return []
+        self.target.refresh_from_db()
+        if self.target.status == OpponentStatus.DEFEATED:
+            return []
+        return [apply_damage_to_opponent(self.target, scaled_damage)]
+
 
 # ---------------------------------------------------------------------------
 # ActionCategory -> FatigueCategory mapping (same values)

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -164,6 +164,27 @@ class CombatAttackResolver:
         )
 
 
+def _sum_active_flat_bonuses(
+    participant: CombatParticipant,
+    encounter: CombatEncounter,
+) -> int:
+    """Sum scaled_value across FLAT_BONUS resolved-effect rows on the
+    participant's active CombatPull rows for this encounter.
+
+    Reads through CharacterCombatPullHandler so the cached/prefetched
+    list is honored — avoids re-querying.
+    """
+    from world.magic.constants import EffectKind  # noqa: PLC0415
+
+    character = participant.character_sheet.character
+    total = 0
+    for pull in character.combat_pulls.active_for_encounter(encounter):
+        for eff in pull.resolved_effects_cached:
+            if eff.kind == EffectKind.FLAT_BONUS and eff.scaled_value:
+                total += eff.scaled_value
+    return total
+
+
 # ---------------------------------------------------------------------------
 # ActionCategory -> FatigueCategory mapping (same values)
 # ---------------------------------------------------------------------------

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -211,6 +211,62 @@ def _build_combat_result(
     )
 
 
+def resolve_combat_technique(  # noqa: PLR0913 - many args needed for resolver construction
+    *,
+    participant: CombatParticipant,
+    action: CombatRoundAction,
+    target: CombatOpponent,
+    fatigue_category: str,
+    offense_check_type: CheckType,
+    offense_check_fn: PerformCheckFn | None,
+) -> CombatTechniqueResult:
+    """Route a damage-path combat technique through use_technique.
+
+    Builds a CombatAttackResolver and passes it to use_technique as
+    resolve_fn. The magic envelope handles anima, soulfray, mishap,
+    PRE_CAST/CAST events, reactive scar interception, and corruption.
+    The resolver does the offense check + damage application inside
+    that envelope.
+
+    Soulfray warning is auto-confirmed at round resolution time —
+    frontend handles preview before submission.
+
+    AFFECTED-per-target events are deferred (CombatOpponent is not an
+    ObjectDB; targets=[] until the opponent <-> ObjectDB relationship
+    is decided).
+
+    Other pull effect kinds are deferred:
+    - INTENSITY_BUMP: needs runtime stats to accept combat context
+    - CAPABILITY_GRANT: tied to non-attack pipeline
+    - NARRATIVE_ONLY: cosmetic surfacing
+    - VITAL_BONUS: already wired through recompute_max_health_with_threads
+    """
+    from world.magic.services import use_technique  # noqa: PLC0415
+
+    encounter = participant.encounter
+    pull_flat_bonus = _sum_active_flat_bonuses(participant, encounter)
+
+    resolver = CombatAttackResolver(
+        participant=participant,
+        action=action,
+        target=target,
+        pull_flat_bonus=pull_flat_bonus,
+        fatigue_category=fatigue_category,
+        offense_check_type=offense_check_type,
+        offense_check_fn=offense_check_fn,
+    )
+
+    technique_use_result = use_technique(
+        character=participant.character_sheet.character,
+        technique=action.focused_action,
+        resolve_fn=resolver,
+        confirm_soulfray_risk=True,
+        targets=[],
+    )
+
+    return _build_combat_result(technique_use_result, resolver)
+
+
 # ---------------------------------------------------------------------------
 # ActionCategory -> FatigueCategory mapping (same values)
 # ---------------------------------------------------------------------------

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable
+from dataclasses import dataclass
 import logging
 import math
 import random
@@ -35,6 +36,7 @@ from flows.events.payloads import (
     DamageAppliedPayload,
     DamagePreApplyPayload,
 )
+from world.checks.services import perform_check
 from world.combat.constants import (
     DEFENSE_CRITICAL_MULTIPLIER,
     DEFENSE_FULL_MULTIPLIER,
@@ -88,6 +90,47 @@ from world.vitals.constants import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# CombatAttackResolver - Damage resolution for combat techniques
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CombatAttackResolver:
+    """Resolves the inner damage step of a combat-cast attack technique.
+
+    Built by resolve_combat_technique() and passed to use_technique() as
+    resolve_fn. State is inspectable at any point during/after the cast,
+    which closures don't allow. Subclassable when non-attack effect types
+    arrive (next PR): CombatBuffResolver, CombatDefenseResolver, etc.
+    """
+
+    participant: CombatParticipant
+    action: CombatRoundAction
+    target: CombatOpponent
+    pull_flat_bonus: int
+    fatigue_category: str
+    offense_check_type: CheckType
+    offense_check_fn: PerformCheckFn | None
+
+    def _roll_check(self) -> CheckResult:
+        """Roll the offense check with effort + pull-bonus modifiers."""
+        check_fn = self.offense_check_fn or perform_check
+        penalty = get_fatigue_penalty(
+            self.participant.character_sheet,
+            self.fatigue_category,
+        )
+        effort_mod = EFFORT_CHECK_MODIFIER.get(self.action.effort_level, 0)
+        extra_modifiers = effort_mod + self.pull_flat_bonus
+        character = self.participant.character_sheet.character
+        return check_fn(
+            character,
+            self.offense_check_type,
+            extra_modifiers=extra_modifiers,
+            fatigue_penalty=penalty,
+        )
+
 
 # ---------------------------------------------------------------------------
 # ActionCategory -> FatigueCategory mapping (same values)

--- a/src/world/combat/tests/test_combat_attack_resolver.py
+++ b/src/world/combat/tests/test_combat_attack_resolver.py
@@ -1,0 +1,74 @@
+"""Unit tests for CombatAttackResolver.
+
+Each test isolates one method. Integration through use_technique is in
+test_combat_magic_integration.py.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import ActionCategory, OpponentTier
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+    ThreatPoolEntryFactory,
+    ThreatPoolFactory,
+)
+from world.combat.models import CombatRoundAction
+from world.combat.services import CombatAttackResolver
+from world.fatigue.constants import EffortLevel, FatigueCategory
+from world.magic.factories import EffectTypeFactory, GiftFactory, TechniqueFactory
+
+
+def _build_resolver(*, pull_flat_bonus: int = 0, base_power: int = 20):
+    """Helper to build a CombatAttackResolver with sane defaults."""
+    encounter = CombatEncounterFactory(round_number=1)
+    pool = ThreatPoolFactory()
+    ThreatPoolEntryFactory(pool=pool, base_damage=30)
+    opponent = CombatOpponentFactory(
+        encounter=encounter,
+        tier=OpponentTier.MOOK,
+        health=50,
+        max_health=50,
+        threat_pool=pool,
+    )
+    sheet = CharacterSheetFactory()
+    participant = CombatParticipantFactory(encounter=encounter, character_sheet=sheet)
+    technique = TechniqueFactory(
+        gift=GiftFactory(),
+        effect_type=EffectTypeFactory(name="Attack", base_power=base_power),
+    )
+    action = CombatRoundAction.objects.create(
+        participant=participant,
+        round_number=1,
+        focused_category=ActionCategory.PHYSICAL,
+        focused_action=technique,
+        focused_target=opponent,
+        effort_level=EffortLevel.MEDIUM,
+    )
+    return CombatAttackResolver(
+        participant=participant,
+        action=action,
+        target=opponent,
+        pull_flat_bonus=pull_flat_bonus,
+        fatigue_category=FatigueCategory.PHYSICAL,
+        offense_check_type=MagicMock(),
+        offense_check_fn=None,
+    )
+
+
+class CombatAttackResolverRollCheckTests(TestCase):
+    def test_pull_bonus_added_to_extra_modifiers(self) -> None:
+        """A pull_flat_bonus of 3 must reach perform_check via extra_modifiers."""
+        resolver = _build_resolver(pull_flat_bonus=3)
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolver._roll_check()
+
+        kwargs = mock_perform.call_args.kwargs
+        # extra_modifiers contains pull bonus + effort modifier (MEDIUM = 0)
+        self.assertGreaterEqual(kwargs["extra_modifiers"], 3)

--- a/src/world/combat/tests/test_combat_attack_resolver.py
+++ b/src/world/combat/tests/test_combat_attack_resolver.py
@@ -89,3 +89,25 @@ class CombatAttackResolverScaleTests(TestCase):
         resolver = _build_resolver(base_power=20)
         check = MagicMock(success_level=0)
         self.assertEqual(resolver._scale(check), 0)
+
+
+class CombatAttackResolverApplyTests(TestCase):
+    def test_apply_returns_damage_results_when_target_alive(self) -> None:
+        resolver = _build_resolver()
+        results = resolver._apply(scaled_damage=10)
+        self.assertEqual(len(results), 1)
+        self.assertGreater(results[0].damage_dealt, 0)
+
+    def test_apply_skips_defeated_target(self) -> None:
+        from world.combat.constants import OpponentStatus
+
+        resolver = _build_resolver()
+        resolver.target.status = OpponentStatus.DEFEATED
+        resolver.target.save(update_fields=["status"])
+        results = resolver._apply(scaled_damage=10)
+        self.assertEqual(results, [])
+
+    def test_apply_returns_empty_on_zero_damage(self) -> None:
+        resolver = _build_resolver()
+        results = resolver._apply(scaled_damage=0)
+        self.assertEqual(results, [])

--- a/src/world/combat/tests/test_combat_attack_resolver.py
+++ b/src/world/combat/tests/test_combat_attack_resolver.py
@@ -125,3 +125,63 @@ class CombatAttackResolverCallTests(TestCase):
         self.assertEqual(result.pull_flat_bonus, 2)
         self.assertEqual(len(result.damage_results), 1)
         self.assertIsNotNone(result.check_result)
+
+
+class SumActiveFlatBonusesTests(TestCase):
+    def test_returns_zero_when_no_pulls(self) -> None:
+        from world.combat.services import _sum_active_flat_bonuses
+
+        resolver = _build_resolver()
+        self.assertEqual(
+            _sum_active_flat_bonuses(resolver.participant, resolver.participant.encounter),
+            0,
+        )
+
+    def test_sums_flat_bonus_scaled_values_across_active_pulls(self) -> None:
+        from world.combat.factories import (
+            CombatPullFactory,
+            CombatPullResolvedEffectFactory,
+        )
+        from world.combat.services import _sum_active_flat_bonuses
+        from world.magic.constants import EffectKind
+
+        resolver = _build_resolver()
+        pull = CombatPullFactory(
+            participant=resolver.participant,
+            round_number=resolver.participant.encounter.round_number,
+        )
+        CombatPullResolvedEffectFactory(pull=pull, kind=EffectKind.FLAT_BONUS, scaled_value=4)
+        CombatPullResolvedEffectFactory(pull=pull, kind=EffectKind.FLAT_BONUS, scaled_value=2)
+
+        resolver.participant.character_sheet.character.combat_pulls.invalidate()
+
+        self.assertEqual(
+            _sum_active_flat_bonuses(resolver.participant, resolver.participant.encounter),
+            6,
+        )
+
+    def test_ignores_non_flat_bonus_kinds(self) -> None:
+        from world.combat.factories import (
+            CombatPullFactory,
+            CombatPullResolvedEffectFactory,
+        )
+        from world.combat.services import _sum_active_flat_bonuses
+        from world.magic.constants import EffectKind, VitalBonusTarget
+
+        resolver = _build_resolver()
+        pull = CombatPullFactory(
+            participant=resolver.participant,
+            round_number=resolver.participant.encounter.round_number,
+        )
+        CombatPullResolvedEffectFactory(
+            pull=pull,
+            kind=EffectKind.VITAL_BONUS,
+            scaled_value=99,
+            vital_target=VitalBonusTarget.MAX_HEALTH,
+        )
+        resolver.participant.character_sheet.character.combat_pulls.invalidate()
+
+        self.assertEqual(
+            _sum_active_flat_bonuses(resolver.participant, resolver.participant.encounter),
+            0,
+        )

--- a/src/world/combat/tests/test_combat_attack_resolver.py
+++ b/src/world/combat/tests/test_combat_attack_resolver.py
@@ -72,3 +72,20 @@ class CombatAttackResolverRollCheckTests(TestCase):
         kwargs = mock_perform.call_args.kwargs
         # extra_modifiers contains pull bonus + effort modifier (MEDIUM = 0)
         self.assertGreaterEqual(kwargs["extra_modifiers"], 3)
+
+
+class CombatAttackResolverScaleTests(TestCase):
+    def test_full_success_returns_full_damage(self) -> None:
+        resolver = _build_resolver(base_power=20)
+        check = MagicMock(success_level=2)
+        self.assertEqual(resolver._scale(check), 20)
+
+    def test_partial_success_returns_half_damage(self) -> None:
+        resolver = _build_resolver(base_power=20)
+        check = MagicMock(success_level=1)
+        self.assertEqual(resolver._scale(check), 10)
+
+    def test_miss_returns_zero_damage(self) -> None:
+        resolver = _build_resolver(base_power=20)
+        check = MagicMock(success_level=0)
+        self.assertEqual(resolver._scale(check), 0)

--- a/src/world/combat/tests/test_combat_attack_resolver.py
+++ b/src/world/combat/tests/test_combat_attack_resolver.py
@@ -111,3 +111,17 @@ class CombatAttackResolverApplyTests(TestCase):
         resolver = _build_resolver()
         results = resolver._apply(scaled_damage=0)
         self.assertEqual(results, [])
+
+
+class CombatAttackResolverCallTests(TestCase):
+    def test_call_returns_resolution_with_all_fields(self) -> None:
+        resolver = _build_resolver(pull_flat_bonus=2, base_power=20)
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            result = resolver()
+
+        self.assertEqual(result.scaled_damage, 20)
+        self.assertEqual(result.pull_flat_bonus, 2)
+        self.assertEqual(len(result.damage_results), 1)
+        self.assertIsNotNone(result.check_result)

--- a/src/world/combat/tests/test_combat_attack_resolver.py
+++ b/src/world/combat/tests/test_combat_attack_resolver.py
@@ -185,3 +185,59 @@ class SumActiveFlatBonusesTests(TestCase):
             _sum_active_flat_bonuses(resolver.participant, resolver.participant.encounter),
             0,
         )
+
+
+class BuildCombatResultTests(TestCase):
+    def test_cancelled_returns_empty_damage_results(self) -> None:
+        from world.combat.services import _build_combat_result
+        from world.magic.types import AnimaCostResult, TechniqueUseResult
+
+        resolver = _build_resolver()
+        cost = AnimaCostResult(
+            base_cost=1,
+            effective_cost=1,
+            control_delta=0,
+            current_anima=10,
+            deficit=0,
+        )
+        cancelled = TechniqueUseResult(
+            anima_cost=cost,
+            confirmed=False,
+            resolution_result=None,
+            technique=resolver.action.focused_action,
+        )
+
+        result = _build_combat_result(cancelled, resolver)
+        self.assertEqual(result.damage_results, [])
+        self.assertIs(result.technique_use_result, cancelled)
+
+    def test_confirmed_extracts_damage_results_from_resolution(self) -> None:
+        from world.combat.services import _build_combat_result
+        from world.combat.types import CombatTechniqueResolution
+        from world.magic.types import AnimaCostResult, TechniqueUseResult
+
+        resolver = _build_resolver()
+        cost = AnimaCostResult(
+            base_cost=1,
+            effective_cost=1,
+            control_delta=0,
+            current_anima=10,
+            deficit=0,
+        )
+        damage_results = [MagicMock(damage_dealt=5)]
+        resolution = CombatTechniqueResolution(
+            check_result=MagicMock(success_level=2),
+            damage_results=damage_results,
+            pull_flat_bonus=0,
+            scaled_damage=20,
+        )
+        confirmed = TechniqueUseResult(
+            anima_cost=cost,
+            confirmed=True,
+            resolution_result=resolution,
+            technique=resolver.action.focused_action,
+        )
+
+        result = _build_combat_result(confirmed, resolver)
+        self.assertEqual(result.damage_results, damage_results)
+        self.assertIs(result.technique_use_result, confirmed)

--- a/src/world/combat/tests/test_combat_magic_integration.py
+++ b/src/world/combat/tests/test_combat_magic_integration.py
@@ -303,3 +303,40 @@ class ReactiveScarCancelTest(TestCase):
             svc_mod.emit_event = original
 
         self.assertEqual(cast_fired, [])
+
+
+class MishapTest(TestCase):
+    """When intensity > control, mishap rider fires after the cast."""
+
+    def test_mishap_path_invoked_on_control_deficit(self) -> None:
+        participant, action, opponent, _, _, _ = _setup_pc_attacking_mook(
+            technique_intensity=15,
+            technique_control=2,
+        )
+
+        captured: list = []
+        import world.magic.services.techniques as svc_mod
+
+        original_mishap = svc_mod._resolve_mishap
+
+        def capturing_mishap(character, pool, check_result):
+            captured.append((character, pool, check_result))
+            return original_mishap(character, pool, check_result)
+
+        with (
+            patch("world.combat.services.perform_check") as mock_perform,
+            patch.object(svc_mod, "select_mishap_pool", return_value=MagicMock()) as mock_select,
+            patch.object(svc_mod, "_resolve_mishap", side_effect=capturing_mishap),
+        ):
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolve_combat_technique(
+                participant=participant,
+                action=action,
+                target=opponent,
+                fatigue_category=FatigueCategory.PHYSICAL,
+                offense_check_type=MagicMock(),
+                offense_check_fn=None,
+            )
+
+            mock_select.assert_called_once()
+            self.assertEqual(len(captured), 1)

--- a/src/world/combat/tests/test_combat_magic_integration.py
+++ b/src/world/combat/tests/test_combat_magic_integration.py
@@ -210,3 +210,96 @@ class EventEmissionTest(TestCase):
 
         self.assertEqual(len(captured), 1)
         self.assertIsInstance(captured[0], TechniqueCastPayload)
+
+
+class ReactiveScarCancelTest(TestCase):
+    """A reactive condition on TECHNIQUE_PRE_CAST cancels the combat cast.
+    No damage applied, no anima deducted, no TECHNIQUE_CAST emitted."""
+
+    SELF_FILTER = {"path": "caster", "op": "==", "value": "self"}
+
+    def _make_cancel_flow(self):
+        from flows.consts import FlowActionChoices
+        from flows.factories import FlowDefinitionFactory, FlowStepDefinitionFactory
+
+        flow = FlowDefinitionFactory()
+        FlowStepDefinitionFactory(
+            flow=flow,
+            parent_id=None,
+            action=FlowActionChoices.CANCEL_EVENT,
+            parameters={},
+        )
+        return flow
+
+    def test_cancel_returns_zero_damage_and_no_anima_deducted(self) -> None:
+        from world.conditions.factories import ReactiveConditionFactory
+
+        participant, action, opponent, anima, _, _ = _setup_pc_attacking_mook(
+            technique_anima_cost=5,
+            technique_intensity=10,
+            technique_control=2,
+        )
+        cancel_flow = self._make_cancel_flow()
+        ReactiveConditionFactory(
+            event_name=EventName.TECHNIQUE_PRE_CAST,
+            filter_condition=self.SELF_FILTER,
+            flow_definition=cancel_flow,
+            target=participant.character_sheet.character,
+        )
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            result = resolve_combat_technique(
+                participant=participant,
+                action=action,
+                target=opponent,
+                fatigue_category=FatigueCategory.PHYSICAL,
+                offense_check_type=MagicMock(),
+                offense_check_fn=None,
+            )
+
+        opponent.refresh_from_db()
+        self.assertEqual(opponent.health, opponent.max_health)
+        anima.refresh_from_db()
+        self.assertEqual(anima.current, 20)
+        self.assertEqual(result.damage_results, [])
+        mock_perform.assert_not_called()
+
+    def test_cancel_suppresses_technique_cast_event(self) -> None:
+        from world.conditions.factories import ReactiveConditionFactory
+
+        participant, action, opponent, _, _, _ = _setup_pc_attacking_mook()
+        cancel_flow = self._make_cancel_flow()
+        ReactiveConditionFactory(
+            event_name=EventName.TECHNIQUE_PRE_CAST,
+            filter_condition=self.SELF_FILTER,
+            flow_definition=cancel_flow,
+            target=participant.character_sheet.character,
+        )
+        cast_fired: list = []
+
+        import world.magic.services.techniques as svc_mod
+
+        original = svc_mod.emit_event
+
+        def capturing(name, payload, **kw):
+            if name == EventName.TECHNIQUE_CAST:
+                cast_fired.append(True)
+            return original(name, payload, **kw)
+
+        svc_mod.emit_event = capturing
+        try:
+            with patch("world.combat.services.perform_check") as mock_perform:
+                mock_perform.return_value = MagicMock(success_level=2)
+                resolve_combat_technique(
+                    participant=participant,
+                    action=action,
+                    target=opponent,
+                    fatigue_category=FatigueCategory.PHYSICAL,
+                    offense_check_type=MagicMock(),
+                    offense_check_fn=None,
+                )
+        finally:
+            svc_mod.emit_event = original
+
+        self.assertEqual(cast_fired, [])

--- a/src/world/combat/tests/test_combat_magic_integration.py
+++ b/src/world/combat/tests/test_combat_magic_integration.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
+from flows.constants import EventName
+from flows.events.payloads import TechniqueCastPayload, TechniquePreCastPayload
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.constants import (
     ActionCategory,
@@ -141,3 +143,70 @@ class AnimaDeductionTest(TestCase):
         anima.refresh_from_db()
         # control_delta = 2 - 10 = -8; effective_cost = max(5 - (-8), 0) = 13.
         self.assertEqual(anima.current, 7)
+
+
+class EventEmissionTest(TestCase):
+    """PRE_CAST and CAST events fire during combat round resolution."""
+
+    def test_pre_cast_emitted_in_combat(self) -> None:
+        participant, action, opponent, _, _, _ = _setup_pc_attacking_mook()
+        captured: list = []
+
+        import world.magic.services.techniques as svc_mod
+
+        original = svc_mod.emit_event
+
+        def capturing(name, payload, **kw):
+            if name == EventName.TECHNIQUE_PRE_CAST:
+                captured.append(payload)
+            return original(name, payload, **kw)
+
+        svc_mod.emit_event = capturing
+        try:
+            with patch("world.combat.services.perform_check") as mock_perform:
+                mock_perform.return_value = MagicMock(success_level=2)
+                resolve_combat_technique(
+                    participant=participant,
+                    action=action,
+                    target=opponent,
+                    fatigue_category=FatigueCategory.PHYSICAL,
+                    offense_check_type=MagicMock(),
+                    offense_check_fn=None,
+                )
+        finally:
+            svc_mod.emit_event = original
+
+        self.assertEqual(len(captured), 1)
+        self.assertIsInstance(captured[0], TechniquePreCastPayload)
+        self.assertIs(captured[0].caster, participant.character_sheet.character)
+
+    def test_cast_emitted_in_combat(self) -> None:
+        participant, action, opponent, _, _, _ = _setup_pc_attacking_mook()
+        captured: list = []
+
+        import world.magic.services.techniques as svc_mod
+
+        original = svc_mod.emit_event
+
+        def capturing(name, payload, **kw):
+            if name == EventName.TECHNIQUE_CAST:
+                captured.append(payload)
+            return original(name, payload, **kw)
+
+        svc_mod.emit_event = capturing
+        try:
+            with patch("world.combat.services.perform_check") as mock_perform:
+                mock_perform.return_value = MagicMock(success_level=2)
+                resolve_combat_technique(
+                    participant=participant,
+                    action=action,
+                    target=opponent,
+                    fatigue_category=FatigueCategory.PHYSICAL,
+                    offense_check_type=MagicMock(),
+                    offense_check_fn=None,
+                )
+        finally:
+            svc_mod.emit_event = original
+
+        self.assertEqual(len(captured), 1)
+        self.assertIsInstance(captured[0], TechniqueCastPayload)

--- a/src/world/combat/tests/test_combat_magic_integration.py
+++ b/src/world/combat/tests/test_combat_magic_integration.py
@@ -340,3 +340,39 @@ class MishapTest(TestCase):
 
             mock_select.assert_called_once()
             self.assertEqual(len(captured), 1)
+
+
+class FlatBonusPullCheckTest(TestCase):
+    """Active FLAT_BONUS CombatPull rows feed extra_modifiers into perform_check."""
+
+    def test_active_flat_bonus_pulls_added_to_extra_modifiers(self) -> None:
+        from world.combat.factories import (
+            CombatPullFactory,
+            CombatPullResolvedEffectFactory,
+        )
+        from world.magic.constants import EffectKind
+
+        participant, action, opponent, _, _, _ = _setup_pc_attacking_mook()
+        pull = CombatPullFactory(
+            participant=participant,
+            round_number=participant.encounter.round_number,
+        )
+        CombatPullResolvedEffectFactory(pull=pull, kind=EffectKind.FLAT_BONUS, scaled_value=3)
+        CombatPullResolvedEffectFactory(pull=pull, kind=EffectKind.FLAT_BONUS, scaled_value=1)
+
+        participant.character_sheet.character.combat_pulls.invalidate()
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolve_combat_technique(
+                participant=participant,
+                action=action,
+                target=opponent,
+                fatigue_category=FatigueCategory.PHYSICAL,
+                offense_check_type=MagicMock(),
+                offense_check_fn=None,
+            )
+
+        kwargs = mock_perform.call_args.kwargs
+        # 3 + 1 from pulls; effort EffortLevel.MEDIUM is 0.
+        self.assertGreaterEqual(kwargs["extra_modifiers"], 4)

--- a/src/world/combat/tests/test_combat_magic_integration.py
+++ b/src/world/combat/tests/test_combat_magic_integration.py
@@ -1,0 +1,143 @@
+"""Integration tests for the combat → use_technique pipeline.
+
+These tests exercise the full round-resolution path with a real
+use_technique envelope. They assert observable side effects (anima
+deduction, event emission, mishap conditions, damage delivered)
+rather than internal call patterns.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from evennia.objects.models import ObjectDB
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import (
+    ActionCategory,
+    EncounterStatus,
+    OpponentTier,
+)
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+    ThreatPoolEntryFactory,
+    ThreatPoolFactory,
+)
+from world.combat.models import CombatRoundAction
+from world.combat.services import resolve_combat_technique
+from world.fatigue.constants import EffortLevel, FatigueCategory
+from world.magic.factories import (
+    CharacterAnimaFactory,
+    EffectTypeFactory,
+    GiftFactory,
+    TechniqueFactory,
+)
+from world.mechanics.factories import CharacterEngagementFactory
+from world.vitals.constants import CharacterStatus
+from world.vitals.models import CharacterVitals
+
+
+def _setup_pc_attacking_mook(
+    *,
+    technique_intensity: int = 5,
+    technique_control: int = 10,
+    technique_anima_cost: int = 3,
+    base_power: int = 20,
+    opponent_health: int = 50,
+):
+    """Build the standard test scenario: 1 PC, 1 mook, technique ready."""
+    encounter = CombatEncounterFactory(
+        status=EncounterStatus.RESOLVING,
+        round_number=1,
+    )
+    pool = ThreatPoolFactory()
+    ThreatPoolEntryFactory(pool=pool, base_damage=30)
+    opponent = CombatOpponentFactory(
+        encounter=encounter,
+        tier=OpponentTier.MOOK,
+        health=opponent_health,
+        max_health=opponent_health,
+        threat_pool=pool,
+    )
+    sheet = CharacterSheetFactory()
+    participant = CombatParticipantFactory(encounter=encounter, character_sheet=sheet)
+    CharacterVitals.objects.create(
+        character_sheet=sheet,
+        health=100,
+        max_health=100,
+        status=CharacterStatus.ALIVE,
+    )
+    anima = CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
+    CharacterEngagementFactory(character=sheet.character)
+    room = ObjectDB.objects.create(
+        db_key="TestRoom",
+        db_typeclass_path="typeclasses.rooms.Room",
+    )
+    sheet.character.location = room
+    sheet.character.save()
+
+    technique = TechniqueFactory(
+        gift=GiftFactory(),
+        effect_type=EffectTypeFactory(name="Attack", base_power=base_power),
+        intensity=technique_intensity,
+        control=technique_control,
+        anima_cost=technique_anima_cost,
+    )
+    action = CombatRoundAction.objects.create(
+        participant=participant,
+        round_number=1,
+        focused_category=ActionCategory.PHYSICAL,
+        focused_action=technique,
+        focused_target=opponent,
+        effort_level=EffortLevel.MEDIUM,
+    )
+    return participant, action, opponent, anima, technique, room
+
+
+class AnimaDeductionTest(TestCase):
+    """Combat-cast technique deducts anima cost from CharacterAnima.current."""
+
+    def test_combat_cast_deducts_anima(self) -> None:
+        participant, action, opponent, anima, _technique, _ = _setup_pc_attacking_mook(
+            technique_anima_cost=3,
+            technique_intensity=5,
+            technique_control=10,
+        )
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolve_combat_technique(
+                participant=participant,
+                action=action,
+                target=opponent,
+                fatigue_category=FatigueCategory.PHYSICAL,
+                offense_check_type=MagicMock(),
+                offense_check_fn=None,
+            )
+
+        anima.refresh_from_db()
+        # control_delta = 10 - 5 = 5; effective_cost = max(3 - 5, 0) = 0.
+        self.assertEqual(anima.current, 20)
+
+    def test_combat_cast_with_high_intensity_deducts_anima(self) -> None:
+        participant, action, opponent, anima, _technique, _ = _setup_pc_attacking_mook(
+            technique_anima_cost=5,
+            technique_intensity=10,
+            technique_control=2,
+        )
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolve_combat_technique(
+                participant=participant,
+                action=action,
+                target=opponent,
+                fatigue_category=FatigueCategory.PHYSICAL,
+                offense_check_type=MagicMock(),
+                offense_check_fn=None,
+            )
+
+        anima.refresh_from_db()
+        # control_delta = 2 - 10 = -8; effective_cost = max(5 - (-8), 0) = 13.
+        self.assertEqual(anima.current, 7)

--- a/src/world/combat/tests/test_combat_magic_integration.py
+++ b/src/world/combat/tests/test_combat_magic_integration.py
@@ -376,3 +376,51 @@ class FlatBonusPullCheckTest(TestCase):
         kwargs = mock_perform.call_args.kwargs
         # 3 + 1 from pulls; effort EffortLevel.MEDIUM is 0.
         self.assertGreaterEqual(kwargs["extra_modifiers"], 4)
+
+
+class FullHappyPathTest(TestCase):
+    """End-to-end: damage applied, anima deducted, events emitted, no errors."""
+
+    def test_full_happy_path(self) -> None:
+        participant, action, opponent, _anima, _, _ = _setup_pc_attacking_mook(
+            technique_anima_cost=2,
+            technique_intensity=5,
+            technique_control=10,
+            base_power=20,
+            opponent_health=50,
+        )
+
+        captured_events: list = []
+        import world.magic.services.techniques as svc_mod
+
+        original = svc_mod.emit_event
+
+        def capturing(name, payload, **kw):
+            captured_events.append(name)
+            return original(name, payload, **kw)
+
+        svc_mod.emit_event = capturing
+        try:
+            with patch("world.combat.services.perform_check") as mock_perform:
+                mock_perform.return_value = MagicMock(success_level=2)
+                result = resolve_combat_technique(
+                    participant=participant,
+                    action=action,
+                    target=opponent,
+                    fatigue_category=FatigueCategory.PHYSICAL,
+                    offense_check_type=MagicMock(),
+                    offense_check_fn=None,
+                )
+        finally:
+            svc_mod.emit_event = original
+
+        self.assertEqual(len(result.damage_results), 1)
+        self.assertGreater(result.damage_results[0].damage_dealt, 0)
+
+        opponent.refresh_from_db()
+        self.assertLess(opponent.health, 50)
+
+        self.assertIn(EventName.TECHNIQUE_PRE_CAST, captured_events)
+        self.assertIn(EventName.TECHNIQUE_CAST, captured_events)
+
+        self.assertTrue(result.technique_use_result.confirmed)

--- a/src/world/combat/tests/test_models.py
+++ b/src/world/combat/tests/test_models.py
@@ -232,3 +232,35 @@ class FactorySmokeTest(TestCase):
 
         phase = BossPhaseFactory()
         self.assertIsNotNone(phase.opponent)
+
+
+class CombatTechniqueIntegrationTests(TestCase):
+    """Smoke tests for combat-magic pipeline dataclasses."""
+
+    def test_combat_technique_resolution_importable(self) -> None:
+        """Smoke test: CombatTechniqueResolution importable and constructible."""
+        from unittest.mock import MagicMock
+
+        from world.checks.types import CheckResult
+        from world.combat.types import CombatTechniqueResolution
+
+        res = CombatTechniqueResolution(
+            check_result=MagicMock(spec=CheckResult),
+            damage_results=[],
+            pull_flat_bonus=0,
+            scaled_damage=0,
+        )
+        self.assertEqual(res.scaled_damage, 0)
+
+    def test_combat_technique_result_importable(self) -> None:
+        """Smoke test: CombatTechniqueResult importable and constructible."""
+        from unittest.mock import MagicMock
+
+        from world.combat.types import CombatTechniqueResult
+        from world.magic.types import TechniqueUseResult
+
+        res = CombatTechniqueResult(
+            damage_results=[],
+            technique_use_result=MagicMock(spec=TechniqueUseResult),
+        )
+        self.assertEqual(res.damage_results, [])

--- a/src/world/combat/tests/test_round_orchestrator.py
+++ b/src/world/combat/tests/test_round_orchestrator.py
@@ -30,7 +30,12 @@ from world.combat.services import resolve_round, upgrade_action_to_combo
 from world.covenants.factories import CovenantRoleFactory
 from world.fatigue.constants import EffortLevel
 from world.fatigue.models import FatiguePool
-from world.magic.factories import EffectTypeFactory, GiftFactory, TechniqueFactory
+from world.magic.factories import (
+    CharacterAnimaFactory,
+    EffectTypeFactory,
+    GiftFactory,
+    TechniqueFactory,
+)
 from world.vitals.constants import CharacterStatus
 from world.vitals.models import CharacterVitals
 
@@ -420,6 +425,7 @@ class ResolveRoundOffenseCheckTests(TestCase):
             max_health=100,
             status=CharacterStatus.ALIVE,
         )
+        CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         technique = TechniqueFactory(
             gift=self.gift,
             effect_type=self.effect_attack,

--- a/src/world/combat/types.py
+++ b/src/world/combat/types.py
@@ -8,12 +8,14 @@ from typing import TYPE_CHECKING
 from world.vitals.types import DamageConsequenceResult
 
 if TYPE_CHECKING:
+    from world.checks.types import CheckResult
     from world.combat.models import (
         CombatOpponent,
         CombatParticipant,
         CombatRoundAction,
         ComboDefinition,
     )
+    from world.magic.types import TechniqueUseResult
 
 
 @dataclass(frozen=True)
@@ -88,3 +90,38 @@ class RoundResolutionResult:
     phase_transitions: list[tuple[CombatOpponent, int]] = field(default_factory=list)
     encounter_completed: bool = False
     available_combos: list[AvailableCombo] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Combat magic pipeline integration (Spec: 2026-04-30)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CombatTechniqueResolution:
+    """Returned from a combat resolver into use_technique.
+
+    Frozen — once the inner resolution is computed it cannot change.
+    Read by the adapter to populate the outer ActionOutcome. Exposes
+    check_result at the top level (no main_result wrapper) — the
+    use_technique extractor accepts this shape per spec
+    2026-04-30-combat-magic-pipeline-integration-design.
+    """
+
+    check_result: CheckResult
+    damage_results: list[OpponentDamageResult]
+    pull_flat_bonus: int
+    scaled_damage: int
+
+
+@dataclass(frozen=True)
+class CombatTechniqueResult:
+    """Adapter's return shape — what _resolve_pc_action consumes.
+
+    Wraps the magic-pipeline outcome (TechniqueUseResult) plus the
+    combat-side damage_results extracted from it. Frozen because the
+    cast is over by the time this is constructed.
+    """
+
+    damage_results: list[OpponentDamageResult]
+    technique_use_result: TechniqueUseResult

--- a/src/world/magic/services/techniques.py
+++ b/src/world/magic/services/techniques.py
@@ -302,10 +302,12 @@ def use_technique(  # noqa: PLR0913, PLR0912, C901 — kw-only args are intentio
 
     # Extract check_result from resolution if not provided explicitly
     effective_check_result = check_result
-    if effective_check_result is None and hasattr(resolution_result, "main_result"):
-        main = resolution_result.main_result
-        if main is not None and hasattr(main, "check_result"):
-            effective_check_result = main.check_result
+    if effective_check_result is None:
+        effective_check_result = getattr(resolution_result, "check_result", None)  # noqa: GETATTR_LITERAL — protocol-style introspection
+        if effective_check_result is None and hasattr(resolution_result, "main_result"):
+            main = resolution_result.main_result
+            if main is not None and hasattr(main, "check_result"):
+                effective_check_result = main.check_result
 
     # Step 7: Soulfray accumulation and stage consequences
     soulfray_result = None

--- a/src/world/magic/tests/test_reactive_integration.py
+++ b/src/world/magic/tests/test_reactive_integration.py
@@ -415,3 +415,67 @@ class TechniqueAffectedEmissionTest(TestCase):
         self.assertIs(p.caster, self.char)
         self.assertIs(p.technique, self.technique)
         self.assertIs(p.target, self.target1)
+
+
+# ---------------------------------------------------------------------------
+# check_result extractor — combat-shape resolution_result
+# ---------------------------------------------------------------------------
+
+
+class TechniqueCheckResultExtractorTest(TestCase):
+    """use_technique extracts check_result from a resolution_result that
+    exposes .check_result directly (combat shape), not just from
+    .main_result.check_result (social shape)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # intensity > control to force mishap pool selection — that path
+        # only fires if check_result is non-None, so it doubles as the
+        # extractor assertion.
+        cls.technique = TechniqueFactory(intensity=10, control=2, anima_cost=1)
+
+    def setUp(self) -> None:
+        self.room = _create_room()
+        self.char, self.anima = _setup_caster(room=self.room)
+
+    def test_extractor_reads_top_level_check_result(self) -> None:
+        """When resolve_fn returns a result with top-level .check_result, the
+        extractor finds it and passes it to soulfray/mishap downstream."""
+        from dataclasses import dataclass
+
+        from world.checks.types import CheckResult
+
+        @dataclass
+        class CombatShapeResolution:
+            check_result: CheckResult
+
+        # fake check_result + control_deficit > 0 should trigger _resolve_mishap
+        # if the extractor finds it.
+        fake_check = MagicMock(spec=CheckResult)
+        fake_check.success_level = 0
+        resolution = CombatShapeResolution(check_result=fake_check)
+
+        captured: list = []
+
+        import world.magic.services.techniques as svc_mod
+
+        original = svc_mod._resolve_mishap
+
+        def capturing(character, pool, check_result):
+            captured.append(check_result)
+            return original(character, pool, check_result)
+
+        svc_mod._resolve_mishap = capturing
+        svc_mod.select_mishap_pool = MagicMock(return_value=MagicMock())
+        try:
+            use_technique(
+                character=self.char,
+                technique=self.technique,
+                resolve_fn=lambda: resolution,
+            )
+        finally:
+            svc_mod._resolve_mishap = original
+
+        # The extractor must have found .check_result and passed it through.
+        self.assertEqual(len(captured), 1)
+        self.assertIs(captured[0], fake_check)

--- a/src/world/magic/tests/test_reactive_integration.py
+++ b/src/world/magic/tests/test_reactive_integration.py
@@ -13,7 +13,7 @@ Tests verify:
 - TECHNIQUE_AFFECTED has correct target and effect
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
@@ -459,22 +459,23 @@ class TechniqueCheckResultExtractorTest(TestCase):
 
         import world.magic.services.techniques as svc_mod
 
-        original = svc_mod._resolve_mishap
+        original_resolve_mishap = svc_mod._resolve_mishap
 
         def capturing(character, pool, check_result):
             captured.append(check_result)
-            return original(character, pool, check_result)
+            return original_resolve_mishap(character, pool, check_result)
 
-        svc_mod._resolve_mishap = capturing
-        svc_mod.select_mishap_pool = MagicMock(return_value=MagicMock())
-        try:
+        # select_mishap_pool returns a truthy pool so _resolve_mishap fires;
+        # patch.object guarantees both are restored on exit.
+        with (
+            patch.object(svc_mod, "_resolve_mishap", side_effect=capturing),
+            patch.object(svc_mod, "select_mishap_pool", return_value=MagicMock()),
+        ):
             use_technique(
                 character=self.char,
                 technique=self.technique,
                 resolve_fn=lambda: resolution,
             )
-        finally:
-            svc_mod._resolve_mishap = original
 
         # The extractor must have found .check_result and passed it through.
         self.assertEqual(len(captured), 1)


### PR DESCRIPTION
Routes damage-path combat techniques through use_technique so the magic stack actually fires during combat. Anima, soulfray,
  mishap rolls, TECHNIQUE_PRE_CAST / TECHNIQUE_CAST events, reactive scar interception, and FLAT_BONUS thread-pull bonuses now
  apply to every combat-cast attack technique — same pipeline as a scene-cast technique.

  Spec: docs/superpowers/specs/2026-04-30-combat-magic-pipeline-integration-design.md

  ## What changed

  Combat-side adapter (combat is the consumer; magic stays generic):
  - New CombatAttackResolver dataclass in world/combat/services.py — frozen, callable, three private steps (_roll_check, _scale,
  _apply). Subclassable for the non-attack resolvers coming next PR.
  - New resolve_combat_technique orchestrator — builds the resolver, sums active FLAT_BONUS pulls, calls
  use_technique(resolve_fn=resolver), returns a CombatTechniqueResult.
  - New _sum_active_flat_bonuses helper — reads through CharacterCombatPullHandler so the prefetched cache is honored.
  - New _build_combat_result helper — translates TechniqueUseResult into the adapter's return shape (cancel path → empty
  damage_results).
  - _resolve_pc_action swap: the inline check + apply_damage_to_opponent block becomes one call to the orchestrator. Combo path
  unchanged. Old _scale_damage_by_check removed.

  Magic-side micro-change (3 lines):
  - use_technique's check_result extractor generalized to accept a top-level .check_result attribute on the resolution result
  (combat shape) in addition to the existing .main_result.check_result (social shape from Scope #4). Existing callers unaffected.

  FLAT_BONUS routing per Spec A §5.8:
  - Active CombatPull rows feed scaled_value of FLAT_BONUS CombatPullResolvedEffect rows into the offense check's extra_modifiers
   (not into damage). Trait/skill/technique threads now help your attack roll, not just your bonus damage.

  ## Explicitly deferred (commented at the call site)

  - Non-attack effect types (Defense / Buff / Movement / Debuff) — needs the conditions-from-techniques resolver.
  - INTENSITY_BUMP pull effects — needs get_runtime_technique_stats to accept combat context so anima cost reflects the bump.
  - CAPABILITY_GRANT, NARRATIVE_ONLY pull effects — tied to non-attack pipeline / cosmetic surfacing.
  - VITAL_BONUS pull effects — already wired through recompute_max_health_with_threads, untouched.
  - TECHNIQUE_AFFECTED per-target events — CombatOpponent isn't ObjectDB, so targets=[] for now. PRE_CAST and CAST still fire.
  - PerformRitualAction player command — separate small PR.

  ## Notable touches

  - One existing test fixture in test_round_orchestrator.py:ResolveRoundOffenseCheckTests._setup_encounter needed
  CharacterAnimaFactory(character=sheet.character, current=20, maximum=20) because use_technique requires CharacterAnima. Real
  test-data integrity fix, not a defensive shim.
  - The _resolve_pc_action damage path has a TODO-marked fallback for the offense_check_type is None case — temporary
  test-compatibility shim only, not production behavior. Should be removed once all combat tests provide a check type.
  - Anima overburn semantics inherit from use_technique (effective_cost can exceed current_anima → soulfray accrues). Frontend
  handles the soulfray preview-and-confirm before round submission; round resolution always passes confirm_soulfray_risk=True.

  ## Stats

  - 20 commits (2 spec + 18 implementation/test/cleanup)
  - 9 files changed, +1486 / -52
  - 22 new tests (13 unit on the resolver/helpers, 9 integration on the full pipeline)

  ## Test plan

  - arx test world.combat world.magic flows --keepdb — 1380 / 1380 pass
  - All required behaviors from the spec verified by integration tests:
    - Anima deducted on combat cast (AnimaDeductionTest × 2)
    - TECHNIQUE_PRE_CAST + TECHNIQUE_CAST emit (EventEmissionTest)
    - Reactive scar can cancel combat cast — no damage, no anima, no TECHNIQUE_CAST (ReactiveScarCancelTest × 2)
    - Mishap fires on control deficit (MishapTest)
    - FLAT_BONUS pulls feed offense check extra_modifiers (FlatBonusPullCheckTest)
    - End-to-end damage path with events (FullHappyPathTest)
  - ruff check / ruff format --check / ty clean
  - No-keepdb regression hit the pre-existing migration dependency bug (fresh DB setup fails with
  auth_permission_content_type_id_codename IntegrityError — not branch-related). Will need to verify on CI rather than locally.