### PR TITLE
chore(vitals/combat): close #595 stragglers (suppression-aware bleed-out, stale docstring)

### DIFF
--- a/src/world/combat/views_outcome_details.py
+++ b/src/world/combat/views_outcome_details.py
@@ -341,7 +341,7 @@ class ActionOutcomeDetailsView(APIView):
 
     Effects derived from existing model state — combo upgrade, ConditionInstance
     correlation by source_technique + applied_at window, target status from
-    CombatOpponent.status / CharacterVitals.status. No new audit tables.
+    CombatOpponent.status / CharacterVitals.life_state. No new audit tables.
     """
 
     permission_classes = [IsAuthenticated]

--- a/src/world/vitals/services.py
+++ b/src/world/vitals/services.py
@@ -445,23 +445,31 @@ def advance_bleed_out(character_sheet: CharacterSheet | None) -> bool:
         BLEED_OUT_CONDITION_NAME,
     )
     from world.conditions.models import (  # noqa: PLC0415 — vitals→conditions cross-domain deferred import
-        ConditionInstance,
         ConditionStage,
+        ConditionTemplate,
+    )
+    from world.conditions.services import (  # noqa: PLC0415 — vitals→conditions cross-domain deferred import
+        get_active_conditions,
     )
 
     if character_sheet is None:
         return False
 
-    # ConditionInstance.target is an ObjectDB FK, and perform_check operates on
-    # ObjectDB; walk back to ObjectDB at the boundary. Refactoring those signatures
-    # is queued for Phase 2 of the OBJECTDB_PARAM rollout.
+    # perform_check still operates on ObjectDB; walk back at the boundary.
+    # Refactoring that layer is queued for Phase 3 of the OBJECTDB_PARAM rollout.
     character = character_sheet.character
 
+    # Route through get_active_conditions (honors suppression by default) rather
+    # than filtering ConditionInstance directly — keeps bleed-out advancement
+    # consistent with the rest of the conditions layer when bleed-out suppression
+    # becomes an authored mechanic. Issue #601.
+    bleed_out = ConditionTemplate.objects.filter(name=BLEED_OUT_CONDITION_NAME).first()
+    if bleed_out is None:
+        return False
     instances = list(
-        ConditionInstance.objects.filter(
-            target=character,
-            condition__name=BLEED_OUT_CONDITION_NAME,
-        ).select_related("condition", "current_stage", "current_stage__resist_check_type")
+        get_active_conditions(character, condition=bleed_out).select_related(
+            "current_stage__resist_check_type"
+        )
     )
 
     for instance in instances:


### PR DESCRIPTION
## Summary

Closes #601. Two of the three non-gating cleanup items from the final #595 review; the third was already resolved by PR #616.

## Pre-flight verification

Before starting I re-checked each item against current main since the codebase has moved since #601 was filed:

| #601 item | Current state | Action |
|---|---|---|
| 1 — `advance_bleed_out` ignores suppression | **Still valid** — body still filters `ConditionInstance.objects.filter(target=character, condition__name=BLEED_OUT_CONDITION_NAME)` directly | Fixed in this PR |
| 2 — `get_effective_capability_value` unguarded `.sheet_data` | **Already resolved** — PR #616's OBJECTDB_PARAM Phase 1 refactor changed the signature to take `CharacterSheet` directly, eliminating the `.sheet_data` access entirely. No action needed. | n/a (noted in commit msg) |
| 3 — Stale docstring `CharacterVitals.status` at `views_outcome_details.py:344` | **Still valid** | Fixed in this PR (one-line rename to `.life_state`) |

## What's in the PR

### Item 1: suppression-aware bleed-out

`advance_bleed_out` now routes through `get_active_conditions(character, condition=bleed_out_template)` instead of querying `ConditionInstance` directly. `get_active_conditions` defaults to `include_suppressed=False`, so suppressed Bleeding-Out instances now correctly hold instead of advancing toward death — consistent with how the rest of the conditions layer behaves.

This is currently a forward-compat change (bleed-out suppression isn't an authored mechanic yet), but the divergence-from-canonical-path was the real concern #601 was tracking.

```python
# Before
instances = list(
    ConditionInstance.objects.filter(
        target=character,
        condition__name=BLEED_OUT_CONDITION_NAME,
    ).select_related(...)
)

# After
bleed_out = ConditionTemplate.objects.filter(name=BLEED_OUT_CONDITION_NAME).first()
if bleed_out is None:
    return False
instances = list(
    get_active_conditions(character, condition=bleed_out).select_related(
        "current_stage__resist_check_type"
    )
)
```

The `select_related` chain shrinks because `get_active_conditions` already eager-loads `condition`, `condition__category`, and `current_stage`; we just add the one extra `current_stage__resist_check_type` we still need for the resist check.

### Item 3: docstring update

One-line rename in `views_outcome_details.py:344` — `CharacterVitals.status` is now `CharacterVitals.life_state` (the field was renamed during the vitals refactor in #595/#611). The same line's `CombatOpponent.status` is still a valid field and stays as-is.

## Test plan

- [x] `arx test world.vitals world.combat world.conditions` — **906 tests, OK**
- [x] `tools/lint_objectdb_param.py` still clean on `vitals/services.py` and `conditions/services.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)