### PR TITLE
Worktrees are ~10 min to create/delete: uv venv full-copies (cache on overlay vs worktrees on D:\ WSL2 mount)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,6 +16,14 @@ services:
       # Shadow Windows-side artefacts with Linux-native named volumes.
       - arxii-venv:/workspaces/arxii/.venv
       - arxii-fe-node-modules:/workspaces/arxii/frontend/node_modules
+      # Git worktrees live under .claude/worktrees. On the bind-mounted
+      # workspace that path is D:\ (a Windows drive over the WSL2 9p mount),
+      # where each worktree's ~245 MB uv venv is FULL-COPIED file-by-file
+      # (cache is cross-filesystem, so uv can't hardlink) — ~10 min to
+      # create/delete. A Linux-native volume here (paired with UV_CACHE_DIR
+      # below, on the SAME volume) lets uv hardlink instead: create drops to
+      # <1 s. fix-volume-perms.sh chowns this mountpoint. See #1037.
+      - arxii-worktrees:/workspaces/arxii/.claude/worktrees
       # Persist Claude Code auth/config so login survives container rebuilds.
       - arxii-claude-home:/home/vscode/.claude
       # Shadow the host's src/.env (which points DATABASE_URL at a bare-metal
@@ -46,6 +54,14 @@ services:
       # post-create.sh migrates an existing ~/.claude.json the first time
       # this env var takes effect. See #505 for full root-cause analysis.
       CLAUDE_CONFIG_DIR: /home/vscode/.claude
+      # Put uv's cache on the SAME filesystem as worktree venvs (the
+      # arxii-worktrees volume above) so `uv sync` in a fresh worktree
+      # HARDLINKS from cache instead of full-copying ~245 MB of tiny files.
+      # uv only hardlinks within one filesystem; cache-on-overlay vs
+      # venv-on-9p was the root cause of ~10 min worktree create/delete.
+      # Verify after a rebuild: a sampled worktree venv file shows links>1
+      # (`stat -c %h .claude/worktrees/<wt>/.venv/bin/activate_this.py`). #1037
+      UV_CACHE_DIR: /workspaces/arxii/.claude/worktrees/.uv-cache
     # Forward the brainstorm-server port so http://localhost:49200/ in the
     # Windows browser reaches the in-container server. The skill's
     # start-server.sh defaults to binding 127.0.0.1; pass --host 0.0.0.0
@@ -84,4 +100,5 @@ volumes:
   arxii-pgdata:
   arxii-venv:
   arxii-fe-node-modules:
+  arxii-worktrees:
   arxii-claude-home:

--- a/.devcontainer/fix-volume-perms.sh
+++ b/.devcontainer/fix-volume-perms.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # Chowns the Docker named-volume mountpoints inside the workspace back to
 # vscode. Docker creates them root-owned because their target paths
-# (/workspaces/arxii/.venv, /workspaces/arxii/frontend/node_modules) are
-# sub-paths of a bind mount and so don't exist in the image to inherit
-# ownership from. Run once from post-create.sh via NOPASSWD sudo.
+# (/workspaces/arxii/.venv, /workspaces/arxii/frontend/node_modules,
+# /workspaces/arxii/.claude/worktrees) are sub-paths of a bind mount and so
+# don't exist in the image to inherit ownership from. Run once from
+# post-create.sh via NOPASSWD sudo.
 set -euo pipefail
 
-for p in /workspaces/arxii/.venv /workspaces/arxii/frontend/node_modules; do
+for p in \
+  /workspaces/arxii/.venv \
+  /workspaces/arxii/frontend/node_modules \
+  /workspaces/arxii/.claude/worktrees; do
   if [[ -d "$p" ]]; then
     chown -R vscode:vscode "$p"
   fi

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -38,6 +38,17 @@ development machine. Key points:
   versa.
 - `.venv` and `frontend/node_modules` are **named volumes** (container-local). This
   prevents Windows-format binaries from leaking into the Linux environment.
+- `.claude/worktrees` is a named volume (`arxii-worktrees`) for the same reason it
+  matters even more there: a git worktree gets its own ~245 MB `uv` venv, and on the
+  bind-mounted Windows path (`D:\` over WSL2's 9p) that venv is full-copied
+  file-by-file — ~10 min to create or delete. With the worktree tree on a
+  Linux-native volume **and `UV_CACHE_DIR` pointed at the same volume**
+  (`.claude/worktrees/.uv-cache`), `uv` hardlinks from cache instead, so a fresh
+  worktree's `uv sync` is under a second. Verify with `stat -c %h` on a sampled venv
+  file showing links > 1. Worktrees are ephemeral, so wiping this volume is safe.
+  (One-time migration note: an existing worktree under `.claude/worktrees` is shadowed
+  by the empty volume on the first rebuild after this lands — finish or remove it
+  first; its files remain on the host disk underneath the mount.) See #1037.
 - The database lives in the `arxii-pgdata` named volume. It is test-only and safe to
   wipe.
 - Your Claude Code login persists in the `arxii-claude-home` named volume (mounted at
@@ -178,6 +189,7 @@ use terminal Path B for anything that needs to run inside the container.
 | Windows filesystem | Isolated — only `/workspaces/arxii` is visible inside the container |
 | `.venv` | Container-local named volume — Linux binaries, not Windows |
 | `frontend/node_modules` | Container-local named volume — same reason |
+| `.claude/worktrees` | Named volume (`arxii-worktrees`) — keeps worktree venvs off the slow 9p mount; `UV_CACHE_DIR` colocated so `uv` hardlinks. Ephemeral, safe to wipe |
 | Database (`arxii-pgdata`) | Named volume — persists across `dc-down`, safe to wipe |
 | Claude Code login (`~/.claude`) | Named volume (`arxii-claude-home`) — auth/config persists across rebuilds; log in once |
 | Network | Default-deny egress — see firewall section below |


### PR DESCRIPTION
Closes #1037

## Summary

Worktrees under `.claude/worktrees` sit on the devcontainer's Windows bind mount (D:\ over WSL2 9p). Each worktree gets its own ~245 MB `uv` venv that is **full-copied** file-by-file there — the `uv` cache lives on `overlay`, a different filesystem, so `uv` can't hardlink. That copy (plus the matching delete) is the ~10 min worktree create/delete cost.

**Fix (mirrors the existing `.venv`/`node_modules` pattern):**
- Mount a Linux-native named volume `arxii-worktrees` at `.claude/worktrees`.
- Point `UV_CACHE_DIR` at `.claude/worktrees/.uv-cache` (the *same* volume) so `uv sync` **hardlinks** from cache instead of copying.
- `fix-volume-perms.sh` chowns the new root-owned mountpoint.
- Documented in `docs/devcontainer-setup.md`.

**Measured on a Linux-native fs:** fresh-venv `uv sync` ~0.7 s hardlinked (sampled file `links=2`) / ~3 s even forced-copy, vs ~10 min on 9p; delete ~0.25 s. Host-agnostic (helps non-WSL hosts too); bonus, the uv cache now persists on a named volume instead of the ephemeral overlay layer.

**Takes effect on the next `just dc-build`.** One-time: an existing worktree under `.claude/worktrees` is shadowed by the empty volume on first rebuild — finish or remove it first (its files remain on the host disk under the mount).

## Follow-ups filed

(none)

## Notes

- Spec: none — chore (devcontainer config); spec gate skipped per the issue-to-merged-pr chore path, approach chosen interactively in this session
- Brainstorm/plan: skipped (chore — devcontainer config; approach chosen interactively, no spec gate)
- Sync-with-main: Branch created fresh from origin/main; sync reported up to date, no conflicts or migration collisions.

<!-- last-addressed-comment: 0 -->
