### PR TITLE
fix(#745): clear three spread follow-ups (pagination, message XSS, seed cost)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "dagre": "^0.8.5",
+    "dompurify": "^3.4.8",
     "framer-motion": "^12.23.26",
     "lucide-react": "^0.536.0",
     "next-themes": "^0.4.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       dagre:
         specifier: ^0.8.5
         version: 0.8.5
+      dompurify:
+        specifier: ^3.4.8
+        version: 3.4.8
       framer-motion:
         specifier: ^12.23.26
         version: 12.23.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -176,25 +179,25 @@ importers:
         version: 18.3.7(@types/react@18.3.23)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.7.0(vite@6.4.2(@types/node@22.16.5)(jiti@1.21.7)(yaml@2.8.3))
+        version: 4.7.0(supports-color@10.2.2)(vite@6.4.2(@types/node@22.16.5)(jiti@1.21.7)(yaml@2.8.3))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.15)
       eslint:
         specifier: ^9.13.0
-        version: 9.32.0(jiti@1.21.7)
+        version: 9.32.0(jiti@1.21.7)(supports-color@10.2.2)
       eslint-plugin-react-hooks:
         specifier: ^5.0.0
-        version: 5.2.0(eslint@9.32.0(jiti@1.21.7))
+        version: 5.2.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))
       eslint-plugin-react-refresh:
         specifier: ^0.4.14
-        version: 0.4.20(eslint@9.32.0(jiti@1.21.7))
+        version: 0.4.20(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
       jsdom:
         specifier: ^26.1.0
-        version: 26.1.0
+        version: 26.1.0(supports-color@10.2.2)
       openapi-typescript:
         specifier: ^7.12.0
         version: 7.12.0(typescript@5.6.3)
@@ -218,13 +221,13 @@ importers:
         version: 5.6.3
       typescript-eslint:
         specifier: ^8.15.0
-        version: 8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)
+        version: 8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3)
       vite:
         specifier: ^6.4.2
         version: 6.4.2(@types/node@22.16.5)(jiti@1.21.7)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.16.5)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.16.5)(jiti@1.21.7)(yaml@2.8.3))
+        version: 4.1.0(@types/node@22.16.5)(jsdom@26.1.0(supports-color@10.2.2))(vite@6.4.2(@types/node@22.16.5)(jiti@1.21.7)(yaml@2.8.3))
 
 packages:
 
@@ -1585,6 +1588,9 @@ packages:
   '@types/react@18.3.23':
     resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -1999,6 +2005,9 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -3538,7 +3547,7 @@ snapshots:
 
   '@babel/compat-data@7.28.0': {}
 
-  '@babel/core@7.28.0':
+  '@babel/core@7.28.0(supports-color@10.2.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
@@ -3585,7 +3594,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.0(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.28.0
@@ -3611,14 +3620,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.2
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.0)':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.0)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.28.2': {}
@@ -3810,14 +3819,14 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.32.0(jiti@1.21.7))':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))':
     dependencies:
-      eslint: 9.32.0(jiti@1.21.7)
+      eslint: 9.32.0(jiti@1.21.7)(supports-color@10.2.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/config-array@0.21.0':
+  '@eslint/config-array@0.21.0(supports-color@10.2.2)':
     dependencies:
       '@eslint/object-schema': 2.1.6
       debug: 4.4.1(supports-color@10.2.2)
@@ -3831,7 +3840,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
+  '@eslint/eslintrc@3.3.1(supports-color@10.2.2)':
     dependencies:
       ajv: 6.14.0
       debug: 4.4.1(supports-color@10.2.2)
@@ -4824,21 +4833,24 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3))(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3))(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/type-utils': 8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.38.0
-      eslint: 9.32.0(jiti@1.21.7)
+      eslint: 9.32.0(jiti@1.21.7)(supports-color@10.2.2)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -4847,14 +4859,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.38.0
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.38.0
       debug: 4.4.1(supports-color@10.2.2)
-      eslint: 9.32.0(jiti@1.21.7)
+      eslint: 9.32.0(jiti@1.21.7)(supports-color@10.2.2)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -4877,13 +4889,13 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  '@typescript-eslint/type-utils@8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(typescript@5.6.3)
       debug: 4.4.1(supports-color@10.2.2)
-      eslint: 9.32.0(jiti@1.21.7)
+      eslint: 9.32.0(jiti@1.21.7)(supports-color@10.2.2)
       ts-api-utils: 2.1.0(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -4907,13 +4919,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(typescript@5.6.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))
       '@typescript-eslint/scope-manager': 8.38.0
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.6.3)
-      eslint: 9.32.0(jiti@1.21.7)
+      eslint: 9.32.0(jiti@1.21.7)(supports-color@10.2.2)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -4925,11 +4937,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.16.5)(jiti@1.21.7)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@6.4.2(@types/node@22.16.5)(jiti@1.21.7)(yaml@2.8.3))':
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.28.0(supports-color@10.2.2)
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0(supports-color@10.2.2))
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0(supports-color@10.2.2))
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -5276,6 +5288,10 @@ snapshots:
       '@babel/runtime': 7.28.2
       csstype: 3.1.3
 
+  dompurify@3.4.8:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.192: {}
@@ -5327,13 +5343,13 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.32.0(jiti@1.21.7)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2)):
     dependencies:
-      eslint: 9.32.0(jiti@1.21.7)
+      eslint: 9.32.0(jiti@1.21.7)(supports-color@10.2.2)
 
-  eslint-plugin-react-refresh@0.4.20(eslint@9.32.0(jiti@1.21.7)):
+  eslint-plugin-react-refresh@0.4.20(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2)):
     dependencies:
-      eslint: 9.32.0(jiti@1.21.7)
+      eslint: 9.32.0(jiti@1.21.7)(supports-color@10.2.2)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -5344,14 +5360,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.32.0(jiti@1.21.7):
+  eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.21.0
+      '@eslint/config-array': 0.21.0(supports-color@10.2.2)
       '@eslint/config-helpers': 0.3.0
       '@eslint/core': 0.15.1
-      '@eslint/eslintrc': 3.3.1
+      '@eslint/eslintrc': 3.3.1(supports-color@10.2.2)
       '@eslint/js': 9.32.0
       '@eslint/plugin-kit': 0.3.4
       '@humanfs/node': 0.16.6
@@ -5555,7 +5571,7 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.1(supports-color@10.2.2)
@@ -5645,13 +5661,13 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@26.1.0:
+  jsdom@26.1.0(supports-color@10.2.2):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.21
@@ -6713,13 +6729,13 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  typescript-eslint@8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3):
+  typescript-eslint@8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3))(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3))(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.3)
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.6.3)
-      eslint: 9.32.0(jiti@1.21.7)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@1.21.7)(supports-color@10.2.2))(typescript@5.6.3)
+      eslint: 9.32.0(jiti@1.21.7)(supports-color@10.2.2)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -6822,7 +6838,7 @@ snapshots:
       jiti: 1.21.7
       yaml: 2.8.3
 
-  vitest@4.1.0(@types/node@22.16.5)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.16.5)(jiti@1.21.7)(yaml@2.8.3)):
+  vitest@4.1.0(@types/node@22.16.5)(jsdom@26.1.0(supports-color@10.2.2))(vite@6.4.2(@types/node@22.16.5)(jiti@1.21.7)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@6.4.2(@types/node@22.16.5)(jiti@1.21.7)(yaml@2.8.3))
@@ -6846,7 +6862,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.16.5
-      jsdom: 26.1.0
+      jsdom: 26.1.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - msw
 

--- a/frontend/src/game/components/EvenniaMessage.tsx
+++ b/frontend/src/game/components/EvenniaMessage.tsx
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import { useMemo } from 'react';
 
 interface EvenniaMessageProps {
@@ -39,11 +40,13 @@ export function EvenniaMessage({ content, className = '' }: EvenniaMessageProps)
     // Convert line breaks
     processed = processed.replace(/<br>/g, '\n');
 
-    return processed;
+    // Messages carry user-authored text (poses, says, names) routed through
+    // Evennia's ANSI→HTML conversion, so the string is untrusted. Sanitize
+    // before injecting: DOMPurify strips scripts/event-handlers/dangerous tags
+    // while keeping the legitimate color <span>s.
+    return DOMPurify.sanitize(processed);
   }, [content]);
 
-  // For now, we'll render HTML directly but sanitize it later if needed
-  // This is safe for Evennia output but would need sanitization for user input
   return (
     <div
       className={`whitespace-pre-wrap font-mono text-sm ${className}`}

--- a/frontend/src/spread/queries.ts
+++ b/frontend/src/spread/queries.ts
@@ -53,7 +53,8 @@ async function fetchSpreadSpecializations(): Promise<SpreadForm[]> {
   if (!res.ok) {
     throw new Error('Failed to load telling forms.');
   }
-  return res.json() as Promise<SpreadForm[]>;
+  const body = (await res.json()) as { results: SpreadForm[] };
+  return body.results;
 }
 
 export function useSpreadSpecializationsQuery(enabled = true) {
@@ -89,7 +90,8 @@ async function fetchSpreadableDeeds(personaId: number): Promise<SpreadableDeed[]
   if (!res.ok) {
     throw new Error('Failed to load deeds you can spread.');
   }
-  return res.json() as Promise<SpreadableDeed[]>;
+  const body = (await res.json()) as { results: SpreadableDeed[] };
+  return body.results;
 }
 
 export function useSpreadableDeedsQuery(personaId: number | null, enabled = true) {

--- a/src/world/scenes/tests/test_area_action_dispatch.py
+++ b/src/world/scenes/tests/test_area_action_dispatch.py
@@ -16,6 +16,7 @@ from world.scenes.action_models import SceneActionRequest
 from world.scenes.action_services import create_and_resolve_area_action
 from world.scenes.factories import PersonaFactory, SceneFactory
 from world.societies.factories import LegendEntryFactory
+from world.societies.spread_services import SPREAD_TALE_TEMPLATE_NAME
 
 
 class AreaActionDispatchTest(TestCase):
@@ -23,7 +24,7 @@ class AreaActionDispatchTest(TestCase):
         spreader = PersonaFactory()
         scene = SceneFactory()
         template = ActionTemplateFactory(
-            name="Spread a Tale",
+            name=SPREAD_TALE_TEMPLATE_NAME,
             target_type=ActionTargetType.AREA,
             category="social",
             ap_cost=20,

--- a/src/world/scenes/tests/test_spread_endpoints.py
+++ b/src/world/scenes/tests/test_spread_endpoints.py
@@ -44,7 +44,7 @@ class SpreadEndpointTest(APITestCase):
         url = reverse("persona-spreadable-deeds", args=[self.persona.pk])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertIn(self.deed.pk, [d["id"] for d in resp.data])
+        self.assertIn(self.deed.pk, [d["id"] for d in resp.data["results"]])
 
     def test_spread_resolves(self) -> None:
         url = reverse("persona-spread", args=[self.persona.pk])

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -325,6 +325,9 @@ class PersonaViewSet(viewsets.ModelViewSet):
 
         persona = self.get_object()
         deeds = get_spreadable_deeds(persona)
+        page = self.paginate_queryset(deeds)
+        if page is not None:
+            return self.get_paginated_response(SpreadableDeedSerializer(page, many=True).data)
         return Response(SpreadableDeedSerializer(deeds, many=True).data)
 
     @extend_schema(responses=SpreadSpecializationSerializer(many=True), tags=["personas"])
@@ -334,6 +337,9 @@ class PersonaViewSet(viewsets.ModelViewSet):
         from world.societies.spread_services import get_spread_specializations  # noqa: PLC0415
 
         specs = get_spread_specializations()
+        page = self.paginate_queryset(specs)
+        if page is not None:
+            return self.get_paginated_response(SpreadSpecializationSerializer(page, many=True).data)
         return Response(SpreadSpecializationSerializer(specs, many=True).data)
 
     @extend_schema(

--- a/src/world/societies/spread_services.py
+++ b/src/world/societies/spread_services.py
@@ -73,8 +73,22 @@ def _ensure_skill(name: str):
 
 def ensure_spread_skills() -> None:
     """Idempotently ensure the spread skills (Performance, Persuasion) + their
-    form specializations exist."""
+    form specializations exist.
+
+    Called several times per spread (template build, modifiers, form list). The
+    repo bans data migrations / seed commands pre-production, so this is the
+    seed-on-first-use path — but the fast-path keeps the steady state at a single
+    count query instead of re-running the get_or_creates every request.
+    """
     from world.skills.models import Specialization  # noqa: PLC0415
+
+    form_names = [name for name, _, _ in SPREAD_FORMS]
+    already_seeded = Specialization.objects.filter(
+        name__in=form_names,
+        parent_skill__trait__name__in=[PERFORMANCE_SKILL_NAME, PERSUASION_SKILL_NAME],
+    ).count() == len(SPREAD_FORMS)
+    if already_seeded:
+        return
 
     skills_by_name = {
         PERFORMANCE_SKILL_NAME: _ensure_skill(PERFORMANCE_SKILL_NAME),
@@ -156,6 +170,12 @@ def get_or_create_spread_a_tale_template():
     from actions.models.action_templates import ActionTemplate  # noqa: PLC0415
     from world.checks.models import CheckCategory, CheckType, CheckTypeTrait  # noqa: PLC0415
     from world.traits.models import Trait, TraitCategory, TraitType  # noqa: PLC0415
+
+    # Fast-path: once seeded, the template (and its skills) exist, so a single
+    # fetch per spread suffices instead of replaying every get_or_create below.
+    existing = ActionTemplate.objects.filter(name="Spread a Tale").first()
+    if existing is not None:
+        return existing
 
     ensure_spread_skills()
     category, _ = CheckCategory.objects.get_or_create(name="Social")

--- a/src/world/societies/spread_services.py
+++ b/src/world/societies/spread_services.py
@@ -13,6 +13,8 @@ from world.scenes.action_resolvers import register_resolver
 from world.societies.models import LegendEntry, OrganizationMembership
 
 SPREAD_TALE_ACTION_KEY = "spread_a_tale"
+# Display name shared by the Spread a Tale ActionTemplate and its CheckType.
+SPREAD_TALE_TEMPLATE_NAME = "Spread a Tale"
 
 # success_level -> fraction of base_value (failure / <=0 yields 0). Tunable.
 TIER_PAYOFF: dict[int, float] = {0: 0.0, 1: 0.10, 2: 0.30, 3: 0.60, 4: 1.00}
@@ -173,14 +175,14 @@ def get_or_create_spread_a_tale_template():
 
     # Fast-path: once seeded, the template (and its skills) exist, so a single
     # fetch per spread suffices instead of replaying every get_or_create below.
-    existing = ActionTemplate.objects.filter(name="Spread a Tale").first()
+    existing = ActionTemplate.objects.filter(name=SPREAD_TALE_TEMPLATE_NAME).first()
     if existing is not None:
         return existing
 
     ensure_spread_skills()
     category, _ = CheckCategory.objects.get_or_create(name="Social")
     check_type, _ = CheckType.objects.get_or_create(
-        name="Spread a Tale",
+        name=SPREAD_TALE_TEMPLATE_NAME,
         defaults={
             "category": category,
             "description": "Telling a deed's tale to a crowd.",
@@ -194,7 +196,7 @@ def get_or_create_spread_a_tale_template():
         check_type=check_type, trait=presence, defaults={"weight": Decimal("0.5")}
     )
     template, _ = ActionTemplate.objects.get_or_create(
-        name="Spread a Tale",
+        name=SPREAD_TALE_TEMPLATE_NAME,
         defaults={
             "check_type": check_type,
             "target_type": ActionTargetType.AREA,

--- a/src/world/societies/tests/test_spread_services.py
+++ b/src/world/societies/tests/test_spread_services.py
@@ -45,3 +45,32 @@ class ComputeSpreadValueTest(TestCase):
         self.assertGreater(
             compute_spread_value(base_value=100, success_level=4, multiplier=2.2), 100
         )
+
+
+class SeedFastPathTest(TestCase):
+    """The seed-on-first-use helpers must not re-seed (or re-write) once seeded."""
+
+    def test_template_seeded_once_and_fast_path_is_cheap(self) -> None:
+        from actions.models.action_templates import ActionTemplate
+        from world.societies.spread_services import get_or_create_spread_a_tale_template
+
+        first = get_or_create_spread_a_tale_template()
+        second = get_or_create_spread_a_tale_template()
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(ActionTemplate.objects.filter(name="Spread a Tale").count(), 1)
+        # Steady state: a single fetch, not the full chain of get_or_creates.
+        with self.assertNumQueries(1):
+            get_or_create_spread_a_tale_template()
+
+    def test_ensure_skills_idempotent(self) -> None:
+        from world.skills.models import Specialization
+        from world.societies.spread_services import ensure_spread_skills
+
+        ensure_spread_skills()
+        ensure_spread_skills()
+        self.assertEqual(
+            Specialization.objects.filter(
+                name__in=["Oratory", "Prose", "Singing", "Propaganda"]
+            ).count(),
+            4,
+        )

--- a/src/world/societies/tests/test_spread_services.py
+++ b/src/world/societies/tests/test_spread_services.py
@@ -52,12 +52,15 @@ class SeedFastPathTest(TestCase):
 
     def test_template_seeded_once_and_fast_path_is_cheap(self) -> None:
         from actions.models.action_templates import ActionTemplate
-        from world.societies.spread_services import get_or_create_spread_a_tale_template
+        from world.societies.spread_services import (
+            SPREAD_TALE_TEMPLATE_NAME,
+            get_or_create_spread_a_tale_template,
+        )
 
         first = get_or_create_spread_a_tale_template()
         second = get_or_create_spread_a_tale_template()
         self.assertEqual(first.pk, second.pk)
-        self.assertEqual(ActionTemplate.objects.filter(name="Spread a Tale").count(), 1)
+        self.assertEqual(ActionTemplate.objects.filter(name=SPREAD_TALE_TEMPLATE_NAME).count(), 1)
         # Steady state: a single fetch, not the full chain of get_or_creates.
         with self.assertNumQueries(1):
             get_or_create_spread_a_tale_template()


### PR DESCRIPTION
Clears the three follow-ups that were noted in the Spread a Tale PR bodies (#781/#844/#845) but never filed — doing them now rather than leaving them as untracked debt in closed-PR history.

### 1. Pagination schema mismatch
`spreadable-deeds` and `spread-specializations` advertised `Paginated*List` responses in the OpenAPI schema (the viewset carries a `pagination_class`, so drf-spectacular infers pagination) but actually returned **bare lists**. Now they genuinely paginate via `paginate_queryset` / `get_paginated_response` — matching `deed-stories` (Phase 4) and the item-app `_paginated_response` precedent. The FE hooks read `.results`; the backend tests assert on `.results`. Schema and reality now agree.

### 2. `EvenniaMessage` XSS surface
The message renderer injected server HTML through `dangerouslySetInnerHTML` behind a literal *"sanitize it later if needed"* TODO. But chat messages carry **user-authored** text (poses, says, names) routed through Evennia's ANSI→HTML conversion, so the string is untrusted — a crafted pose was a stored-XSS vector. Now sanitized with **DOMPurify** (default config: strips `<script>`, event handlers, and dangerous tags while keeping the legitimate color `<span>`s). Adds the `dompurify` dependency. `ChatWindow`'s tests (which render `EvenniaMessage`) still pass under jsdom.

### 3. Lazy template-seed in the request path
`get_or_create_spread_a_tale_template()` + `ensure_spread_skills()` re-ran ~18 idempotent `get_or_create`s on **every** spread POST. The repo bans data migrations / seed commands pre-production, so they correctly stay seed-on-first-use — but a fast-path (one `.first()` fetch / one `.count()`) drops the steady state to a single query. Locked with an `assertNumQueries(1)` test.

### Testing
- PG parity: `world.scenes.tests.test_spread_endpoints` (12) + `world.societies.tests.test_spread_services` (7, incl. the new fast-path + idempotency tests) — green.
- FE `pnpm typecheck` + `pnpm build` + `ChatWindow` vitest — green. API types regenerated.

Refs #745 (closed umbrella) — pure cleanup, no new feature surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
