### PR TITLE
chore(sonarcloud): suppress S1192 for Django lazy model references

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -62,7 +62,7 @@ sonar.sourceEncoding=UTF-8
 
 # Rule-scoped ignores for confirmed architectural false positives.
 # These suppress at analysis time so they never become GitHub issues.
-sonar.issue.ignore.multicriteria=drf_validators,custom_makemigrations
+sonar.issue.ignore.multicriteria=drf_validators,custom_makemigrations,lazy_model_refs
 #   python:S3516 ("method always returns the same value") fires on idiomatic DRF
 #   validators/updaters that return their input (validate -> attrs, validate_x -> x,
 #   update -> instance). Scoped to serializer modules only.
@@ -73,3 +73,12 @@ sonar.issue.ignore.multicriteria.drf_validators.resourceKey=**/*serializers.py
 #   to suppress phantom Evennia migrations.
 sonar.issue.ignore.multicriteria.custom_makemigrations.ruleKey=pythonenterprise:S8443
 sonar.issue.ignore.multicriteria.custom_makemigrations.resourceKey=**/management/commands/makemigrations.py
+#   python:S1192 ("define a constant instead of duplicating this literal") fires on
+#   Django lazy model references — "app_label.ModelName" strings used as FK/M2M
+#   targets. These MUST be repeated string literals: a lazy ref can't import the
+#   model class (avoiding circular imports is the whole reason the string form
+#   exists), so the magic-string concern the rule guards against does not apply.
+#   Matched by file glob (no content matcher exists), so this exempts all S1192 in
+#   models.py — acceptable because every S1192 hit in models.py here is a lazy ref.
+sonar.issue.ignore.multicriteria.lazy_model_refs.ruleKey=python:S1192
+sonar.issue.ignore.multicriteria.lazy_model_refs.resourceKey=**/models.py

--- a/src/world/combat/models.py
+++ b/src/world/combat/models.py
@@ -42,15 +42,6 @@ from world.fatigue.constants import EffortLevel
 from world.magic.constants import EffectKind, VitalBonusTarget
 from world.magic.models.commitments import CommittingDeclaration
 
-# Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
-ACCOUNT_DB_MODEL = "accounts.AccountDB"
-CHECK_TYPE_MODEL = "checks.CheckType"
-CONSEQUENCE_POOL_MODEL = "actions.ConsequencePool"
-CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
-TECHNIQUE_MODEL = "magic.Technique"
-COMBAT_PARTICIPANT_MODEL = "combat.CombatParticipant"
-COMBAT_ENCOUNTER_MODEL = "combat.CombatEncounter"
-
 
 class CombatEncounter(SharedMemoryModel):
     """Top-level container for a combat encounter."""
@@ -268,7 +259,7 @@ class ThreatPoolEntry(SharedMemoryModel):
         ),
     )
     clash_resolution_pool = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.PROTECT,
         null=True,
         blank=True,
@@ -276,7 +267,7 @@ class ThreatPoolEntry(SharedMemoryModel):
         help_text="Consequence pool fired when a Clash initiated by this entry resolves.",
     )
     clash_per_round_pool = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.PROTECT,
         null=True,
         blank=True,
@@ -405,7 +396,7 @@ class CombatOpponent(SharedMemoryModel):
         ),
     )
     barrier_break_pool = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.PROTECT,
         null=True,
         blank=True,
@@ -413,7 +404,7 @@ class CombatOpponent(SharedMemoryModel):
         help_text=("Consequence pool fired when PCs successfully break this opponent's barrier."),
     )
     aftermath_pool = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.PROTECT,
         null=True,
         blank=True,
@@ -625,7 +616,7 @@ class ComboLearning(SharedMemoryModel):
         related_name="learnings",
     )
     character_sheet = models.ForeignKey(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         on_delete=models.CASCADE,
         related_name="combo_learnings",
     )
@@ -656,7 +647,7 @@ class CombatParticipant(SharedMemoryModel):
         related_name="participants",
     )
     character_sheet = models.ForeignKey(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         on_delete=models.CASCADE,
         related_name="combat_participations",
     )
@@ -735,7 +726,7 @@ class CombatRoundAction(SharedMemoryModel):
         default=EffortLevel.MEDIUM,
     )
     focused_action = models.ForeignKey(
-        TECHNIQUE_MODEL,
+        "magic.Technique",
         on_delete=models.CASCADE,
         related_name="+",
         null=True,
@@ -769,21 +760,21 @@ class CombatRoundAction(SharedMemoryModel):
     )
 
     physical_passive = models.ForeignKey(
-        TECHNIQUE_MODEL,
+        "magic.Technique",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="+",
     )
     social_passive = models.ForeignKey(
-        TECHNIQUE_MODEL,
+        "magic.Technique",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="+",
     )
     mental_passive = models.ForeignKey(
-        TECHNIQUE_MODEL,
+        "magic.Technique",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -880,12 +871,12 @@ class CombatPull(SharedMemoryModel):
     """
 
     participant = models.ForeignKey(
-        COMBAT_PARTICIPANT_MODEL,
+        "combat.CombatParticipant",
         on_delete=models.CASCADE,
         related_name="combat_pulls",
     )
     encounter = models.ForeignKey(
-        COMBAT_ENCOUNTER_MODEL,
+        "combat.CombatEncounter",
         on_delete=models.CASCADE,
         related_name="combat_pulls",
     )
@@ -1122,13 +1113,13 @@ class RoundChallengeDeclaration(SharedMemoryModel):
     """
 
     encounter = models.ForeignKey(
-        COMBAT_ENCOUNTER_MODEL,
+        "combat.CombatEncounter",
         on_delete=models.CASCADE,
         related_name="challenge_declarations",
     )
     round_number = models.PositiveIntegerField()
     participant = models.ForeignKey(
-        COMBAT_PARTICIPANT_MODEL,
+        "combat.CombatParticipant",
         on_delete=models.CASCADE,
         related_name="challenge_declarations",
     )
@@ -1204,7 +1195,7 @@ class StrainConfig(SharedMemoryModel):
 
     updated_at = models.DateTimeField(auto_now=True)
     updated_by = models.ForeignKey(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -1321,7 +1312,7 @@ class ClashConfig(SharedMemoryModel):
 
     updated_at = models.DateTimeField(auto_now=True)
     updated_by = models.ForeignKey(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -1360,7 +1351,7 @@ class FleeConfig(SharedMemoryModel):
     """
 
     check_type = models.ForeignKey(
-        CHECK_TYPE_MODEL,
+        "checks.CheckType",
         on_delete=models.PROTECT,
         related_name="+",
         help_text="CheckType rolled for flee attempts.",
@@ -1370,7 +1361,7 @@ class FleeConfig(SharedMemoryModel):
         help_text="Flee difficulty before opponent-tier modifiers.",
     )
     consequence_pool = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1383,7 +1374,7 @@ class FleeConfig(SharedMemoryModel):
     )
     updated_at = models.DateTimeField(auto_now=True)
     updated_by = models.ForeignKey(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -1424,7 +1415,7 @@ class EncounterAftermathRule(SharedMemoryModel):
     outcome = models.CharField(max_length=20, choices=EncounterOutcome.choices)
     risk_level = models.CharField(max_length=20, choices=RiskLevel.choices)
     check_type = models.ForeignKey(
-        CHECK_TYPE_MODEL,
+        "checks.CheckType",
         on_delete=models.PROTECT,
         related_name="+",
         help_text="CheckType rolled per affected participant.",
@@ -1433,7 +1424,7 @@ class EncounterAftermathRule(SharedMemoryModel):
         help_text="Authored difficulty for the aftermath check.",
     )
     consequence_pool = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1484,19 +1475,19 @@ class Clash(SharedMemoryModel):
         related_name="clashes",
     )
     initiator = models.ForeignKey(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="+",
     )
     resolution_consequence_pool = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.PROTECT,
         related_name="+",
     )
     per_round_consequence_pool = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.PROTECT,
         null=True,
         blank=True,
@@ -1687,7 +1678,7 @@ class ClashContribution(SharedMemoryModel):
         help_text="The ClashRound this contribution belongs to.",
     )
     character = models.ForeignKey(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         on_delete=models.CASCADE,
         related_name="+",
         help_text="The PC whose contribution this row records.",
@@ -1701,7 +1692,7 @@ class ClashContribution(SharedMemoryModel):
         help_text="Anima the PC committed to the Clash this round.",
     )
     technique = models.ForeignKey(
-        TECHNIQUE_MODEL,
+        "magic.Technique",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1797,7 +1788,7 @@ class ClashContributionDeclaration(CommittingDeclaration, SharedMemoryModel):
     """
 
     encounter = models.ForeignKey(
-        COMBAT_ENCOUNTER_MODEL,
+        "combat.CombatEncounter",
         on_delete=models.CASCADE,
         related_name="clash_declarations",
         help_text="The encounter this declaration belongs to.",
@@ -1806,7 +1797,7 @@ class ClashContributionDeclaration(CommittingDeclaration, SharedMemoryModel):
         help_text="The encounter round this declaration is for (1-indexed).",
     )
     participant = models.ForeignKey(
-        COMBAT_PARTICIPANT_MODEL,
+        "combat.CombatParticipant",
         on_delete=models.CASCADE,
         related_name="clash_declarations",
         help_text="The PC participant making this contribution.",
@@ -1823,7 +1814,7 @@ class ClashContributionDeclaration(CommittingDeclaration, SharedMemoryModel):
         help_text="Which action slot the PC commits: FOCUSED (primary) or PASSIVE (secondary).",
     )
     technique = models.ForeignKey(
-        TECHNIQUE_MODEL,
+        "magic.Technique",
         on_delete=models.PROTECT,
         related_name="+",
         help_text="The Technique the PC is using for this clash contribution.",
@@ -1862,7 +1853,7 @@ class EncounterRiskAcknowledgement(SharedMemoryModel):
         related_name="risk_acknowledgements",
     )
     character_sheet = models.ForeignKey(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         on_delete=models.CASCADE,
         related_name="combat_risk_acknowledgements",
     )
@@ -1913,7 +1904,7 @@ class EscalationCurve(SharedMemoryModel):
         help_text="Intensity modifier added to each participant's engagement per tick.",
     )
     pace_check_type = models.ForeignKey(
-        CHECK_TYPE_MODEL,
+        "checks.CheckType",
         on_delete=models.PROTECT,
         related_name="escalation_curves",
         help_text="Check rolled each tick to keep control in pace with intensity.",

--- a/src/world/covenants/models.py
+++ b/src/world/covenants/models.py
@@ -22,11 +22,6 @@ if TYPE_CHECKING:
     from world.conditions.models import ConditionTemplate
     from world.covenants.handlers import CovenantMembershipHandler
 
-# Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
-COVENANT_ROLE_MODEL = "covenants.CovenantRole"
-CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
-CONDITION_TEMPLATE_MODEL = "conditions.ConditionTemplate"
-
 
 class Covenant(SharedMemoryModel):
     """The foundational social/magical structure that binds members under a sworn oath.
@@ -288,7 +283,7 @@ class GearArchetypeCompatibility(SharedMemoryModel):
     """
 
     covenant_role = models.ForeignKey(
-        COVENANT_ROLE_MODEL,
+        "covenants.CovenantRole",
         on_delete=models.CASCADE,
         related_name="gear_compatibilities",
     )
@@ -330,12 +325,12 @@ class CharacterCovenantRole(SharedMemoryModel):
     """
 
     character_sheet = models.ForeignKey(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         on_delete=models.CASCADE,
         related_name="covenant_role_assignments",
     )
     covenant_role = models.ForeignKey(
-        COVENANT_ROLE_MODEL,
+        "covenants.CovenantRole",
         on_delete=models.PROTECT,
         related_name="character_assignments",
     )
@@ -471,7 +466,7 @@ class CovenantRite(SharedMemoryModel):
     min_covenant_level = models.PositiveSmallIntegerField(default=1)
     min_members_present = models.PositiveSmallIntegerField(default=2)
     granted_condition = models.ForeignKey(
-        CONDITION_TEMPLATE_MODEL,
+        "conditions.ConditionTemplate",
         on_delete=models.PROTECT,
         related_name="+",
     )
@@ -529,13 +524,13 @@ class CovenantRiteRolePackage(SharedMemoryModel):
         related_name="role_packages",
     )
     covenant_role = models.ForeignKey(
-        COVENANT_ROLE_MODEL,
+        "covenants.CovenantRole",
         on_delete=models.PROTECT,
         related_name="+",
     )
     min_covenant_level = models.PositiveSmallIntegerField(default=1)
     condition_template = models.ForeignKey(
-        CONDITION_TEMPLATE_MODEL,
+        "conditions.ConditionTemplate",
         on_delete=models.PROTECT,
         related_name="+",
     )
@@ -578,7 +573,7 @@ class CovenantRiteInstance(SharedMemoryModel):
         blank=True,
     )
     participants = models.ManyToManyField(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         through="covenants.CovenantRiteParticipant",
         related_name="covenant_rite_instances",
     )
@@ -601,12 +596,12 @@ class CovenantRiteParticipant(SharedMemoryModel):
         related_name="participant_records",
     )
     character_sheet = models.ForeignKey(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         on_delete=models.CASCADE,
         related_name="+",
     )
     granted_condition = models.ForeignKey(
-        CONDITION_TEMPLATE_MODEL,
+        "conditions.ConditionTemplate",
         on_delete=models.PROTECT,
         related_name="+",
     )

--- a/src/world/currency/models.py
+++ b/src/world/currency/models.py
@@ -27,10 +27,6 @@ from world.currency.constants import (
     IncomeStreamKind,
 )
 
-# Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
-PERSONA_MODEL = "scenes.Persona"
-ORGANIZATION_MODEL = "societies.Organization"
-
 
 class CharacterPurse(SharedMemoryModel):
     """A character's personal money, in coppers."""
@@ -54,7 +50,7 @@ class OrganizationTreasury(SharedMemoryModel):
     """An organization's money, in coppers, with rank-gated spend authority."""
 
     organization = models.OneToOneField(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.CASCADE,
         related_name="treasury",
         help_text="The org this treasury belongs to (house, family, guild).",
@@ -199,7 +195,7 @@ class OrgEconomicsProfile(SharedMemoryModel):
     """
 
     organization = models.OneToOneField(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.CASCADE,
         related_name="economics",
         help_text="The org this economic profile belongs to.",
@@ -231,7 +227,7 @@ class OrgIncomeStream(SharedMemoryModel):
     """
 
     organization = models.ForeignKey(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.CASCADE,
         related_name="income_streams",
     )
@@ -298,12 +294,12 @@ class OrgObligation(SharedMemoryModel):
     """
 
     from_organization = models.ForeignKey(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.CASCADE,
         related_name="obligations_owed",
     )
     to_organization = models.ForeignKey(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.CASCADE,
         related_name="obligations_due",
     )
@@ -341,12 +337,12 @@ class ContributionRecord(SharedMemoryModel):
     """
 
     persona = models.ForeignKey(
-        PERSONA_MODEL,
+        "scenes.Persona",
         on_delete=models.CASCADE,
         related_name="org_contributions",
     )
     organization = models.ForeignKey(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.CASCADE,
         related_name="contributions",
     )
@@ -384,12 +380,12 @@ class DebtInstrument(SharedMemoryModel):
     """
 
     debtor_organization = models.ForeignKey(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.CASCADE,
         related_name="debts",
     )
     creditor_organization = models.ForeignKey(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.CASCADE,
         related_name="loans_extended",
         help_text="The creditor (e.g. Blighton, the canonical NPC moneylender house).",
@@ -453,28 +449,28 @@ class Contract(SharedMemoryModel):
     """
 
     proposer_persona = models.ForeignKey(
-        PERSONA_MODEL,
+        "scenes.Persona",
         on_delete=models.CASCADE,
         null=True,
         blank=True,
         related_name="contracts_proposed",
     )
     proposer_organization = models.ForeignKey(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.CASCADE,
         null=True,
         blank=True,
         related_name="contracts_proposed",
     )
     counterparty_persona = models.ForeignKey(
-        PERSONA_MODEL,
+        "scenes.Persona",
         on_delete=models.CASCADE,
         null=True,
         blank=True,
         related_name="contracts_received",
     )
     counterparty_organization = models.ForeignKey(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.CASCADE,
         null=True,
         blank=True,
@@ -493,7 +489,7 @@ class Contract(SharedMemoryModel):
         default=ContractStatus.PROPOSED,
     )
     notary_organization = models.ForeignKey(
-        ORGANIZATION_MODEL,
+        "societies.Organization",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -664,7 +660,7 @@ class Business(SharedMemoryModel):
     """
 
     owner_persona = models.ForeignKey(
-        PERSONA_MODEL,
+        "scenes.Persona",
         on_delete=models.CASCADE,
         related_name="businesses",
     )

--- a/src/world/items/models.py
+++ b/src/world/items/models.py
@@ -23,9 +23,6 @@ from world.items.constants import BodyRegion, EquipmentLayer, GearArchetype, Own
 # duplicated-literal SonarCloud smell (python:S1192).
 _CHARACTER_SHEET_FK = "character_sheets.CharacterSheet"
 _PERSONA_FK = "scenes.Persona"
-SOCIETY_MODEL = "societies.Society"
-CHECK_TYPE_MODEL = "checks.CheckType"
-FACET_MODEL = "magic.Facet"
 
 
 class QualityTier(SharedMemoryModel):
@@ -200,7 +197,7 @@ class ItemTemplate(SharedMemoryModel):
         help_text="Consequences applied when this item is used (null = not usable).",
     )
     on_use_check_type = models.ForeignKey(
-        CHECK_TYPE_MODEL,
+        "checks.CheckType",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -859,7 +856,7 @@ class ItemFacet(SharedMemoryModel):
         related_name="item_facets",
     )
     facet = models.ForeignKey(
-        FACET_MODEL,
+        "magic.Facet",
         on_delete=models.PROTECT,
         related_name="item_attachments",
     )
@@ -1008,7 +1005,7 @@ class FashionPresentation(SharedMemoryModel):
         help_text="The outfit presented (record-keeping; the check reads equipped items).",
     )
     perceiving_society = models.ForeignKey(
-        SOCIETY_MODEL,
+        "societies.Society",
         on_delete=models.PROTECT,
         related_name="fashion_presentations",
     )
@@ -1039,12 +1036,12 @@ class FacetVogueMomentum(SharedMemoryModel):
     """
 
     society = models.ForeignKey(
-        SOCIETY_MODEL,
+        "societies.Society",
         on_delete=models.CASCADE,
         related_name="facet_momentum",
     )
     facet = models.ForeignKey(
-        FACET_MODEL,
+        "magic.Facet",
         on_delete=models.CASCADE,
         related_name="vogue_momentum",
     )
@@ -1082,7 +1079,7 @@ class ItemCheckModifier(SharedMemoryModel):
         help_text="Item template that carries this modifier.",
     )
     check_type = models.ForeignKey(
-        CHECK_TYPE_MODEL,
+        "checks.CheckType",
         on_delete=models.CASCADE,
         related_name="item_check_modifiers",
         help_text="The check type this modifier affects.",
@@ -1116,7 +1113,7 @@ class FacetCraftingConfig(SharedMemoryModel):
     """
 
     check_type = models.ForeignKey(
-        CHECK_TYPE_MODEL,
+        "checks.CheckType",
         on_delete=models.PROTECT,
         null=True,
         blank=True,
@@ -1148,7 +1145,7 @@ class FashionStyle(NaturalKeyMixin, SharedMemoryModel):
     name = models.CharField(max_length=100, unique=True)
     description = models.TextField(blank=True)
     in_vogue_facets = models.ManyToManyField(
-        FACET_MODEL,
+        "magic.Facet",
         related_name="fashion_styles",
         blank=True,
         help_text="Facets that are currently fashionable in this style.",
@@ -1329,7 +1326,7 @@ class Trendsetter(SharedMemoryModel):
     """A crowned 'toast of the season' whose look set a society's trend (#514)."""
 
     society = models.ForeignKey(
-        SOCIETY_MODEL,
+        "societies.Society",
         on_delete=models.CASCADE,
         related_name="trendsetters",
     )

--- a/src/world/missions/models.py
+++ b/src/world/missions/models.py
@@ -52,10 +52,6 @@ _REWARD_BOTH_PARENTS_SET = 2
 # smell (python:S1192).
 _CONSEQUENCE_FK = "checks.Consequence"
 
-# Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
-OBJECT_DB_MODEL = "objects.ObjectDB"
-ROOM_PROFILE_MODEL = "evennia_extensions.RoomProfile"
-
 
 # ---------------------------------------------------------------------------
 # Mission graph data model
@@ -328,7 +324,7 @@ class MissionNode(SharedMemoryModel):
         ),
     )
     locations = models.ManyToManyField(
-        ROOM_PROFILE_MODEL,
+        "evennia_extensions.RoomProfile",
         blank=True,
         related_name="+",
         help_text=(
@@ -497,7 +493,7 @@ class MissionOption(SharedMemoryModel):
         ),
     )
     locations = models.ManyToManyField(
-        ROOM_PROFILE_MODEL,
+        "evennia_extensions.RoomProfile",
         blank=True,
         related_name="+",
         help_text=(
@@ -993,7 +989,7 @@ class MissionInstance(SharedMemoryModel):
         help_text="Where the run currently sits; null = complete.",
     )
     spawned_room = models.ForeignKey(
-        ROOM_PROFILE_MODEL,
+        "evennia_extensions.RoomProfile",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -1005,7 +1001,7 @@ class MissionInstance(SharedMemoryModel):
         ),
     )
     anchor_room = models.ForeignKey(
-        ROOM_PROFILE_MODEL,
+        "evennia_extensions.RoomProfile",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -1095,7 +1091,7 @@ class MissionParticipant(SharedMemoryModel):
         related_name="participants",
     )
     character = models.ForeignKey(
-        OBJECT_DB_MODEL,
+        "objects.ObjectDB",
         on_delete=models.PROTECT,
         related_name="+",
     )
@@ -1243,7 +1239,7 @@ class MissionDeedRecord(SharedMemoryModel):
         related_name="deeds",
     )
     actor = models.ForeignKey(
-        OBJECT_DB_MODEL,
+        "objects.ObjectDB",
         on_delete=models.PROTECT,
         related_name="+",
         help_text="The acting participant's character — consequence follows the actor.",
@@ -1314,7 +1310,7 @@ class MissionGiver(SharedMemoryModel):
         help_text="How this giver reaches the player; selects the target's expected typeclass.",
     )
     target = models.ForeignKey(
-        OBJECT_DB_MODEL,
+        "objects.ObjectDB",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -1433,7 +1429,7 @@ class MissionGiverCooldown(SharedMemoryModel):
     # Character is an ObjectDB here to match MissionParticipant.character — the
     # missions app keys runtime participation on the Evennia object, not a Persona.
     character = models.ForeignKey(
-        OBJECT_DB_MODEL,
+        "objects.ObjectDB",
         on_delete=models.CASCADE,
         related_name="+",
     )
@@ -1469,7 +1465,7 @@ class MissionDeedRewardLine(SharedMemoryModel):
         related_name="reward_lines",
     )
     recipient = models.ForeignKey(
-        OBJECT_DB_MODEL,
+        "objects.ObjectDB",
         on_delete=models.PROTECT,
         related_name="+",
         help_text=(

--- a/src/world/scenes/models.py
+++ b/src/world/scenes/models.py
@@ -29,10 +29,6 @@ if TYPE_CHECKING:
 
     from world.scenes.place_models import InteractionReceiver
 
-# Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
-CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
-INTERACTION_MODEL = "scenes.Interaction"
-
 
 class Scene(CachedPropertiesMixin, SharedMemoryModel):
     """
@@ -192,7 +188,7 @@ class Persona(SharedMemoryModel):
     """
 
     character_sheet = models.ForeignKey(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         on_delete=models.CASCADE,
         related_name="personas",
         help_text="The character sheet this persona belongs to.",
@@ -406,7 +402,7 @@ class PersonaDiscovery(SharedMemoryModel):
         help_text="The persona they were discovered to be the same person as (higher PK)",
     )
     discovered_by = models.ForeignKey(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         on_delete=models.CASCADE,
         related_name="persona_discoveries",
         help_text="The character who figured out these two personas are the same person",
@@ -751,14 +747,14 @@ class InteractionAction(SharedMemoryModel):
     """
 
     pose = models.ForeignKey(
-        INTERACTION_MODEL,
+        "scenes.Interaction",
         on_delete=models.CASCADE,
         related_name="action_links",
         db_constraint=False,
         help_text="The POSE Interaction that elaborates the action(s).",
     )
     action_interaction = models.ForeignKey(
-        INTERACTION_MODEL,
+        "scenes.Interaction",
         on_delete=models.CASCADE,
         related_name="pose_links",
         db_constraint=False,
@@ -810,7 +806,7 @@ class InteractionPowerLedgerEntry(SharedMemoryModel):
     """
 
     interaction = models.ForeignKey(
-        INTERACTION_MODEL,
+        "scenes.Interaction",
         on_delete=models.CASCADE,
         related_name="power_ledger_entries",
         db_constraint=False,
@@ -977,7 +973,7 @@ class SceneRoundParticipant(SharedMemoryModel):
         SceneRound, on_delete=models.CASCADE, related_name="participants"
     )
     character_sheet = models.ForeignKey(
-        CHARACTER_SHEET_MODEL,
+        "character_sheets.CharacterSheet",
         on_delete=models.CASCADE,
         related_name="scene_round_participations",
     )

--- a/src/world/stories/models.py
+++ b/src/world/stories/models.py
@@ -31,10 +31,6 @@ from world.stories.types import (
 if TYPE_CHECKING:
     from django.contrib.auth.base_user import AbstractBaseUser
 
-# Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
-ACCOUNT_DB_MODEL = "accounts.AccountDB"
-CONSEQUENCE_POOL_MODEL = "actions.ConsequencePool"
-
 
 class TrustCategory(SharedMemoryModel):
     """
@@ -64,7 +60,7 @@ class TrustCategory(SharedMemoryModel):
     # Metadata
     created_at = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -149,7 +145,7 @@ class Story(SharedMemoryModel):
 
     # Ownership and management
     owners = models.ManyToManyField(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         related_name="owned_stories",
         help_text="Players who own and can manage this story",
     )
@@ -279,7 +275,7 @@ class StoryTrustRequirement(SharedMemoryModel):
     # Optional metadata
     created_at = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -462,7 +458,7 @@ class PlayerTrust(SharedMemoryModel):
     """
 
     account = models.OneToOneField(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         on_delete=models.CASCADE,
         related_name="trust_profile",
     )
@@ -585,12 +581,12 @@ class StoryFeedback(SharedMemoryModel):
 
     story = models.ForeignKey(Story, on_delete=models.CASCADE, related_name="feedback")
     reviewer = models.ForeignKey(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         on_delete=models.CASCADE,
         related_name="given_feedback",
     )
     reviewed_player = models.ForeignKey(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         on_delete=models.CASCADE,
         related_name="received_feedback",
     )
@@ -915,7 +911,7 @@ class Beat(SharedMemoryModel):
 
     # Consequence pools for beat outcomes (nullable; authoring is opt-in).
     success_consequences = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -923,7 +919,7 @@ class Beat(SharedMemoryModel):
         help_text="ConsequencePool to fire when this beat resolves SUCCESS.",
     )
     failure_consequences = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -931,7 +927,7 @@ class Beat(SharedMemoryModel):
         help_text="ConsequencePool to fire when this beat resolves FAILURE.",
     )
     expired_consequences = models.ForeignKey(
-        CONSEQUENCE_POOL_MODEL,
+        "actions.ConsequencePool",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1538,7 +1534,7 @@ class StoryNote(SharedMemoryModel):
 
     story = models.ForeignKey(Story, on_delete=models.CASCADE, related_name="notes")
     author_account = models.ForeignKey(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1675,7 +1671,7 @@ class SessionRequest(SharedMemoryModel):
         help_text="The GM currently expected to run this session.",
     )
     initiated_by_account = models.ForeignKey(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -1727,7 +1723,7 @@ class StoryGMOffer(SharedMemoryModel):
         related_name="story_offers_received",
     )
     offered_by_account = models.ForeignKey(
-        ACCOUNT_DB_MODEL,
+        "accounts.AccountDB",
         on_delete=models.CASCADE,
         related_name="story_offers_made",
     )


### PR DESCRIPTION
Closes #1113. Follow-up to #1112.

## Why
`python:S1192` ("define a constant instead of duplicating this literal") is effectively a **false positive** for Django **lazy model references** — `"app_label.ModelName"` strings used as FK / M2M targets. These *must* be repeated string literals: a lazy ref can't import the model class (avoiding circular imports is the whole reason the string form exists), so the magic-string risk the rule guards against doesn't apply.

#1112 silenced these by extracting `*_MODEL` constants; this PR replaces that with a proper rule-scoped suppression and reverts the now-unnecessary extractions.

## Changes
- **`sonar-project.properties`** — add a `lazy_model_refs` entry to the existing `sonar.issue.ignore.multicriteria` block (`python:S1192` scoped to `**/models.py`), matching the pattern already used for the other confirmed architectural false positives. This suppresses at analysis time, so these never re-spawn as GitHub issues.
- **Revert the lazy-model-ref constant extractions** from #1112 — 21 `*_MODEL` definitions across `combat/covenants/currency/items/missions/scenes/stories` `models.py` are back to inline literals. Pre-existing `_*_FK` constants left intact; the genuinely-useful non-model-ref constants from #1112 (repeated error messages, factory paths, seed labels) are kept.

## Caveat (documented inline in the config)
`sonar.issue.ignore.multicriteria` matches `ruleKey` + a file glob — there's no content matcher — so this exempts *all* S1192 in `models.py`, not literally "only `app.Model` strings." Acceptable here because every S1192 hit in this codebase's `models.py` files was a lazy ref.

## Verification
- Fast SQLite tier green for all 7 touched apps (3662 tests).
- All pre-commit hooks pass (ruff, `ty`, custom linters).
- No behavior change — each constant became the exact literal it was defined as.

🤖 Generated with [Claude Code](https://claude.com/claude-code)