### PR TITLE
feat(#676): frontend Renown tab on character sheet

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -8033,6 +8033,98 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/npc-services/mission-details/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Staff CRUD for mission-kind offer details (1:1 to an NPCServiceOffer).
+     *
+     *     Parallels ``PermitOfferDetailsViewSet`` (Plan 3 #668) and unblocks the
+     *     npc-services Mission Studio editor (#728). ``role`` on the model is
+     *     denormalized from ``offer.role`` via the model's ``save()`` override
+     *     (per #686 Phase 6), so the serializer marks it read-only — the FE
+     *     sets `offer` and the catalog uniqueness `(role, mission_template)`
+     *     is enforced at the DB level via the auto-mirrored FK.
+     */
+    get: operations['npc_services_mission_details_list'];
+    put?: never;
+    /**
+     * @description Staff CRUD for mission-kind offer details (1:1 to an NPCServiceOffer).
+     *
+     *     Parallels ``PermitOfferDetailsViewSet`` (Plan 3 #668) and unblocks the
+     *     npc-services Mission Studio editor (#728). ``role`` on the model is
+     *     denormalized from ``offer.role`` via the model's ``save()`` override
+     *     (per #686 Phase 6), so the serializer marks it read-only — the FE
+     *     sets `offer` and the catalog uniqueness `(role, mission_template)`
+     *     is enforced at the DB level via the auto-mirrored FK.
+     */
+    post: operations['npc_services_mission_details_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/npc-services/mission-details/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Staff CRUD for mission-kind offer details (1:1 to an NPCServiceOffer).
+     *
+     *     Parallels ``PermitOfferDetailsViewSet`` (Plan 3 #668) and unblocks the
+     *     npc-services Mission Studio editor (#728). ``role`` on the model is
+     *     denormalized from ``offer.role`` via the model's ``save()`` override
+     *     (per #686 Phase 6), so the serializer marks it read-only — the FE
+     *     sets `offer` and the catalog uniqueness `(role, mission_template)`
+     *     is enforced at the DB level via the auto-mirrored FK.
+     */
+    get: operations['npc_services_mission_details_retrieve'];
+    /**
+     * @description Staff CRUD for mission-kind offer details (1:1 to an NPCServiceOffer).
+     *
+     *     Parallels ``PermitOfferDetailsViewSet`` (Plan 3 #668) and unblocks the
+     *     npc-services Mission Studio editor (#728). ``role`` on the model is
+     *     denormalized from ``offer.role`` via the model's ``save()`` override
+     *     (per #686 Phase 6), so the serializer marks it read-only — the FE
+     *     sets `offer` and the catalog uniqueness `(role, mission_template)`
+     *     is enforced at the DB level via the auto-mirrored FK.
+     */
+    put: operations['npc_services_mission_details_update'];
+    post?: never;
+    /**
+     * @description Staff CRUD for mission-kind offer details (1:1 to an NPCServiceOffer).
+     *
+     *     Parallels ``PermitOfferDetailsViewSet`` (Plan 3 #668) and unblocks the
+     *     npc-services Mission Studio editor (#728). ``role`` on the model is
+     *     denormalized from ``offer.role`` via the model's ``save()`` override
+     *     (per #686 Phase 6), so the serializer marks it read-only — the FE
+     *     sets `offer` and the catalog uniqueness `(role, mission_template)`
+     *     is enforced at the DB level via the auto-mirrored FK.
+     */
+    delete: operations['npc_services_mission_details_destroy'];
+    options?: never;
+    head?: never;
+    /**
+     * @description Staff CRUD for mission-kind offer details (1:1 to an NPCServiceOffer).
+     *
+     *     Parallels ``PermitOfferDetailsViewSet`` (Plan 3 #668) and unblocks the
+     *     npc-services Mission Studio editor (#728). ``role`` on the model is
+     *     denormalized from ``offer.role`` via the model's ``save()`` override
+     *     (per #686 Phase 6), so the serializer marks it read-only — the FE
+     *     sets `offer` and the catalog uniqueness `(role, mission_template)`
+     *     is enforced at the DB level via the auto-mirrored FK.
+     */
+    patch: operations['npc_services_mission_details_partial_update'];
+    trace?: never;
+  };
   '/api/npc-services/offers/': {
     parameters: {
       query?: never;
@@ -8221,6 +8313,32 @@ export interface paths {
     head?: never;
     /** @description ViewSet for managing personas within scenes */
     patch: operations['personas_partial_update'];
+    trace?: never;
+  };
+  '/api/personas/{id}/renown/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description #676 Phase G — Read-only renown payload for the renown tab.
+     *
+     *     Returns four prestige axes + total, fame buffer + tier metadata,
+     *     per-society reputation (named tier labels, never numeric values),
+     *     and the persona's recent deeds.
+     *
+     *     Writes happen through the event-firing services (fire_renown_award
+     *     etc.), not this endpoint.
+     */
+    get: operations['personas_renown_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
     trace?: never;
   };
   '/api/places/': {
@@ -14375,6 +14493,45 @@ export interface components {
       flavor_text_needs_rewrite?: boolean;
     };
     /**
+     * @description Staff CRUD for mission-kind offer details (#728).
+     *
+     *     ``role`` is denormalized from ``offer.role`` by the model's ``save()``
+     *     override (per #686 Phase 6) so callers never set it directly — it's
+     *     read-only here, and the unique-constraint promise on
+     *     ``(role, mission_template)`` is enforced at the DB level.
+     */
+    MissionOfferDetails: {
+      readonly id: number;
+      offer: number;
+      /** @description Denormalized from offer.role to enforce (role, mission_template) catalog uniqueness. Kept in sync via save(). */
+      readonly role: number;
+      mission_template: number;
+      /** @description Per-offer weight override for POOL draw. Null falls back to MissionTemplate.base_weight. */
+      weight?: number | null;
+      /** @description Predicate JSON AND-composed with MissionTemplate.availability_rule and NPCServiceOffer.eligibility_rule at evaluation time. Empty dict = no additional gate. */
+      requirements_override?: unknown;
+      /** @description Duration written into NPCRoleCooldown on accept (blocks OTHER missions on the role for this persona). Null falls back to MissionTemplate.cooldown. */
+      role_cooldown_duration?: string | null;
+    };
+    /**
+     * @description Staff CRUD for mission-kind offer details (#728).
+     *
+     *     ``role`` is denormalized from ``offer.role`` by the model's ``save()``
+     *     override (per #686 Phase 6) so callers never set it directly — it's
+     *     read-only here, and the unique-constraint promise on
+     *     ``(role, mission_template)`` is enforced at the DB level.
+     */
+    MissionOfferDetailsRequest: {
+      offer: number;
+      mission_template: number;
+      /** @description Per-offer weight override for POOL draw. Null falls back to MissionTemplate.base_weight. */
+      weight?: number | null;
+      /** @description Predicate JSON AND-composed with MissionTemplate.availability_rule and NPCServiceOffer.eligibility_rule at evaluation time. Empty dict = no additional gate. */
+      requirements_override?: unknown;
+      /** @description Duration written into NPCRoleCooldown on accept (blocks OTHER missions on the role for this persona). Null falls back to MissionTemplate.cooldown. */
+      role_cooldown_duration?: string | null;
+    };
+    /**
      * @description Editor CRUD for MissionOption rows (authored or challenge-sourced).
      *
      *     Both source_kind values are editable; consumer code distinguishes via
@@ -14575,10 +14732,11 @@ export interface components {
      *     cooldown, reward-group rule, active flag, access tier, categories,
      *     availability rule.
      *
-     *     D4 access-tier flip: PATCHing ``access_tier=open`` runs through
-     *     ``validate_access_tier`` below — if any attached giver is not
-     *     ``is_publishable`` (no target FK), the flip is refused with the
-     *     list of unready givers' names so the Studio can show "needs-work."
+     *     Access-tier flip is unguarded post-#686 — the legacy
+     *     ``MissionGiver.is_publishable`` guard was stripped with the
+     *     giver editor surface; an equivalent guard against the new
+     *     ``NPCRole`` + ``NPCServiceOffer`` catalog will land with the
+     *     npc-services authoring follow-up.
      */
     MissionTemplate: {
       readonly id: number;
@@ -14705,10 +14863,11 @@ export interface components {
      *     cooldown, reward-group rule, active flag, access tier, categories,
      *     availability rule.
      *
-     *     D4 access-tier flip: PATCHing ``access_tier=open`` runs through
-     *     ``validate_access_tier`` below — if any attached giver is not
-     *     ``is_publishable`` (no target FK), the flip is refused with the
-     *     list of unready givers' names so the Studio can show "needs-work."
+     *     Access-tier flip is unguarded post-#686 — the legacy
+     *     ``MissionGiver.is_publishable`` guard was stripped with the
+     *     giver editor surface; an equivalent guard against the new
+     *     ``NPCRole`` + ``NPCServiceOffer`` catalog will land with the
+     *     npc-services authoring follow-up.
      */
     MissionTemplateRequest: {
       name: string;
@@ -15772,6 +15931,21 @@ export interface components {
        */
       previous?: string | null;
       results: components['schemas']['MissionNode'][];
+    };
+    PaginatedMissionOfferDetailsList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['MissionOfferDetails'][];
     };
     PaginatedMissionOptionList: {
       /** @example 123 */
@@ -16964,6 +17138,24 @@ export interface components {
       flavor_text_needs_rewrite?: boolean;
     };
     /**
+     * @description Staff CRUD for mission-kind offer details (#728).
+     *
+     *     ``role`` is denormalized from ``offer.role`` by the model's ``save()``
+     *     override (per #686 Phase 6) so callers never set it directly — it's
+     *     read-only here, and the unique-constraint promise on
+     *     ``(role, mission_template)`` is enforced at the DB level.
+     */
+    PatchedMissionOfferDetailsRequest: {
+      offer?: number;
+      mission_template?: number;
+      /** @description Per-offer weight override for POOL draw. Null falls back to MissionTemplate.base_weight. */
+      weight?: number | null;
+      /** @description Predicate JSON AND-composed with MissionTemplate.availability_rule and NPCServiceOffer.eligibility_rule at evaluation time. Empty dict = no additional gate. */
+      requirements_override?: unknown;
+      /** @description Duration written into NPCRoleCooldown on accept (blocks OTHER missions on the role for this persona). Null falls back to MissionTemplate.cooldown. */
+      role_cooldown_duration?: string | null;
+    };
+    /**
      * @description Editor CRUD for MissionOption rows (authored or challenge-sourced).
      *
      *     Both source_kind values are editable; consumer code distinguishes via
@@ -17062,10 +17254,11 @@ export interface components {
      *     cooldown, reward-group rule, active flag, access tier, categories,
      *     availability rule.
      *
-     *     D4 access-tier flip: PATCHing ``access_tier=open`` runs through
-     *     ``validate_access_tier`` below — if any attached giver is not
-     *     ``is_publishable`` (no target FK), the flip is refused with the
-     *     list of unready givers' names so the Studio can show "needs-work."
+     *     Access-tier flip is unguarded post-#686 — the legacy
+     *     ``MissionGiver.is_publishable`` guard was stripped with the
+     *     giver editor surface; an equivalent guard against the new
+     *     ``NPCRole`` + ``NPCServiceOffer`` catalog will land with the
+     *     npc-services authoring follow-up.
      */
     PatchedMissionTemplateRequest: {
       name?: string;
@@ -18303,6 +18496,19 @@ export interface components {
       readonly total_points: number;
       /** @description Return the name of the current tier, or None if no tier reached. */
       readonly current_tier_name: string | null;
+    };
+    /**
+     * @description Full renown payload for a single persona.
+     *
+     *     Read-only. Writes happen through the event-firing services.
+     */
+    Renown: {
+      persona_id: number;
+      persona_name: string;
+      prestige: components['schemas']['_PrestigeBreakdown'];
+      fame: components['schemas']['_Fame'];
+      reputation: components['schemas']['_SocietyReputation'][];
+      recent_deeds: components['schemas']['_Deed'][];
     };
     /**
      * @description * `unsatisfied` - Unsatisfied
@@ -20311,6 +20517,24 @@ export interface components {
      * @enum {string}
      */
     WeeklyVoteTargetTypeEnum: 'interaction' | 'scene_participation' | 'journal';
+    /** @description LegendEntry summary for the recent-deeds list. */
+    _Deed: {
+      id: number;
+      title: string;
+      base_value: number;
+      /** Format: date-time */
+      created_at: string;
+    };
+    /** @description Persona's fame state for the renown tab header. */
+    _Fame: {
+      points: number;
+      tier: string;
+      tier_label: string;
+      /** Format: double */
+      tier_multiplier: number;
+      next_tier: string | null;
+      next_tier_threshold: number | null;
+    };
     /** @description One entry in the near-xp-lock list returned by ThreadHubSummaryView. */
     _NearXPLockProspect: {
       thread_id: number;
@@ -20318,12 +20542,26 @@ export interface components {
       xp_cost: number;
       dev_points_to_boundary: number;
     };
+    /** @description Four-axis breakdown of the persona's total_prestige. */
+    _PrestigeBreakdown: {
+      dwellings: number;
+      items: number;
+      orgs: number;
+      deeds: number;
+      total: number;
+    };
     /** @description One resonance balance entry returned by ThreadHubSummaryView. */
     _ResonanceBalance: {
       resonance_id: number;
       balance: number;
       lifetime_earned: number;
       flavor_text: string;
+    };
+    /** @description One reputation entry: society + tier label (no raw number). */
+    _SocietyReputation: {
+      society_id: number;
+      society_name: string;
+      tier: string;
     };
     /** @description One entry in the weavable_techniques list. */
     _WeavableTechnique: {
@@ -31641,6 +31879,148 @@ export interface operations {
       };
     };
   };
+  npc_services_mission_details_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedMissionOfferDetailsList'];
+        };
+      };
+    };
+  };
+  npc_services_mission_details_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MissionOfferDetailsRequest'];
+      };
+    };
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MissionOfferDetails'];
+        };
+      };
+    };
+  };
+  npc_services_mission_details_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this mission offer details. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MissionOfferDetails'];
+        };
+      };
+    };
+  };
+  npc_services_mission_details_update: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this mission offer details. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MissionOfferDetailsRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MissionOfferDetails'];
+        };
+      };
+    };
+  };
+  npc_services_mission_details_destroy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this mission offer details. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  npc_services_mission_details_partial_update: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this mission offer details. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['PatchedMissionOfferDetailsRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MissionOfferDetails'];
+        };
+      };
+    };
+  };
   npc_services_offers_list: {
     parameters: {
       query?: {
@@ -32360,6 +32740,28 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['Persona'];
+        };
+      };
+    };
+  };
+  personas_renown_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this persona. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Renown'];
         };
       };
     };

--- a/frontend/src/renown/components/DeedsLogCard.tsx
+++ b/frontend/src/renown/components/DeedsLogCard.tsx
@@ -1,0 +1,55 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { DeedEntry } from '../types';
+
+interface Props {
+  deeds: DeedEntry[];
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * Recent deeds — the last N LegendEntry rows, newest first. Phase G API
+ * caps the list (default 20). Each row shows title, date, and base
+ * legend value; spread totals and societies_aware are surfaced when the
+ * deed-detail view lands as a follow-up.
+ */
+export function DeedsLogCard({ deeds }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recent Deeds</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {deeds.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No deeds recorded yet.</p>
+        ) : (
+          <ul className="space-y-3 text-sm">
+            {deeds.map((deed) => (
+              <li key={deed.id} className="border-b pb-2 last:border-b-0">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="font-medium">{deed.title}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatDate(deed.created_at)}
+                  </span>
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  Base legend: <span className="font-mono">{deed.base_value}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/renown/components/FameCard.tsx
+++ b/frontend/src/renown/components/FameCard.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import type { FameBlock } from '../types';
+
+interface Props {
+  fame: FameBlock;
+}
+
+/**
+ * Fame block — tier label, multiplier, current points, progress toward
+ * next tier. ``next_tier`` is null when the persona is at World Famous
+ * (top tier); we hide the progress bar in that case.
+ */
+export function FameCard({ fame }: Props) {
+  const progress =
+    fame.next_tier_threshold !== null && fame.next_tier_threshold > 0
+      ? Math.min(100, Math.round((fame.points / fame.next_tier_threshold) * 100))
+      : 100;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Fame</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <span className="text-2xl font-semibold">{fame.tier_label}</span>
+          <span className="text-sm text-muted-foreground">
+            ×{fame.tier_multiplier.toFixed(2)} prestige
+          </span>
+        </div>
+        <div className="text-sm">
+          <span className="font-medium">{fame.points.toLocaleString()}</span> fame
+          {fame.next_tier !== null && fame.next_tier_threshold !== null ? (
+            <span className="text-muted-foreground">
+              {' '}
+              / {fame.next_tier_threshold.toLocaleString()} to next tier
+            </span>
+          ) : (
+            <span className="text-muted-foreground"> (top tier)</span>
+          )}
+        </div>
+        {fame.next_tier !== null && <Progress value={progress} className="h-2" />}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/renown/components/PrestigeBreakdownCard.tsx
+++ b/frontend/src/renown/components/PrestigeBreakdownCard.tsx
@@ -1,0 +1,47 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { PrestigeBreakdown } from '../types';
+
+interface Props {
+  prestige: PrestigeBreakdown;
+}
+
+const SOURCE_ROWS: Array<{ key: keyof PrestigeBreakdown; label: string; hint: string }> = [
+  { key: 'dwellings', label: 'Dwellings', hint: 'Polished buildings + tenanted rooms.' },
+  { key: 'items', label: 'Fashion', hint: 'Polish on equipped items.' },
+  { key: 'orgs', label: 'Organizations', hint: 'Rank-weighted standing in each.' },
+  { key: 'deeds', label: 'Deeds', hint: 'Permanent accumulation from Renown events.' },
+];
+
+/**
+ * Four-axis prestige breakdown plus the total. Negative values can
+ * appear after scandals or item loss; the colour mutes on negative.
+ */
+export function PrestigeBreakdownCard({ prestige }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Prestige</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="text-3xl font-semibold">{prestige.total.toLocaleString()}</div>
+        <ul className="space-y-2 text-sm">
+          {SOURCE_ROWS.map((row) => (
+            <li key={row.key} className="flex items-baseline justify-between">
+              <div>
+                <div className="font-medium">{row.label}</div>
+                <div className="text-xs text-muted-foreground">{row.hint}</div>
+              </div>
+              <div
+                className={
+                  prestige[row.key] < 0 ? 'font-mono text-destructive' : 'font-mono text-foreground'
+                }
+              >
+                {prestige[row.key].toLocaleString()}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/renown/components/RenownPanel.test.tsx
+++ b/frontend/src/renown/components/RenownPanel.test.tsx
@@ -1,0 +1,128 @@
+import { screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { RenownPanel } from './RenownPanel';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { RenownPayload, RenownEligiblePersona } from '../types';
+
+vi.mock('../queries', () => ({
+  useRenownEligiblePersonasQuery: vi.fn(),
+  usePersonaRenownQuery: vi.fn(),
+}));
+import { useRenownEligiblePersonasQuery, usePersonaRenownQuery } from '../queries';
+
+const mockPersonasQuery = vi.mocked(useRenownEligiblePersonasQuery);
+const mockRenownQuery = vi.mocked(usePersonaRenownQuery);
+
+function makeRenown(overrides: Partial<RenownPayload> = {}): RenownPayload {
+  return {
+    persona_id: 1,
+    persona_name: 'Alice',
+    prestige: { dwellings: 100, items: 50, orgs: 25, deeds: 75, total: 250 },
+    fame: {
+      points: 250,
+      tier: 'talked_about',
+      tier_label: 'Talked About',
+      tier_multiplier: 1.25,
+      next_tier: 'celebrity',
+      next_tier_threshold: 1000,
+    },
+    reputation: [],
+    recent_deeds: [],
+    ...overrides,
+  };
+}
+
+function setPersonas(personas: RenownEligiblePersona[]) {
+  mockPersonasQuery.mockReturnValue({
+    data: personas,
+    isLoading: false,
+  } as unknown as UseQueryResult<RenownEligiblePersona[], Error>);
+}
+
+function setRenown(payload: RenownPayload | undefined, isLoading = false) {
+  mockRenownQuery.mockReturnValue({
+    data: payload,
+    isLoading,
+  } as unknown as UseQueryResult<RenownPayload, Error>);
+}
+
+describe('RenownPanel', () => {
+  it('renders empty state when the sheet has no PRIMARY/ESTABLISHED personas', () => {
+    setPersonas([]);
+    setRenown(undefined);
+    renderWithProviders(<RenownPanel characterSheetId={1} />);
+    expect(screen.getByText(/no personas with renown/i)).toBeInTheDocument();
+  });
+
+  it('renders renown for the primary persona by default', () => {
+    setPersonas([{ id: 1, name: 'Alice', persona_type: 'primary' }]);
+    setRenown(makeRenown());
+    renderWithProviders(<RenownPanel characterSheetId={1} />);
+    expect(screen.getByText('Talked About')).toBeInTheDocument();
+    // total_prestige and fame.points both happen to be 250 in this
+    // fixture; just confirm at least one element rendered that value.
+    expect(screen.getAllByText(/250/).length).toBeGreaterThan(0);
+  });
+
+  it('shows tier multiplier in the fame card', () => {
+    setPersonas([{ id: 1, name: 'Alice', persona_type: 'primary' }]);
+    setRenown(makeRenown());
+    renderWithProviders(<RenownPanel characterSheetId={1} />);
+    expect(screen.getByText(/×1.25 prestige/)).toBeInTheDocument();
+  });
+
+  it('shows persona selector tabs when there are multiple eligible personas', () => {
+    setPersonas([
+      { id: 1, name: 'Alice', persona_type: 'primary' },
+      { id: 2, name: 'Bob the Stranger', persona_type: 'established' },
+    ]);
+    setRenown(makeRenown());
+    renderWithProviders(<RenownPanel characterSheetId={1} />);
+    expect(screen.getByRole('tab', { name: 'Alice' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Bob the Stranger' })).toBeInTheDocument();
+  });
+
+  it('hides the persona selector when only one persona qualifies', () => {
+    setPersonas([{ id: 1, name: 'Alice', persona_type: 'primary' }]);
+    setRenown(makeRenown());
+    renderWithProviders(<RenownPanel characterSheetId={1} />);
+    expect(screen.queryByRole('tab', { name: 'Alice' })).not.toBeInTheDocument();
+  });
+
+  it('renders reputation entries with named tier labels (no raw numbers)', () => {
+    setPersonas([{ id: 1, name: 'Alice', persona_type: 'primary' }]);
+    setRenown(
+      makeRenown({
+        reputation: [
+          { society_id: 1, society_name: 'House of the Sword', tier: 'liked' },
+          { society_id: 2, society_name: 'Order of the Quill', tier: 'reviled' },
+        ],
+      })
+    );
+    renderWithProviders(<RenownPanel characterSheetId={1} />);
+    expect(screen.getByText('House of the Sword')).toBeInTheDocument();
+    expect(screen.getByText('Liked')).toBeInTheDocument();
+    expect(screen.getByText('Reviled')).toBeInTheDocument();
+  });
+
+  it('renders deeds log with title + date', () => {
+    setPersonas([{ id: 1, name: 'Alice', persona_type: 'primary' }]);
+    setRenown(
+      makeRenown({
+        recent_deeds: [
+          { id: 1, title: 'Saved the village', base_value: 50, created_at: '2026-01-15T00:00:00Z' },
+        ],
+      })
+    );
+    renderWithProviders(<RenownPanel characterSheetId={1} />);
+    expect(screen.getByText('Saved the village')).toBeInTheDocument();
+  });
+
+  it('shows empty deeds message when none exist', () => {
+    setPersonas([{ id: 1, name: 'Alice', persona_type: 'primary' }]);
+    setRenown(makeRenown());
+    renderWithProviders(<RenownPanel characterSheetId={1} />);
+    expect(screen.getByText(/no deeds recorded yet/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/renown/components/RenownPanel.tsx
+++ b/frontend/src/renown/components/RenownPanel.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useRenownEligiblePersonasQuery, usePersonaRenownQuery } from '../queries';
+import { FameCard } from './FameCard';
+import { PrestigeBreakdownCard } from './PrestigeBreakdownCard';
+import { ReputationListCard } from './ReputationListCard';
+import { DeedsLogCard } from './DeedsLogCard';
+
+interface Props {
+  /** CharacterSheet pk (shared with the character ObjectDB pk). */
+  characterSheetId: number;
+}
+
+/**
+ * Top-level Renown tab body. Per spec: a sub-panel per PRIMARY/ESTABLISHED
+ * persona on the body. TEMPORARY personas accumulate but don't surface
+ * here.
+ *
+ * Layout:
+ *   - Persona selector (only shown when there are 2+ eligible personas).
+ *   - The selected persona's renown payload, rendered as four cards:
+ *     Fame, Prestige, Reputation, Recent Deeds.
+ */
+export function RenownPanel({ characterSheetId }: Props) {
+  const { data: personas, isLoading: personasLoading } =
+    useRenownEligiblePersonasQuery(characterSheetId);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const effectiveSelectedId =
+    selectedId ??
+    personas?.find((p) => p.persona_type === 'primary')?.id ??
+    personas?.[0]?.id ??
+    null;
+
+  const { data: renown, isLoading: renownLoading } = usePersonaRenownQuery(effectiveSelectedId);
+
+  if (personasLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!personas || personas.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-sm text-muted-foreground">
+          No personas with renown to display.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {personas.length > 1 && (
+        <Tabs value={String(effectiveSelectedId)} onValueChange={(v) => setSelectedId(Number(v))}>
+          <TabsList>
+            {personas.map((p) => (
+              <TabsTrigger key={p.id} value={String(p.id)}>
+                {p.name}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      )}
+
+      {renownLoading || !renown ? (
+        <div className="flex justify-center py-8">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          <FameCard fame={renown.fame} />
+          <PrestigeBreakdownCard prestige={renown.prestige} />
+          <ReputationListCard reputation={renown.reputation} />
+          <DeedsLogCard deeds={renown.recent_deeds} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/renown/components/ReputationListCard.tsx
+++ b/frontend/src/renown/components/ReputationListCard.tsx
@@ -1,0 +1,55 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { SocietyReputationEntry } from '../types';
+
+interface Props {
+  reputation: SocietyReputationEntry[];
+}
+
+const TIER_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  reviled: 'destructive',
+  despised: 'destructive',
+  disliked: 'destructive',
+  disfavored: 'secondary',
+  unknown: 'outline',
+  favored: 'secondary',
+  liked: 'default',
+  honored: 'default',
+  revered: 'default',
+};
+
+function formatTier(tier: string): string {
+  return tier.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Per-society reputation list. Named tier labels only — the raw numeric
+ * value is intentionally never exposed to the client (#676 spec).
+ */
+export function ReputationListCard({ reputation }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Reputation</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {reputation.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No societies have a recorded opinion of this persona yet.
+          </p>
+        ) : (
+          <ul className="space-y-2 text-sm">
+            {reputation.map((entry) => (
+              <li key={entry.society_id} className="flex items-center justify-between">
+                <span className="font-medium">{entry.society_name}</span>
+                <Badge variant={TIER_VARIANT[entry.tier] ?? 'outline'}>
+                  {formatTier(entry.tier)}
+                </Badge>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/renown/queries.ts
+++ b/frontend/src/renown/queries.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/evennia_replacements/api';
+import type { RenownEligiblePersona, RenownPayload } from './types';
+
+async function fetchPersonasForSheet(characterSheetId: number): Promise<RenownEligiblePersona[]> {
+  // Fetch every persona on this sheet, then filter client-side to the
+  // two types that have renown panels. PersonaFilter supports
+  // ``character_sheet`` but not multi-type IN; the result set per body
+  // is small enough that one extra round-trip would cost more than the
+  // client-side filter.
+  const res = await apiFetch(`/api/personas/?character_sheet=${characterSheetId}&page_size=50`);
+  if (!res.ok) {
+    throw new Error('Failed to load personas for renown tab.');
+  }
+  const data = (await res.json()) as {
+    results?: Array<{ id: number; name: string; persona_type: string }>;
+  };
+  return (data.results ?? [])
+    .filter((p) => p.persona_type === 'primary' || p.persona_type === 'established')
+    .map((p) => ({
+      id: p.id,
+      name: p.name,
+      persona_type: p.persona_type as 'primary' | 'established',
+    }));
+}
+
+async function fetchPersonaRenown(personaId: number): Promise<RenownPayload> {
+  const res = await apiFetch(`/api/personas/${personaId}/renown/`);
+  if (!res.ok) {
+    throw new Error('Failed to load renown.');
+  }
+  return res.json();
+}
+
+export function useRenownEligiblePersonasQuery(characterSheetId: number | null) {
+  return useQuery({
+    queryKey: ['renown-personas', characterSheetId],
+    queryFn: () => fetchPersonasForSheet(characterSheetId as number),
+    enabled: characterSheetId !== null,
+  });
+}
+
+export function usePersonaRenownQuery(personaId: number | null) {
+  return useQuery({
+    queryKey: ['renown', personaId],
+    queryFn: () => fetchPersonaRenown(personaId as number),
+    enabled: personaId !== null,
+  });
+}

--- a/frontend/src/renown/types.ts
+++ b/frontend/src/renown/types.ts
@@ -1,0 +1,17 @@
+import type { components } from '@/generated/api';
+
+export type RenownPayload = components['schemas']['Renown'];
+export type FameBlock = components['schemas']['_Fame'];
+export type PrestigeBreakdown = components['schemas']['_PrestigeBreakdown'];
+export type SocietyReputationEntry = components['schemas']['_SocietyReputation'];
+export type DeedEntry = components['schemas']['_Deed'];
+
+/**
+ * A persona that has a renown panel. PRIMARY and ESTABLISHED only —
+ * TEMPORARY personas accumulate stats but don't get a sub-panel per spec.
+ */
+export interface RenownEligiblePersona {
+  id: number;
+  name: string;
+  persona_type: 'primary' | 'established';
+}

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -9,6 +9,8 @@ import {
   CharacterApplicationForm,
 } from '@/components/character';
 import { MessagesSection } from '@/narrative/components/MessagesSection';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { RenownPanel } from '@/renown/components/RenownPanel';
 
 export function CharacterSheetPage() {
   const { id } = useParams();
@@ -31,35 +33,49 @@ export function CharacterSheetPage() {
         />
         {entry.quote && <blockquote className="italic">"{entry.quote}"</blockquote>}
       </div>
-      {entry.description && (
-        <section>
-          <h3 className="text-xl font-semibold">Description</h3>
-          <p>{entry.description}</p>
-        </section>
-      )}
-      <BackgroundSection background={entry.character.background} />
-      <StatsSection
-        age={entry.character.age}
-        gender={entry.character.gender}
-        race={entry.character.race}
-        charClass={entry.character.char_class}
-        level={entry.character.level}
-        concept={entry.character.concept}
-        family={entry.character.family}
-        vocation={entry.character.vocation}
-        socialRank={entry.character.social_rank}
-      />
-      <RelationshipsSection
-        relationships={entry.character.relationships}
-        characterSheetId={entry.character.id}
-      />
-      <GalleriesSection galleries={entry.character.galleries} />
-      {entry.can_apply && <CharacterApplicationForm entryId={entry.id} />}
-      {isMyCharacter && (
-        <div id="messages">
-          <MessagesSection />
-        </div>
-      )}
+
+      <Tabs defaultValue="sheet" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="sheet">Sheet</TabsTrigger>
+          <TabsTrigger value="renown">Renown</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="sheet" className="space-y-4">
+          {entry.description && (
+            <section>
+              <h3 className="text-xl font-semibold">Description</h3>
+              <p>{entry.description}</p>
+            </section>
+          )}
+          <BackgroundSection background={entry.character.background} />
+          <StatsSection
+            age={entry.character.age}
+            gender={entry.character.gender}
+            race={entry.character.race}
+            charClass={entry.character.char_class}
+            level={entry.character.level}
+            concept={entry.character.concept}
+            family={entry.character.family}
+            vocation={entry.character.vocation}
+            socialRank={entry.character.social_rank}
+          />
+          <RelationshipsSection
+            relationships={entry.character.relationships}
+            characterSheetId={entry.character.id}
+          />
+          <GalleriesSection galleries={entry.character.galleries} />
+          {entry.can_apply && <CharacterApplicationForm entryId={entry.id} />}
+          {isMyCharacter && (
+            <div id="messages">
+              <MessagesSection />
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="renown" className="space-y-4">
+          <RenownPanel characterSheetId={entry.character.id} />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -4,6 +4,7 @@ from http import HTTPMethod
 from django.db.models import Prefetch, Q, QuerySet
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import SearchFilter
@@ -45,6 +46,7 @@ from world.scenes.serializers import (
     SceneSummaryRevisionSerializer,
 )
 from world.scenes.services import broadcast_scene_message
+from world.societies.renown_serializers import RenownSerializer, build_renown_payload
 
 
 class SceneViewSet(viewsets.ModelViewSet):
@@ -274,6 +276,7 @@ class PersonaViewSet(viewsets.ModelViewSet):
             .order_by("created_at")
         )
 
+    @extend_schema(responses=RenownSerializer, tags=["personas"])
     @action(detail=True, methods=[HTTPMethod.GET])
     def renown(self, request: Request, pk: int | None = None) -> Response:
         """#676 Phase G — Read-only renown payload for the renown tab.
@@ -285,11 +288,6 @@ class PersonaViewSet(viewsets.ModelViewSet):
         Writes happen through the event-firing services (fire_renown_award
         etc.), not this endpoint.
         """
-        from world.societies.renown_serializers import (  # noqa: PLC0415
-            RenownSerializer,
-            build_renown_payload,
-        )
-
         persona = self.get_object()
         payload = build_renown_payload(persona)
         serializer = RenownSerializer(payload)


### PR DESCRIPTION
## Summary

Phase G UI deliverable from the #676 spec. The backend `PersonaViewSet.renown` action shipped in #734; this lands the React tab that consumes it on the character sheet.

Refs #676.

## What ships

- `@extend_schema(responses=RenownSerializer)` on `PersonaViewSet.renown` so the OpenAPI spec exposes the endpoint and `just gen-api-types` produces `Renown` / `_Fame` / `_PrestigeBreakdown` / `_SocietyReputation` / `_Deed` types.
- New `frontend/src/renown/` module:
  - `types.ts` — type aliases from the generated schema.
  - `queries.ts` — `useRenownEligiblePersonasQuery` (PRIMARY/ESTABLISHED only; TEMPORARY personas accumulate but don't surface per spec) + `usePersonaRenownQuery`.
  - `components/FameCard` — tier label, multiplier, fame points, progress bar to next tier (hidden at World Famous).
  - `components/PrestigeBreakdownCard` — four axes (Dwellings, Fashion, Organizations, Deeds) + total with mute/destructive colouring on negative values.
  - `components/ReputationListCard` — per-society rows with named tier badges. Raw numeric reputation values are intentionally never exposed (#676 spec).
  - `components/DeedsLogCard` — last N legend entries with title, formatted date, base value.
  - `components/RenownPanel` — top-level orchestrator with a persona-selector `Tabs` control (shown only when 2+ eligible personas); defaults to PRIMARY.
- `CharacterSheetPage` refactored to a two-tab layout: **Sheet** (existing content) and **Renown**. Other surfaces unchanged.

## Tests

8 component tests in `RenownPanel.test.tsx` cover: empty state, default-to-primary render, multiplier display, persona selector visibility (multi vs single), reputation named tiers + no raw numbers, deeds log, empty deeds.

## Test plan

- [x] 1708 / 1708 frontend tests green
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean (with `collectstatic` postbuild)
- [ ] Visual smoke against `arx start` once a reviewer is in the docker env

## Not in this PR (deferred)

- **Spread UI** (Phase H frontend) — backend `extend_deed_awareness` ships in #739; no UI yet.
- **Renown card view for other personas** (filtered by viewer's `societies_aware`) — the API already supports `viewer_society` for the perception offset (#738), but the viewer-context hook from the sheet isn't built.
- **Diegetic in-world `RankingDisplay` interact action** (Phase I) — model + MV + nightly refresh cron still pending.
- **Notifications surface** for renown-fired events.
- **Owned-dwellings sub-section** in the Renown tab — needs an API for per-persona dwelling polish breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)