### PR TITLE
feat(#745): Spread a Tale Phase 4 — save-your-telling deed lore (LegendDeedStory)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -8468,9 +8468,10 @@ export interface paths {
     /**
      * @description #745 Phase 4 — Written accounts of a deed this persona knows of.
      *
-     *     Requires ``?deed=<id>`` and that the persona's societies are aware of
-     *     the deed (same awareness gate as spreading), so lore about unknown
-     *     deeds isn't leaked.
+     *     Requires ``?deed=<id>``. Gated on control of this persona (enforced by
+     *     ``get_object``'s object permission) AND that the persona's societies are
+     *     aware of the deed, so lore about unknown deeds isn't leaked. Paginated —
+     *     a popular deed can accrue one account per aware persona.
      */
     get: operations['personas_deed_stories_list'];
     put?: never;

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -8458,6 +8458,51 @@ export interface paths {
     patch: operations['personas_partial_update'];
     trace?: never;
   };
+  '/api/personas/{id}/deed-stories/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description #745 Phase 4 — Written accounts of a deed this persona knows of.
+     *
+     *     Requires ``?deed=<id>`` and that the persona's societies are aware of
+     *     the deed (same awareness gate as spreading), so lore about unknown
+     *     deeds isn't leaked.
+     */
+    get: operations['personas_deed_stories_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/personas/{id}/deed-story/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description #745 Phase 4 — Save (or replace) this persona's account of a deed.
+     *
+     *     Gated on persona control + awareness of the deed. One account per
+     *     (deed, author); re-saving overwrites the prior text.
+     */
+    post: operations['personas_deed_story_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/personas/{id}/renown/': {
     parameters: {
       query?: never;
@@ -12910,6 +12955,16 @@ export interface components {
       readonly color_hex: string;
       readonly icon: string;
     };
+    /** @description A persona's written account of a deed (#745 Phase 4 lore). */
+    DeedStory: {
+      readonly id: number;
+      readonly author_name: string;
+      readonly text: string;
+      /** Format: date-time */
+      readonly created_at: string;
+      /** Format: date-time */
+      readonly updated_at: string;
+    };
     /**
      * @description * `rounds` - Rounds
      *     * `until_cured` - Until Cured
@@ -15818,6 +15873,21 @@ export interface components {
        */
       previous?: string | null;
       results: components['schemas']['CovenantRite'][];
+    };
+    PaginatedDeedStoryList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['DeedStory'][];
     };
     PaginatedDraftApplicationList: {
       /** @example 123 */
@@ -19232,6 +19302,11 @@ export interface components {
       readonly pending_weaving: number;
       readonly pending_owner_bonus: number;
       readonly is_founder: boolean;
+    };
+    /** @description POST body to save (or replace) the caller's account of a deed. */
+    SaveDeedStoryInputRequest: {
+      deed: number;
+      text: string;
     };
     SceneActionRequest: {
       readonly id: number;
@@ -33260,6 +33335,65 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['Persona'];
+        };
+      };
+    };
+  };
+  personas_deed_stories_list: {
+    parameters: {
+      query?: {
+        character?: number;
+        character_sheet?: number;
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
+        persona_type?: string;
+        scene?: number;
+        /** @description A search term. */
+        search?: string;
+      };
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this persona. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedDeedStoryList'];
+        };
+      };
+    };
+  };
+  personas_deed_story_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this persona. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SaveDeedStoryInputRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['DeedStory'];
         };
       };
     };

--- a/frontend/src/renown/components/DeedsLogCard.tsx
+++ b/frontend/src/renown/components/DeedsLogCard.tsx
@@ -1,8 +1,19 @@
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useDeedStoriesQuery } from '@/spread/queries';
+
 import type { DeedEntry } from '../types';
 
 interface Props {
   deeds: DeedEntry[];
+  /**
+   * The persona reading the log — used to fetch a deed's written accounts
+   * (awareness-gated, persona-scoped). Null for the anonymous foreign view,
+   * which hides the accounts affordance.
+   */
+  personaId: number | null;
 }
 
 function formatDate(iso: string): string {
@@ -17,13 +28,47 @@ function formatDate(iso: string): string {
   }
 }
 
+function DeedAccounts({ personaId, deedId }: { personaId: number; deedId: number }) {
+  const [open, setOpen] = useState(false);
+  const { data: stories, isLoading } = useDeedStoriesQuery(personaId, deedId, open);
+
+  return (
+    <div className="mt-1">
+      <Button
+        variant="link"
+        size="sm"
+        className="h-auto p-0 text-xs"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {open ? 'Hide accounts' : 'View accounts'}
+      </Button>
+      {open && (
+        <div className="mt-1 space-y-2 border-l pl-3">
+          {isLoading ? (
+            <p className="text-xs text-muted-foreground">Loading accounts…</p>
+          ) : !stories || stories.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No accounts written yet.</p>
+          ) : (
+            stories.map((story) => (
+              <div key={story.id} className="text-xs">
+                <div className="font-medium">{story.author_name}</div>
+                <p className="whitespace-pre-wrap text-muted-foreground">{story.text}</p>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /**
  * Recent deeds — the last N LegendEntry rows, newest first. Phase G API
  * caps the list (default 20). Each row shows title, date, and base
  * legend value; spread totals and societies_aware are surfaced when the
  * deed-detail view lands as a follow-up.
  */
-export function DeedsLogCard({ deeds }: Props) {
+export function DeedsLogCard({ deeds, personaId }: Props) {
   return (
     <Card>
       <CardHeader>
@@ -45,6 +90,7 @@ export function DeedsLogCard({ deeds }: Props) {
                 <div className="text-xs text-muted-foreground">
                   Base legend: <span className="font-mono">{deed.base_value}</span>
                 </div>
+                {personaId !== null && <DeedAccounts personaId={personaId} deedId={deed.id} />}
               </li>
             ))}
           </ul>

--- a/frontend/src/renown/components/RenownCardPanel.tsx
+++ b/frontend/src/renown/components/RenownCardPanel.tsx
@@ -47,10 +47,16 @@ function CardBody({
       </div>
     );
   }
-  return <CardLayout card={card} />;
+  return <CardLayout card={card} viewerPersonaId={viewerPersonaId} />;
 }
 
-function CardLayout({ card }: { card: RenownCardPayload }) {
+function CardLayout({
+  card,
+  viewerPersonaId,
+}: {
+  card: RenownCardPayload;
+  viewerPersonaId: number | null;
+}) {
   return (
     <div className="grid gap-4 md:grid-cols-2">
       <Card>
@@ -67,7 +73,7 @@ function CardLayout({ card }: { card: RenownCardPayload }) {
         </CardContent>
       </Card>
       <ReputationListCard reputation={card.visible_reputation} />
-      <DeedsLogCard deeds={card.visible_deeds} />
+      <DeedsLogCard deeds={card.visible_deeds} personaId={viewerPersonaId} />
     </div>
   );
 }

--- a/frontend/src/renown/components/RenownPanel.tsx
+++ b/frontend/src/renown/components/RenownPanel.tsx
@@ -47,18 +47,18 @@ function PanelBody({ personaId }: { personaId: number }) {
       <div className="flex justify-end">
         <SpreadTaleDialog personaId={personaId} />
       </div>
-      <CardLayout renown={renown} />
+      <CardLayout renown={renown} personaId={personaId} />
     </div>
   );
 }
 
-function CardLayout({ renown }: { renown: RenownPayload }) {
+function CardLayout({ renown, personaId }: { renown: RenownPayload; personaId: number }) {
   return (
     <div className="grid gap-4 md:grid-cols-2">
       <FameCard fame={renown.fame} />
       <PrestigeBreakdownCard prestige={renown.prestige} />
       <ReputationListCard reputation={renown.reputation} />
-      <DeedsLogCard deeds={renown.recent_deeds} />
+      <DeedsLogCard deeds={renown.recent_deeds} personaId={personaId} />
       <OwnedDwellingsCard dwellings={renown.owned_dwellings} />
       <TenantedRoomsCard rooms={renown.tenanted_rooms} />
     </div>

--- a/frontend/src/spread/SpreadTaleDialog.tsx
+++ b/frontend/src/spread/SpreadTaleDialog.tsx
@@ -65,7 +65,7 @@ export function SpreadTaleDialog({ personaId }: { personaId: number }) {
           </p>
         ) : (
           <SpreadForm
-            key={sceneId}
+            key={`${sceneId}-${open}`}
             personaId={personaId}
             sceneId={sceneId}
             open={open}

--- a/frontend/src/spread/SpreadTaleDialog.tsx
+++ b/frontend/src/spread/SpreadTaleDialog.tsx
@@ -26,6 +26,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useAppSelector } from '@/store/hooks';
 
 import {
+  useSaveDeedStoryMutation,
   useSpreadableDeedsQuery,
   useSpreadMutation,
   useSpreadSpecializationsQuery,
@@ -92,6 +93,7 @@ function SpreadForm({ personaId, sceneId, open, onDone }: FormProps) {
   const [formId, setFormId] = useState<string>(NO_FORM);
   const [result, setResult] = useState<SpreadResult | null>(null);
   const mutation = useSpreadMutation(personaId);
+  const saveStory = useSaveDeedStoryMutation(personaId);
 
   if (isLoading) {
     return (
@@ -110,12 +112,31 @@ function SpreadForm({ personaId, sceneId, open, onDone }: FormProps) {
   }
 
   if (result) {
+    const canSaveAccount = deedId !== null && pose.trim().length > 0;
     return (
       <div className="space-y-4">
         <p className="text-sm">
           The telling lands: <strong>{result.outcome}</strong>, in a {result.band.toLowerCase()}{' '}
           room.
         </p>
+        {canSaveAccount &&
+          (saveStory.isSuccess ? (
+            <p className="text-sm text-muted-foreground">Saved to this deed&apos;s accounts.</p>
+          ) : (
+            <div className="space-y-1">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={saveStory.isPending}
+                onClick={() => saveStory.mutate({ deed: deedId, text: pose })}
+              >
+                {saveStory.isPending ? 'Saving…' : 'Save this telling as your account'}
+              </Button>
+              {saveStory.isError && (
+                <p className="text-sm text-destructive">{(saveStory.error as Error).message}</p>
+              )}
+            </div>
+          ))}
         <DialogFooter>
           <Button onClick={onDone}>Done</Button>
         </DialogFooter>

--- a/frontend/src/spread/queries.ts
+++ b/frontend/src/spread/queries.ts
@@ -35,6 +35,19 @@ export interface SpreadInput {
   specialization?: number | null;
 }
 
+export interface DeedStory {
+  id: number;
+  author_name: string;
+  text: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SaveDeedStoryInput {
+  deed: number;
+  text: string;
+}
+
 async function fetchSpreadSpecializations(): Promise<SpreadForm[]> {
   const res = await apiFetch('/api/personas/spread-specializations/');
   if (!res.ok) {
@@ -89,6 +102,46 @@ export function useSpreadMutation(personaId: number) {
       // A deed may have been deactivated mid-flight — refresh the picker so a
       // stale tale drops out rather than re-failing on retry.
       queryClient.invalidateQueries({ queryKey: ['spreadable-deeds', personaId] });
+    },
+  });
+}
+
+async function fetchDeedStories(personaId: number, deedId: number): Promise<DeedStory[]> {
+  const res = await apiFetch(`/api/personas/${personaId}/deed-stories/?deed=${deedId}`);
+  if (!res.ok) {
+    throw new Error('Failed to load accounts of this deed.');
+  }
+  return res.json() as Promise<DeedStory[]>;
+}
+
+export function useDeedStoriesQuery(
+  personaId: number | null,
+  deedId: number | null,
+  enabled = true
+) {
+  return useQuery({
+    queryKey: ['deed-stories', personaId, deedId],
+    queryFn: () => fetchDeedStories(personaId as number, deedId as number),
+    enabled: personaId !== null && deedId !== null && enabled,
+  });
+}
+
+export function useSaveDeedStoryMutation(personaId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: SaveDeedStoryInput): Promise<DeedStory> => {
+      const res = await apiFetch(`/api/personas/${personaId}/deed-story/`, {
+        method: 'POST',
+        body: JSON.stringify(input),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { detail?: string };
+        throw new Error(body.detail ?? 'Your account could not be saved.');
+      }
+      return res.json() as Promise<DeedStory>;
+    },
+    onSuccess: (_data, input) => {
+      queryClient.invalidateQueries({ queryKey: ['deed-stories', personaId, input.deed] });
     },
   });
 }

--- a/frontend/src/spread/queries.ts
+++ b/frontend/src/spread/queries.ts
@@ -111,7 +111,8 @@ async function fetchDeedStories(personaId: number, deedId: number): Promise<Deed
   if (!res.ok) {
     throw new Error('Failed to load accounts of this deed.');
   }
-  return res.json() as Promise<DeedStory[]>;
+  const body = (await res.json()) as { results: DeedStory[] };
+  return body.results;
 }
 
 export function useDeedStoriesQuery(

--- a/src/schema.json
+++ b/src/schema.json
@@ -14223,9 +14223,10 @@ paths:
       description: |-
         #745 Phase 4 — Written accounts of a deed this persona knows of.
 
-        Requires ``?deed=<id>`` and that the persona's societies are aware of
-        the deed (same awareness gate as spreading), so lore about unknown
-        deeds isn't leaked.
+        Requires ``?deed=<id>``. Gated on control of this persona (enforced by
+        ``get_object``'s object permission) AND that the persona's societies are
+        aware of the deed, so lore about unknown deeds isn't leaked. Paginated —
+        a popular deed can accrue one account per aware persona.
       parameters:
       - in: query
         name: character

--- a/src/schema.json
+++ b/src/schema.json
@@ -14217,6 +14217,99 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/personas/{id}/deed-stories/:
+    get:
+      operationId: personas_deed_stories_list
+      description: |-
+        #745 Phase 4 — Written accounts of a deed this persona knows of.
+
+        Requires ``?deed=<id>`` and that the persona's societies are aware of
+        the deed (same awareness gate as spreading), so lore about unknown
+        deeds isn't leaked.
+      parameters:
+      - in: query
+        name: character
+        schema:
+          type: integer
+      - in: query
+        name: character_sheet
+        schema:
+          type: number
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this persona.
+        required: true
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: persona_type
+        schema:
+          type: string
+      - in: query
+        name: scene
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - personas
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedDeedStoryList'
+          description: ''
+  /api/personas/{id}/deed-story/:
+    post:
+      operationId: personas_deed_story_create
+      description: |-
+        #745 Phase 4 — Save (or replace) this persona's account of a deed.
+
+        Gated on persona control + awareness of the deed. One account per
+        (deed, author); re-saving overwrites the prior text.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this persona.
+        required: true
+      tags:
+      - personas
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SaveDeedStoryInputRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeedStory'
+          description: ''
   /api/personas/{id}/renown/:
     get:
       operationId: personas_renown_retrieve
@@ -22903,6 +22996,33 @@ components:
       - icon
       - id
       - name
+    DeedStory:
+      type: object
+      description: A persona's written account of a deed (#745 Phase 4 lore).
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        author_name:
+          type: string
+          readOnly: true
+        text:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - author_name
+      - created_at
+      - id
+      - text
+      - updated_at
     DefaultDurationTypeEnum:
       enum:
       - rounds
@@ -28829,6 +28949,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CovenantRite'
+    PaginatedDeedStoryList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeedStory'
     PaginatedDraftApplicationList:
       type: object
       required:
@@ -34877,6 +35020,19 @@ components:
       - resonance_type_id
       - resonance_type_name
       - room_profile_id
+    SaveDeedStoryInputRequest:
+      type: object
+      description: POST body to save (or replace) the caller's account of a deed.
+      properties:
+        deed:
+          type: integer
+        text:
+          type: string
+          minLength: 1
+          maxLength: 4000
+      required:
+      - deed
+      - text
     SceneActionRequest:
       type: object
       properties:

--- a/src/world/scenes/tests/test_spread_endpoints.py
+++ b/src/world/scenes/tests/test_spread_endpoints.py
@@ -86,3 +86,44 @@ class SpreadEndpointTest(APITestCase):
             format="json",
         )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_save_deed_story_creates_and_is_listed(self) -> None:
+        save_url = reverse("persona-deed-story", args=[self.persona.pk])
+        resp = self.client.post(
+            save_url, {"deed": self.deed.pk, "text": "I sang of it."}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        self.assertEqual(resp.data["text"], "I sang of it.")
+        self.assertEqual(resp.data["author_name"], self.persona.name)
+
+        list_url = reverse("persona-deed-stories", args=[self.persona.pk])
+        list_resp = self.client.get(list_url, {"deed": self.deed.pk})
+        self.assertEqual(list_resp.status_code, status.HTTP_200_OK, list_resp.data)
+        self.assertEqual([s["text"] for s in list_resp.data], ["I sang of it."])
+
+    def test_save_deed_story_upserts_one_per_author(self) -> None:
+        url = reverse("persona-deed-story", args=[self.persona.pk])
+        self.client.post(url, {"deed": self.deed.pk, "text": "First take."}, format="json")
+        resp = self.client.post(url, {"deed": self.deed.pk, "text": "Revised take."}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+
+        list_url = reverse("persona-deed-stories", args=[self.persona.pk])
+        list_resp = self.client.get(list_url, {"deed": self.deed.pk})
+        self.assertEqual([s["text"] for s in list_resp.data], ["Revised take."])
+
+    def test_save_deed_story_unaware_deed_forbidden(self) -> None:
+        unknown = LegendEntryFactory(persona=PersonaFactory(), base_value=10)
+        url = reverse("persona-deed-story", args=[self.persona.pk])
+        resp = self.client.post(url, {"deed": unknown.pk, "text": "Hearsay."}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_save_deed_story_unowned_persona_forbidden(self) -> None:
+        other = PersonaFactory()
+        url = reverse("persona-deed-story", args=[other.pk])
+        resp = self.client.post(url, {"deed": self.deed.pk, "text": "Nope."}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_deed_stories_requires_deed_param(self) -> None:
+        url = reverse("persona-deed-stories", args=[self.persona.pk])
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)

--- a/src/world/scenes/tests/test_spread_endpoints.py
+++ b/src/world/scenes/tests/test_spread_endpoints.py
@@ -99,7 +99,7 @@ class SpreadEndpointTest(APITestCase):
         list_url = reverse("persona-deed-stories", args=[self.persona.pk])
         list_resp = self.client.get(list_url, {"deed": self.deed.pk})
         self.assertEqual(list_resp.status_code, status.HTTP_200_OK, list_resp.data)
-        self.assertEqual([s["text"] for s in list_resp.data], ["I sang of it."])
+        self.assertEqual([s["text"] for s in list_resp.data["results"]], ["I sang of it."])
 
     def test_save_deed_story_upserts_one_per_author(self) -> None:
         url = reverse("persona-deed-story", args=[self.persona.pk])
@@ -109,7 +109,7 @@ class SpreadEndpointTest(APITestCase):
 
         list_url = reverse("persona-deed-stories", args=[self.persona.pk])
         list_resp = self.client.get(list_url, {"deed": self.deed.pk})
-        self.assertEqual([s["text"] for s in list_resp.data], ["Revised take."])
+        self.assertEqual([s["text"] for s in list_resp.data["results"]], ["Revised take."])
 
     def test_save_deed_story_unaware_deed_forbidden(self) -> None:
         unknown = LegendEntryFactory(persona=PersonaFactory(), base_value=10)

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -53,6 +53,8 @@ from world.societies.renown_serializers import (
     build_renown_payload,
 )
 from world.societies.spread_serializers import (
+    DeedStorySerializer,
+    SaveDeedStoryInputSerializer,
     SpreadableDeedSerializer,
     SpreadInputSerializer,
     SpreadResultSerializer,
@@ -345,12 +347,7 @@ class PersonaViewSet(viewsets.ModelViewSet):
         )
 
         persona = self.get_object()
-        owns_persona = Persona.objects.filter(
-            pk=persona.pk,
-            character_sheet__roster_entry__tenures__player_data__account=request.user,
-            character_sheet__roster_entry__tenures__end_date__isnull=True,
-        ).exists()
-        if not owns_persona:
+        if not self._account_controls_persona(request, persona):
             return Response(
                 {"detail": "You do not control this persona."},
                 status=status.HTTP_403_FORBIDDEN,
@@ -413,6 +410,84 @@ class PersonaViewSet(viewsets.ModelViewSet):
         band = room_activity_band(scene.location).label
         payload = {"resolved": True, "outcome": outcome, "band": band}
         return Response(SpreadResultSerializer(payload).data)
+
+    def _account_controls_persona(self, request: Request, persona: Persona) -> bool:
+        """True when the requesting account currently tenures this persona."""
+        return Persona.objects.filter(
+            pk=persona.pk,
+            character_sheet__roster_entry__tenures__player_data__account=request.user,
+            character_sheet__roster_entry__tenures__end_date__isnull=True,
+        ).exists()
+
+    @extend_schema(responses=DeedStorySerializer(many=True), tags=["personas"])
+    @action(detail=True, methods=[HTTPMethod.GET], url_path="deed-stories")
+    def deed_stories(self, request: Request, pk: int | None = None) -> Response:
+        """#745 Phase 4 — Written accounts of a deed this persona knows of.
+
+        Requires ``?deed=<id>`` and that the persona's societies are aware of
+        the deed (same awareness gate as spreading), so lore about unknown
+        deeds isn't leaked.
+        """
+        from django.shortcuts import get_object_or_404  # noqa: PLC0415
+
+        from world.societies.models import LegendEntry  # noqa: PLC0415
+        from world.societies.spread_services import (  # noqa: PLC0415
+            get_deed_stories,
+            get_spreadable_deeds,
+        )
+
+        persona = self.get_object()
+        deed_id = request.query_params.get("deed")  # noqa: USE_FILTERSET
+        if not deed_id:
+            return Response(
+                {"detail": "A 'deed' query parameter is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        deed = get_object_or_404(LegendEntry, pk=deed_id)
+        if not get_spreadable_deeds(persona).filter(pk=deed.pk).exists():
+            return Response(
+                {"detail": "This persona is not aware of that deed."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        stories = get_deed_stories(deed)
+        return Response(DeedStorySerializer(stories, many=True).data)
+
+    @extend_schema(
+        request=SaveDeedStoryInputSerializer, responses=DeedStorySerializer, tags=["personas"]
+    )
+    @action(detail=True, methods=[HTTPMethod.POST], url_path="deed-story")
+    def deed_story(self, request: Request, pk: int | None = None) -> Response:
+        """#745 Phase 4 — Save (or replace) this persona's account of a deed.
+
+        Gated on persona control + awareness of the deed. One account per
+        (deed, author); re-saving overwrites the prior text.
+        """
+        from django.shortcuts import get_object_or_404  # noqa: PLC0415
+
+        from world.societies.models import LegendEntry  # noqa: PLC0415
+        from world.societies.spread_services import (  # noqa: PLC0415
+            get_spreadable_deeds,
+            save_deed_story,
+        )
+
+        persona = self.get_object()
+        if not self._account_controls_persona(request, persona):
+            return Response(
+                {"detail": "You do not control this persona."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        input_serializer = SaveDeedStoryInputSerializer(data=request.data)
+        input_serializer.is_valid(raise_exception=True)
+        data = input_serializer.validated_data
+
+        deed = get_object_or_404(LegendEntry, pk=data["deed"])
+        if not get_spreadable_deeds(persona).filter(pk=deed.pk).exists():
+            return Response(
+                {"detail": "This persona is not aware of that deed."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        story = save_deed_story(author_persona=persona, deed=deed, text=data["text"])
+        return Response(DeedStorySerializer(story).data, status=status.HTTP_201_CREATED)
 
     @extend_schema(
         responses=RenownCardSerializer,

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -424,9 +424,10 @@ class PersonaViewSet(viewsets.ModelViewSet):
     def deed_stories(self, request: Request, pk: int | None = None) -> Response:
         """#745 Phase 4 — Written accounts of a deed this persona knows of.
 
-        Requires ``?deed=<id>`` and that the persona's societies are aware of
-        the deed (same awareness gate as spreading), so lore about unknown
-        deeds isn't leaked.
+        Requires ``?deed=<id>``. Gated on control of this persona (enforced by
+        ``get_object``'s object permission) AND that the persona's societies are
+        aware of the deed, so lore about unknown deeds isn't leaked. Paginated —
+        a popular deed can accrue one account per aware persona.
         """
         from django.shortcuts import get_object_or_404  # noqa: PLC0415
 
@@ -450,6 +451,9 @@ class PersonaViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_403_FORBIDDEN,
             )
         stories = get_deed_stories(deed)
+        page = self.paginate_queryset(stories)
+        if page is not None:
+            return self.get_paginated_response(DeedStorySerializer(page, many=True).data)
         return Response(DeedStorySerializer(stories, many=True).data)
 
     @extend_schema(

--- a/src/world/societies/spread_serializers.py
+++ b/src/world/societies/spread_serializers.py
@@ -40,3 +40,20 @@ class SpreadResultSerializer(serializers.Serializer):
     resolved = serializers.BooleanField(read_only=True)
     outcome = serializers.CharField(read_only=True)
     band = serializers.CharField(read_only=True)
+
+
+class DeedStorySerializer(serializers.Serializer):
+    """A persona's written account of a deed (#745 Phase 4 lore)."""
+
+    id = serializers.IntegerField(read_only=True)
+    author_name = serializers.CharField(source="author.name", read_only=True)
+    text = serializers.CharField(read_only=True)
+    created_at = serializers.DateTimeField(read_only=True)
+    updated_at = serializers.DateTimeField(read_only=True)
+
+
+class SaveDeedStoryInputSerializer(serializers.Serializer):
+    """POST body to save (or replace) the caller's account of a deed."""
+
+    deed = serializers.IntegerField()
+    text = serializers.CharField(max_length=4000)

--- a/src/world/societies/spread_services.py
+++ b/src/world/societies/spread_services.py
@@ -206,6 +206,29 @@ def get_spreadable_deeds(persona) -> QuerySet[LegendEntry]:
     )
 
 
+def save_deed_story(*, author_persona, deed, text: str):
+    """Upsert ``author_persona``'s written account of ``deed`` (#745 Phase 4).
+
+    One account per (deed, author) — re-saving replaces the prior text. The
+    caller is responsible for awareness/ownership gating; this is a pure write.
+    """
+    from world.societies.models import LegendDeedStory  # noqa: PLC0415
+
+    story, _ = LegendDeedStory.objects.update_or_create(
+        deed=deed, author=author_persona, defaults={"text": text}
+    )
+    return story
+
+
+def get_deed_stories(deed):
+    """The written accounts of ``deed``, newest-edited first (#745 Phase 4)."""
+    from world.societies.models import LegendDeedStory  # noqa: PLC0415
+
+    return (
+        LegendDeedStory.objects.filter(deed=deed).select_related("author").order_by("-updated_at")
+    )
+
+
 def _resolve_spread_tale(action_request, result) -> None:
     """Post-resolution side-effect for the ``spread_a_tale`` scene action.
 


### PR DESCRIPTION
## Spread a Tale — Phase 4: save-your-telling deed lore (`LegendDeedStory`)

Fourth and final planned slice of Spread a Tale (umbrella **#745**). Phases 1+2 merged in #781; Phase 3 (traffic time-of-day) is up in #844. This wires the `LegendDeedStory` model — until now model-only, with no service or API — into a player-facing affordance, and verifies the value calibration.

### What's in this PR

**The lore affordance.** A persona aware of a deed can write their own account of it (one per `(deed, author)`):
- After a **successful telling**, the Spread a Tale dialog offers **"Save this telling as your account"** — turning the pose you just performed into your written account of the deed.
- Each deed in the Renown tab's **Recent Deeds** card gains a **"View accounts"** expander listing every account written about it.

**Backend** (`world.societies` / `world.scenes`):
- `save_deed_story()` upserts one account per `(deed, author)`; `get_deed_stories()` lists a deed's accounts newest-edited first.
- `DeedStorySerializer` + `SaveDeedStoryInputSerializer`.
- `PersonaViewSet.deed_story` (POST) and `.deed_stories` (GET `?deed=`, paginated). Both gated on **persona control** (object permission) **and** society-**awareness** (reuses `get_spreadable_deeds`), so lore about deeds you don't know of isn't leaked. The ownership check is factored into `_account_controls_persona` (now shared with `spread`).

**Frontend:** `useSaveDeedStoryMutation` + `useDeedStoriesQuery` hooks; the save affordance in `SpreadTaleDialog`; the per-deed accounts expander in `DeedsLogCard` (`personaId` threaded through `RenownPanel`/`RenownCardPanel`, nullable so the anonymous foreign-view card hides the affordance).

### Calibration verified (no change)

Per the design constraint that hitting the 9× cap in a single telling should be "nearly impossible": max single-telling value = `base × 1.0` (tier-4+ payoff) `× 2.2` (Thronging, the top band) = **2.2 × base**. The Phase-3 time-of-day factor clamps at traffic 100, so it can't push past Thronging. Against the ~8×base of spread capacity, one perfect max-traffic telling is ~27% of the cap — at least four perfect tellings to max. Calibration left as-is.

### Adversarial review fold-in (in this PR)

A reviewer pass (verified empirically with a throwaway probe) confirmed the headline worry — reading a deed's accounts "as" a persona you don't control — is **not possible**: `get_object`'s object permission already requires persona control. Two real items folded in:
- **`deed-stories` paginated.** It advertised a paginated OpenAPI response (the viewset has a `pagination_class`) but returned a bare list, and a viral deed could return unbounded accounts. Now actually paginated — schema matches reality and the response is bounded.
- **Docstring corrected** to state the gate is control **and** awareness, not awareness-only; **dialog form resets on reopen** so a stale result/"Saved" confirmation doesn't carry over.

### Testing

- PG parity: `world.scenes.tests.test_spread_endpoints` (10 tests, incl. 5 new deed-story cases: create+list, upsert-one-per-author, unaware-deed 403, unowned-persona 403, missing-param 400) — green.
- `ruff` + `ty` + all pre-commit hooks clean; FE `pnpm typecheck` + `eslint` + `pnpm build` clean; API types regenerated.

### Scope

Completes the planned Phase 4 of **#745**. With Phases 1–4 landed (this + #781 + #844), the umbrella can close once #844 and this merge — closing left to a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
