### PR TITLE
Presence-escalation for scarred characters — scar-gated MOVED triggers

### DIFF
--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -1184,11 +1184,11 @@ Cast Disrupted `ConditionTemplate`s.
    `docs/superpowers/specs/2026-05-16-resonance-environment-universal-path-design.md`). No
    grant is needed: magic-capability is derived from `CharacterAura` presence, which is
    created unconditionally at CG finalization by `finalize_magic_data()`.
-2. **Presence-escalation for scarred characters** — characters with heavy opposing scars
-   harmed on mere *entry* (`MOVED`), not only on cast. This is a genuine per-entity exception
-   → correctly a scar-gated MOVED `TriggerDefinition` via `ConditionTemplate.reactive_triggers`
-   M2M (the legitimate flow/trigger use). `evaluate_resonance_environment(technique=None)`
-   already serves this; the ALIGNED universal presence path added here does not subsume it.
+2. ~~**Presence-escalation for scarred characters**~~ — **DONE (#526).** `EventName.MOVED`
+   emitted from `at_post_move`; `Room.dominant_affinity` property; `apply_condition_by_name`
+   flow-step helper; filter-propagation fix in `_install_reactive_side_effects`. Reference
+   pipeline: `wire_scar_escalation_trigger()` in `world/magic/factories.py`. No scar-specific
+   Python — escalation is pure authored data via `ConditionTemplate.reactive_triggers` M2M.
 3. **Defilement (CASTER_DOMINANT)** *(core magic — Tehom's domain, not brother's)* — when a
    strong opposing caster overpowers a weak place, the caster degrades the place's cascade
    resonance. The primitive already returns `direction=CASTER_DOMINANT`; the cast service
@@ -1211,11 +1211,12 @@ Cast Disrupted `ConditionTemplate`s.
 
 The deferred items above, ordered by recommended sequence with rationale and ownership:
 
-1. **Presence-escalation for scarred characters** *(Tehom/brother; cheap)* — authored scar-
-   gated MOVED trigger + an escalation condition (e.g., "Hallowed Agony on entry"). Reuses
-   `evaluate_resonance_environment(technique=None)` and `ConditionTemplate.reactive_triggers`
-   M2M. The ALIGNED universal presence path already works; this adds the OPPOSED side for
-   heavily-scarred characters.
+1. ~~**Presence-escalation for scarred characters**~~ — **DONE (#526).** General primitives
+   added: `EventName.MOVED` emitted from `at_post_move`; `Room.dominant_affinity` property;
+   `apply_condition_by_name` flow-step helper; filter-propagation fix in
+   `_install_reactive_side_effects`. Reference pipeline: `wire_scar_escalation_trigger()` in
+   `world/magic/factories.py`. No scar-specific Python — escalation is pure authored data via
+   `ConditionTemplate.reactive_triggers` M2M.
 2. **`TECHNIQUE_PRE_CAST` block/modify variant** *(Tehom/core; fundamental)* — a true
    pre-cast intercept that can **block or modify** a working *before* it resolves. This
    is a foundational reactive-layer capability, **not** a nice-to-have: v1's post-resolve

--- a/src/flows/filters/evaluator.py
+++ b/src/flows/filters/evaluator.py
@@ -117,6 +117,10 @@ def _resolve_value(raw: Any, *, self_ref: Any) -> Any:
 def _walk_dotted(obj: Any, dotted: str) -> Any:
     current = obj
     for part in dotted.split("."):
+        if current is None:
+            # None propagates (optional-chaining semantics): None.anything → None.
+            # The subsequent comparison (e.g. None == "Celestial") evaluates False.
+            return None
         result = getattr(current, part, SENTINEL)  # noqa: GETATTR_LITERAL — dynamic filter DSL path traversal
         if result is SENTINEL:
             msg = f"Cannot resolve '{part}' on {type(current).__name__} (full path: {dotted})"

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -18,7 +18,7 @@ from evennia.objects.objects import DefaultCharacter
 from commands.utils import serialize_cmdset
 from flows.constants import EventName
 from flows.emit import emit_event
-from flows.events.payloads import AttackLandedPayload, MovePreDepartPayload
+from flows.events.payloads import AttackLandedPayload, MovedPayload, MovePreDepartPayload
 from flows.object_states.character_state import CharacterState
 from flows.service_functions.serializers import build_room_state_payload
 from typeclasses.mixins import ObjectParent
@@ -290,6 +290,8 @@ class Character(ObjectParent, DefaultCharacter):
 
         Sends updated room state to the frontend after movement.
         Reconciles the presence-tied resonance-alignment buff for the new location.
+        Emits EventName.MOVED so reactive triggers (e.g. scar-gated presence
+        escalation) can respond to character arrival.
         """
         # Call parent method to handle trigger registration
         super().at_post_move(source_location, move_type=move_type, **kwargs)
@@ -301,6 +303,17 @@ class Character(ObjectParent, DefaultCharacter):
         # Guard mirrors at_post_puppet: some Character-typeclass objects have no sheet.
         with contextlib.suppress(RosterEntry.DoesNotExist, ObjectDoesNotExist):
             refresh_resonance_alignment(character_sheet=self.sheet_data)
+
+        # Emit MOVED for reactive triggers (e.g. scar-gated presence escalation).
+        # Only emit when destination is a real room; no-op if character has no location.
+        if self.location is not None:
+            payload = MovedPayload(
+                character=self,
+                origin=source_location,
+                destination=self.location,
+                exit_used=kwargs.get("exit_used"),
+            )
+            emit_event(EventName.MOVED, payload, location=self.location)
 
     def at_attacked(self, attacker, weapon, damage_result, action) -> None:
         """Called by combat after damage calc, before damage apply.

--- a/src/typeclasses/rooms.py
+++ b/src/typeclasses/rooms.py
@@ -59,6 +59,18 @@ class Room(ObjectParent, DefaultRoom):
         self.ndb.active_scene = value
 
     @property
+    def dominant_affinity(self):
+        """Dominant cascade affinity for this room, or None if inert.
+
+        Computed from the room's cascade resonances. Used by the filter DSL
+        to gate MOVED triggers on room affinity
+        (path: ``destination.dominant_affinity.name``).
+        """
+        from world.magic.services.resonance_environment import get_room_dominant_affinity
+
+        return get_room_dominant_affinity(self)
+
+    @property
     def sentient_contents(self) -> list:
         """Return objects in this room that have active sessions."""
         sentients = []

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -779,6 +779,7 @@ def _install_reactive_side_effects(
                     trigger_definition=td,
                     obj=target,
                     source_condition=instance,
+                    additional_filter_condition=td.base_filter_condition,
                 )
                 for td in trigger_defs
             ]

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -638,6 +638,29 @@ def apply_condition(  # noqa: PLR0913
     return result
 
 
+def apply_condition_by_name(*, payload: object, condition_name: str) -> None:
+    """Apply a named condition to the character carried by the event payload.
+
+    General-purpose ``CALL_SERVICE_FUNCTION`` target for flow steps that need to
+    apply a condition by name. ``payload`` must have a ``character`` attribute
+    (e.g. ``MovedPayload``). Silently no-ops if the condition name does not
+    exist — allows authored content to reference conditions not yet seeded
+    in a given environment without raising.
+
+    Usage in a FlowStepDefinition::
+
+        action=FlowActionChoices.CALL_SERVICE_FUNCTION,
+        variable_name="world.conditions.services.apply_condition_by_name",
+        parameters={"payload": "@payload", "condition_name": "<name>"},
+    """
+    try:
+        template = ConditionTemplate.get_by_name(condition_name)
+    except ConditionTemplate.DoesNotExist:
+        return
+    target = payload.character  # type: ignore[union-attr]
+    apply_condition(target=target, condition=template)
+
+
 @transaction.atomic
 def bulk_apply_conditions(
     applications: list[BulkConditionApplication],

--- a/src/world/conditions/tests/test_apply_condition_reactive_extension.py
+++ b/src/world/conditions/tests/test_apply_condition_reactive_extension.py
@@ -62,6 +62,32 @@ class ApplyConditionInstallsTriggersTests(TestCase):
 
         self.assertEqual(Trigger.objects.filter(obj=sheet.character).count(), 2)
 
+    def test_base_filter_condition_copied_to_installed_trigger(self):
+        """_install_reactive_side_effects copies TriggerDefinition.base_filter_condition
+        to Trigger.additional_filter_condition so emit_event can evaluate it."""
+        condition = ConditionTemplateFactory(name="T10 filter copy test")
+        flow = FlowDefinitionFactory(name="T10 filter copy flow")
+        filter_cond = {"path": "target", "op": "==", "value": "self"}
+        trigger_def = TriggerDefinitionFactory(
+            name="T10 filter copy td",
+            event_name=EventName.TECHNIQUE_CAST,
+            flow_definition=flow,
+            base_filter_condition=filter_cond,
+        )
+        condition.reactive_triggers.add(trigger_def)
+        sheet = CharacterSheetFactory()
+
+        result = apply_condition(target=sheet.character, condition=condition)
+
+        self.assertTrue(result.success)
+        trigger = Trigger.objects.get(obj=sheet.character, trigger_definition=trigger_def)
+        self.assertEqual(
+            trigger.additional_filter_condition,
+            filter_cond,
+            "base_filter_condition must be copied to Trigger.additional_filter_condition"
+            " on auto-install",
+        )
+
 
 class ApplyConditionIncrementsBridgedStatsTests(TestCase):
     def test_stat_rule_fires_on_gained(self):

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -2139,3 +2139,82 @@ class CovenantInductionRitualFactory(factory.django.DjangoModelFactory):
             ],
         }
     )
+
+
+# =============================================================================
+# Issue #526: Scar-gated MOVED trigger authored content
+# =============================================================================
+
+
+def _build_scar_escalation_flow(escalation_condition_name: str) -> object:
+    """Build (or reuse) a FlowDefinition that applies a named escalation condition.
+
+    One CALL_SERVICE_FUNCTION step calls
+    ``world.conditions.services.apply_condition_by_name`` with the condition name.
+    Idempotent: get_or_create on flow name; skips step creation if steps already exist.
+    """
+    from flows.consts import FlowActionChoices
+    from flows.factories import FlowStepDefinitionFactory
+    from flows.models import FlowDefinition
+
+    flow_name = f"scar_escalation_{escalation_condition_name}"
+    flow, _ = FlowDefinition.objects.get_or_create(name=flow_name)
+    if not flow.steps.exists():
+        FlowStepDefinitionFactory(
+            flow=flow,
+            action=FlowActionChoices.CALL_SERVICE_FUNCTION,
+            variable_name="world.conditions.services.apply_condition_by_name",
+            parameters={
+                "payload": "@payload",
+                "condition_name": escalation_condition_name,
+            },
+        )
+    return flow
+
+
+def wire_scar_escalation_trigger(
+    scar_template: object,
+    escalation_template: object,
+    *,
+    hostile_affinity_name: str,
+) -> object:
+    """Link a MOVED TriggerDefinition to a scar ConditionTemplate.
+
+    Creates (idempotent):
+    - FlowDefinition: one CALL_SERVICE_FUNCTION step → apply_condition_by_name
+    - TriggerDefinition: event_name=MOVED, filter on destination.dominant_affinity.name
+
+    Adds the TriggerDefinition to ``scar_template.reactive_triggers`` (M2M add is idempotent).
+
+    Args:
+        scar_template: The scar ConditionTemplate that bears the trigger.
+        escalation_template: The ConditionTemplate to apply on entry.
+        hostile_affinity_name: Affinity name that triggers escalation
+            (e.g. ``"Celestial"`` for an Abyssal scar — pair #4 in the 9-cell table).
+
+    Returns:
+        The TriggerDefinition that was created or retrieved.
+    """
+    from flows.constants import EventName
+    from flows.models.triggers import TriggerDefinition
+
+    escalation_name = escalation_template.name  # type: ignore[union-attr]
+    flow = _build_scar_escalation_flow(escalation_name)
+
+    trigger_name = f"scar_moved_{scar_template.name}_{hostile_affinity_name.lower()}"  # type: ignore[union-attr]
+    filter_condition = {
+        "path": "destination.dominant_affinity.name",
+        "op": "==",
+        "value": hostile_affinity_name,
+    }
+    trigger_def, _ = TriggerDefinition.objects.get_or_create(
+        name=trigger_name,
+        defaults={
+            "event_name": EventName.MOVED,
+            "flow_definition": flow,
+            "base_filter_condition": filter_condition,
+        },
+    )
+
+    scar_template.reactive_triggers.add(trigger_def)  # type: ignore[union-attr]
+    return trigger_def

--- a/src/world/magic/services/resonance_environment.py
+++ b/src/world/magic/services/resonance_environment.py
@@ -152,6 +152,18 @@ def _dominant_place_affinity(room: DefaultObject, resonances: list[Resonance]) -
     return candidates[0][1]
 
 
+def get_room_dominant_affinity(room: DefaultObject) -> Affinity | None:
+    """Return the dominant cascade affinity for a room, or None if inert.
+
+    Wraps ``_get_room_resonances`` + ``_dominant_place_affinity`` as a public
+    entry point for callers outside this module (e.g. ``Room.dominant_affinity``).
+    Returns None when the room has no RoomProfile, no tagged resonances, or
+    all effective values are zero.
+    """
+    resonances = _get_room_resonances(room)
+    return _dominant_place_affinity(room, resonances)
+
+
 def _place_magnitude(
     room: DefaultObject,
     place_affinity: Affinity,

--- a/src/world/magic/tests/test_scar_moved_triggers.py
+++ b/src/world/magic/tests/test_scar_moved_triggers.py
@@ -1,0 +1,32 @@
+"""Tests for scar-gated MOVED triggers — Issue #526."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from evennia_extensions.factories import CharacterFactory, RoomProfileFactory
+from flows.constants import EventName
+
+
+class MovedEventEmissionTest(TestCase):
+    """at_post_move emits EventName.MOVED so installed triggers fire."""
+
+    def setUp(self):
+        self.room = RoomProfileFactory().objectdb
+        self.character = CharacterFactory()
+        self.character.db_location = self.room
+        self.character.save(update_fields=["db_location"])
+
+    def test_at_post_move_emits_moved_event(self):
+        """at_post_move calls emit_event with EventName.MOVED."""
+        with patch("typeclasses.characters.emit_event") as mock_emit:
+            mock_emit.return_value = MagicMock()
+            self.character.at_post_move(source_location=None)
+
+        calls = [c for c in mock_emit.call_args_list if c.args and c.args[0] == EventName.MOVED]
+        self.assertTrue(
+            len(calls) >= 1,
+            "Expected emit_event(EventName.MOVED, ...) to be called from at_post_move",
+        )

--- a/src/world/magic/tests/test_scar_moved_triggers.py
+++ b/src/world/magic/tests/test_scar_moved_triggers.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 
 from evennia_extensions.factories import CharacterFactory, RoomProfileFactory
 from flows.constants import EventName
+from world.magic.tests._cache_isolation import ResonanceCacheIsolationMixin
 
 
 class MovedEventEmissionTest(TestCase):
@@ -30,3 +31,69 @@ class MovedEventEmissionTest(TestCase):
             len(calls) >= 1,
             "Expected emit_event(EventName.MOVED, ...) to be called from at_post_move",
         )
+
+
+class RoomDominantAffinityTest(ResonanceCacheIsolationMixin, TestCase):
+    """Room.dominant_affinity returns the cascade-dominant Affinity or None."""
+
+    def setUp(self):
+        super().setUp()
+        from world.magic.factories import AffinityFactory, ResonanceFactory
+        from world.magic.services.gain import tag_room_resonance
+
+        self.celestial = AffinityFactory(name="Celestial")
+        self.celestial_res = ResonanceFactory(name="CelestialRes526", affinity=self.celestial)
+
+        self.celestial_profile = RoomProfileFactory()
+        tag_room_resonance(self.celestial_profile, self.celestial_res)
+        self.celestial_room = self.celestial_profile.objectdb
+
+        self.inert_profile = RoomProfileFactory()
+        self.inert_room = self.inert_profile.objectdb
+
+    def test_cascade_room_returns_dominant_affinity(self):
+        """Room with a celestial resonance tagged returns the Celestial affinity."""
+        result = self.celestial_room.dominant_affinity
+        self.assertIsNotNone(result)
+        self.assertEqual(result.name, "Celestial")
+
+    def test_inert_room_returns_none(self):
+        """Room with no cascade resonances returns None."""
+        result = self.inert_room.dominant_affinity
+        self.assertIsNone(result)
+
+    def test_dominant_affinity_name_navigable_in_filter_dsl(self):
+        """Filter DSL can navigate destination.dominant_affinity.name at runtime."""
+        from dataclasses import dataclass
+
+        from flows.filters.evaluator import evaluate_filter
+
+        @dataclass
+        class StubPayload:
+            destination: object
+
+        payload = StubPayload(destination=self.celestial_room)
+        filter_spec = {
+            "path": "destination.dominant_affinity.name",
+            "op": "==",
+            "value": "Celestial",
+        }
+        self.assertTrue(evaluate_filter(filter_spec, payload, self_ref=None))
+
+    def test_filter_dsl_non_matching_room_returns_false(self):
+        """Filter DSL returns False when room affinity does not match the filter value."""
+        from dataclasses import dataclass
+
+        from flows.filters.evaluator import evaluate_filter
+
+        @dataclass
+        class StubPayload:
+            destination: object
+
+        payload = StubPayload(destination=self.inert_room)
+        filter_spec = {
+            "path": "destination.dominant_affinity.name",
+            "op": "==",
+            "value": "Celestial",
+        }
+        self.assertFalse(evaluate_filter(filter_spec, payload, self_ref=None))

--- a/src/world/magic/tests/test_scar_moved_triggers.py
+++ b/src/world/magic/tests/test_scar_moved_triggers.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 
 from evennia_extensions.factories import CharacterFactory, RoomProfileFactory
 from flows.constants import EventName
+from world.conditions.factories import ConditionTemplateFactory
 from world.magic.tests._cache_isolation import ResonanceCacheIsolationMixin
 
 
@@ -97,3 +98,41 @@ class RoomDominantAffinityTest(ResonanceCacheIsolationMixin, TestCase):
             "value": "Celestial",
         }
         self.assertFalse(evaluate_filter(filter_spec, payload, self_ref=None))
+
+
+class ApplyConditionByNameTest(TestCase):
+    """apply_condition_by_name looks up a ConditionTemplate by name and applies it."""
+
+    def setUp(self):
+        from dataclasses import dataclass
+
+        self.template = ConditionTemplateFactory(name="test_escalation_526")
+        self.character = CharacterFactory()
+
+        @dataclass
+        class StubPayload:
+            character: object
+
+        self.payload = StubPayload(character=self.character)
+
+    def test_applies_named_condition_to_payload_character(self):
+        """apply_condition_by_name applies the condition to payload.character."""
+        from world.conditions.models import ConditionInstance
+        from world.conditions.services import apply_condition_by_name
+
+        apply_condition_by_name(payload=self.payload, condition_name="test_escalation_526")
+
+        count = ConditionInstance.objects.filter(
+            target=self.character,
+            condition=self.template,
+        ).count()
+        self.assertEqual(count, 1, "Expected one ConditionInstance after apply_condition_by_name")
+
+    def test_silently_no_ops_when_condition_not_found(self):
+        """apply_condition_by_name does nothing when the condition name doesn't exist."""
+        from world.conditions.models import ConditionInstance
+        from world.conditions.services import apply_condition_by_name
+
+        apply_condition_by_name(payload=self.payload, condition_name="nonexistent_526")
+
+        self.assertEqual(ConditionInstance.objects.filter(target=self.character).count(), 0)

--- a/src/world/magic/tests/test_scar_moved_triggers.py
+++ b/src/world/magic/tests/test_scar_moved_triggers.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from evennia_extensions.factories import CharacterFactory, RoomProfileFactory
 from flows.constants import EventName
 from world.conditions.factories import ConditionTemplateFactory
+from world.conditions.services import apply_condition
 from world.magic.tests._cache_isolation import ResonanceCacheIsolationMixin
 
 
@@ -136,3 +137,70 @@ class ApplyConditionByNameTest(TestCase):
         apply_condition_by_name(payload=self.payload, condition_name="nonexistent_526")
 
         self.assertEqual(ConditionInstance.objects.filter(target=self.character).count(), 0)
+
+
+class WireScarEscalationTriggerTest(TestCase):
+    """wire_scar_escalation_trigger links a MOVED TriggerDefinition to a scar template."""
+
+    def test_trigger_definition_in_reactive_triggers(self):
+        """After wiring, the scar template has a MOVED TriggerDefinition in reactive_triggers."""
+        from flows.constants import EventName
+        from world.magic.factories import wire_scar_escalation_trigger
+
+        scar_template = ConditionTemplateFactory(name="abyssal_scar_526")
+        escalation_template = ConditionTemplateFactory(name="hallowed_agony_526")
+
+        wire_scar_escalation_trigger(
+            scar_template=scar_template,
+            escalation_template=escalation_template,
+            hostile_affinity_name="Celestial",
+        )
+
+        trigger_defs = list(scar_template.reactive_triggers.all())
+        self.assertEqual(len(trigger_defs), 1)
+        td = trigger_defs[0]
+        self.assertEqual(td.event_name, EventName.MOVED)
+        self.assertEqual(
+            td.base_filter_condition,
+            {"path": "destination.dominant_affinity.name", "op": "==", "value": "Celestial"},
+        )
+
+    def test_wiring_is_idempotent(self):
+        """Calling wire_scar_escalation_trigger twice doesn't duplicate rows."""
+        from world.magic.factories import wire_scar_escalation_trigger
+
+        scar_template = ConditionTemplateFactory(name="abyssal_scar_526b")
+        escalation_template = ConditionTemplateFactory(name="hallowed_agony_526b")
+
+        wire_scar_escalation_trigger(
+            scar_template=scar_template,
+            escalation_template=escalation_template,
+            hostile_affinity_name="Celestial",
+        )
+        wire_scar_escalation_trigger(
+            scar_template=scar_template,
+            escalation_template=escalation_template,
+            hostile_affinity_name="Celestial",
+        )
+
+        self.assertEqual(scar_template.reactive_triggers.count(), 1)
+
+    def test_trigger_installed_when_condition_applied(self):
+        """Applying the scar condition auto-installs a Trigger row on the character."""
+        from flows.models.triggers import Trigger
+        from world.magic.factories import wire_scar_escalation_trigger
+
+        scar_template = ConditionTemplateFactory(name="abyssal_scar_526c")
+        escalation_template = ConditionTemplateFactory(name="hallowed_agony_526c")
+        wire_scar_escalation_trigger(
+            scar_template=scar_template,
+            escalation_template=escalation_template,
+            hostile_affinity_name="Celestial",
+        )
+
+        character = CharacterFactory()
+        apply_condition(target=character, condition=scar_template)
+
+        installed = Trigger.objects.filter(obj=character)
+        self.assertEqual(installed.count(), 1)
+        self.assertEqual(installed.first().trigger_definition.event_name, "moved")

--- a/src/world/magic/tests/test_scar_moved_triggers.py
+++ b/src/world/magic/tests/test_scar_moved_triggers.py
@@ -204,3 +204,134 @@ class WireScarEscalationTriggerTest(TestCase):
         installed = Trigger.objects.filter(obj=character)
         self.assertEqual(installed.count(), 1)
         self.assertEqual(installed.first().trigger_definition.event_name, "moved")
+
+
+class ScarMovedTriggerIntegrationTest(ResonanceCacheIsolationMixin, TestCase):
+    """End-to-end: Abyssal-scarred character entering celestial-cascade room gets escalation.
+
+    Full pipeline:
+      apply_condition (installs Trigger) → at_post_move (emits MOVED) →
+      trigger filter (destination.dominant_affinity.name == "Celestial526") →
+      FlowDefinition (CALL_SERVICE_FUNCTION apply_condition_by_name) →
+      escalation ConditionInstance created on character.
+    """
+
+    def setUp(self):
+        super().setUp()  # clears AffinityInteraction cache — create rows AFTER
+
+        from decimal import Decimal
+
+        from world.magic.constants import (
+            AffinityInteractionAggressor,
+            AffinityInteractionKind,
+            ResonanceValence,
+        )
+        from world.magic.factories import (
+            AffinityFactory,
+            AffinityInteractionFactory,
+            ResonanceFactory,
+            wire_scar_escalation_trigger,
+        )
+        from world.magic.services.gain import tag_room_resonance
+
+        # -- Affinities --
+        self.celestial = AffinityFactory(name="Celestial526")
+        self.abyssal = AffinityFactory(name="Abyssal526")
+
+        # -- Pair #4: Abyssal caster in Celestial room → OPPOSED/REJECT/environment aggressor
+        AffinityInteractionFactory(
+            source_affinity=self.abyssal,
+            environment_affinity=self.celestial,
+            valence=ResonanceValence.OPPOSED,
+            kind=AffinityInteractionKind.REJECT,
+            aggressor=AffinityInteractionAggressor.ENVIRONMENT,
+            severity_multiplier=Decimal("1.00"),
+        )
+
+        # -- Celestial cascade room --
+        self.celestial_res = ResonanceFactory(name="CelestialRes526b", affinity=self.celestial)
+        self.celestial_profile = RoomProfileFactory()
+        tag_room_resonance(self.celestial_profile, self.celestial_res)
+        self.celestial_room = self.celestial_profile.objectdb
+
+        # -- Abyssal (aligned for Abyssal scar) room --
+        self.abyssal_res = ResonanceFactory(name="AbyssalRes526b", affinity=self.abyssal)
+        self.abyssal_profile = RoomProfileFactory()
+        tag_room_resonance(self.abyssal_profile, self.abyssal_res)
+        self.abyssal_room = self.abyssal_profile.objectdb
+
+        # -- Inert room --
+        self.inert_profile = RoomProfileFactory()
+        self.inert_room = self.inert_profile.objectdb
+
+        # -- Character --
+        self.character = CharacterFactory()
+
+        # -- Scar + escalation condition templates --
+        self.scar_template = ConditionTemplateFactory(name="AbyssalScar526")
+        self.escalation_template = ConditionTemplateFactory(name="HallowedAgony526")
+
+        # -- Wire the trigger --
+        wire_scar_escalation_trigger(
+            scar_template=self.scar_template,
+            escalation_template=self.escalation_template,
+            hostile_affinity_name="Celestial526",
+        )
+
+        # Apply scar → auto-installs the MOVED Trigger row
+        apply_condition(target=self.character, condition=self.scar_template)
+
+    def _escalation_count(self):
+        from world.conditions.models import ConditionInstance
+
+        return ConditionInstance.objects.filter(
+            target=self.character,
+            condition=self.escalation_template,
+        ).count()
+
+    def _place_in(self, room):
+        """Set character.location without firing hooks (setup only)."""
+        self.character.db_location = room
+        self.character.save(update_fields=["db_location"])
+
+    def test_abyssal_scar_in_celestial_room_applies_escalation(self):
+        """Moving into a Celestial-cascade room applies the escalation condition."""
+        self._place_in(self.celestial_room)
+        self.character.at_post_move(source_location=self.inert_room)
+
+        self.assertEqual(
+            self._escalation_count(),
+            1,
+            "Expected escalation condition after entering celestial room with Abyssal scar",
+        )
+
+    def test_abyssal_scar_in_abyssal_room_no_escalation(self):
+        """Moving into an Abyssal (aligned) room does NOT apply escalation."""
+        self._place_in(self.abyssal_room)
+        self.character.at_post_move(source_location=self.inert_room)
+
+        self.assertEqual(self._escalation_count(), 0, "No escalation expected in Abyssal room")
+
+    def test_abyssal_scar_in_inert_room_no_escalation(self):
+        """Moving into an inert room (no cascade) does NOT apply escalation."""
+        self._place_in(self.inert_room)
+        self.character.at_post_move(source_location=self.celestial_room)
+
+        self.assertEqual(self._escalation_count(), 0, "No escalation expected in inert room")
+
+    def test_unscarred_character_no_escalation(self):
+        """A character without the scar condition does not take escalation on entry."""
+        from world.conditions.models import ConditionInstance
+
+        clean_char = CharacterFactory()
+        clean_char.db_location = self.celestial_room
+        clean_char.save(update_fields=["db_location"])
+        clean_char.at_post_move(source_location=self.inert_room)
+
+        self.assertEqual(
+            ConditionInstance.objects.filter(
+                target=clean_char, condition=self.escalation_template
+            ).count(),
+            0,
+            "Unscarred character should not receive escalation",
+        )


### PR DESCRIPTION
Closes #526

## Summary

Emit EventName.MOVED from at_post_move; add Room.dominant_affinity for filter DSL; add apply_condition_by_name general flow-step helper; fix filter propagation in _install_reactive_side_effects; wire reference scar-gated MOVED trigger via factory. No scar-specific Python — escalation is pure authored data.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #526 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto origin/main.

<!-- last-addressed-comment: 0 -->