### PR TITLE
chore(just): regression recipe uses --parallel by default

### DIFF
--- a/justfile
+++ b/justfile
@@ -86,11 +86,13 @@ test-affected *args:
         echo "yes" | uv run arx test $DOTTED {{args}}
     fi
 
-# Run the full regression suite (no --keepdb, matches CI).
-# Auto-confirms the destroy-test-DB prompt.
+# Run the full regression suite (no --keepdb, matches CI's fresh-DB behavior).
+# Uses --parallel (cpu_count workers) — local wall-clock is multiple-x faster
+# than serial; behavior matches CI in every other way (no --keepdb, full suite,
+# Postgres). Auto-confirms the destroy-test-DB prompt.
 #   just regression
 regression:
-    echo "yes" | uv run arx test
+    echo "yes" | uv run arx test --parallel
 
 # --- Lint / format -----------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`just regression` ran serially, taking ~26 min for the full ~8000-test suite on a fresh DB. `arx test --parallel` (cpu_count workers) is already established and used by `test-parity` — extending it to the regression recipe cuts local wall-clock by multiple-x with no behavior change in the test results themselves.

## Scope

- One-line change to the `regression` recipe in `justfile`.
- Comment updated to reflect the new behavior.

## CI impact

None. CI uses a 4-shard matrix that already parallelises across shards (and runs each shard serially within itself). This change only affects the local-dev `just regression` invocation.

## Test plan

- [ ] Locally: `just regression` completes successfully; wall-clock significantly under 26 min.
- [ ] Test count matches the pre-change baseline (~8061 tests at last measure).
- [ ] No new test failures introduced (i.e., no tests fail under parallel that passed serially — indicating shared-state bugs that were hidden by serial execution).