### PR TITLE
Potential fix for code scanning alert no. 51: Information exposure through an exception

### DIFF
--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -179,9 +179,9 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
                 action_request=action_request,
                 decision=decision,
             )
-        except ValueError as exc:
+        except ValueError as _exc:
             return Response(
-                {"detail": str(exc)},
+                {"detail": "Unable to process this action request."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 


### PR DESCRIPTION
Potential fix for [https://github.com/Arx-Game/arxii/security/code-scanning/51](https://github.com/Arx-Game/arxii/security/code-scanning/51)

To fix this, stop returning raw exception messages in API responses. Keep the same control flow and HTTP status code (400), but replace `{"detail": str(exc)}` with a generic client-safe message.

Best single fix (without changing functionality): in `src/world/scenes/action_views.py`, inside `respond`, update the `except ValueError as exc:` block to avoid using `exc` in the response payload. Since we should not assume logging setup outside shown code, we can rename the exception variable to `_exc` to indicate it is intentionally unused and return a constant error detail string.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
