### PR TITLE
skill+docs: enqueue PRs for the merge queue instead of manual re-sync + merge (WS4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,13 @@ and verify issue number↔title before any mutation. Temporary — removal track
 
 - **Never work directly on main.** Branch first: `git checkout -b feature-name`.
   After a squash-merge: `git checkout main && git pull && git branch -D feature-name`.
+- **`main` uses a merge queue (#991).** Once a PR is green, **enqueue it**
+  (`gh pr merge --auto --squash`, or `enqueue-pr.sh` in the `issue-to-merged-pr`
+  skill) and stop — do not re-sync with main or merge by hand. The queue
+  re-tests the PR on top of the latest main and merges in order; a human
+  approval is the only remaining gate. A migration collision shows up as the
+  loser being bounced from the queue (others keep flowing) — fix it with
+  `arx manage makemigrations --merge` (or renumber), push, re-enqueue.
 - **No `cd &&` compound commands.** Use `git -C /path <command>` for git, or
   absolute paths / a tool's own directory flag otherwise. (Claude Code on Windows
   flags every `cd && <command>` for manual approval as a bare-repo-attack

--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -193,6 +193,12 @@ skipped-design tasks, just edit and commit.
 
 ### 4. Sync with main
 
+Sync **once here** to surface conflicts and migration collisions early and to
+run CI against a recent base. You do **not** need to re-sync every time main
+moves afterward — the merge queue (#991) re-integrates the PR against the
+latest main at merge time, so there is no "update branch before merge" step and
+no re-sync cascade when neighbouring PRs land.
+
 Run `scripts/sync-with-main.sh <branch>`. The script automatically picks the
 right strategy:
 - **Branch not yet on origin (local-only):** rebase onto origin/main. Clean
@@ -236,7 +242,13 @@ in the issue body, so there is no spec-file link to pass.
 > is for design and implementation, not waiting.
 
 Run `scripts/watch-ci.sh <pr-N>`. Outcomes:
-- `OK` (exit 0): post a brief status comment, exit the session.
+- `OK` (exit 0): enqueue for the merge queue with `scripts/enqueue-pr.sh
+  <pr-N>` (arms squash auto-merge), post a brief status comment, exit the
+  session. **Do NOT re-sync with main or merge by hand.** The merge queue
+  re-tests the PR on top of the latest main and merges it in order once a human
+  approves — that human approval is the only remaining gate. If main moves while
+  the PR waits for approval, the queue handles the re-integration; the agent
+  does nothing further.
 - `FAIL <check-name>` (exit 5): enter the CI-fix phase.
 - timeout (exit 6): post a diagnostic, exit.
 
@@ -374,6 +386,7 @@ where it stopped, what the human should decide.
 | File a follow-up issue | `scripts/file-followup.sh <title> <body-path> [labels...]` |
 | Comment on an issue | `scripts/comment-on-issue.sh <issue> <body-path>` |
 | Watch CI | `scripts/watch-ci.sh <pr>` |
+| Enqueue for the merge queue | `scripts/enqueue-pr.sh <pr>` |
 | Read failing log | `scripts/get-ci-failure.sh <pr> <check-name>` |
 | Read unread PR comments | `scripts/read-pr-comments.sh <pr>` |
 | Clean up after merge | `scripts/post-merge-cleanup.sh <branch> <pr>` |

--- a/tools/skills/issue-to-merged-pr/scripts/enqueue-pr.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/enqueue-pr.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# enqueue-pr.sh [--dry-run] <pr-number>
+#
+# Enables auto-merge (squash) on the PR. With the repo's merge queue enabled
+# (#991), this hands the PR to the queue: once its required review + checks are
+# satisfied, GitHub adds it to the queue, which re-tests it on top of main (and
+# any earlier-queued PRs) and merges it in order. No manual re-sync with main,
+# no manual merge click — the agent calls this after CI is green and exits; a
+# human's approval is the only remaining gate.
+#
+# --auto does NOT require the PR to be mergeable yet; it arms the merge to
+# happen later once requirements are met. Idempotent: a second call when
+# auto-merge is already enabled is a no-op success.
+#
+# Exits:
+#   0  auto-merge enabled (or already enabled)
+#   1  usage / generic error
+set -euo pipefail
+
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then DRY_RUN=1; shift; fi
+
+usage() { echo "Usage: $0 [--dry-run] <pr-number>" >&2; exit 1; }
+[[ $# -eq 1 ]] || usage
+PR="$1"
+[[ "$PR" =~ ^[0-9]+$ ]] || usage
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "[dry-run] gh pr merge $PR --auto --squash"
+  exit 0
+fi
+
+out=$(gh pr merge "$PR" --auto --squash 2>&1) || {
+  if grep -qi "already" <<<"$out"; then
+    echo "auto-merge already enabled on #$PR"
+    exit 0
+  fi
+  echo "$out" >&2
+  exit 1
+}
+echo "auto-merge (squash) enabled on #$PR — the merge queue will merge it once approved + green"


### PR DESCRIPTION
WS4 of #991. Switches the `issue-to-merged-pr` flow from "babysit the PR up-to-date with main, then merge by hand" to "enqueue for the merge queue and exit."

## Changes
- **`scripts/enqueue-pr.sh`** — arms squash auto-merge (`gh pr merge --auto --squash`). With the queue enabled, GitHub adds the PR to the queue once its required review + checks are satisfied; the queue re-tests it on top of latest main and merges in order. Idempotent, `--dry-run` supported, shellcheck-clean.
- **SKILL.md** — CI-watch `OK` outcome now enqueues + exits (was: post comment + exit for a human to merge). "Sync with main" reframed as a one-time early-collision check, not a merge prerequisite. Quick-reference table updated.
- **CLAUDE.md** — Git Workflow documents the enqueue flow and the migration-collision recovery (bounced loser → `makemigrations --merge` → re-enqueue).

## Doubles as the queue's first live test
This branch is intentionally **behind main**. If the queue merges it without any manual "Update branch" step, that confirms the lingering `strict` value is inert under the merge queue (the queue supersedes "require branches up to date"). Watching this one through the queue validates the whole setup.

Part of #991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
