### PR TITLE
Feature/location lifecycle helpers

### DIFF
--- a/docs/plans/2026-05-11-location-lifecycle-helpers-design.md
+++ b/docs/plans/2026-05-11-location-lifecycle-helpers-design.md
@@ -1,0 +1,317 @@
+# Location Lifecycle Write Helpers — Design
+
+**Status:** validated brainstorm; ready to implement
+**Date:** 2026-05-11
+**App home:** `world.locations` (extends existing services)
+**Depends on:** `world.locations` (LocationOwnership, LocationTenancy)
+
+## Why this exists
+
+Both the location-ambient-stats and location-ownership-tenancy design
+docs explicitly deferred convenience write helpers, flagging the
+deferral as a known footgun. The current pattern for transferring
+ownership is:
+
+1. Find the existing active row for the target location
+2. Set `ended_at = now()` on it and save
+3. Create a new row with the new holder
+4. Wrap (1)-(3) in `transaction.atomic` so concurrent readers don't see
+   "no active owner" between steps
+
+Every caller has to remember this protocol exactly. Get the order wrong
+and the partial-unique constraint fires. Skip the atomic and a reader
+mid-transfer sees a momentary unowned state. The CLAUDE.md note about
+this is real but easy to miss.
+
+This wedge closes the gap with three small helpers in
+`world.locations.services` so the protocol lives in one place and
+downstream callers (decoration, eviction UX, inheritance, transfer
+tooling, GM admin commands) consume a stable API instead of
+reimplementing the dance.
+
+It is **not** a design for:
+- Permission checks (who can transfer / evict) — caller's concern
+- Eviction notification / grace periods — separate UX system
+- Inheritance on character death — separate progression hook
+- DRF endpoints / API exposure — when consumers materialize
+- Audit trail with structured `transferred_by_persona` — `notes` text
+  field covers v1; add structured audit later if forensics tooling
+  needs it
+- Bulk variants
+
+## Bedrock decisions
+
+### Three helpers, explicit kwargs
+
+```python
+def transfer_ownership(
+    *,
+    area: Area | None = None,
+    room_profile: RoomProfile | None = None,
+    to_persona: Persona | None = None,
+    to_organization: Organization | None = None,
+    notes: str = "",
+    transferred_at: datetime | None = None,
+) -> LocationOwnership
+
+def grant_tenancy(
+    *,
+    area: Area | None = None,
+    room_profile: RoomProfile | None = None,
+    tenant_persona: Persona | None = None,
+    tenant_organization: Organization | None = None,
+    ends_at: datetime | None = None,
+    notes: str = "",
+) -> LocationTenancy
+
+def end_tenancy(
+    tenancy: LocationTenancy,
+    *,
+    ended_at: datetime | None = None,
+) -> LocationTenancy
+```
+
+Explicit kwargs (not auto-detection from types) make call sites readable
+and validation localized:
+
+```python
+transfer_ownership(area=ward, to_organization=house_stark, notes="conquest of 1234")
+grant_tenancy(room_profile=apartment, tenant_persona=traveler, ends_at=next_week)
+end_tenancy(tenancy)
+```
+
+### `transfer_ownership` handles both claim and transfer
+
+The protocol is identical whether the location currently has an active
+owner or not — end whatever exists (if any), create the new row, wrap
+atomically. Conflating "claim" and "transfer" into one operation
+reduces API surface and matches the substrate semantics (the
+partial-unique constraint is on active ownership, not on transfer
+history).
+
+If a caller has a permission rule like "only the current owner can
+authorize a transfer," that's their gate to install before calling
+`transfer_ownership`. The substrate doesn't enforce it.
+
+### `end_tenancy` is one operation, not two
+
+Eviction (owner kicks tenant out) and voluntary departure (tenant
+leaves) use the same code path: set `ends_at`. The semantic distinction
+is purely the caller's UX concern — substrate doesn't model "kicked
+out" vs "moved out."
+
+Future systems may want to record the reason / actor on tenancy
+closure. For v1 the `notes` field on the row covers it; structured
+fields are a follow-up.
+
+### No permission checks in substrate
+
+These helpers don't call `is_owner` or anything else. They just perform
+the write. Callers MUST gate access first (via `is_owner`,
+`OrganizationMembership.rank`, or whatever the consuming system
+requires). Mixing permission gating into the substrate would force
+downstream systems to either bypass it (defeating the point) or live
+with the substrate's rules (forcing one access policy on every system).
+
+### No actor parameter in v1
+
+The plan considered adding `actor_persona` as a structured field on
+each lifecycle operation. v1 defers this — the existing `notes` text
+field can carry actor info ("transferred by Lord Aiden") for now. When
+forensics tooling materializes and the audit trail needs to be
+structured, we add a real FK column on both models with a migration.
+
+## Implementation sketch
+
+```python
+# world/locations/services.py — append
+
+def transfer_ownership(
+    *,
+    area: "Area | None" = None,
+    room_profile: "RoomProfile | None" = None,
+    to_persona: "Persona | None" = None,
+    to_organization: "Organization | None" = None,
+    notes: str = "",
+    transferred_at: "datetime | None" = None,
+) -> LocationOwnership:
+    """Atomically transfer (or claim) ownership of a location.
+
+    Ends the current active LocationOwnership row (if any) and creates
+    a new row with the new holder. Wrapped in transaction.atomic so the
+    "no active owner" window never appears to concurrent readers.
+
+    Handles both first-time claims (no current owner) and transfers
+    (current owner ended, new owner created).
+
+    Caller is responsible for permission gating — substrate does not
+    check authority to transfer.
+    """
+    _validate_location_kwargs(area, room_profile)
+    _validate_holder_kwargs(to_persona, to_organization)
+
+    parent_type = (
+        LocationParentType.AREA if area is not None else LocationParentType.ROOM
+    )
+    holder_type = (
+        HolderType.PERSONA if to_persona is not None else HolderType.ORGANIZATION
+    )
+    when = transferred_at if transferred_at is not None else timezone.now()
+
+    with transaction.atomic():
+        existing_qs = LocationOwnership.objects.filter(ended_at__isnull=True)
+        if area is not None:
+            existing_qs = existing_qs.filter(area=area)
+        else:
+            existing_qs = existing_qs.filter(room_profile=room_profile)
+        existing = existing_qs.first()
+        if existing is not None:
+            existing.ended_at = when
+            existing.save()
+
+        return LocationOwnership.objects.create(
+            parent_type=parent_type,
+            area=area,
+            room_profile=room_profile,
+            holder_type=holder_type,
+            holder_persona=to_persona,
+            holder_organization=to_organization,
+            acquired_at=when,
+            notes=notes,
+        )
+
+
+def grant_tenancy(
+    *,
+    area: "Area | None" = None,
+    room_profile: "RoomProfile | None" = None,
+    tenant_persona: "Persona | None" = None,
+    tenant_organization: "Organization | None" = None,
+    ends_at: "datetime | None" = None,
+    notes: str = "",
+) -> LocationTenancy:
+    """Create a new LocationTenancy row.
+
+    Multiple concurrent tenancies on the same location are valid by
+    design — no conflict check. Caller is responsible for permission
+    gating (only owners should grant tenancy).
+    """
+    _validate_location_kwargs(area, room_profile)
+    _validate_tenant_kwargs(tenant_persona, tenant_organization)
+
+    parent_type = (
+        LocationParentType.AREA if area is not None else LocationParentType.ROOM
+    )
+    tenant_type = (
+        HolderType.PERSONA if tenant_persona is not None else HolderType.ORGANIZATION
+    )
+    return LocationTenancy.objects.create(
+        parent_type=parent_type,
+        area=area,
+        room_profile=room_profile,
+        tenant_type=tenant_type,
+        tenant_persona=tenant_persona,
+        tenant_organization=tenant_organization,
+        ends_at=ends_at,
+        notes=notes,
+    )
+
+
+def end_tenancy(
+    tenancy: LocationTenancy,
+    *,
+    ended_at: "datetime | None" = None,
+) -> LocationTenancy:
+    """End a tenancy by setting ``ends_at``.
+
+    Covers eviction and voluntary departure — the code path is
+    identical and the semantic distinction is the caller's concern.
+    Idempotent: re-calling on an already-ended tenancy overwrites
+    ``ends_at`` to the new value. The new value can be in the past
+    (eviction effective immediately) or in the future (planned end of
+    lease).
+    """
+    tenancy.ends_at = ended_at if ended_at is not None else timezone.now()
+    tenancy.save()
+    return tenancy
+```
+
+Two private validators (one per discriminator pair) keep the bodies
+clean.
+
+## What v1 ships
+
+- 3 public helpers + 2 private validators in
+  `src/world/locations/services.py`
+- Tests covering:
+  - `transfer_ownership` as claim (no current owner) and as transfer
+    (existing owner)
+  - Old + new rows have matching timestamps when caller passes none
+  - Caller-supplied `transferred_at` is honored
+  - Validation: missing both / passing both for parent and holder
+  - Atomicity: after successful transfer, exactly ONE active row exists
+  - Partial-unique constraint not violated under transfer
+  - `grant_tenancy` happy paths (persona + org, area + room)
+  - `grant_tenancy` validation errors
+  - Multiple concurrent tenancies after multiple grants
+  - `end_tenancy` sets `ends_at` to now() by default and to supplied
+    value when given
+  - `end_tenancy` idempotency (callable twice with different times)
+- `world/locations/CLAUDE.md` updated to point at these helpers as the
+  canonical write API
+
+## What v1 explicitly defers
+
+| Item | When to add |
+|---|---|
+| Permission gating inside helpers | Never — caller's concern |
+| Structured `actor_persona` field on operations | When forensics tooling lands |
+| Eviction notification / grace period | With the eviction UX system |
+| Inheritance on character death | Separate progression hook |
+| Bulk variants (`transfer_multiple`, `end_all_tenancies_on`) | When a bulk consumer materializes |
+| DRF actions / API endpoints | When frontend consumers exist |
+| Tenancy "renew" helper | When a real renewal flow surfaces |
+| Recording the **previous** holder explicitly on the new row | If the audit trail needs richer cross-row linking |
+
+## Test plan
+
+- **transfer_ownership: claim**
+  - No existing owner → new row created; `ended_at IS NULL`
+- **transfer_ownership: transfer**
+  - Existing owner → existing row gets `ended_at = when`; new row created with `acquired_at = when`
+  - The two timestamps are identical when caller doesn't pass `transferred_at`
+  - When caller passes `transferred_at`, BOTH timestamps use that value
+- **transfer_ownership: atomicity**
+  - After successful transfer, `LocationOwnership.objects.filter(active...).count() == 1`
+- **transfer_ownership: validation errors**
+  - No parent / both parents → `ValueError`
+  - No holder / both holders → `ValueError`
+- **grant_tenancy: happy paths**
+  - Persona tenant on room
+  - Organization tenant on area
+  - With `ends_at` set (planned lease)
+  - Without `ends_at` (indefinite)
+- **grant_tenancy: validation errors**
+  - Same four cases
+- **grant_tenancy: multiple concurrent**
+  - Three grants on same room, all active, no conflict
+- **end_tenancy: defaults to now**
+- **end_tenancy: honors supplied timestamp**
+- **end_tenancy: idempotent re-end overwrites**
+- **end_tenancy: returns the same instance** (not a re-fetch)
+
+## Cross-cutting notes
+
+- All operations preserve the existing audit-history pattern: history
+  rows are kept; the `ended_at` / `ends_at` filter is what defines
+  "current."
+- The validators raise `ValueError` (Python's standard, not
+  `ValidationError`) — these are programmer-error conditions, not
+  user-input validation. Caller code at API layers maps to appropriate
+  HTTP responses.
+- `transaction.atomic` only wraps `transfer_ownership` because it's the
+  only multi-statement operation. `grant_tenancy` is a single INSERT;
+  `end_tenancy` is a single UPDATE.
+- Helpers are type-annotated (typed app). Imports for `Area`,
+  `RoomProfile`, `Persona`, `Organization`, `datetime` live under
+  `TYPE_CHECKING` to avoid runtime cost.

--- a/src/world/locations/CLAUDE.md
+++ b/src/world/locations/CLAUDE.md
@@ -152,8 +152,10 @@ returns a `QuerySet` filtered for `ends_at IS NULL OR ends_at > now()`.
   retire a row. Keep the row.
 - The partial-unique constraint enforces only ONE active Ownership per
   location. Multiple active Tenancies are allowed and expected.
-- Most authoring goes through `objects.create()` until convenience helpers
-  materialize from real consumers (decoration, locks, vaults).
+- Most authoring goes through the lifecycle helpers (see below). Direct
+  `objects.create()` is fine for test fixtures, but production code uses
+  the helpers so the partial-unique + transactional protocol stays in
+  one place.
 
 ## Relationship lookups (added 2026-05-11)
 
@@ -229,3 +231,38 @@ are a separate concern.
   + tenancy fetch)
 
 Budgets are locked via `assertNumQueries` tests.
+
+## Lifecycle write helpers (added 2026-05-11)
+
+Three helpers in `world.locations.services` wrap the partial-unique +
+transactional protocol so callers don't have to reimplement it:
+
+```python
+from world.locations.services import (
+    transfer_ownership,
+    grant_tenancy,
+    end_tenancy,
+)
+
+# Atomic transfer or claim — ends current owner (if any), creates new row
+transfer_ownership(area=ward, to_organization=house_stark, notes="conquest")
+
+# Single-insert new tenancy — no conflict check
+grant_tenancy(room_profile=apartment, tenant_persona=traveler, ends_at=next_week)
+
+# Single-update setting ends_at — covers eviction and voluntary departure
+end_tenancy(tenancy)
+```
+
+`transfer_ownership` wraps the end-existing + create-new sequence in
+`transaction.atomic` so concurrent readers never see a "no active owner"
+window. It also calls `select_for_update` on the existing-row lookup so
+concurrent transfers on the same parent serialize cleanly (T2 waits for
+T1's commit). Concurrent *claims* of a never-owned location still race
+at the INSERT and rely on the partial-unique constraint to surface
+`IntegrityError` to the loser — rare contention in practice.
+
+**Permission gating is the caller's concern.** These helpers do not
+call `is_owner` or check authority. Consumers must gate access first
+(via `is_owner`, `OrganizationMembership.rank`, etc.) before invoking
+them.

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -359,3 +359,23 @@ def grant_tenancy(  # noqa: PLR0913 — keyword-only XOR-pair API by design
         ends_at=ends_at,
         notes=notes,
     )
+
+
+def end_tenancy(
+    tenancy: LocationTenancy,
+    *,
+    ended_at: datetime | None = None,
+) -> LocationTenancy:
+    """End a tenancy by setting ``ends_at``.
+
+    Covers eviction AND voluntary departure — the code path is identical
+    and the semantic distinction is the caller's UX concern.
+
+    Idempotent: re-calling on an already-ended tenancy overwrites
+    ``ends_at`` with the new value. The new value can be in the past
+    (eviction effective immediately) or in the future (planned end of
+    lease).
+    """
+    tenancy.ends_at = ended_at if ended_at is not None else timezone.now()
+    tenancy.save()
+    return tenancy

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -327,3 +327,35 @@ def transfer_ownership(  # noqa: PLR0913 — keyword-only XOR-pair API by design
             acquired_at=when,
             notes=notes,
         )
+
+
+def grant_tenancy(  # noqa: PLR0913 — keyword-only XOR-pair API by design
+    *,
+    area: Area | None = None,
+    room_profile: RoomProfile | None = None,
+    tenant_persona: Persona | None = None,
+    tenant_organization: Organization | None = None,
+    ends_at: datetime | None = None,
+    notes: str = "",
+) -> LocationTenancy:
+    """Create a new LocationTenancy row.
+
+    Multiple concurrent tenancies on the same location are valid by
+    design — no conflict check. Caller is responsible for permission
+    gating (only owners should grant tenancy).
+    """
+    _validate_location_kwargs(area, room_profile)
+    _validate_holder_kwargs(tenant_persona, tenant_organization)
+
+    parent_type = LocationParentType.AREA if area is not None else LocationParentType.ROOM
+    tenant_type = HolderType.PERSONA if tenant_persona is not None else HolderType.ORGANIZATION
+    return LocationTenancy.objects.create(
+        parent_type=parent_type,
+        area=area,
+        room_profile=room_profile,
+        tenant_type=tenant_type,
+        tenant_persona=tenant_persona,
+        tenant_organization=tenant_organization,
+        ends_at=ends_at,
+        notes=notes,
+    )

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -290,6 +290,14 @@ def transfer_ownership(  # noqa: PLR0913 — keyword-only XOR-pair API by design
 
     Caller is responsible for permission gating — substrate does not
     check authority to transfer.
+
+    Concurrent transfers on the same parent serialize via
+    ``select_for_update`` on the existing-row lookup — the losing caller
+    waits for the winning transaction to commit, then re-reads the now-
+    ended row and proceeds. Concurrent *claims* of a never-owned
+    location still race at the INSERT step and rely on the partial-
+    unique constraint to surface ``IntegrityError`` for the loser; that
+    contention is rare in practice (an area is only claimed once).
     """
     _validate_location_kwargs(area, room_profile)
     _validate_holder_kwargs(to_persona, to_organization)
@@ -299,7 +307,7 @@ def transfer_ownership(  # noqa: PLR0913 — keyword-only XOR-pair API by design
     when = transferred_at if transferred_at is not None else timezone.now()
 
     with transaction.atomic():
-        existing_qs = LocationOwnership.objects.filter(ended_at__isnull=True)
+        existing_qs = LocationOwnership.objects.select_for_update().filter(ended_at__isnull=True)
         if area is not None:
             existing_qs = existing_qs.filter(area=area)
         else:

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -76,7 +76,11 @@ def _validate_location_kwargs(area: Area | None, room_profile: RoomProfile | Non
 
 
 def _validate_holder_kwargs(persona: Persona | None, organization: Organization | None) -> None:
-    """Raise ValueError unless exactly one of (persona, organization) is set."""
+    """Raise ValueError unless exactly one of (persona, organization) is set.
+
+    Used by both ownership (holder) and tenancy (tenant) helpers — both have
+    the same Persona-XOR-Organization shape.
+    """
     if (persona is None) == (organization is None):
         msg = "Must pass exactly one of the persona or organization holder."
         raise ValueError(msg)

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from django.db import models
+from django.db import models, transaction
 from django.utils import timezone
 
 from evennia_extensions.models import RoomProfile
 from world.areas.models import AreaClosure
-from world.locations.constants import STAT_CLAMPS, STAT_DEFAULTS, HolderType, StatKey
+from world.locations.constants import (
+    STAT_CLAMPS,
+    STAT_DEFAULTS,
+    HolderType,
+    LocationParentType,
+    StatKey,
+)
 from world.locations.models import (
     LocationOwnership,
     LocationStatModifier,
@@ -19,6 +25,8 @@ from world.locations.models import (
 from world.societies.models import OrganizationMembership
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from django.db.models import QuerySet
     from evennia.objects.objects import DefaultObject
 
@@ -259,3 +267,55 @@ def tenancies_for(persona: Persona, room: DefaultObject) -> QuerySet[LocationTen
 def is_tenant(persona: Persona, room: DefaultObject) -> bool:
     """True when ``tenancies_for(persona, room)`` has any rows."""
     return tenancies_for(persona, room).exists()
+
+
+def transfer_ownership(  # noqa: PLR0913 — keyword-only XOR-pair API by design
+    *,
+    area: Area | None = None,
+    room_profile: RoomProfile | None = None,
+    to_persona: Persona | None = None,
+    to_organization: Organization | None = None,
+    notes: str = "",
+    transferred_at: datetime | None = None,
+) -> LocationOwnership:
+    """Atomically transfer (or claim) ownership of a location.
+
+    Ends the current active LocationOwnership row (if any) and creates a
+    new row with the new holder. Wrapped in transaction.atomic so the
+    "no active owner" window never appears to concurrent readers.
+
+    Handles both first-time claims (no current owner) and transfers
+    (current owner ended, new owner created). The protocol is identical;
+    conflating them reduces API surface.
+
+    Caller is responsible for permission gating — substrate does not
+    check authority to transfer.
+    """
+    _validate_location_kwargs(area, room_profile)
+    _validate_holder_kwargs(to_persona, to_organization)
+
+    parent_type = LocationParentType.AREA if area is not None else LocationParentType.ROOM
+    holder_type = HolderType.PERSONA if to_persona is not None else HolderType.ORGANIZATION
+    when = transferred_at if transferred_at is not None else timezone.now()
+
+    with transaction.atomic():
+        existing_qs = LocationOwnership.objects.filter(ended_at__isnull=True)
+        if area is not None:
+            existing_qs = existing_qs.filter(area=area)
+        else:
+            existing_qs = existing_qs.filter(room_profile=room_profile)
+        existing = existing_qs.first()
+        if existing is not None:
+            existing.ended_at = when
+            existing.save()
+
+        return LocationOwnership.objects.create(
+            parent_type=parent_type,
+            area=area,
+            room_profile=room_profile,
+            holder_type=holder_type,
+            holder_persona=to_persona,
+            holder_organization=to_organization,
+            acquired_at=when,
+            notes=notes,
+        )

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -22,7 +22,9 @@ if TYPE_CHECKING:
     from django.db.models import QuerySet
     from evennia.objects.objects import DefaultObject
 
+    from world.areas.models import Area
     from world.scenes.models import Persona
+    from world.societies.models import Organization
 
 
 def _room_profile_and_ancestors(
@@ -64,6 +66,20 @@ def _persona_organization_ids(persona: Persona) -> set[int]:
             "organization_id", flat=True
         )
     )
+
+
+def _validate_location_kwargs(area: Area | None, room_profile: RoomProfile | None) -> None:
+    """Raise ValueError unless exactly one of (area, room_profile) is set."""
+    if (area is None) == (room_profile is None):
+        msg = "Must pass exactly one of area or room_profile."
+        raise ValueError(msg)
+
+
+def _validate_holder_kwargs(persona: Persona | None, organization: Organization | None) -> None:
+    """Raise ValueError unless exactly one of (persona, organization) is set."""
+    if (persona is None) == (organization is None):
+        msg = "Must pass exactly one of the persona or organization holder."
+        raise ValueError(msg)
 
 
 def _clamp(value: int, stat_key: StatKey) -> int:

--- a/src/world/locations/tests/test_lifecycle.py
+++ b/src/world/locations/tests/test_lifecycle.py
@@ -10,6 +10,7 @@ from world.locations.models import LocationOwnership, LocationTenancy
 from world.locations.services import (
     _validate_holder_kwargs,
     _validate_location_kwargs,
+    end_tenancy,
     grant_tenancy,
     transfer_ownership,
 )
@@ -187,3 +188,36 @@ class GrantTenancyValidationTests(TestCase):
                 tenant_persona=PersonaFactory(),
                 tenant_organization=OrganizationFactory(),
             )
+
+
+class EndTenancyTests(TestCase):
+    def test_defaults_to_now(self) -> None:
+        tenancy = grant_tenancy(room_profile=RoomProfileFactory(), tenant_persona=PersonaFactory())
+        before = timezone.now()
+        result = end_tenancy(tenancy)
+        after = timezone.now()
+        self.assertIsNotNone(result.ends_at)
+        self.assertGreaterEqual(result.ends_at, before)
+        self.assertLessEqual(result.ends_at, after)
+
+    def test_honors_supplied_ended_at(self) -> None:
+        tenancy = grant_tenancy(room_profile=RoomProfileFactory(), tenant_persona=PersonaFactory())
+        explicit = timezone.now() - timedelta(hours=2)
+        result = end_tenancy(tenancy, ended_at=explicit)
+        self.assertEqual(result.ends_at, explicit)
+
+    def test_returns_same_instance(self) -> None:
+        tenancy = grant_tenancy(room_profile=RoomProfileFactory(), tenant_persona=PersonaFactory())
+        result = end_tenancy(tenancy)
+        self.assertIs(result, tenancy)
+
+    def test_idempotent_re_end_overwrites(self) -> None:
+        tenancy = grant_tenancy(room_profile=RoomProfileFactory(), tenant_persona=PersonaFactory())
+        first = timezone.now() - timedelta(days=2)
+        second = timezone.now() - timedelta(days=1)
+        end_tenancy(tenancy, ended_at=first)
+        tenancy.refresh_from_db()
+        self.assertEqual(tenancy.ends_at, first)
+        end_tenancy(tenancy, ended_at=second)
+        tenancy.refresh_from_db()
+        self.assertEqual(tenancy.ends_at, second)

--- a/src/world/locations/tests/test_lifecycle.py
+++ b/src/world/locations/tests/test_lifecycle.py
@@ -6,10 +6,11 @@ from django.utils import timezone
 from evennia_extensions.factories import RoomProfileFactory
 from world.areas.factories import AreaFactory
 from world.locations.constants import HolderType, LocationParentType
-from world.locations.models import LocationOwnership
+from world.locations.models import LocationOwnership, LocationTenancy
 from world.locations.services import (
     _validate_holder_kwargs,
     _validate_location_kwargs,
+    grant_tenancy,
     transfer_ownership,
 )
 from world.scenes.factories import PersonaFactory
@@ -126,4 +127,63 @@ class TransferOwnershipValidationTests(TestCase):
                 area=AreaFactory(),
                 to_persona=PersonaFactory(),
                 to_organization=OrganizationFactory(),
+            )
+
+
+class GrantTenancyTests(TestCase):
+    def test_persona_tenant_on_room(self) -> None:
+        room = RoomProfileFactory()
+        persona = PersonaFactory()
+        row = grant_tenancy(room_profile=room, tenant_persona=persona)
+        self.assertEqual(row.room_profile, room)
+        self.assertEqual(row.tenant_persona, persona)
+        self.assertEqual(row.parent_type, LocationParentType.ROOM)
+        self.assertEqual(row.tenant_type, HolderType.PERSONA)
+        self.assertIsNone(row.ends_at)
+
+    def test_organization_tenant_on_area(self) -> None:
+        area = AreaFactory()
+        org = OrganizationFactory()
+        row = grant_tenancy(area=area, tenant_organization=org)
+        self.assertEqual(row.area, area)
+        self.assertEqual(row.tenant_organization, org)
+        self.assertEqual(row.parent_type, LocationParentType.AREA)
+        self.assertEqual(row.tenant_type, HolderType.ORGANIZATION)
+
+    def test_with_planned_ends_at(self) -> None:
+        room = RoomProfileFactory()
+        expiry = timezone.now() + timedelta(days=30)
+        row = grant_tenancy(room_profile=room, tenant_persona=PersonaFactory(), ends_at=expiry)
+        self.assertEqual(row.ends_at, expiry)
+
+    def test_multiple_concurrent_tenancies_allowed(self) -> None:
+        room = RoomProfileFactory()
+        for _ in range(3):
+            grant_tenancy(room_profile=room, tenant_persona=PersonaFactory())
+        self.assertEqual(LocationTenancy.objects.filter(room_profile=room).count(), 3)
+
+
+class GrantTenancyValidationTests(TestCase):
+    def test_missing_parent_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            grant_tenancy(tenant_persona=PersonaFactory())
+
+    def test_both_parents_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            grant_tenancy(
+                area=AreaFactory(),
+                room_profile=RoomProfileFactory(),
+                tenant_persona=PersonaFactory(),
+            )
+
+    def test_missing_tenant_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            grant_tenancy(room_profile=RoomProfileFactory())
+
+    def test_both_tenants_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            grant_tenancy(
+                room_profile=RoomProfileFactory(),
+                tenant_persona=PersonaFactory(),
+                tenant_organization=OrganizationFactory(),
             )

--- a/src/world/locations/tests/test_lifecycle.py
+++ b/src/world/locations/tests/test_lifecycle.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+
+from evennia_extensions.factories import RoomProfileFactory
+from world.areas.factories import AreaFactory
+from world.locations.services import (
+    _validate_holder_kwargs,
+    _validate_location_kwargs,
+)
+from world.scenes.factories import PersonaFactory
+from world.societies.factories import OrganizationFactory
+
+
+class ValidateLocationKwargsTests(TestCase):
+    def test_accepts_area_only(self) -> None:
+        _validate_location_kwargs(AreaFactory(), None)
+
+    def test_accepts_room_profile_only(self) -> None:
+        _validate_location_kwargs(None, RoomProfileFactory())
+
+    def test_rejects_both_set(self) -> None:
+        with self.assertRaises(ValueError):
+            _validate_location_kwargs(AreaFactory(), RoomProfileFactory())
+
+    def test_rejects_neither_set(self) -> None:
+        with self.assertRaises(ValueError):
+            _validate_location_kwargs(None, None)
+
+
+class ValidateHolderKwargsTests(TestCase):
+    def test_accepts_persona_only(self) -> None:
+        _validate_holder_kwargs(PersonaFactory(), None)
+
+    def test_accepts_organization_only(self) -> None:
+        _validate_holder_kwargs(None, OrganizationFactory())
+
+    def test_rejects_both_set(self) -> None:
+        with self.assertRaises(ValueError):
+            _validate_holder_kwargs(PersonaFactory(), OrganizationFactory())
+
+    def test_rejects_neither_set(self) -> None:
+        with self.assertRaises(ValueError):
+            _validate_holder_kwargs(None, None)

--- a/src/world/locations/tests/test_lifecycle.py
+++ b/src/world/locations/tests/test_lifecycle.py
@@ -1,10 +1,16 @@
+from datetime import timedelta
+
 from django.test import TestCase
+from django.utils import timezone
 
 from evennia_extensions.factories import RoomProfileFactory
 from world.areas.factories import AreaFactory
+from world.locations.constants import HolderType, LocationParentType
+from world.locations.models import LocationOwnership
 from world.locations.services import (
     _validate_holder_kwargs,
     _validate_location_kwargs,
+    transfer_ownership,
 )
 from world.scenes.factories import PersonaFactory
 from world.societies.factories import OrganizationFactory
@@ -40,3 +46,84 @@ class ValidateHolderKwargsTests(TestCase):
     def test_rejects_neither_set(self) -> None:
         with self.assertRaises(ValueError):
             _validate_holder_kwargs(None, None)
+
+
+class TransferOwnershipClaimTests(TestCase):
+    def test_creates_active_row_when_no_existing_owner(self) -> None:
+        area = AreaFactory()
+        persona = PersonaFactory()
+        row = transfer_ownership(area=area, to_persona=persona)
+        self.assertIsNone(row.ended_at)
+        self.assertEqual(row.area, area)
+        self.assertEqual(row.holder_persona, persona)
+        self.assertEqual(row.parent_type, LocationParentType.AREA)
+        self.assertEqual(row.holder_type, HolderType.PERSONA)
+
+    def test_org_holder_on_room(self) -> None:
+        room = RoomProfileFactory()
+        org = OrganizationFactory()
+        row = transfer_ownership(room_profile=room, to_organization=org)
+        self.assertEqual(row.room_profile, room)
+        self.assertEqual(row.holder_organization, org)
+        self.assertEqual(row.parent_type, LocationParentType.ROOM)
+        self.assertEqual(row.holder_type, HolderType.ORGANIZATION)
+
+
+class TransferOwnershipExistingOwnerTests(TestCase):
+    def test_ends_existing_and_creates_new(self) -> None:
+        area = AreaFactory()
+        old_persona = PersonaFactory()
+        new_persona = PersonaFactory()
+        old = transfer_ownership(area=area, to_persona=old_persona)
+        new = transfer_ownership(area=area, to_persona=new_persona)
+        old.refresh_from_db()
+        self.assertIsNotNone(old.ended_at)
+        self.assertIsNone(new.ended_at)
+        self.assertEqual(
+            LocationOwnership.objects.filter(area=area, ended_at__isnull=True).count(),
+            1,
+        )
+        self.assertEqual(LocationOwnership.objects.filter(area=area).count(), 2)
+
+    def test_old_ended_at_matches_new_acquired_at(self) -> None:
+        area = AreaFactory()
+        transfer_ownership(area=area, to_persona=PersonaFactory())
+        new = transfer_ownership(area=area, to_persona=PersonaFactory())
+        old = LocationOwnership.objects.get(area=area, ended_at__isnull=False)
+        self.assertEqual(old.ended_at, new.acquired_at)
+
+    def test_caller_supplied_transferred_at_honored(self) -> None:
+        area = AreaFactory()
+        explicit_when = timezone.now() - timedelta(days=5)
+        transfer_ownership(area=area, to_persona=PersonaFactory())
+        transfer_ownership(area=area, to_persona=PersonaFactory(), transferred_at=explicit_when)
+        old = LocationOwnership.objects.get(area=area, ended_at__isnull=False)
+        new = LocationOwnership.objects.get(area=area, ended_at__isnull=True)
+        self.assertEqual(old.ended_at, explicit_when)
+        self.assertEqual(new.acquired_at, explicit_when)
+
+
+class TransferOwnershipValidationTests(TestCase):
+    def test_missing_parent_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            transfer_ownership(to_persona=PersonaFactory())
+
+    def test_both_parents_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            transfer_ownership(
+                area=AreaFactory(),
+                room_profile=RoomProfileFactory(),
+                to_persona=PersonaFactory(),
+            )
+
+    def test_missing_holder_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            transfer_ownership(area=AreaFactory())
+
+    def test_both_holders_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            transfer_ownership(
+                area=AreaFactory(),
+                to_persona=PersonaFactory(),
+                to_organization=OrganizationFactory(),
+            )


### PR DESCRIPTION
  # Location lifecycle write helpers

  Closes the substrate gap both prior design docs flagged: callers
  shouldn't have to remember the partial-unique + `transaction.atomic`
  protocol when transferring ownership or managing tenancy lifecycle.

  ## What's new

  Five service functions in `world.locations.services`:

  - `_validate_location_kwargs(area, room_profile)` — private
  - `_validate_holder_kwargs(persona, organization)` — private; reused
    for both ownership (holder) and tenancy (tenant) thanks to the
    identical Persona-XOR-Organization shape
  - `transfer_ownership(*, area=..., room_profile=..., to_persona=...,
    to_organization=..., notes="", transferred_at=None)` — atomic
    transfer or claim; ends current owner (if any), creates new row,
    wrapped in `transaction.atomic` with `select_for_update` so
    concurrent transfers serialize cleanly
  - `grant_tenancy(*, area=..., room_profile=..., tenant_persona=...,
    tenant_organization=..., ends_at=None, notes="")` — single INSERT
  - `end_tenancy(tenancy, *, ended_at=None)` — single UPDATE; covers
    both eviction and voluntary departure

  No new models, no migrations.

  ## Design

  **One helper handles claim and transfer.** The protocol is identical
  and the partial-unique constraint is on active ownership, not on
  transfer history. Conflating them reduces API surface.

  **`select_for_update` on the existing-row lookup.** Concurrent
  transfers on the same parent serialize via row locks — losing
  transactions wait, re-read, and proceed cleanly. Concurrent claims of
  a never-owned location still race at INSERT and rely on the
  partial-unique constraint to surface `IntegrityError` to the loser
  (rare contention).

  **Permission gating is the caller's concern.** Substrate doesn't call
  `is_owner` or anything else. Consumers (decoration, eviction UX, GM
  admin) gate access first via the permission helpers shipped in the
  previous PR.

  **Audit info goes in the `notes` text field** for v1. Structured
  `actor_persona` is deferred until forensics tooling needs it.

  ## Tests

  29 tests in `src/world/locations/tests/test_lifecycle.py`:
  - 8 validator tests (accept/reject × parent/holder pairs)
  - 9 `transfer_ownership` tests (claim path, transfer path, timestamp
    coordination, caller-supplied `transferred_at`, validation errors)
  - 8 `grant_tenancy` tests (persona/org × area/room, planned ends_at,
    multiple concurrent, validation errors)
  - 4 `end_tenancy` tests (defaults to now, supplied timestamp, returns
    same instance, idempotent re-end)

  Adversarial review caught one real race window (concurrent transfers
  racing at INSERT); fixed with `select_for_update`.

  ## Verification

  - 92/92 tests pass in `world.locations` on fresh DB
  - ruff + ty clean
  - No migrations

  ## Test plan

  - [x] `arx test world.locations` on fresh DB
  - [x] `ruff check src/world/locations`
  - [x] `ty check src/world/locations`