### PR TITLE
Feature/combat viewset audit

### DIFF
--- a/frontend/src/magic/api.ts
+++ b/frontend/src/magic/api.ts
@@ -249,11 +249,20 @@ export async function getThreads(): Promise<PaginatedThreadList> {
 /**
  * GET /api/magic/character-resonances/
  *
- * Returns all CharacterResonance rows for the requesting account's characters.
- * Used by ResonancePickerField and similar UI surfaces.
+ * Returns CharacterResonance rows scoped to the requesting account. When
+ * ``characterSheetId`` is provided, narrows the response to that one
+ * character — required for callers operating on a single character so
+ * users with alts don't see a mixed list. Used by ResonancePickerField,
+ * the thread hub/detail pages, and the soul-tether dialogs.
  */
-export async function getCharacterResonances(): Promise<CharacterResonance[]> {
-  const res = await apiFetch(`${CHAR_RESONANCES_URL}/`);
+export async function getCharacterResonances(
+  characterSheetId?: number
+): Promise<CharacterResonance[]> {
+  const url =
+    characterSheetId != null
+      ? `${CHAR_RESONANCES_URL}/?character_sheet=${characterSheetId}`
+      : `${CHAR_RESONANCES_URL}/`;
+  const res = await apiFetch(url);
   if (!res.ok) throw new Error('Failed to load character resonances');
   return res.json() as Promise<CharacterResonance[]>;
 }

--- a/frontend/src/magic/components/SineatingRequestDialog.tsx
+++ b/frontend/src/magic/components/SineatingRequestDialog.tsx
@@ -94,8 +94,10 @@ export function SineatingRequestDialog({
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Data hooks
-  const { data: resonances, isLoading: resonancesLoading } = useCharacterResonances();
+  // Data hooks. Sineating is initiated by the Sinner — scope resonance
+  // lookup to the Sinner's character_sheet so users with alts only see
+  // the right character's resonances in the picker.
+  const { data: resonances, isLoading: resonancesLoading } = useCharacterResonances(sinnerSheetId);
   const { data: scenesData, isLoading: scenesLoading } = useQuery({
     queryKey: ['scenes', 'active'],
     queryFn: fetchActiveScenes,

--- a/frontend/src/magic/components/threads/WeaveThreadWizard.tsx
+++ b/frontend/src/magic/components/threads/WeaveThreadWizard.tsx
@@ -177,8 +177,14 @@ interface WeaveThreadWizardProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   summary: ThreadHubSummary | undefined;
-  /** PK of the acting character sheet (from thread.owner / summary context). */
-  characterSheetId: number;
+  /**
+   * PK of the acting character sheet — the character that will own the
+   * newly woven thread. The wizard scopes resonance lookup to this
+   * sheet so users with alts only see the right character's resonances.
+   * ``undefined`` when there is no active character; the wizard renders
+   * an empty state in that case.
+   */
+  characterSheetId: number | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -192,7 +198,8 @@ export function WeaveThreadWizard({
   characterSheetId,
 }: WeaveThreadWizardProps) {
   const navigate = useNavigate();
-  const { data: characterResonances, isLoading: resonancesLoading } = useCharacterResonances();
+  const { data: characterResonances, isLoading: resonancesLoading } =
+    useCharacterResonances(characterSheetId);
   const { mutate: weaveThread, isPending: weaving, error: weaveError } = useWeaveThread();
 
   const [state, setState] = useState<WizardState>(INITIAL_STATE);
@@ -264,7 +271,8 @@ export function WeaveThreadWizard({
     if (
       !state.selectedKind ||
       state.selectedAnchorId === null ||
-      state.selectedResonanceId === null
+      state.selectedResonanceId === null ||
+      characterSheetId == null
     ) {
       return;
     }

--- a/frontend/src/magic/pages/ThreadDetailPage.tsx
+++ b/frontend/src/magic/pages/ThreadDetailPage.tsx
@@ -28,8 +28,13 @@ export function ThreadDetailPage() {
   const threadId = Number(id ?? '0');
 
   const { data: thread, isLoading: threadLoading } = useThread(threadId);
-  const { data: summary, isLoading: summaryLoading } = useThreadHubSummary();
-  const { data: characterResonances } = useCharacterResonances();
+  // Scope summary + resonances to the thread's owning character so users
+  // with alts see balances and resonance options for the right character.
+  const characterSheetIdFromThread = thread?.owner;
+  const { data: summary, isLoading: summaryLoading } = useThreadHubSummary(
+    characterSheetIdFromThread
+  );
+  const { data: characterResonances } = useCharacterResonances(characterSheetIdFromThread);
   const { data: progressionData } = useAccountProgressionQuery();
 
   const [renameOpen, setRenameOpen] = useState(false);

--- a/frontend/src/magic/pages/ThreadHubPage.tsx
+++ b/frontend/src/magic/pages/ThreadHubPage.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
+import { useAppSelector } from '@/store/hooks';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useThreads, useThreadHubSummary, useCharacterResonances } from '../queries';
 import { ResonanceBalanceCard } from '../components/threads/ResonanceBalanceCard';
 import { ThreadCard } from '../components/threads/ThreadCard';
@@ -11,23 +13,33 @@ import type { Thread, TargetKind } from '../types';
 /**
  * Thread Hub page at /threads.
  *
- * Shows the player's resonance balances and thread list grouped by target_kind.
- * Threads are clickable — navigates to /threads/:id (route ships in Task 16).
- * The "Weave New" button is a stub placeholder (TODO Task 17: mount wizard modal).
+ * Shows the active character's resonance balances and thread list grouped
+ * by target_kind. The active character is the one currently selected in
+ * the game UI (``state.game.active`` from Redux) resolved against the
+ * user's roster entries — never inferred from "the first row of some
+ * unordered list."
  */
 export function ThreadHubPage() {
   const navigate = useNavigate();
+  const activeCharacterName = useAppSelector((state) => state.game.active);
+  const { data: myEntries = [] } = useMyRosterEntriesQuery();
+  // Resolve active character to a character_sheet pk. CharacterSheet
+  // shares its pk with the underlying ObjectDB (character_id) via the
+  // OneToOneField(primary_key=True).
+  const characterSheetId = useMemo(() => {
+    const entry = myEntries.find((e) => e.name === activeCharacterName);
+    return entry?.character_id ?? undefined;
+  }, [myEntries, activeCharacterName]);
+
   const { data: threadsData, isLoading: threadsLoading } = useThreads();
-  const { data: summary, isLoading: summaryLoading } = useThreadHubSummary();
-  const { data: characterResonances, isLoading: resonancesLoading } = useCharacterResonances();
+  const { data: summary, isLoading: summaryLoading } = useThreadHubSummary(characterSheetId);
+  const { data: characterResonances, isLoading: resonancesLoading } =
+    useCharacterResonances(characterSheetId);
 
   const [wizardOpen, setWizardOpen] = useState(false);
 
   const threads = threadsData?.results ?? [];
   const balancesLoading = summaryLoading || resonancesLoading;
-
-  // Derive characterSheetId for the wizard: prefer first resonance, fall back to first thread.
-  const characterSheetId = characterResonances?.[0]?.character_sheet ?? threads[0]?.owner ?? 0;
 
   // Group threads by target_kind
   const threadsByKind = threads.reduce<Record<string, Thread[]>>((acc, thread) => {

--- a/frontend/src/magic/pages/__tests__/ThreadHubPage.test.tsx
+++ b/frontend/src/magic/pages/__tests__/ThreadHubPage.test.tsx
@@ -30,6 +30,17 @@ vi.mock('@/magic/components/threads/WeaveThreadWizard', () => ({
   WeaveThreadWizard: () => null,
 }));
 
+// ThreadHubPage resolves the active character via Redux + roster (matches
+// WardrobePage's pattern). Stub both so the component renders without a
+// real Redux Provider or roster fetch.
+vi.mock('@/store/hooks', () => ({
+  useAppSelector: vi.fn(() => null),
+}));
+
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: vi.fn(() => ({ data: [] })),
+}));
+
 import * as magicQueries from '@/magic/queries';
 import { ThreadHubPage } from '../ThreadHubPage';
 

--- a/frontend/src/magic/queries.ts
+++ b/frontend/src/magic/queries.ts
@@ -136,16 +136,20 @@ export function useThreads() {
 // ---------------------------------------------------------------------------
 
 /**
- * Fetch all CharacterResonance rows for the requesting account's characters.
+ * Fetch CharacterResonance rows scoped to the requesting account.
+ *
+ * Pass ``characterSheetId`` to narrow the result to a single character —
+ * required for any caller that operates on one character at a time, so
+ * users with alts don't see resonances from other characters mixed in.
  *
  * Currently also used inline by ResonancePickerField in the rituals module
  * (see rituals/components/fields/ResonancePickerField.tsx TODO). A follow-up
  * task will import this hook there instead of the inline duplicate.
  */
-export function useCharacterResonances() {
+export function useCharacterResonances(characterSheetId?: number) {
   return useQuery({
-    queryKey: magicKeys.characterResonanceList(),
-    queryFn: () => api.getCharacterResonances(),
+    queryKey: [...magicKeys.characterResonanceList(), characterSheetId ?? null],
+    queryFn: () => api.getCharacterResonances(characterSheetId),
     throwOnError: true,
   });
 }

--- a/frontend/src/rituals/components/RitualForm.tsx
+++ b/frontend/src/rituals/components/RitualForm.tsx
@@ -6,9 +6,17 @@ export interface RitualFormProps {
   values: Record<string, string | number | null>;
   onChange: (values: Record<string, string | number | null>) => void;
   disabled?: boolean;
+  /** Active character_sheet_id for the performance; passed through to fields. */
+  characterSheetId?: number;
 }
 
-export function RitualForm({ schema, values, onChange, disabled }: RitualFormProps) {
+export function RitualForm({
+  schema,
+  values,
+  onChange,
+  disabled,
+  characterSheetId,
+}: RitualFormProps) {
   const handleFieldChange = (fieldName: string, newValue: string | number | null) => {
     const updatedValues = { ...values, [fieldName]: newValue };
     onChange(updatedValues);
@@ -28,6 +36,7 @@ export function RitualForm({ schema, values, onChange, disabled }: RitualFormPro
             onChange={(newValue) => handleFieldChange(field.name, newValue)}
             disabled={disabled}
             formValues={values}
+            characterSheetId={characterSheetId}
           />
         );
       })}

--- a/frontend/src/rituals/components/RitualPerformDialog.tsx
+++ b/frontend/src/rituals/components/RitualPerformDialog.tsx
@@ -146,6 +146,7 @@ export function RitualPerformDialog({
                 values={values}
                 onChange={setValues}
                 disabled={performMutation.isPending}
+                characterSheetId={characterSheetId}
               />
             </div>
           )}

--- a/frontend/src/rituals/components/fields/ResonancePickerField.tsx
+++ b/frontend/src/rituals/components/fields/ResonancePickerField.tsx
@@ -1,8 +1,10 @@
 /**
  * ResonancePickerField — dropdown of the caller's CharacterResonance rows.
  *
- * Calls GET /api/magic/character-resonances/ — scoped to the authenticated
- * user server-side. Each option's value is the CharacterResonance row id
+ * Calls GET /api/magic/character-resonances/?character_sheet=<pk> — scoped
+ * to the authenticated user server-side AND narrowed to the active
+ * character_sheet so users with alts see only the relevant character's
+ * resonances. Each option's value is the CharacterResonance row id
  * (NOT the Resonance type id). Label is the resonance type name.
  *
  * NOTE: This file contains a one-off fetch hook. When Task 3.1 creates
@@ -25,22 +27,34 @@ import type { FieldProps } from '@/rituals/types';
 
 type CharacterResonance = components['schemas']['CharacterResonance'];
 
-async function fetchCharacterResonances(): Promise<CharacterResonance[]> {
-  const res = await apiFetch('/api/magic/character-resonances/');
+async function fetchCharacterResonances(
+  characterSheetId: number | undefined
+): Promise<CharacterResonance[]> {
+  const url =
+    characterSheetId != null
+      ? `/api/magic/character-resonances/?character_sheet=${characterSheetId}`
+      : '/api/magic/character-resonances/';
+  const res = await apiFetch(url);
   if (!res.ok) throw new Error('Failed to load character resonances');
   return res.json() as Promise<CharacterResonance[]>;
 }
 
 /** Temporary hook — move to frontend/src/magic/queries.ts when Task 3.1 lands. */
-function useCharacterResonances() {
+function useCharacterResonances(characterSheetId: number | undefined) {
   return useQuery({
-    queryKey: ['character-resonances'],
-    queryFn: fetchCharacterResonances,
+    queryKey: ['character-resonances', characterSheetId ?? null],
+    queryFn: () => fetchCharacterResonances(characterSheetId),
   });
 }
 
-export function ResonancePickerField({ field, value, onChange, disabled }: FieldProps) {
-  const { data, isLoading } = useCharacterResonances();
+export function ResonancePickerField({
+  field,
+  value,
+  onChange,
+  disabled,
+  characterSheetId,
+}: FieldProps) {
+  const { data, isLoading } = useCharacterResonances(characterSheetId);
   const resonances = data ?? [];
 
   function handleChange(selectedValue: string) {

--- a/frontend/src/rituals/types.ts
+++ b/frontend/src/rituals/types.ts
@@ -53,6 +53,12 @@ export interface FieldProps {
    * to filter capstones by the selected sineater's character sheet.
    */
   formValues?: Record<string, string | number | null>;
+  /**
+   * The active character_sheet_id for this ritual performance — used by
+   * fields that need to scope their options to a single character
+   * (e.g., ResonancePickerField). Always provided by RitualPerformDialog.
+   */
+  characterSheetId?: number;
 }
 
 export interface RitualInputSchema {

--- a/src/flows/tests/test_scene_data_manager.py
+++ b/src/flows/tests/test_scene_data_manager.py
@@ -56,8 +56,15 @@ class TestSceneDataManager(TestCase):
         assert self.mock_state.test_attr == "new_value"
 
     def test_set_context_value_missing_state(self):
-        """Test setting an attribute when state doesn't exist."""
-        result = self.manager.set_context_value(999, "test_attr", "new_value")
+        """Test setting an attribute when state doesn't exist.
+
+        ``get_state_by_pk`` falls back to ``ObjectDB.objects.get(pk=...)``
+        when the state isn't already cached, so we mock that lookup to
+        guarantee no real row collides with the test pk (which can happen
+        in cross-app fresh-DB runs where the auto-increment passes 999).
+        """
+        with patch.object(ObjectDB.objects, "get", side_effect=ObjectDB.DoesNotExist):
+            result = self.manager.set_context_value(999, "test_attr", "new_value")
 
         assert result is None
 
@@ -79,8 +86,13 @@ class TestSceneDataManager(TestCase):
         assert result is None
 
     def test_get_context_value_missing_state(self):
-        """Test getting an attribute when state doesn't exist."""
-        result = self.manager.get_context_value(999, "test_attr")
+        """Test getting an attribute when state doesn't exist.
+
+        See ``test_set_context_value_missing_state`` for why the
+        ObjectDB lookup is mocked.
+        """
+        with patch.object(ObjectDB.objects, "get", side_effect=ObjectDB.DoesNotExist):
+            result = self.manager.get_context_value(999, "test_attr")
 
         assert result is None
 
@@ -110,12 +122,17 @@ class TestSceneDataManager(TestCase):
         assert simple_state.missing_attr == "default_value"
 
     def test_modify_context_value_missing_state(self):
-        """Test modifying when state doesn't exist."""
+        """Test modifying when state doesn't exist.
+
+        See ``test_set_context_value_missing_state`` for why the
+        ObjectDB lookup is mocked.
+        """
 
         def modifier(value):
             return "modified"
 
-        result = self.manager.modify_context_value(999, "test_attr", modifier)
+        with patch.object(ObjectDB.objects, "get", side_effect=ObjectDB.DoesNotExist):
+            result = self.manager.modify_context_value(999, "test_attr", modifier)
 
         assert result is None
 

--- a/src/typeclasses/accounts.py
+++ b/src/typeclasses/accounts.py
@@ -116,6 +116,28 @@ class Account(DefaultAccount):
         return CharacterList(self)
 
     @cached_property
+    def played_character_sheet_ids(self) -> frozenset[int]:
+        """Set of CharacterSheet pks for every character this account currently plays.
+
+        Cached on the AccountDB instance — Evennia's identity map shares
+        the same Account object across requests in a process, so this set
+        survives the request boundary. Used by ViewSets and permission
+        classes that need to scope querysets to "characters the user
+        plays" without re-running the RosterEntry join on every request.
+
+        CharacterSheet shares its pk with its underlying ObjectDB
+        (``primary_key=True`` on the OneToOneField), so these values also
+        serve as character ObjectDB pks for callers that need either.
+
+        Invalidation: any ``RosterTenure`` save (create, ``end_date``
+        change, etc.) clears this cache automatically via
+        ``RosterTenure.related_cache_fields`` → ``clear_cached_properties``.
+        """
+        from world.roster.models import RosterEntry
+
+        return frozenset(RosterEntry.objects.for_account(self).character_ids())
+
+    @cached_property
     def cached_primary_persona_ids(self) -> list[int]:
         """IDs of PRIMARY personas this account is currently playing.
 
@@ -157,7 +179,11 @@ class Account(DefaultAccount):
         Django's ``cached_property``, so we override to clear them
         explicitly.
         """
-        for prop in ("cached_primary_persona_ids", "characters"):
+        for prop in (
+            "cached_primary_persona_ids",
+            "played_character_sheet_ids",
+            "characters",
+        ):
             self.__dict__.pop(prop, None)
 
     def get_available_characters(self):

--- a/src/world/combat/permissions.py
+++ b/src/world/combat/permissions.py
@@ -11,6 +11,24 @@ from world.combat.models import CombatEncounter
 from world.roster.models import RosterEntry
 
 
+def _viewer_character_ids(request: Request, view: APIView) -> set[int]:
+    """Return the request user's played character_sheet ids.
+
+    Prefers ``view._viewer_character_ids(request)`` when the view exposes
+    it (``CombatEncounterViewSet`` does — it caches the set on the
+    request object so permission checks and view body share the same
+    roster query). Falls back to a direct query for any caller wired up
+    with these permissions but lacking the helper.
+    """
+    helper = getattr(view, "_viewer_character_ids", None)  # noqa: GETATTR_LITERAL
+    if helper is not None:
+        return helper(request)
+    if not request.user.is_authenticated:
+        return set()
+    user = cast(AccountDB, request.user)
+    return set(RosterEntry.objects.for_account(user).character_ids())
+
+
 class IsEncounterGMOrStaff(BasePermission):
     """Allow access to GMs of the encounter's scene or staff.
 
@@ -35,7 +53,9 @@ class IsEncounterParticipant(BasePermission):
     """Allow authenticated users who have an active CombatParticipant.
 
     Uses the encounter's participants_cached when available (prefetched
-    by _base_queryset) to avoid a separate query.
+    by _base_queryset) to avoid a separate query. Routes the roster
+    lookup through the view's per-request cache when available so the
+    permission check and view body share a single roster query.
     """
 
     def has_object_permission(
@@ -46,10 +66,7 @@ class IsEncounterParticipant(BasePermission):
     ) -> bool:
         if request.user.is_staff:
             return True
-        user = cast(AccountDB, request.user)
-        character_ids = set(
-            RosterEntry.objects.for_account(user).character_ids(),
-        )
+        character_ids = _viewer_character_ids(request, view)
         return any(p.character_sheet.character_id in character_ids for p in obj.participants_cached)
 
 
@@ -70,8 +87,5 @@ class IsInEncounterRoom(BasePermission):
             return True
         if not obj.scene:
             return False
-        user = cast(AccountDB, request.user)
-        character_ids = set(
-            RosterEntry.objects.for_account(user).character_ids(),
-        )
+        character_ids = _viewer_character_ids(request, view)
         return obj.scene.has_character_present(character_ids)

--- a/src/world/combat/permissions.py
+++ b/src/world/combat/permissions.py
@@ -7,16 +7,23 @@ from rest_framework.views import APIView
 from world.combat.models import CombatEncounter
 
 
-def _viewer_character_ids(request: Request, view: APIView) -> set[int]:
+def _viewer_character_ids(request: Request, _view: APIView) -> frozenset[int]:
     """Return the request user's played character_sheet ids.
 
-    Always routes through ``view._viewer_character_ids(request)`` —
-    these permissions are wired to ``CombatEncounterViewSet`` (in
-    production) and to a stub view in ``test_permissions`` (in tests).
-    The view caches the set on ``request._combat_viewer_character_ids``
-    so the permission check and view body share a single roster query.
+    Reads ``request.user.played_character_sheet_ids`` — a cached_property
+    on the ``Account`` typeclass populated lazily and invalidated when
+    any of the account's ``RosterTenure`` rows mutate (see
+    ``RosterTenure.related_cache_fields``). The cache lives on the
+    identity-mapped Account instance, so it persists across requests for
+    the same user within the same Python process.
+
+    For anonymous users or non-Account user models, ``AttributeError``
+    bubbles up from the missing property and we return an empty set.
     """
-    return view._viewer_character_ids(request)  # noqa: SLF001 — known cooperator
+    try:
+        return request.user.played_character_sheet_ids
+    except AttributeError:
+        return frozenset()
 
 
 class IsEncounterGMOrStaff(BasePermission):

--- a/src/world/combat/permissions.py
+++ b/src/world/combat/permissions.py
@@ -1,36 +1,22 @@
 """Permission classes for combat API endpoints."""
 
-from typing import cast
-
-from evennia.accounts.models import AccountDB
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.views import APIView
 
 from world.combat.models import CombatEncounter
-from world.roster.models import RosterEntry
 
 
-def _viewer_character_ids(request: Request, view: APIView | None) -> set[int]:
+def _viewer_character_ids(request: Request, view: APIView) -> set[int]:
     """Return the request user's played character_sheet ids.
 
-    In production these permissions are only wired to
-    ``CombatEncounterViewSet``, which exposes ``_viewer_character_ids``
-    and caches the set on the request object so permission checks and
-    view body share a single roster query — we prefer that path.
-
-    When the helper isn't available (notably in ``test_permissions``
-    which pass ``view=None`` to drive ``has_object_permission`` in
-    isolation), fall back to a direct query. The fallback is functionally
-    equivalent; it just doesn't share state with a view that isn't there.
+    Always routes through ``view._viewer_character_ids(request)`` —
+    these permissions are wired to ``CombatEncounterViewSet`` (in
+    production) and to a stub view in ``test_permissions`` (in tests).
+    The view caches the set on ``request._combat_viewer_character_ids``
+    so the permission check and view body share a single roster query.
     """
-    helper = getattr(view, "_viewer_character_ids", None)  # noqa: GETATTR_LITERAL
-    if helper is not None:
-        return helper(request)
-    if not request.user.is_authenticated:
-        return set()
-    user = cast(AccountDB, request.user)
-    return set(RosterEntry.objects.for_account(user).character_ids())
+    return view._viewer_character_ids(request)  # noqa: SLF001 — known cooperator
 
 
 class IsEncounterGMOrStaff(BasePermission):

--- a/src/world/combat/permissions.py
+++ b/src/world/combat/permissions.py
@@ -11,14 +11,18 @@ from world.combat.models import CombatEncounter
 from world.roster.models import RosterEntry
 
 
-def _viewer_character_ids(request: Request, view: APIView) -> set[int]:
+def _viewer_character_ids(request: Request, view: APIView | None) -> set[int]:
     """Return the request user's played character_sheet ids.
 
-    Prefers ``view._viewer_character_ids(request)`` when the view exposes
-    it (``CombatEncounterViewSet`` does — it caches the set on the
-    request object so permission checks and view body share the same
-    roster query). Falls back to a direct query for any caller wired up
-    with these permissions but lacking the helper.
+    In production these permissions are only wired to
+    ``CombatEncounterViewSet``, which exposes ``_viewer_character_ids``
+    and caches the set on the request object so permission checks and
+    view body share a single roster query — we prefer that path.
+
+    When the helper isn't available (notably in ``test_permissions``
+    which pass ``view=None`` to drive ``has_object_permission`` in
+    isolation), fall back to a direct query. The fallback is functionally
+    equivalent; it just doesn't share state with a view that isn't there.
     """
     helper = getattr(view, "_viewer_character_ids", None)  # noqa: GETATTR_LITERAL
     if helper is not None:
@@ -56,6 +60,16 @@ class IsEncounterParticipant(BasePermission):
     by _base_queryset) to avoid a separate query. Routes the roster
     lookup through the view's per-request cache when available so the
     permission check and view body share a single roster query.
+
+    **No staff bypass.** The endpoints gated by this permission
+    (``declare``, ``ready``, ``my_action``, ``flee``, ``upgrade_combo``,
+    ``revert_combo``) operate on the caller's own participant row. Staff
+    do not own a participant by virtue of being staff — they must be
+    added as a participant first (e.g., via the ``add_participant`` GM
+    action) before they can act. Granting a staff bypass here paints an
+    inconsistent picture: the permission check passes, but the view
+    body's ``_get_participant`` returns None and the request 403s on
+    "Not a participant" — confusing and pointless.
     """
 
     def has_object_permission(
@@ -64,8 +78,6 @@ class IsEncounterParticipant(BasePermission):
         view: APIView,
         obj: CombatEncounter,
     ) -> bool:
-        if request.user.is_staff:
-            return True
         character_ids = _viewer_character_ids(request, view)
         return any(p.character_sheet.character_id in character_ids for p in obj.participants_cached)
 

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -399,6 +399,17 @@ class AddParticipantSerializer(serializers.Serializer):
     )
 
 
+class JoinEncounterSerializer(serializers.Serializer):
+    """Write serializer for a player self-joining an encounter.
+
+    Requires explicit ``character_sheet_id`` — never auto-selects which
+    of the user's characters joins. The view validates that the chosen
+    sheet belongs to one of the user's active tenures.
+    """
+
+    character_sheet_id = serializers.IntegerField()
+
+
 class AddOpponentSerializer(serializers.Serializer):
     """Write serializer for adding an opponent to an encounter."""
 

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -14,7 +14,6 @@ from world.combat.models import (
     CombatRoundAction,
 )
 from world.fatigue.constants import EffortLevel
-from world.roster.models import RosterEntry
 
 # ---------------------------------------------------------------------------
 # Nested read serializers
@@ -101,13 +100,15 @@ class ParticipantSerializer(serializers.ModelSerializer):
             return False
         if request.user.is_staff:
             return True
-        # Check if viewer owns this character
+        # Check if viewer owns this character. Reads the context entry
+        # populated by EncounterDetailSerializer._build_serializer_context,
+        # falling back to the Account-level cached property.
         viewer_character_ids = self.context.get("viewer_character_ids")
         if viewer_character_ids is None:
-            active_entries = RosterEntry.objects.for_account(request.user)
-            viewer_character_ids = set(
-                active_entries.values_list("character_sheet_id", flat=True),
-            )
+            try:
+                viewer_character_ids = request.user.played_character_sheet_ids
+            except AttributeError:
+                viewer_character_ids = frozenset()
             self.context["viewer_character_ids"] = viewer_character_ids
         if obj.character_sheet.character_id in viewer_character_ids:
             return True
@@ -275,31 +276,23 @@ class EncounterDetailSerializer(serializers.ModelSerializer):
             for p in obj.participants_cached  # type: ignore[attr-defined]
         )
 
-    def _get_viewer_character_ids(self, request: object) -> set[int]:
-        """Get character IDs for the requesting user.
+    def _get_viewer_character_ids(self, request: object) -> set[int] | frozenset[int]:
+        """Get character_sheet IDs for the requesting user.
 
-        Resolution order, fastest first:
+        Resolution order:
         1. Serializer context (populated by ``_build_serializer_context``)
-        2. Per-request cache on ``request._combat_viewer_character_ids``
-           (populated by ``CombatEncounterViewSet._viewer_character_ids``)
-        3. Fresh ``RosterEntry`` query — used only when the serializer
-           is invoked outside the viewset (e.g., from a management
-           command or other code path)
+        2. ``request.user.played_character_sheet_ids`` (cached on the
+           Account typeclass; invalidated by RosterTenure mutations)
         Caches into context after fetching so subsequent fields in the
-        same serializer pass don't re-query.
+        same serializer pass don't re-read.
         """
         cached = self.context.get("viewer_character_ids")
         if cached is not None:
             return cached
-        # Per-request cache populated by CombatEncounterViewSet._viewer_character_ids.
-        request_cached = getattr(request, "_combat_viewer_character_ids", None)  # noqa: GETATTR_LITERAL
-        if request_cached is not None:
-            self.context["viewer_character_ids"] = request_cached
-            return request_cached
-        active_entries = RosterEntry.objects.for_account(request.user)  # type: ignore[union-attr]
-        character_ids = set(
-            active_entries.values_list("character_sheet_id", flat=True),
-        )
+        try:
+            character_ids = request.user.played_character_sheet_ids  # type: ignore[union-attr]
+        except AttributeError:
+            character_ids = frozenset()
         self.context["viewer_character_ids"] = character_ids
         return character_ids
 

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -276,10 +276,26 @@ class EncounterDetailSerializer(serializers.ModelSerializer):
         )
 
     def _get_viewer_character_ids(self, request: object) -> set[int]:
-        """Get character IDs for the requesting user, with context caching."""
+        """Get character IDs for the requesting user.
+
+        Resolution order, fastest first:
+        1. Serializer context (populated by ``_build_serializer_context``)
+        2. Per-request cache on ``request._combat_viewer_character_ids``
+           (populated by ``CombatEncounterViewSet._viewer_character_ids``)
+        3. Fresh ``RosterEntry`` query — used only when the serializer
+           is invoked outside the viewset (e.g., from a management
+           command or other code path)
+        Caches into context after fetching so subsequent fields in the
+        same serializer pass don't re-query.
+        """
         cached = self.context.get("viewer_character_ids")
         if cached is not None:
             return cached
+        # Per-request cache populated by CombatEncounterViewSet._viewer_character_ids.
+        request_cached = getattr(request, "_combat_viewer_character_ids", None)  # noqa: GETATTR_LITERAL
+        if request_cached is not None:
+            self.context["viewer_character_ids"] = request_cached
+            return request_cached
         active_entries = RosterEntry.objects.for_account(request.user)  # type: ignore[union-attr]
         character_ids = set(
             active_entries.values_list("character_sheet_id", flat=True),

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -407,7 +407,7 @@ class JoinEncounterSerializer(serializers.Serializer):
     sheet belongs to one of the user's active tenures.
     """
 
-    character_sheet_id = serializers.IntegerField()
+    character_sheet_id = serializers.IntegerField(min_value=1)
 
 
 class AddOpponentSerializer(serializers.Serializer):

--- a/src/world/combat/tests/test_permissions.py
+++ b/src/world/combat/tests/test_permissions.py
@@ -1,6 +1,10 @@
 """Tests for combat permission classes."""
 
+from typing import cast
+
 from django.test import TestCase
+from evennia.accounts.models import AccountDB
+from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
@@ -13,6 +17,7 @@ from world.combat.permissions import (
     IsInEncounterRoom,
 )
 from world.roster.factories import RosterTenureFactory
+from world.roster.models import RosterEntry
 from world.scenes.factories import SceneFactory, SceneParticipationFactory
 
 
@@ -22,6 +27,22 @@ def _make_request(user: object) -> object:
     request = factory.get("/fake/")
     request.user = user
     return request
+
+
+class _StubView:
+    """Minimal stub of ``CombatEncounterViewSet`` for permission tests.
+
+    Exposes the same ``_viewer_character_ids(request)`` contract the
+    production viewset provides, so the permission classes can route
+    their roster lookup through the view as they would in production —
+    no test-only fallback path needed in ``permissions.py``.
+    """
+
+    def _viewer_character_ids(self, request: Request) -> set[int]:
+        if not request.user.is_authenticated:
+            return set()
+        user = cast(AccountDB, request.user)
+        return set(RosterEntry.objects.for_account(user).character_ids())
 
 
 class IsEncounterGMOrStaffTest(TestCase):
@@ -37,7 +58,7 @@ class IsEncounterGMOrStaffTest(TestCase):
         staff = AccountFactory(is_staff=True)
         request = _make_request(staff)
         self.assertTrue(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
     def test_scene_gm_allowed(self) -> None:
@@ -45,7 +66,7 @@ class IsEncounterGMOrStaffTest(TestCase):
         SceneParticipationFactory(scene=self.scene, account=account, is_gm=True)
         request = _make_request(account)
         self.assertTrue(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
     def test_non_gm_participant_denied(self) -> None:
@@ -53,14 +74,14 @@ class IsEncounterGMOrStaffTest(TestCase):
         SceneParticipationFactory(scene=self.scene, account=account, is_gm=False)
         request = _make_request(account)
         self.assertFalse(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
     def test_non_participant_denied(self) -> None:
         account = AccountFactory()
         request = _make_request(account)
         self.assertFalse(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
     def test_no_scene_denied(self) -> None:
@@ -70,7 +91,7 @@ class IsEncounterGMOrStaffTest(TestCase):
         self.assertFalse(
             self.permission.has_object_permission(
                 request,
-                None,
+                _StubView(),
                 encounter_no_scene,
             ),
         )
@@ -115,7 +136,7 @@ class IsEncounterParticipantTest(TestCase):
     def test_participant_allowed(self) -> None:
         request = _make_request(self.account)
         self.assertTrue(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
     def test_non_participant_denied(self) -> None:
@@ -128,7 +149,7 @@ class IsEncounterParticipantTest(TestCase):
         )
         request = _make_request(other_account)
         self.assertFalse(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
     def test_fled_participant_denied(self) -> None:
@@ -147,7 +168,7 @@ class IsEncounterParticipantTest(TestCase):
         )
         request = _make_request(fled_account)
         self.assertFalse(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
     def test_staff_without_participant_denied(self) -> None:
@@ -159,7 +180,7 @@ class IsEncounterParticipantTest(TestCase):
         staff = AccountFactory(is_staff=True)
         request = _make_request(staff)
         self.assertFalse(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
 
@@ -182,7 +203,7 @@ class IsInEncounterRoomTest(TestCase):
         )
         request = _make_request(account)
         self.assertTrue(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
     def test_character_elsewhere_denied(self) -> None:
@@ -195,14 +216,14 @@ class IsInEncounterRoomTest(TestCase):
         )
         request = _make_request(account)
         self.assertFalse(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
     def test_no_roster_entry_denied(self) -> None:
         account = AccountFactory()
         request = _make_request(account)
         self.assertFalse(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )
 
     def test_no_scene_denied(self) -> None:
@@ -212,7 +233,7 @@ class IsInEncounterRoomTest(TestCase):
         self.assertFalse(
             self.permission.has_object_permission(
                 request,
-                None,
+                _StubView(),
                 encounter_no_scene,
             ),
         )
@@ -221,5 +242,5 @@ class IsInEncounterRoomTest(TestCase):
         staff = AccountFactory(is_staff=True)
         request = _make_request(staff)
         self.assertTrue(
-            self.permission.has_object_permission(request, None, self.encounter),
+            self.permission.has_object_permission(request, _StubView(), self.encounter),
         )

--- a/src/world/combat/tests/test_permissions.py
+++ b/src/world/combat/tests/test_permissions.py
@@ -1,10 +1,6 @@
 """Tests for combat permission classes."""
 
-from typing import cast
-
 from django.test import TestCase
-from evennia.accounts.models import AccountDB
-from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
@@ -17,7 +13,6 @@ from world.combat.permissions import (
     IsInEncounterRoom,
 )
 from world.roster.factories import RosterTenureFactory
-from world.roster.models import RosterEntry
 from world.scenes.factories import SceneFactory, SceneParticipationFactory
 
 
@@ -27,22 +22,6 @@ def _make_request(user: object) -> object:
     request = factory.get("/fake/")
     request.user = user
     return request
-
-
-class _StubView:
-    """Minimal stub of ``CombatEncounterViewSet`` for permission tests.
-
-    Exposes the same ``_viewer_character_ids(request)`` contract the
-    production viewset provides, so the permission classes can route
-    their roster lookup through the view as they would in production —
-    no test-only fallback path needed in ``permissions.py``.
-    """
-
-    def _viewer_character_ids(self, request: Request) -> set[int]:
-        if not request.user.is_authenticated:
-            return set()
-        user = cast(AccountDB, request.user)
-        return set(RosterEntry.objects.for_account(user).character_ids())
 
 
 class IsEncounterGMOrStaffTest(TestCase):
@@ -58,7 +37,7 @@ class IsEncounterGMOrStaffTest(TestCase):
         staff = AccountFactory(is_staff=True)
         request = _make_request(staff)
         self.assertTrue(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
     def test_scene_gm_allowed(self) -> None:
@@ -66,7 +45,7 @@ class IsEncounterGMOrStaffTest(TestCase):
         SceneParticipationFactory(scene=self.scene, account=account, is_gm=True)
         request = _make_request(account)
         self.assertTrue(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
     def test_non_gm_participant_denied(self) -> None:
@@ -74,14 +53,14 @@ class IsEncounterGMOrStaffTest(TestCase):
         SceneParticipationFactory(scene=self.scene, account=account, is_gm=False)
         request = _make_request(account)
         self.assertFalse(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
     def test_non_participant_denied(self) -> None:
         account = AccountFactory()
         request = _make_request(account)
         self.assertFalse(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
     def test_no_scene_denied(self) -> None:
@@ -91,7 +70,7 @@ class IsEncounterGMOrStaffTest(TestCase):
         self.assertFalse(
             self.permission.has_object_permission(
                 request,
-                _StubView(),
+                None,
                 encounter_no_scene,
             ),
         )
@@ -136,7 +115,7 @@ class IsEncounterParticipantTest(TestCase):
     def test_participant_allowed(self) -> None:
         request = _make_request(self.account)
         self.assertTrue(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
     def test_non_participant_denied(self) -> None:
@@ -149,7 +128,7 @@ class IsEncounterParticipantTest(TestCase):
         )
         request = _make_request(other_account)
         self.assertFalse(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
     def test_fled_participant_denied(self) -> None:
@@ -168,7 +147,7 @@ class IsEncounterParticipantTest(TestCase):
         )
         request = _make_request(fled_account)
         self.assertFalse(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
     def test_staff_without_participant_denied(self) -> None:
@@ -180,7 +159,7 @@ class IsEncounterParticipantTest(TestCase):
         staff = AccountFactory(is_staff=True)
         request = _make_request(staff)
         self.assertFalse(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
 
@@ -203,7 +182,7 @@ class IsInEncounterRoomTest(TestCase):
         )
         request = _make_request(account)
         self.assertTrue(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
     def test_character_elsewhere_denied(self) -> None:
@@ -216,14 +195,14 @@ class IsInEncounterRoomTest(TestCase):
         )
         request = _make_request(account)
         self.assertFalse(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
     def test_no_roster_entry_denied(self) -> None:
         account = AccountFactory()
         request = _make_request(account)
         self.assertFalse(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )
 
     def test_no_scene_denied(self) -> None:
@@ -233,7 +212,7 @@ class IsInEncounterRoomTest(TestCase):
         self.assertFalse(
             self.permission.has_object_permission(
                 request,
-                _StubView(),
+                None,
                 encounter_no_scene,
             ),
         )
@@ -242,5 +221,5 @@ class IsInEncounterRoomTest(TestCase):
         staff = AccountFactory(is_staff=True)
         request = _make_request(staff)
         self.assertTrue(
-            self.permission.has_object_permission(request, _StubView(), self.encounter),
+            self.permission.has_object_permission(request, None, self.encounter),
         )

--- a/src/world/combat/tests/test_permissions.py
+++ b/src/world/combat/tests/test_permissions.py
@@ -150,10 +150,15 @@ class IsEncounterParticipantTest(TestCase):
             self.permission.has_object_permission(request, None, self.encounter),
         )
 
-    def test_staff_allowed(self) -> None:
+    def test_staff_without_participant_denied(self) -> None:
+        """Staff users without a CombatParticipant row are denied — this
+        permission gates "act as your own participant" endpoints, which
+        staff can't meaningfully use unless they were added as a
+        participant by a GM. See IsEncounterParticipant docstring.
+        """
         staff = AccountFactory(is_staff=True)
         request = _make_request(staff)
-        self.assertTrue(
+        self.assertFalse(
             self.permission.has_object_permission(request, None, self.encounter),
         )
 

--- a/src/world/combat/tests/test_view_query_counts.py
+++ b/src/world/combat/tests/test_view_query_counts.py
@@ -121,19 +121,24 @@ class MyActionQueryCountTests(_SharedSetupMixin, TestCase):
     def test_warm_my_action_query_count(self) -> None:
         url = f"/api/combat/{self.encounter.pk}/my_action/"
         self.client.get(url)  # warm-up
-        # 4 queries on the second call:
+        # 4 queries observed on the second call (SQL captured via
+        # ``CaptureQueriesContext``):
         #   1. DRF session lookup
-        #   2. CombatEncounter SELECT (get_object runs the .get(), even
-        #      though SharedMemoryModel returns the identity-mapped row)
-        #   3. RosterEntry.for_account(...).character_ids() — shared
-        #      between IsEncounterParticipant and _get_participant via
-        #      request._combat_viewer_character_ids
-        #   4. CombatRoundAction.filter(participant, round_number)
-        # The participants_cached + opponents_cached prefetches do NOT
-        # fire on the warm call: they ran during warm-up and populated
-        # attributes on the identity-mapped encounter, so the second
-        # get_object hands back the same instance with those lists
-        # already attached.
+        #   2. CombatEncounter SELECT (``get_object`` re-evaluates the
+        #      queryset; SharedMemoryModel still returns the same Python
+        #      instance for the row)
+        #   3. RosterEntry character_ids subquery — issued exactly once
+        #      because ``IsEncounterParticipant`` and ``_get_participant``
+        #      share ``request._combat_viewer_character_ids``
+        #   4. CombatRoundAction filter for this participant/round
+        # Notably absent from the warm call: the participants/opponents
+        # prefetch queries that fire during the warm-up. The exact
+        # mechanism is the interaction between Django's prefetch_related
+        # cache and SharedMemoryModel's identity-mapped instances — the
+        # important property is the count, not the explanation. This
+        # assertion is a regression guard: if a new query slips into the
+        # hot path (a new ``.filter`` / ``.get`` / ``.values``), this
+        # test will catch it.
         with self.assertNumQueries(4):
             response = self.client.get(url)
         # 200 with None body when no action declared yet.

--- a/src/world/combat/tests/test_view_query_counts.py
+++ b/src/world/combat/tests/test_view_query_counts.py
@@ -109,8 +109,17 @@ class EncounterRetrieveQueryCountTests(_SharedSetupMixin, TestCase):
     def test_warm_retrieve_query_count(self) -> None:
         url = f"/api/combat/{self.encounter.pk}/"
         self.client.get(url)  # warm-up
-        # 1 session + 1 encounter + 2 prefetch (participants + opponents).
-        with self.assertNumQueries(4):
+        # 3 queries on the warm call: session + encounter + the lone
+        # remaining roster lookup the permission classes need. The
+        # account-level ``played_character_sheet_ids`` cached_property
+        # makes that lookup a single Account attribute read after the
+        # first request fills the cache, but the cache itself wasn't
+        # filled before this test class's warm-up call, so it still
+        # fires once during warm-up. (After warm-up: zero roster
+        # queries.) The participants/opponents prefetches do not fire
+        # on the warm call — they ran during warm-up and the
+        # identity-mapped encounter retains the attribute.
+        with self.assertNumQueries(3):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -121,25 +130,24 @@ class MyActionQueryCountTests(_SharedSetupMixin, TestCase):
     def test_warm_my_action_query_count(self) -> None:
         url = f"/api/combat/{self.encounter.pk}/my_action/"
         self.client.get(url)  # warm-up
-        # 4 queries observed on the second call (SQL captured via
+        # 3 queries observed on the second call (captured via
         # ``CaptureQueriesContext``):
         #   1. DRF session lookup
         #   2. CombatEncounter SELECT (``get_object`` re-evaluates the
-        #      queryset; SharedMemoryModel still returns the same Python
+        #      queryset; SharedMemoryModel returns the same Python
         #      instance for the row)
-        #   3. RosterEntry character_ids subquery — issued exactly once
-        #      because ``IsEncounterParticipant`` and ``_get_participant``
-        #      share ``request._combat_viewer_character_ids``
-        #   4. CombatRoundAction filter for this participant/round
-        # Notably absent from the warm call: the participants/opponents
-        # prefetch queries that fire during the warm-up. The exact
-        # mechanism is the interaction between Django's prefetch_related
-        # cache and SharedMemoryModel's identity-mapped instances — the
-        # important property is the count, not the explanation. This
-        # assertion is a regression guard: if a new query slips into the
-        # hot path (a new ``.filter`` / ``.get`` / ``.values``), this
+        #   3. CombatRoundAction filter for this participant/round
+        # Notably absent from the warm call:
+        #   - participants/opponents prefetches (fired during warm-up;
+        #     identity-mapped encounter retains the attribute)
+        #   - the RosterEntry character_ids query (now served by
+        #     ``Account.played_character_sheet_ids`` — a cached_property
+        #     filled on warm-up and read directly from the in-memory
+        #     Account instance thereafter)
+        # This assertion is a regression guard: if a new query slips into
+        # the hot path (a new ``.filter`` / ``.get`` / ``.values``), this
         # test will catch it.
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             response = self.client.get(url)
         # 200 with None body when no action declared yet.
         self.assertEqual(response.status_code, 200)

--- a/src/world/combat/tests/test_view_query_counts.py
+++ b/src/world/combat/tests/test_view_query_counts.py
@@ -1,0 +1,133 @@
+"""Query-count regression tests for ``CombatEncounterViewSet``.
+
+Locks in the query budgets for the combat hot path. The encounter list /
+detail / action endpoints rely on a ``participants_cached`` +
+``opponents_cached`` prefetch chain plus a pre-computed serializer context
+(``viewer_character_ids`` + ``is_gm``). Once warmed, subsequent requests
+should run a small constant number of queries — no per-row filters, no
+re-walks of the roster join chain.
+
+If the counts here climb, the prefetch discipline has been broken
+somewhere — likely a new ``.filter()`` / ``.get()`` /  ``.values()``
+call that should have walked a cached relation instead. Pin the count,
+document each query, and only relax it if the new query is genuinely
+necessary.
+
+Mirrors the sibling ``world.items.tests.test_item_view_query_counts``.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import ParticipantStatus
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+)
+from world.roster.factories import RosterTenureFactory
+from world.scenes.factories import SceneFactory, SceneParticipationFactory
+
+
+class _SharedSetupMixin:
+    """Common setup: GM account, two player participants, two opponents.
+
+    Multiple participants + opponents ensures any per-row query would
+    multiply.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:  # type: ignore[misc]
+        cls.gm_account = AccountFactory(username="qc_gm")
+        cls.gm_character = CharacterFactory(db_key="QCGmChar")
+        cls.gm_sheet = CharacterSheetFactory(character=cls.gm_character)
+        cls.gm_tenure = RosterTenureFactory(
+            roster_entry__character_sheet__character=cls.gm_character,
+            player_data__account=cls.gm_account,
+        )
+
+        cls.player_account = AccountFactory(username="qc_player")
+        cls.player_character = CharacterFactory(db_key="QCPlayerChar")
+        cls.player_sheet = CharacterSheetFactory(character=cls.player_character)
+        cls.player_tenure = RosterTenureFactory(
+            roster_entry__character_sheet__character=cls.player_character,
+            player_data__account=cls.player_account,
+        )
+
+        # Second player participant — proves participants prefetch holds.
+        cls.player2_account = AccountFactory(username="qc_player2")
+        cls.player2_character = CharacterFactory(db_key="QCPlayer2Char")
+        cls.player2_sheet = CharacterSheetFactory(character=cls.player2_character)
+        cls.player2_tenure = RosterTenureFactory(
+            roster_entry__character_sheet__character=cls.player2_character,
+            player_data__account=cls.player2_account,
+        )
+
+        cls.scene = SceneFactory()
+        SceneParticipationFactory(scene=cls.scene, account=cls.gm_account, is_gm=True)
+
+    def setUp(self) -> None:
+        # Fresh encounter per test (avoids CombatNPC identity-map contamination
+        # — same reason GMLifecycleTest does this).
+        self.encounter = CombatEncounterFactory(scene=self.scene)
+        self.participant = CombatParticipantFactory(
+            encounter=self.encounter,
+            character_sheet=self.player_sheet,
+            status=ParticipantStatus.ACTIVE,
+        )
+        self.participant2 = CombatParticipantFactory(
+            encounter=self.encounter,
+            character_sheet=self.player2_sheet,
+            status=ParticipantStatus.ACTIVE,
+        )
+        CombatOpponentFactory(encounter=self.encounter)
+        CombatOpponentFactory(encounter=self.encounter)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.player_account)
+
+
+class EncounterListQueryCountTests(_SharedSetupMixin, TestCase):
+    """``GET /api/combat/`` — list endpoint."""
+
+    def test_warm_list_query_count(self) -> None:
+        url = "/api/combat/"
+        self.client.get(url)  # warm-up
+        # 1 session + 1 encounters queryset + 1 prefetch chain (participants
+        # + opponents land in a single batched prefetch path).
+        with self.assertNumQueries(3):
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class EncounterRetrieveQueryCountTests(_SharedSetupMixin, TestCase):
+    """``GET /api/combat/<pk>/`` — detail endpoint."""
+
+    def test_warm_retrieve_query_count(self) -> None:
+        url = f"/api/combat/{self.encounter.pk}/"
+        self.client.get(url)  # warm-up
+        # 1 session + 1 encounter + 2 prefetch (participants + opponents).
+        with self.assertNumQueries(4):
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class MyActionQueryCountTests(_SharedSetupMixin, TestCase):
+    """``GET /api/combat/<pk>/my_action/`` — current-round action lookup."""
+
+    def test_warm_my_action_query_count(self) -> None:
+        url = f"/api/combat/{self.encounter.pk}/my_action/"
+        self.client.get(url)  # warm-up
+        # 1 session + 1 encounter + 2 prefetch + 1 roster (in
+        # _get_participant). The per-request roster cache eliminates
+        # the duplicate when an endpoint calls both _get_participant
+        # AND _build_serializer_context — my_action only calls the
+        # former, so it doesn't benefit. Endpoints like ready/declare
+        # that call both shed one query in the same fix.
+        with self.assertNumQueries(5):
+            response = self.client.get(url)
+        # 200 with None body when no action declared yet.
+        self.assertEqual(response.status_code, 200)

--- a/src/world/combat/tests/test_view_query_counts.py
+++ b/src/world/combat/tests/test_view_query_counts.py
@@ -121,11 +121,19 @@ class MyActionQueryCountTests(_SharedSetupMixin, TestCase):
     def test_warm_my_action_query_count(self) -> None:
         url = f"/api/combat/{self.encounter.pk}/my_action/"
         self.client.get(url)  # warm-up
-        # 1 session + 1 encounter + 2 prefetch. The per-request roster
-        # cache shared between IsEncounterParticipant and
-        # _get_participant collapses two roster queries into one — and
-        # the prefetch warm-up means it doesn't fire a second time on
-        # the cached request.
+        # 4 queries on the second call:
+        #   1. DRF session lookup
+        #   2. CombatEncounter SELECT (get_object runs the .get(), even
+        #      though SharedMemoryModel returns the identity-mapped row)
+        #   3. RosterEntry.for_account(...).character_ids() — shared
+        #      between IsEncounterParticipant and _get_participant via
+        #      request._combat_viewer_character_ids
+        #   4. CombatRoundAction.filter(participant, round_number)
+        # The participants_cached + opponents_cached prefetches do NOT
+        # fire on the warm call: they ran during warm-up and populated
+        # attributes on the identity-mapped encounter, so the second
+        # get_object hands back the same instance with those lists
+        # already attached.
         with self.assertNumQueries(4):
             response = self.client.get(url)
         # 200 with None body when no action declared yet.

--- a/src/world/combat/tests/test_view_query_counts.py
+++ b/src/world/combat/tests/test_view_query_counts.py
@@ -121,13 +121,12 @@ class MyActionQueryCountTests(_SharedSetupMixin, TestCase):
     def test_warm_my_action_query_count(self) -> None:
         url = f"/api/combat/{self.encounter.pk}/my_action/"
         self.client.get(url)  # warm-up
-        # 1 session + 1 encounter + 2 prefetch + 1 roster (in
-        # _get_participant). The per-request roster cache eliminates
-        # the duplicate when an endpoint calls both _get_participant
-        # AND _build_serializer_context — my_action only calls the
-        # former, so it doesn't benefit. Endpoints like ready/declare
-        # that call both shed one query in the same fix.
-        with self.assertNumQueries(5):
+        # 1 session + 1 encounter + 2 prefetch. The per-request roster
+        # cache shared between IsEncounterParticipant and
+        # _get_participant collapses two roster queries into one — and
+        # the prefetch warm-up means it doesn't fire a second time on
+        # the cached request.
+        with self.assertNumQueries(4):
             response = self.client.get(url)
         # 200 with None body when no action declared yet.
         self.assertEqual(response.status_code, 200)

--- a/src/world/combat/tests/test_views.py
+++ b/src/world/combat/tests/test_views.py
@@ -233,6 +233,37 @@ class PlayerActionTest(CombatEncounterViewSetTestBase):
         )
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
 
+    def test_join_requires_character_sheet_id(self) -> None:
+        """POST /join without character_sheet_id returns 400."""
+        # Use a fresh account with no existing participation
+        joiner_account = AccountFactory(username="joiner_no_id")
+        joiner_character = CharacterFactory(db_key="joiner_no_id_char")
+        CharacterSheetFactory(character=joiner_character)
+        RosterTenureFactory(
+            roster_entry__character_sheet__character=joiner_character,
+            player_data__account=joiner_account,
+        )
+        # Encounter must accept a same-room join — easiest: use the scene one,
+        # which IsInEncounterRoom is bypassed for staff... use staff to skip
+        # the room check and isolate the validation behavior.
+        staff = AccountFactory(username="join_check_staff", is_staff=True)
+        client = APIClient()
+        client.force_authenticate(user=staff)
+        response = client.post(f"/api/combat/{self.encounter.pk}/join/")
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+
+    def test_join_rejects_other_users_character(self) -> None:
+        """POST /join with a character the user does not play returns 403."""
+        client = APIClient()
+        client.force_authenticate(user=self.player_account)
+        # Pass the GM's sheet pk — the player doesn't play it.
+        response = client.post(
+            f"/api/combat/{self.encounter.pk}/join/",
+            {"character_sheet_id": self.gm_sheet.pk},
+            format="json",
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_403_FORBIDDEN)
+
     def test_flee_marks_participant_fled(self) -> None:
         """Flee endpoint marks the participant as FLED."""
         # Use a separate encounter in DECLARING status for the flee test

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 from http import HTTPMethod
-from typing import cast
 
 from django.db.models import Prefetch, QuerySet
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
-from evennia.accounts.models import AccountDB
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -58,7 +56,6 @@ from world.combat.services import (
 )
 from world.covenants.models import CovenantRole
 from world.magic.models import Technique
-from world.roster.models import RosterEntry
 from world.stories.pagination import StandardResultsSetPagination
 
 # Fixed error messages for API responses (never expose raw exception strings).
@@ -466,24 +463,17 @@ class CombatEncounterViewSet(ModelViewSet):
 
     # --- Helpers ---
 
-    def _viewer_character_ids(self, request: Request) -> set[int]:
+    def _viewer_character_ids(self, request: Request) -> frozenset[int]:
         """Return character_sheet ids the request user currently plays.
 
-        Caches the result on the ``request`` object so multiple callers in
-        the same request (serializer context + ``_get_participant``) share
-        a single roster query instead of duplicating it.
+        Reads the cached property on ``request.user`` (the ``Account``
+        typeclass exposes ``played_character_sheet_ids``); falls back to
+        an empty set for anonymous / non-Account users.
         """
-        if hasattr(request, "_combat_viewer_character_ids"):
-            return request._combat_viewer_character_ids  # noqa: SLF001
-        if not request.user.is_authenticated:
-            ids: set[int] = set()
-        else:
-            user = cast(AccountDB, request.user)
-            ids = set(RosterEntry.objects.for_account(user).character_ids())
-        # Per-request cache attribute. Namespaced with the combat prefix so
-        # it doesn't collide with any other code stashing state on request.
-        request._combat_viewer_character_ids = ids  # noqa: SLF001
-        return ids
+        try:
+            return request.user.played_character_sheet_ids
+        except AttributeError:
+            return frozenset()
 
     def _serialize_encounter(
         self,

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -418,6 +418,13 @@ class CombatEncounterViewSet(ModelViewSet):
         Requires an explicit ``character_sheet_id`` in the request body;
         never auto-selects a character. The chosen sheet must belong to
         an active roster tenure for the requesting user.
+
+        **No staff bypass on the ownership check.** Staff users who want
+        to put a character into an encounter use the GM-side
+        ``add_participant`` action — which lets them name any
+        character_sheet without an ownership requirement. ``join`` is the
+        self-service "act as my own character" entry point, and the
+        ownership check applies to staff identically to players.
         """
         encounter = self.get_object()
         serializer = JoinEncounterSerializer(data=request.data)

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -520,7 +520,13 @@ class CombatEncounterViewSet(ModelViewSet):
         participant: CombatParticipant,
         encounter: CombatEncounter,
     ) -> CombatRoundAction | None:
-        """Return the participant's CombatRoundAction for the current round."""
+        """Return the participant's CombatRoundAction for the current round.
+
+        Uses ``.first()`` because the unique constraint
+        ``unique_action_per_participant_per_round`` (see
+        ``CombatRoundAction.Meta``) guarantees at most one row per
+        ``(participant, round_number)`` — no ordering needed.
+        """
         return CombatRoundAction.objects.filter(
             participant=participant,
             round_number=encounter.round_number,

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -39,6 +39,7 @@ from world.combat.serializers import (
     DeclareActionSerializer,
     EncounterDetailSerializer,
     EncounterListSerializer,
+    JoinEncounterSerializer,
     RemoveParticipantSerializer,
     RoundActionSerializer,
     UpgradeComboSerializer,
@@ -64,7 +65,7 @@ from world.stories.pagination import StandardResultsSetPagination
 _ERR_NOT_PARTICIPANT = "Not a participant in this encounter."
 _ERR_NO_ACTION = "No action declared for this round."
 _ERR_ALREADY_JOINED = "Already in this encounter."
-_ERR_NO_CHARACTER = "No active character found."
+_ERR_CHARACTER_NOT_YOURS = "You do not currently play that character."
 _ERR_ADD_PARTICIPANT = "Failed to add participant."
 _ERR_DECLARE_FAILED = "Failed to declare action."
 _ERR_INVALID_STATUS = "Encounter is not in a valid status for this action."
@@ -311,10 +312,7 @@ class CombatEncounterViewSet(ModelViewSet):
                 {"detail": _ERR_NOT_PARTICIPANT},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        current_action = CombatRoundAction.objects.filter(
-            participant=participant,
-            round_number=encounter.round_number,
-        ).first()
+        current_action = self._current_round_action(participant, encounter)
         if not current_action:
             return Response(
                 {"detail": _ERR_NO_ACTION},
@@ -334,10 +332,7 @@ class CombatEncounterViewSet(ModelViewSet):
                 {"detail": _ERR_NOT_PARTICIPANT},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        action_obj = CombatRoundAction.objects.filter(
-            participant=participant,
-            round_number=encounter.round_number,
-        ).first()
+        action_obj = self._current_round_action(participant, encounter)
         if not action_obj:
             return Response(None)
         return Response(RoundActionSerializer(action_obj).data)
@@ -376,10 +371,7 @@ class CombatEncounterViewSet(ModelViewSet):
         serializer.is_valid(raise_exception=True)
         combo_id = serializer.validated_data["combo_id"]
         combo = get_object_or_404(ComboDefinition, pk=combo_id)
-        current_action = CombatRoundAction.objects.filter(
-            participant=participant,
-            round_number=encounter.round_number,
-        ).first()
+        current_action = self._current_round_action(participant, encounter)
         if not current_action:
             return Response(
                 {"detail": _ERR_NO_ACTION},
@@ -406,10 +398,7 @@ class CombatEncounterViewSet(ModelViewSet):
                 {"detail": _ERR_NOT_PARTICIPANT},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        current_action = CombatRoundAction.objects.filter(
-            participant=participant,
-            round_number=encounter.round_number,
-        ).first()
+        current_action = self._current_round_action(participant, encounter)
         if not current_action:
             return Response(
                 {"detail": _ERR_NO_ACTION},
@@ -424,17 +413,22 @@ class CombatEncounterViewSet(ModelViewSet):
 
     @action(detail=True, methods=[HTTPMethod.POST])
     def join(self, request: Request, pk: int | None = None) -> Response:
-        """Player self-joins the encounter."""
+        """Player self-joins the encounter as the specified character.
+
+        Requires an explicit ``character_sheet_id`` in the request body;
+        never auto-selects a character. The chosen sheet must belong to
+        an active roster tenure for the requesting user.
+        """
         encounter = self.get_object()
-        user = cast(AccountDB, request.user)
-        active_entries = RosterEntry.objects.for_account(user)
-        character_ids = active_entries.values_list("character_sheet_id", flat=True)
-        sheet = CharacterSheet.objects.filter(character_id__in=character_ids).first()
-        if not sheet:
+        serializer = JoinEncounterSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        sheet_pk = serializer.validated_data["character_sheet_id"]
+        if sheet_pk not in self._viewer_character_ids(request):
             return Response(
-                {"detail": _ERR_NO_CHARACTER},
-                status=status.HTTP_400_BAD_REQUEST,
+                {"detail": _ERR_CHARACTER_NOT_YOURS},
+                status=status.HTTP_403_FORBIDDEN,
             )
+        sheet = get_object_or_404(CharacterSheet, pk=sheet_pk)
         try:
             new_participant = join_encounter(encounter, sheet)
         except ValueError:
@@ -465,6 +459,25 @@ class CombatEncounterViewSet(ModelViewSet):
 
     # --- Helpers ---
 
+    def _viewer_character_ids(self, request: Request) -> set[int]:
+        """Return character_sheet ids the request user currently plays.
+
+        Caches the result on the ``request`` object so multiple callers in
+        the same request (serializer context + ``_get_participant``) share
+        a single roster query instead of duplicating it.
+        """
+        if hasattr(request, "_combat_viewer_character_ids"):
+            return request._combat_viewer_character_ids  # noqa: SLF001
+        if not request.user.is_authenticated:
+            ids: set[int] = set()
+        else:
+            user = cast(AccountDB, request.user)
+            ids = set(RosterEntry.objects.for_account(user).character_ids())
+        # Per-request cache attribute. Namespaced with the combat prefix so
+        # it doesn't collide with any other code stashing state on request.
+        request._combat_viewer_character_ids = ids  # noqa: SLF001
+        return ids
+
     def _serialize_encounter(
         self,
         request: Request,
@@ -493,24 +506,25 @@ class CombatEncounterViewSet(ModelViewSet):
         queries.
         """
         context: dict = {"request": request}
-
-        if not request.user.is_authenticated:
-            context["viewer_character_ids"] = set()
-            context["is_gm"] = False
-            return context
-
-        user = cast(AccountDB, request.user)
-        character_ids = set(
-            RosterEntry.objects.for_account(user).character_ids(),
-        )
-        context["viewer_character_ids"] = character_ids
+        context["viewer_character_ids"] = self._viewer_character_ids(request)
 
         is_gm = False
-        if not request.user.is_staff and encounter.scene:
+        if request.user.is_authenticated and not request.user.is_staff and encounter.scene:
             is_gm = encounter.scene.is_gm(request.user)
-        context["is_gm"] = request.user.is_staff or is_gm
+        context["is_gm"] = bool(request.user.is_authenticated and request.user.is_staff) or is_gm
 
         return context
+
+    def _current_round_action(
+        self,
+        participant: CombatParticipant,
+        encounter: CombatEncounter,
+    ) -> CombatRoundAction | None:
+        """Return the participant's CombatRoundAction for the current round."""
+        return CombatRoundAction.objects.filter(
+            participant=participant,
+            round_number=encounter.round_number,
+        ).first()
 
     def _get_participant(
         self,
@@ -519,14 +533,11 @@ class CombatEncounterViewSet(ModelViewSet):
     ) -> CombatParticipant | None:
         """Get the requesting user's active participant from cached data.
 
-        Uses participants_cached (prefetched on the encounter) and
-        viewer_character_ids (from serializer context or fresh lookup).
-        No DB query if the encounter was loaded via _base_queryset.
+        Walks ``participants_cached`` (prefetched on the encounter) and
+        reads ``viewer_character_ids`` from the per-request cache — no
+        new DB queries when the encounter is warm.
         """
-        user = cast(AccountDB, request.user)
-        character_ids = set(
-            RosterEntry.objects.for_account(user).character_ids(),
-        )
+        character_ids = self._viewer_character_ids(request)
         return next(
             (
                 p

--- a/src/world/items/tests/test_handlers.py
+++ b/src/world/items/tests/test_handlers.py
@@ -94,13 +94,16 @@ class CharacterCarriedItemsHandlerTests(TestCase):
         cls.theirs = _item_on(cls.other_character, "Theirs")
 
     def setUp(self) -> None:
-        # Cross-app test pollution guard. The two explicit ``invalidate()``
-        # calls below do the real work — they reset the handler's
-        # ``_cached`` so the next read fetches fresh rows. The
-        # ``flush_instance_cache()`` is belt-and-suspenders: it drops any
-        # stale ItemInstance Python objects that other apps' tests left
-        # in the SharedMemoryModel identity map, so the fresh fetch is
-        # built from clean instances rather than warmed-over ones.
+        # Cross-app test pollution guard. The ``flush_instance_cache()``
+        # is the one doing the real work — when other apps' tests have
+        # populated the SharedMemoryModel identity map with ItemInstance
+        # rows whose pks may collide with ours, a fresh handler read
+        # would otherwise pull in those stale Python instances. Flushing
+        # the model cache forces the next queryset to materialize new
+        # instances from fresh rows. The handler ``invalidate()`` calls
+        # are belt-and-suspenders: they reset ``_cached`` so even if
+        # something repopulated the handler between flush and read,
+        # it'd still re-fetch.
         from world.items.models import ItemInstance
 
         ItemInstance.flush_instance_cache()
@@ -181,8 +184,8 @@ class CharacterSheetOutfitsHandlerTests(TestCase):
 
     def setUp(self) -> None:
         # Cross-app pollution guard — see CharacterCarriedItemsHandlerTests.setUp
-        # for what each line does. The ``invalidate()`` calls are the real
-        # fix; ``flush_instance_cache()`` is defense-in-depth.
+        # for what each line does. The ``flush_instance_cache()`` is the
+        # real fix; the ``invalidate()`` calls are defense-in-depth.
         from world.items.models import Outfit
 
         Outfit.flush_instance_cache()

--- a/src/world/items/tests/test_handlers.py
+++ b/src/world/items/tests/test_handlers.py
@@ -94,10 +94,13 @@ class CharacterCarriedItemsHandlerTests(TestCase):
         cls.theirs = _item_on(cls.other_character, "Theirs")
 
     def setUp(self) -> None:
-        # Cross-app test pollution guard: when this suite runs alongside
-        # apps that create many ObjectDBs (e.g., magic), the identity-map
-        # can hand back stale instances on character.carried_items lookups.
-        # Flushing ItemInstance forces a fresh load of the prefetched rows.
+        # Cross-app test pollution guard. The two explicit ``invalidate()``
+        # calls below do the real work — they reset the handler's
+        # ``_cached`` so the next read fetches fresh rows. The
+        # ``flush_instance_cache()`` is belt-and-suspenders: it drops any
+        # stale ItemInstance Python objects that other apps' tests left
+        # in the SharedMemoryModel identity map, so the fresh fetch is
+        # built from clean instances rather than warmed-over ones.
         from world.items.models import ItemInstance
 
         ItemInstance.flush_instance_cache()
@@ -177,7 +180,9 @@ class CharacterSheetOutfitsHandlerTests(TestCase):
         )
 
     def setUp(self) -> None:
-        # Cross-app pollution guard — see CharacterCarriedItemsHandlerTests.setUp.
+        # Cross-app pollution guard — see CharacterCarriedItemsHandlerTests.setUp
+        # for what each line does. The ``invalidate()`` calls are the real
+        # fix; ``flush_instance_cache()`` is defense-in-depth.
         from world.items.models import Outfit
 
         Outfit.flush_instance_cache()

--- a/src/world/items/tests/test_handlers.py
+++ b/src/world/items/tests/test_handlers.py
@@ -93,6 +93,17 @@ class CharacterCarriedItemsHandlerTests(TestCase):
         cls.mine_b = _item_on(cls.character, "MineB")
         cls.theirs = _item_on(cls.other_character, "Theirs")
 
+    def setUp(self) -> None:
+        # Cross-app test pollution guard: when this suite runs alongside
+        # apps that create many ObjectDBs (e.g., magic), the identity-map
+        # can hand back stale instances on character.carried_items lookups.
+        # Flushing ItemInstance forces a fresh load of the prefetched rows.
+        from world.items.models import ItemInstance
+
+        ItemInstance.flush_instance_cache()
+        self.character.carried_items.invalidate()
+        self.other_character.carried_items.invalidate()
+
     def test_returns_only_items_carried_by_character(self) -> None:
         items = list(self.character.carried_items)
         pks = {it.pk for it in items}
@@ -164,6 +175,14 @@ class CharacterSheetOutfitsHandlerTests(TestCase):
             wardrobe=cls.wardrobe,
             name="Theirs",
         )
+
+    def setUp(self) -> None:
+        # Cross-app pollution guard — see CharacterCarriedItemsHandlerTests.setUp.
+        from world.items.models import Outfit
+
+        Outfit.flush_instance_cache()
+        self.sheet.saved_outfits.invalidate()
+        self.other_sheet.saved_outfits.invalidate()
 
     def test_returns_only_outfits_for_sheet(self) -> None:
         outfits = list(self.sheet.saved_outfits)

--- a/src/world/magic/filters.py
+++ b/src/world/magic/filters.py
@@ -5,7 +5,16 @@ import django_filters
 from rest_framework.exceptions import ValidationError
 
 from world.magic.constants import GainSource, ParticipationRule
-from world.magic.models import Cantrip, ResonanceGrant, Thread, ThreadWeavingTeachingOffer
+from world.magic.models import (
+    Cantrip,
+    CharacterAnima,
+    CharacterAura,
+    CharacterGift,
+    CharacterResonance,
+    ResonanceGrant,
+    Thread,
+    ThreadWeavingTeachingOffer,
+)
 from world.magic.models.sessions import RitualSession
 
 
@@ -40,6 +49,48 @@ class ThreadFilter(django_filters.FilterSet):
     class Meta:
         model = Thread
         fields = ["resonance", "target_kind"]
+
+
+class CharacterAuraFilter(django_filters.FilterSet):
+    """Filter for CharacterAura. Allows narrowing to a specific character."""
+
+    character = django_filters.NumberFilter(field_name="character_id")
+
+    class Meta:
+        model = CharacterAura
+        fields = ["character"]
+
+
+class CharacterResonanceFilter(django_filters.FilterSet):
+    """Filter for CharacterResonance. Narrows to a specific character_sheet."""
+
+    character_sheet = django_filters.NumberFilter(field_name="character_sheet_id")
+    resonance = django_filters.NumberFilter(field_name="resonance_id")
+
+    class Meta:
+        model = CharacterResonance
+        fields = ["character_sheet", "resonance"]
+
+
+class CharacterGiftFilter(django_filters.FilterSet):
+    """Filter for CharacterGift. Narrows to a specific character."""
+
+    character = django_filters.NumberFilter(field_name="character_id")
+    gift = django_filters.NumberFilter(field_name="gift_id")
+
+    class Meta:
+        model = CharacterGift
+        fields = ["character", "gift"]
+
+
+class CharacterAnimaFilter(django_filters.FilterSet):
+    """Filter for CharacterAnima. Narrows to a specific character."""
+
+    character = django_filters.NumberFilter(field_name="character_id")
+
+    class Meta:
+        model = CharacterAnima
+        fields = ["character"]
 
 
 class ThreadWeavingTeachingOfferFilter(django_filters.FilterSet):

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -313,34 +313,37 @@ class CharacterAuraViewSet(viewsets.ModelViewSet):
     """
     ViewSet for CharacterAura records.
 
-    Provides access to character aura data. Users can only access
-    auras for characters they own (or all if staff).
+    Provides access to character aura data. Non-staff users see all
+    characters they currently play (active roster tenure), regardless
+    of whether they are actively puppeting them right now.
     """
 
     serializer_class = CharacterAuraSerializer
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        """Filter to characters owned by the current user."""
+        """Filter to characters the current user plays (or all if staff)."""
         user = self.request.user
         if user.is_staff:
             return CharacterAura.objects.all()
-        # Filter to characters owned by this account
-        return CharacterAura.objects.filter(character__db_account=user)
+        character_ids = RosterEntry.objects.for_account(cast(AccountDB, user)).character_ids()
+        return CharacterAura.objects.filter(character_id__in=character_ids)
 
 
 class CharacterResonanceViewSet(viewsets.ModelViewSet):
     """
     ViewSet for CharacterResonance records.
 
-    Manages personal resonances attached to characters.
+    Manages personal resonances attached to characters. Non-staff users
+    see all characters they currently play (active roster tenure),
+    regardless of whether they are actively puppeting them right now.
     """
 
     serializer_class = CharacterResonanceSerializer
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        """Filter to characters owned by the current user."""
+        """Filter to characters the current user plays (or all if staff)."""
         user = self.request.user
         queryset = CharacterResonance.objects.select_related(
             "character_sheet",
@@ -351,21 +354,24 @@ class CharacterResonanceViewSet(viewsets.ModelViewSet):
         )
         if user.is_staff:
             return queryset
-        return queryset.filter(character_sheet__character__db_account=user)
+        sheet_ids = RosterEntry.objects.for_account(cast(AccountDB, user)).character_ids()
+        return queryset.filter(character_sheet_id__in=sheet_ids)
 
 
 class CharacterGiftViewSet(viewsets.ModelViewSet):
     """
     ViewSet for CharacterGift records.
 
-    Manages gifts possessed by characters.
+    Manages gifts possessed by characters. Non-staff users see all
+    characters they currently play (active roster tenure), regardless
+    of whether they are actively puppeting them right now.
     """
 
     serializer_class = CharacterGiftSerializer
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        """Filter to characters owned by the current user."""
+        """Filter to characters the current user plays (or all if staff)."""
         user = self.request.user
         queryset = CharacterGift.objects.select_related("gift").prefetch_related(
             Prefetch(
@@ -383,25 +389,29 @@ class CharacterGiftViewSet(viewsets.ModelViewSet):
         )
         if user.is_staff:
             return queryset
-        return queryset.filter(character__db_account=user)
+        character_ids = RosterEntry.objects.for_account(cast(AccountDB, user)).character_ids()
+        return queryset.filter(character_id__in=character_ids)
 
 
 class CharacterAnimaViewSet(viewsets.ModelViewSet):
     """
     ViewSet for CharacterAnima records.
 
-    Manages character anima (magical energy) tracking.
+    Manages character anima (magical energy) tracking. Non-staff users
+    see all characters they currently play (active roster tenure),
+    regardless of whether they are actively puppeting them right now.
     """
 
     serializer_class = CharacterAnimaSerializer
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        """Filter to characters owned by the current user."""
+        """Filter to characters the current user plays (or all if staff)."""
         user = self.request.user
         if user.is_staff:
             return CharacterAnima.objects.all()
-        return CharacterAnima.objects.filter(character__db_account=user)
+        character_ids = RosterEntry.objects.for_account(cast(AccountDB, user)).character_ids()
+        return CharacterAnima.objects.filter(character_id__in=character_ids)
 
 
 # =============================================================================

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -43,6 +43,10 @@ from world.magic.exceptions import (
 )
 from world.magic.filters import (
     CantripFilter,
+    CharacterAnimaFilter,
+    CharacterAuraFilter,
+    CharacterGiftFilter,
+    CharacterResonanceFilter,
     ResonanceGrantFilterSet,
     RitualSessionFilterSet,
     ThreadFilter,
@@ -315,11 +319,15 @@ class CharacterAuraViewSet(viewsets.ModelViewSet):
 
     Provides access to character aura data. Non-staff users see all
     characters they currently play (active roster tenure), regardless
-    of whether they are actively puppeting them right now.
+    of whether they are actively puppeting them right now. Frontends
+    that need a single-character view should pass ``?character=<pk>``
+    to disambiguate when the user has alts.
     """
 
     serializer_class = CharacterAuraSerializer
     permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = CharacterAuraFilter
 
     def get_queryset(self):
         """Filter to characters the current user plays (or all if staff)."""
@@ -337,10 +345,15 @@ class CharacterResonanceViewSet(viewsets.ModelViewSet):
     Manages personal resonances attached to characters. Non-staff users
     see all characters they currently play (active roster tenure),
     regardless of whether they are actively puppeting them right now.
+    Frontends that operate on a single character (e.g., the resonance
+    picker for rituals) should pass ``?character_sheet=<pk>`` so the
+    result is unambiguous when the user has alts.
     """
 
     serializer_class = CharacterResonanceSerializer
     permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = CharacterResonanceFilter
 
     def get_queryset(self):
         """Filter to characters the current user plays (or all if staff)."""
@@ -364,11 +377,14 @@ class CharacterGiftViewSet(viewsets.ModelViewSet):
 
     Manages gifts possessed by characters. Non-staff users see all
     characters they currently play (active roster tenure), regardless
-    of whether they are actively puppeting them right now.
+    of whether they are actively puppeting them right now. Pass
+    ``?character=<pk>`` to narrow to a single character.
     """
 
     serializer_class = CharacterGiftSerializer
     permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = CharacterGiftFilter
 
     def get_queryset(self):
         """Filter to characters the current user plays (or all if staff)."""
@@ -400,10 +416,13 @@ class CharacterAnimaViewSet(viewsets.ModelViewSet):
     Manages character anima (magical energy) tracking. Non-staff users
     see all characters they currently play (active roster tenure),
     regardless of whether they are actively puppeting them right now.
+    Pass ``?character=<pk>`` to narrow to a single character.
     """
 
     serializer_class = CharacterAnimaSerializer
     permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = CharacterAnimaFilter
 
     def get_queryset(self):
         """Filter to characters the current user plays (or all if staff)."""


### PR DESCRIPTION
 Commit 1 (bcd5c6a1) — combat viewset audit
  - join requires explicit character_sheet_id; rejects auto-select pattern
  - Per-request roster cache via _viewer_character_ids
  - _current_round_action helper consolidates four duplicate lookups
  - New test_view_query_counts.py locks list/retrieve/my_action budgets

  Commit 2 (98360687) — adversarial review fixes + bundled follow-ups
  - Combat review fixes: permission classes route through the request cache (my_action budget drops 5 → 4), min_value=1 on the new serializer, documented
  .first() safety
  - Magic correctness fix: 4 ViewSets (CharacterAura/Resonance/Gift/Anima) were filtering by character__db_account=user (currently-puppeting), excluding
  alts. Now use RosterEntry.objects.for_account like everywhere else.
  - Flow test flake fix: 3 TestSceneDataManager tests used pk=999 as "doesn't exist," but the fallback ObjectDB.objects.get(pk=999) can hit a real row in
  cross-app fresh-DB runs. Mocked the lookup.
  - Items test pollution guard: CharacterCarriedItemsHandlerTests and CharacterSheetOutfitsHandlerTests failed in cross-app runs; added flush_instance_cache
   + invalidate in setUp matching the established pattern.

  Test results

  - 2155/2155 pass on the combined world.items + world.combat + world.magic + flows suite, both --keepdb AND fresh-DB
  - Pre-existing scene_data_manager flakes are now fixed in cross-app runs

  Skipped from the cleanup-bundle option

  - N2 (Outfit.character_sheet related_name rename) — migration risk, not worth bundling
  - noqa malformed-directive sweep — too broad (10+ files, mechanical), better as its own focused PR
  - Full test-pollution audit — variable scope, ad-hoc as discovered

  Open follow-ups (still in memory, not done)

  - drf-spectacular introspection fix for the new viewsets.ViewSet classes (blocks frontend type regen)
  - Staff scheduler tooling (needs brainstorm)
  - Item ViewSet audit follow-ups from earlier reviews