### PR TITLE
feat(magic): richer resonance-environment formula

### DIFF
--- a/src/world/magic/services/resonance_environment.py
+++ b/src/world/magic/services/resonance_environment.py
@@ -163,6 +163,77 @@ def _place_magnitude(
     )
 
 
+def _all_place_affinity_magnitudes(
+    room: DefaultObject,
+    resonances: list[Resonance],
+) -> dict[Affinity, int]:
+    """Sum effective_value per distinct Affinity across all cascade resonances.
+
+    Used by the enriched formula to weight contributions from every place affinity,
+    not only the dominant one. Affinities whose total is zero are excluded.
+    """
+    sums: dict[int, tuple[Affinity, int]] = {}
+    for r in resonances:
+        aff = r.affinity
+        val = effective_value(room, resonance=r)
+        if aff.pk not in sums:
+            sums[aff.pk] = (aff, 0)
+        aff_obj, current = sums[aff.pk]
+        sums[aff.pk] = (aff_obj, current + val)
+    return {aff_obj: total for aff_obj, total in sums.values() if total > 0}
+
+
+def _working_affinities_for_raw(
+    technique: Technique | None,
+    working_affinity: Affinity,
+) -> list[Affinity]:
+    """Return the ordered list of working affinities for the enriched raw sum.
+
+    Cast-time: all distinct affinities from the gift's resonances, preserving
+    encounter order (the caller's loop is deterministic).
+    Presence-time: just the single dominant aura affinity.
+    """
+    if technique is None:
+        return [working_affinity]
+    seen: set[int] = set()
+    result: list[Affinity] = []
+    for r in technique.gift.resonances.select_related("affinity").all():
+        if r.affinity.pk not in seen:
+            seen.add(r.affinity.pk)
+            result.append(r.affinity)
+    return result
+
+
+def _enriched_raw(
+    aura: CharacterAura,
+    all_working: list[Affinity],
+    place_magnitudes: dict[Affinity, int],
+    primary_valence: str,
+    config: ResonanceEnvironmentConfig,
+) -> Decimal:
+    """Compute the enriched raw severity by summing all same-valence (G, P) pair contributions.
+
+    For each (working-affinity G, place-affinity P) pair whose AffinityInteraction shares
+    ``primary_valence``:
+        contribution = place_magnitude_P × caster_alignment_G × severity_G→P × base_coefficient
+
+    Technique-resonance opposition weighting: ``all_working`` contains every distinct affinity
+    from the gift's resonances (cast-time) or just the dominant aura affinity (presence-time).
+    Multi-resonance place weighting: ``place_magnitudes`` covers every place affinity, so
+    secondary affinities contribute in proportion to their magnitude and interaction severity.
+    Pairs whose interaction row is absent or has a different valence are skipped.
+    """
+    raw = Decimal(0)
+    for g_aff in all_working:
+        g_alignment = getattr(aura, g_aff.name.lower(), Decimal("0.00")) / Decimal(100)
+        for p_aff, p_mag in place_magnitudes.items():
+            g_p = AffinityInteraction.objects.interaction_for(g_aff, p_aff)
+            if g_p is None or g_p.valence != primary_valence:
+                continue
+            raw += Decimal(p_mag) * g_alignment * g_p.severity_multiplier * config.base_coefficient
+    return raw
+
+
 def _working_affinity_cast_time(
     technique: Technique,
     place_affinity: Affinity,
@@ -307,7 +378,7 @@ def evaluate_resonance_environment(
     # Step 4: place_magnitude = sum of effective_value over place-affinity resonances.
     p_magnitude = _place_magnitude(room, place_affinity, room_resonances)
 
-    # Step 5: caster_alignment = caster.aura.<working_affinity_name_lower> / 100.
+    # Step 5: caster_alignment for the primary working affinity (used in direction, Step 7).
     try:
         aura = caster.aura
     except CharacterAura.DoesNotExist:
@@ -317,14 +388,13 @@ def evaluate_resonance_environment(
     caster_aura_value: Decimal = getattr(aura, aura_field, Decimal("0.00"))
     caster_alignment = caster_aura_value / Decimal(100)
 
-    # Step 6: raw = place_magnitude * caster_alignment * severity * base_coefficient.
+    # Step 6 (enriched): see _enriched_raw for formula details.
+    # Technique-resonance opposition weighting: all distinct gift affinities contribute.
+    # Multi-resonance place weighting: all place affinities contribute, not only dominant.
     config = get_resonance_environment_config()
-    raw = (
-        Decimal(p_magnitude)
-        * caster_alignment
-        * interaction.severity_multiplier
-        * config.base_coefficient
-    )
+    all_working = _working_affinities_for_raw(technique, working_affinity)
+    place_magnitudes = _all_place_affinity_magnitudes(room, room_resonances)
+    raw = _enriched_raw(aura, all_working, place_magnitudes, interaction.valence, config)
 
     # Step 7: direction.
     direction = _compute_direction(interaction, caster_alignment, p_magnitude, config)

--- a/src/world/magic/tests/test_evaluate_resonance_environment.py
+++ b/src/world/magic/tests/test_evaluate_resonance_environment.py
@@ -473,12 +473,20 @@ class MultiAffinityGiftTest(ResonanceCacheIsolationMixin, TestCase):
 
         result = evaluate_resonance_environment(caster=caster_obj, room=room, technique=technique)
 
-        # Should choose abyssal (severity 1.0 > 0.3)
+        # Should choose abyssal (severity 1.0 > 0.3) as the primary interaction.
         self.assertEqual(result.source_affinity, abyssal)
         self.assertEqual(result.kind, AffinityInteractionKind.REJECT)
-        # magnitude based on abyssal alignment (70%)
+        # Enriched formula sums both gift-affinity contributions against the celestial place.
+        # (abyssal, celestial): 30 × 0.70 × 1.00 × coeff
+        # (primal, celestial):  30 × 0.20 × 0.30 × coeff  (primal aura=20%)
         cfg = get_resonance_environment_config()
-        expected = round(30 * Decimal("0.70") * Decimal("1.00") * cfg.base_coefficient)
+        expected = round(
+            (
+                Decimal(30) * Decimal("0.70") * Decimal("1.00")
+                + Decimal(30) * Decimal("0.20") * Decimal("0.30")
+            )
+            * cfg.base_coefficient
+        )
         self.assertEqual(result.magnitude, expected)
         # T4: OPPOSED REJECT → interaction is resolved; backfire_difficulty > 0
         self.assertIsNotNone(result.interaction)
@@ -793,3 +801,280 @@ class PresenceTimeTest(ResonanceCacheIsolationMixin, TestCase):
         # T4: inert → interaction=None, backfire_difficulty=0
         self.assertIsNone(result.interaction)
         self.assertEqual(result.backfire_difficulty, 0)
+
+
+class TechniqueOppositionWeightingTest(ResonanceCacheIsolationMixin, TestCase):
+    """Technique-resonance opposition weighting: all gift affinities contribute.
+
+    A technique whose gift contains two OPPOSED affinities produces a higher
+    magnitude than the same technique reduced to its worst affinity alone.
+    """
+
+    def test_secondary_gift_affinity_adds_to_magnitude(self) -> None:
+        """Two OPPOSED gift affinities each contribute; sum > single-affinity alone."""
+        caster_obj = CharacterFactory()
+        room_profile = RoomProfileFactory()
+        room = room_profile.objectdb
+
+        celestial = AffinityFactory(name="Celestial")
+        primal = AffinityFactory(name="Primal")
+        abyssal = AffinityFactory(name="Abyssal")
+
+        # Place: celestial only
+        celestial_place_res = ResonanceFactory(affinity=celestial, name="CelestialPlaceOW")
+        _set_room_resonance_value(room_profile, celestial_place_res, 30)
+
+        # Abyssal→Celestial: REJECT severity 1.00 (primary / strongest)
+        AffinityInteractionFactory(
+            source_affinity=abyssal,
+            environment_affinity=celestial,
+            valence=ResonanceValence.OPPOSED,
+            kind=AffinityInteractionKind.REJECT,
+            aggressor=AffinityInteractionAggressor.ENVIRONMENT,
+            severity_multiplier=Decimal("1.00"),
+        )
+        # Primal→Celestial: REJECT severity 0.50 (secondary)
+        AffinityInteractionFactory(
+            source_affinity=primal,
+            environment_affinity=celestial,
+            valence=ResonanceValence.OPPOSED,
+            kind=AffinityInteractionKind.REJECT,
+            aggressor=AffinityInteractionAggressor.ENVIRONMENT,
+            severity_multiplier=Decimal("0.50"),
+        )
+
+        CharacterAuraFactory(
+            character=caster_obj,
+            celestial=Decimal("10.00"),
+            primal=Decimal("40.00"),
+            abyssal=Decimal("50.00"),
+        )
+
+        # Gift with two resonances: abyssal + primal
+        abyssal_res = ResonanceFactory(affinity=abyssal, name="AbyssalGiftOW")
+        primal_res = ResonanceFactory(affinity=primal, name="PrimalGiftOW")
+        gift = GiftFactory()
+        gift.resonances.add(abyssal_res)
+        gift.resonances.add(primal_res)
+        technique = TechniqueFactory(gift=gift)
+
+        cfg = get_resonance_environment_config()
+        result = evaluate_resonance_environment(caster=caster_obj, room=room, technique=technique)
+
+        # Primary: abyssal (severity 1.00 > 0.50)
+        self.assertEqual(result.source_affinity, abyssal)
+        self.assertEqual(result.kind, AffinityInteractionKind.REJECT)
+
+        # Enriched magnitude: sum of both gift-affinity contributions
+        # (abyssal, celestial): 30 × 0.50 × 1.00 × coeff
+        # (primal,  celestial): 30 × 0.40 × 0.50 × coeff
+        expected = round(
+            (
+                Decimal(30) * Decimal("0.50") * Decimal("1.00")
+                + Decimal(30) * Decimal("0.40") * Decimal("0.50")
+            )
+            * cfg.base_coefficient
+        )
+        self.assertEqual(result.magnitude, expected)
+
+        # Confirm enriched magnitude is greater than the abyssal-alone baseline.
+        abyssal_alone = round(
+            Decimal(30) * Decimal("0.50") * Decimal("1.00") * cfg.base_coefficient
+        )
+        self.assertGreater(result.magnitude, abyssal_alone)
+
+    def test_opposite_valence_gift_affinity_excluded(self) -> None:
+        """An ALIGNED gift-affinity interaction is excluded when primary is OPPOSED.
+
+        Gift has abyssal (OPPOSED vs celestial place) and celestial (ALIGNED vs
+        celestial place). Only the abyssal contribution appears in the magnitude.
+        """
+        caster_obj = CharacterFactory()
+        room_profile = RoomProfileFactory()
+        room = room_profile.objectdb
+
+        celestial = AffinityFactory(name="Celestial")
+        abyssal = AffinityFactory(name="Abyssal")
+
+        celestial_place_res = ResonanceFactory(affinity=celestial, name="CelestialPlaceVF")
+        _set_room_resonance_value(room_profile, celestial_place_res, 40)
+
+        AffinityInteractionFactory(
+            source_affinity=abyssal,
+            environment_affinity=celestial,
+            valence=ResonanceValence.OPPOSED,
+            kind=AffinityInteractionKind.REJECT,
+            aggressor=AffinityInteractionAggressor.ENVIRONMENT,
+            severity_multiplier=Decimal("1.00"),
+        )
+        # Celestial→Celestial: ALIGNED — must NOT contribute when primary valence is OPPOSED
+        AffinityInteractionFactory(
+            source_affinity=celestial,
+            environment_affinity=celestial,
+            valence=ResonanceValence.ALIGNED,
+            kind=AffinityInteractionKind.AMPLIFY,
+            aggressor=AffinityInteractionAggressor.ENVIRONMENT,
+            severity_multiplier=Decimal("1.00"),
+        )
+
+        CharacterAuraFactory(
+            character=caster_obj,
+            celestial=Decimal("50.00"),
+            primal=Decimal("10.00"),
+            abyssal=Decimal("40.00"),
+        )
+
+        abyssal_res = ResonanceFactory(affinity=abyssal, name="AbyssalGiftVF")
+        celestial_res = ResonanceFactory(affinity=celestial, name="CelestialGiftVF")
+        gift = GiftFactory()
+        gift.resonances.add(abyssal_res)
+        gift.resonances.add(celestial_res)
+        technique = TechniqueFactory(gift=gift)
+
+        cfg = get_resonance_environment_config()
+        result = evaluate_resonance_environment(caster=caster_obj, room=room, technique=technique)
+
+        self.assertEqual(result.valence, ResonanceValence.OPPOSED)
+        self.assertEqual(result.source_affinity, abyssal)
+
+        # Only abyssal contributes (celestial affinity is ALIGNED, different valence)
+        expected = round(Decimal(40) * Decimal("0.40") * Decimal("1.00") * cfg.base_coefficient)
+        self.assertEqual(result.magnitude, expected)
+
+
+class MultiResonancePlaceWeightingTest(ResonanceCacheIsolationMixin, TestCase):
+    """Multi-resonance place weighting: secondary place affinities add to magnitude.
+
+    A room with two affinities that both oppose the caster produces a higher
+    magnitude than a room with only the dominant affinity.
+    """
+
+    def test_secondary_place_affinity_adds_to_magnitude(self) -> None:
+        """Two OPPOSED place affinities each contribute; sum > dominant-only alone."""
+        caster_obj = CharacterFactory()
+        room_profile = RoomProfileFactory()
+        room = room_profile.objectdb
+
+        celestial = AffinityFactory(name="Celestial")
+        primal = AffinityFactory(name="Primal")
+        abyssal = AffinityFactory(name="Abyssal")
+
+        # Place: celestial dominant (50) + primal secondary (20)
+        celestial_place_res = ResonanceFactory(affinity=celestial, name="CelestialPlaceMR")
+        primal_place_res = ResonanceFactory(affinity=primal, name="PrimalPlaceMR")
+        _set_room_resonance_value(room_profile, celestial_place_res, 50)
+        _set_room_resonance_value(room_profile, primal_place_res, 20)
+
+        # Abyssal→Celestial: REJECT severity 1.00
+        AffinityInteractionFactory(
+            source_affinity=abyssal,
+            environment_affinity=celestial,
+            valence=ResonanceValence.OPPOSED,
+            kind=AffinityInteractionKind.REJECT,
+            aggressor=AffinityInteractionAggressor.ENVIRONMENT,
+            severity_multiplier=Decimal("1.00"),
+        )
+        # Abyssal→Primal: CORRUPT severity 1.00 (also OPPOSED)
+        AffinityInteractionFactory(
+            source_affinity=abyssal,
+            environment_affinity=primal,
+            valence=ResonanceValence.OPPOSED,
+            kind=AffinityInteractionKind.CORRUPT,
+            aggressor=AffinityInteractionAggressor.CASTER,
+            severity_multiplier=Decimal("1.00"),
+        )
+
+        CharacterAuraFactory(
+            character=caster_obj,
+            celestial=Decimal("10.00"),
+            primal=Decimal("10.00"),
+            abyssal=Decimal("80.00"),
+        )
+
+        abyssal_res = ResonanceFactory(affinity=abyssal, name="AbyssalGiftMR")
+        gift = GiftFactory()
+        gift.resonances.add(abyssal_res)
+        technique = TechniqueFactory(gift=gift)
+
+        cfg = get_resonance_environment_config()
+        result = evaluate_resonance_environment(caster=caster_obj, room=room, technique=technique)
+
+        self.assertEqual(result.source_affinity, abyssal)
+        self.assertEqual(result.environment_affinity, celestial)
+
+        # Enriched magnitude: both place affinities contribute (both OPPOSED with abyssal)
+        # (abyssal, celestial): 50 × 0.80 × 1.00 × coeff
+        # (abyssal, primal):    20 × 0.80 × 1.00 × coeff
+        expected = round(
+            (
+                Decimal(50) * Decimal("0.80") * Decimal("1.00")
+                + Decimal(20) * Decimal("0.80") * Decimal("1.00")
+            )
+            * cfg.base_coefficient
+        )
+        self.assertEqual(result.magnitude, expected)
+
+        # Confirm enriched magnitude is greater than celestial-only baseline.
+        dominant_only = round(
+            Decimal(50) * Decimal("0.80") * Decimal("1.00") * cfg.base_coefficient
+        )
+        self.assertGreater(result.magnitude, dominant_only)
+
+    def test_aligned_secondary_place_affinity_excluded_from_opposed_sum(self) -> None:
+        """Secondary place affinity with ALIGNED interaction is excluded from OPPOSED sum.
+
+        Abyssal caster in a mixed Celestial+Abyssal place:
+        - Abyssal→Celestial: OPPOSED REJECT → contributes to raw
+        - Abyssal→Abyssal:   ALIGNED AMPLIFY → excluded (wrong valence)
+        Only the Celestial contribution appears in the final magnitude.
+        """
+        caster_obj = CharacterFactory()
+        room_profile = RoomProfileFactory()
+        room = room_profile.objectdb
+
+        celestial = AffinityFactory(name="Celestial")
+        abyssal = AffinityFactory(name="Abyssal")
+
+        celestial_place_res = ResonanceFactory(affinity=celestial, name="CelestialPlaceAE")
+        abyssal_place_res = ResonanceFactory(affinity=abyssal, name="AbyssalPlaceAE")
+        _set_room_resonance_value(room_profile, celestial_place_res, 40)
+        _set_room_resonance_value(room_profile, abyssal_place_res, 30)
+
+        AffinityInteractionFactory(
+            source_affinity=abyssal,
+            environment_affinity=celestial,
+            valence=ResonanceValence.OPPOSED,
+            kind=AffinityInteractionKind.REJECT,
+            aggressor=AffinityInteractionAggressor.ENVIRONMENT,
+            severity_multiplier=Decimal("1.00"),
+        )
+        AffinityInteractionFactory(
+            source_affinity=abyssal,
+            environment_affinity=abyssal,
+            valence=ResonanceValence.ALIGNED,
+            kind=AffinityInteractionKind.AMPLIFY,
+            aggressor=AffinityInteractionAggressor.ENVIRONMENT,
+            severity_multiplier=Decimal("1.00"),
+        )
+
+        CharacterAuraFactory(
+            character=caster_obj,
+            celestial=Decimal("10.00"),
+            primal=Decimal("10.00"),
+            abyssal=Decimal("80.00"),
+        )
+
+        abyssal_gift_res = ResonanceFactory(affinity=abyssal, name="AbyssalGiftAE")
+        gift = GiftFactory()
+        gift.resonances.add(abyssal_gift_res)
+        technique = TechniqueFactory(gift=gift)
+
+        cfg = get_resonance_environment_config()
+        result = evaluate_resonance_environment(caster=caster_obj, room=room, technique=technique)
+
+        # Primary: OPPOSED (abyssal→celestial wins as working interaction)
+        self.assertEqual(result.valence, ResonanceValence.OPPOSED)
+
+        # Only celestial place affinity contributes to OPPOSED magnitude
+        expected = round(Decimal(40) * Decimal("0.80") * Decimal("1.00") * cfg.base_coefficient)
+        self.assertEqual(result.magnitude, expected)


### PR DESCRIPTION
Closes #529

## Summary

- **Technique-resonance opposition weighting** (cast-time): instead of picking the single highest-severity gift affinity, sums contributions from _all_ distinct affinities in the gift's resonances — each weighted by the caster's own aura alignment for that affinity and the severity of its interaction with each place affinity
- **Multi-resonance place weighting** (cast-time + presence-time): instead of only the dominant place affinity's magnitude, sums contributions from _all_ place affinities — each weighted by their interaction severity with the working affinity
- Zero change to call sites, `AffinityInteraction` data, `ResonanceEnvironmentConfig`, consequence pools, or boon-tier rows

## Formula

Raw magnitude is now:

```
Σ(place_mag_P × alignment_G × severity_G→P × base_coeff)
```

summed over every `(working-affinity G, place-affinity P)` pair whose `AffinityInteraction` shares the primary valence. Pairs with a different valence are excluded — ALIGNED and OPPOSED magnitudes never mix.

Primary `interaction`, `source_affinity`, `environment_affinity`, `valence`, `kind`, and `direction` are unchanged and still reflect the single worst-case pair.

## Implementation

Three new private helpers in `resonance_environment.py`:
- `_all_place_affinity_magnitudes` — maps every place affinity to its summed effective value
- `_working_affinities_for_raw` — returns gift affinities (cast-time) or the aura-dominant affinity (presence-time)
- `_enriched_raw` — the actual cross-product sum

`evaluate_resonance_environment` stays within ruff complexity limits.

## Test plan

- [ ] Existing 15 tests still pass (only `MultiAffinityGiftTest.test_highest_severity_chosen` expected magnitude updated to reflect the enriched sum)
- [ ] `TechniqueOppositionWeightingTest.test_secondary_gift_affinity_adds_to_magnitude` — secondary gift affinity adds to magnitude
- [ ] `TechniqueOppositionWeightingTest.test_opposite_valence_gift_affinity_excluded` — ALIGNED gift affinity excluded when primary is OPPOSED
- [ ] `MultiResonancePlaceWeightingTest.test_secondary_place_affinity_adds_to_magnitude` — secondary place affinity adds to magnitude
- [ ] `MultiResonancePlaceWeightingTest.test_aligned_secondary_place_affinity_excluded_from_opposed_sum` — ALIGNED place affinity excluded from OPPOSED sum
- [ ] `just test-fast world.magic.tests.test_evaluate_resonance_environment` → 19 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)