### PR TITLE
feat(skills): complexity labels + model-selection automation

### DIFF
--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -113,6 +113,17 @@ Await-approval, and Implementation.
 - Run `scripts/pickup-issue.sh <N>`. It checks the superpowers plugin,
   fetches the issue, infers type, ensures the lane labels exist, claims the
   issue (assign + `status:spec-draft`), creates the branch, and emits JSON.
+- **Model selection.** Read the `model` and `complexity` fields from the
+  emitted JSON. If `model` is non-empty, switch now — before any design,
+  planning, or implementation work:
+  - `complexity:high` → `claude-opus-4-8` — run `/model claude-opus-4-8`
+  - `complexity:medium` → `claude-sonnet-4-6` — run `/model claude-sonnet-4-6`
+  - `complexity:low` → `claude-sonnet-4-6` as the session model; use
+    `opts.model: "claude-haiku-4-5-20251001"` for leaf subagents in workflow
+    scripts where appropriate.
+  - No `complexity:*` label → no change; proceed on the current model.
+  In workflow scripts (`agent()` calls), set `opts.model` consistently with
+  the above mapping so subagents inherit the right tier.
 
 ### 2. Design (skipped for trivial issue types)
 
@@ -217,6 +228,12 @@ The PR body references the approved spec via `Closes #<issue>` — the spec live
 in the issue body, so there is no spec-file link to pass.
 
 ### 6. CI watch
+
+> ⚠️ **NEVER use Opus for CI watch or any looping/polling phase.** The watch
+> loop runs up to 25 minutes at 60-second intervals — potentially 25+ model
+> calls for pure polling work. If you switched to Opus at pickup, switch back
+> to Sonnet (`/model claude-sonnet-4-6`) before running `watch-ci.sh`. Opus
+> is for design and implementation, not waiting.
 
 Run `scripts/watch-ci.sh <pr-N>`. Outcomes:
 - `OK` (exit 0): post a brief status comment, exit the session.

--- a/tools/skills/issue-to-merged-pr/scripts/pickup-issue.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/pickup-issue.sh
@@ -93,11 +93,20 @@ BRANCH="${TYPE}-${ISSUE}-${SLUG}"
 git fetch origin main --quiet
 git checkout -b "$BRANCH" origin/main
 
-# 7. Emit JSON
+# 7. Emit JSON (includes model recommendation from complexity:* label)
 URL=$(jq -r '.url' <<<"$ISSUE_JSON")
+COMPLEXITY=$(jq -r '.labels[] | select(.name | startswith("complexity:")) | .name' <<<"$ISSUE_JSON" | head -1)
+case "$COMPLEXITY" in
+  "complexity:high")   MODEL="claude-opus-4-8" ;;
+  "complexity:medium") MODEL="claude-sonnet-4-6" ;;
+  "complexity:low")    MODEL="claude-sonnet-4-6" ;;
+  *)                   MODEL="" ;;
+esac
 jq -n \
   --arg type "$TYPE" \
   --arg slug "$SLUG" \
   --arg branch "$BRANCH" \
   --arg url "$URL" \
-  '{type: $type, slug: $slug, branch: $branch, parent_issue_url: $url}'
+  --arg model "$MODEL" \
+  --arg complexity "$COMPLEXITY" \
+  '{type: $type, slug: $slug, branch: $branch, parent_issue_url: $url, model: $model, complexity: $complexity}'


### PR DESCRIPTION
## Summary

- Creates `complexity:low/medium/high` labels (done outside this PR — via `gh label create`)
- Applies them to 12 existing magic/combat issues
- `pickup-issue.sh` now extracts the `complexity:*` label and emits `model` + `complexity` fields in its JSON output
- `issue-to-merged-pr` skill gets a model-selection step at pickup: `complexity:high` → Opus, `medium/low` → Sonnet, leaf subagents for `low` → Haiku via `opts.model`
- Adds explicit **NEVER USE OPUS** guard on the CI-watch phase with cost rationale (25-minute watch × ~60s cadence = 25+ calls)

## Test plan

- [ ] `pickup-issue.sh` on a `complexity:high` issue emits `"model": "claude-opus-4-8"` in JSON
- [ ] `pickup-issue.sh` on an issue with no complexity label emits `"model": ""` (no change)
- [ ] CI-watch guard visible in skill at Step 6
- [ ] Labels `complexity:low/medium/high` exist in repo label list

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)