### PR TITLE
Covenant role powers, full stack (#783, #751, #518)

### DIFF
--- a/docs/roadmap/covenants.md
+++ b/docs/roadmap/covenants.md
@@ -1,6 +1,6 @@
 # Covenants
 
-**Status:** in-progress (Slice A entity + membership FK + engagement context shipped; Slice B RitualSession primitive + formation ritual + engagement UI shipped; Slice D covenant progression + Story integration shipped; Slice E Battle covenants + Durance×Battle combat-precedence shipped; Slice F covenant rites shipped including role-aware level-banded severity-scaling stat packages (#753); per-role powers (#751) + dissolution still post-MVP)
+**Status:** in-progress (Slice A entity + membership FK + engagement context shipped; Slice B RitualSession primitive + formation ritual + engagement UI shipped; Slice D covenant progression + Story integration shipped; Slice E Battle covenants + Durance×Battle combat-precedence shipped; Slice F covenant rites shipped including role-aware level-banded severity-scaling stat packages (#753); per-role powers (#751: tier-0 passive capability application surface + per-(role,resonance) `ThreadPullEffect` catalog) shipped; rite stat-buffs now flow into checks (#783); battle/group-ability/role-power/promotion frontend (#518) shipped; dissolution still post-MVP)
 **Depends on:** Magic (Threads, Rituals), Combat (uses speed_rank), Items (gear archetype compatibility), Character Sheets
 
 ## Overview
@@ -580,9 +580,16 @@ exercised in combat integration tests.
 
 This is deliberately **not** "every member is granted an identical castable
 power at covenant level N" (rejected as anti-individualization). Per-**role**
-unique castable techniques and tier-0 passives remain tracked separately in
-**#751** via the existing `Thread`-on-`COVENANT_ROLE` + `ThreadPullEffect`
-machinery.
+unique powers ship via the existing `Thread`-on-`COVENANT_ROLE` +
+`ThreadPullEffect` machinery (**#751**, delivered): the tier-0 passive
+application surface is `CharacterThreadHandler.passive_capability_grants()`
+(engagement-gated, derive-on-read), folded into the capability read in
+`world/conditions/services.py`; a reference per-`(role,resonance)` catalog is
+seeded by `wire_covenant_role_powers_catalog()`. Two holders of the same role
+anchoring different Resonances unlock different capabilities — the
+individualization lever. **#783** (delivered) folds condition-sourced stat
+buffs into `TraitHandler._get_stat_modifier`, so a rite buff now raises
+effective trait values and stat checks, not only the technique multiplier.
 
 ### Slice G — Use-based Thread mechanics
 
@@ -599,9 +606,13 @@ machinery.
   RELATIONSHIP_TRACK / RELATIONSHIP_CAPSTONE / FACET into the same
   "in-action" model that Slice A added for COVENANT_ROLE. Project-wide
   Thread-discipline work, not Covenant-specific.
-- **Frontend UI (remaining)** — Battle covenant UI, group ability triggers,
-  covenant-Story linkage UI (Slice D). Covenant browser, engage/disengage
-  controls, and formation/induction flows landed in Slice B. (No
+- **Frontend UI (remaining)** — covenant-Story linkage UI (Slice D). Covenant
+  browser, engage/disengage controls, and formation/induction flows landed in
+  Slice B. Battle-covenant state (dormant/rise/stand-down), group-ability/rite
+  triggers, per-member role-power display, and the sub-role promotion dialog
+  landed in **#518** (`frontend/src/covenants/components/` +
+  `CovenantDetailPage`, backed by the `/powers/` + `/stand_down/` endpoints).
+  (No
   sworn-objective tracker — sworn_objective is intentionally free text;
   see the durable design decision above.)
 
@@ -638,7 +649,8 @@ machinery.
   "Covenants Slices A+B"); `seed-and-integration-tests.md` task 2Q
   authors the canonical CovenantRole seed set so combat resolution order
   becomes meaningful.
-- The "Frontend UI" bullet in Cross-cutting is partially delivered by Slice B
-  (covenant browser, engage/disengage, formation/induction ritual flow). What
-  remains: sworn-objective tracker, advanced dissolution flows, Battle covenant
-  UI, group ability triggers.
+- The "Frontend UI" bullet in Cross-cutting is delivered by Slice B (covenant
+  browser, engage/disengage, formation/induction ritual flow) plus **#518**
+  (battle-covenant state, group-ability/rite triggers, role-power display,
+  sub-role promotion). What remains: sworn-objective tracker, advanced
+  dissolution flows.

--- a/frontend/src/covenants/__tests__/CovenantDetailPage.test.tsx
+++ b/frontend/src/covenants/__tests__/CovenantDetailPage.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * CovenantDetailPage tests (C9)
+ *
+ * Covers the page-level wiring done in C9:
+ *   1. Existing behavior intact — covenant header (name) + member roster render.
+ *   2. The new panels are mounted: BattleStateBanner, RitesPanel, RolePowersPanel
+ *      (asserted via lightweight stubs).
+ *   3. The viewer's OWN active membership row shows a "Promote" button; a
+ *      non-own row does not.
+ *
+ * Renders the exported `CovenantDetailInner` directly to avoid router param
+ * plumbing. Heavy children are stubbed so we assert mounting + props rather
+ * than their internals.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import { CovenantDetailInner } from '../pages/CovenantDetailPage';
+import type { CovenantWithBattleState, CharacterCovenantRole } from '@/covenants/api';
+import type { PaginatedCharacterCovenantRoleList } from '@/covenants/api';
+
+// ---------------------------------------------------------------------------
+// Mock query modules
+// ---------------------------------------------------------------------------
+
+vi.mock('@/covenants/queries', () => ({
+  useCovenantDetail: vi.fn(),
+  useCovenantMembers: vi.fn(),
+  useEngageMembership: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDisengageMembership: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock('@/rituals/queries', () => ({
+  useRituals: vi.fn(() => ({
+    data: { count: 0, next: null, previous: null, results: [] },
+    isLoading: false,
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Stub heavy children — assert mounting + key props
+// ---------------------------------------------------------------------------
+
+vi.mock('@/covenants/components/BattleStateBanner', () => ({
+  BattleStateBanner: (props: { covenant: CovenantWithBattleState; isActiveMember: boolean }) => (
+    <div data-testid="battle-state-banner" data-active={String(props.isActiveMember)}>
+      banner:{props.covenant.id}
+    </div>
+  ),
+}));
+
+vi.mock('@/covenants/components/RitesPanel', () => ({
+  RitesPanel: (props: { covenantId: number; isActiveMember: boolean }) => (
+    <div data-testid="rites-panel" data-active={String(props.isActiveMember)}>
+      rites:{props.covenantId}
+    </div>
+  ),
+}));
+
+vi.mock('@/covenants/components/RolePowersPanel', () => ({
+  RolePowersPanel: (props: { covenantId: number }) => (
+    <div data-testid="role-powers-panel">powers:{props.covenantId}</div>
+  ),
+}));
+
+vi.mock('@/covenants/components/PromoteRoleDialog', () => ({
+  PromoteRoleDialog: (props: { open: boolean; covenantId: number }) =>
+    props.open ? <div data-testid="promote-dialog">promote:{props.covenantId}</div> : null,
+}));
+
+vi.mock('@/rituals/components/RitualSessionDraftDialog', () => ({
+  RitualSessionDraftDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="induction-dialog" /> : null,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock Redux auth — provide a puppeted character for characterSheetId
+// ---------------------------------------------------------------------------
+
+const OWN_SHEET_ID = 42;
+
+const authState = {
+  auth: {
+    account: {
+      id: 1,
+      username: 'testuser',
+      available_characters: [
+        {
+          id: OWN_SHEET_ID,
+          name: 'Test Character',
+          currently_puppeted_in_session: true,
+        },
+      ],
+      pending_applications: [],
+    },
+  },
+};
+
+vi.mock('react-redux', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-redux')>();
+  return {
+    ...actual,
+    useSelector: vi.fn((selector: (state: unknown) => unknown) => selector(authState)),
+  };
+});
+
+import { useCovenantDetail, useCovenantMembers } from '@/covenants/queries';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const COVENANT_ID = 7;
+
+const makeCovenant = (
+  overrides: Partial<CovenantWithBattleState> = {}
+): CovenantWithBattleState =>
+  ({
+    id: COVENANT_ID,
+    name: 'The Iron Banner',
+    covenant_type: 'battle',
+    covenant_type_display: 'Covenant of Battle',
+    sworn_objective: 'Hold the line.',
+    member_count: 2,
+    level: 3,
+    is_active: true,
+    is_dormant: true,
+    battle_binding: 'standing',
+    battle_binding_display: 'Standing',
+    ...overrides,
+  }) as CovenantWithBattleState;
+
+const makeMembership = (
+  overrides: Partial<CharacterCovenantRole> = {}
+): CharacterCovenantRole =>
+  ({
+    id: 100,
+    character_sheet: OWN_SHEET_ID,
+    covenant: COVENANT_ID,
+    covenant_role: {
+      id: 7,
+      name: 'Vanguard',
+      slug: 'vanguard',
+      covenant_type: 'battle',
+      covenant_type_display: 'Covenant of Battle',
+      archetype: 'sword',
+      archetype_display: 'Sword',
+      speed_rank: 1,
+      description: 'The tip of the spear.',
+    },
+    engaged: false,
+    joined_at: '2026-01-01T00:00:00Z',
+    left_at: null,
+    is_active: true,
+    can_engage: true,
+    engage_blocked_reason: null,
+    ...overrides,
+  }) as CharacterCovenantRole;
+
+function mockDetail(covenant: CovenantWithBattleState | undefined, isLoading = false) {
+  vi.mocked(useCovenantDetail).mockReturnValue({
+    data: covenant,
+    isLoading,
+  } as never);
+}
+
+function mockMembers(members: CharacterCovenantRole[], isLoading = false) {
+  const data: PaginatedCharacterCovenantRoleList = {
+    count: members.length,
+    next: null,
+    previous: null,
+    results: members,
+  };
+  vi.mocked(useCovenantMembers).mockReturnValue({
+    data: isLoading ? undefined : data,
+    isLoading,
+  } as never);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CovenantDetailPage (CovenantDetailInner)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the covenant header and member roster (existing behavior intact)', () => {
+    mockDetail(makeCovenant());
+    mockMembers([makeMembership()]);
+
+    render(<CovenantDetailInner covenantId={COVENANT_ID} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('The Iron Banner')).toBeInTheDocument();
+    expect(screen.getByTestId('member-roster')).toBeInTheDocument();
+    expect(screen.getByText('Character #42')).toBeInTheDocument();
+  });
+
+  it('mounts BattleStateBanner, RitesPanel, and RolePowersPanel', () => {
+    mockDetail(makeCovenant());
+    mockMembers([makeMembership()]);
+
+    render(<CovenantDetailInner covenantId={COVENANT_ID} />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId('battle-state-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('rites-panel')).toHaveTextContent(`rites:${COVENANT_ID}`);
+    expect(screen.getByTestId('role-powers-panel')).toHaveTextContent(`powers:${COVENANT_ID}`);
+    // The viewer is an active member, so the membership-aware panels know it.
+    expect(screen.getByTestId('battle-state-banner')).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTestId('rites-panel')).toHaveAttribute('data-active', 'true');
+  });
+
+  it('shows a Promote button on the viewer\'s own active membership row only', () => {
+    mockDetail(makeCovenant());
+    mockMembers([
+      makeMembership({ id: 100, character_sheet: OWN_SHEET_ID }),
+      makeMembership({ id: 101, character_sheet: 999 }),
+    ]);
+
+    render(<CovenantDetailInner covenantId={COVENANT_ID} />, { wrapper: createWrapper() });
+
+    const rows = screen.getAllByTestId('member-row');
+    expect(rows).toHaveLength(2);
+
+    // Own row (sheet 42) has a Promote button.
+    const promoteButtons = screen.getAllByRole('button', { name: /^Promote$/i });
+    expect(promoteButtons).toHaveLength(1);
+  });
+});

--- a/frontend/src/covenants/__tests__/CovenantDetailPage.test.tsx
+++ b/frontend/src/covenants/__tests__/CovenantDetailPage.test.tsx
@@ -131,9 +131,7 @@ function createWrapper() {
 
 const COVENANT_ID = 7;
 
-const makeCovenant = (
-  overrides: Partial<CovenantWithBattleState> = {}
-): CovenantWithBattleState =>
+const makeCovenant = (overrides: Partial<CovenantWithBattleState> = {}): CovenantWithBattleState =>
   ({
     id: COVENANT_ID,
     name: 'The Iron Banner',
@@ -149,9 +147,7 @@ const makeCovenant = (
     ...overrides,
   }) as CovenantWithBattleState;
 
-const makeMembership = (
-  overrides: Partial<CharacterCovenantRole> = {}
-): CharacterCovenantRole =>
+const makeMembership = (overrides: Partial<CharacterCovenantRole> = {}): CharacterCovenantRole =>
   ({
     id: 100,
     character_sheet: OWN_SHEET_ID,
@@ -230,7 +226,7 @@ describe('CovenantDetailPage (CovenantDetailInner)', () => {
     expect(screen.getByTestId('rites-panel')).toHaveAttribute('data-active', 'true');
   });
 
-  it('shows a Promote button on the viewer\'s own active membership row only', () => {
+  it("shows a Promote button on the viewer's own active membership row only", () => {
     mockDetail(makeCovenant());
     mockMembers([
       makeMembership({ id: 100, character_sheet: OWN_SHEET_ID }),

--- a/frontend/src/covenants/api.ts
+++ b/frontend/src/covenants/api.ts
@@ -18,9 +18,62 @@ import type { components } from '@/generated/api';
 
 export type Covenant = components['schemas']['Covenant'];
 export type CharacterCovenantRole = components['schemas']['CharacterCovenantRole'];
+export type CovenantRole = components['schemas']['CovenantRole'];
 export type PaginatedCovenantList = components['schemas']['PaginatedCovenantList'];
 export type PaginatedCharacterCovenantRoleList =
   components['schemas']['PaginatedCharacterCovenantRoleList'];
+
+// ---------------------------------------------------------------------------
+// Hand-written types for the powers / stand-down endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * One authored CovenantRite row as returned by the powers endpoint, with the
+ * per-covenant gate flags (level_met / members_present_met) the serializer adds.
+ */
+export interface CovenantRiteRow {
+  id: number;
+  ritual: number;
+  covenant_type: string;
+  covenant_type_display: string;
+  min_covenant_level: number;
+  min_members_present: number;
+  granted_condition: number | null;
+  base_severity: number;
+  severity_per_extra_participant: number;
+  max_severity: number;
+  duration_rounds: number;
+  level_met: boolean;
+  members_present_met: boolean;
+}
+
+/**
+ * One active membership's current passive role power, as returned by the powers
+ * endpoint. Members without a woven role-thread have null capability fields.
+ */
+export interface RolePower {
+  membership_id: number;
+  character_sheet: number;
+  covenant_role_id: number;
+  covenant_role_name: string;
+  resonance_name: string | null;
+  capability_name: string | null;
+  narrative_snippet: string | null;
+  engaged: boolean;
+}
+
+/** Combined payload from GET /api/covenants/covenants/{id}/powers/. */
+export interface CovenantPowers {
+  rites: CovenantRiteRow[];
+  role_powers: RolePower[];
+}
+
+/** Response from POST /api/covenants/covenants/{id}/stand_down/. */
+export interface StandDownResult {
+  id: number;
+  is_dormant: boolean;
+  battle_binding: string;
+}
 
 // ---------------------------------------------------------------------------
 // URL constants
@@ -28,6 +81,7 @@ export type PaginatedCharacterCovenantRoleList =
 
 const COVENANTS_URL = '/api/covenants/covenants';
 const CHARACTER_ROLES_URL = '/api/covenants/character-roles';
+const ROLES_URL = '/api/covenants/roles';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -112,4 +166,81 @@ export async function disengageMembership(id: number): Promise<CharacterCovenant
   });
   if (!res.ok) await parseErrorDetail(res, 'Failed to disengage covenant role');
   return res.json() as Promise<CharacterCovenantRole>;
+}
+
+// ---------------------------------------------------------------------------
+// Powers read
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/covenants/covenants/{id}/powers/
+ * Returns the covenant's authored rites (with gate flags) and per-member
+ * passive role powers in one payload.
+ */
+export async function getCovenantPowers(covenantId: number): Promise<CovenantPowers> {
+  const res = await apiFetch(`${COVENANTS_URL}/${covenantId}/powers/`);
+  if (!res.ok) throw new Error(`Failed to load powers for covenant ${covenantId}`);
+  return res.json() as Promise<CovenantPowers>;
+}
+
+// ---------------------------------------------------------------------------
+// Stand-down mutation (battle covenants)
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /api/covenants/covenants/{id}/stand_down/
+ * Stand a raised battle covenant down to dormant. Returns its new battle state.
+ */
+export async function standDownCovenant(covenantId: number): Promise<StandDownResult> {
+  const res = await apiFetch(`${COVENANTS_URL}/${covenantId}/stand_down/`, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify({}),
+  });
+  if (!res.ok) await parseErrorDetail(res, 'Failed to stand down covenant');
+  return res.json() as Promise<StandDownResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Promotion mutation
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /api/covenants/character-roles/{id}/promote/
+ * Promote a membership into one of its current role's sub-roles. Returns the
+ * new CharacterCovenantRole row.
+ */
+export async function promoteMembership(
+  membershipId: number,
+  targetSubroleId: number
+): Promise<CharacterCovenantRole> {
+  const res = await apiFetch(`${CHARACTER_ROLES_URL}/${membershipId}/promote/`, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify({ target_subrole: targetSubroleId }),
+  });
+  if (!res.ok) await parseErrorDetail(res, 'Failed to promote covenant role');
+  return res.json() as Promise<CharacterCovenantRole>;
+}
+
+// ---------------------------------------------------------------------------
+// CovenantRole lookup (unpaginated)
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/covenants/roles/?covenant_type=&parent_role=
+ * Returns the (unpaginated) CovenantRole lookup list. Pass `parent_role` to
+ * fetch a role's sub-roles for the promotion picker.
+ */
+export async function getCovenantRoles(params: {
+  covenant_type?: string;
+  parent_role?: number;
+}): Promise<CovenantRole[]> {
+  const search = new URLSearchParams();
+  if (params.covenant_type != null) search.set('covenant_type', params.covenant_type);
+  if (params.parent_role != null) search.set('parent_role', String(params.parent_role));
+  const query = search.toString();
+  const res = await apiFetch(`${ROLES_URL}/${query ? `?${query}` : ''}`);
+  if (!res.ok) throw new Error('Failed to load covenant roles');
+  return res.json() as Promise<CovenantRole[]>;
 }

--- a/frontend/src/covenants/api.ts
+++ b/frontend/src/covenants/api.ts
@@ -24,6 +24,31 @@ export type PaginatedCharacterCovenantRoleList =
   components['schemas']['PaginatedCharacterCovenantRoleList'];
 
 // ---------------------------------------------------------------------------
+// Hand-written schema extensions (until OpenAPI regen at integration; see #518)
+// ---------------------------------------------------------------------------
+//
+// The generated api.d.ts is a single shared file derived from ALL serializers
+// across the app; regenerating it on this branch would collide with combat
+// serializer changes on another branch. So these new serializer fields are
+// declared by hand here, scoped to the covenants module, until the schema is
+// regenerated at integration.
+
+/** Battle-state fields added to CovenantSerializer in C1. */
+export interface CovenantBattleFields {
+  is_dormant: boolean;
+  battle_binding: string | null;
+  battle_binding_display: string;
+}
+
+/** Covenant detail payload including the C1 battle-state fields. */
+export type CovenantWithBattleState = Covenant & CovenantBattleFields;
+
+/** CovenantRole payload including the parent_role FK added in C4. */
+export interface CovenantRoleWithParent extends CovenantRole {
+  parent_role: number | null;
+}
+
+// ---------------------------------------------------------------------------
 // Hand-written types for the powers / stand-down endpoints
 // ---------------------------------------------------------------------------
 
@@ -41,8 +66,9 @@ export interface CovenantRiteRow {
   granted_condition: number | null;
   base_severity: number;
   severity_per_extra_participant: number;
-  max_severity: number;
-  duration_rounds: number;
+  // Nullable on the backend model (null=True) → serialized as number | null.
+  max_severity: number | null;
+  duration_rounds: number | null;
   level_met: boolean;
   members_present_met: boolean;
 }
@@ -114,10 +140,10 @@ export async function getCovenants(): Promise<PaginatedCovenantList> {
   return res.json() as Promise<PaginatedCovenantList>;
 }
 
-export async function getCovenant(id: number): Promise<Covenant> {
+export async function getCovenant(id: number): Promise<CovenantWithBattleState> {
   const res = await apiFetch(`${COVENANTS_URL}/${id}/`);
   if (!res.ok) throw new Error(`Failed to load covenant ${id}`);
-  return res.json() as Promise<Covenant>;
+  return res.json() as Promise<CovenantWithBattleState>;
 }
 
 // ---------------------------------------------------------------------------
@@ -235,12 +261,12 @@ export async function promoteMembership(
 export async function getCovenantRoles(params: {
   covenant_type?: string;
   parent_role?: number;
-}): Promise<CovenantRole[]> {
+}): Promise<CovenantRoleWithParent[]> {
   const search = new URLSearchParams();
   if (params.covenant_type != null) search.set('covenant_type', params.covenant_type);
   if (params.parent_role != null) search.set('parent_role', String(params.parent_role));
   const query = search.toString();
   const res = await apiFetch(`${ROLES_URL}/${query ? `?${query}` : ''}`);
   if (!res.ok) throw new Error('Failed to load covenant roles');
-  return res.json() as Promise<CovenantRole[]>;
+  return res.json() as Promise<CovenantRoleWithParent[]>;
 }

--- a/frontend/src/covenants/components/BattleStateBanner.tsx
+++ b/frontend/src/covenants/components/BattleStateBanner.tsx
@@ -1,0 +1,164 @@
+/**
+ * BattleStateBanner — battle-covenant dormant/risen state + rise/stand-down.
+ *
+ * Renders only for BATTLE covenants. A dormant battle covenant shows a muted
+ * "dormant" banner with a "Raise" control that fires the ritual-driven rise
+ * flow ("Call the Banners") via the shared RitualSessionDraftDialog — mirroring
+ * the induction flow in CovenantDetailPage / RitesPanel. A risen covenant shows
+ * a positive banner with a "Stand Down" control that calls the stand-down
+ * mutation directly.
+ *
+ * Single responsibility: this component owns only the battle-state surface. The
+ * rite/role-power panels live alongside it.
+ */
+
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useStandDownCovenant } from '@/covenants/queries';
+import { useRituals } from '@/rituals/queries';
+import { RitualSessionDraftDialog } from '@/rituals/components/RitualSessionDraftDialog';
+import type { CovenantWithBattleState } from '@/covenants/api';
+import type { RitualWithSchema } from '@/rituals/types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Stored CovenantType value for battle covenants (CovenantType.BATTLE). */
+const BATTLE_COVENANT_TYPE = 'battle';
+
+/** Name of the ritual that dispatches rise_battle_covenant_via_session. */
+const RISE_RITUAL_NAME = 'Call the Banners';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface BattleStateBannerProps {
+  covenant: CovenantWithBattleState;
+  /** The viewing character's sheet id, or null when no character is puppeted. */
+  characterSheetId: number | null;
+  /** Whether the viewing character is an active member of this covenant. */
+  isActiveMember: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: resolve the rise ritual by name
+// ---------------------------------------------------------------------------
+
+function findRiseRitual(rituals: RitualWithSchema[]): RitualWithSchema | null {
+  return rituals.find((r) => r.name === RISE_RITUAL_NAME) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function BattleStateBanner({
+  covenant,
+  characterSheetId,
+  isActiveMember,
+}: BattleStateBannerProps) {
+  const navigate = useNavigate();
+  const standDown = useStandDownCovenant(covenant.id);
+  const { data: ritualsData, isLoading: ritualsLoading } = useRituals();
+  const [riseDialogOpen, setRiseDialogOpen] = useState(false);
+
+  // Non-battle covenants render nothing.
+  if (covenant.covenant_type !== BATTLE_COVENANT_TYPE) {
+    return null;
+  }
+
+  const allRituals = !ritualsLoading ? ((ritualsData?.results ?? []) as RitualWithSchema[]) : [];
+  const riseRitual = findRiseRitual(allRituals);
+
+  const bindingChip = covenant.battle_binding_display ? (
+    <Badge variant="outline" className="text-xs uppercase tracking-wide">
+      {covenant.battle_binding_display}
+    </Badge>
+  ) : null;
+
+  // ----- Dormant -----------------------------------------------------------
+  if (covenant.is_dormant) {
+    let raiseBlockedReason: string | null = null;
+    if (!isActiveMember) {
+      raiseBlockedReason = 'Only active members can raise the covenant';
+    } else if (characterSheetId === null) {
+      raiseBlockedReason = 'No active character';
+    } else if (riseRitual === null) {
+      raiseBlockedReason = 'Rise ritual unavailable';
+    }
+    const canRaise = raiseBlockedReason === null;
+
+    return (
+      <section
+        data-testid="battle-state-banner"
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-semibold text-destructive">Dormant</h3>
+              {bindingChip}
+            </div>
+            <p className="text-sm text-muted-foreground">This battle covenant is dormant.</p>
+          </div>
+          <Button
+            size="sm"
+            onClick={() => setRiseDialogOpen(true)}
+            disabled={!canRaise}
+            title={raiseBlockedReason ?? undefined}
+            data-testid="battle-raise-button"
+          >
+            Raise
+          </Button>
+        </div>
+
+        {/* Rise dialog — mirrors induction: pass the resolved ritual + sheet,
+            navigate to the new session on success. */}
+        {riseRitual && characterSheetId !== null && (
+          <RitualSessionDraftDialog
+            ritual={riseRitual}
+            characterSheetId={characterSheetId}
+            open={riseDialogOpen}
+            onOpenChange={setRiseDialogOpen}
+            onSuccess={(session) => {
+              setRiseDialogOpen(false);
+              navigate(`/rituals/sessions/${session.id}`);
+            }}
+          />
+        )}
+      </section>
+    );
+  }
+
+  // ----- Risen -------------------------------------------------------------
+  return (
+    <section
+      data-testid="battle-state-banner"
+      className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-4"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold text-emerald-600 dark:text-emerald-400">Risen</h3>
+            {bindingChip}
+          </div>
+          <p className="text-sm text-muted-foreground">This battle covenant has risen to war.</p>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => standDown.mutate()}
+          disabled={!isActiveMember || standDown.isPending}
+          title={!isActiveMember ? 'Only active members can stand the covenant down' : undefined}
+          data-testid="battle-stand-down-button"
+        >
+          {standDown.isPending ? 'Standing down…' : 'Stand Down'}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/covenants/components/PromoteRoleDialog.tsx
+++ b/frontend/src/covenants/components/PromoteRoleDialog.tsx
@@ -1,0 +1,149 @@
+/**
+ * PromoteRoleDialog — controlled dialog for promoting a membership into one of
+ * its current role's sub-roles.
+ *
+ * The membership's current role (membership.covenant_role) is the parent role;
+ * useSubroles(parentRoleId) lists the sub-roles it can be promoted into. The
+ * member picks one, and Promote dispatches usePromoteMembership.mutate. On
+ * success the dialog closes; on a backend 400 the error `detail` (surfaced as
+ * the rejected Error's message by the api layer) is shown inline.
+ *
+ * Parent owns the open state (C9 mounts this from the member row).
+ */
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useSubroles, usePromoteMembership } from '@/covenants/queries';
+import type { CharacterCovenantRole } from '@/covenants/api';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface PromoteRoleDialogProps {
+  covenantId: number;
+  membership: CharacterCovenantRole;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function PromoteRoleDialog({
+  covenantId,
+  membership,
+  open,
+  onOpenChange,
+}: PromoteRoleDialogProps) {
+  const parentRole = membership.covenant_role;
+  const { data: subroles, isLoading } = useSubroles(parentRole.id);
+  const promote = usePromoteMembership(covenantId);
+
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  function handleOpenChange(next: boolean) {
+    onOpenChange(next);
+    if (!next) {
+      setSelectedId(null);
+      promote.reset();
+    }
+  }
+
+  function handlePromote() {
+    if (selectedId == null) return;
+    promote.mutate(
+      { membershipId: membership.id, targetSubroleId: selectedId },
+      {
+        onSuccess: () => handleOpenChange(false),
+      }
+    );
+  }
+
+  const list = subroles ?? [];
+  const hasSubroles = list.length > 0;
+  const errorMessage =
+    promote.isError && promote.error instanceof Error ? promote.error.message : null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Promote {parentRole.name}</DialogTitle>
+          <DialogDescription>Choose a sub-role to unlock for this member.</DialogDescription>
+        </DialogHeader>
+
+        {errorMessage && (
+          <div className="mt-4 rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            <p>{errorMessage}</p>
+          </div>
+        )}
+
+        <div className="mt-4">
+          {isLoading ? (
+            <p className="py-4 text-sm text-muted-foreground">Loading sub-roles…</p>
+          ) : !hasSubroles ? (
+            <p className="py-4 text-sm text-muted-foreground">No sub-roles available.</p>
+          ) : (
+            <ul className="space-y-2" role="radiogroup" aria-label="Available sub-roles">
+              {list.map((subrole) => {
+                const selected = selectedId === subrole.id;
+                return (
+                  <li key={subrole.id}>
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      onClick={() => setSelectedId(subrole.id)}
+                      disabled={promote.isPending}
+                      className={
+                        'w-full rounded-md border px-3 py-2 text-left transition-colors ' +
+                        (selected ? 'border-primary bg-accent' : 'border-border hover:bg-accent/50')
+                      }
+                    >
+                      <span className="block text-sm font-medium">{subrole.name}</span>
+                      {subrole.description && (
+                        <span className="mt-0.5 block text-xs text-muted-foreground">
+                          {subrole.description}
+                        </span>
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        {hasSubroles && (
+          <DialogFooter className="mt-6">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={promote.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={handlePromote}
+              disabled={selectedId == null || promote.isPending}
+            >
+              {promote.isPending ? 'Promoting…' : 'Promote'}
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/covenants/components/RitesPanel.tsx
+++ b/frontend/src/covenants/components/RitesPanel.tsx
@@ -1,0 +1,190 @@
+/**
+ * RitesPanel — covenant "Group Abilities" (rites) display + trigger surface.
+ *
+ * Lists a covenant's authored rites (from useCovenantPowers), each with its
+ * activation gates (covenant level + members present) rendered as requirement
+ * chips. A rite's Perform button is enabled only when both gates are met, the
+ * viewer is an active member, and an active character sheet is known. Clicking
+ * Perform opens the shared RitualSessionDraftDialog for the rite's resolved
+ * ritual, navigating to the new session on success (mirrors the induction flow
+ * in CovenantDetailPage).
+ *
+ * Read-only counterpart panels (role powers, battle state) live alongside this
+ * one; this component owns only the rites surface.
+ */
+
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useCovenantPowers } from '@/covenants/queries';
+import { useRituals } from '@/rituals/queries';
+import { RitualSessionDraftDialog } from '@/rituals/components/RitualSessionDraftDialog';
+import type { CovenantRiteRow } from '@/covenants/api';
+import type { RitualWithSchema } from '@/rituals/types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface RitesPanelProps {
+  covenantId: number;
+  /** Whether the viewing character is an active member of this covenant. */
+  isActiveMember: boolean;
+  /** The viewing character's sheet id, or null when no character is puppeted. */
+  characterSheetId: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Single rite card
+// ---------------------------------------------------------------------------
+
+interface RiteCardProps {
+  rite: CovenantRiteRow;
+  ritual: RitualWithSchema | null;
+  isActiveMember: boolean;
+  characterSheetId: number | null;
+  onPerform: () => void;
+}
+
+function RiteCard({ rite, ritual, isActiveMember, characterSheetId, onPerform }: RiteCardProps) {
+  const label = ritual?.name ?? `Rite #${rite.id}`;
+
+  // Gate evaluation. Order the blocking reasons most-fundamental first.
+  let blockedReason: string | null = null;
+  if (ritual === null) {
+    blockedReason = 'Ritual unavailable';
+  } else if (!rite.level_met) {
+    blockedReason = `Requires covenant level ${rite.min_covenant_level}`;
+  } else if (!rite.members_present_met) {
+    blockedReason = `Requires ${rite.min_members_present} members present`;
+  } else if (!isActiveMember) {
+    blockedReason = 'Only active members can perform rites';
+  } else if (characterSheetId === null) {
+    blockedReason = 'No active character';
+  }
+
+  const canPerform = blockedReason === null;
+
+  return (
+    <Card data-testid="rite-card">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-base">{label}</CardTitle>
+          <Badge variant="outline" className="text-xs">
+            {rite.covenant_type_display}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Requirement chips */}
+        <div className="flex flex-wrap gap-1">
+          <Badge variant={rite.level_met ? 'outline' : 'secondary'} className="text-xs">
+            Level {rite.min_covenant_level}
+          </Badge>
+          <Badge variant={rite.members_present_met ? 'outline' : 'secondary'} className="text-xs">
+            {rite.min_members_present} present
+          </Badge>
+          {rite.duration_rounds !== null && (
+            <Badge variant="outline" className="text-xs">
+              {rite.duration_rounds} rounds
+            </Badge>
+          )}
+          {rite.max_severity !== null && (
+            <Badge variant="outline" className="text-xs">
+              Severity {rite.base_severity}–{rite.max_severity}
+            </Badge>
+          )}
+        </div>
+
+        {/* Action + gate reason */}
+        <div className="flex items-center justify-between gap-3">
+          <Button
+            size="sm"
+            onClick={onPerform}
+            disabled={!canPerform}
+            title={blockedReason ?? undefined}
+            data-testid="rite-perform-button"
+          >
+            Perform
+          </Button>
+          {blockedReason && (
+            <p className="text-xs text-muted-foreground" data-testid="rite-blocked-reason">
+              {blockedReason}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Panel
+// ---------------------------------------------------------------------------
+
+export function RitesPanel({ covenantId, isActiveMember, characterSheetId }: RitesPanelProps) {
+  const navigate = useNavigate();
+  const { data: powers, isLoading: powersLoading } = useCovenantPowers(covenantId);
+  const { data: ritualsData, isLoading: ritualsLoading } = useRituals();
+
+  // Which rite's draft dialog is open (rite id), or null.
+  const [openRiteId, setOpenRiteId] = useState<number | null>(null);
+
+  if (powersLoading) {
+    return null;
+  }
+
+  const rites = powers?.rites ?? [];
+  const allRituals = !ritualsLoading ? ((ritualsData?.results ?? []) as RitualWithSchema[]) : [];
+
+  function resolveRitual(rite: CovenantRiteRow): RitualWithSchema | null {
+    return allRituals.find((r) => r.id === rite.ritual) ?? null;
+  }
+
+  const openRite = openRiteId !== null ? rites.find((r) => r.id === openRiteId) : undefined;
+  const openRitual = openRite ? resolveRitual(openRite) : null;
+
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-semibold">Group Abilities</h2>
+
+      {rites.length === 0 ? (
+        <p className="py-4 text-center text-sm text-muted-foreground">
+          No group abilities available.
+        </p>
+      ) : (
+        <div className="space-y-3" data-testid="rites-list">
+          {rites.map((rite) => (
+            <RiteCard
+              key={rite.id}
+              rite={rite}
+              ritual={resolveRitual(rite)}
+              isActiveMember={isActiveMember}
+              characterSheetId={characterSheetId}
+              onPerform={() => setOpenRiteId(rite.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Draft dialog for the open rite. Mirrors the induction flow: pass the
+          resolved ritual + character sheet, navigate to the session on success. */}
+      {openRite && openRitual && characterSheetId !== null && (
+        <RitualSessionDraftDialog
+          ritual={openRitual}
+          characterSheetId={characterSheetId}
+          open={true}
+          onOpenChange={(next) => {
+            if (!next) setOpenRiteId(null);
+          }}
+          onSuccess={(session) => {
+            setOpenRiteId(null);
+            navigate(`/rituals/sessions/${session.id}`);
+          }}
+        />
+      )}
+    </section>
+  );
+}

--- a/frontend/src/covenants/components/RolePowersPanel.tsx
+++ b/frontend/src/covenants/components/RolePowersPanel.tsx
@@ -1,0 +1,103 @@
+/**
+ * RolePowersPanel — read-only display of each active member's passive role power.
+ *
+ * Reads role_powers from useCovenantPowers and renders one card per membership:
+ *   - The covenant role name prominently, plus the bearer (Character #{sheet}).
+ *   - When a capability is woven, its name + narrative snippet (italic, muted),
+ *     with an "Engaged" badge if the power is live, or a muted "Latent" badge
+ *     when it lies dormant until the member engages.
+ *   - When no capability is unlocked yet, a muted line noting the (optional)
+ *     resonance the role channels but no power.
+ *
+ * Single-responsibility sibling to RitesPanel: no mutations, no dialogs.
+ */
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useCovenantPowers } from '@/covenants/queries';
+import type { RolePower } from '@/covenants/api';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface RolePowersPanelProps {
+  covenantId: number;
+}
+
+// ---------------------------------------------------------------------------
+// Single role-power card
+// ---------------------------------------------------------------------------
+
+function RolePowerCard({ power }: { power: RolePower }) {
+  const hasCapability = power.capability_name !== null;
+
+  return (
+    <Card data-testid="role-power-card">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle className="text-base">{power.covenant_role_name}</CardTitle>
+            <p className="text-xs text-muted-foreground">Character #{power.character_sheet}</p>
+          </div>
+          {hasCapability &&
+            (power.engaged ? (
+              <Badge variant="default" className="text-xs">
+                Engaged
+              </Badge>
+            ) : (
+              <Badge variant="secondary" className="text-xs">
+                Latent
+              </Badge>
+            ))}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {hasCapability ? (
+          <>
+            <p className="text-sm font-medium">{power.capability_name}</p>
+            {power.narrative_snippet && (
+              <p className="text-sm italic text-muted-foreground">{power.narrative_snippet}</p>
+            )}
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {power.resonance_name
+              ? `Channeling ${power.resonance_name} — no power unlocked`
+              : 'No role power yet'}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Panel
+// ---------------------------------------------------------------------------
+
+export function RolePowersPanel({ covenantId }: RolePowersPanelProps) {
+  const { data: powers, isLoading } = useCovenantPowers(covenantId);
+
+  if (isLoading) {
+    return null;
+  }
+
+  const rolePowers = powers?.role_powers ?? [];
+
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-semibold">Role Powers</h2>
+
+      {rolePowers.length === 0 ? (
+        <p className="py-4 text-center text-sm text-muted-foreground">No role powers.</p>
+      ) : (
+        <div className="space-y-3" data-testid="role-powers-list">
+          {rolePowers.map((power) => (
+            <RolePowerCard key={power.membership_id} power={power} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/covenants/components/__tests__/BattleStateBanner.test.tsx
+++ b/frontend/src/covenants/components/__tests__/BattleStateBanner.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * BattleStateBanner Tests
+ *
+ * Covers the battle-covenant dormant/risen banner:
+ *   1. Battle + dormant + active member + sheet + rise ritual present →
+ *      renders the dormant banner with an ENABLED "Raise" button; clicking it
+ *      opens the RitualSessionDraftDialog (mocked).
+ *   2. Battle + risen + active member → renders a "Stand Down" button; clicking
+ *      it calls the stand-down mutation's mutate.
+ *   3. Non-battle covenant → renders nothing.
+ *   4. Battle + dormant but NOT an active member → "Raise" is not actionable
+ *      (disabled).
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { BattleStateBanner } from '../BattleStateBanner';
+import type { CovenantWithBattleState } from '@/covenants/api';
+import type { RitualWithSchema, PaginatedRitualList } from '@/rituals/types';
+
+// ---------------------------------------------------------------------------
+// Mock query modules
+// ---------------------------------------------------------------------------
+
+vi.mock('@/covenants/queries', () => ({
+  useStandDownCovenant: vi.fn(),
+}));
+
+vi.mock('@/rituals/queries', () => ({
+  useRituals: vi.fn(),
+}));
+
+// Stub the dialog so we can assert open state without rendering its internals.
+vi.mock('@/rituals/components/RitualSessionDraftDialog', () => ({
+  RitualSessionDraftDialog: ({ open, ritual }: { open: boolean; ritual: RitualWithSchema }) =>
+    open ? <div data-testid="draft-dialog">Drafting {ritual.name}</div> : null,
+}));
+
+import { useStandDownCovenant } from '@/covenants/queries';
+import { useRituals } from '@/rituals/queries';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeCovenant = (overrides: Partial<CovenantWithBattleState> = {}): CovenantWithBattleState =>
+  ({
+    id: 7,
+    name: 'The Iron Banner',
+    covenant_type: 'battle',
+    covenant_type_display: 'Covenant of Battle',
+    is_dormant: true,
+    battle_binding: 'standing',
+    battle_binding_display: 'Standing',
+    ...overrides,
+  }) as CovenantWithBattleState;
+
+const makeRiseRitual = (overrides: Partial<RitualWithSchema> = {}): RitualWithSchema =>
+  ({
+    id: 200,
+    name: 'Call the Banners',
+    description: '',
+    narrative_prose: '',
+    hedge_accessible: false,
+    glimpse_eligible: false,
+    execution_kind: 'SERVICE',
+    input_schema: null,
+    author_account_id: null,
+    check_config: null,
+    client_hosted: false,
+    participation_rule: 'FORMATION',
+    min_participants: null,
+    max_participants: null,
+    ...overrides,
+  }) as RitualWithSchema;
+
+function mockRituals(rituals: RitualWithSchema[], isLoading = false) {
+  const data: PaginatedRitualList = {
+    count: rituals.length,
+    next: null,
+    previous: null,
+    results: rituals,
+  };
+  vi.mocked(useRituals).mockReturnValue({
+    data: isLoading ? undefined : data,
+    isLoading,
+  } as never);
+}
+
+function mockStandDown(mutate = vi.fn()) {
+  vi.mocked(useStandDownCovenant).mockReturnValue({
+    mutate,
+    isPending: false,
+  } as never);
+  return mutate;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BattleStateBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStandDown();
+  });
+
+  it('renders the dormant banner with an enabled Raise button that opens the dialog', async () => {
+    const user = userEvent.setup();
+    mockRituals([makeRiseRitual()]);
+
+    render(
+      <BattleStateBanner
+        covenant={makeCovenant({ is_dormant: true })}
+        characterSheetId={42}
+        isActiveMember={true}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText(/this battle covenant is dormant/i)).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /raise/i });
+    expect(button).toBeEnabled();
+
+    expect(screen.queryByTestId('draft-dialog')).not.toBeInTheDocument();
+    await user.click(button);
+    expect(screen.getByTestId('draft-dialog')).toBeInTheDocument();
+  });
+
+  it('renders a Stand Down button that calls the stand-down mutation when risen', async () => {
+    const user = userEvent.setup();
+    const mutate = mockStandDown();
+    mockRituals([makeRiseRitual()]);
+
+    render(
+      <BattleStateBanner
+        covenant={makeCovenant({ is_dormant: false })}
+        characterSheetId={42}
+        isActiveMember={true}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    const button = screen.getByRole('button', { name: /stand down/i });
+    expect(button).toBeEnabled();
+    await user.click(button);
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it('renders nothing for a non-battle covenant', () => {
+    mockRituals([makeRiseRitual()]);
+
+    const { container } = render(
+      <BattleStateBanner
+        covenant={makeCovenant({ covenant_type: 'durance' })}
+        characterSheetId={42}
+        isActiveMember={true}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('disables Raise for a non-active member', () => {
+    mockRituals([makeRiseRitual()]);
+
+    render(
+      <BattleStateBanner
+        covenant={makeCovenant({ is_dormant: true })}
+        characterSheetId={42}
+        isActiveMember={false}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByRole('button', { name: /raise/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/covenants/components/__tests__/PromoteRoleDialog.test.tsx
+++ b/frontend/src/covenants/components/__tests__/PromoteRoleDialog.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * PromoteRoleDialog Tests
+ *
+ * Covers the controlled sub-role promotion dialog:
+ *   1. Open with sub-roles present → renders the sub-role names.
+ *   2. Select a sub-role + click Promote → usePromoteMembership.mutate called
+ *      with { membershipId, targetSubroleId }.
+ *   3. Mutation error → the backend `detail` message is shown inline.
+ *   4. Empty sub-roles → "No sub-roles available." and no actionable Promote.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { PromoteRoleDialog } from '../PromoteRoleDialog';
+import type { CharacterCovenantRole, CovenantRoleWithParent } from '@/covenants/api';
+
+// ---------------------------------------------------------------------------
+// Mock query module
+// ---------------------------------------------------------------------------
+
+vi.mock('@/covenants/queries', () => ({
+  useSubroles: vi.fn(),
+  usePromoteMembership: vi.fn(),
+}));
+
+import { useSubroles, usePromoteMembership } from '@/covenants/queries';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeMembership = (): CharacterCovenantRole =>
+  ({
+    id: 99,
+    character_sheet: 42,
+    covenant: 1,
+    covenant_role: {
+      id: 7,
+      name: 'Vanguard',
+      slug: 'vanguard',
+      covenant_type: 'battle',
+      covenant_type_display: 'Covenant of Battle',
+      archetype: 'sword',
+      archetype_display: 'Sword',
+      speed_rank: 1,
+      description: 'The tip of the spear.',
+    },
+    engaged: true,
+    joined_at: '2026-01-01T00:00:00Z',
+    left_at: null,
+    is_active: true,
+    can_engage: false,
+    engage_blocked_reason: null,
+  }) as CharacterCovenantRole;
+
+const makeSubrole = (overrides: Partial<CovenantRoleWithParent> = {}): CovenantRoleWithParent => ({
+  id: 21,
+  name: 'Banner-Bearer',
+  slug: 'banner-bearer',
+  covenant_type: 'battle',
+  covenant_type_display: 'Covenant of Battle',
+  archetype: 'sword',
+  archetype_display: 'Sword',
+  speed_rank: 1,
+  description: 'Carries the host into the breach.',
+  parent_role: 7,
+  ...overrides,
+});
+
+function mockSubroles(data: CovenantRoleWithParent[] | undefined, isLoading = false) {
+  vi.mocked(useSubroles).mockReturnValue({
+    data: isLoading ? undefined : data,
+    isLoading,
+  } as never);
+}
+
+function mockPromote(overrides: Record<string, unknown> = {}) {
+  const mutate = vi.fn();
+  vi.mocked(usePromoteMembership).mockReturnValue({
+    mutate,
+    isPending: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  } as never);
+  return mutate;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PromoteRoleDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the sub-role names when open with sub-roles present', () => {
+    mockSubroles([makeSubrole(), makeSubrole({ id: 22, name: 'Shield-Wall' })]);
+    mockPromote();
+
+    render(
+      <PromoteRoleDialog
+        covenantId={1}
+        membership={makeMembership()}
+        open
+        onOpenChange={() => {}}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText('Banner-Bearer')).toBeInTheDocument();
+    expect(screen.getByText('Shield-Wall')).toBeInTheDocument();
+  });
+
+  it('calls mutate with the membership id and selected sub-role id on Promote', () => {
+    mockSubroles([makeSubrole()]);
+    const mutate = mockPromote();
+
+    render(
+      <PromoteRoleDialog
+        covenantId={1}
+        membership={makeMembership()}
+        open
+        onOpenChange={() => {}}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    fireEvent.click(screen.getByText('Banner-Bearer'));
+    fireEvent.click(screen.getByRole('button', { name: /^Promote$/i }));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate.mock.calls[0][0]).toEqual({ membershipId: 99, targetSubroleId: 21 });
+  });
+
+  it('shows the backend error detail when the mutation errors', () => {
+    mockSubroles([makeSubrole()]);
+    mockPromote({
+      isError: true,
+      error: new Error('Member must be engaged to promote.'),
+    });
+
+    render(
+      <PromoteRoleDialog
+        covenantId={1}
+        membership={makeMembership()}
+        open
+        onOpenChange={() => {}}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText('Member must be engaged to promote.')).toBeInTheDocument();
+  });
+
+  it('shows a no-sub-roles message and no actionable Promote when the list is empty', () => {
+    mockSubroles([]);
+    const mutate = mockPromote();
+
+    render(
+      <PromoteRoleDialog
+        covenantId={1}
+        membership={makeMembership()}
+        open
+        onOpenChange={() => {}}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText(/No sub-roles available\./i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Promote$/i })).not.toBeInTheDocument();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/covenants/components/__tests__/RitesPanel.test.tsx
+++ b/frontend/src/covenants/components/__tests__/RitesPanel.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * RitesPanel Tests
+ *
+ * Covers the covenant "Group Abilities" (rites) panel:
+ *   1. A fully-gated-open rite (level + members met, active member, sheet set)
+ *      renders an ENABLED Perform button.
+ *   2. A rite failing members_present_met disables Perform and surfaces the
+ *      member-count requirement reason.
+ *   3. Clicking an enabled Perform opens the RitualSessionDraftDialog (mocked).
+ *   4. No rites → empty-state message.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { RitesPanel } from '../RitesPanel';
+import type { CovenantRiteRow, CovenantPowers } from '@/covenants/api';
+import type { RitualWithSchema, PaginatedRitualList } from '@/rituals/types';
+
+// ---------------------------------------------------------------------------
+// Mock query modules
+// ---------------------------------------------------------------------------
+
+vi.mock('@/covenants/queries', () => ({
+  useCovenantPowers: vi.fn(),
+}));
+
+vi.mock('@/rituals/queries', () => ({
+  useRituals: vi.fn(),
+}));
+
+// Stub the dialog so we can assert open state without rendering its internals.
+vi.mock('@/rituals/components/RitualSessionDraftDialog', () => ({
+  RitualSessionDraftDialog: ({ open, ritual }: { open: boolean; ritual: RitualWithSchema }) =>
+    open ? <div data-testid="draft-dialog">Drafting {ritual.name}</div> : null,
+}));
+
+import { useCovenantPowers } from '@/covenants/queries';
+import { useRituals } from '@/rituals/queries';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeRite = (overrides: Partial<CovenantRiteRow> = {}): CovenantRiteRow => ({
+  id: 1,
+  ritual: 100,
+  covenant_type: 'WAR',
+  covenant_type_display: 'War',
+  min_covenant_level: 2,
+  min_members_present: 3,
+  granted_condition: null,
+  base_severity: 1,
+  severity_per_extra_participant: 1,
+  max_severity: 5,
+  duration_rounds: 4,
+  level_met: true,
+  members_present_met: true,
+  ...overrides,
+});
+
+const makeRitual = (overrides: Partial<RitualWithSchema> = {}): RitualWithSchema =>
+  ({
+    id: 100,
+    name: 'Banner Call',
+    description: '',
+    narrative_prose: '',
+    hedge_accessible: false,
+    glimpse_eligible: false,
+    execution_kind: 'SERVICE',
+    input_schema: null,
+    author_account_id: null,
+    check_config: null,
+    client_hosted: false,
+    participation_rule: 'SESSION',
+    min_participants: null,
+    max_participants: null,
+    ...overrides,
+  }) as RitualWithSchema;
+
+function mockPowers(rites: CovenantRiteRow[], isLoading = false) {
+  const data: CovenantPowers = { rites, role_powers: [] };
+  vi.mocked(useCovenantPowers).mockReturnValue({
+    data: isLoading ? undefined : data,
+    isLoading,
+  } as never);
+}
+
+function mockRituals(rituals: RitualWithSchema[]) {
+  const data: PaginatedRitualList = {
+    count: rituals.length,
+    next: null,
+    previous: null,
+    results: rituals,
+  };
+  vi.mocked(useRituals).mockReturnValue({ data, isLoading: false } as never);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RitesPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an enabled Perform button for a fully-open rite', () => {
+    mockPowers([makeRite()]);
+    mockRituals([makeRitual()]);
+
+    render(<RitesPanel covenantId={1} isActiveMember={true} characterSheetId={42} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText('Banner Call')).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /perform/i });
+    expect(button).toBeEnabled();
+  });
+
+  it('disables Perform and shows the member-count reason when members are not met', () => {
+    mockPowers([makeRite({ members_present_met: false, min_members_present: 4 })]);
+    mockRituals([makeRitual()]);
+
+    render(<RitesPanel covenantId={1} isActiveMember={true} characterSheetId={42} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByRole('button', { name: /perform/i })).toBeDisabled();
+    expect(screen.getByText(/Requires 4 members present/i)).toBeInTheDocument();
+  });
+
+  it('opens the draft dialog when an enabled Perform is clicked', async () => {
+    const user = userEvent.setup();
+    mockPowers([makeRite()]);
+    mockRituals([makeRitual()]);
+
+    render(<RitesPanel covenantId={1} isActiveMember={true} characterSheetId={42} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.queryByTestId('draft-dialog')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /perform/i }));
+    expect(screen.getByTestId('draft-dialog')).toBeInTheDocument();
+  });
+
+  it('renders an empty-state message when there are no rites', () => {
+    mockPowers([]);
+    mockRituals([makeRitual()]);
+
+    render(<RitesPanel covenantId={1} isActiveMember={true} characterSheetId={42} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText(/No group abilities available/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/covenants/components/__tests__/RolePowersPanel.test.tsx
+++ b/frontend/src/covenants/components/__tests__/RolePowersPanel.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * RolePowersPanel Tests
+ *
+ * Covers the read-only covenant "Role Powers" panel, which surfaces each active
+ * member's passive role power:
+ *   1. An engaged role_power with a capability renders the capability name, the
+ *      narrative snippet, and an "Engaged" badge.
+ *   2. A role_power with capability_name: null renders the "no power" message and
+ *      does NOT fabricate a capability.
+ *   3. A non-engaged role_power with a capability renders the capability but a
+ *      "Latent" indicator rather than "Engaged".
+ *   4. No role_powers → empty-state message.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { RolePowersPanel } from '../RolePowersPanel';
+import type { RolePower, CovenantPowers } from '@/covenants/api';
+
+// ---------------------------------------------------------------------------
+// Mock query module
+// ---------------------------------------------------------------------------
+
+vi.mock('@/covenants/queries', () => ({
+  useCovenantPowers: vi.fn(),
+}));
+
+import { useCovenantPowers } from '@/covenants/queries';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeRolePower = (overrides: Partial<RolePower> = {}): RolePower => ({
+  membership_id: 1,
+  character_sheet: 42,
+  covenant_role_id: 7,
+  covenant_role_name: 'Warlord',
+  resonance_name: 'Fury',
+  capability_name: 'Banner of the Vanguard',
+  narrative_snippet: 'The host rallies to a single unbroken line.',
+  engaged: true,
+  ...overrides,
+});
+
+function mockPowers(rolePowers: RolePower[], isLoading = false) {
+  const data: CovenantPowers = { rites: [], role_powers: rolePowers };
+  vi.mocked(useCovenantPowers).mockReturnValue({
+    data: isLoading ? undefined : data,
+    isLoading,
+  } as never);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RolePowersPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the capability, snippet, and an Engaged badge for an engaged power', () => {
+    mockPowers([makeRolePower()]);
+
+    render(<RolePowersPanel covenantId={1} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Warlord')).toBeInTheDocument();
+    expect(screen.getByText('Character #42')).toBeInTheDocument();
+    expect(screen.getByText('Banner of the Vanguard')).toBeInTheDocument();
+    expect(screen.getByText('The host rallies to a single unbroken line.')).toBeInTheDocument();
+    expect(screen.getByText('Engaged')).toBeInTheDocument();
+  });
+
+  it('shows a no-power message when capability_name is null without inventing a capability', () => {
+    mockPowers([
+      makeRolePower({
+        capability_name: null,
+        narrative_snippet: null,
+        resonance_name: 'Fury',
+        engaged: false,
+      }),
+    ]);
+
+    render(<RolePowersPanel covenantId={1} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Warlord')).toBeInTheDocument();
+    expect(screen.queryByText('Banner of the Vanguard')).not.toBeInTheDocument();
+    expect(screen.queryByText('Engaged')).not.toBeInTheDocument();
+    expect(screen.getByText(/no power unlocked/i)).toBeInTheDocument();
+    expect(screen.getByText(/Fury/)).toBeInTheDocument();
+  });
+
+  it('renders a Latent indicator for a non-engaged power with a capability', () => {
+    mockPowers([makeRolePower({ engaged: false })]);
+
+    render(<RolePowersPanel covenantId={1} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Banner of the Vanguard')).toBeInTheDocument();
+    expect(screen.queryByText('Engaged')).not.toBeInTheDocument();
+    expect(screen.getByText('Latent')).toBeInTheDocument();
+  });
+
+  it('renders an empty-state message when there are no role powers', () => {
+    mockPowers([]);
+
+    render(<RolePowersPanel covenantId={1} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText(/No role powers/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/covenants/pages/CovenantDetailPage.tsx
+++ b/frontend/src/covenants/pages/CovenantDetailPage.tsx
@@ -29,6 +29,10 @@ import {
 } from '@/covenants/queries';
 import { useRituals } from '@/rituals/queries';
 import { RitualSessionDraftDialog } from '@/rituals/components/RitualSessionDraftDialog';
+import { BattleStateBanner } from '@/covenants/components/BattleStateBanner';
+import { RitesPanel } from '@/covenants/components/RitesPanel';
+import { RolePowersPanel } from '@/covenants/components/RolePowersPanel';
+import { PromoteRoleDialog } from '@/covenants/components/PromoteRoleDialog';
 import type { CharacterCovenantRole } from '@/covenants/api';
 import type { RitualWithSchema, RitualInputSchema } from '@/rituals/types';
 
@@ -67,6 +71,7 @@ function MemberRow({ membership, isOwnMembership, covenantId }: MemberRowProps) 
   const engage = useEngageMembership(covenantId);
   const disengage = useDisengageMembership(covenantId);
   const isBusy = engage.isPending || disengage.isPending;
+  const [promoteOpen, setPromoteOpen] = useState(false);
 
   const role = membership.covenant_role;
   const characterSheetId = membership.character_sheet;
@@ -108,29 +113,40 @@ function MemberRow({ membership, isOwnMembership, covenantId }: MemberRowProps) 
       </div>
 
       {isOwnMembership && membership.is_active && (
-        <div className="shrink-0">
-          {membership.engaged ? (
-            <Button size="sm" variant="outline" onClick={handleDisengage} disabled={isBusy}>
-              {disengage.isPending ? 'Disengaging…' : 'Disengage'}
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <div className="flex items-center gap-2">
+            {membership.engaged ? (
+              <Button size="sm" variant="outline" onClick={handleDisengage} disabled={isBusy}>
+                {disengage.isPending ? 'Disengaging…' : 'Disengage'}
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleEngage}
+                disabled={isBusy || !membership.can_engage}
+                title={
+                  !membership.can_engage && membership.engage_blocked_reason
+                    ? membership.engage_blocked_reason
+                    : undefined
+                }
+              >
+                {engage.isPending ? 'Engaging…' : 'Engage'}
+              </Button>
+            )}
+            <Button size="sm" variant="outline" onClick={() => setPromoteOpen(true)}>
+              Promote
             </Button>
-          ) : (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={handleEngage}
-              disabled={isBusy || !membership.can_engage}
-              title={
-                !membership.can_engage && membership.engage_blocked_reason
-                  ? membership.engage_blocked_reason
-                  : undefined
-              }
-            >
-              {engage.isPending ? 'Engaging…' : 'Engage'}
-            </Button>
-          )}
+          </div>
           {!membership.can_engage && membership.engage_blocked_reason && !membership.engaged && (
-            <p className="mt-1 text-xs text-muted-foreground">{membership.engage_blocked_reason}</p>
+            <p className="text-xs text-muted-foreground">{membership.engage_blocked_reason}</p>
           )}
+          <PromoteRoleDialog
+            covenantId={covenantId}
+            membership={membership}
+            open={promoteOpen}
+            onOpenChange={setPromoteOpen}
+          />
         </div>
       )}
     </div>
@@ -153,7 +169,7 @@ function findInductionRitual(rituals: RitualWithSchema[]): RitualWithSchema | nu
 // Inner page
 // ---------------------------------------------------------------------------
 
-function CovenantDetailInner({ covenantId }: { covenantId: number }) {
+export function CovenantDetailInner({ covenantId }: { covenantId: number }) {
   const navigate = useNavigate();
   const account = useSelector((state: RootState) => state.auth.account);
 
@@ -189,6 +205,13 @@ function CovenantDetailInner({ covenantId }: { covenantId: number }) {
 
   return (
     <div className="space-y-6">
+      {/* Battle-state banner (renders null for non-battle covenants) */}
+      <BattleStateBanner
+        covenant={covenant}
+        characterSheetId={characterSheetId}
+        isActiveMember={isActiveMember}
+      />
+
       {/* Covenant header */}
       <Card>
         <CardHeader className="pb-3">
@@ -249,6 +272,20 @@ function CovenantDetailInner({ covenantId }: { covenantId: number }) {
             ))}
           </div>
         )}
+      </section>
+
+      {/* Covenant rites */}
+      <section>
+        <RitesPanel
+          covenantId={covenantId}
+          isActiveMember={isActiveMember}
+          characterSheetId={characterSheetId}
+        />
+      </section>
+
+      {/* Per-member passive role powers */}
+      <section>
+        <RolePowersPanel covenantId={covenantId} />
       </section>
 
       {/* Induction dialog */}

--- a/frontend/src/covenants/queries.ts
+++ b/frontend/src/covenants/queries.ts
@@ -17,6 +17,8 @@ export const covenantKeys = {
   list: () => [...covenantKeys.all, 'list'] as const,
   detail: (id: number) => [...covenantKeys.all, 'detail', id] as const,
   members: (covenantId: number) => [...covenantKeys.all, 'members', covenantId] as const,
+  powers: (covenantId: number) => [...covenantKeys.all, 'powers', covenantId] as const,
+  subroles: (parentRoleId: number) => [...covenantKeys.all, 'subroles', parentRoleId] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -49,6 +51,28 @@ export function useCovenantMembers(covenantId: number) {
   });
 }
 
+export function useCovenantPowers(covenantId: number) {
+  return useQuery({
+    queryKey: covenantKeys.powers(covenantId),
+    queryFn: () => api.getCovenantPowers(covenantId),
+    enabled: covenantId > 0,
+    throwOnError: true,
+  });
+}
+
+/**
+ * Fetch a role's sub-roles for the promotion picker. Disabled until a parent
+ * role id is known.
+ */
+export function useSubroles(parentRoleId: number | null) {
+  return useQuery({
+    queryKey: covenantKeys.subroles(parentRoleId ?? 0),
+    queryFn: () => api.getCovenantRoles({ parent_role: parentRoleId as number }),
+    enabled: parentRoleId != null,
+    throwOnError: true,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Mutation hooks
 // ---------------------------------------------------------------------------
@@ -71,6 +95,30 @@ export function useDisengageMembership(covenantId: number) {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: covenantKeys.members(covenantId) }).catch(() => {});
       qc.invalidateQueries({ queryKey: covenantKeys.detail(covenantId) }).catch(() => {});
+    },
+  });
+}
+
+export function usePromoteMembership(covenantId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { membershipId: number; targetSubroleId: number }) =>
+      api.promoteMembership(vars.membershipId, vars.targetSubroleId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: covenantKeys.members(covenantId) }).catch(() => {});
+      qc.invalidateQueries({ queryKey: covenantKeys.detail(covenantId) }).catch(() => {});
+      qc.invalidateQueries({ queryKey: covenantKeys.powers(covenantId) }).catch(() => {});
+    },
+  });
+}
+
+export function useStandDownCovenant(covenantId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.standDownCovenant(covenantId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: covenantKeys.detail(covenantId) }).catch(() => {});
+      qc.invalidateQueries({ queryKey: covenantKeys.powers(covenantId) }).catch(() => {});
     },
   });
 }

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -2961,6 +2961,65 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/covenants/covenants/{id}/powers/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description GET /api/covenants/covenants/{id}/powers/
+     *
+     *     Return the covenant's available rites (with per-covenant gate flags) and
+     *     per-member passive role powers in one payload, for the React detail page.
+     *
+     *     Visibility is enforced by ``get_object()`` (the membership-scoped
+     *     ``get_queryset``): a non-staff user with no active membership gets 404.
+     *     Deliberately does NOT serialize the Covenant via ``CovenantSerializer``
+     *     (that touches the Postgres-only legend materialized view).
+     */
+    get: operations['covenants_covenants_powers_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/covenants/covenants/{id}/stand_down/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description POST /api/covenants/covenants/{id}/stand_down/
+     *
+     *     Stand a risen STANDING battle covenant back down to dormant, clearing
+     *     engagement on its members. The "rise" path is ritual-fired; this is the
+     *     plain inverse the covenant detail UI POSTs to.
+     *
+     *     Visibility/membership is enforced by ``get_object()`` (the
+     *     membership-scoped ``get_queryset``): a non-staff user with no active
+     *     membership gets 404. Returns 400 with a ``detail`` message when the
+     *     target is not a standing battle covenant.
+     *
+     *     Returns a minimal confirmation dict rather than ``CovenantSerializer``
+     *     (which touches the Postgres-only legend materialized view); the
+     *     frontend re-fetches the covenant detail separately.
+     */
+    post: operations['covenants_covenants_stand_down_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/covenants/gear-compatibilities/': {
     parameters: {
       query?: never;
@@ -12180,6 +12239,12 @@ export interface components {
       readonly effective_cost: number;
       readonly soulfray_warning: components['schemas']['SoulfrayWarning'] | null;
     };
+    /**
+     * @description * `standing` - Standing (unit or banner — can rise again)
+     *     * `campaign` - Campaign (one-time event — dissolves when done)
+     * @enum {string}
+     */
+    BattleBindingEnum: 'standing' | 'campaign';
     /** @description Full serializer for Beat including all Phase 2 predicate config fields. */
     Beat: {
       readonly id: number;
@@ -13520,6 +13585,16 @@ export interface components {
       /** Format: date-time */
       readonly dissolved_at: string | null;
       readonly is_active: boolean;
+      /** @description Battle covenants only: True when a STANDING covenant has stood down and awaits a 'call the banners' rise ritual. A dormant covenant cannot be engaged. Never True for DURANCE or CAMPAIGN covenants. */
+      readonly is_dormant: boolean;
+      /**
+       * @description Battle covenants only (Slice E). STANDING can rise again; CAMPAIGN dissolves when its objective concludes. Empty for DURANCE covenants.
+       *
+       *     * `standing` - Standing (unit or banner — can rise again)
+       *     * `campaign` - Campaign (one-time event — dissolves when done)
+       */
+      readonly battle_binding: components['schemas']['BattleBindingEnum'];
+      readonly battle_binding_display: string;
       readonly member_count: number;
       readonly legend_total: number;
       readonly storylines: number[];
@@ -13579,6 +13654,8 @@ export interface components {
       readonly speed_rank: number;
       /** @description Player-facing description of the role's identity and combat style. */
       readonly description: string;
+      /** @description Null for primary roles. Set for sub-roles. */
+      readonly parent_role: number | null;
     };
     /**
      * @description * `sword` - Sword
@@ -25899,6 +25976,48 @@ export interface operations {
       };
     };
   };
+  covenants_covenants_powers_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Covenant'];
+        };
+      };
+    };
+  };
+  covenants_covenants_stand_down_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Covenant'];
+        };
+      };
+    };
+  };
   covenants_gear_compatibilities_list: {
     parameters: {
       query?: {
@@ -26071,6 +26190,7 @@ export interface operations {
          *     * `battle` - Covenant of Battle
          */
         covenant_type?: 'battle' | 'durance';
+        parent_role?: number;
       };
       header?: never;
       path?: never;

--- a/src/schema.json
+++ b/src/schema.json
@@ -4074,6 +4074,71 @@ paths:
               schema:
                 $ref: '#/components/schemas/Covenant'
           description: ''
+  /api/covenants/covenants/{id}/powers/:
+    get:
+      operationId: covenants_covenants_powers_retrieve
+      description: |-
+        GET /api/covenants/covenants/{id}/powers/
+
+        Return the covenant's available rites (with per-covenant gate flags) and
+        per-member passive role powers in one payload, for the React detail page.
+
+        Visibility is enforced by ``get_object()`` (the membership-scoped
+        ``get_queryset``): a non-staff user with no active membership gets 404.
+        Deliberately does NOT serialize the Covenant via ``CovenantSerializer``
+        (that touches the Postgres-only legend materialized view).
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - covenants
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Covenant'
+          description: ''
+  /api/covenants/covenants/{id}/stand_down/:
+    post:
+      operationId: covenants_covenants_stand_down_create
+      description: |-
+        POST /api/covenants/covenants/{id}/stand_down/
+
+        Stand a risen STANDING battle covenant back down to dormant, clearing
+        engagement on its members. The "rise" path is ritual-fired; this is the
+        plain inverse the covenant detail UI POSTs to.
+
+        Visibility/membership is enforced by ``get_object()`` (the
+        membership-scoped ``get_queryset``): a non-staff user with no active
+        membership gets 404. Returns 400 with a ``detail`` message when the
+        target is not a standing battle covenant.
+
+        Returns a minimal confirmation dict rather than ``CovenantSerializer``
+        (which touches the Postgres-only legend materialized view); the
+        frontend re-fetches the covenant detail separately.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - covenants
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Covenant'
+          description: ''
   /api/covenants/gear-compatibilities/:
     get:
       operationId: covenants_gear_compatibilities_list
@@ -4283,6 +4348,10 @@ paths:
 
           * `durance` - Covenant of the Durance
           * `battle` - Covenant of Battle
+      - in: query
+        name: parent_role
+        schema:
+          type: integer
       tags:
       - covenants
       security:
@@ -20833,6 +20902,14 @@ components:
       - soulfray_warning
       - technique_id
       - technique_name
+    BattleBindingEnum:
+      enum:
+      - standing
+      - campaign
+      type: string
+      description: |-
+        * `standing` - Standing (unit or banner — can rise again)
+        * `campaign` - Campaign (one-time event — dissolves when done)
     Beat:
       type: object
       description: Full serializer for Beat including all Phase 2 predicate config
@@ -23777,6 +23854,24 @@ components:
         is_active:
           type: boolean
           readOnly: true
+        is_dormant:
+          type: boolean
+          readOnly: true
+          description: 'Battle covenants only: True when a STANDING covenant has stood
+            down and awaits a ''call the banners'' rise ritual. A dormant covenant
+            cannot be engaged. Never True for DURANCE or CAMPAIGN covenants.'
+        battle_binding:
+          allOf:
+          - $ref: '#/components/schemas/BattleBindingEnum'
+          readOnly: true
+          description: |-
+            Battle covenants only (Slice E). STANDING can rise again; CAMPAIGN dissolves when its objective concludes. Empty for DURANCE covenants.
+
+            * `standing` - Standing (unit or banner — can rise again)
+            * `campaign` - Campaign (one-time event — dissolves when done)
+        battle_binding_display:
+          type: string
+          readOnly: true
         member_count:
           type: integer
           readOnly: true
@@ -23789,12 +23884,15 @@ components:
             type: integer
           readOnly: true
       required:
+      - battle_binding
+      - battle_binding_display
       - covenant_type
       - covenant_type_display
       - dissolved_at
       - formed_at
       - id
       - is_active
+      - is_dormant
       - legend_total
       - level
       - member_count
@@ -23925,6 +24023,11 @@ components:
           readOnly: true
           description: Player-facing description of the role's identity and combat
             style.
+        parent_role:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: Null for primary roles. Set for sub-roles.
       required:
       - archetype
       - archetype_display
@@ -23933,6 +24036,7 @@ components:
       - description
       - id
       - name
+      - parent_role
       - slug
       - speed_rank
     CovenantRoleArchetypeEnum:

--- a/src/world/checks/tests/test_condition_modifiers_in_checks.py
+++ b/src/world/checks/tests/test_condition_modifiers_in_checks.py
@@ -1,0 +1,141 @@
+"""Condition stat-buffs fold into effective trait values and stat checks (#783).
+
+A1 wired covenant-rite stat ModifierTargets to their Traits. A2 makes those
+condition-sourced bonuses raise the *effective* trait value everywhere — both
+the technique multiplier (already wired) and stat checks — by folding
+get_condition_modifier_total into TraitHandler._get_stat_modifier.
+"""
+
+from decimal import Decimal
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import (
+    CheckCategoryFactory,
+    CheckTypeFactory,
+    CheckTypeTraitFactory,
+)
+from world.checks.services import perform_check
+from world.conditions.factories import (
+    ConditionModifierEffectFactory,
+    ConditionTemplateFactory,
+)
+from world.conditions.services import apply_condition
+from world.mechanics.factories import ModifierTargetFactory
+from world.mechanics.models import ModifierTarget
+from world.traits.factories import CheckSystemSetupFactory
+from world.traits.models import (
+    CharacterTraitValue,
+    CheckRank,
+    PointConversionRange,
+    Trait,
+    TraitCategory,
+    TraitType,
+)
+
+
+class ConditionModifierInTraitValueTest(TestCase):
+    """Test 1: an active condition's stat buff raises the effective trait value."""
+
+    def setUp(self):
+        Trait.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        ModifierTarget.clear_trait_cache()
+
+    def test_condition_stat_buff_raises_effective_trait_value(self):
+        base = 30
+        bonus = 15
+        stat_name = "a2_trait_strength"
+
+        sheet = CharacterSheetFactory()
+        character = sheet.character
+
+        strength = Trait.objects.create(
+            name=stat_name,
+            trait_type=TraitType.STAT,
+            category=TraitCategory.PHYSICAL,
+        )
+        CharacterTraitValue.objects.create(character=character, trait=strength, value=base)
+
+        # ModifierTarget LINKED to the Trait (target_trait set), as A1 wires it.
+        target = ModifierTargetFactory(name="a2_strength_target", target_trait=strength)
+
+        condition = ConditionTemplateFactory(name="a2_strength_buff")
+        ConditionModifierEffectFactory(condition=condition, modifier_target=target, value=bonus)
+        apply_condition(target=character, condition=condition)
+
+        Trait.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        ModifierTarget.clear_trait_cache()
+
+        self.assertEqual(character.traits.get_trait_value(stat_name), base + bonus)
+
+
+class ConditionModifierInCheckTest(TestCase):
+    """Test 2: end-to-end — the condition bonus raises a stat check's trait points."""
+
+    @classmethod
+    def setUpTestData(cls):
+        Trait.flush_instance_cache()
+        CheckSystemSetupFactory.create()
+        PointConversionRange.objects.get_or_create(
+            trait_type=TraitType.STAT,
+            min_value=1,
+            defaults={"max_value": 100, "points_per_level": 1},
+        )
+        for rank_val, min_pts, name in [
+            (0, 0, "A2None"),
+            (1, 10, "A2Novice"),
+            (2, 25, "A2Competent"),
+            (3, 50, "A2Expert"),
+        ]:
+            CheckRank.objects.get_or_create(
+                rank=rank_val,
+                defaults={"min_points": min_pts, "name": name},
+            )
+        # The character must have a CharacterSheet: _get_stat_modifier reads
+        # self.character.sheet_data and returns 0 when it is absent, so a bare
+        # CharacterFactory() (no sheet) would never see the condition fold-in.
+        cls.character = CharacterSheetFactory().character
+        cls.strength, _ = Trait.objects.get_or_create(
+            name="a2_check_strength",
+            defaults={
+                "trait_type": TraitType.STAT,
+                "category": TraitCategory.PHYSICAL,
+            },
+        )
+        cls.category = CheckCategoryFactory(name="a2_check_combat")
+        cls.check_type = CheckTypeFactory(name="a2_check_power_strike", category=cls.category)
+        CheckTypeTraitFactory(
+            check_type=cls.check_type,
+            trait=cls.strength,
+            weight=Decimal("1.0"),
+        )
+
+    def setUp(self):
+        Trait.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        ModifierTarget.clear_trait_cache()
+
+    def test_condition_bonus_raises_check_trait_points(self):
+        base = 30
+        bonus = 40
+        CharacterTraitValue.objects.create(
+            character=self.character, trait=self.strength, value=base
+        )
+
+        result_base = perform_check(self.character, self.check_type, target_difficulty=0)
+
+        target = ModifierTargetFactory(name="a2_check_strength_target", target_trait=self.strength)
+        condition = ConditionTemplateFactory(name="a2_check_strength_buff")
+        ConditionModifierEffectFactory(condition=condition, modifier_target=target, value=bonus)
+        apply_condition(target=self.character, condition=condition)
+
+        Trait.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        ModifierTarget.clear_trait_cache()
+
+        result_buffed = perform_check(self.character, self.check_type, target_difficulty=0)
+
+        self.assertGreater(result_buffed.trait_points, result_base.trait_points)

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -1126,6 +1126,23 @@ def process_damage_interactions(
 # =============================================================================
 
 
+def _passive_capability_grants(character_sheet: "CharacterSheet") -> set[int]:
+    """Thread-passive CapabilityType PKs granted to ``character_sheet`` (#751 B2).
+
+    Single source of thread-passive grants — delegates to the B1 handler
+    (``CharacterThreadHandler.passive_capability_grants``), the canonical,
+    engagement-gated authority. Instantiated directly from the sheet's character
+    rather than via the ``character.threads`` typeclass property so it also works
+    when ``character_sheet.character`` is a bare ObjectDB (the test setup in
+    test_services.py), where that lazy property is absent. The handler only needs
+    ``character.sheet_data``, which a sheet-bearing ObjectDB always exposes.
+    Magic is imported locally to avoid a circular import at module load.
+    """
+    from world.magic.handlers import CharacterThreadHandler  # noqa: PLC0415
+
+    return CharacterThreadHandler(character_sheet.character).passive_capability_grants()
+
+
 def get_capability_status(
     character_sheet: "CharacterSheet",
     capability: CapabilityType,
@@ -1287,7 +1304,16 @@ def get_effective_capability_value(
     # boundary. Refactoring its signature is Phase 2 follow-up.
     status = get_capability_status(character_sheet, capability)
     condition_total = sum(modifier for _instance, modifier in status.condition_contributions)
-    return max(0, baseline + modifier_total + condition_total)
+    # Thread-passive grants (#751 B2): an engaged tier-0 role CAPABILITY_GRANT
+    # means the capability is POSSESSED → contribute an additive floor of 1
+    # (intrinsic capacity, not a condition). Folded here rather than in
+    # get_capability_status because that chokepoint is shared with
+    # get_capability_value, whose condition-only semantics must stay intact.
+    # The handler caches threads and runs ~2 queries; this is a per-capability
+    # read, not a loop, so the cost is acceptable.
+    granted = _passive_capability_grants(character_sheet)
+    grant_floor = 1 if capability.pk in granted else 0
+    return max(0, baseline + modifier_total + condition_total + grant_floor)
 
 
 def get_all_capability_values(character_sheet: "CharacterSheet") -> dict[int, int]:
@@ -1306,41 +1332,50 @@ def get_all_capability_values(character_sheet: "CharacterSheet") -> dict[int, in
     """
     target = character_sheet.character
     active_instances = list(get_active_conditions(target))
-    if not active_instances:
-        return {}
 
-    # Build batch filter
-    condition_ids = [i.condition_id for i in active_instances]
-    query = Q(condition_id__in=condition_ids)
-    stage_ids = [i.current_stage_id for i in active_instances if i.current_stage_id]
-    if stage_ids:
-        query |= Q(stage_id__in=stage_ids)
-
-    effects = ConditionCapabilityEffect.objects.filter(query).select_related("capability")
-
-    # Build instance lookup maps
-    instance_by_condition: dict[int, ConditionInstance] = {
-        i.condition_id: i for i in active_instances
-    }
-    instance_by_stage: dict[int, ConditionInstance] = {
-        i.current_stage_id: i for i in active_instances if i.current_stage_id
-    }
-
-    # Aggregate
+    # Aggregate condition-derived values (may be empty with no active conditions).
     totals: dict[int, int] = {}
-    for effect in effects:
-        instance = instance_by_condition.get(effect.condition_id) or instance_by_stage.get(
-            effect.stage_id
-        )
-        if not instance:
-            continue
+    if active_instances:
+        # Build batch filter
+        condition_ids = [i.condition_id for i in active_instances]
+        query = Q(condition_id__in=condition_ids)
+        stage_ids = [i.current_stage_id for i in active_instances if i.current_stage_id]
+        if stage_ids:
+            query |= Q(stage_id__in=stage_ids)
 
-        modifier = effect.value
-        if instance.current_stage:
-            modifier = int(modifier * instance.current_stage.severity_multiplier)
+        effects = ConditionCapabilityEffect.objects.filter(query).select_related("capability")
 
-        cap_id = effect.capability_id
-        totals[cap_id] = totals.get(cap_id, 0) + modifier
+        # Build instance lookup maps
+        instance_by_condition: dict[int, ConditionInstance] = {
+            i.condition_id: i for i in active_instances
+        }
+        instance_by_stage: dict[int, ConditionInstance] = {
+            i.current_stage_id: i for i in active_instances if i.current_stage_id
+        }
+
+        for effect in effects:
+            instance = instance_by_condition.get(effect.condition_id) or instance_by_stage.get(
+                effect.stage_id
+            )
+            if not instance:
+                continue
+
+            modifier = effect.value
+            if instance.current_stage:
+                modifier = int(modifier * instance.current_stage.severity_multiplier)
+
+            cap_id = effect.capability_id
+            totals[cap_id] = totals.get(cap_id, 0) + modifier
+
+    # Thread-passive grants (#751 B2): fold engaged tier-0 role CAPABILITY_GRANT
+    # PKs in with an additive floor of 1 so the obstacle/action-generation
+    # consumer (mechanics._get_condition_sources) sees them. Called ONCE; the
+    # handler caches threads. The early-return for the no-active-conditions case
+    # was removed above so grants surface even when the character has no
+    # conditions at all.
+    granted = _passive_capability_grants(character_sheet)
+    for cap_id in granted:
+        totals[cap_id] = totals.get(cap_id, 0) + 1
 
     # Floor at 0
     return {cap_id: max(0, val) for cap_id, val in totals.items()}

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -1131,16 +1131,24 @@ def _passive_capability_grants(character_sheet: "CharacterSheet") -> set[int]:
 
     Single source of thread-passive grants — delegates to the B1 handler
     (``CharacterThreadHandler.passive_capability_grants``), the canonical,
-    engagement-gated authority. Instantiated directly from the sheet's character
-    rather than via the ``character.threads`` typeclass property so it also works
-    when ``character_sheet.character`` is a bare ObjectDB (the test setup in
+    engagement-gated authority. Prefers the character's memoized ``.threads``
+    handler (a typeclass ``cached_property`` returning the same instance across
+    calls in a request), so a sweep over many techniques reuses one cached grant
+    set instead of re-querying per requirement (no N+1). Falls back to a fresh
+    ``CharacterThreadHandler`` only when ``.threads`` is unavailable — e.g. when
+    ``character_sheet.character`` is a bare ObjectDB (the test setup in
     test_services.py), where that lazy property is absent. The handler only needs
     ``character.sheet_data``, which a sheet-bearing ObjectDB always exposes.
     Magic is imported locally to avoid a circular import at module load.
     """
-    from world.magic.handlers import CharacterThreadHandler  # noqa: PLC0415
+    character = character_sheet.character
+    try:
+        handler = character.threads
+    except AttributeError:
+        from world.magic.handlers import CharacterThreadHandler  # noqa: PLC0415
 
-    return CharacterThreadHandler(character_sheet.character).passive_capability_grants()
+        handler = CharacterThreadHandler(character)
+    return handler.passive_capability_grants()
 
 
 def get_capability_status(

--- a/src/world/conditions/tests/test_thread_passive_capability_source.py
+++ b/src/world/conditions/tests/test_thread_passive_capability_source.py
@@ -1,0 +1,93 @@
+"""Tests for thread-passive capability grants in the conditions read path (#751 / B2).
+
+Task B1 added ``CharacterThreadHandler.passive_capability_grants()`` (the single
+source of thread-passive CapabilityType grants, engagement-gated). B2 folds that
+result into the canonical capability read so gameplay actually sees the grant:
+
+- ``get_effective_capability_value`` (intrinsic/agency read) gains a +1 floor per
+  granted capability.
+- ``get_all_capability_values`` (bulk dict, consumed by the obstacle/action system)
+  surfaces granted PKs at value >= 1 EVEN when the character has no active conditions.
+
+A passive grant means the capability is POSSESSED → it contributes a value floor of
+1, additive with other sources (it never clobbers a higher existing value).
+"""
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.conditions.factories import CapabilityTypeFactory
+from world.conditions.services import (
+    get_all_capability_values,
+    get_effective_capability_value,
+)
+from world.covenants.factories import (
+    CharacterCovenantRoleFactory,
+    CovenantFactory,
+    CovenantRoleFactory,
+)
+from world.magic.constants import EffectKind, TargetKind
+from world.magic.factories import (
+    ResonanceFactory,
+    ThreadFactory,
+    ThreadPullEffectFactory,
+)
+
+
+class ThreadPassiveCapabilitySourceTests(TestCase):
+    """Engaged tier-0 CAPABILITY_GRANT role threads surface in the capability read."""
+
+    def _build(self, *, engaged: bool):
+        """Build a character + engaged/unengaged tier-0 role CAPABILITY_GRANT.
+
+        Mirrors the B1 chain (see magic/tests/test_passive_capability_grants.py):
+        CovenantRole + Resonance + COVENANT_ROLE Thread + tier-0 capability_grant
+        ThreadPullEffect + a CharacterCovenantRole engagement record.
+        Returns (sheet, capability).
+        """
+        sheet = CharacterSheetFactory()
+        role = CovenantRoleFactory()
+        resonance = ResonanceFactory()
+        cap = CapabilityTypeFactory()
+
+        ThreadFactory(
+            owner=sheet,
+            resonance=resonance,
+            target_kind=TargetKind.COVENANT_ROLE,
+            target_trait=None,
+            target_covenant_role=role,
+            level=10,
+        )
+        ThreadPullEffectFactory(
+            target_kind=TargetKind.COVENANT_ROLE,
+            resonance=resonance,
+            tier=0,
+            min_thread_level=0,
+            effect_kind=EffectKind.CAPABILITY_GRANT,
+            flat_bonus_amount=None,
+            capability_grant=cap,
+        )
+        CharacterCovenantRoleFactory(
+            character_sheet=sheet,
+            covenant=CovenantFactory(),
+            covenant_role=role,
+            engaged=engaged,
+            left_at=None,
+        )
+        return sheet, cap
+
+    def test_engaged_role_grant_raises_effective_capability(self) -> None:
+        sheet, cap = self._build(engaged=True)
+        self.assertGreaterEqual(get_effective_capability_value(sheet, cap), 1)
+
+    def test_engaged_role_grant_appears_in_all_capability_values(self) -> None:
+        sheet, cap = self._build(engaged=True)
+        # No active conditions on this character — the grant must still surface.
+        values = get_all_capability_values(sheet)
+        self.assertIn(cap.pk, values)
+        self.assertGreaterEqual(values[cap.pk], 1)
+
+    def test_no_grant_without_engagement(self) -> None:
+        sheet, cap = self._build(engaged=False)
+        self.assertEqual(get_effective_capability_value(sheet, cap), cap.innate_baseline)
+        self.assertNotIn(cap.pk, get_all_capability_values(sheet))

--- a/src/world/covenants/factories.py
+++ b/src/world/covenants/factories.py
@@ -1,5 +1,7 @@
 """FactoryBoy factories for covenant models."""
 
+from typing import TYPE_CHECKING
+
 import factory
 from factory import django as factory_django
 
@@ -15,6 +17,9 @@ from world.covenants.models import (
     GearArchetypeCompatibility,
 )
 from world.items.constants import GearArchetype
+
+if TYPE_CHECKING:
+    from world.conditions.models import CapabilityType
 
 
 class CovenantRoleFactory(factory_django.DjangoModelFactory):
@@ -374,6 +379,158 @@ def wire_covenant_rite_content() -> CovenantRite:
     )
 
     return rite
+
+
+def wire_covenant_role_powers_catalog() -> "tuple[CovenantRole, list[CapabilityType]]":
+    """Idempotent seed: an authored per-(role, resonance) role-powers catalog.
+
+    Authors ONE Sword (offense) archetype CovenantRole for the Covenant of Battle
+    and, for each of two distinct authored resonances channelling that role, the
+    pair of pull effects that make the role mechanically real:
+
+    - A **tier-0 CAPABILITY_GRANT** — the covenant's always-on *gift* to an engaged
+      holder who has woven their role-thread on that resonance. Two holders of the
+      same role anchoring DIFFERENT resonances thereby unlock DIFFERENT capabilities
+      (the #751 individualization lever — identity is across characters, not within
+      one).
+    - A **tier-1 active pull** — a paid in-the-moment surge (FLAT_BONUS for the first
+      resonance, INTENSITY_BUMP for the second) showing the active-pull half of the
+      catalog alongside the passive gift.
+
+    Doubles as integration-test setUp AND staff/new-player seed data (per the
+    factories-as-seed-data convention). Every create is a ``get_or_create`` keyed on
+    its natural/unique key, so a second call is a no-op — no data migration.
+
+    Returns ``(role, [cap_for_res_a, cap_for_res_b])``.
+    """
+    from world.conditions.models import CapabilityType
+    from world.magic.constants import EffectKind, TargetKind
+    from world.magic.models import Affinity, Resonance, ThreadPullEffect
+
+    # ------------------------------------------------------------------
+    # The Sword (offense) role — PRIMARY (no parent_role/resonance, level 0).
+    # ------------------------------------------------------------------
+    role, _ = CovenantRole.objects.get_or_create(
+        slug="battle-warblade",
+        defaults={
+            "name": "Warblade",
+            "covenant_type": CovenantType.BATTLE,
+            "archetype": RoleArchetype.SWORD,
+            "speed_rank": 2,
+            "description": (
+                "The covenant's drawn edge — those who carry the oath into the killing "
+                "press and answer threat with threat."
+            ),
+        },
+    )
+
+    # ------------------------------------------------------------------
+    # Two authored resonances (each needs an Affinity FK).
+    # ------------------------------------------------------------------
+    affinity, _ = Affinity.objects.get_or_create(
+        name="Primal",
+        defaults={"description": "The wild, untamed source of magical power."},
+    )
+    res_ember, _ = Resonance.objects.get_or_create(
+        name="Ember Wrath",
+        defaults={
+            "description": (
+                "A resonance of blazing, forward fury — the war-fire that does not retreat."
+            ),
+            "affinity": affinity,
+        },
+    )
+    res_keening, _ = Resonance.objects.get_or_create(
+        name="Keening Edge",
+        defaults={
+            "description": (
+                "A resonance of honed, singing precision — the blade that finds the seam."
+            ),
+            "affinity": affinity,
+        },
+    )
+
+    # ------------------------------------------------------------------
+    # One distinct capability per resonance (the gift each unlocks).
+    # ------------------------------------------------------------------
+    cap_ember, _ = CapabilityType.objects.get_or_create(
+        name="Warblade: Sundering Strike",
+        defaults={
+            "description": "Channel the covenant's war-fire to shatter a foe's guard.",
+            "innate_baseline": 0,
+        },
+    )
+    cap_keening, _ = CapabilityType.objects.get_or_create(
+        name="Warblade: Seam-Finder",
+        defaults={
+            "description": "Read the singing edge to strike unerringly through any gap.",
+            "innate_baseline": 0,
+        },
+    )
+
+    # ------------------------------------------------------------------
+    # Per resonance: tier-0 passive CAPABILITY_GRANT + a tier-1 active pull.
+    # Keyed (target_kind, resonance, tier, min_thread_level) — the unique lookup.
+    # ------------------------------------------------------------------
+    ThreadPullEffect.objects.get_or_create(
+        target_kind=TargetKind.COVENANT_ROLE,
+        resonance=res_ember,
+        tier=0,
+        min_thread_level=0,
+        defaults={
+            "effect_kind": EffectKind.CAPABILITY_GRANT,
+            "capability_grant": cap_ember,
+            "narrative_snippet": (
+                "The Ember Wrath you carry for the covenant kindles in your grip; the "
+                "oath answers, and your strikes learn to shatter what stands against them."
+            ),
+        },
+    )
+    ThreadPullEffect.objects.get_or_create(
+        target_kind=TargetKind.COVENANT_ROLE,
+        resonance=res_ember,
+        tier=1,
+        min_thread_level=0,
+        defaults={
+            "effect_kind": EffectKind.FLAT_BONUS,
+            "flat_bonus_amount": 3,
+            "narrative_snippet": (
+                "You pull harder on the war-fire and it surges — a blaze of borrowed "
+                "fury behind the blow."
+            ),
+        },
+    )
+
+    ThreadPullEffect.objects.get_or_create(
+        target_kind=TargetKind.COVENANT_ROLE,
+        resonance=res_keening,
+        tier=0,
+        min_thread_level=0,
+        defaults={
+            "effect_kind": EffectKind.CAPABILITY_GRANT,
+            "capability_grant": cap_keening,
+            "narrative_snippet": (
+                "The Keening Edge you bear for the covenant sings low in the bones of "
+                "your hand; the oath answers, and your eye finds the seam before the cut."
+            ),
+        },
+    )
+    ThreadPullEffect.objects.get_or_create(
+        target_kind=TargetKind.COVENANT_ROLE,
+        resonance=res_keening,
+        tier=1,
+        min_thread_level=0,
+        defaults={
+            "effect_kind": EffectKind.INTENSITY_BUMP,
+            "intensity_bump_amount": 1,
+            "narrative_snippet": (
+                "You draw the singing edge taut and it answers — every line of the "
+                "strike sharpened a degree past mortal keenness."
+            ),
+        },
+    )
+
+    return role, [cap_ember, cap_keening]
 
 
 def make_engaged_member(

--- a/src/world/covenants/factories.py
+++ b/src/world/covenants/factories.py
@@ -218,15 +218,24 @@ def wire_covenant_rite_content() -> CovenantRite:
         defaults={"description": "Primary character statistics.", "display_order": 10},
     )
 
+    from world.traits.models import Trait
+
     def _stat(name: str) -> ModifierTarget:
+        trait = Trait.get_by_name(name)
         target, _ = ModifierTarget.objects.get_or_create(
             category=stat_cat,
             name=name,
             defaults={
                 "description": f"{name.capitalize()} stat modifier target.",
                 "is_active": True,
+                "target_trait": trait,
             },
         )
+        # Backfill linkage on a pre-existing orphan row (get_or_create only
+        # sets defaults on create).
+        if target.target_trait_id is None and trait is not None:
+            target.target_trait = trait
+            target.save(update_fields=["target_trait"])
         return target
 
     # ------------------------------------------------------------------

--- a/src/world/covenants/filters.py
+++ b/src/world/covenants/filters.py
@@ -13,11 +13,16 @@ from world.covenants.models import (
 
 
 class CovenantRoleFilter(django_filters.FilterSet):
-    """Filter covenant roles by covenant type."""
+    """Filter covenant roles by covenant type and parent role.
+
+    ``parent_role`` lets the promotion UI fetch a role's sub-roles directly,
+    e.g. ``?parent_role=<id>`` returns the woven-resonance sub-roles a member
+    of that parent role may be promoted into.
+    """
 
     class Meta:
         model = CovenantRole
-        fields = ["covenant_type"]
+        fields = ["covenant_type", "parent_role"]
 
 
 class CharacterCovenantRoleFilter(django_filters.FilterSet):

--- a/src/world/covenants/serializers.py
+++ b/src/world/covenants/serializers.py
@@ -33,6 +33,7 @@ class CovenantRoleSerializer(serializers.ModelSerializer):
             "archetype_display",
             "speed_rank",
             "description",
+            "parent_role",
         ]
         read_only_fields = fields
 

--- a/src/world/covenants/serializers.py
+++ b/src/world/covenants/serializers.py
@@ -178,6 +178,26 @@ class CovenantRiteSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class CovenantRolePassivePowerSerializer(serializers.Serializer):
+    """Read-only shape for one active membership's current passive role power.
+
+    A member's passive power is the tier-0 CAPABILITY_GRANT ThreadPullEffect for
+    the resonance their COVENANT_ROLE thread channels. Members without a woven
+    role-thread (or whose thread level is below the effect's min_thread_level)
+    have null capability fields; resonance_name may still be populated when a
+    thread exists.
+    """
+
+    membership_id = serializers.IntegerField(read_only=True)
+    character_sheet = serializers.IntegerField(read_only=True)
+    covenant_role_id = serializers.IntegerField(read_only=True)
+    covenant_role_name = serializers.CharField(read_only=True)
+    resonance_name = serializers.CharField(read_only=True, allow_null=True)
+    capability_name = serializers.CharField(read_only=True, allow_null=True)
+    narrative_snippet = serializers.CharField(read_only=True, allow_null=True)
+    engaged = serializers.BooleanField(read_only=True)
+
+
 class GearArchetypeCompatibilitySerializer(serializers.ModelSerializer):
     """Read-only serializer for GearArchetypeCompatibility join rows."""
 

--- a/src/world/covenants/serializers.py
+++ b/src/world/covenants/serializers.py
@@ -85,6 +85,9 @@ class CovenantSerializer(serializers.ModelSerializer):
     covenant_type_display = serializers.CharField(
         source="get_covenant_type_display", read_only=True
     )
+    battle_binding_display = serializers.CharField(
+        source="get_battle_binding_display", read_only=True
+    )
     member_count = serializers.SerializerMethodField()
     is_active = serializers.SerializerMethodField()
     legend_total = serializers.SerializerMethodField()
@@ -102,6 +105,9 @@ class CovenantSerializer(serializers.ModelSerializer):
             "formed_at",
             "dissolved_at",
             "is_active",
+            "is_dormant",
+            "battle_binding",
+            "battle_binding_display",
             "member_count",
             "legend_total",
             "storylines",

--- a/src/world/covenants/services.py
+++ b/src/world/covenants/services.py
@@ -45,6 +45,21 @@ MINIMUM_FOUNDERS = 2
 _COVENANT_NAME_UNIQUE_MARKER = "name"  # substring in DB integrity error for name uniqueness
 
 
+def _invalidate_role_caches(character_sheet: CharacterSheet) -> None:
+    """Bust the character's thread-handler grant cache after an engagement change.
+
+    ``CharacterThreadHandler.passive_capability_grants()`` (#751) caches the
+    engaged-role-gated CAPABILITY_GRANT set on the long-lived, idmapper-cached
+    Character typeclass instance. Engaging/disengaging a covenant role changes
+    that set, so the handler must be invalidated or role powers go stale.
+
+    Resolves the character via the same ``character_sheet.character`` reverse
+    relation the sibling ``.covenant_roles.invalidate()`` calls use throughout
+    this module — an engaged membership always has a resolved typeclass.
+    """
+    character_sheet.character.threads.invalidate()
+
+
 @transaction.atomic
 def create_covenant(
     *,
@@ -137,6 +152,7 @@ def change_role(
         covenant_role=new_role,
     )
     membership.character_sheet.character.covenant_roles.invalidate()
+    _invalidate_role_caches(membership.character_sheet)
     membership.covenant.member_roster.invalidate()
     return new_row
 
@@ -164,6 +180,7 @@ def dissolve_covenant(*, covenant: Covenant) -> None:
     for sheet_id in affected_sheet_ids:
         sheet = CharacterSheet.objects.get(pk=sheet_id)
         sheet.character.covenant_roles.invalidate()
+        _invalidate_role_caches(sheet)
     covenant.member_roster.invalidate()
 
 
@@ -194,6 +211,7 @@ def end_covenant_role(*, assignment: CharacterCovenantRole) -> None:
     assignment.left_at = timezone.now()
     assignment.save(update_fields=["engaged", "left_at"])
     assignment.character_sheet.character.covenant_roles.invalidate()
+    _invalidate_role_caches(assignment.character_sheet)
     assignment.covenant.member_roster.invalidate()
 
 
@@ -221,6 +239,7 @@ def set_engaged_membership(*, membership: CharacterCovenantRole) -> None:
     membership.engaged = True
     membership.save(update_fields=["engaged"])
     membership.character_sheet.character.covenant_roles.invalidate()
+    _invalidate_role_caches(membership.character_sheet)
 
 
 @transaction.atomic
@@ -231,6 +250,7 @@ def clear_engaged_membership(*, membership: CharacterCovenantRole) -> None:
     membership.engaged = False
     membership.save(update_fields=["engaged"])
     membership.character_sheet.character.covenant_roles.invalidate()
+    _invalidate_role_caches(membership.character_sheet)
 
 
 @transaction.atomic
@@ -254,6 +274,7 @@ def clear_engaged_for_type(*, character_sheet: CharacterSheet, covenant_type: st
         row.engaged = False
         row.save(update_fields=["engaged"])
     character_sheet.character.covenant_roles.invalidate()
+    _invalidate_role_caches(character_sheet)
 
 
 def precedence_role_for_combat(character_sheet: CharacterSheet) -> CovenantRole | None:
@@ -451,6 +472,7 @@ def stand_down_battle_covenant(*, covenant: Covenant) -> None:
         m.engaged = False
         m.save(update_fields=["engaged"])
         m.character_sheet.character.covenant_roles.invalidate()
+        _invalidate_role_caches(m.character_sheet)
 
 
 def _emit_rise_message(covenant: Covenant) -> None:

--- a/src/world/covenants/tests/test_battle_covenant_actions.py
+++ b/src/world/covenants/tests/test_battle_covenant_actions.py
@@ -1,0 +1,159 @@
+"""Tests for POST /api/covenants/covenants/{id}/stand_down/.
+
+The stand_down action stands a risen STANDING battle covenant back down to
+dormant (clearing engagement). It deliberately returns a minimal confirmation
+dict rather than serializing the Covenant via CovenantSerializer (which would
+touch the Postgres-only legend materialized view), so these tests run on SQLite.
+"""
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+class StandDownActionTestCase(TestCase):
+    """Base: an authenticated user with an active membership on a covenant."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia.accounts.models import AccountDB
+
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.covenants.constants import BattleBinding, CovenantType
+        from world.covenants.factories import (
+            CharacterCovenantRoleFactory,
+            CovenantFactory,
+            CovenantRoleFactory,
+        )
+        from world.roster.factories import (
+            PlayerDataFactory,
+            RosterEntryFactory,
+            RosterTenureFactory,
+        )
+
+        cls.user = AccountDB.objects.create_user(
+            username="cov_standdown_user",
+            email="cov_standdown@test.com",
+            password="testpass123",
+        )
+
+        # Sheet + active tenure for the default user.
+        cls.sheet = CharacterSheetFactory()
+        cls.roster_entry = RosterEntryFactory(character_sheet=cls.sheet)
+        cls.player_data = PlayerDataFactory(account=cls.user)
+        cls.tenure = RosterTenureFactory(
+            roster_entry=cls.roster_entry,
+            player_data=cls.player_data,
+            end_date=None,
+        )
+
+        # A risen (is_dormant=False) STANDING BATTLE covenant the user is in.
+        cls.battle_role = CovenantRoleFactory(covenant_type=CovenantType.BATTLE)
+        cls.battle_covenant = CovenantFactory(
+            name="StandDownBattleCov",
+            covenant_type=CovenantType.BATTLE,
+            battle_binding=BattleBinding.STANDING,
+            is_dormant=False,
+        )
+        cls.membership = CharacterCovenantRoleFactory(
+            character_sheet=cls.sheet,
+            covenant=cls.battle_covenant,
+            covenant_role=cls.battle_role,
+            engaged=True,
+        )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _url(self, pk: int) -> str:
+        return f"/api/covenants/covenants/{pk}/stand_down/"
+
+
+class StandDownSuccessTests(StandDownActionTestCase):
+    """The happy path: a risen standing battle covenant goes dormant."""
+
+    def test_stand_down_dormantizes_risen_standing_battle_covenant(self) -> None:
+        response = self.client.post(self._url(self.battle_covenant.pk))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["is_dormant"])
+        self.assertEqual(response.data["id"], self.battle_covenant.pk)
+
+        # Re-fetch from DB to confirm the flip persisted.
+        from world.covenants.models import Covenant
+
+        refreshed = Covenant.objects.get(pk=self.battle_covenant.pk)
+        self.assertTrue(refreshed.is_dormant)
+
+
+class StandDownRejectionTests(StandDownActionTestCase):
+    """Domain-guard rejections map to 400 with a detail message."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.covenants.constants import CovenantType
+        from world.covenants.factories import (
+            CharacterCovenantRoleFactory,
+            CovenantFactory,
+            CovenantRoleFactory,
+        )
+
+        super().setUpTestData()
+
+        # A non-battle covenant the same user is also a member of.
+        cls.durance_role = CovenantRoleFactory(covenant_type=CovenantType.DURANCE)
+        cls.durance_covenant = CovenantFactory(
+            name="StandDownDuranceCov",
+            covenant_type=CovenantType.DURANCE,
+        )
+        CharacterCovenantRoleFactory(
+            character_sheet=cls.sheet,
+            covenant=cls.durance_covenant,
+            covenant_role=cls.durance_role,
+        )
+
+    def test_stand_down_rejects_non_battle_covenant(self) -> None:
+        response = self.client.post(self._url(self.durance_covenant.pk))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+
+        # Unchanged: a non-battle covenant cannot be dormant.
+        from world.covenants.models import Covenant
+
+        refreshed = Covenant.objects.get(pk=self.durance_covenant.pk)
+        self.assertFalse(refreshed.is_dormant)
+
+
+class StandDownScopingTests(StandDownActionTestCase):
+    """Non-members cannot target a covenant they have no membership on (404)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.covenants.constants import BattleBinding, CovenantType
+        from world.covenants.factories import CovenantFactory
+
+        super().setUpTestData()
+        cls.foreign_covenant = CovenantFactory(
+            name="ForeignStandDownCov",
+            covenant_type=CovenantType.BATTLE,
+            battle_binding=BattleBinding.STANDING,
+            is_dormant=False,
+        )
+
+    def test_stand_down_requires_membership(self) -> None:
+        response = self.client.post(self._url(self.foreign_covenant.pk))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Untouched.
+        from world.covenants.models import Covenant
+
+        refreshed = Covenant.objects.get(pk=self.foreign_covenant.pk)
+        self.assertFalse(refreshed.is_dormant)
+
+    def test_unauthenticated_denied(self) -> None:
+        unauthenticated = APIClient()
+        response = unauthenticated.post(self._url(self.battle_covenant.pk))
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )

--- a/src/world/covenants/tests/test_covenant_powers_endpoint.py
+++ b/src/world/covenants/tests/test_covenant_powers_endpoint.py
@@ -1,0 +1,222 @@
+"""Tests for GET /api/covenants/covenants/{id}/powers/.
+
+The powers action exposes a covenant's available rites (with per-covenant gate
+flags) and per-member role passive powers in one request. It deliberately does
+NOT serialize the Covenant via CovenantSerializer (that would touch the
+Postgres-only legend materialized view), so these tests run on SQLite.
+"""
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+class CovenantPowersEndpointTestCase(TestCase):
+    """Base: an authenticated user with an active membership on a covenant."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia.accounts.models import AccountDB
+
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.covenants.constants import CovenantType
+        from world.covenants.factories import (
+            CharacterCovenantRoleFactory,
+            CovenantFactory,
+            CovenantRoleFactory,
+        )
+        from world.roster.factories import (
+            PlayerDataFactory,
+            RosterEntryFactory,
+            RosterTenureFactory,
+        )
+
+        cls.user = AccountDB.objects.create_user(
+            username="cov_powers_user",
+            email="cov_powers@test.com",
+            password="testpass123",
+        )
+
+        # Sheet + active tenure for the default user.
+        cls.sheet = CharacterSheetFactory()
+        cls.roster_entry = RosterEntryFactory(character_sheet=cls.sheet)
+        cls.player_data = PlayerDataFactory(account=cls.user)
+        cls.tenure = RosterTenureFactory(
+            roster_entry=cls.roster_entry,
+            player_data=cls.player_data,
+            end_date=None,
+        )
+
+        cls.covenant = CovenantFactory(
+            name="PowersCov", covenant_type=CovenantType.DURANCE, level=3
+        )
+        cls.role = CovenantRoleFactory(covenant_type=CovenantType.DURANCE)
+        cls.membership = CharacterCovenantRoleFactory(
+            character_sheet=cls.sheet,
+            covenant=cls.covenant,
+            covenant_role=cls.role,
+        )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _url(self, pk: int) -> str:
+        return f"/api/covenants/covenants/{pk}/powers/"
+
+
+class PowersRitesTests(CovenantPowersEndpointTestCase):
+    """The 'rites' half of the powers payload."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.covenants.factories import CovenantRiteFactory
+
+        super().setUpTestData()
+        # Gate thresholds chosen so we can assert both flags against the
+        # covenant's level (3) and active member count (1).
+        # level_met: covenant.level (3) >= 2 → True
+        # members_present_met: active_member_count (1) >= 5 → False
+        cls.rite = CovenantRiteFactory(
+            covenant_type=cls.covenant.covenant_type,
+            min_covenant_level=2,
+            min_members_present=5,
+        )
+
+    def test_powers_returns_rites_with_gate_flags(self) -> None:
+        response = self.client.get(self._url(self.covenant.pk))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("rites", response.data)
+        rites = response.data["rites"]
+        matching = [r for r in rites if r["id"] == self.rite.pk]
+        self.assertEqual(len(matching), 1, "Authored rite for the type should appear")
+        rite = matching[0]
+        self.assertTrue(rite["level_met"])  # level 3 >= min 2
+        self.assertFalse(rite["members_present_met"])  # 1 member < min 5
+        # Reuses CovenantRiteSerializer fields.
+        self.assertIn("min_covenant_level", rite)
+        self.assertIn("min_members_present", rite)
+
+
+class PowersRolePowersTests(TestCase):
+    """The 'role_powers' half of the payload — per active membership."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia.accounts.models import AccountDB
+
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.covenants.constants import CovenantType
+        from world.covenants.factories import (
+            CharacterCovenantRoleFactory,
+            CovenantFactory,
+            wire_covenant_role_powers_catalog,
+        )
+        from world.magic.constants import TargetKind
+        from world.magic.factories import ThreadFactory
+        from world.magic.models import Resonance
+        from world.roster.factories import (
+            PlayerDataFactory,
+            RosterEntryFactory,
+            RosterTenureFactory,
+        )
+
+        cls.user = AccountDB.objects.create_user(
+            username="cov_rp_user",
+            email="cov_rp@test.com",
+            password="testpass123",
+        )
+        cls.sheet = CharacterSheetFactory()
+        cls.roster_entry = RosterEntryFactory(character_sheet=cls.sheet)
+        cls.player_data = PlayerDataFactory(account=cls.user)
+        cls.tenure = RosterTenureFactory(
+            roster_entry=cls.roster_entry,
+            player_data=cls.player_data,
+            end_date=None,
+        )
+
+        # Authored Sword role + two resonances, each with a tier-0 CAPABILITY_GRANT.
+        cls.role, cls.caps = wire_covenant_role_powers_catalog()
+        cls.cap_ember = cls.caps[0]
+        cls.resonance = Resonance.objects.get(name="Ember Wrath")
+
+        # A BATTLE covenant the role belongs to.
+        cls.covenant = CovenantFactory(
+            name="RolePowersBattleCov",
+            covenant_type=CovenantType.BATTLE,
+            battle_binding="standing",
+        )
+        # Member WITH a woven, engaged role-thread on Ember Wrath.
+        cls.membership = CharacterCovenantRoleFactory(
+            character_sheet=cls.sheet,
+            covenant=cls.covenant,
+            covenant_role=cls.role,
+            engaged=True,
+        )
+        ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            target_kind=TargetKind.COVENANT_ROLE,
+            target_trait=None,
+            target_covenant_role=cls.role,
+            level=5,
+        )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def test_powers_returns_member_role_power(self) -> None:
+        response = self.client.get(f"/api/covenants/covenants/{self.covenant.pk}/powers/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("role_powers", response.data)
+        rows = response.data["role_powers"]
+        mine = [r for r in rows if r["membership_id"] == self.membership.pk]
+        self.assertEqual(len(mine), 1)
+        row = mine[0]
+        self.assertEqual(row["capability_name"], self.cap_ember.name)
+        self.assertEqual(row["resonance_name"], self.resonance.name)
+        self.assertTrue(row["engaged"])
+        self.assertEqual(row["covenant_role_id"], self.role.pk)
+        self.assertEqual(row["character_sheet"], self.sheet.pk)
+        self.assertIsNotNone(row["narrative_snippet"])
+
+
+class PowersMemberWithoutThreadTests(CovenantPowersEndpointTestCase):
+    """A member with no role-thread has a null power."""
+
+    def test_powers_member_without_thread_has_null_power(self) -> None:
+        response = self.client.get(self._url(self.covenant.pk))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rows = response.data["role_powers"]
+        mine = [r for r in rows if r["membership_id"] == self.membership.pk]
+        self.assertEqual(len(mine), 1)
+        row = mine[0]
+        self.assertIsNone(row["capability_name"])
+        self.assertIsNone(row["resonance_name"])
+        self.assertIsNone(row["narrative_snippet"])
+        self.assertEqual(row["covenant_role_id"], self.role.pk)
+
+
+class PowersAuthAndScopingTests(CovenantPowersEndpointTestCase):
+    """Auth + per-user visibility scoping (matches the viewset queryset)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.covenants.factories import CovenantFactory
+
+        super().setUpTestData()
+        # A covenant the user has NO membership on.
+        cls.foreign_covenant = CovenantFactory(name="ForeignPowersCov")
+
+    def test_unauthenticated_denied(self) -> None:
+        unauthenticated = APIClient()
+        response = unauthenticated.get(self._url(self.covenant.pk))
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
+
+    def test_non_member_cannot_see_foreign_covenant_powers(self) -> None:
+        response = self.client.get(self._url(self.foreign_covenant.pk))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/src/world/covenants/tests/test_covenant_serializer_battle_fields.py
+++ b/src/world/covenants/tests/test_covenant_serializer_battle_fields.py
@@ -1,0 +1,38 @@
+"""Tests for battle-state fields exposed on CovenantSerializer (#518, Task C1)."""
+
+from django.test import TestCase, tag
+
+from world.covenants.constants import BattleBinding, CovenantType
+from world.covenants.factories import CovenantFactory
+from world.covenants.serializers import CovenantSerializer
+
+
+class CovenantSerializerBattleFieldDeclarationTests(TestCase):
+    """SQLite-safe: assert battle-state fields are declared without serializing.
+
+    Serializing a Covenant triggers legend_total → a PG materialized view that
+    does not exist under SQLite (#758), so this guard only inspects the declared
+    field set and never touches `.data`.
+    """
+
+    def test_battle_fields_declared(self) -> None:
+        field_names = set(CovenantSerializer().fields.keys())
+        self.assertIn("is_dormant", field_names)
+        self.assertIn("battle_binding", field_names)
+        self.assertIn("battle_binding_display", field_names)
+
+
+@tag("postgres")  # serializes legend_total → societies_covenantlegendsummary (PG view) — #758
+class CovenantSerializerBattleFieldValueTests(TestCase):
+    """Verify the serialized values of the battle-state fields."""
+
+    def test_standing_dormant_battle_covenant_values(self) -> None:
+        cov = CovenantFactory(
+            covenant_type=CovenantType.BATTLE,
+            battle_binding=BattleBinding.STANDING,
+            is_dormant=True,
+        )
+        data = CovenantSerializer(cov).data
+        self.assertTrue(data["is_dormant"])
+        self.assertEqual(data["battle_binding"], BattleBinding.STANDING)
+        self.assertTrue(data["battle_binding_display"])

--- a/src/world/covenants/tests/test_engagement_invalidates_role_powers.py
+++ b/src/world/covenants/tests/test_engagement_invalidates_role_powers.py
@@ -1,0 +1,84 @@
+"""Service-layer regression for #751: engagement changes bust the role-power cache.
+
+``CharacterThreadHandler.passive_capability_grants()`` caches the engaged-role-gated
+CAPABILITY_GRANT set on the long-lived, idmapper-cached Character typeclass instance
+(and its memoized ``.threads`` handler). Engaging/disengaging a covenant role changes
+that set, so the engagement service functions MUST invalidate the thread handler or a
+just-engaged role power would not apply (and a disengaged one would linger).
+
+These tests prove the SERVICE invalidates — they never call ``invalidate()`` by hand;
+they read the grant set through the same memoized ``character.threads`` handler the
+service resolves via ``membership.character_sheet.character.threads``.
+"""
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.conditions.factories import CapabilityTypeFactory
+from world.covenants.factories import (
+    CharacterCovenantRoleFactory,
+    CovenantFactory,
+    CovenantRoleFactory,
+)
+from world.covenants.services import clear_engaged_membership, set_engaged_membership
+from world.magic.constants import EffectKind, TargetKind
+from world.magic.factories import (
+    ResonanceFactory,
+    ThreadFactory,
+    ThreadPullEffectFactory,
+)
+
+
+class EngagementInvalidatesRolePowersTests(TestCase):
+    """set_engaged_membership / clear_engaged_membership bust the cached grant set."""
+
+    def _make_covenant_role_thread(self, *, sheet, role, resonance, level=10):
+        return ThreadFactory(
+            owner=sheet,
+            resonance=resonance,
+            target_kind=TargetKind.COVENANT_ROLE,
+            target_trait=None,
+            target_covenant_role=role,
+            level=level,
+        )
+
+    def _make_tier0_capability_effect(self, *, resonance, capability):
+        return ThreadPullEffectFactory(
+            target_kind=TargetKind.COVENANT_ROLE,
+            resonance=resonance,
+            tier=0,
+            min_thread_level=0,
+            effect_kind=EffectKind.CAPABILITY_GRANT,
+            flat_bonus_amount=None,
+            capability_grant=capability,
+        )
+
+    def test_engage_then_disengage_invalidates_grant_cache(self):
+        sheet = CharacterSheetFactory()
+        character = sheet.character
+        role = CovenantRoleFactory()
+        resonance = ResonanceFactory()
+        cap = CapabilityTypeFactory()
+
+        self._make_covenant_role_thread(sheet=sheet, role=role, resonance=resonance)
+        self._make_tier0_capability_effect(resonance=resonance, capability=cap)
+
+        membership = CharacterCovenantRoleFactory(
+            character_sheet=sheet,
+            covenant=CovenantFactory(),
+            covenant_role=role,
+            engaged=False,
+            left_at=None,
+        )
+
+        # Populate the cache via the SAME memoized handler the service will invalidate.
+        # Unengaged → cap absent (and now cached on character.threads).
+        self.assertNotIn(cap.pk, character.threads.passive_capability_grants())
+
+        # Engage via the service — it must invalidate the thread handler.
+        set_engaged_membership(membership=membership)
+        self.assertIn(cap.pk, character.threads.passive_capability_grants())
+
+        # Disengage via the service — the cap must drop out again.
+        clear_engaged_membership(membership=membership)
+        self.assertNotIn(cap.pk, character.threads.passive_capability_grants())

--- a/src/world/covenants/tests/test_rite_target_trait_linkage.py
+++ b/src/world/covenants/tests/test_rite_target_trait_linkage.py
@@ -1,0 +1,46 @@
+"""Task A1 (#783): rite-seeded stat ModifierTargets must link their Trait.
+
+``wire_covenant_rite_content`` creates stat ``ModifierTarget`` rows for the
+covenant-rite buffs. Those targets must set ``target_trait`` so that
+``ModifierTarget.get_for_trait`` (which filters ``target_trait__isnull=False``)
+can resolve them — otherwise the buffs never reach the trait cache.
+
+The canonical stat Traits are not auto-seeded in a fresh test DB, so this test
+seeds willpower/composure/stability the same way the trait tests do
+(``Trait.objects.get_or_create`` with ``TraitType.STAT``).
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from world.covenants.factories import wire_covenant_rite_content
+from world.mechanics.models import ModifierTarget
+from world.traits.models import Trait, TraitCategory, TraitType
+
+
+class RiteStatTargetTraitLinkageTest(TestCase):
+    """Seeded stat ModifierTargets link to their canonical Trait."""
+
+    def setUp(self) -> None:
+        # Canonical stat Traits are not auto-present in a fresh test DB; seed
+        # them here so Trait.get_by_name resolves inside the wire helper.
+        for stat_name in ("willpower", "composure", "stability"):
+            Trait.objects.get_or_create(
+                name=stat_name,
+                defaults={
+                    "trait_type": TraitType.STAT,
+                    "category": TraitCategory.MENTAL,
+                    "description": f"{stat_name.capitalize()} stat.",
+                },
+            )
+
+    def test_seeded_stat_targets_have_target_trait_set(self) -> None:
+        wire_covenant_rite_content()
+        for stat_name in ("willpower", "composure", "stability"):
+            target = ModifierTarget.objects.get(category__name="stat", name=stat_name)
+            self.assertIsNotNone(
+                target.target_trait,
+                f"stat ModifierTarget {stat_name!r} must link its Trait (no orphan)",
+            )
+            self.assertEqual(target.target_trait, Trait.get_by_name(stat_name))

--- a/src/world/covenants/tests/test_role_powers_catalog.py
+++ b/src/world/covenants/tests/test_role_powers_catalog.py
@@ -1,0 +1,121 @@
+"""Tests for the authored per-(role, resonance) role-powers catalog (#751 / Task B3).
+
+``wire_covenant_role_powers_catalog`` seeds ONE Sword-archetype CovenantRole with a
+per-(role, resonance) catalog: two authored resonances, each granting a distinct
+tier-0 CAPABILITY_GRANT (the covenant's passive gift) plus a tier-1 active pull.
+Individualization is ACROSS characters — two holders of the SAME role who anchor
+DIFFERENT resonances unlock DIFFERENT capabilities. These tests prove idempotency
+and that end-to-end individualization through the passive-application pipeline
+(B1 handler -> B2 capability read).
+"""
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.conditions.services import get_effective_capability_value
+from world.covenants.factories import (
+    CharacterCovenantRoleFactory,
+    CovenantFactory,
+    wire_covenant_role_powers_catalog,
+)
+from world.covenants.models import CovenantRole
+from world.magic.constants import TargetKind
+from world.magic.models import Thread, ThreadPullEffect
+
+
+class RolePowersCatalogTests(TestCase):
+    """Catalog seed: idempotent + individualized across holders of one role."""
+
+    def test_catalog_is_idempotent_and_individualized(self):
+        role_a, caps_a = wire_covenant_role_powers_catalog()
+        role_b, caps_b = wire_covenant_role_powers_catalog()
+
+        # Same role row returned; no duplicate CovenantRole created.
+        self.assertEqual(role_a.pk, role_b.pk)
+
+        # The two returned capabilities are distinct (per-resonance individualization).
+        cap_a, cap_b = caps_a
+        self.assertNotEqual(cap_a.pk, cap_b.pk)
+        self.assertEqual({c.pk for c in caps_a}, {c.pk for c in caps_b})
+
+        # At least two distinct resonances each carry a tier-0 CAPABILITY_GRANT.
+        distinct_grant_resonances = (
+            ThreadPullEffect.objects.filter(
+                target_kind=TargetKind.COVENANT_ROLE,
+                tier=0,
+                effect_kind="CAPABILITY_GRANT",
+            )
+            .values("resonance")
+            .distinct()
+            .count()
+        )
+        self.assertGreaterEqual(distinct_grant_resonances, 2)
+
+    def _weave_role_thread(self, *, sheet, role, resonance, level=20):
+        """Weave an active COVENANT_ROLE thread for ``sheet`` on ``role``/``resonance``."""
+        thread = Thread(
+            owner=sheet,
+            resonance=resonance,
+            target_kind=TargetKind.COVENANT_ROLE,
+            target_covenant_role=role,
+            level=level,
+        )
+        thread.full_clean()
+        thread.save()
+        return thread
+
+    def _engage_holder(self, *, sheet, role):
+        """Give ``sheet`` a covenant of the role's type + an engaged active membership."""
+        covenant = CovenantFactory(covenant_type=role.covenant_type)
+        return CharacterCovenantRoleFactory(
+            character_sheet=sheet,
+            covenant=covenant,
+            covenant_role=role,
+            engaged=True,
+            left_at=None,
+        )
+
+    def test_two_holders_same_role_different_resonance_get_different_capabilities(self):
+        role, (cap_a, cap_b) = wire_covenant_role_powers_catalog()
+
+        # The two resonances are the ones carrying the tier-0 grants for this role.
+        grant_effects = list(
+            ThreadPullEffect.objects.filter(
+                target_kind=TargetKind.COVENANT_ROLE,
+                tier=0,
+                effect_kind="CAPABILITY_GRANT",
+                capability_grant__in=[cap_a, cap_b],
+            ).select_related("resonance")
+        )
+        res_for_cap = {e.capability_grant_id: e.resonance for e in grant_effects}
+        res_a = res_for_cap[cap_a.pk]
+        res_b = res_for_cap[cap_b.pk]
+
+        # Two DIFFERENT characters (each its own CharacterSheet). sheet_data is the
+        # canonical CharacterSheet accessor (ty resolves it; the bare factory return
+        # is inferred as the factory class).
+        sheet_a = CharacterSheetFactory().character.sheet_data
+        sheet_b = CharacterSheetFactory().character.sheet_data
+
+        # Each holder anchors the SAME role on a DIFFERENT resonance.
+        self._weave_role_thread(sheet=sheet_a, role=role, resonance=res_a)
+        self._weave_role_thread(sheet=sheet_b, role=role, resonance=res_b)
+        self._engage_holder(sheet=sheet_a, role=role)
+        self._engage_holder(sheet=sheet_b, role=role)
+
+        # Holder A possesses cap_a, not cap_b.
+        self.assertGreaterEqual(get_effective_capability_value(sheet_a, cap_a), 1)
+        self.assertEqual(get_effective_capability_value(sheet_a, cap_b), 0)
+
+        # Holder B possesses cap_b, not cap_a.
+        self.assertGreaterEqual(get_effective_capability_value(sheet_b, cap_b), 1)
+        self.assertEqual(get_effective_capability_value(sheet_b, cap_a), 0)
+
+    def test_catalog_role_is_sword_primary(self):
+        role, _caps = wire_covenant_role_powers_catalog()
+        # Authored as a PRIMARY role (no parent, no resonance, level 0) per clean().
+        self.assertIsNone(role.parent_role_id)
+        self.assertIsNone(role.resonance_id)
+        self.assertEqual(role.unlock_thread_level, 0)
+        fetched = CovenantRole.objects.get(pk=role.pk)
+        self.assertEqual(fetched.archetype, "sword")

--- a/src/world/covenants/tests/test_views.py
+++ b/src/world/covenants/tests/test_views.py
@@ -694,3 +694,40 @@ class PromoteActionViewTests(CovenantsViewTestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class CovenantRoleViewTests(CovenantsViewTestCase):
+    """Tests for GET /api/covenants/roles/ including the parent_role filter."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        from world.covenants.factories import SubroleCovenantRoleFactory
+
+        cls.parent_role = CovenantRoleFactory(name="RoleFilter Parent")
+        cls.sub_a = SubroleCovenantRoleFactory(
+            name="RoleFilter Sub A", parent_role=cls.parent_role
+        )
+        cls.sub_b = SubroleCovenantRoleFactory(
+            name="RoleFilter Sub B", parent_role=cls.parent_role
+        )
+        cls.other_parent = CovenantRoleFactory(name="RoleFilter Other Parent")
+        cls.other_sub = SubroleCovenantRoleFactory(
+            name="RoleFilter Other Sub", parent_role=cls.other_parent
+        )
+
+    def test_list_exposes_parent_role(self) -> None:
+        """The serializer exposes parent_role so sub-roles are identifiable."""
+        response = self.client.get(f"/api/covenants/roles/?parent_role={self.parent_role.pk}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for row in response.data:
+            self.assertIn("parent_role", row)
+
+    def test_filter_by_parent_role_returns_only_its_subroles(self) -> None:
+        """?parent_role=<id> returns exactly that role's sub-roles."""
+        response = self.client.get(f"/api/covenants/roles/?parent_role={self.parent_role.pk}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {row["id"] for row in response.data}
+        self.assertEqual(returned_ids, {self.sub_a.pk, self.sub_b.pk})
+        for row in response.data:
+            self.assertEqual(row["parent_role"], self.parent_role.pk)

--- a/src/world/covenants/tests/test_views.py
+++ b/src/world/covenants/tests/test_views.py
@@ -705,12 +705,8 @@ class CovenantRoleViewTests(CovenantsViewTestCase):
         from world.covenants.factories import SubroleCovenantRoleFactory
 
         cls.parent_role = CovenantRoleFactory(name="RoleFilter Parent")
-        cls.sub_a = SubroleCovenantRoleFactory(
-            name="RoleFilter Sub A", parent_role=cls.parent_role
-        )
-        cls.sub_b = SubroleCovenantRoleFactory(
-            name="RoleFilter Sub B", parent_role=cls.parent_role
-        )
+        cls.sub_a = SubroleCovenantRoleFactory(name="RoleFilter Sub A", parent_role=cls.parent_role)
+        cls.sub_b = SubroleCovenantRoleFactory(name="RoleFilter Sub B", parent_role=cls.parent_role)
         cls.other_parent = CovenantRoleFactory(name="RoleFilter Other Parent")
         cls.other_sub = SubroleCovenantRoleFactory(
             name="RoleFilter Other Sub", parent_role=cls.other_parent

--- a/src/world/covenants/views.py
+++ b/src/world/covenants/views.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 
 from world.covenants.exceptions import (
     CovenantEngagementPrerequisiteNotMetError,
+    NotAStandingBattleCovenantError,
     SubrolePromotionError,
 )
 from world.covenants.filters import (
@@ -46,6 +47,7 @@ from world.covenants.services import (
     clear_engaged_membership,
     promote_to_subrole,
     set_engaged_membership,
+    stand_down_battle_covenant,
 )
 
 
@@ -313,6 +315,39 @@ class CovenantViewSet(viewsets.ReadOnlyModelViewSet):
             rite_data.append(entry)
 
         return Response({"rites": rite_data, "role_powers": role_power_data})
+
+    @action(detail=True, methods=["POST"])
+    def stand_down(self, request: Request, pk: int | None = None) -> Response:
+        """POST /api/covenants/covenants/{id}/stand_down/
+
+        Stand a risen STANDING battle covenant back down to dormant, clearing
+        engagement on its members. The "rise" path is ritual-fired; this is the
+        plain inverse the covenant detail UI POSTs to.
+
+        Visibility/membership is enforced by ``get_object()`` (the
+        membership-scoped ``get_queryset``): a non-staff user with no active
+        membership gets 404. Returns 400 with a ``detail`` message when the
+        target is not a standing battle covenant.
+
+        Returns a minimal confirmation dict rather than ``CovenantSerializer``
+        (which touches the Postgres-only legend materialized view); the
+        frontend re-fetches the covenant detail separately.
+        """
+        covenant = self.get_object()
+        try:
+            stand_down_battle_covenant(covenant=covenant)
+        except NotAStandingBattleCovenantError as exc:
+            return Response(
+                {"detail": exc.user_message},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response(
+            {
+                "id": covenant.id,
+                "is_dormant": covenant.is_dormant,
+                "battle_binding": covenant.battle_binding,
+            }
+        )
 
 
 class CovenantRiteViewSet(viewsets.ReadOnlyModelViewSet):

--- a/src/world/covenants/views.py
+++ b/src/world/covenants/views.py
@@ -36,6 +36,7 @@ from world.covenants.serializers import (
     CharacterCovenantRoleSerializer,
     CovenantLevelThresholdSerializer,
     CovenantRiteSerializer,
+    CovenantRolePassivePowerSerializer,
     CovenantRoleSerializer,
     CovenantSerializer,
     GearArchetypeCompatibilitySerializer,
@@ -184,6 +185,41 @@ class GearArchetypeCompatibilityViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_class = GearArchetypeCompatibilityFilter
 
 
+def _build_role_power_row(
+    membership: CharacterCovenantRole,
+    threads_by_key: dict,
+    effects_by_resonance: dict,
+) -> dict:
+    """Join one active membership to its current passive role power (no queries).
+
+    ``threads_by_key`` is keyed (owner_id, covenant_role_id);
+    ``effects_by_resonance`` maps resonance_id → tier-0 CAPABILITY_GRANT effect.
+    A member with no woven role-thread (or a thread below the effect's
+    ``min_thread_level``) has null capability fields.
+    """
+    thread = threads_by_key.get((membership.character_sheet_id, membership.covenant_role_id))
+    resonance_name = None
+    capability_name = None
+    narrative_snippet = None
+    if thread is not None and thread.resonance_id is not None:
+        resonance_name = thread.resonance.name
+        effect = effects_by_resonance.get(thread.resonance_id)
+        if effect is not None and thread.level >= effect.min_thread_level:
+            if effect.capability_grant is not None:
+                capability_name = effect.capability_grant.name
+            narrative_snippet = effect.narrative_snippet or None
+    return {
+        "membership_id": membership.pk,
+        "character_sheet": membership.character_sheet_id,
+        "covenant_role_id": membership.covenant_role_id,
+        "covenant_role_name": membership.covenant_role.name,
+        "resonance_name": resonance_name,
+        "capability_name": capability_name,
+        "narrative_snippet": narrative_snippet,
+        "engaged": membership.engaged,
+    }
+
+
 class CovenantViewSet(viewsets.ReadOnlyModelViewSet):
     """Read-only ViewSet for Covenant.
 
@@ -207,6 +243,76 @@ class CovenantViewSet(viewsets.ReadOnlyModelViewSet):
             memberships__character_sheet__roster_entry__tenures__end_date__isnull=True,
             memberships__character_sheet__roster_entry__tenures__player_data__account=self.request.user,
         ).distinct()
+
+    @action(detail=True, methods=["GET"])
+    def powers(self, request: Request, pk: int | None = None) -> Response:
+        """GET /api/covenants/covenants/{id}/powers/
+
+        Return the covenant's available rites (with per-covenant gate flags) and
+        per-member passive role powers in one payload, for the React detail page.
+
+        Visibility is enforced by ``get_object()`` (the membership-scoped
+        ``get_queryset``): a non-staff user with no active membership gets 404.
+        Deliberately does NOT serialize the Covenant via ``CovenantSerializer``
+        (that touches the Postgres-only legend materialized view).
+        """
+        from world.magic.constants import EffectKind, TargetKind  # noqa: PLC0415
+        from world.magic.models import Thread, ThreadPullEffect  # noqa: PLC0415
+
+        covenant = self.get_object()
+
+        # --- Active memberships (one query, role pre-joined) -----------------
+        memberships = list(
+            covenant.memberships.filter(left_at__isnull=True).select_related("covenant_role")
+        )
+        active_member_count = len(memberships)
+
+        sheet_ids = {m.character_sheet_id for m in memberships}
+        role_ids = {m.covenant_role_id for m in memberships}
+
+        # --- Threads: one query keyed (owner, role) -------------------------
+        threads_by_key: dict[tuple[int, int], Thread] = {}
+        resonance_ids: set[int] = set()
+        if sheet_ids and role_ids:
+            for thread in Thread.objects.filter(
+                owner_id__in=sheet_ids,
+                target_kind=TargetKind.COVENANT_ROLE,
+                target_covenant_role_id__in=role_ids,
+                retired_at__isnull=True,
+            ).select_related("resonance"):
+                threads_by_key[(thread.owner_id, thread.target_covenant_role_id)] = thread
+                if thread.resonance_id is not None:
+                    resonance_ids.add(thread.resonance_id)
+
+        # --- Tier-0 CAPABILITY_GRANT effects: one query keyed by resonance ---
+        effects_by_resonance: dict[int, ThreadPullEffect] = {}
+        if resonance_ids:
+            for effect in ThreadPullEffect.objects.filter(
+                target_kind=TargetKind.COVENANT_ROLE,
+                tier=0,
+                effect_kind=EffectKind.CAPABILITY_GRANT,
+                resonance_id__in=resonance_ids,
+            ).select_related("capability_grant"):
+                effects_by_resonance[effect.resonance_id] = effect
+
+        # --- Join in Python --------------------------------------------------
+        role_power_rows = [
+            _build_role_power_row(membership, threads_by_key, effects_by_resonance)
+            for membership in memberships
+        ]
+        role_power_data = CovenantRolePassivePowerSerializer(role_power_rows, many=True).data
+
+        # --- Rites: authored per covenant_type, with gate flags --------------
+        rite_data = []
+        for rite in CovenantRite.objects.filter(
+            covenant_type=covenant.covenant_type
+        ).select_related("ritual", "granted_condition"):
+            entry = dict(CovenantRiteSerializer(rite).data)
+            entry["level_met"] = covenant.level >= rite.min_covenant_level
+            entry["members_present_met"] = active_member_count >= rite.min_members_present
+            rite_data.append(entry)
+
+        return Response({"rites": rite_data, "role_powers": role_power_data})
 
 
 class CovenantRiteViewSet(viewsets.ReadOnlyModelViewSet):

--- a/src/world/magic/handlers.py
+++ b/src/world/magic/handlers.py
@@ -139,6 +139,64 @@ class CharacterThreadHandler:
             total += row.vital_bonus_amount * multiplier
         return total
 
+    def passive_capability_grants(self) -> set[int]:
+        """Return CapabilityType PKs granted by tier-0 CAPABILITY_GRANT effects.
+
+        Derive-on-read mirror of ``passive_vital_bonuses``. For COVENANT_ROLE
+        threads the grant only applies while the character holds an active,
+        *engaged* CharacterCovenantRole for that role (Slice A §3.6 / #751).
+        Other thread kinds always pass (anchor-in-scope via PROTECT — see
+        ``passive_vital_bonuses``). Single batched query; no N+1.
+        """
+        threads = self._all
+        if not threads:
+            return set()
+
+        threads_by_key: dict[tuple[str, int], list[Thread]] = {}
+        for t in threads:
+            threads_by_key.setdefault((t.target_kind, t.resonance_id), []).append(t)
+
+        from django.db.models import Q  # noqa: PLC0415
+
+        q = Q()
+        for target_kind, resonance_id in threads_by_key:
+            q |= Q(target_kind=target_kind, resonance_id=resonance_id)
+
+        effects = (
+            ThreadPullEffect.objects.filter(
+                q,
+                tier=0,
+                effect_kind=EffectKind.CAPABILITY_GRANT,
+            )
+            .exclude(capability_grant__isnull=True)
+            .select_related("capability_grant")
+        )
+
+        from world.covenants.models import CharacterCovenantRole  # noqa: PLC0415
+
+        engaged_role_ids = set(
+            CharacterCovenantRole.objects.filter(
+                character_sheet=self.character.sheet_data,
+                engaged=True,
+                left_at__isnull=True,
+            ).values_list("covenant_role_id", flat=True)
+        )
+
+        granted: set[int] = set()
+        for row in effects:
+            candidates = threads_by_key.get((row.target_kind, row.resonance_id), [])
+            for t in candidates:
+                if row.min_thread_level > t.level:
+                    continue
+                if (
+                    row.target_kind == TargetKind.COVENANT_ROLE
+                    and t.target_covenant_role_id not in engaged_role_ids
+                ):
+                    continue
+                granted.add(row.capability_grant_id)
+                break  # one qualifying thread suffices for this effect
+        return granted
+
     def invalidate(self) -> None:
         """Clear the cached thread list. Called by mutation services."""
         self.__dict__.pop("_all", None)

--- a/src/world/magic/handlers.py
+++ b/src/world/magic/handlers.py
@@ -142,6 +142,18 @@ class CharacterThreadHandler:
     def passive_capability_grants(self) -> set[int]:
         """Return CapabilityType PKs granted by tier-0 CAPABILITY_GRANT effects.
 
+        Thin accessor over the per-handler cached grant set
+        (``_passive_capability_grants_cache``). Cleared by ``invalidate()``
+        alongside ``_all`` so a sweep over many techniques reuses one memoized
+        result (one set of queries per character per request, not per
+        requirement).
+        """
+        return self._passive_capability_grants_cache
+
+    @cached_property
+    def _passive_capability_grants_cache(self) -> set[int]:
+        """Compute CapabilityType PKs granted by tier-0 CAPABILITY_GRANT effects.
+
         Derive-on-read mirror of ``passive_vital_bonuses``. For COVENANT_ROLE
         threads the grant only applies while the character holds an active,
         *engaged* CharacterCovenantRole for that role (Slice A §3.6 / #751).
@@ -200,6 +212,7 @@ class CharacterThreadHandler:
     def invalidate(self) -> None:
         """Clear the cached thread list. Called by mutation services."""
         self.__dict__.pop("_all", None)
+        self.__dict__.pop("_passive_capability_grants_cache", None)
 
 
 class CharacterResonanceHandler:

--- a/src/world/magic/tests/test_passive_capability_grants.py
+++ b/src/world/magic/tests/test_passive_capability_grants.py
@@ -70,6 +70,44 @@ class PassiveCapabilityGrantsTests(TestCase):
         granted = character.threads.passive_capability_grants()
         self.assertIn(cap.pk, granted)
 
+    def test_grant_set_caches_and_busts_on_invalidate(self):
+        """The per-handler grant set is memoized and refreshed by ``invalidate()``.
+
+        Compute once while unengaged (cap absent), then engage the role and
+        recompute WITHOUT invalidating: the stale cache must still hide the cap.
+        After ``invalidate()`` the recomputed set must now include it — proving
+        the cache busts and re-derives.
+        """
+        sheet = CharacterSheetFactory()
+        character = sheet.character
+        role = CovenantRoleFactory()
+        resonance = ResonanceFactory()
+        cap = CapabilityTypeFactory()
+
+        self._make_covenant_role_thread(sheet=sheet, role=role, resonance=resonance)
+        self._make_tier0_capability_effect(resonance=resonance, capability=cap)
+
+        membership = CharacterCovenantRoleFactory(
+            character_sheet=sheet,
+            covenant=CovenantFactory(),
+            covenant_role=role,
+            engaged=False,
+            left_at=None,
+        )
+
+        handler = character.threads
+        # First read: unengaged → cap absent (and now cached).
+        self.assertNotIn(cap.pk, handler.passive_capability_grants())
+
+        # Engage the role but do NOT invalidate: the cached set is stale.
+        membership.engaged = True
+        membership.save(update_fields=["engaged"])
+        self.assertNotIn(cap.pk, handler.passive_capability_grants())
+
+        # Invalidate → recompute picks up the newly-engaged capability.
+        handler.invalidate()
+        self.assertIn(cap.pk, handler.passive_capability_grants())
+
     def test_unengaged_role_does_not_grant(self):
         sheet = CharacterSheetFactory()
         character = sheet.character

--- a/src/world/magic/tests/test_passive_capability_grants.py
+++ b/src/world/magic/tests/test_passive_capability_grants.py
@@ -1,0 +1,193 @@
+"""Tests for ``CharacterThreadHandler.passive_capability_grants`` (#751 / Task B1).
+
+Tier-0 CAPABILITY_GRANT ThreadPullEffect rows on COVENANT_ROLE threads are
+applied only while the character holds an active, *engaged* CharacterCovenantRole
+for that role. The handler returns the SET of granted CapabilityType PKs.
+"""
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.conditions.factories import CapabilityTypeFactory
+from world.covenants.constants import CovenantType
+from world.covenants.factories import (
+    CharacterCovenantRoleFactory,
+    CovenantFactory,
+    CovenantRoleFactory,
+)
+from world.magic.constants import EffectKind, TargetKind
+from world.magic.factories import (
+    ResonanceFactory,
+    ThreadFactory,
+    ThreadPullEffectFactory,
+)
+
+
+class PassiveCapabilityGrantsTests(TestCase):
+    """Engagement-gated tier-0 CAPABILITY_GRANT application."""
+
+    def _make_covenant_role_thread(self, *, sheet, role, resonance, level=10):
+        """Build a COVENANT_ROLE thread for ``sheet`` anchored to ``role``/``resonance``."""
+        return ThreadFactory(
+            owner=sheet,
+            resonance=resonance,
+            target_kind=TargetKind.COVENANT_ROLE,
+            target_trait=None,
+            target_covenant_role=role,
+            level=level,
+        )
+
+    def _make_tier0_capability_effect(self, *, resonance, capability):
+        """Author a tier-0 CAPABILITY_GRANT effect for a COVENANT_ROLE thread."""
+        return ThreadPullEffectFactory(
+            target_kind=TargetKind.COVENANT_ROLE,
+            resonance=resonance,
+            tier=0,
+            min_thread_level=0,
+            effect_kind=EffectKind.CAPABILITY_GRANT,
+            flat_bonus_amount=None,
+            capability_grant=capability,
+        )
+
+    def test_engaged_role_grants_tier0_capability(self):
+        sheet = CharacterSheetFactory()
+        character = sheet.character
+        role = CovenantRoleFactory()
+        resonance = ResonanceFactory()
+        cap = CapabilityTypeFactory()
+
+        self._make_covenant_role_thread(sheet=sheet, role=role, resonance=resonance)
+        self._make_tier0_capability_effect(resonance=resonance, capability=cap)
+
+        CharacterCovenantRoleFactory(
+            character_sheet=sheet,
+            covenant=CovenantFactory(),
+            covenant_role=role,
+            engaged=True,
+            left_at=None,
+        )
+
+        granted = character.threads.passive_capability_grants()
+        self.assertIn(cap.pk, granted)
+
+    def test_unengaged_role_does_not_grant(self):
+        sheet = CharacterSheetFactory()
+        character = sheet.character
+        role = CovenantRoleFactory()
+        resonance = ResonanceFactory()
+        cap = CapabilityTypeFactory()
+
+        self._make_covenant_role_thread(sheet=sheet, role=role, resonance=resonance)
+        self._make_tier0_capability_effect(resonance=resonance, capability=cap)
+
+        CharacterCovenantRoleFactory(
+            character_sheet=sheet,
+            covenant=CovenantFactory(),
+            covenant_role=role,
+            engaged=False,
+            left_at=None,
+        )
+
+        granted = character.threads.passive_capability_grants()
+        self.assertNotIn(cap.pk, granted)
+
+    def test_two_resonances_grant_different_capabilities(self):
+        """Two engaged roles, each with its own resonance/thread, grant both caps.
+
+        The ``uniq_thread_covenant_role_active`` constraint forbids two active
+        COVENANT_ROLE threads on the same (owner, role), and engaged-uniqueness
+        is per covenant_type, so the individualization lever is exercised with
+        two roles of different covenant types (DURANCE + BATTLE).
+        """
+        sheet = CharacterSheetFactory()
+        character = sheet.character
+        role_a = CovenantRoleFactory(covenant_type=CovenantType.DURANCE)
+        role_b = CovenantRoleFactory(covenant_type=CovenantType.BATTLE)
+        res_a = ResonanceFactory()
+        res_b = ResonanceFactory()
+        cap_a = CapabilityTypeFactory()
+        cap_b = CapabilityTypeFactory()
+
+        self._make_covenant_role_thread(sheet=sheet, role=role_a, resonance=res_a)
+        self._make_covenant_role_thread(sheet=sheet, role=role_b, resonance=res_b)
+        self._make_tier0_capability_effect(resonance=res_a, capability=cap_a)
+        self._make_tier0_capability_effect(resonance=res_b, capability=cap_b)
+
+        CharacterCovenantRoleFactory(
+            character_sheet=sheet,
+            covenant=CovenantFactory(covenant_type=CovenantType.DURANCE),
+            covenant_role=role_a,
+            engaged=True,
+            left_at=None,
+        )
+        CharacterCovenantRoleFactory(
+            character_sheet=sheet,
+            covenant=CovenantFactory(
+                covenant_type=CovenantType.BATTLE,
+                battle_binding="standing",
+            ),
+            covenant_role=role_b,
+            engaged=True,
+            left_at=None,
+        )
+
+        granted = character.threads.passive_capability_grants()
+        self.assertEqual(granted, {cap_a.pk, cap_b.pk})
+
+    def test_same_resonance_two_roles_grants_when_any_engaged(self):
+        """Two roles share one resonance + one tier-0 effect; engagement of any wins.
+
+        The schema permits two active COVENANT_ROLE threads on the SAME resonance
+        but DIFFERENT roles (the unique constraint is on (owner, role), not
+        resonance). Both threads collapse into the single (COVENANT_ROLE,
+        resonance) effect-lookup key, so the grant must be decided by an EXISTS
+        over all threads sharing the key — not by whichever thread happens to win
+        a dict slot. The pre-fix single-winner logic withheld the grant whenever
+        the unengaged role's thread won the slot (nondeterministic — Thread has no
+        Meta.ordering). The two roles are of different covenant types to satisfy
+        both the per-(owner,role) thread constraint and the per-(character,
+        covenant_type) engaged constraint.
+        """
+        sheet = CharacterSheetFactory()
+        character = sheet.character
+        role_durance = CovenantRoleFactory(covenant_type=CovenantType.DURANCE)
+        role_battle = CovenantRoleFactory(covenant_type=CovenantType.BATTLE)
+        resonance = ResonanceFactory()
+        cap = CapabilityTypeFactory()
+
+        # Two active COVENANT_ROLE threads on the SAME resonance, different roles.
+        self._make_covenant_role_thread(sheet=sheet, role=role_durance, resonance=resonance)
+        self._make_covenant_role_thread(sheet=sheet, role=role_battle, resonance=resonance)
+        # Exactly ONE tier-0 effect for that (COVENANT_ROLE, resonance) key.
+        self._make_tier0_capability_effect(resonance=resonance, capability=cap)
+
+        membership_durance = CharacterCovenantRoleFactory(
+            character_sheet=sheet,
+            covenant=CovenantFactory(covenant_type=CovenantType.DURANCE),
+            covenant_role=role_durance,
+            engaged=False,
+            left_at=None,
+        )
+        CharacterCovenantRoleFactory(
+            character_sheet=sheet,
+            covenant=CovenantFactory(
+                covenant_type=CovenantType.BATTLE,
+                battle_binding="standing",
+            ),
+            covenant_role=role_battle,
+            engaged=False,
+            left_at=None,
+        )
+
+        # Case B first: NEITHER role engaged → C is NOT granted.
+        granted = character.threads.passive_capability_grants()
+        self.assertNotIn(cap.pk, granted)
+
+        # Case A: engage exactly one of the two roles → C IS granted (regardless
+        # of which thread would have won any single-winner dict slot).
+        membership_durance.engaged = True
+        membership_durance.save(update_fields=["engaged"])
+        character.threads.invalidate()
+
+        granted = character.threads.passive_capability_grants()
+        self.assertIn(cap.pk, granted)

--- a/src/world/traits/handlers.py
+++ b/src/world/traits/handlers.py
@@ -204,6 +204,7 @@ class TraitHandler:
         capacity (which resolves 6 stat values per participant) from firing
         a per-stat N+1 on the combat detail hot path (#552).
         """
+        from world.conditions.services import get_condition_modifier_total  # noqa: PLC0415
         from world.mechanics.models import ModifierTarget  # noqa: PLC0415
         from world.mechanics.services import get_modifier_total  # noqa: PLC0415
 
@@ -215,7 +216,7 @@ class TraitHandler:
         target = ModifierTarget.get_for_trait(trait)
         if target is None:
             return 0
-        return get_modifier_total(sheet, target)
+        return get_modifier_total(sheet, target) + get_condition_modifier_total(sheet, target)
 
     def get_trait_display_value(self, trait_name: str) -> float:
         """


### PR DESCRIPTION
Bundle 2 — a vertical slice making covenant rite buffs and role-scoped powers mechanically real end-to-end, then surfacing them in the web UI. Built in dependency order #783 → #751 → #518.

Closes #783, closes #751, closes #518.

## What landed

**#783 — rite stat-buffs into the trait/check pipeline**
- `wire_covenant_rite_content` now links seeded stat `ModifierTarget`s to their `Trait` (no orphan `target_trait=None`).
- `TraitHandler._get_stat_modifier` folds in `get_condition_modifier_total`, so a rite buff now raises **effective trait values and stat checks**, not only the technique multiplier it already hit. Confirmed no double-count with the technique path (separate `multiplier_target`).

**#751 — tier-0 passive role powers (derive-on-read)**
- New `CharacterThreadHandler.passive_capability_grants()` — engagement-gated tier-0 `CAPABILITY_GRANT` resolution, mirroring `passive_vital_bonuses` (single batched query). Correctly handles same-resonance/different-role threads via an all-threads-per-key EXISTS check.
- Folded into the canonical capability read (`get_effective_capability_value` + `get_all_capability_values`) as a single source; memoized to avoid an N+1 in `technique_performable`; cache invalidated on every covenant engagement change.
- `wire_covenant_role_powers_catalog()` — reference per-`(role,resonance)` catalog (FactoryBoy seed, no migration). Two holders of the same role anchoring different Resonances unlock different capabilities — the individualization lever, proven end-to-end.

**#518 — battle / group-ability / role-power / promotion UI**
- Backend: `is_dormant`/`battle_binding` on `CovenantSerializer`; `GET /covenants/{id}/powers/` (available rites with gate flags + per-member role powers, 3 batched queries); `POST /covenants/{id}/stand_down/`; `parent_role` exposed for sub-role lookup.
- Frontend: `RitesPanel`, `RolePowersPanel`, `BattleStateBanner` (dormant indicator + "Call the Banners" rise ritual + stand-down), `PromoteRoleDialog`, all wired into `CovenantDetailPage`. Reuses the existing `RitualSessionDraftDialog` trigger path — no new fire endpoint. First vitest coverage for the dir.

## Notes
- **Cross-bundle isolation (vs `combat-ui-unified` #716/#918):** no changes to `resolve_pull_effects` / `ResolvedPullEffect` / `world/magic/serializers.py` / `world/combat/**`. The passive capability surface is additive; only the *passive* (tier-0) path is built, never the active combat-pull consumer.
- API schema + generated types regenerated (`just gen-api-types`) for the new serializer fields — additive only (0 deletions).
- Two follow-ups to be filed: a latent same-resonance keying issue in `passive_vital_bonuses`, and the `has_capability` predicate using the condition-only capability read (so it doesn't yet see intrinsic/role grants).

## Testing
- Backend: new unit + integration tests per task; full SQLite fast tier for covenants/conditions/magic green (2358 tests); ruff + `ty` clean.
- Frontend: 19 covenants vitest tests; `pnpm typecheck` + `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)