### PR TITLE
Tag DISTINCT-ON-dependent tests @tag(postgres) — magic/combat SQLite tiers are red at baseline

### DIFF
--- a/src/world/magic/tests/integration/test_soul_tether_flow.py
+++ b/src/world/magic/tests/integration/test_soul_tether_flow.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import TestCase, tag
 from evennia.objects.models import ObjectDB
 
 from world.character_sheets.factories import CharacterSheetFactory
@@ -348,6 +348,7 @@ class SoulTetherFullPipelineTests(TestCase):
     # Steps 2–6: Full lifecycle (single sequential test to share capstone ref)
     # -----------------------------------------------------------------------
 
+    @tag("postgres")
     def test_04_full_lifecycle(self) -> None:
         """Steps 2–6: Sineating → redirect → rescue → dissolution → persistence."""
         rel_out = CharacterRelationship.objects.get(source=self.sinner, target=self.sineater)
@@ -762,6 +763,7 @@ class ManyToManyIndependenceTests(TestCase):
         self.assertGreater(thread_a.hollow_current, 0, "Sinner A's Hollow should have filled")
         self.assertEqual(thread_b.hollow_current, 0, "Sinner B's Hollow must not be affected")
 
+    @tag("postgres")
     def test_rescue_for_sinner_a_leaves_sinner_b_unchanged(self) -> None:
         """Rescue for Sinner A reduces Sinner A's corruption; Sinner B's is untouched."""
         # Set Sinner A to stage 3; Sinner B stays clean.
@@ -866,6 +868,7 @@ class ManyToManyIndependenceTests(TestCase):
         )
         self.assertTrue(thread_b.exists(), "Sinner B's Thread must survive Bond A dissolution")
 
+    @tag("postgres")
     def test_tether_strain_is_single_instance_across_both_bonds(self) -> None:
         """Rescue for Sinner A creates a Tether Strain instance on the Sineater.
 

--- a/src/world/magic/tests/test_anima_services.py
+++ b/src/world/magic/tests/test_anima_services.py
@@ -2,7 +2,7 @@
 
 from decimal import Decimal
 
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from world.magic.factories import CharacterAnimaFactory, SoulfrayConfigFactory, TechniqueFactory
 from world.magic.services import (
@@ -215,6 +215,7 @@ class GetSoulfrayWarningTests(TestCase):
     def test_no_soulfray_returns_none(self) -> None:
         assert get_soulfray_warning(self.character) is None
 
+    @tag("postgres")
     def test_soulfray_present_returns_warning(self) -> None:
         from world.conditions.services import apply_condition
 

--- a/src/world/magic/tests/test_pending_stage_advance_offer.py
+++ b/src/world/magic/tests/test_pending_stage_advance_offer.py
@@ -18,7 +18,7 @@ from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.utils import timezone
 from rest_framework.test import APITestCase
 
@@ -591,6 +591,7 @@ class ResolveStageAdvanceFromDbHappyPathTests(TestCase):
         cls.thread.hollow_current = 8
         cls.thread.save()
 
+    @tag("postgres")
     def test_happy_path_returns_result(self) -> None:
         """resolve_stage_advance_prompt_from_db returns a StageAdvanceBonusResult."""
         _seed_pending_offer(
@@ -605,6 +606,7 @@ class ResolveStageAdvanceFromDbHappyPathTests(TestCase):
         self.assertFalse(result.declined)
         self.assertEqual(result.hollow_drained, 3)
 
+    @tag("postgres")
     def test_happy_path_deletes_pending_row(self) -> None:
         """resolve_stage_advance_prompt_from_db deletes the PendingStageAdvanceOffer on success."""
         _seed_pending_offer(

--- a/src/world/magic/tests/test_soul_tether_services.py
+++ b/src/world/magic/tests/test_soul_tether_services.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from decimal import Decimal
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from flows.models.triggers import Trigger
 from world.character_sheets.factories import CharacterSheetFactory
@@ -1072,6 +1072,7 @@ def _make_tethered_pair_with_corruption(
 # ---------------------------------------------------------------------------
 
 
+@tag("postgres")
 class PerformSoulTetherRescueStage3Tests(TestCase):
     """Phase 8 §9.4 — stage-3 rescue happy path."""
 
@@ -1170,6 +1171,7 @@ class PerformSoulTetherRescueStage3Tests(TestCase):
 # ---------------------------------------------------------------------------
 
 
+@tag("postgres")
 class PerformSoulTetherRescueStage5Tests(TestCase):
     """Phase 8 §9.4 — stage-5 rescue lifts protagonism_lock when dropping below stage 5."""
 
@@ -1407,6 +1409,7 @@ class PerformSoulTetherRescueGateTests(TestCase):
             )
         self.assertIn("insufficient resonance", ctx.exception.user_message)
 
+    @tag("postgres")
     def test_repeat_in_scene_raises(self) -> None:
         """Second rescue attempt for same (sineater, sinner, scene) raises RescueValidationError."""
         from world.magic.exceptions import RescueValidationError

--- a/src/world/magic/tests/test_soul_tether_subscribers.py
+++ b/src/world/magic/tests/test_soul_tether_subscribers.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import TestCase, tag
 from evennia.objects.models import ObjectDB
 
 from world.character_sheets.factories import CharacterSheetFactory
@@ -793,6 +793,7 @@ class StageAdvancePromptNonCorruptionConditionTests(TestCase):
         self.assertEqual(len(_pending_stage_advance_offers), 0)
 
 
+@tag("postgres")
 class StageAdvanceBonusAcceptTests(TestCase):
     """7.2 — Accept path: resolve_stage_advance_prompt drains Hollow + adds Strain."""
 


### PR DESCRIPTION
Closes #919

## Summary

Tag the 23 DISTINCT-ON-dependent world.magic tests @tag("postgres") so the SQLite fast tier skips them while the Postgres parity tier (CI) still runs them. All 23 errored at baseline with NotSupportedError: DISTINCT ON, raised from conditions/services._build_bulk_context (a PostgreSQL-only feature) via the soul-tether / anima-warning / pending-stage-advance flows. Granularity is class-level for the three classes whose every method routes through that path (PerformSoulTetherRescueStage3Tests, PerformSoulTetherRescueStage5Tests, StageAdvanceBonusAcceptTests) and method-level for the 7 methods across 4 other classes, so SQLite-capable sibling tests keep running on the fast tier. After: world.magic --sqlite goes 1816 tests / 23 errors to 1793 tests / OK (exactly 23 excluded — no over-tagging). world.combat --sqlite is already green at this HEAD (845 tests / OK); the 13 errors noted when the issue was filed have since been resolved, so no combat changes are needed. Option 2 (a SQLite fallback in _build_bulk_context) was rejected as it would violate the PostgreSQL-only / no-DB-agnostic-workarounds invariant.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #919 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: Rebased cleanly onto origin/main; no conflicts.

<!-- last-addressed-comment: 0 -->