### PR TITLE
feat(#972): seed magic progression content + wire PathCodexGrant at CG finalize

### DIFF
--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -136,6 +136,11 @@ What was built:
 Requires authored `CodexEntry` rows + `PathCodexGrant`s for the magic features (and
 `MagicProgressionMilestone` rows) to surface real content — engine only; content
 authoring is separate.
+- Content authored (#972): `seed_magic_progression()` seeds the 14-milestone matrix
+  (5 concept milestones at Prospect — the L1–2 tutorial; `second_gift`+`stage_crossing`
+  recurring at each crossing), 11 codex entries (resonance/motif public, rest gated), and
+  `PathCodexGrant` rows for all active Prospect paths. `PathCodexGrant` is now consumed at
+  CG finalize via `_finalize_path_codex_grants` (mirrors the tradition grant).
 
 ## What's Needed for MVP
 

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -808,6 +808,34 @@ def _finalize_tradition_codex_grants(draft: CharacterDraft, sheet: CharacterShee
         )
 
 
+def _finalize_path_codex_grants(draft: CharacterDraft, sheet: CharacterSheet) -> None:
+    """Apply Path codex grants. No-op without a selected path.
+
+    Mirrors _finalize_tradition_codex_grants: the chosen Path teaches the
+    character which magic milestones exist (drives the dashboard discovery
+    tiers). Idempotent via get_or_create.
+    """
+    if not draft.selected_path:
+        return
+
+    from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
+    from world.codex.models import CharacterCodexKnowledge, PathCodexGrant  # noqa: PLC0415
+
+    grant_entry_ids = list(
+        PathCodexGrant.objects.filter(path=draft.selected_path).values_list("entry_id", flat=True)
+    )
+    if not grant_entry_ids:
+        return
+
+    roster_entry = sheet.roster_entry
+    for entry_id in grant_entry_ids:
+        CharacterCodexKnowledge.objects.get_or_create(
+            roster_entry=roster_entry,
+            entry_id=entry_id,
+            defaults={"status": CodexKnowledgeStatus.KNOWN},
+        )
+
+
 def _finalize_anima_ritual(draft: CharacterDraft, sheet: CharacterSheet) -> None:
     """Step 5: create player anima Ritual + sidecar + CharacterRitualKnowledge.
 
@@ -863,6 +891,9 @@ def finalize_magic_data(draft: CharacterDraft, sheet: CharacterSheet) -> None:
 
     # 3. Apply tradition codex grants
     _finalize_tradition_codex_grants(draft, sheet)
+
+    # 3b. Apply path codex grants (teaches which magic milestones exist)
+    _finalize_path_codex_grants(draft, sheet)
 
     # 4. Create CharacterAura with defaults
     glimpse_story = draft.draft_data.get("glimpse_story", "")

--- a/src/world/character_creation/tests/test_path_codex_grants.py
+++ b/src/world/character_creation/tests/test_path_codex_grants.py
@@ -1,0 +1,86 @@
+"""Tests for _finalize_path_codex_grants: consuming PathCodexGrant at CG finalization."""
+
+from django.test import TestCase
+
+from world.character_creation.factories import CharacterDraftFactory
+from world.classes.factories import PathFactory
+
+
+class FinalizePathCodexGrantsTests(TestCase):
+    """Tests for _finalize_path_codex_grants service function."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from world.codex.factories import CodexEntryFactory, PathCodexGrantFactory
+
+        cls.path = PathFactory()
+        cls.codex_entry = CodexEntryFactory()
+        PathCodexGrantFactory(path=cls.path, entry=cls.codex_entry)
+
+    def _make_sheet_with_roster_entry(self):
+        """Create a CharacterSheet with a wired RosterEntry.
+
+        Mirrors the pattern from test_traditions.py FinalizeMagicTraditionTests:
+            sheet = CharacterSheetFactory()
+            RosterEntryFactory(character_sheet__character=sheet.character)
+            sheet.refresh_from_db()
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.roster.factories import RosterEntryFactory
+
+        sheet = CharacterSheetFactory()
+        RosterEntryFactory(character_sheet__character=sheet.character)
+        sheet.refresh_from_db()
+        return sheet
+
+    def test_creates_codex_knowledge_for_path_grants(self):
+        """Grants applied when draft has a selected_path with PathCodexGrant rows."""
+        from world.character_creation.services import _finalize_path_codex_grants
+        from world.codex.constants import CodexKnowledgeStatus
+        from world.codex.models import CharacterCodexKnowledge
+
+        sheet = self._make_sheet_with_roster_entry()
+        draft = CharacterDraftFactory(selected_path=self.path)
+
+        _finalize_path_codex_grants(draft, sheet)
+
+        knowledge = CharacterCodexKnowledge.objects.filter(
+            roster_entry=sheet.roster_entry,
+            entry=self.codex_entry,
+        )
+        assert knowledge.exists()
+        assert knowledge.first().status == CodexKnowledgeStatus.KNOWN
+
+    def test_no_selected_path_is_noop(self):
+        """No rows created when draft has no selected_path."""
+        from world.character_creation.services import _finalize_path_codex_grants
+        from world.codex.models import CharacterCodexKnowledge
+
+        sheet = self._make_sheet_with_roster_entry()
+        draft = CharacterDraftFactory(selected_path=None)
+
+        _finalize_path_codex_grants(draft, sheet)
+
+        assert (
+            CharacterCodexKnowledge.objects.filter(
+                roster_entry=sheet.roster_entry,
+            ).count()
+            == 0
+        )
+
+    def test_idempotent_double_call_creates_one_row(self):
+        """Calling _finalize_path_codex_grants twice creates exactly one row per entry."""
+        from world.character_creation.services import _finalize_path_codex_grants
+        from world.codex.models import CharacterCodexKnowledge
+
+        sheet = self._make_sheet_with_roster_entry()
+        draft = CharacterDraftFactory(selected_path=self.path)
+
+        _finalize_path_codex_grants(draft, sheet)
+        _finalize_path_codex_grants(draft, sheet)
+
+        count = CharacterCodexKnowledge.objects.filter(
+            roster_entry=sheet.roster_entry,
+            entry=self.codex_entry,
+        ).count()
+        assert count == 1

--- a/src/world/codex/factories.py
+++ b/src/world/codex/factories.py
@@ -36,6 +36,7 @@ class CodexSubjectFactory(DjangoModelFactory):
 
     class Meta:
         model = CodexSubject
+        django_get_or_create = ("category", "parent", "name")
 
     category = factory.SubFactory(CodexCategoryFactory)
     parent = None
@@ -122,6 +123,7 @@ class PathCodexGrantFactory(DjangoModelFactory):
 
     class Meta:
         model = PathCodexGrant
+        django_get_or_create = ("path", "entry")
 
     path = factory.SubFactory("world.classes.factories.PathFactory")
     entry = factory.SubFactory(CodexEntryFactory)

--- a/src/world/codex/tests/test_factories_idempotent.py
+++ b/src/world/codex/tests/test_factories_idempotent.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from world.classes.factories import PathFactory
+from world.codex.factories import (
+    CodexCategoryFactory,
+    CodexEntryFactory,
+    CodexSubjectFactory,
+    PathCodexGrantFactory,
+)
+
+
+class CodexFactoryIdempotencyTests(TestCase):
+    def test_subject_factory_get_or_create(self):
+        cat = CodexCategoryFactory(name="Magic")
+        s1 = CodexSubjectFactory(category=cat, parent=None, name="The Mage's Journey")
+        s2 = CodexSubjectFactory(category=cat, parent=None, name="The Mage's Journey")
+        assert s1.pk == s2.pk
+
+    def test_path_grant_factory_get_or_create(self):
+        path = PathFactory()
+        entry = CodexEntryFactory()
+        g1 = PathCodexGrantFactory(path=path, entry=entry)
+        g2 = PathCodexGrantFactory(path=path, entry=entry)
+        assert g1.pk == g2.pk

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -2576,8 +2576,9 @@ def seed_magic_progression(prospect_paths=None):
     rows for every active Prospect path (or ``prospect_paths`` if given).
 
     Doubles as integration-test setUp and staff/new-player seed data; safe to
-    call repeatedly. Entry content upserts via update_or_create so edited copy
-    re-applies on re-seed (idmapper-safe; loaddata would not update).
+    call repeatedly. Both entry copy (name, summary, lore_content, is_public)
+    AND milestone fields (route_name, sort_order, codex_entry) re-apply on
+    re-seed via update_or_create (idmapper-safe; loaddata would not update).
     """
     from world.classes.models import Path, PathStage
     from world.codex.factories import (
@@ -2587,6 +2588,7 @@ def seed_magic_progression(prospect_paths=None):
     )
     from world.codex.models import CodexEntry
     from world.magic.constants import MagicMilestoneKind as K
+    from world.magic.models import MagicProgressionMilestone
 
     category = CodexCategoryFactory(name="Magic")
     subject = CodexSubjectFactory(category=category, parent=None, name="The Mage's Journey")
@@ -2604,8 +2606,7 @@ def seed_magic_progression(prospect_paths=None):
         "threads": (
             "Weaving Threads",
             False,
-            "Threads bind your magic to people, places, and ideas,"
-            " deepening what you can affect.",
+            "Threads bind your magic to people, places, and ideas, deepening what you can affect.",
             "Thread-weaving is the craft of tying a working to a target"
             " so its power deepens over time.",
         ),
@@ -2700,12 +2701,14 @@ def seed_magic_progression(prospect_paths=None):
         entries[key] = entry
 
     for stage, kind, entry_key, route, order in MATRIX:
-        MagicProgressionMilestoneFactory(
+        MagicProgressionMilestone.objects.update_or_create(
             stage=stage,
             kind=kind,
-            codex_entry=entries[entry_key],
-            route_name=route,
-            sort_order=order,
+            defaults={
+                "codex_entry": entries[entry_key],
+                "route_name": route,
+                "sort_order": order,
+            },
         )
 
     gated_keys = [k for k, v in ENTRIES.items() if not v[1]]

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -2566,3 +2566,152 @@ class MagicProgressionMilestoneFactory(factory.django.DjangoModelFactory):
     kind = MagicMilestoneKind.THREAD_WEAVING
     codex_entry = factory.SubFactory("world.codex.factories.CodexEntryFactory")
     sort_order = 0
+
+
+def seed_magic_progression(prospect_paths=None):
+    """Idempotent seed for the magic progression dashboard.
+
+    Authors the codex category/subject, 11 CodexEntry rows, 14
+    MagicProgressionMilestone rows ((stage, kind) unique), and PathCodexGrant
+    rows for every active Prospect path (or ``prospect_paths`` if given).
+
+    Doubles as integration-test setUp and staff/new-player seed data; safe to
+    call repeatedly. Entry content upserts via update_or_create so edited copy
+    re-applies on re-seed (idmapper-safe; loaddata would not update).
+    """
+    from world.classes.models import Path, PathStage
+    from world.codex.factories import (
+        CodexCategoryFactory,
+        CodexSubjectFactory,
+        PathCodexGrantFactory,
+    )
+    from world.codex.models import CodexEntry
+    from world.magic.constants import MagicMilestoneKind as K
+
+    category = CodexCategoryFactory(name="Magic")
+    subject = CodexSubjectFactory(category=category, parent=None, name="The Mage's Journey")
+
+    # entry_key -> (name, is_public, summary, lore_content)
+    ENTRIES = {
+        "resonance": (
+            "Your Resonance",
+            True,
+            "Every mage carries a resonance — the signature of their magic."
+            " Discovering yours is the first step.",
+            "A resonance is the elemental and emotional signature"
+            " that colours a mage's every working.",
+        ),
+        "threads": (
+            "Weaving Threads",
+            False,
+            "Threads bind your magic to people, places, and ideas,"
+            " deepening what you can affect.",
+            "Thread-weaving is the craft of tying a working to a target"
+            " so its power deepens over time.",
+        ),
+        "motif": (
+            "Your Motif",
+            True,
+            "Your motif is the personal aesthetic your magic wears"
+            " — how your power looks and feels.",
+            "A motif is the through-line of a mage's self-expression,"
+            " the consistent style of their workings.",
+        ),
+        "techniques": (
+            "Developing Techniques",
+            False,
+            "Techniques are the shaped workings you develop and refine over a magical career.",
+            "Where a cantrip is a first spark, a developed technique is a deliberate,"
+            " honed working.",
+        ),
+        "anima": (
+            "Anima Rituals",
+            False,
+            "Anima rituals let you spend your inner reserve to power deeper magic.",
+            "Anima is the wellspring a mage draws on for ritual work,"
+            " replenished through rest and meaning.",
+        ),
+        "second_gift": (
+            "Awakening Another Gift",
+            False,
+            "As you grow, you can awaken an additional Gift — a new wellspring of power.",
+            "A Gift is an innate channel for magic. Most mages awaken to one;"
+            " the gifted few open more as they ascend.",
+        ),
+        "cross_potential": (
+            "Crossing to Potential",
+            False,
+            "Crossing from Prospect to Potential is the first true threshold of a mage's path.",
+            "When a Prospect has learned what magic is and can do, they become ready"
+            " to cross into Potential. The crossing is marked by ceremony.",
+        ),
+        "cross_puissant": (
+            "Crossing to Puissant",
+            False,
+            "Crossing the threshold to Puissant opens a more powerful Path.",
+            "The crossing to Puissant is a major threshold, attended by ceremony,"
+            " that opens a more powerful Path.",
+        ),
+        "cross_true": (
+            "Crossing to True",
+            False,
+            "Crossing to True is a major ascension of a mage's path.",
+            "The crossing to True is a major threshold, attended by ceremony.",
+        ),
+        "cross_grand": (
+            "Crossing to Grand",
+            False,
+            "Crossing to Grand is among the rarest ascensions a mage achieves.",
+            "The crossing to Grand is a major threshold, attended by ceremony.",
+        ),
+        "cross_transcendent": (
+            "Crossing to Transcendent",
+            False,
+            "Crossing to Transcendent carries a mage beyond mortal limits.",
+            "The crossing to Transcendent is the final threshold, attended by ceremony.",
+        ),
+    }
+
+    # (stage, kind, entry_key, route_name, sort_order)
+    MATRIX = [
+        (PathStage.PROSPECT, K.RESONANCE_DISCOVERY, "resonance", "", 0),
+        (PathStage.PROSPECT, K.THREAD_WEAVING, "threads", "/threads", 1),
+        (PathStage.PROSPECT, K.MOTIF, "motif", "", 2),
+        (PathStage.PROSPECT, K.TECHNIQUE_DEVELOPMENT, "techniques", "/techniques/build", 3),
+        (PathStage.PROSPECT, K.ANIMA_RITUAL, "anima", "/rituals", 4),
+        (PathStage.POTENTIAL, K.SECOND_GIFT, "second_gift", "", 0),
+        (PathStage.POTENTIAL, K.STAGE_CROSSING, "cross_potential", "/magic/progression", 1),
+        (PathStage.PUISSANT, K.SECOND_GIFT, "second_gift", "", 0),
+        (PathStage.PUISSANT, K.STAGE_CROSSING, "cross_puissant", "/magic/progression", 1),
+        (PathStage.TRUE, K.SECOND_GIFT, "second_gift", "", 0),
+        (PathStage.TRUE, K.STAGE_CROSSING, "cross_true", "/magic/progression", 1),
+        (PathStage.GRAND, K.SECOND_GIFT, "second_gift", "", 0),
+        (PathStage.GRAND, K.STAGE_CROSSING, "cross_grand", "/magic/progression", 1),
+        (PathStage.TRANSCENDENT, K.STAGE_CROSSING, "cross_transcendent", "/magic/progression", 0),
+    ]
+
+    entries = {}
+    for key, (name, is_public, summary, lore) in ENTRIES.items():
+        entry, _ = CodexEntry.objects.update_or_create(
+            subject=subject,
+            name=name,
+            defaults={"summary": summary, "lore_content": lore, "is_public": is_public},
+        )
+        entries[key] = entry
+
+    for stage, kind, entry_key, route, order in MATRIX:
+        MagicProgressionMilestoneFactory(
+            stage=stage,
+            kind=kind,
+            codex_entry=entries[entry_key],
+            route_name=route,
+            sort_order=order,
+        )
+
+    gated_keys = [k for k, v in ENTRIES.items() if not v[1]]
+    paths = prospect_paths
+    if paths is None:
+        paths = Path.objects.filter(stage=PathStage.PROSPECT, is_active=True)
+    for path in paths:
+        for key in gated_keys:
+            PathCodexGrantFactory(path=path, entry=entries[key])

--- a/src/world/magic/tests/test_seed_progression.py
+++ b/src/world/magic/tests/test_seed_progression.py
@@ -1,11 +1,14 @@
 from django.test import TestCase
 
+from world.character_sheets.factories import CharacterSheetFactory
 from world.classes.factories import PathFactory
 from world.classes.models import PathStage
-from world.codex.models import CodexEntry, PathCodexGrant
-from world.magic.constants import MagicMilestoneKind
+from world.codex.constants import CodexKnowledgeStatus
+from world.codex.models import CharacterCodexKnowledge, CodexEntry, PathCodexGrant
+from world.magic.constants import MagicMilestoneKind, MilestoneDiscoveryTier
 from world.magic.factories import seed_magic_progression
 from world.magic.models import MagicProgressionMilestone
+from world.roster.factories import RosterEntryFactory
 
 
 class SeedMagicProgressionTests(TestCase):
@@ -74,3 +77,46 @@ class SeedMagicProgressionTests(TestCase):
         seed_magic_progression()
         m.refresh_from_db()
         assert m.route_name == "/threads"
+
+    def test_e2e_dashboard_reveal(self):
+        """Grant → knowledge → dashboard reveal: full end-to-end path."""
+        from world.magic.services.progression_dashboard import build_progression_dashboard
+
+        seed_magic_progression()
+
+        # Build a sheet with a resolving roster_entry (mirrors reference test pattern).
+        sheet = CharacterSheetFactory()
+        roster_entry = RosterEntryFactory(character_sheet=sheet)
+
+        # --- Before knowledge grants ---
+        result = build_progression_dashboard(sheet)
+        prospect_view = next(sv for sv in result if sv.stage == PathStage.PROSPECT)
+
+        # Public entries (resonance_discovery, motif) are KNOWN even with no knowledge row.
+        tier_by_kind = {mv.kind: mv.tier for mv in prospect_view.milestones}
+        assert (
+            tier_by_kind.get(MagicMilestoneKind.RESONANCE_DISCOVERY) == MilestoneDiscoveryTier.KNOWN
+        )
+        assert tier_by_kind.get(MagicMilestoneKind.MOTIF) == MilestoneDiscoveryTier.KNOWN
+
+        # Gated entry (thread_weaving) is UNKNOWN → collapsed, not in milestones list.
+        assert MagicMilestoneKind.THREAD_WEAVING not in tier_by_kind
+        assert prospect_view.has_undiscovered is True
+
+        # --- Grant codex knowledge for all entries on self.prospect ---
+        granted_entry_ids = list(
+            PathCodexGrant.objects.filter(path=self.prospect).values_list("entry_id", flat=True)
+        )
+        for entry_id in granted_entry_ids:
+            CharacterCodexKnowledge.objects.create(
+                roster_entry=roster_entry,
+                entry_id=entry_id,
+                status=CodexKnowledgeStatus.KNOWN,
+            )
+
+        # --- After knowledge grants ---
+        result2 = build_progression_dashboard(sheet)
+        prospect_view2 = next(sv for sv in result2 if sv.stage == PathStage.PROSPECT)
+
+        tier_by_kind2 = {mv.kind: mv.tier for mv in prospect_view2.milestones}
+        assert tier_by_kind2.get(MagicMilestoneKind.THREAD_WEAVING) == MilestoneDiscoveryTier.KNOWN

--- a/src/world/magic/tests/test_seed_progression.py
+++ b/src/world/magic/tests/test_seed_progression.py
@@ -8,6 +8,7 @@ from world.codex.models import CharacterCodexKnowledge, CodexEntry, PathCodexGra
 from world.magic.constants import MagicMilestoneKind, MilestoneDiscoveryTier
 from world.magic.factories import seed_magic_progression
 from world.magic.models import MagicProgressionMilestone
+from world.magic.services.progression_dashboard import build_progression_dashboard
 from world.roster.factories import RosterEntryFactory
 
 
@@ -80,8 +81,6 @@ class SeedMagicProgressionTests(TestCase):
 
     def test_e2e_dashboard_reveal(self):
         """Grant → knowledge → dashboard reveal: full end-to-end path."""
-        from world.magic.services.progression_dashboard import build_progression_dashboard
-
         seed_magic_progression()
 
         # Build a sheet with a resolving roster_entry (mirrors reference test pattern).
@@ -120,3 +119,8 @@ class SeedMagicProgressionTests(TestCase):
 
         tier_by_kind2 = {mv.kind: mv.tier for mv in prospect_view2.milestones}
         assert tier_by_kind2.get(MagicMilestoneKind.THREAD_WEAVING) == MilestoneDiscoveryTier.KNOWN
+        assert (
+            tier_by_kind2[MagicMilestoneKind.TECHNIQUE_DEVELOPMENT] == MilestoneDiscoveryTier.KNOWN
+        )
+        assert tier_by_kind2[MagicMilestoneKind.ANIMA_RITUAL] == MilestoneDiscoveryTier.KNOWN
+        assert prospect_view2.has_undiscovered is False

--- a/src/world/magic/tests/test_seed_progression.py
+++ b/src/world/magic/tests/test_seed_progression.py
@@ -37,8 +37,12 @@ class SeedMagicProgressionTests(TestCase):
     def test_creates_11_entries_and_public_flags(self):
         seed_magic_progression()
         assert CodexEntry.objects.filter(subject__name="The Mage's Journey").count() == 11
-        public = set(CodexEntry.objects.filter(is_public=True).values_list("name", flat=True))
-        assert {"Your Resonance", "Your Motif"} <= public
+        public = set(
+            CodexEntry.objects.filter(
+                subject__name="The Mage's Journey", is_public=True
+            ).values_list("name", flat=True)
+        )
+        assert public == {"Your Resonance", "Your Motif"}
         assert "Weaving Threads" not in public
 
     def test_second_gift_shares_one_entry(self):
@@ -59,3 +63,14 @@ class SeedMagicProgressionTests(TestCase):
         assert MagicProgressionMilestone.objects.count() == 14
         assert CodexEntry.objects.filter(subject__name="The Mage's Journey").count() == 11
         assert PathCodexGrant.objects.filter(path=self.prospect).count() == 9
+
+    def test_reseed_updates_milestone_route(self):
+        seed_magic_progression()
+        m = MagicProgressionMilestone.objects.get(
+            stage=PathStage.PROSPECT, kind=MagicMilestoneKind.THREAD_WEAVING
+        )
+        m.route_name = "/stale"
+        m.save()
+        seed_magic_progression()
+        m.refresh_from_db()
+        assert m.route_name == "/threads"

--- a/src/world/magic/tests/test_seed_progression.py
+++ b/src/world/magic/tests/test_seed_progression.py
@@ -1,0 +1,61 @@
+from django.test import TestCase
+
+from world.classes.factories import PathFactory
+from world.classes.models import PathStage
+from world.codex.models import CodexEntry, PathCodexGrant
+from world.magic.constants import MagicMilestoneKind
+from world.magic.factories import seed_magic_progression
+from world.magic.models import MagicProgressionMilestone
+
+
+class SeedMagicProgressionTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.prospect = PathFactory(name="Awakening", stage=PathStage.PROSPECT, is_active=True)
+        cls.inactive = PathFactory(name="Retired", stage=PathStage.PROSPECT, is_active=False)
+
+    def test_creates_14_milestones_with_distribution(self):
+        seed_magic_progression()
+        assert MagicProgressionMilestone.objects.count() == 14
+        by_stage = {}
+        for m in MagicProgressionMilestone.objects.all():
+            by_stage.setdefault(m.stage, set()).add(m.kind)
+        assert by_stage[PathStage.PROSPECT] == {
+            MagicMilestoneKind.RESONANCE_DISCOVERY,
+            MagicMilestoneKind.THREAD_WEAVING,
+            MagicMilestoneKind.MOTIF,
+            MagicMilestoneKind.TECHNIQUE_DEVELOPMENT,
+            MagicMilestoneKind.ANIMA_RITUAL,
+        }
+        assert by_stage[PathStage.TRANSCENDENT] == {MagicMilestoneKind.STAGE_CROSSING}
+        for stage in (PathStage.POTENTIAL, PathStage.PUISSANT, PathStage.TRUE, PathStage.GRAND):
+            assert by_stage[stage] == {
+                MagicMilestoneKind.SECOND_GIFT,
+                MagicMilestoneKind.STAGE_CROSSING,
+            }
+
+    def test_creates_11_entries_and_public_flags(self):
+        seed_magic_progression()
+        assert CodexEntry.objects.filter(subject__name="The Mage's Journey").count() == 11
+        public = set(CodexEntry.objects.filter(is_public=True).values_list("name", flat=True))
+        assert {"Your Resonance", "Your Motif"} <= public
+        assert "Weaving Threads" not in public
+
+    def test_second_gift_shares_one_entry(self):
+        seed_magic_progression()
+        sg = MagicProgressionMilestone.objects.filter(kind=MagicMilestoneKind.SECOND_GIFT)
+        entry_ids = {m.codex_entry_id for m in sg}
+        assert len(entry_ids) == 1
+
+    def test_grants_gated_entries_to_active_prospect_paths_only(self):
+        seed_magic_progression()
+        granted_paths = set(PathCodexGrant.objects.values_list("path__name", flat=True))
+        assert granted_paths == {"Awakening"}
+        assert PathCodexGrant.objects.filter(path=self.prospect).count() == 9
+
+    def test_idempotent(self):
+        seed_magic_progression()
+        seed_magic_progression()
+        assert MagicProgressionMilestone.objects.count() == 14
+        assert CodexEntry.objects.filter(subject__name="The Mage's Journey").count() == 11
+        assert PathCodexGrant.objects.filter(path=self.prospect).count() == 9


### PR DESCRIPTION
Closes #972

## Summary

Authors the content that populates the magic progression dashboard (engine built in #536), delivered as an idempotent FactoryBoy seed chain — **plus** the small wiring that makes it actually visible.

**What's built**
- `seed_magic_progression()` (`world/magic/factories.py`): a `Magic` codex category + `The Mage's Journey` subject, **11 `CodexEntry`** rows, **14 `MagicProgressionMilestone`** rows, and `PathCodexGrant` rows for every active Prospect path. Idempotent (entries + milestones via `update_or_create`; joins via `django_get_or_create`) so it doubles as integration-test setup and staff/new-player seed data — not a data migration.
- Milestone matrix per the designer's model: the **five ability-concept milestones cluster at Prospect** (the L1–2 tutorial whose completion gates becoming a Potential); `second_gift` + `stage_crossing` **recur at each crossing** (Potential/Puissant/True/Grand), `stage_crossing` at Transcendent. `resonance`/`motif` public; the rest codex-gated.
- **Wiring (the load-bearing fix):** `PathCodexGrant` was BUILT but had *no runtime consumer*, so authored grants revealed nothing. Added `_finalize_path_codex_grants` in `finalize_magic_data`, a direct mirror of the wired `_finalize_tradition_codex_grants` — so choosing a Path at CG grants the codex knowledge the dashboard gates on.

**Spoiler discipline:** the five `stage_crossing` codex entries carry only neutral, conceptual lore; the Audere Majora ceremony wording stays a private DB seed, never committed.

**Tests:** seed-chain distribution/counts/idempotency, the end-to-end grant→knowledge→dashboard reveal, and the CG-finalize wiring. `ty` + `ruff` clean; magic/codex/character_creation fast tiers green.

**For the reviewer (design nuance, not a bug):** a `stage_crossing` milestone sits at its *destination* stage and the engine has no `_already_have` check for it, so e.g. a Potential mage sees "Crossing to Potential: ELIGIBLE" (the crossing they've already made). That matches the approved matrix; if you'd prefer it reflect the crossing *ahead* (or read `AudereMajoraCrossing` receipts to mark achieved crossings), say so and I'll file a follow-up.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #972 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto latest origin/main (6 commits replayed; no migrations, no conflicts).

<!-- last-addressed-comment: 0 -->