### PR TITLE
chore(skills): TEMP grounding-before-action harness workaround (#647)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Ambiguous "?" sentences force the user to guess whether they're being asked to respond. When in doubt, no `?` in user-facing text outside of `AskUserQuestion`.
 
+<!-- TEMP HARNESS-BUNDLING-WORKAROUND — remove when GH #647 is resolved -->
+**[TEMP] Ground before you act — load the `grounding-before-action` skill at session start.** Claude Code 2.1.158 has a regression: a tool result emitted in the **same message** as the call it depends on is invisible at compose time, so the model confabulates what it returned and acts on the fiction (caused real erroneous GitHub edits; see `tools/skills/grounding-before-action/`). Until it's patched: never co-emit `AskUserQuestion` (or any sentence stating what a tool returned) with the tool calls it depends on — emit calls, end the turn, observe, then act. Verify issue number↔title before any mutation. This is a **temporary** workaround tracked in **#647** (grep `HARNESS-BUNDLING-WORKAROUND`); delete it when the harness is fixed.
+
 ## Git Workflow
 
 > For end-to-end issue → merged-PR work, see the `issue-to-merged-pr` skill at `tools/skills/issue-to-merged-pr/`. It handles branch creation, PR opening, CI watching, and post-merge cleanup. The conventions below still apply; the skill is built on top of them.

--- a/tools/skills/README.md
+++ b/tools/skills/README.md
@@ -55,6 +55,15 @@ Regenerates `docs/systems/MODEL_MAP.md` — an auto-generated map of all
 Django model relationships and service function signatures. Prevents
 expensive codebase searches when working across multiple apps.
 
+### grounding-before-action `[TEMP — HARNESS-BUNDLING-WORKAROUND]`
+
+**Temporary workaround for a Claude Code 2.1.158 regression** where a tool
+result co-emitted in the same assistant message as the call it depends on is
+invisible at compose time, causing the model to confabulate the result and act
+on it. Enforces un-bundling `AskUserQuestion`/result-claims from their tool
+calls and verifying issue number↔title before mutations. **Delete this skill
+when the harness is fixed** — removal manifest + test in GH #647.
+
 ## Updating skills
 
 In the devcontainer or Linux/macOS bare-metal: just edit the files

--- a/tools/skills/grounding-before-action/SKILL.md
+++ b/tools/skills/grounding-before-action/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: grounding-before-action
+description: Use at the start of every session and before composing ANY message that contains an AskUserQuestion or a sentence stating what a tool returned / what an issue/file/branch contains / what a subagent found. Also before any irreversible or outward-facing action (gh/git writes — issue comment/edit/label/assign/close, PR ops, pushes, file deletes). Especially when a tool result looks empty or hasn't appeared — that is the moment confabulation happens.
+---
+
+# Grounding Before Action
+
+<!-- TEMP HARNESS-BUNDLING-WORKAROUND — remove when GH #647 is resolved.
+     This skill exists ONLY to work around a Claude Code 2.1.158 regression
+     (co-emitted tool results are invisible at compose time). Delete the whole
+     skill dir + the CLAUDE.md/README pointers + the memory note when the
+     harness is fixed. See issue #647 for the removal manifest + test. -->
+
+> ⚠️ **TEMPORARY — harness workaround (grep: `HARNESS-BUNDLING-WORKAROUND`).**
+> This is not permanent project discipline. It exists because Claude Code
+> **2.1.158** (latest as of 2026-05-30) cannot see a tool result that is
+> emitted in the **same assistant message** as the call it depends on. When the
+> harness is fixed, **delete this skill** per the manifest in **GH #647**.
+
+## The one rule
+
+**Never put a tool call and a claim-about-its-result in the same message.**
+
+Concretely:
+- `AskUserQuestion` goes in its **own message**, alone — never co-emitted with the tool calls whose output the question reasons about.
+- Any sentence asserting what a tool returned — file contents, an issue's title/body, comment counts, a branch name, a subagent's findings — must be written in a turn that comes **after** the turn that produced it, where you can actually see the result.
+
+Emit calls → **end the turn** → observe the real results → **then** compose whatever depends on them.
+
+## Why (the bug, precisely)
+
+Tool results are **not** lost or garbled. They arrive intact. The failure is that when you bundle a dependent step into the same message as its tool call, you are composing that step **before the result exists in your view** — so you see a blank and fill it with a plausible story. The batch then resolves and the real output sits right next to your fabrication. The content of the lie is random (an "empty" file, a "corrupted" read, "41 passing tests", a fake issue #643); the cause is fixed: **dependent step co-emitted with its call.**
+
+## The gates
+
+1. **Un-bundle.** `AskUserQuestion` and result-narrating sentences get their own message. If you're about to write "the output shows…" or a question reasoning about a result, in the same message as the call producing it — STOP, split it.
+2. **A read is only true for the instant it returned.** State drifts and turns are long; **re-read immediately before acting**, in a turn where the fresh result is visible before the write.
+3. **One sequential call for state-changing or state-reading git/gh work.** No large parallel batches. Independent *pure reads* may batch; never batch a read with the action it informs. (See [[feedback-sequential-mutations]].)
+4. **Verify number↔title before ANY issue mutation.** Before `gh issue comment/edit/--add-label/--add-assignee/close` (or PR equivalents), fetch and quote the target's number AND title — and confirm `gh issue create` returned the number you think it did (it is NOT the next sequential number). Never assume numbers are sequential or that a remembered title is current.
+5. **Reads → user-checkable summary → writes.** Surface what you observed (titles, IDs, counts) before a batch of irreversible actions, so it can be checked.
+6. **If you didn't see it, you don't know it.** Never narrate a tool result, file content, issue body, or subagent finding you have not observed in a returned result. "Probably returned…", "should say…", "the agent found…" are confabulation. Say "I haven't seen it yet" and go look.
+
+## Red flags — STOP, you're about to confabulate
+
+- You're writing an `AskUserQuestion` in the same message as other tool calls.
+- A result looks empty/partial/corrupted and you're tempted to "proceed as if…" or to report a problem with the tooling. (The tooling is fine — you just haven't seen the result yet.)
+- You're about to `gh issue edit/comment/close` without a title quote in this turn, or trusting that `gh issue create` made issue #N+1.
+- You're describing what a subagent "found" but can't point to its returned text.
+- You're relying on a read from earlier in a long turn for a write happening now.
+
+**All of these mean: end the turn, observe the real result (or re-read), then act.**
+
+| Rationalization | Reality |
+|---|---|
+| "The output is empty, I'll infer it" | Empty-at-compose ≠ empty. End the turn; it's there when you look. |
+| "The reads look corrupted/fabricated" | They're not. You composed that claim before seeing them. |
+| "I already read that issue earlier" | State drifts, turns are long. Re-read in the same turn as the write. |
+| "Bundling the read + the edit is faster" | Bundling IS the bug. One call, observe, then act. |
+| "Issue #N+1 follows #N" | Numbers aren't guessable. Quote the create URL / `gh issue view`. |
+| "Saying it stalled is harmless" | Groundless status claims are confabulation too — and burn user trust. |
+
+## Real-world impact
+
+2026-05-30, in the very session this skill was written: the author bundled `AskUserQuestion` calls with the tool calls they depended on, repeatedly saw blanks at compose time, and confabulated — first "output stalled," then "reads are corrupted/fabricated," and earlier an entire subagent investigation that never ran (invented file contents, an Explore report, "41 passing tests", the bodies of issues #635/#636, and a non-existent issue #643). Acting on that fiction produced real erroneous GitHub edits (wrong assignee/label/comments) that had to be reverted. The author then **broke this very skill minutes after writing and GREEN-testing it** — proving both that the skill is needed and that a passive document is a weak guard against this harness bug. The prior day, #629 was clobbered by editing an issue whose title was assumed from its number (gate 4). Every instance is the same move: a dependent step co-emitted with its tool call.


### PR DESCRIPTION
## Summary

**Temporary** workaround for a Claude Code **2.1.158** regression: a tool result emitted in the **same assistant message** as the call it depends on is invisible at compose time, so the model confabulates what the tool returned and acts on the fiction.

This session, that bug caused real erroneous GitHub edits (assigning/labelling/commenting on the **wrong** issues based on invented issue bodies, plus a fabricated subagent investigation and a non-existent issue #643 — all since reverted). It mirrors the prior #629 clobber.

## What this adds (all clearly marked TEMP)

- `tools/skills/grounding-before-action/SKILL.md` — skill enforcing the **un-bundling rule**: `AskUserQuestion` and result-narrating sentences each go in their own message; emit calls → end the turn → observe → then act. Plus verify issue number↔title before any mutation. GREEN-tested against a pressure scenario (subagent complied under time + sunk-cost + authority pressure).
- `CLAUDE.md` + `tools/skills/README.md` — TEMP-marked session-start pointers.

## Why temporary

We're already on the latest Claude Code (2.1.158 = npm `latest`), so we can't wait it out by updating today. When a release makes co-emitted tool results visible at compose time, **delete the whole set.**

## Rip-out

Tracked in **#647** (the removal manifest + test live there). Every artifact carries the grep token `HARNESS-BUNDLING-WORKAROUND`; removal is `grep -rn HARNESS-BUNDLING-WORKAROUND` → delete listed files + the out-of-repo memory note → close #647.

Closes nothing; intentionally leaves #647 open as the rip-out reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
