### PR TITLE
feat(#1001a/#996): single-target focused attacks + critical pose auto-expand

### DIFF
--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -525,11 +525,13 @@ Shipped since the original list:
 - Focused-category resolution — **DONE** (#558/#614): sourced from the technique's authored `action_category`; the `passive-physical` stub is gone.
 - `ClashStateSerializer` — **DONE**: exposes `contributors` and `side_favored`.
 - `lend-to-clash` / `CLASH_SUPPORT` — **REJECTED BY DESIGN (#559)**: a clash binds to the focused action only; there is no passive-contribution concept. Do not re-add a Lend surface.
+- Single-target focused attacks — **#1001a DONE**: the focused slot's `TargetPicker` (was a Phase-5 kind-`<select>` placeholder) now lists real combatants from the encounter; `YourTurn` threads the chosen target into the focused dispatch as `focused_opponent_target_id` (CombatOpponent PK) / `focused_ally_target_id` (CombatParticipant PK). `CombatRoundContext.record_declaration` resolves those ids to instances scoped to the encounter (forged-id safety) and persists them via `declare_action`. `OpponentSerializer` exposes `objectdb_id` so the card maps the applicable-pulls `target_object_id` correctly.
+- Auto-expand pose units on critical events — **#996 DONE**: `InteractionActionLinkSerializer` exposes `has_critical_effect` (cheap, N+1-safe signal: the linked `CombatRoundAction`'s `focused_opponent_target` is DEFEATED, derived from a prefetch — no condition queries); `PoseUnit` initialises its expanded state from `action_links.some(l => l.has_critical_effect)`. The `is_critical` row highlight shipped earlier in #1004.
 
 Still open (tracked):
 
 - `submit_pose` REST endpoint does not broadcast via WebSocket — #878
-- Auto-expand pose units on critical events (KO, death) — pending player-preference toggle (no issue yet)
+- Per-player preference toggle for critical-event auto-expand (#996 ships it always-on) — no issue yet
 - `CombatOpponent` portrait FK — NPC avatars are initial-letter-only (no issue yet)
 - Outcome-panel scoping/visibility polish — #866
 - Scene-side adoption of `<ActionDeclarationCard>` (no `ScenePull` envelope) — out of this spec's scope

--- a/frontend/src/actions/ActionDeclarationCard.tsx
+++ b/frontend/src/actions/ActionDeclarationCard.tsx
@@ -26,7 +26,7 @@ import type { PlayerAction } from '@/scenes/actionTypes';
 import { useTechnique, useCharacterResonances } from '@/magic/queries';
 import { ThreadPullPicker } from '@/magic/components/threads/ThreadPullPicker';
 import type { ApplicablePullsRequest } from '@/magic/types';
-import type { ActionContext, EffortLevel } from './types';
+import type { ActionContext, EffortLevel, TargetOption } from './types';
 
 // ---------------------------------------------------------------------------
 // Public props contract
@@ -43,6 +43,12 @@ export interface ActionDeclarationCardProps {
   actionContext: ActionContext;
   onContextChange: (next: ActionContext) => void;
   readOnly?: boolean;
+  /**
+   * Selectable combatants for the focused-target picker (#1001a). When provided
+   * (combat), the picker lists real opponents/allies; when omitted (scenes), it
+   * falls back to the kind-only selector.
+   */
+  targets?: TargetOption[];
 }
 
 // ---------------------------------------------------------------------------
@@ -147,30 +153,117 @@ interface TargetPickerProps {
   targetKind: ActionContext['targetKind'];
   onTargetChange: (targetKind: ActionContext['targetKind'], targetId: number | undefined) => void;
   disabled?: boolean;
+  /** Real combatants (combat). When undefined, render the kind-only fallback. */
+  targets?: TargetOption[];
 }
 
-function TargetPicker({ targetId, targetKind, onTargetChange, disabled }: TargetPickerProps) {
-  // Phase 5 placeholder — kind select only.
-  // Real combatant-list target picker is wired in Phase 7.
+/** Kind-only fallback selector used in scenes (no combatant list available). */
+function TargetKindSelect({ targetId, targetKind, onTargetChange, disabled }: TargetPickerProps) {
   return (
-    <div className="flex items-center gap-2">
-      <select
-        disabled={disabled}
-        value={targetKind ?? ''}
-        onChange={(e) => {
-          const kind = e.target.value as ActionContext['targetKind'];
-          onTargetChange(kind || undefined, targetId);
-        }}
-        className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
-      >
-        <option value="">— no target —</option>
-        <option value="opponent">Opponent</option>
-        <option value="ally">Ally</option>
-        <option value="social">Social</option>
-        <option value="self">Self</option>
-      </select>
-      {targetKind && targetKind !== 'self' && (
-        <span className="text-xs text-muted-foreground">(target picker: Phase 7)</span>
+    <select
+      disabled={disabled}
+      value={targetKind ?? ''}
+      onChange={(e) => {
+        const kind = e.target.value as ActionContext['targetKind'];
+        onTargetChange(kind || undefined, targetId);
+      }}
+      className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
+    >
+      <option value="">— no target —</option>
+      <option value="opponent">Opponent</option>
+      <option value="ally">Ally</option>
+      <option value="social">Social</option>
+      <option value="self">Self</option>
+    </select>
+  );
+}
+
+/** One combatant button. */
+function TargetButton({
+  option,
+  selected,
+  disabled,
+  onSelect,
+}: {
+  option: TargetOption;
+  selected: boolean;
+  disabled?: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onSelect}
+      className={cn(
+        'rounded border px-2.5 py-1 text-left text-xs font-medium transition-colors',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        selected
+          ? 'border-primary bg-primary/10 text-primary'
+          : 'border-border bg-background text-foreground hover:border-primary/50'
+      )}
+    >
+      {option.name}
+    </button>
+  );
+}
+
+function TargetPicker(props: TargetPickerProps) {
+  const { targetId, targetKind, onTargetChange, disabled, targets } = props;
+
+  // Scenes: no combatant list → kind-only selector.
+  if (targets === undefined) {
+    return (
+      <div className="flex items-center gap-2">
+        <TargetKindSelect {...props} />
+      </div>
+    );
+  }
+
+  const opponents = targets.filter((t) => t.kind === 'opponent');
+  const allies = targets.filter((t) => t.kind === 'ally');
+  const hasSelection = targetKind !== undefined && targetId !== undefined;
+
+  const renderGroup = (label: string, options: TargetOption[]) =>
+    options.length > 0 && (
+      <div className="space-y-1">
+        <p className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</p>
+        <div className="flex flex-wrap gap-1.5">
+          {options.map((option) => (
+            <TargetButton
+              key={`${option.kind}-${option.id}`}
+              option={option}
+              selected={targetKind === option.kind && targetId === option.id}
+              disabled={disabled}
+              onSelect={() => onTargetChange(option.kind, option.id)}
+            />
+          ))}
+        </div>
+      </div>
+    );
+
+  return (
+    <div className="space-y-2" data-testid="combatant-target-picker">
+      {targets.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No targets available.</p>
+      ) : (
+        <>
+          {renderGroup('Opponents', opponents)}
+          {renderGroup('Allies', allies)}
+          <button
+            type="button"
+            disabled={disabled || !hasSelection}
+            onClick={() => onTargetChange(undefined, undefined)}
+            className={cn(
+              'text-[11px] underline-offset-2 transition-colors',
+              hasSelection
+                ? 'text-muted-foreground hover:text-foreground hover:underline'
+                : 'cursor-not-allowed text-muted-foreground/50'
+            )}
+          >
+            Clear target
+          </button>
+        </>
       )}
     </div>
   );
@@ -265,6 +358,7 @@ export function ActionDeclarationCard({
   actionContext,
   onContextChange,
   readOnly = false,
+  targets,
 }: ActionDeclarationCardProps) {
   // Fetch available techniques for this character.
   const { data, isLoading } = useTQQuery({
@@ -297,17 +391,41 @@ export function ActionDeclarationCard({
   }, [resonances]);
 
   // Build applicable-pulls context from current card state.
+  //
+  // Id-space note (#1001a): in combat (`targets` provided) actionContext.targetId
+  // is the dispatch PK (CombatOpponent / CombatParticipant), which is NOT the
+  // applicable-pulls id-space. The pulls API wants the opponent's ObjectDB pk
+  // (target_object_id) — carried on the selected TargetOption.objectId — and a
+  // persona id for allies, which the combat list does not carry (left null; no
+  // regression — combat ally pulls were never scoped). In scenes (no `targets`)
+  // the legacy mapping stands: targetId is the object/persona id directly.
   const pullsContext = useMemo<ApplicablePullsRequest | null>(() => {
     if (characterSheetId <= 0) return null;
+    const isCombatTargeting = targets !== undefined;
+    const selectedTarget = targets?.find(
+      (t) => t.kind === actionContext.targetKind && t.id === actionContext.targetId
+    );
+
+    let targetObjectId: number | null = null;
+    let targetPersonaId: number | null = null;
+    if (isCombatTargeting) {
+      targetObjectId =
+        actionContext.targetKind === 'opponent' ? (selectedTarget?.objectId ?? null) : null;
+      // Combat allies carry no persona id; opponent scoping uses target_object_id.
+    } else {
+      targetObjectId =
+        actionContext.targetKind === 'opponent' ? (actionContext.targetId ?? null) : null;
+      targetPersonaId =
+        actionContext.targetKind === 'social' || actionContext.targetKind === 'ally'
+          ? (actionContext.targetId ?? null)
+          : null;
+    }
+
     return {
       character_sheet_id: characterSheetId,
       technique_id: actionContext.techniqueId ?? null,
-      target_persona_id:
-        actionContext.targetKind === 'social' || actionContext.targetKind === 'ally'
-          ? (actionContext.targetId ?? null)
-          : null,
-      target_object_id:
-        actionContext.targetKind === 'opponent' ? (actionContext.targetId ?? null) : null,
+      target_persona_id: targetPersonaId,
+      target_object_id: targetObjectId,
       scene_id: null, // wired in Phase 7 when CombatTurnPanel passes scene context
       effect_type_id: null,
     };
@@ -316,6 +434,7 @@ export function ActionDeclarationCard({
     actionContext.techniqueId,
     actionContext.targetKind,
     actionContext.targetId,
+    targets,
   ]);
 
   // Clear revert notice after 4 seconds
@@ -389,6 +508,7 @@ export function ActionDeclarationCard({
           targetKind={actionContext.targetKind}
           onTargetChange={handleTargetChange}
           disabled={readOnly}
+          targets={targets}
         />
       </Section>
 

--- a/frontend/src/actions/__tests__/ActionDeclarationCard.test.tsx
+++ b/frontend/src/actions/__tests__/ActionDeclarationCard.test.tsx
@@ -578,3 +578,109 @@ describe('ActionDeclarationCard — Task 6.4 ThreadPullPicker section', () => {
     expect(screen.getByTestId('thread-pull-picker-stub')).toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1001a — single-target focused picker
+// ---------------------------------------------------------------------------
+
+describe('ActionDeclarationCard — #1001a combatant target picker', () => {
+  beforeEach(() => {
+    mockedFetchActions.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+    mockUseTechnique(null);
+    mockPickerHooks();
+  });
+
+  const TARGETS = [
+    { id: 7, kind: 'opponent' as const, name: 'Bandit Captain', objectId: 42 },
+    { id: 9, kind: 'ally' as const, name: 'Sir Alaric' },
+  ];
+
+  it('falls back to the kind-only selector when no targets are provided', () => {
+    render(
+      <ActionDeclarationCard
+        characterId={1}
+        characterSheetId={1}
+        actionContext={emptyContext()}
+        onContextChange={() => {}}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.queryByTestId('combatant-target-picker')).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /no target/i })).toBeInTheDocument();
+  });
+
+  it('lists opponents and allies when targets are provided', () => {
+    render(
+      <ActionDeclarationCard
+        characterId={1}
+        characterSheetId={1}
+        actionContext={emptyContext()}
+        onContextChange={() => {}}
+        targets={TARGETS}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByTestId('combatant-target-picker')).toBeInTheDocument();
+    expect(screen.getByText('Bandit Captain')).toBeInTheDocument();
+    expect(screen.getByText('Sir Alaric')).toBeInTheDocument();
+  });
+
+  it('emits the picked opponent kind + dispatch PK on selection', async () => {
+    const onContextChange = vi.fn();
+    render(
+      <ActionDeclarationCard
+        characterId={1}
+        characterSheetId={1}
+        actionContext={emptyContext()}
+        onContextChange={onContextChange}
+        targets={TARGETS}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    await userEvent.click(screen.getByText('Bandit Captain'));
+    expect(onContextChange).toHaveBeenCalledWith(
+      expect.objectContaining({ targetKind: 'opponent', targetId: 7 })
+    );
+  });
+
+  it('emits the picked ally kind + participant PK on selection', async () => {
+    const onContextChange = vi.fn();
+    render(
+      <ActionDeclarationCard
+        characterId={1}
+        characterSheetId={1}
+        actionContext={emptyContext()}
+        onContextChange={onContextChange}
+        targets={TARGETS}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    await userEvent.click(screen.getByText('Sir Alaric'));
+    expect(onContextChange).toHaveBeenCalledWith(
+      expect.objectContaining({ targetKind: 'ally', targetId: 9 })
+    );
+  });
+
+  it('clears the selected target', async () => {
+    const onContextChange = vi.fn();
+    render(
+      <ActionDeclarationCard
+        characterId={1}
+        characterSheetId={1}
+        actionContext={emptyContext({ targetKind: 'opponent', targetId: 7 })}
+        onContextChange={onContextChange}
+        targets={TARGETS}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    await userEvent.click(screen.getByText(/clear target/i));
+    expect(onContextChange).toHaveBeenCalledWith(
+      expect.objectContaining({ targetKind: undefined, targetId: undefined })
+    );
+  });
+});

--- a/frontend/src/actions/types.ts
+++ b/frontend/src/actions/types.ts
@@ -19,7 +19,29 @@ export interface ActionContext {
   /** Technique PK selected for this action. */
   techniqueId?: number;
   targetKind?: 'opponent' | 'ally' | 'social' | 'self';
+  /**
+   * Selected target's PK. In combat this is the dispatch PK — a CombatOpponent
+   * PK when targetKind is 'opponent', a CombatParticipant PK when 'ally' —
+   * threaded to the dispatch as focused_opponent_target_id / focused_ally_target_id.
+   */
   targetId?: number;
   effort: EffortLevel;
   strainCommitment: number;
+}
+
+/**
+ * One selectable combatant in the focused-target picker (#1001a). The shared
+ * ActionDeclarationCard receives these from the combat panel; scene usage omits
+ * them and falls back to the kind-only selector.
+ */
+export interface TargetOption {
+  /** Dispatch PK: CombatOpponent PK (opponent) or CombatParticipant PK (ally). */
+  id: number;
+  kind: 'opponent' | 'ally';
+  name: string;
+  /**
+   * The combatant's in-world ObjectDB pk, used for the applicable-pulls API
+   * (target_object_id). Present for opponents; null/undefined otherwise.
+   */
+  objectId?: number | null;
 }

--- a/frontend/src/combat/__tests__/ActiveState.test.tsx
+++ b/frontend/src/combat/__tests__/ActiveState.test.tsx
@@ -50,6 +50,7 @@ function makeEncounter(clashes: ClashState[] = []): EncounterDetail {
     opponents: [
       {
         id: 10,
+        objectdb_id: null,
         name: 'Mire Knight',
         tier: 'elite',
         health: 10,

--- a/frontend/src/combat/__tests__/CombatantsList.test.tsx
+++ b/frontend/src/combat/__tests__/CombatantsList.test.tsx
@@ -95,6 +95,7 @@ function makeParticipant(overrides: Partial<Participant> = {}): Participant {
 function makeOpponent(overrides: Partial<Opponent> = {}): Opponent {
   return {
     id: 1,
+    objectdb_id: null,
     name: 'Mire Knight',
     tier: 'elite',
     health: 5,

--- a/frontend/src/combat/__tests__/YourTurn.test.tsx
+++ b/frontend/src/combat/__tests__/YourTurn.test.tsx
@@ -938,6 +938,94 @@ describe('YourTurn — cover declaration', () => {
 // Robustness — own-action resolution is position-independent
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// #1001a — single-target focused attacks
+// ---------------------------------------------------------------------------
+
+describe('YourTurn — #1001a focused target', () => {
+  function encounterWithCombatants(): EncounterDetail {
+    return makeEncounter({
+      status: 'declaring',
+      // Self (id=5, sheet=100) + one ally (id=7).
+      participants: [makeSelfParticipant(5), makeParticipant(7, 'Shield Bearer')],
+      opponents: [
+        {
+          id: 11,
+          objectdb_id: 42,
+          name: 'Bandit Captain',
+          status: 'active',
+        },
+      ],
+    } as unknown as EncounterDetail);
+  }
+
+  it('passes active opponents + allies as targets to the focused card', () => {
+    setupMocks();
+
+    render(<YourTurn {...defaultProps({ encounter: encounterWithCombatants() })} />, {
+      wrapper: createWrapper(),
+    });
+
+    const focusedCall = mockActionDeclarationCard.mock.calls.find(
+      (c) => (c[0] as { actionContext: { slot: string } }).actionContext.slot === 'focused'
+    );
+    expect(focusedCall).toBeDefined();
+    const targets = (focusedCall![0] as { targets?: Array<{ id: number; kind: string }> }).targets;
+    expect(targets).toEqual([
+      { id: 11, kind: 'opponent', name: 'Bandit Captain', objectId: 42 },
+      { id: 7, kind: 'ally', name: 'Shield Bearer' },
+    ]);
+  });
+
+  it('threads focused_opponent_target_id into the focused dispatch kwargs', async () => {
+    setupMocks();
+
+    // Stub the focused card so "select" emits a technique AND an opponent target.
+    mockActionDeclarationCard.mockImplementation(({ actionContext, onContextChange, readOnly }) => {
+      const slot = (actionContext as { slot: string }).slot;
+      return (
+        <div data-testid={`action-card-${slot}`} data-readonly={String(readOnly ?? false)}>
+          <button
+            type="button"
+            data-testid={`card-select-technique-${slot}`}
+            onClick={() =>
+              onContextChange({
+                slot,
+                effort: 'MEDIUM',
+                strainCommitment: 0,
+                techniqueId: 50,
+                ...(slot === 'focused' ? { targetKind: 'opponent', targetId: 11 } : {}),
+              } as never)
+            }
+          >
+            select technique
+          </button>
+        </div>
+      );
+    });
+
+    render(<YourTurn {...defaultProps({ encounter: encounterWithCombatants() })} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('card-select-technique-focused'));
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ready-badge')).toBeInTheDocument();
+    });
+
+    const calls = mockMutateAsync.mock.calls as Array<[{ kwargs: Record<string, unknown> }]>;
+    expect(calls[0][0].kwargs).toMatchObject({
+      effort_level: 'medium',
+      focused_opponent_target_id: 11,
+    });
+    expect(calls[0][0].kwargs).not.toHaveProperty('focused_ally_target_id');
+
+    mockActionDeclarationCard.mockImplementation(defaultCardImpl);
+  });
+});
+
 describe('YourTurn — own-action resolved by participant PK, not position', () => {
   it('shows flee badge even when another participant action appears first in the list (GM view)', () => {
     // Simulates the GM/staff scenario where current_round_actions contains

--- a/frontend/src/combat/sections/YourTurn.tsx
+++ b/frontend/src/combat/sections/YourTurn.tsx
@@ -15,7 +15,7 @@
 import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { ActionDeclarationCard } from '@/actions/ActionDeclarationCard';
-import type { ActionContext, ActionSlot, EffortLevel } from '@/actions/types';
+import type { ActionContext, ActionSlot, EffortLevel, TargetOption } from '@/actions/types';
 import type { PlayerAction } from '@/scenes/actionTypes';
 import { ThreadPullDialog } from '@/magic/components/threads/ThreadPullDialog';
 import {
@@ -340,6 +340,25 @@ export function YourTurn({
     (p) => p.status === 'active' && p.id !== myParticipantId
   );
 
+  // Focused-target options (#1001a): active opponents + allies. Opponents carry
+  // their ObjectDB id for the applicable-pulls API; the dispatch uses the
+  // CombatOpponent / CombatParticipant PK (`id`).
+  const focusedTargets: TargetOption[] = [
+    ...(encounter?.opponents ?? [])
+      .filter((o) => o.status === 'active')
+      .map((o) => ({
+        id: o.id,
+        kind: 'opponent' as const,
+        name: o.name,
+        objectId: o.objectdb_id,
+      })),
+    ...coverableAllies.map((p) => ({
+      id: p.id,
+      kind: 'ally' as const,
+      name: p.character_name,
+    })),
+  ];
+
   // Current declared maneuver (from own round action).
   const declaredManeuver = ownRoundAction?.maneuver ?? null;
 
@@ -376,6 +395,16 @@ export function YourTurn({
 
     // 1. Focused action (if technique selected)
     if (focusedContext.techniqueId !== undefined) {
+      // Thread the chosen single target onto the focused declaration (#1001a).
+      // The backend resolves these PKs to instances scoped to the encounter.
+      const targetKwargs: Record<string, number> = {};
+      if (focusedContext.targetId !== undefined) {
+        if (focusedContext.targetKind === 'opponent') {
+          targetKwargs.focused_opponent_target_id = focusedContext.targetId;
+        } else if (focusedContext.targetKind === 'ally') {
+          targetKwargs.focused_ally_target_id = focusedContext.targetId;
+        }
+      }
       dispatchJobs.push(() =>
         dispatchAction({
           ref: {
@@ -383,7 +412,7 @@ export function YourTurn({
             technique_id: focusedContext.techniqueId ?? null,
             action_slot: 'focused',
           },
-          kwargs: { effort_level: effortLevel },
+          kwargs: { effort_level: effortLevel, ...targetKwargs },
         })
       );
     }
@@ -501,6 +530,7 @@ export function YourTurn({
             setFocusedContext(next);
           }}
           readOnly={isLocked}
+          targets={focusedTargets}
         />
       </div>
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -15261,10 +15261,12 @@ export interface components {
        *     ``True`` when this action's linked ``CombatRoundAction`` targeted an
        *     opponent that is now ``DEFEATED`` — the dominant load-bearing outcome the
        *     detail panel highlights. Reads ONLY prefetched data (the linked action's
-       *     ``combat_round_actions`` + ``focused_opponent_target``); no condition or
+       *     ``cached_round_actions`` + ``focused_opponent_target``); no condition or
        *     vitals queries, so it stays N+1-safe. The prefetch is set up in
-       *     ``interaction_views`` (``action_interaction__combat_round_actions`` with
-       *     ``focused_opponent_target`` select_related).
+       *     ``interaction_views`` as
+       *     ``action_links__action_interaction__combat_round_actions`` with
+       *     ``to_attr="cached_round_actions"`` and ``focused_opponent_target``
+       *     select_related, so reading ``cached_round_actions`` never queries.
        */
       readonly has_critical_effect: boolean;
     };

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -15178,6 +15178,18 @@ export interface components {
       /** @description Display order within the pose (low values render first). */
       ordering?: number;
       readonly action_interaction: components['schemas']['InlineActionInteraction'];
+      /**
+       * @description Cheap critical signal for first-paint auto-expand (#996).
+       *
+       *     ``True`` when this action's linked ``CombatRoundAction`` targeted an
+       *     opponent that is now ``DEFEATED`` — the dominant load-bearing outcome the
+       *     detail panel highlights. Reads ONLY prefetched data (the linked action's
+       *     ``combat_round_actions`` + ``focused_opponent_target``); no condition or
+       *     vitals queries, so it stays N+1-safe. The prefetch is set up in
+       *     ``interaction_views`` (``action_interaction__combat_round_actions`` with
+       *     ``focused_opponent_target`` select_related).
+       */
+      readonly has_critical_effect: boolean;
     };
     /** @description Serializes the InteractionAction bridge for the action_links field on a POSE. */
     InteractionActionLinkRequest: {
@@ -16515,6 +16527,7 @@ export interface components {
      */
     Opponent: {
       readonly id: number;
+      readonly objectdb_id: number | null;
       name: string;
       description?: string;
       tier: components['schemas']['OpponentTierEnum'];

--- a/frontend/src/scenes/components/PoseUnit.test.tsx
+++ b/frontend/src/scenes/components/PoseUnit.test.tsx
@@ -186,6 +186,64 @@ describe('PoseUnit', () => {
     expect(screen.queryByTestId('pose-unit-detail-panel')).toBeNull();
   });
 
+  it('auto-expands the detail panel on first paint when a link is critical (#996)', () => {
+    const interaction = makeInteraction({
+      mode: 'pose',
+      content: 'A decisive blow.',
+      action_links: [
+        {
+          id: 100,
+          ordering: 0,
+          has_critical_effect: true,
+          action_interaction: {
+            id: 201,
+            content: '[Strike] using Tidal Fury -- Critical',
+            mode: 'action',
+            timestamp: '2026-01-01T00:00:01Z',
+          },
+        },
+      ],
+    });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    // Panel is visible WITHOUT any click.
+    expect(screen.getByTestId('pose-unit-detail-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('pose-unit-detail-panel')).toHaveTextContent('201');
+  });
+
+  it('stays collapsed on first paint when no link is critical', () => {
+    const interaction = makeInteraction({
+      mode: 'pose',
+      content: 'A glancing blow.',
+      action_links: [
+        {
+          id: 100,
+          ordering: 0,
+          has_critical_effect: false,
+          action_interaction: {
+            id: 201,
+            content: '[Strike] using Tidal Fury -- Partial',
+            mode: 'action',
+            timestamp: '2026-01-01T00:00:01Z',
+          },
+        },
+      ],
+    });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('pose-unit-detail-panel')).toBeNull();
+  });
+
   it('calls onAddTarget on double-click of persona name', () => {
     const onAddTarget = vi.fn();
     const interaction = makeInteraction({ mode: 'pose' });

--- a/frontend/src/scenes/components/PoseUnit.tsx
+++ b/frontend/src/scenes/components/PoseUnit.tsx
@@ -92,11 +92,13 @@ export interface PoseUnitProps {
 }
 
 export function PoseUnit({ interaction, sceneId, onAddTarget, onAttachAction }: PoseUnitProps) {
-  const [expanded, setExpanded] = useState(false);
-
   const isAction = interaction.mode === 'action';
   const actionLinks = interaction.action_links ?? [];
   const hasLinks = actionLinks.length > 0;
+
+  // Auto-expand on first paint when a linked action had a critical outcome
+  // (e.g. it defeated its focused opponent) so players don't miss it (#996).
+  const [expanded, setExpanded] = useState(() => actionLinks.some((l) => l.has_critical_effect));
 
   const actionInteractionIds = actionLinks.map((l) => l.action_interaction.id);
 

--- a/frontend/src/scenes/types.ts
+++ b/frontend/src/scenes/types.ts
@@ -64,6 +64,12 @@ export interface ActionLink {
   id: number;
   ordering: number;
   action_interaction: InlineActionInteraction;
+  /**
+   * Cheap critical-outcome signal (#996): true when the linked action defeated
+   * its focused opponent. Drives first-paint auto-expand of the detail panel.
+   * Optional for fixture/cache leniency — absent is treated as non-critical.
+   */
+  has_critical_effect?: boolean;
 }
 
 /** One selectable reaction chip on a window (#904). */

--- a/src/schema.json
+++ b/src/schema.json
@@ -27413,10 +27413,12 @@ components:
             ``True`` when this action's linked ``CombatRoundAction`` targeted an
             opponent that is now ``DEFEATED`` — the dominant load-bearing outcome the
             detail panel highlights. Reads ONLY prefetched data (the linked action's
-            ``combat_round_actions`` + ``focused_opponent_target``); no condition or
+            ``cached_round_actions`` + ``focused_opponent_target``); no condition or
             vitals queries, so it stays N+1-safe. The prefetch is set up in
-            ``interaction_views`` (``action_interaction__combat_round_actions`` with
-            ``focused_opponent_target`` select_related).
+            ``interaction_views`` as
+            ``action_links__action_interaction__combat_round_actions`` with
+            ``to_attr="cached_round_actions"`` and ``focused_opponent_target``
+            select_related, so reading ``cached_round_actions`` never queries.
           readOnly: true
       required:
       - action_interaction

--- a/src/schema.json
+++ b/src/schema.json
@@ -27301,8 +27301,22 @@ components:
           allOf:
           - $ref: '#/components/schemas/InlineActionInteraction'
           readOnly: true
+        has_critical_effect:
+          type: boolean
+          description: |-
+            Cheap critical signal for first-paint auto-expand (#996).
+
+            ``True`` when this action's linked ``CombatRoundAction`` targeted an
+            opponent that is now ``DEFEATED`` — the dominant load-bearing outcome the
+            detail panel highlights. Reads ONLY prefetched data (the linked action's
+            ``combat_round_actions`` + ``focused_opponent_target``); no condition or
+            vitals queries, so it stays N+1-safe. The prefetch is set up in
+            ``interaction_views`` (``action_interaction__combat_round_actions`` with
+            ``focused_opponent_target`` select_related).
+          readOnly: true
       required:
       - action_interaction
+      - has_critical_effect
       - id
     InteractionActionLinkRequest:
       type: object
@@ -29985,6 +29999,10 @@ components:
         id:
           type: integer
           readOnly: true
+        objectdb_id:
+          type: integer
+          readOnly: true
+          nullable: true
         name:
           type: string
           maxLength: 200
@@ -30060,6 +30078,7 @@ components:
       - id
       - max_health
       - name
+      - objectdb_id
       - probing_threshold
       - soak_value
       - thumbnail_media_url

--- a/src/world/combat/round_context.py
+++ b/src/world/combat/round_context.py
@@ -39,7 +39,12 @@ from actions.errors import ActionDispatchError
 from actions.round_context import RoundContext
 from world.character_sheets.models import CharacterSheet
 from world.combat.constants import EncounterStatus, ParticipantStatus
-from world.combat.models import CombatParticipant, CombatRoundAction, RoundChallengeDeclaration
+from world.combat.models import (
+    CombatOpponent,
+    CombatParticipant,
+    CombatRoundAction,
+    RoundChallengeDeclaration,
+)
 
 # Encounter statuses that represent an ongoing (non-completed) combat.
 _ACTIVE_ENCOUNTER_STATUSES: frozenset[str] = frozenset(
@@ -177,8 +182,7 @@ class CombatRoundContext(RoundContext):
 
         if slot == CombatActionSlot.FOCUSED:
             focused = technique
-            opponent_target = kwargs.get("focused_opponent_target")
-            ally_target = kwargs.get("focused_ally_target")
+            opponent_target, ally_target = self._resolve_focused_targets(kwargs)
             # XOR authority lives on the backend: the just-declared focused action
             # WINS over any previously-declared passive in the same category, so we
             # clear that colliding passive before declare_action validates. This
@@ -215,6 +219,48 @@ class CombatRoundContext(RoundContext):
             social_passive=social,
             mental_passive=mental,
         )
+
+    def _resolve_focused_targets(
+        self,
+        kwargs: dict[str, Any],
+    ) -> tuple[CombatOpponent | None, CombatParticipant | None]:
+        """Resolve the focused target ids supplied by the player dispatch.
+
+        The frontend sends ``focused_opponent_target_id`` (a ``CombatOpponent`` PK)
+        or ``focused_ally_target_id`` (a ``CombatParticipant`` PK) in the COMBAT
+        dispatch kwargs.  Both are resolved **scoped to this context's encounter**
+        so a forged/stale id from another encounter cannot be targeted.  Already-
+        resolved instance kwargs (``focused_opponent_target`` /
+        ``focused_ally_target``) take precedence when present, so direct callers
+        can pass instances.
+
+        Raises:
+            ActionDispatchError: ``UNKNOWN_ACTION_REF`` if a supplied id does not
+                resolve to an entity in this encounter.
+        """
+        opponent: CombatOpponent | None = kwargs.get("focused_opponent_target")
+        opponent_id = kwargs.get("focused_opponent_target_id")
+        if opponent is None and opponent_id is not None:
+            try:
+                opponent = CombatOpponent.objects.get(
+                    pk=opponent_id,
+                    encounter=self._encounter,
+                )
+            except CombatOpponent.DoesNotExist as exc:
+                raise ActionDispatchError(ActionDispatchError.UNKNOWN_ACTION_REF) from exc
+
+        ally: CombatParticipant | None = kwargs.get("focused_ally_target")
+        ally_id = kwargs.get("focused_ally_target_id")
+        if ally is None and ally_id is not None:
+            try:
+                ally = CombatParticipant.objects.get(
+                    pk=ally_id,
+                    encounter=self._encounter,
+                )
+            except CombatParticipant.DoesNotExist as exc:
+                raise ActionDispatchError(ActionDispatchError.UNKNOWN_ACTION_REF) from exc
+
+        return opponent, ally
 
     @transaction.atomic
     def _record_challenge_declaration(

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -102,11 +102,18 @@ class OpponentSerializer(serializers.ModelSerializer):
     active_conditions = serializers.SerializerMethodField()
     thumbnail_url = serializers.SerializerMethodField()
     thumbnail_media_url = serializers.SerializerMethodField()
+    # The in-world ObjectDB pk, distinct from this opponent's own pk (``id``).
+    # ``id`` is the CombatOpponent PK the focused-target dispatch sends as
+    # ``focused_opponent_target_id``; ``objectdb_id`` is the ObjectDB pk the
+    # applicable-pulls API consumes as ``target_object_id``. Plain FK column —
+    # no query. Null for opponents with no backing ObjectDB.
+    objectdb_id = serializers.IntegerField(read_only=True, allow_null=True)
 
     class Meta:
         model = CombatOpponent
         fields = [
             "id",
+            "objectdb_id",
             "name",
             "description",
             "tier",

--- a/src/world/combat/tests/test_focused_target_dispatch.py
+++ b/src/world/combat/tests/test_focused_target_dispatch.py
@@ -1,0 +1,193 @@
+"""Tests for single-target focused-attack dispatch (#1001a).
+
+The player dispatch carries the chosen focused target as ``focused_opponent_target_id``
+(a ``CombatOpponent`` PK) or ``focused_ally_target_id`` (a ``CombatParticipant`` PK)
+in the COMBAT dispatch ``kwargs``.  ``CombatRoundContext.record_declaration`` must
+resolve those ids — scoped to the context's own encounter (forged-id safety) — into
+model instances and persist them on the merged ``CombatRoundAction`` row, exactly as
+``actions.player_interface`` drives the live path.
+
+A pure-damage technique (``base_power``, no condition rows) REQUIRES a
+``focused_opponent_target`` (``declare_action`` raises otherwise), so a successful
+declaration of one proves the target threaded all the way through.
+"""
+
+import django.test
+
+from actions.constants import ActionBackend
+from actions.errors import ActionDispatchError
+from actions.factories import ActionTemplateFactory
+from actions.player_interface import dispatch_player_action
+from actions.round_context import get_active_round_context
+from actions.types import ActionRef, PlayerAction
+from world.combat.constants import ActionCategory, EncounterStatus, ParticipantStatus
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+)
+from world.combat.models import CombatRoundAction
+from world.fatigue.constants import EffortLevel
+from world.magic.factories import (
+    CharacterTechniqueFactory,
+    EffectTypeFactory,
+    TechniqueFactory,
+)
+from world.vitals.models import CharacterVitals
+
+
+def _damage_technique(category: str = ActionCategory.PHYSICAL) -> object:
+    """A pure-damage technique: ``base_power`` set, no condition rows.
+
+    ``declare_action`` requires a ``focused_opponent_target`` for these, so a
+    successful focused declaration proves the dispatched target id threaded through.
+    """
+    technique = TechniqueFactory(damage_profile=False, action_category=category)
+    technique.effect_type = EffectTypeFactory(base_power=10)
+    technique.save()
+    return technique
+
+
+def _combat_player_action(technique: object) -> PlayerAction:
+    ref = ActionRef(
+        backend=ActionBackend.COMBAT,
+        technique_id=technique.pk,  # type: ignore[attr-defined]
+        action_slot="focused",
+    )
+    return PlayerAction(
+        backend=ActionBackend.COMBAT,
+        display_name="Test Focused Attack",
+        ref=ref,
+    )
+
+
+class TestFocusedTargetRecordDeclaration(django.test.TestCase):
+    """``record_declaration`` resolves focused target ids scoped to the encounter."""
+
+    def setUp(self) -> None:
+        self.encounter = CombatEncounterFactory(
+            status=EncounterStatus.DECLARING,
+            round_number=1,
+        )
+        self.participant = CombatParticipantFactory(
+            encounter=self.encounter,
+            status=ParticipantStatus.ACTIVE,
+        )
+        self.sheet = self.participant.character_sheet
+        CharacterVitals.objects.create(
+            character_sheet=self.sheet,
+            health=100,
+            max_health=100,
+        )
+        self.opponent = CombatOpponentFactory(encounter=self.encounter)
+        ctx = get_active_round_context(self.sheet)
+        assert ctx is not None
+        self.ctx = ctx
+
+    def _row(self) -> CombatRoundAction:
+        row = CombatRoundAction.objects.filter(
+            participant=self.participant,
+            round_number=self.encounter.round_number,
+        ).first()
+        assert row is not None
+        return row
+
+    def test_focused_opponent_target_id_persisted(self) -> None:
+        """A damage technique with focused_opponent_target_id persists the opponent."""
+        technique = _damage_technique()
+        self.ctx.record_declaration(
+            self.sheet,
+            _combat_player_action(technique),
+            {
+                "effort_level": EffortLevel.MEDIUM,
+                "focused_opponent_target_id": self.opponent.pk,
+            },
+        )
+        row = self._row()
+        self.assertEqual(row.focused_opponent_target_id, self.opponent.pk)
+
+    def test_unknown_opponent_target_id_rejected(self) -> None:
+        """An opponent id that does not resolve in this encounter is rejected."""
+        technique = _damage_technique()
+        with self.assertRaises(ActionDispatchError):
+            self.ctx.record_declaration(
+                self.sheet,
+                _combat_player_action(technique),
+                {
+                    "effort_level": EffortLevel.MEDIUM,
+                    "focused_opponent_target_id": 999_999,
+                },
+            )
+
+    def test_opponent_target_id_from_other_encounter_rejected(self) -> None:
+        """An opponent belonging to a different encounter must not be targetable."""
+        other_encounter = CombatEncounterFactory(
+            status=EncounterStatus.DECLARING,
+            round_number=1,
+        )
+        foreign_opponent = CombatOpponentFactory(encounter=other_encounter)
+        technique = _damage_technique()
+        with self.assertRaises(ActionDispatchError):
+            self.ctx.record_declaration(
+                self.sheet,
+                _combat_player_action(technique),
+                {
+                    "effort_level": EffortLevel.MEDIUM,
+                    "focused_opponent_target_id": foreign_opponent.pk,
+                },
+            )
+
+
+class TestFocusedTargetEndToEnd(django.test.TestCase):
+    """Drive the REAL ``dispatch_player_action`` entry point with a target id."""
+
+    def setUp(self) -> None:
+        from evennia.utils.idmapper import models as idmapper_models
+
+        idmapper_models.flush_cache()
+
+        self.encounter = CombatEncounterFactory(
+            status=EncounterStatus.DECLARING,
+            round_number=1,
+        )
+        self.participant = CombatParticipantFactory(
+            encounter=self.encounter,
+            status=ParticipantStatus.ACTIVE,
+        )
+        self.sheet = self.participant.character_sheet
+        self.character = self.sheet.character
+        CharacterVitals.objects.create(
+            character_sheet=self.sheet,
+            health=100,
+            max_health=100,
+        )
+        self.opponent = CombatOpponentFactory(encounter=self.encounter)
+
+    def test_focused_opponent_target_threads_through_dispatch(self) -> None:
+        """A targeted damage technique dispatched end-to-end persists the opponent."""
+        technique = TechniqueFactory(damage_profile=False, action_category=ActionCategory.PHYSICAL)
+        technique.effect_type = EffectTypeFactory(base_power=10)
+        technique.action_template = ActionTemplateFactory()
+        technique.save()
+        CharacterTechniqueFactory(character=self.sheet, technique=technique)
+
+        ref = ActionRef(
+            backend=ActionBackend.COMBAT,
+            technique_id=technique.pk,
+            action_slot="focused",
+        )
+        dispatch_player_action(
+            self.character,
+            ref,
+            {
+                "effort_level": EffortLevel.MEDIUM,
+                "focused_opponent_target_id": self.opponent.pk,
+            },
+        )
+
+        row = CombatRoundAction.objects.filter(
+            participant=self.participant,
+            round_number=self.encounter.round_number,
+        ).first()
+        assert row is not None
+        self.assertEqual(row.focused_opponent_target_id, self.opponent.pk)

--- a/src/world/scenes/interaction_serializers.py
+++ b/src/world/scenes/interaction_serializers.py
@@ -27,10 +27,39 @@ class InteractionActionLinkSerializer(serializers.ModelSerializer):
     """Serializes the InteractionAction bridge for the action_links field on a POSE."""
 
     action_interaction = InlineActionInteractionSerializer(read_only=True)
+    has_critical_effect = serializers.SerializerMethodField()
 
     class Meta:
         model = InteractionAction
-        fields = ["id", "ordering", "action_interaction"]
+        fields = ["id", "ordering", "action_interaction", "has_critical_effect"]
+
+    def get_has_critical_effect(self, obj: InteractionAction) -> bool:
+        """Cheap critical signal for first-paint auto-expand (#996).
+
+        ``True`` when this action's linked ``CombatRoundAction`` targeted an
+        opponent that is now ``DEFEATED`` — the dominant load-bearing outcome the
+        detail panel highlights. Reads ONLY prefetched data (the linked action's
+        ``cached_round_actions`` + ``focused_opponent_target``); no condition or
+        vitals queries, so it stays N+1-safe. The prefetch is set up in
+        ``interaction_views`` as
+        ``action_links__action_interaction__combat_round_actions`` with
+        ``to_attr="cached_round_actions"`` and ``focused_opponent_target``
+        select_related, so reading ``cached_round_actions`` never queries.
+        """
+        from world.combat.constants import OpponentStatus  # noqa: PLC0415
+
+        action_interaction = obj.action_interaction
+        if action_interaction is None:
+            return False
+        # cached_round_actions is a Prefetch(to_attr=...) attribute set by the
+        # interaction_views queryset; getattr with a default keeps serialization
+        # safe if this serializer is ever used without that prefetch.
+        round_actions = getattr(action_interaction, "cached_round_actions", [])  # noqa: GETATTR_LITERAL
+        for round_action in round_actions:
+            opponent = round_action.focused_opponent_target
+            if opponent is not None and opponent.status == OpponentStatus.DEFEATED:
+                return True
+        return False
 
 
 class InteractionReceiverSerializer(serializers.ModelSerializer):

--- a/src/world/scenes/interaction_views.py
+++ b/src/world/scenes/interaction_views.py
@@ -91,6 +91,10 @@ class InteractionViewSet(
         return context
 
     def get_queryset(self) -> QuerySet[Interaction]:
+        # Deferred: world.combat imports world.scenes at module scope elsewhere;
+        # importing CombatRoundAction lazily keeps this view free of an import cycle.
+        from world.combat.models import CombatRoundAction  # noqa: PLC0415
+
         base_qs = Interaction.objects.select_related(
             "persona__character_sheet",
             "persona__character_sheet__roster_entry",
@@ -122,6 +126,18 @@ class InteractionViewSet(
                 "action_links",
                 queryset=InteractionAction.objects.select_related("action_interaction"),
                 to_attr="cached_action_links",
+            ),
+            # has_critical_effect (#996): attach each linked ACTION's
+            # CombatRoundAction(s) + focused opponent to the action_interaction
+            # instances as `cached_round_actions`. A separate top-level path
+            # prefetch (not nested inside the to_attr queryset above, where a
+            # two-hop prefetch through the select_related forward FK fails to
+            # attach). SharedMemoryModel shares instances by pk, so this lands on
+            # the very same action_interaction objects cached_action_links exposes.
+            Prefetch(
+                "action_links__action_interaction__combat_round_actions",
+                queryset=CombatRoundAction.objects.select_related("focused_opponent_target"),
+                to_attr="cached_round_actions",
             ),
             Prefetch(
                 "reaction_windows",

--- a/src/world/scenes/tests/test_action_link_critical.py
+++ b/src/world/scenes/tests/test_action_link_critical.py
@@ -1,0 +1,138 @@
+"""Tests for ``has_critical_effect`` on the action-link payload (#996).
+
+The pose feed exposes a cheap per-action-link flag so the frontend can
+auto-expand the outcome detail panel on first paint when a linked action had a
+load-bearing (critical) outcome — currently: it defeated its focused opponent.
+
+The signal MUST be derived purely from prefetched data (the linked ACTION's
+``combat_round_actions`` + their ``focused_opponent_target``); it must not add a
+query per action link.
+"""
+
+from __future__ import annotations
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import OpponentStatus
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+    CombatRoundActionFactory,
+)
+from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
+from world.scenes.constants import InteractionMode, ScenePrivacyMode
+from world.scenes.factories import InteractionFactory, PersonaFactory, SceneFactory
+from world.scenes.models import Interaction, InteractionAction
+
+
+class ActionLinkCriticalEffectTests(APITestCase):
+    """``has_critical_effect`` reflects opponent-defeat on the linked action."""
+
+    def setUp(self) -> None:
+        from evennia.utils.idmapper import models as idmapper_models
+
+        idmapper_models.flush_cache()
+
+        # Identity chain so the authenticated account "owns" the pose persona
+        # (own-persona interactions always appear in the feed).
+        self.account = AccountFactory()
+        self.character = CharacterFactory()
+        self.roster_entry = RosterEntryFactory(character_sheet__character=self.character)
+        self.player_data = PlayerDataFactory(account=self.account)
+        self.tenure = RosterTenureFactory(
+            player_data=self.player_data,
+            roster_entry=self.roster_entry,
+        )
+        self.sheet = CharacterSheetFactory(character=self.character)
+        self.persona = self.sheet.primary_persona
+        # ACTION interactions use a persona the account does NOT own AND live in
+        # a PRIVATE scene, so they never surface as their own feed rows — the feed
+        # stays at exactly the poses (isolating the per-link query count).
+        self.action_persona = PersonaFactory()
+        self.private_scene = SceneFactory(privacy_mode=ScenePrivacyMode.PRIVATE)
+
+        self.encounter = CombatEncounterFactory()
+
+        self.client.force_authenticate(user=self.account)
+
+    def _make_pose(self) -> Interaction:
+        return InteractionFactory(persona=self.persona, mode=InteractionMode.POSE)
+
+    def _add_link(self, pose: Interaction, opponent_status: str) -> None:
+        """Link ``pose`` to a fresh ACTION whose round-action targeted an opponent
+        in ``opponent_status``."""
+        opponent = CombatOpponentFactory(encounter=self.encounter, status=opponent_status)
+        action_interaction = InteractionFactory(
+            persona=self.action_persona,
+            mode=InteractionMode.ACTION,
+            scene=self.private_scene,
+        )
+        # Fresh participant per round-action: (participant, round_number) is unique.
+        participant = CombatParticipantFactory(encounter=self.encounter)
+        CombatRoundActionFactory(
+            participant=participant,
+            interaction=action_interaction,
+            interaction_timestamp=action_interaction.timestamp,
+            focused_opponent_target=opponent,
+        )
+        existing = pose.action_links.count()
+        InteractionAction.objects.create(
+            pose=pose,
+            action_interaction=action_interaction,
+            ordering=existing,
+        )
+
+    def _link_for_pose(self, results: list[dict], pose_id: int) -> dict:
+        pose_row = next(r for r in results if r["id"] == pose_id)
+        self.assertEqual(len(pose_row["action_links"]), 1)
+        return pose_row["action_links"][0]
+
+    def test_has_critical_effect_true_when_opponent_defeated(self) -> None:
+        pose = self._make_pose()
+        self._add_link(pose, OpponentStatus.DEFEATED)
+        response = self.client.get(reverse("interaction-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        link = self._link_for_pose(response.data["results"], pose.pk)
+        self.assertTrue(link["has_critical_effect"])
+
+    def test_has_critical_effect_false_when_opponent_active(self) -> None:
+        pose = self._make_pose()
+        self._add_link(pose, OpponentStatus.ACTIVE)
+        response = self.client.get(reverse("interaction-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        link = self._link_for_pose(response.data["results"], pose.pk)
+        self.assertFalse(link["has_critical_effect"])
+
+    def test_critical_flag_is_not_n_plus_one(self) -> None:
+        """has_critical_effect reads prefetched data: the linked CombatRoundActions
+        are fetched in ONE query for the whole feed, not one per action link."""
+        pose = self._make_pose()
+        self._add_link(pose, OpponentStatus.DEFEATED)
+        self._add_link(pose, OpponentStatus.DEFEATED)
+        self._add_link(pose, OpponentStatus.DEFEATED)
+        url = reverse("interaction-list")
+
+        # Warm the SharedMemoryModel identity map so the measured request reflects
+        # steady-state query behaviour, not cold-cache noise.
+        self.client.get(url)
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        pose_row = next(r for r in response.data["results"] if r["id"] == pose.pk)
+        self.assertEqual(len(pose_row["action_links"]), 3)
+
+        cra_queries = [q for q in ctx.captured_queries if "combatroundaction" in q["sql"].lower()]
+        self.assertLessEqual(
+            len(cra_queries),
+            1,
+            f"has_critical_effect issued {len(cra_queries)} CombatRoundAction queries "
+            "for 3 links — expected a single prefetch (N+1 regression).",
+        )


### PR DESCRIPTION
Completes the last combat-UI residuals: **#1001a** (single-target focused attacks) and **#996** (auto-expand pose units on critical events). The other #1001 sub-items (#1001b PC thumbnails, #1001c RoundFlow chip) and #997 already shipped in #1004.

## #1001a — full-stack single-target focused attacks
Previously the focused-attack `TargetPicker` was a Phase-5 kind-`<select>` placeholder; nothing set `focused_opponent_target` from the player dispatch (resolution fell back to by-kind).

- **Frontend** — `ActionDeclarationCard` gains an optional `targets` prop; when present (combat) the picker lists real combatants grouped opponents/allies, when omitted (scenes) it keeps the kind-only fallback. `YourTurn` derives `targets` from the encounter (active opponents + allies) and threads the chosen target into the focused dispatch as `focused_opponent_target_id` (CombatOpponent PK) / `focused_ally_target_id` (CombatParticipant PK).
- **Backend** — `CombatRoundContext.record_declaration` resolves those ids to instances **scoped to its own encounter** (forged/stale-id safety → `ActionDispatchError`) and persists them via `declare_action`. The dispatch layer stays combat-agnostic (resolution lives in the combat `RoundContext`).
- **Id-space** — `OpponentSerializer` now exposes `objectdb_id` (the ObjectDB pk) so the card maps applicable-pulls' `target_object_id` correctly — distinct from the CombatOpponent PK the dispatch uses.

## #996 — auto-expand pose units on critical events
The `is_critical` row highlight shipped in #1004; this adds the auto-expand.

- `InteractionActionLinkSerializer` exposes `has_critical_effect`: a cheap, **N+1-safe** signal (the linked `CombatRoundAction`'s `focused_opponent_target` is `DEFEATED`), derived from a `Prefetch(to_attr="cached_round_actions")` attached to the same idmapped `action_interaction` the `cached_action_links` serializer reads — no condition/vitals queries.
- `PoseUnit` initialises its expanded state from `action_links.some(l => l.has_critical_effect)`.

## Tests
- Backend: `test_focused_target_dispatch.py` (persist + forged-id rejection + e2e dispatch), `test_action_link_critical.py` (true/false + N+1 guard asserting a single `CombatRoundAction` query for 3 links). `world.combat` (935) + `world.scenes` fast tiers green.
- Frontend: target-picker rendering/selection/clear, focused-dispatch kwargs threading, PoseUnit auto-expand on/off. typecheck + lint + `pnpm build` green.

No migration (no model fields changed). `schema.json` + `api.d.ts` regenerated.

Closes #996
Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)