### PR TITLE
fix(missions): reject negative cooldown on MissionTemplate

### DIFF
--- a/src/world/missions/migrations/0007_cooldown_min_value.py
+++ b/src/world/missions/migrations/0007_cooldown_min_value.py
@@ -1,0 +1,27 @@
+# Hand-written migration — add MinValueValidator(timedelta(0)) to
+# MissionTemplate.cooldown so the field rejects negative durations at
+# the API + clean() layer.
+# Hand-written because `arx manage makemigrations` hangs on the Evennia
+# superuser-creation wizard in this devcontainer.
+
+import datetime
+
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("missions", "0006_missiongiver_name_unique"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="missiontemplate",
+            name="cooldown",
+            field=models.DurationField(
+                help_text="Per-giver re-offer cooldown. Must be non-negative.",
+                validators=[django.core.validators.MinValueValidator(datetime.timedelta(0))],
+            ),
+        ),
+    ]

--- a/src/world/missions/models.py
+++ b/src/world/missions/models.py
@@ -15,7 +15,10 @@ and ``checks.Consequence``; this app introduces no new check or consequence
 models.
 """
 
+from datetime import timedelta
+
 from django.core.exceptions import ValidationError
+from django.core.validators import MinValueValidator
 from django.db import models
 from django.db.models import Q
 from evennia.utils.idmapper.models import SharedMemoryModel
@@ -116,7 +119,10 @@ class MissionTemplate(SharedMemoryModel):
         default=0,
         help_text="Percent chance this template replaces an existing offer (0-100).",
     )
-    cooldown = models.DurationField(help_text="Per-giver re-offer cooldown.")
+    cooldown = models.DurationField(
+        validators=[MinValueValidator(timedelta(0))],
+        help_text="Per-giver re-offer cooldown. Must be non-negative.",
+    )
     reward_group_rule = models.CharField(
         max_length=16,
         choices=RewardGroupRule.choices,

--- a/src/world/missions/tests/test_api_template_create.py
+++ b/src/world/missions/tests/test_api_template_create.py
@@ -111,6 +111,26 @@ class MissionTemplateCreateTests(TestCase):
         res = self.client.post(URL, self._valid_body(percent_replace=100), format="json")
         self.assertEqual(res.status_code, 201, res.content)
 
+    def test_rejects_negative_cooldown(self) -> None:
+        """ISO 8601 accepts a leading sign — guard at the validator layer."""
+        res = self.client.post(URL, self._valid_body(cooldown="-P1D"), format="json")
+        self.assertEqual(res.status_code, 400, res.content)
+        self.assertIn("cooldown", res.json())
+
+    def test_accepts_zero_cooldown(self) -> None:
+        """Zero-duration cooldown is the boundary — must be accepted."""
+        res = self.client.post(
+            URL, self._valid_body(name="zero-cooldown", cooldown="P0D"), format="json"
+        )
+        self.assertEqual(res.status_code, 201, res.content)
+
+    def test_accepts_positive_cooldown(self) -> None:
+        """Regression — normal positive cooldowns still accepted after the validator."""
+        res = self.client.post(
+            URL, self._valid_body(name="positive-cooldown", cooldown="P7D"), format="json"
+        )
+        self.assertEqual(res.status_code, 201, res.content)
+
 
 class MissionTemplatePatchRenameTests(TestCase):
     """PATCH /api/missions/templates/<pk>/ rename collision behavior.


### PR DESCRIPTION
## Summary

ISO 8601 duration parsing accepts a leading sign (`-P1D` → -1 day), so `MissionTemplate.cooldown` (a `DurationField`) silently stored negatives. `timezone.now() + negative_cooldown` puts `available_at` in the past, making the mission immediately re-offerable regardless of the cooldown design intent.

Adds `MinValueValidator(timedelta(0))` on the field plus a regression test.

Hand-written migration 0005 — `arx manage makemigrations` hangs on the Evennia setup wizard in the devcontainer; same workaround pattern as PR #575's 0005 and 0006.

Closes #576.

## Test plan

- [ ] `just test-fast world.missions.tests.test_api_template_create` — `test_rejects_negative_cooldown` passes.
- [ ] `just test-parity world.missions` — full app suite green on PG.
- [ ] CI applies migration 0005 cleanly on fresh DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)