### PR TITLE
feat(#745): Spread a Tale Phase 3 — traffic time-of-day + activity band UI

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -9709,6 +9709,23 @@ export interface paths {
     patch: operations['scenes_partial_update'];
     trace?: never;
   };
+  '/api/scenes/{id}/activity/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description #745 — The scene room's current activity band (qualitative, time-aware). */
+    get: operations['scenes_activity_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/scenes/{id}/finish/': {
     parameters: {
       query?: never;
@@ -19309,6 +19326,10 @@ export interface components {
      * @enum {string}
      */
     SceneActionStatusEnum: 'pending' | 'accepted' | 'denied' | 'resolved' | 'expired';
+    /** @description A scene room's current activity band (shown before a teller commits). */
+    SceneActivity: {
+      readonly band: string;
+    };
     /** @description Full scene representation with personas */
     SceneDetail: {
       readonly id: number;
@@ -35398,6 +35419,28 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['SceneDetail'];
+        };
+      };
+    };
+  };
+  scenes_activity_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this scene. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SceneActivity'];
         };
       };
     };

--- a/frontend/src/spread/SpreadTaleDialog.tsx
+++ b/frontend/src/spread/SpreadTaleDialog.tsx
@@ -26,6 +26,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useAppSelector } from '@/store/hooks';
 
 import {
+  useSceneActivityQuery,
   useSpreadableDeedsQuery,
   useSpreadMutation,
   useSpreadSpecializationsQuery,
@@ -86,6 +87,7 @@ interface FormProps {
 function SpreadForm({ personaId, sceneId, open, onDone }: FormProps) {
   const { data: deeds, isLoading } = useSpreadableDeedsQuery(personaId, open);
   const { data: forms } = useSpreadSpecializationsQuery(open);
+  const { data: activity } = useSceneActivityQuery(sceneId, open);
   const [deedId, setDeedId] = useState<number | null>(null);
   const [pose, setPose] = useState('');
   const [effort, setEffort] = useState('medium');
@@ -141,6 +143,10 @@ function SpreadForm({ personaId, sceneId, open, onDone }: FormProps) {
 
   return (
     <div className="space-y-4">
+      {activity && (
+        <p className="text-sm text-muted-foreground">The room is {activity.band.toLowerCase()}.</p>
+      )}
+
       <Select value={deedId?.toString() ?? ''} onValueChange={(v) => setDeedId(Number(v))}>
         <SelectTrigger aria-label="Tale to spread">
           <SelectValue placeholder="Choose a tale to tell" />

--- a/frontend/src/spread/queries.ts
+++ b/frontend/src/spread/queries.ts
@@ -51,6 +51,26 @@ export function useSpreadSpecializationsQuery(enabled = true) {
   });
 }
 
+export interface SceneActivity {
+  band: string;
+}
+
+async function fetchSceneActivity(sceneId: number): Promise<SceneActivity> {
+  const res = await apiFetch(`/api/scenes/${sceneId}/activity/`);
+  if (!res.ok) {
+    throw new Error('Failed to read the room.');
+  }
+  return res.json() as Promise<SceneActivity>;
+}
+
+export function useSceneActivityQuery(sceneId: number | null, enabled = true) {
+  return useQuery({
+    queryKey: ['scene-activity', sceneId],
+    queryFn: () => fetchSceneActivity(sceneId as number),
+    enabled: sceneId !== null && enabled,
+  });
+}
+
 async function fetchSpreadableDeeds(personaId: number): Promise<SpreadableDeed[]> {
   const res = await apiFetch(`/api/personas/${personaId}/spreadable-deeds/`);
   if (!res.ok) {

--- a/src/schema.json
+++ b/src/schema.json
@@ -16620,6 +16620,29 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/scenes/{id}/activity/:
+    get:
+      operationId: scenes_activity_retrieve
+      description: '#745 — The scene room''s current activity band (qualitative, time-aware).'
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this scene.
+        required: true
+      tags:
+      - scenes
+      security:
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SceneActivity'
+          description: ''
   /api/scenes/{id}/finish/:
     post:
       operationId: scenes_finish_create
@@ -35024,6 +35047,15 @@ components:
         * `denied` - Denied
         * `resolved` - Resolved
         * `expired` - Expired
+    SceneActivity:
+      type: object
+      description: A scene room's current activity band (shown before a teller commits).
+      properties:
+        band:
+          type: string
+          readOnly: true
+      required:
+      - band
     SceneDetail:
       type: object
       description: Full scene representation with personas

--- a/src/world/locations/activity_services.py
+++ b/src/world/locations/activity_services.py
@@ -10,8 +10,19 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from world.game_clock.constants import TimePhase
+
 if TYPE_CHECKING:
     from evennia.objects.objects import DefaultObject
+
+# IC time-of-day multiplier on a room's traffic before banding (#745 Phase 3).
+# A place waxes busier toward evening and empties at night/dawn. Tunable.
+PHASE_TRAFFIC_FACTOR: dict[TimePhase, float] = {
+    TimePhase.DAWN: 0.6,
+    TimePhase.DAY: 1.0,
+    TimePhase.DUSK: 1.15,
+    TimePhase.NIGHT: 0.5,
+}
 
 # (TRAFFIC threshold, band label, spread multiplier), ascending by threshold.
 # The highest threshold <= the value wins. Tunable.
@@ -45,17 +56,27 @@ def band_for_traffic(traffic: int) -> ActivityBand:
     return ActivityBand(label=chosen[1], multiplier=chosen[2])
 
 
-def room_activity_band(room: DefaultObject | None) -> ActivityBand:
+def room_activity_band(
+    room: DefaultObject | None, *, ic_phase: TimePhase | None = None
+) -> ActivityBand:
     """Activity band for an Evennia room object (e.g. ``scene.location``).
 
-    Reads the room's cascade-resolved TRAFFIC stat. Rooms with no profile (or a
-    None room) fall through to the TRAFFIC default (Busy baseline).
+    Reads the room's cascade-resolved TRAFFIC stat, then bends it by the IC
+    time-of-day (a market reads Busy by day, Bustling at dusk, Quiet at dawn).
+    Rooms with no profile (or a None room) fall through to the TRAFFIC default.
+    ``ic_phase`` defaults to the live IC phase; pass it to override (tests).
     """
+    from world.game_clock.services import get_ic_phase  # noqa: PLC0415
     from world.locations.constants import StatKey  # noqa: PLC0415
     from world.locations.services import effective_stats_for_rooms  # noqa: PLC0415
 
     if room is None:
-        return band_for_traffic(50)
-    stats = effective_stats_for_rooms([room], [StatKey.TRAFFIC])
-    traffic = stats.get(room.pk, {}).get(StatKey.TRAFFIC, 50)
-    return band_for_traffic(traffic)
+        traffic = 50
+    else:
+        stats = effective_stats_for_rooms([room], [StatKey.TRAFFIC])
+        traffic = stats.get(room.pk, {}).get(StatKey.TRAFFIC, 50)
+
+    phase = ic_phase if ic_phase is not None else get_ic_phase()
+    factor = PHASE_TRAFFIC_FACTOR.get(phase, 1.0) if phase is not None else 1.0
+    effective = max(0, min(100, round(traffic * factor)))
+    return band_for_traffic(effective)

--- a/src/world/locations/tests/test_activity_services.py
+++ b/src/world/locations/tests/test_activity_services.py
@@ -2,7 +2,8 @@
 
 from django.test import SimpleTestCase
 
-from world.locations.activity_services import band_for_traffic
+from world.game_clock.constants import TimePhase
+from world.locations.activity_services import band_for_traffic, room_activity_band
 
 
 class ActivityBandTest(SimpleTestCase):
@@ -24,3 +25,18 @@ class ActivityBandTest(SimpleTestCase):
     def test_boundaries_pick_higher_band(self) -> None:
         self.assertEqual(band_for_traffic(70).label, "Bustling")
         self.assertEqual(band_for_traffic(69).label, "Busy")
+
+
+class RoomActivityBandPhaseTest(SimpleTestCase):
+    """Time-of-day bends the band. room=None → traffic 50 (Busy baseline)."""
+
+    def test_day_is_baseline(self) -> None:
+        self.assertEqual(room_activity_band(None, ic_phase=TimePhase.DAY).label, "Busy")
+
+    def test_night_quiets_the_room(self) -> None:
+        # 50 × 0.5 = 25 → Quiet
+        self.assertEqual(room_activity_band(None, ic_phase=TimePhase.NIGHT).label, "Quiet")
+
+    def test_dawn_thins_the_room(self) -> None:
+        # 50 × 0.6 = 30 → Steady
+        self.assertEqual(room_activity_band(None, ic_phase=TimePhase.DAWN).label, "Steady")

--- a/src/world/scenes/tests/test_spread_endpoints.py
+++ b/src/world/scenes/tests/test_spread_endpoints.py
@@ -92,3 +92,15 @@ class SpreadEndpointTest(APITestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.data)
         self.assertIn("band", resp.data)
+
+    def test_scene_activity_private_scene_blocks_non_participant(self) -> None:
+        from world.scenes.constants import ScenePrivacyMode
+
+        private_scene = SceneFactory(privacy_mode=ScenePrivacyMode.PRIVATE)
+        # self.account is not a participant of private_scene.
+        url = reverse("scene-activity", args=[private_scene.pk])
+        resp = self.client.get(url)
+        self.assertIn(
+            resp.status_code,
+            (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND),
+        )

--- a/src/world/scenes/tests/test_spread_endpoints.py
+++ b/src/world/scenes/tests/test_spread_endpoints.py
@@ -86,3 +86,9 @@ class SpreadEndpointTest(APITestCase):
             format="json",
         )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_scene_activity_returns_a_band(self) -> None:
+        url = reverse("scene-activity", args=[self.scene.pk])
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.data)
+        self.assertIn("band", resp.data)

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -53,6 +53,7 @@ from world.societies.renown_serializers import (
     build_renown_payload,
 )
 from world.societies.spread_serializers import (
+    SceneActivitySerializer,
     SpreadableDeedSerializer,
     SpreadInputSerializer,
     SpreadResultSerializer,
@@ -260,6 +261,16 @@ class SceneViewSet(viewsets.ModelViewSet):
         broadcast_scene_message(scene, SceneAction.END)
         serializer = self.get_serializer(scene)
         return Response(serializer.data)
+
+    @extend_schema(responses=SceneActivitySerializer, tags=["scenes"])
+    @action(detail=True, methods=[HTTPMethod.GET])
+    def activity(self, request: Request, pk: int | None = None) -> Response:
+        """#745 — The scene room's current activity band (qualitative, time-aware)."""
+        from world.locations.activity_services import room_activity_band  # noqa: PLC0415
+
+        scene = self.get_object()
+        band = room_activity_band(scene.location)
+        return Response(SceneActivitySerializer({"band": band.label}).data)
 
 
 class PersonaViewSet(viewsets.ModelViewSet):

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -189,9 +189,9 @@ class SceneViewSet(viewsets.ModelViewSet):
         elif self.action in ["update", "partial_update", "destroy"]:
             # Only scene owners or staff can modify/delete scenes
             permission_classes = [IsSceneOwnerOrStaff]
-        elif self.action == "retrieve":
-            # For retrieving scenes, use both authentication and
-            # private scene access checks
+        elif self.action in ["retrieve", "activity"]:
+            # Retrieving a scene or reading its activity band must respect
+            # private/ephemeral-scene access (participants/staff only).
             permission_classes = [IsAuthenticatedOrReadOnly, ReadOnlyOrSceneParticipant]
         else:
             # Default permissions for list, create, spotlight

--- a/src/world/societies/spread_serializers.py
+++ b/src/world/societies/spread_serializers.py
@@ -40,3 +40,9 @@ class SpreadResultSerializer(serializers.Serializer):
     resolved = serializers.BooleanField(read_only=True)
     outcome = serializers.CharField(read_only=True)
     band = serializers.CharField(read_only=True)
+
+
+class SceneActivitySerializer(serializers.Serializer):
+    """A scene room's current activity band (shown before a teller commits)."""
+
+    band = serializers.CharField(read_only=True)


### PR DESCRIPTION
## Spread a Tale — Phase 3: traffic time-of-day + surfacing the activity band

Third slice of the Spread a Tale feature (umbrella **#745**). Phases 1+2 (the end-to-end vertical slice + forms/specializations) merged in #781. This adds the IC-time dimension to room traffic and surfaces the resulting activity band in the UI before a teller commits.

### What's in this PR

- **Time-of-day bends traffic.** `room_activity_band` now multiplies the room's `TRAFFIC` stat by a per-IC-phase factor before banding, so the same room reads busier or quieter with the clock:
  - dawn ×0.6 / day ×1.0 / dusk ×1.15 (evening bustle) / night ×0.5 — tunable via `PHASE_TRAFFIC_FACTOR`.
  - Falls back to factor 1.0 when there's no game clock (phase `None`), so non-clock environments band on raw traffic.
- **New `GET /api/scenes/{id}/activity/` endpoint** returns the current qualitative band for a scene's room.
- **Dialog shows the band pre-commit.** The Spread a Tale dialog now reads the activity band and shows *"The room is bustling."* before the teller commits, so the location's contribution is legible up front. The result echo keeps showing *"…in a busy room."*

### Adversarial review fold-in (in this PR)

A reviewer pass on the diff caught one real bug, fixed here:

- **Authorization gap (info leak):** the new `activity` action fell through to `IsAuthenticatedOrReadOnly` with no object-level check, so a non-participant could read a **private/ephemeral** scene's activity band by pk (state leak + existence oracle). Now gated by `ReadOnlyOrSceneParticipant` (same as `retrieve`), with a negative test asserting a non-participant gets 403/404 on a PRIVATE scene.

Reviewer also noted (accepted as minor, not fixed): `room_activity_band` resolves the IC phase via a cheap singleton query on each call, so the band is computed twice in the spread POST path (resolver for the value, view for the response label) plus once for the `activity` endpoint. These are a couple of singleton `SELECT`s on a single user action, not an N+1 — left as-is.

### Testing

- PG parity: `world.scenes.tests.test_spread_endpoints` (7 tests, incl. the new private-scene gate) — green.
- `room_activity_band` phase tests (DB-free `SimpleTestCase`) — green.
- `ruff` + `ty` clean; FE `pnpm typecheck` + `eslint` + `pnpm build` clean; API types regenerated (the `activity` endpoint is in `api.d.ts`).

### Scope

Part of **#745** — does **not** close it. Phase 4 (save-the-telling-to-lore affordance + calibration tuning) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
