### PR TITLE
refactor(events): move active_persona_ids cache off the viewset onto …

### DIFF
--- a/src/typeclasses/accounts.py
+++ b/src/typeclasses/accounts.py
@@ -116,19 +116,25 @@ class Account(DefaultAccount):
         return CharacterList(self)
 
     @cached_property
-    def cached_active_persona_ids(self) -> list[int]:
-        """PRIMARY persona IDs for this account's currently-played characters.
+    def cached_primary_persona_ids(self) -> list[int]:
+        """IDs of PRIMARY personas this account is currently playing.
 
         Cached on the AccountDB instance — Evennia's identity map shares
         the same Account object across requests in a process, so this list
         survives the request boundary. Used by visibility filters and
         serializer contexts that need the caller's persona set.
 
-        Stale only if the player adds/removes a PRIMARY persona; resets on
-        process restart. To invalidate explicitly:
-        ``del account.cached_active_persona_ids``.
+        Invalidation: any RosterTenure save (create, ``end_date`` mutation,
+        any other change) clears this cache automatically via
+        ``RosterTenure.related_cache_fields``. The PRIMARY-persona invariant
+        is one-per-sheet for life, so persona-type changes are not a normal
+        churn surface; if a future code path mutates ``persona_type`` on a
+        sheet that already has an active tenure, that path needs to clear
+        this cache explicitly via ``account.clear_cached_properties()``.
         """
-        from world.scenes.constants import PersonaType
+        from world.scenes.constants import (
+            PersonaType,
+        )
         from world.scenes.models import Persona
 
         return list(
@@ -136,8 +142,23 @@ class Account(DefaultAccount):
                 character_sheet__roster_entry__tenures__player_data__account=self,
                 character_sheet__roster_entry__tenures__end_date__isnull=True,
                 persona_type=PersonaType.PRIMARY,
-            ).values_list("id", flat=True)
+            )
+            .values_list("id", flat=True)
+            .distinct()
         )
+
+    def clear_cached_properties(self) -> None:
+        """Drop our ``@cached_property`` entries from the instance ``__dict__``.
+
+        Called by ``RelatedCacheClearingMixin.clear_related_caches`` on
+        related models (e.g. ``RosterTenure``) so account-level caches stay
+        in sync with persona/tenure mutations. The mixin's default fallback
+        only handles ``functools.cached_property`` — these properties use
+        Django's ``cached_property``, so we override to clear them
+        explicitly.
+        """
+        for prop in ("cached_primary_persona_ids", "characters"):
+            self.__dict__.pop(prop, None)
 
     def get_available_characters(self):
         """Returns characters this player can currently control."""

--- a/src/typeclasses/accounts.py
+++ b/src/typeclasses/accounts.py
@@ -115,6 +115,30 @@ class Account(DefaultAccount):
         """Return characters actively played by this account."""
         return CharacterList(self)
 
+    @cached_property
+    def cached_active_persona_ids(self) -> list[int]:
+        """PRIMARY persona IDs for this account's currently-played characters.
+
+        Cached on the AccountDB instance — Evennia's identity map shares
+        the same Account object across requests in a process, so this list
+        survives the request boundary. Used by visibility filters and
+        serializer contexts that need the caller's persona set.
+
+        Stale only if the player adds/removes a PRIMARY persona; resets on
+        process restart. To invalidate explicitly:
+        ``del account.cached_active_persona_ids``.
+        """
+        from world.scenes.constants import PersonaType
+        from world.scenes.models import Persona
+
+        return list(
+            Persona.objects.filter(
+                character_sheet__roster_entry__tenures__player_data__account=self,
+                character_sheet__roster_entry__tenures__end_date__isnull=True,
+                persona_type=PersonaType.PRIMARY,
+            ).values_list("id", flat=True)
+        )
+
     def get_available_characters(self):
         """Returns characters this player can currently control."""
         return self.player_data.get_available_characters()

--- a/src/world/events/tests/test_views.py
+++ b/src/world/events/tests/test_views.py
@@ -386,3 +386,56 @@ class EventDetailQueryCountTestCase(APITestCase):
             response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data["is_gm"])
+
+
+class AccountPersonaCacheInvalidationTestCase(APITestCase):
+    """Account.cached_primary_persona_ids invalidates on RosterTenure save.
+
+    The cached_property lives on the SharedMemoryModel-cached Account
+    instance, which persists across requests in the same process. Without
+    invalidation, a new tenure approval (or an end-date mutation) would
+    leave the cache stale and the player wouldn't see their new character
+    in event visibility filters until the process restarts.
+
+    ``RosterTenure.related_cache_fields`` chains to ``"player_data.account"``
+    so any tenure save fires ``Account.clear_cached_properties()``.
+    """
+
+    def test_new_tenure_invalidates_persona_cache(self) -> None:
+        account = AccountFactory()
+        # First read: empty (no tenures yet). This populates the cache.
+        self.assertEqual(account.cached_primary_persona_ids, [])
+
+        # CharacterSheetFactory auto-creates a PRIMARY persona via post_generation.
+        sheet = CharacterSheetFactory()
+        RosterTenureFactory(
+            player_data__account=account,
+            roster_entry__character_sheet=sheet,
+        )
+
+        # Cache should have been invalidated by the tenure save; second read
+        # reflects the new persona without an explicit refresh.
+        self.assertEqual(
+            account.cached_primary_persona_ids,
+            [sheet.primary_persona.id],
+        )
+
+    def test_tenure_end_date_set_invalidates_persona_cache(self) -> None:
+        """Setting end_date on a tenure clears the cache (player loses access)."""
+        from django.utils import timezone
+
+        account = AccountFactory()
+        sheet = CharacterSheetFactory()
+        tenure = RosterTenureFactory(
+            player_data__account=account,
+            roster_entry__character_sheet=sheet,
+        )
+        # Cache populates with the persona id while the tenure is active.
+        self.assertEqual(len(account.cached_primary_persona_ids), 1)
+
+        # End the tenure; saving fires the related-cache cascade.
+        tenure.end_date = timezone.now()
+        tenure.save()
+
+        # Cache invalidated; recompute reflects the now-ended tenure.
+        self.assertEqual(account.cached_primary_persona_ids, [])

--- a/src/world/events/tests/test_views.py
+++ b/src/world/events/tests/test_views.py
@@ -377,12 +377,12 @@ class EventDetailQueryCountTestCase(APITestCase):
         # the viewer-GM set: increasing the loop above to 30 events should
         # leave this number unchanged. Steady-state queries:
         #   1. session lookup
-        #   2. ``_active_persona_ids`` (cached_property) — one Persona query
-        #      with a RosterEntry subquery; shared by visibility filter and
-        #      serializer context
-        #   3. event detail (with select_related / prefetch)
-        #   4. ``_get_viewer_gm_event_ids`` — single query for the GM-event set
-        with self.assertNumQueries(4):
+        #   2. event detail (with select_related / prefetch)
+        #   3. ``_get_viewer_gm_event_ids`` — single query for the GM-event set
+        # The active-persona-ids lookup that previously fired here is now a
+        # cached_property on the Account typeclass — populated once per
+        # account per process by the warmup, free thereafter.
+        with self.assertNumQueries(3):
             response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data["is_gm"])

--- a/src/world/events/views.py
+++ b/src/world/events/views.py
@@ -3,7 +3,6 @@ from collections.abc import Callable
 from django.db import IntegrityError
 from django.db.models import Prefetch, Q, QuerySet
 from django.shortcuts import get_object_or_404
-from django.utils.functional import cached_property
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.decorators import action
@@ -51,8 +50,6 @@ from world.events.services import (
 )
 from world.events.types import EventError
 from world.game_clock.constants import TimePhase
-from world.roster.models import RosterEntry
-from world.scenes.constants import PersonaType
 from world.scenes.models import Persona, Scene
 from world.societies.models import Organization, Society
 from world.stories.pagination import StandardResultsSetPagination
@@ -116,26 +113,18 @@ class EventViewSet(ModelViewSet):
     def get_queryset(self) -> QuerySet[Event]:
         return self._apply_visibility_filter(self._base_queryset().order_by("scheduled_real_time"))
 
-    @cached_property
     def _active_persona_ids(self) -> list[int]:
-        """Persona IDs for the requesting user's active characters.
+        """PRIMARY persona IDs for the requesting user's active characters.
 
-        Cached on the viewset instance (which is fresh per request) so the
-        visibility filter, lifecycle actions, and ``get_serializer_context``
-        share one resolution instead of each firing the same RosterEntry +
-        Persona query pair.
+        Reads ``user.cached_active_persona_ids`` — a cached_property on the
+        Account typeclass. Evennia's identity map keeps the same Account
+        instance in memory across requests, so this list is computed once
+        per account per process and reused across requests.
         """
-        if not self.request.user.is_authenticated:
+        user = self.request.user
+        if not user.is_authenticated:
             return []
-        character_ids = RosterEntry.objects.for_account(self.request.user).values_list(
-            "character_sheet_id", flat=True
-        )
-        return list(
-            Persona.objects.filter(
-                character_sheet_id__in=character_ids,
-                persona_type=PersonaType.PRIMARY,
-            ).values_list("id", flat=True)
-        )
+        return user.cached_active_persona_ids
 
     def _apply_visibility_filter(self, qs: QuerySet[Event]) -> QuerySet[Event]:
         """Filter queryset to only events visible to the requesting user."""
@@ -148,7 +137,7 @@ class EventViewSet(ModelViewSet):
         if not self.request.user.is_authenticated:
             return qs.filter(is_public=True)
 
-        persona_ids = self._active_persona_ids
+        persona_ids = self._active_persona_ids()
 
         if not persona_ids:
             return qs.filter(is_public=True)
@@ -174,7 +163,7 @@ class EventViewSet(ModelViewSet):
 
     def perform_create(self, serializer: EventCreateSerializer) -> None:
         """Create event via service function, deriving host from request user."""
-        persona_ids = self._active_persona_ids
+        persona_ids = self._active_persona_ids()
         if not persona_ids:
             raise DRFValidationError(EventError.NO_PERSONA)
         active_persona = Persona.objects.get(id=persona_ids[0])
@@ -236,7 +225,7 @@ class EventViewSet(ModelViewSet):
 
     def get_serializer_context(self) -> dict:
         context = super().get_serializer_context()
-        context["persona_ids"] = set(self._active_persona_ids)
+        context["persona_ids"] = set(self._active_persona_ids())
         context["viewer_gm_event_ids"] = self._get_viewer_gm_event_ids()
         return context
 

--- a/src/world/events/views.py
+++ b/src/world/events/views.py
@@ -116,15 +116,16 @@ class EventViewSet(ModelViewSet):
     def _active_persona_ids(self) -> list[int]:
         """PRIMARY persona IDs for the requesting user's active characters.
 
-        Reads ``user.cached_active_persona_ids`` — a cached_property on the
-        Account typeclass. Evennia's identity map keeps the same Account
-        instance in memory across requests, so this list is computed once
-        per account per process and reused across requests.
+        Reads ``user.cached_primary_persona_ids`` — a cached_property on
+        the Account typeclass. Evennia's identity map keeps the same
+        Account instance in memory across requests, so this list is
+        computed once per account per process and reused across requests.
+        Invalidation is wired via ``RosterTenure.related_cache_fields``.
         """
         user = self.request.user
         if not user.is_authenticated:
             return []
-        return user.cached_active_persona_ids
+        return user.cached_primary_persona_ids
 
     def _apply_visibility_filter(self, qs: QuerySet[Event]) -> QuerySet[Event]:
         """Filter queryset to only events visible to the requesting user."""

--- a/src/world/roster/models/tenures.py
+++ b/src/world/roster/models/tenures.py
@@ -33,8 +33,10 @@ class RosterTenure(RelatedCacheClearingMixin, SharedMemoryModel):
         related_name="tenures",
     )
 
-    # Automatically clear player_data caches when tenure changes
-    related_cache_fields: ClassVar[list[str]] = ["player_data"]
+    # Automatically clear player_data and account caches when tenure changes.
+    # Account.cached_primary_persona_ids depends on (player_data, end_date)
+    # — any tenure save (create, end-date set, etc.) needs to invalidate it.
+    related_cache_fields: ClassVar[list[str]] = ["player_data", "player_data.account"]
 
     # Anonymity system
     player_number = models.PositiveIntegerField(


### PR DESCRIPTION
…Account

TehomCD's review on PR #423 pointed out that caching state on the viewset is the wrong location even when the viewset is per-request fresh: the cache is discarded when the request ends, providing no value beyond deduplicating within a single request.

The architecturally correct cache anchor for "this account's active persona IDs" is the Account itself — Evennia's identity map keeps the same Account instance in memory across all requests in a process, so a ``cached_property`` on the typeclass survives the request boundary and is computed once per account per process.

Changes:

1. Add `Account.cached_active_persona_ids` (typeclasses/accounts.py). Direct join from AccountDB to Persona, no PlayerData hop required. Stale only on persona add/remove; resets on process restart.

2. `EventViewSet._active_persona_ids` is now a thin delegator to `request.user.cached_active_persona_ids`. The viewset stores nothing. Drops `RosterEntry`, `PersonaType`, and `cached_property` imports from the events views (no longer needed here).

3. `test_event_retrieve_query_count_with_gm_check` now locks the steady-state count at 3 queries (was 4). The persona-ids lookup that previously fired on each request is now a cache hit after the warmup. Updated the comment to explain the cache anchor.