### PR TITLE
Player mission abandon (clean) — wire MissionStatus.ABANDONED

### DIFF
--- a/docs/roadmap/missions.md
+++ b/docs/roadmap/missions.md
@@ -26,7 +26,7 @@ Missions are branching narrative quest chains — the primary way characters int
 ## Open Gaps (from the 2026-06-10 code audit; #923 economy work closes the money one)
 - **Reward sinks are stubs**: `world/missions/integrations/` — money/beat record in-memory; rumor/crime_watch raise. Money lands via economy sub-issue #932; renown is already real.
 - **No discovery surface**: no browse/board endpoint — players find missions only via NPC interaction or room triggers.
-- **No abandon/expire**: `ABANDONED`/`EXPIRED` enum values exist; nothing sets them.
+- **Abandon**: #1023 ✅ shipped — `play.abandon_mission` + `MissionJournalViewSet.abandon` let the contract holder walk away from an `ACTIVE` run (→ `ABANDONED`, frees the cap slot, keeps the giver cooldown). Auto-**expiry** was intentionally dropped (missions are private; persisting until abandoned is fine) — `EXPIRED` stays a defined-but-unused status for a possible future GM action.
 - **Multiplayer engine unwired**: JOINT/VOTE/COINFLIP orchestration is built + tested but not attached to the API — solo-only live (invite/party surface: #887).
 - **Per-candidate overrides STORED BUT UNCONSUMED** (Phase D wires per-candidate emission; the mission roulette reveal #933 couples to it).
 - **Instanced play**: `spawn_instanced_room` wiring is #886 (prison/ransom #931 is its flagship consumer).

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -8020,6 +8020,35 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/missions/journal/{id}/abandon/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description #885 — the player's mission journal + beat play loop.
+     *
+     *     list: every mission the puppeted character participates in (compass +
+     *     deeds + bookends). beat: the current node as the character sees it —
+     *     LIVE options only (location ∧ visibility; visibility=eligibility, no
+     *     greyed-out entries). resolve: take an option; the engine rolls and
+     *     routes; the actor gets clear STORY prose, the room gets a
+     *     source-ambiguous ambient stir.
+     *
+     *     Participant gating: a non-participant probing instance ids gets 404
+     *     (never 403 — existence must not leak).
+     */
+    post: operations['missions_journal_abandon_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/missions/journal/{id}/beat/': {
     parameters: {
       query?: never;
@@ -15693,6 +15722,11 @@ export interface components {
      * @enum {string}
      */
     MemberTypeEnum: 'character' | 'placeholder' | 'npc';
+    /** @description Result of the #1023 abandon endpoint — the run's id and new status. */
+    MissionAbandonResult: {
+      readonly id: number;
+      readonly status: string;
+    };
     /**
      * @description List + detail serializer for MissionCategory browse.
      *
@@ -32985,6 +33019,41 @@ export interface operations {
         content: {
           'application/json': components['schemas']['PaginatedJournalEntryList'][];
         };
+      };
+    };
+  };
+  missions_journal_abandon_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MissionAbandonResult'];
+        };
+      };
+      /** @description Run not active / not the contract holder. */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Not a participant / no such mission. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/src/schema.json
+++ b/src/schema.json
@@ -12319,6 +12319,42 @@ paths:
                 items:
                   $ref: '#/components/schemas/PaginatedJournalEntryList'
           description: ''
+  /api/missions/journal/{id}/abandon/:
+    post:
+      operationId: missions_journal_abandon_create
+      description: |-
+        #885 — the player's mission journal + beat play loop.
+
+        list: every mission the puppeted character participates in (compass +
+        deeds + bookends). beat: the current node as the character sees it —
+        LIVE options only (location ∧ visibility; visibility=eligibility, no
+        greyed-out entries). resolve: take an option; the engine rolls and
+        routes; the actor gets clear STORY prose, the room gets a
+        source-ambiguous ambient stir.
+
+        Participant gating: a non-participant probing instance ids gets 404
+        (never 403 — existence must not leak).
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - missions
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MissionAbandonResult'
+          description: ''
+        '400':
+          description: Run not active / not the contract holder.
+        '404':
+          description: Not a participant / no such mission.
   /api/missions/journal/{id}/beat/:
     get:
       operationId: missions_journal_beat_retrieve
@@ -28374,6 +28410,19 @@ components:
         * `character` - Character
         * `placeholder` - Placeholder
         * `npc` - NPC
+    MissionAbandonResult:
+      type: object
+      description: 'Result of the #1023 abandon endpoint — the run''s id and new status.'
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        status:
+          type: string
+          readOnly: true
+      required:
+      - id
+      - status
     MissionCategory:
       type: object
       description: |-

--- a/src/world/missions/serializers.py
+++ b/src/world/missions/serializers.py
@@ -584,3 +584,10 @@ class BeatResolveRequestSerializer(serializers.Serializer):
 
     option_id = serializers.IntegerField(min_value=1)
     approach_id = serializers.IntegerField(required=False, allow_null=True, min_value=1)
+
+
+class MissionAbandonResultSerializer(serializers.Serializer):
+    """Result of the #1023 abandon endpoint — the run's id and new status."""
+
+    id = serializers.IntegerField(read_only=True)
+    status = serializers.CharField(read_only=True)

--- a/src/world/missions/services/play.py
+++ b/src/world/missions/services/play.py
@@ -23,6 +23,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.db import transaction
+from django.utils import timezone
+
 from world.missions.constants import MissionStatus
 from world.missions.models import MissionDeedRecord, MissionOptionRoute, MissionParticipant
 from world.missions.services.resolution import build_option_list, resolve_option
@@ -51,8 +54,13 @@ class NotParticipantError(BeatActionError):
     """
 
 
+class AbandonMissionError(BeatActionError):
+    """An abandon request that can't proceed (not active / not contract holder)."""
+
+
 _ERR_NOT_PARTICIPANT = "You are not part of that mission."
 _ERR_NOT_ACTIVE = "That mission is no longer in progress."
+_ERR_NOT_CONTRACT_HOLDER = "Only the mission's contract holder can abandon it."
 _ERR_OPTION_NOT_LIVE = (
     "That option isn't available to you here — it may have moved on, or "
     "you may need to be somewhere else."
@@ -72,6 +80,40 @@ def participant_for(instance: MissionInstance, character: ObjectDB) -> MissionPa
     if participant is None:
         raise NotParticipantError(_ERR_NOT_PARTICIPANT)
     return participant
+
+
+def abandon_mission(instance: MissionInstance, character: ObjectDB) -> MissionInstance:
+    """Abandon an ACTIVE mission at the contract holder's request (#1023).
+
+    The player's deliberate walk-away. Mirrors the terminal write in
+    ``resolution._finish_terminal`` (status → ABANDONED, stamp ``completed_at``,
+    clear ``current_node``, tear down any spawned instanced room) but does NOT
+    fire the Beat-completion seam — abandoning is not completing — and applies
+    no standing penalty. The PC active-NPC-mission cap counts only ``ACTIVE``
+    runs, so the slot frees automatically; the giver's ``NPCRoleCooldown`` is
+    left intact so the same NPC can't be immediately re-rolled.
+
+    Contract-holder-only solo path; multiplayer vote-to-abandon rides the
+    multiplayer-engine API follow-up. Non-participant raises (404 at the view);
+    not-active / not-contract-holder raise ``AbandonMissionError`` (400).
+    """
+    participant = participant_for(instance, character)
+    if instance.status != MissionStatus.ACTIVE:
+        raise AbandonMissionError(_ERR_NOT_ACTIVE)
+    if not participant.is_contract_holder:
+        raise AbandonMissionError(_ERR_NOT_CONTRACT_HOLDER)
+    with transaction.atomic():
+        instance.status = MissionStatus.ABANDONED
+        instance.completed_at = timezone.now()
+        instance.current_node = None
+        instance.save()
+        if instance.spawned_room_id is not None:
+            # Reuse the instanced-room lifecycle service so an abandoned run
+            # doesn't strand its spawned room (mirrors resolution teardown).
+            from world.instances.services import complete_instanced_room  # noqa: PLC0415
+
+            complete_instanced_room(instance.spawned_room.objectdb)
+    return instance
 
 
 def beat_for(instance: MissionInstance, character: ObjectDB) -> BeatView | None:

--- a/src/world/missions/tests/test_1023_mission_abandon.py
+++ b/src/world/missions/tests/test_1023_mission_abandon.py
@@ -1,0 +1,160 @@
+"""Tests for #1023 — clean player mission abandon.
+
+Covers the `play.abandon_mission` service (contract-holder gate, terminal
+write, slot-freeing, spawned-room teardown) and the `MissionJournalViewSet`
+`abandon` action (200 / 400 / 404).
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import (
+    AccountFactory,
+    CharacterFactory,
+    ObjectDBFactory,
+    RoomProfileFactory,
+)
+from world.character_sheets.factories import CharacterSheetFactory
+from world.missions.constants import MissionStatus, OptionKind, OptionSource
+from world.missions.factories import (
+    MissionNodeFactory,
+    MissionOptionFactory,
+    MissionParticipantFactory,
+    MissionTemplateFactory,
+)
+from world.missions.models import MissionInstance
+from world.missions.services.play import (
+    AbandonMissionError,
+    NotParticipantError,
+    abandon_mission,
+)
+from world.missions.services.run import staff_assign_mission
+
+
+def _room(name: str):
+    room = ObjectDBFactory(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+    profile = RoomProfileFactory(objectdb=room)
+    return room, profile
+
+
+def _pc():
+    character = CharacterFactory()
+    CharacterSheetFactory(character=character)
+    return character
+
+
+def _graph(name: str):
+    """Entry node → one BRANCH option to a terminal second node."""
+    template = MissionTemplateFactory(name=name)
+    entry = MissionNodeFactory(template=template, key="entry", is_entry=True)
+    second = MissionNodeFactory(template=template, key="second")
+    MissionOptionFactory(
+        node=entry,
+        option_kind=OptionKind.BRANCH,
+        source_kind=OptionSource.AUTHORED,
+        authored_ic_framing="PLACEHOLDER take the first step",
+        branch_target=second,
+    )
+    return template
+
+
+def _assigned_active():
+    """A freshly staff-assigned ACTIVE run + its contract-holder character."""
+    character = _pc()
+    instance = staff_assign_mission(_graph("abandon-me"), character)
+    return instance, character
+
+
+class AbandonMissionServiceTests(TestCase):
+    def test_contract_holder_abandons_active(self):
+        instance, character = _assigned_active()
+        self.assertEqual(instance.status, MissionStatus.ACTIVE)
+        abandon_mission(instance, character)
+        instance.refresh_from_db()
+        self.assertEqual(instance.status, MissionStatus.ABANDONED)
+        self.assertIsNotNone(instance.completed_at)
+        self.assertIsNone(instance.current_node_id)
+
+    def test_abandon_frees_active_slot(self):
+        instance, character = _assigned_active()
+        abandon_mission(instance, character)
+        still_active = MissionInstance.objects.filter(
+            participants__character=character,
+            status=MissionStatus.ACTIVE,
+        ).count()
+        self.assertEqual(still_active, 0)
+
+    def test_non_contract_holder_cannot_abandon(self):
+        instance, _ = _assigned_active()
+        other = _pc()
+        MissionParticipantFactory(instance=instance, character=other, is_contract_holder=False)
+        with self.assertRaises(AbandonMissionError):
+            abandon_mission(instance, other)
+        instance.refresh_from_db()
+        self.assertEqual(instance.status, MissionStatus.ACTIVE)
+
+    def test_non_participant_raises(self):
+        instance, _ = _assigned_active()
+        with self.assertRaises(NotParticipantError):
+            abandon_mission(instance, _pc())
+
+    def test_already_terminal_cannot_be_abandoned(self):
+        instance, character = _assigned_active()
+        abandon_mission(instance, character)
+        instance.refresh_from_db()
+        with self.assertRaises(AbandonMissionError):
+            abandon_mission(instance, character)
+
+    def test_spawned_room_torn_down(self):
+        instance, character = _assigned_active()
+        room, profile = _room("Instanced Vault")
+        instance.spawned_room = profile
+        instance.save(update_fields=["spawned_room"])
+        with mock.patch("world.instances.services.complete_instanced_room") as teardown:
+            abandon_mission(instance, character)
+        teardown.assert_called_once_with(room)
+
+    def test_no_spawned_room_skips_teardown(self):
+        instance, character = _assigned_active()
+        with mock.patch("world.instances.services.complete_instanced_room") as teardown:
+            abandon_mission(instance, character)
+        teardown.assert_not_called()
+
+
+class AbandonMissionAPITests(TestCase):
+    def setUp(self):
+        self.account = AccountFactory()
+        self.character = _pc()
+        self.instance = staff_assign_mission(_graph("api-abandon"), self.character)
+        self.client = APIClient()
+        self.client.force_authenticate(self.account)
+
+    def _post_abandon(self, as_character):
+        with mock.patch("world.missions.views._puppet_character", return_value=as_character):
+            return self.client.post(f"/api/missions/journal/{self.instance.pk}/abandon/")
+
+    def test_contract_holder_abandon_returns_200(self):
+        res = self._post_abandon(self.character)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["id"], self.instance.pk)
+        self.assertEqual(res.data["status"], MissionStatus.ABANDONED.value)
+        self.instance.refresh_from_db()
+        self.assertEqual(self.instance.status, MissionStatus.ABANDONED)
+
+    def test_non_participant_gets_404(self):
+        res = self._post_abandon(_pc())
+        self.assertEqual(res.status_code, 404)
+        self.instance.refresh_from_db()
+        self.assertEqual(self.instance.status, MissionStatus.ACTIVE)
+
+    def test_non_contract_holder_gets_400(self):
+        other = _pc()
+        MissionParticipantFactory(instance=self.instance, character=other, is_contract_holder=False)
+        res = self._post_abandon(other)
+        self.assertEqual(res.status_code, 400)
+        self.instance.refresh_from_db()
+        self.assertEqual(self.instance.status, MissionStatus.ACTIVE)

--- a/src/world/missions/views.py
+++ b/src/world/missions/views.py
@@ -57,6 +57,7 @@ from world.missions.serializers import (
     BeatResolveRequestSerializer,
     BeatViewSerializer,
     JournalEntrySerializer,
+    MissionAbandonResultSerializer,
     MissionCategorySerializer,
     MissionGiverSerializer,
     MissionInstanceSerializer,
@@ -513,3 +514,31 @@ class MissionJournalViewSet(viewsets.ViewSet):
             # an internal error (CodeQL exception-exposure rule).
             raise ValidationError(exc.user_message) from exc
         return Response(ResolvedBeatSerializer(result).data)
+
+    @extend_schema(
+        request=None,
+        responses={
+            200: MissionAbandonResultSerializer,
+            400: OpenApiResponse(description="Run not active / not the contract holder."),
+            404: OpenApiResponse(description="Not a participant / no such mission."),
+        },
+    )
+    @action(detail=True, methods=("POST",))
+    def abandon(self, request: Request, pk: str | None = None) -> Response:
+        from rest_framework.exceptions import ValidationError  # noqa: PLC0415
+
+        from world.missions.services.play import (  # noqa: PLC0415
+            BeatActionError,
+            abandon_mission,
+        )
+
+        instance, character = self._instance_for(request, pk)
+        try:
+            instance = abandon_mission(instance, character)
+        except BeatActionError as exc:
+            # Typed, user-safe message (CodeQL exception-exposure rule); a
+            # non-participant already 404'd in _instance_for.
+            raise ValidationError(exc.user_message) from exc
+        return Response(
+            MissionAbandonResultSerializer({"id": instance.pk, "status": instance.status}).data
+        )


### PR DESCRIPTION
Closes #1023

## Summary

Wires the defined-but-never-set `MissionStatus.ABANDONED` as a clean player action. `play.abandon_mission(instance, character)` lets the contract holder walk away from an ACTIVE run — contract-holder-only and ACTIVE-only (both typed `AbandonMissionError`), mirroring `resolution._finish_terminal` (status→ABANDONED, stamp completed_at, clear current_node, tear down any spawned instanced room) but skipping the beat-completion seam (abandon isn't completion) and applying no penalty. The PC active-mission cap counts only ACTIVE runs so the slot frees automatically; the giver's NPCRoleCooldown is left intact. A `MissionJournalViewSet.abandon` POST action mirrors `resolve` (404 non-participant / 400 not-active-or-not-holder / 200 {id,status}). Per design discussion, auto-expiry was intentionally dropped — missions are private, so persisting until abandoned is fine; EXPIRED stays a defined-but-unused status for a possible future GM action. No model/field/migration. Adversarial 3-lens review found no blockers. Forward note: when the multiplayer engine wires up, abandoning a shared run will relocate other participants out of the spawned room — to be handled in that follow-up.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1023 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch current with origin/main; no rebase needed, no migration.

<!-- last-addressed-comment: 0 -->