### PR TITLE
chore(devcontainer): read git identity from dev.env instead of hardcoding

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -13,9 +13,23 @@ eval "$(~/.local/bin/mise activate bash)"
 # Git identity so commits made from inside the container land with the right
 # author. ~/.gitconfig lives in the container's writable layer (not a named
 # volume), so this needs to re-run on every fresh container — cheap and
-# idempotent. Values mirror the host's bare-metal identity.
-git config --global user.name "Dan Brannigan"
-git config --global user.email "apostatecd@yahoo.com"
+# idempotent. Read each contributor's personal identity from dev.env
+# (gitignored, per-contributor) so we don't have to hardcode anyone's name
+# in the script.
+if [ -f .devcontainer/dev.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .devcontainer/dev.env
+  set +a
+fi
+if [ -n "${GIT_USER_NAME:-}" ] && [ -n "${GIT_USER_EMAIL:-}" ]; then
+  git config --global user.name "$GIT_USER_NAME"
+  git config --global user.email "$GIT_USER_EMAIL"
+else
+  echo "[post-create] GIT_USER_NAME / GIT_USER_EMAIL not set in .devcontainer/dev.env." >&2
+  echo "[post-create] Add them there (see sync-env.sh placeholders), or run" >&2
+  echo "[post-create] 'git config --global user.name ...' yourself in the container." >&2
+fi
 # Safe-directory exemption: git in modern versions refuses to operate on a
 # repo owned by a different uid than the current user. The bind-mounted repo
 # is owned by whoever owns it on Windows, which isn't the container's vscode

--- a/.devcontainer/sync-env.sh
+++ b/.devcontainer/sync-env.sh
@@ -19,6 +19,10 @@ if [ ! -f "$src_env" ]; then
 DEBUG=True
 SECRET_KEY=$(head -c 50 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 50)
 DATABASE_URL=${db_url}
+# Set your git author identity here so post-create.sh wires it into the
+# container's ~/.gitconfig and your commits attribute correctly.
+GIT_USER_NAME=
+GIT_USER_EMAIL=
 EOF
   echo "Generated $dev_env (no src/.env found; minimal defaults written)."
   exit 0
@@ -30,6 +34,17 @@ if grep -q '^DATABASE_URL=' "$dev_env"; then
   sed -i "s|^DATABASE_URL=.*\$|DATABASE_URL=${db_url}|" "$dev_env"
 else
   echo "DATABASE_URL=${db_url}" >> "$dev_env"
+fi
+
+# Add empty GIT_USER_NAME / GIT_USER_EMAIL placeholders if not already
+# present, so contributors see where to put their identity for
+# post-create.sh to consume.
+if ! grep -q '^GIT_USER_NAME=' "$dev_env"; then
+  printf '\n# Git author identity — set these so post-create.sh wires them into the container.\n' >> "$dev_env"
+  printf 'GIT_USER_NAME=\n' >> "$dev_env"
+fi
+if ! grep -q '^GIT_USER_EMAIL=' "$dev_env"; then
+  printf 'GIT_USER_EMAIL=\n' >> "$dev_env"
 fi
 
 echo "Generated $dev_env from $src_env (DATABASE_URL → compose db service)."

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -237,6 +237,27 @@ ngrok is intentionally not in the allowlist. The container is not designed for
 integration tests that need an inbound tunnel. If you need that, add the relevant
 ngrok API and tunnel hosts to `init-firewall.sh` and rebuild.
 
+## Git author identity
+
+`post-create.sh` wires your name + email into the container's `~/.gitconfig`
+so commits made inside the devcontainer attribute to you. The values are
+read from `.devcontainer/dev.env` (gitignored, per-contributor):
+
+```
+GIT_USER_NAME=Your Name
+GIT_USER_EMAIL=you@example.com
+```
+
+`sync-env.sh` includes empty placeholders for these when it generates
+`dev.env` for the first time. Fill them in before running `just dc-up`,
+or `post-create.sh` will skip the git identity step and print a hint
+telling you to set them yourself.
+
+If you change them later, edit `dev.env` and rebuild the container
+(`just dc-down && just dc-up`) so `post-create.sh` re-runs and picks up
+the new values, or run `git config --global user.name/email ...` directly
+inside the container for an immediate one-off override.
+
 ## GitHub access for the issue→PR workflow
 
 The container ships with `gh` installed and reads `GH_TOKEN` from `dev.env`


### PR DESCRIPTION
## Summary

`post-create.sh` previously baked one contributor's name + email into the container's `~/.gitconfig`. Every fresh container created commits attributed to whoever was hardcoded — Dan and Dave were silently fighting to be the "right" identity in the script.

Now `post-create.sh` sources `.devcontainer/dev.env` (gitignored, per-contributor) and applies `GIT_USER_NAME` / `GIT_USER_EMAIL` if set, or prints a skip-with-hint message if not.

`sync-env.sh` ships empty placeholders for both vars so new contributors see where to put their identity. `docs/devcontainer-setup.md` gets a "Git author identity" section.

Addresses #575 review feedback from @TehomCD.

## Test plan

- [ ] On an existing container: `.devcontainer/dev.env` has no `GIT_USER_*` lines yet. Add them, rebuild via \`just dc-down && just dc-up\`, verify `git config --global --get user.name` inside the container returns the set value.
- [ ] Wipe `.devcontainer/dev.env` and `src/.env`, run `bash .devcontainer/sync-env.sh`; verify generated `dev.env` has empty `GIT_USER_NAME=` / `GIT_USER_EMAIL=` placeholders.
- [ ] On a fresh container where neither var is set, verify `post-create.sh` prints the skip message and does NOT call `git config --global`.