### PR TITLE
feat(#931): ransom demands + pay-from-treasury

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -3175,6 +3175,28 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/currency/org-books/{id}/pay-ransom/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description Pay a held member's ransom from this org's treasury (#931).
+     *
+     *     Body: ``{"captivity_id": <int>}``. Member-gated like the books read;
+     *     the demand must be owed by this org. Returns the refreshed books.
+     */
+    post: operations['currency_org_books_pay_ransom_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/distinctions/categories/': {
     parameters: {
       query?: never;
@@ -13737,6 +13759,13 @@ export interface components {
      * @enum {string}
      */
     DeliveryEnum: 'pose' | 'whisper' | 'table_talk' | 'mutter';
+    /** @description A ransom demand owed by this org for one of its captured members (#931). */
+    DemandRow: {
+      captivity_id: number;
+      captive_name: string;
+      captor: string;
+      amount: number;
+    };
     /**
      * @description * `trivial` - Trivial
      *     * `easy` - Easy
@@ -16606,6 +16635,7 @@ export interface components {
       obligations: components['schemas']['ObligationRow'][];
       contributions: components['schemas']['ContributionRow'][];
       ledger: components['schemas']['LedgerRow'][];
+      demands: components['schemas']['DemandRow'][];
     };
     OrganizationSearch: {
       id: number;
@@ -26164,6 +26194,48 @@ export interface operations {
         content: {
           'application/json': components['schemas']['OrgBooks'];
         };
+      };
+      /** @description Not a member of the organization. */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description No such organization. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  currency_org_books_pay_ransom_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['OrgBooks'];
+        };
+      };
+      /** @description The ransom could not be paid. */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
       /** @description Not a member of the organization. */
       403: {

--- a/src/schema.json
+++ b/src/schema.json
@@ -4375,6 +4375,37 @@ paths:
           description: Not a member of the organization.
         '404':
           description: No such organization.
+  /api/currency/org-books/{id}/pay-ransom/:
+    post:
+      operationId: currency_org_books_pay_ransom_create
+      description: |-
+        Pay a held member's ransom from this org's treasury (#931).
+
+        Body: ``{"captivity_id": <int>}``. Member-gated like the books read;
+        the demand must be owed by this org. Returns the refreshed books.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - currency
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrgBooks'
+          description: ''
+        '400':
+          description: The ransom could not be paid.
+        '403':
+          description: Not a member of the organization.
+        '404':
+          description: No such organization.
   /api/distinctions/categories/:
     get:
       operationId: distinctions_categories_list
@@ -24223,6 +24254,24 @@ components:
         * `whisper` - Whisper (target only)
         * `table_talk` - Table talk (your place)
         * `mutter` - Mutter (partial echo)
+    DemandRow:
+      type: object
+      description: A ransom demand owed by this org for one of its captured members
+        (#931).
+      properties:
+        captivity_id:
+          type: integer
+        captive_name:
+          type: string
+        captor:
+          type: string
+        amount:
+          type: integer
+      required:
+      - amount
+      - captive_name
+      - captivity_id
+      - captor
     DifficultyChoiceEnum:
       enum:
       - trivial
@@ -30170,10 +30219,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LedgerRow'
+        demands:
+          type: array
+          items:
+            $ref: '#/components/schemas/DemandRow'
       required:
       - balance
       - contributions
       - debts
+      - demands
       - graft_pct
       - income_streams
       - ledger

--- a/src/world/captivity/exceptions.py
+++ b/src/world/captivity/exceptions.py
@@ -28,3 +28,21 @@ class NotHeldError(CaptivityError):
     """The captivity is already resolved — it cannot be resolved again."""
 
     user_message = "That captivity has already ended."
+
+
+class NoCaptorError(CaptivityError):
+    """A ransom needs a captor org to demand it; this captivity has none."""
+
+    user_message = "No captor is holding this character to ransom."
+
+
+class NoRansomError(CaptivityError):
+    """There is no ransom demand to pay on this captivity."""
+
+    user_message = "There is no ransom demand to pay."
+
+
+class InsufficientTreasuryError(CaptivityError):
+    """The paying organization's treasury cannot cover the ransom."""
+
+    user_message = "The treasury cannot cover that ransom."

--- a/src/world/captivity/ransom.py
+++ b/src/world/captivity/ransom.py
@@ -36,20 +36,17 @@ if TYPE_CHECKING:
 _RANSOM_FLOOR_COPPERS = 100_000
 
 
-def _estimate_annual_income(captive: CharacterSheet) -> int | None:  # noqa: ARG001
-    """A captive's annual income in coppers, for sizing a ~1-year ransom.
+def default_ransom_amount(captive: CharacterSheet) -> int:  # noqa: ARG001
+    """The captor's default demand: ~1 year of the captive's income.
 
-    PLACEHOLDER seam (#931): returns None until the income ledger
-    (professions/businesses) exists — read it here when it does, and the
-    family-org income as a secondary fallback.
+    PLACEHOLDER seam (#931): until the income ledger (professions/businesses)
+    exists there is nothing to read, so every captive defaults to the flat
+    floor. When it lands, compute ~1 year of the captive's income here (with
+    the family-org income as a secondary fallback) and keep the floor as the
+    final fallback. A GM may always override the amount at demand time.
     """
-    return None
-
-
-def default_ransom_amount(captive: CharacterSheet) -> int:
-    """The captor's default demand: ~1 year of income, else the flat floor."""
-    income = _estimate_annual_income(captive)
-    return income if income is not None else _RANSOM_FLOOR_COPPERS
+    # TODO(#931): read the income ledger here once professions/businesses ship.
+    return _RANSOM_FLOOR_COPPERS
 
 
 def demand_ransom(

--- a/src/world/captivity/ransom.py
+++ b/src/world/captivity/ransom.py
@@ -1,0 +1,133 @@
+"""Ransom demands & payment (#931).
+
+An NPC captor demands payment for a held captive: a one-shot Contract owed by
+the captive's family org to the captor org, surfaced on the family books and
+settled by ``pay_ransom`` (treasury transfer → frees the captive) — the
+pay-from-treasury-vs-rescue fork. The amount is ~1 year of the captive's
+income, but until professions/income ledgers exist that figure isn't
+computable, so it falls to a flat floor (a GM may always override).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+from django.utils import timezone
+
+from world.captivity.constants import CaptivityStatus
+from world.captivity.exceptions import (
+    InsufficientTreasuryError,
+    NoCaptorError,
+    NoRansomError,
+    NotHeldError,
+)
+from world.captivity.services import resolve_captivity
+from world.currency.constants import ContractFormality, ContractStatus
+from world.currency.models import Contract, ContractTerm
+from world.currency.services import get_or_create_treasury, transfer
+
+if TYPE_CHECKING:
+    from world.captivity.models import Captivity
+    from world.character_sheets.models import CharacterSheet
+    from world.societies.models import Organization
+
+# 1000g floor (1g = 100c), used until incomes are computable. GM may override.
+_RANSOM_FLOOR_COPPERS = 100_000
+
+
+def _estimate_annual_income(captive: CharacterSheet) -> int | None:  # noqa: ARG001
+    """A captive's annual income in coppers, for sizing a ~1-year ransom.
+
+    PLACEHOLDER seam (#931): returns None until the income ledger
+    (professions/businesses) exists — read it here when it does, and the
+    family-org income as a secondary fallback.
+    """
+    return None
+
+
+def default_ransom_amount(captive: CharacterSheet) -> int:
+    """The captor's default demand: ~1 year of income, else the flat floor."""
+    income = _estimate_annual_income(captive)
+    return income if income is not None else _RANSOM_FLOOR_COPPERS
+
+
+def demand_ransom(
+    captivity: Captivity,
+    *,
+    paying_organization: Organization,
+    amount: int | None = None,
+) -> Contract:
+    """Raise the captor's ransom demand against ``paying_organization`` (#931).
+
+    A one-shot HANDSHAKE contract left PROPOSED — the weekly settlement cron
+    only touches NOTARIZED+ACTIVE contracts, so this is never auto-paid; it
+    waits on the payer's decision (``pay_ransom``) versus a rescue. Links the
+    contract onto the captivity. Raises ``NoCaptorError`` without a captor org.
+    """
+    captor = captivity.captor_organization
+    if captor is None:
+        raise NoCaptorError
+    value = amount if amount is not None else default_ransom_amount(captivity.captive)
+
+    with transaction.atomic():
+        contract = Contract.objects.create(
+            proposer_organization=captor,
+            counterparty_organization=paying_organization,
+            # PLACEHOLDER player-facing prose — rewrite in the project voice.
+            title=f"PLACEHOLDER: Ransom for {captivity.captive.character.key}",
+            terms="PLACEHOLDER. Pay the sum demanded for the captive's safe return.",
+            formality=ContractFormality.HANDSHAKE,
+            status=ContractStatus.PROPOSED,
+        )
+        ContractTerm.objects.create(
+            contract=contract,
+            payer_is_proposer=False,  # the counterparty (family org) pays the captor
+            amount=value,
+            recurring=False,
+        )
+        captivity.ransom_contract = contract
+        captivity.save(update_fields=["ransom_contract"])
+    return contract
+
+
+def pay_ransom(captivity: Captivity) -> None:
+    """Pay a held captive's ransom from the payer org's treasury → frees them.
+
+    Transfers the demanded sum payer→captor, completes the contract, and
+    resolves the captivity as RANSOMED. Raises ``NoRansomError`` (no demand),
+    ``NotHeldError`` (already resolved), or ``InsufficientTreasuryError``.
+    """
+    contract = captivity.ransom_contract
+    if contract is None:
+        raise NoRansomError
+    if captivity.status != CaptivityStatus.HELD:
+        raise NotHeldError
+
+    term = contract.payment_terms.first()
+    if term is None:
+        raise NoRansomError
+    payer = contract.counterparty_organization
+    captor = contract.proposer_organization
+    if payer is None or captor is None:
+        raise NoRansomError
+
+    payer_treasury = get_or_create_treasury(payer)
+    if payer_treasury.balance < term.amount:
+        raise InsufficientTreasuryError
+
+    with transaction.atomic():
+        transfer(
+            amount=term.amount,
+            reason="ransom",
+            from_treasury=payer_treasury,
+            to_treasury=get_or_create_treasury(captor),
+        )
+        term.fulfilled = True
+        term.save(update_fields=["fulfilled"])
+        contract.status = ContractStatus.COMPLETED
+        contract.signed_at = contract.signed_at or timezone.now()
+        contract.save(update_fields=["status", "signed_at"])
+
+    # Freed once paid — outside the txn (it relocates the body / tears the cell).
+    resolve_captivity(captivity, status=CaptivityStatus.RANSOMED)

--- a/src/world/captivity/tests/test_ransom.py
+++ b/src/world/captivity/tests/test_ransom.py
@@ -1,0 +1,97 @@
+"""Ransom demand & payment tests (#931)."""
+
+from django.test import TestCase
+
+from world.captivity.constants import CaptivityStatus
+from world.captivity.exceptions import (
+    InsufficientTreasuryError,
+    NoCaptorError,
+    NoRansomError,
+    NotHeldError,
+)
+from world.captivity.ransom import _RANSOM_FLOOR_COPPERS, demand_ransom, pay_ransom
+from world.captivity.services import capture_character
+from world.character_sheets.factories import CharacterSheetFactory
+from world.character_sheets.types import LifecycleState
+from world.currency.constants import ContractStatus
+from world.currency.services import get_or_create_treasury, transfer
+from world.societies.factories import OrganizationFactory
+
+
+class DemandRansomTests(TestCase):
+    def test_demand_creates_a_floored_contract_linked_to_the_captivity(self) -> None:
+        captor = OrganizationFactory()
+        family = OrganizationFactory()
+        captivity = capture_character(captive=CharacterSheetFactory(), captor_organization=captor)
+
+        contract = demand_ransom(captivity, paying_organization=family)
+
+        assert contract.proposer_organization == captor
+        assert contract.counterparty_organization == family
+        assert contract.status == ContractStatus.PROPOSED
+        term = contract.payment_terms.get()
+        assert term.amount == _RANSOM_FLOOR_COPPERS  # no income figure yet → floor
+        assert term.recurring is False
+        captivity.refresh_from_db()
+        assert captivity.ransom_contract == contract
+
+    def test_gm_amount_overrides_the_default(self) -> None:
+        captivity = capture_character(
+            captive=CharacterSheetFactory(), captor_organization=OrganizationFactory()
+        )
+        contract = demand_ransom(captivity, paying_organization=OrganizationFactory(), amount=5_000)
+        assert contract.payment_terms.get().amount == 5_000
+
+    def test_demand_without_a_captor_is_rejected(self) -> None:
+        captivity = capture_character(captive=CharacterSheetFactory())  # no captor org
+
+        with self.assertRaises(NoCaptorError):
+            demand_ransom(captivity, paying_organization=OrganizationFactory())
+
+
+class PayRansomTests(TestCase):
+    def _held_with_demand(self, *, fund: int):
+        captor = OrganizationFactory()
+        family = OrganizationFactory()
+        captivity = capture_character(captive=CharacterSheetFactory(), captor_organization=captor)
+        demand_ransom(captivity, paying_organization=family)
+        if fund:
+            transfer(amount=fund, reason="seed", to_treasury=get_or_create_treasury(family))
+        return captivity, captor, family
+
+    def test_paying_frees_the_captive_and_moves_the_money(self) -> None:
+        captivity, captor, family = self._held_with_demand(fund=_RANSOM_FLOOR_COPPERS + 500)
+
+        pay_ransom(captivity)
+
+        captivity.refresh_from_db()
+        assert captivity.status == CaptivityStatus.RANSOMED
+        captivity.captive.refresh_from_db()
+        assert captivity.captive.lifecycle_state == LifecycleState.ALIVE
+        assert get_or_create_treasury(captor).balance == _RANSOM_FLOOR_COPPERS
+        assert get_or_create_treasury(family).balance == 500
+        captivity.ransom_contract.refresh_from_db()
+        assert captivity.ransom_contract.status == ContractStatus.COMPLETED
+
+    def test_insufficient_treasury_is_rejected(self) -> None:
+        captivity, _captor, _family = self._held_with_demand(fund=0)
+
+        with self.assertRaises(InsufficientTreasuryError):
+            pay_ransom(captivity)
+        captivity.refresh_from_db()
+        assert captivity.status == CaptivityStatus.HELD  # still held — no partial state
+
+    def test_paying_a_captivity_without_a_demand_is_rejected(self) -> None:
+        captivity = capture_character(
+            captive=CharacterSheetFactory(), captor_organization=OrganizationFactory()
+        )
+
+        with self.assertRaises(NoRansomError):
+            pay_ransom(captivity)
+
+    def test_paying_an_already_resolved_captivity_is_rejected(self) -> None:
+        captivity, _captor, _family = self._held_with_demand(fund=_RANSOM_FLOOR_COPPERS)
+        pay_ransom(captivity)
+
+        with self.assertRaises(NotHeldError):
+            pay_ransom(captivity)

--- a/src/world/currency/tests/test_views.py
+++ b/src/world/currency/tests/test_views.py
@@ -123,3 +123,80 @@ class OrgBooksApiTests(TestCase):
             response = self.client.get("/api/currency/org-books/")
         assert response.status_code == 200
         assert response.json() == []
+
+
+class OrgBooksRansomTests(TestCase):
+    """#931 — ransom demands surface on the books and pay from the treasury."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.societies.factories import OrganizationFactory, OrganizationMembershipFactory
+
+        cls.user = AccountFactory(username="ransom_user")
+        cls.org = OrganizationFactory()
+        cls.member = PersonaFactory()
+        cls.outsider = PersonaFactory()
+        OrganizationMembershipFactory(persona=cls.member, organization=cls.org, rank=1)
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _held_member(self, *, fund: int = 0):
+        from world.captivity.ransom import _RANSOM_FLOOR_COPPERS, demand_ransom
+        from world.captivity.services import capture_character
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.currency.services import get_or_create_treasury, transfer
+        from world.societies.factories import OrganizationFactory
+
+        captor = OrganizationFactory()
+        captivity = capture_character(captive=CharacterSheetFactory(), captor_organization=captor)
+        demand_ransom(captivity, paying_organization=self.org)
+        if fund:
+            transfer(amount=fund, reason="seed", to_treasury=get_or_create_treasury(self.org))
+        return captivity, captor, _RANSOM_FLOOR_COPPERS
+
+    def test_demands_appear_on_the_books(self) -> None:
+        captivity, captor, floor = self._held_member()
+        with mock.patch("world.currency.views._viewer_persona", return_value=self.member):
+            data = self.client.get(f"/api/currency/org-books/{self.org.pk}/").json()
+        assert len(data["demands"]) == 1
+        row = data["demands"][0]
+        assert row["captivity_id"] == captivity.pk
+        assert row["captor"] == captor.name
+        assert row["amount"] == floor
+
+    def test_pay_ransom_frees_the_captive_and_clears_the_demand(self) -> None:
+        from world.captivity.constants import CaptivityStatus
+
+        captivity, _captor, _floor = self._held_member(fund=100_000)
+        with mock.patch("world.currency.views._viewer_persona", return_value=self.member):
+            resp = self.client.post(
+                f"/api/currency/org-books/{self.org.pk}/pay-ransom/",
+                {"captivity_id": captivity.pk},
+                format="json",
+            )
+        assert resp.status_code == 200
+        assert resp.json()["demands"] == []  # cleared from the books
+        captivity.refresh_from_db()
+        assert captivity.status == CaptivityStatus.RANSOMED
+
+    def test_pay_ransom_non_member_denied(self) -> None:
+        captivity, _captor, _floor = self._held_member(fund=100_000)
+        with mock.patch("world.currency.views._viewer_persona", return_value=self.outsider):
+            resp = self.client.post(
+                f"/api/currency/org-books/{self.org.pk}/pay-ransom/",
+                {"captivity_id": captivity.pk},
+                format="json",
+            )
+        assert resp.status_code == 403
+
+    def test_pay_ransom_insufficient_treasury_is_400(self) -> None:
+        captivity, _captor, _floor = self._held_member(fund=0)
+        with mock.patch("world.currency.views._viewer_persona", return_value=self.member):
+            resp = self.client.post(
+                f"/api/currency/org-books/{self.org.pk}/pay-ransom/",
+                {"captivity_id": captivity.pk},
+                format="json",
+            )
+        assert resp.status_code == 400

--- a/src/world/currency/views.py
+++ b/src/world/currency/views.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, viewsets
-from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -28,6 +29,7 @@ from world.currency.services import get_or_create_economics, get_or_create_treas
 
 _MSG_NO_ORG = "No such organization."
 _MSG_NOT_MEMBER = "You are not a member of that organization."
+_MSG_NO_CAPTIVITY = "No such ransom demand for this organization."
 _RECENT_ROWS = 50
 
 
@@ -73,6 +75,15 @@ class LedgerRowSerializer(serializers.Serializer):
     created_at = serializers.DateTimeField()
 
 
+class DemandRowSerializer(serializers.Serializer):
+    """A ransom demand owed by this org for one of its captured members (#931)."""
+
+    captivity_id = serializers.IntegerField()
+    captive_name = serializers.CharField()
+    captor = serializers.CharField()
+    amount = serializers.IntegerField()
+
+
 class MyBooksRowSerializer(serializers.Serializer):
     """One organization whose books the viewer may open."""
 
@@ -95,6 +106,7 @@ class OrgBooksSerializer(serializers.Serializer):
     obligations = ObligationRowSerializer(many=True)
     contributions = ContributionRowSerializer(many=True)
     ledger = LedgerRowSerializer(many=True)
+    demands = DemandRowSerializer(many=True)
 
 
 class OrgBooksViewSet(viewsets.ViewSet):
@@ -134,24 +146,65 @@ class OrgBooksViewSet(viewsets.ViewSet):
         },
     )
     def retrieve(self, request: Request, pk: str | None = None) -> Response:
-        from world.societies.models import Organization, OrganizationMembership  # noqa: PLC0415
-
-        organization = Organization.objects.filter(pk=pk).first()
-        if organization is None:
-            raise NotFound(_MSG_NO_ORG)
-
-        persona = _viewer_persona(request)
-        is_member = (
-            persona is not None
-            and OrganizationMembership.objects.filter(
-                persona=persona, organization=organization
-            ).exists()
-        )
-        if not is_member:
-            raise PermissionDenied(_MSG_NOT_MEMBER)
-
+        organization = _require_member_org(request, pk)
         payload = _books_payload(organization)
         return Response(OrgBooksSerializer(payload).data)
+
+    @extend_schema(
+        request=None,
+        responses={
+            200: OrgBooksSerializer,
+            400: OpenApiResponse(description="The ransom could not be paid."),
+            403: OpenApiResponse(description="Not a member of the organization."),
+            404: OpenApiResponse(description="No such organization."),
+        },
+    )
+    @action(detail=True, methods=["post"], url_path="pay-ransom")
+    def pay_ransom(self, request: Request, pk: str | None = None) -> Response:
+        """Pay a held member's ransom from this org's treasury (#931).
+
+        Body: ``{"captivity_id": <int>}``. Member-gated like the books read;
+        the demand must be owed by this org. Returns the refreshed books.
+        """
+        from world.captivity.exceptions import CaptivityError  # noqa: PLC0415
+        from world.captivity.models import Captivity  # noqa: PLC0415
+        from world.captivity.ransom import pay_ransom as pay_ransom_service  # noqa: PLC0415
+
+        organization = _require_member_org(request, pk)
+        captivity_id = request.data.get("captivity_id")
+        captivity = Captivity.objects.filter(pk=captivity_id).first()
+        if captivity is None:
+            raise NotFound(_MSG_NO_CAPTIVITY)
+        contract = captivity.ransom_contract
+        if contract is None or contract.counterparty_organization_id != organization.pk:
+            # This org does not owe that ransom — never leak others' demands.
+            raise NotFound(_MSG_NO_CAPTIVITY)
+
+        try:
+            pay_ransom_service(captivity)
+        except CaptivityError as exc:
+            raise ValidationError(exc.user_message) from exc
+
+        return Response(OrgBooksSerializer(_books_payload(organization)).data)
+
+
+def _require_member_org(request: Request, pk: str | None):
+    """The organization at ``pk``, or raise — gated to the viewer's membership."""
+    from world.societies.models import Organization, OrganizationMembership  # noqa: PLC0415
+
+    organization = Organization.objects.filter(pk=pk).first()
+    if organization is None:
+        raise NotFound(_MSG_NO_ORG)
+    persona = _viewer_persona(request)
+    is_member = (
+        persona is not None
+        and OrganizationMembership.objects.filter(
+            persona=persona, organization=organization
+        ).exists()
+    )
+    if not is_member:
+        raise PermissionDenied(_MSG_NOT_MEMBER)
+    return organization
 
 
 def _viewer_persona(request: Request):
@@ -267,4 +320,37 @@ def _books_payload(organization) -> dict:
             )[:_RECENT_ROWS]
         ],
         "ledger": ledger,
+        "demands": _ransom_demands(organization),
     }
+
+
+def _ransom_demands(organization) -> list[dict]:
+    """Active ransom demands this org owes for its captured members (#931).
+
+    A captor's demand is a Contract whose counterparty is this org, linked to a
+    still-HELD captivity. Queried from the captivity side (constants-only import
+    — no app cycle); terms prefetched so the amount lookup is not an N+1.
+    """
+    from world.captivity.constants import CaptivityStatus  # noqa: PLC0415
+    from world.captivity.models import Captivity  # noqa: PLC0415
+
+    captivities = (
+        Captivity.objects.filter(
+            ransom_contract__counterparty_organization=organization,
+            status=CaptivityStatus.HELD,
+        )
+        .select_related("captive__character", "captor_organization")
+        .prefetch_related("ransom_contract__payment_terms")  # noqa: PREFETCH_STRING
+    )
+    rows = []
+    for cap in captivities:
+        terms = list(cap.ransom_contract.payment_terms.all())
+        rows.append(
+            {
+                "captivity_id": cap.pk,
+                "captive_name": cap.captive.character.key,
+                "captor": cap.captor_organization.name if cap.captor_organization else "",
+                "amount": terms[0].amount if terms else 0,
+            }
+        )
+    return rows


### PR DESCRIPTION
Part of #931 (prison & ransom). The ransom payment loop, building on the merged captivity core (#969), CAPTURE effect (#975/#982), and org-books (#968).

## What

An NPC captor demands a sum for a held captive; it surfaces on the family books; the org pays it from the treasury to free them — the **pay-from-treasury vs rescue** fork from the spec.

- **`world/captivity/ransom.py`**
  - `demand_ransom(captivity, *, paying_organization, amount=None)` — a one-shot **HANDSHAKE** Contract (captor = proposer, family = counterparty), left **PROPOSED** so the weekly settlement cron never auto-pays it (it waits on the payer's decision). Links it onto `Captivity.ransom_contract`.
  - `pay_ransom(captivity)` — transfers the demand payer→captor, completes the contract, and resolves the captivity as **RANSOMED** (which frees the captive via the existing relocate-and-teardown).
- **Amount** — GM-provided, else `default_ransom_amount`: ~1 year of the captive's income via the **`_estimate_annual_income` seam**, which returns `None` until profession/income ledgers exist, so it falls to a **1000g floor** today (per the ruling: GM input or floor, with the income function slotting in later).
- **Books `demands` section** — the org-books payload now lists active ransoms the org owes, and a **member-gated `POST /org-books/{id}/pay-ransom/`** action pays one and returns the refreshed books. Typed `CaptivityError`s surface their `user_message` as 400, never `str(exc)`.

No model changes — `Captivity.ransom_contract` shipped with the captivity core, so no migration.

## Deferred (noted)

- The FE: a "demands" panel + pay button on the family-books screen (the payload + endpoint are ready for it).
- Auto-creating the demand at capture time (needs the paying-org resolution); `demand_ransom` is the building block the capture authoring / GM calls.

## Tests

21 `world.captivity` (9 new ransom: demand defaults/override/no-captor; pay frees + moves money / insufficient / no-demand / already-resolved) + 57 `world.currency` (new: demands on the books, pay frees + clears the demand, non-member 403, insufficient 400). All OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- last-addressed-comment: 0 -->
