### PR TITLE
fix(#918): identify the viewer's combat participant by character_sheet_id

### DIFF
--- a/frontend/src/combat/CombatTurnPanel.tsx
+++ b/frontend/src/combat/CombatTurnPanel.tsx
@@ -18,7 +18,7 @@ import { AudereMajoraOfferGate } from '@/magic/components/AudereMajoraOfferGate'
 import { useAvailableActions, useCombatEncounter, useConsequenceOutcomes } from './queries';
 import { YourTurn } from './sections/YourTurn';
 import { ResonanceBudget } from './sections/ResonanceBudget';
-import { VitalPools, findViewerParticipant } from './sections/VitalPools';
+import { VitalPools, findOwnParticipant } from './sections/VitalPools';
 import { CombatantsList } from './sections/CombatantsList';
 import { ActiveState } from './sections/ActiveState';
 import { RoundFlow } from './sections/RoundFlow';
@@ -148,12 +148,11 @@ export function CombatTurnPanel({
   const isParticipant = encounter.is_participant;
   const roundNumber = encounter.round_number ?? 0;
 
-  // Audere active strip — the puppeted participant's row (Participant exposes
-  // no character/sheet id, so reuse VitalPools' owner-vitals heuristic) carries
-  // the Audere condition in active_conditions while the breakthrough is live.
-  // active_conditions entries are ConditionInstances typed loosely on the
-  // generated schema (SerializerMethodField); cast at the boundary.
-  const viewerParticipant = findViewerParticipant(encounter.participants);
+  // Audere active strip — the viewer's own participant row (matched by
+  // character_sheet_id) carries the Audere condition in active_conditions while
+  // the breakthrough is live. active_conditions entries are ConditionInstances
+  // typed loosely on the generated schema (SerializerMethodField); cast at the boundary.
+  const viewerParticipant = findOwnParticipant(encounter.participants, characterSheetId);
   const isAudereActive = ((viewerParticipant?.active_conditions ?? []) as ConditionInstance[]).some(
     (c) => c.name === 'Audere'
   );
@@ -231,6 +230,7 @@ export function CombatTurnPanel({
       <VitalPools
         encounter={encounter}
         characterId={characterId}
+        characterSheetId={characterSheetId}
         collapsed={collapsed.vitalPools}
         onToggleCollapse={() => toggleSection('vitalPools')}
         data-testid="section-vital-pools"

--- a/frontend/src/combat/__tests__/CombatTurnPanel.test.tsx
+++ b/frontend/src/combat/__tests__/CombatTurnPanel.test.tsx
@@ -153,13 +153,13 @@ function mockEncounter(overrides?: Partial<EncounterDetail>) {
 }
 
 /**
- * Viewer participant fixture: non-null health marks it as the puppeted row
- * (same owner-vitals heuristic findViewerParticipant uses).
+ * Viewer participant fixture. The viewer's own row is matched by character_sheet_id
+ * (= the characterSheetId prop passed in these tests), not by health presence. (#918)
  */
 function makeParticipant(overrides: Partial<Participant> = {}): Participant {
   return {
     id: 1,
-    character_sheet_id: 1001,
+    character_sheet_id: 100,
     character_name: 'Aerande',
     status: 'active',
     health: 8,
@@ -366,6 +366,60 @@ describe('CombatTurnPanel — Phase 8 rail sections', () => {
     });
 
     expect(screen.queryByTestId('audere-active-strip')).not.toBeInTheDocument();
+  });
+
+  it('keys the Audere strip off the viewer own row, not the first participant', () => {
+    // A non-viewer participant listed first carries Audere; the viewer's own row
+    // does not. The strip reflects the VIEWER's conditions (matched by sheet id),
+    // so it stays hidden — the old health-presence heuristic would have picked the
+    // first row and shown it. (#918)
+    mockEncounter({
+      is_participant: true,
+      participants: [
+        makeParticipant({
+          id: 2,
+          character_sheet_id: 2002,
+          character_name: 'Other',
+          active_conditions: [
+            { id: 7, name: 'Audere', display_priority: 10 } as unknown as {
+              [key: string]: unknown;
+            },
+          ],
+        }),
+        makeParticipant({ id: 1, character_sheet_id: 100, character_name: 'Self' }),
+      ],
+    });
+
+    render(<CombatTurnPanel encounterId={1} characterId={10} characterSheetId={100} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.queryByTestId('audere-active-strip')).not.toBeInTheDocument();
+  });
+
+  it('shows the Audere strip when the viewer own row carries Audere even if listed last', () => {
+    mockEncounter({
+      is_participant: true,
+      participants: [
+        makeParticipant({ id: 2, character_sheet_id: 2002, character_name: 'Other' }),
+        makeParticipant({
+          id: 1,
+          character_sheet_id: 100,
+          character_name: 'Self',
+          active_conditions: [
+            { id: 7, name: 'Audere', display_priority: 10 } as unknown as {
+              [key: string]: unknown;
+            },
+          ],
+        }),
+      ],
+    });
+
+    render(<CombatTurnPanel encounterId={1} characterId={10} characterSheetId={100} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId('audere-active-strip')).toBeInTheDocument();
   });
 
   it('all sections start expanded by default', () => {

--- a/frontend/src/combat/__tests__/VitalPools.test.tsx
+++ b/frontend/src/combat/__tests__/VitalPools.test.tsx
@@ -102,7 +102,7 @@ describe('VitalPools', () => {
   it('renders the health bar with correct values', () => {
     const encounter = makeEncounter([makeParticipant({ health: 8, max_health: 10 })]);
 
-    render(<VitalPools encounter={encounter} characterId={10} />, {
+    render(<VitalPools encounter={encounter} characterId={10} characterSheetId={1001} />, {
       wrapper: createWrapper(),
     });
 
@@ -115,7 +115,7 @@ describe('VitalPools', () => {
   it('shows amber fill when health is below 50%', () => {
     const encounter = makeEncounter([makeParticipant({ health: 4, max_health: 10 })]);
 
-    render(<VitalPools encounter={encounter} characterId={10} />, {
+    render(<VitalPools encounter={encounter} characterId={10} characterSheetId={1001} />, {
       wrapper: createWrapper(),
     });
 
@@ -127,7 +127,7 @@ describe('VitalPools', () => {
   it('shows green fill when health is at or above 50%', () => {
     const encounter = makeEncounter([makeParticipant({ health: 6, max_health: 10 })]);
 
-    render(<VitalPools encounter={encounter} characterId={10} />, {
+    render(<VitalPools encounter={encounter} characterId={10} characterSheetId={1001} />, {
       wrapper: createWrapper(),
     });
 
@@ -138,7 +138,7 @@ describe('VitalPools', () => {
   it('renders the anima bar with correct values', () => {
     const encounter = makeEncounter([makeParticipant()]);
 
-    render(<VitalPools encounter={encounter} characterId={10} />, {
+    render(<VitalPools encounter={encounter} characterId={10} characterSheetId={1001} />, {
       wrapper: createWrapper(),
     });
 
@@ -158,7 +158,7 @@ describe('VitalPools', () => {
       }),
     ]);
 
-    render(<VitalPools encounter={encounter} characterId={10} />, {
+    render(<VitalPools encounter={encounter} characterId={10} characterSheetId={1001} />, {
       wrapper: createWrapper(),
     });
 
@@ -179,7 +179,7 @@ describe('VitalPools', () => {
   it('no longer renders the placeholder affordances', () => {
     const encounter = makeEncounter([makeParticipant()]);
 
-    render(<VitalPools encounter={encounter} characterId={10} />, {
+    render(<VitalPools encounter={encounter} characterId={10} characterSheetId={1001} />, {
       wrapper: createWrapper(),
     });
 
@@ -198,7 +198,7 @@ describe('VitalPools', () => {
       }),
     ]);
 
-    render(<VitalPools encounter={encounter} characterId={10} />, {
+    render(<VitalPools encounter={encounter} characterId={10} characterSheetId={1001} />, {
       wrapper: createWrapper(),
     });
 
@@ -211,7 +211,7 @@ describe('VitalPools', () => {
   it('hides fatigue bars when fatigue is null (no vitals permission)', () => {
     const encounter = makeEncounter([makeParticipant({ fatigue: null })]);
 
-    render(<VitalPools encounter={encounter} characterId={10} />, {
+    render(<VitalPools encounter={encounter} characterId={10} characterSheetId={1001} />, {
       wrapper: createWrapper(),
     });
 
@@ -225,7 +225,7 @@ describe('VitalPools', () => {
   it('shows dash when no participant health is available', () => {
     const encounter = makeEncounter([makeParticipant({ health: null, max_health: null })]);
 
-    render(<VitalPools encounter={encounter} characterId={10} />, {
+    render(<VitalPools encounter={encounter} characterId={10} characterSheetId={1001} />, {
       wrapper: createWrapper(),
     });
 
@@ -233,12 +233,52 @@ describe('VitalPools', () => {
     expect(screen.getByText('—')).toBeInTheDocument();
   });
 
+  it('matches the viewer own row by sheet id when several participants have visible health', () => {
+    // A GM/staff viewer can see every participant's health, so health-presence no
+    // longer identifies "self". The viewer's own row must be matched by sheet id —
+    // the regression #918 fixes (the old heuristic showed the first non-null row).
+    const other = makeParticipant({
+      id: 2,
+      character_sheet_id: 2002,
+      character_name: 'Other',
+      health: 3,
+      max_health: 10,
+    });
+    const own = makeParticipant({
+      id: 1,
+      character_sheet_id: 1001,
+      character_name: 'Self',
+      health: 9,
+      max_health: 10,
+    });
+    // `other` is listed first — the old heuristic would have shown its health (3/10).
+    const encounter = makeEncounter([other, own]);
+
+    render(<VitalPools encounter={encounter} characterId={10} characterSheetId={1001} />, {
+      wrapper: createWrapper(),
+    });
+
+    const healthBar = screen.getByTestId('vital-health-bar');
+    expect(healthBar).toHaveTextContent('9');
+    expect(healthBar).toHaveTextContent('/ 10');
+    // Not the first participant's health.
+    expect(healthBar).not.toHaveTextContent('3');
+  });
+
   it('collapses content when collapsed=true', () => {
     const encounter = makeEncounter([makeParticipant()]);
 
-    render(<VitalPools encounter={encounter} characterId={10} collapsed={true} />, {
-      wrapper: createWrapper(),
-    });
+    render(
+      <VitalPools
+        encounter={encounter}
+        characterId={10}
+        characterSheetId={1001}
+        collapsed={true}
+      />,
+      {
+        wrapper: createWrapper(),
+      }
+    );
 
     expect(screen.queryByTestId('vital-health-bar')).not.toBeInTheDocument();
   });

--- a/frontend/src/combat/sections/VitalPools.tsx
+++ b/frontend/src/combat/sections/VitalPools.tsx
@@ -3,10 +3,9 @@
  *
  * Health: sourced from the viewer's participant row in EncounterDetail.participants.
  *   - Color shifts amber when health_percentage < 0.5.
- *   - Identified by finding the participant with non-null health (the viewer's own
- *     vitals are only returned for the viewer; other participants' health is hidden).
- *   - If viewer is staff/GM, health is visible for all — we fall back to the first
- *     participant whose `health` field is non-null.
+ *   - The viewer's row is identified by an exact `character_sheet_id` match against
+ *     the viewer's own sheet — not a health-presence heuristic, which picked an
+ *     arbitrary row for staff/GM viewers who can see everyone's vitals. (#918)
  *
  * Anima: sourced from useCharacterAnima(characterId).
  *   - characterId is the ObjectDB PK (same as what CharacterAnimaFilter uses).
@@ -31,6 +30,8 @@ export interface VitalPoolsProps {
   encounter: EncounterDetail;
   /** The viewer's character ObjectDB PK — used to query CharacterAnima. */
   characterId: number;
+  /** The viewer's CharacterSheet PK — identifies their own participant row. */
+  characterSheetId: number;
   /** Whether the section is collapsed. Controlled by parent (Task 8.6). */
   collapsed?: boolean;
   onToggleCollapse?: () => void;
@@ -41,17 +42,19 @@ export interface VitalPoolsProps {
 // ---------------------------------------------------------------------------
 
 /**
- * Find the viewer's participant row.
+ * Find the viewer's own participant row by exact character-sheet identity.
  *
- * The API only returns health/max_health for the viewer's own character.
- * We detect "own" by finding the first participant with a non-null health value.
- * If none have health (observer mode or all-null), returns undefined.
+ * Replaces the former health-presence heuristic, which picked an arbitrary row
+ * for staff/GM viewers who can see every participant's vitals. (#918)
  *
  * Exported: CombatTurnPanel reuses this to locate the puppeted participant for
- * the active-Audere strip (Participant exposes no character/sheet id field).
+ * the active-Audere strip. Returns undefined for observers (no matching row).
  */
-export function findViewerParticipant(participants: Participant[]): Participant | undefined {
-  return participants.find((p) => p.health !== null && p.health !== undefined);
+export function findOwnParticipant(
+  participants: Participant[],
+  characterSheetId: number
+): Participant | undefined {
+  return participants.find((p) => p.character_sheet_id === characterSheetId);
 }
 
 // ---------------------------------------------------------------------------
@@ -96,13 +99,14 @@ function BarRow({ label, current, maximum, fillClass = 'bg-primary', testId }: B
 export function VitalPools({
   encounter,
   characterId,
+  characterSheetId,
   collapsed = false,
   onToggleCollapse,
 }: VitalPoolsProps) {
   const { data: animaData, isLoading: animaLoading } = useCharacterAnima(characterId);
 
-  // Health derived from the viewer's participant row.
-  const viewerParticipant = findViewerParticipant(encounter.participants);
+  // Health derived from the viewer's own participant row (exact sheet match).
+  const viewerParticipant = findOwnParticipant(encounter.participants, characterSheetId);
   const health = viewerParticipant?.health ?? null;
   const maxHealth = viewerParticipant?.max_health ?? null;
   const healthPct =


### PR DESCRIPTION
## Summary

Fixes #918 — the combat frontend identified "my participant" via `findViewerParticipant`, a heuristic that picked the **first participant row with non-null health**. Vitals are owner-visible, but staff, scene GMs, and multi-character owners can view *every* row's vitals, so the heuristic selected an arbitrary participant for them — affecting `VitalPools` (health/fatigue bars) and the `CombatTurnPanel` active-Audere strip (#873).

The `Participant` serializer already exposes `character_sheet_id` (roster-public, already in the payload), and `YourTurn` already matched on it. This PR:

- Replaces `findViewerParticipant` with an exact `findOwnParticipant(participants, characterSheetId)` at both call sites.
- Threads the viewer's `characterSheetId` into `VitalPools`.
- Deletes the heuristic and corrects the now-stale "Participant exposes no character/sheet id" comments.
- Adds regression tests for the GM / multiple-visible-health case the heuristic got wrong (both `VitalPools` health and the Audere strip — verifying the viewer's *own* row is used regardless of list position).

Frontend-only; no backend/serializer change (the field was already exposed and is roster-public).

## Context — most of #716 was already shipped

This branch was scoped as a "combat UI rebuild" for #716, but a verify-against-code pass found #716's unified combat UI **already built & merged piecemeal** (Phases 5/7/8 — `CombatTurnPanel` + all rail sections, `ActionDeclarationCard`, `ThreadPullPicker`, `PoseUnit`, the `InteractionAction` bridge + auto-link, the applicable-pulls API, clash-contribution dispatch, etc.). So the only genuine remaining in-domain code work was #918. Alongside this PR I groomed #716 into a residual-item tracker and filed successor issues #996 (auto-expand pose units on critical events) and #997 (CombatOpponent portrait FK).

## Testing

- `vitest run` on the two affected suites — **26 pass** (incl. 3 new regression tests)
- `pnpm typecheck` — clean
- `pnpm lint` (changed files) — 0 errors (1 pre-existing `react-refresh` warning, unchanged)
- `pnpm build` — ✓ built

Closes #918. Refs #716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
