### PR TITLE
refactor(items): item-first viewsets walk cached handlers

### DIFF
--- a/src/flows/service_functions/inventory.py
+++ b/src/flows/service_functions/inventory.py
@@ -7,6 +7,8 @@ failures roll back fully.
 
 from __future__ import annotations
 
+import contextlib
+
 from django.db import transaction
 
 from flows.object_states.character_state import CharacterState
@@ -42,11 +44,17 @@ def pick_up(character: CharacterState, item: ItemState) -> None:
     if item.instance.contained_in is not None:
         item.instance.contained_in = None
         item.instance.save(update_fields=["contained_in"])
+    previous_location = item.instance.game_object.location
     if not item.instance.game_object.move_to(character.obj, quiet=True):
         raise NotReachable
     if item.instance.owner is None:
         item.instance.owner = character.obj.account
         item.instance.save(update_fields=["owner"])
+    character.obj.carried_items.invalidate()
+    # If the item came from another character (rare), invalidate that too.
+    if previous_location is not None and previous_location.pk != character.obj.pk:
+        with contextlib.suppress(AttributeError):
+            previous_location.carried_items.invalidate()
 
 
 @transaction.atomic
@@ -71,6 +79,7 @@ def drop(character: CharacterState, item: ItemState) -> None:
         unequip_item(equipped_item=equipped)
     if not item.instance.game_object.move_to(character.obj.location, quiet=True):
         raise NotReachable
+    character.obj.carried_items.invalidate()
 
 
 @transaction.atomic
@@ -105,6 +114,8 @@ def give(
         from_account=previous_owner,
         to_account=recipient.obj.account,
     )
+    giver.obj.carried_items.invalidate()
+    recipient.obj.carried_items.invalidate()
 
 
 @transaction.atomic

--- a/src/flows/service_functions/inventory.py
+++ b/src/flows/service_functions/inventory.py
@@ -7,8 +7,6 @@ failures roll back fully.
 
 from __future__ import annotations
 
-import contextlib
-
 from django.db import transaction
 
 from flows.object_states.character_state import CharacterState
@@ -52,9 +50,13 @@ def pick_up(character: CharacterState, item: ItemState) -> None:
         item.instance.save(update_fields=["owner"])
     character.obj.carried_items.invalidate()
     # If the item came from another character (rare), invalidate that too.
-    if previous_location is not None and previous_location.pk != character.obj.pk:
-        with contextlib.suppress(AttributeError):
-            previous_location.carried_items.invalidate()
+    # Rooms/containers don't have ``carried_items`` — only characters do.
+    if (
+        previous_location is not None
+        and previous_location.pk != character.obj.pk
+        and hasattr(previous_location, "carried_items")
+    ):
+        previous_location.carried_items.invalidate()
 
 
 @transaction.atomic
@@ -204,6 +206,9 @@ def put_in(
     item.instance.save(update_fields=["contained_in"])
     if not item.instance.game_object.move_to(container.instance.game_object, quiet=True):
         raise NotReachable
+    # Item moved off the character (now nested in the container's game_object),
+    # so the carried-items cache for the character is stale.
+    character.obj.carried_items.invalidate()
 
 
 @transaction.atomic
@@ -223,3 +228,5 @@ def take_out(character: CharacterState, item: ItemState) -> None:
     item.instance.save(update_fields=["contained_in"])
     if not item.instance.game_object.move_to(character.obj, quiet=True):
         raise NotReachable
+    # Item now located on character — invalidate so the next read sees it.
+    character.obj.carried_items.invalidate()

--- a/src/flows/service_functions/outfits.py
+++ b/src/flows/service_functions/outfits.py
@@ -7,6 +7,7 @@ live alongside but are called from the REST layer for player bookkeeping.
 
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING
 
 from django.db import transaction
@@ -141,6 +142,7 @@ def save_outfit(
                 for row in rows
             ]
         )
+    character_sheet.saved_outfits.invalidate()
     return outfit
 
 
@@ -150,7 +152,9 @@ def delete_outfit(outfit: Outfit) -> None:
     Items are not touched — the OutfitSlot rows cascade-delete with the
     Outfit, but never the underlying ItemInstance.
     """
+    sheet = outfit.character_sheet
     outfit.delete()
+    sheet.saved_outfits.invalidate()
 
 
 @transaction.atomic
@@ -193,12 +197,15 @@ def add_outfit_slot(
         body_region=body_region,
         equipment_layer=equipment_layer,
     ).delete()
-    return OutfitSlot.objects.create(
+    slot = OutfitSlot.objects.create(
         outfit=outfit,
         item_instance=item_instance,
         body_region=body_region,
         equipment_layer=equipment_layer,
     )
+    with contextlib.suppress(AttributeError):
+        del outfit.cached_outfit_slots
+    return slot
 
 
 @transaction.atomic
@@ -214,3 +221,5 @@ def remove_outfit_slot(
         body_region=body_region,
         equipment_layer=equipment_layer,
     ).delete()
+    with contextlib.suppress(AttributeError):
+        del outfit.cached_outfit_slots

--- a/src/flows/service_functions/outfits.py
+++ b/src/flows/service_functions/outfits.py
@@ -7,7 +7,6 @@ live alongside but are called from the REST layer for player bookkeeping.
 
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING
 
 from django.db import transaction
@@ -203,8 +202,7 @@ def add_outfit_slot(
         body_region=body_region,
         equipment_layer=equipment_layer,
     )
-    with contextlib.suppress(AttributeError):
-        del outfit.cached_outfit_slots
+    _invalidate_outfit_slot_caches(outfit)
     return slot
 
 
@@ -221,5 +219,19 @@ def remove_outfit_slot(
         body_region=body_region,
         equipment_layer=equipment_layer,
     ).delete()
-    with contextlib.suppress(AttributeError):
+    _invalidate_outfit_slot_caches(outfit)
+
+
+def _invalidate_outfit_slot_caches(outfit: Outfit) -> None:
+    """Invalidate the per-outfit slot cache AND the parent sheet's outfits cache.
+
+    The per-outfit ``cached_outfit_slots`` lives in ``outfit.__dict__``. The
+    parent ``CharacterSheetOutfitsHandler`` caches a list of Outfit instances
+    that were loaded with their slots prefetched — those instances may be
+    different Python objects than ``outfit`` here (SharedMemoryModel identity
+    is path-dependent on FK access patterns), so we also invalidate the
+    sheet-level handler to be safe.
+    """
+    if hasattr(outfit, "cached_outfit_slots"):
         del outfit.cached_outfit_slots
+    outfit.character_sheet.saved_outfits.invalidate()

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -156,6 +156,13 @@ class Character(ObjectParent, DefaultCharacter):
         return CharacterEquipmentHandler(self)
 
     @cached_property
+    def carried_items(self):
+        """Cached handler for items located on this character (inventory)."""
+        from world.items.handlers import CharacterCarriedItemsHandler
+
+        return CharacterCarriedItemsHandler(self)
+
+    @cached_property
     def covenant_roles(self):
         """Cached handler for this character's covenant role assignments (Spec D §3.3)."""
         from world.covenants.handlers import CharacterCovenantRoleHandler

--- a/src/world/character_sheets/models.py
+++ b/src/world/character_sheets/models.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from world.achievements.models import Achievement
     from world.classes.models import CharacterClassLevel
     from world.conditions.models import ConditionTemplate
+    from world.items.handlers import CharacterSheetOutfitsHandler
     from world.magic.models.affinity import Resonance
     from world.scenes.models import Persona
 
@@ -502,6 +503,18 @@ class CharacterSheet(SharedMemoryModel):
         if instance is None or instance.current_stage is None:
             return 0
         return instance.current_stage.stage_order
+
+    @cached_property
+    def saved_outfits(self) -> CharacterSheetOutfitsHandler:
+        """Cached handler for this sheet's saved outfit definitions.
+
+        Named ``saved_outfits`` rather than ``outfits`` because Django's
+        reverse RelatedManager from ``Outfit.character_sheet`` already
+        occupies the ``outfits`` attribute on this class.
+        """
+        from world.items.handlers import CharacterSheetOutfitsHandler  # noqa: PLC0415
+
+        return CharacterSheetOutfitsHandler(self)
 
     @cached_property
     def is_protagonism_locked(self) -> bool:

--- a/src/world/items/handlers.py
+++ b/src/world/items/handlers.py
@@ -13,7 +13,8 @@ from django.db.models import Prefetch
 from evennia.objects.models import ObjectDB
 
 if TYPE_CHECKING:
-    from world.items.models import EquippedItem, ItemFacet
+    from world.character_sheets.models import CharacterSheet
+    from world.items.models import EquippedItem, ItemFacet, ItemInstance, Outfit
     from world.magic.models import Facet
 
 
@@ -74,6 +75,133 @@ class CharacterEquipmentHandler:
             for item_facet in equipped.item_instance.cached_item_facets
             if item_facet.facet_id == facet.pk
         ]
+
+    def invalidate(self) -> None:
+        self._cached = None
+
+
+class CharacterCarriedItemsHandler:
+    """Cached handler for items located on (carried by) a character.
+
+    "Carried" = ``ItemInstance`` rows whose ``game_object.location`` is
+    the character — i.e., the character's inventory contents, including
+    equipped items (an equipped item's game_object is also located on
+    the wearer).
+
+    Mutators (pick up / drop / give / transfer) must call
+    ``character.carried_items.invalidate()`` so the next read re-fetches.
+    """
+
+    def __init__(self, character: ObjectDB) -> None:
+        self._character = character
+        self._cached: list[ItemInstance] | None = None
+
+    @property
+    def _items(self) -> list[ItemInstance]:
+        if self._cached is None:
+            from world.items.models import ItemFacet, ItemInstance  # noqa: PLC0415
+
+            qs = (
+                ItemInstance.objects.filter(game_object__db_location=self._character)
+                .select_related(
+                    "template",
+                    "quality_tier",
+                    "game_object",
+                    "image",
+                    "template__image",
+                )
+                .prefetch_related(
+                    Prefetch(
+                        "item_facets",
+                        queryset=ItemFacet.objects.select_related(
+                            "facet",
+                            "attachment_quality_tier",
+                        ),
+                        to_attr="cached_item_facets",
+                    ),
+                )
+            )
+            self._cached = list(qs)
+        return self._cached
+
+    def __iter__(self) -> Iterator[ItemInstance]:
+        return iter(self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def all(self) -> list[ItemInstance]:
+        """Return a fresh list of cached items (safe to mutate)."""
+        return list(self._items)
+
+    def get(self, pk: int) -> ItemInstance | None:
+        """Return the carried item with this pk, or None."""
+        for item in self._items:
+            if item.pk == pk:
+                return item
+        return None
+
+    def invalidate(self) -> None:
+        self._cached = None
+
+
+class CharacterSheetOutfitsHandler:
+    """Cached handler for a character_sheet's saved outfits.
+
+    Walks ``CharacterSheet.outfits`` reverse relation once and caches
+    the list with each outfit's slots prefetched. Mutators
+    (save_outfit / delete_outfit / outfit slot edits) must call
+    ``sheet.outfits.invalidate()``.
+    """
+
+    def __init__(self, sheet: CharacterSheet) -> None:
+        self._sheet = sheet
+        self._cached: list[Outfit] | None = None
+
+    @property
+    def _outfits(self) -> list[Outfit]:
+        if self._cached is None:
+            from world.items.models import Outfit, OutfitSlot  # noqa: PLC0415
+
+            qs = (
+                Outfit.objects.filter(character_sheet=self._sheet)
+                .select_related(
+                    "character_sheet",
+                    "wardrobe",
+                    "wardrobe__template",
+                )
+                .prefetch_related(
+                    Prefetch(
+                        "slots",
+                        queryset=OutfitSlot.objects.select_related(
+                            "item_instance",
+                            "item_instance__template",
+                            "item_instance__quality_tier",
+                        ),
+                        to_attr="cached_outfit_slots",
+                    ),
+                )
+                .order_by("name")
+            )
+            self._cached = list(qs)
+        return self._cached
+
+    def __iter__(self) -> Iterator[Outfit]:
+        return iter(self._outfits)
+
+    def __len__(self) -> int:
+        return len(self._outfits)
+
+    def all(self) -> list[Outfit]:
+        """Return a fresh list of cached outfits (safe to mutate)."""
+        return list(self._outfits)
+
+    def get(self, pk: int) -> Outfit | None:
+        """Return the outfit with this pk, or None."""
+        for outfit in self._outfits:
+            if outfit.pk == pk:
+                return outfit
+        return None
 
     def invalidate(self) -> None:
         self._cached = None

--- a/src/world/items/handlers.py
+++ b/src/world/items/handlers.py
@@ -2,6 +2,29 @@
 
 Spec D §3.3. Single load, in-memory cache, explicit invalidation by
 mutators (equip/unequip/attach_facet/remove_facet_from_item).
+
+Identity-divergence caveat
+--------------------------
+Handler invalidation works by mutating state on a specific Python
+instance: ``handler._cached = None``. The handler is stored on the
+parent (``character.equipped_items`` is a cached_property), so the
+mutation only propagates to readers that walk the same Python instance.
+
+SharedMemoryModel's identity map *usually* returns the same instance
+for the same pk — but the guarantee is path-dependent. ``ObjectDB.objects.get(pk=X)``
+and FK descriptor access (``sheet.character``) go through the identity
+map; ``select_related("character")`` on a queryset bypasses it and
+materializes a fresh instance.
+
+Practical rule: **never invalidate a handler reached through
+``select_related``**. If you fetched a row with
+``EquippedItem.objects.select_related("character").get(...)`` and need
+to invalidate, refetch the character via
+``ObjectDB.objects.get(pk=row.character_id)`` first, or skip
+``select_related("character")`` and let lazy FK access go through the
+identity map.
+
+See ``services/facets.py`` for an existing comment on the same point.
 """
 
 from __future__ import annotations

--- a/src/world/items/tests/test_handlers.py
+++ b/src/world/items/tests/test_handlers.py
@@ -59,3 +59,130 @@ class CharacterEquipmentHandlerTests(TestCase):
         with self.assertNumQueries(0):
             list(self.character.equipped_items.iter_item_facets())
             list(self.character.equipped_items.item_facets_for(self.facet_a))
+
+
+class CharacterCarriedItemsHandlerTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+        from world.items.factories import (
+            ItemInstanceFactory,
+            ItemTemplateFactory,
+            QualityTierFactory,
+        )
+
+        cls.character = CharacterFactory(db_key="CarriedHandlerChar")
+        cls.other_character = CharacterFactory(db_key="OtherCarriedChar")
+        cls.template = ItemTemplateFactory(name="CarriedHandlerTpl")
+        cls.quality = QualityTierFactory(name="CarriedHandlerQ", color_hex="#abcdef")
+
+        def _item_on(owner_obj, key: str):
+            obj = ObjectDBFactory(
+                db_key=key,
+                db_typeclass_path="typeclasses.objects.Object",
+            )
+            obj.location = owner_obj
+            obj.save()
+            return ItemInstanceFactory(
+                template=cls.template,
+                quality_tier=cls.quality,
+                game_object=obj,
+            )
+
+        cls.mine_a = _item_on(cls.character, "MineA")
+        cls.mine_b = _item_on(cls.character, "MineB")
+        cls.theirs = _item_on(cls.other_character, "Theirs")
+
+    def test_returns_only_items_carried_by_character(self) -> None:
+        items = list(self.character.carried_items)
+        pks = {it.pk for it in items}
+        self.assertEqual(pks, {self.mine_a.pk, self.mine_b.pk})
+
+    def test_get_returns_item_by_pk(self) -> None:
+        self.assertEqual(self.character.carried_items.get(self.mine_a.pk), self.mine_a)
+        self.assertIsNone(self.character.carried_items.get(self.theirs.pk))
+
+    def test_invalidate_clears_cache(self) -> None:
+        first = list(self.character.carried_items)
+        self.character.carried_items.invalidate()
+        second = list(self.character.carried_items)
+        self.assertEqual({i.pk for i in first}, {i.pk for i in second})
+
+    def test_no_query_after_first_load(self) -> None:
+        list(self.character.carried_items)  # warm
+        with self.assertNumQueries(0):
+            for item in self.character.carried_items:
+                # Walking the prefetched chain costs no queries.
+                _ = item.template_id
+                _ = item.quality_tier_id
+                list(item.cached_item_facets)
+
+
+class CharacterSheetOutfitsHandlerTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.items.factories import (
+            ItemInstanceFactory,
+            ItemTemplateFactory,
+            OutfitFactory,
+            QualityTierFactory,
+        )
+
+        cls.character = CharacterFactory(db_key="OutfitsHandlerChar")
+        cls.sheet = CharacterSheetFactory(character=cls.character)
+        # Wardrobe item required by Outfit.clean()
+        wardrobe_tpl = ItemTemplateFactory(name="WardrobeTpl", is_wardrobe=True)
+        cls.quality = QualityTierFactory(name="OutfitHandlerQ", color_hex="#123456")
+        wardrobe_obj = ObjectDBFactory(
+            db_key="WardrobeObj",
+            db_typeclass_path="typeclasses.objects.Object",
+        )
+        cls.wardrobe = ItemInstanceFactory(
+            template=wardrobe_tpl,
+            quality_tier=cls.quality,
+            game_object=wardrobe_obj,
+        )
+
+        cls.outfit_a = OutfitFactory(
+            character_sheet=cls.sheet,
+            wardrobe=cls.wardrobe,
+            name="Court",
+        )
+        cls.outfit_b = OutfitFactory(
+            character_sheet=cls.sheet,
+            wardrobe=cls.wardrobe,
+            name="Battle",
+        )
+
+        # Outfit on another sheet — must not appear.
+        other_character = CharacterFactory(db_key="OutfitsOtherChar")
+        cls.other_sheet = CharacterSheetFactory(character=other_character)
+        cls.other_outfit = OutfitFactory(
+            character_sheet=cls.other_sheet,
+            wardrobe=cls.wardrobe,
+            name="Theirs",
+        )
+
+    def test_returns_only_outfits_for_sheet(self) -> None:
+        outfits = list(self.sheet.saved_outfits)
+        pks = {o.pk for o in outfits}
+        self.assertEqual(pks, {self.outfit_a.pk, self.outfit_b.pk})
+
+    def test_get_returns_outfit_by_pk(self) -> None:
+        self.assertEqual(self.sheet.saved_outfits.get(self.outfit_a.pk), self.outfit_a)
+        self.assertIsNone(self.sheet.saved_outfits.get(self.other_outfit.pk))
+
+    def test_invalidate_clears_cache(self) -> None:
+        first = list(self.sheet.saved_outfits)
+        self.sheet.saved_outfits.invalidate()
+        second = list(self.sheet.saved_outfits)
+        self.assertEqual({o.pk for o in first}, {o.pk for o in second})
+
+    def test_no_query_after_first_load(self) -> None:
+        list(self.sheet.saved_outfits)  # warm
+        with self.assertNumQueries(0):
+            for outfit in self.sheet.saved_outfits:
+                _ = outfit.wardrobe_id
+                list(outfit.cached_outfit_slots)

--- a/src/world/items/tests/test_item_instance_views.py
+++ b/src/world/items/tests/test_item_instance_views.py
@@ -119,6 +119,11 @@ class ItemInstanceViewSetTests(TestCase):
     # Auth guard
     # ------------------------------------------------------------------
 
+    def test_list_requires_character_param(self) -> None:
+        """GET without ?character returns 400."""
+        response = self.client.get("/api/items/inventory/")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_list_unauthenticated_returns_401(self) -> None:
         """Unauthenticated requests are rejected."""
         self.client.force_authenticate(user=None)
@@ -187,8 +192,8 @@ class ItemInstanceViewSetTests(TestCase):
     def test_list_excludes_items_on_characters_user_does_not_play(self) -> None:
         """A non-staff user cannot see items located on a character they do not play.
 
-        Even if they pass that character's id as a filter — the queryset scope
-        runs first, the filter is just a refinement.
+        Item-first scoping: passing another character's pk returns 404 —
+        we don't reveal whether the character exists or not.
         """
         # Build a character the request user does NOT play.
         other_character = CharacterFactory(
@@ -196,17 +201,15 @@ class ItemInstanceViewSetTests(TestCase):
             location=self.room,
         )
         CharacterSheetFactory(character=other_character)
-        # No tenure for self.user → scope excludes other_character's items.
-        other_item = self._make_item_at(
+        # No tenure for self.user → scope rejects this request.
+        self._make_item_at(
             location=other_character,
             db_key="InvViewOtherItem",
             quality_tier=self.quality,
         )
 
         response = self.client.get(f"/api/items/inventory/?character={other_character.pk}")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        result_ids = {row["id"] for row in response.data["results"]}
-        self.assertNotIn(other_item.pk, result_ids)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_staff_sees_all_items(self) -> None:
         """Staff users bypass the per-account scope."""

--- a/src/world/items/tests/test_item_view_query_counts.py
+++ b/src/world/items/tests/test_item_view_query_counts.py
@@ -1,0 +1,262 @@
+"""Query-count regression tests for the refactored item endpoints.
+
+Locks in the query budgets after the item-first / cached-handler refactor.
+Each test does one warm-up GET (loads session, fills the identity map,
+warms the relevant cached handler) and then asserts the query count on a
+second identical GET.
+
+If these counts climb, the SharedMemoryModel identity-map discipline has
+been broken somewhere — likely a new ``.filter()`` / ``.get()`` /
+``.values()`` call that should have walked a cached relation instead.
+
+See ``test_visible_worn_query_counts.py`` for the older sibling pattern.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import (
+    AccountFactory,
+    CharacterFactory,
+    ObjectDBFactory,
+)
+from world.character_sheets.factories import CharacterSheetFactory
+from world.items.constants import BodyRegion, EquipmentLayer
+from world.items.factories import (
+    ItemFacetFactory,
+    ItemInstanceFactory,
+    ItemTemplateFactory,
+    OutfitFactory,
+    OutfitSlotFactory,
+    QualityTierFactory,
+    TemplateSlotFactory,
+)
+from world.items.models import EquippedItem, ItemFacet, ItemInstance, Outfit
+from world.magic.factories import FacetFactory
+from world.roster.factories import (
+    PlayerDataFactory,
+    RosterEntryFactory,
+    RosterTenureFactory,
+)
+
+
+class _OwnedCharacterMixin:
+    """Account A plays character A; both live in the same room.
+
+    Use this for any endpoint test that needs an authenticated user who
+    owns a character.
+    """
+
+    def setUp(self) -> None:
+        # Flush identity caches so prior tests don't leak stale handler state
+        # into our assertions.
+        EquippedItem.flush_instance_cache()
+        ItemFacet.flush_instance_cache()
+        ItemInstance.flush_instance_cache()
+        Outfit.flush_instance_cache()
+
+        self.room = ObjectDBFactory(
+            db_key="ItemQCRoom",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        self.account = AccountFactory(username="item_qc_account")
+        self.character = CharacterFactory(db_key="ItemQCChar", location=self.room)
+        self.sheet = CharacterSheetFactory(character=self.character)
+        self.entry = RosterEntryFactory(character_sheet=self.sheet)
+        self.player_data = PlayerDataFactory(account=self.account)
+        self.tenure = RosterTenureFactory(
+            roster_entry=self.entry,
+            player_data=self.player_data,
+            end_date=None,
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.account)
+
+
+class EquippedItemListQueryCountTests(_OwnedCharacterMixin, TestCase):
+    """Lock in ``GET /api/items/equipped-items/?character=N``."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        template = ItemTemplateFactory(name="ItemQCShirt")
+        TemplateSlotFactory(
+            template=template,
+            body_region=BodyRegion.TORSO,
+            equipment_layer=EquipmentLayer.BASE,
+        )
+        item_obj = ObjectDBFactory(
+            db_key="ItemQCShirtObj",
+            db_typeclass_path="typeclasses.objects.Object",
+        )
+        item_obj.location = self.character
+        item_obj.save()
+        instance = ItemInstanceFactory(template=template, game_object=item_obj)
+        EquippedItem.objects.create(
+            character=self.character,
+            item_instance=instance,
+            body_region=BodyRegion.TORSO,
+            equipment_layer=EquipmentLayer.BASE,
+        )
+
+    def test_warm_list_query_count(self) -> None:
+        """After warm-up the endpoint should not re-query the equipment handler."""
+        url = f"/api/items/equipped-items/?character={self.character.pk}"
+        self.client.get(url)  # warm-up
+        # 1 session lookup + 1 roster permission check; handler is warm,
+        # ObjectDB is identity-mapped.
+        with self.assertNumQueries(2):
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class ItemInstanceListQueryCountTests(_OwnedCharacterMixin, TestCase):
+    """Lock in ``GET /api/items/inventory/?character=N``."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        template = ItemTemplateFactory(name="ItemQCInvTpl")
+        for i in range(3):
+            obj = ObjectDBFactory(
+                db_key=f"ItemQCInvObj{i}",
+                db_typeclass_path="typeclasses.objects.Object",
+            )
+            obj.location = self.character
+            obj.save()
+            ItemInstanceFactory(template=template, game_object=obj)
+
+    def test_warm_list_query_count(self) -> None:
+        url = f"/api/items/inventory/?character={self.character.pk}"
+        self.client.get(url)  # warm-up
+        with self.assertNumQueries(2):
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class ItemFacetListQueryCountTests(_OwnedCharacterMixin, TestCase):
+    """Lock in ``GET /api/items/item-facets/?item_instance=N``."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        template = ItemTemplateFactory(name="ItemQCFacetTpl", facet_capacity=3)
+        self.quality = QualityTierFactory(name="ItemQCFacetQ", color_hex="#abcdef")
+        obj = ObjectDBFactory(
+            db_key="ItemQCFacetObj",
+            db_typeclass_path="typeclasses.objects.Object",
+        )
+        obj.location = self.character
+        obj.save()
+        self.instance = ItemInstanceFactory(
+            template=template,
+            game_object=obj,
+            owner=self.account,
+        )
+        for i in range(2):
+            facet = FacetFactory(name=f"ItemQCFacet{i}")
+            ItemFacetFactory(
+                item_instance=self.instance,
+                facet=facet,
+                attachment_quality_tier=self.quality,
+            )
+
+    def test_warm_list_query_count(self) -> None:
+        url = f"/api/items/item-facets/?item_instance={self.instance.pk}"
+        self.client.get(url)  # warm-up
+        # 1 session + 1 ItemInstance fetch (prefetch served from cache after
+        # warm-up via the identity map).
+        with self.assertNumQueries(2):
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class OutfitListQueryCountTests(_OwnedCharacterMixin, TestCase):
+    """Lock in ``GET /api/items/outfits/?character_sheet=N``."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        wardrobe_template = ItemTemplateFactory(
+            name="ItemQCWardrobeTpl",
+            is_wardrobe=True,
+        )
+        wardrobe_obj = ObjectDBFactory(
+            db_key="ItemQCWardrobeObj",
+            db_typeclass_path="typeclasses.objects.Object",
+        )
+        wardrobe_obj.location = self.room
+        wardrobe_obj.save()
+        wardrobe = ItemInstanceFactory(
+            template=wardrobe_template,
+            game_object=wardrobe_obj,
+        )
+        for i in range(2):
+            OutfitFactory(
+                character_sheet=self.sheet,
+                wardrobe=wardrobe,
+                name=f"ItemQCOutfit{i}",
+            )
+
+    def test_warm_list_query_count(self) -> None:
+        url = f"/api/items/outfits/?character_sheet={self.sheet.pk}"
+        self.client.get(url)  # warm-up
+        # 1 session + 1 roster permission check. Sheet is identity-mapped;
+        # saved_outfits handler is warm.
+        with self.assertNumQueries(2):
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class OutfitSlotListQueryCountTests(_OwnedCharacterMixin, TestCase):
+    """Lock in ``GET /api/items/outfit-slots/?outfit=N``."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        wardrobe_template = ItemTemplateFactory(
+            name="ItemQCSlotWardrobeTpl",
+            is_wardrobe=True,
+        )
+        wardrobe_obj = ObjectDBFactory(
+            db_key="ItemQCSlotWardrobeObj",
+            db_typeclass_path="typeclasses.objects.Object",
+        )
+        wardrobe_obj.location = self.room
+        wardrobe_obj.save()
+        wardrobe = ItemInstanceFactory(
+            template=wardrobe_template,
+            game_object=wardrobe_obj,
+        )
+        self.outfit = OutfitFactory(
+            character_sheet=self.sheet,
+            wardrobe=wardrobe,
+            name="ItemQCSlotOutfit",
+        )
+        for region, layer in (
+            (BodyRegion.TORSO, EquipmentLayer.BASE),
+            (BodyRegion.FEET, EquipmentLayer.BASE),
+        ):
+            template = ItemTemplateFactory(name=f"ItemQCSlot_{region}_{layer}")
+            TemplateSlotFactory(
+                template=template,
+                body_region=region,
+                equipment_layer=layer,
+            )
+            obj = ObjectDBFactory(
+                db_key=f"ItemQCSlot_{region}_{layer}_obj",
+                db_typeclass_path="typeclasses.objects.Object",
+            )
+            instance = ItemInstanceFactory(template=template, game_object=obj)
+            OutfitSlotFactory(
+                outfit=self.outfit,
+                item_instance=instance,
+                body_region=region,
+                equipment_layer=layer,
+            )
+
+    def test_warm_list_query_count(self) -> None:
+        url = f"/api/items/outfit-slots/?outfit={self.outfit.pk}"
+        self.client.get(url)  # warm-up
+        # 1 session + 1 Outfit fetch + 1 roster permission check.
+        # Slots prefetch served from cache after warm-up.
+        with self.assertNumQueries(3):
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/src/world/items/tests/test_outfit_views.py
+++ b/src/world/items/tests/test_outfit_views.py
@@ -186,14 +186,8 @@ class OutfitViewSetTests(_OutfitViewSetSetupMixin, TestCase):
         self.assertIn(own_outfit.pk, result_ids)
         self.assertNotIn(other_outfit.pk, result_ids)
 
-    def test_list_scoped_to_user_even_with_other_sheet_filter(self) -> None:
-        """Filtering by ?character_sheet=<other> still returns nothing for non-staff.
-
-        Regression test for the queryset scope: the filter is a refinement on
-        top of the scoped queryset, not an override. A user passing another
-        character's sheet id sees an empty list, not a 403 — the items are
-        simply not in their queryset.
-        """
+    def test_list_other_sheet_returns_404(self) -> None:
+        """Non-staff asking for another user's sheet outfits gets 404 (no leak)."""
         OutfitFactory(
             character_sheet=self.sheet_b,
             wardrobe=self.wardrobe,
@@ -201,8 +195,12 @@ class OutfitViewSetTests(_OutfitViewSetSetupMixin, TestCase):
         )
 
         response = self.client.get(f"/api/items/outfits/?character_sheet={self.sheet_b.pk}")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["results"], [])
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_list_requires_character_sheet_param(self) -> None:
+        """GET without ?character_sheet returns 400."""
+        response = self.client.get("/api/items/outfits/")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_retrieve_other_users_outfit_returns_404(self) -> None:
         """GET detail on another user's outfit is hidden from the queryset (404)."""
@@ -215,14 +213,9 @@ class OutfitViewSetTests(_OutfitViewSetSetupMixin, TestCase):
         response = self.client.get(f"/api/items/outfits/{other_outfit.pk}/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_staff_sees_all_outfits(self) -> None:
-        """Staff users bypass the per-account scope on the outfit list."""
+    def test_staff_can_view_any_sheet_outfits(self) -> None:
+        """Staff users bypass the per-account scope and can read any sheet."""
         staff = AccountFactory(username="outfit_view_staff", is_staff=True)
-        OutfitFactory(
-            character_sheet=self.sheet_a,
-            wardrobe=self.wardrobe,
-            name="StaffSeesAOutfit",
-        )
         OutfitFactory(
             character_sheet=self.sheet_b,
             wardrobe=self.wardrobe,
@@ -230,10 +223,9 @@ class OutfitViewSetTests(_OutfitViewSetSetupMixin, TestCase):
         )
         self.client.force_authenticate(user=staff)
 
-        response = self.client.get("/api/items/outfits/")
+        response = self.client.get(f"/api/items/outfits/?character_sheet={self.sheet_b.pk}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         names = {r["name"] for r in response.data["results"]}
-        self.assertIn("StaffSeesAOutfit", names)
         self.assertIn("StaffSeesBOutfit", names)
 
     def test_retrieve_returns_outfit_with_slots(self) -> None:
@@ -655,41 +647,36 @@ class OutfitSlotViewSetTests(_OutfitViewSetSetupMixin, TestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(self.outfit.slots.count(), 0)
 
-    def test_list_excludes_other_users_outfit_slots(self) -> None:
-        """A non-staff user cannot list slots that belong to another user's outfit."""
+    def test_list_other_users_outfit_returns_404(self) -> None:
+        """Non-staff asking for another user's outfit slots gets 404 (no leak)."""
         other_outfit = OutfitFactory(
             character_sheet=self.sheet_b,
             wardrobe=self.wardrobe,
             name="OtherSlotOwnerLook",
         )
-        # Build a slot on the other user's outfit; we expect it to be hidden.
-        other_slot = OutfitSlotFactory(
+        OutfitSlotFactory(
             outfit=other_outfit,
             item_instance=self.shirt,
             body_region=BodyRegion.TORSO,
             equipment_layer=EquipmentLayer.BASE,
         )
 
-        response = self.client.get("/api/items/outfit-slots/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        result_ids = {row["id"] for row in response.data["results"]}
-        self.assertNotIn(other_slot.pk, result_ids)
+        response = self.client.get(f"/api/items/outfit-slots/?outfit={other_outfit.pk}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_staff_sees_all_outfit_slots(self) -> None:
-        """Staff users bypass the per-account scope on the outfit-slot list."""
-        # Build slots in two outfits (one per sheet).
-        OutfitSlotFactory(
-            outfit=self.outfit,
-            item_instance=self.shirt,
-            body_region=BodyRegion.TORSO,
-            equipment_layer=EquipmentLayer.BASE,
-        )
+    def test_list_requires_outfit_param(self) -> None:
+        """GET without ?outfit returns 400."""
+        response = self.client.get("/api/items/outfit-slots/")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_staff_can_view_any_outfit_slots(self) -> None:
+        """Staff users bypass the per-account scope when reading slots."""
         other_outfit = OutfitFactory(
             character_sheet=self.sheet_b,
             wardrobe=self.wardrobe,
             name="StaffSlotOtherOwnerLook",
         )
-        OutfitSlotFactory(
+        other_slot = OutfitSlotFactory(
             outfit=other_outfit,
             item_instance=self.glove,
             body_region=BodyRegion.LEFT_HAND,
@@ -699,11 +686,7 @@ class OutfitSlotViewSetTests(_OutfitViewSetSetupMixin, TestCase):
         staff = AccountFactory(username="outfit_slot_view_staff", is_staff=True)
         self.client.force_authenticate(user=staff)
 
-        response = self.client.get("/api/items/outfit-slots/")
+        response = self.client.get(f"/api/items/outfit-slots/?outfit={other_outfit.pk}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Expect both this-test's slots represented (staff sees both outfits).
-        # We can't assert exactly two because other tests in this DB run could
-        # have created slots, but we can confirm both names appear.
-        outfit_ids_in_response = {row["outfit"] for row in response.data["results"]}
-        self.assertIn(self.outfit.pk, outfit_ids_in_response)
-        self.assertIn(other_outfit.pk, outfit_ids_in_response)
+        result_ids = {row["id"] for row in response.data["results"]}
+        self.assertIn(other_slot.pk, result_ids)

--- a/src/world/items/tests/test_views.py
+++ b/src/world/items/tests/test_views.py
@@ -159,19 +159,44 @@ class ItemFacetViewTests(ItemViewTestCase):
         super().setUp()
         # Authenticate as the item owner by default.
         self.client.force_authenticate(user=self.owner)
+        # Test pollution guard: prior tests leave stale prefetch caches on the
+        # identity-mapped ItemInstances. Flushing the model's instance cache
+        # forces a fresh instance on the next ``.get(pk=...)`` so the view's
+        # prefetch isn't shadowed by stale state on the test class's instances.
+        from world.items.models import ItemFacet, ItemInstance
+
+        ItemFacet.flush_instance_cache()
+        ItemInstance.flush_instance_cache()
 
     def test_list_returns_facets(self) -> None:
-        """GET list includes an attached ItemFacet."""
+        """GET list includes an attached ItemFacet for an owned item."""
         row = attach_facet_to_item(
             crafter=self.owner,
             item_instance=self.item_owner,
             facet=self.facet_a,
             attachment_quality_tier=self.quality,
         )
-        response = self.client.get("/api/items/item-facets/")
+        response = self.client.get(f"/api/items/item-facets/?item_instance={self.item_owner.pk}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         result_ids = [r["id"] for r in response.data["results"]]
         self.assertIn(row.pk, result_ids)
+
+    def test_list_requires_item_instance_param(self) -> None:
+        """GET without ?item_instance returns 400."""
+        response = self.client.get("/api/items/item-facets/")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_list_non_owner_returns_404(self) -> None:
+        """Non-owner asking for another user's item's facets gets 404 (no leak)."""
+        attach_facet_to_item(
+            crafter=self.non_owner,
+            item_instance=self.item_other,
+            facet=self.facet_a,
+            attachment_quality_tier=self.quality,
+        )
+        # Authenticated as owner — but item_other belongs to non_owner.
+        response = self.client.get(f"/api/items/item-facets/?item_instance={self.item_other.pk}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_filter_by_item_instance(self) -> None:
         """GET ?item_instance=<pk> returns only that item's facets."""
@@ -363,6 +388,22 @@ class EquippedItemViewTests(ItemViewTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.client.force_authenticate(user=self.user)
+        # Test pollution guard: prior tests that bypass unequip_item with
+        # direct ``row.delete()`` leave stale entries in the equipped_items
+        # handler cache. Direct .invalidate() on self.character resets that
+        # character's handler. We also flush EquippedItem instance cache so
+        # any stale (pk=None) instances aren't returned by later filter().
+        from evennia.objects.models import ObjectDB
+
+        from world.items.models import EquippedItem
+
+        EquippedItem.flush_instance_cache()
+        # Invalidate via the same path the view uses (ObjectDB.objects.get)
+        # so handler state matches across test and view code paths.
+        char = ObjectDB.objects.get(pk=self.character.pk)
+        char.equipped_items.invalidate()
+        other = ObjectDB.objects.get(pk=self.other_character.pk)
+        other.equipped_items.invalidate()
 
     # ------------------------------------------------------------------
     # GET list
@@ -377,12 +418,45 @@ class EquippedItemViewTests(ItemViewTestCase):
             body_region=BodyRegion.TORSO,
             equipment_layer=EquipmentLayer.BASE,
         )
-        response = self.client.get("/api/items/equipped-items/")
+        response = self.client.get(f"/api/items/equipped-items/?character={self.character.pk}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         result_ids = [r["id"] for r in response.data["results"]]
         self.assertIn(row.pk, result_ids)
         # Clean up so other tests don't see this row.
         row.delete()
+
+    def test_list_requires_character_param(self) -> None:
+        """GET list without ?character returns 400."""
+        response = self.client.get("/api/items/equipped-items/")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_list_other_user_character_returns_404(self) -> None:
+        """Non-staff cannot list a character they don't play."""
+        response = self.client.get(
+            f"/api/items/equipped-items/?character={self.other_character.pk}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_list_staff_can_view_any_character(self) -> None:
+        """Staff bypass: can list any character's equipped items."""
+        self.user.is_staff = True
+        self.user.save()
+        instance = ItemInstanceFactory(template=self.template)
+        row = equip_item(
+            character_sheet=self.other_sheet,
+            item_instance=instance,
+            body_region=BodyRegion.TORSO,
+            equipment_layer=EquipmentLayer.BASE,
+        )
+        response = self.client.get(
+            f"/api/items/equipped-items/?character={self.other_character.pk}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result_ids = [r["id"] for r in response.data["results"]]
+        self.assertIn(row.pk, result_ids)
+        row.delete()
+        self.user.is_staff = False
+        self.user.save()
 
     def test_filter_by_character(self) -> None:
         """GET ?character=<pk> filters to only that character's equipped items."""

--- a/src/world/items/views.py
+++ b/src/world/items/views.py
@@ -1,5 +1,6 @@
 """API ViewSets for items."""
 
+import contextlib
 from dataclasses import dataclass
 from typing import cast
 
@@ -149,95 +150,255 @@ class ItemTemplateViewSet(viewsets.ReadOnlyModelViewSet):
         return ItemTemplateListSerializer
 
 
-class ItemFacetViewSet(viewsets.ModelViewSet):
-    """ViewSet for ItemFacet attach/list/delete."""
+class ItemFacetViewSet(viewsets.ViewSet):
+    """ViewSet for ItemFacet attach/list/delete.
+
+    Item-first / item-scoped shape:
+
+    - ``item_instance`` query parameter is REQUIRED for list.
+    - List/retrieve return 404 unless the requester owns the item or
+      is staff.
+    - Walks ``item.cached_item_facets`` for list (one prefetch on cold
+      load, zero on warm cache).
+    """
 
     http_method_names = ["get", "post", "delete", "head", "options"]
     permission_classes = [ItemFacetWritePermission]
-    pagination_class = ItemTemplatePagination
     filter_backends = [DjangoFilterBackend]
     filterset_class = ItemFacetFilter
-    queryset = ItemFacet.objects.select_related(
-        "item_instance",
-        "facet",
-        "applied_by_account",
-        "attachment_quality_tier",
-    ).order_by("-applied_at")
 
-    def get_serializer_class(self) -> type[serializers.ModelSerializer]:
-        """Use write serializer for create, read serializer otherwise."""
-        if self.action == "create":
-            return ItemFacetWriteSerializer
-        return ItemFacetReadSerializer
+    def list(self, request: Request) -> Response:
+        """Return ItemFacet rows for ``?item_instance=<pk>``."""
+        user = cast(AccountDB, request.user)
+        # noqa: USE_FILTERSET — required scope param for item-first endpoint
+        instance_pk = _parse_int_param(request.query_params.get("item_instance"))  # noqa: USE_FILTERSET
+        if instance_pk is None:
+            raise serializers.ValidationError(
+                {"item_instance": "This query parameter is required."}
+            )
+        try:
+            item = (
+                ItemInstance.objects.select_related("owner")
+                .prefetch_related(
+                    Prefetch(
+                        "item_facets",
+                        queryset=ItemFacet.objects.select_related(
+                            "facet",
+                            "attachment_quality_tier",
+                            "applied_by_account",
+                        ),
+                        to_attr="cached_item_facets",
+                    ),
+                )
+                .get(pk=instance_pk)
+            )
+        except ItemInstance.DoesNotExist as exc:
+            raise NotFound from exc
 
-    def perform_destroy(self, instance: ItemFacet) -> None:
-        """Remove facet via service so cache invalidation fires."""
-        remove_facet_from_item(item_facet=instance)
+        if not user.is_staff and item.owner_id != user.pk:
+            raise NotFound
+
+        rows = list(item.cached_item_facets)
+        paginator = ItemTemplatePagination()
+        page = paginator.paginate_queryset(rows, request, view=self)  # ty: ignore[invalid-argument-type]
+        serializer = ItemFacetReadSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request: Request, pk: str | None = None) -> Response:
+        """Return a single ItemFacet if the requester owns its item."""
+        user = cast(AccountDB, request.user)
+        row_pk = _parse_int_param(pk)
+        if row_pk is None:
+            raise NotFound
+        try:
+            row = ItemFacet.objects.select_related(
+                "item_instance",
+                "item_instance__owner",
+                "facet",
+                "attachment_quality_tier",
+                "applied_by_account",
+            ).get(pk=row_pk)
+        except ItemFacet.DoesNotExist as exc:
+            raise NotFound from exc
+
+        if not user.is_staff and row.item_instance.owner_id != user.pk:
+            raise NotFound
+
+        serializer = ItemFacetReadSerializer(row)
+        return Response(serializer.data)
+
+    def create(self, request: Request) -> Response:
+        """Attach a facet via the serializer (which calls the service)."""
+        serializer = ItemFacetWriteSerializer(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        row = serializer.save()
+        read = ItemFacetReadSerializer(row)
+        return Response(read.data, status=201)
+
+    def destroy(self, request: Request, pk: str | None = None) -> Response:
+        """Remove the facet via the service (which fires cache invalidation)."""
+        row_pk = _parse_int_param(pk)
+        if row_pk is None:
+            raise NotFound
+        try:
+            row = ItemFacet.objects.select_related("item_instance").get(pk=row_pk)
+        except ItemFacet.DoesNotExist as exc:
+            raise NotFound from exc
+        # Run object-level permission so non-owners are rejected with 403.
+        self.check_object_permissions(request, row)
+        remove_facet_from_item(item_facet=row)
+        return Response(status=204)
 
 
-class ItemInstanceViewSet(viewsets.ReadOnlyModelViewSet):
+class ItemInstanceViewSet(viewsets.ViewSet):
     """Read-only listing of ItemInstance rows for a character's inventory.
 
-    The wardrobe page uses this to render carried-but-not-worn items. The
-    ``character`` query parameter filters to items whose ``game_object.location``
-    is the requested character (i.e., currently held by them).
+    Item-first / character-scoped shape:
 
-    Permission scoping (non-staff): only items located on a character the
-    request user currently plays are returned. Staff see everything.
+    - ``character`` query parameter is REQUIRED.
+    - Non-staff users can only inspect inventory of characters they
+      currently play (active roster tenure).
+    - Walks ``character.carried_items`` cached handler — no DB query
+      when warm.
+
+    The wardrobe page uses this to render carried-but-not-worn items;
+    the frontend filters out equipped items locally.
     """
 
     permission_classes = [IsAuthenticated]
-    serializer_class = ItemInstanceReadSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_class = ItemInstanceFilter
-    pagination_class = ItemTemplatePagination
-    queryset = (
-        ItemInstance.objects.select_related(
-            "template",
-            "quality_tier",
-            "game_object",
-            "image",
-            "template__image",
-        )
-        .prefetch_related(
-            Prefetch(
-                "item_facets",
-                queryset=ItemFacet.objects.select_related("facet", "attachment_quality_tier"),
-                to_attr="cached_item_facets",
-            ),
-        )
-        .order_by("-pk")
-    )
 
-    def get_queryset(self) -> QuerySet[ItemInstance]:
-        """Scope to items located on characters the request user plays."""
-        qs = super().get_queryset()
-        if self.request.user.is_staff:
-            return qs
-        character_ids = RosterEntry.objects.for_account(
-            cast(AccountDB, self.request.user)
-        ).values_list("character_sheet_id", flat=True)
-        return qs.filter(game_object__db_location__id__in=character_ids)
+    def list(self, request: Request) -> Response:
+        """Return ItemInstance rows located on ``?character=<pk>``."""
+        user = cast(AccountDB, request.user)
+        # noqa: USE_FILTERSET — required scope param for item-first endpoint
+        character_pk = _parse_int_param(request.query_params.get("character"))  # noqa: USE_FILTERSET
+        if character_pk is None:
+            raise serializers.ValidationError({"character": "This query parameter is required."})
+        try:
+            character = ObjectDB.objects.get(pk=character_pk)
+        except ObjectDB.DoesNotExist as exc:
+            raise NotFound from exc
+
+        if not user.is_staff and not _user_owns_character(user, character):
+            raise NotFound
+
+        rows = list(character.carried_items)
+        paginator = ItemTemplatePagination()
+        page = paginator.paginate_queryset(rows, request, view=self)  # ty: ignore[invalid-argument-type]
+        serializer = ItemInstanceReadSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request: Request, pk: str | None = None) -> Response:
+        """Return a single ItemInstance if the requester may view it."""
+        user = cast(AccountDB, request.user)
+        item_pk = _parse_int_param(pk)
+        if item_pk is None:
+            raise NotFound
+        try:
+            item = (
+                ItemInstance.objects.select_related(
+                    "template",
+                    "quality_tier",
+                    "game_object",
+                    "image",
+                    "template__image",
+                )
+                .prefetch_related(
+                    Prefetch(
+                        "item_facets",
+                        queryset=ItemFacet.objects.select_related(
+                            "facet",
+                            "attachment_quality_tier",
+                        ),
+                        to_attr="cached_item_facets",
+                    ),
+                )
+                .get(pk=item_pk)
+            )
+        except ItemInstance.DoesNotExist as exc:
+            raise NotFound from exc
+
+        if not user.is_staff:
+            holder = item.game_object.db_location
+            if holder is None or not _user_owns_character(user, holder):
+                raise NotFound
+
+        serializer = ItemInstanceReadSerializer(item)
+        return Response(serializer.data)
 
 
-class EquippedItemViewSet(viewsets.ReadOnlyModelViewSet):
+def _user_owns_character(user: AccountDB, character: ObjectDB) -> bool:
+    """True if ``user`` currently plays the character at ``character.pk``.
+
+    Uses ``RosterEntry.objects.for_account`` — the canonical helper. The
+    character_sheet pk equals the character ObjectDB pk by construction.
+    """
+    return RosterEntry.objects.for_account(user).filter(character_sheet_id=character.pk).exists()
+
+
+class EquippedItemViewSet(viewsets.ViewSet):
     """Read-only ViewSet for EquippedItem (GET list/detail).
+
+    Item-first / character-scoped shape:
+
+    - ``character`` query parameter is REQUIRED for list.
+    - Non-staff users can only see equipped items for characters they
+      currently play (active roster tenure).
+    - Walks ``character.equipped_items`` cached handler — no DB query
+      when warm.
 
     Mutations (equip/unequip) flow through the unified action dispatcher
     via the ``execute_action`` websocket inputfunc — REST stays read-only.
     """
 
-    serializer_class = EquippedItemReadSerializer
     permission_classes = [IsAuthenticated]
-    pagination_class = ItemTemplatePagination
     filter_backends = [DjangoFilterBackend]
     filterset_class = EquippedItemFilter
-    queryset = EquippedItem.objects.select_related(
-        "item_instance",
-        "item_instance__template",
-        "character",
-        "character__sheet_data",
-    ).order_by("-pk")
+
+    def list(self, request: Request) -> Response:
+        """Return equipped items for ``?character=<pk>``."""
+        user = cast(AccountDB, request.user)
+        # noqa: USE_FILTERSET — required scope param for item-first endpoint
+        character_pk = _parse_int_param(request.query_params.get("character"))  # noqa: USE_FILTERSET
+        if character_pk is None:
+            raise serializers.ValidationError({"character": "This query parameter is required."})
+        try:
+            character = ObjectDB.objects.get(pk=character_pk)
+        except ObjectDB.DoesNotExist as exc:
+            raise NotFound from exc
+
+        if not user.is_staff and not _user_owns_character(user, character):
+            raise NotFound  # don't leak existence
+
+        rows = list(character.equipped_items)
+        paginator = ItemTemplatePagination()
+        page = paginator.paginate_queryset(rows, request, view=self)  # ty: ignore[invalid-argument-type]
+        serializer = EquippedItemReadSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request: Request, pk: str | None = None) -> Response:
+        """Return a single EquippedItem if the requester may view it."""
+        user = cast(AccountDB, request.user)
+        row_pk = _parse_int_param(pk)
+        if row_pk is None:
+            raise NotFound
+        try:
+            row = EquippedItem.objects.select_related(
+                "item_instance",
+                "item_instance__template",
+                "character",
+                "character__sheet_data",
+            ).get(pk=row_pk)
+        except EquippedItem.DoesNotExist as exc:
+            raise NotFound from exc
+
+        if not user.is_staff and not _user_owns_character(user, row.character):
+            raise NotFound
+
+        serializer = EquippedItemReadSerializer(row)
+        return Response(serializer.data)
 
 
 class OutfitWritePermission(PlayerOrStaffPermission):
@@ -289,103 +450,238 @@ class OutfitSlotWritePermission(PlayerOrStaffPermission):
         return _account_currently_plays(cast(AccountDB, request.user), obj.outfit.character_sheet)
 
 
-class OutfitViewSet(viewsets.ModelViewSet):
+class OutfitViewSet(viewsets.ViewSet):
     """ViewSet for Outfit definitions (save / list / rename / delete).
 
-    Save delegates to ``save_outfit`` (snapshots current loadout). PATCH
-    updates the Outfit row directly. DELETE delegates to ``delete_outfit``.
-    Per design, equip/unequip and apply/undress flow through the action
-    dispatcher — this ViewSet only handles configuration CRUD.
+    Item-first / sheet-scoped shape:
+
+    - ``character_sheet`` query parameter is REQUIRED for list.
+    - List walks ``sheet.saved_outfits`` cached handler.
+    - Write actions delegate to existing serializers + services,
+      gated by OutfitWritePermission.
     """
 
     permission_classes = [OutfitWritePermission]
-    pagination_class = ItemTemplatePagination
     filter_backends = [DjangoFilterBackend]
     filterset_class = OutfitFilter
-    queryset = (
-        Outfit.objects.select_related(
-            "character_sheet",
-            "wardrobe",
-            "wardrobe__template",
+
+    def list(self, request: Request) -> Response:
+        """Return outfits saved on ``?character_sheet=<pk>``."""
+        user = cast(AccountDB, request.user)
+        # noqa: USE_FILTERSET — required scope param for item-first endpoint
+        sheet_pk = _parse_int_param(request.query_params.get("character_sheet"))  # noqa: USE_FILTERSET
+        if sheet_pk is None:
+            raise serializers.ValidationError(
+                {"character_sheet": "This query parameter is required."}
+            )
+        try:
+            sheet = CharacterSheet.objects.get(pk=sheet_pk)
+        except CharacterSheet.DoesNotExist as exc:
+            raise NotFound from exc
+
+        if not user.is_staff and not _account_currently_plays(user, sheet):
+            raise NotFound
+
+        rows = list(sheet.saved_outfits)
+        paginator = ItemTemplatePagination()
+        page = paginator.paginate_queryset(rows, request, view=self)  # ty: ignore[invalid-argument-type]
+        serializer = OutfitReadSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request: Request, pk: str | None = None) -> Response:
+        """Return a single Outfit if the requester may view it."""
+        user = cast(AccountDB, request.user)
+        outfit_pk = _parse_int_param(pk)
+        if outfit_pk is None:
+            raise NotFound
+        try:
+            outfit = (
+                Outfit.objects.select_related(
+                    "character_sheet",
+                    "wardrobe",
+                    "wardrobe__template",
+                )
+                .prefetch_related(
+                    Prefetch(
+                        "slots",
+                        queryset=OutfitSlot.objects.select_related(
+                            "item_instance",
+                            "item_instance__template",
+                            "item_instance__quality_tier",
+                        ),
+                        to_attr="cached_outfit_slots",
+                    ),
+                )
+                .get(pk=outfit_pk)
+            )
+        except Outfit.DoesNotExist as exc:
+            raise NotFound from exc
+
+        if not user.is_staff and not _account_currently_plays(user, outfit.character_sheet):
+            raise NotFound
+
+        serializer = OutfitReadSerializer(outfit)
+        return Response(serializer.data)
+
+    def create(self, request: Request) -> Response:
+        """Create an Outfit via the existing write serializer (calls save_outfit)."""
+        serializer = OutfitWriteSerializer(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        outfit = serializer.save()
+        read = OutfitReadSerializer(outfit)
+        return Response(read.data, status=201)
+
+    def update(self, request: Request, pk: str | None = None) -> Response:
+        """Full update (PUT) — rename/edit outfit row directly."""
+        return self._update(request, pk, partial=False)
+
+    def partial_update(self, request: Request, pk: str | None = None) -> Response:
+        """Partial update (PATCH)."""
+        return self._update(request, pk, partial=True)
+
+    def _update(self, request: Request, pk: str | None, *, partial: bool) -> Response:
+        outfit_pk = _parse_int_param(pk)
+        if outfit_pk is None:
+            raise NotFound
+        try:
+            outfit = Outfit.objects.select_related("character_sheet").get(pk=outfit_pk)
+        except Outfit.DoesNotExist as exc:
+            raise NotFound from exc
+        self.check_object_permissions(request, outfit)
+        serializer = OutfitWriteSerializer(
+            outfit,
+            data=request.data,
+            partial=partial,
+            context={"request": request},
         )
-        .prefetch_related(
-            Prefetch(
-                "slots",
-                queryset=OutfitSlot.objects.select_related(
-                    "item_instance",
-                    "item_instance__template",
-                    "item_instance__quality_tier",
-                ),
-                to_attr="cached_outfit_slots",
-            ),
-        )
-        .order_by("name")
-    )
+        serializer.is_valid(raise_exception=True)
+        outfit = serializer.save()
+        # Invalidate the sheet's outfits handler so the rename shows next read.
+        outfit.character_sheet.saved_outfits.invalidate()
+        read = OutfitReadSerializer(outfit)
+        return Response(read.data)
 
-    def get_queryset(self) -> QuerySet[Outfit]:
-        """Scope to outfits owned by characters the request user plays."""
-        qs = super().get_queryset()
-        if self.request.user.is_staff:
-            return qs
-        sheet_ids = RosterEntry.objects.for_account(cast(AccountDB, self.request.user)).values_list(
-            "character_sheet_id", flat=True
-        )
-        return qs.filter(character_sheet_id__in=sheet_ids)
-
-    def get_serializer_class(self) -> type[serializers.ModelSerializer]:
-        """Use write serializer for create/update; read serializer otherwise."""
-        if self.action in ("create", "update", "partial_update"):
-            return OutfitWriteSerializer
-        return OutfitReadSerializer
-
-    def perform_destroy(self, instance: Outfit) -> None:
-        """Delegate destruction to the delete_outfit service."""
-        delete_outfit(instance)
+    def destroy(self, request: Request, pk: str | None = None) -> Response:
+        """Delete via the delete_outfit service (cascades slots)."""
+        outfit_pk = _parse_int_param(pk)
+        if outfit_pk is None:
+            raise NotFound
+        try:
+            outfit = Outfit.objects.select_related("character_sheet").get(pk=outfit_pk)
+        except Outfit.DoesNotExist as exc:
+            raise NotFound from exc
+        self.check_object_permissions(request, outfit)
+        sheet = outfit.character_sheet
+        delete_outfit(outfit)
+        sheet.saved_outfits.invalidate()
+        return Response(status=204)
 
 
-class OutfitSlotViewSet(viewsets.ModelViewSet):
+class OutfitSlotViewSet(viewsets.ViewSet):
     """ViewSet for OutfitSlot create/list/delete.
 
-    Flat per-slot endpoint (matches ``EquippedItemViewSet`` shape — one
-    POST adds or replaces a single slot, one DELETE removes one slot).
+    Item-first / outfit-scoped shape:
+
+    - ``outfit`` query parameter is REQUIRED for list.
+    - List walks ``outfit.cached_outfit_slots`` (prefetch target).
+    - Write actions delegate to existing serializers + services.
     """
 
     http_method_names = ["get", "post", "delete", "head", "options"]
     permission_classes = [OutfitSlotWritePermission]
-    pagination_class = ItemTemplatePagination
     filter_backends = [DjangoFilterBackend]
     filterset_class = OutfitSlotFilter
-    queryset = OutfitSlot.objects.select_related(
-        "outfit",
-        "outfit__character_sheet",
-        "item_instance",
-        "item_instance__template",
-        "item_instance__quality_tier",
-    ).order_by("body_region", "equipment_layer")
 
-    def get_queryset(self) -> QuerySet[OutfitSlot]:
-        """Scope to slots whose outfit belongs to a character the user plays."""
-        qs = super().get_queryset()
-        if self.request.user.is_staff:
-            return qs
-        sheet_ids = RosterEntry.objects.for_account(cast(AccountDB, self.request.user)).values_list(
-            "character_sheet_id", flat=True
-        )
-        return qs.filter(outfit__character_sheet_id__in=sheet_ids)
+    def list(self, request: Request) -> Response:
+        """Return OutfitSlot rows for ``?outfit=<pk>``."""
+        user = cast(AccountDB, request.user)
+        # noqa: USE_FILTERSET — required scope param for item-first endpoint
+        outfit_pk = _parse_int_param(request.query_params.get("outfit"))  # noqa: USE_FILTERSET
+        if outfit_pk is None:
+            raise serializers.ValidationError({"outfit": "This query parameter is required."})
+        try:
+            outfit = (
+                Outfit.objects.select_related("character_sheet")
+                .prefetch_related(
+                    Prefetch(
+                        "slots",
+                        queryset=OutfitSlot.objects.select_related(
+                            "item_instance",
+                            "item_instance__template",
+                            "item_instance__quality_tier",
+                        ),
+                        to_attr="cached_outfit_slots",
+                    ),
+                )
+                .get(pk=outfit_pk)
+            )
+        except Outfit.DoesNotExist as exc:
+            raise NotFound from exc
 
-    def get_serializer_class(self) -> type[serializers.ModelSerializer]:
-        """Use write serializer for create; read serializer otherwise."""
-        if self.action == "create":
-            return OutfitSlotWriteSerializer
-        return OutfitSlotReadSerializer
+        if not user.is_staff and not _account_currently_plays(user, outfit.character_sheet):
+            raise NotFound
 
-    def perform_destroy(self, instance: OutfitSlot) -> None:
-        """Delegate destruction to remove_outfit_slot (idempotent)."""
+        rows = list(outfit.cached_outfit_slots)
+        paginator = ItemTemplatePagination()
+        page = paginator.paginate_queryset(rows, request, view=self)  # ty: ignore[invalid-argument-type]
+        serializer = OutfitSlotReadSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request: Request, pk: str | None = None) -> Response:
+        """Return a single OutfitSlot if the requester may view it."""
+        user = cast(AccountDB, request.user)
+        slot_pk = _parse_int_param(pk)
+        if slot_pk is None:
+            raise NotFound
+        try:
+            slot = OutfitSlot.objects.select_related(
+                "outfit",
+                "outfit__character_sheet",
+                "item_instance",
+                "item_instance__template",
+                "item_instance__quality_tier",
+            ).get(pk=slot_pk)
+        except OutfitSlot.DoesNotExist as exc:
+            raise NotFound from exc
+
+        if not user.is_staff and not _account_currently_plays(user, slot.outfit.character_sheet):
+            raise NotFound
+
+        serializer = OutfitSlotReadSerializer(slot)
+        return Response(serializer.data)
+
+    def create(self, request: Request) -> Response:
+        """Create an OutfitSlot via the existing write serializer."""
+        serializer = OutfitSlotWriteSerializer(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        slot = serializer.save()
+        # Invalidate the outfit's slots cache so future reads see the new row.
+        with contextlib.suppress(AttributeError):
+            del slot.outfit.cached_outfit_slots
+        read = OutfitSlotReadSerializer(slot)
+        return Response(read.data, status=201)
+
+    def destroy(self, request: Request, pk: str | None = None) -> Response:
+        """Delete via remove_outfit_slot (idempotent)."""
+        slot_pk = _parse_int_param(pk)
+        if slot_pk is None:
+            raise NotFound
+        try:
+            slot = OutfitSlot.objects.select_related("outfit", "outfit__character_sheet").get(
+                pk=slot_pk
+            )
+        except OutfitSlot.DoesNotExist as exc:
+            raise NotFound from exc
+        self.check_object_permissions(request, slot)
+        outfit = slot.outfit
         remove_outfit_slot(
-            outfit=instance.outfit,
-            body_region=instance.body_region,
-            equipment_layer=instance.equipment_layer,
+            outfit=outfit,
+            body_region=slot.body_region,
+            equipment_layer=slot.equipment_layer,
         )
+        with contextlib.suppress(AttributeError):
+            del outfit.cached_outfit_slots
+        return Response(status=204)
 
 
 def _parse_int_param(value: object) -> int | None:

--- a/src/world/items/views.py
+++ b/src/world/items/views.py
@@ -1,6 +1,5 @@
 """API ViewSets for items."""
 
-import contextlib
 from dataclasses import dataclass
 from typing import cast
 
@@ -62,9 +61,15 @@ from world.items.services.facets import remove_facet_from_item
 from world.roster.models import RosterEntry
 
 
-def _account_currently_plays(user: AccountDB, sheet: CharacterSheet) -> bool:
-    """True if ``user`` has an active roster tenure on ``sheet``."""
-    return RosterEntry.objects.for_account(user).filter(character_sheet=sheet).exists()
+def _user_plays_pk(user: AccountDB, pk: int) -> bool:
+    """True if ``user`` has an active roster tenure on the character_sheet at ``pk``.
+
+    Character pk equals CharacterSheet pk by construction
+    (``CharacterSheet.character = OneToOneField(primary_key=True)``), so this
+    helper covers both "does the user play this Character?" and "does the
+    user play this CharacterSheet?" without needing two helpers.
+    """
+    return RosterEntry.objects.for_account(user).filter(character_sheet_id=pk).exists()
 
 
 class ItemFacetWritePermission(PlayerOrStaffPermission):
@@ -281,7 +286,7 @@ class ItemInstanceViewSet(viewsets.ViewSet):
         except ObjectDB.DoesNotExist as exc:
             raise NotFound from exc
 
-        if not user.is_staff and not _user_owns_character(user, character):
+        if not user.is_staff and not _user_plays_pk(user, character.pk):
             raise NotFound
 
         rows = list(character.carried_items)
@@ -322,20 +327,11 @@ class ItemInstanceViewSet(viewsets.ViewSet):
 
         if not user.is_staff:
             holder = item.game_object.db_location
-            if holder is None or not _user_owns_character(user, holder):
+            if holder is None or not _user_plays_pk(user, holder.pk):
                 raise NotFound
 
         serializer = ItemInstanceReadSerializer(item)
         return Response(serializer.data)
-
-
-def _user_owns_character(user: AccountDB, character: ObjectDB) -> bool:
-    """True if ``user`` currently plays the character at ``character.pk``.
-
-    Uses ``RosterEntry.objects.for_account`` — the canonical helper. The
-    character_sheet pk equals the character ObjectDB pk by construction.
-    """
-    return RosterEntry.objects.for_account(user).filter(character_sheet_id=character.pk).exists()
 
 
 class EquippedItemViewSet(viewsets.ViewSet):
@@ -369,7 +365,7 @@ class EquippedItemViewSet(viewsets.ViewSet):
         except ObjectDB.DoesNotExist as exc:
             raise NotFound from exc
 
-        if not user.is_staff and not _user_owns_character(user, character):
+        if not user.is_staff and not _user_plays_pk(user, character.pk):
             raise NotFound  # don't leak existence
 
         rows = list(character.equipped_items)
@@ -394,7 +390,7 @@ class EquippedItemViewSet(viewsets.ViewSet):
         except EquippedItem.DoesNotExist as exc:
             raise NotFound from exc
 
-        if not user.is_staff and not _user_owns_character(user, row.character):
+        if not user.is_staff and not _user_plays_pk(user, row.character.pk):
             raise NotFound
 
         serializer = EquippedItemReadSerializer(row)
@@ -421,12 +417,12 @@ class OutfitWritePermission(PlayerOrStaffPermission):
             sheet = CharacterSheet.objects.get(pk=sheet_pk)
         except (CharacterSheet.DoesNotExist, ValueError, TypeError):
             return True
-        return _account_currently_plays(cast(AccountDB, request.user), sheet)
+        return _user_plays_pk(cast(AccountDB, request.user), sheet.pk)
 
     def has_object_permission_for_player(
         self, request: Request, view: APIView, obj: Outfit
     ) -> bool:
-        return _account_currently_plays(cast(AccountDB, request.user), obj.character_sheet)
+        return _user_plays_pk(cast(AccountDB, request.user), obj.character_sheet_id)
 
 
 class OutfitSlotWritePermission(PlayerOrStaffPermission):
@@ -442,12 +438,12 @@ class OutfitSlotWritePermission(PlayerOrStaffPermission):
             outfit = Outfit.objects.select_related("character_sheet").get(pk=outfit_pk)
         except (Outfit.DoesNotExist, ValueError, TypeError):
             return True
-        return _account_currently_plays(cast(AccountDB, request.user), outfit.character_sheet)
+        return _user_plays_pk(cast(AccountDB, request.user), outfit.character_sheet_id)
 
     def has_object_permission_for_player(
         self, request: Request, view: APIView, obj: OutfitSlot
     ) -> bool:
-        return _account_currently_plays(cast(AccountDB, request.user), obj.outfit.character_sheet)
+        return _user_plays_pk(cast(AccountDB, request.user), obj.outfit.character_sheet_id)
 
 
 class OutfitViewSet(viewsets.ViewSet):
@@ -479,7 +475,7 @@ class OutfitViewSet(viewsets.ViewSet):
         except CharacterSheet.DoesNotExist as exc:
             raise NotFound from exc
 
-        if not user.is_staff and not _account_currently_plays(user, sheet):
+        if not user.is_staff and not _user_plays_pk(user, sheet.pk):
             raise NotFound
 
         rows = list(sheet.saved_outfits)
@@ -517,7 +513,7 @@ class OutfitViewSet(viewsets.ViewSet):
         except Outfit.DoesNotExist as exc:
             raise NotFound from exc
 
-        if not user.is_staff and not _account_currently_plays(user, outfit.character_sheet):
+        if not user.is_staff and not _user_plays_pk(user, outfit.character_sheet_id):
             raise NotFound
 
         serializer = OutfitReadSerializer(outfit)
@@ -618,7 +614,7 @@ class OutfitSlotViewSet(viewsets.ViewSet):
         except Outfit.DoesNotExist as exc:
             raise NotFound from exc
 
-        if not user.is_staff and not _account_currently_plays(user, outfit.character_sheet):
+        if not user.is_staff and not _user_plays_pk(user, outfit.character_sheet_id):
             raise NotFound
 
         rows = list(outfit.cached_outfit_slots)
@@ -644,25 +640,29 @@ class OutfitSlotViewSet(viewsets.ViewSet):
         except OutfitSlot.DoesNotExist as exc:
             raise NotFound from exc
 
-        if not user.is_staff and not _account_currently_plays(user, slot.outfit.character_sheet):
+        if not user.is_staff and not _user_plays_pk(user, slot.outfit.character_sheet_id):
             raise NotFound
 
         serializer = OutfitSlotReadSerializer(slot)
         return Response(serializer.data)
 
     def create(self, request: Request) -> Response:
-        """Create an OutfitSlot via the existing write serializer."""
+        """Create an OutfitSlot via the existing write serializer.
+
+        Cache invalidation lives inside ``add_outfit_slot`` (called by the
+        serializer's ``create``), so no manual invalidation is needed here.
+        """
         serializer = OutfitSlotWriteSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         slot = serializer.save()
-        # Invalidate the outfit's slots cache so future reads see the new row.
-        with contextlib.suppress(AttributeError):
-            del slot.outfit.cached_outfit_slots
         read = OutfitSlotReadSerializer(slot)
         return Response(read.data, status=201)
 
     def destroy(self, request: Request, pk: str | None = None) -> Response:
-        """Delete via remove_outfit_slot (idempotent)."""
+        """Delete via remove_outfit_slot (idempotent).
+
+        Cache invalidation lives inside ``remove_outfit_slot``.
+        """
         slot_pk = _parse_int_param(pk)
         if slot_pk is None:
             raise NotFound
@@ -673,14 +673,11 @@ class OutfitSlotViewSet(viewsets.ViewSet):
         except OutfitSlot.DoesNotExist as exc:
             raise NotFound from exc
         self.check_object_permissions(request, slot)
-        outfit = slot.outfit
         remove_outfit_slot(
-            outfit=outfit,
+            outfit=slot.outfit,
             body_region=slot.body_region,
             equipment_layer=slot.equipment_layer,
         )
-        with contextlib.suppress(AttributeError):
-            del outfit.cached_outfit_slots
         return Response(status=204)
 
 


### PR DESCRIPTION
Refactors five Item-app ViewSets from queryset-backed to item-first / character-scoped to stop re-querying for data the SharedMemoryModel identity map already holds.

- EquippedItemViewSet, ItemInstanceViewSet, ItemFacetViewSet, OutfitViewSet, OutfitSlotViewSet now require their scope param (?character, ?item_instance, ?character_sheet, ?outfit) and walk cached handlers instead of running fresh querysets.
- New CharacterCarriedItemsHandler (character.carried_items) and CharacterSheetOutfitsHandler (character_sheet.saved_outfits) mirror the existing CharacterEquipmentHandler pattern with explicit invalidate() hooks.
- pick_up/drop/give now invalidate the relevant character's carried_items handler; save_outfit/delete_outfit and outfit slot edits invalidate the sheet's saved_outfits and the outfit's cached_outfit_slots.
- EquippedItemViewSet previously had no user-scoping (any authenticated user could GET any character's equipped items). Now requires that the requester play the target character or be staff, returning 404 for out-of-scope requests rather than leaking existence.

CharacterSheet.saved_outfits is named "saved_outfits" rather than "outfits" because the Outfit.character_sheet FK already occupies the "outfits" name with its reverse RelatedManager.