### PR TITLE
chore: regen API types for #896's action_interaction (unblocks api-types-drift on all PRs)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -19899,6 +19899,8 @@ export interface components {
       readonly resolved_difficulty: number | null;
       /** @description The interaction recording the result of this action */
       readonly result_interaction: number | null;
+      /** @description ACTION-mode Interaction for this cast (carries the power ledger). */
+      readonly action_interaction: number | null;
       /** @description Extra anima the player commits beyond base cost. Bounded by available anima at resolution time. */
       strain_commitment?: number;
       /** @description Risk level of the encounter a PENDING hostile cast would pull the target into (#777). */

--- a/src/schema.json
+++ b/src/schema.json
@@ -36141,6 +36141,11 @@ components:
           readOnly: true
           nullable: true
           description: The interaction recording the result of this action
+        action_interaction:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: ACTION-mode Interaction for this cast (carries the power ledger).
         strain_commitment:
           type: integer
           maximum: 2147483647
@@ -36164,6 +36169,7 @@ components:
           nullable: true
           description: When this action was resolved
       required:
+      - action_interaction
       - combat_risk_level
       - created_at
       - id


### PR DESCRIPTION
## Why every PR is suddenly failing `api-types-drift`

Merge order this afternoon: #891 added the `api-types-drift` CI gate → #896 added `SceneActionRequest.action_interaction` to the cast API **without regenerating types** (its last CI run predated the gate, so it merged green). Main's committed `schema.json` / `api.d.ts` are now stale, and **every PR that branches from or updates to current main fails the gate** — currently #897 and #900; #899 will too on its next update.

## Fix

Pure `just gen-api-types` output, nothing hand-edited: the `action_interaction` readonly field (+2 lines `api.d.ts`, +6 lines `schema.json`) — byte-identical to the drift CI reports. Frontend build (`tsc -b`) green locally.

**Merge this first** — then the other open PRs just need an update-from-main to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)