### PR TITLE
feat(admin): surface VitalsConsequenceConfig + DamageType pool FKs (closes #609)

### DIFF
--- a/src/world/conditions/admin.py
+++ b/src/world/conditions/admin.py
@@ -35,9 +35,10 @@ class CapabilityTypeAdmin(admin.ModelAdmin):
 
 @admin.register(DamageType)
 class DamageTypeAdmin(admin.ModelAdmin):
-    list_display = ["name", "resonance", "color_hex"]
+    list_display = ["name", "resonance", "wound_pool", "death_pool", "color_hex"]
     list_filter = ["resonance"]
     search_fields = ["name"]
+    autocomplete_fields = ["wound_pool", "death_pool"]
 
 
 # =============================================================================

--- a/src/world/vitals/admin.py
+++ b/src/world/vitals/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from world.vitals.models import CharacterVitals
+from world.vitals.models import CharacterVitals, VitalsConsequenceConfig
 
 
 @admin.register(CharacterVitals)
@@ -8,3 +8,27 @@ class CharacterVitalsAdmin(admin.ModelAdmin):
     list_display = ["character_sheet", "health", "max_health", "life_state", "died_at"]
     list_filter = ["life_state"]
     search_fields = ["character_sheet__character__db_key"]
+
+
+@admin.register(VitalsConsequenceConfig)
+class VitalsConsequenceConfigAdmin(admin.ModelAdmin):
+    """Singleton (pk=1) — global fallback consequence pools for survivability.
+
+    knockout_pool fires when a character is knocked out (damage-type-agnostic).
+    default_wound_pool / default_death_pool are the fallbacks used when a
+    DamageType doesn't specify its own wound_pool / death_pool. Leaving a slot
+    null makes that branch skip silently.
+    """
+
+    list_display = [
+        "pk",
+        "knockout_pool",
+        "default_wound_pool",
+        "default_death_pool",
+        "updated_at",
+    ]
+    autocomplete_fields = ["knockout_pool", "default_wound_pool", "default_death_pool"]
+
+    def has_add_permission(self, request: object) -> bool:  # noqa: ARG002
+        """Prevent adding a second config — there can be only one."""
+        return not VitalsConsequenceConfig.objects.exists()


### PR DESCRIPTION
## Summary

Closes #609. PR #611 added the survivability consequence pool system but no Django admin surface for authoring it — pools were only settable via shell. The model docstring's "Authored via admin" claim over-promised. This wires up the two admin surfaces.

### `vitals/admin.py` — `VitalsConsequenceConfigAdmin`
- Singleton pattern (`has_add_permission` returns False once one exists), mirroring `SpreadingConfigAdmin` in `world/societies/admin.py`.
- `autocomplete_fields` on the three pool FKs (`knockout_pool`, `default_wound_pool`, `default_death_pool`). `ConsequencePoolAdmin` already has `search_fields = ("name",)` so autocomplete works without changes there.
- `list_display` shows all three pools + `updated_at` for at-a-glance audit of current config.

### `conditions/admin.py` — `DamageTypeAdmin`
- `list_display` extended with `wound_pool` and `death_pool` so staff can see at a glance which damage types have authored pools vs. fall back to the `VitalsConsequenceConfig` defaults.
- `autocomplete_fields = ["wound_pool", "death_pool"]` for editing.

## Design notes

- **Unconfigured pools skip silently** (per PR #611's design), so authoring is incremental: staff can wire up the knockout pool first, then per-damage-type wound/death pools as content gets authored. No reason to over-engineer the admin around "must configure everything."
- **Skipped the optional third bullet** from #609 (seed reference pools) — authored pool content is a separate workstream and CLAUDE.md discourages seed-data management commands. Staff use the new admin surfaces to author pools manually.

## Test plan

- [x] `pre-commit run` clean
- [x] `arx manage check` — no system issues (Django's admin system check catches `autocomplete_fields` pointing at models without `search_fields`, missing FKs, etc.)
- [x] `arx test world.conditions world.vitals` — 288 tests, OK
- [ ] Manually click through admin to confirm the dropdowns populate (worth doing on the deployed staff frontend before relying on this; not required for merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)