### PR TITLE
feat(linter): expand objectdb-param scope to conditions/services.py (#604 Phase 2)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,15 +61,16 @@ repos:
         language: system
         pass_filenames: true
         types: [python]
-        # Phase 1 scope: vitals + magic capability_requirements. Future PRs
-        # expand this regex one app at a time as their service modules are
-        # triaged. (Conditions/services.py has 37 pre-existing violations and
-        # gets its own Phase 2 PR.) See CLAUDE.md "Avoid direct FKs to ObjectDB"
-        # for the OBJECTDB_PARAM noqa token and rollout policy.
+        # Phase 1 + 2 scope: vitals + magic capability_requirements +
+        # conditions/services.py. Future PRs expand this regex one app at a
+        # time as their service modules are triaged. See CLAUDE.md "Avoid
+        # direct FKs to ObjectDB" for the OBJECTDB_PARAM noqa token and
+        # rollout policy.
         files: |
           (?x)^src/world/(
             vitals/services\.py
             |magic/services/capability_requirements\.py
+            |conditions/services\.py
           )$
       - id: check-migrations
         name: Check Django migrations

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -89,7 +89,7 @@ if TYPE_CHECKING:
 SECONDS_PER_ROUND = 6
 
 
-def _invalidate_condition_handler(target: "ObjectDB") -> None:
+def _invalidate_condition_handler(target: "ObjectDB") -> None:  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     """Invalidate the target's cached conditions handler.
 
     ``conditions`` is installed as a ``cached_property`` on ``ObjectParent``
@@ -112,7 +112,7 @@ def _invalidate_condition_handler(target: "ObjectDB") -> None:
 
 
 def get_active_conditions(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     *,
     category: "ConditionCategory | None" = None,
     condition: ConditionTemplate | None = None,
@@ -153,7 +153,7 @@ def get_active_conditions(
 
 
 def has_condition(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     condition: ConditionTemplate,
     *,
     include_suppressed: bool = False,
@@ -175,7 +175,7 @@ def has_condition(
 
 
 def get_condition_instance(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     condition: ConditionTemplate,
     *,
     include_suppressed: bool = False,
@@ -200,7 +200,7 @@ def get_condition_instance(
 class _ApplyConditionParams:
     """Parameters for applying a condition (reduces argument count)."""
 
-    target: "ObjectDB"
+    target: "ObjectDB"  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     severity: int = 1
     duration_rounds: int | None = None
     stack_count: int = 1
@@ -239,7 +239,7 @@ class _BulkConditionContext:
 
 
 def _build_bulk_context(
-    targets: list["ObjectDB"],
+    targets: list["ObjectDB"],  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     templates: list[ConditionTemplate],
 ) -> _BulkConditionContext:
     """Batch-fetch all data needed for applying conditions to multiple targets.
@@ -450,7 +450,7 @@ def _create_instance_from_context(
 
 
 def _apply_single(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     template: ConditionTemplate,
     params: _ApplyConditionParams,
     ctx: _BulkConditionContext,
@@ -564,12 +564,12 @@ def _handle_refresh(
 
 @transaction.atomic
 def apply_condition(  # noqa: PLR0913
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     condition: ConditionTemplate,
     *,
     severity: int = 1,
     duration_rounds: int | None = None,
-    source_character: "ObjectDB | None" = None,
+    source_character: "ObjectDB | None" = None,  # noqa: OBJECTDB_PARAM — source_character covers NPC + PC ObjectDB cases; narrowing is broader Phase 3 work
     source_technique: "Technique | None" = None,
     source_description: str = "",
 ) -> ApplyConditionResult:
@@ -640,7 +640,7 @@ def apply_condition(  # noqa: PLR0913
 def bulk_apply_conditions(
     applications: list[BulkConditionApplication],
     *,
-    source_character: "ObjectDB | None" = None,
+    source_character: "ObjectDB | None" = None,  # noqa: OBJECTDB_PARAM — source_character covers NPC + PC ObjectDB cases; narrowing is broader Phase 3 work
     source_technique: "Technique | None" = None,
     source_description: str = "",
 ) -> list[ApplyConditionResult]:
@@ -728,7 +728,7 @@ def bulk_apply_conditions(
 
 
 def _install_reactive_side_effects(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     condition: ConditionTemplate,
     instance: ConditionInstance,
 ) -> None:
@@ -777,7 +777,7 @@ def _install_reactive_side_effects(
 
 
 def _notify_stories_condition_applied(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     instance: ConditionInstance,
 ) -> None:
     """Route condition-applied events to the stories reactivity module.
@@ -797,7 +797,7 @@ def _notify_stories_condition_applied(
 
 
 def _notify_stories_condition_expired(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     condition: ConditionTemplate,
 ) -> None:
     """Route condition-removed events to the stories reactivity module.
@@ -818,7 +818,7 @@ def _notify_stories_condition_expired(
 
 @transaction.atomic
 def remove_condition(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     condition: ConditionTemplate,
     *,
     remove_all_stacks: bool = True,
@@ -883,7 +883,7 @@ def remove_condition(
 
 @transaction.atomic
 def remove_conditions_by_category(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     category: "ConditionCategory",
 ) -> list[ConditionTemplate]:
     """
@@ -938,7 +938,7 @@ def _should_remove_existing(
 
 @transaction.atomic
 def process_damage_interactions(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     damage_type: DamageType,
 ) -> DamageInteractionResult:
     """
@@ -1010,7 +1010,7 @@ def process_damage_interactions(
 
 
 def get_capability_status(
-    target: "ObjectDB",
+    character_sheet: "CharacterSheet",
     capability: CapabilityType,
 ) -> CapabilityStatus:
     """
@@ -1026,6 +1026,7 @@ def get_capability_status(
     Returns:
         CapabilityStatus with total value and per-condition breakdown
     """
+    target = character_sheet.character
     result = CapabilityStatus()
 
     active_instances = get_active_conditions(target)
@@ -1050,7 +1051,7 @@ def get_capability_status(
 
 
 def get_capability_value(
-    target: "ObjectDB",
+    character_sheet: "CharacterSheet",
     capability: CapabilityType,
 ) -> int:
     """
@@ -1066,7 +1067,7 @@ def get_capability_value(
     Returns:
         Integer capability value (0 = effectively blocked / not possessed)
     """
-    return get_capability_status(target, capability).value
+    return get_capability_status(character_sheet, capability).value
 
 
 def get_effective_capability_value(
@@ -1095,12 +1096,12 @@ def get_effective_capability_value(
     )
     # get_capability_status still operates on ObjectDB; walk back at the
     # boundary. Refactoring its signature is Phase 2 follow-up.
-    status = get_capability_status(character_sheet.character, capability)
+    status = get_capability_status(character_sheet, capability)
     condition_total = sum(modifier for _instance, modifier in status.condition_contributions)
     return max(0, baseline + modifier_total + condition_total)
 
 
-def get_all_capability_values(target: "ObjectDB") -> dict[int, int]:
+def get_all_capability_values(character_sheet: "CharacterSheet") -> dict[int, int]:
     """
     Get all capability values for a character.
 
@@ -1114,6 +1115,7 @@ def get_all_capability_values(target: "ObjectDB") -> dict[int, int]:
     Returns:
         Dict mapping capability PK to total values (floor 0)
     """
+    target = character_sheet.character
     active_instances = list(get_active_conditions(target))
     if not active_instances:
         return {}
@@ -1156,7 +1158,7 @@ def get_all_capability_values(target: "ObjectDB") -> dict[int, int]:
 
 
 def get_check_modifier(
-    target: "ObjectDB",
+    character_sheet: "CharacterSheet",
     check_type: CheckType,
 ) -> CheckModifierResult:
     """
@@ -1169,6 +1171,7 @@ def get_check_modifier(
     Returns:
         CheckModifierResult with total and breakdown
     """
+    target = character_sheet.character
     ctype = check_type
 
     result = CheckModifierResult(total_modifier=0, breakdown=[])
@@ -1200,7 +1203,7 @@ def get_check_modifier(
 
 
 def get_resistance_modifier(
-    target: "ObjectDB",
+    character_sheet: "CharacterSheet",
     damage_type: DamageType | None = None,
 ) -> ResistanceModifierResult:
     """
@@ -1213,6 +1216,7 @@ def get_resistance_modifier(
     Returns:
         ResistanceModifierResult with total and breakdown
     """
+    target = character_sheet.character
     dtype = damage_type
 
     result = ResistanceModifierResult(total_modifier=0, breakdown=[])
@@ -1250,7 +1254,7 @@ def get_resistance_modifier(
 
 
 @transaction.atomic
-def process_round_start(target: "ObjectDB") -> RoundTickResult:
+def process_round_start(target: "ObjectDB") -> RoundTickResult:  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     """
     Process start-of-round effects for all conditions on a target.
 
@@ -1266,7 +1270,7 @@ def process_round_start(target: "ObjectDB") -> RoundTickResult:
 
 
 @transaction.atomic
-def process_round_end(target: "ObjectDB") -> RoundTickResult:
+def process_round_end(target: "ObjectDB") -> RoundTickResult:  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     """
     Process end-of-round effects for all conditions on a target.
 
@@ -1289,7 +1293,7 @@ def process_round_end(target: "ObjectDB") -> RoundTickResult:
 
 
 @transaction.atomic
-def process_action_tick(target: "ObjectDB") -> RoundTickResult:
+def process_action_tick(target: "ObjectDB") -> RoundTickResult:  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     """
     Process on-action damage for conditions (when target takes an action).
 
@@ -1305,7 +1309,7 @@ def process_action_tick(target: "ObjectDB") -> RoundTickResult:
 
 
 def _process_round_tick(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     timing: DamageTickTiming,
 ) -> RoundTickResult:
     """
@@ -1349,7 +1353,7 @@ def _process_round_tick(
 
 
 def _process_duration_and_progression(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     result: RoundTickResult,
 ) -> None:
     """
@@ -1404,7 +1408,7 @@ def _get_next_stage(instance: ConditionInstance) -> ConditionStage | None:
 
 
 def suppress_condition(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     condition: ConditionTemplate,
     *,
     duration_rounds: int | None = None,
@@ -1435,7 +1439,7 @@ def suppress_condition(
 
 
 def unsuppress_condition(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     condition: ConditionTemplate,
 ) -> bool:
     """
@@ -1460,7 +1464,7 @@ def unsuppress_condition(
 
 
 def clear_all_conditions(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
     *,
     only_negative: bool = False,
     only_category: "ConditionCategory | None" = None,
@@ -1497,7 +1501,7 @@ def clear_all_conditions(
     return count
 
 
-def get_turn_order_modifier(target: "ObjectDB") -> int:
+def get_turn_order_modifier(character_sheet: "CharacterSheet") -> int:
     """
     Get the total turn order modifier from all conditions.
 
@@ -1507,6 +1511,7 @@ def get_turn_order_modifier(target: "ObjectDB") -> int:
     Returns:
         Integer modifier to turn order (positive = act earlier)
     """
+    target = character_sheet.character
     result = (
         get_active_conditions(target)
         .filter(condition__affects_turn_order=True)
@@ -1515,7 +1520,7 @@ def get_turn_order_modifier(target: "ObjectDB") -> int:
     return result["total"]
 
 
-def get_aggro_priority(target: "ObjectDB") -> int:
+def get_aggro_priority(character_sheet: "CharacterSheet") -> int:
     """
     Get the total aggro priority from all conditions.
 
@@ -1525,6 +1530,7 @@ def get_aggro_priority(target: "ObjectDB") -> int:
     Returns:
         Integer priority (higher = more likely to be targeted)
     """
+    target = character_sheet.character
     result = (
         get_active_conditions(target)
         .filter(condition__draws_aggro=True)
@@ -1539,7 +1545,7 @@ def get_aggro_priority(target: "ObjectDB") -> int:
 
 
 def _get_condition_percent_modifier(
-    target: "ObjectDB",
+    character_sheet: "CharacterSheet",
     category_name: str,
     condition_name: str,
 ) -> int:
@@ -1557,6 +1563,7 @@ def _get_condition_percent_modifier(
     Returns:
         Total percentage modifier (e.g., 100 means +100%)
     """
+    target = character_sheet.character
     try:
         sheet = target.sheet_data
     except AttributeError:
@@ -1572,7 +1579,7 @@ def _get_condition_percent_modifier(
 
 
 def get_condition_control_percent_modifier(
-    target: "ObjectDB",
+    character_sheet: "CharacterSheet",
     condition_name: str,
 ) -> int:
     """
@@ -1588,11 +1595,13 @@ def get_condition_control_percent_modifier(
     Returns:
         Total percentage modifier (e.g., 100 for Wrathful)
     """
-    return _get_condition_percent_modifier(target, "condition_control_percent", condition_name)
+    return _get_condition_percent_modifier(
+        character_sheet, "condition_control_percent", condition_name
+    )
 
 
 def get_condition_intensity_percent_modifier(
-    target: "ObjectDB",
+    character_sheet: "CharacterSheet",
     condition_name: str,
 ) -> int:
     """
@@ -1609,11 +1618,13 @@ def get_condition_intensity_percent_modifier(
     Returns:
         Total percentage modifier (e.g., 50 for Wrathful)
     """
-    return _get_condition_percent_modifier(target, "condition_intensity_percent", condition_name)
+    return _get_condition_percent_modifier(
+        character_sheet, "condition_intensity_percent", condition_name
+    )
 
 
 def get_condition_penalty_percent_modifier(
-    target: "ObjectDB",
+    character_sheet: "CharacterSheet",
     condition_name: str,
 ) -> int:
     """
@@ -1629,7 +1640,9 @@ def get_condition_penalty_percent_modifier(
     Returns:
         Total percentage modifier (e.g., 100 for Hubris)
     """
-    return _get_condition_percent_modifier(target, "condition_penalty_percent", condition_name)
+    return _get_condition_percent_modifier(
+        character_sheet, "condition_penalty_percent", condition_name
+    )
 
 
 # =============================================================================
@@ -1809,7 +1822,7 @@ def apply_stage_entry_aftermath(payload: ConditionStageChangedPayload) -> None:
 
 
 def _resolve_character_sheet_for_target(
-    target: "ObjectDB",
+    target: "ObjectDB",  # noqa: OBJECTDB_PARAM — input IS ObjectDB by design; this helper resolves ObjectDB→CharacterSheet
 ) -> "CharacterSheet | None":
     """Walk an ObjectDB target back to its CharacterSheet, or None.
 
@@ -2018,7 +2031,7 @@ def _thread_anchors_to_character(thread: "Thread", target_sheet: "CharacterSheet
     return False
 
 
-def _scene_participant(scene: "Scene", character: "ObjectDB") -> bool:
+def _scene_participant(scene: "Scene", character_sheet: "CharacterSheet") -> bool:
     """Return True when *character* has a SceneParticipation row in *scene*.
 
     SceneParticipation links accounts, not characters directly. The character's
@@ -2030,7 +2043,7 @@ def _scene_participant(scene: "Scene", character: "ObjectDB") -> bool:
     from world.scenes.models import SceneParticipation  # noqa: PLC0415
 
     try:
-        entry = RosterEntry.objects.get(character_sheet_id=character.pk)
+        entry = RosterEntry.objects.get(character_sheet_id=character_sheet.pk)
         tenure = entry.tenures.filter(end_date__isnull=True).first()
         if tenure is None:
             return False

--- a/src/world/conditions/tests/test_services.py
+++ b/src/world/conditions/tests/test_services.py
@@ -8,6 +8,7 @@ from django.test import TestCase, tag
 from evennia.objects.models import ObjectDB
 
 from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.conditions.constants import (
     ConditionInteractionOutcome,
@@ -65,6 +66,8 @@ class GetActiveConditionsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.category1 = ConditionCategoryFactory(name="debuff", is_negative=True)
         cls.category2 = ConditionCategoryFactory(name="buff", is_negative=False)
 
@@ -120,6 +123,8 @@ class HasConditionTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.condition = ConditionTemplateFactory(name="frozen")
 
     def test_has_condition_false_when_absent(self):
@@ -146,6 +151,8 @@ class ApplyConditionTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.source = ObjectDB.objects.create(db_key="SourceCharacter")
         cls.condition = ConditionTemplateFactory(
             name="burning",
@@ -272,6 +279,8 @@ class ApplyConditionProgressionTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.progressive = ConditionTemplateFactory(
             name="poison",
             has_progression=True,
@@ -313,6 +322,8 @@ class ApplyConditionInteractionsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.burning = ConditionTemplateFactory(name="burning")
         cls.wet = ConditionTemplateFactory(name="wet")
         cls.frozen = ConditionTemplateFactory(name="frozen")
@@ -364,6 +375,8 @@ class RemoveConditionTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.condition = ConditionTemplateFactory(name="frozen")
 
     def test_remove_condition_deletes_instance(self):
@@ -409,6 +422,8 @@ class RemoveConditionsByCategoryTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.debuff_category = ConditionCategoryFactory(name="debuff")
         cls.buff_category = ConditionCategoryFactory(name="buff")
 
@@ -436,6 +451,8 @@ class ProcessDamageInteractionsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.fire = DamageTypeFactory(name="fire")
         cls.cold = DamageTypeFactory(name="cold")
         cls.force = DamageTypeFactory(name="force")
@@ -518,6 +535,8 @@ class GetCapabilityStatusTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.movement = CapabilityTypeFactory(name="movement")
         cls.speech = CapabilityTypeFactory(name="speech")
 
@@ -550,7 +569,7 @@ class GetCapabilityStatusTest(TestCase):
         """Large negative value floors to 0 (effectively blocked)."""
         ConditionInstanceFactory(target=self.target, condition=self.paralyzed)
 
-        status = get_capability_status(self.target, self.movement)
+        status = get_capability_status(self.target.sheet_data, self.movement)
 
         assert status.value == 0
         assert len(status.condition_contributions) == 1
@@ -559,7 +578,7 @@ class GetCapabilityStatusTest(TestCase):
         """Negative value reduces capability."""
         ConditionInstanceFactory(target=self.target, condition=self.slowed)
 
-        status = get_capability_status(self.target, self.movement)
+        status = get_capability_status(self.target.sheet_data, self.movement)
 
         # -5 floors to 0 since there's no base value
         assert status.value == 0
@@ -571,7 +590,7 @@ class GetCapabilityStatusTest(TestCase):
         """Positive value enhances capability."""
         ConditionInstanceFactory(target=self.target, condition=self.hasted)
 
-        status = get_capability_status(self.target, self.movement)
+        status = get_capability_status(self.target.sheet_data, self.movement)
 
         assert status.value == 10
         assert len(status.condition_contributions) == 1
@@ -581,7 +600,7 @@ class GetCapabilityStatusTest(TestCase):
         ConditionInstanceFactory(target=self.target, condition=self.hasted)
         ConditionInstanceFactory(target=self.target, condition=self.slowed)
 
-        status = get_capability_status(self.target, self.movement)
+        status = get_capability_status(self.target.sheet_data, self.movement)
 
         # 10 + (-5) = 5
         assert status.value == 5
@@ -589,7 +608,7 @@ class GetCapabilityStatusTest(TestCase):
 
     def test_no_conditions_returns_zero(self):
         """No conditions means capability value is 0."""
-        status = get_capability_status(self.target, self.movement)
+        status = get_capability_status(self.target.sheet_data, self.movement)
 
         assert status.value == 0
         assert len(status.condition_contributions) == 0
@@ -598,7 +617,7 @@ class GetCapabilityStatusTest(TestCase):
         """Conditions on movement don't affect speech."""
         ConditionInstanceFactory(target=self.target, condition=self.paralyzed)
 
-        status = get_capability_status(self.target, self.speech)
+        status = get_capability_status(self.target.sheet_data, self.speech)
 
         assert status.value == 0
         assert len(status.condition_contributions) == 0
@@ -608,7 +627,7 @@ class GetCapabilityStatusTest(TestCase):
         ConditionInstanceFactory(target=self.target, condition=self.paralyzed)
         ConditionInstanceFactory(target=self.target, condition=self.slowed)
 
-        status = get_capability_status(self.target, self.movement)
+        status = get_capability_status(self.target.sheet_data, self.movement)
 
         # -100 + (-5) = -105, floored to 0
         assert status.value == 0
@@ -620,6 +639,8 @@ class GetCapabilityValueTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.flight = CapabilityTypeFactory(name="flight")
         cls.buffed = ConditionTemplateFactory(name="wings")
 
@@ -632,11 +653,11 @@ class GetCapabilityValueTest(TestCase):
     def test_returns_value(self):
         """get_capability_value returns just the integer."""
         ConditionInstanceFactory(target=self.target, condition=self.buffed)
-        assert get_capability_value(self.target, self.flight) == 15
+        assert get_capability_value(self.target.sheet_data, self.flight) == 15
 
     def test_no_conditions_returns_zero(self):
         """No conditions means 0."""
-        assert get_capability_value(self.target, self.flight) == 0
+        assert get_capability_value(self.target.sheet_data, self.flight) == 0
 
 
 class GetAllCapabilityValuesTest(TestCase):
@@ -645,6 +666,8 @@ class GetAllCapabilityValuesTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.movement = CapabilityTypeFactory(name="movement")
         cls.flight = CapabilityTypeFactory(name="flight")
 
@@ -670,34 +693,34 @@ class GetAllCapabilityValuesTest(TestCase):
 
     def test_empty_when_no_conditions(self):
         """Returns empty dict when character has no conditions."""
-        result = get_all_capability_values(self.target)
+        result = get_all_capability_values(self.target.sheet_data)
         assert result == {}
 
     def test_single_capability(self):
         """Returns single capability from one condition."""
         ConditionInstanceFactory(target=self.target, condition=self.winged)
-        result = get_all_capability_values(self.target)
+        result = get_all_capability_values(self.target.sheet_data)
         assert result == {self.flight.id: 20}
 
     def test_multiple_capabilities(self):
         """Returns all affected capabilities."""
         ConditionInstanceFactory(target=self.target, condition=self.hasted)
         ConditionInstanceFactory(target=self.target, condition=self.winged)
-        result = get_all_capability_values(self.target)
+        result = get_all_capability_values(self.target.sheet_data)
         assert result == {self.movement.id: 10, self.flight.id: 20}
 
     def test_stacking_same_capability(self):
         """Multiple conditions on same capability stack additively."""
         ConditionInstanceFactory(target=self.target, condition=self.hasted)
         ConditionInstanceFactory(target=self.target, condition=self.slowed)
-        result = get_all_capability_values(self.target)
+        result = get_all_capability_values(self.target.sheet_data)
         # 10 + (-3) = 7
         assert result == {self.movement.id: 7}
 
     def test_floor_at_zero(self):
         """Negative totals clamp to 0."""
         ConditionInstanceFactory(target=self.target, condition=self.slowed)
-        result = get_all_capability_values(self.target)
+        result = get_all_capability_values(self.target.sheet_data)
         # -3 floored to 0
         assert result == {self.movement.id: 0}
 
@@ -708,6 +731,8 @@ class GetCheckModifierTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.combat_attack = CheckTypeFactory(name="combat-attack")
 
         cls.frightened = ConditionTemplateFactory(name="frightened")
@@ -731,7 +756,7 @@ class GetCheckModifierTest(TestCase):
         """Test check modifier from single condition."""
         ConditionInstanceFactory(target=self.target, condition=self.frightened)
 
-        result = get_check_modifier(self.target, self.combat_attack)
+        result = get_check_modifier(self.target.sheet_data, self.combat_attack)
 
         assert result.total_modifier == -20
         assert len(result.breakdown) == 1
@@ -741,7 +766,7 @@ class GetCheckModifierTest(TestCase):
         ConditionInstanceFactory(target=self.target, condition=self.frightened)
         ConditionInstanceFactory(target=self.target, condition=self.empowered)
 
-        result = get_check_modifier(self.target, self.combat_attack)
+        result = get_check_modifier(self.target.sheet_data, self.combat_attack)
 
         assert result.total_modifier == -5  # -20 + 15
         assert len(result.breakdown) == 2
@@ -758,7 +783,7 @@ class GetCheckModifierTest(TestCase):
 
         ConditionInstanceFactory(target=self.target, condition=scaling, severity=3)
 
-        result = get_check_modifier(self.target, self.combat_attack)
+        result = get_check_modifier(self.target.sheet_data, self.combat_attack)
 
         assert result.total_modifier == -15  # -5 * 3
 
@@ -769,6 +794,8 @@ class GetResistanceModifierTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.fire = DamageTypeFactory(name="fire")
         cls.lightning = DamageTypeFactory(name="lightning")
 
@@ -790,7 +817,7 @@ class GetResistanceModifierTest(TestCase):
         """Test positive resistance modifier."""
         ConditionInstanceFactory(target=self.target, condition=self.wet)
 
-        result = get_resistance_modifier(self.target, self.fire)
+        result = get_resistance_modifier(self.target.sheet_data, self.fire)
 
         assert result.total_modifier == 50
 
@@ -798,7 +825,7 @@ class GetResistanceModifierTest(TestCase):
         """Test negative resistance modifier (vulnerability)."""
         ConditionInstanceFactory(target=self.target, condition=self.wet)
 
-        result = get_resistance_modifier(self.target, self.lightning)
+        result = get_resistance_modifier(self.target.sheet_data, self.lightning)
 
         assert result.total_modifier == -50
 
@@ -814,10 +841,10 @@ class GetResistanceModifierTest(TestCase):
         ConditionInstanceFactory(target=self.target, condition=warded)
 
         # Should apply to any damage type
-        result = get_resistance_modifier(self.target, self.fire)
+        result = get_resistance_modifier(self.target.sheet_data, self.fire)
         assert result.total_modifier == 25
 
-        result = get_resistance_modifier(self.target, self.lightning)
+        result = get_resistance_modifier(self.target.sheet_data, self.lightning)
         assert result.total_modifier == 25
 
 
@@ -827,6 +854,8 @@ class RoundProcessingTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.fire = DamageTypeFactory(name="fire")
 
         cls.burning = ConditionTemplateFactory(
@@ -914,6 +943,8 @@ class SuppressConditionTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.condition = ConditionTemplateFactory(name="poisoned")
 
     def test_suppress_condition(self):
@@ -951,6 +982,8 @@ class ClearAllConditionsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.debuff_category = ConditionCategoryFactory(name="debuff", is_negative=True)
         cls.buff_category = ConditionCategoryFactory(name="buff", is_negative=False)
 
@@ -996,6 +1029,8 @@ class CombatModifiersTest(TestCase):
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
 
+        CharacterSheetFactory(character=cls.target)
+
         cls.hasted = ConditionTemplateFactory(
             name="hasted",
             affects_turn_order=True,
@@ -1017,7 +1052,7 @@ class CombatModifiersTest(TestCase):
         ConditionInstanceFactory(target=self.target, condition=self.hasted)
         ConditionInstanceFactory(target=self.target, condition=self.slowed)
 
-        modifier = get_turn_order_modifier(self.target)
+        modifier = get_turn_order_modifier(self.target.sheet_data)
 
         assert modifier == 2  # 5 - 3
 
@@ -1025,7 +1060,7 @@ class CombatModifiersTest(TestCase):
         """Test getting aggro priority."""
         ConditionInstanceFactory(target=self.target, condition=self.taunted)
 
-        priority = get_aggro_priority(self.target)
+        priority = get_aggro_priority(self.target.sheet_data)
 
         assert priority == 10
 
@@ -1036,6 +1071,8 @@ class StageSpecificEffectsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.target = ObjectDB.objects.create(db_key="TestTarget")
+
+        CharacterSheetFactory(character=cls.target)
         cls.movement = CapabilityTypeFactory(name="movement")
 
         cls.poison = ConditionTemplateFactory(name="paralytic-poison", has_progression=True)
@@ -1093,7 +1130,7 @@ class StageSpecificEffectsTest(TestCase):
             current_stage=self.stage1,
         )
 
-        status = get_capability_status(self.target, self.movement)
+        status = get_capability_status(self.target.sheet_data, self.movement)
 
         # -25 * 1.0 severity = -25, floored to 0
         assert status.value == 0
@@ -1107,7 +1144,7 @@ class StageSpecificEffectsTest(TestCase):
             current_stage=self.stage2,
         )
 
-        status = get_capability_status(self.target, self.movement)
+        status = get_capability_status(self.target.sheet_data, self.movement)
 
         # -50 * 1.5 severity = -75, floored to 0
         assert status.value == 0
@@ -1121,7 +1158,7 @@ class StageSpecificEffectsTest(TestCase):
             current_stage=self.stage3,
         )
 
-        status = get_capability_status(self.target, self.movement)
+        status = get_capability_status(self.target.sheet_data, self.movement)
 
         # -100 * 2.0 severity = -200, floored to 0
         assert status.value == 0
@@ -1244,9 +1281,9 @@ class ConditionPercentageModifiersTest(TestCase):
             get_condition_penalty_percent_modifier,
         )
 
-        control = get_condition_control_percent_modifier(self.target, "anger")
-        intensity = get_condition_intensity_percent_modifier(self.target, "anger")
-        penalty = get_condition_penalty_percent_modifier(self.target, "humbled")
+        control = get_condition_control_percent_modifier(self.target.sheet_data, "anger")
+        intensity = get_condition_intensity_percent_modifier(self.target.sheet_data, "anger")
+        penalty = get_condition_penalty_percent_modifier(self.target.sheet_data, "humbled")
 
         assert control == 0
         assert intensity == 0
@@ -1266,7 +1303,7 @@ class ConditionPercentageModifiersTest(TestCase):
         )
         create_distinction_modifiers(char_distinction)
 
-        modifier = get_condition_control_percent_modifier(self.target, "anger")
+        modifier = get_condition_control_percent_modifier(self.target.sheet_data, "anger")
 
         assert modifier == 100
 
@@ -1284,7 +1321,7 @@ class ConditionPercentageModifiersTest(TestCase):
         )
         create_distinction_modifiers(char_distinction)
 
-        modifier = get_condition_intensity_percent_modifier(self.target, "anger")
+        modifier = get_condition_intensity_percent_modifier(self.target.sheet_data, "anger")
 
         assert modifier == 50
 
@@ -1302,7 +1339,7 @@ class ConditionPercentageModifiersTest(TestCase):
         )
         create_distinction_modifiers(char_distinction)
 
-        modifier = get_condition_penalty_percent_modifier(self.target, "humbled")
+        modifier = get_condition_penalty_percent_modifier(self.target.sheet_data, "humbled")
 
         assert modifier == 100
 
@@ -1320,8 +1357,8 @@ class ConditionPercentageModifiersTest(TestCase):
         create_distinction_modifiers(char_distinction)
 
         # Should match regardless of case
-        assert get_condition_control_percent_modifier(self.target, "ANGER") == 100
-        assert get_condition_control_percent_modifier(self.target, "Anger") == 100
+        assert get_condition_control_percent_modifier(self.target.sheet_data, "ANGER") == 100
+        assert get_condition_control_percent_modifier(self.target.sheet_data, "Anger") == 100
 
     def test_modifiers_stack_from_multiple_sources(self):
         """Test that percentage modifiers from multiple sources stack."""
@@ -1367,7 +1404,7 @@ class ConditionPercentageModifiersTest(TestCase):
         )
         create_distinction_modifiers(other_cd)
 
-        modifier = get_condition_control_percent_modifier(self.target, "anger")
+        modifier = get_condition_control_percent_modifier(self.target.sheet_data, "anger")
 
         assert modifier == 125  # 100 + 25
 

--- a/src/world/conditions/views.py
+++ b/src/world/conditions/views.py
@@ -308,8 +308,8 @@ class CharacterConditionsViewSet(CharacterContextMixin, viewsets.ViewSet):
         check_modifiers = _aggregate_check_modifiers(lookups)
         resistance_modifiers = _aggregate_resistance_modifiers(lookups)
 
-        turn_order_mod = get_turn_order_modifier(character)
-        aggro = get_aggro_priority(character)
+        turn_order_mod = get_turn_order_modifier(character.sheet_data)
+        aggro = get_aggro_priority(character.sheet_data)
 
         return Response(
             {

--- a/src/world/mechanics/services.py
+++ b/src/world/mechanics/services.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import Prefetch
 
@@ -574,7 +575,14 @@ def _get_trait_sources(character: ObjectDB) -> list[CapabilitySource]:
 
 def _get_condition_sources(character: ObjectDB) -> list[CapabilitySource]:
     """Get Capability sources from active conditions."""
-    cap_values = get_all_capability_values(character)
+    try:
+        sheet = character.sheet_data
+    except ObjectDoesNotExist:
+        # No CharacterSheet → no capability mods from conditions can be derived;
+        # capabilities are character-specific and conditions on a sheet-less
+        # object don't materialize as CharacterModifier rows.
+        return []
+    cap_values = get_all_capability_values(sheet)
 
     sources: list[CapabilitySource] = []
     for cap_id, value in cap_values.items():

--- a/src/world/missions/predicates.py
+++ b/src/world/missions/predicates.py
@@ -177,7 +177,7 @@ def _resolve_has_capability(ctx: ResolverContext, *, name: str) -> bool:
     capability = CapabilityType.objects.filter(name=name).first()
     if capability is None:
         return False
-    return get_capability_value(ctx.character, capability) > 0
+    return get_capability_value(ctx.character.sheet_data, capability) > 0
 
 
 def _resolve_has_thread(ctx: ResolverContext) -> bool:

--- a/src/world/missions/services/challenge_options.py
+++ b/src/world/missions/services/challenge_options.py
@@ -63,7 +63,7 @@ def challenge_options_for_character(
         # directly rather than re-looking-up by name.
         qualifies = (
             approach.is_default
-            or get_capability_value(character, approach.application.capability) > 0
+            or get_capability_value(character.sheet_data, approach.application.capability) > 0
         )
         if not qualifies:
             continue


### PR DESCRIPTION
## Summary

Phase 2 of #604 — expands the OBJECTDB_PARAM lint regex (added in #616) to cover `world/conditions/services.py`. 36 violations triaged into refactor + justified-noqa per the pattern from Phase 1.

The lint regex now reads:
\`\`\`yaml
files: |
  (?x)^src/world/(
    vitals/services\.py
    |magic/services/capability_requirements\.py
    |conditions/services\.py
  )$
\`\`\`

## What got refactored (12 functions)

**11 capability functions** that are character-specific: `target: ObjectDB` → `character_sheet: CharacterSheet`
- `get_capability_status`, `get_capability_value`, `get_all_capability_values`
- `get_check_modifier`, `get_resistance_modifier`
- `get_turn_order_modifier`, `get_aggro_priority`
- `_get_condition_percent_modifier`, `get_condition_control_percent_modifier`, `get_condition_intensity_percent_modifier`, `get_condition_penalty_percent_modifier`

These delegate internally to `get_active_conditions()` which still takes `ObjectDB` (conditions ARE intentionally generic per the `_invalidate_condition_handler` docstring — apply to characters/rooms/exits/items). They keep a `target = character_sheet.character` back-compat alias so the bodies that walk to the ObjectDB layer don't need touching.

**Bonus: `_scene_participant` mis-annotation fixed.** Its signature said `character: ObjectDB`, but the body uses `character_sheet_id=character.pk` and its callers already pass `CharacterSheet`. The type now matches reality — no behavior change, just truthful annotation.

## What got noqa'd (24 functions)

Condition-state functions where ObjectDB is genuinely the right type. The justification cites the `_invalidate_condition_handler` docstring directly:
\`\`\`python
target: "ObjectDB",  # noqa: OBJECTDB_PARAM — conditions apply to any typeclassed object (Character/Room/Exit/Item per _invalidate_condition_handler)
\`\`\`

`source_character` args (in `apply_condition` / `bulk_apply_conditions`) get a slightly different justification: `# noqa: OBJECTDB_PARAM — source_character covers NPC + PC ObjectDB cases; narrowing is broader Phase 3 work`.

## Phase 1 internal cleanup

`get_effective_capability_value` no longer walks `character_sheet.character` for its `get_capability_status` call — that function now takes the sheet directly. The walk-back-at-boundary pattern is gone for this one call.

## Caller updates

- `missions/predicates.py` + `missions/services/challenge_options.py`: pass `.sheet_data`
- `mechanics/services.py:_get_condition_sources`: try/except around `.sheet_data` access — characters without sheets get an empty source list (capabilities are character-specific so this is correct)
- `conditions/views.py`: `get_turn_order_modifier` + `get_aggro_priority` call sites in the conditions detail view
- 35 test call sites in `conditions/tests/test_services.py` updated to pass `.sheet_data`; the affected test setUps now create a `CharacterSheetFactory(character=cls.target)` alongside the ObjectDB target

## What's still out of scope

- Conditions' own `target: ObjectDB` parameters across the 24 noqa'd functions: these can be refactored to a discriminator pattern (CharacterSheet | RoomProfile | ItemTemplate | ...) in a future PR, but that's bigger scope and doesn't really buy much — the lint is already correctly justified.
- Other apps' service modules: magic/anima.py, soulfray.py, techniques.py, threads.py, actions/services.py, etc. Phase 3+.

## Test plan

- [x] `pre-commit run` clean
- [x] Linter passes on vitals + magic capability_requirements + conditions/services.py
- [x] `arx test world.conditions world.combat world.magic world.vitals world.missions world.mechanics` — **3052 tests, OK, 6 skipped** (zero failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)