### PR TITLE
fix(deps): bump react-router to 6.30.4 (Dependabot #89)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,7 +90,7 @@
   },
   "pnpm": {
     "overrides": {
-      "@remix-run/router": "1.23.2",
+      "@remix-run/router": "1.23.3",
       "ajv@6": "6.14.0",
       "brace-expansion@1": "1.1.15",
       "brace-expansion@2": "2.0.3",
@@ -105,7 +105,7 @@
       "minimatch@9": "9.0.9",
       "picomatch@4": "4.0.4",
       "postcss@8": "8.5.15",
-      "react-router@6": "6.30.2",
+      "react-router@6": "6.30.4",
       "ws@8": "8.20.1",
       "yaml@1": "1.10.3",
       "yaml@2": "2.8.3"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@remix-run/router': 1.23.2
+  '@remix-run/router': 1.23.3
   ajv@6: 6.14.0
   brace-expansion@1: 1.1.15
   brace-expansion@2: 2.0.3
@@ -20,7 +20,7 @@ overrides:
   minimatch@9: 9.0.9
   picomatch@4: 4.0.4
   postcss@8: 8.5.15
-  react-router@6: 6.30.2
+  react-router@6: 6.30.4
   ws@8: 8.20.1
   yaml@1: 1.10.3
   yaml@2: 2.8.3
@@ -1309,8 +1309,8 @@ packages:
       react-redux:
         optional: true
 
-  '@remix-run/router@1.23.2':
-    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
+  '@remix-run/router@1.23.3':
+    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
     engines: {node: '>=14.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
@@ -2960,8 +2960,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.30.2:
-    resolution: {integrity: sha512-H2Bm38Zu1bm8KUE5NVWRMzuIyAV8p/JrOaBJAwVmp37AXG72+CZJlEBw6pdn9i5TBgLMhNDgijS4ZlblpHyWTA==}
+  react-router@6.30.4:
+    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -3553,11 +3553,11 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
+      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0(supports-color@10.2.2))
       '@babel/helpers': 7.28.2
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.28.0(supports-color@10.2.2)
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
       debug: 4.4.1(supports-color@10.2.2)
@@ -3587,17 +3587,17 @@ snapshots:
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.28.0(supports-color@10.2.2)
       '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)':
+  '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.28.0(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.28.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3640,7 +3640,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.2
 
-  '@babel/traverse@7.28.0':
+  '@babel/traverse@7.28.0(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.0
@@ -4608,7 +4608,7 @@ snapshots:
       react: 18.3.1
       react-redux: 9.2.0(@types/react@18.3.23)(react@18.3.1)(redux@5.0.1)
 
-  '@remix-run/router@1.23.2': {}
+  '@remix-run/router@1.23.3': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -6384,14 +6384,14 @@ snapshots:
 
   react-router-dom@6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.2
+      '@remix-run/router': 1.23.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.2(react@18.3.1)
+      react-router: 6.30.4(react@18.3.1)
 
-  react-router@6.30.2(react@18.3.1):
+  react-router@6.30.4(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.2
+      '@remix-run/router': 1.23.3
       react: 18.3.1
 
   react-select@5.10.2(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ allowBuilds:
 # selectors (e.g. `minimatch@9`) are used because compound `>=X <Y` selectors
 # are not supported by pnpm v11 overrides.
 overrides:
-  '@remix-run/router': '1.23.2'
+  '@remix-run/router': '1.23.3'
   'ajv@6': '6.14.0'
   'brace-expansion@1': '1.1.15'
   'brace-expansion@2': '2.0.3'
@@ -33,7 +33,7 @@ overrides:
   'minimatch@9': '9.0.9'
   'picomatch@4': '4.0.4'
   'postcss@8': '8.5.15'
-  'react-router@6': '6.30.2'
+  'react-router@6': '6.30.4'
   'ws@8': '8.20.1'
   'yaml@1': '1.10.3'
   'yaml@2': '2.8.3'


### PR DESCRIPTION
## Dependabot alerts addressed

### ✅ #89 react-router (medium) — fixed
Open-redirect advisory: `react-router < 6.30.4` mis-handles same-origin redirects to paths starting `//`, reinterpreting them as protocol-relative URLs (open redirect).

- Override `react-router@6` **6.30.2 → 6.30.4**
- Override `@remix-run/router` **1.23.2 → 1.23.3** (required by react-router 6.30.4)
- Updated in both `frontend/pnpm-workspace.yaml` (authoritative for pnpm v11) and `frontend/package.json` (kept mirrored).

**Verified:** `pnpm build` green; vitest **1144/1144** passing.

### ⚠️ #90 esbuild (high) — NOT addressable in-tree right now
The only patched esbuild is `0.28.1`, which sits **outside every vite release's esbuild range** (vite 6.4.x requires `^0.25.0`; even vite 7 caps at `^0.27.0`). Forcing `0.28.1` via override was tested and **breaks `vite build`**:

> `Transforming destructuring to the configured target environment ("chrome87", …) is not supported yet`

The advisory's exploit vector is esbuild's **Deno module** fetching its binary without integrity verification via `NPM_CONFIG_REGISTRY`. This project installs esbuild via **pnpm/npm with lockfile-pinned `@esbuild/*` binaries** — the Deno path is never exercised — so it is realistically **not affected**.

**Recommendation:** dismiss #90 as "vulnerable code not used" (Deno-only vector), or leave it open and bump esbuild once a vite release adopts `esbuild ^0.28`. Deferred to a maintainer — not changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)