### PR TITLE
feat(#982): shared-cell grouping for CAPTURE consequence effects

### DIFF
--- a/src/world/captivity/services.py
+++ b/src/world/captivity/services.py
@@ -22,13 +22,14 @@ from world.captivity.constants import RESOLVED_STATUSES, CaptivityStatus
 from world.captivity.exceptions import AlreadyCapturedError, NotHeldError
 from world.captivity.models import Captivity
 from world.character_sheets.types import LifecycleState
+from world.instances.constants import InstanceStatus
+from world.instances.models import InstancedRoom
 from world.instances.services import complete_instanced_room, spawn_instanced_room
 
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
     from world.character_sheets.models import CharacterSheet
-    from world.instances.models import InstancedRoom
     from world.societies.models import Organization
 
 # PLACEHOLDER cell flavor — rewrite in the project voice before launch.
@@ -46,12 +47,16 @@ def capture_character(  # noqa: PLR0913 — keyword-only; each arg is a distinct
     return_location: ObjectDB | None = None,
     offscreen_loss_allowed: bool = False,
     cell: InstancedRoom | None = None,
+    group_key: str | None = None,
     cell_name: str | None = None,
     cell_description: str | None = None,
 ) -> Captivity:
     """Take one character into a cell and record the captivity.
 
-    Spawns a fresh cell unless ``cell`` is supplied (the shared-cell path).
+    Spawns a fresh cell unless ``cell`` is supplied (the explicit shared-cell
+    path) or ``group_key`` matches an existing active cell (the keyed
+    shared-cell path: captives of the same capture event reuse one cell — the
+    consequence-effect path can't pass a cell object, so it passes a key).
     Flips the captive's lifecycle to CAPTURED and moves their body inside.
 
     Raises ``AlreadyCapturedError`` if the character is already held.
@@ -60,13 +65,15 @@ def capture_character(  # noqa: PLR0913 — keyword-only; each arg is a distinct
         raise AlreadyCapturedError
 
     with transaction.atomic():
+        if cell is None and group_key is not None:
+            cell = _active_group_cell(group_key)
         if cell is None:
             room = spawn_instanced_room(
                 name=cell_name or _DEFAULT_CELL_NAME,
                 description=cell_description or _DEFAULT_CELL_DESCRIPTION,
                 owner=captive,
                 return_location=return_location,
-                source_key=f"capture:{captive.pk}",
+                source_key=group_key or f"capture:{captive.pk}",
             )
             cell = room.instance_data
 
@@ -181,6 +188,20 @@ def resolve_captivity(captivity: Captivity, *, status: str) -> None:
     room = cell.room
     Captivity.objects.filter(cell=cell).update(cell=None)
     complete_instanced_room(room)
+
+
+def _active_group_cell(group_key: str) -> InstancedRoom | None:
+    """The still-active cell already spawned for this capture group, if any.
+
+    Cells are tagged with the group key as their ``source_key``; a resolved
+    group's cell is completed/torn down, so an ACTIVE match means the group is
+    still being held and the next captive joins it (the shared-cell default).
+    """
+    return (
+        InstancedRoom.objects.filter(source_key=group_key, status=InstanceStatus.ACTIVE)
+        .order_by("-created_at")
+        .first()
+    )
 
 
 def _relocate_freed_captive(captive: CharacterSheet, cell: InstancedRoom | None) -> None:

--- a/src/world/captivity/tests/test_services.py
+++ b/src/world/captivity/tests/test_services.py
@@ -77,6 +77,36 @@ class CapturePartyTests(TestCase):
         assert InstancedRoom.objects.count() == 0
 
 
+class CaptureGroupKeyTests(TestCase):
+    def test_same_group_key_shares_one_cell(self) -> None:
+        first, second = CharacterSheetFactory(), CharacterSheetFactory()
+
+        a = capture_character(captive=first, group_key="event-1")
+        b = capture_character(captive=second, group_key="event-1")
+
+        assert a.cell_id == b.cell_id
+
+    def test_different_group_keys_get_separate_cells(self) -> None:
+        first, second = CharacterSheetFactory(), CharacterSheetFactory()
+
+        a = capture_character(captive=first, group_key="event-1")
+        b = capture_character(captive=second, group_key="event-2")
+
+        assert a.cell_id != b.cell_id
+
+    def test_resolved_group_cell_is_not_reused(self) -> None:
+        first = CharacterSheetFactory()
+        a = capture_character(captive=first, group_key="event-1")
+        old_cell_id = a.cell_id
+        resolve_captivity(a, status=CaptivityStatus.ESCAPED)  # tears the cell down
+
+        second = CharacterSheetFactory()
+        b = capture_character(captive=second, group_key="event-1")
+
+        # The old cell is no longer ACTIVE, so a fresh one is spawned.
+        assert b.cell_id != old_cell_id
+
+
 class ResolveCaptivityTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:

--- a/src/world/mechanics/effect_handlers.py
+++ b/src/world/mechanics/effect_handlers.py
@@ -395,6 +395,24 @@ def _apply_magical_scars(
     )
 
 
+def _capture_group_key(
+    effect: "ConsequenceEffect",
+    context: "ResolutionContext",
+) -> str | None:
+    """Stable key grouping captives of one capture event into a shared cell.
+
+    Keyed on the resolution's scene (the encounter's location handle the
+    context reliably carries) plus the captor org, so the same captor taking
+    several PCs in one scene shares a cell, while different captors — or no
+    scene at all — fall back to separate cells.
+    """
+    scene = context.scene
+    if scene is None:
+        return None
+    captor_part = effect.capture_captor_organization_id or "none"
+    return f"capture:scene:{scene.pk}:{captor_part}"
+
+
 def _apply_capture(
     effect: "ConsequenceEffect",
     context: "ResolutionContext",
@@ -430,6 +448,10 @@ def _apply_capture(
             # TARGET capture. target.location may be None; the service allows it.
             return_location=target.location,
             offscreen_loss_allowed=effect.capture_offscreen_loss_allowed,
+            # Captives taken in one encounter (same scene + captor) share a
+            # cell — the shared-cell default, honoured on the per-character
+            # consequence path. No scene → per-character cells (group_key None).
+            group_key=_capture_group_key(effect, context),
         )
     except AlreadyCapturedError:
         return AppliedEffect(

--- a/src/world/mechanics/tests/test_effect_handlers.py
+++ b/src/world/mechanics/tests/test_effect_handlers.py
@@ -15,6 +15,7 @@ from world.checks.factories import ConsequenceEffectFactory, ConsequenceFactory
 from world.checks.types import ResolutionContext
 from world.conditions.factories import DamageTypeFactory
 from world.mechanics.effect_handlers import _resolve_target, apply_effect
+from world.scenes.factories import SceneFactory
 from world.societies.factories import OrganizationFactory
 from world.vitals.models import CharacterVitals
 
@@ -236,3 +237,40 @@ class CaptureHandlerTests(TestCase):
         assert result.applied is False
         assert result.skip_reason is not None
         assert Captivity.objects.filter(captive=sheet).count() == 1
+
+
+class CaptureGroupingTests(TestCase):
+    """The CAPTURE handler groups captives of one encounter into a shared cell (#982)."""
+
+    @staticmethod
+    def _capture_effect():
+        return ConsequenceEffectFactory(
+            consequence=ConsequenceFactory(),
+            effect_type=EffectType.CAPTURE,
+        )
+
+    def _capture(self, key: str, *, scene):
+        character = CharacterFactory(db_key=key)
+        sheet = CharacterSheetFactory(character=character)
+        apply_effect(self._capture_effect(), ResolutionContext(character=character, scene=scene))
+        return Captivity.objects.get(captive=sheet)
+
+    def test_same_scene_captures_share_a_cell(self) -> None:
+        scene = SceneFactory()
+
+        first = self._capture("grp_same_a", scene=scene)
+        second = self._capture("grp_same_b", scene=scene)
+
+        assert first.cell_id == second.cell_id
+
+    def test_different_scenes_do_not_share(self) -> None:
+        first = self._capture("grp_diff_a", scene=SceneFactory())
+        second = self._capture("grp_diff_b", scene=SceneFactory())
+
+        assert first.cell_id != second.cell_id
+
+    def test_no_scene_uses_separate_cells(self) -> None:
+        first = self._capture("grp_none_a", scene=None)
+        second = self._capture("grp_none_b", scene=None)
+
+        assert first.cell_id != second.cell_id


### PR DESCRIPTION
Closes #982. Spun out of the adversarial review of #975 (the CAPTURE consequence-effect seam).

## Problem

The CAPTURE consequence effect fired `capture_character` per resolved target, so two PCs captured by **separate per-character consequences** (e.g. each defeated PC's own combat-aftermath pool) got **separate cells**. Your shared-cell-default ruling only held on the programmatic `capture_party` path (missions / scripted captures), not on the consequence-effect path.

## Fix

- **`capture_character` gains an optional `group_key`.** When set (and no explicit `cell` object is passed), it reuses the still-`ACTIVE` `InstancedRoom` already tagged with that key (as its `source_key`), else spawns one tagged with it. A resolved group's cell is torn down on release, so a later capture with the same key correctly starts a fresh cell rather than re-joining a dead one (covered by a test).
- **The CAPTURE handler derives the key from `context.scene` + captor org** — the encounter's scene is the location handle the resolution context reliably carries. Same captor taking several PCs in one scene → one shared cell; different captors, or no scene at all → separate cells (the safe per-character fallback).

No model changes (service logic + handler only) → no migration.

## Notes / limitation

The shared cell's `return_location` is the first captive's location (the cell is spawned once). For a group taken together in one scene that's the same room anyway; release still falls back to each captive's home if needed. A per-captive return location would need storing it per-`Captivity` row — out of scope here.

## Tests

289 across `world.captivity` + `world.mechanics`, OK on the fast tier. New: service-level (same `group_key` shares a cell; different keys separate; a resolved group's cell isn't reused) and handler-level (same scene shares; different scenes don't; no scene → separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- last-addressed-comment: 0 -->
