### PR TITLE
test(missions): close coverage gaps from PR #575 follow-up (#589)

### DIFF
--- a/frontend/src/missions/__tests__/CreateMissionPage.test.tsx
+++ b/frontend/src/missions/__tests__/CreateMissionPage.test.tsx
@@ -169,6 +169,30 @@ describe('CreateMissionPage', () => {
     });
   });
 
+  it('flattens deeply nested error trees (3+ levels)', async () => {
+    const mutateAsync = vi.fn().mockRejectedValue(
+      new ApiValidationError({
+        categories: [{ pk: [{ deep: ['multi-level error message'] }] }],
+      })
+    );
+    vi.spyOn(queries, 'useCreateMissionTemplate').mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useCreateMissionTemplate>);
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'X' } });
+    fireEvent.change(screen.getByLabelText(/summary/i), { target: { value: 'lore' } });
+    fireEvent.change(screen.getByLabelText(/level band min/i), { target: { value: '1' } });
+    fireEvent.change(screen.getByLabelText(/level band max/i), { target: { value: '5' } });
+    fireEvent.change(screen.getByLabelText(/risk tier/i), { target: { value: '2' } });
+    fireEvent.change(screen.getByLabelText(/cooldown.*amount/i), { target: { value: '1' } });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/multi-level error message/i)).toBeInTheDocument();
+      expect(screen.queryByText(/\[object Object\]/i)).not.toBeInTheDocument();
+    });
+  });
+
   it('displays a banner when API returns a detail-only error (401/403/500)', async () => {
     const mutateAsync = vi
       .fn()

--- a/src/world/missions/tests/test_api_template_create.py
+++ b/src/world/missions/tests/test_api_template_create.py
@@ -155,6 +155,18 @@ class MissionTemplateCreateTests(TestCase):
         # Assert the cooldown round-trips as a non-null, non-empty value.
         self.assertTrue(fetched["cooldown"], "cooldown should be present and non-empty")
 
+    def test_create_accepts_explicit_empty_categories(self) -> None:
+        res = self.client.post(URL, self._valid_body(categories=[]), format="json")
+        self.assertEqual(res.status_code, 201, res.content)
+        self.assertEqual(res.json()["categories"], [])
+
+    def test_create_omitting_categories_key_defaults_to_empty(self) -> None:
+        body = self._valid_body()
+        body.pop("categories", None)
+        res = self.client.post(URL, body, format="json")
+        self.assertEqual(res.status_code, 201, res.content)
+        self.assertEqual(res.json()["categories"], [])
+
 
 class MissionTemplatePatchRenameTests(TestCase):
     """PATCH /api/missions/templates/<pk>/ rename collision behavior.

--- a/src/world/missions/tests/test_api_template_create.py
+++ b/src/world/missions/tests/test_api_template_create.py
@@ -131,6 +131,30 @@ class MissionTemplateCreateTests(TestCase):
         )
         self.assertEqual(res.status_code, 201, res.content)
 
+    def test_create_then_get_round_trips(self) -> None:
+        body = self._valid_body(name="Round Trip Mission")
+        res = self.client.post(URL, body, format="json")
+        self.assertEqual(res.status_code, 201, res.content)
+        created = res.json()
+        detail = self.client.get(f"{URL}{created['id']}/")
+        self.assertEqual(detail.status_code, 200, detail.content)
+        fetched = detail.json()
+        # The detail serializer extends list with active_instances/lifetime_completions;
+        # the list-shape fields must match what we sent.
+        for key in (
+            "name",
+            "summary",
+            "level_band_min",
+            "level_band_max",
+            "risk_tier",
+            "arc_scope",
+        ):
+            self.assertEqual(fetched[key], body[key], f"mismatch on {key}")
+        # DRF DurationField serializes timedelta to its own string format
+        # (e.g. "1 00:00:00"), not the ISO 8601 we POST ("P1D").
+        # Assert the cooldown round-trips as a non-null, non-empty value.
+        self.assertTrue(fetched["cooldown"], "cooldown should be present and non-empty")
+
 
 class MissionTemplatePatchRenameTests(TestCase):
     """PATCH /api/missions/templates/<pk>/ rename collision behavior.


### PR DESCRIPTION
## Summary

Closes 4 of the 5 coverage gaps listed in #589 (the 5th — drill-down isError tests — landed in PR #600).

- **#589.1** flattenErrorMessage 3+ level nesting test on CreateMissionPage
- **#589.2** backend POST template → GET roundtrip test
- **#589.3** explicit categories=[] vs omitted-key tests

The remaining item from the issue body — frontend integration test covering the full create-mission flow end-to-end — is bigger work (needs a real React Query provider + MSW or similar). Leaving as a follow-up; the unit-level coverage we have is comprehensive for now.

### Cooldown round-trip note

The spec called for asserting `fetched[key] == body[key]` including `cooldown`. In practice, DRF's `DurationField` serializes the stored `timedelta` as `"1 00:00:00"` on read, while we POST ISO 8601 (`"P1D"`). The round-trip test asserts cooldown is non-null/non-empty (catches dropped-field regressions) without asserting exact string format. No production code was changed.

## Test plan

- [ ] `just test-fast world.missions` green (+3 backend tests: 460 → 463)
- [ ] `pnpm test --run src/missions/` green (+1 frontend test: 63 → 64)
- [ ] No production code changes — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)