### PR TITLE
chore(#942): delete dead per-pool AP regen methods; stamp last_daily_regen in batch

### DIFF
--- a/src/world/action_points/models.py
+++ b/src/world/action_points/models.py
@@ -9,7 +9,6 @@ via cron (daily per game day, weekly).
 from __future__ import annotations
 
 from django.db import models, transaction
-from django.utils import timezone
 from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 
@@ -284,53 +283,6 @@ class ActionPointPool(SharedMemoryModel):
                 self.current = pool.current
 
         return actually_added
-
-    def apply_daily_regen(self) -> int:
-        """
-        Apply daily regeneration and update timestamp.
-
-        Called by cron job for daily AP regeneration.
-        Uses select_for_update to prevent race conditions.
-        Applies character modifiers (e.g., Indolent reduces regen, Efficient increases cap).
-
-        Returns:
-            Amount actually added (may be less if near maximum or 0 if modifiers reduce to 0).
-        """
-        base_regen = ActionPointConfig.get_daily_regen()
-        regen_modifier = self._get_ap_modifier("ap_daily_regen")
-        regen_amount = max(0, base_regen + regen_modifier)  # Floor at 0
-        effective_max = self.get_effective_maximum()
-
-        with transaction.atomic():
-            pool = ActionPointPool.objects.select_for_update().get(pk=self.pk)
-
-            space_available = effective_max - pool.current
-            actually_added = min(regen_amount, max(0, space_available))
-
-            pool.current += actually_added
-            pool.last_daily_regen = timezone.now()
-            pool.save(update_fields=["current", "last_daily_regen"])
-
-            self.current = pool.current
-            self.last_daily_regen = pool.last_daily_regen
-
-        return actually_added
-
-    def apply_weekly_regen(self) -> int:
-        """
-        Apply weekly regeneration.
-
-        Called by cron job for weekly AP regeneration.
-        Uses select_for_update to prevent race conditions.
-        Applies character modifiers (e.g., Indolent reduces regen, Efficient increases cap).
-
-        Returns:
-            Amount actually added (may be less if near maximum or 0 if modifiers reduce to 0).
-        """
-        base_regen = ActionPointConfig.get_weekly_regen()
-        regen_modifier = self._get_ap_modifier("ap_weekly_regen")
-        regen_amount = max(0, base_regen + regen_modifier)  # Floor at 0
-        return self.regenerate(regen_amount)
 
     def can_afford(self, amount: int) -> bool:
         """Check if character has enough current AP to spend."""

--- a/src/world/action_points/tests/test_models.py
+++ b/src/world/action_points/tests/test_models.py
@@ -468,105 +468,6 @@ class ActionPointPoolGetOrCreateTests(ActionPointPoolTestCase):
         assert pool.current == 300
 
 
-class ActionPointPoolApplyDailyRegenTests(ActionPointPoolTestCase):
-    """Tests for ActionPointPool.apply_daily_regen method."""
-
-    @classmethod
-    def setUpTestData(cls):
-        """Set up test data."""
-        cls.character = CharacterFactory()
-
-    def test_apply_daily_regen_adds_ap(self):
-        """apply_daily_regen adds configured daily amount."""
-        ActionPointConfigFactory(daily_regen=10, is_active=True)
-        pool = ActionPointPoolFactory(character=self.character, current=100, maximum=200)
-        old_timestamp = pool.last_daily_regen
-
-        added = pool.apply_daily_regen()
-
-        assert added == 10
-        pool.refresh_from_db()
-        assert pool.current == 110
-        assert pool.last_daily_regen > old_timestamp
-
-    def test_apply_daily_regen_capped_at_maximum(self):
-        """apply_daily_regen caps at maximum."""
-        ActionPointConfigFactory(daily_regen=10, is_active=True)
-        pool = ActionPointPoolFactory(character=self.character, current=195, maximum=200)
-
-        added = pool.apply_daily_regen()
-
-        assert added == 5
-        pool.refresh_from_db()
-        assert pool.current == 200
-
-    def test_apply_daily_regen_at_maximum(self):
-        """apply_daily_regen adds nothing when at maximum but still updates timestamp."""
-        ActionPointConfigFactory(daily_regen=10, is_active=True)
-        pool = ActionPointPoolFactory(character=self.character, current=200, maximum=200)
-        old_timestamp = pool.last_daily_regen
-
-        added = pool.apply_daily_regen()
-
-        assert added == 0
-        pool.refresh_from_db()
-        assert pool.current == 200
-        assert pool.last_daily_regen > old_timestamp
-
-    def test_apply_daily_regen_uses_fallback(self):
-        """apply_daily_regen uses fallback when no active config."""
-        # No active config, fallback is 5
-        pool = ActionPointPoolFactory(character=self.character, current=100, maximum=200)
-
-        added = pool.apply_daily_regen()
-
-        assert added == 5
-        pool.refresh_from_db()
-        assert pool.current == 105
-
-
-class ActionPointPoolApplyWeeklyRegenTests(ActionPointPoolTestCase):
-    """Tests for ActionPointPool.apply_weekly_regen method."""
-
-    @classmethod
-    def setUpTestData(cls):
-        """Set up test data."""
-        cls.character = CharacterFactory()
-
-    def test_apply_weekly_regen_adds_ap(self):
-        """apply_weekly_regen adds configured weekly amount."""
-        ActionPointConfigFactory(weekly_regen=100, is_active=True)
-        pool = ActionPointPoolFactory(character=self.character, current=50, maximum=200)
-
-        added = pool.apply_weekly_regen()
-
-        assert added == 100
-        pool.refresh_from_db()
-        assert pool.current == 150
-
-    def test_apply_weekly_regen_capped_at_maximum(self):
-        """apply_weekly_regen caps at maximum."""
-        ActionPointConfigFactory(weekly_regen=100, is_active=True)
-        pool = ActionPointPoolFactory(character=self.character, current=150, maximum=200)
-
-        added = pool.apply_weekly_regen()
-
-        assert added == 50
-        pool.refresh_from_db()
-        assert pool.current == 200
-
-    def test_apply_weekly_regen_uses_fallback(self):
-        """apply_weekly_regen uses fallback when no active config."""
-        # No active config, fallback is 100
-        pool = ActionPointPoolFactory(character=self.character, current=50, maximum=200)
-
-        added = pool.apply_weekly_regen()
-
-        assert added == 100
-        pool.refresh_from_db()
-        assert pool.current == 150
-
-
 class ActionPointPoolModifierTests(ActionPointPoolTestCase):
     """Tests for AP modifier integration with the mechanics system."""
 
@@ -612,28 +513,11 @@ class ActionPointPoolModifierTests(ActionPointPoolTestCase):
         assert pool._get_ap_modifier("ap_daily_regen") == 0
 
     def test_positive_daily_modifier(self) -> None:
-        """Positive modifier increases daily regen."""
+        """Positive modifier is reflected in _get_ap_modifier totals."""
         self._create_ap_modifier(self.daily_target, 3)
-        ActionPointConfigFactory(daily_regen=5, is_active=True)
         pool = ActionPointPoolFactory(character=self.character, current=100, maximum=200)
 
-        added = pool.apply_daily_regen()
-
-        assert added == 8  # 5 base + 3 modifier
-        pool.refresh_from_db()
-        assert pool.current == 108
-
-    def test_negative_daily_modifier_floors_at_zero(self) -> None:
-        """Negative modifier can reduce regen to 0 but not below."""
-        self._create_ap_modifier(self.daily_target, -10)
-        ActionPointConfigFactory(daily_regen=5, is_active=True)
-        pool = ActionPointPoolFactory(character=self.character, current=100, maximum=200)
-
-        added = pool.apply_daily_regen()
-
-        assert added == 0  # max(0, 5 + -10) = 0
-        pool.refresh_from_db()
-        assert pool.current == 100
+        assert pool._get_ap_modifier("ap_daily_regen") == 3
 
     def test_maximum_modifier_increases_effective_max(self) -> None:
         """AP maximum modifier increases effective maximum."""
@@ -645,27 +529,11 @@ class ActionPointPoolModifierTests(ActionPointPoolTestCase):
         assert effective_max == 300  # 200 base + 100 modifier
 
     def test_weekly_modifier_applied(self) -> None:
-        """Weekly regen applies modifier from distinctions."""
+        """Weekly modifier is reflected in _get_ap_modifier totals."""
         self._create_ap_modifier(self.weekly_target, 20)
-        ActionPointConfigFactory(weekly_regen=100, is_active=True)
         pool = ActionPointPoolFactory(character=self.character, current=50, maximum=200)
 
-        added = pool.apply_weekly_regen()
-
-        assert added == 120  # 100 base + 20 modifier
-        pool.refresh_from_db()
-        assert pool.current == 170
-
-    def test_daily_regen_uses_base_rate_without_modifiers(self) -> None:
-        """Daily regen uses base rate when no modifiers exist."""
-        ActionPointConfigFactory(daily_regen=5, is_active=True)
-        pool = ActionPointPoolFactory(character=self.character, current=100, maximum=200)
-
-        added = pool.apply_daily_regen()
-
-        assert added == 5
-        pool.refresh_from_db()
-        assert pool.current == 105
+        assert pool._get_ap_modifier("ap_weekly_regen") == 20
 
     def test_effective_maximum_minimum_is_one(self) -> None:
         """Effective maximum floors at 1 even with large negative modifier."""

--- a/src/world/action_points/tests/test_models.py
+++ b/src/world/action_points/tests/test_models.py
@@ -544,17 +544,12 @@ class ActionPointPoolModifierTests(ActionPointPoolTestCase):
 
         assert effective_max == 1
 
-    def test_regen_without_sheet_uses_base(self) -> None:
-        """Characters without a CharacterSheet regenerate at base rate."""
-        ActionPointConfigFactory(daily_regen=5, is_active=True)
+    def test_modifier_without_sheet_is_zero(self) -> None:
+        """Characters without a CharacterSheet have no modifiers (base rate)."""
         character_no_sheet = CharacterFactory()
         pool = ActionPointPoolFactory(character=character_no_sheet, current=100, maximum=200)
 
-        added = pool.apply_daily_regen()
-
-        assert added == 5
-        pool.refresh_from_db()
-        assert pool.current == 105
+        assert pool._get_ap_modifier("ap_daily_regen") == 0
 
     def test_unknown_target_returns_zero(self) -> None:
         """Unknown modifier target name returns 0."""

--- a/src/world/game_clock/tasks.py
+++ b/src/world/game_clock/tasks.py
@@ -104,7 +104,7 @@ def _fetch_ap_modifier_map(
     return mod_lookup, target_pk_map
 
 
-def _apply_ap_regen(regen_target_name: str, base_regen: int) -> int:
+def _apply_ap_regen(regen_target_name: str, base_regen: int, *, stamp_daily: bool = False) -> int:
     """Shared batch regen logic for daily and weekly AP regeneration.
 
     Fetches all pools, computes per-character effective regen/max with modifiers,
@@ -112,7 +112,13 @@ def _apply_ap_regen(regen_target_name: str, base_regen: int) -> int:
 
     Protagonism-locked characters (terminal corruption stage 5) are skipped
     silently — their AP does not regenerate while subsumed.
+
+    With ``stamp_daily``, regenerated pools also get ``last_daily_regen``
+    set to now (admin-display field; the scheduler's ScheduledTaskRecord
+    remains the authoritative timing record).
     """
+    from django.utils import timezone
+
     from world.action_points.models import ActionPointPool
     from world.conditions.models import ConditionInstance
 
@@ -149,22 +155,27 @@ def _apply_ap_regen(regen_target_name: str, base_regen: int) -> int:
         to_update.append(pool)
 
     if to_update:
-        ActionPointPool.objects.bulk_update(to_update, ["current"], batch_size=500)
+        fields = ["current"]
+        if stamp_daily:
+            now = timezone.now()
+            for pool in to_update:
+                pool.last_daily_regen = now
+            fields.append("last_daily_regen")
+        ActionPointPool.objects.bulk_update(to_update, fields, batch_size=500)
     return len(to_update)
 
 
 def batch_ap_daily_regen() -> None:
     """Apply daily AP regen to all character pools.
 
-    Note: per-pool ``last_daily_regen`` is updated separately from the batch
-    bulk_update. The scheduler's ``ScheduledTaskRecord.last_run_at`` is the
-    authoritative timing record; the pool-level timestamp is for admin display
-    only and is set by the model-level ``apply_daily_regen()`` method.
+    The scheduler's ``ScheduledTaskRecord.last_run_at`` is the authoritative
+    timing record; the pool-level ``last_daily_regen`` stamped here is for
+    admin display only.
     """
     from world.action_points.models import ActionPointConfig
 
     base_regen = ActionPointConfig.get_daily_regen()
-    count = _apply_ap_regen("ap_daily_regen", base_regen)
+    count = _apply_ap_regen("ap_daily_regen", base_regen, stamp_daily=True)
     logger.info("AP daily regen: %d pools regenerated", count)
 
 

--- a/src/world/game_clock/tests/test_tasks.py
+++ b/src/world/game_clock/tests/test_tasks.py
@@ -91,6 +91,19 @@ class BatchApDailyRegenTests(TestCase):
         pool.refresh_from_db()
         self.assertEqual(pool.current, 200)
 
+    def test_daily_regen_stamps_timestamp(self) -> None:
+        """Regenerated pools get last_daily_regen stamped (admin display)."""
+        from world.action_points.factories import ActionPointPoolFactory
+
+        pool = ActionPointPoolFactory(character=self.character, current=100, maximum=200)
+        old_timestamp = pool.last_daily_regen
+
+        batch_ap_daily_regen()
+
+        pool.refresh_from_db()
+        self.assertEqual(pool.current, 105)
+        self.assertGreater(pool.last_daily_regen, old_timestamp)
+
     def test_regen_with_positive_modifier(self) -> None:
         """Positive modifier increases regen amount in batch."""
         from world.action_points.factories import ActionPointPoolFactory


### PR DESCRIPTION
Closes #942.

## Summary
- Deletes `ActionPointPool.apply_daily_regen()` / `.apply_weekly_regen()` — both claimed "called by cron job" but the scheduler's `batch_ap_daily_regen`/`batch_ap_weekly_regen` use the `_apply_ap_regen()` bulk path exclusively. The bulk path is also strictly superior: it skips protagonism-locked sheets, which the per-pool methods never did.
- The one real behavior the deleted method carried — stamping the admin-display `last_daily_regen` timestamp — moves into the daily batch (`stamp_daily=True` on `_apply_ap_regen`), so the admin field keeps updating after deletion.
- Fixes the stale docstring in `game_clock/tasks.py` that pointed at the deleted method.
- Tests: drops the two per-pool test classes + the modifier tests that routed through them (the batch path already has equivalent coverage in `game_clock/tests/test_tasks.py`, including modifiers and protagonism-lock); rewrites two modifier tests to target `_get_ap_modifier` directly; adds a batch-side timestamp-stamping test.

## Verification
Per Apostate's conditional ruling on #942 (delete only if redundant with the real regen path): the cron tasks are registered at server start (`register_all_tasks`, GameTickScript) and regen via the bulk path — the per-pool methods were redundant duplicates, not placeholders.

`uv run arx test world.action_points world.game_clock` — 156 tests, green. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)