### PR TITLE
feat: persona switcher UI for active-persona

### DIFF
--- a/frontend/src/combat/pages/__tests__/CombatScenePage.test.tsx
+++ b/frontend/src/combat/pages/__tests__/CombatScenePage.test.tsx
@@ -73,6 +73,7 @@ vi.mock('@/roster/queries', () => ({
         name: 'Aerande',
         character_id: 10,
         primary_persona_id: 99,
+        active_persona_id: 99,
         profile_picture_url: null,
       },
     ],

--- a/frontend/src/fashion/__tests__/FashionPresentationPanel.test.tsx
+++ b/frontend/src/fashion/__tests__/FashionPresentationPanel.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@/roster/queries', () => ({
         character_id: 3,
         profile_picture_url: null,
         primary_persona_id: null,
+        active_persona_id: null,
       },
     ],
   }),

--- a/frontend/src/game/components/GameTopBar.tsx
+++ b/frontend/src/game/components/GameTopBar.tsx
@@ -4,6 +4,8 @@ import { useGameSocket } from '@/hooks/useGameSocket';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import type { MyRosterEntry } from '@/roster/types';
 
+import { PersonaSwitcher } from './PersonaSwitcher';
+
 interface GameTopBarProps {
   characters: MyRosterEntry[];
 }
@@ -53,7 +55,10 @@ export function GameTopBar({ characters }: GameTopBarProps) {
             <AvatarImage src={activeCharacter.profile_picture_url ?? undefined} alt={active} />
             <AvatarFallback className="text-xs">{getInitials(active)}</AvatarFallback>
           </Avatar>
-          <span className="text-sm font-medium">{active}</span>
+          <PersonaSwitcher
+            characterSheetId={activeCharacter.character_id}
+            activePersonaId={activeCharacter.active_persona_id}
+          />
         </div>
       ) : null}
 

--- a/frontend/src/game/components/PersonaSwitcher.tsx
+++ b/frontend/src/game/components/PersonaSwitcher.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from 'react';
+
+import { PersonaAvatar, type PersonaAvatarSource } from '@/components/PersonaAvatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+import {
+  useCharacterPersonasQuery,
+  useSetActivePersonaMutation,
+  type SwitchablePersona,
+} from '../personaQueries';
+
+interface PersonaSwitcherProps {
+  characterSheetId: number;
+  activePersonaId: number | null;
+}
+
+const TYPE_LABEL: Record<SwitchablePersona['persona_type'], string> = {
+  primary: 'True self',
+  established: 'Alt identity',
+  temporary: 'Mask',
+};
+
+function avatarSource(p: SwitchablePersona): PersonaAvatarSource {
+  return { name: p.name, thumbnailUrl: p.thumbnail_url, thumbnailMediaUrl: p.thumbnail_media_url };
+}
+
+/**
+ * Top-bar control for the face the player is presenting as (#1043).
+ *
+ * Shows the worn identity and, when the character has more than one face, lets the
+ * player switch via `POST /api/personas/set-active/`. The worn face is made
+ * deliberately obvious so a player never acts as the wrong identity by accident.
+ */
+export function PersonaSwitcher({ characterSheetId, activePersonaId }: PersonaSwitcherProps) {
+  const { data: personas = [] } = useCharacterPersonasQuery(characterSheetId);
+  const setActive = useSetActivePersonaMutation();
+
+  const worn = useMemo(
+    () =>
+      personas.find((p) => p.id === activePersonaId) ??
+      personas.find((p) => p.persona_type === 'primary') ??
+      personas[0],
+    [personas, activePersonaId]
+  );
+
+  if (!worn) return null;
+
+  // A single face — nothing to switch; just name the worn identity.
+  if (personas.length <= 1) {
+    return <span className="text-sm font-medium">{worn.name}</span>;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="flex items-center gap-1.5 rounded px-2 py-1 text-sm font-medium ring-1 ring-primary/40 hover:bg-accent disabled:opacity-50"
+        disabled={setActive.isPending}
+        title="Switch which identity you are presenting as"
+      >
+        <span>{worn.name}</span>
+        <span className="text-xs text-muted-foreground" aria-hidden>
+          ▾
+        </span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-56">
+        <DropdownMenuLabel>Presenting as</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuRadioGroup
+          value={worn.id.toString()}
+          onValueChange={(value) => {
+            const id = Number(value);
+            if (id !== worn.id) {
+              setActive.mutate(id);
+            }
+          }}
+        >
+          {personas.map((p) => (
+            <DropdownMenuRadioItem key={p.id} value={p.id.toString()} className="gap-2">
+              <PersonaAvatar source={avatarSource(p)} size="sm" />
+              <span className="flex flex-col">
+                <span>{p.name}</span>
+                <span className="text-xs text-muted-foreground">{TYPE_LABEL[p.persona_type]}</span>
+              </span>
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/game/components/__tests__/PersonaSwitcher.test.tsx
+++ b/frontend/src/game/components/__tests__/PersonaSwitcher.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SwitchablePersona } from '../../personaQueries';
+import { PersonaSwitcher } from '../PersonaSwitcher';
+
+const { state, mutate } = vi.hoisted(() => ({
+  state: { personas: [] as SwitchablePersona[] },
+  mutate: vi.fn(),
+}));
+
+vi.mock('../../personaQueries', () => ({
+  useCharacterPersonasQuery: () => ({ data: state.personas }),
+  useSetActivePersonaMutation: () => ({ mutate, isPending: false }),
+}));
+
+function persona(
+  id: number,
+  name: string,
+  type: SwitchablePersona['persona_type']
+): SwitchablePersona {
+  return {
+    id,
+    name,
+    persona_type: type,
+    is_fake_name: type === 'temporary',
+    thumbnail_url: null,
+    thumbnail_media_url: null,
+  };
+}
+
+describe('PersonaSwitcher', () => {
+  it('shows the worn face when more than one identity exists', () => {
+    state.personas = [
+      persona(1, 'Bob the Great', 'primary'),
+      persona(2, 'Robert DVile', 'established'),
+    ];
+    render(<PersonaSwitcher characterSheetId={1} activePersonaId={2} />);
+    expect(screen.getByText('Robert DVile')).toBeInTheDocument();
+  });
+
+  it('renders just the name (no switcher) for a single identity', () => {
+    state.personas = [persona(1, 'Bob the Great', 'primary')];
+    render(<PersonaSwitcher characterSheetId={1} activePersonaId={1} />);
+    expect(screen.getByText('Bob the Great')).toBeInTheDocument();
+    expect(screen.queryByTitle(/Switch which identity/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/game/personaQueries.ts
+++ b/frontend/src/game/personaQueries.ts
@@ -1,0 +1,80 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { apiFetch } from '@/evennia_replacements/api';
+
+export type PersonaType = 'primary' | 'established' | 'temporary';
+
+/** A face a character can present as, for the top-bar switcher. */
+export interface SwitchablePersona {
+  id: number;
+  name: string;
+  persona_type: PersonaType;
+  is_fake_name: boolean;
+  thumbnail_url: string | null;
+  thumbnail_media_url: string | null;
+}
+
+const personaKeys = {
+  forCharacterSheet: (characterSheetId: number) =>
+    ['character-personas', characterSheetId] as const,
+};
+
+async function fetchCharacterPersonas(characterSheetId: number): Promise<SwitchablePersona[]> {
+  const res = await apiFetch(`/api/personas/?character_sheet=${characterSheetId}&page_size=100`);
+  if (!res.ok) {
+    throw new Error('Failed to load personas.');
+  }
+  const data = (await res.json()) as {
+    results?: Array<{
+      id: number;
+      name: string;
+      persona_type?: PersonaType;
+      is_fake_name?: boolean;
+      thumbnail_url?: string | null;
+      thumbnail_media_url?: string | null;
+    }>;
+  };
+  return (data.results ?? []).map((p) => ({
+    id: p.id,
+    name: p.name,
+    persona_type: p.persona_type ?? 'established',
+    is_fake_name: p.is_fake_name ?? false,
+    thumbnail_url: p.thumbnail_url ?? null,
+    thumbnail_media_url: p.thumbnail_media_url ?? null,
+  }));
+}
+
+/** The faces a character can wear (PRIMARY + ESTABLISHED + TEMPORARY masks). */
+export function useCharacterPersonasQuery(characterSheetId: number | null) {
+  return useQuery({
+    queryKey:
+      characterSheetId !== null
+        ? personaKeys.forCharacterSheet(characterSheetId)
+        : ['character-personas', 'none'],
+    queryFn: () => fetchCharacterPersonas(characterSheetId as number),
+    enabled: characterSheetId !== null,
+  });
+}
+
+async function setActivePersona(personaId: number): Promise<number> {
+  const res = await apiFetch('/api/personas/set-active/', {
+    method: 'POST',
+    body: JSON.stringify({ persona_id: personaId }),
+  });
+  if (!res.ok) {
+    throw new Error('Could not switch to that identity.');
+  }
+  const data = (await res.json()) as { active_persona_id: number };
+  return data.active_persona_id;
+}
+
+/** Switch the worn face. Invalidates the roster bootstrap so the bar re-reads it. */
+export function useSetActivePersonaMutation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (personaId: number) => setActivePersona(personaId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['my-roster-entries'] });
+    },
+  });
+}

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -16770,6 +16770,11 @@ export interface components {
        *     Used by player-submission forms to attach a reporter_persona.
        */
       readonly primary_persona_id: number | null;
+      /**
+       * @description The face currently worn — the durable ``active_persona`` (#981) if set,
+       *     else the PRIMARY. Lets the top-bar switcher highlight the worn identity.
+       */
+      readonly active_persona_id: number | null;
     };
     NPCRole: {
       readonly id: number;

--- a/frontend/src/inventory/pages/__tests__/WardrobePage.test.tsx
+++ b/frontend/src/inventory/pages/__tests__/WardrobePage.test.tsx
@@ -88,6 +88,7 @@ function makeRosterEntry(overrides: Partial<MyRosterEntry> = {}): MyRosterEntry 
     character_id: CHARACTER_ID,
     profile_picture_url: null,
     primary_persona_id: null,
+    active_persona_id: null,
     ...overrides,
   };
 }

--- a/frontend/src/roster/types.ts
+++ b/frontend/src/roster/types.ts
@@ -11,6 +11,8 @@ export interface MyRosterEntry {
   character_id: number;
   profile_picture_url: string | null;
   primary_persona_id: number | null;
+  /** The face currently worn (durable active_persona, else primary) — #981/#1043. */
+  active_persona_id: number | null;
 }
 
 export interface CharacterGallery {

--- a/frontend/src/scenes/components/ActionAttachment.test.tsx
+++ b/frontend/src/scenes/components/ActionAttachment.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@/roster/queries', () => ({
         character_id: 42,
         profile_picture_url: null,
         primary_persona_id: null,
+        active_persona_id: null,
       },
     ],
   })),

--- a/frontend/src/scenes/components/ActionPanel.test.tsx
+++ b/frontend/src/scenes/components/ActionPanel.test.tsx
@@ -48,6 +48,7 @@ vi.mock('@/roster/queries', () => ({
         character_id: 42,
         profile_picture_url: null,
         primary_persona_id: null,
+        active_persona_id: null,
       },
     ],
   })),
@@ -211,6 +212,7 @@ describe('ActionPanel', () => {
           character_id: 42,
           profile_picture_url: null,
           primary_persona_id: 77,
+          active_persona_id: 77,
         },
       ],
     } as ReturnType<typeof useMyRosterEntriesQuery>);

--- a/frontend/src/scenes/components/PersonaContextMenu.test.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@/roster/queries', () => ({
         character_id: 42,
         profile_picture_url: null,
         primary_persona_id: null,
+        active_persona_id: null,
       },
     ],
   })),

--- a/frontend/src/scenes/components/ReactionStrip.test.tsx
+++ b/frontend/src/scenes/components/ReactionStrip.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@/roster/queries', () => ({
         character_id: 42,
         profile_picture_url: null,
         primary_persona_id: 7,
+        active_persona_id: 7,
       },
     ],
   })),

--- a/src/schema.json
+++ b/src/schema.json
@@ -30305,7 +30305,15 @@ components:
 
             Used by player-submission forms to attach a reporter_persona.
           readOnly: true
+        active_persona_id:
+          type: integer
+          nullable: true
+          description: |-
+            The face currently worn — the durable ``active_persona`` (#981) if set,
+            else the PRIMARY. Lets the top-bar switcher highlight the worn identity.
+          readOnly: true
       required:
+      - active_persona_id
       - character_id
       - id
       - name

--- a/src/world/roster/serializers/roster_core.py
+++ b/src/world/roster/serializers/roster_core.py
@@ -84,6 +84,7 @@ class MyRosterEntrySerializer(serializers.ModelSerializer):
     )
     profile_picture_url = serializers.SerializerMethodField()
     primary_persona_id = serializers.SerializerMethodField()
+    active_persona_id = serializers.SerializerMethodField()
 
     class Meta:
         model = RosterEntry
@@ -93,6 +94,7 @@ class MyRosterEntrySerializer(serializers.ModelSerializer):
             "character_id",
             "profile_picture_url",
             "primary_persona_id",
+            "active_persona_id",
         )
         read_only_fields: ClassVar[tuple[str, ...]] = fields
 
@@ -114,6 +116,13 @@ class MyRosterEntrySerializer(serializers.ModelSerializer):
             return obj.character_sheet.primary_persona.pk
         except ObjectDoesNotExist:
             return None
+
+    def get_active_persona_id(self, obj: RosterEntry) -> int | None:
+        """The face currently worn — the durable ``active_persona`` (#981) if set,
+        else the PRIMARY. Lets the top-bar switcher highlight the worn identity."""
+        if obj.character_sheet.active_persona_id is not None:
+            return obj.character_sheet.active_persona_id
+        return self.get_primary_persona_id(obj)
 
 
 class RosterEntryListSerializer(serializers.ModelSerializer):

--- a/src/world/roster/tests/test_serializers.py
+++ b/src/world/roster/tests/test_serializers.py
@@ -495,3 +495,22 @@ class MyRosterEntrySerializerTestCase(TestCase):
         entry = RosterEntryFactory(character_sheet__primary_persona=False)
         data = MyRosterEntrySerializer(entry).data
         assert data["primary_persona_id"] is None
+
+    def test_active_persona_id_defaults_to_primary(self):
+        """active_persona_id falls back to the PRIMARY when no face is worn."""
+        data = MyRosterEntrySerializer(self.entry).data
+        assert data["active_persona_id"] == self.entry.character_sheet.primary_persona.pk
+
+    def test_active_persona_id_returns_worn_face(self):
+        """active_persona_id reflects the durable active_persona when set."""
+        from world.scenes.constants import PersonaType
+        from world.scenes.factories import PersonaFactory
+
+        entry = RosterEntryFactory()
+        sheet = entry.character_sheet
+        alt = PersonaFactory(character_sheet=sheet, persona_type=PersonaType.ESTABLISHED)
+        sheet.active_persona = alt
+        sheet.save(update_fields=["active_persona"])
+
+        data = MyRosterEntrySerializer(entry).data
+        assert data["active_persona_id"] == alt.pk


### PR DESCRIPTION
Closes #1043. Follow-up to #981/#1044 (active-persona backend) — players couldn't yet present as an alt/mask through the web client; the `set-active` endpoint had no UI.

## What's here
**Backend:** expose `active_persona_id` (the worn face — durable `active_persona`, else PRIMARY) on `MyRosterEntrySerializer`, so the top bar reads the current face on load. + 2 serializer tests; regenerated api types.

**Frontend:**
- `personaQueries.ts` — `useCharacterPersonasQuery` (lists PRIMARY/ESTABLISHED/TEMPORARY faces) + `useSetActivePersonaMutation` (`POST /api/personas/set-active/`, invalidates the roster bootstrap).
- `PersonaSwitcher.tsx` — a `DropdownMenu` in `GameTopBar` showing the worn identity and letting the player switch. The current face is made deliberately obvious (the switcher *is* the name display); a single-face character shows just the name, no menu — so switching faces is never an accidental act.
- Component test + the `MyRosterEntry` mocks across the suite updated for the new field.

## Gates
Backend roster tests 18/18; FE `pnpm build` (tsc -b + vite) green; typecheck, lint, component test, api-types regen all clean.

## Out of scope
TEMPORARY-mask donning/removal mechanics (separate system) — per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)