### PR TITLE
docs(tenets): exact numbers in the ledger, descriptive labels in the fiction (#780)

### DIFF
--- a/docs/roadmap/design-tenets.md
+++ b/docs/roadmap/design-tenets.md
@@ -243,6 +243,22 @@ entry, or consent. Drama is opt-in and foreseeable (per "Risk is a conscious
 player choice") — never sprung on a player as a non-consented consequence.
 Within those bounds, lean in.
 
+### Exact numbers for currencies and progression
+
+Default-to-narrative has one firm exception: a quantity the player *spends* or
+*races toward* is shown as an exact number, never softened into a tier word or a
+mood. Legend is the case in point — it is the currency of renown and the gate on
+path advancement, so a player needs a precise, visceral sense of how much a deed
+earned them and how far they sit from the next threshold. Numbers a player makes
+decisions on — is this worth my action points, am I close to leveling — are not
+texture; they're the ledger, and the ledger is exact.
+
+Narrative description and tier labels still wrap these quantities *elsewhere*, so
+RP about reputation stays human and the table doesn't read like a spreadsheet —
+but they supplement the number, never replace it. The test: if a player would
+act differently knowing the quantity, show the quantity. Abstract the texture,
+not the ledger.
+
 ## Designing systems
 
 ### Walk every user's view, end to end

--- a/docs/roadmap/design-tenets.md
+++ b/docs/roadmap/design-tenets.md
@@ -243,21 +243,28 @@ entry, or consent. Drama is opt-in and foreseeable (per "Risk is a conscious
 player choice") — never sprung on a player as a non-consented consequence.
 Within those bounds, lean in.
 
-### Exact numbers for currencies and progression
+### Exact numbers in the ledger, descriptive labels in the fiction
 
-Default-to-narrative has one firm exception: a quantity the player *spends* or
-*races toward* is shown as an exact number, never softened into a tier word or a
-mood. Legend is the case in point — it is the currency of renown and the gate on
-path advancement, so a player needs a precise, visceral sense of how much a deed
-earned them and how far they sit from the next threshold. Numbers a player makes
-decisions on — is this worth my action points, am I close to leveling — are not
-texture; they're the ledger, and the ledger is exact.
+Show-the-number and default-to-narrative aren't really in tension — they live in
+different registers, and the line between "a currency" and "a merely descriptive
+quantity" is genuinely fuzzy, so don't try to sort every number into one bin. The
+rule that actually holds: **the player's own decision-making surface shows the
+exact quantity; the IC fiction renders that same quantity with adjectives and
+labels.** Keep the figure precise wherever a player budgets or races on it; never
+let an IC mouth or a piece of prose emit a raw number.
 
-Narrative description and tier labels still wrap these quantities *elsewhere*, so
-RP about reputation stays human and the table doesn't read like a spreadsheet —
-but they supplement the number, never replace it. The test: if a player would
-act differently knowing the quantity, show the quantity. Abstract the texture,
-not the ledger.
+A player weighing whether a deed was worth the action points, or how close they
+are to a path threshold, needs legend as an exact figure — that's the ledger, and
+the ledger is exact. But an NPC never *says* "nineteen resonance" in character;
+they say "two knights less a pawn." Legend, resonance, how hard a blow lands, how
+much power stands behind a working — all are exact where the player acts and
+qualitative where the world speaks them.
+
+A sketch we're carrying for that descriptive register (well past MVP, noted so it
+stays consistent as it comes up): resonance magnitudes map onto chess pieces —
+~1 a pawn, ~10 a knight, ~100 a bishop, ~1,000 a rook, ~10,000 a king, ~100,000 a
+queen — so "19 resonance" is spoken as "two knights less a pawn." A scale to grow
+into, not a committed system.
 
 ## Designing systems
 


### PR DESCRIPTION
Resolves the **#780** tenet question.

**Decision:** legend stays player-facing as an **exact number** — but the sharper framing (per discussion) is **register, not category**. The line between "a currency" and "a merely descriptive quantity" is fuzzy, so the rule isn't *which numbers* are exact; it's *where*:

- **The player's decision surface shows the exact figure** — legend is the currency of renown and the gate on path advancement, so a player needs precision to know what a deed earned them and how close they are to the next threshold. The ledger is exact.
- **The IC fiction speaks it in labels** — an NPC never says "19 resonance," they say "two knights less a pawn." Legend, resonance, how hard a blow lands, how much power stands behind a working: exact where the player acts, qualitative where the world speaks them.

Also records, as an explicitly **past-MVP sketch** (so it stays consistent as resonance values surface, not a committed system), the resonance→chess-piece magnitude scale: ~1 pawn / ~10 knight / ~100 bishop / ~1,000 rook / ~10,000 king / ~100,000 queen.

Deliberately framed without naming the hidden-mechanics counterpart, which stays out of grep-able docs. **No behavior change** — the renown surfaces already show the raw number; this ratifies it and records the IC-presentation discipline for later.

Closes #780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
