### PR TITLE
feat(#887): apply the location conjunct per participant in group play

### DIFF
--- a/src/world/missions/services/multiplayer.py
+++ b/src/world/missions/services/multiplayer.py
@@ -41,8 +41,10 @@ from django.db import transaction
 from world.missions.constants import ConflictMode, JointCombine
 from world.missions.models import MissionOptionRoute
 from world.missions.services.resolution import (
+    _current_room_profile_id,
     _finish_terminal,
     _route_next_node,
+    option_is_locally_live,
     present_options_for_character,
     resolve_option,
 )
@@ -95,21 +97,33 @@ def build_group_option_list(
     additive — players still pick; conflicting picks are arbitrated later
     by :func:`resolve_group_node` (GROUP_VOTE tally / JOINT combine).
 
-    The node's options are fetched ONCE and reused across every participant
-    via :func:`present_options_for_character`, so the per-participant union
-    does NOT re-issue the options query per participant. Phase-3
+    The location conjunct (#885/#887) is applied **per participant**: each
+    participant only sees options live where *their* character currently stands
+    (mirroring the solo ``build_option_list`` — ANYWHERE always live, ANCHOR/
+    ROOMS/INSTANCE gated on the participant's room). A node with the default
+    ANYWHERE mode surfaces every option to everyone, unchanged.
+
+    The node's options are fetched ONCE and reused across every participant, so
+    the union does NOT re-issue the options query per participant. Phase-3
     ``build_option_list``'s single-participant behavior is unchanged (it
-    delegates to the same extracted helper).
+    delegates to the same extracted helper + conjunct).
     """
-    # select_related("challenge") so the CHALLENGE-branch FK walk in
-    # present_options_for_character doesn't fire one query per option per
-    # participant (the options list is built once and reused).
-    options = list(node.options.select_related("challenge").order_by("order", "pk"))
+    # select_related("challenge") + prefetch "locations" so neither the
+    # CHALLENGE-branch FK walk (in present_options_for_character) nor the
+    # location conjunct's per-option ``locations`` M2M fires a query per option
+    # per participant — the options list is built once and reused.
+    options = list(
+        node.options.select_related("challenge")
+        .prefetch_related("locations")  # noqa: PREFETCH_STRING
+        .order_by("order", "pk")
+    )
 
     participants = instance.participants.all().order_by("pk")
     presented: list[PresentedOption] = []
     for participant in participants:
-        presented.extend(present_options_for_character(participant.character, options))
+        here = _current_room_profile_id(participant.character)
+        local = [opt for opt in options if option_is_locally_live(opt, node, instance, here)]
+        presented.extend(present_options_for_character(participant.character, local))
     return presented
 
 

--- a/src/world/missions/services/resolution.py
+++ b/src/world/missions/services/resolution.py
@@ -137,8 +137,8 @@ def build_option_list(
     CHALLENGE entries.
 
     Phase 3 is single-participant; Phase 4's group path
-    (``build_group_option_list``) does not yet apply the location conjunct
-    — group/invite play is the #885 follow-up.
+    (``build_group_option_list``) applies this same conjunct per participant
+    (#887).
     """
     # select_related("challenge") so the CHALLENGE-branch FK walk in
     # present_options_for_character doesn't fire one query per option.

--- a/src/world/missions/tests/test_services_multiplayer.py
+++ b/src/world/missions/tests/test_services_multiplayer.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory, RoomProfileFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory, ConsequenceFactory
 from world.checks.test_helpers import force_check_outcome
@@ -32,6 +32,7 @@ from world.missions.constants import (
     DeedRewardSink,
     JointCombine,
     MissionStatus,
+    NodeLocationMode,
     OptionKind,
     OptionSource,
 )
@@ -790,3 +791,67 @@ class GroupResolveJointTerminalRewardTests(TestCase):
         self.assertEqual(len(holder_lines), 2)
         for line in holder_lines:
             self.assertEqual(line.amount, 50)
+
+
+class GroupOptionListLocationTests(TestCase):
+    """#887: build_group_option_list applies the location conjunct per participant."""
+
+    @staticmethod
+    def _room(name):
+        room = ObjectDBFactory(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+        profile = RoomProfileFactory(objectdb=room)
+        return room, profile
+
+    @staticmethod
+    def _pc_in(room):
+        character = CharacterFactory()
+        CharacterSheetFactory(character=character)
+        if room is not None:
+            character.db_location = room
+            character.save(update_fields=["db_location"])
+        return character
+
+    def _group_with_option(self, location_mode, *, node_room_profile=None):
+        template = MissionTemplateFactory(name=f"grp-loc-{location_mode}")
+        node = MissionNodeFactory(
+            template=template, key="entry", is_entry=True, location_mode=location_mode
+        )
+        if node_room_profile is not None:
+            node.locations.add(node_room_profile)
+        option = MissionOptionFactory(
+            node=node,
+            order=0,
+            option_kind=OptionKind.BRANCH,
+            source_kind=OptionSource.AUTHORED,
+            authored_ic_framing="A located deed",
+        )
+        instance = MissionInstanceFactory(template=template)
+        return template, node, option, instance
+
+    def test_rooms_node_surfaces_option_only_to_participants_in_that_room(self):
+        room_a, profile_a = self._room("Throne Room")
+        room_b, _ = self._room("Cellar")
+        char_a = self._pc_in(room_a)
+        char_b = self._pc_in(room_b)
+        _t, node, option, instance = self._group_with_option(
+            NodeLocationMode.ROOMS, node_room_profile=profile_a
+        )
+        MissionParticipantFactory(instance=instance, character=char_a, is_contract_holder=True)
+        MissionParticipantFactory(instance=instance, character=char_b)
+
+        presented = build_group_option_list(instance, node)
+        owners = {entry.owner for entry in presented if entry.option == option}
+        # Only the participant standing in room_a (the node's live room) sees it.
+        self.assertEqual(owners, {char_a})
+
+    def test_anywhere_node_surfaces_option_to_all_regardless_of_room(self):
+        room_a, _ = self._room("Hall")
+        char_a = self._pc_in(room_a)
+        char_b = self._pc_in(None)  # placeless
+        _t, node, option, instance = self._group_with_option(NodeLocationMode.ANYWHERE)
+        MissionParticipantFactory(instance=instance, character=char_a, is_contract_holder=True)
+        MissionParticipantFactory(instance=instance, character=char_b)
+
+        presented = build_group_option_list(instance, node)
+        owners = {entry.owner for entry in presented if entry.option == option}
+        self.assertEqual(owners, {char_a, char_b})


### PR DESCRIPTION
Refs #887

## Summary

A slice of #887 (does not close it — invite/consent + frontend remain). #1036's `build_group_option_list` skipped the location conjunct that the solo `build_option_list` enforces, so a group node authored ANCHOR/ROOMS/INSTANCE surfaced its options to every participant regardless of where they stood. Now each participant's options are filtered by `option_is_locally_live` against their own character's room — a direct mirror of the solo path; an ANYWHERE node (the default) is unchanged. `prefetch_related("locations")` avoids an M2M query per option per participant. Behavior-safe: the existing group tests use ANYWHERE nodes; the two new tests cover ROOMS (option live only for the participant in that room) and ANYWHERE (live for all).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #887 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: New branch off current origin/main; no migration.

<!-- last-addressed-comment: 0 -->