### PR TITLE
Combat UI: fatigue pools on VitalPools + conditions on CombatantsList (#552, #553)

### DIFF
--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -404,14 +404,14 @@ the React frontend.
 - `CombatRoundAction → Interaction` join FK needed for effect enumeration in `outcome-details` endpoint (v1 returns empty effects)
 - Deep-link routing for outcome-detail effects — **#551 DONE**: outcome-effect deep links open a Redux-driven `DeepLinkModalHost` routing 5 kinds (combo/opponent/participant/condition/clash); added read-only `GET /api/conditions/instances/<pk>/`.
 - Auto-expand pose units on critical events (KO, death) — pending player-preference toggle
-- Fatigue model not yet exposed; VitalPools shows `0/10` placeholders
+- Fatigue pools — **#552 DONE**: `ParticipantSerializer` exposes physical/social/mental fatigue (current + capacity); `VitalPools` renders real values. Strain stays anima (ratified); the anima→fatigue "pushing" cost is tracked in #624.
 - `CombatOpponent` portrait FK — NPC avatars are initial-letter-only
 - ActiveState Commit/Lend buttons — **#555 DONE**: ActiveState is read-only; the clash-commit path lives in YourTurn's `ClashContributionRow` (no parallel surface).
 - Focused-category technique taxonomy (was **#558**) — **reframed/descoped to #614**: needs a physical/social/mental technique taxonomy that does not exist yet.
 - `ClashStateSerializer` does not expose `contributors` or `side_favored`
-- Conditions data not surfaced on CombatantsList rows
+- Conditions on combatant rows — **#553 DONE**: Participant + Opponent serializers expose `active_conditions` (visibility-filtered); `CombatantsList` rows render condition badges that deep-link to the condition detail modal (reuses #551's `DeepLinkModalHost`).
 - `submit_pose` REST endpoint does not broadcast via WebSocket
-- Strain budget hardcoded `max=10`; needs `CombatParticipant.available_strain` exposed
+- Strain budget — `CombatParticipant.available_strain` (anima) is exposed + drives the slider max; the hardcoded `10` is now only a missing-data fallback. Per-category fatigue binding deferred (#614 taxonomy, #624 fatigue cost).
 - Focused-category resolution stubbed to `passive-physical`
 - `lend-to-clash` not wired; no `CLASH_SUPPORT` `PlayerAction` descriptor exists
 - Scene-side adoption of `<ActionDeclarationCard>` (no `ScenePull` envelope) — out of this spec's scope

--- a/docs/superpowers/specs/2026-05-30-combat-state-surfacing-fatigue-conditions-design.md
+++ b/docs/superpowers/specs/2026-05-30-combat-state-surfacing-fatigue-conditions-design.md
@@ -1,0 +1,49 @@
+# Combat-state surfacing: fatigue pools + conditions on the combat UI
+
+**Issues:** #552 (fatigue on VitalPools), #553 (conditions on CombatantsList rows)
+**Branch:** `feature-552-expose-fatigue-model-on-combatparticipan`
+**Milestone:** Next Playable Boss Fight
+**Date:** 2026-05-30
+
+Two display-only combat-UI completions surfacing existing backend state. Both add `SerializerMethodField`s to the combat serializers and render in adjacent React sections. **No migrations** (`FatiguePool` and the conditions system already exist). Heavy reuse; the one new component is a condition badge.
+
+## Verify-against-code ledger (capability check applied per #620)
+
+| Surface | Verdict | Evidence |
+|---|---|---|
+| `FatiguePool` (physical/social/mental_current) + `get_fatigue_capacity`/`get_fatigue_percentage`/`get_fatigue_penalty` | BUILT, NOT WIRED | `src/world/fatigue/models.py:8`; `src/world/fatigue/services.py` |
+| `CombatParticipant.available_strain` (returns `CharacterAnima.current`) | BUILT & WIRED | `src/world/combat/models.py:570` — **stays anima; do not change** |
+| `ParticipantSerializer` / `OpponentSerializer` | BUILT & WIRED | `src/world/combat/serializers.py:71` — no fatigue, no conditions fields yet |
+| `VitalPools` (renders `0/10` placeholders) | BUILT, NOT WIRED | `frontend/src/combat/sections/VitalPools.tsx:177` (TODO(fatigue)) |
+| `ConditionInstanceSerializer` (icon, color_hex, name, severity, …) | BUILT & WIRED | `src/world/conditions/serializers.py:116` |
+| `get_active_conditions(target, …)` | BUILT & WIRED | `src/world/conditions/services.py:114` |
+| `CombatantsList` rows (condition-icon stub) | BUILT, NOT WIRED | `frontend/src/combat/sections/CombatantsList.tsx:90` (TODO(conditions)) |
+| `openDeepLink({modal:'condition', id})` + `DeepLinkModalHost` → `ConditionDetailModal` | BUILT & WIRED | `frontend/src/store/deepLinkModalSlice.ts`; `combat/modals/DeepLinkModalHost.tsx:52` (shipped #551) |
+| condition-badge component (icon/color_hex) | ABSENT | `EffectKindBadge` is for outcome kinds, not conditions — genuinely new |
+| fatigue/conditions displayed anywhere else (capability check) | ABSENT | neither is shown on any other surface → no parallel implementation |
+
+## #552 — fatigue pools on VitalPools (display)
+
+- **Backend:** add fatigue fields to `ParticipantSerializer` via a `SerializerMethodField` (e.g. `fatigue: {physical: {current, capacity}, social: {…}, mental: {…}}`), sourced from the participant's `character_sheet.fatigue` (`FatiguePool`) for `*_current` and `get_fatigue_capacity(sheet, category)` for capacity. Defensive: a participant with no `FatiguePool` row → zeros/null (mirror `available_strain`'s try/except). Prefetch `character_sheet__fatigue` on the encounter queryset to avoid N+1.
+- **Frontend:** `VitalPools.tsx` renders real `current / capacity` per pool instead of `0/10`; drop the "(placeholder)" / `opacity-50` / "not yet implemented" affordances. Use a fatigue zone/percentage for bar fill if the serializer exposes it.
+- **Strain slider: UNCHANGED.** `available_strain` stays anima (ratified — strain *is* anima). The "hardcoded 10" fallback stays only as a missing-data fallback.
+- **Deferred (follow-up, file at PR time):** "pushing"/low-anima should also *incur* fatigue — a future mechanic, out of scope here.
+
+## #553 — conditions on CombatantsList rows
+
+- **Backend:** add `active_conditions` to BOTH `ParticipantSerializer` and `OpponentSerializer` via `SerializerMethodField`, returning `ConditionInstanceSerializer(get_active_conditions(target), many=True).data`. Target = the participant's character ObjectDB / the opponent's target. Respect `is_visible_to_others` (don't leak hidden conditions to other players — filter on it, matching how condition visibility works elsewhere). Prefetch to avoid N+1.
+- **Frontend — new `ConditionBadge` component** (`frontend/src/combat/components/ConditionBadge.tsx` or similar): renders one condition's `icon` + `color_hex` (small badge/chip), `title`/tooltip = name (+ severity/stage). Accessible `<button>` that dispatches `openDeepLink({modal:'condition', id})` on click. No new modal — reuse the shipped `ConditionDetailModal` via the deep-link host.
+- **Frontend — `CombatantsList.tsx`:** in `ParticipantRow` and `OpponentRow`, replace the `TODO(conditions)` stub with a row of `ConditionBadge`s from `participant.active_conditions` / `opponent.active_conditions` (ordered by `display_priority`). Empty list → render nothing.
+
+## Testing
+- Backend (`world.combat` + `world.conditions`): serializer tests asserting `fatigue` pool values (with + without a `FatiguePool` row) and `active_conditions` (participant + opponent; visibility filtering; empty case). No query explosion (assert prefetch). `world.combat` is SQLite-with-caveats → use `just test-parity world.combat` for the serializer additions; conditions is SQLite-clean.
+- Frontend (vitest): `VitalPools` renders real values (no "placeholder"); `ConditionBadge` renders icon/color + click dispatches `openDeepLink`; `CombatantsList` rows render badges from `active_conditions` and an empty list renders none.
+- No migration (confirm `git diff --name-only main | grep migration` empty).
+
+## Follow-ups (file at PR time)
+- Fatigue-cost-on-push: pushing/low-anima incurs fatigue (mechanics — future).
+- (Already tracked) #614 per-category strain binding once the technique taxonomy exists.
+
+## Out of scope
+- Changing `available_strain` away from anima (ratified: strain = anima).
+- #554 portraits, #557 WebSocket poses (separate milestone issues).

--- a/frontend/src/combat/__tests__/ActiveState.test.tsx
+++ b/frontend/src/combat/__tests__/ActiveState.test.tsx
@@ -56,6 +56,7 @@ function makeEncounter(clashes: ClashState[] = []): EncounterDetail {
         max_health: 10,
         soak_value: null,
         probing_threshold: null,
+        active_conditions: [],
       },
     ],
     current_round_actions: [],

--- a/frontend/src/combat/__tests__/CombatantsList.test.tsx
+++ b/frontend/src/combat/__tests__/CombatantsList.test.tsx
@@ -69,6 +69,8 @@ function makeParticipant(overrides: Partial<Participant> = {}): Participant {
     max_health: 10,
     character_status: 'healthy',
     available_strain: null,
+    fatigue: null,
+    active_conditions: [],
     ...overrides,
   };
 }
@@ -82,6 +84,7 @@ function makeOpponent(overrides: Partial<Opponent> = {}): Opponent {
     max_health: 10,
     soak_value: null,
     probing_threshold: null,
+    active_conditions: [],
     ...overrides,
   };
 }

--- a/frontend/src/combat/__tests__/CombatantsList.test.tsx
+++ b/frontend/src/combat/__tests__/CombatantsList.test.tsx
@@ -2,10 +2,18 @@
  * Tests for CombatantsList rail section.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { ReactNode } from 'react';
+
+import { deepLinkModalSlice } from '@/store/deepLinkModalSlice';
+import type { components } from '@/generated/api';
+
+type ConditionInstance = components['schemas']['ConditionInstance'];
 
 // ---------------------------------------------------------------------------
 // Module mocks — PersonaAvatar is used; stub it to simplify tests
@@ -24,13 +32,32 @@ import type { EncounterDetail, Participant, Opponent } from '../types';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createWrapper() {
+function makeStore() {
+  return configureStore({ reducer: { deepLinkModal: deepLinkModalSlice.reducer } });
+}
+
+function createWrapper(store: ReturnType<typeof makeStore> = makeStore()) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
   return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    return (
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </Provider>
+    );
   };
+}
+
+function makeCondition(overrides: Partial<ConditionInstance> = {}): ConditionInstance {
+  return {
+    id: 7,
+    name: 'Bleeding Out',
+    icon: '🩸',
+    color_hex: '#cc0000',
+    display_priority: 10,
+    ...overrides,
+  } as unknown as ConditionInstance;
 }
 
 function makeParticipant(overrides: Partial<Participant> = {}): Participant {
@@ -163,6 +190,72 @@ describe('CombatantsList', () => {
     });
 
     expect(screen.queryByTestId('participant-row-1')).not.toBeInTheDocument();
+  });
+
+  it('renders condition badges for a participant with active_conditions', () => {
+    const encounter = makeEncounter(
+      [
+        makeParticipant({
+          id: 1,
+          active_conditions: [makeCondition({ id: 7, name: 'Bleeding Out' })],
+        }) as Participant,
+      ],
+      []
+    );
+
+    render(<CombatantsList encounter={encounter} />, { wrapper: createWrapper() });
+
+    const row = screen.getByTestId('participant-row-1');
+    expect(within(row).getByRole('button', { name: /Bleeding Out/i })).toBeInTheDocument();
+  });
+
+  it('renders condition badges for an opponent with active_conditions', () => {
+    const encounter = makeEncounter(
+      [],
+      [
+        makeOpponent({
+          id: 10,
+          active_conditions: [makeCondition({ id: 9, name: 'Stunned' })],
+        }) as Opponent,
+      ]
+    );
+
+    render(<CombatantsList encounter={encounter} />, { wrapper: createWrapper() });
+
+    const row = screen.getByTestId('opponent-row-10');
+    expect(within(row).getByRole('button', { name: /Stunned/i })).toBeInTheDocument();
+  });
+
+  it('renders no condition badges when active_conditions is empty', () => {
+    const encounter = makeEncounter(
+      [makeParticipant({ id: 1, active_conditions: [] }) as Participant],
+      []
+    );
+
+    render(<CombatantsList encounter={encounter} />, { wrapper: createWrapper() });
+
+    const row = screen.getByTestId('participant-row-1');
+    expect(within(row).queryByTestId('condition-row')).not.toBeInTheDocument();
+  });
+
+  it('clicking a condition badge dispatches openDeepLink with the condition id', async () => {
+    const store = makeStore();
+    const user = userEvent.setup();
+    const encounter = makeEncounter(
+      [
+        makeParticipant({
+          id: 1,
+          active_conditions: [makeCondition({ id: 7, name: 'Bleeding Out' })],
+        }) as Participant,
+      ],
+      []
+    );
+
+    render(<CombatantsList encounter={encounter} />, { wrapper: createWrapper(store) });
+
+    await user.click(screen.getByRole('button', { name: /Bleeding Out/i }));
+
+    expect(store.getState().deepLinkModal.current).toEqual({ modal: 'condition', id: 7 });
   });
 
   it('renders PersonaAvatar for each combatant', () => {

--- a/frontend/src/combat/__tests__/RoundFlow.test.tsx
+++ b/frontend/src/combat/__tests__/RoundFlow.test.tsx
@@ -32,6 +32,8 @@ function makeParticipant(id: number, name: string): Participant {
     max_health: 10,
     character_status: 'healthy',
     available_strain: null,
+    fatigue: null,
+    active_conditions: [],
   };
 }
 

--- a/frontend/src/combat/__tests__/VitalPools.test.tsx
+++ b/frontend/src/combat/__tests__/VitalPools.test.tsx
@@ -45,6 +45,11 @@ function makeParticipant(overrides: Partial<Participant> = {}): Participant {
     max_health: 10,
     character_status: 'healthy',
     available_strain: null,
+    fatigue: {
+      physical: { current: 3, capacity: 12 },
+      social: { current: 1, capacity: 9 },
+      mental: { current: 4, capacity: 11 },
+    },
     ...overrides,
   };
 }
@@ -128,19 +133,79 @@ describe('VitalPools', () => {
     expect(screen.getByText('5')).toBeInTheDocument();
   });
 
-  it('renders three fatigue placeholder bars', () => {
+  it('renders three fatigue bars with real values', () => {
+    const encounter = makeEncounter([
+      makeParticipant({
+        fatigue: {
+          physical: { current: 3, capacity: 12 },
+          social: { current: 1, capacity: 8 },
+          mental: { current: 5, capacity: 10 },
+        },
+      }),
+    ]);
+
+    render(<VitalPools encounter={encounter} characterId={10} />, {
+      wrapper: createWrapper(),
+    });
+
+    const physical = screen.getByTestId('vital-fatigue-physical-bar');
+    const social = screen.getByTestId('vital-fatigue-social-bar');
+    const mental = screen.getByTestId('vital-fatigue-mental-bar');
+    expect(physical).toBeInTheDocument();
+    expect(social).toBeInTheDocument();
+    expect(mental).toBeInTheDocument();
+
+    // Real values, not the 0/10 placeholder.
+    expect(physical).toHaveTextContent('3');
+    expect(physical).toHaveTextContent('/ 12');
+    expect(social).toHaveTextContent('/ 8');
+    expect(mental).toHaveTextContent('/ 10');
+  });
+
+  it('no longer renders the placeholder affordances', () => {
     const encounter = makeEncounter([makeParticipant()]);
 
     render(<VitalPools encounter={encounter} characterId={10} />, {
       wrapper: createWrapper(),
     });
 
-    expect(screen.getByTestId('vital-fatigue-physical-bar')).toBeInTheDocument();
-    expect(screen.getByTestId('vital-fatigue-social-bar')).toBeInTheDocument();
-    expect(screen.getByTestId('vital-fatigue-mental-bar')).toBeInTheDocument();
-    // Placeholder text
-    const placeholders = screen.getAllByText('(placeholder)');
-    expect(placeholders).toHaveLength(3);
+    expect(screen.queryByText('(placeholder)')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Fatigue tracking not yet implemented')).not.toBeInTheDocument();
+  });
+
+  it('clamps the fatigue fill width to [0, 100%]', () => {
+    const encounter = makeEncounter([
+      makeParticipant({
+        fatigue: {
+          physical: { current: 20, capacity: 10 }, // over capacity
+          social: { current: 0, capacity: 0 }, // divide-by-zero guard
+          mental: { current: 5, capacity: 10 },
+        },
+      }),
+    ]);
+
+    render(<VitalPools encounter={encounter} characterId={10} />, {
+      wrapper: createWrapper(),
+    });
+
+    const physicalFill = screen.getByTestId('vital-fatigue-physical-bar-fill');
+    expect(physicalFill).toHaveStyle({ width: '100%' });
+    const socialFill = screen.getByTestId('vital-fatigue-social-bar-fill');
+    expect(socialFill).toHaveStyle({ width: '0%' });
+  });
+
+  it('hides fatigue bars when fatigue is null (no vitals permission)', () => {
+    const encounter = makeEncounter([makeParticipant({ fatigue: null })]);
+
+    render(<VitalPools encounter={encounter} characterId={10} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.queryByTestId('vital-fatigue-physical-bar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('vital-fatigue-social-bar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('vital-fatigue-mental-bar')).not.toBeInTheDocument();
+    // No fake numbers.
+    expect(screen.queryByText('0 / 10')).not.toBeInTheDocument();
   });
 
   it('shows dash when no participant health is available', () => {

--- a/frontend/src/combat/__tests__/VitalPools.test.tsx
+++ b/frontend/src/combat/__tests__/VitalPools.test.tsx
@@ -50,6 +50,7 @@ function makeParticipant(overrides: Partial<Participant> = {}): Participant {
       social: { current: 1, capacity: 9 },
       mental: { current: 4, capacity: 11 },
     },
+    active_conditions: [],
     ...overrides,
   };
 }

--- a/frontend/src/combat/components/ConditionBadge.tsx
+++ b/frontend/src/combat/components/ConditionBadge.tsx
@@ -1,0 +1,49 @@
+/**
+ * ConditionBadge — small chip representing a single active condition on a
+ * combatant. Renders the condition's icon, tinted by its `color_hex`, and
+ * deep-links to the shared condition-detail modal on click.
+ *
+ * Reuses the existing deep-link slice (`openDeepLink`) + `ConditionDetailModal`
+ * (mounted via DeepLinkModalHost) — no new modal or dispatch path. (#553)
+ */
+
+import { useAppDispatch } from '@/store/hooks';
+import { openDeepLink } from '@/store/deepLinkModalSlice';
+import type { components } from '@/generated/api';
+
+type ConditionInstance = components['schemas']['ConditionInstance'];
+
+export interface ConditionBadgeProps {
+  condition: ConditionInstance;
+}
+
+/** Build the tooltip text: name plus stage/stacks when present. */
+function buildTooltip(condition: ConditionInstance): string {
+  const parts: string[] = [condition.name];
+  if (condition.stage_name) {
+    parts.push(`(${condition.stage_name})`);
+  }
+  if (typeof condition.stacks === 'number' && condition.stacks > 1) {
+    parts.push(`x${condition.stacks}`);
+  }
+  return parts.join(' ');
+}
+
+export function ConditionBadge({ condition }: ConditionBadgeProps) {
+  const dispatch = useAppDispatch();
+  const tooltip = buildTooltip(condition);
+
+  return (
+    <button
+      type="button"
+      title={tooltip}
+      aria-label={tooltip}
+      onClick={() => dispatch(openDeepLink({ modal: 'condition', id: condition.id }))}
+      className="inline-flex h-5 min-w-5 items-center justify-center rounded-full border px-1 text-xs leading-none hover:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      style={{ borderColor: condition.color_hex, color: condition.color_hex }}
+      data-testid={`condition-badge-${condition.id}`}
+    >
+      <span aria-hidden="true">{condition.icon}</span>
+    </button>
+  );
+}

--- a/frontend/src/combat/components/__tests__/ConditionBadge.test.tsx
+++ b/frontend/src/combat/components/__tests__/ConditionBadge.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for ConditionBadge — small chip rendering a single active condition,
+ * deep-linking to the shared condition-detail modal on click.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import type { ReactNode } from 'react';
+
+import { ConditionBadge } from '../ConditionBadge';
+import { deepLinkModalSlice } from '@/store/deepLinkModalSlice';
+import type { components } from '@/generated/api';
+
+type ConditionInstance = components['schemas']['ConditionInstance'];
+
+function makeStore() {
+  return configureStore({ reducer: { deepLinkModal: deepLinkModalSlice.reducer } });
+}
+
+function Wrapper({
+  children,
+  store = makeStore(),
+}: {
+  children: ReactNode;
+  store?: ReturnType<typeof makeStore>;
+}) {
+  return <Provider store={store}>{children}</Provider>;
+}
+
+function makeCondition(overrides: Partial<ConditionInstance> = {}): ConditionInstance {
+  return {
+    id: 7,
+    name: 'Bleeding Out',
+    icon: '🩸',
+    color_hex: '#cc0000',
+    display_priority: 10,
+    ...overrides,
+  } as unknown as ConditionInstance;
+}
+
+describe('ConditionBadge', () => {
+  it('renders the icon', () => {
+    render(
+      <Wrapper>
+        <ConditionBadge condition={makeCondition()} />
+      </Wrapper>
+    );
+
+    expect(screen.getByText('🩸')).toBeInTheDocument();
+  });
+
+  it('exposes an accessible name / tooltip with the condition name', () => {
+    render(
+      <Wrapper>
+        <ConditionBadge condition={makeCondition()} />
+      </Wrapper>
+    );
+
+    const button = screen.getByRole('button', { name: /Bleeding Out/i });
+    expect(button).toHaveAttribute('title', expect.stringContaining('Bleeding Out'));
+  });
+
+  it('dispatches openDeepLink({modal: "condition", id}) on click', async () => {
+    const store = makeStore();
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper store={store}>
+        <ConditionBadge condition={makeCondition({ id: 7 })} />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByRole('button', { name: /Bleeding Out/i }));
+
+    expect(store.getState().deepLinkModal.current).toEqual({ modal: 'condition', id: 7 });
+  });
+
+  it('applies color_hex via inline style', () => {
+    render(
+      <Wrapper>
+        <ConditionBadge condition={makeCondition({ color_hex: '#00aa00' })} />
+      </Wrapper>
+    );
+
+    const button = screen.getByRole('button', { name: /Bleeding Out/i });
+    // jsdom normalizes hex to rgb in the serialized style string.
+    expect(button.style.color).toBe('rgb(0, 170, 0)');
+    expect(button.style.borderColor).toBe('rgb(0, 170, 0)');
+  });
+});

--- a/frontend/src/combat/sections/CombatantsList.tsx
+++ b/frontend/src/combat/sections/CombatantsList.tsx
@@ -11,15 +11,49 @@
  *
  * NPCs are visually distinct from PCs via a destructive-tinted border + background.
  *
- * Condition icon row: placeholder until conditions are surfaced in the encounter
- *   payload. TODO(conditions): wire real condition data when available.
+ * Condition badges: each row renders its `active_conditions` as ConditionBadge
+ *   chips that deep-link to the shared condition-detail modal on click.
  *
  * Phase 8, Task 8.3 — unified-combat-ui plan.
  */
 
 import { cn } from '@/lib/utils';
 import { PersonaAvatar } from '@/components/PersonaAvatar';
+import { ConditionBadge } from '../components/ConditionBadge';
 import type { EncounterDetail, Participant, Opponent } from '../types';
+import type { components } from '@/generated/api';
+
+type ConditionInstance = components['schemas']['ConditionInstance'];
+
+// ---------------------------------------------------------------------------
+// ConditionRow — flex row of condition badges for a combatant
+// ---------------------------------------------------------------------------
+
+interface ConditionRowProps {
+  /**
+   * active_conditions is typed loosely as `{[key: string]: unknown}[]` on the
+   * generated Participant/Opponent schemas (it's a SerializerMethodField); each
+   * entry is really a ConditionInstance. Cast at the boundary.
+   */
+  conditions?: { [key: string]: unknown }[];
+}
+
+function ConditionRow({ conditions }: ConditionRowProps) {
+  if (!conditions || conditions.length === 0) {
+    return null;
+  }
+  // Backend already orders by display_priority desc; be defensive and re-sort.
+  const sorted = [...(conditions as ConditionInstance[])].sort(
+    (a, b) => b.display_priority - a.display_priority
+  );
+  return (
+    <div className="mt-1 flex flex-wrap gap-1" data-testid="condition-row">
+      {sorted.map((condition) => (
+        <ConditionBadge key={condition.id} condition={condition} />
+      ))}
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Props
@@ -87,9 +121,8 @@ function ParticipantRow({ participant }: ParticipantRowProps) {
         <p className="truncate text-xs font-medium text-foreground">{participant.character_name}</p>
         {/* HP mini-bar */}
         <HpBar health={participant.health} maxHealth={participant.max_health} className="mt-0.5" />
-        {/* Condition icon row — placeholder until conditions in encounter payload.
-         * TODO(conditions): render condition icons when encounter detail exposes them.
-         */}
+        {/* Condition badges — deep-link to the condition-detail modal on click. */}
+        <ConditionRow conditions={participant.active_conditions} />
       </div>
     </div>
   );
@@ -121,6 +154,8 @@ function OpponentRow({ opponent }: OpponentRowProps) {
         <p className="truncate text-xs font-medium text-foreground">{opponent.name}</p>
         {/* HP mini-bar */}
         <HpBar health={opponent.health} maxHealth={opponent.max_health} className="mt-0.5" />
+        {/* Condition badges — deep-link to the condition-detail modal on click. */}
+        <ConditionRow conditions={opponent.active_conditions} />
       </div>
     </div>
   );

--- a/frontend/src/combat/sections/VitalPools.tsx
+++ b/frontend/src/combat/sections/VitalPools.tsx
@@ -11,9 +11,10 @@
  * Anima: sourced from useCharacterAnima(characterId).
  *   - characterId is the ObjectDB PK (same as what CharacterAnimaFilter uses).
  *
- * Fatigue (Physical / Social / Mental): not yet modeled in the backend.
- *   Rendered as placeholder bars at 0/10.
- *   TODO(fatigue): wire real values when the fatigue model ships.
+ * Fatigue (Physical / Social / Mental): sourced from the viewer's participant
+ *   row's `fatigue` field (the same row that supplies health). Each pool is
+ *   `{ current, capacity }`. When `fatigue` is null (viewer lacks vitals
+ *   permission) the fatigue bars are hidden entirely — no fake numbers. (#552)
  *
  * Phase 8, Task 8.2 — unified-combat-ui plan.
  */
@@ -109,6 +110,15 @@ export function VitalPools({
   const animaCurrent = animaData?.current ?? null;
   const animaMaximum = animaData?.maximum ?? null;
 
+  // Fatigue pools come from the same viewer participant row. Null when the
+  // viewer lacks vitals permission — in that case we render no fatigue bars.
+  const fatigue = viewerParticipant?.fatigue ?? null;
+  const fatiguePools: { key: string; label: string }[] = [
+    { key: 'physical', label: 'Physical' },
+    { key: 'social', label: 'Social' },
+    { key: 'mental', label: 'Mental' },
+  ];
+
   return (
     <div className="rounded-md border border-border bg-card" data-testid="vital-pools-section">
       {/* Section header */}
@@ -174,30 +184,35 @@ export function VitalPools({
             </div>
           )}
 
-          {/* Fatigue (Physical / Social / Mental)
-           * TODO(fatigue): wire real values when the fatigue model ships.
-           * Fatigue is not modeled in the backend as of Phase 8. These are
-           * placeholder bars at 0/10.
-           */}
-          {(['Physical', 'Social', 'Mental'] as const).map((label) => (
-            <div
-              key={label}
-              className="space-y-1 opacity-50"
-              data-testid={`vital-fatigue-${label.toLowerCase()}-bar`}
-              title="Fatigue tracking not yet implemented"
-            >
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-foreground">{label} Fatigue</span>
-                <span className="font-mono text-xs text-muted-foreground">
-                  0 / 10
-                  <span className="ml-1 text-[10px] uppercase tracking-wide text-muted-foreground/60">
-                    (placeholder)
-                  </span>
-                </span>
-              </div>
-              <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted" />
-            </div>
-          ))}
+          {/* Fatigue (Physical / Social / Mental) — real values from the
+           * viewer's participant row. Hidden entirely when fatigue is null
+           * (viewer lacks vitals permission). */}
+          {fatigue !== null &&
+            fatiguePools.map(({ key, label }) => {
+              const pool = fatigue[key];
+              const current = pool?.current ?? 0;
+              const capacity = pool?.capacity ?? 0;
+              const pct = capacity > 0 ? Math.min(100, Math.max(0, (current / capacity) * 100)) : 0;
+              const testId = `vital-fatigue-${key}-bar`;
+              return (
+                <div key={key} className="space-y-1" data-testid={testId}>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-foreground">{label} Fatigue</span>
+                    <span className="font-mono text-xs text-foreground">
+                      {current}
+                      <span className="text-muted-foreground"> / {capacity}</span>
+                    </span>
+                  </div>
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-orange-500 transition-all"
+                      style={{ width: `${pct}%` }}
+                      data-testid={`${testId}-fill`}
+                    />
+                  </div>
+                </div>
+              );
+            })}
         </div>
       )}
     </div>

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -14651,6 +14651,17 @@ export interface components {
       readonly probing_threshold: number | null;
       current_phase?: number;
       status?: components['schemas']['OpponentStatusEnum'];
+      /**
+       * @description Active conditions on this opponent's in-world ObjectDB.
+       *
+       *     Public conditions (``is_visible_to_others=True``) are shown to
+       *     everyone; hidden conditions only to GM/staff. Ordered by
+       *     ``display_priority`` (highest first). Opponents with no backing
+       *     ObjectDB (or none applied) serialize to ``[]``.
+       */
+      readonly active_conditions: {
+        [key: string]: unknown;
+      }[];
     };
     /**
      * @description Read serializer for combat opponents.
@@ -16048,6 +16059,18 @@ export interface components {
           [key: string]: number;
         };
       } | null;
+      /**
+       * @description Active conditions on this participant's character ObjectDB.
+       *
+       *     Public conditions (``is_visible_to_others=True``) are shown to
+       *     everyone; hidden conditions only to the character's owner, GMs, or
+       *     staff — reusing the same ownership gate as vitals
+       *     (``_can_view_vitals``). Ordered by ``display_priority`` (highest
+       *     first). No conditions → ``[]``.
+       */
+      readonly active_conditions: {
+        [key: string]: unknown;
+      }[];
     };
     /**
      * @description Read serializer for combat participants.

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -16031,6 +16031,23 @@ export interface components {
        *     The frontend's YourTurn strain slider reads this as its max value.
        */
       readonly available_strain: number | null;
+      /**
+       * @description Return the three fatigue pools (physical/social/mental).
+       *
+       *     Each pool is ``{"current": N, "capacity": M}``. ``current`` reads the
+       *     persisted ``FatiguePool`` row (0 when no row exists yet); ``capacity``
+       *     is derived from the character's endurance stats via
+       *     ``get_fatigue_capacity``. Gated by the same vitals-visibility rules as
+       *     health/strain — outsiders get ``None``.
+       *
+       *     The frontend's VitalPools component reads this to render fatigue bars
+       *     (replacing the ``0/10`` placeholder). See #552.
+       */
+      readonly fatigue: {
+        [key: string]: {
+          [key: string]: number;
+        };
+      } | null;
     };
     /**
      * @description Read serializer for combat participants.

--- a/justfile
+++ b/justfile
@@ -177,6 +177,9 @@ clean-pyc:
 gen-api-types:
     uv run arx manage spectacular --file schema.json --validate
     pnpm --prefix frontend generate:types
+    # openapi-typescript output isn't prettier-formatted; normalize so the diff is
+    # just the real schema change, not a whole-file quote/indent reflow.
+    pnpm --prefix frontend exec prettier --write src/generated/api.d.ts
     @echo "gen-api-types: schema regenerated and frontend types updated."
 
 # --- Devcontainer (host-side; run these OUTSIDE the container) ---------------

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from django.db.models import Prefetch
 from django.shortcuts import get_object_or_404
@@ -17,9 +17,59 @@ from world.combat.models import (
     CombatParticipant,
     CombatRoundAction,
 )
+from world.conditions.serializers import ConditionInstanceSerializer
+from world.conditions.services import get_active_conditions
 from world.fatigue.constants import EffortLevel, FatigueCategory
 from world.fatigue.services import get_fatigue_capacity
 from world.magic.models import CharacterTechnique, Technique
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+# ---------------------------------------------------------------------------
+# Condition helpers
+# ---------------------------------------------------------------------------
+
+
+# Attribute name the viewset's Prefetch(to_attr=...) lands the active
+# ConditionInstances on (on the participant's character / opponent's
+# objectdb ObjectDB). Read here so the serializer avoids an N+1.
+ACTIVE_CONDITIONS_CACHE_ATTR = "active_condition_instances"
+
+
+def _serialize_active_conditions(
+    target: ObjectDB,
+    *,
+    can_view_hidden: bool,
+    context: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Serialize a target's active conditions, filtered by visibility.
+
+    Public conditions (``is_visible_to_others=True``) are always included;
+    hidden ones only when ``can_view_hidden`` is True (owner/GM/staff).
+    Results are ordered by the template's ``display_priority`` (highest
+    first). Reuses ``ConditionInstanceSerializer``.
+
+    Prefers the viewset's ``Prefetch(to_attr=ACTIVE_CONDITIONS_CACHE_ATTR)``
+    cache (built with the same select_related + suppression filter as
+    ``get_active_conditions``) — visibility filter + priority ordering run
+    in Python over the identity-mapped list, so no per-row query fires.
+    Falls back to ``get_active_conditions`` for callers that build the
+    serializer directly (e.g. unit tests).
+    """
+    cached = getattr(target, ACTIVE_CONDITIONS_CACHE_ATTR, None)  # noqa: GETATTR_LITERAL — Prefetch(to_attr=...) cache
+    if cached is not None:
+        instances = [
+            inst for inst in cached if can_view_hidden or inst.condition.is_visible_to_others
+        ]
+        instances.sort(key=lambda inst: inst.condition.display_priority, reverse=True)
+    else:
+        qs = get_active_conditions(target)
+        if not can_view_hidden:
+            qs = qs.filter(condition__is_visible_to_others=True)
+        instances = list(qs.order_by("-condition__display_priority"))
+    return ConditionInstanceSerializer(instances, many=True, context=context).data
+
 
 # ---------------------------------------------------------------------------
 # Nested read serializers
@@ -35,6 +85,7 @@ class OpponentSerializer(serializers.ModelSerializer):
 
     soak_value = serializers.SerializerMethodField()
     probing_threshold = serializers.SerializerMethodField()
+    active_conditions = serializers.SerializerMethodField()
 
     class Meta:
         model = CombatOpponent
@@ -50,6 +101,7 @@ class OpponentSerializer(serializers.ModelSerializer):
             "probing_threshold",
             "current_phase",
             "status",
+            "active_conditions",
         ]
 
     def _is_gm_or_staff(self) -> bool:
@@ -67,6 +119,23 @@ class OpponentSerializer(serializers.ModelSerializer):
     def get_probing_threshold(self, obj: CombatOpponent) -> int | None:
         """Probing threshold — GM/staff only."""
         return obj.probing_threshold if self._is_gm_or_staff() else None
+
+    def get_active_conditions(self, obj: CombatOpponent) -> list[dict[str, Any]]:
+        """Active conditions on this opponent's in-world ObjectDB.
+
+        Public conditions (``is_visible_to_others=True``) are shown to
+        everyone; hidden conditions only to GM/staff. Ordered by
+        ``display_priority`` (highest first). Opponents with no backing
+        ObjectDB (or none applied) serialize to ``[]``.
+        """
+        target = obj.objectdb
+        if target is None:
+            return []
+        return _serialize_active_conditions(
+            target,
+            can_view_hidden=self._is_gm_or_staff(),
+            context=self.context,
+        )
 
 
 class ParticipantSerializer(serializers.ModelSerializer):
@@ -86,6 +155,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
     character_status = serializers.SerializerMethodField()
     available_strain = serializers.SerializerMethodField()
     fatigue = serializers.SerializerMethodField()
+    active_conditions = serializers.SerializerMethodField()
 
     class Meta:
         model = CombatParticipant
@@ -98,6 +168,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
             "character_status",
             "available_strain",
             "fatigue",
+            "active_conditions",
         ]
 
     def _can_view_vitals(self, obj: CombatParticipant) -> bool:
@@ -215,6 +286,27 @@ class ParticipantSerializer(serializers.ModelSerializer):
                 ),
             }
         return pools
+
+    def get_active_conditions(self, obj: CombatParticipant) -> list[dict[str, Any]]:
+        """Active conditions on this participant's character ObjectDB.
+
+        Public conditions (``is_visible_to_others=True``) are shown to
+        everyone; hidden conditions only to the character's owner, GMs, or
+        staff — reusing the same ownership gate as vitals
+        (``_can_view_vitals``). Ordered by ``display_priority`` (highest
+        first). No conditions → ``[]``.
+        """
+        try:
+            character_sheet = obj.character_sheet
+        except AttributeError:
+            return []
+        if character_sheet is None:
+            return []
+        return _serialize_active_conditions(
+            character_sheet.character,
+            can_view_hidden=self._can_view_vitals(obj),
+            context=self.context,
+        )
 
 
 class RoundActionSerializer(serializers.ModelSerializer):

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -17,7 +17,8 @@ from world.combat.models import (
     CombatParticipant,
     CombatRoundAction,
 )
-from world.fatigue.constants import EffortLevel
+from world.fatigue.constants import EffortLevel, FatigueCategory
+from world.fatigue.services import get_fatigue_capacity
 from world.magic.models import CharacterTechnique, Technique
 
 # ---------------------------------------------------------------------------
@@ -84,6 +85,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
     max_health = serializers.SerializerMethodField()
     character_status = serializers.SerializerMethodField()
     available_strain = serializers.SerializerMethodField()
+    fatigue = serializers.SerializerMethodField()
 
     class Meta:
         model = CombatParticipant
@@ -95,6 +97,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
             "max_health",
             "character_status",
             "available_strain",
+            "fatigue",
         ]
 
     def _can_view_vitals(self, obj: CombatParticipant) -> bool:
@@ -174,6 +177,44 @@ class ParticipantSerializer(serializers.ModelSerializer):
         if not self._can_view_vitals(obj):
             return None
         return obj.available_strain
+
+    def get_fatigue(self, obj: CombatParticipant) -> dict[str, dict[str, int]] | None:
+        """Return the three fatigue pools (physical/social/mental).
+
+        Each pool is ``{"current": N, "capacity": M}``. ``current`` reads the
+        persisted ``FatiguePool`` row (0 when no row exists yet); ``capacity``
+        is derived from the character's endurance stats via
+        ``get_fatigue_capacity``. Gated by the same vitals-visibility rules as
+        health/strain — outsiders get ``None``.
+
+        The frontend's VitalPools component reads this to render fatigue bars
+        (replacing the ``0/10`` placeholder). See #552.
+        """
+        if not self._can_view_vitals(obj):
+            return None
+        try:
+            character_sheet = obj.character_sheet
+        except AttributeError:
+            return None
+        if character_sheet is None:
+            return None
+
+        # Read the prefetched OneToOne (select_related on the viewset queryset)
+        # exactly once — no per-category re-query. None when no row exists yet.
+        fatigue_pool = getattr(character_sheet, "fatigue", None)  # noqa: GETATTR_LITERAL — OneToOne reverse accessor may be unset
+        well_rested = fatigue_pool.well_rested if fatigue_pool else False
+        pools: dict[str, dict[str, int]] = {}
+        for category in FatigueCategory:
+            current = fatigue_pool.get_current(category.value) if fatigue_pool else 0
+            pools[category.value] = {
+                "current": current,
+                "capacity": get_fatigue_capacity(
+                    character_sheet,
+                    category.value,
+                    well_rested=well_rested,
+                ),
+            }
+        return pools
 
 
 class RoundActionSerializer(serializers.ModelSerializer):

--- a/src/world/combat/tests/test_active_conditions_serializer.py
+++ b/src/world/combat/tests/test_active_conditions_serializer.py
@@ -1,0 +1,160 @@
+"""Tests for active_conditions on Participant + Opponent serializers (#553)."""
+
+from __future__ import annotations
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from evennia_extensions.factories import AccountFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+)
+from world.combat.serializers import OpponentSerializer, ParticipantSerializer
+from world.conditions.factories import (
+    ConditionInstanceFactory,
+    ConditionTemplateFactory,
+)
+
+
+class ParticipantActiveConditionsTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.sheet = CharacterSheetFactory()
+        self.encounter = CombatEncounterFactory()
+        self.participant = CombatParticipantFactory(
+            encounter=self.encounter, character_sheet=self.sheet
+        )
+        self.encounter.participants_cached = [self.participant]
+        self.character = self.sheet.character
+
+    def _staff_request(self):
+        factory = APIRequestFactory()
+        request = factory.get("/")
+        staff = AccountFactory()
+        staff.is_staff = True
+        staff.save()
+        request.user = staff
+        return request
+
+    def _outsider_request(self):
+        factory = APIRequestFactory()
+        request = factory.get("/")
+        request.user = AccountFactory()
+        return request
+
+    def test_active_conditions_serialized_shape(self) -> None:
+        public = ConditionTemplateFactory(
+            name="PublicCondition",
+            is_visible_to_others=True,
+            display_priority=5,
+            icon="skull",
+            color_hex="#ff0000",
+        )
+        ConditionInstanceFactory(target=self.character, condition=public)
+        request = self._staff_request()
+        data = ParticipantSerializer(self.participant, context={"request": request}).data
+
+        conditions = data["active_conditions"]
+        self.assertEqual(len(conditions), 1)
+        entry = conditions[0]
+        for key in ("id", "name", "icon", "color_hex", "display_priority"):
+            self.assertIn(key, entry)
+        self.assertEqual(entry["name"], "PublicCondition")
+        self.assertEqual(entry["display_priority"], 5)
+
+    def test_hidden_condition_visible_to_staff(self) -> None:
+        hidden = ConditionTemplateFactory(name="HiddenCondition", is_visible_to_others=False)
+        ConditionInstanceFactory(target=self.character, condition=hidden)
+        request = self._staff_request()
+        data = ParticipantSerializer(self.participant, context={"request": request}).data
+        names = [c["name"] for c in data["active_conditions"]]
+        self.assertIn("HiddenCondition", names)
+
+    def test_hidden_condition_excluded_for_outsider(self) -> None:
+        public = ConditionTemplateFactory(name="PublicCondition", is_visible_to_others=True)
+        hidden = ConditionTemplateFactory(name="HiddenCondition", is_visible_to_others=False)
+        ConditionInstanceFactory(target=self.character, condition=public)
+        ConditionInstanceFactory(target=self.character, condition=hidden)
+        request = self._outsider_request()
+        data = ParticipantSerializer(self.participant, context={"request": request}).data
+        names = [c["name"] for c in data["active_conditions"]]
+        self.assertIn("PublicCondition", names)
+        self.assertNotIn("HiddenCondition", names)
+
+    def test_ordered_by_display_priority(self) -> None:
+        low = ConditionTemplateFactory(
+            name="LowPriority", is_visible_to_others=True, display_priority=1
+        )
+        high = ConditionTemplateFactory(
+            name="HighPriority", is_visible_to_others=True, display_priority=9
+        )
+        ConditionInstanceFactory(target=self.character, condition=low)
+        ConditionInstanceFactory(target=self.character, condition=high)
+        request = self._staff_request()
+        data = ParticipantSerializer(self.participant, context={"request": request}).data
+        names = [c["name"] for c in data["active_conditions"]]
+        self.assertEqual(names, ["HighPriority", "LowPriority"])
+
+    def test_empty_when_no_conditions(self) -> None:
+        request = self._staff_request()
+        data = ParticipantSerializer(self.participant, context={"request": request}).data
+        self.assertEqual(data["active_conditions"], [])
+
+
+class OpponentActiveConditionsTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.encounter = CombatEncounterFactory()
+        self.opponent = CombatOpponentFactory(encounter=self.encounter)
+        self.target = self.opponent.objectdb
+
+    def _staff_request(self):
+        factory = APIRequestFactory()
+        request = factory.get("/")
+        staff = AccountFactory()
+        staff.is_staff = True
+        staff.save()
+        request.user = staff
+        return request
+
+    def _outsider_request(self):
+        factory = APIRequestFactory()
+        request = factory.get("/")
+        request.user = AccountFactory()
+        return request
+
+    def test_opponent_public_condition_serialized(self) -> None:
+        public = ConditionTemplateFactory(
+            name="OppPublic", is_visible_to_others=True, display_priority=3
+        )
+        ConditionInstanceFactory(target=self.target, condition=public)
+        request = self._outsider_request()
+        data = OpponentSerializer(self.opponent, context={"request": request}).data
+        conditions = data["active_conditions"]
+        self.assertEqual(len(conditions), 1)
+        for key in ("id", "name", "icon", "color_hex", "display_priority"):
+            self.assertIn(key, conditions[0])
+        self.assertEqual(conditions[0]["name"], "OppPublic")
+
+    def test_opponent_hidden_condition_excluded_for_outsider(self) -> None:
+        hidden = ConditionTemplateFactory(name="OppHidden", is_visible_to_others=False)
+        ConditionInstanceFactory(target=self.target, condition=hidden)
+        request = self._outsider_request()
+        data = OpponentSerializer(self.opponent, context={"request": request}).data
+        self.assertEqual(data["active_conditions"], [])
+
+    def test_opponent_hidden_condition_visible_to_staff(self) -> None:
+        hidden = ConditionTemplateFactory(name="OppHidden", is_visible_to_others=False)
+        ConditionInstanceFactory(target=self.target, condition=hidden)
+        request = self._staff_request()
+        data = OpponentSerializer(self.opponent, context={"request": request}).data
+        names = [c["name"] for c in data["active_conditions"]]
+        self.assertIn("OppHidden", names)
+
+    def test_opponent_empty_when_no_conditions(self) -> None:
+        request = self._staff_request()
+        data = OpponentSerializer(self.opponent, context={"request": request}).data
+        self.assertEqual(data["active_conditions"], [])

--- a/src/world/combat/tests/test_participant_fatigue.py
+++ b/src/world/combat/tests/test_participant_fatigue.py
@@ -1,0 +1,111 @@
+"""Tests for fatigue pools on ParticipantSerializer (#552)."""
+
+from __future__ import annotations
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from evennia_extensions.factories import AccountFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatParticipantFactory,
+)
+from world.combat.serializers import ParticipantSerializer
+from world.fatigue.constants import (
+    CAPACITY_STAT_MULTIPLIER,
+    CAPACITY_WILLPOWER_MULTIPLIER,
+    FatigueCategory,
+)
+from world.fatigue.models import FatiguePool
+from world.fatigue.tests import setup_stat as _setup_stat
+from world.traits.models import TraitCategory
+
+
+class ParticipantSerializerFatigueTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        FatiguePool.flush_instance_cache()
+        self.sheet = CharacterSheetFactory()
+        self.encounter = CombatEncounterFactory()
+        self.participant = CombatParticipantFactory(
+            encounter=self.encounter, character_sheet=self.sheet
+        )
+        # Make the encounter's participants_cached attribute available for the
+        # vitals-permission check that walks it.
+        self.encounter.participants_cached = [self.participant]
+
+        # Give the sheet known endurance stats so capacities are deterministic.
+        char = self.sheet.character
+        _setup_stat(char, "stamina", 30, TraitCategory.PHYSICAL)  # display 3
+        _setup_stat(char, "composure", 40, TraitCategory.SOCIAL)  # display 4
+        _setup_stat(char, "stability", 50, TraitCategory.MENTAL)  # display 5
+        _setup_stat(char, "willpower", 20, TraitCategory.META)  # display 2
+
+        self.expected_capacity = {
+            FatigueCategory.PHYSICAL.value: (
+                3 * CAPACITY_STAT_MULTIPLIER + 2 * CAPACITY_WILLPOWER_MULTIPLIER
+            ),
+            FatigueCategory.SOCIAL.value: (
+                4 * CAPACITY_STAT_MULTIPLIER + 2 * CAPACITY_WILLPOWER_MULTIPLIER
+            ),
+            FatigueCategory.MENTAL.value: (
+                5 * CAPACITY_STAT_MULTIPLIER + 2 * CAPACITY_WILLPOWER_MULTIPLIER
+            ),
+        }
+
+    def _staff_request(self):
+        factory = APIRequestFactory()
+        request = factory.get("/")
+        staff = AccountFactory()
+        staff.is_staff = True
+        staff.save()
+        request.user = staff
+        return request
+
+    def test_fatigue_field_reports_current_and_capacity(self) -> None:
+        FatiguePool.objects.create(
+            character_sheet=self.sheet,
+            physical_current=4,
+            social_current=7,
+            mental_current=2,
+        )
+        request = self._staff_request()
+        data = ParticipantSerializer(self.participant, context={"request": request}).data
+
+        fatigue = data["fatigue"]
+        self.assertEqual(
+            fatigue["physical"],
+            {"current": 4, "capacity": self.expected_capacity["physical"]},
+        )
+        self.assertEqual(
+            fatigue["social"],
+            {"current": 7, "capacity": self.expected_capacity["social"]},
+        )
+        self.assertEqual(
+            fatigue["mental"],
+            {"current": 2, "capacity": self.expected_capacity["mental"]},
+        )
+
+    def test_fatigue_field_defaults_to_zero_current_with_no_pool(self) -> None:
+        # No FatiguePool row exists for this sheet -> current values default to 0,
+        # while capacity is still derived from the character's stats.
+        request = self._staff_request()
+        data = ParticipantSerializer(self.participant, context={"request": request}).data
+
+        fatigue = data["fatigue"]
+        for category in FatigueCategory:
+            self.assertEqual(fatigue[category.value]["current"], 0)
+            self.assertEqual(
+                fatigue[category.value]["capacity"],
+                self.expected_capacity[category.value],
+            )
+
+    def test_fatigue_field_hidden_from_outsiders(self) -> None:
+        FatiguePool.objects.create(character_sheet=self.sheet, physical_current=4)
+        factory = APIRequestFactory()
+        request = factory.get("/")
+        request.user = AccountFactory()
+
+        data = ParticipantSerializer(self.participant, context={"request": request}).data
+        self.assertIsNone(data["fatigue"])

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from http import HTTPMethod
 
-from django.db.models import Prefetch, QuerySet
+from django.db.models import Prefetch, Q, QuerySet
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.decorators import action
@@ -34,6 +35,7 @@ from world.combat.permissions import (
     IsInEncounterRoom,
 )
 from world.combat.serializers import (
+    ACTIVE_CONDITIONS_CACHE_ATTR,
     AddOpponentSerializer,
     AddParticipantSerializer,
     DeclareActionSerializer,
@@ -56,6 +58,7 @@ from world.combat.services import (
     run_combo_detection,
     upgrade_action_to_combo,
 )
+from world.conditions.models import ConditionInstance
 from world.covenants.models import CovenantRole
 from world.magic.models import Technique
 from world.stories.pagination import StandardResultsSetPagination
@@ -101,6 +104,33 @@ class CombatEncounterViewSet(ModelViewSet):
             return EncounterListSerializer
         return EncounterDetailSerializer
 
+    def _active_conditions_prefetch(self, lookup: str) -> Prefetch:
+        """Prefetch active ConditionInstances onto a target ObjectDB.
+
+        ``lookup`` is the relation path to the ObjectDB whose conditions we
+        want (``character_sheet__character`` for participants,
+        ``objectdb`` for opponents). The queryset mirrors
+        ``get_active_conditions`` — same suppression filter and
+        select_related — and lands on
+        ``ACTIVE_CONDITIONS_CACHE_ATTR`` so the serializer reads it
+        without an N+1. Visibility filtering + display-priority ordering
+        run in Python in the serializer.
+        """
+        not_suppressed = Q(is_suppressed=False) | Q(
+            suppressed_until__isnull=False,
+            suppressed_until__lt=timezone.now(),
+        )
+        condition_qs = ConditionInstance.objects.filter(not_suppressed).select_related(
+            "condition",
+            "condition__category",
+            "current_stage",
+        )
+        return Prefetch(
+            f"{lookup}__condition_instances",
+            queryset=condition_qs,
+            to_attr=ACTIVE_CONDITIONS_CACHE_ATTR,
+        )
+
     def _base_queryset(self) -> QuerySet[CombatEncounter]:
         return CombatEncounter.objects.select_related("scene").prefetch_related(
             Prefetch(
@@ -110,12 +140,18 @@ class CombatEncounterViewSet(ModelViewSet):
                     "character_sheet__vitals",
                     "character_sheet__fatigue",
                     "covenant_role",
-                ).filter(status=ParticipantStatus.ACTIVE),
+                )
+                .filter(status=ParticipantStatus.ACTIVE)
+                .prefetch_related(
+                    self._active_conditions_prefetch("character_sheet__character"),
+                ),
                 to_attr="participants_cached",
             ),
             Prefetch(
                 "opponents",
-                queryset=CombatOpponent.objects.all(),
+                queryset=CombatOpponent.objects.prefetch_related(
+                    self._active_conditions_prefetch("objectdb"),
+                ),
                 to_attr="opponents_cached",
             ),
             Prefetch(

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -108,6 +108,7 @@ class CombatEncounterViewSet(ModelViewSet):
                 queryset=CombatParticipant.objects.select_related(
                     "character_sheet__character",
                     "character_sheet__vitals",
+                    "character_sheet__fatigue",
                     "covenant_role",
                 ).filter(status=ParticipantStatus.ACTIVE),
                 to_attr="participants_cached",

--- a/src/world/fatigue/services.py
+++ b/src/world/fatigue/services.py
@@ -55,7 +55,12 @@ def _get_display_stat_value(character_sheet: CharacterSheet, stat_name: str) -> 
     return raw_value
 
 
-def get_fatigue_capacity(character_sheet: CharacterSheet, category: str) -> int:
+def get_fatigue_capacity(
+    character_sheet: CharacterSheet,
+    category: str,
+    *,
+    well_rested: bool | None = None,
+) -> int:
     """Calculate max fatigue capacity for a category.
 
     Formula: endurance_stat * CAPACITY_STAT_MULTIPLIER + willpower * CAPACITY_WILLPOWER_MULTIPLIER
@@ -64,6 +69,10 @@ def get_fatigue_capacity(character_sheet: CharacterSheet, category: str) -> int:
     Args:
         character_sheet: The character's sheet.
         category: FatigueCategory value (physical/social/mental).
+        well_rested: Optional pre-resolved well_rested flag. Pass it when the
+            caller already has the FatiguePool loaded (e.g. via a prefetch) to
+            avoid an extra ``get_or_create_fatigue_pool`` query. When ``None``
+            (default) the pool is fetched/created and its flag is read.
 
     Returns:
         Integer fatigue capacity.
@@ -76,8 +85,9 @@ def get_fatigue_capacity(character_sheet: CharacterSheet, category: str) -> int:
         endurance_value * CAPACITY_STAT_MULTIPLIER + willpower_value * CAPACITY_WILLPOWER_MULTIPLIER
     )
 
-    pool = get_or_create_fatigue_pool(character_sheet)
-    if pool.well_rested:
+    if well_rested is None:
+        well_rested = get_or_create_fatigue_pool(character_sheet).well_rested
+    if well_rested:
         return int(base_capacity * WELL_RESTED_MULTIPLIER)
 
     return base_capacity

--- a/src/world/mechanics/models.py
+++ b/src/world/mechanics/models.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
     from world.mechanics.types import PrerequisiteEvaluation
+    from world.traits.models import Trait
 from world.mechanics.constants import (
     SOURCE_TYPE_DISTINCTION,
     SOURCE_TYPE_UNKNOWN,
@@ -160,6 +161,15 @@ class ModifierTarget(NaturalKeyMixin, SharedMemoryModel):
     # See TECH_DEBT.md §"Future Target FKs" for full tracking list.
     objects = ModifierTargetManager()
 
+    # Class-level cache mapping target_trait_id -> ModifierTarget, mirroring
+    # Trait._name_to_trait_map. The stat-modifier hot path (TraitHandler.
+    # _get_stat_modifier) resolves a ModifierTarget by its target_trait FK
+    # per stat read; that lookup is keyed by a non-PK field, so it misses the
+    # SharedMemoryModel identity map and re-queries each call. This cache
+    # serves it from memory after the first build (#552).
+    _trait_cache_built = False
+    _trait_to_target_map: dict[int, "ModifierTarget"] = {}
+
     class Meta:
         unique_together = ["category", "name"]
         ordering = ["category__display_order", "display_order", "name"]
@@ -170,6 +180,42 @@ class ModifierTarget(NaturalKeyMixin, SharedMemoryModel):
 
     def __str__(self):
         return f"{self.name} ({self.category.name})"
+
+    @classmethod
+    def get_for_trait(cls, trait: "Trait") -> "ModifierTarget | None":
+        """Return the ModifierTarget whose ``target_trait`` is ``trait`` (cached).
+
+        Keyed by ``target_trait_id`` so repeated stat-modifier lookups don't
+        re-query. Returns ``None`` when no target points at the trait.
+        """
+        if not cls._trait_cache_built:
+            cls._build_trait_cache()
+        return cls._trait_to_target_map.get(trait.pk)
+
+    @classmethod
+    def _build_trait_cache(cls) -> None:
+        """Build the target_trait_id -> ModifierTarget mapping."""
+        cls._trait_to_target_map = {
+            target.target_trait_id: target
+            for target in cls.objects.filter(target_trait__isnull=False)
+        }
+        cls._trait_cache_built = True
+
+    @classmethod
+    def clear_trait_cache(cls) -> None:
+        """Clear the target_trait cache (call when targets are modified)."""
+        cls._trait_cache_built = False
+        cls._trait_to_target_map = {}
+
+    def save(self, *args: object, **kwargs: object) -> None:
+        """Invalidate the target_trait cache on any ModifierTarget mutation."""
+        super().save(*args, **kwargs)
+        type(self).clear_trait_cache()
+
+    def delete(self, *args: object, **kwargs: object) -> object:
+        """Invalidate the target_trait cache when a target is removed."""
+        type(self).clear_trait_cache()
+        return super().delete(*args, **kwargs)
 
 
 class ModifierSource(SharedMemoryModel):

--- a/src/world/traits/handlers.py
+++ b/src/world/traits/handlers.py
@@ -185,33 +185,37 @@ class TraitHandler:
         # Check if this is a stat that might have modifiers
         trait = Trait.get_by_name(trait_name)
         if trait and trait.trait_type == TraitType.STAT:
-            modifier = self._get_stat_modifier(trait_name.lower())
+            modifier = self._get_stat_modifier(trait)
             return base_value + modifier
 
         return base_value
 
-    def _get_stat_modifier(self, stat_name: str) -> int:
+    def _get_stat_modifier(self, trait: "Trait") -> int:
         """
         Get the total modifier for a stat from character's distinctions etc.
 
         Uses the ModifierTarget.target_trait FK for type-safe lookup
-        instead of string matching.
+        instead of string matching. Takes the already-resolved ``Trait``
+        instance (from ``get_trait_value``'s cached ``get_by_name``) so no
+        redundant ``Trait.objects.get(name__iexact=...)`` query fires, and
+        resolves the ModifierTarget through ``ModifierTarget.get_for_trait``
+        — a class-level cache keyed by ``target_trait_id`` — so neither the
+        trait nor the target lookup re-queries per call. This kept fatigue
+        capacity (which resolves 6 stat values per participant) from firing
+        a per-stat N+1 on the combat detail hot path (#552).
         """
         from world.mechanics.models import ModifierTarget  # noqa: PLC0415
         from world.mechanics.services import get_modifier_total  # noqa: PLC0415
-        from world.traits.models import Trait  # noqa: PLC0415
 
         try:
             sheet = self.character.sheet_data
         except Exception:  # noqa: BLE001
             return 0
 
-        try:
-            trait = Trait.objects.get(name__iexact=stat_name)
-            target = ModifierTarget.objects.get(target_trait=trait)
-            return get_modifier_total(sheet, target)
-        except (Trait.DoesNotExist, ModifierTarget.DoesNotExist):
+        target = ModifierTarget.get_for_trait(trait)
+        if target is None:
             return 0
+        return get_modifier_total(sheet, target)
 
     def get_trait_display_value(self, trait_name: str) -> float:
         """


### PR DESCRIPTION
Closes #552
Closes #553

## Summary

Two combat-state surfacing completions for the "Next Playable Boss Fight" milestone — heavy reuse, no migrations.

**#552 — fatigue pools on VitalPools.** `ParticipantSerializer` now exposes a `fatigue` field (physical/social/mental `{current, capacity}`, sourced from `FatiguePool` + `get_fatigue_capacity`), gated on vitals-view permission (null for outsiders). `VitalPools.tsx` renders the real values (the `0/10` placeholder is gone). **`available_strain` stays anima** (ratified — strain *is* anima); the anima→fatigue "pushing" cost is a separate future mechanic tracked in #624.

**#553 — conditions on CombatantsList rows.** `ParticipantSerializer` + `OpponentSerializer` expose `active_conditions` (reusing `ConditionInstanceSerializer` + `get_active_conditions`), visibility-filtered (hidden conditions only to owner/GM/staff). A new `ConditionBadge` renders each condition's icon/color on combatant rows and **deep-links into the condition detail modal shipped in #551** (`openDeepLink({modal:'condition', id})` → `DeepLinkModalHost`) — no new modal.

## Performance (N+1 fix)
Exposing fatigue surfaced a pre-existing per-participant N+1: `get_fatigue_capacity` → `TraitHandler._get_stat_modifier` fired uncached name-based `Trait` + `ModifierTarget` lookups per stat per category per participant. Fixed by reusing the codebase's existing class-cache pattern — passing the already-cached `Trait` into `_get_stat_modifier`, and adding `ModifierTarget.get_for_trait` (mirrors `Trait._name_to_trait_map`, with save/delete invalidation). The warm-retrieve query count holds at **5** (`test_view_query_counts`); fatigue/conditions are served from warm prefetches + the class cache. Conditions are prefetched via `Prefetch(to_attr="active_condition_instances")`.

## Also
- `just gen-api-types` now prettier-normalizes `api.d.ts`, so the diff is the real schema change instead of a whole-file quote/indent reflow (this churn wasted time on two prior PRs).

## Verification
- Final whole-branch review: APPROVED (security/visibility, N+1 + cache-invalidation, anti-reinvention, correctness all verified).
- **PG parity (CI tier): 313/313** — the new tests + `test_view_query_counts` + full `world.mechanics`/`world.traits`/`world.fatigue`.
- Frontend: VitalPools/CombatantsList/ConditionBadge 25/25 (full suite 1691 green pre-rebase).
- No migration; no model field changes (the `ModifierTarget` cache is class-level Python). Rebased clean onto current `main` (post #619/#620/#623 merges).

## Follow-ups
- #624 — fatigue cost from pushing (anima-spend on action-typed techniques accrues fatigue; strain amplifies). Blocked on #614.
- #614 — physical/social/mental technique taxonomy (would enable per-category strain binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
