### PR TITLE
Passive-effect + capability-read correctness follow-ups (#1009, #1010)

### DIFF
--- a/src/world/magic/handlers.py
+++ b/src/world/magic/handlers.py
@@ -109,11 +109,17 @@ class CharacterThreadHandler:
         if not threads:
             return 0
 
-        # Build lookup: (target_kind, resonance_id) → thread level, so we can
-        # apply the right multiplier after the batched query.
-        thread_level: dict[tuple[str, int], int] = {
-            (t.target_kind, t.resonance_id): t.level for t in threads
-        }
+        # Build lookup: (target_kind, resonance_id) → HIGHEST thread level for
+        # that key, so we apply the right multiplier after the batched query.
+        # Two threads of one kind on the same resonance (e.g. two COVENANT_ROLE
+        # roles, or two TRAIT anchors) share a key; the bonus applies once,
+        # scaled by the best qualifying thread (#1009). A plain dict
+        # comprehension would let the last-iterated thread win
+        # nondeterministically (Thread has no Meta.ordering).
+        thread_level: dict[tuple[str, int], int] = {}
+        for t in threads:
+            key = (t.target_kind, t.resonance_id)
+            thread_level[key] = max(thread_level.get(key, 0), t.level)
 
         # One query for all tier-0 VITAL_BONUS rows that match any of this
         # character's (target_kind, resonance_id) pairs.

--- a/src/world/magic/tests/test_vital_bonus_routing.py
+++ b/src/world/magic/tests/test_vital_bonus_routing.py
@@ -141,6 +141,40 @@ class MaxHealthVitalBonusTests(TestCase):
         self.assertEqual(self.vitals.max_health, 116)
 
 
+class SameResonanceLevelMultiplierTests(TestCase):
+    """#1009: two same-resonance threads of one kind must not collapse the
+    level multiplier nondeterministically. The bonus applies ONCE per
+    (kind, resonance), scaled by the HIGHEST-level qualifying thread."""
+
+    def setUp(self) -> None:
+        self.sheet = CharacterSheetFactory()
+
+    def test_uses_highest_level_among_same_resonance_threads(self) -> None:
+        resonance = ResonanceFactory()
+        # Two TRAIT threads on the SAME resonance, different traits, share the
+        # (TRAIT, resonance_id) key. Create the HIGH-level thread first (lower
+        # pk) and the LOW-level thread last, so the old last-writer-wins dict
+        # would deterministically pick the low level (5 → ×1 → 5). The fix uses
+        # the max (25 → ×2 → 10), independent of insertion order.
+        high = ThreadFactory(owner=self.sheet, resonance=resonance, level=25)
+        ThreadFactory(owner=self.sheet, resonance=resonance, level=5)
+        ThreadPullEffectFactory(
+            target_kind=high.target_kind,
+            resonance=resonance,
+            tier=0,
+            min_thread_level=0,
+            effect_kind=EffectKind.VITAL_BONUS,
+            flat_bonus_amount=None,
+            vital_bonus_amount=5,
+            vital_target=VitalBonusTarget.MAX_HEALTH,
+        )
+
+        total = self.sheet.character.threads.passive_vital_bonuses(VitalBonusTarget.MAX_HEALTH)
+        # Once, highest level: 5 × max(1, 25 // 10) = 10.
+        # NOT 5 (low-level multiplier 1) and NOT 15 (stacking 5×1 + 5×2).
+        self.assertEqual(total, 10)
+
+
 class ClampNotInjureTests(TestCase):
     """Shrinking max_health never pushes current_health below its prior level."""
 

--- a/src/world/missions/services/challenge_options.py
+++ b/src/world/missions/services/challenge_options.py
@@ -10,16 +10,18 @@ data-source integration). Of the ``ChallengeTemplate`` fields only
 ``severity`` rides along, as the approach rolls' difficulty (design §8.4 Q4).
 
 Capability ownership is **not** re-implemented here. It is decided by
-``world.conditions.services.get_capability_value`` — the single definition
-of "does this acting character own capability X" (the Phase-0
-``has_capability`` predicate resolver wraps the same call).
+``world.conditions.services.get_effective_capability_value`` — the single
+definition of "does this acting character own capability X" across all
+sources (innate baseline, intrinsic modifiers, thread-passive role grants,
+conditions); the Phase-0 ``has_capability`` predicate resolver wraps the same
+call. (#1010: switched from the condition-only read.)
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from world.conditions.services import get_capability_value
+from world.conditions.services import get_effective_capability_value
 from world.mechanics.models import ChallengeApproach, ChallengeTemplate
 from world.missions.types import ChallengeOption
 
@@ -37,7 +39,7 @@ def challenge_options_for_character(
     :class:`~world.missions.types.ChallengeOption` when the acting
     ``character`` qualifies — they hold the approach's
     ``Application.capability`` (per
-    ``conditions.services.get_capability_value``) — or the approach is
+    ``conditions.services.get_effective_capability_value``) — or the approach is
     ``is_default`` (offered to everyone). Approaches the character neither
     qualifies for nor that are ``is_default`` are excluded; the result is
     legitimately empty when the challenge defines no default and the
@@ -63,7 +65,8 @@ def challenge_options_for_character(
         # directly rather than re-looking-up by name.
         qualifies = (
             approach.is_default
-            or get_capability_value(character.sheet_data, approach.application.capability) > 0
+            or get_effective_capability_value(character.sheet_data, approach.application.capability)
+            > 0
         )
         if not qualifies:
             continue

--- a/src/world/missions/tests/test_resolvers.py
+++ b/src/world/missions/tests/test_resolvers.py
@@ -149,6 +149,13 @@ class ConditionCapabilityResolverTests(TestCase):
     def test_has_capability_false_when_unknown(self) -> None:
         self.assertFalse(self.ctx.has_leaf("has_capability", name="flight"))
 
+    def test_has_capability_true_from_non_condition_source(self) -> None:
+        """#1010: a capability possessed via a non-condition source (here an
+        innate baseline; also covers distinction/equipment/role-passive grants)
+        satisfies has_capability via the effective read, not just conditions."""
+        CapabilityTypeFactory(name="winged", innate_baseline=1)
+        self.assertTrue(self.ctx.has_leaf("has_capability", name="winged"))
+
 
 class ThreadResolverTests(TestCase):
     """has_thread / min_thread_level — owner is a CharacterSheet."""

--- a/src/world/missions/tests/test_services_challenge_options.py
+++ b/src/world/missions/tests/test_services_challenge_options.py
@@ -82,6 +82,21 @@ class ChallengeOptionsForCharacterTests(TestCase):
         options = challenge_options_for_character(self.challenge, self.char_without)
         self.assertEqual([o.approach.pk for o in options], [self.approach_default.pk])
 
+    def test_qualifies_via_non_condition_capability_source(self) -> None:
+        """#1010: qualification uses the effective capability value, so a
+        capability possessed via a non-condition source (here an innate
+        baseline; also covers distinction/equipment/role-passive grants)
+        qualifies an approach — not only condition-granted capabilities."""
+        cap_swim = CapabilityTypeFactory(name="co-swim", innate_baseline=1)
+        approach_swim = ChallengeApproachFactory(
+            challenge_template=self.challenge,
+            application=ApplicationFactory(name="co-app-swim", capability=cap_swim),
+            display_name="Swim across",
+        )
+        # char_without holds no conditions; the innate baseline qualifies it.
+        options = challenge_options_for_character(self.challenge, self.char_without)
+        self.assertIn(approach_swim.pk, {o.approach.pk for o in options})
+
     def test_auto_succeeds_is_carried_and_gated_by_capability(self) -> None:
         # auto_succeeds rides onto the option; it does NOT bypass the
         # capability gate — only is_default does.

--- a/src/world/predicates/predicates.py
+++ b/src/world/predicates/predicates.py
@@ -171,17 +171,19 @@ def _resolve_has_condition(ctx: ResolverContext, *, key: str) -> bool:
 def _resolve_has_capability(ctx: ResolverContext, *, name: str) -> bool:
     """True if the character effectively possesses the named capability.
 
-    Capabilities are additive modifiers granted/removed by active
-    conditions. ``conditions.services.get_capability_value`` aggregates them
-    and floors at 0, where "0 == effectively blocked / not possessed".
+    Uses the *effective* capability value — innate baseline + intrinsic
+    modifiers (distinction/species/equipment) + thread-passive role grants +
+    active conditions — floored at 0, where "0 == effectively blocked / not
+    possessed". (#1010: the prior condition-only read missed intrinsic and
+    role-passive sources.)
     """
     from world.conditions.models import CapabilityType  # noqa: PLC0415
-    from world.conditions.services import get_capability_value  # noqa: PLC0415
+    from world.conditions.services import get_effective_capability_value  # noqa: PLC0415
 
     capability = CapabilityType.objects.filter(name=name).first()
     if capability is None:
         return False
-    return get_capability_value(ctx.character.sheet_data, capability) > 0
+    return get_effective_capability_value(ctx.character.sheet_data, capability) > 0
 
 
 def _resolve_has_thread(ctx: ResolverContext) -> bool:


### PR DESCRIPTION
Two small correctness fixes surfaced during the Bundle 2 review (PR #1008), in the passive-effect / capability-read paths.

Closes #1009, closes #1010.

## #1009 — `passive_vital_bonuses` level multiplier
The handler keyed its per-thread level lookup on `(target_kind, resonance_id)` via a dict comprehension, so two threads of one kind on the **same resonance** (allowed by the schema — e.g. two `COVENANT_ROLE` roles, or two `TRAIT` anchors) collapsed into one slot and the `VITAL_BONUS` multiplier was taken from a nondeterministically-chosen thread (no `Meta.ordering`). Fix: take the **max level per key** — the bonus applies once per `(kind, resonance)`, scaled by the highest-level qualifying thread. Mirrors the `passive_capability_grants` treatment. Regression test is red on the old code (creates the high-level thread first so last-writer-wins picked the low level).

## #1010 — `has_capability` / challenge approaches read all capability sources
`_resolve_has_capability` (`predicates.py`) and `challenge_options_for_character` (`missions/services/challenge_options.py`) gated on the **condition-only** `get_capability_value`, contradicting the predicate's "effectively possesses" contract — they ignored intrinsic capabilities (distinction/species/equipment) and the role-passive grants #751 added. Switched both to `get_effective_capability_value`. After this, **no live "has capability" gate remains on the condition-only read** (verified). Tests prove a capability possessed via a non-condition source (innate baseline) now satisfies both gates.

## Testing
- New regression tests per fix (each red on the prior code).
- Fast SQLite tier green for magic + missions + predicates (2,395 tests); `ruff` + `ty` clean; pre-commit clean.
- No serializer/model changes → no migration, no schema regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)