### PR TITLE
test(missions): isError card tests for list pages (closes #589)

### DIFF
--- a/frontend/src/missions/__tests__/ListPageErrorCards.test.tsx
+++ b/frontend/src/missions/__tests__/ListPageErrorCards.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * isError card tests for the list-style mission pages.
+ *
+ * `useMissionTemplates` and `useMissionGivers` (per queries.ts) deliberately
+ * drop `throwOnError` so their consuming pages handle isError inline rather
+ * than crashing to the global ErrorBoundary. This file pins that contract:
+ * each list page renders its inline "couldn't load" card when the hook
+ * returns isError: true.
+ *
+ * Closes #589 item 5 — companion to the PageErrorCards / DrillDownPageErrorCards
+ * tests that cover the throwOnError'd detail pages.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GiverLibraryPage } from '../pages/GiverLibraryPage';
+import { MissionBrowserPage } from '../pages/MissionBrowserPage';
+import * as queries from '../queries';
+
+// MissionDetailPanel fires its own queries; stub it so this file's mocks stay
+// minimal. Mirrors the pattern from MissionBrowserPage.test.tsx.
+vi.mock('../components/MissionDetailPanel', () => ({
+  MissionDetailPanel: () => <div data-testid="mission-detail-panel-stub" />,
+}));
+
+function withProviders(children: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('MissionBrowserPage isError card', () => {
+  it('renders the inline "Couldn\'t load missions" card when useMissionTemplates errors', () => {
+    vi.spyOn(queries, 'useMissionTemplates').mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof queries.useMissionTemplates>);
+
+    render(withProviders(<MissionBrowserPage />));
+
+    const errorCard = screen.getByTestId('mission-list-error');
+    expect(errorCard).toBeInTheDocument();
+    expect(errorCard).toHaveAttribute('role', 'alert');
+    expect(errorCard).toHaveTextContent(/couldn't load missions/i);
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+});
+
+describe('GiverLibraryPage isError card', () => {
+  it('renders the inline "Couldn\'t load givers" card when useMissionGivers errors', () => {
+    vi.spyOn(queries, 'useMissionGivers').mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof queries.useMissionGivers>);
+
+    render(withProviders(<GiverLibraryPage />));
+
+    const errorCard = screen.getByTestId('giver-list-error');
+    expect(errorCard).toBeInTheDocument();
+    expect(errorCard).toHaveAttribute('role', 'alert');
+    expect(errorCard).toHaveTextContent(/couldn't load givers/i);
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #589 — item 5 was the only remaining gap. Items 1-4 were already covered by PR #607.

## Pre-flight verification

Re-checked each item from the issue against current main since #589 was filed before PR #607:

| #589 item | Status |
|---|---|
| 1. `flattenErrorMessage` 3+ level nesting test | ✅ Done (`CreateMissionPage.test.tsx:172`) |
| 2. Frontend happy-path integration test | ✅ Done (`CreateMissionPage.test.tsx:73`) |
| 3. Backend round-trip POST→GET | ✅ Done (`test_api_template_create.py:134`) |
| 4. `categories=[]` vs omitted | ✅ Done (`test_api_template_create.py:159,168`) |
| **5. isError tests for hooks without `throwOnError`** | **Fixed in this PR** |

## What's in the PR

Per `queries.ts` comments, `useMissionTemplates` and `useMissionGivers` deliberately omit `throwOnError` so `MissionBrowserPage` and `GiverLibraryPage` can handle isError inline (render a "couldn't load" card with Retry) rather than crashing to the global ErrorBoundary. The comment explicitly says "tracked as a follow-up" — this PR is that follow-up.

New test file: `frontend/src/missions/__tests__/ListPageErrorCards.test.tsx`. Two tests, one per page:

- `MissionBrowserPage isError card` — mocks `useMissionTemplates` to return `isError: true`, asserts `data-testid="mission-list-error"` renders with `role="alert"`, the "Couldn't load missions." text, and a Retry button.
- `GiverLibraryPage isError card` — same shape for `useMissionGivers` / "Couldn't load givers." / `data-testid="giver-list-error"`.

## Why a new test file?

`GiverLibrary.test.tsx` uses module-level `vi.mock('../queries', ...)` with fixed return values for ~10 hooks. Overriding `useMissionGivers` per-test would have required refactoring the entire mock to use controllable `vi.fn()`s. Cheaper to add a small focused file using `vi.spyOn` per-test — mirrors the pattern from `PageErrorCards.test.tsx` and `DrillDownPageErrorCards.test.tsx` for the `throwOnError`'d detail pages.

## Test plan

- [x] `pnpm vitest run src/missions/__tests__/ListPageErrorCards.test.tsx` — 2 tests pass
- [x] `pnpm vitest run src/missions/__tests__/` — 66 tests, all pass (no regression)
- [x] `pnpm typecheck` clean
- [x] pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)