### PR TITLE
Feature/drf spectacular distinctions clock

### DIFF
--- a/docs/plans/2026-05-18-drf-spectacular-distinctions-clock.md
+++ b/docs/plans/2026-05-18-drf-spectacular-distinctions-clock.md
@@ -1,0 +1,184 @@
+# drf-spectacular schema coverage: DraftDistinctionViewSet + ClockViewSet
+
+> Executed directly (overnight, unattended) on `feature/drf-spectacular-distinctions-clock`.
+
+**Goal:** Two `viewsets.ViewSet` subclasses ship with no `@extend_schema`, so drf-spectacular can't introspect them and their endpoints are missing/wrong in `src/schema.json` → `frontend/src/generated/api.d.ts`. Apply the documented recipe (memory `drf-spectacular pattern for viewsets.ViewSet`; reference `src/world/items/views.py`) so the schema + generated FE types are correct. **Schema-only / behavior-neutral**: add `@extend_schema` decorators + descriptor serializers; do NOT rewire view bodies' existing ad-hoc validation.
+
+**Tech stack:** DRF + drf-spectacular; `ty`-checked (`src/world/game_clock`, `src/world/distinctions` — check pyproject; `serializers.py` ty-excluded); ruff; React + generated `api.d.ts`. FE gate = `pnpm -C frontend build` (tsc -b + vite), NOT just typecheck.
+
+**Command-shape discipline:** Write/Edit tools only (no heredoc/`$()`); `git -C`; `pnpm -C frontend`; forward-slash `/c/...`; tests via `echo "yes" | uv run arx test <mod>` in background (real exit code, no `tail` pipe); never `> file` redirection.
+
+---
+
+## Recipe (from memory + items reference)
+
+Per `viewsets.ViewSet`: class `@extend_schema(tags=["<app>"])` + `serializer_class = <ReadSerializer>`; per action `@extend_schema(request=..., responses=...)`; `destroy` → `responses={204: None}`; non-paginated list → `responses=<S>(many=True)` (bare array) — these viewsets do NOT use DRF pagination wrapper, so NO `_paginated_response`. Path params (`draft_id`, `pk`) are auto-detected from the URL conf. Imports: `from drf_spectacular.utils import extend_schema, inline_serializer` (+ `OpenApiParameter, OpenApiTypes` only if a query param is needed — none here).
+
+---
+
+### Task 1: game_clock descriptor serializer
+
+**Files:** Modify `src/world/game_clock/serializers.py`
+
+Add a reusable detail-response serializer (the staff actions + error paths return `{"detail": str}`):
+
+```python
+class ClockDetailSerializer(serializers.Serializer):
+    """Generic ``{"detail": "..."}`` response (staff actions + errors)."""
+
+    detail = serializers.CharField()
+```
+
+**Verify:** `uv run ruff check src/world/game_clock/serializers.py`
+
+**Commit:** `feat(game_clock): add ClockDetailSerializer schema descriptor`
+
+---
+
+### Task 2: decorate ClockViewSet
+
+**Files:** Modify `src/world/game_clock/views.py`
+
+Add import: `from drf_spectacular.utils import extend_schema`. Import `ClockDetailSerializer`, `ClockConvertResponseSerializer`, `ClockStateSerializer` (already imported) from serializers.
+
+- Class: `@extend_schema(tags=["game-clock"])` above `class ClockViewSet`; add `serializer_class = ClockStateSerializer` class attr (schema default; harmless at runtime per recipe gotcha).
+- `list`: `@extend_schema(responses=ClockStateSerializer)`
+- `convert` (`@action(detail=False, methods=["get"])`): keep the `@action`, add **above it** `@extend_schema(parameters=[ClockConvertSerializer], responses=ClockConvertResponseSerializer)` — `parameters=[<serializer>]` lets spectacular expand the query fields (ic_date/real_date). (If spectacular rejects a serializer in `parameters`, fall back to two explicit `OpenApiParameter(name="ic_date"/"real_date", type=OpenApiTypes.DATETIME, location=QUERY, required=False)` and import `OpenApiParameter, OpenApiTypes`.)
+- `adjust`: `@extend_schema(request=ClockAdjustSerializer, responses=ClockDetailSerializer)`
+- `ratio`: `@extend_schema(request=ClockRatioSerializer, responses=ClockDetailSerializer)`
+- `pause`: `@extend_schema(request=None, responses=ClockDetailSerializer)`
+- `unpause`: `@extend_schema(request=None, responses=ClockDetailSerializer)`
+
+Decorator order: `@extend_schema(...)` ABOVE `@action(...)` for the action methods.
+
+**Verify:** `uv run ruff check src/world/game_clock/views.py`; `uv run ty check src/world/game_clock/views.py`
+
+**Commit:** `feat(game_clock): @extend_schema coverage for ClockViewSet`
+
+---
+
+### Task 3: distinctions descriptor serializers
+
+**Files:** Modify `src/world/distinctions/serializers.py`
+
+The DraftDistinction endpoints traffic in `draft_data` JSON via `build_distinction_entry` (`world.distinctions.types.DraftDistinctionEntry` TypedDict: `distinction_id:int, distinction_name:str, distinction_slug:str, category_slug:str, rank:int, cost:int, notes:str`). Add **schema-only descriptor serializers** (NOT wired into view validation — purely for `@extend_schema`):
+
+```python
+class DraftDistinctionEntrySerializer(serializers.Serializer):
+    """Read shape of one distinction entry in draft_data (mirrors
+    world.distinctions.types.DraftDistinctionEntry). Schema descriptor
+    only — the view reads/writes the draft_data JSON directly."""
+
+    distinction_id = serializers.IntegerField()
+    distinction_name = serializers.CharField()
+    distinction_slug = serializers.CharField()
+    category_slug = serializers.CharField()
+    rank = serializers.IntegerField()
+    cost = serializers.IntegerField()
+    notes = serializers.CharField(allow_blank=True)
+
+
+class DraftDistinctionCreateSerializer(serializers.Serializer):
+    """Request body for add (create)."""
+
+    distinction_id = serializers.IntegerField()
+    rank = serializers.IntegerField(required=False, default=1)
+    notes = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class DraftDistinctionSwapSerializer(serializers.Serializer):
+    """Request body for swap."""
+
+    remove_id = serializers.IntegerField()
+    add_id = serializers.IntegerField()
+    rank = serializers.IntegerField(required=False, default=1)
+    notes = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class DraftDistinctionSyncItemSerializer(serializers.Serializer):
+    """One {id, rank} pair in the sync request list."""
+
+    id = serializers.IntegerField()
+    rank = serializers.IntegerField(required=False, default=1)
+
+
+class DraftDistinctionSyncSerializer(serializers.Serializer):
+    """Request body for sync (full replace)."""
+
+    distinctions = DraftDistinctionSyncItemSerializer(many=True)
+```
+
+(swap/sync response wrappers — `{"removed": int, "added": <entry>}` and `{"distinctions": [<entry>]}` — declared inline at the view via `inline_serializer` in Task 4.)
+
+**Verify:** `uv run ruff check src/world/distinctions/serializers.py`
+
+**Commit:** `feat(distinctions): add DraftDistinction schema descriptor serializers`
+
+---
+
+### Task 4: decorate DraftDistinctionViewSet
+
+**Files:** Modify `src/world/distinctions/views.py`
+
+Add imports: `from drf_spectacular.utils import extend_schema, inline_serializer`; `from rest_framework import serializers` (if not present); import the five new serializers.
+
+- Class: `@extend_schema(tags=["distinctions"])` above `class DraftDistinctionViewSet`; `serializer_class = DraftDistinctionEntrySerializer` class attr.
+- `list`: `@extend_schema(responses=DraftDistinctionEntrySerializer(many=True))` (bare array — matches `Response(distinctions)`).
+- `create`: `@extend_schema(request=DraftDistinctionCreateSerializer, responses=DraftDistinctionEntrySerializer)`.
+- `destroy`: `@extend_schema(responses={204: None})`.
+- `swap` (keep `@action(detail=False, methods=["post"])`): above it,
+  `@extend_schema(request=DraftDistinctionSwapSerializer, responses=inline_serializer(name="DraftDistinctionSwapResult", fields={"removed": serializers.IntegerField(), "added": DraftDistinctionEntrySerializer()}))`.
+- `sync` (keep `@action(detail=False, methods=["put"])`): above it,
+  `@extend_schema(request=DraftDistinctionSyncSerializer, responses=inline_serializer(name="DraftDistinctionSyncResult", fields={"distinctions": DraftDistinctionEntrySerializer(many=True)}))`.
+
+Do NOT change any view body logic. `__future__ annotations` is already imported in this file — fine.
+
+**Verify:** `uv run ruff check src/world/distinctions/views.py`; `uv run ty check src/world/distinctions/views.py`
+
+**Commit:** `feat(distinctions): @extend_schema coverage for DraftDistinctionViewSet`
+
+---
+
+### Task 5: regenerate schema + FE types (handle Prettier drift)
+
+Per memory `feedback_gen_api_types_prettier_drift`: bare `just gen-api-types` always dirties `api.d.ts` with a non-semantic reflow; the real invariant is `committed api.d.ts == prettier(openapi-typescript(schema))`.
+
+1. `just gen-api-types` (regens `src/schema.json` + `frontend/src/generated/api.d.ts`).
+2. `pnpm -C frontend exec prettier --write src/generated/api.d.ts`
+3. `git -C <repo> diff --stat src/schema.json frontend/src/generated/api.d.ts` — expect **real additions** for the now-covered endpoints (clock state/convert/adjust/ratio/pause/unpause, draft distinctions list/create/destroy/swap/sync). Sanity-check the new component names exist (`ClockState`, `ClockDetail`, `DraftDistinctionEntry`, etc.).
+4. If `just gen-api-types` errors (spectacular warnings-as-errors), read the error, fix the offending decorator (most likely the `convert` `parameters=[serializer]` form — switch to explicit `OpenApiParameter`), re-run.
+
+**Commit:** `chore(api): regenerate schema + api.d.ts for clock/distinction coverage`
+
+---
+
+### Task 6: reconcile FE consumers + gates
+
+FE consumers: `frontend/src/character-creation/components/DistinctionsStage.tsx`, `ReviewStage.tsx`, `frontend/src/hooks/useDistinctions.ts`, `frontend/src/types/distinctions.ts`, `frontend/src/character-creation/types.ts`. Clock: grep for a consumer.
+
+1. `pnpm -C frontend build` — the real gate. If `tsc -b` fails because a consumer referenced a generated name that changed/now-exists, reconcile (prefer using the now-correct generated type; do not weaken types). Hand-written `frontend/src/types/distinctions.ts` may now duplicate a generated type — leave it unless tsc demands a change; no behavior edits.
+2. `pnpm -C frontend lint` on changed FE files (if any changed).
+3. Backend: `echo "yes" | uv run arx test world.distinctions world.game_clock` (fresh DB, background, real exit code) — must stay green (behavior unchanged).
+4. `uv run ruff check src/world/distinctions/ src/world/game_clock/`; `uv run ty check src/world/distinctions/views.py src/world/game_clock/views.py`.
+
+**Commit (if FE reconciled):** `fix(fe): reconcile consumers with regenerated api types`
+
+---
+
+### Task 7: full gate, push, PR
+
+1. Full affected backend suites on fresh DB (no `--keepdb`): `echo "yes" | uv run arx test world.distinctions world.game_clock world.character_creation` (character_creation consumes draft distinctions) — `OK`.
+2. `pnpm -C frontend build` clean; `pnpm -C frontend exec vitest run src/character-creation` (distinctions UI) green.
+3. Adversarial review (superpowers:requesting-code-review) over `origin/main..HEAD`: focus = schema fidelity (does each `@extend_schema` response shape EXACTLY match what the view returns? especially `list` bare-array vs wrapper, the `{detail}` shapes, the swap/sync wrappers), behavior-neutrality (no view-body logic changed), no `dict[str,Any]`/Any, query discipline. Fix Critical/Important.
+4. Commit plan + any ledger note with `-f` (docs/plans gitignored).
+5. `git -C <repo> push -u origin feature/drf-spectacular-distinctions-clock`; report PR URL + summary for manual PR (no `gh`).
+6. superpowers:finishing-a-development-branch.
+
+---
+
+## Out of scope / risks
+
+- Do NOT rewire view-body validation to the new serializers (behavior change/risk). Schema descriptors only.
+- The `ReadOnlyModelViewSet` classes (DistinctionCategory/DistinctionViewSet, game_clock has none) auto-introspect — leave them.
+- If spectacular cannot represent the `convert` query-serializer cleanly, the explicit-`OpenApiParameter` fallback is the bound; do not invent new request shapes.
+- Stop and leave a written status if a gate hard-fails in a way that needs a design call (don't hack the schema to pass).

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -1775,7 +1775,7 @@ export interface paths {
       cookie?: never;
     };
     /** @description GET / — return the current clock state. */
-    get: operations['clock_retrieve'];
+    get: operations['clock_list'];
     put?: never;
     post?: never;
     delete?: never;
@@ -2958,7 +2958,7 @@ export interface paths {
      *
      *     Returns the distinctions array from draft.draft_data.
      */
-    get: operations['distinctions_drafts_distinctions_retrieve'];
+    get: operations['distinctions_drafts_distinctions_list'];
     put?: never;
     /**
      * @description Add a distinction to the draft.
@@ -10467,6 +10467,8 @@ export interface components {
       story: number;
       title: string;
       description?: string;
+      /** @description Summary of what happened in this chapter */
+      summary?: string;
       order: number;
     };
     /** @description Serializer for creating chapters */
@@ -10474,6 +10476,8 @@ export interface components {
       story: number;
       title: string;
       description?: string;
+      /** @description Summary of what happened in this chapter */
+      summary?: string;
       order: number;
     };
     /** @description Full serializer for chapter details */
@@ -10936,6 +10940,44 @@ export interface components {
       lifetime_earned?: number;
       /** @description Optional player-defined description of how this resonance manifests. */
       flavor_text?: string;
+    };
+    /** @description Request serializer for staff clock adjustment. */
+    ClockAdjustRequest: {
+      /** Format: date-time */
+      ic_datetime: string;
+      reason: string;
+    };
+    /** @description Response serializer for date conversion results. */
+    ClockConvertResponse: {
+      /** Format: date-time */
+      ic_date?: string;
+      /** Format: date-time */
+      real_date?: string;
+    };
+    /** @description Generic ``{"detail": "..."}`` response (staff actions + errors). */
+    ClockDetail: {
+      detail: string;
+    };
+    /** @description Request serializer for staff time-ratio change. */
+    ClockRatioRequest: {
+      /** Format: double */
+      ratio: number;
+      reason: string;
+    };
+    /** @description Read-only serializer for the current clock state. */
+    ClockState: {
+      /** Format: date-time */
+      ic_datetime: string;
+      year: number;
+      month: number;
+      day: number;
+      hour: number;
+      minute: number;
+      phase: components['schemas']['PhaseEnum'];
+      season: components['schemas']['SeasonEnum'];
+      /** Format: double */
+      light_level: number;
+      paused: boolean;
     };
     CodexCategory: {
       readonly id: number;
@@ -11486,6 +11528,50 @@ export interface components {
         [key: string]: unknown;
       };
     };
+    /** @description Request body for adding a distinction to a draft (create). */
+    DraftDistinctionCreateRequest: {
+      distinction_id: number;
+      /** @default 1 */
+      rank: number;
+      /** @default  */
+      notes: string;
+    };
+    /** @description Read shape of one distinction entry stored in draft_data. */
+    DraftDistinctionEntry: {
+      distinction_id: number;
+      distinction_name: string;
+      distinction_slug: string;
+      category_slug: string;
+      rank: number;
+      cost: number;
+      notes: string;
+    };
+    /** @description Request body for swapping mutually-exclusive distinctions. */
+    DraftDistinctionSwapRequest: {
+      remove_id: number;
+      add_id: number;
+      /** @default 1 */
+      rank: number;
+      /** @default  */
+      notes: string;
+    };
+    DraftDistinctionSwapResult: {
+      removed: number;
+      added: components['schemas']['DraftDistinctionEntry'];
+    };
+    /** @description One ``{id, rank}`` pair in the sync request list. */
+    DraftDistinctionSyncItemRequest: {
+      id: number;
+      /** @default 1 */
+      rank: number;
+    };
+    /** @description Request body for replacing the full distinction list (sync). */
+    DraftDistinctionSyncRequest: {
+      distinctions: components['schemas']['DraftDistinctionSyncItemRequest'][];
+    };
+    DraftDistinctionSyncResult: {
+      distinctions: components['schemas']['DraftDistinctionEntry'][];
+    };
     /** @description Serializer for EffectType lookup records. */
     EffectType: {
       readonly id: number;
@@ -11581,6 +11667,12 @@ export interface components {
       chapter: number;
       title: string;
       description?: string;
+      /** @description Summary of this episode's plot beats */
+      summary?: string;
+      /** @description Player-facing text shown when progress RESTS at this episode (no chosen transition). Required before PLOT promotion. */
+      resting_conclusion?: string;
+      /** @description Explicit 'this is an ending' marker; satisfies PLOT promotion when there is no outbound transition. */
+      is_ending?: boolean;
       order: number;
     };
     /** @description Serializer for creating episodes */
@@ -11588,6 +11680,12 @@ export interface components {
       chapter: number;
       title: string;
       description?: string;
+      /** @description Summary of this episode's plot beats */
+      summary?: string;
+      /** @description Player-facing text shown when progress RESTS at this episode (no chosen transition). Required before PLOT promotion. */
+      resting_conclusion?: string;
+      /** @description Explicit 'this is an ending' marker; satisfies PLOT promotion when there is no outbound transition. */
+      is_ending?: boolean;
       order: number;
     };
     /** @description Full serializer for episode details */
@@ -15029,6 +15127,14 @@ export interface components {
      * @enum {string}
      */
     PersonaTypeEnum: 'primary' | 'established' | 'temporary';
+    /**
+     * @description * `dawn` - Dawn
+     *     * `day` - Day
+     *     * `dusk` - Dusk
+     *     * `night` - Night
+     * @enum {string}
+     */
+    PhaseEnum: 'dawn' | 'day' | 'dusk' | 'night';
     Place: {
       readonly id: number;
       name: string;
@@ -16154,6 +16260,14 @@ export interface components {
      * @enum {string}
      */
     ScopeEnum: 'unassigned' | 'character' | 'group' | 'global';
+    /**
+     * @description * `spring` - Spring
+     *     * `summer` - Summer
+     *     * `autumn` - Autumn
+     *     * `winter` - Winter
+     * @enum {string}
+     */
+    SeasonEnum: 'spring' | 'summer' | 'autumn' | 'winter';
     /** @description Read-only serializer for SessionRequest records. */
     SessionRequest: {
       readonly id: number;
@@ -19698,7 +19812,7 @@ export interface operations {
       };
     };
   };
-  clock_retrieve: {
+  clock_list: {
     parameters: {
       query?: never;
       header?: never;
@@ -19707,12 +19821,13 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ClockState'][];
+        };
       };
     };
   };
@@ -19723,32 +19838,41 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ClockAdjustRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ClockDetail'];
+        };
       };
     };
   };
   clock_convert_retrieve: {
     parameters: {
-      query?: never;
+      query?: {
+        ic_date?: string;
+        real_date?: string;
+      };
       header?: never;
       path?: never;
       cookie?: never;
     };
     requestBody?: never;
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ClockConvertResponse'];
+        };
       };
     };
   };
@@ -19761,12 +19885,13 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ClockDetail'];
+        };
       };
     };
   };
@@ -19777,14 +19902,19 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ClockRatioRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ClockDetail'];
+        };
       };
     };
   };
@@ -19797,12 +19927,13 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ClockDetail'];
+        };
       };
     };
   };
@@ -21116,7 +21247,7 @@ export interface operations {
       };
     };
   };
-  distinctions_drafts_distinctions_retrieve: {
+  distinctions_drafts_distinctions_list: {
     parameters: {
       query?: never;
       header?: never;
@@ -21127,12 +21258,13 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['DraftDistinctionEntry'][];
+        };
       };
     };
   };
@@ -21145,14 +21277,19 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['DraftDistinctionCreateRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       201: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['DraftDistinctionEntry'];
+        };
       };
     };
   };
@@ -21186,14 +21323,19 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['DraftDistinctionSwapRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['DraftDistinctionSwapResult'];
+        };
       };
     };
   };
@@ -21206,14 +21348,19 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['DraftDistinctionSyncRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['DraftDistinctionSyncResult'];
+        };
       };
     };
   };

--- a/src/world/distinctions/serializers.py
+++ b/src/world/distinctions/serializers.py
@@ -315,3 +315,57 @@ class CharacterDistinctionOtherSerializer(serializers.ModelSerializer):
             "staff_mapped_distinction",
         ]
         read_only_fields = ["id", "status", "staff_mapped_distinction"]
+
+
+# ---------------------------------------------------------------------------
+# DraftDistinctionViewSet schema descriptors
+#
+# The draft-distinction endpoints read/write the `draft_data` JSON blob
+# directly (via build_distinction_entry / ad-hoc dict validation), so there
+# are no model serializers. These describe the existing wire contract for
+# drf-spectacular ONLY — they are not wired into request validation, so they
+# introduce no behavior change. Field shape mirrors
+# world.distinctions.types.DraftDistinctionEntry.
+# ---------------------------------------------------------------------------
+
+
+class DraftDistinctionEntrySerializer(serializers.Serializer):
+    """Read shape of one distinction entry stored in draft_data."""
+
+    distinction_id = serializers.IntegerField()
+    distinction_name = serializers.CharField()
+    distinction_slug = serializers.CharField()
+    category_slug = serializers.CharField()
+    rank = serializers.IntegerField()
+    cost = serializers.IntegerField()
+    notes = serializers.CharField(allow_blank=True)
+
+
+class DraftDistinctionCreateSerializer(serializers.Serializer):
+    """Request body for adding a distinction to a draft (create)."""
+
+    distinction_id = serializers.IntegerField()
+    rank = serializers.IntegerField(required=False, default=1)
+    notes = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class DraftDistinctionSwapSerializer(serializers.Serializer):
+    """Request body for swapping mutually-exclusive distinctions."""
+
+    remove_id = serializers.IntegerField()
+    add_id = serializers.IntegerField()
+    rank = serializers.IntegerField(required=False, default=1)
+    notes = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class DraftDistinctionSyncItemSerializer(serializers.Serializer):
+    """One ``{id, rank}`` pair in the sync request list."""
+
+    id = serializers.IntegerField()
+    rank = serializers.IntegerField(required=False, default=1)
+
+
+class DraftDistinctionSyncSerializer(serializers.Serializer):
+    """Request body for replacing the full distinction list (sync)."""
+
+    distinctions = DraftDistinctionSyncItemSerializer(many=True)

--- a/src/world/distinctions/views.py
+++ b/src/world/distinctions/views.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 from django.db.models import Prefetch
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import status, viewsets
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import IsAuthenticated
@@ -29,6 +30,10 @@ from world.distinctions.serializers import (
     DistinctionCategorySerializer,
     DistinctionDetailSerializer,
     DistinctionListSerializer,
+    DraftDistinctionCreateSerializer,
+    DraftDistinctionEntrySerializer,
+    DraftDistinctionSwapSerializer,
+    DraftDistinctionSyncSerializer,
 )
 from world.distinctions.types import ValidatedDistinction, build_distinction_entry
 
@@ -119,6 +124,7 @@ class DistinctionViewSet(viewsets.ReadOnlyModelViewSet):
         return context
 
 
+@extend_schema(tags=["distinctions"])
 class DraftDistinctionViewSet(viewsets.ViewSet):
     """
     ViewSet for managing distinctions on a CharacterDraft.
@@ -130,6 +136,9 @@ class DraftDistinctionViewSet(viewsets.ViewSet):
     - swap: Swap mutually exclusive distinctions
     """
 
+    # Schema default read shape — drf-spectacular uses this for
+    # introspection on viewsets.ViewSet; per-action decorators override.
+    serializer_class = DraftDistinctionEntrySerializer
     permission_classes = [IsAuthenticated]
 
     def _get_draft(self, draft_id: int) -> CharacterDraft:
@@ -242,6 +251,7 @@ class DraftDistinctionViewSet(viewsets.ViewSet):
         """Build the dictionary entry for a distinction on a draft."""
         return build_distinction_entry(distinction, rank, notes)
 
+    @extend_schema(responses=DraftDistinctionEntrySerializer(many=True))
     def list(self, request, draft_id: int):
         """
         List distinctions currently on the draft.
@@ -252,6 +262,10 @@ class DraftDistinctionViewSet(viewsets.ViewSet):
         distinctions = draft.draft_data.get("distinctions", [])
         return Response(distinctions)
 
+    @extend_schema(
+        request=DraftDistinctionCreateSerializer,
+        responses=DraftDistinctionEntrySerializer,
+    )
     def create(self, request, draft_id: int):
         """
         Add a distinction to the draft.
@@ -279,6 +293,7 @@ class DraftDistinctionViewSet(viewsets.ViewSet):
 
         return Response(new_entry, status=status.HTTP_201_CREATED)
 
+    @extend_schema(responses={204: None})
     def destroy(self, request, draft_id: int, pk: int):
         """
         Remove a distinction from the draft.
@@ -306,6 +321,16 @@ class DraftDistinctionViewSet(viewsets.ViewSet):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    @extend_schema(
+        request=DraftDistinctionSwapSerializer,
+        responses=inline_serializer(
+            name="DraftDistinctionSwapResult",
+            fields={
+                "removed": serializers.IntegerField(),
+                "added": DraftDistinctionEntrySerializer(),
+            },
+        ),
+    )
     @action(detail=False, methods=["post"])
     def swap(self, request, draft_id: int):
         """
@@ -368,6 +393,13 @@ class DraftDistinctionViewSet(viewsets.ViewSet):
 
         return Response({"removed": remove_id, "added": new_entry})
 
+    @extend_schema(
+        request=DraftDistinctionSyncSerializer,
+        responses=inline_serializer(
+            name="DraftDistinctionSyncResult",
+            fields={"distinctions": DraftDistinctionEntrySerializer(many=True)},
+        ),
+    )
     @action(detail=False, methods=["put"])
     def sync(self, request, draft_id: int):
         """

--- a/src/world/game_clock/serializers.py
+++ b/src/world/game_clock/serializers.py
@@ -55,3 +55,9 @@ class ClockRatioSerializer(serializers.Serializer):
 
     ratio = serializers.FloatField(min_value=0.01)
     reason = serializers.CharField(max_length=500)
+
+
+class ClockDetailSerializer(serializers.Serializer):
+    """Generic ``{"detail": "..."}`` response (staff actions + errors)."""
+
+    detail = serializers.CharField()

--- a/src/world/game_clock/views.py
+++ b/src/world/game_clock/views.py
@@ -1,6 +1,7 @@
 """API views for the game clock system."""
 
 from django.utils import timezone
+from drf_spectacular.utils import extend_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
@@ -12,6 +13,7 @@ from world.game_clock.serializers import (
     ClockAdjustSerializer,
     ClockConvertResponseSerializer,
     ClockConvertSerializer,
+    ClockDetailSerializer,
     ClockRatioSerializer,
     ClockStateSerializer,
 )
@@ -29,9 +31,13 @@ from world.game_clock.services import (
 from world.game_clock.types import ClockError
 
 
+@extend_schema(tags=["game-clock"])
 class ClockViewSet(viewsets.ViewSet):
     """ViewSet for game clock queries and staff management."""
 
+    # Schema default read shape — drf-spectacular uses this for
+    # introspection on viewsets.ViewSet; per-action decorators override.
+    serializer_class = ClockStateSerializer
     permission_classes = [IsAuthenticated]
     # Must stay in sync with the @action methods that require IsAdminUser below.
     _staff_actions = frozenset({"adjust", "ratio", "pause", "unpause"})
@@ -42,6 +48,7 @@ class ClockViewSet(viewsets.ViewSet):
             return [IsAdminUser()]
         return [IsAuthenticated()]
 
+    @extend_schema(responses=ClockStateSerializer)
     def list(self, request: Request) -> Response:
         """GET / — return the current clock state."""
         clock = GameClock.get_active()
@@ -72,6 +79,10 @@ class ClockViewSet(viewsets.ViewSet):
         serializer = ClockStateSerializer(data)
         return Response(serializer.data)
 
+    @extend_schema(
+        parameters=[ClockConvertSerializer],
+        responses=ClockConvertResponseSerializer,
+    )
     @action(detail=False, methods=["get"])
     def convert(self, request: Request) -> Response:
         """GET /convert/ — convert between IC and real dates."""
@@ -107,6 +118,7 @@ class ClockViewSet(viewsets.ViewSet):
         response_serializer = ClockConvertResponseSerializer(response_data)
         return Response(response_serializer.data)
 
+    @extend_schema(request=ClockAdjustSerializer, responses=ClockDetailSerializer)
     @action(detail=False, methods=["post"])
     def adjust(self, request: Request) -> Response:
         """POST /adjust/ — staff: set the IC clock time."""
@@ -127,6 +139,7 @@ class ClockViewSet(viewsets.ViewSet):
 
         return Response({"detail": "Clock adjusted."})
 
+    @extend_schema(request=ClockRatioSerializer, responses=ClockDetailSerializer)
     @action(detail=False, methods=["post"])
     def ratio(self, request: Request) -> Response:
         """POST /ratio/ — staff: change the time ratio."""
@@ -147,6 +160,7 @@ class ClockViewSet(viewsets.ViewSet):
 
         return Response({"detail": "Time ratio updated."})
 
+    @extend_schema(request=None, responses=ClockDetailSerializer)
     @action(detail=False, methods=["post"])
     def pause(self, request: Request) -> Response:
         """POST /pause/ — staff: pause the clock."""
@@ -160,6 +174,7 @@ class ClockViewSet(viewsets.ViewSet):
 
         return Response({"detail": "Clock paused."})
 
+    @extend_schema(request=None, responses=ClockDetailSerializer)
     @action(detail=False, methods=["post"])
     def unpause(self, request: Request) -> Response:
         """POST /unpause/ — staff: unpause the clock."""


### PR DESCRIPTION
  ## Summary
  The two `viewsets.ViewSet` subclasses that lacked `@extend_schema` now have
  full drf-spectacular coverage (recipe: memory `drf-spectacular pattern for
  viewsets.ViewSet`; reference `world/items/views.py`). Schema-only, behavior-
  neutral — descriptor serializers are not wired into request validation.

  - game_clock: ClockViewSet (list/convert/adjust/ratio/pause/unpause) + ClockDetailSerializer
  - distinctions: DraftDistinctionViewSet (list/create/destroy/swap/sync) + 5 descriptor serializers
  - api.d.ts regenerated (9 new component types; src/schema.json gitignored)