### PR TITLE
feat(#906): pemit GM surface — staff-only private narrative emit

### DIFF
--- a/src/actions/definitions/communication.py
+++ b/src/actions/definitions/communication.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from actions.base import Action
 from actions.constants import ActionCategory, TargetKind
+from actions.prerequisites import Prerequisite, StaffOnlyPrerequisite
 from actions.types import ActionContext, ActionResult, TargetFilters, TargetType
 from flows.scene_data_manager import SceneDataManager
 from flows.service_functions.communication import message_location, send_message
@@ -186,6 +187,71 @@ class EmitAction(Action):
             mode=InteractionMode.EMIT,
             target_personas=target_personas,
             place=place,
+        )
+
+        return ActionResult(success=True)
+
+
+@dataclass
+class PemitAction(Action):
+    """Staff-only private narrative emit to an explicit receiver list (#906).
+
+    The Arx 1 "pemit": GM narration delivered only to the listed characters.
+    Rides the receiver-scoped EMIT path — the persisted interaction carries
+    receiver rows, so the feed shows it only to those receivers (and the
+    scene log never shows more than the room heard). Works inside scenes
+    (record_interaction resolves the active scene from the room) and at
+    room level outside scenes (persists scene-less), per the #906 ruling.
+    """
+
+    key: str = "pemit"
+    name: str = "Private Emit"
+    icon: str = "scroll"
+    category: str = "communication"
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.AREA
+
+    intent_event: str | None = "before_pemit"
+    result_event: str | None = "pemit"
+
+    def get_prerequisites(self) -> list[Prerequisite]:
+        return [StaffOnlyPrerequisite()]
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from core_management.permissions import is_staff_observer  # noqa: PLC0415
+
+        # run() does not evaluate prerequisites; enforce the gate here too.
+        if not is_staff_observer(actor):
+            return ActionResult(success=False, message="Staff only.")
+
+        text = kwargs.get("text", "")
+        receivers: list[ObjectDB] = kwargs.get("receivers", [])
+        if not text:
+            return ActionResult(success=False, message="Pemit what?")
+        if not receivers:
+            return ActionResult(success=False, message="Pemit to whom?")
+
+        receiver_personas = _characters_to_active_personas(receivers)
+        if receiver_personas is None:
+            return ActionResult(success=False, message="No valid receivers found.")
+
+        sdm = context.scene_data if context else SceneDataManager()
+
+        # Direct delivery to each receiver only — never the whole room.
+        for receiver in receivers:
+            receiver_state = sdm.initialize_state_for_object(receiver)
+            send_message(receiver_state, text)
+
+        record_interaction(
+            character=actor,
+            content=text,
+            mode=InteractionMode.EMIT,
+            receivers=receiver_personas,
         )
 
         return ActionResult(success=True)

--- a/src/actions/prerequisites.py
+++ b/src/actions/prerequisites.py
@@ -28,3 +28,20 @@ class Prerequisite:
         context: dict | None = None,
     ) -> tuple[bool, str]:
         raise NotImplementedError
+
+
+@dataclass
+class StaffOnlyPrerequisite(Prerequisite):
+    """The actor's account must be staff (GM tooling gate)."""
+
+    def is_met(
+        self,
+        actor: ObjectDB,
+        target: ObjectDB | None = None,
+        context: dict | None = None,
+    ) -> tuple[bool, str]:
+        from core_management.permissions import is_staff_observer  # noqa: PLC0415
+
+        if is_staff_observer(actor):
+            return True, ""
+        return False, "Staff only."

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from actions.base import Action
-from actions.definitions.communication import PoseAction, SayAction, WhisperAction
+from actions.definitions.communication import (
+    PemitAction,
+    PoseAction,
+    SayAction,
+    WhisperAction,
+)
 from actions.definitions.items import (
     ActivatePermitAction,
     EquipAction,
@@ -30,6 +35,7 @@ _ALL_ACTIONS: list[Action] = [
     SayAction(),
     PoseAction(),
     WhisperAction(),
+    PemitAction(),
     GetAction(),
     DropAction(),
     GiveAction(),

--- a/src/actions/tests/test_actions.py
+++ b/src/actions/tests/test_actions.py
@@ -147,6 +147,104 @@ class WhisperActionTests(TestCase):
         assert result.success is False
 
 
+class PemitActionTests(TestCase):
+    """Staff-only private narrative emit (#906)."""
+
+    def _staff_actor(self, room):
+        account = AccountFactory(username="pemit_staff", is_staff=True)
+        actor = ObjectDBFactory(
+            db_key="GM",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        actor.db_account = account
+        actor.save()
+        return actor
+
+    def test_pemit_delivers_to_receivers_only(self):
+        from actions.definitions.communication import PemitAction
+
+        room = ObjectDBFactory(db_key="Room", db_typeclass_path="typeclasses.rooms.Room")
+        actor = self._staff_actor(room)
+        receiver = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        bystander = ObjectDBFactory(
+            db_key="Eve",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        action = PemitAction()
+        with (
+            patch.object(receiver, "msg") as recv_msg,
+            patch.object(bystander, "msg") as bystander_msg,
+        ):
+            result = action.run(actor, receivers=[receiver], text="A chill wind finds you.")
+        assert result.success is True
+        recv_msg.assert_called_once()
+        bystander_msg.assert_not_called()
+
+    def test_pemit_rejects_non_staff(self):
+        from actions.definitions.communication import PemitAction
+
+        room = ObjectDBFactory(db_key="Room", db_typeclass_path="typeclasses.rooms.Room")
+        account = AccountFactory(username="pemit_player", is_staff=False)
+        actor = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        actor.db_account = account
+        actor.save()
+        receiver = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        action = PemitAction()
+        result = action.run(actor, receivers=[receiver], text="sneaky")
+        assert result.success is False
+        assert "Staff only" in result.message
+
+    def test_pemit_availability_requires_staff(self):
+        from actions.definitions.communication import PemitAction
+
+        room = ObjectDBFactory(db_key="Room", db_typeclass_path="typeclasses.rooms.Room")
+        account = AccountFactory(username="pemit_player2", is_staff=False)
+        actor = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        actor.db_account = account
+        actor.save()
+        availability = PemitAction().check_availability(actor)
+        assert availability.available is False
+
+    def test_pemit_without_receivers_fails(self):
+        from actions.definitions.communication import PemitAction
+
+        room = ObjectDBFactory(db_key="Room", db_typeclass_path="typeclasses.rooms.Room")
+        actor = self._staff_actor(room)
+        result = PemitAction().run(actor, receivers=[], text="to no one")
+        assert result.success is False
+
+    def test_pemit_without_text_fails(self):
+        from actions.definitions.communication import PemitAction
+
+        room = ObjectDBFactory(db_key="Room", db_typeclass_path="typeclasses.rooms.Room")
+        actor = self._staff_actor(room)
+        receiver = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        result = PemitAction().run(actor, receivers=[receiver], text="")
+        assert result.success is False
+
+
 class GetActionTests(TestCase):
     def test_get_moves_item_to_actor(self):
         room = ObjectDBFactory(

--- a/src/actions/tests/test_actions.py
+++ b/src/actions/tests/test_actions.py
@@ -171,6 +171,7 @@ class PemitActionTests(TestCase):
             db_typeclass_path="typeclasses.characters.Character",
             location=room,
         )
+        CharacterSheetFactory(character=receiver)
         bystander = ObjectDBFactory(
             db_key="Eve",
             db_typeclass_path="typeclasses.characters.Character",

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -145,6 +145,7 @@ class ActionRegistryTests(TestCase):
             "say",
             "pose",
             "whisper",
+            "pemit",
             "get",
             "drop",
             "give",

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -25,6 +25,7 @@ from commands.evennia_overrides.builder import CmdDig, CmdLink, CmdOpen, CmdUnli
 from commands.evennia_overrides.communication import (
     CmdEmit,
     CmdPage,
+    CmdPemit,
     CmdPose,
     CmdSay,
     CmdTabletalk,
@@ -89,6 +90,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdWhisper())
         self.add(CmdPose())
         self.add(CmdEmit())
+        self.add(CmdPemit())
         self.add(CmdTabletalk())
         self.add(CmdLock())
         self.add(CmdUnlock())

--- a/src/commands/evennia_overrides/communication.py
+++ b/src/commands/evennia_overrides/communication.py
@@ -8,7 +8,13 @@ from django.core.exceptions import ObjectDoesNotExist
 from evennia import Command
 from evennia.utils import search
 
-from actions.definitions.communication import EmitAction, PoseAction, SayAction, WhisperAction
+from actions.definitions.communication import (
+    EmitAction,
+    PemitAction,
+    PoseAction,
+    SayAction,
+    WhisperAction,
+)
 from commands.command import ArxCommand
 from commands.exceptions import CommandError
 from commands.frontend import FrontendMetadataMixin
@@ -174,6 +180,41 @@ class CmdPose(ArxCommand):
         if targets:
             result["targets"] = targets
         return result
+
+
+class CmdPemit(ArxCommand):
+    """Staff-only private narrative emit to specific characters (#906).
+
+    Usage: pemit <name>[,<name>...]=<text>
+
+    Delivers GM narration only to the listed characters; the persisted
+    interaction is receiver-scoped, so nobody else (or the log) sees more
+    than the receivers heard. Works in and out of scenes.
+    """
+
+    key = "pemit"
+    locks = "cmd:perm(Builder)"
+    action = PemitAction()
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        args = (self.args or "").strip()
+        if "=" not in args:
+            msg = "Usage: pemit <name>[,<name>...]=<text>"
+            raise CommandError(msg)
+        names_part, text = args.split("=", 1)
+        text = text.strip()
+        names = [n.strip() for n in names_part.split(",") if n.strip()]
+        if not names or not text:
+            msg = "Usage: pemit <name>[,<name>...]=<text>"
+            raise CommandError(msg)
+        receivers = []
+        for name in names:
+            target = self.caller.search(name)
+            if not target:
+                msg = f"Could not find '{name}'."
+                raise CommandError(msg)
+            receivers.append(target)
+        return {"receivers": receivers, "text": text}
 
 
 class CmdEmit(ArxCommand):


### PR DESCRIPTION
Closes #906.

## Summary
- `PemitAction` (`pemit` key, registered for web dispatch): staff-gated private narrative emit to an explicit character list. Content delivers ONLY to the listed receivers and persists as a receiver-scoped `EMIT` interaction — the feed/log shows it only to those receivers (#900 receiver scoping), upholding the invariant that the persisted log never shows more than what was heard.
- **Scenes + room-level per Apostate's ruling**: `record_interaction` resolves the active scene from the actor's room; with no active scene the interaction persists scene-less, so GM narration to one player works anywhere. Ephemeral scenes keep their push-only/never-persist behavior.
- Staff gate enforced twice: `StaffOnlyPrerequisite` (new, reusable — drives `check_availability` so the action only surfaces for staff) AND an inline `is_staff_observer` check in `execute` (since `run()` doesn't evaluate prerequisites).
- Telnet: `pemit <name>[,<name>...]=<text>` behind `cmd:perm(Builder)`.

## Scene-UI affordance
Deferred to #907 (whisper receiver picker) — pemit's web affordance needs the same multi-recipient picker that #907 builds for whisper delivery; building it twice would be a parallel implementation. Noted on the issue.

## Tests
`uv run arx test actions commands` — 303 tests, green. New coverage: receiver-only delivery (bystander gets nothing), non-staff rejection at execute AND availability, empty-text/empty-receivers failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)