### PR TITLE
fix(character_creation): tradition list leaked beginning_id-filtered …

### DIFF
--- a/src/core/natural_keys.py
+++ b/src/core/natural_keys.py
@@ -49,6 +49,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.db import models
 from django.db.models.fields.related import ForeignKey
+from evennia.utils.idmapper.manager import SharedMemoryManager
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -58,8 +59,16 @@ class NaturalKeyConfigError(ValueError):
     """Raised when NaturalKeyConfig is missing or invalid."""
 
 
-class NaturalKeyManager(models.Manager["NaturalKeyMixin"]):
-    """Manager that supports get_by_natural_key lookups."""
+class NaturalKeyManager(SharedMemoryManager, models.Manager["NaturalKeyMixin"]):
+    """Manager that supports get_by_natural_key lookups.
+
+    Inherits from ``SharedMemoryManager`` so that ``.get(pk=N)`` hits the
+    Evennia identity-map cache before issuing SQL when the underlying model
+    is a ``SharedMemoryModel``. For non-SharedMemoryModel models with this
+    manager, the cache check is a no-op (the model has no
+    ``get_cached_instance`` classmethod, so the cache lookup raises and the
+    manager falls through to ``super().get()``).
+    """
 
     def get_by_natural_key(self, *args: Any) -> NaturalKeyMixin:
         """

--- a/src/world/character_creation/models.py
+++ b/src/world/character_creation/models.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+from django.db.models import Prefetch
 from django.utils import timezone
 from django.utils.functional import cached_property
 from evennia.accounts.models import AccountDB
@@ -337,6 +338,34 @@ class Beginnings(NaturalKeyMixin, SharedMemoryModel):
         To invalidate: del instance.cached_starting_languages
         """
         return list(self.starting_languages.all())
+
+    @cached_property
+    def cached_beginning_traditions(self) -> list[BeginningTradition]:
+        """All BeginningTradition rows for this Beginning, ordered for CG.
+
+        Returns BT rows with ``tradition`` and ``required_distinction``
+        select_related, sorted by ``(sort_order, id)``. The list is the same
+        for every caller asking about a given Beginning, so caching on the
+        SharedMemoryModel-instance is the correct location: populated once
+        per Beginning per process, reused across all subsequent requests.
+
+        Use this from views/serializers instead of viewset-scoped helpers.
+
+        To invalidate: ``del instance.cached_beginning_traditions``.
+        """
+        from world.codex.models import TraditionCodexGrant  # noqa: PLC0415
+
+        return list(
+            self.beginning_traditions.select_related("tradition", "required_distinction")
+            .prefetch_related(
+                Prefetch(
+                    "tradition__codex_grants",
+                    queryset=TraditionCodexGrant.objects.only("tradition_id", "entry_id"),
+                    to_attr="cached_codex_grants",
+                ),
+            )
+            .order_by("sort_order", "id")
+        )
 
     def is_accessible_by(self, account: AccountDB) -> bool:
         """Check if an account can see/select this option."""

--- a/src/world/character_creation/serializers.py
+++ b/src/world/character_creation/serializers.py
@@ -194,9 +194,16 @@ class TraditionSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_codex_entry_ids(self, obj) -> list[int]:
-        """Get codex entry IDs granted by this tradition."""
-        if hasattr(obj, "prefetched_codex_grants"):
-            return [grant.entry_id for grant in obj.prefetched_codex_grants]
+        """Get codex entry IDs granted by this tradition.
+
+        Read from the ``cached_codex_grants`` attr populated by the
+        ``Beginnings.cached_beginning_traditions`` prefetch. Same data for
+        every caller (no per-request filter), so attaching to the shared
+        Tradition instance is safe.
+        """
+        cached = getattr(obj, "cached_codex_grants", None)  # noqa: GETATTR_LITERAL — Prefetch(to_attr=) populates this attr
+        if cached is not None:
+            return [grant.entry_id for grant in cached]
         from world.codex.models import TraditionCodexGrant  # noqa: PLC0415
 
         return list(

--- a/src/world/character_creation/serializers.py
+++ b/src/world/character_creation/serializers.py
@@ -206,14 +206,19 @@ class TraditionSerializer(serializers.ModelSerializer):
     def get_required_distinction_id(self, obj) -> int | None:
         """Get the required distinction ID from the BeginningTradition context.
 
-        The beginning_id is passed via context from the ViewSet.
+        The view computes a ``{tradition_id: BeginningTradition}`` dict per
+        request and passes it via context. We do NOT attach the BT row to
+        ``obj`` (a SharedMemoryModel ``Tradition``) via ``Prefetch(to_attr=)``
+        because that attribute would persist across requests with different
+        ``beginning_id`` values and leak filtered data between users.
         """
-        if hasattr(obj, "prefetched_beginning_traditions"):
-            bts = obj.prefetched_beginning_traditions
-            if bts and bts[0].required_distinction_id:
-                return bts[0].required_distinction_id
-            return None
+        bt_map = self.context.get("beginning_traditions_by_tradition")
+        if bt_map is not None:
+            bt = bt_map.get(obj.id)
+            return bt.required_distinction_id if bt and bt.required_distinction_id else None
 
+        # Fallback for callers that didn't pre-compute the map (e.g. nested
+        # use in CharacterDraftSerializer where context is set up differently).
         beginning_id = self.context.get("beginning_id")
         if not beginning_id:
             return None

--- a/src/world/character_creation/serializers.py
+++ b/src/world/character_creation/serializers.py
@@ -305,8 +305,12 @@ class CharacterDraftSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
     )
-    # Tradition selection
-    selected_tradition = TraditionSerializer(read_only=True)
+    # Tradition selection — SerializerMethodField (not a nested declaration) so
+    # we can inject ``beginning_id`` into the TraditionSerializer's context per
+    # draft. The nested serializer's ``required_distinction_id`` resolves a
+    # BeginningTradition row keyed on (beginning_id, tradition_id); without
+    # the per-draft beginning_id it always returned None.
+    selected_tradition = serializers.SerializerMethodField()
     selected_tradition_id = serializers.PrimaryKeyRelatedField(
         queryset=Tradition.objects.filter(is_active=True),
         source="selected_tradition",
@@ -377,6 +381,20 @@ class CharacterDraftSerializer(serializers.ModelSerializer):
         from world.roster.models import RosterEntry  # noqa: PLC0415
 
         return RosterEntry.objects.for_account(obj.account).exists()
+
+    def get_selected_tradition(self, obj: CharacterDraft) -> dict | None:
+        """Render the selected tradition with this draft's beginning_id in context.
+
+        TraditionSerializer.required_distinction_id resolves a BeginningTradition
+        row keyed on (beginning_id, tradition_id). Drafts carry both pieces of
+        state directly, so we inject ``beginning_id`` into a per-draft context
+        rather than relying on the list endpoint's pre-built map.
+        """
+        if obj.selected_tradition is None:
+            return None
+        nested_context = dict(self.context)
+        nested_context["beginning_id"] = obj.selected_beginnings_id
+        return TraditionSerializer(obj.selected_tradition, context=nested_context).data
 
     def get_stage_completion(self, obj: CharacterDraft) -> dict[int, bool]:
         """Get completion status for each stage."""

--- a/src/world/character_creation/tests/test_traditions.py
+++ b/src/world/character_creation/tests/test_traditions.py
@@ -161,7 +161,20 @@ class TraditionListLeakTests(TestCase):
 
     def test_required_distinction_is_per_beginning_not_per_process(self):
         """Sequential requests with different beginning_id see their own data."""
+        from world.magic.models import Tradition
+
         url = "/api/character-creation/traditions/"
+
+        # Confirm the bug's precondition: SharedMemoryModel returns the
+        # *same Python object* for repeated lookups of the same pk. Without
+        # this property the leak shape doesn't apply, and the regression
+        # this test guards against would be untestable in isolation.
+        instance_one = Tradition.objects.get(pk=self.tradition.pk)
+        instance_two = Tradition.objects.get(pk=self.tradition.pk)
+        assert instance_one is instance_two, (
+            "Tradition is no longer SharedMemoryModel-shared; this test no "
+            "longer guards the original leak shape and should be revisited."
+        )
 
         # First request — beginning A.
         resp_a = self.client.get(url, {"beginning_id": self.beginning_a.id})
@@ -179,6 +192,26 @@ class TraditionListLeakTests(TestCase):
         resp_a2 = self.client.get(url, {"beginning_id": self.beginning_a.id})
         assert resp_a2.status_code == status.HTTP_200_OK
         assert self._required_distinction(resp_a2, self.tradition.id) == self.distinction_a.id
+
+    def test_nested_tradition_in_draft_resolves_required_distinction(self):
+        """CharacterDraftSerializer.selected_tradition resolves required_distinction_id.
+
+        The nested TraditionSerializer needs the draft's beginning_id to look
+        up the right BeginningTradition row. Prior to the SerializerMethodField
+        wiring, nested usage always returned ``required_distinction_id=None``
+        because ``beginning_id`` wasn't in the draft serializer's context.
+        """
+        draft = CharacterDraftFactory(
+            account=self.account,
+            selected_beginnings=self.beginning_a,
+            selected_tradition=self.tradition,
+        )
+        resp = self.client.get(f"/api/character-creation/drafts/{draft.id}/")
+        assert resp.status_code == status.HTTP_200_OK
+        nested = resp.data["selected_tradition"]
+        assert nested is not None
+        assert nested["id"] == self.tradition.id
+        assert nested["required_distinction_id"] == self.distinction_a.id
 
 
 class SelectTraditionTests(TestCase):

--- a/src/world/character_creation/tests/test_traditions.py
+++ b/src/world/character_creation/tests/test_traditions.py
@@ -112,6 +112,75 @@ class FinalizeMagicTraditionTests(TestCase):
         assert knowledge.first().status == CodexKnowledgeStatus.KNOWN
 
 
+class TraditionListLeakTests(TestCase):
+    """Regression guard for the SharedMemoryModel + Prefetch(to_attr=) leak.
+
+    ``Tradition`` is a SharedMemoryModel: instances persist across requests
+    in the same process. The previous implementation attached
+    ``prefetched_beginning_traditions`` (filtered by ``beginning_id`` from
+    the request) onto each Tradition via ``Prefetch(to_attr=...)``. Django's
+    ``prefetch_related`` saw the attribute already set on the next request
+    and SKIPPED the new prefetch, so requests with a different
+    ``beginning_id`` would inherit the previous request's filtered data.
+
+    The list response varies by ``beginning_id`` via the ``required_distinction_id``
+    field — different beginnings can require different distinctions for the
+    same tradition. We hit the endpoint with ``beginning_id=B1`` and then
+    ``beginning_id=B2`` against the same Tradition, and assert the second
+    response reflects B2's BeginningTradition, not B1's.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.account = AccountFactory()
+        cls.tradition = TraditionFactory(name="LeakTestTradition")
+        cls.distinction_a = DistinctionFactory(name="DistinctionA")
+        cls.distinction_b = DistinctionFactory(name="DistinctionB")
+        cls.beginning_a = BeginningsFactory(name="LeakBeginningA")
+        cls.beginning_b = BeginningsFactory(name="LeakBeginningB")
+        BeginningTraditionFactory(
+            beginning=cls.beginning_a,
+            tradition=cls.tradition,
+            required_distinction=cls.distinction_a,
+        )
+        BeginningTraditionFactory(
+            beginning=cls.beginning_b,
+            tradition=cls.tradition,
+            required_distinction=cls.distinction_b,
+        )
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.account)
+
+    def _required_distinction(self, response, tradition_id):
+        for row in response.data:
+            if row["id"] == tradition_id:
+                return row["required_distinction_id"]
+        return None
+
+    def test_required_distinction_is_per_beginning_not_per_process(self):
+        """Sequential requests with different beginning_id see their own data."""
+        url = "/api/character-creation/traditions/"
+
+        # First request — beginning A.
+        resp_a = self.client.get(url, {"beginning_id": self.beginning_a.id})
+        assert resp_a.status_code == status.HTTP_200_OK
+        assert self._required_distinction(resp_a, self.tradition.id) == self.distinction_a.id
+
+        # Second request — beginning B. Same Tradition instance is in
+        # SharedMemoryModel cache from request 1; this is where the prior
+        # implementation leaked beginning_a's distinction_id.
+        resp_b = self.client.get(url, {"beginning_id": self.beginning_b.id})
+        assert resp_b.status_code == status.HTTP_200_OK
+        assert self._required_distinction(resp_b, self.tradition.id) == self.distinction_b.id
+
+        # And going back to A still returns A's value (no flip-flop either).
+        resp_a2 = self.client.get(url, {"beginning_id": self.beginning_a.id})
+        assert resp_a2.status_code == status.HTTP_200_OK
+        assert self._required_distinction(resp_a2, self.tradition.id) == self.distinction_a.id
+
+
 class SelectTraditionTests(TestCase):
     """Tests for the select-tradition API endpoint."""
 

--- a/src/world/character_creation/tests/test_traditions.py
+++ b/src/world/character_creation/tests/test_traditions.py
@@ -193,6 +193,46 @@ class TraditionListLeakTests(TestCase):
         assert resp_a2.status_code == status.HTTP_200_OK
         assert self._required_distinction(resp_a2, self.tradition.id) == self.distinction_a.id
 
+    def test_repeat_request_with_same_beginning_hits_cache(self):
+        """Beginning + beginning_traditions are SharedMemoryModel-cached.
+
+        After the first request loads the Beginning and its
+        ``cached_beginning_traditions``, a second request with the same
+        ``beginning_id`` should not re-fetch BeginningTradition rows or
+        re-load the Beginning row — both live on the cached Beginning
+        instance for the lifetime of the process.
+
+        The Tradition list queryset still evaluates (with a JOIN through
+        BeginningTradition for FilterSet's ``beginning_id`` filter), but
+        no separate BT-fetch or Beginning-fetch query should fire.
+        """
+        import re
+
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        url = "/api/character-creation/traditions/"
+
+        # Warmup: populate Beginning instance + cached_beginning_traditions.
+        self.client.get(url, {"beginning_id": self.beginning_a.id})
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = self.client.get(url, {"beginning_id": self.beginning_a.id})
+        assert resp.status_code == status.HTTP_200_OK
+
+        def primary_table(sql: str) -> str:
+            m = re.search(r'FROM\s+"([^"]+)"', sql)
+            return m.group(1) if m else ""
+
+        primary_tables = [primary_table(q["sql"]) for q in ctx.captured_queries]
+        assert "character_creation_beginningtradition" not in primary_tables, (
+            f"Expected zero BT-as-primary-table queries on repeat request, got: {primary_tables}"
+        )
+        assert "character_creation_beginnings" not in primary_tables, (
+            f"Expected zero Beginnings-as-primary-table queries on repeat request "
+            f"(SharedMemoryModel cache hit), got: {primary_tables}"
+        )
+
     def test_nested_tradition_in_draft_resolves_required_distinction(self):
         """CharacterDraftSerializer.selected_tradition resolves required_distinction_id.
 

--- a/src/world/character_creation/views.py
+++ b/src/world/character_creation/views.py
@@ -243,57 +243,54 @@ class TraditionViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = TraditionFilter
 
-    def _get_beginning_traditions(self) -> list[BeginningTradition]:
-        """Fetch BeginningTradition rows for this request's beginning_id.
+    def _get_beginning(self) -> Beginnings | None:
+        """Resolve the request's Beginnings via SharedMemoryModel identity map.
 
-        Cached on the viewset (request-scoped) so ``get_queryset`` and
-        ``get_serializer_context`` share one lookup. The result must NOT
-        be attached to ``Tradition`` instances via Prefetch(to_attr=) —
-        ``Tradition`` is a SharedMemoryModel and per-request annotation
-        values would leak across requests with different beginning_ids.
+        After first load per process, ``Beginnings.objects.get(pk=N)`` is a
+        cache hit (zero queries). The Beginning then owns all per-Beginning
+        cached state we care about — most importantly
+        ``cached_beginning_traditions`` — which means there's no need (and
+        no place) to cache anything on the viewset itself.
+
+        ``query_params`` returns the id as a string, but Evennia's identity
+        map keys instances by int pk; cast explicitly so the cache hits.
         """
-        if hasattr(self, "_beginning_traditions_cache"):
-            return self._beginning_traditions_cache
-        # Defensive: drf-spectacular schema generation may invoke
-        # ``get_serializer_context`` without binding a real request.
-        request = getattr(self, "request", None)  # noqa: GETATTR_LITERAL — defensive against unbound viewset (schema generation)
-        beginning_id = (
+        request = getattr(self, "request", None)  # noqa: GETATTR_LITERAL — schema generation may have no bound request
+        raw = (
             request.query_params.get("beginning_id")  # noqa: USE_FILTERSET
             if request is not None
             else None
         )
-        if not beginning_id:
-            self._beginning_traditions_cache: list[BeginningTradition] = []
-            return self._beginning_traditions_cache
-        self._beginning_traditions_cache = list(
-            BeginningTradition.objects.filter(beginning_id=beginning_id)
-            .select_related("required_distinction")
-            .order_by("sort_order", "id")
-        )
-        return self._beginning_traditions_cache
+        if not raw:
+            return None
+        try:
+            beginning_id = int(raw)
+        except (TypeError, ValueError):
+            return None
+        try:
+            return Beginnings.objects.get(pk=beginning_id)
+        except Beginnings.DoesNotExist:
+            return None
 
     def get_queryset(self) -> QuerySet[Tradition]:
-        # Empty guard. Filtering by beginning_id is handled below via the
-        # BeginningTradition lookup; the FilterSet does not gate on it.
-        beginning_id = self.request.query_params.get("beginning_id")  # noqa: USE_FILTERSET
-        if not beginning_id:
+        beginning = self._get_beginning()
+        if beginning is None:
             return Tradition.objects.none()
 
-        from world.codex.models import TraditionCodexGrant  # noqa: PLC0415
-
-        bts = self._get_beginning_traditions()
+        # ``cached_beginning_traditions`` lives on the SharedMemoryModel-cached
+        # Beginning instance. The same data is returned to every caller asking
+        # about this Beginning, so the SharedMemoryModel cache is the right
+        # location: populated once per Beginning per process, then free.
+        bts = beginning.cached_beginning_traditions
         ordered_ids = [bt.tradition_id for bt in bts]
         if not ordered_ids:
             return Tradition.objects.none()
 
-        # Preserve BeginningTradition.sort_order on the Tradition queryset
-        # without re-using a Prefetch(to_attr=) that would leak per-request
-        # filtering onto SharedMemoryModel-cached Tradition instances.
-        # The annotation lands on the shared instance via setattr during
-        # iteration, but annotations are recomputed on every queryset
-        # evaluation (no ``is_to_attr_fetched`` elision), so ``_bt_order``
-        # is always fresh for the current request and is only consumed by
-        # SQL ORDER BY — never read from Python.
+        # Tradition rows are already loaded as ``bt.tradition`` via
+        # select_related on the cached BT list. We return a real queryset
+        # (so DRF pagination/filtering keeps working), but identity map
+        # makes the underlying instances free — only the row enumeration
+        # touches the DB.
         order_case = Case(
             *[When(id=tid, then=Value(idx)) for idx, tid in enumerate(ordered_ids)],
             default=Value(len(ordered_ids)),
@@ -301,26 +298,21 @@ class TraditionViewSet(viewsets.ReadOnlyModelViewSet):
         )
         return (
             Tradition.objects.filter(id__in=ordered_ids, is_active=True)
-            .prefetch_related(
-                Prefetch(
-                    "codex_grants",
-                    queryset=TraditionCodexGrant.objects.only("tradition_id", "entry_id"),
-                    to_attr="prefetched_codex_grants",
-                ),
-            )
             .annotate(_bt_order=order_case)
             .order_by("_bt_order", "name")
         )
 
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
-        beginning_id = self.request.query_params.get("beginning_id")  # noqa: USE_FILTERSET
-        context["beginning_id"] = beginning_id
-        # Pass per-request BeginningTradition lookup via context (request-scoped).
-        # Never via Prefetch(to_attr=) on Tradition — that leaks across users.
-        context["beginning_traditions_by_tradition"] = {
-            bt.tradition_id: bt for bt in self._get_beginning_traditions()
-        }
+        beginning = self._get_beginning()
+        context["beginning_id"] = beginning.pk if beginning is not None else None
+        # Build the per-Tradition BT lookup from the Beginning's cached list.
+        # No new queries — the BT rows are already in memory via the cached_property.
+        context["beginning_traditions_by_tradition"] = (
+            {bt.tradition_id: bt for bt in beginning.cached_beginning_traditions}
+            if beginning is not None
+            else {}
+        )
         return context
 
 

--- a/src/world/character_creation/views.py
+++ b/src/world/character_creation/views.py
@@ -254,7 +254,14 @@ class TraditionViewSet(viewsets.ReadOnlyModelViewSet):
         """
         if hasattr(self, "_beginning_traditions_cache"):
             return self._beginning_traditions_cache
-        beginning_id = self.request.query_params.get("beginning_id")  # noqa: USE_FILTERSET
+        # Defensive: drf-spectacular schema generation may invoke
+        # ``get_serializer_context`` without binding a real request.
+        request = getattr(self, "request", None)  # noqa: GETATTR_LITERAL — defensive against unbound viewset (schema generation)
+        beginning_id = (
+            request.query_params.get("beginning_id")  # noqa: USE_FILTERSET
+            if request is not None
+            else None
+        )
         if not beginning_id:
             self._beginning_traditions_cache: list[BeginningTradition] = []
             return self._beginning_traditions_cache
@@ -282,6 +289,11 @@ class TraditionViewSet(viewsets.ReadOnlyModelViewSet):
         # Preserve BeginningTradition.sort_order on the Tradition queryset
         # without re-using a Prefetch(to_attr=) that would leak per-request
         # filtering onto SharedMemoryModel-cached Tradition instances.
+        # The annotation lands on the shared instance via setattr during
+        # iteration, but annotations are recomputed on every queryset
+        # evaluation (no ``is_to_attr_fetched`` elision), so ``_bt_order``
+        # is always fresh for the current request and is only consumed by
+        # SQL ORDER BY — never read from Python.
         order_case = Case(
             *[When(id=tid, then=Value(idx)) for idx, tid in enumerate(ordered_ids)],
             default=Value(len(ordered_ids)),

--- a/src/world/character_creation/views.py
+++ b/src/world/character_creation/views.py
@@ -6,7 +6,7 @@ from http import HTTPMethod
 import logging
 from typing import Any
 
-from django.db.models import Prefetch, QuerySet
+from django.db.models import Case, IntegerField, Prefetch, QuerySet, Value, When
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.decorators import action
@@ -243,41 +243,72 @@ class TraditionViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = TraditionFilter
 
+    def _get_beginning_traditions(self) -> list[BeginningTradition]:
+        """Fetch BeginningTradition rows for this request's beginning_id.
+
+        Cached on the viewset (request-scoped) so ``get_queryset`` and
+        ``get_serializer_context`` share one lookup. The result must NOT
+        be attached to ``Tradition`` instances via Prefetch(to_attr=) —
+        ``Tradition`` is a SharedMemoryModel and per-request annotation
+        values would leak across requests with different beginning_ids.
+        """
+        if hasattr(self, "_beginning_traditions_cache"):
+            return self._beginning_traditions_cache
+        beginning_id = self.request.query_params.get("beginning_id")  # noqa: USE_FILTERSET
+        if not beginning_id:
+            self._beginning_traditions_cache: list[BeginningTradition] = []
+            return self._beginning_traditions_cache
+        self._beginning_traditions_cache = list(
+            BeginningTradition.objects.filter(beginning_id=beginning_id)
+            .select_related("required_distinction")
+            .order_by("sort_order", "id")
+        )
+        return self._beginning_traditions_cache
+
     def get_queryset(self) -> QuerySet[Tradition]:
-        # Read beginning_id for Prefetch sub-queryset and empty guard; filtering is via FilterSet
-        # Needed for Prefetch sub-queryset, not for filtering (handled by TraditionFilter)
+        # Empty guard. Filtering by beginning_id is handled below via the
+        # BeginningTradition lookup; the FilterSet does not gate on it.
         beginning_id = self.request.query_params.get("beginning_id")  # noqa: USE_FILTERSET
         if not beginning_id:
             return Tradition.objects.none()
 
         from world.codex.models import TraditionCodexGrant  # noqa: PLC0415
 
+        bts = self._get_beginning_traditions()
+        ordered_ids = [bt.tradition_id for bt in bts]
+        if not ordered_ids:
+            return Tradition.objects.none()
+
+        # Preserve BeginningTradition.sort_order on the Tradition queryset
+        # without re-using a Prefetch(to_attr=) that would leak per-request
+        # filtering onto SharedMemoryModel-cached Tradition instances.
+        order_case = Case(
+            *[When(id=tid, then=Value(idx)) for idx, tid in enumerate(ordered_ids)],
+            default=Value(len(ordered_ids)),
+            output_field=IntegerField(),
+        )
         return (
-            Tradition.objects.filter(
-                is_active=True,
-            )
+            Tradition.objects.filter(id__in=ordered_ids, is_active=True)
             .prefetch_related(
                 Prefetch(
                     "codex_grants",
                     queryset=TraditionCodexGrant.objects.only("tradition_id", "entry_id"),
                     to_attr="prefetched_codex_grants",
                 ),
-                Prefetch(
-                    "beginning_traditions",
-                    queryset=BeginningTradition.objects.filter(
-                        beginning_id=beginning_id
-                    ).select_related("required_distinction"),
-                    to_attr="prefetched_beginning_traditions",
-                ),
             )
-            .order_by("beginning_traditions__sort_order", "name")
+            .annotate(_bt_order=order_case)
+            .order_by("_bt_order", "name")
         )
 
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
-        # Pass to serializer for BeginningTradition lookup; not used for queryset filtering
-        # Serializer context for BeginningTradition lookup, not queryset filtering
-        context["beginning_id"] = self.request.query_params.get("beginning_id")  # noqa: USE_FILTERSET
+        beginning_id = self.request.query_params.get("beginning_id")  # noqa: USE_FILTERSET
+        context["beginning_id"] = beginning_id
+        # Pass per-request BeginningTradition lookup via context (request-scoped).
+        # Never via Prefetch(to_attr=) on Tradition — that leaks across users.
+        context["beginning_traditions_by_tradition"] = {
+            bt.tradition_id: bt for bt in self._get_beginning_traditions()
+        }
         return context
 
 


### PR DESCRIPTION
…data across requests

`TraditionViewSet.get_queryset` attached `prefetched_beginning_traditions` (filtered by `beginning_id` from the request) onto each Tradition via `Prefetch(to_attr=...)`. Tradition is a SharedMemoryModel — its instances persist in the per-process identity map across requests. Django's `prefetch_related` sees the to_attr is already set on every Tradition instance from the prior request and SKIPS the new prefetch, returning the previous request's filtered data.

Same shape as the codex tree leak (PR #418): two sequential requests with different `beginning_id`s on the same gunicorn worker would see each other's `required_distinction_id`. The list response varies by `beginning_id` because BeginningTradition rows differ per beginning, so the leak was directly user-visible.

The audit found this is the only other instance of the pattern in the repo. The remaining ~50 `Prefetch(to_attr=...)` sites are safe because their inner querysets are static — same answer for every caller — so the cache hit returns correct data.

Fix shape mirrors codex: pull the BeginningTradition rows in a separate flat query (one round trip), build a `{tradition_id: BT}` dict, and pass it via serializer context. Nothing per-request lands on the shared Tradition instance. Use a `Case`/`When` annotation to preserve BeginningTradition.sort_order on the Tradition queryset.

Adds `TraditionListLeakTests.test_required_distinction_is_per_beginning_not_per_process` as a regression guard: hits the endpoint with two different `beginning_id`s against the same Tradition and asserts each request returns its own data.