### PR TITLE
fix(missions): predicate JSON references givers by id, not name (#577)

### DIFF
--- a/frontend/src/missions/components/PredicateBuilder.tsx
+++ b/frontend/src/missions/components/PredicateBuilder.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/components/ui/select';
 
 import {
+  useMissionGivers,
   usePredicateLeaves,
   type PredicateLeaf,
   type PredicateLeafParam,
@@ -413,6 +414,21 @@ function LeafView({
             // each with their own requirements_override).
             const inputId = `${builderId}-leaf-${value.leaf}-${p.name}`;
             const raw = value.params[p.name];
+            // Special-case params that reference a giver by PK — render a
+            // name-bearing picker instead of a bare number input so authors
+            // see who they're referencing (issue #577).
+            if (p.name === 'giver_id') {
+              return (
+                <GiverIdParamPicker
+                  key={p.name}
+                  id={inputId}
+                  paramName={p.name}
+                  paramType={p.type}
+                  value={raw}
+                  onChange={(next) => setParam(p.name, next)}
+                />
+              );
+            }
             const display = raw === undefined || raw === null ? '' : String(raw);
             return (
               <div key={p.name}>
@@ -430,6 +446,50 @@ function LeafView({
           })}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function GiverIdParamPicker({
+  id,
+  paramName,
+  paramType,
+  value,
+  onChange,
+}: {
+  id: string;
+  paramName: string;
+  paramType: PredicateParamType;
+  value: unknown;
+  onChange: (next: string) => void;
+}) {
+  // useMissionGivers returns the cached first page. If the dataset ever
+  // grows past one page we can swap to a search-as-you-type input; not
+  // worth the complexity today.
+  const { data, isLoading, isError } = useMissionGivers();
+  const givers = data?.results ?? [];
+  const current = value === undefined || value === null ? '' : String(value);
+  return (
+    <div>
+      <Label className="text-xs" htmlFor={id}>
+        {paramName} <span className="text-muted-foreground">({paramType})</span>
+      </Label>
+      <Select value={current} onValueChange={(v) => onChange(v)}>
+        <SelectTrigger id={id}>
+          <SelectValue placeholder={isLoading ? 'Loading givers…' : 'Pick a giver…'} />
+        </SelectTrigger>
+        <SelectContent>
+          {isError ? (
+            <div className="px-2 py-1 text-xs text-destructive">Failed to load givers.</div>
+          ) : (
+            givers.map((g) => (
+              <SelectItem key={g.id} value={String(g.id)}>
+                {g.name} <span className="text-muted-foreground">(#{g.id})</span>
+              </SelectItem>
+            ))
+          )}
+        </SelectContent>
+      </Select>
     </div>
   );
 }

--- a/src/world/missions/migrations/0008_predicate_giver_name_to_id.py
+++ b/src/world/missions/migrations/0008_predicate_giver_name_to_id.py
@@ -1,0 +1,114 @@
+# Hand-written migration — rewrite min_giver_standing predicate leaves from
+# `{giver: "<name>"}` to `{giver_id: <pk>}` so authored rule trees survive
+# giver renames. Walks every predicate-tree JSONField in the missions app
+# (MissionTemplate.availability_rule, MissionOption.visibility_rule,
+# MissionGiverOffering.requirements_override) and rewrites in place.
+#
+# If a giver name can't be resolved (giver was deleted), the leaf is left
+# as-is and a warning is printed — the rule was already broken (the runtime
+# resolver would fail closed); the migration shouldn't claim to fix what it
+# can't.
+#
+# Hand-written because `arx manage makemigrations` hangs on the Evennia
+# superuser-creation wizard in this devcontainer.
+
+from __future__ import annotations
+
+from django.db import migrations
+
+_LEAF_NAME = "min_giver_standing"
+_OLD_PARAM = "giver"
+_NEW_PARAM = "giver_id"
+
+# Local copies of the Phase-0 evaluator's JSON-tree structural keys.
+# Inlined (rather than imported from predicates.py) so this migration stays
+# self-contained — apps/predicates.py is free to evolve in the future
+# without breaking a long-applied historical migration.
+_KEY_OP = "op"
+_KEY_OF = "of"
+_KEY_LEAF = "leaf"
+_KEY_PARAMS = "params"
+
+
+def _walk(node, giver_name_to_id, warnings):
+    """Recursively rewrite predicate-tree nodes in place.
+
+    Operates on the dict tree produced by the Phase 0 evaluator. Mutates
+    `node` in place; returns nothing. AND/OR/NOT nodes recurse into their
+    `of` operands. Leaf nodes with the target name + old param shape are
+    rewritten to the new shape.
+    """
+    if not isinstance(node, dict) or not node:
+        return
+    if _KEY_OP in node:
+        for child in node.get(_KEY_OF, []) or []:
+            _walk(child, giver_name_to_id, warnings)
+        return
+    if node.get(_KEY_LEAF) != _LEAF_NAME:
+        return
+    params = node.get(_KEY_PARAMS) or {}
+    if _OLD_PARAM not in params:
+        return  # already migrated or never used the old shape
+    name = params.pop(_OLD_PARAM)
+    pk = giver_name_to_id.get(name)
+    if pk is None:
+        # Restore the param so we don't silently lose the broken reference;
+        # the rule was already failing closed at runtime.
+        params[_OLD_PARAM] = name
+        warnings.append(name)
+        return
+    params[_NEW_PARAM] = pk
+    node[_KEY_PARAMS] = params
+
+
+def rewrite_predicate_givers(apps, schema_editor):
+    MissionGiver = apps.get_model("missions", "MissionGiver")
+    MissionTemplate = apps.get_model("missions", "MissionTemplate")
+    MissionOption = apps.get_model("missions", "MissionOption")
+    MissionGiverOffering = apps.get_model("missions", "MissionGiverOffering")
+
+    giver_name_to_id = dict(MissionGiver.objects.values_list("name", "pk"))
+    warnings: list[str] = []
+
+    for tmpl in MissionTemplate.objects.exclude(availability_rule={}):
+        original = tmpl.availability_rule
+        _walk(original, giver_name_to_id, warnings)
+        tmpl.availability_rule = original
+        tmpl.save(update_fields=["availability_rule"])
+
+    for opt in MissionOption.objects.exclude(visibility_rule={}):
+        original = opt.visibility_rule
+        _walk(original, giver_name_to_id, warnings)
+        opt.visibility_rule = original
+        opt.save(update_fields=["visibility_rule"])
+
+    for offering in MissionGiverOffering.objects.exclude(requirements_override={}):
+        original = offering.requirements_override
+        _walk(original, giver_name_to_id, warnings)
+        offering.requirements_override = original
+        offering.save(update_fields=["requirements_override"])
+
+    if warnings:
+        unique = sorted(set(warnings))
+        print(
+            "0008_predicate_giver_name_to_id: "
+            f"could not resolve {len(unique)} giver name(s) — "
+            "rule(s) left in old shape (already broken at runtime): "
+            f"{', '.join(unique)}"
+        )
+
+
+def noop_reverse(apps, schema_editor):
+    """Reverse is a no-op: rewriting PKs back to names would require a
+    snapshot of the original names, which we don't preserve. PKs are stable
+    so this migration is one-way in practice."""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("missions", "0007_cooldown_min_value"),
+    ]
+
+    operations = [
+        migrations.RunPython(rewrite_predicate_givers, noop_reverse),
+    ]

--- a/src/world/missions/predicates.py
+++ b/src/world/missions/predicates.py
@@ -37,7 +37,7 @@ CharacterSheet.DoesNotExist loudly rather than silently gate.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 from evennia.objects.models import ObjectDB
 
@@ -45,6 +45,14 @@ from world.missions.types import LeafRegistry, LeafResolver, PredicateContext, R
 
 if TYPE_CHECKING:
     from world.scenes.models import Persona
+
+
+# Semantic type aliases for predicate-leaf params. The catalog endpoint
+# reads the Annotated metadata to give the frontend builder enough info
+# to render a domain-aware widget (e.g. a giver picker) instead of a
+# bare number input. Keep these wrapping plain primitives so the resolver
+# bodies stay typed in terms of the runtime type.
+GiverId = Annotated[int, "giver_id"]
 
 # Rule-tree schema keys (the sanctioned dynamic-JSON case — these name the
 # structural keys of the AND/OR/NOT tree, not free-form identifiers).
@@ -224,32 +232,34 @@ def _resolve_has_skill(ctx: ResolverContext, *, skill: str) -> bool:
     return ctv is not None and ctv.value > 0
 
 
-def _resolve_min_giver_standing(ctx: ResolverContext, *, giver: str, min_affection: int) -> bool:
-    """True if the character's standing with the named giver is >= ``min_affection``.
+def _resolve_min_giver_standing(ctx: ResolverContext, *, giver_id: int, min_affection: int) -> bool:
+    """True if the character's standing with the giver (by PK) is >= ``min_affection``.
 
-    ``giver`` is the ``MissionGiver.name``. Standing is the giver's
-    affection toward the character. No standing row means affection is
-    implicitly 0. An unknown giver name fails closed (returns False).
+    ``giver_id`` is the ``MissionGiver`` primary key. Standing is the
+    giver's affection toward the character. No standing row means
+    affection is implicitly 0. An unknown giver id fails closed
+    (returns False). PK-keyed so giver renames don't silently break
+    authored predicate rules.
     """
     from world.missions.models import MissionGiverStanding  # noqa: PLC0415
 
     standing = (
-        MissionGiverStanding.objects.filter(giver__name=giver, character=ctx.character)
+        MissionGiverStanding.objects.filter(giver_id=giver_id, character=ctx.character)
         .values_list("affection", flat=True)
         .first()
     )
     if standing is None:
-        if not _giver_exists(giver):
+        if not _giver_exists(giver_id):
             return False
         return min_affection <= 0
     return standing >= min_affection
 
 
-def _giver_exists(name: str) -> bool:
-    """Internal helper: True if a MissionGiver with this name exists."""
+def _giver_exists(giver_id: int) -> bool:
+    """Internal helper: True if a MissionGiver with this PK exists."""
     from world.missions.models import MissionGiver  # noqa: PLC0415
 
-    return MissionGiver.objects.filter(name=name).exists()
+    return MissionGiver.objects.filter(pk=giver_id).exists()
 
 
 def _resolve_has_resonance(ctx: ResolverContext, *, name: str) -> bool:

--- a/src/world/missions/tests/test_resolvers.py
+++ b/src/world/missions/tests/test_resolvers.py
@@ -358,8 +358,9 @@ class ResonanceResolverTests(TestCase):
 class GiverStandingResolverTests(TestCase):
     """min_giver_standing: gates on MissionGiverStanding.affection for a giver.
 
-    The giver is referenced by slug (added in 0003); the comparison is
-    affection >= ``min``. No standing row means affection is implicitly 0.
+    The giver is referenced by PK (since #577 — giver renames no longer
+    invalidate authored rules). The comparison is affection >= ``min``.
+    No standing row means affection is implicitly 0.
     """
 
     @classmethod
@@ -379,46 +380,55 @@ class GiverStandingResolverTests(TestCase):
 
     def test_true_when_at_threshold(self) -> None:
         self.assertTrue(
-            self.ctx.has_leaf("min_giver_standing", giver="liked-giver", min_affection=50)
+            self.ctx.has_leaf("min_giver_standing", giver_id=self.liked_giver.pk, min_affection=50)
         )
 
     def test_true_when_above_threshold(self) -> None:
         self.assertTrue(
-            self.ctx.has_leaf("min_giver_standing", giver="liked-giver", min_affection=10)
+            self.ctx.has_leaf("min_giver_standing", giver_id=self.liked_giver.pk, min_affection=10)
         )
 
     def test_false_when_below_threshold(self) -> None:
         self.assertFalse(
-            self.ctx.has_leaf("min_giver_standing", giver="liked-giver", min_affection=51)
+            self.ctx.has_leaf("min_giver_standing", giver_id=self.liked_giver.pk, min_affection=51)
         )
 
     def test_negative_affection_below_zero_threshold(self) -> None:
         # disliked: affection=-20; threshold 0 must FAIL.
         self.assertFalse(
-            self.ctx.has_leaf("min_giver_standing", giver="disliked-giver", min_affection=0)
+            self.ctx.has_leaf(
+                "min_giver_standing", giver_id=self.disliked_giver.pk, min_affection=0
+            )
         )
 
     def test_no_standing_row_means_zero_affection(self) -> None:
         # No standing row exists for unknown-giver/character → affection=0.
         self.assertTrue(
-            self.ctx.has_leaf("min_giver_standing", giver="unknown-giver", min_affection=0)
+            self.ctx.has_leaf("min_giver_standing", giver_id=self.unknown_giver.pk, min_affection=0)
         )
         self.assertFalse(
-            self.ctx.has_leaf("min_giver_standing", giver="unknown-giver", min_affection=1)
+            self.ctx.has_leaf("min_giver_standing", giver_id=self.unknown_giver.pk, min_affection=1)
         )
 
     def test_false_when_no_such_giver(self) -> None:
-        # Bogus slug — the predicate fails closed rather than raising.
-        self.assertFalse(
-            self.ctx.has_leaf("min_giver_standing", giver="nope-doesnt-exist", min_affection=0)
-        )
+        # Bogus PK — the predicate fails closed rather than raising.
+        self.assertFalse(self.ctx.has_leaf("min_giver_standing", giver_id=999999, min_affection=0))
 
     def test_evaluate_dispatches(self) -> None:
         rule = {
             "leaf": "min_giver_standing",
-            "params": {"giver": "liked-giver", "min_affection": 50},
+            "params": {"giver_id": self.liked_giver.pk, "min_affection": 50},
         }
         self.assertTrue(evaluate(rule, self.ctx))
+
+    def test_rename_does_not_invalidate_rule(self) -> None:
+        # The whole point of the migration to PK references: renaming the
+        # giver must NOT silently break authored rules that reference it.
+        self.liked_giver.name = "liked-giver-renamed"
+        self.liked_giver.save(update_fields=["name"])
+        self.assertTrue(
+            self.ctx.has_leaf("min_giver_standing", giver_id=self.liked_giver.pk, min_affection=50)
+        )
 
 
 class OrgMembershipResolverTests(TestCase):


### PR DESCRIPTION
## Summary

PR #575 made giver names mutable (PATCH rename via \`MissionGiverSerializer.validate_name\`). Authored \`availability_rule\` / \`visibility_rule\` / \`requirements_override\` JSON trees referenced givers by string name in \`min_giver_standing\` leaves — renaming a giver silently invalidated every rule referencing it. The rule then fail-closed to False without surfacing the broken reference. Caught in PR #575's adversarial reviews; deferred as #577.

Switches the contract to PK references (option (a) from the issue):

- **Resolver**: \`_resolve_min_giver_standing\` now takes \`giver_id: int\` (was \`giver: str\`); \`_giver_exists\` looks up by PK
- **Frontend**: \`PredicateBuilder\` special-cases the \`giver_id\` param name with a name-bearing \`Select\` populated from \`useMissionGivers\` — authors still see WHO they're referencing, but the saved rule is rename-invariant
- **Data migration 0008** walks the three JSONField surfaces and rewrites existing \`{giver: "<name>"}\` leaves to \`{giver_id: <pk>}\`. Orphan references (giver deleted between authoring and migration) are preserved as-is with a warning print, since the rule was already broken at runtime — the migration shouldn't claim to fix what it can't.
- **Tests**: existing min_giver_standing tests updated to use \`giver_id\`; new \`test_rename_does_not_invalidate_rule\` regression test pins the fix.

Closes #577.

## Test plan

- [ ] \`just test-fast world.missions\` passes (461 tests, all green locally)
- [ ] \`pnpm typecheck\` clean
- [ ] CI applies migration 0008 cleanly on fresh DB
- [ ] Manual: edit a template's availability rule, pick \`min_giver_standing\`, confirm the giver picker shows giver names (not bare PKs)