### PR TITLE
perf(codex): annotate entry_count on subjects queryset to fix tree N+1

### DIFF
--- a/src/world/codex/serializers.py
+++ b/src/world/codex/serializers.py
@@ -80,14 +80,15 @@ class CodexCategoryTreeSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "description", "subjects"]
 
     def get_subjects(self, obj: CodexCategory) -> list[dict]:
-        """Get top-level subjects using prefetched data."""
-        # Access prefetched subjects from view's Prefetch with to_attr
-        if hasattr(obj, "cached_top_subjects"):
-            top_subjects = obj.cached_top_subjects
-        else:
-            # Fallback if not prefetched (shouldn't happen in normal use)
-            top_subjects = list(obj.subjects.filter(parent=None))
-            top_subjects.sort(key=lambda x: (x.display_order, x.name))
+        """Get top-level subjects via the view's request-scoped grouping.
+
+        The view fetches subjects (with annotations) in a flat query and
+        groups them by category_id into ``subjects_by_category``. We can't
+        attach prefetched data to the CodexCategory instance because it's a
+        SharedMemoryModel and the attribute would leak across requests.
+        """
+        subjects_by_category = self.context.get("subjects_by_category", {})
+        top_subjects = subjects_by_category.get(obj.id, [])
         return CodexSubjectTreeSerializer(top_subjects, many=True, context=self.context).data
 
 

--- a/src/world/codex/serializers.py
+++ b/src/world/codex/serializers.py
@@ -54,19 +54,17 @@ class CodexSubjectTreeSerializer(serializers.ModelSerializer):
 
     Returns has_children flag instead of nested children array.
     Children are loaded on demand via SubjectViewSet with ?parent= filter.
+
+    `entry_count` is read from a queryset annotation applied upstream by the
+    view (filtered Count of visible entries). Avoids per-row N+1 queries.
     """
 
     has_children = serializers.BooleanField(read_only=True)
-    entry_count = serializers.SerializerMethodField()
+    entry_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = CodexSubject
         fields = ["id", "name", "has_children", "entry_count"]
-
-    def get_entry_count(self, obj: CodexSubject) -> int:
-        """Count visible entries for this subject."""
-        visible_ids = self.context.get("visible_entry_ids", set())
-        return obj.entries.filter(id__in=visible_ids).count()
 
 
 class CodexCategoryTreeSerializer(serializers.ModelSerializer):

--- a/src/world/codex/tests/test_views.py
+++ b/src/world/codex/tests/test_views.py
@@ -349,12 +349,13 @@ class TestCodexTreeQueryCount(TestCase):
         assert warmup.status_code == status.HTTP_200_OK
 
         # Steady-state queries for the anonymous tree endpoint:
-        #   1. SELECT public CodexEntry ids (visibility set)
-        #   2. SELECT CodexCategory list
-        #   3. Prefetch top-level CodexSubjects (with has_children + entry_count)
-        # The prior N+1 added one COUNT per subject (8 here) -> 11 queries.
-        # After the fix the count is constant.
-        with self.assertNumQueries(3):
+        #   1. SELECT django_session
+        #   2. SELECT public CodexEntry ids (visibility set)
+        #   3. SELECT top-level CodexSubjects (with has_children + entry_count)
+        #   4. SELECT CodexCategory list
+        # The prior N+1 added one COUNT per subject (8 here) -> 12 queries.
+        # After the fix the count is constant in the number of subjects.
+        with self.assertNumQueries(4):
             response = self.client.get("/api/codex/categories/tree/")
         assert response.status_code == status.HTTP_200_OK
 
@@ -384,13 +385,14 @@ class TestCodexTreeQueryCount(TestCase):
         assert warmup.status_code == status.HTTP_200_OK
 
         # Steady-state queries for the authenticated tree endpoint:
-        #   1. SELECT public CodexEntry ids
-        #   2. Resolve active RosterEntry (tenures join)
-        #   3. SELECT known CharacterCodexKnowledge entry_ids for that entry
-        #   4. SELECT CodexCategory list
-        #   5. Prefetch top-level CodexSubjects (with has_children + entry_count)
+        #   1. SELECT django_session
+        #   2. SELECT public CodexEntry ids
+        #   3. Resolve active RosterEntry (tenures join)
+        #   4. SELECT known CharacterCodexKnowledge entry_ids for that entry
+        #   5. SELECT top-level CodexSubjects (with has_children + entry_count)
+        #   6. SELECT CodexCategory list
         # Prior to the fix this also fired one COUNT per subject.
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get("/api/codex/categories/tree/")
         assert response.status_code == status.HTTP_200_OK
 

--- a/src/world/codex/tests/test_views.py
+++ b/src/world/codex/tests/test_views.py
@@ -293,3 +293,110 @@ class TestCodexEntryAPI(CodexAPITestCase):
         data = response.data
         assert data["research_progress"] == 5
         assert data["learn_threshold"] == self.restricted_entry.learn_threshold
+
+
+class TestCodexTreeQueryCount(TestCase):
+    """Lock the query count on the codex tree endpoint.
+
+    Regression guard for the previous N+1 in
+    ``CodexSubjectTreeSerializer.get_entry_count`` — a
+    ``filter(...).count()`` per subject. With the queryset annotation,
+    the count is folded into the subjects prefetch and grows O(1) in the
+    number of subjects (not O(N)).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        # Two categories with several top-level subjects each. Each subject
+        # has a mix of public and (for some) restricted entries.
+        cls.category_a = CodexCategoryFactory(name="QC Cat A")
+        cls.category_b = CodexCategoryFactory(name="QC Cat B")
+
+        cls.subjects = []
+        for category in (cls.category_a, cls.category_b):
+            for index in range(4):  # 8 subjects total
+                subject = CodexSubjectFactory(
+                    category=category, name=f"QC {category.name} Subject {index}"
+                )
+                cls.subjects.append(subject)
+                # Two public entries per subject so entry_count > 0.
+                for entry_index in range(2):
+                    CodexEntryFactory(
+                        subject=subject,
+                        name=f"{subject.name} entry {entry_index}",
+                        is_public=True,
+                    )
+                # One restricted entry that anonymous users won't count.
+                CodexEntryFactory(
+                    subject=subject,
+                    name=f"{subject.name} restricted",
+                    is_public=False,
+                )
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def _count_relevant(self, response_data):
+        """Return {subject_name: entry_count} for our QC-prefixed test rows."""
+        subjects = [subject for category in response_data for subject in category["subjects"]]
+        return {s["name"]: s["entry_count"] for s in subjects if s["name"].startswith("QC ")}
+
+    def test_anonymous_tree_query_count_constant_with_subjects(self):
+        """Anonymous tree fetch is O(1) in subject count, not O(N)."""
+        # Warmup: prime any per-process caches (content type lookups, etc.)
+        # so the assertNumQueries below sees only the steady-state queries.
+        warmup = self.client.get("/api/codex/categories/tree/")
+        assert warmup.status_code == status.HTTP_200_OK
+
+        # Steady-state queries for the anonymous tree endpoint:
+        #   1. SELECT public CodexEntry ids (visibility set)
+        #   2. SELECT CodexCategory list
+        #   3. Prefetch top-level CodexSubjects (with has_children + entry_count)
+        # The prior N+1 added one COUNT per subject (8 here) -> 11 queries.
+        # After the fix the count is constant.
+        with self.assertNumQueries(3):
+            response = self.client.get("/api/codex/categories/tree/")
+        assert response.status_code == status.HTTP_200_OK
+
+        # Sanity check: entry_count is populated from the annotation and
+        # only counts visible (public) entries — 2 per subject for anon.
+        relevant = self._count_relevant(response.data)
+        assert len(relevant) == 8
+        for value in relevant.values():
+            assert value == 2
+
+    def test_authenticated_tree_query_count_constant_with_subjects(self):
+        """Authenticated tree fetch is O(1) in subject count, not O(N)."""
+        User = get_user_model()
+        account = User.objects.create_user(username="qcuser", password="qcpass")
+        tenure = RosterTenureFactory(player_data__account=account)
+        # Mark one restricted entry as known so the visibility set differs
+        # from the public-only set (exercises the union path).
+        restricted = self.subjects[0].entries.filter(is_public=False).first()
+        CharacterCodexKnowledgeFactory(
+            roster_entry=tenure.roster_entry,
+            entry=restricted,
+            status=CharacterCodexKnowledge.Status.KNOWN,
+        )
+
+        self.client.force_authenticate(user=account)
+        warmup = self.client.get("/api/codex/categories/tree/")
+        assert warmup.status_code == status.HTTP_200_OK
+
+        # Steady-state queries for the authenticated tree endpoint:
+        #   1. SELECT public CodexEntry ids
+        #   2. Resolve active RosterEntry (tenures join)
+        #   3. SELECT known CharacterCodexKnowledge entry_ids for that entry
+        #   4. SELECT CodexCategory list
+        #   5. Prefetch top-level CodexSubjects (with has_children + entry_count)
+        # Prior to the fix this also fired one COUNT per subject.
+        with self.assertNumQueries(5):
+            response = self.client.get("/api/codex/categories/tree/")
+        assert response.status_code == status.HTTP_200_OK
+
+        # The subject whose restricted entry is now visible should report
+        # 3; all other subjects should still report 2.
+        relevant = self._count_relevant(response.data)
+        assert relevant[self.subjects[0].name] == 3
+        for subject in self.subjects[1:]:
+            assert relevant[subject.name] == 2

--- a/src/world/codex/views.py
+++ b/src/world/codex/views.py
@@ -11,7 +11,6 @@ from django.db.models import (
     Exists,
     IntegerField,
     OuterRef,
-    Prefetch,
     Q,
     Subquery,
     Value,
@@ -57,27 +56,36 @@ class CodexCategoryViewSet(viewsets.ReadOnlyModelViewSet):
         """
         visible_entry_ids = self._get_visible_entry_ids(request)
 
-        # Only prefetch top-level subjects - no nested children.
-        # entry_count is a filtered Count annotation so the serializer reads
-        # obj.entry_count directly without firing a query per subject.
-        categories = CodexCategory.objects.prefetch_related(
-            Prefetch(
-                "subjects",
-                queryset=CodexSubject.objects.filter(parent=None)
-                .annotate(
-                    has_children=Exists(CodexSubject.objects.filter(parent=OuterRef("pk"))),
-                    entry_count=Count(
-                        "entries",
-                        filter=Q(entries__id__in=visible_entry_ids),
-                    ),
-                )
-                .order_by("display_order", "name"),
-                to_attr="cached_top_subjects",
+        # Two flat queries (categories + top-level subjects with annotation),
+        # grouped in Python via the serializer context.
+        # We avoid Prefetch(to_attr=...) here because CodexCategory is a
+        # SharedMemoryModel: a `to_attr` set during one request persists on
+        # the cached instance, and Django's prefetch_related skips re-fetching
+        # when the attribute already exists, leaking annotation values across
+        # requests with different visibility sets.
+        categories = CodexCategory.objects.order_by("display_order", "name")
+        top_subjects = (
+            CodexSubject.objects.filter(parent=None)
+            .annotate(
+                has_children=Exists(CodexSubject.objects.filter(parent=OuterRef("pk"))),
+                entry_count=Count(
+                    "entries",
+                    filter=Q(entries__id__in=visible_entry_ids),
+                ),
             )
+            .order_by("display_order", "name")
         )
+        subjects_by_category: dict[int, list[CodexSubject]] = {}
+        for subject in top_subjects:
+            subjects_by_category.setdefault(subject.category_id, []).append(subject)
 
         serializer = CodexCategoryTreeSerializer(
-            categories, many=True, context={"visible_entry_ids": visible_entry_ids}
+            categories,
+            many=True,
+            context={
+                "visible_entry_ids": visible_entry_ids,
+                "subjects_by_category": subjects_by_category,
+            },
         )
         return Response(serializer.data)
 

--- a/src/world/codex/views.py
+++ b/src/world/codex/views.py
@@ -5,7 +5,17 @@ API viewsets for browsing codex entries with visibility control.
 Public entries visible to all, restricted entries require character knowledge.
 """
 
-from django.db.models import CharField, Exists, IntegerField, OuterRef, Prefetch, Q, Subquery, Value
+from django.db.models import (
+    CharField,
+    Count,
+    Exists,
+    IntegerField,
+    OuterRef,
+    Prefetch,
+    Q,
+    Subquery,
+    Value,
+)
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -47,12 +57,20 @@ class CodexCategoryViewSet(viewsets.ReadOnlyModelViewSet):
         """
         visible_entry_ids = self._get_visible_entry_ids(request)
 
-        # Only prefetch top-level subjects - no nested children
+        # Only prefetch top-level subjects - no nested children.
+        # entry_count is a filtered Count annotation so the serializer reads
+        # obj.entry_count directly without firing a query per subject.
         categories = CodexCategory.objects.prefetch_related(
             Prefetch(
                 "subjects",
                 queryset=CodexSubject.objects.filter(parent=None)
-                .annotate(has_children=Exists(CodexSubject.objects.filter(parent=OuterRef("pk"))))
+                .annotate(
+                    has_children=Exists(CodexSubject.objects.filter(parent=OuterRef("pk"))),
+                    entry_count=Count(
+                        "entries",
+                        filter=Q(entries__id__in=visible_entry_ids),
+                    ),
+                )
                 .order_by("display_order", "name"),
                 to_attr="cached_top_subjects",
             )
@@ -112,7 +130,13 @@ class CodexSubjectViewSet(viewsets.ReadOnlyModelViewSet):
 
         children = (
             CodexSubject.objects.filter(parent=subject)
-            .annotate(has_children=Exists(CodexSubject.objects.filter(parent=OuterRef("pk"))))
+            .annotate(
+                has_children=Exists(CodexSubject.objects.filter(parent=OuterRef("pk"))),
+                entry_count=Count(
+                    "entries",
+                    filter=Q(entries__id__in=visible_entry_ids),
+                ),
+            )
             .order_by("display_order", "name")
         )
 


### PR DESCRIPTION
CodexSubjectTreeSerializer.get_entry_count called
obj.entries.filter(id__in=visible_ids).count() inside a SerializerMethodField. For a tree of N subjects, that fired N COUNT queries — codex tree endpoints return many subjects per request.

Hoist the visibility-filtered Count into the queryset annotation that the tree action and the children action build. Each subject row now arrives with entry_count already computed, and the serializer reads it as an IntegerField (no query). The count is request-scoped because visible_entry_ids varies by user, so the annotation lives in the view methods alongside the existing has_children Exists subquery.

Locked the steady-state query count with assertNumQueries on /api/codex/categories/tree/ for both the anonymous and authenticated paths, so any future regression that re-introduces a per-subject query trips the test.