### PR TITLE
Pre-cast power read-back — derived power vs channeled intensity (#524)

### DIFF
--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -482,6 +482,17 @@ examine-decoration `sections` on the mutable `ExaminePrePayload` + render-back i
 (scar presence-escalation), and wiring `TriggerHandler.reset_scene_counts` to a
 scene-boundary event.
 
+**Power vs Intensity (epic #633, Issue 0 = #524):** introduced a derived, never-stored
+`power` value distinct from channeled `intensity`. A pre-cast `TECHNIQUE_PRE_CAST`
+`MODIFY_PAYLOAD` on `power` now reaches resolution (the discarded-edit gap is closed);
+combat scales damage/conditions on the injected power (folding in the caster's full
+intensity envelope + pull bumps — front edge of Direction C). Intensity still solely
+drives anima cost, mishap, resonance attribution, and Soulfray (a ward never reduces it).
+Power is recomputed each cast via `_derive_power` (`world/magic/services/techniques.py`);
+later issues #634-#639 add modifier/level/thread/aura/Audere terms, the persistent-buff
+surface, Direction-C consolidation, and the Direction-B pipeline. Research +
+candidate-directions report: `docs/superpowers/specs/2026-05-30-power-intensity-research-report.md`.
+
 Scope 5.5 is the deliberate "light up flows/triggers" PR. It must follow Scope 5
 **sooner rather than later** — mage scars without reactive side effects are
 half a feature, and every later system that wants reactive behavior is blocked

--- a/docs/superpowers/specs/2026-05-30-power-intensity-research-critique.md
+++ b/docs/superpowers/specs/2026-05-30-power-intensity-research-critique.md
@@ -1,0 +1,64 @@
+I now have enough verified ground truth to write the critique. My code reads confirm the report is largely accurate but materially incomplete in several specific, high-value ways. Returning the prioritized gap analysis.
+
+---
+
+# Completeness Critique — Power vs. Intensity Research Report
+
+The report is well-anchored and its verified code claims (the two functions, the `target_damage_type` FK, `EQUIPMENT_RELEVANT_CATEGORIES` membership, the discarded pre-cast payload) all check out against the code. But for a "range widely before committing" mandate it converges too early, misses an already-built precedent that changes the risk calculus, and under-states several tradeoffs. Prioritized gaps below.
+
+## P0 — Must address before the design conversation
+
+**1. The report misses an already-wired MODIFY_PAYLOAD read-back precedent that directly de-risks Issue 1 and informs the whole architecture.**
+`world/magic/services/corruption.py:389-427` already does *exactly* the pattern the report frames as an open, unsolved gap: it builds a `CorruptionAccruingPayload`, emits `CORRUPTION_ACCRUING`, then **reads `pre_payload.amount` back** after dispatch, short-circuits on zero, and re-reads for partial absorption. This is the canonical "reactive subscriber reduces the landed value, not the channeled cost" mechanic — the user's exact ward-reduces-power invariant, already shipped for corruption. The report's Section 2.4 / Issue 1 treat the read-back as novel surgery. It is not; it is a copy of a working pattern.
+*Concrete follow-up:* Add a section reconciling the new work against `corruption.py`'s pre-mutation-event idiom. This is itself a latent **parallel-implementation risk** the report failed to flag: if Issue 1 invents a *different* read-back convention than the corruption path, you get two divergent reactive-payload idioms in the same app. The design should adopt the corruption idiom or refactor both onto a shared helper.
+
+**2. The "three scaling formulas" claim is wrong in count and wrong about consistency — and the discrepancy is load-bearing.**
+There are **four** intensity-scaling sites, not three: `TechniqueCapabilityGrant.compute_value` (`models/techniques.py:468`), `TechniqueAppliedCondition.compute_severity` (`:657`) and `.compute_duration_rounds` (`:672`), and `TechniqueDamageProfile.compute_damage_budget` (`:736`) — four distinct multiplier fields (`intensity_multiplier`, `severity_intensity_multiplier`, `duration_intensity_multiplier`, `damage_intensity_multiplier`). More importantly: **capability grants already diverge from combat.** `compute_value` falls back to `self.technique.intensity` when `effective_intensity is None` (`:465-467`), and the combat resolver does *not* pass it an effective intensity. So capability magnitude today ignores combat pull bumps entirely — it is a *third* intensity-reading behavior, contradicting the report's clean "world-side family all reads `compute_effective_intensity`" picture (Section 3.2 lists the capability grant under world-side, but in code it's not wired to the combat function at all).
+*Concrete follow-up:* Re-audit which of the four formulas actually receive `effective_intensity` from a live caller vs. silently fall back to `technique.intensity`. The intensity→power migration (Issue 2/3) must enumerate all four and confirm each call path, or the "atomic one-line swap" promised in Issue 2 will miss the capability path.
+
+## P1 — Significant gaps that narrow the option space prematurely
+
+**3. Converged too early on four "architectures" that are mostly the same decision dressed differently; missed genuinely distinct axes.**
+Directions A/B/C are largely *the same mechanism* (route power through `CharacterModifier` + `get_modifier_breakdown`) differing only in *where the function lives*. Only D is conceptually distinct. The report presents four directions but the real decision tree has under-explored orthogonal axes it never separates:
+   - **Where power is derived** (runtime-stats fn vs. combat fn vs. pipeline vs. model method) — what A/B/C actually vary.
+   - **When power is computed** (snapshot at cast vs. re-derived) — raised only in passing for B/D; relevant to *all* of them.
+   - **Whether power is a stored field, a transient computed value, or an event-payload value** — never cleanly posed.
+   - **Whether power is scalar or vectored** (one number vs. per-facet like PoE Power Level fanning to magnitude/penetration/area separately) — the report cites PoE Power Level as supporting a single scalar, but the opposite reading (power as a small struct) is never offered as a candidate.
+*Concrete follow-up:* Re-cast Section 5 as a decision matrix over these orthogonal axes rather than four pre-bundled packages. The bundling hides combinations (e.g., "scalar power as transient field on RuntimeTechniqueStats, re-derived, no penetration contest") that may dominate.
+
+**4. The "no parallel implementations" constraint is applied to the two intensity functions but NOT to the four scaling formulas or the corruption precedent.**
+The report correctly flags `get_runtime_technique_stats` vs `compute_effective_intensity`. But per the codebase's own anti-reinvention rule, the **four near-identical `base + mult × intensity` formulas** are a textbook parallel-impl smell that the report relegates to an "open question" (7.1 #3) rather than a constraint violation to resolve. And see P0#1 — the reactive read-back is a third parallel-impl exposure. Given the user's hard "no parallel implementations" stance, these should be P0/P1 *findings*, not optional refactors.
+
+**5. Buffs-via-existing-modifier-system: the report endorses this but never verifies `get_modifier_breakdown` can express what power needs.**
+Directions B and the PoE/GAS lessons require multiplicative and override ops. The report admits (B's cons, D) that the current breakdown is **additive-only** and that extending it is "its own design" — but never actually reads `get_modifier_breakdown` to confirm it's additive-only, nor checks whether amplification (mentioned at 2.3) already provides a multiplicative hook. If "buffs via existing modifier system" is a hard constraint and the existing system is additive-only, then "+50% power to fire" is **not currently expressible** and that is a gating finding, not a footnote.
+*Concrete follow-up:* Read `get_modifier_breakdown` / `get_modifier_total` and the amplification logic. Determine concretely whether multiplicative power buffs are in-scope of the existing system or require extending it. This decides whether the "use the existing modifier system" mandate is even satisfiable for the multiplicative use cases.
+
+## P2 — Tradeoffs stated too weakly; angles not consulted
+
+**6. Direction D's double-counting risk is the most important tradeoff in the report and is hand-waved.**
+D introduces a penetration-vs-resistance contest "that would interact with the existing check/clash and damage-budget systems (potential double-counting of 'defense')." This is stated as a one-line con but it's potentially **disqualifying** — Arxii already resolves defense three ways (checks, clash, damage budgets). The report should either rule D out on these grounds or do the work of showing how penetration coexists with clash. As written it lets D look more viable than the code supports.
+
+**7. Game-design angles not consulted that would add value:**
+   - **Failure/mishap as the reward-side of power, not just cost-side.** The report keeps Soulfray/mishap purely on the channeled axis (correct), but never explores whether *low landed power despite high channel* (warded-to-zero) should feed back into mishap/Soulfray narrative — WFRP/Shadowrun lessons are cited but only for cost-on-channel, not for the dramatically interesting "you overpaid and it bounced" state beyond D's outcome label.
+   - **No consultation of the existing `clash` strain_commitment axis as a possible third lever.** Clash check rolls are driven by `strain_commitment`, not intensity (the report flags this as intensity-independent). But strain_commitment is conceptually adjacent to "how hard you're pushing" — the report never asks whether power should relate to strain_commitment at all, treating them as fully orthogonal without justification.
+   - **Resonance/corruption attribution under amped power.** If a pre-cast amp raises landed power, does per-resonance corruption attribution (which the report keeps on intensity) still feel right narratively when an *external* amp did the work. Edge case worth a design opinion.
+
+**8. Use cases not covered:**
+   - **Multi-target / AoE power division** — does landed power split across targets, or apply per-target. None of the directions address it; the damage-budget path may already assume single-target.
+   - **Power on healing / beneficial techniques** — every example is offensive (wards, damage, severity). "+power to fire spells" framing ignores whether power scales beneficial magnitude symmetrically, and whether a "ward" can ever *reduce a buff's* landed power (griefing vector).
+   - **NPC/threat-pool side.** `ThreatPoolEntry.base_damage` and the NPC clash path (`clash.py:1185`) use authored values directly and bypass `compute_effective_intensity` entirely. The report's world-side classification implicitly assumes PC casters; it never states whether NPCs get a power axis or stay on flat authored damage. This is a real coverage hole for combat.
+   - **Stacking limits / diminishing returns on power** — the report inherits additive stacking "for free" but never asks whether unbounded "+power" stacking is desirable, which is a balance question the existing modifier system may not gate.
+
+**9. Terminology collision is identified but the report itself muddies it.**
+Section 7.1 #2 correctly flags "power" is overloaded (`base_power`, `IntensityTier` "calculated power", `base_damage`). Good. But Sections 1–6 then use "power" pervasively as the new concept anyway, which will leak into the design conversation as exactly the confusion it warns about. Recommend the report adopt the disambiguated term (`landed_magnitude` / `effective_power`) *throughout* now, not defer it.
+
+## Suggested follow-up research round (concrete)
+
+1. Read `get_modifier_breakdown` + amplification logic; produce a definitive yes/no on whether multiplicative/override power buffs are expressible without extending it (gates P1#5).
+2. Audit all four scaling-formula call sites for their actual intensity source (effective vs. fallback); confirm the capability-grant divergence (P0#2).
+3. Document the `corruption.py` pre-mutation-event read-back idiom as the reference pattern for the pre-cast read-back; decide adopt-vs-refactor-to-shared-helper (P0#1).
+4. Spike whether D's penetration contest can coexist with clash without double-counting, or formally rule D out (P2#6).
+5. Add NPC/threat-pool, AoE, and beneficial-technique use cases to the coverage matrix (P2#8).
+6. Re-pose Section 5 as orthogonal axes (where/when/storage/scalar-vs-vector), not four pre-bundled packages (P1#3).
+
+Code anchors verified during this critique: `src/world/magic/services/corruption.py:389-427` (working read-back precedent the report omits), `src/world/magic/models/techniques.py:465-468` (capability grant falls back to `technique.intensity`, not wired to combat), `:657/:672/:736` + `:468` (four scaling formulas, not three), `src/world/combat/clash.py:1185` (NPC path bypasses `compute_effective_intensity`), `src/world/mechanics/constants.py:82-90` and `models.py:120-158` (report's verified claims confirmed accurate).

--- a/docs/superpowers/specs/2026-05-30-power-intensity-research-report.md
+++ b/docs/superpowers/specs/2026-05-30-power-intensity-research-report.md
@@ -1,0 +1,255 @@
+I have enough verified ground truth. Key corrections from my code read: `target_damage_type` and `target_check_type` FKs already exist on `ModifierTarget` (the archaeology claimed damage-type scoping was non-existent), and `EQUIPMENT_RELEVANT_CATEGORIES` currently holds `{stat, magic, affinity, resonance}` (notably NOT `technique_stat`). These shape the candidate directions. Writing the report now.
+
+# Power vs. Intensity in Arxii Magic — Research Landscape Report
+
+*Status: exploratory considerations document. No design is selected. The purpose is to map the option space, anchor it in the actual code, and surface tradeoffs for a later design conversation.*
+
+---
+
+## 1. Executive summary
+
+Arxii's magic system already has a load-bearing axis split baked into every technique: **intensity** (raw power channeled) and **control** (safety/precision). When intensity outruns control at runtime, anima cost spikes, mishap pools escalate, and Soulfray/corruption accrue. This is the engine of the "heroic sacrifice" tension and it works.
+
+The problem the user wants to solve is that this single `intensity` axis is doing **two conceptually different jobs at once**:
+
+- **What the caster CHANNELS** — drives anima cost, control-deficit/mishap selection, resonance/corruption attribution, Soulfray. A ward thrown by a *defender* must never reduce this; reducing it would mean the caster magically paid less for what they poured in.
+- **The EFFECTIVE MAGNITUDE the working carries into the world** — drives damage budgets, condition severity/duration, capability grants. This is the lever that *should* be modifiable pre-cast (wards, amps) and via persistent buffs ("+power to fire spells").
+
+Today these two jobs collapse onto the same `technique.intensity` value, read by two parallel functions (`get_runtime_technique_stats` for the magic envelope, `compute_effective_intensity` for combat resolution). There is no place to insert a "power" modifier that changes what lands without also changing what the caster paid. The user's framing — **intensity = channeled (immutable by defenders), power = effective magnitude (modifiable)** — is precisely the separation that mature systems (Ars Magica's Casting Total vs Penetration, GAS's BaseValue vs CurrentValue, PoE's base × modifier pools) institutionalize.
+
+Why now: the magic north-star (cast → pose → log → outcome) needs legible, modifiable outcomes; pre-cast wards/amps and persistent buffs are on the near roadmap; and there is an existing, unwired reactive `TECHNIQUE_PRE_CAST` MODIFY_PAYLOAD hook whose mutations are currently **discarded** (`world/magic/services/techniques.py` reads pre-event `stats.intensity` after emit, never the modified payload). The architecture is at a fork: either reconcile the two intensity computations now, or accrete a third.
+
+---
+
+## 2. Current state of the code
+
+### 2.1 Two intensity computations — parallel implementations, by design but undocumented
+
+There are **two independent functions** producing "effective intensity," at different abstraction levels, with no shared code path:
+
+**`get_runtime_technique_stats(technique, character)`** — `world/magic/services/techniques.py:156-208` (verified). Returns `RuntimeTechniqueStats(intensity, control)`. Combines four streams in sequence:
+1. Base `technique.intensity + technique.control` (`:168-170`).
+2. **Identity stream** via `CharacterModifier` rows on `technique_stat` ModifierTargets named `"intensity"`/`"control"` (`:181-184`, using `get_modifier_total`).
+3. **Process stream** from `CharacterEngagement.intensity_modifier`/`control_modifier`, or `+social_safety` to control when unengaged (`:190-195`).
+4. **IntensityTier control penalty**, a threshold lookup keyed on the *final* runtime intensity (`:202-203`).
+
+This is the **only** place `CharacterModifier` intensity/control bonuses and `IntensityTier` penalties are applied. It feeds `calculate_effective_anima_cost` via the control-delta formula (`effective_cost = max(base_cost − (runtime_control − runtime_intensity), 0)`, `:211-238`), mishap-pool selection (`control_deficit = intensity − control`), per-resonance corruption attribution, and the `TECHNIQUE_PRE_CAST`/`TECHNIQUE_CAST` event payloads.
+
+**`compute_effective_intensity(participant, action)`** — `world/combat/services.py:332-358` (verified). Returns `int`. Reads `technique.intensity` as base and adds only `INTENSITY_BUMP` `scaled_value`s from active `CombatPull` rows. **Does not** consult `CharacterModifier`, `IntensityTier`, `CharacterEngagement`, or social safety. Feeds `compute_damage_budget`, `compute_severity`, `compute_duration_rounds` in `CombatTechniqueResolver`.
+
+The combat function's own docstring (`:342-345`) advertises "Future hooks (additive, no signature change required): Condition-derived… Item-derived… Environmental modifiers" — i.e., it is *intended* as the extension point for world-side scaling, but it is narrower than the magic path and silently ignores identity bonuses.
+
+### 2.2 Reconciliation verdict
+
+These are **genuinely parallel implementations of "effective intensity," not one system with two callers.** They overlap on the base term (`technique.intensity`) and diverge on everything else. The divergence is *currently* defensible (combat = pull-only escalation; magic = full envelope) but it is a live parallel-impl risk per the codebase's anti-reinvention rule: any future "+intensity in combat from a distinction" would have to be added to `compute_effective_intensity` even though `get_runtime_technique_stats` already knows how to compute it. The resolver closure does **not** receive `stats.intensity` from `use_technique`; it recomputes independently. So editing `technique.intensity` affects anima/mishap/events through one path and damage through the other — they happen to read the same base field, which masks the duplication.
+
+### 2.3 Do modifiers already touch intensity? Yes — partially
+
+- **Intensity/control ARE ModifierTargets.** `technique_stat` category with names `intensity`/`control` (`world/mechanics/constants.py:14-16`, verified). `CharacterModifier` rows tune them; applied only in `get_runtime_technique_stats`.
+- **Scoping FKs already exist on `ModifierTarget`** — and **more than the archaeology claimed**. Verified at `world/mechanics/models.py:120-158`: `target_resonance`, `target_affinity`, `target_capability`, `target_check_type`, **and `target_damage_type`** (OneToOne to `conditions.DamageType`) all exist today. The archaeology's claim that damage-type scoping is "non-existent" on `ModifierTarget` is **stale** — the FK is present (category described as "resistance"). This materially de-risks element/damage-type-scoped power.
+- **Equipment relevance is gated.** `EQUIPMENT_RELEVANT_CATEGORIES = {stat, magic, affinity, resonance}` (`constants.py:82-90`, verified). Notably `technique_stat` is **not** in this set — so equipment does not currently feed intensity/control even though distinctions do. A "power" category would need explicit inclusion to be equipment-driven.
+- **Stacking is centralized** in `get_modifier_breakdown` (additive sum with amplification and negative-immunity rules) — a power category gets this behavior for free if routed through `CharacterModifier`.
+
+### 2.4 The unwired reactive hook
+
+`TECHNIQUE_PRE_CAST` is emitted with `intensity=stats.intensity` and is MODIFY_PAYLOAD-capable (set/multiply/add/min/max, `flows/models/flows.py:541-554`), **but the modified value is never read back** — downstream resolution uses the pre-event `stats.intensity`. So reactive intensity modulation is currently cosmetic. This is a missing *read step*, not a duplication. (This worktree is literally named `feature-524-precast-modify-path`, suggesting that gap is the active concern.)
+
+---
+
+## 3. The intensity-vs-power distinction
+
+### 3.1 Conceptual model
+
+| | **Intensity (channeled)** | **Power (effective magnitude)** |
+|---|---|---|
+| Definition | What the caster pours in | What the working carries into the world / target |
+| Owner of the value | The caster's commitment + identity | The caster's commitment, *then* modified by amps/wards/buffs/environment |
+| Mutable by a defender's ward? | **Never** | **Yes** (a ward subtracts here) |
+| Drives | anima cost, control-deficit → mishap pool, Soulfray, per-resonance corruption attribution, resonance signature | damage budget, condition severity/duration, capability magnitude, penetration vs. resistance |
+| Risk is priced on | this (you pay full overreach cost for what you channeled) | not this (you can be warded down to zero effect and still pay) |
+
+The single most important invariant the user stated: **a ward reduces power, not intensity.** This mirrors Ars Magica exactly — a spell can be flawlessly cast (full Casting Total spent) yet bounce off Parma Magica (zero penetration). The caster still paid. WFRP makes the same point: risk is priced on dice channeled, reward realized only as effect that lands.
+
+### 3.2 Current consumers, classified
+
+**Caster-side (must read INTENSITY, the channeled value):**
+- `calculate_effective_anima_cost` via control-delta (`techniques.py:211-238`)
+- `control_deficit → select_mishap_pool` (`:348-350`)
+- `ResonanceInvolvement` per-resonance share for corruption (`:112-153`)
+- Soulfray severity (already intensity-*independent* — driven by anima deficit/depletion ratio, `soulfray.py:17-42`; included here because it sits in the channel-cost family)
+- `TECHNIQUE_PRE_CAST` / `TECHNIQUE_CAST` payloads (audit/reactive signal)
+
+**World-side (should read POWER, the modifiable value):**
+- `compute_damage_budget(effective_intensity, success_level)` (`combat/services.py:206`)
+- `compute_severity` / `compute_duration_rounds` for applied conditions (`:251-265`)
+- `TechniqueCapabilityGrant` value formula (`base + intensity_mult × intensity`)
+- clash gating via `compute_effective_intensity` (`clash.py:1176`)
+
+**Intensity-independent today (neither — flagged so a redesign doesn't accidentally wire them):**
+- Clash *check roll* (driven by strain_commitment, not intensity, `clash.py:223-229`)
+- Social action checks (difficulty-based, `action_services.py:328-339`)
+- Resonance-environment backfire (driven by aura × room valence, not intensity, `resonance_environment.py:500-549`)
+
+### 3.3 Where "power" would live
+
+The clean reading of the user's framing: **power = a derived, world-side magnitude = f(channeled intensity, pre-cast amps, persistent buffs, environment), computed at resolution and consumed by the world-side family only.** Intensity stays the caster-side ground truth. The three intensity-scaling formulas (damage, condition severity, capability) should read `effective_power`; the cost/mishap/corruption family keeps reading `intensity`. The open design question is *which mechanism* derives power — that is Section 5.
+
+A note on terminology collision (Section 7 expands): the codebase already uses "power" loosely (`EffectType.base_power`, `IntensityTier`'s "calculated power" help text, `TechniqueDamageProfile.base_damage`). Whatever is chosen must disambiguate "power" (the new modifiable magnitude) from these existing uses, or rename.
+
+---
+
+## 4. Lessons from other systems
+
+Organized by theme; each attributed.
+
+### Scaling / upcasting (effect as a function of a per-cast input)
+- **D&D 5e upcasting** is the cleanest "same spell, variable input → spell-defined scaling function." Fireball = 8d6 + 1d6/slot above 3rd. Store *base + per-step delta*, compute effective magnitude from the channeled level rather than authoring variants. ([5thsrd.org/spellcasting](https://5thsrd.org/spellcasting/), [roll20 Fireball](https://roll20.net/compendium/dnd5e/Fireball))
+- **D&D 5e cantrips** scale on a *different* axis — character level, not per-cast resource — proving "power as a function of caster development" is a distinct channel. ([5thsrd cantrips](https://5thsrd.org/spellcasting/cantrips/))
+- **PoE2 / Tyranny Power Level** is a single scalar that simultaneously lifts magnitude, accuracy, penetration, area — "one intensity number fans out to many facets." Strong precedent for a single derived `effective_power` feeding damage+severity+duration+capability uniformly. ([Power Level](https://pillarsofeternity2.wiki.fextralife.com/Power+Level))
+
+### Magnitude bought from a resource
+- **Mage: the Awakening 2e** spends successes to raise *factors* (potency/duration/scale), with one nominated **Primary Factor** scaling at a better rate — i.e., buffs change the *conversion rate*, not raw input. ([rpg.stackexchange](https://rpg.stackexchange.com/questions/107002/))
+- **Shadowrun Force** is one dial setting effect, dice cap, *and* drain together. ([Force](https://shadowrun.fandom.com/wiki/Force))
+- **GURPS** scales effect by energy poured; high skill *cheapens the conversion* (efficiency as a modifier, not additive power). ([gurpsland](https://gurpsland.byethost33.com/m_ecr.htm)) — directly analogous to Arxii's control-delta lowering anima cost.
+
+### Channeled-vs-effective split (the core ask)
+- **Ars Magica** is the canonical model: **Casting Total** (channeled) − **Spell Level** (toll) = surplus → **Penetration** (effective reach), compared to Magic Resistance. A perfect cast can land zero effect on a warded target; the caster still paid. Higher spell level inherently penetrates worse — a built-in scale-vs-reach tradeoff. ([ironboundtome](https://ironboundtome.wordpress.com/2011/11/12/how-does-mr-and-penetration-work-in-ars-magica/), [redcap Ch.9](https://www.redcap.org/page/Ars_Magica_5E_Standard_Edition,_Chapter_Nine:_Spells))
+- **GAS BaseValue vs CurrentValue**: CurrentValue = BaseValue + active modifiers, **never stored, always recomputed**. Map intensity → BaseValue, power → CurrentValue; wards/amps are just modifier objects. ([GASDocumentation](https://github.com/tranek/GASDocumentation))
+
+### Overreach cost (Soulfray / corruption family)
+- **Mage Awakening Reach**: free up to a margin set by mastery, then each increment adds Paradox dice — *free-threshold-then-escalating-cost*, the exact shape of a Soulfray gate. Cost can both harm the caster *and* degrade the cast. ([rpg.stackexchange](https://rpg.stackexchange.com/questions/107002/))
+- **Shadowrun overcasting**: Force > Magic flips drain *type* (Stun → lethal Physical) — cost **type transition**, not just amount. ([Overcasting](https://shadowrun.fandom.com/wiki/Overcasting))
+- **WFRP Winds of Magic**: extra power dice scale reward and miscast risk together; risk priced on channel, reward on effect. ([warhammerfantasy wiki](https://warhammerfantasy.fandom.com))
+- Cross-cutting lesson: **price overreach on intensity (channeled), realize reward on power (landed)** — a suppression environment becomes legibly scary ("full Soulfray cost, 50% landed power"). This is *already* how Arxii works (Soulfray reads deficit, not power) and must be preserved.
+
+### Buffs / modifiers (the "use the existing modifier system" mandate)
+- **PoE two-pool math**: `Final = (Base + flatAdded) × (1 + Σincreased) × Π(1+more_i)`. Additive "increased" all sum into one pool; "more" each multiply. Principled stacking with two behaviors. ([maxroll](https://maxroll.gg/poe/getting-started/poe-damage-calculation))
+- **5e Metamagic** = priced, composable, *typed* modifiers each touching a distinct axis (magnitude / contest / targeting / delivery / cost). Template for keeping power adjustments orthogonal and stackable. ([dnd5e.wikidot metamagic](https://www.dnd5e.wikidot.com/sorcerer:metamagic))
+- **GAS aggregation**: fixed op order (Add → Multiply → Divide → Override) removes order ambiguity; Override-to-zero models a hard null-field ward. ([GASDocumentation](https://github.com/tranek/GASDocumentation))
+
+### Element-scoped modifiers ("+power to fire spells")
+- **PoE tag-matched modifiers**: a fire-spell hit collects "increased fire" + "increased elemental" + "increased spell" + generic, summed by **tag match** — no per-element special fields. "+X to fire spells" is *data*, not a rule. ([poewiki Damage](https://www.poewiki.net/wiki/Damage), [Fire Damage](https://www.poewiki.net/wiki/Fire_Damage)) — maps onto Arxii's existing `target_resonance` / `target_damage_type` scoping FKs.
+
+### Reactive / interrupt (pre-cast wards/amps, counters)
+- **MTG Stack + priority + LIFO**: a counter placed in the response window resolves first and injects a modifier into the target's pipeline (reduce *landing*, not *channeling*). ([Stack](https://mtg.fandom.com/wiki/Stack), [Priority](https://mtg.fandom.com/wiki/Priority))
+- **MTG layers + dependency**: deterministic ordering of heterogeneous continuous effects; the dependency rule reorders "this buff only exists because that effect changed the element." Future-proofs against ad-hoc modifier-interaction mess. ([Layer](https://mtg.fandom.com/wiki/Layer), [Dependency](https://mtg.fandom.com/wiki/Dependency))
+- **Noita per-cast modifier queue** vs persistent cast-state — clean per-cast-vs-persistent lifecycle distinction (pre-cast amp = ephemeral; "+power to fire" = persistent condition). ([Noita modifiers](https://noita.wiki.gg/wiki/Modifier_Spells))
+
+### World/environment modifies power
+- **GAS snapshot vs non-snapshot capture**: lock power at cast time, or keep re-deriving from live world/relationship state. The exact knob for "a sustained ward grows as you carry it toward a resonant node." ([GASDocumentation](https://github.com/tranek/GASDocumentation))
+- **Ars Magica Aura** as a flat environment Add/Subtract to the total; **Genshin elemental gauge** as decaying world-state power that follow-ups react with. ([genshin gauge theory](https://genshin-impact.fandom.com/wiki/Elemental_Gauge_Theory))
+
+---
+
+## 5. Candidate design directions
+
+Four distinct architectures. **No winner is selected.** Each is evaluated on: mechanism, modifier-system reuse, use-case coverage, pros/cons, parallel-impl risk.
+
+---
+
+### Direction A — "Power" as a new ModifierTarget category computed inside runtime stats
+
+**How it works.** Introduce a `power` `ModifierCategory` and `RuntimeTechniqueStats` grows a third field `power`. `get_runtime_technique_stats` becomes the single source: it computes `intensity`, `control` as today, then derives `power` = `f(intensity)` + power-scoped `CharacterModifier` totals (+ pre-cast amp/ward modifiers injected as transient `CharacterModifier`/payload entries). The three world-side formulas (damage/severity/capability) are changed to read `stats.power`; the cost/mishap/corruption family keeps reading `stats.intensity`. `compute_effective_intensity` is **deleted or reduced to a thin shim** that calls `get_runtime_technique_stats` and returns `.power` + combat-pull bumps.
+
+**Modifier-system reuse.** Maximal. Power becomes another `ModifierTarget`; element scoping reuses the **already-present** `target_resonance` / `target_damage_type` FKs; stacking/amplification/immunity come free from `get_modifier_breakdown`; "+power to fire" is a `CharacterModifier` row on a resonance-scoped power target. Add `power` to `EQUIPMENT_RELEVANT_CATEGORIES` if equipment should drive it.
+
+**Use-case coverage.** Persistent "+power to fire" and amps: native. Pre-cast ward: a transient negative power modifier (must NOT touch intensity — satisfied by construction). Soulfray: untouched (reads intensity). Resonance-environment power shift: a power modifier sourced from room valence.
+
+**Pros.** Single computation; eliminates the parallel impl; uses the mandated modifier system end-to-end; the existing scoping FKs make element-scoping nearly free.
+**Cons.** `get_runtime_technique_stats` becomes a god-function. Combat's resolver currently *doesn't* have a `CharacterSheet`-rich call path identical to magic; threading the full magic envelope into combat resolution is real surgery. "Power as f(intensity)" entangles the two axes inside one function — the conceptual separation lives only in field names, not in code structure.
+**Parallel-impl risk.** *Resolves* the existing one if `compute_effective_intensity` is truly collapsed; *creates a new one* if combat keeps its own pull-summing path alongside the new power field.
+
+---
+
+### Direction B — A dedicated effect-resolution pipeline with ordered modifier stages (GAS/MTG-inspired)
+
+**How it works.** A new resolution component takes `(channeled_intensity, technique, caster, target, environment, reactive_window)` and runs ordered **channels/stages**: Channel 0 = channeled intensity (BaseValue); Channel 1 = caster identity/resonance; Channel 2 = persistent buffs (incl. element-scoped); Channel 3 = environment; Channel 4 = reactive (pre-cast wards/amps, counters). `effective_power` = output of the final channel, **never stored, always recomputed** (GAS CurrentValue). Each channel boundary is a clamp/gate point and a row in a player-facing "power ledger." Intensity is the immutable input; the pipeline only produces power.
+
+**Modifier-system reuse.** Medium-to-high *if* each stage's modifiers are sourced from `CharacterModifier` rows via `get_modifier_total` (additive pool) plus a small set of multiplicative/override ops the current breakdown doesn't yet express. Risk: GAS-style Multiply/Divide/Override is a **superset** of the current additive-only `get_modifier_breakdown`, so either extend that function (preferred) or the pipeline grows its own math (parallel impl).
+
+**Use-case coverage.** Strongest for reactive (the unwired `TECHNIQUE_PRE_CAST` MODIFY_PAYLOAD becomes Channel 4 read back into resolution — closes the existing gap), environment shifts (Channel 3), and live "power ledger" UI for the cast→pose→log→outcome loop. Snapshot-vs-non-snapshot becomes a per-technique flag (sustained wards re-derive). Element-scoped buffs are tag-matched in Channel 2.
+
+**Pros.** Cleanest conceptual separation (intensity literally a different pipeline stage than power); deterministic ordering kills order-of-ops bugs; the itemized ledger directly serves the north-star outcome legibility; reactive becomes first-class.
+**Cons.** Largest new surface — highest reinvention danger if it doesn't strictly delegate stacking to the existing modifier system. Two resolution philosophies (pipeline vs. current direct formula reads) would coexist during migration. Needs the additive-only breakdown extended to multiplicative/override ops, which is its own design.
+**Parallel-impl risk.** **High** unless disciplined: a pipeline that recomputes modifier totals instead of calling `get_modifier_total` would be a third intensity/power computation. Must be built *on top of* `get_modifier_breakdown`, not beside it.
+
+---
+
+### Direction C — Extend `compute_effective_intensity` into the unified effective-power computation
+
+**How it works.** Take the combat function at its own word (its docstring already promises additive world-side hooks) and grow it into `compute_effective_power(caster, technique, action, environment)`: base intensity + combat-pull bumps + power-scoped `CharacterModifier` totals + pre-cast amp/ward deltas + environment. Rename to reflect that it returns *power*. The magic envelope's `get_runtime_technique_stats` keeps owning intensity/control (caster-side), and resolution calls the new function for the world-side number. Soulfray/mishap/cost stay on `get_runtime_technique_stats.intensity`.
+
+**Modifier-system reuse.** Medium. The function would call `get_modifier_total` for power-scoped targets and reuse scoping FKs — but it currently lives in `combat/services.py` and is combat-shaped (takes `CombatParticipant`/`CombatRoundAction`). Generalizing it to non-combat casts (social, scene actions, environment-only) means broadening the signature away from combat types.
+
+**Use-case coverage.** Combat intensity ramp: native (it already sums pulls). Damage/severity/capability already call it. Persistent/element buffs and amps: add via modifier totals. Pre-cast ward: a negative term. Spell-tier scaling: a `f(technique.level)` term. The non-combat magic paths would need it wired in (they currently use intensity directly for cost only and don't scale world-side magnitude outside combat).
+
+**Pros.** Smallest conceptual leap; honors an explicit existing extension point; keeps caster-side and world-side computations cleanly in *separate functions* (arguably the truest structural expression of the user's split — intensity in one function, power in another). Lower blast radius than B.
+**Cons.** The function is combat-namespaced and combat-typed; generalizing it risks an awkward home (does it move to `magic/services`?). Two functions still exist — but now with a *documented contract* (one = channeled, one = effective) rather than accidental overlap.
+**Parallel-impl risk.** **Low-to-medium** — it *converts* the existing parallel pair into a deliberate two-function split (intensity fn + power fn) with a clear boundary. Risk is mostly that the rename/move is half-done and a third path sneaks in for non-combat casts.
+
+---
+
+### Direction D — Ars-Magica-style magnitude/toll layer (power = surplus after a manifestation toll)
+
+**How it works.** Reframe entirely: channeled intensity pays a **toll** (the technique's level/magnitude cost) to manifest; only **surplus** becomes power, which is then contested against target resistance (penetration vs. Magic Resistance). `effective_power = channeled_intensity − manifestation_toll + penetration_buffs`, compared to a target's ward/resistance. Wards raise the *target's resistance* (subtracting from landed effect) without touching channeled intensity. Higher technique tier = bigger toll = less surplus, a built-in scale-vs-reach tradeoff.
+
+**Modifier-system reuse.** The penetration-buff and resistance terms are `CharacterModifier` totals (caster's penetration target; target's resistance target — `target_damage_type`/`target_resonance` scoping already supports element-keyed resistance). Toll is `f(technique.level)`. Stacking via existing breakdown.
+
+**Use-case coverage.** Pre-cast ward weakening incoming power: *the* canonical model — ward = target resistance, subtracts from landed power, never from intensity (invariant satisfied structurally). Persistent +power: penetration buff. Spell-tier scaling: the toll *is* tier scaling, with the elegant inversion that bigger spells penetrate worse. Soulfray: priced on full channeled intensity regardless of penetration (suppression becomes legibly punishing — matches WFRP/Shadowrun lessons). Resonance-environment: an aura Add to channel or a resistance shift.
+
+**Pros.** The most principled, literature-validated channeled-vs-effective separation; ward-doesn't-touch-intensity is enforced by the math, not by discipline; "cast succeeded but bounced off the ward" becomes a first-class, pose-able outcome state (great for cast→pose→log). Introduces a genuine target-resistance contest the system lacks.
+**Cons.** Largest *design* change — introduces a resistance/penetration contest that doesn't exist today and would interact with the existing check/clash and damage-budget systems (potential double-counting of "defense"). Risks conflating with the existing `IntensityTier` "calculated power" and damage-budget mechanics. Most likely to require rebalancing every authored technique.
+**Parallel-impl risk.** **Medium-high on the resistance side** — Arxii already resolves defense through checks, clash, and damage budgets; a new penetration-vs-resistance layer could become a parallel defense system unless explicitly unified with one of those.
+
+---
+
+## 6. Use-case coverage matrix
+
+How each direction handles the concrete cases. (✓ native / clean; ◐ workable with added plumbing; ✗ awkward or requires rethinking that direction's core.)
+
+| Use case | A — Power as ModifierTarget in runtime stats | B — Ordered pipeline | C — Extend compute_effective_intensity | D — Magnitude/toll + penetration |
+|---|---|---|---|---|
+| **Pre-cast ward weakens incoming power** (must not touch intensity) | ◐ transient negative power modifier; invariant by convention | ✓ Channel 4 reactive modifier; intensity is an earlier untouched stage | ◐ negative term in power fn; intensity fn untouched | ✓ ward = target resistance; invariant enforced by math |
+| **Pre-cast amp** | ✓ transient positive power modifier | ✓ Channel 4 positive modifier (reads the currently-unwired MODIFY_PAYLOAD) | ✓ positive term | ✓ penetration buff or toll reduction |
+| **Persistent "+power to fire spells"** | ✓ resonance-scoped `CharacterModifier` (uses existing `target_resonance`) | ✓ tag-matched Channel 2 modifier | ✓ scoped modifier total | ✓ scoped penetration buff |
+| **Combat intensity ramp** | ◐ shim must still fold in pull bumps | ✓ a channel; or pull bumps as Channel 0 input | ✓ native (already sums pulls) | ◐ pulls raise channeled intensity → more surplus |
+| **Spell-level / tier scaling** | ◐ add `f(level)` term to power derivation | ✓ a channel | ✓ `f(level)` term | ✓ tier *is* the toll (bigger tier → less reach), elegant |
+| **Soulfray overreach interaction** | ✓ unchanged (reads intensity) | ✓ priced on Channel 0 intensity | ✓ unchanged (intensity fn) | ✓ priced on full channeled intensity, ignores penetration |
+| **Resonance-environment power shift** | ◐ env-sourced power modifier (env currently affects backfire, not magnitude) | ✓ Channel 3 environment stage; supports non-snapshot re-derivation | ◐ env term in power fn | ◐ aura Add or resistance shift |
+| **"Bounced off a ward" as a legible outcome** | ✗ not modeled (power floored at 0, no contest state) | ◐ representable as a final-channel clamp event | ✗ not modeled | ✓ first-class (penetration ≤ resistance = manifested, zero landed) |
+| **Live "power ledger" UI for pose/log** | ◐ derivable but not structured | ✓ each channel is a ledger row (best fit) | ◐ derivable | ◐ two-line ledger (toll, penetration) |
+| **Eliminates current parallel impl** | ✓ if shim truly collapses combat fn | ◐ only if built atop existing breakdown | ✓ converts to a documented two-fn split | ◐ may add a new defense path |
+
+---
+
+## 7. Open questions & decomposition sketch
+
+### 7.1 Key decisions still to make
+
+1. **Is "power" a third field on `RuntimeTechniqueStats`, a return of a (renamed) `compute_effective_*`, or the output of a new pipeline component?** This is the A/B/C/D fork and should be decided first; everything else follows.
+2. **Terminology disambiguation.** "Power" is already overloaded (`EffectType.base_power`, `IntensityTier` help text "calculated power," `TechniqueDamageProfile.base_damage`). Either reserve a precise term (e.g., `effective_power` / `landed_magnitude`) or rename existing uses. Decide before writing code so the model field names don't collide.
+3. **Should the three intensity-scaling formulas be unified behind one helper?** `TechniqueDamageProfile`, `TechniqueAppliedCondition`, `TechniqueCapabilityGrant` all use `base + mult × effective_intensity` with no shared code (archaeology-flagged triple). Whatever drives them should switch from `effective_intensity` to `effective_power` *in lockstep* — a shared helper would make that a one-line change instead of three.
+4. **Element scoping mechanism.** Reuse the **already-present** `target_resonance` / `target_damage_type` FKs (preferred — they exist, verified `models.py:127,151`) vs. a new scope field. The archaeology underestimated what's built here; the cheap path is real.
+5. **Is power equipment-driven?** If yes, add a `power` category to `EQUIPMENT_RELEVANT_CATEGORIES` (`constants.py:82`) and wire the equipment walk; if no, keep it distinction/condition-sourced.
+6. **Wire the reactive read-back (independent of A–D).** The `TECHNIQUE_PRE_CAST` MODIFY_PAYLOAD result is currently discarded. Reading it back is a prerequisite for *any* reactive pre-cast ward/amp and is the named subject of the current worktree. Decide: re-read `pre_payload`, expand `resolve_fn` signature, or have the resolver introspect the payload.
+7. **Does any direction introduce a target-resistance contest (D), and if so how does it avoid double-counting** the defense already expressed through checks/clash/damage-budgets?
+8. **Snapshot vs. non-snapshot** (does power lock at cast time or re-derive for sustained effects?) — relevant mainly to B/D; decide whether the live-world re-derivation is in scope for v1 or deferred.
+9. **Preserve invariants:** Soulfray stays priced on channeled intensity; clash *check rolls* and social-action checks stay intensity-independent; resonance-environment backfire stays valence-driven. Confirm none of A–D accidentally wires these.
+
+### 7.2 Rough decomposition into a sequence of issues (not a commitment)
+
+A plausible ordering that front-loads de-risking and keeps each step shippable:
+
+- **Issue 0 — Reconciliation spike & contract doc.** Document the `get_runtime_technique_stats` vs `compute_effective_intensity` boundary as it stands; correct the stale `docs/systems` claims about ModifierTarget scoping FKs (per the anti-reinvention "fix the doc at source" rule). Pick the A/B/C/D direction. *No code behavior change.*
+- **Issue 1 — Wire the pre-cast MODIFY_PAYLOAD read-back.** Make reactive intensity/power mutation actually affect resolution. Self-contained, unblocks all reactive use-cases, matches the current worktree's intent.
+- **Issue 2 — Unify the three intensity-scaling formulas behind one helper** reading a single `effective_*` value. Pure refactor; makes the later intensity→power swap atomic.
+- **Issue 3 — Introduce the `power` concept** per the chosen direction (new field / renamed function / pipeline skeleton), reading channeled intensity as input and feeding *only* the world-side family. Caster-side family unchanged. Add tests asserting a ward reduces power but not anima cost / mishap pool / Soulfray.
+- **Issue 4 — Route power through the modifier system:** persistent "+power to fire" via resonance/damage-type-scoped `CharacterModifier`; decide equipment relevance. Reuse `get_modifier_breakdown`.
+- **Issue 5 — Collapse / formalize the parallel impl:** either reduce `compute_effective_intensity` to a documented shim (A/C) or ensure the pipeline (B) delegates all stacking to the existing breakdown.
+- **Issue 6 (optional / direction-dependent) — Environment power shift and/or penetration-vs-resistance contest**, plus the player-facing power ledger for cast→pose→log.
+
+This sequence lets the cheap, high-value wins (read-back wire, formula unification) land regardless of which architecture wins, and defers the heaviest reinvention risk (B's op-math extension, D's resistance contest) until after the direction is ratified.
+
+---
+
+*Relevant code anchors for the design conversation: `src/world/magic/services/techniques.py:156-238` (runtime stats + anima cost), `src/world/combat/services.py:332-358` (compute_effective_intensity), `src/world/mechanics/models.py:120-158` (ModifierTarget scoping FKs — including the present `target_damage_type`), `src/world/mechanics/constants.py:9-16,82-90` (category names + equipment-relevant set), `src/flows/models/flows.py:541-554` (MODIFY_PAYLOAD ops).*

--- a/docs/superpowers/specs/2026-05-30-precast-power-readback-design.md
+++ b/docs/superpowers/specs/2026-05-30-precast-power-readback-design.md
@@ -1,0 +1,180 @@
+# Issue 0 — Pre-cast Power Read-back Design (#524)
+
+**Status:** approved design, pre-implementation.
+**Companion research:** `docs/superpowers/specs/2026-05-30-power-intensity-research-report.md` (landscape + 4 candidate directions) and `...-critique.md`. This spec implements the report's **Issue 0/1** and the leading edge of **Direction C** (unify the two effective-intensity computations into one derived power value).
+
+---
+
+## 1. Problem
+
+`use_technique` (`src/world/magic/services/techniques.py`) emits `TECHNIQUE_PRE_CAST` with a mutable payload, but **discards any edits**: after the emit it keeps using the pre-event `stats.intensity` for resolution. A reactive pre-cast trigger that does `MODIFY_PAYLOAD` (a ward weakening an incoming working, an amp strengthening it) therefore has **no effect on what actually lands**. The cancel path works; the modify path is a no-op. This is the #524 gap.
+
+Fixing it cleanly requires naming the thing being modified correctly. Per the research and the user's framing:
+
+- **Intensity** = what the caster *channels*. Caster-side. Drives anima cost, mishap (`control_deficit`), resonance/corruption attribution, Soulfray. **A defender's ward must never reduce this.**
+- **Power** = the *effective magnitude the working carries into the world*. World/target-side. Drives damage budgets, condition severity/duration, capability grants. **This is the modifiable lever** (pre-cast wards/amps now; persistent buffs, Audere spikes, environment shifts later).
+
+**Load-bearing invariant (user):** *Power is always a **derived** value, never stored.* It is recomputed each cast as the sum of the caster's intensity + (later) level, threads, aura/resonance, and applicable modifiers. Modifiers *contribute to* power; they are never *stored as* power. This spec introduces power as a derived value seeded from intensity; later issues add the other input terms. No persisted power column, ever.
+
+---
+
+## 2. Scope
+
+### In scope (PR1)
+1. Add a derived `power` to the pre-cast payload, seeded from the caster's channeled intensity.
+2. Read the post-hook `power` back in `use_technique` and feed it to resolution + the world-side event payloads.
+3. Extend the `resolve_fn` contract to receive `power`; the combat resolver **consumes** it for damage/severity/duration/capability, unifying it with the combat pull bumps. Clash and scenes accept-and-ignore (their resolution is intensity-independent today).
+4. Reduce `compute_effective_intensity` to its pull-summing role and route combat scaling through the injected `power + pulls` (the front edge of Direction C).
+5. Tests proving the intensity/power split: a ward reduces landed effect but not anima/mishap/Soulfray.
+
+### Out of scope (later issues, tracked separately)
+- `power` as a `ModifierTarget` category + persistent buffs ("+power to fire spells").
+- Level / thread / aura terms in the power derivation.
+- Audere / Audere Majora power spike (a derivation term).
+- Environment power shift; penetration-vs-resistance contest; the player-facing "power ledger".
+- The full ordered pipeline (Direction B).
+
+These will be filed as follow-on issues during the broader decomposition.
+
+---
+
+## 3. Current code (verified anchors)
+
+- `use_technique` — `src/world/magic/services/techniques.py:241-428`. Step 2 computes anima cost from `stats.intensity` (caster-side, stays). Lines 289-309 emit `TECHNIQUE_PRE_CAST` then check only `was_cancelled()`. Line 315 calls `resolve_fn()` (no args). Lines 348/357/407 reuse `stats.intensity`.
+- `TechniquePreCastPayload` — `src/flows/events/payloads.py:188-194`: `caster, technique, targets, intensity`. Non-frozen (mutable). `TechniqueCastPayload` (frozen) and `TechniqueAffectedPayload` carry the world-side result.
+- `MODIFY_PAYLOAD` — `src/flows/models/flows.py` `_execute_modify_payload`: ops `set/multiply/add/min/max` via `setattr` on the payload field.
+- `resolve_fn` call sites (3 production):
+  - `src/world/combat/services.py:485` — passes a `CombatTechniqueResolver` instance (callable). The resolver calls `compute_effective_intensity(self.participant, self.action)` in `_apply_damage` (`:206`) and `_apply_conditions` (`:251`).
+  - `src/world/combat/clash.py:233` — passes a local no-arg `resolve_fn` doing a strain-based `perform_check`; intensity-independent.
+  - `src/world/scenes/action_services.py:328` — passes `lambda: start_action_resolution(...)`; difficulty-based; intensity-independent.
+- `compute_effective_intensity` — `src/world/combat/services.py:332-358`: `technique.intensity + Σ INTENSITY_BUMP pull scaled_values`. Does NOT consult identity modifiers (that lives only in `get_runtime_technique_stats`).
+- `get_runtime_technique_stats` — `src/world/magic/services/techniques.py:156-208`: the full caster envelope (base + identity `CharacterModifier` + engagement + tier penalty) → `RuntimeTechniqueStats(intensity, control)`.
+
+---
+
+## 4. Design
+
+### 4.1 Payload: add derived `power`
+
+`TechniquePreCastPayload` (`payloads.py`) gains `power: int`, alongside the retained `intensity: int`:
+
+```python
+@dataclass
+class TechniquePreCastPayload:
+    caster: Character
+    technique: Technique
+    targets: list[Character | ObjectDB]
+    intensity: int   # channeled — immutable; what the caster put in
+    power: int       # derived effective magnitude — the editable lever
+```
+
+`intensity` stays so triggers can *read* the channeled value (e.g. "ward scales with how hard they pushed") while editing only `power`. `TechniqueCastPayload` and `TechniqueAffectedPayload` each gain a `power: int` field carrying the post-hook value to observers/downstream triggers.
+
+### 4.2 `use_technique`: seed, read back, thread through
+
+In `use_technique`, the seed is the **derived power**. For PR1 the derivation is `power = stats.intensity` (the full caster envelope). A small private helper marks the extension point for later input terms (level/threads/aura/modifiers):
+
+```python
+def _derive_power(*, channeled_intensity: int, technique: Technique, character: ObjectDB) -> int:
+    """Derive effective power. NEVER stored — recomputed each cast.
+
+    PR1: power == channeled intensity. Later issues add level, threads,
+    aura/resonance, and power-scoped modifier terms here (Direction C/B).
+    """
+    return channeled_intensity
+```
+
+Flow changes (all in `use_technique`):
+1. Seed `pre_payload.power = _derive_power(channeled_intensity=stats.intensity, technique=technique, character=character)` (and keep `intensity=stats.intensity`).
+2. After the emit (non-cancelled), read `effective_power = pre_payload.power` (a trigger may have edited it).
+3. Call resolution with it: `resolution_result = resolve_fn(power=effective_power)`.
+4. Use `effective_power` in the `TECHNIQUE_CAST` and `TECHNIQUE_AFFECTED` payloads.
+5. **Unchanged:** anima cost (Step 2, already computed pre-hook from `stats.intensity`), `control_deficit` mishap (`stats.intensity - stats.control`), resonance involvements (`stats.intensity`), Soulfray (deficit-based). The caster-side family never reads `power`.
+
+### 4.3 `resolve_fn` contract: `(*, power: int)`
+
+All resolvers become keyword-callable with `power`:
+
+- **clash** (`clash.py`): `def resolve_fn(*, power: int) -> object:` — ignores `power` (`# noqa: ARG001` with a comment: clash check is strain-driven, not power-scaled). Body unchanged.
+- **scenes** (`action_services.py`): change `resolve_fn=lambda: start_action_resolution(...)` to `resolve_fn=lambda *, power: start_action_resolution(...)` — ignores `power` (difficulty-driven). Body unchanged.
+- **combat** (`CombatTechniqueResolver.__call__`): becomes `def __call__(self, *, power: int) -> CombatTechniqueResolution:` and threads `power` into `_apply_damage(check_result, power=power)` and `_apply_conditions(check_result, power=power)`.
+
+### 4.4 Combat: consume injected power (front edge of Direction C)
+
+The combat resolver currently calls `compute_effective_intensity(participant, action)` in two places and uses the result as `effective_intensity=` for damage budget, severity, and duration. Change those to use the **injected power plus the combat pull bumps**:
+
+- Split `compute_effective_intensity` so the pull-summation is reusable:
+
+```python
+def sum_intensity_bump_pulls(participant: CombatParticipant) -> int:
+    """Σ of active INTENSITY_BUMP pull scaled_values for this participant's encounter."""
+    total = 0
+    character = participant.character_sheet.character
+    for pull in character.combat_pulls.active_for_encounter(participant.encounter):
+        for eff in pull.resolved_effects_cached:
+            if eff.kind == EffectKind.INTENSITY_BUMP and eff.scaled_value:
+                total += eff.scaled_value
+    return total
+
+
+def compute_effective_intensity(participant: CombatParticipant, action: CombatRoundAction) -> int:
+    """DEPRECATED scaling entry point — retained for the clash intensity floor only.
+
+    Equals technique.intensity + INTENSITY_BUMP pulls. Damage/severity/duration now
+    scale on the power injected by use_technique (which already folds in the caster's
+    full intensity envelope) plus sum_intensity_bump_pulls. See Direction C.
+    """
+    technique = action.focused_action
+    if technique is None:
+        return 0
+    return technique.intensity + sum_intensity_bump_pulls(participant)
+```
+
+- In `_apply_damage` / `_apply_conditions`, replace `eff_intensity = compute_effective_intensity(...)` with:
+
+```python
+eff_power = power + sum_intensity_bump_pulls(self.participant)
+```
+
+and pass `effective_intensity=eff_power` into `compute_damage_budget` / `compute_severity` / `compute_duration_rounds` (the profile/condition method parameter name stays `effective_intensity` for PR1 — renaming those formula params to `effective_power` is a follow-on cleanup to avoid churn here).
+
+**Consequence (intended):** combat damage now reflects the caster's identity intensity modifiers (carried by `power`←`stats.intensity`), which `compute_effective_intensity` previously ignored. With no production data and a disposable dev DB, there is no balance to preserve; this is the correct unification. Combat tests that asserted exact damage numbers will be updated to the new derivation.
+
+- The **clash intensity floor** (`clash.py:1176`, `compute_effective_intensity(...) < intensity_floor`) keeps calling `compute_effective_intensity` — it is a gameplay gate on channeled+pull intensity, not a power consumer. Left as-is.
+
+### 4.5 Why this honors the "power is always derived" invariant
+
+`power` exists only as: a transient payload field (seeded by `_derive_power`, editable by triggers) and a `resolve_fn` parameter. It is never written to a model column. Each cast recomputes it. Later issues extend `_derive_power` with more input terms — the derivation point is centralized so those additions are one-place changes.
+
+---
+
+## 5. Testing
+
+All on the SQLite inner loop where possible (`flows`, `magic` is PG-tier — use `just test-parity` for magic/combat).
+
+1. **Magic envelope (magic tier):** pre-cast trigger that does `MODIFY_PAYLOAD {field: power, op: multiply, value: 0.5}` →
+   - resolution receives halved power (assert via a resolver spy / the `TECHNIQUE_CAST` payload `power`),
+   - anima cost unchanged, mishap pool selection unchanged, Soulfray severity unchanged (assert the caster-side outputs equal a no-trigger control run).
+2. **No-edit identity:** with no pre-cast trigger, `power == stats.intensity` and every downstream number equals today's behavior for the magic path.
+3. **Combat (combat tier):** pre-cast amp `{field: power, op: add, value: N}` → opponent damage rises by the budget delta; a ward `{op: multiply, value: 0.5}` → damage falls; anima/mishap/Soulfray unchanged. Confirm pull bumps still add on top (`eff_power = power + pulls`).
+4. **Contract:** clash and scenes resolvers accept `power=` and behave identically to today (their outputs are power-independent).
+5. **Regression:** full `just test-fast flows`; `just test-parity world.magic`; `just test-parity world.combat`; `just test-parity world.scenes`. Update combat damage-number assertions to the unified derivation.
+
+---
+
+## 6. Risks & coordination
+
+- **Combat-instance overlap:** PR1 edits `src/world/combat/services.py` (`compute_effective_intensity`, `CombatTechniqueResolver`) and `clash.py` (signature only) — territory the parallel combat instance has worked in. Coordinate / flag at PR time; rebase before pushing. No `frontend/` or `api.d.ts` involvement.
+- **`resolve_fn` signature is a breaking contract change** — all 3 production call sites + every test that builds a `resolve_fn`/resolver are updated in the same PR (the research listed them; `test_magic_story_pipeline`, `test_corruption_per_cast_pipeline`, `test_alteration_pipeline`, `test_use_technique`, etc. use `MagicMock`/`lambda: ...` and must become `lambda *, power: ...` or accept the kwarg).
+- **Formula param name:** keeping `effective_intensity=` on `compute_damage_budget`/`compute_severity`/`compute_duration_rounds` in PR1 (passing power into it) is a deliberate small inconsistency to bound scope; renamed in a Direction-C follow-on.
+
+---
+
+## 7. Follow-on issues to file (decomposition)
+
+- Power as a `ModifierTarget` category + `_derive_power` reads power-scoped `CharacterModifier` totals (reuse existing `target_resonance`/`target_damage_type` scoping FKs).
+- Persistent "+power to fire spells" buffs (data, via the modifier system).
+- Audere / Audere Majora power-spike term in `_derive_power` (gated on Audere state) — ties to #543.
+- Level / thread / aura terms in `_derive_power`.
+- Rename `effective_intensity=` → `effective_power=` across the three scaling formulas; collapse `compute_effective_intensity` fully.
+- Environment power shift; penetration-vs-resistance; player-facing power ledger; the full ordered pipeline (Direction B).

--- a/src/flows/events/payloads.py
+++ b/src/flows/events/payloads.py
@@ -192,6 +192,7 @@ class TechniquePreCastPayload:
     technique: Technique
     targets: list[Character | ObjectDB]
     intensity: int
+    power: int
 
 
 @dataclass(frozen=True)
@@ -200,6 +201,7 @@ class TechniqueCastPayload:
     technique: Technique
     targets: list[Character | ObjectDB]
     intensity: int
+    power: int
     # `result` is the return of a caller-provided ``resolve_fn: Callable[..., Any]``;
     # its shape is defined by the caller, not this layer. Intentionally opaque.
     result: object
@@ -209,6 +211,7 @@ class TechniqueCastPayload:
 class TechniqueAffectedPayload:
     caster: Character
     technique: Technique
+    power: int
     target: Character | ObjectDB
     effect: object
 

--- a/src/integration_tests/pipeline/test_alteration_pipeline.py
+++ b/src/integration_tests/pipeline/test_alteration_pipeline.py
@@ -486,7 +486,7 @@ class AlterationFullPipelineTests(TestCase):
             return use_technique(
                 character=self.character,
                 technique=self.technique,
-                resolve_fn=lambda: "resolved",
+                resolve_fn=lambda *, power: "resolved",  # noqa: ARG005
                 confirm_soulfray_risk=True,
             )
 

--- a/src/integration_tests/pipeline/test_corruption_per_cast_pipeline.py
+++ b/src/integration_tests/pipeline/test_corruption_per_cast_pipeline.py
@@ -210,14 +210,14 @@ class TestCorruptionPerCastPipeline(TestCase):
         result_base = use_technique(
             character=sheet_base.character,
             technique=technique_base,
-            resolve_fn=lambda: None,
+            resolve_fn=lambda *, power: None,  # noqa: ARG005
         )
 
         # Audere cast
         result_audere = use_technique(
             character=sheet_audere.character,
             technique=technique_audere,
-            resolve_fn=lambda: None,
+            resolve_fn=lambda *, power: None,  # noqa: ARG005
         )
 
         # Both should have accrual results
@@ -282,7 +282,7 @@ class TestCorruptionPerCastPipeline(TestCase):
         result = use_technique(
             character=sheet.character,
             technique=technique,
-            resolve_fn=lambda: None,
+            resolve_fn=lambda *, power: None,  # noqa: ARG005
         )
 
         self.assertIsNotNone(result.corruption_summary)
@@ -361,7 +361,7 @@ class TestCorruptionPerCastPipeline(TestCase):
         result = use_technique(
             character=sheet.character,
             technique=technique,
-            resolve_fn=lambda: None,
+            resolve_fn=lambda *, power: None,  # noqa: ARG005
         )
 
         self.assertIsNotNone(result.corruption_summary)
@@ -426,7 +426,7 @@ class TestCorruptionPerCastPipeline(TestCase):
             use_technique(
                 character=sheet.character,
                 technique=technique,
-                resolve_fn=lambda: None,
+                resolve_fn=lambda *, power: None,  # noqa: ARG005
             )
 
         self.assertIn(

--- a/src/world/combat/clash.py
+++ b/src/world/combat/clash.py
@@ -220,7 +220,7 @@ def commit_to_clash(  # noqa: PLR0913 — kw-only API; all params are part of th
     # 3. Build a resolve closure that performs only the check — no damage, no
     #    conditions.  use_technique calls resolve_fn() and stores its return
     #    value as resolution_result; we return a CheckResult directly.
-    def resolve_fn() -> object:
+    def resolve_fn(*, power: int) -> object:  # noqa: ARG001 — clash check is strain-driven, not power-scaled
         return perform_check(
             objectdb,
             check_type,

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -173,7 +173,25 @@ class CombatTechniqueResolver:
             fatigue_penalty=penalty,
         )
 
-    def _apply_damage(self, check_result: CheckResult) -> list[OpponentDamageResult]:
+    def _sum_intensity_bump_pulls(self) -> int:
+        """Sum INTENSITY_BUMP scaled_values from active CombatPulls.
+
+        Isolated from compute_effective_intensity so __call__ can combine
+        the injected power (already includes identity modifiers) with the
+        pull-specific bump without double-counting the base technique intensity.
+        """
+        encounter = self.participant.encounter
+        character = self.participant.character_sheet.character
+        pull_bonus = 0
+        for pull in character.combat_pulls.active_for_encounter(encounter):
+            for eff in pull.resolved_effects_cached:
+                if eff.kind == EffectKind.INTENSITY_BUMP and eff.scaled_value:
+                    pull_bonus += eff.scaled_value
+        return pull_bonus
+
+    def _apply_damage(
+        self, check_result: CheckResult, *, eff_intensity: int
+    ) -> list[OpponentDamageResult]:
         """Iterate technique.damage_profiles. For each profile:
         - skip if SL < minimum_success_level
         - compute formula budget via compute_damage_budget
@@ -203,8 +221,6 @@ class CombatTechniqueResolver:
         if multiplier <= 0:
             return []
 
-        eff_intensity = compute_effective_intensity(self.participant, self.action)
-
         results: list[OpponentDamageResult] = []
         for profile in profiles:
             if sl < profile.minimum_success_level:
@@ -231,6 +247,8 @@ class CombatTechniqueResolver:
     def _apply_conditions(
         self,
         check_result: CheckResult,
+        *,
+        eff_intensity: int,
     ) -> list[AppliedConditionResult]:
         """Apply technique-authored conditions to appropriate targets.
 
@@ -238,6 +256,9 @@ class CombatTechniqueResolver:
         whose minimum_success_level exceeds the check result, resolves each row's
         target_kind to a concrete ObjectDB, computes severity/duration via the row's
         formula methods, and delegates to bulk_apply_conditions for the whole batch.
+
+        ``eff_intensity`` is the combined effective intensity (injected power + pull bumps)
+        computed by ``__call__`` and forwarded here.
         """
         from world.conditions.services import bulk_apply_conditions  # noqa: PLC0415
         from world.conditions.types import BulkConditionApplication  # noqa: PLC0415
@@ -248,7 +269,6 @@ class CombatTechniqueResolver:
         if not rows:
             return []
 
-        eff_intensity = compute_effective_intensity(self.participant, self.action)
         caster_od = self.participant.character_sheet.character
 
         bulk_applications: list[BulkConditionApplication] = []
@@ -297,10 +317,20 @@ class CombatTechniqueResolver:
             )
         return out
 
-    def __call__(self) -> CombatTechniqueResolution:
+    def __call__(self, *, power: int) -> CombatTechniqueResolution:
+        """Resolve the combat technique inner step.
+
+        ``power`` is injected by ``use_technique`` after the PRE_CAST envelope
+        (it equals stats.intensity including identity modifiers, and may have
+        been further modified by a pre-cast MODIFY_PAYLOAD hook).  INTENSITY_BUMP
+        pull bonuses from the current round are added on top inside this method
+        so the final effective intensity = power + pull intensity bumps.
+        """
+        pull_intensity = self._sum_intensity_bump_pulls()
+        eff_intensity = power + pull_intensity
         check_result = self._roll_check()
-        damage_results = self._apply_damage(check_result)
-        applied_conditions = self._apply_conditions(check_result)
+        damage_results = self._apply_damage(check_result, eff_intensity=eff_intensity)
+        applied_conditions = self._apply_conditions(check_result, eff_intensity=eff_intensity)
         return CombatTechniqueResolution(
             check_result=check_result,
             damage_results=damage_results,

--- a/src/world/combat/tests/test_combat_magic_integration.py
+++ b/src/world/combat/tests/test_combat_magic_integration.py
@@ -425,3 +425,105 @@ class FullHappyPathTest(TestCase):
         self.assertIn(EventName.TECHNIQUE_CAST, captured_events)
 
         self.assertTrue(result.technique_use_result.confirmed)
+
+
+class IdentityIntensityModifierRaisesCombatDamageTest(TestCase):
+    """Identity intensity CharacterModifier raises combat damage via injected power.
+
+    get_runtime_technique_stats sums CharacterModifier rows on the intensity
+    ModifierTarget into stats.intensity.  use_technique derives power from that
+    value and injects it into the resolver.  CombatTechniqueResolver.__call__
+    uses injected power (not technique.intensity) as its effective intensity seed,
+    so a caster with a +N identity intensity modifier must deal strictly more
+    opponent damage than an identical caster without that modifier.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from decimal import Decimal
+
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=2, multiplier=Decimal("1.00"), label="Full"
+        )
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=1, multiplier=Decimal("0.50"), label="Partial"
+        )
+
+    def _resolve_with_identity_modifier(self, *, identity_intensity_bonus: int) -> int:
+        """Run one resolve_combat_technique with or without an identity intensity modifier.
+
+        Returns the total damage dealt to the opponent.
+        """
+        from decimal import Decimal
+
+        from world.distinctions.factories import (
+            DistinctionEffectFactory,
+            DistinctionFactory,
+        )
+        from world.magic.factories import TechniqueDamageProfileFactory
+        from world.mechanics.constants import TECHNIQUE_STAT_CATEGORY_NAME, TECHNIQUE_STAT_INTENSITY
+        from world.mechanics.factories import ModifierCategoryFactory, ModifierTargetFactory
+        from world.mechanics.models import CharacterModifier, ModifierSource
+
+        # Base setup: intensity=5 so damage profile scaling is non-zero.
+        participant, action, _opponent, _anima, technique, _room = _setup_pc_attacking_mook(
+            technique_intensity=5,
+            technique_control=10,
+            technique_anima_cost=2,
+            base_power=0,  # No EffectType base_power — damage comes entirely from profile.
+            opponent_health=999,
+        )
+        # Replace the auto-seeded profile with one that has damage_intensity_multiplier=2.
+        # budget = base_damage(0) + eff_intensity × 2.0
+        # With identity_bonus=0: eff_intensity=5 → budget=10 → damage=10 (at SL=2, mult=1.0).
+        # With identity_bonus=10: eff_intensity=15 → budget=30 → damage=30.
+        technique.damage_profiles.all().delete()
+        TechniqueDamageProfileFactory(
+            technique=technique,
+            base_damage=0,
+            damage_intensity_multiplier=Decimal("2.0"),
+            minimum_success_level=1,
+        )
+
+        if identity_intensity_bonus > 0:
+            # Create a ModifierTarget for technique_stat intensity.
+            category = ModifierCategoryFactory(name=TECHNIQUE_STAT_CATEGORY_NAME)
+            target = ModifierTargetFactory(name=TECHNIQUE_STAT_INTENSITY, category=category)
+
+            # Create a DistinctionEffect pointing at that target (required by
+            # get_modifier_breakdown's source.distinction_effect access).
+            distinction = DistinctionFactory()
+            effect = DistinctionEffectFactory(
+                distinction=distinction,
+                target=target,
+                value_per_rank=identity_intensity_bonus,
+            )
+            source = ModifierSource.objects.create(distinction_effect=effect)
+            CharacterModifier.objects.create(
+                character=participant.character_sheet,
+                target=target,
+                value=identity_intensity_bonus,
+                source=source,
+            )
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            result = resolve_combat_technique(
+                participant=participant,
+                action=action,
+                fatigue_category=FatigueCategory.PHYSICAL,
+                offense_check_type=MagicMock(),
+                offense_check_fn=None,
+            )
+
+        return sum(r.damage_dealt for r in result.damage_results)
+
+    def test_identity_intensity_modifier_raises_damage(self) -> None:
+        """A caster WITH a +10 identity intensity modifier deals strictly more damage."""
+        damage_base = self._resolve_with_identity_modifier(identity_intensity_bonus=0)
+        damage_boosted = self._resolve_with_identity_modifier(identity_intensity_bonus=10)
+        self.assertGreater(
+            damage_boosted,
+            damage_base,
+            f"Expected boosted damage ({damage_boosted}) > base damage ({damage_base}).",
+        )

--- a/src/world/combat/tests/test_combat_technique_resolver.py
+++ b/src/world/combat/tests/test_combat_technique_resolver.py
@@ -93,7 +93,7 @@ class CombatTechniqueResolverApplyDamageTests(TestCase):
     def test_apply_damage_returns_damage_results_when_target_alive(self) -> None:
         resolver = _build_resolver()
         check = MagicMock(success_level=2)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(len(results), 1)
         self.assertGreater(results[0].damage_dealt, 0)
 
@@ -103,13 +103,13 @@ class CombatTechniqueResolverApplyDamageTests(TestCase):
         target.status = OpponentStatus.DEFEATED
         target.save(update_fields=["status"])
         check = MagicMock(success_level=2)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(results, [])
 
     def test_apply_damage_returns_empty_on_miss(self) -> None:
         resolver = _build_resolver()
         check = MagicMock(success_level=0)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(results, [])
 
     def test_apply_damage_returns_empty_when_no_target(self) -> None:
@@ -117,13 +117,13 @@ class CombatTechniqueResolverApplyDamageTests(TestCase):
         # Remove the opponent target from the action
         resolver.action.focused_opponent_target = None
         check = MagicMock(success_level=2)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(results, [])
 
     def test_apply_damage_half_on_partial_success(self) -> None:
         resolver = _build_resolver(base_power=20)
         check = MagicMock(success_level=1)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(len(results), 1)
         # half of 20 = 10, but actual damage_dealt may differ due to soak
         self.assertGreater(results[0].damage_dealt, 0)
@@ -133,7 +133,7 @@ class CombatTechniqueResolverApplyConditionsTests(TestCase):
     def test_apply_conditions_stub_returns_empty_list(self) -> None:
         resolver = _build_resolver()
         check = MagicMock(success_level=2)
-        results = resolver._apply_conditions(check)
+        results = resolver._apply_conditions(check, eff_intensity=0)
         self.assertEqual(results, [])
 
 
@@ -170,7 +170,7 @@ class ApplyConditionsTests(TestCase):
     def test_returns_empty_when_no_rows(self) -> None:
         """Technique with no condition_applications rows returns []."""
         check = MagicMock(success_level=2)
-        results = self.resolver._apply_conditions(check)
+        results = self.resolver._apply_conditions(check, eff_intensity=0)
         self.assertEqual(results, [])
 
     def test_skips_condition_below_minimum_sl(self) -> None:
@@ -192,7 +192,7 @@ class ApplyConditionsTests(TestCase):
 
             mock_bulk.return_value = [ApplyConditionResult(success=True)]
             check = MagicMock(success_level=1)
-            results = self.resolver._apply_conditions(check)
+            results = self.resolver._apply_conditions(check, eff_intensity=0)
 
         # Only one row passed the SL gate → bulk called with one application
         self.assertEqual(len(results), 1)
@@ -215,7 +215,7 @@ class ApplyConditionsTests(TestCase):
         with patch("world.conditions.services.bulk_apply_conditions") as mock_bulk:
             mock_bulk.return_value = [ApplyConditionResult(success=True)]
             check = MagicMock(success_level=2)
-            results = self.resolver._apply_conditions(check)
+            results = self.resolver._apply_conditions(check, eff_intensity=0)
 
         self.assertEqual(len(results), 1)
         result = results[0]
@@ -238,7 +238,7 @@ class ApplyConditionsTests(TestCase):
 
             mock_bulk.return_value = [ApplyConditionResult(success=True)]
             check = MagicMock(success_level=1)
-            results = self.resolver._apply_conditions(check)
+            results = self.resolver._apply_conditions(check, eff_intensity=0)
 
         self.assertEqual(len(results), 1)
         call_args = mock_bulk.call_args[0][0]
@@ -271,7 +271,7 @@ class ApplyConditionsTests(TestCase):
 
             mock_bulk.return_value = [ApplyConditionResult(success=True)]
             check = MagicMock(success_level=2)
-            results = self.resolver._apply_conditions(check)
+            results = self.resolver._apply_conditions(check, eff_intensity=0)
 
         self.assertEqual(len(results), 1)
         call_args = mock_bulk.call_args[0][0]
@@ -290,7 +290,7 @@ class ApplyConditionsTests(TestCase):
 
         with patch("world.conditions.services.bulk_apply_conditions") as mock_bulk:
             check = MagicMock(success_level=2)
-            results = self.resolver._apply_conditions(check)
+            results = self.resolver._apply_conditions(check, eff_intensity=0)
 
         mock_bulk.assert_not_called()
         self.assertEqual(results, [])
@@ -312,9 +312,8 @@ class ApplyConditionsTests(TestCase):
             from world.conditions.types import ApplyConditionResult
 
             mock_bulk.return_value = [ApplyConditionResult(success=True)]
-            with patch("world.combat.services.compute_effective_intensity", return_value=5):
-                check = MagicMock(success_level=1)
-                results = self.resolver._apply_conditions(check)
+            check = MagicMock(success_level=1)
+            results = self.resolver._apply_conditions(check, eff_intensity=5)
 
         # base_severity=2, effective_intensity=5 * multiplier=1.0 = 5, total = 7
         call_args = mock_bulk.call_args[0][0]
@@ -337,7 +336,7 @@ class ApplyConditionsTests(TestCase):
 
             mock_bulk.return_value = [ApplyConditionResult(success=True)]
             check = MagicMock(success_level=1)
-            results = self.resolver._apply_conditions(check)
+            results = self.resolver._apply_conditions(check, eff_intensity=0)
 
         call_args = mock_bulk.call_args[0][0]
         # cond_a.default_duration_value=2
@@ -357,7 +356,7 @@ class ApplyConditionsTests(TestCase):
 
             mock_bulk.return_value = [ApplyConditionResult(success=False)]
             check = MagicMock(success_level=2)
-            results = self.resolver._apply_conditions(check)
+            results = self.resolver._apply_conditions(check, eff_intensity=0)
 
         self.assertEqual(len(results), 1)
         self.assertFalse(results[0].success)
@@ -374,7 +373,7 @@ class ApplyConditionsTests(TestCase):
 
         with patch("world.conditions.services.bulk_apply_conditions") as mock_bulk:
             check = MagicMock(success_level=2)
-            results = self.resolver._apply_conditions(check)
+            results = self.resolver._apply_conditions(check, eff_intensity=0)
 
         mock_bulk.assert_not_called()
         self.assertEqual(results, [])
@@ -395,7 +394,7 @@ class CombatTechniqueResolverCallTests(TestCase):
 
         with patch("world.combat.services.perform_check") as mock_perform:
             mock_perform.return_value = MagicMock(success_level=2)
-            result = resolver()
+            result = resolver(power=5)
 
         self.assertGreater(result.scaled_damage, 0)
         self.assertEqual(result.pull_flat_bonus, 2)
@@ -462,6 +461,78 @@ class SumActiveFlatBonusesTests(TestCase):
             _sum_active_flat_bonuses(resolver.participant, resolver.participant.encounter),
             0,
         )
+
+
+class ResolverConsumesPowerTests(TestCase):
+    """CombatTechniqueResolver.__call__(power=N) uses injected power for scaling.
+
+    These tests establish the RED gate: higher power → larger damage budget;
+    lower power (or 0) → smaller/zero budget. The resolver's __call__ must
+    accept a `power` keyword argument and route it through _apply_damage and
+    _apply_conditions as the base intensity, augmented by INTENSITY_BUMP pulls.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from decimal import Decimal
+
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=2, multiplier=Decimal("1.00"), label="Full"
+        )
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=1, multiplier=Decimal("0.50"), label="Partial"
+        )
+
+    def _build_resolver_with_intensity_profile(self) -> CombatTechniqueResolver:
+        """Build a resolver whose technique has a damage profile that scales with intensity."""
+        from decimal import Decimal
+
+        from world.magic.factories import TechniqueDamageProfileFactory
+
+        resolver = _build_resolver(base_power=0)
+        # Remove any auto-seeded profile (base_power=0 may seed an empty one).
+        resolver.action.focused_action.damage_profiles.all().delete()
+        # Profile where budget = base_damage + intensity × multiplier.
+        # base_damage=10 so even power=0 produces a nonzero baseline.
+        TechniqueDamageProfileFactory(
+            technique=resolver.action.focused_action,
+            base_damage=10,
+            damage_intensity_multiplier=Decimal("1.0"),
+            minimum_success_level=1,
+        )
+        return resolver
+
+    def test_higher_power_yields_larger_scaled_damage(self) -> None:
+        """resolver(power=20) must produce more scaled_damage than resolver(power=0)."""
+        resolver = self._build_resolver_with_intensity_profile()
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            low_result = resolver(power=0)
+
+        # Rebuild to get a fresh opponent with full health.
+        resolver_hi = self._build_resolver_with_intensity_profile()
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            high_result = resolver_hi(power=20)
+
+        self.assertGreater(
+            high_result.scaled_damage,
+            low_result.scaled_damage,
+            "Higher injected power must produce larger scaled_damage.",
+        )
+
+    def test_zero_power_with_no_pulls_uses_base_damage_only(self) -> None:
+        """resolver(power=0) with no INTENSITY_BUMP pulls still returns damage from base_damage."""
+        resolver = self._build_resolver_with_intensity_profile()
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            result = resolver(power=0)
+
+        # base_damage=10, intensity part=0×1.0=0 → budget=10 → damage > 0 after soak.
+        self.assertGreater(result.scaled_damage, 0)
 
 
 class BuildCombatResultTests(TestCase):
@@ -607,7 +678,7 @@ class ApplyDamageWithProfilesTests(EvenniaTestCase):
         # Sanity: no profiles remain.
         self.assertEqual(resolver.action.focused_action.damage_profiles.count(), 0)
         check = MagicMock(success_level=2)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(results, [])
 
     def test_single_component_full_success(self) -> None:
@@ -617,7 +688,7 @@ class ApplyDamageWithProfilesTests(EvenniaTestCase):
         # The auto-seeded profile has base_damage=10, damage_intensity_multiplier=0.
         # SL=2 → multiplier=1.0 → budget=10 → scaled=10 → apply_damage_to_opponent.
         check = MagicMock(success_level=2)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(len(results), 1)
         self.assertGreater(results[0].damage_dealt, 0)
 
@@ -625,7 +696,7 @@ class ApplyDamageWithProfilesTests(EvenniaTestCase):
         """1 profile base_damage=20; SL=1 → multiplier=0.5 → 10 budget → >0 damage after soak."""
         resolver = _build_resolver(base_power=20)
         check = MagicMock(success_level=1)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(len(results), 1)
         self.assertGreater(results[0].damage_dealt, 0)
 
@@ -642,17 +713,13 @@ class ApplyDamageWithProfilesTests(EvenniaTestCase):
             minimum_success_level=2,
         )
         check = MagicMock(success_level=1)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(results, [])
 
     def test_intensity_scales_damage(self) -> None:
-        """A profile with damage_intensity_multiplier=1.0 produces more damage when
-        an INTENSITY_BUMP pull raises effective_intensity above the technique baseline."""
-        from world.combat.factories import (
-            CombatPullFactory,
-            CombatPullResolvedEffectFactory,
-        )
-        from world.magic.constants import EffectKind
+        """A profile with damage_intensity_multiplier=1.0 produces more damage with
+        higher eff_intensity.  Passing eff_intensity=5 directly (simulating a pull bump)
+        must produce damage > 0."""
         from world.magic.factories import TechniqueDamageProfileFactory
 
         resolver = _build_resolver(base_power=0)
@@ -666,24 +733,11 @@ class ApplyDamageWithProfilesTests(EvenniaTestCase):
             damage_intensity_multiplier=Decimal("1.0"),
             minimum_success_level=1,
         )
-        # Add an INTENSITY_BUMP pull to raise effective_intensity by 5.
-        encounter = resolver.participant.encounter
-        pull = CombatPullFactory(
-            participant=resolver.participant,
-            encounter=encounter,
-            round_number=encounter.round_number,
-        )
-        CombatPullResolvedEffectFactory(
-            pull=pull,
-            kind=EffectKind.INTENSITY_BUMP,
-            scaled_value=5,
-        )
-        resolver.participant.character_sheet.character.combat_pulls.invalidate()
 
-        # technique.intensity defaults to some value; after bump effective_intensity > 0.
+        # Pass eff_intensity=5 directly (simulating power=0 + pull_bump=5).
         check = MagicMock(success_level=2)
-        results = resolver._apply_damage(check)
-        # budget = intensity × 1.0; must produce at least 1 result with damage > 0.
+        results = resolver._apply_damage(check, eff_intensity=5)
+        # budget = 5 × 1.0 = 5 → damage > 0.
         self.assertEqual(len(results), 1)
         self.assertGreater(results[0].damage_dealt, 0)
 
@@ -702,7 +756,7 @@ class ApplyDamageWithProfilesTests(EvenniaTestCase):
             minimum_success_level=1,
         )
         check = MagicMock(success_level=2)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(len(results), 2)
         self.assertGreater(results[0].damage_dealt, 0)
         self.assertGreater(results[1].damage_dealt, 0)
@@ -727,7 +781,7 @@ class ApplyDamageWithProfilesTests(EvenniaTestCase):
             minimum_success_level=1,
         )
         check = MagicMock(success_level=2)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         # Only 1 result: the second profile was skipped because target was defeated.
         self.assertEqual(len(results), 1)
 
@@ -738,5 +792,5 @@ class ApplyDamageWithProfilesTests(EvenniaTestCase):
         target.status = OpponentStatus.DEFEATED
         target.save(update_fields=["status"])
         check = MagicMock(success_level=2)
-        results = resolver._apply_damage(check)
+        results = resolver._apply_damage(check, eff_intensity=5)
         self.assertEqual(results, [])

--- a/src/world/magic/services/techniques.py
+++ b/src/world/magic/services/techniques.py
@@ -153,6 +153,21 @@ def _build_resonance_involvements(
     )
 
 
+def _derive_power(
+    *,
+    channeled_intensity: int,
+    technique: Technique | None,  # noqa: ARG001 — reserved for future power terms (#634-#637)
+    character: ObjectDB | None,  # noqa: ARG001 — reserved for future power terms (#634-#637)
+) -> int:
+    """Derive effective power. NEVER stored — recomputed each cast.
+
+    PR1: power == channeled intensity. Later issues (#634-#637) add level,
+    threads, aura/resonance, and power-scoped modifier terms here. The
+    ``technique``/``character`` params are the future inputs; unused in PR1.
+    """
+    return channeled_intensity
+
+
 def get_runtime_technique_stats(
     technique: Technique,
     character: ObjectDB | None,
@@ -238,6 +253,21 @@ def calculate_effective_anima_cost(
     )
 
 
+def _derive_power(
+    *,
+    channeled_intensity: int,
+    technique: Technique | None,  # noqa: ARG001 — reserved for future power terms (#634-#637)
+    character: ObjectDB | None,  # noqa: ARG001 — reserved for future power terms (#634-#637)
+) -> int:
+    """Derive effective power. NEVER stored — recomputed each cast.
+
+    PR1: power == channeled intensity. Later issues (#634-#637) add level,
+    threads, aura/resonance, and power-scoped modifier terms here. The
+    ``technique``/``character`` params are the future inputs; unused in PR1.
+    """
+    return channeled_intensity
+
+
 def use_technique(  # noqa: PLR0913, PLR0912, C901, PLR0915 — kw-only args are intentional; step 10 pushed statement count over threshold
     *,
     character: ObjectDB,
@@ -289,11 +319,15 @@ def use_technique(  # noqa: PLR0913, PLR0912, C901, PLR0915 — kw-only args are
     # --- TECHNIQUE_PRE_CAST (cancellable, before anima deduction) ---
     effective_targets = targets or []
     caster_room = getattr(character, "location", None)  # noqa: GETATTR_LITERAL
+    seed_power = _derive_power(
+        channeled_intensity=stats.intensity, technique=technique, character=character
+    )
     pre_payload = TechniquePreCastPayload(
         caster=character,
         technique=technique,
         targets=effective_targets,
         intensity=stats.intensity,
+        power=seed_power,
     )
     if caster_room is not None:
         stack = emit_event(
@@ -308,11 +342,16 @@ def use_technique(  # noqa: PLR0913, PLR0912, C901, PLR0915 — kw-only args are
                 technique=technique,
             )
 
+    # Read back power after any pre-cast MODIFY_PAYLOAD hooks (mutable payload).
+    # pre_payload.power holds seed_power when no room exists (no emit path),
+    # and the post-hook value when the emit path ran.
+    effective_power = pre_payload.power
+
     # Step 4: Deduct anima
     deficit = deduct_anima(character, cost.effective_cost)
 
     # Steps 5 + 6: Resolution
-    resolution_result = resolve_fn()
+    resolution_result = resolve_fn(power=effective_power)
 
     # Extract check_result from resolution if not provided explicitly
     effective_check_result = check_result
@@ -405,6 +444,7 @@ def use_technique(  # noqa: PLR0913, PLR0912, C901, PLR0915 — kw-only args are
                 technique=technique,
                 targets=effective_targets,
                 intensity=stats.intensity,
+                power=effective_power,
                 result=resolution_result,
             ),
             location=caster_room,
@@ -420,6 +460,7 @@ def use_technique(  # noqa: PLR0913, PLR0912, C901, PLR0915 — kw-only args are
                     caster=character,
                     technique=technique,
                     target=affected_target,
+                    power=effective_power,
                     effect=resolution_result,
                 ),
                 location=target_room,

--- a/src/world/magic/services/techniques.py
+++ b/src/world/magic/services/techniques.py
@@ -253,21 +253,6 @@ def calculate_effective_anima_cost(
     )
 
 
-def _derive_power(
-    *,
-    channeled_intensity: int,
-    technique: Technique | None,  # noqa: ARG001 — reserved for future power terms (#634-#637)
-    character: ObjectDB | None,  # noqa: ARG001 — reserved for future power terms (#634-#637)
-) -> int:
-    """Derive effective power. NEVER stored — recomputed each cast.
-
-    PR1: power == channeled intensity. Later issues (#634-#637) add level,
-    threads, aura/resonance, and power-scoped modifier terms here. The
-    ``technique``/``character`` params are the future inputs; unused in PR1.
-    """
-    return channeled_intensity
-
-
 def use_technique(  # noqa: PLR0913, PLR0912, C901, PLR0915 — kw-only args are intentional; step 10 pushed statement count over threshold
     *,
     character: ObjectDB,

--- a/src/world/magic/tests/integration/test_corruption_flow.py
+++ b/src/world/magic/tests/integration/test_corruption_flow.py
@@ -468,7 +468,7 @@ class FullCastPipelineCorruptionTests(TestCase):
         result = use_technique(
             character=sheet.character,
             technique=technique,
-            resolve_fn=lambda: None,
+            resolve_fn=lambda *, power: None,  # noqa: ARG005
         )
 
         # Summary is attached to the result
@@ -503,7 +503,7 @@ class FullCastPipelineCorruptionTests(TestCase):
         result = use_technique(
             character=sheet.character,
             technique=technique,
-            resolve_fn=lambda: None,
+            resolve_fn=lambda *, power: None,  # noqa: ARG005
         )
 
         # Summary is still attached (orchestrator ran, just skipped Celestial)
@@ -548,7 +548,7 @@ class FullCastPipelineCorruptionTests(TestCase):
         result = use_technique(
             character=sheet.character,
             technique=technique,
-            resolve_fn=lambda: None,
+            resolve_fn=lambda *, power: None,  # noqa: ARG005
         )
 
         assert result.corruption_summary is not None
@@ -602,7 +602,7 @@ class FullCastPipelineCorruptionTests(TestCase):
             use_technique(
                 character=sheet.character,
                 technique=technique,
-                resolve_fn=lambda: None,
+                resolve_fn=lambda *, power: None,  # noqa: ARG005
             )
 
         assert EventName.CORRUPTION_WARNING in emitted_event_names
@@ -622,7 +622,7 @@ class FullCastPipelineCorruptionTests(TestCase):
         result = use_technique(
             character=character,
             technique=technique,
-            resolve_fn=lambda: None,
+            resolve_fn=lambda *, power: None,  # noqa: ARG005
         )
 
         # Cast succeeded

--- a/src/world/magic/tests/test_reactive_integration.py
+++ b/src/world/magic/tests/test_reactive_integration.py
@@ -474,7 +474,7 @@ class TechniqueCheckResultExtractorTest(TestCase):
             use_technique(
                 character=self.char,
                 technique=self.technique,
-                resolve_fn=lambda: resolution,
+                resolve_fn=lambda *, power: resolution,  # noqa: ARG005
             )
 
         # The extractor must have found .check_result and passed it through.

--- a/src/world/magic/tests/test_resonance_environment_service.py
+++ b/src/world/magic/tests/test_resonance_environment_service.py
@@ -894,7 +894,7 @@ class UseTechniqueResonanceEnvironmentIntegrationTest(ResonanceCacheIsolationMix
             result = use_technique(
                 character=self.character,
                 technique=self.technique,
-                resolve_fn=lambda: "resolved",
+                resolve_fn=lambda *, power: "resolved",  # noqa: ARG005
             )
 
         # use_technique should complete successfully
@@ -931,7 +931,7 @@ class UseTechniqueResonanceEnvironmentIntegrationTest(ResonanceCacheIsolationMix
         result = use_technique(
             character=self.character,
             technique=self.technique,
-            resolve_fn=lambda: "resolved",
+            resolve_fn=lambda *, power: "resolved",  # noqa: ARG005
         )
 
         self.assertTrue(result.confirmed)

--- a/src/world/magic/tests/test_use_technique.py
+++ b/src/world/magic/tests/test_use_technique.py
@@ -1,18 +1,206 @@
 """Tests for use_technique orchestrator."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
+from evennia.objects.models import ObjectDB
 
+from flows.constants import EventName
+from flows.consts import FlowActionChoices
+from flows.factories import FlowDefinitionFactory, FlowStepDefinitionFactory
 from world.checks.factories import CheckTypeFactory
+from world.conditions.factories import ReactiveConditionFactory
 from world.magic.factories import (
     CharacterAnimaFactory,
     TechniqueFactory,
 )
 from world.magic.services import use_technique
+from world.magic.services.techniques import get_runtime_technique_stats
 from world.magic.types import TechniqueUseResult
 from world.mechanics.factories import CharacterEngagementFactory
 from world.traits.factories import CheckOutcomeFactory
+
+
+class DerivePowerTests(TestCase):
+    """Test the _derive_power helper."""
+
+    def test_derive_power_equals_channeled_intensity_in_pr1(self) -> None:
+        from world.magic.services.techniques import _derive_power
+
+        self.assertEqual(_derive_power(channeled_intensity=7, technique=None, character=None), 7)
+
+
+# ---------------------------------------------------------------------------
+# Pre-cast MODIFY_PAYLOAD power read-back
+# ---------------------------------------------------------------------------
+
+SELF_FILTER = {"path": "caster", "op": "==", "value": "self"}
+
+
+def _create_room(key: str = "PowerTestRoom") -> ObjectDB:
+    return ObjectDB.objects.create(
+        db_key=key,
+        db_typeclass_path="typeclasses.rooms.Room",
+    )
+
+
+def _make_multiply_power_flow(factor: float) -> object:
+    """Return a FlowDefinition with a MODIFY_PAYLOAD step that multiplies power."""
+    flow = FlowDefinitionFactory()
+    FlowStepDefinitionFactory(
+        flow=flow,
+        parent_id=None,
+        action=FlowActionChoices.MODIFY_PAYLOAD,
+        parameters={"field": "power", "op": "multiply", "value": factor},
+    )
+    return flow
+
+
+class PreCastPowerReadBackTests(TestCase):
+    """A pre-cast MODIFY_PAYLOAD on power is read back into resolve_fn and CAST/AFFECTED."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # intensity=10 so 10 * 0.5 = 5.0 — avoids fractional truncation ambiguity
+        cls.technique = TechniqueFactory(intensity=10, control=15, anima_cost=3)
+
+    def setUp(self) -> None:
+        self.room = _create_room("PreCastPowerRoom")
+        self.anima = CharacterAnimaFactory(current=20, maximum=20)
+        self.character = self.anima.character
+        CharacterEngagementFactory(character=self.character)
+        self.character.location = self.room
+
+    def test_resolve_fn_receives_halved_power(self) -> None:
+        """Pre-cast trigger multiplies power by 0.5; resolver receives halved value."""
+        half_flow = _make_multiply_power_flow(0.5)
+        ReactiveConditionFactory(
+            event_name=EventName.TECHNIQUE_PRE_CAST,
+            filter_condition=SELF_FILTER,
+            flow_definition=half_flow,
+            target=self.character,
+        )
+        self.character.trigger_handler._populated = False
+
+        expected_runtime_intensity = get_runtime_technique_stats(
+            self.technique, self.character
+        ).intensity
+        # MODIFY_PAYLOAD multiply does not truncate to int; use numeric equality
+        expected_power = expected_runtime_intensity * 0.5
+
+        captured: dict[str, object] = {}
+
+        def spy(*, power: int) -> SimpleNamespace:
+            captured["power"] = power
+            return SimpleNamespace(check_result=None)
+
+        use_technique(
+            character=self.character,
+            technique=self.technique,
+            resolve_fn=spy,
+        )
+
+        self.assertIn("power", captured)
+        self.assertEqual(captured["power"], expected_power)
+
+    def test_resolve_fn_receives_power_kwarg(self) -> None:
+        """resolve_fn must be called with power as a keyword argument."""
+        captured: dict[str, object] = {}
+
+        def spy(*, power: int) -> SimpleNamespace:
+            captured["power"] = power
+            return SimpleNamespace(check_result=None)
+
+        use_technique(
+            character=self.character,
+            technique=self.technique,
+            resolve_fn=spy,
+        )
+
+        self.assertIn("power", captured)
+
+
+class PreCastModifyPowerInvariantTests(TestCase):
+    """A pre-cast MODIFY_PAYLOAD on power must NOT affect caster-side outputs.
+
+    power is a downstream scaling hint for the resolve_fn; the cost/mishap/soulfray
+    path runs on channeled_intensity, which is fixed before the PRE_CAST hook fires.
+    These tests prove the invariant by running use_technique with and without a
+    ward that halves power and asserting that caster-side outputs are identical.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.technique = TechniqueFactory(
+            intensity=5,
+            control=10,
+            anima_cost=3,
+        )
+
+    def _run_with_ward(self, *, with_ward: bool) -> "tuple[int, object, object]":
+        """Return (anima_delta, was_mishap, soulfray_result) for one use_technique call."""
+        room = _create_room(f"InvariantRoom{'Ward' if with_ward else 'Control'}")
+        anima = CharacterAnimaFactory(current=20, maximum=20)
+        character = anima.character
+        CharacterEngagementFactory(character=character)
+        character.location = room
+
+        if with_ward:
+            half_flow = _make_multiply_power_flow(0.5)
+            ReactiveConditionFactory(
+                event_name=EventName.TECHNIQUE_PRE_CAST,
+                filter_condition=SELF_FILTER,
+                flow_definition=half_flow,
+                target=character,
+            )
+            character.trigger_handler._populated = False
+
+        def spy(*, power: int) -> SimpleNamespace:
+            return SimpleNamespace(check_result=None)
+
+        result = use_technique(
+            character=character,
+            technique=self.technique,
+            resolve_fn=spy,
+        )
+
+        anima.refresh_from_db()
+        anima_delta = 20 - anima.current
+        soulfray_severity = (
+            result.soulfray_result.severity_added if result.soulfray_result is not None else None
+        )
+        return anima_delta, result.was_mishap, soulfray_severity
+
+    def test_power_ward_does_not_change_anima_cost(self) -> None:
+        """Pre-cast power *= 0.5 must not change the anima deducted."""
+        delta_control, _, _ = self._run_with_ward(with_ward=False)
+        delta_ward, _, _ = self._run_with_ward(with_ward=True)
+        self.assertEqual(
+            delta_control,
+            delta_ward,
+            "Anima delta must be identical with and without a pre-cast power modifier.",
+        )
+
+    def test_power_ward_does_not_change_mishap_flag(self) -> None:
+        """Pre-cast power *= 0.5 must not change was_mishap."""
+        _, mishap_control, _ = self._run_with_ward(with_ward=False)
+        _, mishap_ward, _ = self._run_with_ward(with_ward=True)
+        self.assertEqual(
+            mishap_control,
+            mishap_ward,
+            "was_mishap must be identical with and without a pre-cast power modifier.",
+        )
+
+    def test_power_ward_does_not_change_soulfray_severity(self) -> None:
+        """Pre-cast power *= 0.5 must not change soulfray severity (both None here)."""
+        _, _, soulfray_control = self._run_with_ward(with_ward=False)
+        _, _, soulfray_ward = self._run_with_ward(with_ward=True)
+        self.assertEqual(
+            soulfray_control,
+            soulfray_ward,
+            "Soulfray severity must be identical with and without a pre-cast power modifier.",
+        )
 
 
 class UseTechniqueBasicTests(TestCase):
@@ -241,7 +429,7 @@ class UseTechniqueCheckResultExtractionTests(TestCase):
         result = use_technique(
             character=self.character,
             technique=self.technique,
-            resolve_fn=lambda: mock_resolution,
+            resolve_fn=lambda *, power: mock_resolution,  # noqa: ARG005 — power is future seam
             confirm_soulfray_risk=True,
         )
 
@@ -292,7 +480,7 @@ class UseTechniqueCheckResultExtractionTests(TestCase):
         use_technique(
             character=self.character,
             technique=self.technique,
-            resolve_fn=lambda: mock_resolution,
+            resolve_fn=lambda *, power: mock_resolution,  # noqa: ARG005 — power is future seam
             confirm_soulfray_risk=True,
         )
 

--- a/src/world/mechanics/tests/test_pipeline_integration.py
+++ b/src/world/mechanics/tests/test_pipeline_integration.py
@@ -925,7 +925,7 @@ class TechniqueUseFlowTests(PipelineTestMixin, TestCase):
             is_revealed=True,
         )
 
-    def _resolve_challenge(self) -> object:
+    def _resolve_challenge(self, *, power: int) -> object:  # noqa: ARG002
         """Helper that calls resolve_challenge with mocked check."""
         sources = get_capability_sources_for_character(self.character)
         gen_source = next(s for s in sources if s.capability_name == "generation")
@@ -1056,7 +1056,7 @@ class TechniqueUseFlowTests(PipelineTestMixin, TestCase):
             use_technique(
                 character=self.character,
                 technique=controlled_technique,
-                resolve_fn=lambda: "ok",
+                resolve_fn=lambda *, power: "ok",  # noqa: ARG005
             )
             mock_pool.assert_not_called()
 
@@ -1067,7 +1067,7 @@ class TechniqueUseFlowTests(PipelineTestMixin, TestCase):
         result = use_technique(
             character=self.character,
             technique=self.flow_technique,
-            resolve_fn=lambda: "ok",
+            resolve_fn=lambda *, power: "ok",  # noqa: ARG005
         )
 
         assert result.anima_cost.base_cost == 8
@@ -1586,7 +1586,7 @@ class SoulfrayProgressionTests(PipelineTestMixin, TestCase):
         result = use_technique(
             character=self.character,
             technique=self.soulfray_technique,
-            resolve_fn=lambda: "ok",
+            resolve_fn=lambda *, power: "ok",  # noqa: ARG005
         )
 
         assert result.soulfray_result is None
@@ -1620,7 +1620,7 @@ class SoulfrayProgressionTests(PipelineTestMixin, TestCase):
         result = use_technique(
             character=self.character,
             technique=self.soulfray_technique,
-            resolve_fn=lambda: "ok",
+            resolve_fn=lambda *, power: "ok",  # noqa: ARG005
         )
 
         assert result.soulfray_result is not None
@@ -1650,7 +1650,7 @@ class SoulfrayProgressionTests(PipelineTestMixin, TestCase):
         result = use_technique(
             character=self.character,
             technique=self.soulfray_technique,
-            resolve_fn=lambda: "ok",
+            resolve_fn=lambda *, power: "ok",  # noqa: ARG005
         )
 
         # No warning was raised (no pre-existing Soulfray condition)
@@ -1677,7 +1677,7 @@ class SoulfrayProgressionTests(PipelineTestMixin, TestCase):
         result = use_technique(
             character=self.character,
             technique=self.soulfray_technique,
-            resolve_fn=lambda: "ok",
+            resolve_fn=lambda *, power: "ok",  # noqa: ARG005
             confirm_soulfray_risk=False,
         )
 
@@ -1718,7 +1718,7 @@ class SoulfrayProgressionTests(PipelineTestMixin, TestCase):
         result = use_technique(
             character=self.character,
             technique=self.soulfray_technique,
-            resolve_fn=lambda: "ok",
+            resolve_fn=lambda *, power: "ok",  # noqa: ARG005
             confirm_soulfray_risk=True,
         )
 
@@ -1757,7 +1757,7 @@ class SoulfrayProgressionTests(PipelineTestMixin, TestCase):
             result = use_technique(
                 character=self.character,
                 technique=self.soulfray_technique,
-                resolve_fn=lambda: "ok",
+                resolve_fn=lambda *, power: "ok",  # noqa: ARG005
                 confirm_soulfray_risk=True,
             )
 
@@ -1816,7 +1816,7 @@ class SoulfrayProgressionTests(PipelineTestMixin, TestCase):
         result = use_technique(
             character=self.character,
             technique=self.soulfray_technique,
-            resolve_fn=lambda: "ok",
+            resolve_fn=lambda *, power: "ok",  # noqa: ARG005
             confirm_soulfray_risk=True,
             check_result=botch_result,
         )
@@ -1859,7 +1859,7 @@ class SoulfrayProgressionTests(PipelineTestMixin, TestCase):
         result = use_technique(
             character=self.character,
             technique=self.wild_technique,
-            resolve_fn=lambda: "ok",
+            resolve_fn=lambda *, power: "ok",  # noqa: ARG005
             check_result=check_result,
         )
 
@@ -1914,7 +1914,7 @@ class SoulfrayProgressionTests(PipelineTestMixin, TestCase):
         result = use_technique(
             character=self.character,
             technique=self.wild_technique,
-            resolve_fn=lambda: "ok",
+            resolve_fn=lambda *, power: "ok",  # noqa: ARG005
             confirm_soulfray_risk=True,
             check_result=check_result,
         )

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -328,7 +328,7 @@ def _resolve_enhanced_action(  # noqa: PLR0913 — keyword-only API, all params 
     technique_result = use_technique(
         character=character,
         technique=technique,
-        resolve_fn=lambda: start_action_resolution(
+        resolve_fn=lambda *, power: start_action_resolution(  # noqa: ARG005 — scenes check is difficulty-driven, not power-scaled
             character=character,
             template=action_template,
             target_difficulty=difficulty,


### PR DESCRIPTION
## Pre-cast Power Read-back (Issue 0 of epic #633)

Introduces a derived **power** value distinct from channeled **intensity**, and closes the #524 gap where a pre-cast `TECHNIQUE_PRE_CAST` `MODIFY_PAYLOAD` edit was silently discarded.

Closes #524.

### The split
- **Intensity** = what the caster *channels*. Still solely drives anima cost, mishap (`control_deficit`), resonance attribution, and Soulfray. **A ward never reduces it.**
- **Power** = the *effective magnitude* the working carries into the world (damage, condition severity/duration, capability). The modifiable lever — editable by pre-cast triggers now; persistent buffs / Audere spike / environment later (#634-#639).
- **Invariant:** power is **always derived, never stored** — recomputed each cast in `_derive_power` (`world/magic/services/techniques.py`). PR1 derives `power == channeled intensity`; later issues add level/thread/aura/modifier terms at that one seam.

### What changed
| File | Change |
|---|---|
| `flows/events/payloads.py` | `power: int` on `TechniquePreCastPayload` (mutable), `TechniqueCastPayload`, `TechniqueAffectedPayload` |
| `world/magic/services/techniques.py` | `_derive_power()`; `use_technique` seeds `power`, reads the post-hook value back, calls `resolve_fn(power=...)`, threads it into CAST/AFFECTED. Caster-side keeps reading `stats.intensity` |
| `world/combat/services.py` | `CombatTechniqueResolver.__call__(*, power)` scales damage/conditions on `power + INTENSITY_BUMP pulls` — folds in the caster's full intensity envelope (front edge of Direction C). `compute_effective_intensity` retained for the clash intensity floor |
| `world/combat/clash.py`, `world/scenes/action_services.py` | `resolve_fn` accepts `power` (ignored — those resolutions are strain/difficulty-driven) |

### Behavioral consequence (intended)
Combat damage now reflects the caster's identity intensity modifiers, which `compute_effective_intensity` previously ignored. No production data / disposable dev DB → the balance shift is acceptable and correct (spec §4.4).

### Tests
- Read-back: a pre-cast `power *= 0.5` reaches `resolve_fn`.
- **Invariants:** the same ward does NOT change anima cost, mishap, or Soulfray (caster-side untouched).
- End-to-end: a caster with an identity intensity `CharacterModifier` deals strictly more combat damage.
- Full parity gate (PG): `world.magic` 1432 OK · `world.combat` 630 OK · `world.scenes` 272 OK · `world.mechanics` 259 OK · `flows` 255 OK · magic pipeline integration 19 OK. Lint clean. Rebased onto current `origin/main` (`74a7c699`); no file overlap with the parallel combat work.

### Follow-ons (epic #633)
#634 power ModifierTarget · #635 persistent buffs · #636 Audere spike · #637 level/thread/aura · #638 Direction C consolidation · #639 Direction B pipeline. Research + candidate-directions report committed under `docs/superpowers/specs/2026-05-30-power-intensity-research-report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
