### PR TITLE
feat(#907): multi-recipient whisper-delivery receiver picker

### DIFF
--- a/frontend/src/scenes/actionQueries.ts
+++ b/frontend/src/scenes/actionQueries.ts
@@ -38,6 +38,8 @@ export async function createActionRequest(
     strain_commitment?: number;
     /** Audience routing override (#903); omit to use the template default. */
     delivery?: string;
+    /** Explicit WHISPER audience as persona ids (#907); empty/omitted = target alone. */
+    delivery_receiver_ids?: number[];
   }
 ): Promise<ActionRequestResponse> {
   // Backend SceneActionRequestCreateSerializer expects:
@@ -61,6 +63,9 @@ export async function createActionRequest(
   }
   if (body.delivery !== undefined) {
     requestBody.delivery = body.delivery;
+  }
+  if (body.delivery_receiver_ids !== undefined && body.delivery_receiver_ids.length > 0) {
+    requestBody.delivery_receiver_ids = body.delivery_receiver_ids;
   }
   const res = await apiFetch('/api/action-requests/', {
     method: 'POST',

--- a/frontend/src/scenes/components/PersonaContextMenu.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   DropdownMenu,
@@ -16,6 +16,14 @@ import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { createActionRequest } from '../actionQueries';
 import type { ActionAttachmentInfo, PlayerActionsResponse, PlayerAction } from '../actionTypes';
+import type { SceneDetail } from '../types';
+import { WhisperReceiverPicker } from './WhisperReceiverPicker';
+
+/** The whisper action awaiting a recipient choice (#907). */
+interface PendingWhisper {
+  actionKey: string;
+  techniqueId?: number;
+}
 
 interface Props {
   personaId: number;
@@ -47,12 +55,23 @@ export function PersonaContextMenu({
   // The ActionAttachment component populates this cache when opened.
   const data = queryClient.getQueryData<PlayerActionsResponse>(['available-actions', characterId]);
 
+  // #907: present scene personas (excluding the target) are the extra-listener
+  // pool. Read from the already-loaded scene cache; empty if not yet present.
+  const scene = queryClient.getQueryData<SceneDetail>(['scene', sceneId]);
+  const whisperCandidates = useMemo(
+    () => (scene?.personas ?? []).filter((p) => p.id !== personaId),
+    [scene, personaId]
+  );
+
+  const [pendingWhisper, setPendingWhisper] = useState<PendingWhisper | null>(null);
+
   const performAction = useMutation({
     mutationFn: (params: {
       action_key: string;
       target_persona_id: number;
       technique_id?: number;
       delivery?: string;
+      delivery_receiver_ids?: number[];
     }) => createActionRequest(sceneId, params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
@@ -68,96 +87,125 @@ export function PersonaContextMenu({
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button className="cursor-pointer font-medium hover:underline">{children}</button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        <DropdownMenuLabel>Actions on {personaName}</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {/* Direct execute: fires the action immediately via REST, independent of
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button className="cursor-pointer font-medium hover:underline">{children}</button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>Actions on {personaName}</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {/* Direct execute: fires the action immediately via REST, independent of
             any pose in the composer. This is a "quick action" path. The submenu
             picks the audience (#903); the plain "Default" entry sends NO delivery
             so the backend's template default stays the single fallback authority. */}
-        {targetedActions.map((action) => {
-          const techniqueId = action.ref.technique_id ?? undefined;
-          const actionKey =
-            action.ref.registry_key ??
-            action.action_template?.name.toLowerCase() ??
-            action.display_name.toLowerCase();
-          const fire = (delivery?: string) =>
-            performAction.mutate({
-              action_key: actionKey,
-              target_persona_id: personaId,
-              technique_id: techniqueId,
-              delivery,
-            });
-          const defaultDelivery = action.action_template?.default_delivery ?? 'pose';
-          return (
-            <DropdownMenuSub
-              key={`${action.ref.backend}-${action.ref.challenge_instance_id ?? ''}-${action.ref.approach_id ?? ''}-${action.ref.registry_key ?? ''}`}
-            >
-              <DropdownMenuSubTrigger disabled={performAction.isPending}>
-                <Zap className="mr-2 h-4 w-4" />
-                {action.display_name}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                <DropdownMenuItem disabled={performAction.isPending} onClick={() => fire()}>
-                  Default ({defaultDelivery.replace('_', ' ')})
-                </DropdownMenuItem>
-                <DropdownMenuItem disabled={performAction.isPending} onClick={() => fire('pose')}>
-                  Openly (whole room)
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={performAction.isPending}
-                  onClick={() => fire('whisper')}
-                >
-                  Subtly (target only)
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={performAction.isPending}
-                  onClick={() => fire('table_talk')}
-                >
-                  At your table
-                </DropdownMenuItem>
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-          );
-        })}
-        {/* Attach to Pose: stores the action in the composer so it is submitted
-            alongside the next pose. Visually separated from the direct execute items. */}
-        {onAttachAction && targetedActions.length > 0 && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel className="text-xs">Attach to Pose</DropdownMenuLabel>
-            {targetedActions.map((action) => {
-              const techniqueId = action.ref.technique_id ?? undefined;
-              const actionKey =
-                action.ref.registry_key ??
-                action.action_template?.name.toLowerCase() ??
-                action.display_name.toLowerCase();
-              return (
-                <DropdownMenuItem
-                  key={`attach-${action.ref.backend}-${action.ref.challenge_instance_id ?? ''}-${action.ref.approach_id ?? ''}-${action.ref.registry_key ?? ''}`}
-                  onClick={() =>
-                    onAttachAction({
-                      actionKey,
-                      name: action.display_name,
-                      target: personaName,
-                      requiresTarget: true,
-                      techniqueId,
-                      targetPersonaId: personaId,
-                    })
-                  }
-                >
+          {targetedActions.map((action) => {
+            const techniqueId = action.ref.technique_id ?? undefined;
+            const actionKey =
+              action.ref.registry_key ??
+              action.action_template?.name.toLowerCase() ??
+              action.display_name.toLowerCase();
+            const fire = (delivery?: string) =>
+              performAction.mutate({
+                action_key: actionKey,
+                target_persona_id: personaId,
+                technique_id: techniqueId,
+                delivery,
+              });
+            const defaultDelivery = action.action_template?.default_delivery ?? 'pose';
+            return (
+              <DropdownMenuSub
+                key={`${action.ref.backend}-${action.ref.challenge_instance_id ?? ''}-${action.ref.approach_id ?? ''}-${action.ref.registry_key ?? ''}`}
+              >
+                <DropdownMenuSubTrigger disabled={performAction.isPending}>
                   <Zap className="mr-2 h-4 w-4" />
                   {action.display_name}
-                </DropdownMenuItem>
-              );
-            })}
-          </>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  <DropdownMenuItem disabled={performAction.isPending} onClick={() => fire()}>
+                    Default ({defaultDelivery.replace('_', ' ')})
+                  </DropdownMenuItem>
+                  <DropdownMenuItem disabled={performAction.isPending} onClick={() => fire('pose')}>
+                    Openly (whole room)
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={performAction.isPending}
+                    onClick={() => fire('whisper')}
+                  >
+                    Subtly (target only)
+                  </DropdownMenuItem>
+                  {whisperCandidates.length > 0 && (
+                    <DropdownMenuItem
+                      disabled={performAction.isPending}
+                      onClick={() => setPendingWhisper({ actionKey, techniqueId })}
+                    >
+                      Subtly (choose listeners…)
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem
+                    disabled={performAction.isPending}
+                    onClick={() => fire('table_talk')}
+                  >
+                    At your table
+                  </DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            );
+          })}
+          {/* Attach to Pose: stores the action in the composer so it is submitted
+            alongside the next pose. Visually separated from the direct execute items. */}
+          {onAttachAction && targetedActions.length > 0 && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-xs">Attach to Pose</DropdownMenuLabel>
+              {targetedActions.map((action) => {
+                const techniqueId = action.ref.technique_id ?? undefined;
+                const actionKey =
+                  action.ref.registry_key ??
+                  action.action_template?.name.toLowerCase() ??
+                  action.display_name.toLowerCase();
+                return (
+                  <DropdownMenuItem
+                    key={`attach-${action.ref.backend}-${action.ref.challenge_instance_id ?? ''}-${action.ref.approach_id ?? ''}-${action.ref.registry_key ?? ''}`}
+                    onClick={() =>
+                      onAttachAction({
+                        actionKey,
+                        name: action.display_name,
+                        target: personaName,
+                        requiresTarget: true,
+                        techniqueId,
+                        targetPersonaId: personaId,
+                      })
+                    }
+                  >
+                    <Zap className="mr-2 h-4 w-4" />
+                    {action.display_name}
+                  </DropdownMenuItem>
+                );
+              })}
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <WhisperReceiverPicker
+        open={pendingWhisper !== null}
+        onClose={() => setPendingWhisper(null)}
+        targetName={personaName}
+        candidates={whisperCandidates}
+        onConfirm={(receiverIds) => {
+          if (pendingWhisper !== null) {
+            performAction.mutate({
+              action_key: pendingWhisper.actionKey,
+              target_persona_id: personaId,
+              technique_id: pendingWhisper.techniqueId,
+              delivery: 'whisper',
+              // Include the target so it still hears, plus the chosen listeners.
+              delivery_receiver_ids: [personaId, ...receiverIds],
+            });
+          }
+          setPendingWhisper(null);
+        }}
+      />
+    </>
   );
 }

--- a/frontend/src/scenes/components/WhisperReceiverPicker.test.tsx
+++ b/frontend/src/scenes/components/WhisperReceiverPicker.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { WhisperReceiverPicker } from './WhisperReceiverPicker';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import type { ScenePersona } from '@/scenes/types';
+
+const candidates: ScenePersona[] = [
+  { id: 11, name: 'Brand' },
+  { id: 12, name: 'Corwin' },
+];
+
+describe('WhisperReceiverPicker', () => {
+  it('lists candidates and confirms the selected ids', () => {
+    const onConfirm = vi.fn();
+    renderWithProviders(
+      <WhisperReceiverPicker
+        open
+        onClose={() => {}}
+        targetName="Random"
+        candidates={candidates}
+        onConfirm={onConfirm}
+      />
+    );
+
+    expect(screen.getByText('Brand')).toBeInTheDocument();
+    expect(screen.getByText('Corwin')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Corwin'));
+    fireEvent.click(screen.getByRole('button', { name: /Whisper to 2/ }));
+
+    expect(onConfirm).toHaveBeenCalledWith([12]);
+  });
+
+  it('confirms an empty list when nothing is selected', () => {
+    const onConfirm = vi.fn();
+    renderWithProviders(
+      <WhisperReceiverPicker
+        open
+        onClose={() => {}}
+        targetName="Random"
+        candidates={candidates}
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /target only/ }));
+    expect(onConfirm).toHaveBeenCalledWith([]);
+  });
+
+  it('shows an empty state when no one else is present', () => {
+    renderWithProviders(
+      <WhisperReceiverPicker
+        open
+        onClose={() => {}}
+        targetName="Random"
+        candidates={[]}
+        onConfirm={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId('whisper-picker-empty')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/scenes/components/WhisperReceiverPicker.tsx
+++ b/frontend/src/scenes/components/WhisperReceiverPicker.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import type { ScenePersona } from '../types';
+
+interface WhisperReceiverPickerProps {
+  open: boolean;
+  onClose: () => void;
+  /** The action's target — always hears the whisper; shown as a fixed recipient. */
+  targetName: string;
+  /** Other present personas the player may add as listeners. */
+  candidates: ScenePersona[];
+  /** Called with the additional persona ids to whisper to (target is added by the caller). */
+  onConfirm: (receiverIds: number[]) => void;
+}
+
+/**
+ * #907 — choose extra listeners for a "Subtly" (whisper) action. The action
+ * target always hears it; this picks additional scene participants who also do.
+ */
+export function WhisperReceiverPicker({
+  open,
+  onClose,
+  targetName,
+  candidates,
+  onConfirm,
+}: WhisperReceiverPickerProps) {
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+
+  // Reset the selection whenever the dialog (re)opens.
+  useEffect(() => {
+    if (open) setSelected(new Set());
+  }, [open]);
+
+  function toggle(id: number) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Whisper to…</DialogTitle>
+          <DialogDescription>
+            {targetName} hears this. Choose anyone else who should overhear it.
+          </DialogDescription>
+        </DialogHeader>
+
+        {candidates.length === 0 ? (
+          <p className="py-2 text-sm text-muted-foreground" data-testid="whisper-picker-empty">
+            No one else is present to overhear.
+          </p>
+        ) : (
+          <ul className="max-h-64 space-y-2 overflow-y-auto" data-testid="whisper-picker-list">
+            {candidates.map((persona) => (
+              <li key={persona.id}>
+                <label className="flex cursor-pointer items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(persona.id)}
+                    onChange={() => toggle(persona.id)}
+                    className="h-4 w-4 rounded border-input"
+                  />
+                  {persona.name}
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={() => onConfirm(Array.from(selected))}>
+            {selected.size > 0 ? `Whisper to ${selected.size + 1}` : 'Whisper to target only'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/scenes/types.ts
+++ b/frontend/src/scenes/types.ts
@@ -34,9 +34,18 @@ export interface SceneListItem {
   participants: SceneParticipant[];
 }
 
+/** A persona present in a scene (has posed/participated) — the whisper-audience pool (#907). */
+export interface ScenePersona {
+  id: number;
+  name: string;
+  persona_type?: string;
+}
+
 export interface SceneDetail extends SceneListItem {
   is_active: boolean;
   is_owner: boolean;
+  /** Personas reachable via the scene's interactions; the delivery-receiver pool. */
+  personas?: ScenePersona[];
 }
 
 export interface InteractionPersona {


### PR DESCRIPTION
Closes #907. Follow-up from #903 (action delivery types).

## What

The backend already ships a multi-recipient whisper audience — `SceneActionRequest.delivery_receivers` (M2M to Persona) and `delivery_receiver_ids` on the action API. The #903 menu only offered **"Subtly (target only)"**, always whispering to the action target alone. This adds the picker.

- A **"Subtly (choose listeners…)"** item appears on each action's delivery submenu (only when someone else is present) and opens a small dialog listing the **other personas present in the scene** — read from the already-loaded scene cache's `personas` list, no new fetch.
- On confirm, the chosen listeners **plus the target** are sent as `delivery_receiver_ids` with `delivery: 'whisper'` (the target always hears it; the picker adds overhearers).
- New `WhisperReceiverPicker` dialog — a checkbox list following the existing `ThreadFilterModal` pattern (plain HTML checkboxes, no new UI primitive needed).
- `createActionRequest` gains `delivery_receiver_ids`; `SceneDetail` gains a typed `personas` field (the generated schema types it only as an untyped dict array, since the serializer's `get_personas` returns `list[dict]`).

`delivery_receiver_ids` are persona pks; the backend existence-validates them (no scene-participation requirement), so the client-side filtering to present personas is UX, not a security gate.

## Tests

3 `WhisperReceiverPicker` component tests (lists candidates + confirms selected ids; confirms empty when nothing selected; empty-state when no one else present). `pnpm typecheck`, ESLint, Prettier, and the production `pnpm build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- last-addressed-comment: 0 -->
