### PR TITLE
Add CombatOpponent portrait FK + use in PersonaAvatar fallback

### DIFF
--- a/frontend/src/combat/__tests__/ActiveState.test.tsx
+++ b/frontend/src/combat/__tests__/ActiveState.test.tsx
@@ -57,6 +57,8 @@ function makeEncounter(clashes: ClashState[] = []): EncounterDetail {
         soak_value: null,
         probing_threshold: null,
         active_conditions: [],
+        thumbnail_url: '',
+        thumbnail_media_url: null,
       },
     ],
     current_round_actions: [],

--- a/frontend/src/combat/__tests__/CombatantsList.test.tsx
+++ b/frontend/src/combat/__tests__/CombatantsList.test.tsx
@@ -20,9 +20,20 @@ type ConditionInstance = components['schemas']['ConditionInstance'];
 // ---------------------------------------------------------------------------
 
 vi.mock('@/components/PersonaAvatar', () => ({
-  PersonaAvatar: ({ source }: { source: { name: string } }) => (
-    <span data-testid="persona-avatar">{source.name[0].toUpperCase()}</span>
-  ),
+  PersonaAvatar: ({
+    source,
+  }: {
+    source: { name: string; thumbnailUrl?: string | null; thumbnailMediaUrl?: string | null };
+  }) => {
+    const url = source.thumbnailMediaUrl ?? source.thumbnailUrl ?? null;
+    return url ? (
+      <span data-testid="persona-avatar">
+        <img src={url} alt={source.name} />
+      </span>
+    ) : (
+      <span data-testid="persona-avatar">{source.name[0].toUpperCase()}</span>
+    );
+  },
 }));
 
 import { CombatantsList } from '../sections/CombatantsList';
@@ -85,6 +96,8 @@ function makeOpponent(overrides: Partial<Opponent> = {}): Opponent {
     soak_value: null,
     probing_threshold: null,
     active_conditions: [],
+    thumbnail_url: '',
+    thumbnail_media_url: null,
     ...overrides,
   };
 }
@@ -151,6 +164,44 @@ describe('CombatantsList', () => {
     expect(screen.getByTestId('opponent-row-11')).toBeInTheDocument();
     expect(screen.getByText('Mire Knight')).toBeInTheDocument();
     expect(screen.getByText('Shadow Archer')).toBeInTheDocument();
+  });
+
+  it('renders an opponent portrait when a thumbnail media URL is present', () => {
+    const encounter = makeEncounter(
+      [],
+      [
+        makeOpponent({
+          id: 21,
+          name: 'Ogre',
+          thumbnail_media_url: 'https://media.example/ogre.png',
+        }),
+      ]
+    );
+
+    render(<CombatantsList encounter={encounter} />, { wrapper: createWrapper() });
+
+    const row = screen.getByTestId('opponent-row-21');
+    const img = within(row).getByRole('img');
+    expect(img).toHaveAttribute('src', 'https://media.example/ogre.png');
+  });
+
+  it('renders an initial-letter avatar for an opponent without a thumbnail', () => {
+    const encounter = makeEncounter(
+      [],
+      [
+        makeOpponent({
+          id: 22,
+          name: 'Wraith',
+          thumbnail_media_url: null,
+        }),
+      ]
+    );
+
+    render(<CombatantsList encounter={encounter} />, { wrapper: createWrapper() });
+
+    const row = screen.getByTestId('opponent-row-22');
+    expect(within(row).queryByRole('img')).not.toBeInTheDocument();
+    expect(within(row).getByText('W')).toBeInTheDocument();
   });
 
   it('NPC rows have destructive styling to distinguish from PCs', () => {

--- a/frontend/src/combat/sections/CombatantsList.tsx
+++ b/frontend/src/combat/sections/CombatantsList.tsx
@@ -5,9 +5,9 @@
  *   thumbnail would require a separate query per PC; deferred to a follow-up task).
  *   Source: EncounterDetail.participants.
  *
- * NPC rows: PersonaAvatar (initial-letter only — CombatOpponent has no Persona FK;
- *   v1 uses name-derived initial letter, a portrait FK addition is a future task).
- *   Source: EncounterDetail.opponents.
+ * NPC rows: PersonaAvatar resolving the opponent's persona thumbnail (serializer
+ *   `thumbnail_url` / `thumbnail_media_url`), falling back to a name-derived initial
+ *   letter when the opponent has no persona. Source: EncounterDetail.opponents.
  *
  * NPCs are visually distinct from PCs via a destructive-tinted border + background.
  *
@@ -145,10 +145,17 @@ function OpponentRow({ opponent }: OpponentRowProps) {
       )}
       data-testid={`opponent-row-${opponent.id}`}
     >
-      {/* Avatar — initial-letter only. CombatOpponent has no Persona FK in v1.
-       * TODO(avatars): add portrait FK to CombatOpponent and resolve here.
+      {/* Avatar — portrait resolves via the opponent's persona thumbnail; falls
+       * back to an initial-letter avatar when the opponent is persona-less.
        */}
-      <PersonaAvatar source={{ name: opponent.name }} size="sm" />
+      <PersonaAvatar
+        source={{
+          name: opponent.name,
+          thumbnailUrl: opponent.thumbnail_url,
+          thumbnailMediaUrl: opponent.thumbnail_media_url,
+        }}
+        size="sm"
+      />
 
       <div className="min-w-0 flex-1">
         <p className="truncate text-xs font-medium text-foreground">{opponent.name}</p>

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -2341,7 +2341,7 @@ export interface paths {
      *
      *     Effects derived from existing model state — combo upgrade, ConditionInstance
      *     correlation by source_technique + applied_at window, target status from
-     *     CombatOpponent.status / CharacterVitals.status. No new audit tables.
+     *     CombatOpponent.status / CharacterVitals.life_state. No new audit tables.
      */
     get: operations['combat_action_outcome_details_retrieve'];
     put?: never;
@@ -14662,6 +14662,22 @@ export interface components {
       readonly active_conditions: {
         [key: string]: unknown;
       }[];
+      /**
+       * @description Direct portrait URL, resolved through the opponent's persona.
+       *
+       *     Mirrors ``PersonaSerializer.thumbnail_url`` (the persona's
+       *     ``thumbnail_url`` URLField — ``""`` when unset). Persona-less
+       *     opponents (``persona=None``) return ``None``.
+       */
+      readonly thumbnail_url: string | null;
+      /**
+       * @description PlayerMedia portrait URL, resolved through the opponent's persona.
+       *
+       *     Mirrors ``PersonaSerializer.get_thumbnail_media_url``: returns the
+       *     linked ``PlayerMedia.cloudinary_url``, or ``None`` when the persona
+       *     has no thumbnail (or the opponent has no persona).
+       */
+      readonly thumbnail_media_url: string | null;
     };
     /**
      * @description Read serializer for combat opponents.

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -86,6 +86,8 @@ class OpponentSerializer(serializers.ModelSerializer):
     soak_value = serializers.SerializerMethodField()
     probing_threshold = serializers.SerializerMethodField()
     active_conditions = serializers.SerializerMethodField()
+    thumbnail_url = serializers.SerializerMethodField()
+    thumbnail_media_url = serializers.SerializerMethodField()
 
     class Meta:
         model = CombatOpponent
@@ -102,6 +104,8 @@ class OpponentSerializer(serializers.ModelSerializer):
             "current_phase",
             "status",
             "active_conditions",
+            "thumbnail_url",
+            "thumbnail_media_url",
         ]
 
     def _is_gm_or_staff(self) -> bool:
@@ -136,6 +140,28 @@ class OpponentSerializer(serializers.ModelSerializer):
             can_view_hidden=self._is_gm_or_staff(),
             context=self.context,
         )
+
+    def get_thumbnail_url(self, obj: CombatOpponent) -> str | None:
+        """Direct portrait URL, resolved through the opponent's persona.
+
+        Mirrors ``PersonaSerializer.thumbnail_url`` (the persona's
+        ``thumbnail_url`` URLField — ``""`` when unset). Persona-less
+        opponents (``persona=None``) return ``None``.
+        """
+        if obj.persona_id is None:
+            return None
+        return obj.persona.thumbnail_url
+
+    def get_thumbnail_media_url(self, obj: CombatOpponent) -> str | None:
+        """PlayerMedia portrait URL, resolved through the opponent's persona.
+
+        Mirrors ``PersonaSerializer.get_thumbnail_media_url``: returns the
+        linked ``PlayerMedia.cloudinary_url``, or ``None`` when the persona
+        has no thumbnail (or the opponent has no persona).
+        """
+        if obj.persona_id is None or obj.persona.thumbnail_id is None:
+            return None
+        return obj.persona.thumbnail.cloudinary_url
 
 
 class ParticipantSerializer(serializers.ModelSerializer):

--- a/src/world/combat/tests/test_opponent_portrait_serializer.py
+++ b/src/world/combat/tests/test_opponent_portrait_serializer.py
@@ -1,0 +1,58 @@
+"""Tests for opponent portrait fields on OpponentSerializer (#554).
+
+The portrait is resolved through the opponent's IDENTITY
+(``CombatOpponent.persona``), not a dedicated field — ``Persona`` already
+owns the thumbnail. ``OpponentSerializer`` mirrors ``PersonaSerializer``'s
+``thumbnail_url`` / ``thumbnail_media_url`` semantics so opponents and
+personas behave identically on the frontend.
+
+Built in ``setUp`` rather than ``setUpTestData``: ``CombatOpponentFactory``
+caches an Evennia ObjectDB on the model (a ``DbHolder``), which is not
+deepcopyable — so storing opponent instances as class attributes breaks the
+``setUpTestData`` deepcopy. See the factory docstring.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from world.combat.factories import CombatEncounterFactory, CombatOpponentFactory
+from world.combat.serializers import OpponentSerializer
+from world.roster.factories import PlayerMediaFactory
+from world.scenes.factories import PersonaFactory
+
+
+class OpponentPortraitSerializerTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.encounter = CombatEncounterFactory()
+
+    def test_persona_with_thumbnail_exposes_media_and_direct_url(self) -> None:
+        media = PlayerMediaFactory()
+        persona = PersonaFactory(
+            thumbnail=media,
+            thumbnail_url="https://cdn.example/direct.png",
+        )
+        opponent = CombatOpponentFactory(encounter=self.encounter, persona=persona)
+
+        data = OpponentSerializer(opponent).data
+        self.assertEqual(data["thumbnail_media_url"], media.cloudinary_url)
+        self.assertEqual(data["thumbnail_url"], "https://cdn.example/direct.png")
+
+    def test_persona_without_thumbnail_returns_none_media_url(self) -> None:
+        persona = PersonaFactory(thumbnail=None, thumbnail_url="")
+        opponent = CombatOpponentFactory(encounter=self.encounter, persona=persona)
+
+        data = OpponentSerializer(opponent).data
+        self.assertIsNone(data["thumbnail_media_url"])
+        # Matches PersonaSerializer: thumbnail_url is the model URLField,
+        # which is "" (blank) when unset.
+        self.assertEqual(data["thumbnail_url"], "")
+
+    def test_persona_less_opponent_returns_none_for_both(self) -> None:
+        # Factory default: persona=None (ephemeral MOOK).
+        opponent = CombatOpponentFactory(encounter=self.encounter)
+
+        data = OpponentSerializer(opponent).data
+        self.assertIsNone(data["thumbnail_media_url"])
+        self.assertIsNone(data["thumbnail_url"])

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -149,7 +149,9 @@ class CombatEncounterViewSet(ModelViewSet):
             ),
             Prefetch(
                 "opponents",
-                queryset=CombatOpponent.objects.prefetch_related(
+                queryset=CombatOpponent.objects.select_related(
+                    "persona__thumbnail",
+                ).prefetch_related(
                     self._active_conditions_prefetch("objectdb"),
                 ),
                 to_attr="opponents_cached",


### PR DESCRIPTION
Closes #554

## Summary

NPC combat opponents now render a real portrait in the CombatantsList instead of an initial-letter avatar.

**Design decision (anti-reinvention / verify-against-code):** the issue proposed adding a `portrait` FK to `CombatOpponent`, but `CombatOpponent` already has a `persona` FK and `Persona` already owns the appearance source of truth (`thumbnail` → `PlayerMedia`). A separate portrait field would duplicate a derivable value. Per maintainer ratification (every opponent will have an identity — Persona or a future template carrying one), the portrait is **resolved through the persona**, with **no new model field and no migration**.

**Backend** (`cc5b74cd`): `OpponentSerializer` gains `thumbnail_url` + `thumbnail_media_url` (same names/semantics as `PersonaSerializer`), resolved via `opponent.persona`; `select_related("persona__thumbnail")` added to the encounter-detail queryset to avoid N+1.

**Frontend** (`492f36a1`): `OpponentRow` passes the resolved URLs into the existing `PersonaAvatar` (which already does image→initials fallback); API types regenerated.

**Testing:** new backend serializer tests (persona-with-thumbnail → URL, persona-without → null, persona-less → null) pass on the SQLite tier; `test_view_query_counts` unchanged (confirms no N+1). Full frontend suite green (172 files, 1695 tests). PG parity left to CI (a sibling worktree contends on the shared Postgres test DB this session).

**Follow-up:** PC participant portraits (`ParticipantRow` still initials-only) filed as a separate issue — same pattern applied to participants via primary persona.

## Follow-ups filed

(none)

## Notes

- Brainstorm/plan: ran (design resolved interactively with the maintainer; lightweight — no separate spec doc, anti-reinvention ledger embedded above)
- Sync-with-main: Rebased onto origin/main; no conflicts.

<!-- last-addressed-comment: 0 -->