### PR TITLE
feat(#930): the family books screen — shelf, composite ledger UI, mixed-form currency

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -153,6 +153,22 @@ const CovenantDetailPage = lazy(() =>
 );
 
 // ---------------------------------------------------------------------------
+// Lazy-loaded org books pages (#930)
+// ---------------------------------------------------------------------------
+
+const BooksShelfPage = lazy(() =>
+  import('@/org_books/pages/BooksShelfPage').then((m) => ({
+    default: m.BooksShelfPage,
+  }))
+);
+
+const OrgBooksPage = lazy(() =>
+  import('@/org_books/pages/OrgBooksPage').then((m) => ({
+    default: m.OrgBooksPage,
+  }))
+);
+
+// ---------------------------------------------------------------------------
 // Lazy-loaded rituals pages
 // ---------------------------------------------------------------------------
 
@@ -706,6 +722,30 @@ function App() {
             <Suspense fallback={<PageLoadingFallback />}>
               <ProtectedRoute>
                 <CovenantDetailPage />
+              </ProtectedRoute>
+            </Suspense>
+          }
+        />
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Org books — the family-books / management screen (#930)            */}
+        {/* ------------------------------------------------------------------ */}
+        <Route
+          path="/books"
+          element={
+            <Suspense fallback={<PageLoadingFallback />}>
+              <ProtectedRoute>
+                <BooksShelfPage />
+              </ProtectedRoute>
+            </Suspense>
+          }
+        />
+        <Route
+          path="/books/:orgId"
+          element={
+            <Suspense fallback={<PageLoadingFallback />}>
+              <ProtectedRoute>
+                <OrgBooksPage />
               </ProtectedRoute>
             </Suspense>
           }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -25,7 +25,10 @@ const links = [
 ];
 
 /** Nav links visible only to authenticated users (account != null). */
-const authLinks = [{ to: '/stories/my-active', label: 'My Stories' }];
+const authLinks = [
+  { to: '/stories/my-active', label: 'My Stories' },
+  { to: '/books', label: 'Books' },
+];
 
 export function Header() {
   const account = useAppSelector((state) => state.auth.account);

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -3123,6 +3123,29 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/currency/org-books/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description GET /org-books/{org_id}/ — the member-visible books.
+     *
+     *     The list endpoint is the viewer's own shelf — only orgs the presented
+     *     persona belongs to, never a browse of all orgs (the diegetic posture
+     *     mirrors RankingDisplayViewSet).
+     */
+    get: operations['currency_org_books_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/currency/org-books/{id}/': {
     parameters: {
       query?: never;
@@ -3131,10 +3154,11 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * @description Retrieve-only: GET /org-books/{org_id}/ — the member-visible books.
+     * @description GET /org-books/{org_id}/ — the member-visible books.
      *
-     *     No list endpoint: books are reached from an org you belong to, not
-     *     browsed. Mirrors RankingDisplayViewSet's diegetic posture.
+     *     The list endpoint is the viewer's own shelf — only orgs the presented
+     *     persona belongs to, never a browse of all orgs (the diegetic posture
+     *     mirrors RankingDisplayViewSet).
      */
     get: operations['currency_org_books_retrieve'];
     put?: never;
@@ -13435,6 +13459,7 @@ export interface components {
       | 'fatigue'
       | 'strain';
     ContributionRow: {
+      id: number;
       persona_name: string;
       amount: number;
       reason: string;
@@ -13638,6 +13663,7 @@ export interface components {
       readonly icon: string;
     };
     DebtRow: {
+      id: number;
       creditor: string;
       principal: number;
       arrears: number;
@@ -15045,6 +15071,7 @@ export interface components {
       readonly minimum_tier: number;
     };
     IncomeStreamRow: {
+      id: number;
       name: string;
       kind: string;
       gross_amount: number;
@@ -15433,6 +15460,7 @@ export interface components {
       compass_anywhere: boolean;
     };
     LedgerRow: {
+      id: number;
       amount: number;
       reason: string;
       direction: string;
@@ -16172,6 +16200,13 @@ export interface components {
       /** @description Whether this modifier target is currently active in the game */
       is_active?: boolean;
     };
+    /** @description One organization whose books the viewer may open. */
+    MyBooksRow: {
+      organization_id: number;
+      organization_name: string;
+      rank: number;
+      rank_title: string;
+    };
     /** @description Serialize a summary of a roster entry for account menus. */
     MyRosterEntry: {
       readonly id: number;
@@ -16379,6 +16414,7 @@ export interface components {
     /** @enum {unknown} */
     NullEnum: null;
     ObligationRow: {
+      id: number;
       name: string;
       to_organization: string;
       percent: number;
@@ -26007,6 +26043,25 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['CovenantRole'];
+        };
+      };
+    };
+  };
+  currency_org_books_list: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MyBooksRow'][];
         };
       };
     };

--- a/frontend/src/lib/__tests__/currency.test.ts
+++ b/frontend/src/lib/__tests__/currency.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { formatCoppers } from '../currency';
+
+describe('formatCoppers', () => {
+  it('formats zero as 0c', () => {
+    expect(formatCoppers(0)).toBe('0c');
+  });
+
+  it('formats pure copper', () => {
+    expect(formatCoppers(7)).toBe('7c');
+  });
+
+  it('formats silver and copper', () => {
+    expect(formatCoppers(47)).toBe('4s 7c');
+  });
+
+  it('formats the full mixed form', () => {
+    expect(formatCoppers(347)).toBe('3g 4s 7c');
+  });
+
+  it('omits zero components', () => {
+    expect(formatCoppers(300)).toBe('3g');
+    expect(formatCoppers(305)).toBe('3g 5c');
+    expect(formatCoppers(40)).toBe('4s');
+  });
+
+  it('groups large gold amounts', () => {
+    expect(formatCoppers(300_000)).toBe('3,000g');
+    expect(formatCoppers(1_000_000)).toBe('10,000g');
+  });
+
+  it('marks negative amounts', () => {
+    expect(formatCoppers(-1_234)).toBe('-12g 3s 4c');
+  });
+});

--- a/frontend/src/lib/currency.ts
+++ b/frontend/src/lib/currency.ts
@@ -1,0 +1,29 @@
+/**
+ * Currency display helpers.
+ *
+ * All backend money is integer coppers (the single base unit). The canonical
+ * display rule is the mixed form — "3g 4s 7c" — and the system always does
+ * the arithmetic: players never see raw copper totals they have to convert.
+ * Ladder: 10c = 1s, 100c = 1g. Named instruments above gold (Gold Knight,
+ * Baroness, ...) are physical items, not display units; ledgers read in gold.
+ */
+
+const COPPERS_PER_SILVER = 10;
+const COPPERS_PER_GOLD = 100;
+
+/** Format integer coppers as the canonical mixed form, e.g. "3g 4s 7c". */
+export function formatCoppers(coppers: number): string {
+  const negative = coppers < 0;
+  const total = Math.abs(Math.trunc(coppers));
+
+  const gold = Math.floor(total / COPPERS_PER_GOLD);
+  const silver = Math.floor((total % COPPERS_PER_GOLD) / COPPERS_PER_SILVER);
+  const copper = total % COPPERS_PER_SILVER;
+
+  const parts: string[] = [];
+  if (gold > 0) parts.push(`${gold.toLocaleString('en-US')}g`);
+  if (silver > 0) parts.push(`${silver}s`);
+  if (copper > 0 || parts.length === 0) parts.push(`${copper}c`);
+
+  return `${negative ? '-' : ''}${parts.join(' ')}`;
+}

--- a/frontend/src/org_books/api.ts
+++ b/frontend/src/org_books/api.ts
@@ -1,0 +1,52 @@
+/**
+ * Org books API functions (#930 — the family-books / management screen).
+ *
+ * Covers OrgBooksViewSet (/api/currency/org-books/):
+ *   - list: the viewer's own shelf — orgs their presented persona belongs to
+ *   - retrieve: the member-visible books for one org
+ *
+ * Uses apiFetch from @/evennia_replacements/api.
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+import type { components } from '@/generated/api';
+
+// ---------------------------------------------------------------------------
+// Generated type aliases
+// ---------------------------------------------------------------------------
+
+export type OrgBooks = components['schemas']['OrgBooks'];
+export type MyBooksRow = components['schemas']['MyBooksRow'];
+export type IncomeStreamRow = components['schemas']['IncomeStreamRow'];
+export type DebtRow = components['schemas']['DebtRow'];
+export type ObligationRow = components['schemas']['ObligationRow'];
+export type ContributionRow = components['schemas']['ContributionRow'];
+export type LedgerRow = components['schemas']['LedgerRow'];
+
+// ---------------------------------------------------------------------------
+// URL constants
+// ---------------------------------------------------------------------------
+
+const ORG_BOOKS_URL = '/api/currency/org-books';
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+/** GET /api/currency/org-books/ — orgs whose books the viewer may open. */
+export async function getMyBooksShelf(): Promise<MyBooksRow[]> {
+  const res = await apiFetch(`${ORG_BOOKS_URL}/`);
+  if (!res.ok) throw new Error('Failed to load your organizations');
+  return res.json() as Promise<MyBooksRow[]>;
+}
+
+/** GET /api/currency/org-books/{orgId}/ — the whole books page in one read. */
+export async function getOrgBooks(orgId: number): Promise<OrgBooks> {
+  const res = await apiFetch(`${ORG_BOOKS_URL}/${orgId}/`);
+  if (!res.ok) {
+    if (res.status === 403) throw new Error('You are not a member of that organization.');
+    if (res.status === 404) throw new Error('No such organization.');
+    throw new Error(`Failed to load books for organization ${orgId}`);
+  }
+  return res.json() as Promise<OrgBooks>;
+}

--- a/frontend/src/org_books/pages/BooksShelfPage.tsx
+++ b/frontend/src/org_books/pages/BooksShelfPage.tsx
@@ -1,0 +1,90 @@
+/**
+ * BooksShelfPage — the organizations whose books the viewer may open.
+ *
+ * Diegetic posture: this is your own shelf, never a browse of all orgs.
+ * Each card links to /books/:orgId (the family-books screen).
+ */
+
+import { Link } from 'react-router-dom';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { MyBooksRow } from '@/org_books/api';
+import { useMyBooksShelf } from '@/org_books/queries';
+
+function ShelfSkeleton() {
+  return (
+    <div className="space-y-3" data-testid="books-shelf-skeleton">
+      {[0, 1].map((i) => (
+        <div key={i} className="animate-pulse rounded-lg border bg-card p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-5 w-48" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+            <Skeleton className="h-8 w-24 shrink-0" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ShelfCard({ row }: { row: MyBooksRow }) {
+  return (
+    <Card>
+      <CardContent className="py-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="text-base font-semibold">{row.organization_name}</span>
+              <Badge variant="outline" className="shrink-0 text-xs">
+                {row.rank_title}
+              </Badge>
+            </div>
+            <p className="mt-0.5 text-sm text-muted-foreground">Rank {row.rank}</p>
+          </div>
+          <Button variant="outline" size="sm" className="shrink-0" asChild>
+            <Link to={`/books/${row.organization_id}`}>Open the books</Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ShelfInner() {
+  const { data, isLoading } = useMyBooksShelf();
+
+  if (isLoading) return <ShelfSkeleton />;
+
+  const rows = data ?? [];
+  if (rows.length === 0) {
+    return (
+      <p className="py-8 text-center text-muted-foreground" data-testid="books-shelf-empty">
+        You hold no position that opens an organization&apos;s books.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3" data-testid="books-shelf">
+      {rows.map((row) => (
+        <ShelfCard key={row.organization_id} row={row} />
+      ))}
+    </div>
+  );
+}
+
+export function BooksShelfPage() {
+  return (
+    <div className="container mx-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+      <h1 className="mb-6 text-2xl font-bold">The Books</h1>
+      <ErrorBoundary>
+        <ShelfInner />
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/frontend/src/org_books/pages/OrgBooksPage.tsx
+++ b/frontend/src/org_books/pages/OrgBooksPage.tsx
@@ -1,0 +1,319 @@
+/**
+ * OrgBooksPage — the family books / management screen (#930).
+ *
+ * One composite read (GET /api/currency/org-books/{orgId}/) renders the whole
+ * page: treasury, graft, income streams, debts, obligations, contributions,
+ * and the recent ledger. Exact numbers, per the ledger tenet — the books are
+ * where a house stops estimating. Line-item affordances (summon a steward or
+ * the creditor's representative about a row) arrive with the NPC-summon work;
+ * the row IDs in the payload exist for that.
+ */
+
+import { useParams } from 'react-router-dom';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { formatCoppers } from '@/lib/currency';
+import { formatRelativeTime } from '@/lib/relativeTime';
+import type { DebtRow } from '@/org_books/api';
+import { useOrgBooks } from '@/org_books/queries';
+
+// ---------------------------------------------------------------------------
+// Small display helpers
+// ---------------------------------------------------------------------------
+
+/** 50 bps → "0.5%/mo" */
+function formatMonthlyInterest(bps: number): string {
+  return `${(bps / 100).toLocaleString('en-US', { maximumFractionDigits: 2 })}%/mo`;
+}
+
+function DebtStatusBadge({ debt }: { debt: DebtRow }) {
+  if (debt.in_default) return <Badge variant="destructive">In default</Badge>;
+  if (debt.diverting) return <Badge variant="secondary">Diverting</Badge>;
+  return <Badge variant="outline">Current</Badge>;
+}
+
+function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+function EmptyRows({ label }: { label: string }) {
+  return <p className="py-2 text-sm text-muted-foreground">{label}</p>;
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function BooksSkeleton() {
+  return (
+    <div className="space-y-4" data-testid="org-books-skeleton">
+      <Skeleton className="h-8 w-64" />
+      <div className="grid gap-4 sm:grid-cols-3">
+        {[0, 1, 2].map((i) => (
+          <Skeleton key={i} className="h-24" />
+        ))}
+      </div>
+      {[0, 1, 2].map((i) => (
+        <Skeleton key={i} className="h-40" />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inner page (inside error boundary)
+// ---------------------------------------------------------------------------
+
+function OrgBooksInner({ orgId }: { orgId: number }) {
+  const { data: books, isLoading } = useOrgBooks(orgId);
+
+  if (isLoading || !books) return <BooksSkeleton />;
+
+  return (
+    <div className="space-y-4" data-testid="org-books">
+      <h1 className="text-2xl font-bold">{books.organization_name} — the Books</h1>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Treasury</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold" data-testid="treasury-balance">
+              {formatCoppers(books.balance)}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Spending authority
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">Ranks 1–{books.spend_rank_max}</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">may draw on the treasury</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Graft</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">{books.graft_pct}%</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              leaks from every income before it reaches the treasury
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <SectionCard title="Income">
+        {books.income_streams.length === 0 ? (
+          <EmptyRows label="No income streams on the books." />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Stream</TableHead>
+                <TableHead>Kind</TableHead>
+                <TableHead className="text-right">Gross / cycle</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {books.income_streams.map((stream) => (
+                <TableRow key={stream.id}>
+                  <TableCell className="font-medium">{stream.name}</TableCell>
+                  <TableCell className="text-muted-foreground">{stream.kind}</TableCell>
+                  <TableCell className="text-right">{formatCoppers(stream.gross_amount)}</TableCell>
+                  <TableCell>
+                    {stream.active ? (
+                      <Badge variant="outline">Active</Badge>
+                    ) : (
+                      <Badge variant="secondary">Dormant</Badge>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </SectionCard>
+
+      <SectionCard title="Debts">
+        {books.debts.length === 0 ? (
+          <EmptyRows label="The house owes no one. Enjoy it while it lasts." />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Creditor</TableHead>
+                <TableHead className="text-right">Principal</TableHead>
+                <TableHead className="text-right">Arrears</TableHead>
+                <TableHead className="text-right">Interest</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {books.debts.map((debt) => (
+                <TableRow key={debt.id}>
+                  <TableCell className="font-medium">{debt.creditor}</TableCell>
+                  <TableCell className="text-right">{formatCoppers(debt.principal)}</TableCell>
+                  <TableCell className="text-right">
+                    {debt.arrears > 0 ? (
+                      <span className="text-destructive">{formatCoppers(debt.arrears)}</span>
+                    ) : (
+                      formatCoppers(0)
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {formatMonthlyInterest(debt.interest_bps_monthly)}
+                  </TableCell>
+                  <TableCell>
+                    <DebtStatusBadge debt={debt} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </SectionCard>
+
+      <SectionCard title="Obligations">
+        {books.obligations.length === 0 ? (
+          <EmptyRows label="No standing obligations." />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Obligation</TableHead>
+                <TableHead>Owed to</TableHead>
+                <TableHead className="text-right">Share of declared income</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {books.obligations.map((obligation) => (
+                <TableRow key={obligation.id}>
+                  <TableCell className="font-medium">{obligation.name}</TableCell>
+                  <TableCell>{obligation.to_organization}</TableCell>
+                  <TableCell className="text-right">{obligation.percent}%</TableCell>
+                  <TableCell>
+                    {obligation.active ? (
+                      <Badge variant="outline">Active</Badge>
+                    ) : (
+                      <Badge variant="secondary">Suspended</Badge>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </SectionCard>
+
+      <SectionCard title="Contributions">
+        {books.contributions.length === 0 ? (
+          <EmptyRows label="No member contributions recorded." />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Member</TableHead>
+                <TableHead className="text-right">Amount</TableHead>
+                <TableHead>Reason</TableHead>
+                <TableHead className="text-right">When</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {books.contributions.map((contribution) => (
+                <TableRow key={contribution.id}>
+                  <TableCell className="font-medium">{contribution.persona_name}</TableCell>
+                  <TableCell className="text-right">{formatCoppers(contribution.amount)}</TableCell>
+                  <TableCell className="text-muted-foreground">{contribution.reason}</TableCell>
+                  <TableCell className="text-right text-muted-foreground">
+                    {formatRelativeTime(contribution.created_at)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </SectionCard>
+
+      <SectionCard title="Recent ledger">
+        {books.ledger.length === 0 ? (
+          <EmptyRows label="No movements yet." />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-20" />
+                <TableHead className="text-right">Amount</TableHead>
+                <TableHead>Reason</TableHead>
+                <TableHead className="text-right">When</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {books.ledger.map((entry) => (
+                <TableRow key={`${entry.direction}-${entry.id}`}>
+                  <TableCell>
+                    {entry.direction === 'in' ? (
+                      <Badge variant="outline">In</Badge>
+                    ) : (
+                      <Badge variant="secondary">Out</Badge>
+                    )}
+                  </TableCell>
+                  <TableCell
+                    className={`text-right ${entry.direction === 'out' ? 'text-destructive' : ''}`}
+                  >
+                    {formatCoppers(entry.amount)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{entry.reason}</TableCell>
+                  <TableCell className="text-right text-muted-foreground">
+                    {formatRelativeTime(entry.created_at)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </SectionCard>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page export
+// ---------------------------------------------------------------------------
+
+export function OrgBooksPage() {
+  const { orgId } = useParams<{ orgId: string }>();
+  const id = Number(orgId);
+
+  return (
+    <div className="container mx-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+      <ErrorBoundary>
+        <OrgBooksInner orgId={Number.isFinite(id) ? id : 0} />
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/frontend/src/org_books/queries.ts
+++ b/frontend/src/org_books/queries.ts
@@ -1,0 +1,37 @@
+/**
+ * Org books React Query hooks (#930).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import * as api from './api';
+
+// ---------------------------------------------------------------------------
+// Query key factory
+// ---------------------------------------------------------------------------
+
+export const orgBooksKeys = {
+  all: ['org-books'] as const,
+  shelf: () => [...orgBooksKeys.all, 'shelf'] as const,
+  books: (orgId: number) => [...orgBooksKeys.all, 'books', orgId] as const,
+};
+
+// ---------------------------------------------------------------------------
+// Read hooks
+// ---------------------------------------------------------------------------
+
+export function useMyBooksShelf() {
+  return useQuery({
+    queryKey: orgBooksKeys.shelf(),
+    queryFn: () => api.getMyBooksShelf(),
+    throwOnError: true,
+  });
+}
+
+export function useOrgBooks(orgId: number) {
+  return useQuery({
+    queryKey: orgBooksKeys.books(orgId),
+    queryFn: () => api.getOrgBooks(orgId),
+    enabled: orgId > 0,
+    throwOnError: true,
+  });
+}

--- a/src/schema.json
+++ b/src/schema.json
@@ -4317,14 +4317,37 @@ paths:
               schema:
                 $ref: '#/components/schemas/CovenantRole'
           description: ''
+  /api/currency/org-books/:
+    get:
+      operationId: currency_org_books_list
+      description: |-
+        GET /org-books/{org_id}/ — the member-visible books.
+
+        The list endpoint is the viewer's own shelf — only orgs the presented
+        persona belongs to, never a browse of all orgs (the diegetic posture
+        mirrors RankingDisplayViewSet).
+      tags:
+      - currency
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MyBooksRow'
+          description: ''
   /api/currency/org-books/{id}/:
     get:
       operationId: currency_org_books_retrieve
       description: |-
-        Retrieve-only: GET /org-books/{org_id}/ — the member-visible books.
+        GET /org-books/{org_id}/ — the member-visible books.
 
-        No list endpoint: books are reached from an org you belong to, not
-        browsed. Mirrors RankingDisplayViewSet's diegetic posture.
+        The list endpoint is the viewer's own shelf — only orgs the presented
+        persona belongs to, never a browse of all orgs (the diegetic posture
+        mirrors RankingDisplayViewSet).
       parameters:
       - in: path
         name: id
@@ -23654,6 +23677,8 @@ components:
     ContributionRow:
       type: object
       properties:
+        id:
+          type: integer
         persona_name:
           type: string
         amount:
@@ -23666,6 +23691,7 @@ components:
       required:
       - amount
       - created_at
+      - id
       - persona_name
       - reason
     Covenant:
@@ -24077,6 +24103,8 @@ components:
     DebtRow:
       type: object
       properties:
+        id:
+          type: integer
         creditor:
           type: string
         principal:
@@ -24093,6 +24121,7 @@ components:
       - arrears
       - creditor
       - diverting
+      - id
       - in_default
       - interest_bps_monthly
       - principal
@@ -27110,6 +27139,8 @@ components:
     IncomeStreamRow:
       type: object
       properties:
+        id:
+          type: integer
         name:
           type: string
         kind:
@@ -27121,6 +27152,7 @@ components:
       required:
       - active
       - gross_amount
+      - id
       - kind
       - name
     InlineActionInteraction:
@@ -27992,6 +28024,8 @@ components:
     LedgerRow:
       type: object
       properties:
+        id:
+          type: integer
         amount:
           type: integer
         reason:
@@ -28005,6 +28039,7 @@ components:
       - amount
       - created_at
       - direction
+      - id
       - reason
     LibraryEntry:
       type: object
@@ -29363,6 +29398,23 @@ components:
       - category_name
       - id
       - name
+    MyBooksRow:
+      type: object
+      description: One organization whose books the viewer may open.
+      properties:
+        organization_id:
+          type: integer
+        organization_name:
+          type: string
+        rank:
+          type: integer
+        rank_title:
+          type: string
+      required:
+      - organization_id
+      - organization_name
+      - rank
+      - rank_title
     MyRosterEntry:
       type: object
       description: Serialize a summary of a roster entry for account menus.
@@ -29789,6 +29841,8 @@ components:
     ObligationRow:
       type: object
       properties:
+        id:
+          type: integer
         name:
           type: string
         to_organization:
@@ -29799,6 +29853,7 @@ components:
           type: boolean
       required:
       - active
+      - id
       - name
       - percent
       - to_organization

--- a/src/world/currency/tests/test_views.py
+++ b/src/world/currency/tests/test_views.py
@@ -74,6 +74,8 @@ class OrgBooksApiTests(TestCase):
         assert data["obligations"][0]["percent"] == 20
         assert data["contributions"][0]["amount"] == 200
         assert any(row["direction"] == "in" for row in data["ledger"])
+        for section in ("income_streams", "debts", "obligations", "contributions", "ledger"):
+            assert all(isinstance(row["id"], int) for row in data[section])
 
     def test_non_member_denied(self) -> None:
         with mock.patch("world.currency.views._viewer_persona", return_value=self.outsider):
@@ -94,3 +96,30 @@ class OrgBooksApiTests(TestCase):
         self.client.force_authenticate(user=None)
         response = self._get()
         assert response.status_code in (401, 403)
+
+    def test_list_is_viewer_shelf(self) -> None:
+        from world.societies.factories import (
+            OrganizationFactory,
+            OrganizationMembershipFactory,
+        )
+
+        second_org = OrganizationFactory()
+        OrganizationMembershipFactory(persona=self.member, organization=second_org, rank=1)
+        # An org the viewer does NOT belong to must never appear on the shelf.
+        OrganizationFactory()
+
+        with mock.patch("world.currency.views._viewer_persona", return_value=self.member):
+            response = self.client.get("/api/currency/org-books/")
+
+        assert response.status_code == 200
+        rows = response.json()
+        assert [row["organization_id"] for row in rows] == [second_org.pk, self.org.pk]
+        assert rows[0]["rank"] == 1
+        assert rows[0]["organization_name"] == second_org.name
+        assert rows[0]["rank_title"] == second_org.get_rank_title(1)
+
+    def test_list_without_persona_is_empty(self) -> None:
+        with mock.patch("world.currency.views._viewer_persona", return_value=None):
+            response = self.client.get("/api/currency/org-books/")
+        assert response.status_code == 200
+        assert response.json() == []

--- a/src/world/currency/views.py
+++ b/src/world/currency/views.py
@@ -32,6 +32,7 @@ _RECENT_ROWS = 50
 
 
 class IncomeStreamRowSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
     name = serializers.CharField()
     kind = serializers.CharField()
     gross_amount = serializers.IntegerField()
@@ -39,6 +40,7 @@ class IncomeStreamRowSerializer(serializers.Serializer):
 
 
 class DebtRowSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
     creditor = serializers.CharField()
     principal = serializers.IntegerField()
     arrears = serializers.IntegerField()
@@ -48,6 +50,7 @@ class DebtRowSerializer(serializers.Serializer):
 
 
 class ObligationRowSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
     name = serializers.CharField()
     to_organization = serializers.CharField()
     percent = serializers.IntegerField()
@@ -55,6 +58,7 @@ class ObligationRowSerializer(serializers.Serializer):
 
 
 class ContributionRowSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
     persona_name = serializers.CharField()
     amount = serializers.IntegerField()
     reason = serializers.CharField(allow_blank=True)
@@ -62,10 +66,20 @@ class ContributionRowSerializer(serializers.Serializer):
 
 
 class LedgerRowSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
     amount = serializers.IntegerField()
     reason = serializers.CharField()
     direction = serializers.CharField()  # "in" | "out"
     created_at = serializers.DateTimeField()
+
+
+class MyBooksRowSerializer(serializers.Serializer):
+    """One organization whose books the viewer may open."""
+
+    organization_id = serializers.IntegerField()
+    organization_name = serializers.CharField()
+    rank = serializers.IntegerField()
+    rank_title = serializers.CharField()
 
 
 class OrgBooksSerializer(serializers.Serializer):
@@ -84,13 +98,33 @@ class OrgBooksSerializer(serializers.Serializer):
 
 
 class OrgBooksViewSet(viewsets.ViewSet):
-    """Retrieve-only: GET /org-books/{org_id}/ — the member-visible books.
+    """GET /org-books/{org_id}/ — the member-visible books.
 
-    No list endpoint: books are reached from an org you belong to, not
-    browsed. Mirrors RankingDisplayViewSet's diegetic posture.
+    The list endpoint is the viewer's own shelf — only orgs the presented
+    persona belongs to, never a browse of all orgs (the diegetic posture
+    mirrors RankingDisplayViewSet).
     """
 
     permission_classes = [IsAuthenticated]
+
+    @extend_schema(responses={200: MyBooksRowSerializer(many=True)})
+    def list(self, request: Request) -> Response:
+        persona = _viewer_persona(request)
+        if persona is None:
+            return Response([])
+        memberships = persona.organization_memberships.select_related(
+            "organization", "organization__org_type"
+        ).order_by("rank", "organization__name")
+        rows = [
+            {
+                "organization_id": m.organization.pk,
+                "organization_name": m.organization.name,
+                "rank": m.rank,
+                "rank_title": m.organization.get_rank_title(m.rank),
+            }
+            for m in memberships
+        ]
+        return Response(MyBooksRowSerializer(rows, many=True).data)
 
     @extend_schema(
         responses={
@@ -149,6 +183,7 @@ def _books_payload(organization) -> dict:
         [
             *(
                 {
+                    "id": t.pk,
                     "amount": t.amount,
                     "reason": t.reason,
                     "direction": "in",
@@ -158,6 +193,7 @@ def _books_payload(organization) -> dict:
             ),
             *(
                 {
+                    "id": t.pk,
                     "amount": t.amount,
                     "reason": t.reason,
                     "direction": "out",
@@ -177,11 +213,18 @@ def _books_payload(organization) -> dict:
         "spend_rank_max": treasury.spend_rank_max,
         "graft_pct": economics.graft_pct,
         "income_streams": [
-            {"name": s.name, "kind": s.kind, "gross_amount": s.gross_amount, "active": s.active}
+            {
+                "id": s.pk,
+                "name": s.name,
+                "kind": s.kind,
+                "gross_amount": s.gross_amount,
+                "active": s.active,
+            }
             for s in OrgIncomeStream.objects.filter(organization=organization)
         ],
         "debts": [
             {
+                "id": d.pk,
                 "creditor": d.creditor_organization.name,
                 "principal": d.principal,
                 "arrears": d.arrears,
@@ -195,6 +238,7 @@ def _books_payload(organization) -> dict:
         ],
         "obligations": [
             {
+                "id": o.pk,
                 "name": o.name,
                 "to_organization": o.to_organization.name,
                 "percent": o.percent,
@@ -206,6 +250,7 @@ def _books_payload(organization) -> dict:
         ],
         "contributions": [
             {
+                "id": c.pk,
                 "persona_name": c.persona.name,
                 "amount": c.amount,
                 "reason": c.reason,


### PR DESCRIPTION
Part of #930 (does not close it — the summon-representative loops and the Command Center room feature are the remainder). Second slice after the merged read API (#958): the React family-books screen itself.

## Summary

- **`/books` — the shelf.** New list endpoint on the org-books viewset returns the orgs the viewer's presented persona belongs to (rank + rank title shown); never a browse of all orgs, preserving the diegetic posture. A "Books" nav link appears for authenticated users.
- **`/books/:orgId` — the books.** One composite read renders the whole management screen: treasury balance, spending-authority rank, Graft %, income streams, debts (arrears highlighted, in-default/diverting badges), obligations, member contributions, and the recent ledger with in/out direction.
- **Exact numbers, mixed form.** New `formatCoppers` helper renders every amount in the canonical "3g 4s 7c" form (10c = 1s, 100c = 1g; large amounts as "3,000g") so players never do arithmetic — per the umbrella's ledger tenet.
- **Row PKs in the payload.** Every books row now carries its model `id` — React keys today, the summon-someone-about-this-line targeting handle when the NPC-summon work lands.

## Remainder for #930 (next slice)

The signature summon-representative loops (summon the Blighton rep / a steward about a line item, checks with backfires, AP/coin/cooldown gating) and the Command Center room feature (#675) need the NPC-summon backend that doesn't exist yet — no dead buttons shipped in the meantime.

## Tests

- `world.currency`: 53 tests OK (new: shelf list scoped to the viewer's memberships + ordering, persona-less empty shelf, row-id presence in every section).
- Frontend: 1898 vitest tests OK (incl. new `formatCoppers` suite); `pnpm typecheck`, ESLint, Prettier, and the production `pnpm build` all clean.

## Notes

- Spec: approved on the umbrella #923 (sub-issue 7); sibling sub-issues followed the same pattern
- Brainstorm/plan: skipped (umbrella spec carries the design)
- Sync-with-main: branched from current main; no sync needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- last-addressed-comment: 0 -->
