### PR TITLE
feat(appearance): web serializer overlays active-persona descriptors (N+1-safe)

### DIFF
--- a/src/world/character_sheets/serializers.py
+++ b/src/world/character_sheets/serializers.py
@@ -46,7 +46,12 @@ from world.character_sheets.types import (
 )
 from world.classes.models import PathStage
 from world.distinctions.models import CharacterDistinction
-from world.forms.models import CharacterForm, CharacterFormValue, FormType
+from world.forms.models import (
+    CharacterForm,
+    CharacterFormValue,
+    FormType,
+    PersonaTraitDescriptor,
+)
 from world.goals.models import CharacterGoal
 from world.magic.constants import RitualExecutionKind
 from world.magic.models import (
@@ -60,6 +65,7 @@ from world.magic.models import (
 )
 from world.progression.models import CharacterPathHistory
 from world.roster.models import RosterTenure
+from world.scenes.constants import PersonaType
 from world.scenes.models import Persona
 from world.skills.models import CharacterSkillValue, CharacterSpecializationValue
 from world.traits.models import CharacterTraitValue, TraitType
@@ -167,17 +173,39 @@ _APPEARANCE_PREFETCH_RELATED: tuple[str | Prefetch, ...] = (
 )
 
 
+def _resolve_active_persona(sheet: CharacterSheet) -> Persona | None:
+    """The presented face, resolved from prefetched ``cached_personas`` (0 queries).
+
+    Mirrors ``scenes.services.active_persona_for_sheet`` (the ``active_persona`` FK,
+    else the PRIMARY persona) but reads the prefetch so the builder stays query-free.
+    """
+    personas: list[Persona] = sheet.cached_personas
+    active_id = sheet.active_persona_id
+    if active_id is not None:
+        return next((p for p in personas if p.pk == active_id), None)
+    return next((p for p in personas if p.persona_type == PersonaType.PRIMARY), None)
+
+
 def _build_appearance(sheet: CharacterSheet) -> AppearanceSection:
-    """Build the appearance section dict from a CharacterSheet."""
+    """Build the appearance section: normalized TRUE-form traits overlaid with the
+    active persona's descriptors (descriptor, else normalized) — mirroring the telnet
+    ``item_data`` composition. Query-free: reads prefetched forms + personas.
+    """
     character = sheet.character
 
-    # Get form traits from the TRUE form (prefetched + filtered via to_attr).
+    active = _resolve_active_persona(sheet)
+    descriptors: dict[int, str] = (
+        {d.trait_id: d.text for d in active.cached_trait_descriptors} if active is not None else {}
+    )
+
     true_forms: list[CharacterForm] = character.cached_true_forms
     if true_forms:
-        true_form = true_forms[0]
         form_traits: list[FormTraitEntry] = [
-            FormTraitEntry(trait=fv.trait.display_name, value=fv.option.display_name)
-            for fv in true_form.cached_values
+            FormTraitEntry(
+                trait=fv.trait.display_name,
+                value=descriptors.get(fv.trait_id) or fv.option.display_name,
+            )
+            for fv in true_forms[0].cached_values
         ]
     else:
         form_traits = []
@@ -525,7 +553,15 @@ _PERSONAS_SELECT_RELATED: tuple[str, ...] = ()
 _PERSONAS_PREFETCH_RELATED: tuple[str | Prefetch, ...] = (
     Prefetch(
         "personas",
-        queryset=Persona.objects.select_related("thumbnail"),
+        queryset=Persona.objects.select_related("thumbnail").prefetch_related(
+            # Each persona's per-trait descriptors, so the appearance builder can
+            # overlay the active face's descriptors at zero extra queries.
+            Prefetch(
+                "trait_descriptors",
+                queryset=PersonaTraitDescriptor.objects.select_related("trait"),
+                to_attr="cached_trait_descriptors",
+            )
+        ),
         to_attr="cached_personas",
     ),
 )

--- a/src/world/character_sheets/tests/test_viewset.py
+++ b/src/world/character_sheets/tests/test_viewset.py
@@ -489,6 +489,21 @@ class TestAppearanceSection(TestCase):
         assert trait_map["Hair Color"] == "Black"
         assert trait_map["Eye Color"] == "Green"
 
+    def test_form_traits_show_active_persona_descriptor(self) -> None:
+        """A descriptor on the active persona overrides the normalized value."""
+        from world.forms.factories import PersonaTraitDescriptorFactory
+        from world.forms.models import FormTrait
+
+        PersonaTraitDescriptorFactory(
+            persona=self.sheet.primary_persona,
+            trait=FormTrait.objects.get(name="hair_color"),
+            text="Crimson",
+        )
+
+        trait_map = {t["trait"]: t["value"] for t in self._get_appearance()["form_traits"]}
+        assert trait_map["Hair Color"] == "Crimson"  # descriptor wins
+        assert trait_map["Eye Color"] == "Green"  # no descriptor → normalized
+
 
 class TestAppearanceNoTrueForm(TestCase):
     """Tests for appearance section when no TRUE form exists."""
@@ -1849,7 +1864,7 @@ class TestCharacterSheetQueryCount(TestCase):
         This test locks in the prefetch strategy. If a new N+1 regression
         is introduced, the query count will increase and this test will fail.
 
-        24 queries breakdown (SharedMemoryModel caching reduces some lookups):
+        25 queries breakdown (SharedMemoryModel caching reduces some lookups):
          1-4.  Session management (check, savepoint, insert, release)
          5.    CharacterSheet + select_related (character, identity FKs,
                build, aura, roster_entry, profile_picture__media)
@@ -1869,10 +1884,11 @@ class TestCharacterSheetQueryCount(TestCase):
         19.    motif resonance facet_assignments (nested Prefetch)
         20.    goals
         21.    personas + thumbnails (via Prefetch select_related)
-        22-24. Session management (savepoint, update, release)
+        22.    persona trait_descriptors (nested Prefetch — appearance overlay)
+        23-25. Session management (savepoint, update, release)
         """
         url = f"/api/character-sheets/{self.character.pk}/"
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(25):
             response = self.client.get(url)
         assert response.status_code == 200
         # Verify all sections are populated


### PR DESCRIPTION
Closes #1108 — the final piece of slice 1 (the architecture's single render composition, now on the web). Builds on the merged substrate #1120; independent of #1119/#1122 (different files).

## What's here
The web character-sheet `_build_appearance` now overlays the **active persona's** `PersonaTraitDescriptor` onto the TRUE-form traits — value = descriptor, else normalized — so the web renders the same composed appearance the telnet `item_data` does. One source, both clients.

## Staying within the 0-query contract
The serializer's hard rule is every section builder runs in **0 queries** after the prefetch. So:
- `trait_descriptors` are hung off the **existing** personas prefetch (`cached_personas`), with `select_related("trait")`.
- The active face is resolved **in-memory** from `cached_personas` (`active_persona_id` is a column; PRIMARY fallback) — mirrors `active_persona_for_sheet` without a query.
- Net: one extra prefetch query on the endpoint → `test_query_count_bounded` 24 → 25; `test_appearance_zero_queries` stays 0.

## Tests
Added `test_form_traits_show_active_persona_descriptor` (descriptor overrides normalized); viewset suite green (115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)