### PR TITLE
feat(skills): rework friction-audit + add takeaway-capture step

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,13 +6,18 @@
   "remoteUser": "vscode",
   // The ghcr.io/anthropics/devcontainer-features/claude-code feature is
   // intentionally NOT used. Its install runs on every container creation
-  // (npm install -g, unconditionally pulling latest), which appears to
-  // trigger Claude Code's first-run migration logic — that wipes
-  // /home/vscode/.claude/.claude.json (the onboarding/account state)
-  // even though the named volume persists .credentials.json. Result:
-  // re-login on every dc-down/dc-up. Instead we install Claude Code at
-  // image-build time in the Dockerfile so login persists across container
-  // recreates; explicit upgrades happen on `just dc-build`.
+  // (npm install -g, unconditionally pulling latest); we install Claude
+  // Code at image-build time in the Dockerfile instead, so explicit
+  // upgrades happen on `just dc-build`.
+  //
+  // Login persistence (issue #505 fix): the named volume arxii-claude-home
+  // covers /home/vscode/.claude/ (the directory), but Claude Code's
+  // onboarding state file defaults to ~/.claude.json — a SIBLING of the
+  // directory, outside the volume. That mismatch caused re-login on every
+  // dc-down/dc-up. The fix sets CLAUDE_CONFIG_DIR=/home/vscode/.claude in
+  // docker-compose.yml so .claude.json lands inside the volume and
+  // persists. post-create.sh carries an existing ~/.claude.json forward
+  // on first run after this change.
   "features": {},
   // One-time setup with network OPEN (deps + db schema).
   "postCreateCommand": "bash .devcontainer/post-create.sh",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -38,6 +38,14 @@ services:
       # to one port lets us forward exactly that one to the Windows host
       # instead of opening a 16k-port range.
       BRAINSTORM_PORT: "49200"
+      # Relocate Claude Code's config directory inside the named-volume mount
+      # so .claude.json (account/onboarding state) persists across
+      # dc-down/dc-up. Default location is ~/.claude.json (a sibling of the
+      # .claude/ directory and OUTSIDE the named volume), which gets reset
+      # to image state on every container recreate — forcing re-login.
+      # post-create.sh migrates an existing ~/.claude.json the first time
+      # this env var takes effect. See #505 for full root-cause analysis.
+      CLAUDE_CONFIG_DIR: /home/vscode/.claude
     # Forward the brainstorm-server port so http://localhost:49200/ in the
     # Windows browser reaches the in-container server. The skill's
     # start-server.sh defaults to binding 127.0.0.1; pass --host 0.0.0.0

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -27,6 +27,25 @@ git config --global --add safe.directory /workspaces/arxii
 # to write into them.
 sudo /usr/local/bin/fix-volume-perms.sh
 
+# Claude Code .claude.json relocation (issue #505).
+#
+# CLAUDE_CONFIG_DIR (set in docker-compose.yml) points Claude Code at
+# /home/vscode/.claude/ for its config dir, so .claude.json lands INSIDE
+# the arxii-claude-home named volume and persists across dc-down/dc-up.
+#
+# One-shot migration: if a pre-relocation .claude.json exists at the old
+# default path (~/.claude.json) AND the new persisted location doesn't yet
+# have one, move the file. This carries the user's existing login state
+# forward on the first dc-up after this change lands, so they don't need
+# to re-authenticate.
+#
+# Idempotent: subsequent runs see ~/.claude/.claude.json already present
+# and skip. Never overwrites existing persisted state.
+if [ -f /home/vscode/.claude.json ] && [ ! -f /home/vscode/.claude/.claude.json ]; then
+  mv /home/vscode/.claude.json /home/vscode/.claude/.claude.json
+  echo "[post-create] migrated ~/.claude.json -> ~/.claude/.claude.json (issue #505)"
+fi
+
 # settings.py requires SECRET_KEY and DATABASE_URL (django-environ, raises if
 # missing). No .env ships in a fresh checkout. DATABASE_URL also arrives via
 # compose env, but settings reads src/.env, so write it there too.

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,9 @@ src/schema.json
 **/fixtures/*.json
 # Fixture integrity tests (require local fixtures)
 **/test_fixture_integrity.py
+
+# workflow-friction-audit: user-local secret-pattern extensions
+# Default patterns ship in secret-patterns-defaults.txt (committed);
+# this file is for project-specific token prefixes that shouldn't be
+# shared across machines.
+tools/skills/workflow-friction-audit/secret-patterns.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Agent Communication
+
+**Questions in user-facing text must be unambiguous.** If you write a sentence that ends in `?` in text the user sees, it must either:
+- Be issued through `AskUserQuestion` (the answer is required to proceed), OR
+- Be restated as a statement when it's rhetorical self-direction (e.g., "Checking whether the skill expects a reviewer dispatch step." — not "Does the skill expect a reviewer dispatch step?").
+
+Ambiguous "?" sentences force the user to guess whether they're being asked to respond. When in doubt, no `?` in user-facing text outside of `AskUserQuestion`.
+
 ## Git Workflow
 
 > For end-to-end issue → merged-PR work, see the `issue-to-merged-pr` skill at `tools/skills/issue-to-merged-pr/`. It handles branch creation, PR opening, CI watching, and post-merge cleanup. The conventions below still apply; the skill is built on top of them.

--- a/docs/superpowers/specs/2026-05-26-skill-friction-audit-and-takeaways-design.md
+++ b/docs/superpowers/specs/2026-05-26-skill-friction-audit-and-takeaways-design.md
@@ -1,0 +1,226 @@
+# Skill: friction-audit redesign + takeaway-capture step
+
+**Date:** 2026-05-26
+**Closes:** #500, #504
+**Related:** #505 (deferred login persistence), #501/#503 (issue-to-merged-pr origin)
+
+## Goals
+
+1. **Restore a friction-tracking skill** that works in the devcontainer environment, where Claude Code runs with `--dangerously-skip-permissions` and permission prompts never fire (so the deleted `workflow-friction-audit`'s "permission denial" trigger model produced nothing to observe).
+2. **Add a takeaway-capture step** to `issue-to-merged-pr`'s SKILL.md lifecycle so non-obvious lessons surfaced during PR review or post-merge cleanup are carried forward as comments on related issues — discoverable by future agents who pick up adjacent work.
+
+Both target the same problem class (signal extraction from agentic workflows) and ship together because they share the secret-redaction discipline below.
+
+## Non-goals
+
+- A hook-driven log capture mechanism for the friction skill. Logging is via Claude's voluntary invocation, not `PostToolUse` hooks. (Out of scope; see "Deferred" below.)
+- Fixing the `~/.claude.json` persistence gap captured in #505.
+- Replacing the existing auto-memory system. Friction log is a separate file, not indexed in `MEMORY.md`.
+
+## Design — workflow-friction-audit (issue #500)
+
+### Skill location
+
+`tools/skills/workflow-friction-audit/SKILL.md` — same path as the deleted skill. The PR symlinks it into `~/.claude/skills/` via the existing `post-create.sh` loop.
+
+### Trigger: logging
+
+Claude invokes the skill when it notices any of:
+
+- A `Bash` tool call exited non-zero in a way suggesting a recurring environment quirk (not normal test/lint failure during the task).
+- A tool name or path the agent expected to exist didn't.
+- An external tool (`gh`, `git`, `arx`, etc.) returned an error that looks pattern-shaped, not one-off.
+- A retry-with-different-approach pattern Claude notices itself doing.
+
+The skill logs ONE entry per noticed event. No deduplication at log-time — that's the audit's job.
+
+### Log file
+
+Path: `/home/vscode/.claude/projects/-workspaces-arxii/memory/friction-log.md`
+
+This directory is inside the `arxii-claude-home` named volume, so the log survives `dc-down/dc-up` (same durability as the existing auto-memory).
+
+Not indexed in `MEMORY.md`. Friction is ephemeral; pruned aggressively after each audit.
+
+Entry format (append-only):
+
+```markdown
+## YYYY-MM-DD — <short-category>
+- **Event:** <one-sentence summary of what failed/surprised — NOT raw output>
+- **Context:** <2-3 sentences: what we were trying, why this happened, suspected root cause>
+- **Suspected fix:** <CLAUDE.md edit, script update, doc note, or "investigate further">
+```
+
+Categories are free-form short tags (`bash-error`, `gh-label-mismatch`, `path-not-found`, etc.) — the audit step groups by these.
+
+### Audit trigger
+
+When the log file currently contains ≥5 entries, the skill fires at the next user-facing turn boundary. Claude includes the consolidated proposal in its next response to the user rather than interrupting mid-task.
+
+(Pruning after each audit is the state-keeping mechanism — the entry count IS the "since last audit" count. There is no separate audit-counter file.)
+
+"User-facing turn boundary" = the next time Claude is about to send a text response back to the user (not mid-tool-call sequence). If Claude is in the middle of an executing-plans run with no natural user-facing turn coming up soon, defer to the next pause.
+
+### Audit output
+
+ONE consolidated proposal:
+
+1. Group log entries by root cause / category.
+2. For each group, describe the recurring pattern in 1-2 sentences.
+3. For each group, propose ONE concrete action: a CLAUDE.md edit (with the proposed diff inline), a script update, or "this needs broader discussion."
+
+The skill then offers the user two paths:
+
+**Path A — apply now.** Claude shows the unified diff for CLAUDE.md / script edits, user approves (whole batch or per-group). Approved edits land via `Edit` tool. Entries that fed an *approved* group are pruned; entries that fed a *rejected* group remain (so they re-surface on the next audit with whatever new context has accumulated). Entries not included in any group also remain.
+
+**Path B — file as issue.** Claude calls `file-followup.sh` from `tools/skills/issue-to-merged-pr/scripts/` with the proposal as the issue body. Captures the returned issue number, surfaces the issue URL in the user-facing message so the user can follow up. Log entries that fed the proposal are pruned after `file-followup.sh` returns exit 0; on non-zero exit, NO pruning happens (the log stays intact for retry). The filed issue is now the authoritative record.
+
+(Calling `file-followup.sh` and other scripts under `tools/skills/issue-to-merged-pr/scripts/` from the friction-audit and takeaway-capture paths is consistent with CLAUDE.md's `gh`-exception intent — those scripts ARE the sanctioned `gh` wrappers. No CLAUDE.md edit needed; the exception's wording covers the scripts themselves, not just the originating skill's direct lifecycle.)
+
+Pruning is via `Edit` on the log file (remove the entries; keep the rest of the file). No backups, no archive — pruned content is gone. (If users want history, the audit proposal that became an issue is the durable record.)
+
+### Secret-redaction discipline
+
+Three layers — applies to BOTH the friction-audit and the takeaway-capture step.
+
+**Layer 1 — log-time capture discipline.** Entries are human-written summaries, not raw output paste-throughs. The SKILL.md gives explicit rules:
+
+- Summarize the error type. E.g., `gh api 401 (auth failure on repos/.../contents)` — not the full error block.
+- Never log: `env` output, `curl` requests/responses, anything with `Authorization:` headers, `.env` file contents, any string matching the patterns in Layer 2.
+- When in doubt, log the symptom (`gh push failed: permission denied`) not the detail (verbatim stderr).
+
+**Layer 2 — pre-output regex sweep.** Before producing the consolidated proposal, the skill scans the proposal text against a denylist. Default patterns (also listed in SKILL.md):
+
+```
+ghp_[A-Za-z0-9]{36,}            github_pat_[A-Za-z0-9_]{60,}
+gho_[A-Za-z0-9]{36,}            ghu_[A-Za-z0-9]{36,}
+ghs_[A-Za-z0-9]{36,}            ghr_[A-Za-z0-9]{36,}
+sk-[A-Za-z0-9]{20,}             xoxb-[A-Za-z0-9-]{20,}
+xoxp-[A-Za-z0-9-]{20,}          AKIA[0-9A-Z]{16}
+ASIA[0-9A-Z]{16}                -----BEGIN [A-Z ]+PRIVATE KEY-----
+Authorization:\s*Bearer\s+\S+   AIza[0-9A-Za-z_-]{35}
+```
+
+User-extensible via `tools/skills/workflow-friction-audit/secret-patterns.txt` (gitignored — projects don't share secret-pattern lists). The skill loads this file on top of the defaults if it exists.
+
+**Mechanism (how the scan runs):** Claude writes the candidate proposal to a temp file, then runs
+
+```bash
+grep -E -n -f tools/skills/workflow-friction-audit/secret-patterns-defaults.txt \
+  $( [ -f tools/skills/workflow-friction-audit/secret-patterns.txt ] && \
+     printf '%s' '-f tools/skills/workflow-friction-audit/secret-patterns.txt' ) \
+  <proposal-tempfile>
+```
+
+via the `Bash` tool. Exit 0 (match found) → abort; exit 1 (no match) → continue. No wrapper script — the SKILL.md instructs Claude to run the command directly so the user sees the exact patterns being scanned.
+
+On match: abort the audit and surface to the user — "proposal contains a potential secret matching `<pattern>` at line N, please redact manually before continuing." NO auto-redaction (a bad regex match auto-replacing the wrong substring is worse than the user dealing with it).
+
+**Layer 3 — post-time hard gate.** Re-run the same scan on the final issue body immediately before calling `file-followup.sh`. If it matches → refuse to call the script, show the user the offending lines, exit. Belt-and-suspenders since the issue-filing path is the public-exposure risk.
+
+### Files added
+
+- `tools/skills/workflow-friction-audit/SKILL.md` — the skill itself.
+- `tools/skills/workflow-friction-audit/secret-patterns-defaults.txt` — the default denylist (committed).
+- Gitignore entry for `tools/skills/workflow-friction-audit/secret-patterns.txt` (user-local extension).
+
+## Design — takeaway-capture step (issue #504)
+
+Two new sub-steps injected into `tools/skills/issue-to-merged-pr/SKILL.md`, in the existing Steps 8 (PR-comment phase) and 9 (post-merge cleanup).
+
+### Step 8 addition — after addressing review comments
+
+After all actionable comments are committed (existing Step 8 behavior), before bumping the `<!-- last-addressed-comment: -->` marker, Claude evaluates each addressed comment for a takeaway worth carrying forward to related issues.
+
+**Criteria for "takeaway worth posting":**
+- Surfaces a gotcha, workflow weakness, or design decision that future agents working on related issues would benefit from.
+- The insight is not already in CLAUDE.md (those go to the friction-audit's CLAUDE.md-edit path instead).
+- The target issue exists and is open (or recently closed, < 90 days).
+
+**Post unilaterally.** No user confirmation. Keeps the step lightweight. The bar is set by the criteria above; if Claude is unsure, skip the post (better to lose one takeaway than spam).
+
+### Step 9 addition — post-merge cleanup
+
+After `post-merge-cleanup.sh` emits its JSON, Claude reviews the merge for the same kind of takeaway. Targets: issues in `linked_issue_actions`, deferred follow-ups Claude filed during the PR's lifecycle. Same posting bar, same format.
+
+### Comment format
+
+Posted via `comment-on-issue.sh`:
+
+```markdown
+> **Takeaway from PR #<N>:** <one-sentence headline>
+>
+> <2-4 sentences of specific insight>
+>
+> Refs: PR #<N>, related: #<other-issues-if-any>
+```
+
+### Guardrails — ordering and scope
+
+Explicit rules in SKILL.md, to prevent conflating "needs change in this PR" with "future takeaway":
+
+1. **Default disposition: actionable.** For every review comment, first ask "can this be addressed in this PR?" Treat as actionable unless clearly out-of-scope (separable concern, different system, or reviewer explicitly framed it as future work).
+
+2. **Takeaway evaluation runs AFTER all actionable work is committed.** Only once the PR is updated for every in-scope comment does Claude evaluate for cross-issue takeaways.
+
+3. **A single comment can yield both.** Address the change in code AND post the takeaway on a related issue — not mutually exclusive.
+
+4. **Insight about THIS PR's work stays in THIS PR.** The takeaway-comment path is for cross-issue carryforward only. PR-local insights go in the PR description or commit message.
+
+5. **When uncertain about scope, address it.** Tie-breaker: if Claude can't decide whether a comment is in-scope or future work, address it now. User can ask for backout; cheaper than the comment getting filed elsewhere and forgotten.
+
+### Secret-redaction applies
+
+The same three-layer discipline from the friction-audit applies to takeaway comments. Posted comments are public; the post-time hard gate (Layer 3) runs before every `comment-on-issue.sh` call from the takeaway path.
+
+### When to bail
+
+Adds one entry to SKILL.md's "When to bail" section: if a takeaway comment would contain a secret-pattern match, abort the post and surface to the user. (Mirrors the friction-audit hard gate.)
+
+### Files modified
+
+- `tools/skills/issue-to-merged-pr/SKILL.md` — Steps 8 and 9 sub-step additions, "When to bail" entry, the secret-redaction cross-reference.
+
+## CLAUDE.md addition — agent communication discipline
+
+Folded in (not deferred to the audit's dogfood case) because the friction surfaced during the brainstorm itself: the user couldn't tell whether a sentence ending in `?` was a question to them or rhetorical agent self-talk.
+
+Add a new short section to `CLAUDE.md`, placed between the opening paragraph and `## Git Workflow`:
+
+```markdown
+## Agent Communication
+
+**Questions in user-facing text must be unambiguous.** If you write a sentence that ends in `?` in text the user sees, it must either:
+- Be issued through `AskUserQuestion` (the answer is required to proceed), OR
+- Be restated as a statement, not a question, when it's rhetorical self-direction (e.g., "Checking whether the skill expects a reviewer dispatch step." not "Does the skill expect a reviewer dispatch step?").
+
+Ambiguous "?" sentences force the user to guess whether they're being asked to respond. When in doubt, no `?` in user-facing text outside of `AskUserQuestion`.
+```
+
+This is the friction-audit's pattern in miniature — a noticed-during-work ambiguity that turns into a permanent CLAUDE.md edit. We do it directly in this PR rather than dogfooding the audit on itself because the rule is small, clear, and the planner is already touching CLAUDE.md-edit infrastructure.
+
+## Deferred / out-of-scope
+
+- **Hook-driven log capture** for the friction-audit (auto-append on `PostToolUse` exit non-zero). Considered; deferred because: (a) requires settings.json hook config the user has to commit, (b) the voluntary-logging model is simpler to land first and validates the audit/proposal flow before adding the more reliable but heavier collector.
+- **#505 — login persistence fix.** Already captured.
+- **Repo type-label vocabulary mismatch.** The `pickup-issue.sh` script expects `feature/fix/chore/...` labels but this repo uses GitHub-default `enhancement/bug/documentation`. Surfaced during issue filing for this PR. Recording here as the **first dogfood entry** the friction-audit's audit step will likely produce against this repo: a real recurring friction. Not fixed in this PR (would expand scope to script + label vocabulary changes).
+
+## Testing
+
+Manual, scenario-based (no automated tests; these are skills, not code paths).
+
+**workflow-friction-audit:**
+1. Create a fresh friction-log.md with 5 fabricated entries, invoke the skill, verify the proposal lists groups + concrete actions.
+2. Same, but include a fake `ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` in one entry's context — verify Layer 2 abort fires.
+3. Same, but redact, then apply-now path — verify diff shown, partial-rejection of one group keeps THAT group's entries while pruning the approved groups'.
+4. Same, but file-as-issue path — verify `file-followup.sh` called, issue body matches proposal, log pruned only after exit 0, returned URL surfaced.
+5. **Dogfood case** — after this PR merges, invoke the audit against this repo's actual friction-log.md. Verify the `pickup-issue.sh` label vocabulary mismatch surfaces as a real entry (this PR's "Deferred" section predicts it will be the first dogfood finding). Closes the loop on the spec's own claim.
+
+**takeaway-capture:**
+1. Simulate a PR-comment-phase invocation with a review comment that's both actionable AND has takeaway value — verify code change made first, takeaway posted second, on the right issue.
+2. Same, but with a comment that's clearly PR-local — verify NO takeaway post.
+3. Post-merge cleanup invocation with a `linked_issue_actions: needs-attention` entry — verify takeaway posted on that issue.
+
+## Open questions
+
+None remaining. Brainstorming covered: log location, audit trigger, edit-application path, takeaway autonomy, secret redaction, scope-conflation guardrails.

--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -109,12 +109,24 @@ skipped-design tasks, just edit and commit.
 
 ### 4. Sync with main
 
-Run `scripts/sync-with-main.sh <branch>`. On conflict (exit 4):
+Run `scripts/sync-with-main.sh <branch>`. The script automatically picks the
+right strategy:
+- **Branch not yet on origin (local-only):** rebase onto origin/main. Clean
+  linear history.
+- **Branch already on origin (pushed):** merge origin/main in. Avoids
+  rewriting already-published history, so the next `git push` is a fast-
+  forward — no force-push (and no user approval prompt for it).
+
+The choice is recorded in the JSON's `strategy` field on conflict.
+
+On conflict (exit 4):
 - Read the emitted JSON.
 - For each entry in `potentially_impacted_issues` where the impact is
   judged real, call `scripts/comment-on-issue.sh <issue> <body-file>` to
   notify the other issue's stakeholders.
-- Resolve the conflicts, continue the rebase.
+- Resolve the conflicts, then continue the in-progress sync
+  (`git rebase --continue` or `git merge --continue` depending on
+  `strategy`).
 
 ### 5. Push & open PR
 

--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -168,6 +168,7 @@ When phase detection lands on **PR-comment**:
 - Run `scripts/read-pr-comments.sh <pr-N>` — get unread comments as JSON.
 - Address each: edit code, commit.
 - Push.
+- **Takeaway evaluation** (see below — runs before the marker bump).
 - Update the PR body marker:
 
 ```bash
@@ -177,6 +178,53 @@ BODY=$(gh pr view <pr> --json body --jq .body)
 NEW_BODY=$(sed -E "s/<!-- last-addressed-comment: [0-9]+ -->/<!-- last-addressed-comment: $NEW_MAX -->/" <<<"$BODY")
 printf '%s' "$NEW_BODY" | gh pr edit <pr> --body-file -
 ```
+
+#### Takeaway evaluation
+
+After all actionable comments are committed (above) and **before** bumping the marker, evaluate each addressed comment for a non-obvious takeaway worth posting on a related issue.
+
+**Criteria for "takeaway worth posting":**
+- The comment surfaced a gotcha, workflow weakness, or design decision that future agents working on a related, currently-open (or recently-closed, <90d) issue would benefit from.
+- The insight is not about THIS PR's work — PR-local insights go in the PR description or commit message, never a sibling-issue comment.
+
+**Ordering rules — follow in this order:**
+1. **Default disposition: actionable.** For every review comment, first ask "can this be addressed in this PR?" Treat as actionable unless clearly out-of-scope (separable concern, different system, or reviewer framed it as future work).
+2. Address all actionable comments in code FIRST. Takeaway evaluation runs only after.
+3. A single comment can yield both a code change AND a takeaway — not mutually exclusive.
+4. When uncertain whether a comment is in-scope or future work, **address it now**. Tie-breaker.
+
+**Posting:** post unilaterally (no user confirmation; the criteria above set the bar). Format:
+
+```
+> **Takeaway from PR #<N>:** <one-sentence headline>
+>
+> <2-4 sentences of specific insight>
+>
+> Refs: PR #<N>, related: #<other-issues-if-any>
+```
+
+Run the **Layer 3 secret-scan** before posting (cross-references `tools/skills/workflow-friction-audit/`):
+
+```bash
+TAKEAWAY_TMP=$(mktemp)
+# Write the comment body to "$TAKEAWAY_TMP" via the Write tool or a heredoc.
+
+USER_PATTERNS=tools/skills/workflow-friction-audit/secret-patterns.txt
+if [ -f "$USER_PATTERNS" ]; then
+  grep -E -n -f tools/skills/workflow-friction-audit/secret-patterns-defaults.txt -f "$USER_PATTERNS" "$TAKEAWAY_TMP"
+else
+  grep -E -n -f tools/skills/workflow-friction-audit/secret-patterns-defaults.txt "$TAKEAWAY_TMP"
+fi
+```
+
+- **Exit 0** (secret match): abort the post, surface the offending line to the user, exit (see "When to bail"). Do NOT call `comment-on-issue.sh`.
+- **Exit 1** (clean): proceed —
+
+```bash
+bash tools/skills/issue-to-merged-pr/scripts/comment-on-issue.sh <target-issue-N> "$TAKEAWAY_TMP"
+```
+
+Then continue to the marker bump.
 
 Return to CI watch.
 
@@ -188,6 +236,14 @@ Run `scripts/post-merge-cleanup.sh <branch> <pr-N>`. Read the JSON:
 - For review-driven follow-ups identified during the PR-comment phase,
   file them now with `scripts/file-followup.sh`.
 
+#### Takeaway evaluation (post-merge)
+
+Review the merged work for any non-obvious takeaway worth posting on:
+- Issues in `linked_issue_actions` (especially `needs-attention` entries).
+- Deferred follow-ups Claude filed during the PR's lifecycle.
+
+Apply the same criteria, ordering rules, format, and Layer 3 secret-scan as Step 8's takeaway evaluation. Post unilaterally if criteria are met. Use `scripts/comment-on-issue.sh` for the post.
+
 ## When to bail (stop and wait for human)
 
 - CI repeat-failure or thrash cap (see above).
@@ -196,6 +252,9 @@ Run `scripts/post-merge-cleanup.sh <branch> <pr-N>`. Read the JSON:
   post on the original issue suggesting a split, exit before opening any PR.
 - Any `gh` command fails with auth errors. Surface the error and the
   `gh auth status` output; the user needs to update their PAT.
+- A takeaway-capture post would contain a secret-pattern match (Layer 3
+  gate from `tools/skills/workflow-friction-audit/`). Abort the post,
+  surface the offending line to the user, exit without commenting.
 
 Each bail writes a structured PR or issue comment with: what was attempted,
 where it stopped, what the human should decide.

--- a/tools/skills/issue-to-merged-pr/scripts/open-pr.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/open-pr.sh
@@ -20,6 +20,12 @@
 #   1  usage / generic error
 set -euo pipefail
 
+# bash 5.2+ defaults `patsub_replacement` ON, which makes `&` in the
+# replacement string of `${var//pat/rep}` substitute with the matched
+# pattern (sed-like). PR_SUMMARY content frequently contains `&` (e.g.,
+# "Steps 8 & 9"), so leave this OFF so the substitution is literal.
+shopt -u patsub_replacement
+
 DRY_RUN=0
 if [[ "${1:-}" == "--dry-run" ]]; then
   DRY_RUN=1

--- a/tools/skills/issue-to-merged-pr/scripts/sync-with-main.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/sync-with-main.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 # sync-with-main.sh <branch>
 #
-# Fetches origin/main, rebases the named branch onto it.
+# Fetches origin/main and integrates it into the named branch. Strategy
+# depends on whether the branch has already been pushed to origin:
+#
+# - **Branch not on origin (local-only):** rebase. Clean linear history;
+#   no force-push needed because the branch is local.
+# - **Branch already on origin (pushed):** merge. Avoids rewriting
+#   already-published history, so the subsequent `git push` is a
+#   fast-forward and doesn't need `--force-with-lease` (which requires
+#   user approval in restricted environments).
+#
 # On conflict: emits JSON listing conflicted files, conflict symbols
 # (function/class names extracted from `git diff --unified=0` hunk headers
 # against origin/main), and any open issues whose body/comments
@@ -9,9 +18,9 @@
 # over-inclusive — prefers false positives to false negatives.
 #
 # Exits:
-#   0  rebase succeeded with no conflicts (no JSON emitted)
+#   0  sync succeeded with no conflicts (no JSON emitted)
 #   1  usage / generic error
-#   4  rebase produced conflicts (JSON emitted to stdout; rebase left in progress)
+#   4  sync produced conflicts (JSON emitted to stdout; sync left in progress)
 set -euo pipefail
 
 usage() {
@@ -25,8 +34,17 @@ BRANCH="$1"
 git fetch origin --quiet
 git checkout "$BRANCH" --quiet
 
-if git rebase origin/main; then
-  exit 0
+# Decide rebase vs merge based on whether the branch is published.
+if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+  SYNC_STRATEGY="merge"
+  if git merge origin/main --no-edit; then
+    exit 0
+  fi
+else
+  SYNC_STRATEGY="rebase"
+  if git rebase origin/main; then
+    exit 0
+  fi
 fi
 
 # Conflicts present. Collect conflicted files.
@@ -90,6 +108,7 @@ jq -n \
   --argjson c "$CONFLICTS_JSON" \
   --argjson s "$SYMBOLS_JSON" \
   --argjson i "$IMPACTED" \
-  '{conflicts: $c, conflict_symbols: $s, potentially_impacted_issues: $i}'
+  --arg strategy "$SYNC_STRATEGY" \
+  '{strategy: $strategy, conflicts: $c, conflict_symbols: $s, potentially_impacted_issues: $i}'
 
 exit 4

--- a/tools/skills/workflow-friction-audit/SKILL.md
+++ b/tools/skills/workflow-friction-audit/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: workflow-friction-audit
+description: Use when you notice a recurring tool-call failure or environment-quirk pattern. Logs the friction; when ≥5 entries accumulate, proposes CLAUDE.md edits (apply now) or files a follow-up issue. Replaces the permission-prompt model that doesn't apply in the devcontainer (where Claude runs with --dangerously-skip-permissions).
+---
+
+# Workflow Friction Audit
+
+## Purpose
+
+Track recurring **tool-call failures** and **environment quirks** in a persistent log. When enough entries accumulate, group them by root cause and propose permanent fixes — CLAUDE.md edits, script updates, or follow-up issues.
+
+This replaces the deleted permission-prompt-tracking version that produced nothing to observe in the devcontainer.
+
+## When to log
+
+Append an entry when you notice any of:
+
+- A `Bash` tool call exited non-zero in a way that suggests a recurring environment quirk (not a normal test/lint failure during the work itself).
+- A tool name or path you expected to exist didn't.
+- An external tool (`gh`, `git`, `arx`, etc.) errored with a message that looks pattern-shaped, not one-off.
+- You retried with a different approach because the first didn't work, and the workaround feels like it'll recur.
+
+One entry per noticed event. No deduplication at log-time — that's the audit's job.
+
+## Log file
+
+Path: `/home/vscode/.claude/projects/-workspaces-arxii/memory/friction-log.md`
+
+This directory is inside the `arxii-claude-home` named volume, so the log survives `dc-down/dc-up`. It is NOT indexed in `MEMORY.md` (friction is ephemeral; pruned after each audit).
+
+Append entries in this format:
+
+```markdown
+## YYYY-MM-DD — <short-category>
+- **Event:** <one-sentence summary — NOT raw output>
+- **Context:** <2-3 sentences: what we were trying, why this happened, suspected root cause>
+- **Suspected fix:** <CLAUDE.md edit, script update, doc note, or "investigate further">
+```
+
+Categories are free-form short tags — examples: `bash-error`, `gh-label-mismatch`, `path-not-found`, `cli-args-changed`, `retry-pattern`. The audit groups by these.
+
+If the file doesn't exist yet, create it with a single H1 header `# Friction Log` and append below.
+
+## Capture discipline — secrets
+
+**Entries are human-written summaries, not raw output paste-throughs.** Layer 1 of the three-layer redaction discipline.
+
+- Summarize the error type. E.g., `gh api 401 (auth failure on repos/.../contents)` — not the full error block.
+- Never log: `env` output, `curl` requests/responses, anything with `Authorization:` headers, `.env` file contents, anything matching the patterns in `secret-patterns-defaults.txt`.
+- When in doubt, log the symptom (`gh push failed: permission denied`) not the detail (verbatim stderr).
+
+## When to audit
+
+When the log file currently contains **≥5 entries**, run the audit at the next user-facing turn boundary. Include the consolidated proposal in your next response to the user rather than interrupting mid-task.
+
+"User-facing turn boundary" = the next time you're about to send a text response back to the user (not mid-tool-call sequence). If you're in the middle of an `executing-plans` run with no natural user-facing turn coming up soon, defer to the next pause.
+
+Pruning after each audit is the state-keeping mechanism — the entry count IS the "since last audit" count. There is no separate audit-counter file.
+
+## The audit
+
+### Step 1: Read the log and group entries
+
+Read `/home/vscode/.claude/projects/-workspaces-arxii/memory/friction-log.md`. Group entries by root cause (often, but not always, by their category tag). A group is ≥2 entries with the same underlying cause; isolated single entries can be their own group if the fix is concrete.
+
+### Step 2: Draft the consolidated proposal
+
+One Markdown document. For each group:
+
+```markdown
+### Group: <short label>
+
+**Pattern (N entries):** <1-2 sentence summary of the recurring cause>
+
+**Proposed action:** <ONE concrete action — CLAUDE.md diff, script update, "investigate further", etc.>
+```
+
+End with a brief overall summary (one paragraph).
+
+### Step 3: Layer 2 — pre-output regex sweep
+
+Before showing the proposal to the user, write it to a temp file and scan for secrets:
+
+```bash
+PROPOSAL_TMP=$(mktemp)
+# Write the proposal text to "$PROPOSAL_TMP" via the Write tool or a heredoc.
+
+USER_PATTERNS=tools/skills/workflow-friction-audit/secret-patterns.txt
+if [ -f "$USER_PATTERNS" ]; then
+  grep -E -n -f tools/skills/workflow-friction-audit/secret-patterns-defaults.txt -f "$USER_PATTERNS" "$PROPOSAL_TMP"
+else
+  grep -E -n -f tools/skills/workflow-friction-audit/secret-patterns-defaults.txt "$PROPOSAL_TMP"
+fi
+```
+
+Interpret the exit code:
+- **Exit 0** (match found): abort the audit. Surface to the user: "Proposal contains a potential secret matching `<pattern>` at line N (showing: `<the matching line>`). Please redact manually before continuing." Do not auto-redact. Do not prune the log.
+- **Exit 1** (no match): continue to Step 4.
+
+### Step 4: Offer two paths to the user
+
+Show the user the proposal, then ask:
+
+> "Two paths from here:
+> 1. **Apply now** — I'll show the unified diff for any CLAUDE.md / script edits in the proposal; you approve (whole batch or per-group), and I'll land the changes and prune the log.
+> 2. **File as issue** — I'll call `file-followup.sh` with the proposal as the issue body; you review later via normal PR flow. Log prunes once the issue is filed.
+>
+> Which one?"
+
+Use `AskUserQuestion` for a structured response, or plain text — your call based on session context.
+
+### Step 5a: Apply now (Path A)
+
+For each group's proposed action that's a file edit:
+- Show the unified diff (use `Edit` tool's preview, or write out the `old_string` → `new_string` blocks).
+- Ask which groups the user approves (or "all").
+- Apply approved edits via `Edit` tool.
+
+Pruning rule:
+- Entries that fed an **approved** group → remove from the log.
+- Entries that fed a **rejected** group → leave in place (they re-surface on the next audit).
+- Entries not in any group → leave in place.
+
+Use `Edit` on the log file to remove the approved entries.
+
+### Step 5b: File as issue (Path B)
+
+Run Layer 3 — the post-time hard gate — by re-running the grep from Step 3 on the final issue body (which is the same proposal text; if you edited it after Step 3, re-scan). If exit 0, abort with the same user-surfaced message.
+
+Then:
+
+```bash
+ISSUE_NUM=$(bash tools/skills/issue-to-merged-pr/scripts/file-followup.sh \
+  "Friction audit: <short summary>" \
+  "$PROPOSAL_TMP" \
+  enhancement)
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+echo "Filed: https://github.com/$REPO/issues/$ISSUE_NUM"
+```
+
+(Read the repo dynamically via `gh repo view` — never hardcode the org/name.)
+
+If `file-followup.sh` exits 0:
+- Surface the issue URL in your user-facing message.
+- Prune ALL entries that fed the proposal from the log (the issue is now the authoritative record).
+
+If `file-followup.sh` exits non-zero:
+- Surface the error to the user.
+- **Do NOT prune** — the log stays intact for retry.
+
+## Layer 3 — post-time gate (also applies to takeaway-capture)
+
+This skill's secret-redaction patterns and the `grep -E -f` mechanism are reused by the takeaway-capture sub-steps in `tools/skills/issue-to-merged-pr/SKILL.md`. Same defaults file, same user-extension file, same abort discipline. Before any `comment-on-issue.sh` call from that skill's takeaway path, run the same scan.
+
+## Anti-patterns
+
+- **Don't log normal test failures during the task.** "My code change broke a test, then I fixed it" is not friction — it's the work. Friction is environmental, recurring, fix-elsewhere-in-the-stack.
+- **Don't paste raw output into entries.** That's where secrets leak. Summarize.
+- **Don't add overly broad CLAUDE.md edits** ("never use `gh`"). The redesign's whole point is targeted fixes for specific recurring patterns.
+- **Don't audit during single-task flow.** Wait for a natural turn boundary.
+- **Don't auto-apply CLAUDE.md edits.** User always approves before edits land (Path A) or before an issue is filed (Path B).
+
+## Calibration
+
+When in doubt about whether something is worth logging: **log it.** The audit step's grouping and the user's Path-A rejection are the filters. Better to over-log and have entries pruned than to miss a real pattern.
+
+When in doubt about whether something is worth proposing in an audit: **propose it cautiously.** A weak proposal the user rejects leaves entries in the log for the next audit to revisit with more data. A strong proposal that gets approved becomes a permanent fix.

--- a/tools/skills/workflow-friction-audit/secret-patterns-defaults.txt
+++ b/tools/skills/workflow-friction-audit/secret-patterns-defaults.txt
@@ -1,0 +1,14 @@
+ghp_[A-Za-z0-9]{36,}
+github_pat_[A-Za-z0-9_]{60,}
+gho_[A-Za-z0-9]{36,}
+ghu_[A-Za-z0-9]{36,}
+ghs_[A-Za-z0-9]{36,}
+ghr_[A-Za-z0-9]{36,}
+sk-[A-Za-z0-9]{20,}
+xoxb-[A-Za-z0-9-]{20,}
+xoxp-[A-Za-z0-9-]{20,}
+AKIA[0-9A-Z]{16}
+ASIA[0-9A-Z]{16}
+-----BEGIN [A-Z ]+PRIVATE KEY-----
+Authorization:[[:space:]]*Bearer[[:space:]]+\S+
+AIza[0-9A-Za-z_-]{35}


### PR DESCRIPTION
Closes #500

## Summary

Bundle of two skill changes plus a CLAUDE.md addition and a devcontainer login-persistence fix. **Also closes #504 and #505.**

- **Redesigned `workflow-friction-audit`** (#500): tracks failed tool calls instead of permission denials (which never fire in the devcontainer with `--dangerously-skip-permissions`). Logs to `memory/friction-log.md` inside the `arxii-claude-home` named volume so the log survives `dc-down/dc-up`. At ≥5 entries, fires a consolidated audit with two paths — apply CLAUDE.md edits now, or file as a follow-up issue. Three-layer secret-redaction discipline (capture / pre-output regex sweep / post-time hard gate) shared with the takeaway-capture step below.
- **Takeaway-capture sub-steps** added to `issue-to-merged-pr` SKILL.md Steps 8 & 9 (#504). After addressing PR-review comments (Step 8) and after post-merge cleanup (Step 9), evaluates for non-obvious takeaways worth posting on related issues. Explicit ordering rules prevent conflating "address in this PR" with "future takeaway" — actionable-first, single comment can yield both, tie-breaker is "address it now."
- **`CLAUDE.md` Agent Communication section**: a small discipline rule for unambiguous user-facing questions (use `AskUserQuestion` or restate as a statement). Noticed during the brainstorm itself — folded in directly rather than dogfooded through the friction-audit's first audit, since the rule is small and clear.
- **Devcontainer login-persistence fix (#505)**: root cause is that the `arxii-claude-home` named volume covers `/home/vscode/.claude/` (the directory) but Claude Code's account state file defaults to `~/.claude.json` — a SIBLING outside the volume. Fix sets `CLAUDE_CONFIG_DIR=/home/vscode/.claude` so `.claude.json` lives inside the volume. `post-create.sh` migrates an existing `~/.claude.json` forward on first run after this change so the current session isn't lost. The `devcontainer.json` comment block had the wrong path AND the wrong attributed cause — rewritten with accurate diagnosis.

### Bug fixes folded in

Two real friction events surfaced while dogfooding this PR through the `issue-to-merged-pr` lifecycle — both folded in directly:

- **`open-pr.sh` `patsub_replacement` (bash 5.2)** — template substitution corrupted my summary text: `Steps 8 & 9` rendered as `Steps 8 {{summary}} 9`. Root cause: bash 5.2 defaults `shopt -s patsub_replacement` ON, which makes `&` in the replacement of `${var//pat/rep}` substitute with the matched pattern (sed-like behavior). One-line fix (`shopt -u patsub_replacement` at top of `open-pr.sh`).
- **`sync-with-main.sh` rebase-after-push → force-push approval friction** — the script unconditionally rebased onto origin/main even when the branch was already pushed, forcing the next `git push` to use `--force-with-lease`, which prompts the user for approval (and is a real ergonomic problem if the user isn't around). Fix: detect whether the branch exists on origin (`git ls-remote --heads`); if yes, **merge** origin/main in instead of rebasing. Subsequent push is a fast-forward. The integration strategy is recorded in the conflict-JSON's `strategy` field. SKILL.md updated accordingly. Validated immediately by pushing this very commit without force.

### Notes for review

The label-vocabulary mismatch surfaced during issue filing (`pickup-issue.sh` expects `feature/fix/chore/...` but this repo uses GH default `enhancement/bug/documentation`) is the predicted first dogfood entry the new friction-audit will catch against this repo. Intentionally not fixed in this PR — recorded as a testing scenario in the spec.

## Follow-ups filed

(none — all three issues addressed in this PR)

## Notes

- Brainstorm/plan: ran — see [spec](docs/superpowers/specs/2026-05-26-skill-friction-audit-and-takeaways-design.md)
- Sync-with-main: merged origin/main (1 commit ahead: #499) — branch was already pushed so used merge instead of rebase per the new sync-with-main.sh workflow

<!-- last-addressed-comment: 0 -->