### PR TITLE
perf: consolidate group-play endpoint queries (follow-up to #1036)

### DIFF
--- a/src/world/missions/services/multiplayer.py
+++ b/src/world/missions/services/multiplayer.py
@@ -149,14 +149,13 @@ def resolve_group_node(
             attempts = tuple(sorted(picks.items(), key=lambda item: item[0].pk))
             deeds = _resolve_joint(instance, node, presented, attempts)
         else:
-            option, actor = _tally_group_winner(instance, ballots)
+            option, actor = _tally_group_winner(ballots)
             deeds = _resolve_single_winner(instance, node, presented, option, actor)
         MissionGroupBallot.objects.filter(instance=instance, node=node).delete()
     return deeds
 
 
 def _tally_group_winner(
-    instance: MissionInstance,
     ballots: list[MissionGroupBallot],
 ) -> tuple[MissionOption, MissionParticipant]:
     """The GROUP_VOTE winning option + acting participant from the ballots.
@@ -188,12 +187,14 @@ def _tally_group_winner(
     tied = [by_pk[pk] for pk in sorted(counts) if counts[pk] == top]
     winner = tied[0] if len(tied) == 1 else random.choice(tied)  # noqa: S311
 
-    holder = contract_holder(instance)
+    # The actor is a picker of the winner, holder preferred. ``is_contract_holder``
+    # is already loaded on each ballot's participant (select_related upstream), so
+    # we find the holder among the pickers in-memory — no ``contract_holder`` query.
     pickers = sorted(
         (ballot.participant for ballot in ballots if ballot.picked_option_id == winner.pk),
         key=lambda participant: participant.pk,
     )
-    actor = next((p for p in pickers if p.pk == holder.pk), pickers[0])
+    actor = next((p for p in pickers if p.is_contract_holder), pickers[0])
     return winner, actor
 
 

--- a/src/world/missions/services/play.py
+++ b/src/world/missions/services/play.py
@@ -332,14 +332,43 @@ def _resolve_group_if_ready(
     return None
 
 
-def _group_beat_view(instance: MissionInstance, node: MissionNode) -> GroupBeatView:
-    """Compose the group beat: union option list + every ballot's pick/vote."""
-    presented = build_group_option_list(instance, node)
-    ballots = (
+def _resolve_if_expired(
+    instance: MissionInstance, node: MissionNode
+) -> list[MissionDeedRecord] | None:
+    """Resolve the group node only if its vote window has elapsed; else None.
+
+    The cheap start-of-action check: a fresh pick/vote can't *complete* the round
+    before it's even recorded, so the only reason to resolve up front is a window
+    that already expired (someone returning after the party left). The full
+    readiness check (``_resolve_group_if_ready``) runs after the write.
+    """
+    deadline = _group_window_deadline(instance, node)
+    if deadline is not None and timezone.now() >= deadline:
+        return resolve_group_node(instance, node)
+    return None
+
+
+def _group_beat_view(
+    instance: MissionInstance,
+    node: MissionNode,
+    *,
+    presented: list[PresentedOption] | None = None,
+) -> GroupBeatView:
+    """Compose the group beat: union option list + every ballot's pick/vote.
+
+    Pass ``presented`` when the caller already built the group option list (e.g.
+    ``submit_group_pick`` after locating the picked entry) to avoid a second
+    per-participant fan-out. The ballots are fetched once and the deadline / phase
+    derived from them in Python (no extra ``Min``/``count`` queries).
+    """
+    if presented is None:
+        presented = build_group_option_list(instance, node)
+    ballots = list(
         MissionGroupBallot.objects.filter(instance=instance, node=node)
         .select_related("participant")
         .order_by("participant__pk")
     )
+    n_active = instance.participants.count()
     ballot_states = tuple(
         GroupBallotState(
             character_id=ballot.participant.character_id,
@@ -348,13 +377,17 @@ def _group_beat_view(instance: MissionInstance, node: MissionNode) -> GroupBeatV
         )
         for ballot in ballots
     )
-    deadline = _group_window_deadline(instance, node)
+    earliest = min((ballot.created_at for ballot in ballots), default=None)
+    deadline = (
+        earliest + timedelta(seconds=GROUP_VOTE_TIMEOUT_SECONDS) if earliest is not None else None
+    )
+    phase = PHASE_VOTE if (n_active > 0 and len(ballots) >= n_active) else PHASE_PICK
     return GroupBeatView(
         instance_id=instance.pk,
         node_key=node.key,
         flavor_text=node.flavor_text,
         conflict_mode=node.conflict_mode,
-        phase=PHASE_VOTE if _all_picked(instance, node) else PHASE_PICK,
+        phase=phase,
         options=tuple(_beat_option(presented_option) for presented_option in presented),
         ballots=ballot_states,
         expires_at=deadline.isoformat() if deadline is not None else None,
@@ -385,7 +418,7 @@ def group_beat(instance: MissionInstance, character: ObjectDB) -> GroupBeatResul
     """Present the group decision beat, resolving first if the window expired."""
     participant_for(instance, character)
     node = _group_node(instance)
-    if _resolve_group_if_ready(instance, node) is not None:
+    if _resolve_if_expired(instance, node) is not None:
         return _resolved_group_result(instance, character)
     return GroupBeatResult(group_beat=_group_beat_view(instance, node), resolved=None)
 
@@ -400,12 +433,13 @@ def submit_group_pick(
     """Record ``character``'s stage-1 pick (must be one of their own live options)."""
     participant = participant_for(instance, character)
     node = _group_node(instance)
-    if _resolve_group_if_ready(instance, node) is not None:
+    if _resolve_if_expired(instance, node) is not None:
         return _resolved_group_result(instance, character)
+    presented = build_group_option_list(instance, node)
     entry = next(
         (
             presented_option
-            for presented_option in build_group_option_list(instance, node)
+            for presented_option in presented
             if presented_option.option.pk == option_id
             and presented_option.owner.pk == character.pk
             and (presented_option.approach.pk if presented_option.approach else None) == approach_id
@@ -428,7 +462,11 @@ def submit_group_pick(
     # None here and opens the vote phase instead).
     if _resolve_group_if_ready(instance, node) is not None:
         return _resolved_group_result(instance, character)
-    return GroupBeatResult(group_beat=_group_beat_view(instance, node), resolved=None)
+    # Reuse the option list already built above (the union doesn't change when a
+    # pick is recorded) so the beat view doesn't re-run the per-participant fan-out.
+    return GroupBeatResult(
+        group_beat=_group_beat_view(instance, node, presented=presented), resolved=None
+    )
 
 
 def cast_group_vote(
@@ -440,7 +478,7 @@ def cast_group_vote(
     """Record ``character``'s stage-2 vote; auto-resolve when all have voted."""
     participant = participant_for(instance, character)
     node = _group_node(instance)
-    if _resolve_group_if_ready(instance, node) is not None:
+    if _resolve_if_expired(instance, node) is not None:
         return _resolved_group_result(instance, character)
     if not _all_picked(instance, node):
         raise BeatActionError(_ERR_VOTE_NOT_OPEN)

--- a/src/world/missions/tests/test_services_multiplayer.py
+++ b/src/world/missions/tests/test_services_multiplayer.py
@@ -214,7 +214,7 @@ class TallyGroupWinnerTests(TestCase):
 
     def test_no_votes_falls_back_to_pick_plurality(self) -> None:
         ballots = self._ballots({self.holder: self.opt1, self.p2: self.opt1, self.p3: self.opt2})
-        option, actor = _tally_group_winner(self.instance, ballots)
+        option, actor = _tally_group_winner(ballots)
         self.assertEqual(option, self.opt1)
         self.assertEqual(actor, self.holder)  # holder picked the winner
 
@@ -224,14 +224,14 @@ class TallyGroupWinnerTests(TestCase):
             {self.holder: self.opt1, self.p2: self.opt1, self.p3: self.opt2},
             votes={self.holder: self.opt2, self.p2: self.opt2, self.p3: self.opt2},
         )
-        option, actor = _tally_group_winner(self.instance, ballots)
+        option, actor = _tally_group_winner(ballots)
         self.assertEqual(option, self.opt2)
         # Actor must be the only PICKER of opt2 (p3), never a mere voter.
         self.assertEqual(actor, self.p3)
 
     def test_tie_breaks_at_random_among_tied(self) -> None:
         ballots = self._ballots({self.holder: self.opt1, self.p2: self.opt2})
-        option, actor = _tally_group_winner(self.instance, ballots)
+        option, actor = _tally_group_winner(ballots)
         self.assertIn(option, {self.opt1, self.opt2})
         # Actor always picked whatever won.
         picked_by_actor = {b.picked_option for b in ballots if b.participant == actor}
@@ -239,7 +239,7 @@ class TallyGroupWinnerTests(TestCase):
 
     def test_actor_prefers_holder_among_pickers(self) -> None:
         ballots = self._ballots({self.holder: self.opt1, self.p2: self.opt1})
-        _, actor = _tally_group_winner(self.instance, ballots)
+        _, actor = _tally_group_winner(ballots)
         self.assertEqual(actor, self.holder)
 
 


### PR DESCRIPTION
Closes #1039

## Summary

Behavior-preserving query consolidation on the #1036 group-decision endpoints (the full #1036 suite stays green; no schema/migration). `_tally_group_winner` finds the contract holder among the already-select_related'd ballots instead of a separate query; `_group_beat_view` fetches the ballots once and derives deadline + phase in Python (drops the Min aggregate + two counts) and accepts a prebuilt `presented` list; `submit_group_pick` reuses the option list it built (was built twice) and threads it through; and the start-of-action readiness check becomes `_resolve_if_expired` (deadline-only) since a fresh pick/vote can't complete the round before it's recorded — the full readiness check still runs after the write. Net: the per-pick/vote request drops from ~10-14 queries to ~4-5, all bounded by (small) party size.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1039 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch current with origin/main; no rebase needed.

<!-- last-addressed-comment: 0 -->