### PR TITLE
Conditions: UNTIL_END_OF_COMBAT not expired at combat end (generic gap)

### DIFF
--- a/docs/systems/conditions.md
+++ b/docs/systems/conditions.md
@@ -90,9 +90,10 @@ Effects use mutually exclusive FKs: `condition` (all stages) OR `stage` (stage-s
 from world.conditions.services import (
     # Core operations
     apply_condition,               # Apply with stacking/interaction handling (atomic)
-    remove_condition,              # Remove condition (optionally just one stack)
+    remove_condition,              # Remove condition (optionally just one stack / incl. suppressed)
     remove_conditions_by_category, # Remove all in a category
     clear_all_conditions,          # Bulk removal with filters
+    expire_end_of_combat_conditions, # Sweep UNTIL_END_OF_COMBAT conds on targets at combat end
 
     # Queries
     get_active_conditions,         # QuerySet of active instances on target

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -2237,10 +2237,31 @@ def cleanup_completed_encounter(encounter: CombatEncounter) -> None:
     ObjectDB is destroyed; the SET_NULL FK behavior nulls
     CombatOpponent.objectdb after deletion.
     """
-    # Sweep covenant rite buffs for this encounter.
+    # Sweep covenant rite buffs for this encounter (stamps completed_at on the
+    # rite instances in addition to removing their granted condition).
     from world.covenants.services import complete_rites_for_encounter  # noqa: PLC0415
 
     complete_rites_for_encounter(encounter=encounter)
+
+    # Generically expire any remaining UNTIL_END_OF_COMBAT conditions on the
+    # encounter's participants and opponents. The rite sweep above already
+    # removed its own (rite-granted) buffs, so this is idempotent for those;
+    # it catches every other end-of-combat condition (e.g. technique-applied)
+    # that nothing else expires. Runs before ephemeral NPC deletion so the
+    # sweep observes those targets too.
+    from world.conditions.services import expire_end_of_combat_conditions  # noqa: PLC0415
+
+    participant_targets = [
+        p.character_sheet.character
+        for p in CombatParticipant.objects.filter(encounter=encounter).select_related(
+            "character_sheet__character"
+        )
+    ]
+    opponent_targets = [
+        opp.objectdb
+        for opp in CombatOpponent.objects.filter(encounter=encounter).select_related("objectdb")
+    ]
+    expire_end_of_combat_conditions(participant_targets + opponent_targets)
 
     qs = CombatOpponent.objects.filter(
         encounter=encounter,

--- a/src/world/combat/tests/test_cleanup_completed_encounter.py
+++ b/src/world/combat/tests/test_cleanup_completed_encounter.py
@@ -59,6 +59,67 @@ class CleanupCompletedEncounterTests(EvenniaTestCase):
         self.assertIsNotNone(named_od_id)
         self.assertIsNotNone(pvp_od_id)
 
+    def test_cleanup_expires_until_end_of_combat_conditions(self):
+        """Generic gap (#763): a non-rite UNTIL_END_OF_COMBAT condition on an
+        encounter participant is expired when the encounter completes, while a
+        ROUNDS-duration condition on the same participant survives."""
+        from world.combat.factories import CombatEncounterFactory, CombatParticipantFactory
+        from world.combat.services import cleanup_completed_encounter
+        from world.conditions.constants import DurationType
+        from world.conditions.factories import ConditionInstanceFactory, ConditionTemplateFactory
+        from world.conditions.models import ConditionInstance
+
+        encounter = CombatEncounterFactory()
+        participant = CombatParticipantFactory(encounter=encounter)
+        target = participant.character_sheet.character
+
+        end_combat_tmpl = ConditionTemplateFactory(
+            name="Battle Fury", default_duration_type=DurationType.UNTIL_END_OF_COMBAT
+        )
+        rounds_tmpl = ConditionTemplateFactory(
+            name="Bleeding", default_duration_type=DurationType.ROUNDS
+        )
+        end_combat_inst = ConditionInstanceFactory(
+            target=target, condition=end_combat_tmpl, rounds_remaining=None
+        )
+        rounds_inst = ConditionInstanceFactory(
+            target=target, condition=rounds_tmpl, rounds_remaining=3
+        )
+
+        cleanup_completed_encounter(encounter)
+
+        self.assertFalse(ConditionInstance.objects.filter(pk=end_combat_inst.pk).exists())
+        self.assertTrue(ConditionInstance.objects.filter(pk=rounds_inst.pk).exists())
+
+    def test_cleanup_expires_until_end_of_combat_on_persistent_opponent(self):
+        """Generic gap (#763): a persistent (non-ephemeral) NPC opponent that
+        survives cleanup still has its UNTIL_END_OF_COMBAT conditions swept —
+        proving the sweep, not ObjectDB deletion, clears them."""
+        from world.combat.factories import CombatEncounterFactory, ThreatPoolFactory
+        from world.combat.services import add_opponent, cleanup_completed_encounter
+        from world.conditions.constants import DurationType
+        from world.conditions.factories import ConditionInstanceFactory, ConditionTemplateFactory
+        from world.conditions.models import ConditionInstance
+        from world.scenes.factories import PersonaFactory
+
+        encounter = CombatEncounterFactory()
+        pool = ThreatPoolFactory()
+        persona = PersonaFactory()  # named opponent => persistent, survives cleanup
+        opp = add_opponent(
+            encounter, name="Boss", tier="boss", max_health=100, threat_pool=pool, persona=persona
+        )
+        tmpl = ConditionTemplateFactory(
+            name="Marked for Death", default_duration_type=DurationType.UNTIL_END_OF_COMBAT
+        )
+        inst = ConditionInstanceFactory(target=opp.objectdb, condition=tmpl, rounds_remaining=None)
+
+        cleanup_completed_encounter(encounter)
+
+        from evennia.objects.models import ObjectDB
+
+        self.assertTrue(ObjectDB.objects.filter(pk=opp.objectdb_id).exists())  # opponent survived
+        self.assertFalse(ConditionInstance.objects.filter(pk=inst.pk).exists())  # condition swept
+
     def test_cleanup_recheck_refuses_persistent_references(self):
         """Layer 5 guard: even if a corrupt row escaped Layers 1-4 and was flagged
         ephemeral despite having persistent identity references, cleanup re-checks

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -10,6 +10,7 @@ Design principles:
 - Bidirectional modifiers (conditions can be good or bad depending on context)
 """
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import timedelta
 from decimal import Decimal
@@ -849,6 +850,7 @@ def remove_condition(
     condition: ConditionTemplate,
     *,
     remove_all_stacks: bool = True,
+    include_suppressed: bool = False,
 ) -> bool:
     """
     Remove a condition from a target.
@@ -857,6 +859,8 @@ def remove_condition(
         target: The ObjectDB instance
         condition: ConditionTemplate instance
         remove_all_stacks: If False, only remove one stack
+        include_suppressed: Also remove the condition if it is currently
+            suppressed (default skips suppressed instances)
 
     Returns:
         True if condition was removed
@@ -864,7 +868,7 @@ def remove_condition(
     Emits reactive events:
     - CONDITION_REMOVED (post-delete, frozen)
     """
-    instance = get_condition_instance(target, condition)
+    instance = get_condition_instance(target, condition, include_suppressed=include_suppressed)
     if not instance:
         return False
 
@@ -971,6 +975,48 @@ def remove_conditions_by_category(
     _invalidate_condition_handler(target)
     for template in removed:
         _notify_stories_condition_expired(target, template)
+    return removed
+
+
+@transaction.atomic
+def expire_end_of_combat_conditions(
+    targets: Iterable["ObjectDB"],  # noqa: OBJECTDB_PARAM
+) -> list[ConditionTemplate]:
+    """Remove all UNTIL_END_OF_COMBAT conditions from the given targets.
+
+    Called when a combat encounter completes (see
+    ``world.combat.services.cleanup_completed_encounter``). The duration
+    countdown in ``_process_duration_and_progression`` only decrements ROUNDS
+    instances, so nothing else expires end-of-combat conditions — without this
+    sweep they would persist indefinitely after combat ends.
+
+    Reuses ``remove_condition`` per instance so the full teardown fires
+    (CONDITION_REMOVED reactive event, stories notification, deferred-death
+    resolution). Suppressed instances are included. Idempotent: targets with
+    no such conditions are no-ops, so it composes safely with system-specific
+    sweeps that already removed their own buffs (e.g. covenant rites).
+
+    Args:
+        targets: ObjectDB instances to sweep (encounter participants and
+            opponents). ``None`` entries are ignored.
+
+    Returns:
+        The list of removed ConditionTemplates.
+    """
+    target_list = [t for t in targets if t is not None]
+    if not target_list:
+        return []
+
+    instances = ConditionInstance.objects.filter(
+        target_id__in=[t.pk for t in target_list],
+        condition__default_duration_type=DurationType.UNTIL_END_OF_COMBAT,
+    ).select_related("condition", "target")
+
+    removed: list[ConditionTemplate] = []
+    for instance in instances:
+        was_removed = remove_condition(instance.target, instance.condition, include_suppressed=True)
+        if was_removed:
+            removed.append(instance.condition)
     return removed
 
 


### PR DESCRIPTION
Closes #763

## Summary

`DurationType.UNTIL_END_OF_COMBAT` was selectable but nothing generically expired such conditions when combat ended:

- The end-of-round duration countdown (`_process_duration_and_progression`) only decrements `DurationType.ROUNDS` instances; `rounds_remaining` is `None` for every other duration type.
- `cleanup_completed_encounter` only swept **covenant-rite** buffs (via `complete_rites_for_encounter`, added by #516). Any other `UNTIL_END_OF_COMBAT` condition (e.g. a future technique-applied buff) would persist indefinitely after combat.

This was latent today (only the #516 rite used the duration, and it self-sweeps), but a real gap for any future end-of-combat condition.

### Change

- **New** `conditions.services.expire_end_of_combat_conditions(targets)` — removes all `UNTIL_END_OF_COMBAT` `ConditionInstance`s on the given targets. Reuses `remove_condition` per instance so the full teardown fires (`CONDITION_REMOVED` reactive event, stories notification, deferred-death resolution). Idempotent, so it composes safely with system-specific sweeps that already removed their own buffs.
- **Extended** `remove_condition(..., include_suppressed=False)` — threads through to `get_condition_instance` so suppressed end-of-combat conditions are also cleared (default behavior unchanged).
- **Wired** into `cleanup_completed_encounter` for all encounter participants **and** opponents, after the rite sweep (idempotent for rite-granted buffs) and before ephemeral-NPC deletion (so persistent NPC opponents get their end-of-combat conditions cleared too).

### Anti-reinvention pass (verified against code)

- `remove_condition` (`conditions/services.py`) — **[BUILT & WIRED]**, reused (the rite sweep already calls it). Not duplicated.
- `remove_conditions_by_category` / `clear_all_conditions` — **[BUILT & WIRED]** but category-/all-scoped, not duration-scoped; neither fits. So one thin duration-scoped helper is genuinely **[ABSENT]** and justified.

## Tests

- `test_cleanup_expires_until_end_of_combat_conditions` — non-rite `UNTIL_END_OF_COMBAT` condition on a participant is cleared at combat end; a `ROUNDS` condition on the same participant survives (TDD: confirmed red→green).
- `test_cleanup_expires_until_end_of_combat_on_persistent_opponent` — a surviving persistent NPC opponent has its end-of-combat condition swept (proving the sweep, not ObjectDB deletion, clears it).

## Notes

- **Design gate:** spec-review gate intentionally skipped per maintainer direction — this is a small, fully-specified latent gap-fill. Anti-reinvention pass done inline (above).
- **Testing:** `conditions` (SQLite-clean) passes fully (258); the new cleanup tests pass; all pre-commit hooks pass. Local PG parity was blocked by a concurrent worktree holding the shared `test_arxiidev` DB — the change uses no PG-specific SQL, so SQLite coverage is representative, and **CI's isolated fresh-PG shards are the parity gate**. The only SQLite-tier failures observed (a combat `DISTINCT ON` test, covenants API `status_code` tests) are pre-existing tier artifacts in code paths this change never touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
