### PR TITLE
feat(#520): exhaustion wire — strain_damage → health on collapse (PR 3/series)

### DIFF
--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -761,7 +761,7 @@ tied to the combat subsystem.
 
 ### Cross-System Dependencies (not owned by combat)
 - **Covenants (world.covenants)** — needs: full covenant/party model (formation, ritual, membership), covenant passive bonuses, covenant armor/thread integration, API + frontend for covenant management
-- **Vitals (world.vitals)** — needs: integration with non-combat damage sources (poison, spells, exhaustion), death/unconscious state transitions from non-combat contexts (e.g., dream-walking, traps). Built (#521): VitalsPanel on the character sheet + owner/staff-gated `GET /api/vitals/<id>/` read endpoint
+- **Vitals (world.vitals)** — needs: integration with non-combat damage sources (poison, spells, exhaustion), death/unconscious state transitions from non-combat contexts (e.g., dream-walking, traps). Built (#521): VitalsPanel on the character sheet + owner/staff-gated `GET /api/vitals/<id>/` read endpoint. Built (#520 Phase 5): exhaustion — fatigue-collapse `strain_damage` now routes to real health via `apply_exhaustion_damage` → `process_damage_consequences` (shared `resolve_fatigue_collapse`), fired by the live technique cast path and by a non-cast over-capacity trigger on scene-round resolution (`tick_round_for_targets`)
 - **Conditions** — permanent wounds/scars as ConditionTemplates with authored content
 
 ## Design Document

--- a/src/world/fatigue/action_pipeline.py
+++ b/src/world/fatigue/action_pipeline.py
@@ -15,10 +15,9 @@ from world.checks.types import CheckResult
 from world.fatigue.constants import EFFORT_CHECK_MODIFIER, EffortLevel
 from world.fatigue.services import (
     apply_fatigue,
-    attempt_endurance_check,
-    attempt_power_through,
     get_fatigue_penalty,
     get_fatigue_zone,
+    resolve_fatigue_collapse,
     should_check_collapse,
 )
 from world.fatigue.types import ActionResult
@@ -109,14 +108,10 @@ def _execute_action_with_fatigue(
     strain_damage = 0
 
     if collapse_triggered:
-        passed_endurance = attempt_endurance_check(character_sheet, fatigue_category)
-        if not passed_endurance:
-            power_success, strain = attempt_power_through(character_sheet, fatigue_category)
-            strain_damage = strain
-            if power_success:
-                powered_through = True
-            else:
-                collapsed = True
+        collapse = resolve_fatigue_collapse(character_sheet, fatigue_category)
+        collapsed = collapse.collapsed
+        powered_through = collapse.powered_through
+        strain_damage = collapse.strain_damage
 
     return ActionResult(
         fatigue_applied=fatigue_applied,

--- a/src/world/fatigue/constants.py
+++ b/src/world/fatigue/constants.py
@@ -2,6 +2,10 @@ from django.db import models
 
 from actions.constants import ActionCategory
 
+# Name of the authored DamageType applied when fatigue collapse strain reaches health.
+# Resolved/created on demand via _ensure_exhaustion_damage_type (no fixture/migration).
+EXHAUSTION_DAMAGE_TYPE_NAME = "exhaustion"
+
 
 class FatigueZone(models.TextChoices):
     FRESH = "fresh", "Fresh"

--- a/src/world/fatigue/services.py
+++ b/src/world/fatigue/services.py
@@ -7,6 +7,9 @@ collapse checks, and rest mechanics.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 
 from world.action_points.models import ActionPointPool
@@ -19,6 +22,7 @@ from world.fatigue.constants import (
     CAPACITY_WILLPOWER_MULTIPLIER,
     COLLAPSE_RISK_ZONES,
     EFFORT_COST_MULTIPLIER,
+    EXHAUSTION_DAMAGE_TYPE_NAME,
     FATIGUE_ENDURANCE_STAT,
     MIN_FATIGUE_COST,
     REST_AP_COST,
@@ -29,9 +33,16 @@ from world.fatigue.constants import (
     FatigueZone,
 )
 from world.fatigue.models import FatiguePool
-from world.fatigue.types import RestResult
+from world.fatigue.types import FatigueCollapseResult, RestResult
 from world.traits.constants import PrimaryStat
 from world.traits.models import Trait, TraitType
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from evennia.objects.models import ObjectDB
+
+    from world.conditions.models import DamageType
 
 
 def get_or_create_fatigue_pool(character_sheet: CharacterSheet) -> FatiguePool:
@@ -241,11 +252,36 @@ def apply_technique_fatigue(
     if zone not in _TECHNIQUE_COLLAPSE_ZONES:
         return amount
 
-    endurance_passed = attempt_endurance_check(character_sheet, category)
-    if not endurance_passed:
-        attempt_power_through(character_sheet, category)
+    resolve_fatigue_collapse(character_sheet, category)
 
     return amount
+
+
+def resolve_fatigue_collapse(
+    character_sheet: CharacterSheet,
+    category: str,
+) -> FatigueCollapseResult:
+    """Run the fatigue collapse sequence for one category and apply strain damage.
+
+    Shared by the technique-cast path (apply_technique_fatigue), the action
+    pipeline (_execute_action_with_fatigue), and the round-resolution trigger so
+    the endurance -> power-through -> health-damage sequence lives in one place.
+
+    The caller is responsible for the *gate* (zone or effort) that decides whether
+    collapse risk applies; this assumes risk applies and rolls it. On a failed
+    endurance check the strain computed by attempt_power_through is applied to
+    health via apply_exhaustion_damage regardless of the power-through outcome.
+    """
+    if attempt_endurance_check(character_sheet, category):
+        return FatigueCollapseResult(collapsed=False, powered_through=False, strain_damage=0)
+
+    power_success, strain_damage = attempt_power_through(character_sheet, category)
+    apply_exhaustion_damage(character_sheet, strain_damage)
+    return FatigueCollapseResult(
+        collapsed=not power_success,
+        powered_through=power_success,
+        strain_damage=strain_damage,
+    )
 
 
 def should_check_collapse(
@@ -394,6 +430,89 @@ def attempt_power_through(
         target_difficulty=target_difficulty,
     )
     return result.success_level > 0, strain_damage
+
+
+def _ensure_exhaustion_damage_type() -> DamageType:
+    """Resolve (or create on demand) the authored 'exhaustion' DamageType.
+
+    Engine-required reference data, seeded in-code like _ensure_*_check_type rather
+    than via a fixture/data migration. Null wound/death pools fall back to the
+    VitalsConsequenceConfig defaults in process_damage_consequences.
+    """
+    from world.conditions.models import DamageType  # noqa: PLC0415
+
+    damage_type, _ = DamageType.objects.get_or_create(
+        name=EXHAUSTION_DAMAGE_TYPE_NAME,
+        defaults={
+            "description": "Health lost to fatigue collapse when a character overexerts.",
+        },
+    )
+    return damage_type
+
+
+def apply_exhaustion_damage(character_sheet: CharacterSheet, amount: int) -> None:
+    """Apply fatigue-collapse strain as actual health damage.
+
+    Mirrors mechanics._deal_damage: decrement health, persist, then run the
+    survivability pipeline (which may apply Unconscious/Bleeding-Out per the
+    consequence pools — the acute exhaustion outcome). No-ops for non-positive
+    strain or a sheet without a CharacterVitals row.
+    """
+    if amount <= 0:
+        return
+
+    from world.vitals.services import process_damage_consequences  # noqa: PLC0415
+
+    try:
+        vitals = character_sheet.vitals
+    except (AttributeError, ObjectDoesNotExist):
+        return
+
+    vitals.health -= amount
+    vitals.save(update_fields=["health"])
+
+    process_damage_consequences(
+        character_sheet=character_sheet,
+        damage_dealt=amount,
+        damage_type=_ensure_exhaustion_damage_type(),
+    )
+
+
+def tick_fatigue_collapse_for_targets(
+    targets: Iterable[ObjectDB],  # noqa: OBJECTDB_PARAM
+) -> None:
+    """Evaluate non-cast over-capacity fatigue collapse for each target.
+
+    The acute, round-driven exhaustion trigger: a character sitting in the
+    OVEREXERTED/EXHAUSTED zone risks collapse on round resolution even without
+    casting. Reuses the technique-cast zone gate (_TECHNIQUE_COLLAPSE_ZONES) and
+    the shared resolve_fatigue_collapse sequence, so collapse damage routes
+    through the same acute path (can incapacitate/kill via the consequence pools).
+
+    Empty ``targets`` is a no-op — the AFK-safety primitive (no participants ->
+    no progression). Called by the shared round orchestrator
+    (vitals.tick_round_for_targets) on round resolution.
+    """
+    for target in targets:
+        if target is None:
+            continue
+        try:
+            sheet = target.sheet_data
+        except (AttributeError, ObjectDoesNotExist):
+            continue
+        if sheet is None:
+            continue
+        try:
+            # Probe fatigue capability once; targets without a traits handler
+            # (NPCs / non-character objects in the round) are not fatigue-tracked.
+            capacities = {cat: get_fatigue_capacity(sheet, cat) for cat in FATIGUE_ENDURANCE_STAT}
+        except AttributeError:
+            continue
+        for category, capacity in capacities.items():
+            if capacity <= 0:
+                continue
+            if get_fatigue_zone(sheet, category) in _TECHNIQUE_COLLAPSE_ZONES:
+                resolve_fatigue_collapse(sheet, category)
 
 
 def reset_fatigue(character_sheet: CharacterSheet) -> None:

--- a/src/world/fatigue/tests/test_action_pipeline.py
+++ b/src/world/fatigue/tests/test_action_pipeline.py
@@ -166,7 +166,7 @@ class ExecuteActionCollapseTests(TestCase):
         pool.set_current("physical", 35)
         pool.save()
 
-        with patch("world.fatigue.action_pipeline.attempt_endurance_check", return_value=True):
+        with patch("world.fatigue.services.attempt_endurance_check", return_value=True):
             result = execute_action_with_fatigue(
                 self.sheet, ActionCategory.PHYSICAL, 5, EffortLevel.MEDIUM
             )
@@ -194,7 +194,7 @@ class ExecuteActionCollapseTests(TestCase):
     def test_passes_endurance_no_collapse(self):
         """Passing endurance check means no collapse."""
         self._set_near_overexerted()
-        with patch("world.fatigue.action_pipeline.attempt_endurance_check", return_value=True):
+        with patch("world.fatigue.services.attempt_endurance_check", return_value=True):
             result = execute_action_with_fatigue(
                 self.sheet, ActionCategory.PHYSICAL, 5, EffortLevel.HIGH
             )
@@ -206,8 +206,8 @@ class ExecuteActionCollapseTests(TestCase):
         """Failing endurance but passing power through: powered_through=True with strain."""
         self._set_near_overexerted()
         with (
-            patch("world.fatigue.action_pipeline.attempt_endurance_check", return_value=False),
-            patch("world.fatigue.action_pipeline.attempt_power_through", return_value=(True, 3)),
+            patch("world.fatigue.services.attempt_endurance_check", return_value=False),
+            patch("world.fatigue.services.attempt_power_through", return_value=(True, 3)),
         ):
             result = execute_action_with_fatigue(
                 self.sheet, ActionCategory.PHYSICAL, 5, EffortLevel.HIGH
@@ -221,8 +221,8 @@ class ExecuteActionCollapseTests(TestCase):
         """Failing both endurance and power through: collapsed=True."""
         self._set_near_overexerted()
         with (
-            patch("world.fatigue.action_pipeline.attempt_endurance_check", return_value=False),
-            patch("world.fatigue.action_pipeline.attempt_power_through", return_value=(False, 2)),
+            patch("world.fatigue.services.attempt_endurance_check", return_value=False),
+            patch("world.fatigue.services.attempt_power_through", return_value=(False, 2)),
         ):
             result = execute_action_with_fatigue(
                 self.sheet, ActionCategory.PHYSICAL, 5, EffortLevel.HIGH

--- a/src/world/fatigue/tests/test_exhaustion_damage.py
+++ b/src/world/fatigue/tests/test_exhaustion_damage.py
@@ -1,0 +1,233 @@
+"""Tests for exhaustion strain -> health damage wiring (#520 Phase 5)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from actions.constants import ActionCategory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.factories import StrainConfigFactory
+from world.conditions.models import DamageType
+from world.fatigue.constants import EXHAUSTION_DAMAGE_TYPE_NAME
+from world.fatigue.models import FatiguePool
+from world.fatigue.services import (
+    apply_exhaustion_damage,
+    apply_technique_fatigue,
+    get_or_create_fatigue_pool,
+    resolve_fatigue_collapse,
+    tick_fatigue_collapse_for_targets,
+)
+from world.fatigue.tests import setup_stat
+from world.traits.models import TraitCategory
+from world.vitals.factories import CharacterVitalsFactory
+from world.vitals.services import tick_round_for_targets
+
+_ENDURANCE = "world.fatigue.services.attempt_endurance_check"
+_POWER_THROUGH = "world.fatigue.services.attempt_power_through"
+
+
+class ApplyExhaustionDamageTests(TestCase):
+    """apply_exhaustion_damage decrements health and routes through the damage pipeline."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+        cls.vitals = CharacterVitalsFactory(
+            character_sheet=cls.sheet, health=100, max_health=100, base_max_health=100
+        )
+
+    def test_reduces_health_by_amount(self):
+        """Strain damage is subtracted from current health."""
+        apply_exhaustion_damage(self.sheet, 7)
+        self.vitals.refresh_from_db()
+        self.assertEqual(self.vitals.health, 93)
+
+    def test_authors_exhaustion_damage_type(self):
+        """The 'exhaustion' DamageType is created on demand (get_or_create)."""
+        self.assertFalse(DamageType.objects.filter(name=EXHAUSTION_DAMAGE_TYPE_NAME).exists())
+        apply_exhaustion_damage(self.sheet, 3)
+        self.assertTrue(DamageType.objects.filter(name=EXHAUSTION_DAMAGE_TYPE_NAME).exists())
+
+    def test_zero_or_negative_amount_is_noop(self):
+        """Non-positive strain leaves health untouched."""
+        apply_exhaustion_damage(self.sheet, 0)
+        apply_exhaustion_damage(self.sheet, -5)
+        self.vitals.refresh_from_db()
+        self.assertEqual(self.vitals.health, 100)
+
+
+class ApplyExhaustionDamageNoVitalsTests(TestCase):
+    """A sheet without vitals is skipped gracefully (mirrors _deal_damage)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+
+    def test_missing_vitals_is_noop(self):
+        """No CharacterVitals row -> no crash, no damage."""
+        apply_exhaustion_damage(self.sheet, 5)  # must not raise
+
+
+class ResolveFatigueCollapseTests(TestCase):
+    """resolve_fatigue_collapse runs endurance + power-through and applies strain."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+        cls.vitals = CharacterVitalsFactory(
+            character_sheet=cls.sheet, health=100, max_health=100, base_max_health=100
+        )
+
+    def test_endurance_pass_no_damage(self):
+        """Passing the endurance check avoids collapse and deals no damage."""
+        with patch(_ENDURANCE, return_value=True):
+            result = resolve_fatigue_collapse(self.sheet, ActionCategory.PHYSICAL)
+        self.assertFalse(result.collapsed)
+        self.assertFalse(result.powered_through)
+        self.assertEqual(result.strain_damage, 0)
+        self.vitals.refresh_from_db()
+        self.assertEqual(self.vitals.health, 100)
+
+    def test_both_checks_fail_collapses_and_damages(self):
+        """Failing both checks collapses the character and applies strain to health."""
+        with (
+            patch(_ENDURANCE, return_value=False),
+            patch(_POWER_THROUGH, return_value=(False, 8)),
+        ):
+            result = resolve_fatigue_collapse(self.sheet, ActionCategory.PHYSICAL)
+        self.assertTrue(result.collapsed)
+        self.assertFalse(result.powered_through)
+        self.assertEqual(result.strain_damage, 8)
+        self.vitals.refresh_from_db()
+        self.assertEqual(self.vitals.health, 92)
+
+    def test_powerthrough_success_still_damages(self):
+        """Strain damage applies even when the willpower power-through succeeds."""
+        with (
+            patch(_ENDURANCE, return_value=False),
+            patch(_POWER_THROUGH, return_value=(True, 5)),
+        ):
+            result = resolve_fatigue_collapse(self.sheet, ActionCategory.PHYSICAL)
+        self.assertFalse(result.collapsed)
+        self.assertTrue(result.powered_through)
+        self.assertEqual(result.strain_damage, 5)
+        self.vitals.refresh_from_db()
+        self.assertEqual(self.vitals.health, 95)
+
+
+class TechniqueCastCollapseCostsHealthTests(TestCase):
+    """The live technique-cast path (apply_technique_fatigue) now costs health on collapse."""
+
+    def setUp(self):
+        FatiguePool.flush_instance_cache()
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+        cls.vitals = CharacterVitalsFactory(
+            character_sheet=cls.sheet, health=100, max_health=100, base_max_health=100
+        )
+        StrainConfigFactory()
+        setup_stat(cls.sheet.character, "stamina", 10, TraitCategory.PHYSICAL)
+        setup_stat(cls.sheet.character, "willpower", 10, TraitCategory.META)
+
+    def _exhaust(self):
+        pool = get_or_create_fatigue_pool(self.sheet)
+        pool.set_current(ActionCategory.PHYSICAL, 100)  # far over capacity -> EXHAUSTED
+        pool.save()
+        FatiguePool.flush_instance_cache()
+
+    def test_cast_collapse_reduces_health(self):
+        """Casting while exhausted and failing collapse subtracts strain from health."""
+        self._exhaust()
+        with (
+            patch(_ENDURANCE, return_value=False),
+            patch(_POWER_THROUGH, return_value=(False, 8)),
+        ):
+            apply_technique_fatigue(self.sheet, ActionCategory.PHYSICAL, 4, 0)
+        self.vitals.refresh_from_db()
+        self.assertEqual(self.vitals.health, 92)
+
+    def test_immune_cast_does_not_cost_health(self):
+        """fatigue_collapse_immune suppresses the collapse damage entirely."""
+        self._exhaust()
+        with (
+            patch(_ENDURANCE, return_value=False),
+            patch(_POWER_THROUGH, return_value=(False, 8)),
+        ):
+            apply_technique_fatigue(
+                self.sheet, ActionCategory.PHYSICAL, 4, 0, immune_to_fatigue_collapse=True
+            )
+        self.vitals.refresh_from_db()
+        self.assertEqual(self.vitals.health, 100)
+
+
+class RoundResolutionCollapseTriggerTests(TestCase):
+    """Non-cast over-capacity collapse fires on round resolution (acute tier)."""
+
+    def setUp(self):
+        FatiguePool.flush_instance_cache()
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+        cls.vitals = CharacterVitalsFactory(
+            character_sheet=cls.sheet, health=100, max_health=100, base_max_health=100
+        )
+        setup_stat(cls.sheet.character, "stamina", 10, TraitCategory.PHYSICAL)
+        setup_stat(cls.sheet.character, "willpower", 10, TraitCategory.META)
+
+    def _exhaust(self):
+        pool = get_or_create_fatigue_pool(self.sheet)
+        pool.set_current(ActionCategory.PHYSICAL, 100)  # far over capacity -> EXHAUSTED
+        pool.save()
+        FatiguePool.flush_instance_cache()
+
+    def test_overcapacity_target_collapses_on_resolution(self):
+        """An over-capacity character takes exhaustion damage at round resolution."""
+        self._exhaust()
+        with (
+            patch(_ENDURANCE, return_value=False),
+            patch(_POWER_THROUGH, return_value=(False, 6)),
+        ):
+            tick_fatigue_collapse_for_targets([self.sheet.character])
+        self.vitals.refresh_from_db()
+        self.assertEqual(self.vitals.health, 94)
+
+    def test_round_tick_orchestrator_drives_collapse(self):
+        """The vitals round-tick orchestrator invokes the fatigue collapse trigger."""
+        self._exhaust()
+        with (
+            patch(_ENDURANCE, return_value=False),
+            patch(_POWER_THROUGH, return_value=(False, 6)),
+        ):
+            tick_round_for_targets([self.sheet.character], timing="end")
+        self.vitals.refresh_from_db()
+        self.assertEqual(self.vitals.health, 94)
+
+    def test_fresh_target_never_checks_collapse(self):
+        """A character below the collapse zones is not rolled (no spurious damage)."""
+        with patch(_ENDURANCE) as mock_endurance:
+            tick_fatigue_collapse_for_targets([self.sheet.character])
+            mock_endurance.assert_not_called()
+        self.vitals.refresh_from_db()
+        self.assertEqual(self.vitals.health, 100)
+
+    def test_empty_targets_is_noop(self):
+        """No participants -> no collapse evaluation (AFK-safety primitive)."""
+        tick_fatigue_collapse_for_targets([])  # must not raise
+
+    def test_non_character_target_is_skipped(self):
+        """A round target with no traits handler (NPC/object) is skipped, not crashed."""
+        from evennia.objects.models import ObjectDB
+
+        bare = ObjectDB.objects.create(db_key="NPC-prop")
+        CharacterVitalsFactory(
+            character_sheet=CharacterSheetFactory(character=bare),
+            health=100,
+            max_health=100,
+            base_max_health=100,
+        )
+        tick_fatigue_collapse_for_targets([bare])  # must not raise

--- a/src/world/fatigue/types.py
+++ b/src/world/fatigue/types.py
@@ -25,6 +25,20 @@ class ActionResult:
 
 
 @dataclass
+class FatigueCollapseResult:
+    """Outcome of running the fatigue collapse sequence for one category.
+
+    The caller decides *whether* collapse risk applies (zone/effort gate); this
+    captures the result of the endurance + power-through rolls and the strain
+    damage applied to health.
+    """
+
+    collapsed: bool
+    powered_through: bool
+    strain_damage: int
+
+
+@dataclass
 class RestResult:
     """Result of a rest attempt."""
 

--- a/src/world/vitals/services.py
+++ b/src/world/vitals/services.py
@@ -735,9 +735,13 @@ def tick_round_for_targets(
         else:
             process_round_end(target)
     if timing == ROUND_TICK_END:
+        from world.fatigue.services import tick_fatigue_collapse_for_targets  # noqa: PLC0415
+
         for target in target_list:
             try:
                 sheet = target.sheet_data
             except (AttributeError, ObjectDoesNotExist):
                 continue
             advance_bleed_out(sheet)
+        # Non-cast over-capacity exhaustion collapse (acute tier, #520 Phase 5).
+        tick_fatigue_collapse_for_targets(target_list)


### PR DESCRIPTION
## Summary

Phase 5 of the **#520** non-combat rounds epic (PR 3 of the series, off merged #1042 + #1046). Wires the already-computed fatigue-collapse `strain_damage` into **real health loss** and adds the **non-cast over-capacity** collapse trigger. No new damage plumbing — it reuses `process_damage_consequences` and the existing fatigue collapse machinery.

## What changed

- **`apply_exhaustion_damage(sheet, amount)`** — mirrors `mechanics._deal_damage` (health decrement → `process_damage_consequences`) with an on-demand `"exhaustion"` `DamageType` resolved via `_ensure_exhaustion_damage_type` (`get_or_create`, matching the existing `_ensure_*_check_type` convention — **no fixture/data-migration**, per repo rules). Graceful no-op for non-positive strain or a sheet without vitals.
- **`resolve_fatigue_collapse(sheet, category)`** — extracts the endurance→power-through sequence that was **duplicated** in `apply_technique_fatigue` and `_execute_action_with_fatigue` into one helper that applies strain damage in a **single place**. The **live technique-cast path** now costs health on collapse (the previous code computed `strain_damage` and discarded it).
- **`tick_fatigue_collapse_for_targets(targets)`** — non-cast over-capacity trigger for OVEREXERTED/EXHAUSTED characters, hooked into the shared round orchestrator (`vitals.tick_round_for_targets`) on resolution. **Acute tier only** (AFK-safe: no active round → no progression); non-character round targets (no traits handler) are skipped.

## Spec deviations (code-grounded)

- **Wire point** is `attempt_power_through`'s convergence via `resolve_fatigue_collapse`, **not** the spec's named `action_pipeline.py` — that module has no production callers, while `apply_technique_fatigue` (the live cast path) was discarding the strain. One change now covers both paths.
- **DamageType** is seeded in-code (`get_or_create`) rather than the spec's loosely-suggested fixture/migration, matching repo conventions and the no-data-migration rule.
- **Long-term clamped tier** (the never-lethal chronic path) remains **Phase 7**, unchanged here.

## Tests

14 new tests in `world/fatigue/tests/test_exhaustion_damage.py`: damage application, `resolve_fatigue_collapse` outcomes, technique-cast collapse costing health, the round-resolution trigger (incl. orchestrator integration), and graceful no-vitals / non-character skips. Existing `action_pipeline` collapse tests repointed to the shared helper. Local fast-tier green for `world.fatigue`, `world.vitals`, `world.combat`, `world.scenes`, `world.magic`, `world.conditions`, `world.mechanics`.

Refs #520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)