### PR TITLE
feat(#728): Mission Studio — NPC roles + service offers staff editor (core)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,6 +55,16 @@ const CreateMissionPage = lazy(() =>
     default: m.CreateMissionPage,
   }))
 );
+const NPCRolesLibraryPage = lazy(() =>
+  import('@/npc_services/pages/NPCRolesLibraryPage').then((m) => ({
+    default: m.NPCRolesLibraryPage,
+  }))
+);
+const NPCRoleEditorPage = lazy(() =>
+  import('@/npc_services/pages/NPCRoleEditorPage').then((m) => ({
+    default: m.NPCRoleEditorPage,
+  }))
+);
 import { StaffInboxPage } from './staff/pages/StaffInboxPage';
 import { StaffApplicationsPage } from './staff/pages/StaffApplicationsPage';
 import { StaffApplicationDetailPage } from './staff/pages/StaffApplicationDetailPage';
@@ -358,8 +368,28 @@ function App() {
         />
         {/* /staff/missions/givers routes removed per #686: NPC-mediated
             mission-giver editor moved to the npc-services framework
-            (NPCRole + NPCServiceOffer). The npc-services staff editor
-            is a follow-up. */}
+            (NPCRole + NPCServiceOffer). The npc-services staff editor (#728)
+            lives at /staff/npc-services/roles. */}
+        <Route
+          path="/staff/npc-services/roles"
+          element={
+            <StaffRoute>
+              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                <NPCRolesLibraryPage />
+              </Suspense>
+            </StaffRoute>
+          }
+        />
+        <Route
+          path="/staff/npc-services/roles/:id"
+          element={
+            <StaffRoute>
+              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                <NPCRoleEditorPage />
+              </Suspense>
+            </StaffRoute>
+          }
+        />
         <Route
           path="/staff/applications"
           element={

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -32525,10 +32525,12 @@ export interface operations {
   npc_services_mission_details_list: {
     parameters: {
       query?: {
+        offer?: number;
         /** @description A page number within the paginated result set. */
         page?: number;
         /** @description Number of results to return per page. */
         page_size?: number;
+        role?: number;
       };
       header?: never;
       path?: never;
@@ -32812,6 +32814,8 @@ export interface operations {
   npc_services_permit_details_list: {
     parameters: {
       query?: {
+        building_kind?: number;
+        offer?: number;
         /** @description A page number within the paginated result set. */
         page?: number;
         /** @description Number of results to return per page. */

--- a/frontend/src/npc_services/api.ts
+++ b/frontend/src/npc_services/api.ts
@@ -1,0 +1,131 @@
+/**
+ * NPC-services staff editor API wrappers (#728 — Mission Studio).
+ *
+ * Pure functions over the shipped `/api/npc-services/*` endpoints (all
+ * staff-only, IsAdminUser on the backend). Pair with the React Query hooks in
+ * queries.ts. Reuses the Mission Studio error helpers so DRF error shapes
+ * surface identically across the two editors.
+ */
+import { ApiValidationError } from '@/missions/api';
+
+import { apiFetch } from '@/evennia_replacements/api';
+
+import type {
+  MissionOfferDetails,
+  MissionOfferDetailsRequest,
+  NPCRole,
+  NPCRoleFilters,
+  NPCRoleRequest,
+  NPCServiceOffer,
+  NPCServiceOfferRequest,
+  PaginatedResponse,
+} from './types';
+
+export { ApiValidationError, flattenErrorMessage } from '@/missions/api';
+
+const BASE_URL = '/api/npc-services';
+
+function buildQueryString(params: object): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') continue;
+    search.append(key, String(value));
+  }
+  const s = search.toString();
+  return s ? `?${s}` : '';
+}
+
+async function writeJson<T>(url: string, method: string, body: unknown): Promise<T> {
+  const res = await apiFetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({}));
+    throw new ApiValidationError(detail);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// NPCRole
+// ---------------------------------------------------------------------------
+
+export async function listRoles(filters: NPCRoleFilters = {}): Promise<PaginatedResponse<NPCRole>> {
+  const res = await apiFetch(`${BASE_URL}/roles/${buildQueryString(filters)}`);
+  if (!res.ok) throw new Error('Failed to load NPC roles');
+  return res.json();
+}
+
+export async function getRole(id: number): Promise<NPCRole> {
+  const res = await apiFetch(`${BASE_URL}/roles/${id}/`);
+  if (!res.ok) throw new Error(`Failed to load role ${id}`);
+  return res.json();
+}
+
+export function createRole(body: NPCRoleRequest): Promise<NPCRole> {
+  return writeJson(`${BASE_URL}/roles/`, 'POST', body);
+}
+
+export function patchRole(id: number, body: Partial<NPCRoleRequest>): Promise<NPCRole> {
+  return writeJson(`${BASE_URL}/roles/${id}/`, 'PATCH', body);
+}
+
+export async function deleteRole(id: number): Promise<void> {
+  const res = await apiFetch(`${BASE_URL}/roles/${id}/`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`Failed to delete role ${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// NPCServiceOffer
+// ---------------------------------------------------------------------------
+
+export async function listOffers(
+  filters: { role?: number; kind?: string; page_size?: number } = {}
+): Promise<PaginatedResponse<NPCServiceOffer>> {
+  const res = await apiFetch(`${BASE_URL}/offers/${buildQueryString(filters)}`);
+  if (!res.ok) throw new Error('Failed to load offers');
+  return res.json();
+}
+
+export function createOffer(body: NPCServiceOfferRequest): Promise<NPCServiceOffer> {
+  return writeJson(`${BASE_URL}/offers/`, 'POST', body);
+}
+
+export function patchOffer(
+  id: number,
+  body: Partial<NPCServiceOfferRequest>
+): Promise<NPCServiceOffer> {
+  return writeJson(`${BASE_URL}/offers/${id}/`, 'PATCH', body);
+}
+
+export async function deleteOffer(id: number): Promise<void> {
+  const res = await apiFetch(`${BASE_URL}/offers/${id}/`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`Failed to delete offer ${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// MissionOfferDetails (per mission-kind offer)
+// ---------------------------------------------------------------------------
+
+export async function listMissionDetails(
+  filters: { offer?: number; role?: number; page_size?: number } = {}
+): Promise<PaginatedResponse<MissionOfferDetails>> {
+  const res = await apiFetch(`${BASE_URL}/mission-details/${buildQueryString(filters)}`);
+  if (!res.ok) throw new Error('Failed to load mission offer details');
+  return res.json();
+}
+
+export function createMissionDetails(
+  body: MissionOfferDetailsRequest
+): Promise<MissionOfferDetails> {
+  return writeJson(`${BASE_URL}/mission-details/`, 'POST', body);
+}
+
+export function patchMissionDetails(
+  id: number,
+  body: Partial<MissionOfferDetailsRequest>
+): Promise<MissionOfferDetails> {
+  return writeJson(`${BASE_URL}/mission-details/${id}/`, 'PATCH', body);
+}

--- a/frontend/src/npc_services/pages/NPCRoleEditorPage.tsx
+++ b/frontend/src/npc_services/pages/NPCRoleEditorPage.tsx
@@ -1,0 +1,435 @@
+/**
+ * NPC Role editor (#728 — Mission Studio).
+ *
+ * Drill-down editor for one NPCRole: its descriptive/rapport fields plus the
+ * service offers it holds (mission + permit kinds). Mission offers expose the
+ * MissionOfferDetails panel (template, weight, cooldown, requirements rule).
+ * Replaces the deleted GiverEditorPage against the unified npc-services surface.
+ */
+import { Loader2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { StudioBreadcrumb } from '@/missions/components/StudioBreadcrumb';
+import {
+  PredicateBuilder,
+  coercePredicate,
+  validatePredicate,
+  type PredicateNode,
+} from '@/missions/components/PredicateBuilder';
+import { useMissionTemplates, usePredicateLeaves } from '@/missions/queries';
+
+import { ApiValidationError, flattenErrorMessage } from '../api';
+import {
+  useCreateMissionDetails,
+  useCreateOffer,
+  useDeleteOffer,
+  useDeleteRole,
+  useMissionDetailsForRole,
+  useOffersForRole,
+  usePatchMissionDetails,
+  usePatchOffer,
+  usePatchRole,
+  useRole,
+} from '../queries';
+import type { MissionOfferDetails, NPCServiceOffer } from '../types';
+
+const EMPTY_RULE: PredicateNode = {};
+
+function errText(err: unknown, fallback: string): string {
+  return err instanceof ApiValidationError ? flattenErrorMessage(err.fieldErrors) : fallback;
+}
+
+function numOrNull(raw: string): number | null {
+  const t = raw.trim();
+  if (t === '') return null;
+  const n = Number(t);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function NPCRoleEditorPage() {
+  const { id } = useParams<{ id: string }>();
+  const roleId = id ? Number(id) : null;
+  const { data: role, isLoading } = useRole(roleId);
+
+  if (isLoading || !role || roleId === null) {
+    return (
+      <div className="flex justify-center py-16">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl space-y-6 py-6">
+      <StudioBreadcrumb
+        crumbs={[{ label: 'NPC Roles', to: '/staff/npc-services/roles' }, { label: role.name }]}
+      />
+      <RoleFieldsCard roleId={roleId} />
+      <OffersSection roleId={roleId} />
+    </div>
+  );
+}
+
+function RoleFieldsCard({ roleId }: { roleId: number }) {
+  const { data: role } = useRole(roleId);
+  const patch = usePatchRole();
+  const del = useDeleteRole();
+  const navigate = useNavigate();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [template, setTemplate] = useState('');
+  const [rapport, setRapport] = useState('');
+  const [faction, setFaction] = useState('');
+
+  useEffect(() => {
+    if (!role) return;
+    setName(role.name ?? '');
+    setDescription(role.description ?? '');
+    setTemplate(role.default_description_template ?? '');
+    setRapport(role.default_rapport_starting_value?.toString() ?? '');
+    setFaction(role.faction_affiliation?.toString() ?? '');
+  }, [role]);
+
+  const save = () => {
+    patch.mutate({
+      id: roleId,
+      body: {
+        name: name.trim(),
+        description,
+        default_description_template: template,
+        default_rapport_starting_value: numOrNull(rapport) ?? 0,
+        faction_affiliation: numOrNull(faction),
+      },
+    });
+  };
+
+  const remove = () => {
+    if (!window.confirm('Delete this role and all its offers?')) return;
+    del.mutate(roleId, { onSuccess: () => navigate('/staff/npc-services/roles') });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Role</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Field label="Name">
+          <Input value={name} onChange={(e) => setName(e.target.value)} />
+        </Field>
+        <Field label="Description">
+          <Textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={3} />
+        </Field>
+        <Field label="Default description template">
+          <Textarea value={template} onChange={(e) => setTemplate(e.target.value)} rows={2} />
+        </Field>
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Default rapport">
+            <Input type="number" value={rapport} onChange={(e) => setRapport(e.target.value)} />
+          </Field>
+          <Field label="Faction affiliation (id)">
+            <Input
+              type="number"
+              value={faction}
+              onChange={(e) => setFaction(e.target.value)}
+              placeholder="optional"
+            />
+          </Field>
+        </div>
+        {patch.isError && (
+          <p className="text-sm text-destructive">{errText(patch.error, 'Could not save.')}</p>
+        )}
+        <div className="flex justify-between">
+          <Button size="sm" onClick={save} disabled={!name.trim() || patch.isPending}>
+            {patch.isPending ? 'Saving…' : 'Save role'}
+          </Button>
+          <Button size="sm" variant="destructive" onClick={remove} disabled={del.isPending}>
+            Delete
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function OffersSection({ roleId }: { roleId: number }) {
+  const { data: offersData, isLoading } = useOffersForRole(roleId);
+  const { data: detailsData } = useMissionDetailsForRole(roleId);
+  const offers = offersData?.results ?? [];
+  const detailsByOffer = new Map<number, MissionOfferDetails>();
+  for (const d of detailsData?.results ?? []) {
+    if (typeof d.offer === 'number') detailsByOffer.set(d.offer, d);
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Offers</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <div className="flex justify-center py-4">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : offers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No offers yet.</p>
+        ) : (
+          offers.map((offer) => (
+            <OfferCard
+              key={offer.id}
+              roleId={roleId}
+              offer={offer}
+              details={detailsByOffer.get(offer.id) ?? null}
+            />
+          ))
+        )}
+        <AddOfferForm roleId={roleId} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function OfferCard({
+  roleId,
+  offer,
+  details,
+}: {
+  roleId: number;
+  offer: NPCServiceOffer;
+  details: MissionOfferDetails | null;
+}) {
+  const patchOffer = usePatchOffer(roleId);
+  const patchDetails = usePatchMissionDetails(roleId);
+  const del = useDeleteOffer(roleId);
+  const leaves = usePredicateLeaves().data ?? [];
+
+  const [label, setLabel] = useState(offer.label ?? '');
+  const [drawMode, setDrawMode] = useState(offer.draw_mode ?? 'menu');
+  const [rapportReq, setRapportReq] = useState(offer.rapport_requirement?.toString() ?? '');
+  const [isFinal, setIsFinal] = useState(offer.is_final ?? false);
+  const [rule, setRule] = useState<PredicateNode>(
+    (offer.eligibility_rule as PredicateNode) ?? EMPTY_RULE
+  );
+  const [weight, setWeight] = useState(details?.weight?.toString() ?? '');
+
+  const ruleErrors = validatePredicate(rule, leaves);
+
+  const save = () => {
+    if (ruleErrors.length > 0) return;
+    patchOffer.mutate({
+      id: offer.id,
+      body: {
+        label: label.trim(),
+        draw_mode: drawMode,
+        rapport_requirement: numOrNull(rapportReq) ?? 0,
+        is_final: isFinal,
+        eligibility_rule: coercePredicate(rule, leaves),
+      },
+    });
+    if (offer.kind === 'mission' && details) {
+      patchDetails.mutate({ id: details.id, body: { weight: numOrNull(weight) ?? 1 } });
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border p-3">
+      <div className="flex items-center justify-between">
+        <Badge variant={offer.kind === 'mission' ? 'default' : 'secondary'}>{offer.kind}</Badge>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-destructive"
+          onClick={() => del.mutate(offer.id)}
+        >
+          Remove
+        </Button>
+      </div>
+
+      <Field label="Label">
+        <Input value={label} onChange={(e) => setLabel(e.target.value)} />
+      </Field>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Draw mode">
+          <Select value={drawMode} onValueChange={(v) => setDrawMode(v as 'menu' | 'pool')}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="menu">Menu</SelectItem>
+              <SelectItem value="pool">Pool</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Rapport requirement">
+          <Input type="number" value={rapportReq} onChange={(e) => setRapportReq(e.target.value)} />
+        </Field>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm">
+        <Switch checked={isFinal} onCheckedChange={setIsFinal} />
+        Final action (ends the interaction)
+      </label>
+
+      {offer.kind === 'mission' &&
+        (details ? (
+          <Field label="Weight">
+            <Input type="number" value={weight} onChange={(e) => setWeight(e.target.value)} />
+          </Field>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            This mission offer has no MissionOfferDetails row yet — pick a template via the
+            add-offer flow.
+          </p>
+        ))}
+
+      <PredicateBuilder label="Eligibility rule" value={rule} onChange={setRule} />
+      {ruleErrors.length > 0 && <p className="text-sm text-destructive">{ruleErrors[0]}</p>}
+
+      {(patchOffer.isError || patchDetails.isError) && (
+        <p className="text-sm text-destructive">
+          {errText(patchOffer.error ?? patchDetails.error, 'Could not save the offer.')}
+        </p>
+      )}
+      <Button
+        size="sm"
+        onClick={save}
+        disabled={ruleErrors.length > 0 || patchOffer.isPending || !label.trim()}
+      >
+        {patchOffer.isPending ? 'Saving…' : 'Save offer'}
+      </Button>
+    </div>
+  );
+}
+
+function AddOfferForm({ roleId }: { roleId: number }) {
+  const [open, setOpen] = useState(false);
+  const [kind, setKind] = useState<'mission' | 'permit'>('mission');
+  const [label, setLabel] = useState('');
+  const [templateId, setTemplateId] = useState<string>('');
+  const createOffer = useCreateOffer(roleId);
+  const createDetails = useCreateMissionDetails(roleId);
+  const { data: templatesData } = useMissionTemplates({});
+  const templates = templatesData?.results ?? [];
+
+  const submit = () => {
+    if (!label.trim()) return;
+    if (kind === 'mission' && !templateId) return;
+    createOffer.mutate(
+      { role: roleId, kind, label: label.trim() },
+      {
+        onSuccess: (offer) => {
+          if (kind === 'mission') {
+            createDetails.mutate(
+              { offer: offer.id, mission_template: Number(templateId) },
+              {
+                onSuccess: () => {
+                  setOpen(false);
+                  setLabel('');
+                  setTemplateId('');
+                },
+              }
+            );
+          } else {
+            setOpen(false);
+            setLabel('');
+          }
+        },
+      }
+    );
+  };
+
+  if (!open) {
+    return (
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        Add offer
+      </Button>
+    );
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border border-dashed p-3">
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Kind">
+          <Select value={kind} onValueChange={(v) => setKind(v as 'mission' | 'permit')}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="mission">Mission</SelectItem>
+              <SelectItem value="permit">Permit</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Label">
+          <Input value={label} onChange={(e) => setLabel(e.target.value)} />
+        </Field>
+      </div>
+
+      {kind === 'mission' && (
+        <Field label="Mission template">
+          <Select value={templateId} onValueChange={setTemplateId}>
+            <SelectTrigger>
+              <SelectValue placeholder="Choose a template" />
+            </SelectTrigger>
+            <SelectContent>
+              {templates.map((t) => (
+                <SelectItem key={t.id} value={t.id.toString()}>
+                  {t.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+      )}
+
+      {(createOffer.isError || createDetails.isError) && (
+        <p className="text-sm text-destructive">
+          {errText(createOffer.error ?? createDetails.error, 'Could not add the offer.')}
+        </p>
+      )}
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          onClick={submit}
+          disabled={
+            !label.trim() ||
+            (kind === 'mission' && !templateId) ||
+            createOffer.isPending ||
+            createDetails.isPending
+          }
+        >
+          {createOffer.isPending || createDetails.isPending ? 'Adding…' : 'Add'}
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => setOpen(false)}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/npc_services/pages/NPCRoleEditorPage.tsx
+++ b/frontend/src/npc_services/pages/NPCRoleEditorPage.tsx
@@ -217,7 +217,8 @@ function OfferCard({
   const patchOffer = usePatchOffer(roleId);
   const patchDetails = usePatchMissionDetails(roleId);
   const del = useDeleteOffer(roleId);
-  const leaves = usePredicateLeaves().data ?? [];
+  const leavesQuery = usePredicateLeaves();
+  const leaves = leavesQuery.data ?? [];
 
   const [label, setLabel] = useState(offer.label ?? '');
   const [drawMode, setDrawMode] = useState(offer.draw_mode ?? 'menu');
@@ -228,7 +229,9 @@ function OfferCard({
   );
   const [weight, setWeight] = useState(details?.weight?.toString() ?? '');
 
-  const ruleErrors = validatePredicate(rule, leaves);
+  // Only validate/coerce once the predicate-leaf catalog has loaded — otherwise
+  // every leaf reads as "unknown" and a valid persisted rule becomes un-saveable.
+  const ruleErrors = leavesQuery.isSuccess ? validatePredicate(rule, leaves) : [];
 
   const save = () => {
     if (ruleErrors.length > 0) return;
@@ -239,11 +242,12 @@ function OfferCard({
         draw_mode: drawMode,
         rapport_requirement: numOrNull(rapportReq) ?? 0,
         is_final: isFinal,
-        eligibility_rule: coercePredicate(rule, leaves),
+        eligibility_rule: leavesQuery.isSuccess ? coercePredicate(rule, leaves) : rule,
       },
     });
     if (offer.kind === 'mission' && details) {
-      patchDetails.mutate({ id: details.id, body: { weight: numOrNull(weight) ?? 1 } });
+      // null weight intentionally falls back to MissionTemplate.base_weight.
+      patchDetails.mutate({ id: details.id, body: { weight: numOrNull(weight) } });
     }
   };
 
@@ -325,6 +329,7 @@ function AddOfferForm({ roleId }: { roleId: number }) {
   const [templateId, setTemplateId] = useState<string>('');
   const createOffer = useCreateOffer(roleId);
   const createDetails = useCreateMissionDetails(roleId);
+  const deleteOffer = useDeleteOffer(roleId);
   const { data: templatesData } = useMissionTemplates({});
   const templates = templatesData?.results ?? [];
 
@@ -344,6 +349,10 @@ function AddOfferForm({ roleId }: { roleId: number }) {
                   setLabel('');
                   setTemplateId('');
                 },
+                // Compensating rollback: the details create failed (usually the
+                // (role, mission_template) uniqueness), so drop the now-orphaned
+                // offer rather than leave a mission offer with no template.
+                onError: () => deleteOffer.mutate(offer.id),
               }
             );
           } else {

--- a/frontend/src/npc_services/pages/NPCRolesLibraryPage.tsx
+++ b/frontend/src/npc_services/pages/NPCRolesLibraryPage.tsx
@@ -1,0 +1,130 @@
+/**
+ * NPC Roles library (#728 — Mission Studio).
+ *
+ * Lists NPCRole rows, supports name search + create, and links into the
+ * per-role editor. Replaces the deleted GiverLibraryPage against the unified
+ * npc-services surface.
+ */
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { ApiValidationError, flattenErrorMessage } from '../api';
+import { useCreateRole, useRoles } from '../queries';
+
+export function NPCRolesLibraryPage() {
+  const [search, setSearch] = useState('');
+  const { data, isLoading } = useRoles({ name: search || undefined });
+  const roles = data?.results ?? [];
+
+  return (
+    <div className="container mx-auto max-w-4xl space-y-6 py-6">
+      <div>
+        <h1 className="text-2xl font-semibold">NPC Roles</h1>
+        <p className="text-sm text-muted-foreground">
+          Author the roles NPCs play and the services (missions, permits) they offer.
+        </p>
+      </div>
+
+      <CreateRoleCard />
+
+      <div className="space-y-3">
+        <Input
+          placeholder="Search roles by name…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="Search roles"
+        />
+
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : roles.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">No roles found.</p>
+        ) : (
+          <ul className="space-y-2">
+            {roles.map((role) => (
+              <li key={role.id}>
+                <Link to={`/staff/npc-services/roles/${role.id}`}>
+                  <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+                    <CardContent className="py-3">
+                      <div className="font-medium">{role.name}</div>
+                      {role.description && (
+                        <div className="line-clamp-1 text-sm text-muted-foreground">
+                          {role.description}
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CreateRoleCard() {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const navigate = useNavigate();
+  const createRole = useCreateRole();
+
+  const submit = () => {
+    if (!name.trim()) return;
+    createRole.mutate(
+      { name: name.trim() },
+      { onSuccess: (role) => navigate(`/staff/npc-services/roles/${role.id}`) }
+    );
+  };
+
+  if (!open) {
+    return (
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        New role
+      </Button>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">New role</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="space-y-1">
+          <Label htmlFor="new-role-name">Name</Label>
+          <Input
+            id="new-role-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Dockside Fixer"
+          />
+        </div>
+        {createRole.isError && (
+          <p className="text-sm text-destructive">
+            {createRole.error instanceof ApiValidationError
+              ? flattenErrorMessage(createRole.error.fieldErrors)
+              : 'Could not create the role.'}
+          </p>
+        )}
+        <div className="flex gap-2">
+          <Button size="sm" onClick={submit} disabled={!name.trim() || createRole.isPending}>
+            {createRole.isPending ? 'Creating…' : 'Create'}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/npc_services/queries.ts
+++ b/frontend/src/npc_services/queries.ts
@@ -1,0 +1,152 @@
+/**
+ * React Query hooks for the NPC-services staff editor (#728).
+ */
+import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+
+import {
+  createMissionDetails,
+  createOffer,
+  createRole,
+  deleteOffer,
+  deleteRole,
+  getRole,
+  listMissionDetails,
+  listOffers,
+  listRoles,
+  patchMissionDetails,
+  patchOffer,
+  patchRole,
+} from './api';
+import type {
+  MissionOfferDetailsRequest,
+  NPCRoleFilters,
+  NPCRoleRequest,
+  NPCServiceOfferRequest,
+  PaginatedResponse,
+  NPCRole,
+  NPCServiceOffer,
+  MissionOfferDetails,
+} from './types';
+
+export const npcServiceKeys = {
+  all: ['npc-services'] as const,
+  roles: () => [...npcServiceKeys.all, 'roles'] as const,
+  roleList: (filters: NPCRoleFilters) => [...npcServiceKeys.roles(), 'list', filters] as const,
+  roleDetail: (id: number) => [...npcServiceKeys.roles(), 'detail', id] as const,
+  offers: () => [...npcServiceKeys.all, 'offers'] as const,
+  offerList: (roleId: number) => [...npcServiceKeys.offers(), 'list', roleId] as const,
+  missionDetails: () => [...npcServiceKeys.all, 'mission-details'] as const,
+  missionDetailList: (roleId: number) =>
+    [...npcServiceKeys.missionDetails(), 'list', roleId] as const,
+};
+
+export function useRoles(filters: NPCRoleFilters = {}): UseQueryResult<PaginatedResponse<NPCRole>> {
+  return useQuery({
+    queryKey: npcServiceKeys.roleList(filters),
+    queryFn: () => listRoles(filters),
+    staleTime: 30_000,
+  });
+}
+
+export function useRole(id: number | null): UseQueryResult<NPCRole> {
+  return useQuery({
+    queryKey: npcServiceKeys.roleDetail(id ?? -1),
+    queryFn: () => getRole(id as number),
+    enabled: id !== null,
+  });
+}
+
+export function useOffersForRole(
+  roleId: number | null
+): UseQueryResult<PaginatedResponse<NPCServiceOffer>> {
+  return useQuery({
+    queryKey: npcServiceKeys.offerList(roleId ?? -1),
+    queryFn: () => listOffers({ role: roleId as number, page_size: 200 }),
+    enabled: roleId !== null,
+  });
+}
+
+export function useMissionDetailsForRole(
+  roleId: number | null
+): UseQueryResult<PaginatedResponse<MissionOfferDetails>> {
+  return useQuery({
+    queryKey: npcServiceKeys.missionDetailList(roleId ?? -1),
+    queryFn: () => listMissionDetails({ role: roleId as number, page_size: 200 }),
+    enabled: roleId !== null,
+  });
+}
+
+export function useCreateRole() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: NPCRoleRequest) => createRole(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: npcServiceKeys.roles() }),
+  });
+}
+
+export function usePatchRole() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: number; body: Partial<NPCRoleRequest> }) =>
+      patchRole(id, body),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: npcServiceKeys.roleDetail(id) });
+      qc.invalidateQueries({ queryKey: npcServiceKeys.roles() });
+    },
+  });
+}
+
+export function useDeleteRole() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => deleteRole(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: npcServiceKeys.roles() }),
+  });
+}
+
+function invalidateRoleOffers(qc: ReturnType<typeof useQueryClient>, roleId: number) {
+  qc.invalidateQueries({ queryKey: npcServiceKeys.offerList(roleId) });
+  qc.invalidateQueries({ queryKey: npcServiceKeys.missionDetailList(roleId) });
+}
+
+export function useCreateOffer(roleId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: NPCServiceOfferRequest) => createOffer(body),
+    onSuccess: () => invalidateRoleOffers(qc, roleId),
+  });
+}
+
+export function usePatchOffer(roleId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: number; body: Partial<NPCServiceOfferRequest> }) =>
+      patchOffer(id, body),
+    onSuccess: () => invalidateRoleOffers(qc, roleId),
+  });
+}
+
+export function useDeleteOffer(roleId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => deleteOffer(id),
+    onSuccess: () => invalidateRoleOffers(qc, roleId),
+  });
+}
+
+export function useCreateMissionDetails(roleId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: MissionOfferDetailsRequest) => createMissionDetails(body),
+    onSuccess: () => invalidateRoleOffers(qc, roleId),
+  });
+}
+
+export function usePatchMissionDetails(roleId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: number; body: Partial<MissionOfferDetailsRequest> }) =>
+      patchMissionDetails(id, body),
+    onSuccess: () => invalidateRoleOffers(qc, roleId),
+  });
+}

--- a/frontend/src/npc_services/types.ts
+++ b/frontend/src/npc_services/types.ts
@@ -1,0 +1,28 @@
+/**
+ * NPC-services staff editor types (#728 — Mission Studio).
+ *
+ * Aliases over the generated OpenAPI schema so the editor pages stay in sync
+ * with the backend `NPCRole` / `NPCServiceOffer` / `MissionOfferDetails` surface.
+ */
+import type { components } from '@/generated/api';
+
+export type NPCRole = components['schemas']['NPCRole'];
+export type NPCRoleRequest = components['schemas']['NPCRoleRequest'];
+export type NPCServiceOffer = components['schemas']['NPCServiceOffer'];
+export type NPCServiceOfferRequest = components['schemas']['NPCServiceOfferRequest'];
+export type MissionOfferDetails = components['schemas']['MissionOfferDetails'];
+export type MissionOfferDetailsRequest = components['schemas']['MissionOfferDetailsRequest'];
+
+export interface PaginatedResponse<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}
+
+export interface NPCRoleFilters {
+  name?: string;
+  faction_affiliation?: number;
+  page?: number;
+  page_size?: number;
+}

--- a/frontend/src/staff/pages/StaffHubPage.tsx
+++ b/frontend/src/staff/pages/StaffHubPage.tsx
@@ -105,6 +105,20 @@ export function StaffHubPage() {
             </CardContent>
           </Card>
         </Link>
+
+        <Link to="/staff/npc-services/roles">
+          <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+            <CardHeader>
+              <CardTitle>NPC Services</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Author NPC roles and the service offers they make — mission-giving and permit
+                issuance — on the unified offer framework.
+              </p>
+            </CardContent>
+          </Card>
+        </Link>
       </div>
     </div>
   );

--- a/src/schema.json
+++ b/src/schema.json
@@ -13298,6 +13298,10 @@ paths:
         sets `offer` and the catalog uniqueness `(role, mission_template)`
         is enforced at the DB level via the auto-mirrored FK.
       parameters:
+      - in: query
+        name: offer
+        schema:
+          type: number
       - name: page
         required: false
         in: query
@@ -13310,6 +13314,10 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
+      - in: query
+        name: role
+        schema:
+          type: number
       tags:
       - npc-services
       security:
@@ -13630,6 +13638,14 @@ paths:
       operationId: npc_services_permit_details_list
       description: Staff CRUD for permit offer details (1:1 to an NPCServiceOffer).
       parameters:
+      - in: query
+        name: building_kind
+        schema:
+          type: number
+      - in: query
+        name: offer
+        schema:
+          type: number
       - name: page
         required: false
         in: query

--- a/src/world/npc_services/filters.py
+++ b/src/world/npc_services/filters.py
@@ -2,7 +2,14 @@
 
 import django_filters
 
-from world.npc_services.models import NPCRole, NPCServiceOffer, NPCStanding, OfferCooldown
+from world.npc_services.models import (
+    MissionOfferDetails,
+    NPCRole,
+    NPCServiceOffer,
+    NPCStanding,
+    OfferCooldown,
+    PermitOfferDetails,
+)
 
 
 class NPCStandingFilterSet(django_filters.FilterSet):
@@ -41,4 +48,22 @@ class OfferCooldownFilterSet(django_filters.FilterSet):
 
     class Meta:
         model = OfferCooldown
+        fields: list[str] = []
+
+
+class MissionOfferDetailsFilterSet(django_filters.FilterSet):
+    offer = django_filters.NumberFilter(field_name="offer_id")
+    role = django_filters.NumberFilter(field_name="role_id")
+
+    class Meta:
+        model = MissionOfferDetails
+        fields: list[str] = []
+
+
+class PermitOfferDetailsFilterSet(django_filters.FilterSet):
+    offer = django_filters.NumberFilter(field_name="offer_id")
+    building_kind = django_filters.NumberFilter(field_name="building_kind_id")
+
+    class Meta:
+        model = PermitOfferDetails
         fields: list[str] = []

--- a/src/world/npc_services/tests/test_api_mission_details.py
+++ b/src/world/npc_services/tests/test_api_mission_details.py
@@ -75,6 +75,22 @@ class MissionOfferDetailsViewSetTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
+    def test_filter_by_role_scopes_results(self) -> None:
+        """?role= scopes to one role's details (the FE editor relies on it)."""
+        MissionOfferDetailsFactory(offer=self._make_mission_offer(), mission_template=self.template)
+        other_role = NPCRoleFactory(name="other-role")
+        other_offer = NPCServiceOfferFactory(
+            role=other_role, kind=OfferKind.MISSION, label="other-offer"
+        )
+        MissionOfferDetailsFactory(
+            offer=other_offer, mission_template=MissionTemplateFactory(name="other-template")
+        )
+
+        response = self.client.get(self.URL, {"role": self.role.pk})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["role"], self.role.pk)
+
     def test_create_round_trip(self) -> None:
         offer = self._make_mission_offer()
         response = self.client.post(

--- a/src/world/npc_services/views.py
+++ b/src/world/npc_services/views.py
@@ -21,10 +21,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from world.npc_services.filters import (
+    MissionOfferDetailsFilterSet,
     NPCRoleFilterSet,
     NPCServiceOfferFilterSet,
     NPCStandingFilterSet,
     OfferCooldownFilterSet,
+    PermitOfferDetailsFilterSet,
 )
 from world.npc_services.models import (
     MissionOfferDetails,
@@ -122,6 +124,8 @@ class PermitOfferDetailsViewSet(viewsets.ModelViewSet):
     serializer_class = PermitOfferDetailsSerializer
     permission_classes = [IsAuthenticated, IsAdminUser]
     pagination_class = NPCServicesPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = PermitOfferDetailsFilterSet
 
 
 class MissionOfferDetailsViewSet(viewsets.ModelViewSet):
@@ -139,6 +143,8 @@ class MissionOfferDetailsViewSet(viewsets.ModelViewSet):
     serializer_class = MissionOfferDetailsSerializer
     permission_classes = [IsAuthenticated, IsAdminUser]
     pagination_class = NPCServicesPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = MissionOfferDetailsFilterSet
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Mission Studio — NPC roles + service offers editor (core)

Replaces the D3 giver pages (`GiverLibraryPage` / `GiverEditorPage`) deleted in #686 with a staff editor built on the **unified npc-services surface** that #686 shipped. Until now, NPC-mediated mission authoring was Django-admin-only.

### What's in this PR

New `frontend/src/npc_services/` module:
- **Data layer** (`types.ts` / `api.ts` / `queries.ts`) over the shipped `/api/npc-services/{roles,offers,mission-details}` endpoints — typed off the generated OpenAPI schema, reusing the Mission Studio `ApiValidationError` / `flattenErrorMessage` helpers so DRF errors surface identically.
- **Role library page** (`/staff/npc-services/roles`) — list + name search + inline create, links into the editor. Replaces `GiverLibraryPage`.
- **Role editor page** (`/staff/npc-services/roles/:id`) — replaces `GiverEditorPage`:
  - Role fields (name, description, default description template, default rapport, faction affiliation) with save + delete.
  - **Offers section** — add/edit/delete **mission** and **permit** offers; attaching a mission template creates the `MissionOfferDetails` row; edit `label` / `draw_mode` / `rapport_requirement` / `is_final` / `weight`; an **eligibility-rule `PredicateBuilder`** (reused from missions) with validate-on-save.
- **Routing** + a **Staff Hub** "NPC Services" nav card.

### Testing
`pnpm typecheck` + `pnpm lint` (0 errors) + `pnpm build` all green.

### Scope note (`Refs #728`, not `Closes`)
This is the **core editor** — the main "replace the deleted giver pages" goal. Deliberately deferred for a follow-up (so this stays a reviewable unit and you can steer the advanced UX): the secondary offer knobs (`rapport_delta_success/failure`, `check_type`/`check_difficulty`, `cooldown`, `requirements_override` predicate, `role_cooldown_duration`), a dedicated permit-details panel, the faction filter, and per-role offer counts. None are blocking — the editor can create roles and mission/permit offers and attach templates today.

One assumption worth a look in review: the eligibility-rule editor reuses the **missions** predicate-leaf catalog (`usePredicateLeaves`) — the only one available. If npc-services offers should validate against a different leaf set, that's a small swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
