### PR TITLE
fix(items): @extend_schema decorators for item-first viewsets

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -4914,14 +4914,24 @@ export interface paths {
     };
     /** @description Return a single Outfit if the requester may view it. */
     get: operations['items_outfits_retrieve'];
-    /** @description Full update (PUT) — rename/edit outfit row directly. */
+    /**
+     * @description Full update (PUT) — rename/redescribe an outfit.
+     *
+     *     Only ``name`` and ``description`` are mutable. ``character_sheet``
+     *     and ``wardrobe`` are write-once (set at create time). See
+     *     ``OutfitRenameSerializer`` for the accepted request shape.
+     */
     put: operations['items_outfits_update'];
     post?: never;
     /** @description Delete via the delete_outfit service (cascades slots). */
     delete: operations['items_outfits_destroy'];
     options?: never;
     head?: never;
-    /** @description Partial update (PATCH). */
+    /**
+     * @description Partial update (PATCH) — rename/redescribe an outfit.
+     *
+     *     Same field set as PUT (only ``name``/``description``).
+     */
     patch: operations['items_outfits_partial_update'];
     trace?: never;
   };
@@ -12865,6 +12875,20 @@ export interface components {
       /** Format: date-time */
       readonly updated_at: string;
     };
+    /**
+     * @description Write serializer for renames/redescribes (PUT / PATCH on Outfit).
+     *
+     *     Distinct from ``OutfitWriteSerializer`` because update only touches
+     *     ``name`` and ``description`` — exposing ``character_sheet`` and
+     *     ``wardrobe`` in the request schema would imply they're editable when
+     *     they're write-once. The viewset wires this serializer via
+     *     ``@extend_schema`` on update/partial_update so the public API contract
+     *     matches reality.
+     */
+    OutfitRenameRequest: {
+      name: string;
+      description?: string;
+    };
     /** @description Read serializer for OutfitSlot — nests the item instance. */
     OutfitSlotRead: {
       readonly id: number;
@@ -13166,6 +13190,14 @@ export interface components {
       previous?: string | null;
       results?: components['schemas']['EpisodeScene'][];
     };
+    PaginatedEquippedItemReadList: {
+      count: number;
+      /** Format: uri */
+      next: string | null;
+      /** Format: uri */
+      previous: string | null;
+      results: components['schemas']['EquippedItemRead'][];
+    };
     PaginatedEraList: {
       /** @example 123 */
       count?: number;
@@ -13381,6 +13413,22 @@ export interface components {
       previous?: string | null;
       results?: components['schemas']['InteractionList'][];
     };
+    PaginatedItemFacetReadList: {
+      count: number;
+      /** Format: uri */
+      next: string | null;
+      /** Format: uri */
+      previous: string | null;
+      results: components['schemas']['ItemFacetRead'][];
+    };
+    PaginatedItemInstanceReadList: {
+      count: number;
+      /** Format: uri */
+      next: string | null;
+      /** Format: uri */
+      previous: string | null;
+      results: components['schemas']['ItemInstanceRead'][];
+    };
     PaginatedItemTemplateListList: {
       /** @example 123 */
       count?: number;
@@ -13425,6 +13473,22 @@ export interface components {
        */
       previous?: string | null;
       results?: components['schemas']['OrganizationSearch'][];
+    };
+    PaginatedOutfitReadList: {
+      count: number;
+      /** Format: uri */
+      next: string | null;
+      /** Format: uri */
+      previous: string | null;
+      results: components['schemas']['OutfitRead'][];
+    };
+    PaginatedOutfitSlotReadList: {
+      count: number;
+      /** Format: uri */
+      next: string | null;
+      /** Format: uri */
+      previous: string | null;
+      results: components['schemas']['OutfitSlotRead'][];
     };
     PaginatedPendingAlterationList: {
       /** @example 123 */
@@ -14273,14 +14337,19 @@ export interface components {
       current_episode?: number | null;
       is_active?: boolean;
     };
-    /** @description Write serializer for Outfit — POST snapshots current loadout via save_outfit. */
-    PatchedOutfitWriteRequest: {
+    /**
+     * @description Write serializer for renames/redescribes (PUT / PATCH on Outfit).
+     *
+     *     Distinct from ``OutfitWriteSerializer`` because update only touches
+     *     ``name`` and ``description`` — exposing ``character_sheet`` and
+     *     ``wardrobe`` in the request schema would imply they're editable when
+     *     they're write-once. The viewset wires this serializer via
+     *     ``@extend_schema`` on update/partial_update so the public API contract
+     *     matches reality.
+     */
+    PatchedOutfitRenameRequest: {
       name?: string;
       description?: string;
-      /** @description The character this sheet belongs to */
-      character_sheet?: number;
-      /** @description The wardrobe ItemInstance this outfit is stored in. */
-      wardrobe?: number;
     };
     PatchedPersonaRequest: {
       /** @description The character sheet this persona belongs to. */
@@ -23558,7 +23627,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['EquippedItemRead'][];
+          'application/json': components['schemas']['PaginatedEquippedItemReadList'][];
         };
       };
     };
@@ -23644,7 +23713,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['ItemInstanceRead'][];
+          'application/json': components['schemas']['PaginatedItemInstanceReadList'][];
         };
       };
     };
@@ -23687,7 +23756,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['ItemFacetRead'][];
+          'application/json': components['schemas']['PaginatedItemFacetReadList'][];
         };
       };
     };
@@ -23773,7 +23842,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['OutfitSlotRead'][];
+          'application/json': components['schemas']['PaginatedOutfitSlotReadList'][];
         };
       };
     };
@@ -23859,7 +23928,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['OutfitRead'][];
+          'application/json': components['schemas']['PaginatedOutfitReadList'][];
         };
       };
     };
@@ -23919,7 +23988,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['OutfitWriteRequest'];
+        'application/json': components['schemas']['OutfitRenameRequest'];
       };
     };
     responses: {
@@ -23964,7 +24033,7 @@ export interface operations {
     };
     requestBody?: {
       content: {
-        'application/json': components['schemas']['PatchedOutfitWriteRequest'];
+        'application/json': components['schemas']['PatchedOutfitRenameRequest'];
       };
     };
     responses: {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -2163,7 +2163,20 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** @description Player self-joins the encounter. */
+    /**
+     * @description Player self-joins the encounter as the specified character.
+     *
+     *     Requires an explicit ``character_sheet_id`` in the request body;
+     *     never auto-selects a character. The chosen sheet must belong to
+     *     an active roster tenure for the requesting user.
+     *
+     *     **No staff bypass on the ownership check.** Staff users who want
+     *     to put a character into an encounter use the GM-side
+     *     ``add_participant`` action — which lets them name any
+     *     character_sheet without an ownership requirement. ``join`` is the
+     *     self-service "act as my own character" entry point, and the
+     *     ownership check applies to staff identically to players.
+     */
     post: operations['combat_join_create'];
     delete?: never;
     options?: never;
@@ -2646,6 +2659,31 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/covenants/character-roles/{id}/promote/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description POST /api/covenants/character-roles/{id}/promote/
+     *
+     *     Promote the membership from its current parent role to a sub-role.
+     *     Body: { "target_subrole": <pk> }
+     *
+     *     Returns the new CharacterCovenantRole row on success.
+     *     Returns 400 with a user_message body on promotion failures.
+     */
+    post: operations['covenants_character_roles_promote_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/covenants/covenants/': {
     parameters: {
       query?: never;
@@ -2718,6 +2756,50 @@ export interface paths {
     };
     /** @description Read-only ViewSet for authored covenant×archetype compatibility rows. */
     get: operations['covenants_gear_compatibilities_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/covenants/level-thresholds/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only ViewSet for CovenantLevelThreshold authored lookup table.
+     *
+     *     Returns the legend totals required to reach each covenant level.
+     *     No pagination — this is a small, stable lookup table.
+     */
+    get: operations['covenants_level_thresholds_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/covenants/level-thresholds/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only ViewSet for CovenantLevelThreshold authored lookup table.
+     *
+     *     Returns the legend totals required to reach each covenant level.
+     *     No pagination — this is a small, stable lookup table.
+     */
+    get: operations['covenants_level_thresholds_retrieve'];
     put?: never;
     post?: never;
     delete?: never;
@@ -4629,12 +4711,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /**
-     * @description Read-only ViewSet for EquippedItem (GET list/detail).
-     *
-     *     Mutations (equip/unequip) flow through the unified action dispatcher
-     *     via the ``execute_action`` websocket inputfunc — REST stays read-only.
-     */
+    /** @description Return equipped items for ``?character=<pk>``. */
     get: operations['items_equipped_items_list'];
     put?: never;
     post?: never;
@@ -4651,12 +4728,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /**
-     * @description Read-only ViewSet for EquippedItem (GET list/detail).
-     *
-     *     Mutations (equip/unequip) flow through the unified action dispatcher
-     *     via the ``execute_action`` websocket inputfunc — REST stays read-only.
-     */
+    /** @description Return a single EquippedItem if the requester may view it. */
     get: operations['items_equipped_items_retrieve'];
     put?: never;
     post?: never;
@@ -4707,16 +4779,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /**
-     * @description Read-only listing of ItemInstance rows for a character's inventory.
-     *
-     *     The wardrobe page uses this to render carried-but-not-worn items. The
-     *     ``character`` query parameter filters to items whose ``game_object.location``
-     *     is the requested character (i.e., currently held by them).
-     *
-     *     Permission scoping (non-staff): only items located on a character the
-     *     request user currently plays are returned. Staff see everything.
-     */
+    /** @description Return ItemInstance rows located on ``?character=<pk>``. */
     get: operations['items_inventory_list'];
     put?: never;
     post?: never;
@@ -4733,16 +4796,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /**
-     * @description Read-only listing of ItemInstance rows for a character's inventory.
-     *
-     *     The wardrobe page uses this to render carried-but-not-worn items. The
-     *     ``character`` query parameter filters to items whose ``game_object.location``
-     *     is the requested character (i.e., currently held by them).
-     *
-     *     Permission scoping (non-staff): only items located on a character the
-     *     request user currently plays are returned. Staff see everything.
-     */
+    /** @description Return a single ItemInstance if the requester may view it. */
     get: operations['items_inventory_retrieve'];
     put?: never;
     post?: never;
@@ -4759,10 +4813,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** @description ViewSet for ItemFacet attach/list/delete. */
+    /** @description Return ItemFacet rows for ``?item_instance=<pk>``. */
     get: operations['items_item_facets_list'];
     put?: never;
-    /** @description ViewSet for ItemFacet attach/list/delete. */
+    /** @description Attach a facet via the serializer (which calls the service). */
     post: operations['items_item_facets_create'];
     delete?: never;
     options?: never;
@@ -4777,11 +4831,11 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** @description ViewSet for ItemFacet attach/list/delete. */
+    /** @description Return a single ItemFacet if the requester owns its item. */
     get: operations['items_item_facets_retrieve'];
     put?: never;
     post?: never;
-    /** @description ViewSet for ItemFacet attach/list/delete. */
+    /** @description Remove the facet via the service (which fires cache invalidation). */
     delete: operations['items_item_facets_destroy'];
     options?: never;
     head?: never;
@@ -4795,19 +4849,14 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /**
-     * @description ViewSet for OutfitSlot create/list/delete.
-     *
-     *     Flat per-slot endpoint (matches ``EquippedItemViewSet`` shape — one
-     *     POST adds or replaces a single slot, one DELETE removes one slot).
-     */
+    /** @description Return OutfitSlot rows for ``?outfit=<pk>``. */
     get: operations['items_outfit_slots_list'];
     put?: never;
     /**
-     * @description ViewSet for OutfitSlot create/list/delete.
+     * @description Create an OutfitSlot via the existing write serializer.
      *
-     *     Flat per-slot endpoint (matches ``EquippedItemViewSet`` shape — one
-     *     POST adds or replaces a single slot, one DELETE removes one slot).
+     *     Cache invalidation lives inside ``add_outfit_slot`` (called by the
+     *     serializer's ``create``), so no manual invalidation is needed here.
      */
     post: operations['items_outfit_slots_create'];
     delete?: never;
@@ -4823,20 +4872,14 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /**
-     * @description ViewSet for OutfitSlot create/list/delete.
-     *
-     *     Flat per-slot endpoint (matches ``EquippedItemViewSet`` shape — one
-     *     POST adds or replaces a single slot, one DELETE removes one slot).
-     */
+    /** @description Return a single OutfitSlot if the requester may view it. */
     get: operations['items_outfit_slots_retrieve'];
     put?: never;
     post?: never;
     /**
-     * @description ViewSet for OutfitSlot create/list/delete.
+     * @description Delete via remove_outfit_slot (idempotent).
      *
-     *     Flat per-slot endpoint (matches ``EquippedItemViewSet`` shape — one
-     *     POST adds or replaces a single slot, one DELETE removes one slot).
+     *     Cache invalidation lives inside ``remove_outfit_slot``.
      */
     delete: operations['items_outfit_slots_destroy'];
     options?: never;
@@ -4851,24 +4894,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /**
-     * @description ViewSet for Outfit definitions (save / list / rename / delete).
-     *
-     *     Save delegates to ``save_outfit`` (snapshots current loadout). PATCH
-     *     updates the Outfit row directly. DELETE delegates to ``delete_outfit``.
-     *     Per design, equip/unequip and apply/undress flow through the action
-     *     dispatcher — this ViewSet only handles configuration CRUD.
-     */
+    /** @description Return outfits saved on ``?character_sheet=<pk>``. */
     get: operations['items_outfits_list'];
     put?: never;
-    /**
-     * @description ViewSet for Outfit definitions (save / list / rename / delete).
-     *
-     *     Save delegates to ``save_outfit`` (snapshots current loadout). PATCH
-     *     updates the Outfit row directly. DELETE delegates to ``delete_outfit``.
-     *     Per design, equip/unequip and apply/undress flow through the action
-     *     dispatcher — this ViewSet only handles configuration CRUD.
-     */
+    /** @description Create an Outfit via the existing write serializer (calls save_outfit). */
     post: operations['items_outfits_create'];
     delete?: never;
     options?: never;
@@ -4883,44 +4912,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /**
-     * @description ViewSet for Outfit definitions (save / list / rename / delete).
-     *
-     *     Save delegates to ``save_outfit`` (snapshots current loadout). PATCH
-     *     updates the Outfit row directly. DELETE delegates to ``delete_outfit``.
-     *     Per design, equip/unequip and apply/undress flow through the action
-     *     dispatcher — this ViewSet only handles configuration CRUD.
-     */
+    /** @description Return a single Outfit if the requester may view it. */
     get: operations['items_outfits_retrieve'];
-    /**
-     * @description ViewSet for Outfit definitions (save / list / rename / delete).
-     *
-     *     Save delegates to ``save_outfit`` (snapshots current loadout). PATCH
-     *     updates the Outfit row directly. DELETE delegates to ``delete_outfit``.
-     *     Per design, equip/unequip and apply/undress flow through the action
-     *     dispatcher — this ViewSet only handles configuration CRUD.
-     */
+    /** @description Full update (PUT) — rename/edit outfit row directly. */
     put: operations['items_outfits_update'];
     post?: never;
-    /**
-     * @description ViewSet for Outfit definitions (save / list / rename / delete).
-     *
-     *     Save delegates to ``save_outfit`` (snapshots current loadout). PATCH
-     *     updates the Outfit row directly. DELETE delegates to ``delete_outfit``.
-     *     Per design, equip/unequip and apply/undress flow through the action
-     *     dispatcher — this ViewSet only handles configuration CRUD.
-     */
+    /** @description Delete via the delete_outfit service (cascades slots). */
     delete: operations['items_outfits_destroy'];
     options?: never;
     head?: never;
-    /**
-     * @description ViewSet for Outfit definitions (save / list / rename / delete).
-     *
-     *     Save delegates to ``save_outfit`` (snapshots current loadout). PATCH
-     *     updates the Outfit row directly. DELETE delegates to ``delete_outfit``.
-     *     Per design, equip/unequip and apply/undress flow through the action
-     *     dispatcher — this ViewSet only handles configuration CRUD.
-     */
+    /** @description Partial update (PATCH). */
     patch: operations['items_outfits_partial_update'];
     trace?: never;
   };
@@ -5117,14 +5118,20 @@ export interface paths {
     /**
      * @description ViewSet for CharacterAnima records.
      *
-     *     Manages character anima (magical energy) tracking.
+     *     Manages character anima (magical energy) tracking. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Pass ``?character=<pk>`` to narrow to a single character.
      */
     get: operations['magic_character_anima_list'];
     put?: never;
     /**
      * @description ViewSet for CharacterAnima records.
      *
-     *     Manages character anima (magical energy) tracking.
+     *     Manages character anima (magical energy) tracking. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Pass ``?character=<pk>`` to narrow to a single character.
      */
     post: operations['magic_character_anima_create'];
     delete?: never;
@@ -5143,20 +5150,29 @@ export interface paths {
     /**
      * @description ViewSet for CharacterAnima records.
      *
-     *     Manages character anima (magical energy) tracking.
+     *     Manages character anima (magical energy) tracking. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Pass ``?character=<pk>`` to narrow to a single character.
      */
     get: operations['magic_character_anima_retrieve'];
     /**
      * @description ViewSet for CharacterAnima records.
      *
-     *     Manages character anima (magical energy) tracking.
+     *     Manages character anima (magical energy) tracking. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Pass ``?character=<pk>`` to narrow to a single character.
      */
     put: operations['magic_character_anima_update'];
     post?: never;
     /**
      * @description ViewSet for CharacterAnima records.
      *
-     *     Manages character anima (magical energy) tracking.
+     *     Manages character anima (magical energy) tracking. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Pass ``?character=<pk>`` to narrow to a single character.
      */
     delete: operations['magic_character_anima_destroy'];
     options?: never;
@@ -5164,7 +5180,10 @@ export interface paths {
     /**
      * @description ViewSet for CharacterAnima records.
      *
-     *     Manages character anima (magical energy) tracking.
+     *     Manages character anima (magical energy) tracking. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Pass ``?character=<pk>`` to narrow to a single character.
      */
     patch: operations['magic_character_anima_partial_update'];
     trace?: never;
@@ -5179,16 +5198,22 @@ export interface paths {
     /**
      * @description ViewSet for CharacterAura records.
      *
-     *     Provides access to character aura data. Users can only access
-     *     auras for characters they own (or all if staff).
+     *     Provides access to character aura data. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Frontends
+     *     that need a single-character view should pass ``?character=<pk>``
+     *     to disambiguate when the user has alts.
      */
     get: operations['magic_character_auras_list'];
     put?: never;
     /**
      * @description ViewSet for CharacterAura records.
      *
-     *     Provides access to character aura data. Users can only access
-     *     auras for characters they own (or all if staff).
+     *     Provides access to character aura data. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Frontends
+     *     that need a single-character view should pass ``?character=<pk>``
+     *     to disambiguate when the user has alts.
      */
     post: operations['magic_character_auras_create'];
     delete?: never;
@@ -5207,23 +5232,32 @@ export interface paths {
     /**
      * @description ViewSet for CharacterAura records.
      *
-     *     Provides access to character aura data. Users can only access
-     *     auras for characters they own (or all if staff).
+     *     Provides access to character aura data. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Frontends
+     *     that need a single-character view should pass ``?character=<pk>``
+     *     to disambiguate when the user has alts.
      */
     get: operations['magic_character_auras_retrieve'];
     /**
      * @description ViewSet for CharacterAura records.
      *
-     *     Provides access to character aura data. Users can only access
-     *     auras for characters they own (or all if staff).
+     *     Provides access to character aura data. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Frontends
+     *     that need a single-character view should pass ``?character=<pk>``
+     *     to disambiguate when the user has alts.
      */
     put: operations['magic_character_auras_update'];
     post?: never;
     /**
      * @description ViewSet for CharacterAura records.
      *
-     *     Provides access to character aura data. Users can only access
-     *     auras for characters they own (or all if staff).
+     *     Provides access to character aura data. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Frontends
+     *     that need a single-character view should pass ``?character=<pk>``
+     *     to disambiguate when the user has alts.
      */
     delete: operations['magic_character_auras_destroy'];
     options?: never;
@@ -5231,8 +5265,11 @@ export interface paths {
     /**
      * @description ViewSet for CharacterAura records.
      *
-     *     Provides access to character aura data. Users can only access
-     *     auras for characters they own (or all if staff).
+     *     Provides access to character aura data. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Frontends
+     *     that need a single-character view should pass ``?character=<pk>``
+     *     to disambiguate when the user has alts.
      */
     patch: operations['magic_character_auras_partial_update'];
     trace?: never;
@@ -5247,14 +5284,20 @@ export interface paths {
     /**
      * @description ViewSet for CharacterGift records.
      *
-     *     Manages gifts possessed by characters.
+     *     Manages gifts possessed by characters. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Pass
+     *     ``?character=<pk>`` to narrow to a single character.
      */
     get: operations['magic_character_gifts_list'];
     put?: never;
     /**
      * @description ViewSet for CharacterGift records.
      *
-     *     Manages gifts possessed by characters.
+     *     Manages gifts possessed by characters. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Pass
+     *     ``?character=<pk>`` to narrow to a single character.
      */
     post: operations['magic_character_gifts_create'];
     delete?: never;
@@ -5273,20 +5316,29 @@ export interface paths {
     /**
      * @description ViewSet for CharacterGift records.
      *
-     *     Manages gifts possessed by characters.
+     *     Manages gifts possessed by characters. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Pass
+     *     ``?character=<pk>`` to narrow to a single character.
      */
     get: operations['magic_character_gifts_retrieve'];
     /**
      * @description ViewSet for CharacterGift records.
      *
-     *     Manages gifts possessed by characters.
+     *     Manages gifts possessed by characters. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Pass
+     *     ``?character=<pk>`` to narrow to a single character.
      */
     put: operations['magic_character_gifts_update'];
     post?: never;
     /**
      * @description ViewSet for CharacterGift records.
      *
-     *     Manages gifts possessed by characters.
+     *     Manages gifts possessed by characters. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Pass
+     *     ``?character=<pk>`` to narrow to a single character.
      */
     delete: operations['magic_character_gifts_destroy'];
     options?: never;
@@ -5294,7 +5346,10 @@ export interface paths {
     /**
      * @description ViewSet for CharacterGift records.
      *
-     *     Manages gifts possessed by characters.
+     *     Manages gifts possessed by characters. Non-staff users see all
+     *     characters they currently play (active roster tenure), regardless
+     *     of whether they are actively puppeting them right now. Pass
+     *     ``?character=<pk>`` to narrow to a single character.
      */
     patch: operations['magic_character_gifts_partial_update'];
     trace?: never;
@@ -5309,14 +5364,24 @@ export interface paths {
     /**
      * @description ViewSet for CharacterResonance records.
      *
-     *     Manages personal resonances attached to characters.
+     *     Manages personal resonances attached to characters. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Frontends that operate on a single character (e.g., the resonance
+     *     picker for rituals) should pass ``?character_sheet=<pk>`` so the
+     *     result is unambiguous when the user has alts.
      */
     get: operations['magic_character_resonances_list'];
     put?: never;
     /**
      * @description ViewSet for CharacterResonance records.
      *
-     *     Manages personal resonances attached to characters.
+     *     Manages personal resonances attached to characters. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Frontends that operate on a single character (e.g., the resonance
+     *     picker for rituals) should pass ``?character_sheet=<pk>`` so the
+     *     result is unambiguous when the user has alts.
      */
     post: operations['magic_character_resonances_create'];
     delete?: never;
@@ -5335,20 +5400,35 @@ export interface paths {
     /**
      * @description ViewSet for CharacterResonance records.
      *
-     *     Manages personal resonances attached to characters.
+     *     Manages personal resonances attached to characters. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Frontends that operate on a single character (e.g., the resonance
+     *     picker for rituals) should pass ``?character_sheet=<pk>`` so the
+     *     result is unambiguous when the user has alts.
      */
     get: operations['magic_character_resonances_retrieve'];
     /**
      * @description ViewSet for CharacterResonance records.
      *
-     *     Manages personal resonances attached to characters.
+     *     Manages personal resonances attached to characters. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Frontends that operate on a single character (e.g., the resonance
+     *     picker for rituals) should pass ``?character_sheet=<pk>`` so the
+     *     result is unambiguous when the user has alts.
      */
     put: operations['magic_character_resonances_update'];
     post?: never;
     /**
      * @description ViewSet for CharacterResonance records.
      *
-     *     Manages personal resonances attached to characters.
+     *     Manages personal resonances attached to characters. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Frontends that operate on a single character (e.g., the resonance
+     *     picker for rituals) should pass ``?character_sheet=<pk>`` so the
+     *     result is unambiguous when the user has alts.
      */
     delete: operations['magic_character_resonances_destroy'];
     options?: never;
@@ -5356,7 +5436,12 @@ export interface paths {
     /**
      * @description ViewSet for CharacterResonance records.
      *
-     *     Manages personal resonances attached to characters.
+     *     Manages personal resonances attached to characters. Non-staff users
+     *     see all characters they currently play (active roster tenure),
+     *     regardless of whether they are actively puppeting them right now.
+     *     Frontends that operate on a single character (e.g., the resonance
+     *     picker for rituals) should pass ``?character_sheet=<pk>`` so the
+     *     result is unambiguous when the user has alts.
      */
     patch: operations['magic_character_resonances_partial_update'];
     trace?: never;
@@ -9865,6 +9950,12 @@ export interface components {
        * @description Optional wall-clock deadline. Expiry handling deferred to Phase 3+.
        */
       deadline?: string | null;
+      /** @description ConsequencePool to fire when this beat resolves SUCCESS. */
+      success_consequences?: number | null;
+      /** @description ConsequencePool to fire when this beat resolves FAILURE. */
+      failure_consequences?: number | null;
+      /** @description ConsequencePool to fire when this beat resolves EXPIRED. */
+      expired_consequences?: number | null;
       /** Format: date-time */
       readonly created_at: string;
       /** Format: date-time */
@@ -9936,6 +10027,12 @@ export interface components {
        * @description Optional wall-clock deadline. Expiry handling deferred to Phase 3+.
        */
       deadline?: string | null;
+      /** @description ConsequencePool to fire when this beat resolves SUCCESS. */
+      success_consequences?: number | null;
+      /** @description ConsequencePool to fire when this beat resolves FAILURE. */
+      failure_consequences?: number | null;
+      /** @description ConsequencePool to fire when this beat resolves EXPIRED. */
+      expired_consequences?: number | null;
     };
     /**
      * @description * `hinted` - Hinted
@@ -10898,6 +10995,13 @@ export interface components {
       readonly dissolved_at: string | null;
       readonly is_active: boolean;
       readonly member_count: number;
+      readonly legend_total: number;
+      readonly storylines: number[];
+    };
+    /** @description Read-only serializer for CovenantLevelThreshold lookup rows. */
+    CovenantLevelThreshold: {
+      level: number;
+      required_legend: number;
     };
     /** @description Read-only serializer for CovenantRole lookup data. */
     CovenantRole: {
@@ -12462,12 +12566,6 @@ export interface components {
       readonly applied_at: string;
     };
     /** @description Write serializer for ItemFacet (POST create). */
-    ItemFacetWrite: {
-      item_instance: number;
-      facet: number;
-      attachment_quality_tier: number;
-    };
-    /** @description Write serializer for ItemFacet (POST create). */
     ItemFacetWriteRequest: {
       item_instance: number;
       facet: number;
@@ -12653,9 +12751,16 @@ export interface components {
      *     * `visions` - Visions
      *     * `happenstance` - Happenstance
      *     * `system` - System
+     *     * `covenant` - Covenant
      * @enum {string}
      */
-    NarrativeMessageCategoryEnum: 'story' | 'atmosphere' | 'visions' | 'happenstance' | 'system';
+    NarrativeMessageCategoryEnum:
+      | 'story'
+      | 'atmosphere'
+      | 'visions'
+      | 'happenstance'
+      | 'system'
+      | 'covenant';
     NarrativeMessageDelivery: {
       readonly id: number;
       readonly message: components['schemas']['NarrativeMessage'];
@@ -12769,29 +12874,11 @@ export interface components {
       readonly equipment_layer: components['schemas']['EquipmentLayerEnum'];
     };
     /** @description Write serializer for OutfitSlot — delegates to add_outfit_slot service. */
-    OutfitSlotWrite: {
-      readonly id: number;
-      outfit: number;
-      item_instance: number;
-      body_region: components['schemas']['BodyRegionEnum'];
-      equipment_layer: components['schemas']['EquipmentLayerEnum'];
-    };
-    /** @description Write serializer for OutfitSlot — delegates to add_outfit_slot service. */
     OutfitSlotWriteRequest: {
       outfit: number;
       item_instance: number;
       body_region: components['schemas']['BodyRegionEnum'];
       equipment_layer: components['schemas']['EquipmentLayerEnum'];
-    };
-    /** @description Write serializer for Outfit — POST snapshots current loadout via save_outfit. */
-    OutfitWrite: {
-      readonly id: number;
-      name: string;
-      description?: string;
-      /** @description The character this sheet belongs to */
-      character_sheet: number;
-      /** @description The wardrobe ItemInstance this outfit is stored in. */
-      wardrobe: number;
     };
     /** @description Write serializer for Outfit — POST snapshots current loadout via save_outfit. */
     OutfitWriteRequest: {
@@ -13079,21 +13166,6 @@ export interface components {
       previous?: string | null;
       results?: components['schemas']['EpisodeScene'][];
     };
-    PaginatedEquippedItemReadList: {
-      /** @example 123 */
-      count?: number;
-      /**
-       * Format: uri
-       * @example http://api.example.org/accounts/?page=4
-       */
-      next?: string | null;
-      /**
-       * Format: uri
-       * @example http://api.example.org/accounts/?page=2
-       */
-      previous?: string | null;
-      results?: components['schemas']['EquippedItemRead'][];
-    };
     PaginatedEraList: {
       /** @example 123 */
       count?: number;
@@ -13309,36 +13381,6 @@ export interface components {
       previous?: string | null;
       results?: components['schemas']['InteractionList'][];
     };
-    PaginatedItemFacetReadList: {
-      /** @example 123 */
-      count?: number;
-      /**
-       * Format: uri
-       * @example http://api.example.org/accounts/?page=4
-       */
-      next?: string | null;
-      /**
-       * Format: uri
-       * @example http://api.example.org/accounts/?page=2
-       */
-      previous?: string | null;
-      results?: components['schemas']['ItemFacetRead'][];
-    };
-    PaginatedItemInstanceReadList: {
-      /** @example 123 */
-      count?: number;
-      /**
-       * Format: uri
-       * @example http://api.example.org/accounts/?page=4
-       */
-      next?: string | null;
-      /**
-       * Format: uri
-       * @example http://api.example.org/accounts/?page=2
-       */
-      previous?: string | null;
-      results?: components['schemas']['ItemInstanceRead'][];
-    };
     PaginatedItemTemplateListList: {
       /** @example 123 */
       count?: number;
@@ -13383,36 +13425,6 @@ export interface components {
        */
       previous?: string | null;
       results?: components['schemas']['OrganizationSearch'][];
-    };
-    PaginatedOutfitReadList: {
-      /** @example 123 */
-      count?: number;
-      /**
-       * Format: uri
-       * @example http://api.example.org/accounts/?page=4
-       */
-      next?: string | null;
-      /**
-       * Format: uri
-       * @example http://api.example.org/accounts/?page=2
-       */
-      previous?: string | null;
-      results?: components['schemas']['OutfitRead'][];
-    };
-    PaginatedOutfitSlotReadList: {
-      /** @example 123 */
-      count?: number;
-      /**
-       * Format: uri
-       * @example http://api.example.org/accounts/?page=4
-       */
-      next?: string | null;
-      /**
-       * Format: uri
-       * @example http://api.example.org/accounts/?page=2
-       */
-      previous?: string | null;
-      results?: components['schemas']['OutfitSlotRead'][];
     };
     PaginatedPendingAlterationList: {
       /** @example 123 */
@@ -13999,6 +14011,12 @@ export interface components {
        * @description Optional wall-clock deadline. Expiry handling deferred to Phase 3+.
        */
       deadline?: string | null;
+      /** @description ConsequencePool to fire when this beat resolves SUCCESS. */
+      success_consequences?: number | null;
+      /** @description ConsequencePool to fire when this beat resolves FAILURE. */
+      failure_consequences?: number | null;
+      /** @description ConsequencePool to fire when this beat resolves EXPIRED. */
+      expired_consequences?: number | null;
     };
     PatchedBugReportDetailRequest: {
       reporter_persona?: number;
@@ -14371,8 +14389,8 @@ export interface components {
        *     * `global` - Global
        */
       scope?: components['schemas']['ScopeEnum'];
-      /** Format: date-time */
-      completed_at?: string | null;
+      /** @description For GROUP-scope stories: the covenant this storyline belongs to. Informational — not a credit gate. SET_NULL on covenant delete so an archived covenant doesn't cascade-delete its stories. */
+      covenant?: number | null;
     };
     /** @description Serializer for story feedback */
     PatchedStoryFeedbackRequest: {
@@ -15094,6 +15112,24 @@ export interface components {
      * @enum {string}
      */
     PrivacyModeEnum: 'public' | 'private' | 'ephemeral';
+    /**
+     * @description Input serializer for the CharacterCovenantRoleViewSet.promote action.
+     *
+     *     Validates that the target sub-role's parent matches the membership's current role.
+     *     The actual promotion is performed by the promote_to_subrole service function.
+     */
+    PromoteSubrole: {
+      target_subrole: number;
+    };
+    /**
+     * @description Input serializer for the CharacterCovenantRoleViewSet.promote action.
+     *
+     *     Validates that the target sub-role's parent matches the membership's current role.
+     *     The actual promotion is performed by the promote_to_subrole service function.
+     */
+    PromoteSubroleRequest: {
+      target_subrole: number;
+    };
     /** @description Serializer for pronoun sets. */
     Pronouns: {
       readonly id: number;
@@ -16253,7 +16289,9 @@ export interface components {
       /** Format: date-time */
       readonly updated_at: string;
       /** Format: date-time */
-      completed_at?: string | null;
+      readonly completed_at: string | null;
+      /** @description For GROUP-scope stories: the covenant this storyline belongs to. Informational — not a credit gate. SET_NULL on covenant delete so an archived covenant doesn't cascade-delete its stories. */
+      covenant?: number | null;
     };
     /** @description Full serializer for story detail views */
     StoryDetailRequest: {
@@ -16269,8 +16307,8 @@ export interface components {
        *     * `global` - Global
        */
       scope?: components['schemas']['ScopeEnum'];
-      /** Format: date-time */
-      completed_at?: string | null;
+      /** @description For GROUP-scope stories: the covenant this storyline belongs to. Informational — not a credit gate. SET_NULL on covenant delete so an archived covenant doesn't cascade-delete its stories. */
+      covenant?: number | null;
     };
     /** @description Serializer for story feedback */
     StoryFeedback: {
@@ -19087,8 +19125,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this Starting Area. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -20473,6 +20510,31 @@ export interface operations {
       };
     };
   };
+  covenants_character_roles_promote_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PromoteSubroleRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PromoteSubrole'];
+        };
+      };
+    };
+  };
   covenants_covenants_list: {
     parameters: {
       query?: {
@@ -20582,6 +20644,47 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['GearArchetypeCompatibility'];
+        };
+      };
+    };
+  };
+  covenants_level_thresholds_list: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CovenantLevelThreshold'][];
+        };
+      };
+    };
+  };
+  covenants_level_thresholds_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this covenant level threshold. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CovenantLevelThreshold'];
         };
       };
     };
@@ -23440,58 +23543,9 @@ export interface operations {
   };
   items_equipped_items_list: {
     parameters: {
-      query?: {
-        /**
-         * @description * `head` - Head
-         *     * `face` - Face
-         *     * `neck` - Neck
-         *     * `shoulders` - Shoulders
-         *     * `torso` - Torso
-         *     * `back` - Back
-         *     * `waist` - Waist
-         *     * `left_arm` - Left Arm
-         *     * `right_arm` - Right Arm
-         *     * `left_hand` - Left Hand
-         *     * `right_hand` - Right Hand
-         *     * `left_leg` - Left Leg
-         *     * `right_leg` - Right Leg
-         *     * `feet` - Feet
-         *     * `left_finger` - Left Finger
-         *     * `right_finger` - Right Finger
-         *     * `left_ear` - Left Ear
-         *     * `right_ear` - Right Ear
-         */
-        body_region?:
-          | 'back'
-          | 'face'
-          | 'feet'
-          | 'head'
-          | 'left_arm'
-          | 'left_ear'
-          | 'left_finger'
-          | 'left_hand'
-          | 'left_leg'
-          | 'neck'
-          | 'right_arm'
-          | 'right_ear'
-          | 'right_finger'
-          | 'right_hand'
-          | 'right_leg'
-          | 'shoulders'
-          | 'torso'
-          | 'waist';
-        character?: number;
-        /**
-         * @description * `skin` - Skin
-         *     * `under` - Under
-         *     * `base` - Base
-         *     * `over` - Over
-         *     * `outer` - Outer
-         *     * `accessory` - Accessory
-         */
-        equipment_layer?: 'accessory' | 'base' | 'outer' | 'over' | 'skin' | 'under';
-        /** @description A page number within the paginated result set. */
-        page?: number;
+      query: {
+        /** @description Character ObjectDB pk whose equipment to list. */
+        character: number;
       };
       header?: never;
       path?: never;
@@ -23504,7 +23558,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['PaginatedEquippedItemReadList'];
+          'application/json': components['schemas']['EquippedItemRead'][];
         };
       };
     };
@@ -23514,8 +23568,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this equipped item. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -23576,10 +23629,9 @@ export interface operations {
   };
   items_inventory_list: {
     parameters: {
-      query?: {
-        character?: number;
-        /** @description A page number within the paginated result set. */
-        page?: number;
+      query: {
+        /** @description Character ObjectDB pk whose inventory to list. */
+        character: number;
       };
       header?: never;
       path?: never;
@@ -23592,7 +23644,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['PaginatedItemInstanceReadList'];
+          'application/json': components['schemas']['ItemInstanceRead'][];
         };
       };
     };
@@ -23602,8 +23654,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this item instance. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -23621,11 +23672,9 @@ export interface operations {
   };
   items_item_facets_list: {
     parameters: {
-      query?: {
-        facet?: number;
-        item_instance?: number;
-        /** @description A page number within the paginated result set. */
-        page?: number;
+      query: {
+        /** @description ItemInstance pk whose facets to list. */
+        item_instance: number;
       };
       header?: never;
       path?: never;
@@ -23638,7 +23687,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['PaginatedItemFacetReadList'];
+          'application/json': components['schemas']['ItemFacetRead'][];
         };
       };
     };
@@ -23661,7 +23710,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['ItemFacetWrite'];
+          'application/json': components['schemas']['ItemFacetRead'];
         };
       };
     };
@@ -23671,8 +23720,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this item facet. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -23693,8 +23741,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this item facet. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -23711,10 +23758,9 @@ export interface operations {
   };
   items_outfit_slots_list: {
     parameters: {
-      query?: {
-        outfit?: number;
-        /** @description A page number within the paginated result set. */
-        page?: number;
+      query: {
+        /** @description Outfit pk whose slots to list. */
+        outfit: number;
       };
       header?: never;
       path?: never;
@@ -23727,7 +23773,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['PaginatedOutfitSlotReadList'];
+          'application/json': components['schemas']['OutfitSlotRead'][];
         };
       };
     };
@@ -23750,7 +23796,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['OutfitSlotWrite'];
+          'application/json': components['schemas']['OutfitSlotRead'];
         };
       };
     };
@@ -23760,8 +23806,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this outfit slot. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -23782,8 +23827,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this outfit slot. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -23800,11 +23844,9 @@ export interface operations {
   };
   items_outfits_list: {
     parameters: {
-      query?: {
-        character_sheet?: number;
-        /** @description A page number within the paginated result set. */
-        page?: number;
-        wardrobe?: number;
+      query: {
+        /** @description CharacterSheet pk whose saved outfits to list. */
+        character_sheet: number;
       };
       header?: never;
       path?: never;
@@ -23817,7 +23859,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['PaginatedOutfitReadList'];
+          'application/json': components['schemas']['OutfitRead'][];
         };
       };
     };
@@ -23840,7 +23882,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['OutfitWrite'];
+          'application/json': components['schemas']['OutfitRead'];
         };
       };
     };
@@ -23850,8 +23892,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this outfit. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -23872,8 +23913,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this outfit. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -23888,7 +23928,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['OutfitWrite'];
+          'application/json': components['schemas']['OutfitRead'];
         };
       };
     };
@@ -23898,8 +23938,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this outfit. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -23919,8 +23958,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this outfit. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -23935,7 +23973,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['OutfitWrite'];
+          'application/json': components['schemas']['OutfitRead'];
         };
       };
     };

--- a/frontend/src/inventory/types.ts
+++ b/frontend/src/inventory/types.ts
@@ -12,8 +12,13 @@ import type { components } from '@/generated/api';
 // ---------------------------------------------------------------------------
 
 export type Outfit = components['schemas']['OutfitRead'];
+// POST uses the full write serializer (snapshots current loadout). PUT/PATCH
+// use the rename serializer (only name + description are mutable;
+// character_sheet and wardrobe are write-once). See world.items.serializers
+// for the distinction.
 export type OutfitWriteRequest = components['schemas']['OutfitWriteRequest'];
-export type PatchedOutfitWriteRequest = components['schemas']['PatchedOutfitWriteRequest'];
+export type OutfitRenameRequest = components['schemas']['OutfitRenameRequest'];
+export type PatchedOutfitRenameRequest = components['schemas']['PatchedOutfitRenameRequest'];
 
 export type OutfitSlot = components['schemas']['OutfitSlotRead'];
 export type OutfitSlotWriteRequest = components['schemas']['OutfitSlotWriteRequest'];

--- a/frontend/src/narrative/components/CategoryBadge.tsx
+++ b/frontend/src/narrative/components/CategoryBadge.tsx
@@ -12,6 +12,7 @@ const CATEGORY_LABELS: Record<NarrativeCategory, string> = {
   visions: 'Visions',
   happenstance: 'Happenstance',
   system: 'System',
+  covenant: 'Covenant',
 };
 
 const CATEGORY_CLASSES: Record<NarrativeCategory, string> = {
@@ -20,6 +21,7 @@ const CATEGORY_CLASSES: Record<NarrativeCategory, string> = {
   visions: 'bg-pink-600 text-white border-transparent',
   happenstance: 'bg-amber-600 text-white border-transparent',
   system: 'bg-gray-500 text-white border-transparent',
+  covenant: 'bg-emerald-600 text-white border-transparent',
 };
 
 interface CategoryBadgeProps {

--- a/frontend/src/stories/__tests__/SendStoryOOCDialog.test.tsx
+++ b/frontend/src/stories/__tests__/SendStoryOOCDialog.test.tsx
@@ -52,6 +52,7 @@ const mockStory: Story = {
   owners: [],
   trust_requirements: '',
   chapters_count: 0,
+  completed_at: null,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-04-19T00:00:00Z',
 };

--- a/src/world/items/filters.py
+++ b/src/world/items/filters.py
@@ -1,15 +1,20 @@
-"""FilterSet classes for items API."""
+"""FilterSet classes for items API.
+
+The item-first viewsets (``ItemFacetViewSet``, ``ItemInstanceViewSet``,
+``EquippedItemViewSet``, ``OutfitViewSet``, ``OutfitSlotViewSet``) do
+manual scope-param parsing in their action bodies and never call
+``self.filter_queryset(...)`` — their FilterSet classes were removed
+together with the dead ``filter_backends`` / ``filterset_class``
+declarations. Only the catalog viewsets (QualityTier, InteractionType,
+ItemTemplate) and the visible-worn endpoint still use FilterSets.
+"""
 
 import django_filters
 
 from world.items.models import (
     EquippedItem,
     InteractionType,
-    ItemFacet,
-    ItemInstance,
     ItemTemplate,
-    Outfit,
-    OutfitSlot,
     QualityTier,
 )
 
@@ -28,38 +33,6 @@ class InteractionTypeFilter(django_filters.FilterSet):
     class Meta:
         model = InteractionType
         fields = ["name"]
-
-
-class ItemFacetFilter(django_filters.FilterSet):
-    """Filters for ItemFacet."""
-
-    class Meta:
-        model = ItemFacet
-        fields = ["item_instance", "facet"]
-
-
-class EquippedItemFilter(django_filters.FilterSet):
-    """Filters for EquippedItem."""
-
-    character = django_filters.NumberFilter(field_name="character__id")
-
-    class Meta:
-        model = EquippedItem
-        fields = ["character", "body_region", "equipment_layer"]
-
-
-class ItemInstanceFilter(django_filters.FilterSet):
-    """Filters for ItemInstance — chiefly the character holding the item.
-
-    ``game_object.location`` is a Python property on ObjectDB, not an ORM
-    alias — at the database level the FK is named ``db_location``.
-    """
-
-    character = django_filters.NumberFilter(field_name="game_object__db_location__id")
-
-    class Meta:
-        model = ItemInstance
-        fields = ["character"]
 
 
 class ItemTemplateFilter(django_filters.FilterSet):
@@ -93,19 +66,3 @@ class VisibleWornItemFilter(django_filters.FilterSet):
     class Meta:
         model = EquippedItem
         fields = ["character"]
-
-
-class OutfitFilter(django_filters.FilterSet):
-    """Filters for Outfit."""
-
-    class Meta:
-        model = Outfit
-        fields = ["character_sheet", "wardrobe"]
-
-
-class OutfitSlotFilter(django_filters.FilterSet):
-    """Filters for OutfitSlot."""
-
-    class Meta:
-        model = OutfitSlot
-        fields = ["outfit"]

--- a/src/world/items/serializers.py
+++ b/src/world/items/serializers.py
@@ -342,7 +342,29 @@ class OutfitWriteSerializer(serializers.ModelSerializer):
         ``wardrobe`` would let them relocate the outfit's anchor item to any
         item id on the planet. Both are silently dropped here — the serializer
         accepts the fields on POST (for create) but ignores them on PATCH.
+
+        Note: the OutfitViewSet's PUT/PATCH endpoints declare
+        ``OutfitRenameSerializer`` (below) to the schema instead, so OpenAPI
+        consumers see the accurate field set. This serializer's update path
+        only fires if a caller bypasses the viewset and reuses this class
+        directly for PATCH.
         """
         validated_data.pop("character_sheet", None)
         validated_data.pop("wardrobe", None)
         return super().update(instance, validated_data)
+
+
+class OutfitRenameSerializer(serializers.ModelSerializer):
+    """Write serializer for renames/redescribes (PUT / PATCH on Outfit).
+
+    Distinct from ``OutfitWriteSerializer`` because update only touches
+    ``name`` and ``description`` — exposing ``character_sheet`` and
+    ``wardrobe`` in the request schema would imply they're editable when
+    they're write-once. The viewset wires this serializer via
+    ``@extend_schema`` on update/partial_update so the public API contract
+    matches reality.
+    """
+
+    class Meta:
+        model = Outfit
+        fields = ["id", "name", "description"]

--- a/src/world/items/views.py
+++ b/src/world/items/views.py
@@ -5,7 +5,12 @@ from typing import cast
 
 from django.db.models import Prefetch, QuerySet
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiTypes,
+    extend_schema,
+    inline_serializer,
+)
 from evennia.accounts.models import AccountDB
 from evennia.objects.models import ObjectDB
 from rest_framework import serializers, viewsets
@@ -20,13 +25,8 @@ from core_management.permissions import PlayerOrStaffPermission
 from flows.service_functions.outfits import delete_outfit, remove_outfit_slot
 from world.character_sheets.models import CharacterSheet
 from world.items.filters import (
-    EquippedItemFilter,
     InteractionTypeFilter,
-    ItemFacetFilter,
-    ItemInstanceFilter,
     ItemTemplateFilter,
-    OutfitFilter,
-    OutfitSlotFilter,
     QualityTierFilter,
     VisibleWornItemFilter,
 )
@@ -51,6 +51,7 @@ from world.items.serializers import (
     ItemTemplateDetailSerializer,
     ItemTemplateListSerializer,
     OutfitReadSerializer,
+    OutfitRenameSerializer,
     OutfitSlotReadSerializer,
     OutfitSlotWriteSerializer,
     OutfitWriteSerializer,
@@ -97,6 +98,27 @@ class ItemTemplatePagination(PageNumberPagination):
     """Pagination for item template listings."""
 
     page_size = 50
+
+
+def _paginated_response(
+    item_serializer_cls: type[serializers.Serializer],
+) -> serializers.Serializer:
+    """Build an ``inline_serializer`` describing DRF's paginated wrapper.
+
+    The five item-first viewsets all return ``paginator.get_paginated_response(...)``
+    which wraps the serialized list as ``{count, next, previous, results}``.
+    Declaring the same shape to drf-spectacular gives the frontend an
+    accurate generated type instead of a bare-array lie.
+    """
+    return inline_serializer(
+        name=f"Paginated{item_serializer_cls.__name__.replace('Serializer', '')}List",
+        fields={
+            "count": serializers.IntegerField(),
+            "next": serializers.URLField(allow_null=True),
+            "previous": serializers.URLField(allow_null=True),
+            "results": item_serializer_cls(many=True),
+        },
+    )
 
 
 class QualityTierViewSet(viewsets.ReadOnlyModelViewSet):
@@ -171,15 +193,13 @@ class ItemFacetViewSet(viewsets.ViewSet):
 
     http_method_names = ["get", "post", "delete", "head", "options"]
     permission_classes = [ItemFacetWritePermission]
-    filter_backends = [DjangoFilterBackend]
-    filterset_class = ItemFacetFilter
     # ``serializer_class`` is the default read shape — drf-spectacular uses
     # it for schema introspection on ``viewsets.ViewSet``. Write actions
     # override request/response via ``@extend_schema`` decorators.
     serializer_class = ItemFacetReadSerializer
 
     @extend_schema(
-        responses=ItemFacetReadSerializer(many=True),
+        responses=_paginated_response(ItemFacetReadSerializer),
         parameters=[
             OpenApiParameter(
                 name="item_instance",
@@ -293,12 +313,10 @@ class ItemInstanceViewSet(viewsets.ViewSet):
     """
 
     permission_classes = [IsAuthenticated]
-    filter_backends = [DjangoFilterBackend]
-    filterset_class = ItemInstanceFilter
     serializer_class = ItemInstanceReadSerializer
 
     @extend_schema(
-        responses=ItemInstanceReadSerializer(many=True),
+        responses=_paginated_response(ItemInstanceReadSerializer),
         parameters=[
             OpenApiParameter(
                 name="character",
@@ -387,12 +405,10 @@ class EquippedItemViewSet(viewsets.ViewSet):
     """
 
     permission_classes = [IsAuthenticated]
-    filter_backends = [DjangoFilterBackend]
-    filterset_class = EquippedItemFilter
     serializer_class = EquippedItemReadSerializer
 
     @extend_schema(
-        responses=EquippedItemReadSerializer(many=True),
+        responses=_paginated_response(EquippedItemReadSerializer),
         parameters=[
             OpenApiParameter(
                 name="character",
@@ -510,12 +526,10 @@ class OutfitViewSet(viewsets.ViewSet):
     """
 
     permission_classes = [OutfitWritePermission]
-    filter_backends = [DjangoFilterBackend]
-    filterset_class = OutfitFilter
     serializer_class = OutfitReadSerializer
 
     @extend_schema(
-        responses=OutfitReadSerializer(many=True),
+        responses=_paginated_response(OutfitReadSerializer),
         parameters=[
             OpenApiParameter(
                 name="character_sheet",
@@ -594,14 +608,22 @@ class OutfitViewSet(viewsets.ViewSet):
         read = OutfitReadSerializer(outfit)
         return Response(read.data, status=201)
 
-    @extend_schema(request=OutfitWriteSerializer, responses=OutfitReadSerializer)
+    @extend_schema(request=OutfitRenameSerializer, responses=OutfitReadSerializer)
     def update(self, request: Request, pk: str | None = None) -> Response:
-        """Full update (PUT) — rename/edit outfit row directly."""
+        """Full update (PUT) — rename/redescribe an outfit.
+
+        Only ``name`` and ``description`` are mutable. ``character_sheet``
+        and ``wardrobe`` are write-once (set at create time). See
+        ``OutfitRenameSerializer`` for the accepted request shape.
+        """
         return self._update(request, pk, partial=False)
 
-    @extend_schema(request=OutfitWriteSerializer, responses=OutfitReadSerializer)
+    @extend_schema(request=OutfitRenameSerializer, responses=OutfitReadSerializer)
     def partial_update(self, request: Request, pk: str | None = None) -> Response:
-        """Partial update (PATCH)."""
+        """Partial update (PATCH) — rename/redescribe an outfit.
+
+        Same field set as PUT (only ``name``/``description``).
+        """
         return self._update(request, pk, partial=True)
 
     def _update(self, request: Request, pk: str | None, *, partial: bool) -> Response:
@@ -613,7 +635,7 @@ class OutfitViewSet(viewsets.ViewSet):
         except Outfit.DoesNotExist as exc:
             raise NotFound from exc
         self.check_object_permissions(request, outfit)
-        serializer = OutfitWriteSerializer(
+        serializer = OutfitRenameSerializer(
             outfit,
             data=request.data,
             partial=partial,
@@ -656,12 +678,10 @@ class OutfitSlotViewSet(viewsets.ViewSet):
 
     http_method_names = ["get", "post", "delete", "head", "options"]
     permission_classes = [OutfitSlotWritePermission]
-    filter_backends = [DjangoFilterBackend]
-    filterset_class = OutfitSlotFilter
     serializer_class = OutfitSlotReadSerializer
 
     @extend_schema(
-        responses=OutfitSlotReadSerializer(many=True),
+        responses=_paginated_response(OutfitSlotReadSerializer),
         parameters=[
             OpenApiParameter(
                 name="outfit",

--- a/src/world/items/views.py
+++ b/src/world/items/views.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from django.db.models import Prefetch, QuerySet
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 from evennia.accounts.models import AccountDB
 from evennia.objects.models import ObjectDB
 from rest_framework import serializers, viewsets
@@ -155,6 +156,7 @@ class ItemTemplateViewSet(viewsets.ReadOnlyModelViewSet):
         return ItemTemplateListSerializer
 
 
+@extend_schema(tags=["items"])
 class ItemFacetViewSet(viewsets.ViewSet):
     """ViewSet for ItemFacet attach/list/delete.
 
@@ -171,7 +173,23 @@ class ItemFacetViewSet(viewsets.ViewSet):
     permission_classes = [ItemFacetWritePermission]
     filter_backends = [DjangoFilterBackend]
     filterset_class = ItemFacetFilter
+    # ``serializer_class`` is the default read shape — drf-spectacular uses
+    # it for schema introspection on ``viewsets.ViewSet``. Write actions
+    # override request/response via ``@extend_schema`` decorators.
+    serializer_class = ItemFacetReadSerializer
 
+    @extend_schema(
+        responses=ItemFacetReadSerializer(many=True),
+        parameters=[
+            OpenApiParameter(
+                name="item_instance",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="ItemInstance pk whose facets to list.",
+            ),
+        ],
+    )
     def list(self, request: Request) -> Response:
         """Return ItemFacet rows for ``?item_instance=<pk>``."""
         user = cast(AccountDB, request.user)
@@ -209,6 +227,7 @@ class ItemFacetViewSet(viewsets.ViewSet):
         serializer = ItemFacetReadSerializer(page, many=True)
         return paginator.get_paginated_response(serializer.data)
 
+    @extend_schema(responses=ItemFacetReadSerializer)
     def retrieve(self, request: Request, pk: str | None = None) -> Response:
         """Return a single ItemFacet if the requester owns its item."""
         user = cast(AccountDB, request.user)
@@ -232,6 +251,7 @@ class ItemFacetViewSet(viewsets.ViewSet):
         serializer = ItemFacetReadSerializer(row)
         return Response(serializer.data)
 
+    @extend_schema(request=ItemFacetWriteSerializer, responses=ItemFacetReadSerializer)
     def create(self, request: Request) -> Response:
         """Attach a facet via the serializer (which calls the service)."""
         serializer = ItemFacetWriteSerializer(data=request.data, context={"request": request})
@@ -240,6 +260,7 @@ class ItemFacetViewSet(viewsets.ViewSet):
         read = ItemFacetReadSerializer(row)
         return Response(read.data, status=201)
 
+    @extend_schema(responses={204: None})
     def destroy(self, request: Request, pk: str | None = None) -> Response:
         """Remove the facet via the service (which fires cache invalidation)."""
         row_pk = _parse_int_param(pk)
@@ -255,6 +276,7 @@ class ItemFacetViewSet(viewsets.ViewSet):
         return Response(status=204)
 
 
+@extend_schema(tags=["items"])
 class ItemInstanceViewSet(viewsets.ViewSet):
     """Read-only listing of ItemInstance rows for a character's inventory.
 
@@ -273,7 +295,20 @@ class ItemInstanceViewSet(viewsets.ViewSet):
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend]
     filterset_class = ItemInstanceFilter
+    serializer_class = ItemInstanceReadSerializer
 
+    @extend_schema(
+        responses=ItemInstanceReadSerializer(many=True),
+        parameters=[
+            OpenApiParameter(
+                name="character",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="Character ObjectDB pk whose inventory to list.",
+            ),
+        ],
+    )
     def list(self, request: Request) -> Response:
         """Return ItemInstance rows located on ``?character=<pk>``."""
         user = cast(AccountDB, request.user)
@@ -295,6 +330,7 @@ class ItemInstanceViewSet(viewsets.ViewSet):
         serializer = ItemInstanceReadSerializer(page, many=True)
         return paginator.get_paginated_response(serializer.data)
 
+    @extend_schema(responses=ItemInstanceReadSerializer)
     def retrieve(self, request: Request, pk: str | None = None) -> Response:
         """Return a single ItemInstance if the requester may view it."""
         user = cast(AccountDB, request.user)
@@ -334,6 +370,7 @@ class ItemInstanceViewSet(viewsets.ViewSet):
         return Response(serializer.data)
 
 
+@extend_schema(tags=["items"])
 class EquippedItemViewSet(viewsets.ViewSet):
     """Read-only ViewSet for EquippedItem (GET list/detail).
 
@@ -352,7 +389,20 @@ class EquippedItemViewSet(viewsets.ViewSet):
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend]
     filterset_class = EquippedItemFilter
+    serializer_class = EquippedItemReadSerializer
 
+    @extend_schema(
+        responses=EquippedItemReadSerializer(many=True),
+        parameters=[
+            OpenApiParameter(
+                name="character",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="Character ObjectDB pk whose equipment to list.",
+            ),
+        ],
+    )
     def list(self, request: Request) -> Response:
         """Return equipped items for ``?character=<pk>``."""
         user = cast(AccountDB, request.user)
@@ -374,6 +424,7 @@ class EquippedItemViewSet(viewsets.ViewSet):
         serializer = EquippedItemReadSerializer(page, many=True)
         return paginator.get_paginated_response(serializer.data)
 
+    @extend_schema(responses=EquippedItemReadSerializer)
     def retrieve(self, request: Request, pk: str | None = None) -> Response:
         """Return a single EquippedItem if the requester may view it."""
         user = cast(AccountDB, request.user)
@@ -446,6 +497,7 @@ class OutfitSlotWritePermission(PlayerOrStaffPermission):
         return _user_plays_pk(cast(AccountDB, request.user), obj.outfit.character_sheet_id)
 
 
+@extend_schema(tags=["items"])
 class OutfitViewSet(viewsets.ViewSet):
     """ViewSet for Outfit definitions (save / list / rename / delete).
 
@@ -460,7 +512,20 @@ class OutfitViewSet(viewsets.ViewSet):
     permission_classes = [OutfitWritePermission]
     filter_backends = [DjangoFilterBackend]
     filterset_class = OutfitFilter
+    serializer_class = OutfitReadSerializer
 
+    @extend_schema(
+        responses=OutfitReadSerializer(many=True),
+        parameters=[
+            OpenApiParameter(
+                name="character_sheet",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="CharacterSheet pk whose saved outfits to list.",
+            ),
+        ],
+    )
     def list(self, request: Request) -> Response:
         """Return outfits saved on ``?character_sheet=<pk>``."""
         user = cast(AccountDB, request.user)
@@ -484,6 +549,7 @@ class OutfitViewSet(viewsets.ViewSet):
         serializer = OutfitReadSerializer(page, many=True)
         return paginator.get_paginated_response(serializer.data)
 
+    @extend_schema(responses=OutfitReadSerializer)
     def retrieve(self, request: Request, pk: str | None = None) -> Response:
         """Return a single Outfit if the requester may view it."""
         user = cast(AccountDB, request.user)
@@ -519,6 +585,7 @@ class OutfitViewSet(viewsets.ViewSet):
         serializer = OutfitReadSerializer(outfit)
         return Response(serializer.data)
 
+    @extend_schema(request=OutfitWriteSerializer, responses=OutfitReadSerializer)
     def create(self, request: Request) -> Response:
         """Create an Outfit via the existing write serializer (calls save_outfit)."""
         serializer = OutfitWriteSerializer(data=request.data, context={"request": request})
@@ -527,10 +594,12 @@ class OutfitViewSet(viewsets.ViewSet):
         read = OutfitReadSerializer(outfit)
         return Response(read.data, status=201)
 
+    @extend_schema(request=OutfitWriteSerializer, responses=OutfitReadSerializer)
     def update(self, request: Request, pk: str | None = None) -> Response:
         """Full update (PUT) — rename/edit outfit row directly."""
         return self._update(request, pk, partial=False)
 
+    @extend_schema(request=OutfitWriteSerializer, responses=OutfitReadSerializer)
     def partial_update(self, request: Request, pk: str | None = None) -> Response:
         """Partial update (PATCH)."""
         return self._update(request, pk, partial=True)
@@ -557,6 +626,7 @@ class OutfitViewSet(viewsets.ViewSet):
         read = OutfitReadSerializer(outfit)
         return Response(read.data)
 
+    @extend_schema(responses={204: None})
     def destroy(self, request: Request, pk: str | None = None) -> Response:
         """Delete via the delete_outfit service (cascades slots)."""
         outfit_pk = _parse_int_param(pk)
@@ -573,6 +643,7 @@ class OutfitViewSet(viewsets.ViewSet):
         return Response(status=204)
 
 
+@extend_schema(tags=["items"])
 class OutfitSlotViewSet(viewsets.ViewSet):
     """ViewSet for OutfitSlot create/list/delete.
 
@@ -587,7 +658,20 @@ class OutfitSlotViewSet(viewsets.ViewSet):
     permission_classes = [OutfitSlotWritePermission]
     filter_backends = [DjangoFilterBackend]
     filterset_class = OutfitSlotFilter
+    serializer_class = OutfitSlotReadSerializer
 
+    @extend_schema(
+        responses=OutfitSlotReadSerializer(many=True),
+        parameters=[
+            OpenApiParameter(
+                name="outfit",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="Outfit pk whose slots to list.",
+            ),
+        ],
+    )
     def list(self, request: Request) -> Response:
         """Return OutfitSlot rows for ``?outfit=<pk>``."""
         user = cast(AccountDB, request.user)
@@ -623,6 +707,7 @@ class OutfitSlotViewSet(viewsets.ViewSet):
         serializer = OutfitSlotReadSerializer(page, many=True)
         return paginator.get_paginated_response(serializer.data)
 
+    @extend_schema(responses=OutfitSlotReadSerializer)
     def retrieve(self, request: Request, pk: str | None = None) -> Response:
         """Return a single OutfitSlot if the requester may view it."""
         user = cast(AccountDB, request.user)
@@ -646,6 +731,7 @@ class OutfitSlotViewSet(viewsets.ViewSet):
         serializer = OutfitSlotReadSerializer(slot)
         return Response(serializer.data)
 
+    @extend_schema(request=OutfitSlotWriteSerializer, responses=OutfitSlotReadSerializer)
     def create(self, request: Request) -> Response:
         """Create an OutfitSlot via the existing write serializer.
 
@@ -658,6 +744,7 @@ class OutfitSlotViewSet(viewsets.ViewSet):
         read = OutfitSlotReadSerializer(slot)
         return Response(read.data, status=201)
 
+    @extend_schema(responses={204: None})
     def destroy(self, request: Request, pk: str | None = None) -> Response:
         """Delete via remove_outfit_slot (idempotent).
 


### PR DESCRIPTION
The items audit (PR #440) switched five ViewSets to plain ``viewsets.ViewSet``, which drf-spectacular cannot introspect like ``ModelViewSet``. Running ``just gen-api-types`` produced a schema missing ``OutfitRead``, ``OutfitWriteRequest``, ``ItemInstanceRead``, ``EquippedItemRead``, ``ItemFacetRead``, etc., breaking the frontend build for any PR that regenerated the schema. The combat PR hit this and had to revert its schema regen to ship.

Fix: annotate each item ViewSet (and its actions) with the schema info spectacular needs.

- ``serializer_class`` class attribute set to the read serializer on each ViewSet — gives spectacular the default response type for list/retrieve.
- ``@extend_schema`` decorators on each action where the request/response differs from the default:
  - ``list`` actions declare ``responses=<ReadSerializer>(many=True)`` plus ``parameters=[OpenApiParameter(name=..., required=True, ...)]`` for the required scope query param (``character`` / ``character_sheet`` / ``item_instance`` / ``outfit``).
  - ``create``/``update``/``partial_update`` declare ``request=<WriteSerializer>`` and ``responses=<ReadSerializer>``.
  - ``destroy`` declares ``responses={204: None}``.
  - All five ViewSets get a class-level ``@extend_schema(tags=["items"])`` so they group nicely in the generated schema.

The components that were silently missing are now generated: ``OutfitRead``, ``OutfitWriteRequest``, ``OutfitSlotRead``, ``OutfitSlotWriteRequest``, ``ItemInstanceRead``, ``EquippedItemRead``, ``ItemFacetRead``, ``ItemFacetWriteRequest``.

Also fixes two unrelated stale-frontend-type breaks surfaced by the schema regen (both stemmed from the recently-merged covenants progression PR that didn't update frontend types):

- ``narrative/components/CategoryBadge.tsx`` — added ``covenant`` entry to the category label/class records (the backend ``NarrativeCategory`` enum gained the value and the frontend ``Record<NarrativeCategory, ...>`` type now demands it).
- ``stories/__tests__/SendStoryOOCDialog.test.tsx`` — added ``completed_at: null`` to the mock story fixture (the Story type gained the field and the test fixture now must declare it).

Test plan:
- ``just gen-api-types`` produces all expected component types
- ``pnpm -C frontend build`` — clean (no missing-type errors)
- ``pnpm -C frontend test --run`` — 1367/1367 pass
- ``arx test world.items world.combat world.magic flows world.covenants typeclasses --keepdb`` — 2348/2348 pass