### PR TITLE
Feature/location permissions

### DIFF
--- a/docs/plans/2026-05-11-location-permissions-design.md
+++ b/docs/plans/2026-05-11-location-permissions-design.md
@@ -70,13 +70,39 @@ will filter further on rank. Downstream systems already have to read
 membership for rank; pushing rank logic into the substrate would duplicate
 that read pointlessly.
 
-### Strict persona scoping — no alt-piercing
+### Strict persona scoping — IC visibility drives recognition
 
-Per the no-alt-outing hard rule, all helpers are strictly persona-scoped.
-If LordAiden's primary persona owns the manor, his alt persona (e.g.,
-"Captain Storm") is NOT recognized as an owner — even though they share
-a CharacterSheet. This falls out naturally from FK filtering on persona
-exactly. Tests explicitly verify the no-alt-piercing case.
+All helpers are strictly persona-scoped. This serves **two distinct
+cases**, with different rationales:
+
+- **alt_personas** (different personas of the **same** `CharacterSheet`):
+  OOC, the character owns the property. IC, the *whole point* of a
+  secondary persona is that it's secret — the household knows the
+  outward-facing persona as the owner, and would treat the character's
+  other personas as intruders unless those personas have been
+  discovered/revealed. A discovery-aware downstream check can compose
+  permissions on top, but the substrate reflects the IC default: secret
+  personas are not recognized.
+
+- **alt_characters** (different `CharacterSheet`s under the same
+  Account): different characters, full stop. The Account-level link is
+  an OOC bookkeeping construct and never grants standing. We actively
+  *want* alt_characters to be treated as strangers to one another's
+  property so that players can't game the system via shared rights
+  between their own characters.
+
+Both cases collapse to: compare by `holder_persona_id == persona.pk`
+(or the org-membership equivalent). The no-alt-outing hard rule (about
+*display*) is unrelated — it bans surfacing the Account-level link to
+other users, which is separate from access checks.
+
+Tests explicitly cover:
+- `test_alt_persona_of_owner_not_recognized_as_owner` — alt_personas
+  case (substrate doesn't pierce)
+- `test_alt_persona_with_own_org_membership_gets_standing` — positive
+  test that membership is per-persona, not per-character
+- `test_alt_persona_of_tenant_not_recognized_as_tenant` — tenancy
+  equivalent
 
 ## Service surface
 

--- a/docs/plans/2026-05-11-location-permissions-design.md
+++ b/docs/plans/2026-05-11-location-permissions-design.md
@@ -1,0 +1,243 @@
+# Location Permissions Helpers — Design
+
+**Status:** validated brainstorm; ready to implement
+**Date:** 2026-05-11
+**App home:** `world.locations` (extends existing services)
+**Depends on:** `world.locations` (LocationOwnership, LocationTenancy,
+`effective_owner`, `current_tenants`), `world.scenes` (Persona),
+`world.societies` (Organization, OrganizationMembership)
+
+## Why this exists
+
+The ambient-stats and ownership-tenancy substrates shipped in PRs #432
+and #434 are ready but have no consumers. Every downstream system that
+needs to gate behavior on "who has standing at this location" — decoration,
+locks, vaults, eviction, installation permissions — would otherwise have
+to reimplement the same persona-or-org-membership walk.
+
+This wedge provides the canonical first consumer of the ownership and
+tenancy substrate: a small set of relationship-lookup helpers that answer
+"does this persona have owner / tenant standing at this room?" Specific
+permission checks (`can_decorate`, `can_evict`, `can_install`, etc.) live
+in their consuming systems where the rules naturally belong.
+
+It is **not** a design for:
+- Specific gameplay permissions (decoration, locks, vault access, etc.)
+- Rank-aware filtering ("rank 1-2 only can evict")
+- DRF permission classes
+- API endpoints
+- Bulk variants
+
+Each is a downstream concern.
+
+## Bedrock decisions
+
+### Relationship lookups, not action checks
+
+The substrate exposes "who has standing here," not "who can perform action
+X here." Each downstream system has different rules:
+
+- **Decoration**: owner or tenant
+- **Eviction**: owner only, and rank-gated within owning org
+- **Lock from non-occupants**: owner OR tenant of this specific room
+- **Install a vault**: owner only, rank 1-2 in owning org
+- **View audit history**: owner only, plus staff
+
+Encoding these rules in the substrate would put the wrong layer in charge.
+Decoration rules live in the decoration system; eviction rules live in the
+eviction system. The substrate just answers the relationship lookup, and
+each system composes specific checks on top.
+
+### Org membership counts as standing
+
+Most real ownership in the game is via Organizations (noble houses, guilds,
+gangs, businesses, secret societies, commoner families — see
+`OrganizationType` in `world.societies`). If `is_owner` only matched direct
+persona-to-persona FKs, every downstream system would reimplement the
+membership walk.
+
+`OrganizationMembership` (in `world.societies.models`) has no lifecycle
+fields (no `left_at`, no `is_active`). Departures are model deletes via
+CASCADE. So "current member" = "exists in the table." No soft-leave filter
+needed.
+
+### Rank filtering is downstream's concern
+
+The substrate does NOT gate on `OrganizationMembership.rank`. A rank-5
+member of a noble house counts as having owner standing per the substrate
+— but eviction or vault-installation rules in their consuming systems
+will filter further on rank. Downstream systems already have to read
+membership for rank; pushing rank logic into the substrate would duplicate
+that read pointlessly.
+
+### Strict persona scoping — no alt-piercing
+
+Per the no-alt-outing hard rule, all helpers are strictly persona-scoped.
+If LordAiden's primary persona owns the manor, his alt persona (e.g.,
+"Captain Storm") is NOT recognized as an owner — even though they share
+a CharacterSheet. This falls out naturally from FK filtering on persona
+exactly. Tests explicitly verify the no-alt-piercing case.
+
+## Service surface
+
+```python
+# world/locations/services.py — append
+
+def _persona_organization_ids(persona: "Persona") -> set[int]:
+    """Return the set of organization IDs this persona is a current member of.
+
+    Membership is presence in OrganizationMembership — there are no
+    soft-leave fields on that model, so a row in the table is a current
+    membership. Departures are model deletes.
+    """
+
+
+def ownership_for(
+    persona: "Persona", room: "DefaultObject"
+) -> LocationOwnership | None:
+    """Return the cascade-resolved LocationOwnership row that gives this
+    persona standing at this room, or None.
+
+    Standing exists when:
+      - The cascade-resolved owner is this persona directly (holder_type
+        is PERSONA and holder_persona_id == persona.pk), OR
+      - The cascade-resolved owner is an Organization this persona is a
+        current member of.
+
+    Does NOT consider OrganizationMembership.rank — downstream consumers
+    that need rank filtering (eviction, installation permissions, etc.)
+    read it themselves.
+
+    Query budget: 3 (2 for effective_owner + 1 for org_ids; the org_ids
+    fetch is skipped on PERSONA-holder matches via short-circuit).
+    """
+
+
+def is_owner(persona: "Persona", room: "DefaultObject") -> bool:
+    """True when ``ownership_for(persona, room)`` returns a row."""
+
+
+def tenancies_for(
+    persona: "Persona", room: "DefaultObject"
+) -> "QuerySet[LocationTenancy]":
+    """Return the QuerySet of currently-active tenancies that give this
+    persona standing at this room.
+
+    Includes:
+      - Direct persona tenancies (tenant_type=PERSONA,
+        tenant_persona=persona), AND
+      - Organization tenancies where this persona is a current member of
+        the tenant_organization.
+
+    Builds on ``current_tenants(room)`` which already filters for active
+    tenancies and collects across the room + ancestor-area chain.
+
+    Query budget: 3 (2 for current_tenants closure walk + tenancy fetch,
+    1 for org_ids).
+    """
+
+
+def is_tenant(persona: "Persona", room: "DefaultObject") -> bool:
+    """True when ``tenancies_for(persona, room).exists()``."""
+```
+
+## Implementation sketch
+
+```python
+def _persona_organization_ids(persona):
+    return set(
+        OrganizationMembership.objects.filter(persona=persona)
+        .values_list("organization_id", flat=True)
+    )
+
+
+def ownership_for(persona, room):
+    row = effective_owner(room)
+    if row is None:
+        return None
+    if row.holder_type == HolderType.PERSONA:
+        return row if row.holder_persona_id == persona.pk else None
+    # HolderType.ORGANIZATION
+    if row.holder_organization_id in _persona_organization_ids(persona):
+        return row
+    return None
+
+
+def is_owner(persona, room):
+    return ownership_for(persona, room) is not None
+
+
+def tenancies_for(persona, room):
+    org_ids = _persona_organization_ids(persona)
+    return current_tenants(room).filter(
+        models.Q(tenant_persona=persona)
+        | models.Q(tenant_organization_id__in=org_ids)
+    )
+
+
+def is_tenant(persona, room):
+    return tenancies_for(persona, room).exists()
+```
+
+## What v1 ships
+
+- 5 functions in `src/world/locations/services.py` (1 private helper + 4 public)
+- `OrganizationMembership` imported from `world.societies.models`
+- Tests covering the relationship matrix and the query budget
+- `world/locations/CLAUDE.md` updated with the new layer
+
+## What v1 explicitly defers
+
+| Item | When to add |
+|---|---|
+| Specific permission checks (`can_decorate`, `can_evict`, `can_install`, etc.) | When their consuming systems land |
+| Rank-aware filtering | Downstream — each consumer reads rank from `OrganizationMembership` directly |
+| DRF permission classes | When API consumers materialize |
+| Bulk variants (`is_owner_of_any`, etc.) | When a bulk consumer appears |
+| Convenience write helpers (transfer_ownership, evict, etc.) | Separate brainstorm — design doc for ownership/tenancy flagged this |
+| Multi-persona bridging ("this character's other personas") | Explicitly forbidden by no-alt-outing hard rule |
+| Audit-history visibility checks | Out of scope; downstream |
+| Recursive org structure (sub-orgs of orgs) | Out of scope; `world.societies` doesn't model this today |
+
+## Test plan
+
+- **Direct persona ownership:**
+  - `ownership_for(owner_persona, room)` returns the row; `is_owner` True
+  - `ownership_for(stranger_persona, room)` returns None; `is_owner` False
+- **Organization ownership + persona membership:**
+  - `ownership_for(member_persona, room)` returns the row; `is_owner` True
+  - `ownership_for(non_member_persona, room)` returns None; `is_owner` False
+- **No ownership in the chain:**
+  - `ownership_for(any_persona, room)` returns None
+- **Cascade interaction:** Building owned by org, room cascades to building.
+  - `ownership_for(org_member, room)` returns the building-level row
+- **No-alt-piercing:** Primary persona owns the manor; alt persona of the
+  same character returns None.
+- **Direct persona tenancy:**
+  - `tenancies_for(tenant_persona, room)` returns the row
+  - `is_tenant` True
+- **Organization tenancy + persona membership:**
+  - `tenancies_for(org_member_persona, room)` returns the row
+  - Non-member returns empty
+- **Multiple tenancies, partial match:**
+  - Room has 1 building-level org tenancy + 2 room-level persona tenancies
+  - `tenancies_for(building_org_member, room)` returns only the org tenancy
+  - `tenancies_for(room_tenant_persona, room)` returns only their direct tenancy
+- **Expired tenancy excluded** — implicit via `current_tenants` already filtering
+- **Query budget:**
+  - `is_owner(persona_owner, room)` with PERSONA-holder match: assertNumQueries(2)
+    (effective_owner runs 2; the org_ids fetch is skipped via short-circuit)
+  - `is_owner(persona_member, room)` with ORGANIZATION-holder match: assertNumQueries(3)
+  - `tenancies_for(persona, room)` consumed: assertNumQueries(3)
+
+## Cross-cutting notes
+
+- The `ownership_for` short-circuit when the holder is a Persona avoids
+  the org_ids fetch — a free optimization that takes the common case
+  ("did this individual persona buy the inn room") down to 2 queries.
+- The substrate is strictly read-side. Writes still go through `objects.create()`
+  on the underlying models per the existing CLAUDE.md guidance, until the
+  deferred transfer/evict helpers land.
+- Per project memory: tests must enforce the documented query budget via
+  `assertNumQueries`. The previous adversarial review caught this category
+  as one we keep missing.

--- a/src/world/locations/CLAUDE.md
+++ b/src/world/locations/CLAUDE.md
@@ -154,3 +154,64 @@ returns a `QuerySet` filtered for `ends_at IS NULL OR ends_at > now()`.
   location. Multiple active Tenancies are allowed and expected.
 - Most authoring goes through `objects.create()` until convenience helpers
   materialize from real consumers (decoration, locks, vaults).
+
+## Relationship lookups (added 2026-05-11)
+
+Four helpers answer "does this persona have owner / tenant standing at
+this room?" — the canonical first consumer of the Ownership and Tenancy
+substrate. Specific permission checks (`can_decorate`, `can_evict`,
+`can_install`, etc.) live in their consuming systems where the rules
+naturally belong.
+
+```python
+from world.locations.services import (
+    ownership_for,
+    is_owner,
+    tenancies_for,
+    is_tenant,
+)
+
+# Returns the LocationOwnership row, or None
+row = ownership_for(persona, room)
+
+# Same but boolean
+if is_owner(persona, room):
+    ...
+
+# QuerySet of currently-active tenancies that give this persona standing
+for tenancy in tenancies_for(persona, room):
+    ...
+
+if is_tenant(persona, room):
+    ...
+```
+
+### Standing rules
+
+A persona has **owner standing** when:
+
+- The cascade-resolved owner is this persona directly, OR
+- The cascade-resolved owner is an Organization this persona is a current
+  member of (any rank)
+
+A persona has **tenant standing** when:
+
+- An active LocationTenancy for the room or an ancestor area has
+  `tenant_persona = this persona`, OR
+- An active tenancy targets an Organization this persona is a current
+  member of (any rank)
+
+The helpers do NOT consider rank — downstream systems gate on
+`OrganizationMembership.rank` themselves. The helpers DO respect the
+no-alt-outing rule — an alt persona of the same CharacterSheet that
+owns the room does NOT get owner standing.
+
+### Query budgets
+
+- `is_owner` / `ownership_for` with PERSONA-holder match: **2 queries**
+  (the org_ids fetch is short-circuited via early return)
+- `is_owner` / `ownership_for` with ORGANIZATION-holder match: **3 queries**
+- `is_tenant` / `tenancies_for`: **3 queries** (org_ids + closure walk
+  + tenancy fetch)
+
+Budgets are locked via `assertNumQueries` tests.

--- a/src/world/locations/CLAUDE.md
+++ b/src/world/locations/CLAUDE.md
@@ -202,9 +202,23 @@ A persona has **tenant standing** when:
   member of (any rank)
 
 The helpers do NOT consider rank — downstream systems gate on
-`OrganizationMembership.rank` themselves. The helpers DO respect the
-no-alt-outing rule — an alt persona of the same CharacterSheet that
-owns the room does NOT get owner standing.
+`OrganizationMembership.rank` themselves.
+
+The helpers are **strictly per-persona**. This covers two distinct
+cases with different rationales:
+
+- **alt_personas** (same `CharacterSheet`, different Persona): OOC the
+  character owns the room, but the secondary persona is *secret* by
+  design — house guards / servants treat it as an intruder until the
+  persona link is discovered. Substrate reflects the IC default; a
+  discovery-aware downstream check can compose on top.
+- **alt_characters** (same Account, different `CharacterSheet`):
+  different characters, no shared standing under any circumstance. The
+  Account link is OOC bookkeeping only.
+
+Don't confuse this with the no-alt-outing hard rule — that's about
+*display* (never expose Account-level character links). Access checks
+are a separate concern.
 
 ### Query budgets
 

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 from evennia_extensions.models import RoomProfile
 from world.areas.models import AreaClosure
-from world.locations.constants import STAT_CLAMPS, STAT_DEFAULTS, StatKey
+from world.locations.constants import STAT_CLAMPS, STAT_DEFAULTS, HolderType, StatKey
 from world.locations.models import (
     LocationOwnership,
     LocationStatModifier,
@@ -180,3 +180,36 @@ def current_tenants(room: DefaultObject) -> QuerySet[LocationTenancy]:
         .select_related("area", "tenant_persona", "tenant_organization")
         .filter(models.Q(room_profile=profile) | models.Q(area_id__in=ancestor_ids))
     )
+
+
+def ownership_for(persona: Persona, room: DefaultObject) -> LocationOwnership | None:
+    """Return the LocationOwnership row that gives this persona standing
+    at this room, or None.
+
+    Standing exists when:
+      - The cascade-resolved owner is this persona directly, OR
+      - The cascade-resolved owner is an Organization this persona is a
+        current member of.
+
+    Does not consider OrganizationMembership.rank — downstream gating
+    on rank is each consumer's responsibility.
+
+    Query budget: 2 queries when the holder is a Persona (short-circuit
+    skips the org_ids fetch); 3 when the holder is an Organization.
+    """
+    row = effective_owner(room)
+    if row is None:
+        return None
+    if row.holder_type == HolderType.PERSONA:
+        if row.holder_persona_id == persona.pk:
+            return row
+        return None
+    # HolderType.ORGANIZATION
+    if row.holder_organization_id in _persona_organization_ids(persona):
+        return row
+    return None
+
+
+def is_owner(persona: Persona, room: DefaultObject) -> bool:
+    """True when ``ownership_for(persona, room)`` returns a row."""
+    return ownership_for(persona, room) is not None

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -213,3 +213,29 @@ def ownership_for(persona: Persona, room: DefaultObject) -> LocationOwnership | 
 def is_owner(persona: Persona, room: DefaultObject) -> bool:
     """True when ``ownership_for(persona, room)`` returns a row."""
     return ownership_for(persona, room) is not None
+
+
+def tenancies_for(persona: Persona, room: DefaultObject) -> QuerySet[LocationTenancy]:
+    """Return the QuerySet of currently-active tenancies that give this
+    persona standing at this room.
+
+    Includes:
+      - Direct persona tenancies (tenant_persona = this persona)
+      - Organization tenancies where this persona is a current member
+        of the tenant_organization
+
+    Builds on ``current_tenants(room)`` (which already filters for
+    active rows and collects across the room + ancestor-area chain),
+    then narrows to rows relevant to this persona.
+
+    Query budget: 3 queries (org_ids + closure walk + tenancy fetch).
+    """
+    org_ids = _persona_organization_ids(persona)
+    return current_tenants(room).filter(
+        models.Q(tenant_persona=persona) | models.Q(tenant_organization_id__in=org_ids)
+    )
+
+
+def is_tenant(persona: Persona, room: DefaultObject) -> bool:
+    """True when ``tenancies_for(persona, room)`` has any rows."""
+    return tenancies_for(persona, room).exists()

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -16,10 +16,13 @@ from world.locations.models import (
     LocationStatOverride,
     LocationTenancy,
 )
+from world.societies.models import OrganizationMembership
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
     from evennia.objects.objects import DefaultObject
+
+    from world.scenes.models import Persona
 
 
 def _room_profile_and_ancestors(
@@ -47,6 +50,20 @@ def _room_profile_and_ancestors(
             AreaClosure.objects.filter(descendant_id=area.pk).values_list("ancestor_id", flat=True)
         )
     return profile, ancestor_ids
+
+
+def _persona_organization_ids(persona: Persona) -> set[int]:
+    """Return organization IDs this persona is a current member of.
+
+    OrganizationMembership has no lifecycle fields (no left_at, no
+    is_active) — departures are model deletes. So presence in the table
+    is current membership.
+    """
+    return set(
+        OrganizationMembership.objects.filter(persona=persona).values_list(
+            "organization_id", flat=True
+        )
+    )
 
 
 def _clamp(value: int, stat_key: StatKey) -> int:

--- a/src/world/locations/tests/test_permissions.py
+++ b/src/world/locations/tests/test_permissions.py
@@ -4,11 +4,13 @@ from evennia_extensions.factories import RoomProfileFactory
 from world.areas.constants import AreaLevel
 from world.areas.factories import AreaFactory
 from world.locations.constants import HolderType, LocationParentType
-from world.locations.models import LocationOwnership
+from world.locations.models import LocationOwnership, LocationTenancy
 from world.locations.services import (
     _persona_organization_ids,
     is_owner,
+    is_tenant,
     ownership_for,
+    tenancies_for,
 )
 from world.scenes.factories import PersonaFactory
 from world.societies.factories import (
@@ -171,3 +173,129 @@ class OwnershipForQueryBudgetTests(TestCase):
         # ORGANIZATION-holder match: effective_owner (2) + org_ids fetch (1).
         with self.assertNumQueries(3):
             ownership_for(member, room)
+
+
+class TenanciesForTests(TestCase):
+    def setUp(self) -> None:
+        self.building = AreaFactory(level=AreaLevel.BUILDING)
+        self.profile = RoomProfileFactory(area=self.building)
+        self.room = self.profile.objectdb
+
+    def test_direct_persona_tenant_matches(self) -> None:
+        tenant = PersonaFactory()
+        row = LocationTenancy.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.profile,
+            tenant_type=HolderType.PERSONA,
+            tenant_persona=tenant,
+        )
+        self.assertEqual(list(tenancies_for(tenant, self.room)), [row])
+        self.assertTrue(is_tenant(tenant, self.room))
+
+    def test_unrelated_persona_returns_empty(self) -> None:
+        tenant = PersonaFactory()
+        stranger = PersonaFactory()
+        LocationTenancy.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.profile,
+            tenant_type=HolderType.PERSONA,
+            tenant_persona=tenant,
+        )
+        self.assertEqual(list(tenancies_for(stranger, self.room)), [])
+        self.assertFalse(is_tenant(stranger, self.room))
+
+    def test_org_member_has_tenant_standing(self) -> None:
+        org = OrganizationFactory()
+        member = PersonaFactory()
+        OrganizationMembershipFactory(persona=member, organization=org)
+        row = LocationTenancy.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.building,
+            tenant_type=HolderType.ORGANIZATION,
+            tenant_organization=org,
+        )
+        self.assertEqual(list(tenancies_for(member, self.room)), [row])
+        self.assertTrue(is_tenant(member, self.room))
+
+    def test_org_non_member_returns_empty(self) -> None:
+        org = OrganizationFactory()
+        non_member = PersonaFactory()
+        LocationTenancy.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.building,
+            tenant_type=HolderType.ORGANIZATION,
+            tenant_organization=org,
+        )
+        self.assertEqual(list(tenancies_for(non_member, self.room)), [])
+        self.assertFalse(is_tenant(non_member, self.room))
+
+    def test_multiple_tenancies_partial_match(self) -> None:
+        """Room has 1 building-org tenancy + 2 room-level persona tenancies.
+        Query as the building-org member — only the org row applies.
+        """
+        org = OrganizationFactory()
+        org_member = PersonaFactory()
+        OrganizationMembershipFactory(persona=org_member, organization=org)
+        room_tenant_a = PersonaFactory()
+        room_tenant_b = PersonaFactory()
+
+        org_row = LocationTenancy.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.building,
+            tenant_type=HolderType.ORGANIZATION,
+            tenant_organization=org,
+        )
+        LocationTenancy.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.profile,
+            tenant_type=HolderType.PERSONA,
+            tenant_persona=room_tenant_a,
+        )
+        LocationTenancy.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.profile,
+            tenant_type=HolderType.PERSONA,
+            tenant_persona=room_tenant_b,
+        )
+
+        # Org member sees only their org row
+        self.assertEqual(list(tenancies_for(org_member, self.room)), [org_row])
+        # room_tenant_a sees only their own row
+        result_a = list(tenancies_for(room_tenant_a, self.room))
+        self.assertEqual(len(result_a), 1)
+        self.assertEqual(result_a[0].tenant_persona, room_tenant_a)
+
+    def test_no_alt_piercing_on_tenancy(self) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.scenes.models import PersonaType
+
+        sheet = CharacterSheetFactory()
+        primary = sheet.primary_persona
+        alt = PersonaFactory(character_sheet=sheet, persona_type=PersonaType.ESTABLISHED)
+        LocationTenancy.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.profile,
+            tenant_type=HolderType.PERSONA,
+            tenant_persona=primary,
+        )
+        self.assertTrue(is_tenant(primary, self.room))
+        self.assertFalse(is_tenant(alt, self.room))
+
+
+class TenanciesForQueryBudgetTests(TestCase):
+    def test_three_queries_per_call(self) -> None:
+        building = AreaFactory(level=AreaLevel.BUILDING)
+        profile = RoomProfileFactory(area=building)
+        persona = PersonaFactory()
+        LocationTenancy.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=profile,
+            tenant_type=HolderType.PERSONA,
+            tenant_persona=persona,
+        )
+        from evennia.objects.models import ObjectDB
+
+        room = ObjectDB.objects.get(pk=profile.objectdb.pk)
+        # tenancies_for: org_ids (1) + closure walk (1) + tenancy fetch (1) = 3
+        with self.assertNumQueries(3):
+            list(tenancies_for(persona, room))

--- a/src/world/locations/tests/test_permissions.py
+++ b/src/world/locations/tests/test_permissions.py
@@ -1,6 +1,15 @@
 from django.test import TestCase
 
-from world.locations.services import _persona_organization_ids
+from evennia_extensions.factories import RoomProfileFactory
+from world.areas.constants import AreaLevel
+from world.areas.factories import AreaFactory
+from world.locations.constants import HolderType, LocationParentType
+from world.locations.models import LocationOwnership
+from world.locations.services import (
+    _persona_organization_ids,
+    is_owner,
+    ownership_for,
+)
 from world.scenes.factories import PersonaFactory
 from world.societies.factories import (
     OrganizationFactory,
@@ -27,3 +36,138 @@ class PersonaOrganizationIdsTests(TestCase):
         OrganizationFactory()  # unjoined org — must not appear in result
         OrganizationMembershipFactory(persona=persona, organization=joined_org)
         self.assertEqual(_persona_organization_ids(persona), {joined_org.pk})
+
+
+class OwnershipForTests(TestCase):
+    def setUp(self) -> None:
+        self.city = AreaFactory(level=AreaLevel.CITY)
+        self.ward = AreaFactory(level=AreaLevel.WARD, parent=self.city)
+        self.profile = RoomProfileFactory(area=self.ward)
+        self.room = self.profile.objectdb
+
+    def test_direct_persona_owner_matches(self) -> None:
+        persona = PersonaFactory()
+        row = LocationOwnership.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.ward,
+            holder_type=HolderType.PERSONA,
+            holder_persona=persona,
+        )
+        self.assertEqual(ownership_for(persona, self.room), row)
+        self.assertTrue(is_owner(persona, self.room))
+
+    def test_unrelated_persona_does_not_match(self) -> None:
+        owner = PersonaFactory()
+        stranger = PersonaFactory()
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.ward,
+            holder_type=HolderType.PERSONA,
+            holder_persona=owner,
+        )
+        self.assertIsNone(ownership_for(stranger, self.room))
+        self.assertFalse(is_owner(stranger, self.room))
+
+    def test_org_member_has_standing(self) -> None:
+        org = OrganizationFactory()
+        member = PersonaFactory()
+        OrganizationMembershipFactory(persona=member, organization=org)
+        row = LocationOwnership.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.ward,
+            holder_type=HolderType.ORGANIZATION,
+            holder_organization=org,
+        )
+        self.assertEqual(ownership_for(member, self.room), row)
+        self.assertTrue(is_owner(member, self.room))
+
+    def test_org_non_member_does_not_match(self) -> None:
+        org = OrganizationFactory()
+        non_member = PersonaFactory()
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.ward,
+            holder_type=HolderType.ORGANIZATION,
+            holder_organization=org,
+        )
+        self.assertIsNone(ownership_for(non_member, self.room))
+        self.assertFalse(is_owner(non_member, self.room))
+
+    def test_no_ownership_in_chain(self) -> None:
+        persona = PersonaFactory()
+        self.assertIsNone(ownership_for(persona, self.room))
+        self.assertFalse(is_owner(persona, self.room))
+
+    def test_org_ownership_cascades_to_room(self) -> None:
+        """Building (city in this case) owns; query the room within."""
+        org = OrganizationFactory()
+        member = PersonaFactory()
+        OrganizationMembershipFactory(persona=member, organization=org)
+        row = LocationOwnership.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.city,
+            holder_type=HolderType.ORGANIZATION,
+            holder_organization=org,
+        )
+        self.assertEqual(ownership_for(member, self.room), row)
+
+    def test_no_alt_piercing(self) -> None:
+        """An alt persona of the same character that owns the room does
+        not get owner standing. Persona scoping is strict per the
+        no-alt-outing hard rule.
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.scenes.models import PersonaType
+
+        sheet = CharacterSheetFactory()
+        primary = sheet.primary_persona
+        alt = PersonaFactory(character_sheet=sheet, persona_type=PersonaType.ESTABLISHED)
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.ward,
+            holder_type=HolderType.PERSONA,
+            holder_persona=primary,
+        )
+        self.assertTrue(is_owner(primary, self.room))
+        self.assertFalse(is_owner(alt, self.room))
+
+
+class OwnershipForQueryBudgetTests(TestCase):
+    """Lock the query budget so it doesn't silently regress."""
+
+    def test_persona_holder_short_circuits_org_lookup(self) -> None:
+        ward = AreaFactory(level=AreaLevel.WARD)
+        profile = RoomProfileFactory(area=ward)
+        persona = PersonaFactory()
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=ward,
+            holder_type=HolderType.PERSONA,
+            holder_persona=persona,
+        )
+        from evennia.objects.models import ObjectDB
+
+        room = ObjectDB.objects.get(pk=profile.objectdb.pk)
+        # PERSONA-holder match: effective_owner (2 queries) + persona compare
+        # (no DB hit). Total: 2 queries.
+        with self.assertNumQueries(2):
+            ownership_for(persona, room)
+
+    def test_org_holder_costs_three_queries(self) -> None:
+        ward = AreaFactory(level=AreaLevel.WARD)
+        profile = RoomProfileFactory(area=ward)
+        org = OrganizationFactory()
+        member = PersonaFactory()
+        OrganizationMembershipFactory(persona=member, organization=org)
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=ward,
+            holder_type=HolderType.ORGANIZATION,
+            holder_organization=org,
+        )
+        from evennia.objects.models import ObjectDB
+
+        room = ObjectDB.objects.get(pk=profile.objectdb.pk)
+        # ORGANIZATION-holder match: effective_owner (2) + org_ids fetch (1).
+        with self.assertNumQueries(3):
+            ownership_for(member, room)

--- a/src/world/locations/tests/test_permissions.py
+++ b/src/world/locations/tests/test_permissions.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+
+from world.locations.services import _persona_organization_ids
+from world.scenes.factories import PersonaFactory
+from world.societies.factories import (
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+)
+
+
+class PersonaOrganizationIdsTests(TestCase):
+    def test_returns_empty_set_for_persona_with_no_memberships(self) -> None:
+        persona = PersonaFactory()
+        self.assertEqual(_persona_organization_ids(persona), set())
+
+    def test_returns_all_org_ids_for_member(self) -> None:
+        persona = PersonaFactory()
+        org_a = OrganizationFactory()
+        org_b = OrganizationFactory()
+        OrganizationMembershipFactory(persona=persona, organization=org_a)
+        OrganizationMembershipFactory(persona=persona, organization=org_b)
+        self.assertEqual(_persona_organization_ids(persona), {org_a.pk, org_b.pk})
+
+    def test_excludes_orgs_persona_is_not_a_member_of(self) -> None:
+        persona = PersonaFactory()
+        joined_org = OrganizationFactory()
+        OrganizationFactory()  # unjoined org — must not appear in result
+        OrganizationMembershipFactory(persona=persona, organization=joined_org)
+        self.assertEqual(_persona_organization_ids(persona), {joined_org.pk})

--- a/src/world/locations/tests/test_permissions.py
+++ b/src/world/locations/tests/test_permissions.py
@@ -113,17 +113,28 @@ class OwnershipForTests(TestCase):
         )
         self.assertEqual(ownership_for(member, self.room), row)
 
-    def test_no_alt_piercing(self) -> None:
-        """An alt persona of the same character that owns the room does
-        not get owner standing. Persona scoping is strict per the
-        no-alt-outing hard rule.
+    def test_alt_persona_of_owner_not_recognized_as_owner(self) -> None:
+        """An alt_persona (secondary persona of the same character) does
+        not automatically get owner standing.
+
+        OOC the character owns the room, but the WHOLE POINT of a
+        secondary persona is that it's secret — the household knows the
+        outward-facing persona as the owner, and would treat the
+        character's other personas as intruders unless those personas
+        have been discovered/revealed. Substrate is therefore strictly
+        per-persona; downstream PersonaDiscovery-aware code can compose
+        a discovery-respecting check on top.
+
+        Distinct from the alt_characters case (different CharacterSheet,
+        same Account) — those never share standing under any
+        circumstance.
         """
         from world.character_sheets.factories import CharacterSheetFactory
         from world.scenes.models import PersonaType
 
         sheet = CharacterSheetFactory()
         primary = sheet.primary_persona
-        alt = PersonaFactory(character_sheet=sheet, persona_type=PersonaType.ESTABLISHED)
+        alt_persona = PersonaFactory(character_sheet=sheet, persona_type=PersonaType.ESTABLISHED)
         LocationOwnership.objects.create(
             parent_type=LocationParentType.AREA,
             area=self.ward,
@@ -131,7 +142,31 @@ class OwnershipForTests(TestCase):
             holder_persona=primary,
         )
         self.assertTrue(is_owner(primary, self.room))
-        self.assertFalse(is_owner(alt, self.room))
+        self.assertFalse(is_owner(alt_persona, self.room))
+
+    def test_alt_persona_with_own_org_membership_gets_standing(self) -> None:
+        """An alt_persona with its OWN independent OrganizationMembership
+        gets standing via that membership — the substrate is per-persona,
+        not per-character. Locks in that having a sibling persona who
+        is a member is NOT the same as having the membership.
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.scenes.models import PersonaType
+
+        sheet = CharacterSheetFactory()
+        primary = sheet.primary_persona
+        alt_persona = PersonaFactory(character_sheet=sheet, persona_type=PersonaType.ESTABLISHED)
+        org = OrganizationFactory()
+        # Only the alt_persona joins the org — primary has no membership.
+        OrganizationMembershipFactory(persona=alt_persona, organization=org)
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.ward,
+            holder_type=HolderType.ORGANIZATION,
+            holder_organization=org,
+        )
+        self.assertTrue(is_owner(alt_persona, self.room))
+        self.assertFalse(is_owner(primary, self.room))
 
 
 class OwnershipForQueryBudgetTests(TestCase):
@@ -265,13 +300,21 @@ class TenanciesForTests(TestCase):
         self.assertEqual(len(result_a), 1)
         self.assertEqual(result_a[0].tenant_persona, room_tenant_a)
 
-    def test_no_alt_piercing_on_tenancy(self) -> None:
+    def test_alt_persona_of_tenant_not_recognized_as_tenant(self) -> None:
+        """An alt_persona (secondary persona of the same character) does
+        not automatically get tenant standing for the same reason as the
+        ownership case: the secondary persona is secret IC and would not
+        be recognized as the legitimate tenant until discovered.
+
+        Substrate is per-persona. Discovery-aware tenant checks are a
+        downstream concern.
+        """
         from world.character_sheets.factories import CharacterSheetFactory
         from world.scenes.models import PersonaType
 
         sheet = CharacterSheetFactory()
         primary = sheet.primary_persona
-        alt = PersonaFactory(character_sheet=sheet, persona_type=PersonaType.ESTABLISHED)
+        alt_persona = PersonaFactory(character_sheet=sheet, persona_type=PersonaType.ESTABLISHED)
         LocationTenancy.objects.create(
             parent_type=LocationParentType.ROOM,
             room_profile=self.profile,
@@ -279,7 +322,7 @@ class TenanciesForTests(TestCase):
             tenant_persona=primary,
         )
         self.assertTrue(is_tenant(primary, self.room))
-        self.assertFalse(is_tenant(alt, self.room))
+        self.assertFalse(is_tenant(alt_persona, self.room))
 
 
 class TenanciesForQueryBudgetTests(TestCase):


### PR DESCRIPTION
 # Location permissions helpers

  Adds the canonical first consumer of the Ownership + Tenancy substrate
  shipped in #434: four relationship-lookup helpers that answer "does
  this persona have owner / tenant standing at this room?" Specific
  permission checks (`can_decorate`, `can_evict`, `can_install`, etc.)
  live in their consuming systems where the rules naturally belong.

  ## What's new

  - `_persona_organization_ids(persona) -> set[int]` — private helper
  - `ownership_for(persona, room) -> LocationOwnership | None` —
    cascade-aware; matches direct persona OR org membership; short-
    circuits org-ids fetch on persona-holder match (2 queries vs 3)
  - `is_owner(persona, room) -> bool`
  - `tenancies_for(persona, room) -> QuerySet[LocationTenancy]` — filters
    `current_tenants(room)` to rows where the persona has standing
  - `is_tenant(persona, room) -> bool`

  No new models or migrations.

  ## Design

  Per-persona scoping covers two distinct cases:

  - **alt_personas** (same CharacterSheet, different Persona): OOC the
    character owns the property, but secondary personas are *secret*
    IC and the household would treat them as intruders until
    discovered. Substrate reflects the IC default; PersonaDiscovery-aware
    checks compose on top later.
  - **alt_characters** (same Account, different CharacterSheet):
    different characters, no shared standing under any circumstance.

  The no-alt-outing hard rule is about *display* of account-level
  links — unrelated to access checks.

  Org membership counts as standing (any rank). Rank filtering is
  downstream's concern.

  ## Tests

  20 tests in `src/world/locations/tests/test_permissions.py` including:
  - Direct persona / org-member happy paths for both ownership and tenancy
  - Cascade interaction (ownership at a higher area resolves down)
  - Multiple concurrent tenancies, partial match
  - `test_alt_persona_of_owner_not_recognized_as_owner` —
    alt_personas case (secret persona, IC default)
  - `test_alt_persona_with_own_org_membership_gets_standing` —
    per-persona membership semantic
  - `test_alt_persona_of_tenant_not_recognized_as_tenant`
  - `assertNumQueries` enforcement of the documented 2-query (PERSONA
    holder) and 3-query (ORG holder) budgets

  ## Verification

  - 20/20 in `test_permissions.py`; 430/430 across affected suites
    (`world.locations`, `world.scenes`, `world.societies`) on fresh DB
  - ruff + ty clean
  - Adversarial review found no critical/important issues

  ## Test plan

  - [x] `arx test world.locations world.scenes world.societies` on fresh DB
  - [x] `ruff check src/world/locations`
  - [x] `ty check src/world/locations`