### PR TITLE
feat(magic): surface teacher display name on teaching offers (closes #540)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -19358,6 +19358,7 @@ export interface components {
       readonly id: number;
       /** @description Teaching tenure offering this unlock. */
       readonly teacher: number;
+      readonly teacher_display_name: string;
       /** @description Authored unlock being offered. */
       readonly unlock: number;
       readonly unlock_target_kind: string;

--- a/frontend/src/magic/CLAUDE.md
+++ b/frontend/src/magic/CLAUDE.md
@@ -229,8 +229,9 @@ Step 2: select anchor. Step 3: name + description + confirm. Calls `useWeaveThre
 ### `components/threads/TeachingOfferCard.tsx`
 
 Card for a single `ThreadWeavingTeachingOffer` in `WeavingTeachingOffersPage`. Shows offer
-details and opens `AcceptOfferDialog`. Teacher display name currently shows "Teacher #N"
-pending a name-lookup endpoint.
+details and opens `AcceptOfferDialog`. Teacher is shown via the anonymity-respecting
+`RosterTenure.display_name` (e.g. "2nd player of Ariel") surfaced as
+`teacher_display_name` on the serializer.
 
 ### `components/threads/AcceptOfferDialog.tsx`
 

--- a/frontend/src/magic/__tests__/queries.test.tsx
+++ b/frontend/src/magic/__tests__/queries.test.tsx
@@ -497,6 +497,7 @@ const mockThreadHubSummary = {
 const mockTeachingOffer = {
   id: 1,
   teacher: 5,
+  teacher_display_name: '1st player of Ember',
   unlock: 10,
   unlock_target_kind: 'TRAIT',
   unlock_display_name: 'Fire Shaping',

--- a/frontend/src/magic/components/threads/TeachingOfferCard.tsx
+++ b/frontend/src/magic/components/threads/TeachingOfferCard.tsx
@@ -2,8 +2,8 @@
  * TeachingOfferCard — displays a single ThreadWeavingTeachingOffer.
  *
  * Shows:
- *  - Teacher (RosterTenure PK — displayed as "Teacher #N" for v1 since the
- *    serializer does not embed a display name field)
+ *  - Teacher display name (anonymity-respecting; e.g. "2nd player of Ariel"
+ *    from RosterTenure.display_name via serializer.teacher_display_name)
  *  - Unlock description (unlock_target_kind + unlock_display_name)
  *  - Pitch text
  *  - XP cost (effective_xp_cost_for_viewer, already Path-multiplied)
@@ -32,7 +32,7 @@ export function TeachingOfferCard({ offer, onAccept }: TeachingOfferCardProps) {
         <div className="min-w-0 flex-1 space-y-1">
           {/* Teacher */}
           <p className="text-sm font-medium text-foreground" data-testid="teaching-offer-teacher">
-            Teacher #{offer.teacher}
+            {offer.teacher_display_name}
           </p>
 
           {/* Unlock description */}

--- a/frontend/src/magic/pages/__tests__/WeavingTeachingOffersPage.test.tsx
+++ b/frontend/src/magic/pages/__tests__/WeavingTeachingOffersPage.test.tsx
@@ -39,6 +39,7 @@ const makeOffer = (
 ): ThreadWeavingTeachingOffer => ({
   id: 1,
   teacher: 42,
+  teacher_display_name: '2nd player of Ariel',
   unlock: 10,
   unlock_target_kind: 'TRAIT',
   unlock_display_name: 'Persuasion',
@@ -128,7 +129,7 @@ describe('WeavingTeachingOffersPage', () => {
 
     expect(screen.getByTestId('teaching-offers-list')).toBeInTheDocument();
     expect(screen.getByTestId('teaching-offer-card-1')).toBeInTheDocument();
-    expect(screen.getByTestId('teaching-offer-teacher')).toHaveTextContent('Teacher #42');
+    expect(screen.getByTestId('teaching-offer-teacher')).toHaveTextContent('2nd player of Ariel');
     expect(screen.getByTestId('teaching-offer-unlock')).toHaveTextContent('TRAIT');
     expect(screen.getByTestId('teaching-offer-unlock')).toHaveTextContent('Persuasion');
     expect(screen.getByTestId('teaching-offer-xp-cost')).toHaveTextContent('8 XP');

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -1025,6 +1025,11 @@ class ThreadWeavingTeachingOfferSerializer(serializers.ModelSerializer):
     unlock_target_kind = serializers.CharField(source="unlock.target_kind", read_only=True)
     unlock_display_name = serializers.CharField(source="unlock.display_name", read_only=True)
     unlock_xp_cost = serializers.IntegerField(source="unlock.xp_cost", read_only=True)
+    # Anonymity-respecting display from RosterTenure.display_name — e.g. "2nd
+    # player of Ariel". Replaces the raw teacher PK in the UI (#540). Path:
+    # teacher (RosterTenure) → roster_entry → character_sheet → character.
+    # ViewSet's select_related extends through this chain to avoid N+1.
+    teacher_display_name = serializers.CharField(source="teacher.display_name", read_only=True)
     effective_xp_cost_for_viewer = serializers.SerializerMethodField()
 
     class Meta:
@@ -1032,6 +1037,7 @@ class ThreadWeavingTeachingOfferSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "teacher",
+            "teacher_display_name",
             "unlock",
             "unlock_target_kind",
             "unlock_display_name",

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -857,6 +857,9 @@ class ThreadWeavingTeachingOfferViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = ThreadWeavingTeachingOffer.objects.select_related(
         "teacher",
+        # FK chain consumed by ThreadWeavingTeachingOfferSerializer.teacher_display_name
+        # (RosterTenure.display_name walks roster_entry → character_sheet → character).
+        "teacher__roster_entry__character_sheet__character",
         "unlock",
         "unlock__unlock_trait",
         "unlock__unlock_gift",


### PR DESCRIPTION
## Summary

Closes #540. TeachingOfferCard was rendering "Teacher #N" (raw RosterTenure PK) because the serializer didn't expose a display-name field. This PR surfaces the existing **anonymity-respecting** `RosterTenure.display_name` (e.g. "2nd player of Ariel") as a new `teacher_display_name` field — minimal, reuses what's already there.

## What changed

**Backend:**
- `ThreadWeavingTeachingOfferSerializer` — new `teacher_display_name = CharField(source="teacher.display_name", read_only=True)`. Read-only, sourced from the existing property on `RosterTenure`.
- `ThreadWeavingTeachingOfferViewSet.queryset` — extends `select_related` to `teacher__roster_entry__character_sheet__character` (the FK chain `RosterTenure.display_name` walks). N+0 per row instead of N+3.

**Frontend:**
- `TeachingOfferCard` reads `offer.teacher_display_name` instead of `Teacher #{offer.teacher}`.
- Regenerated `api.d.ts` carries the new field.
- Test fixture + assertion updated.
- `magic/CLAUDE.md` note refreshed (was flagged "pending a name-lookup endpoint"; now resolved).

## Why `RosterTenure.display_name` and not something else

It already exists and is used by `RosterTenureAdmin.list_display` — so the format is the project convention. Returns:
- `"2nd player of Ariel"` when player_number is set (the anonymity layer Arx II uses)
- `"Player of Ariel"` when player_number is null
- `"Unknown Character"` defensively if `roster_entry` is null

This is the right level of disclosure: shows who the character is, hides which specific player. Matches the project's anonymity model from `roster/CLAUDE.md`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest WeavingTeachingOffersPage` — 9/9 pass (fixture + assertion updated for the new field)
- [x] `arx test world.magic.tests.test_api world.magic.tests.test_teaching_offer_accept_view` — 57/57 OK
- [x] pre-commit clean (prettier auto-formatted, ran twice)
- [ ] Visual sanity check on a deployed teaching offer (out of scope for this PR — the test fixtures cover the rendering contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)