### PR TITLE
Mission-offer policy enrichment: era arc-replace + org-reputation count input (follow-up to #726)

### DIFF
--- a/docs/roadmap/missions.md
+++ b/docs/roadmap/missions.md
@@ -31,7 +31,8 @@ Missions are branching narrative quest chains — the primary way characters int
 - **Per-candidate overrides STORED BUT UNCONSUMED** (Phase D wires per-candidate emission; the mission roulette reveal #933 couples to it).
 - **Instanced play**: `spawn_instanced_room` wiring is #886 (prison/ransom #931 is its flagship consumer).
 - **Trigger-giver target picker**: #882. **Categorical room binding**: #888.
-- **POOL count policy**: #726 ✅ shipped — `offer_policy.mission_pool_count` scales the POOL slate by NPC standing (stranger → 1, trusted → 5, wired into the live interaction render); `has_completed_mission` predicate leaf gates chained missions; `MissionOfferDetails.draw_priority` surfaces chain/high-stakes offers ahead of the general pool. Deferred follow-ups: era/`percent_replace` per-slot arc-replace, and org-reputation as a count input.
+- **POOL count policy**: #726 ✅ shipped — `offer_policy.mission_pool_count` scales the POOL slate by NPC standing (stranger → 1, trusted → 5, wired into the live interaction render); `has_completed_mission` predicate leaf gates chained missions; `MissionOfferDetails.draw_priority` surfaces chain/high-stakes offers ahead of the general pool.
+- **Offer-policy enrichment**: #1020 ✅ shipped — org-reputation folded into the count (`max(npc_standing, org)` when the role fronts an org); Era arc-replace draws active-season offers (`created_in_era` + `percent_replace`) ahead of the general pool, behind explicit chains. Ordering/bands live in `npc_services/constants.py` for playtest retuning.
 - **Zero seed content**: a fresh DB has no missions (part of the seed/content pass).
 
 ## Notes

--- a/src/world/missions/tests/test_1020_offer_policy_enrichment.py
+++ b/src/world/missions/tests/test_1020_offer_policy_enrichment.py
@@ -1,0 +1,190 @@
+"""Tests for the #1020 mission-offer policy enrichment.
+
+Two dimensions layered onto the #726 POOL policy:
+
+- **Org-reputation count input** — ``mission_pool_count`` lifts the slate by the
+  persona's ``OrganizationReputation`` tier when the role fronts an org
+  (``NPCRole.faction_affiliation``); the final count is
+  ``max(npc_standing_count, org_count)``.
+- **Era arc-replace** — active-Era ("season") offers whose ``percent_replace``
+  roll wins are drawn ahead of the general pool, behind explicit
+  ``draw_priority`` chains. Randomness is exercised at the deterministic
+  0 / 100 boundaries.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.missions.factories import MissionNodeFactory, MissionTemplateFactory
+from world.npc_services.constants import DrawMode, OfferKind
+from world.npc_services.factories import (
+    MissionOfferDetailsFactory,
+    NPCRoleFactory,
+    NPCServiceOfferFactory,
+    NPCStandingFactory,
+)
+from world.npc_services.models import NPCServiceOffer
+from world.npc_services.offer_policy import mission_pool_count
+from world.npc_services.services import _arc_offer_wins, _draw_pool_offers
+from world.scenes.factories import PersonaFactory
+from world.societies.factories import OrganizationFactory, OrganizationReputationFactory
+from world.stories.constants import EraStatus
+from world.stories.factories import EraFactory
+
+
+def _make_pc():
+    """Character + sheet → its auto-created PRIMARY persona."""
+    character = CharacterFactory()
+    sheet = CharacterSheetFactory(character=character)
+    return character, sheet.primary_persona
+
+
+def _make_offer(role, *, label, era=None, percent_replace=0, draw_priority=0):
+    """POOL-mode MISSION offer with a controllable template era / percent_replace."""
+    template = MissionTemplateFactory(created_in_era=era, percent_replace=percent_replace)
+    MissionNodeFactory(template=template, key="entry", is_entry=True)
+    offer = NPCServiceOfferFactory(
+        role=role,
+        kind=OfferKind.MISSION,
+        label=label,
+        draw_mode=DrawMode.POOL,
+    )
+    MissionOfferDetailsFactory(offer=offer, mission_template=template, draw_priority=draw_priority)
+    return offer
+
+
+def _pool_offers(role):
+    return list(NPCServiceOffer.objects.filter(role=role, draw_mode=DrawMode.POOL).order_by("pk"))
+
+
+class OrgReputationCountTests(TestCase):
+    """``mission_pool_count`` folds org reputation in via ``max(npc, org)``."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.character, cls.pc_persona = _make_pc()
+        cls.npc = PersonaFactory()
+        cls.org = OrganizationFactory()
+        cls.role = NPCRoleFactory(faction_affiliation=cls.org)
+        cls.role_no_org = NPCRoleFactory()  # faction_affiliation is None
+
+    def test_no_affiliation_skips_org_path(self):
+        self.assertEqual(
+            mission_pool_count(role=self.role_no_org, persona=self.pc_persona, npc_persona=None), 1
+        )
+
+    def test_affiliated_role_no_rep_row_is_floor(self):
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=None), 1
+        )
+
+    def test_unknown_tier_gives_no_lift(self):
+        # value 0 → UNKNOWN tier (rank 4, below the FAVORED floor) → count 1.
+        OrganizationReputationFactory(persona=self.pc_persona, organization=self.org, value=0)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=None), 1
+        )
+
+    def test_favored_tier_lifts_count(self):
+        # value 150 → FAVORED (rank 5) → org band 2.
+        OrganizationReputationFactory(persona=self.pc_persona, organization=self.org, value=150)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=None), 2
+        )
+
+    def test_revered_tier_full_slate(self):
+        # value 900 → REVERED (rank 8) → org band 5.
+        OrganizationReputationFactory(persona=self.pc_persona, organization=self.org, value=900)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=None), 5
+        )
+
+    def test_max_of_npc_and_org_takes_npc(self):
+        # NPC affection 25 → 3; org FAVORED → 2; max == 3.
+        NPCStandingFactory(persona=self.pc_persona, npc_persona=self.npc, affection=25)
+        OrganizationReputationFactory(persona=self.pc_persona, organization=self.org, value=150)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=self.npc), 3
+        )
+
+    def test_max_of_npc_and_org_takes_org(self):
+        # No NPC standing → 1; org REVERED → 5; max == 5.
+        OrganizationReputationFactory(persona=self.pc_persona, organization=self.org, value=900)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=self.npc), 5
+        )
+
+
+class ArcOfferWinTests(TestCase):
+    """``_arc_offer_wins`` — the deterministic 0 / 100 roll boundaries."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.role = NPCRoleFactory()
+        cls.era = EraFactory(status=EraStatus.ACTIVE)
+        cls.other_era = EraFactory(name="other", status=EraStatus.CONCLUDED)
+
+    def test_percent_100_always_wins(self):
+        offer = _make_offer(self.role, label="arc", era=self.era, percent_replace=100)
+        self.assertTrue(_arc_offer_wins(offer, self.era.pk))
+
+    def test_percent_0_never_wins(self):
+        offer = _make_offer(self.role, label="arc0", era=self.era, percent_replace=0)
+        self.assertFalse(_arc_offer_wins(offer, self.era.pk))
+
+    def test_offer_from_other_era_never_wins(self):
+        offer = _make_offer(self.role, label="old", era=self.other_era, percent_replace=100)
+        self.assertFalse(_arc_offer_wins(offer, self.era.pk))
+
+    def test_offer_with_no_era_never_wins(self):
+        offer = _make_offer(self.role, label="eraless", era=None, percent_replace=100)
+        self.assertFalse(_arc_offer_wins(offer, self.era.pk))
+
+
+class ArcReplaceDrawTests(TestCase):
+    """Arc winners draw ahead of the general pool, behind explicit chains."""
+
+    def setUp(self):
+        self.role = NPCRoleFactory()
+
+    def test_no_active_era_is_noop(self):
+        # Arc-eligible template but no ACTIVE era → drawn as plain general pool.
+        upcoming = EraFactory(status=EraStatus.UPCOMING)
+        _make_offer(self.role, label="arc", era=upcoming, percent_replace=100)
+        for i in range(4):
+            _make_offer(self.role, label=f"gen-{i}")
+        drawn = _draw_pool_offers(_pool_offers(self.role), 5)
+        self.assertEqual(len(drawn), 5)  # all five, no error, no special ordering
+
+    def test_arc_winner_outranks_general_pool(self):
+        era = EraFactory(status=EraStatus.ACTIVE)
+        arc = _make_offer(self.role, label="arc", era=era, percent_replace=100)
+        for i in range(5):
+            _make_offer(self.role, label=f"gen-{i}")
+        # One slot: the always-winning arc offer is promoted over the general pool.
+        for _ in range(20):
+            self.assertEqual(_draw_pool_offers(_pool_offers(self.role), 1), [arc])
+
+    def test_chain_priority_outranks_arc_winner(self):
+        era = EraFactory(status=EraStatus.ACTIVE)
+        chain = _make_offer(self.role, label="chain", draw_priority=5)  # not arc
+        _make_offer(self.role, label="arc", era=era, percent_replace=100)
+        for i in range(3):
+            _make_offer(self.role, label=f"gen-{i}")
+        # One slot: explicit chain beats the arc winner.
+        for _ in range(20):
+            self.assertEqual(_draw_pool_offers(_pool_offers(self.role), 1), [chain])
+
+    def test_arc_winner_and_chain_both_included_when_slots_allow(self):
+        era = EraFactory(status=EraStatus.ACTIVE)
+        chain = _make_offer(self.role, label="chain", draw_priority=5)
+        arc = _make_offer(self.role, label="arc", era=era, percent_replace=100)
+        for i in range(4):
+            _make_offer(self.role, label=f"gen-{i}")
+        # Two slots: chain (tier 1) then arc winner (tier 2), general never reached.
+        for _ in range(20):
+            drawn = _draw_pool_offers(_pool_offers(self.role), 2)
+            self.assertEqual(set(drawn), {chain, arc})

--- a/src/world/missions/tests/test_726_offer_pool_policy.py
+++ b/src/world/missions/tests/test_726_offer_pool_policy.py
@@ -75,37 +75,56 @@ class MissionPoolCountTests(TestCase):
     def setUpTestData(cls):
         cls.character, cls.pc_persona = _make_pc()
         cls.npc = PersonaFactory()
+        # A role with no org affiliation isolates the NPC-standing input
+        # (org count falls back to the floor, so max() is a no-op here).
+        cls.role = NPCRoleFactory()
 
     def test_class1_functionary_gets_floor(self):
         # npc_persona is None → no standing surface → one trial job.
-        self.assertEqual(mission_pool_count(persona=self.pc_persona, npc_persona=None), 1)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=None), 1
+        )
 
     def test_no_standing_row_gets_floor(self):
-        self.assertEqual(mission_pool_count(persona=self.pc_persona, npc_persona=self.npc), 1)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=self.npc), 1
+        )
 
     def test_neutral_affection_gets_floor(self):
         NPCStandingFactory(persona=self.pc_persona, npc_persona=self.npc, affection=0)
-        self.assertEqual(mission_pool_count(persona=self.pc_persona, npc_persona=self.npc), 1)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=self.npc), 1
+        )
 
     def test_negative_affection_gets_floor(self):
         NPCStandingFactory(persona=self.pc_persona, npc_persona=self.npc, affection=-40)
-        self.assertEqual(mission_pool_count(persona=self.pc_persona, npc_persona=self.npc), 1)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=self.npc), 1
+        )
 
     def test_lower_band_boundary(self):
         NPCStandingFactory(persona=self.pc_persona, npc_persona=self.npc, affection=10)
-        self.assertEqual(mission_pool_count(persona=self.pc_persona, npc_persona=self.npc), 2)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=self.npc), 2
+        )
 
     def test_mid_band(self):
         NPCStandingFactory(persona=self.pc_persona, npc_persona=self.npc, affection=25)
-        self.assertEqual(mission_pool_count(persona=self.pc_persona, npc_persona=self.npc), 3)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=self.npc), 3
+        )
 
     def test_just_below_a_band_uses_lower_band(self):
         NPCStandingFactory(persona=self.pc_persona, npc_persona=self.npc, affection=49)
-        self.assertEqual(mission_pool_count(persona=self.pc_persona, npc_persona=self.npc), 3)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=self.npc), 3
+        )
 
     def test_ceiling_clamp(self):
         NPCStandingFactory(persona=self.pc_persona, npc_persona=self.npc, affection=10_000)
-        self.assertEqual(mission_pool_count(persona=self.pc_persona, npc_persona=self.npc), 5)
+        self.assertEqual(
+            mission_pool_count(role=self.role, persona=self.pc_persona, npc_persona=self.npc), 5
+        )
 
 
 class DrawPriorityTests(TestCase):
@@ -159,7 +178,7 @@ class StandingDrivenCountIntegrationTests(TestCase):
             _make_mission_offer(self.role, label=f"pool-{i}")
 
     def _pool_count_listed(self, persona, character):
-        count = mission_pool_count(persona=persona, npc_persona=self.npc)
+        count = mission_pool_count(role=self.role, persona=persona, npc_persona=self.npc)
         session = start_interaction(
             role=self.role, persona=persona, character=character, npc_persona=self.npc
         )

--- a/src/world/npc_services/constants.py
+++ b/src/world/npc_services/constants.py
@@ -33,3 +33,18 @@ MISSION_POOL_COUNT_BANDS: tuple[tuple[int, int], ...] = (
     (50, 4),  # confidant
     (100, 5),  # inner circle — full slate
 )
+
+# #1020 — org-reputation lift to the POOL count for NPCs that front an org
+# (``NPCRole.faction_affiliation``). Keyed on the persona's ReputationTier
+# *rank* — the declaration order of ``societies.types.ReputationTier``
+# (reviled=0 … unknown=4 … revered=8). Walked like MISSION_POOL_COUNT_BANDS
+# (highest met floor wins). The final POOL count is
+# ``max(npc-standing count, org count)``, so org favor lifts the floor without
+# capping a personally-cultivated contact. Tuning values — adjust freely.
+MISSION_POOL_ORG_COUNT_BANDS: tuple[tuple[int, int], ...] = (
+    (0, 1),  # reviled..unknown — org connection alone gives no slate lift
+    (5, 2),  # favored
+    (6, 3),  # liked
+    (7, 4),  # honored
+    (8, 5),  # revered
+)

--- a/src/world/npc_services/offer_policy.py
+++ b/src/world/npc_services/offer_policy.py
@@ -1,12 +1,18 @@
-"""POOL-draw count policy for mission offers (#726).
+"""POOL-draw count policy for mission offers (#726, #1020).
 
 The unified offer machinery (``services.available_offers``) samples POOL-mode
 offers down to a ``pool_count`` when one is supplied; historically the live
 caller passed ``None`` (show every eligible offer), so the standing-driven count
 the design called for never ran. This module owns the *how many*: it reads the
-PC's durable standing with the NPC and maps it through the
-``MISSION_POOL_COUNT_BANDS`` tiers so a stranger sees one trial job and a trusted
-contact sees a full slate.
+PC's durable standing and maps it through count bands so a stranger sees one
+trial job and a trusted contact sees a full slate.
+
+Two standing inputs (#1020): the per-NPC ``NPCStanding.affection`` and — when
+the role fronts an organization (``NPCRole.faction_affiliation``) — the
+persona's ``OrganizationReputation`` tier with that org. The final count is the
+``max`` of the two, so org favor lifts the slate from *any* of that org's
+functionaries even with no personal standing, while a personally-cultivated
+contact still lifts it on their own.
 
 Deliberately narrow. *Which* missions and *what tier* stay in the predicate
 system (an offer's ``eligibility_rule`` — ``min_npc_standing``,
@@ -22,24 +28,50 @@ from typing import TYPE_CHECKING
 from world.npc_services.constants import (
     MISSION_POOL_COUNT_BANDS,
     MISSION_POOL_COUNT_FLOOR,
+    MISSION_POOL_ORG_COUNT_BANDS,
 )
 from world.npc_services.models import NPCStanding
+from world.societies.models import OrganizationReputation
+from world.societies.types import ReputationTier
 
 if TYPE_CHECKING:
+    from world.npc_services.models import NPCRole
     from world.scenes.models import Persona
 
+# Tier → rank from the source enum's declaration order (reviled=0 … revered=8).
+# Derived, not duplicated, so a new tier in ``societies.types`` flows through.
+_TIER_RANK: dict[ReputationTier, int] = {tier: rank for rank, tier in enumerate(ReputationTier)}
 
-def mission_pool_count(*, persona: Persona, npc_persona: Persona | None) -> int:
-    """POOL offer count to surface for ``persona`` at this NPC (#726).
 
-    Class-1 nameless functionaries (``npc_persona is None``) and any PC with no
-    ``NPCStanding`` row (or neutral/negative affection) get
-    ``MISSION_POOL_COUNT_FLOOR`` — one trial job. Otherwise the count is the
-    highest ``MISSION_POOL_COUNT_BANDS`` tier whose affection floor the standing
-    meets. A single ``values_list`` read; no row → treated as affection 0.
+def mission_pool_count(*, role: NPCRole, persona: Persona, npc_persona: Persona | None) -> int:
+    """POOL offer count to surface for ``persona`` at this NPC (#726, #1020).
 
-    Org-standing as an additional input is a deferred follow-up; v1 keys on the
-    per-NPC standing only.
+    ``max`` of the per-NPC standing count and the org-reputation count (the
+    latter only when ``role`` fronts an org). Each input falls back to
+    ``MISSION_POOL_COUNT_FLOOR`` (one trial job) when absent, so the ``max`` is a
+    no-op for strangers / non-affiliated roles and behavior matches #726.
+    """
+    return max(
+        _npc_standing_count(persona, npc_persona),
+        _org_reputation_count(role, persona),
+    )
+
+
+def _band_count(bands: tuple[tuple[int, int], ...], value: int) -> int:
+    """Walk ascending ``(floor, count)`` bands; the highest met floor wins."""
+    count = MISSION_POOL_COUNT_FLOOR
+    for floor, band_count in bands:
+        if value >= floor:
+            count = band_count
+    return count
+
+
+def _npc_standing_count(persona: Persona, npc_persona: Persona | None) -> int:
+    """Count from per-NPC ``NPCStanding.affection`` (#726).
+
+    Class-1 functionaries (``npc_persona is None``) and any PC with no standing
+    row (or neutral/negative affection) land on the floor. One ``values_list``
+    read; no row → affection 0.
     """
     affection = 0
     if npc_persona is not None:
@@ -49,9 +81,25 @@ def mission_pool_count(*, persona: Persona, npc_persona: Persona | None) -> int:
             .first()
             or 0
         )
-    count = MISSION_POOL_COUNT_FLOOR
-    # Bands are ascending by floor; the last one whose floor is met wins.
-    for floor, band_count in MISSION_POOL_COUNT_BANDS:
-        if affection >= floor:
-            count = band_count
-    return count
+    return _band_count(MISSION_POOL_COUNT_BANDS, affection)
+
+
+def _org_reputation_count(role: NPCRole, persona: Persona) -> int:
+    """Count from the persona's org reputation, when ``role`` fronts an org (#1020).
+
+    No affiliation or no reputation row → floor (the ``max`` in
+    ``mission_pool_count`` then leaves the NPC-standing count untouched). One
+    indexed read, only when the role fronts an org.
+    """
+    org_id = role.faction_affiliation_id
+    if org_id is None:
+        return MISSION_POOL_COUNT_FLOOR
+    value = (
+        OrganizationReputation.objects.filter(persona=persona, organization_id=org_id)
+        .values_list("value", flat=True)
+        .first()
+    )
+    if value is None:
+        return MISSION_POOL_COUNT_FLOOR
+    tier_rank = _TIER_RANK[ReputationTier.from_value(value)]
+    return _band_count(MISSION_POOL_ORG_COUNT_BANDS, tier_rank)

--- a/src/world/npc_services/services.py
+++ b/src/world/npc_services/services.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import logging
+import random
 from typing import TYPE_CHECKING
 
 from django.db import transaction
@@ -392,37 +393,33 @@ class _WeightedOffer:
 
 
 def _draw_pool_offers(offers: list[NPCServiceOffer], count: int) -> list[NPCServiceOffer]:
-    """Priority-tiered weighted draw of up to ``count`` offers, no replacement.
+    """Ordered, weighted draw of up to ``count`` offers, without replacement.
 
-    Offers are grouped into ``draw_priority`` tiers (#726); the highest tier is
-    exhausted first with guaranteed inclusion (drawn until it empties or the
-    count is hit) before any lower tier is considered, so chain-unlock /
-    high-stakes follow-up missions surface ahead of the general pool. Within a
-    tier the draw is weighted-without-replacement on ``_weight_for_offer`` —
-    identical to the historical single-tier behaviour when every offer sits at
-    priority 0. Zero-weight offers are excluded so a row never silently
-    vanishes due to a null/zero weight.
-
-    Per-slot arc-replace (``MissionTemplate.percent_replace`` against an
-    active-Era arc pool) remains deferred — see the #726 follow-up.
+    Offers are drawn in ordered groups (see ``_ordered_draw_groups``): explicit
+    ``draw_priority`` tiers (chains / high-stakes, #726) first with guaranteed
+    inclusion, then active-Era arc-replace winners (#1020), then the general
+    pool. Each group is drawn weighted-without-replacement on
+    ``_weight_for_offer``; a group is only reached once the groups above it are
+    exhausted or the count is filled. With no priority offers and no active Era
+    this collapses to the historical single weighted draw. Zero-weight offers
+    are excluded so a row never silently vanishes due to a null/zero weight.
     """
     from world.checks.outcome_utils import select_weighted  # noqa: PLC0415
 
     if count <= 0 or not offers:
         return []
 
-    by_tier: dict[int, list[_WeightedOffer]] = {}
+    weighted: list[_WeightedOffer] = []
     for offer in offers:
         weight = _weight_for_offer(offer)
-        if weight <= 0:
-            continue
-        by_tier.setdefault(_draw_priority_for_offer(offer), []).append(
-            _WeightedOffer(offer=offer, weight=weight)
-        )
+        if weight > 0:
+            weighted.append(_WeightedOffer(offer=offer, weight=weight))
+    if not weighted:
+        return []
 
     drawn: list[NPCServiceOffer] = []
-    for tier in sorted(by_tier, reverse=True):
-        remaining = by_tier[tier]
+    for group in _ordered_draw_groups(weighted):
+        remaining = list(group)
         while remaining and len(drawn) < count:
             pick = select_weighted(remaining)
             drawn.append(pick.offer)
@@ -430,6 +427,80 @@ def _draw_pool_offers(offers: list[NPCServiceOffer], count: int) -> list[NPCServ
         if len(drawn) >= count:
             break
     return drawn
+
+
+def _ordered_draw_groups(weighted: list[_WeightedOffer]) -> list[list[_WeightedOffer]]:
+    """Order the eligible POOL offers into draw groups (#726, #1020).
+
+    1. Explicit ``draw_priority`` tiers (chains / high-stakes), highest first —
+       guaranteed inclusion.
+    2. Active-Era arc-replace winners — priority-0 offers whose
+       ``percent_replace`` roll won this render (ambient seasonal lift).
+    3. The remaining general (priority-0) pool.
+
+    Ordering is deliberately chains > arc > general: authored chains are
+    deliberate narrative wiring and must not be bumped by a season roll, while
+    arc content outranks the generic pool. The split is data-light (see
+    ``constants``) so the ordering can be retuned after playtesting.
+    """
+    priority_tiers: dict[int, list[_WeightedOffer]] = {}
+    general: list[_WeightedOffer] = []
+    for weighted_offer in weighted:
+        tier = _draw_priority_for_offer(weighted_offer.offer)
+        if tier > 0:
+            priority_tiers.setdefault(tier, []).append(weighted_offer)
+        else:
+            general.append(weighted_offer)
+
+    arc_winners, general_rest = _split_arc_winners(general)
+
+    groups = [priority_tiers[tier] for tier in sorted(priority_tiers, reverse=True)]
+    groups.append(arc_winners)
+    groups.append(general_rest)
+    return groups
+
+
+def _split_arc_winners(
+    general: list[_WeightedOffer],
+) -> tuple[list[_WeightedOffer], list[_WeightedOffer]]:
+    """Partition the general pool into active-Era arc winners and the rest (#1020).
+
+    "Arc offers" are MISSION offers whose template's ``created_in_era`` is the
+    single ACTIVE Era; each rolls its ``percent_replace`` once per render and,
+    on a win, is promoted ahead of the general pool. No active Era → no winners
+    (the #726 behaviour, at the cost of one ``Era.objects.get_active()`` probe).
+    The arc check rides the ``mission_offer_details__mission_template``
+    select_related in ``available_offers``, so it adds no per-offer query.
+    """
+    from world.stories.models import Era  # noqa: PLC0415
+
+    active_era = Era.objects.get_active()
+    if active_era is None:
+        return [], general
+    winners: list[_WeightedOffer] = []
+    rest: list[_WeightedOffer] = []
+    for weighted_offer in general:
+        bucket = winners if _arc_offer_wins(weighted_offer.offer, active_era.pk) else rest
+        bucket.append(weighted_offer)
+    return winners, rest
+
+
+def _arc_offer_wins(offer: NPCServiceOffer, active_era_pk: int) -> bool:
+    """True if ``offer`` is an active-Era arc mission that won its replace roll (#1020).
+
+    Non-MISSION offers, missing details, and templates not authored in the
+    active Era never win. ``percent_replace`` is the 0–100 win chance:
+    0 → never (``randint(1, 100) <= 0`` is always False), 100 → always.
+    """
+    if offer.kind != OfferKind.MISSION.value:
+        return False
+    try:
+        template = offer.mission_offer_details.mission_template
+    except MissionOfferDetails.DoesNotExist:
+        return False
+    if template.created_in_era_id != active_era_pk:
+        return False
+    return random.randint(1, 100) <= template.percent_replace  # noqa: S311
 
 
 def _draw_priority_for_offer(offer: NPCServiceOffer) -> int:

--- a/src/world/npc_services/views.py
+++ b/src/world/npc_services/views.py
@@ -172,6 +172,7 @@ def _serialize_state(
         available_offers(
             session,
             pool_count=mission_pool_count(
+                role=session.role,
                 persona=session.persona,
                 npc_persona=session.npc_persona,
             ),


### PR DESCRIPTION
Closes #1020

## Summary

Enriches the #726 mission-offer POOL policy along the two dimensions deferred from that PR — no new models, pure service + constants. (1) Org-reputation as a count input: `mission_pool_count` regains a `role` arg and, when the role fronts an org (`NPCRole.faction_affiliation`), folds the persona's `OrganizationReputation` tier into the count as `max(npc_standing, org)` — so org favor lifts the slate from any of that org's functionaries while a personally-cultivated contact still lifts it independently (tier rank derived from `societies.types.ReputationTier`, not duplicated). (2) Era arc-replace: `_draw_pool_offers` draws in ordered groups — explicit `draw_priority` chains first, then active-Era arc winners (template `created_in_era` == ACTIVE Era and a winning `percent_replace` roll), then the general pool; no active Era is a no-op (one indexed `get_active()` probe). Ordering/bands live in `constants.py` for playtest retuning. An adversarial 3-lens review (correctness, query/identity-map, integration) found no blockers; the only flagged item (roadmap line) is addressed in this branch. Note: the pre-existing #726 per-render `mission_pool_count` read is now up to two indexed probes when a role both fronts an org and has POOL offers — a per-request memo could erase it later if start-path query counts are tracked.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1020 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch already current with origin/main (created post-#726); no rebase needed, no migration (none added).

<!-- last-addressed-comment: 0 -->