### PR TITLE
fix(events,gm): address review conditions on query-fix-events-gm

### DIFF
--- a/src/world/events/tests/test_views.py
+++ b/src/world/events/tests/test_views.py
@@ -377,10 +377,12 @@ class EventDetailQueryCountTestCase(APITestCase):
         # the viewer-GM set: increasing the loop above to 30 events should
         # leave this number unchanged. Steady-state queries:
         #   1. session lookup
-        #   2-3. ``_get_active_persona_ids`` for visibility filter + context
-        #   4. event detail (with select_related / prefetch)
-        #   5. ``_get_viewer_gm_event_ids`` — single query for the GM-event set
-        with self.assertNumQueries(5):
+        #   2. ``_active_persona_ids`` (cached_property) — one Persona query
+        #      with a RosterEntry subquery; shared by visibility filter and
+        #      serializer context
+        #   3. event detail (with select_related / prefetch)
+        #   4. ``_get_viewer_gm_event_ids`` — single query for the GM-event set
+        with self.assertNumQueries(4):
             response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data["is_gm"])

--- a/src/world/events/views.py
+++ b/src/world/events/views.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from django.db import IntegrityError
 from django.db.models import Prefetch, Q, QuerySet
 from django.shortcuts import get_object_or_404
+from django.utils.functional import cached_property
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.decorators import action
@@ -115,8 +116,15 @@ class EventViewSet(ModelViewSet):
     def get_queryset(self) -> QuerySet[Event]:
         return self._apply_visibility_filter(self._base_queryset().order_by("scheduled_real_time"))
 
-    def _get_active_persona_ids(self) -> list[int]:
-        """Get persona IDs for the requesting user's active characters."""
+    @cached_property
+    def _active_persona_ids(self) -> list[int]:
+        """Persona IDs for the requesting user's active characters.
+
+        Cached on the viewset instance (which is fresh per request) so the
+        visibility filter, lifecycle actions, and ``get_serializer_context``
+        share one resolution instead of each firing the same RosterEntry +
+        Persona query pair.
+        """
         if not self.request.user.is_authenticated:
             return []
         character_ids = RosterEntry.objects.for_account(self.request.user).values_list(
@@ -140,7 +148,7 @@ class EventViewSet(ModelViewSet):
         if not self.request.user.is_authenticated:
             return qs.filter(is_public=True)
 
-        persona_ids = self._get_active_persona_ids()
+        persona_ids = self._active_persona_ids
 
         if not persona_ids:
             return qs.filter(is_public=True)
@@ -166,7 +174,7 @@ class EventViewSet(ModelViewSet):
 
     def perform_create(self, serializer: EventCreateSerializer) -> None:
         """Create event via service function, deriving host from request user."""
-        persona_ids = self._get_active_persona_ids()
+        persona_ids = self._active_persona_ids
         if not persona_ids:
             raise DRFValidationError(EventError.NO_PERSONA)
         active_persona = Persona.objects.get(id=persona_ids[0])
@@ -228,7 +236,7 @@ class EventViewSet(ModelViewSet):
 
     def get_serializer_context(self) -> dict:
         context = super().get_serializer_context()
-        context["persona_ids"] = set(self._get_active_persona_ids())
+        context["persona_ids"] = set(self._active_persona_ids)
         context["viewer_gm_event_ids"] = self._get_viewer_gm_event_ids()
         return context
 
@@ -239,14 +247,12 @@ class EventViewSet(ModelViewSet):
             service_fn(event)
         except EventError as e:
             return Response({"detail": e.user_message}, status=status.HTTP_400_BAD_REQUEST)
-        context = {
-            "request": request,
-            "persona_ids": set(self._get_active_persona_ids()),
-            "viewer_gm_event_ids": self._get_viewer_gm_event_ids(),
-        }
         event.flush_from_cache(force=True)
         return Response(
-            EventDetailSerializer(self._base_queryset().get(pk=event.pk), context=context).data
+            EventDetailSerializer(
+                self._base_queryset().get(pk=event.pk),
+                context=self.get_serializer_context(),
+            ).data
         )
 
     @action(detail=True, methods=["post"])

--- a/src/world/gm/tests/test_table_views.py
+++ b/src/world/gm/tests/test_table_views.py
@@ -361,6 +361,20 @@ class GMTableComputedFieldsTest(TestCase):
         serializer = GMTableSerializer(table, context={"request": FakeRequest()})
         assert serializer.data["viewer_role"] == "none"
 
+    def test_viewer_role_no_request_in_context_returns_none(self) -> None:
+        """get_viewer_role bails out cleanly when context has no request.
+
+        DRF can serialize without a request (e.g. management commands,
+        Celery tasks, ad-hoc usage). The serializer falls back to NONE
+        rather than crashing on ``self.context["request"]``.
+        """
+        from world.gm.models import GMTable
+        from world.gm.serializers import GMTableSerializer
+
+        table = GMTable.objects.get(pk=self.table.pk)
+        serializer = GMTableSerializer(table)
+        assert serializer.data["viewer_role"] == "none"
+
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Wave 1 Gap 3: Player-facing membership visibility


### PR DESCRIPTION
Three followups from the PR #420 review:

1. Cache `_active_persona_ids` as a `cached_property` on `EventViewSet`. The visibility filter and `get_serializer_context` were each calling `_get_active_persona_ids`, firing the same Persona-with-RosterEntry- subquery query twice per request. The viewset is fresh per request so caching is safe and request-scoped.

2. Refactor `_lifecycle_action` to use `self.get_serializer_context()` instead of re-building a `{request, persona_ids, viewer_gm_event_ids}` dict by hand. Keeps the lifecycle path in lock-step with whatever keys `get_serializer_context` adds in the future.

3. Add a fallback test for `GMTableSerializer.get_viewer_role` with no request in the serializer context. The serializer can be invoked outside a viewset (management commands, ad-hoc usage) and should return NONE rather than crash on `self.context["request"]`.

Update the steady-state query count for
`EventDetailQueryCountTestCase.test_event_retrieve_query_count_with_gm_check` from 5 to 4 — caching `_active_persona_ids` removes one duplicate Persona/RosterEntry resolution per request.