### PR TITLE
feat(#933): mission-route candidate roulette — spin the random draw (stacked on #941)

### DIFF
--- a/src/world/missions/services/resolution.py
+++ b/src/world/missions/services/resolution.py
@@ -66,6 +66,7 @@ from world.checks.consequence_resolution import apply_resolution
 from world.checks.models import Consequence
 from world.checks.outcome_utils import select_weighted
 from world.checks.services import perform_check
+from world.checks.theater import maybe_emit_resolution_theater
 from world.checks.types import CheckResult, PendingResolution, ResolutionContext
 from world.missions.constants import MissionStatus, NodeLocationMode, OptionKind, OptionSource
 from world.missions.models import (
@@ -387,6 +388,47 @@ def _route_next_node(
     return route.target_node, None
 
 
+_MIN_ROULETTE_FACES = 2  # a wheel needs at least two faces to be worth spinning
+
+
+def _emit_candidate_roulette(
+    character: ObjectDB,
+    route: MissionOptionRoute,
+    chosen: MissionOptionRouteCandidate,
+    title: str,
+) -> None:
+    """Reveal a random-set draw on the roller's roulette wheel (#933).
+
+    Faces are the candidates that resolve to a consequence (the candidate's
+    own, else the route's), weighted by each candidate's selection weight; the
+    wheel lands on the chosen candidate. Reuses the #924 theater seam, which
+    fires only when a face carries real stakes (character_loss / theater) — so
+    routine random sets stay quiet, and the canonical mission-failure reveal
+    (Death flickering to Imprisonment) lights up.
+    """
+    faces: list[Consequence] = []
+    selected: Consequence | None = None
+    for candidate in route.candidates.select_related("consequence__outcome_tier").all():
+        conseq = candidate.consequence or route.consequence
+        if conseq is None or conseq.outcome_tier_id is None:
+            continue  # no tier to render a face for; skip it
+        face = Consequence(
+            outcome_tier=conseq.outcome_tier,
+            label=conseq.label,
+            weight=candidate.weight,
+            character_loss=conseq.character_loss,
+            theater=conseq.theater,
+        )
+        faces.append(face)
+        if candidate.pk == chosen.pk:
+            selected = face
+    if selected is None or len(faces) < _MIN_ROULETTE_FACES:  # nothing to spin
+        return
+    maybe_emit_resolution_theater(
+        character=character, title=title, consequences=faces, selected=selected
+    )
+
+
 def _spawn_mission_instance_room(
     instance: MissionInstance, option: MissionOption, character: ObjectDB
 ) -> None:
@@ -551,6 +593,8 @@ def resolve_option(  # noqa: PLR0913
     # (it always advances, so it is never the terminal route).
     if candidate is not None:
         emit_candidate_rewards(instance, candidate, deed)
+        # #933: spin the candidate draw on the roller's wheel (theater self-gates).
+        _emit_candidate_roulette(character, route, candidate, instance.template.name)
     if is_terminal:
         # Phase 5b.0: emit the terminal route's authored reward lines. The gate
         # is the local is_terminal flag, set ABOVE the deed.create

--- a/src/world/missions/tests/test_services_resolution_resolve.py
+++ b/src/world/missions/tests/test_services_resolution_resolve.py
@@ -209,6 +209,59 @@ class ResolveCheckOptionTests(TestCase):
             deed = resolve_option(self.instance, self.entry, self.check_option, self.actor)
         self.assertIsNone(deed.route_candidate)
 
+    def _random_route(self, outcome):
+        return MissionOptionRouteFactory(
+            option=self.check_option,
+            outcome_tier=outcome,
+            target_node=None,
+            is_random_set=True,
+        )
+
+    def test_random_set_emits_roulette_with_candidate_faces(self) -> None:
+        # #933: the wheel faces are the candidate consequences, weighted by the
+        # candidate's selection weight, landing on the chosen candidate.
+        outcome = CheckOutcomeFactory(name="RouletteFail", success_level=-1)
+        route = self._random_route(outcome)
+        death = ConsequenceFactory(outcome_tier=outcome, label="Death", character_loss=True)
+        prison = ConsequenceFactory(outcome_tier=outcome, label="Imprisonment")
+        MissionOptionRouteCandidateFactory(
+            route=route, target_node=self.node_a, weight=3, consequence=death
+        )
+        MissionOptionRouteCandidateFactory(
+            route=route, target_node=self.node_b, weight=1, consequence=prison
+        )
+        theater = "world.missions.services.resolution.maybe_emit_resolution_theater"
+        with force_check_outcome(outcome), patch(theater) as emit:
+            deed = resolve_option(self.instance, self.entry, self.check_option, self.actor)
+
+        emit.assert_called_once()
+        kwargs = emit.call_args.kwargs
+        faces = kwargs["consequences"]
+        self.assertEqual({f.label for f in faces}, {"Death", "Imprisonment"})
+        self.assertEqual({f.weight for f in faces}, {3, 1})  # candidate weights
+        self.assertEqual(kwargs["selected"].label, deed.route_candidate.consequence.label)
+
+    def test_single_candidate_does_not_spin(self) -> None:
+        outcome = CheckOutcomeFactory(name="RouletteSolo", success_level=-1)
+        route = self._random_route(outcome)
+        MissionOptionRouteCandidateFactory(
+            route=route,
+            target_node=self.node_a,
+            weight=1,
+            consequence=ConsequenceFactory(outcome_tier=outcome),
+        )
+        theater = "world.missions.services.resolution.maybe_emit_resolution_theater"
+        with force_check_outcome(outcome), patch(theater) as emit:
+            resolve_option(self.instance, self.entry, self.check_option, self.actor)
+
+        emit.assert_not_called()
+
+    def test_non_random_route_does_not_spin(self) -> None:
+        theater = "world.missions.services.resolution.maybe_emit_resolution_theater"
+        with force_check_outcome(self.success), patch(theater) as emit:
+            resolve_option(self.instance, self.entry, self.check_option, self.actor)
+        emit.assert_not_called()
+
 
 class ResolveChallengeOptionTests(TestCase):
     """CHALLENGE option: approach check (or auto-success) → route on outcome.


### PR DESCRIPTION
Closes #933. **Stacked on #941** (per-candidate emission) — base is the #941 branch; retarget to `main` once it merges. Follow-up from #924 (resolution theater).

## What

The #924 checks-level emit seam was live for `select_consequence` pools, but the canonical #923 demo — a mission failure scrolling **Death → flickering → Imprisonment** — lives in mission *route candidates*, which select through their own weighted path, not `select_consequence`. #941 made the engine consume the chosen candidate; this lights up its reveal:

- When a random-set CHECK route resolves, `_emit_candidate_roulette` builds the wheel **faces from the candidate consequences** (the candidate's own, else the route's), each weighted by the **candidate's selection weight** so the wheel proportions match the real odds, and **lands on the fired candidate**.
- It reuses `world.checks.theater.maybe_emit_resolution_theater` **verbatim** — which self-gates on `character_loss` / `theater`, so routine random sets stay quiet and the dramatic ones light up. No parallel emitter (the #924 doctrine).

This was deliberately deferred until #941: a wheel labeling faces from candidate consequences while the *applied* consequence was still the route-level one would have shown "Death" and applied something else — the theater would lie. Now the candidate the wheel lands on **is** the candidate that resolved.

## Scope

Wired on the CHECK path, where the canonical mission-failure demo lives. (BRANCH random-sets — rarer, and the route isn't in scope post-block there — are a noted follow-up.)

## Tests

535 `world.missions` tests pass. New: faces are the candidate consequences weighted by candidate weight and land on the chosen one; a single-candidate set doesn't spin; a non-random route doesn't spin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- last-addressed-comment: 0 -->
