### PR TITLE
feat(#534): rich text pose composer — links, scene-participant mentions, content validation

### DIFF
--- a/frontend/src/components/RichTextInput.tsx
+++ b/frontend/src/components/RichTextInput.tsx
@@ -133,6 +133,40 @@ export function RichTextInput({
     [autocompleteState, value, onChange]
   );
 
+  const handleLinkInsert = React.useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const currentValue = textarea.value;
+    const selected = currentValue.slice(start, end);
+
+    let insert: string;
+    let cursorStart: number;
+    let cursorEnd: number;
+
+    if (selected.length > 0) {
+      // Wrap selection as label; select the URL placeholder so user can type it
+      insert = `[${selected}](https://)`;
+      cursorStart = start + 1 + selected.length + 2; // position of 'h' in 'https://'
+      cursorEnd = cursorStart + 'https://'.length;
+    } else {
+      // No selection: insert template with cursor inside [] so user types label first
+      insert = '[](https://)';
+      cursorStart = start + 1;
+      cursorEnd = start + 1;
+    }
+
+    const newValue = currentValue.slice(0, start) + insert + currentValue.slice(end);
+    onChange(newValue);
+
+    requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.selectionStart = cursorStart;
+      textarea.selectionEnd = cursorEnd;
+    });
+  }, [onChange]);
+
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       // Handle autocomplete navigation first
@@ -197,6 +231,11 @@ export function RichTextInput({
           handleWrap('~~', '~~');
           return;
         }
+        if (e.key === 'k') {
+          e.preventDefault();
+          handleLinkInsert();
+          return;
+        }
       }
 
       // Enter to submit, Shift+Enter for newline
@@ -209,7 +248,15 @@ export function RichTextInput({
       // Pass through to parent handler
       onKeyDown?.(e);
     },
-    [autocompleteState, filteredItems, handleAutocompleteSelect, handleWrap, onSubmit, onKeyDown]
+    [
+      autocompleteState,
+      filteredItems,
+      handleAutocompleteSelect,
+      handleWrap,
+      handleLinkInsert,
+      onSubmit,
+      onKeyDown,
+    ]
   );
 
   const handleChange = React.useCallback(
@@ -280,6 +327,16 @@ export function RichTextInput({
           onClick={() => handleWrap('~~', '~~')}
         >
           S
+        </button>
+        <button
+          type="button"
+          title="Link (Ctrl+K)"
+          aria-label="Link"
+          className="flex h-6 w-6 items-center justify-center rounded text-xs hover:bg-accent hover:text-accent-foreground"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={handleLinkInsert}
+        >
+          🔗
         </button>
         <div className="mx-1 h-4 w-px bg-border" />
         <ColorPicker onSelectColor={handleColorSelect} />

--- a/frontend/src/components/__tests__/RichTextInput.test.tsx
+++ b/frontend/src/components/__tests__/RichTextInput.test.tsx
@@ -122,6 +122,35 @@ describe('RichTextInput', () => {
     expect(textarea).not.toHaveAttribute('placeholder');
   });
 
+  it('renders a Link toolbar button', () => {
+    render(<RichTextInput {...defaultProps} />);
+    expect(screen.getByTitle('Link (Ctrl+K)')).toBeInTheDocument();
+  });
+
+  it('Ctrl+K inserts link template with no selection', () => {
+    const onChange = vi.fn();
+    render(<RichTextInput value="" onChange={onChange} onSubmit={vi.fn()} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+    Object.defineProperty(textarea, 'selectionStart', { value: 0, writable: true });
+    Object.defineProperty(textarea, 'selectionEnd', { value: 0, writable: true });
+    fireEvent.keyDown(textarea, { key: 'k', ctrlKey: true });
+
+    expect(onChange).toHaveBeenCalledWith('[](https://)');
+  });
+
+  it('Ctrl+K wraps selected text as link label', () => {
+    const onChange = vi.fn();
+    render(<RichTextInput value="visit example" onChange={onChange} onSubmit={vi.fn()} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+    Object.defineProperty(textarea, 'selectionStart', { value: 6, writable: true });
+    Object.defineProperty(textarea, 'selectionEnd', { value: 13, writable: true });
+    fireEvent.keyDown(textarea, { key: 'k', ctrlKey: true });
+
+    expect(onChange).toHaveBeenCalledWith('visit [example](https://)');
+  });
+
   describe('@mention autocomplete', () => {
     const characters = [
       { name: 'Alice', thumbnail_url: null },

--- a/frontend/src/game/components/CommandInput.test.tsx
+++ b/frontend/src/game/components/CommandInput.test.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
 import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
 import type { RenderOptions } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement, ReactNode } from 'react';
 import { CommandInput } from './CommandInput';
 import type { ComposerMode } from './CommandInput';
 
 // Wrap every render call in a QueryClientProvider so useQuery hooks work in tests.
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
-function render(ui: React.ReactElement, options?: RenderOptions) {
-  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+function render(ui: ReactElement, options?: RenderOptions) {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
   return rtlRender(ui, { wrapper: Wrapper, ...options });
@@ -77,6 +77,7 @@ describe('CommandInput', () => {
     sendMock.mockClear();
     submitPoseMock.mockClear();
     fetchSceneMock.mockClear();
+    queryClient.clear();
   });
 
   it('renders ghost text with mode label when composerMode is provided', () => {

--- a/frontend/src/game/components/CommandInput.test.tsx
+++ b/frontend/src/game/components/CommandInput.test.tsx
@@ -1,10 +1,24 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
+import type { RenderOptions } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CommandInput } from './CommandInput';
 import type { ComposerMode } from './CommandInput';
 
+// Wrap every render call in a QueryClientProvider so useQuery hooks work in tests.
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+function render(ui: React.ReactElement, options?: RenderOptions) {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return rtlRender(ui, { wrapper: Wrapper, ...options });
+}
+
 const sendMock = vi.fn();
 const submitPoseMock = vi.fn(() => Promise.resolve());
+const fetchSceneMock = vi.fn();
 
 vi.mock('@/hooks/useGameSocket', () => ({
   useGameSocket: () => ({ send: sendMock }),
@@ -12,6 +26,10 @@ vi.mock('@/hooks/useGameSocket', () => ({
 
 vi.mock('@/scenes/queries', () => ({
   submitPose: (...args: unknown[]) => submitPoseMock(...(args as [])),
+  fetchScene: (...args: unknown[]) => fetchSceneMock(...(args as [])),
+  sceneKeys: {
+    detail: (id: string) => ['scene', String(id)] as const,
+  },
 }));
 
 vi.mock('@/store/hooks', () => ({
@@ -58,6 +76,7 @@ describe('CommandInput', () => {
   beforeEach(() => {
     sendMock.mockClear();
     submitPoseMock.mockClear();
+    fetchSceneMock.mockClear();
   });
 
   it('renders ghost text with mode label when composerMode is provided', () => {
@@ -276,5 +295,33 @@ describe('CommandInput', () => {
 
     expect(sendMock).toHaveBeenCalledWith('Alice', 'pose stands ready');
     expect(submitPoseMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('mention autocomplete source', () => {
+  beforeEach(() => {
+    queryClient.clear();
+  });
+
+  it('uses scene participants when sceneId is provided', async () => {
+    fetchSceneMock.mockResolvedValue({
+      id: 42,
+      name: 'Test Scene',
+      participants: [{ id: 1, name: 'ScenePersona', roster_entry: null }],
+      is_active: true,
+      is_owner: false,
+      description: '',
+      date_started: '',
+      location: null,
+    });
+
+    render(<CommandInput character="Alice" sceneId="42" />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    Object.defineProperty(textarea, 'selectionStart', { value: 1, writable: true });
+    fireEvent.change(textarea, { target: { value: '@', selectionStart: 1 } });
+
+    await screen.findByText('ScenePersona');
+    expect(screen.queryByText('Bob')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/game/components/CommandInput.tsx
+++ b/frontend/src/game/components/CommandInput.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
-import * as React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useGameSocket } from '@/hooks/useGameSocket';
 import { RichTextInput } from '@/components/RichTextInput';
@@ -223,7 +222,7 @@ export function CommandInput({
     return text;
   }, [composerMode, actionAttachment, isEntrance]);
 
-  const autocompleteItems = React.useMemo(() => {
+  const autocompleteItems = useMemo(() => {
     if (sceneId && sceneDetail?.participants) {
       return sceneDetail.participants.map((p) => ({
         name: p.name,

--- a/frontend/src/game/components/CommandInput.tsx
+++ b/frontend/src/game/components/CommandInput.tsx
@@ -1,4 +1,6 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useGameSocket } from '@/hooks/useGameSocket';
 import { RichTextInput } from '@/components/RichTextInput';
 import { ModeSelector } from '@/scenes/components/ModeSelector';
@@ -6,7 +8,8 @@ import { ActionAttachment } from '@/scenes/components/ActionAttachment';
 import { useAppSelector } from '@/store/hooks';
 import type { MyRosterEntry } from '@/roster/types';
 import type { ActionAttachmentInfo } from '@/scenes/actionTypes';
-import { submitPose } from '@/scenes/queries';
+import { submitPose, fetchScene, sceneKeys } from '@/scenes/queries';
+import type { SceneDetail } from '@/scenes/queries';
 
 export interface ComposerMode {
   command: string; // "pose" | "say" | "tt" | "whisper"
@@ -85,6 +88,12 @@ export function CommandInput({
     if (!activeCharacter) return [];
     const room = state.game.sessions[activeCharacter]?.room;
     return room?.characters ?? [];
+  });
+
+  const { data: sceneDetail } = useQuery<SceneDetail>({
+    queryKey: sceneKeys.detail(sceneId ?? ''),
+    queryFn: () => fetchScene(sceneId!),
+    enabled: !!sceneId,
   });
 
   const handleSubmit = useCallback(() => {
@@ -214,6 +223,16 @@ export function CommandInput({
     return text;
   }, [composerMode, actionAttachment, isEntrance]);
 
+  const autocompleteItems = React.useMemo(() => {
+    if (sceneId && sceneDetail?.participants) {
+      return sceneDetail.participants.map((p) => ({
+        name: p.name,
+        thumbnail_url: null as string | null,
+      }));
+    }
+    return roomCharacters;
+  }, [sceneId, sceneDetail?.participants, roomCharacters]);
+
   // Append @name when a pending target arrives
   useEffect(() => {
     if (targetToAppend) {
@@ -269,7 +288,7 @@ export function CommandInput({
           ) : undefined
         }
         ghostText={ghostText}
-        autocompleteItems={roomCharacters}
+        autocompleteItems={autocompleteItems}
       />
     </div>
   );

--- a/frontend/src/lib/__tests__/formatParser.test.ts
+++ b/frontend/src/lib/__tests__/formatParser.test.ts
@@ -158,4 +158,40 @@ describe('parseFormattedContent', () => {
     });
     expect(result[1]).toEqual({ type: 'text', content: ', and more' });
   });
+
+  it('parses markdown link [text](url) as link with display text as content', () => {
+    const result = parseFormattedContent('[click here](https://example.com)');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: 'link',
+      content: 'click here',
+      url: 'https://example.com',
+    });
+  });
+
+  it('parses markdown link surrounded by text', () => {
+    const result = parseFormattedContent('visit [my site](https://example.com) today');
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ type: 'text', content: 'visit ' });
+    expect(result[1]).toEqual({ type: 'link', content: 'my site', url: 'https://example.com' });
+    expect(result[2]).toEqual({ type: 'text', content: ' today' });
+  });
+
+  it('rejects non-http markdown link — renders as plain text', () => {
+    const result = parseFormattedContent('[evil](javascript:void(0))');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('text');
+  });
+
+  it('bare URL and markdown link coexist', () => {
+    const result = parseFormattedContent('https://bare.com and [label](https://md.com)');
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({
+      type: 'link',
+      content: 'https://bare.com',
+      url: 'https://bare.com',
+    });
+    expect(result[1]).toEqual({ type: 'text', content: ' and ' });
+    expect(result[2]).toEqual({ type: 'link', content: 'label', url: 'https://md.com' });
+  });
 });

--- a/frontend/src/lib/formatParser.ts
+++ b/frontend/src/lib/formatParser.ts
@@ -55,13 +55,16 @@ interface Token {
     | 'italicMarker'
     | 'strikeMarker'
     | 'url'
+    | 'markdownLink'
     | 'text';
   start: number;
   end: number;
   /** For colorStart: the resolved hex value. */
   hex?: string;
-  /** For url: the matched URL string. */
+  /** For url / markdownLink: the matched URL string. */
   url?: string;
+  /** For markdownLink: the display text between [ and ]. */
+  displayText?: string;
 }
 
 // Pattern for color codes: |r, |[123], etc. and |n for reset
@@ -70,6 +73,7 @@ const COLOR_RESET_RE = /\|n/g;
 const BOLD_RE = /\*\*/g;
 const STRIKE_RE = /~~/g;
 const URL_RE = /https?:\/\/[^\s<>"{}|\\^`[\]]+/g;
+const MARKDOWN_LINK_RE = /\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)/g;
 
 /** Trailing punctuation that is unlikely to be part of a URL. */
 const TRAILING_PUNCT = new Set(['.', ',', ')', '!', '?', ':', ';']);
@@ -128,6 +132,18 @@ function collectTokens(text: string): Token[] {
     if (url.length > 0) {
       tokens.push({ kind: 'url', start: m.index, end, url });
     }
+  }
+
+  // Markdown links [display](https://url)
+  MARKDOWN_LINK_RE.lastIndex = 0;
+  while ((m = MARKDOWN_LINK_RE.exec(text)) !== null) {
+    tokens.push({
+      kind: 'markdownLink',
+      start: m.index,
+      end: m.index + m[0].length,
+      url: m[2],
+      displayText: m[1],
+    });
   }
 
   // Sort by position
@@ -354,27 +370,39 @@ export function parseFormattedContent(text: string): Segment[] {
     }
   }
 
-  // Add URL ranges
+  // Add URL and markdown-link ranges
   for (let i = 0; i < tokens.length; i++) {
     if (consumed.has(i)) continue;
-    if (tokens[i].kind === 'url') {
-      // Check URL isn't inside an already-matched range
+    const t = tokens[i];
+    if (t.kind === 'url' || t.kind === 'markdownLink') {
       let inside = false;
       for (const r of ranges) {
-        if (tokens[i].start >= r.fullStart && tokens[i].end <= r.fullEnd) {
+        if (t.start >= r.fullStart && t.end <= r.fullEnd) {
           inside = true;
           break;
         }
       }
       if (!inside) {
-        ranges.push({
-          type: 'link',
-          contentStart: tokens[i].start,
-          contentEnd: tokens[i].end,
-          fullStart: tokens[i].start,
-          fullEnd: tokens[i].end,
-          url: tokens[i].url,
-        });
+        if (t.kind === 'markdownLink') {
+          const displayLen = t.displayText?.length ?? 0;
+          ranges.push({
+            type: 'link',
+            contentStart: t.start + 1,
+            contentEnd: t.start + 1 + displayLen,
+            fullStart: t.start,
+            fullEnd: t.end,
+            url: t.url,
+          });
+        } else {
+          ranges.push({
+            type: 'link',
+            contentStart: t.start,
+            contentEnd: t.end,
+            fullStart: t.start,
+            fullEnd: t.end,
+            url: t.url,
+          });
+        }
         consumed.add(i);
       }
     }

--- a/frontend/src/lib/formatParser.ts
+++ b/frontend/src/lib/formatParser.ts
@@ -73,7 +73,7 @@ const COLOR_RESET_RE = /\|n/g;
 const BOLD_RE = /\*\*/g;
 const STRIKE_RE = /~~/g;
 const URL_RE = /https?:\/\/[^\s<>"{}|\\^`[\]]+/g;
-const MARKDOWN_LINK_RE = /\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)/g;
+const MARKDOWN_LINK_RE = /\[([^\]\n]{1,500})\]\((https?:\/\/[^\s)]{1,2048})\)/g;
 
 /** Trailing punctuation that is unlikely to be part of a URL. */
 const TRAILING_PUNCT = new Set(['.', ',', ')', '!', '?', ':', ';']);

--- a/src/world/scenes/interaction_serializers.py
+++ b/src/world/scenes/interaction_serializers.py
@@ -1,3 +1,5 @@
+import re as _re
+
 from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 
@@ -13,6 +15,13 @@ from world.scenes.models import (
 )
 from world.scenes.place_models import InteractionReceiver
 from world.scenes.types import PersonaPayload, ReactionAggregation
+
+_MAX_POSE_LENGTH = 10_000
+
+_DANGEROUS_LINK_RE = _re.compile(
+    r"\[[^\]]*\]\((?!https?://)",
+    _re.IGNORECASE,
+)
 
 
 class InlineActionInteractionSerializer(serializers.ModelSerializer):
@@ -299,6 +308,21 @@ class PoseSubmitSerializer(serializers.Serializer):
             return None
         if not Scene.objects.filter(pk=value).exists():
             msg = "Scene not found."
+            raise serializers.ValidationError(msg)
+        return value
+
+    def validate_content(self, value: str) -> str:
+        if not value.strip():
+            msg = "Pose content cannot be blank."
+            raise serializers.ValidationError(msg)
+        if len(value) > _MAX_POSE_LENGTH:
+            msg = f"Pose content exceeds the maximum length of {_MAX_POSE_LENGTH} characters."
+            raise serializers.ValidationError(msg)
+        if "\x00" in value:
+            msg = "Pose content contains invalid characters."
+            raise serializers.ValidationError(msg)
+        if _DANGEROUS_LINK_RE.search(value):
+            msg = "Links must use http:// or https:// URLs."
             raise serializers.ValidationError(msg)
         return value
 

--- a/src/world/scenes/tests/test_interaction_views.py
+++ b/src/world/scenes/tests/test_interaction_views.py
@@ -533,6 +533,58 @@ class PoseSubmitViewTests(APITestCase):
         assert resp.status_code == 400
         mock_broadcast.assert_not_called()
 
+    def test_submit_pose_rejects_blank_content(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"persona_id": self.persona.pk, "content": "   "},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "content" in response.data
+
+    def test_submit_pose_rejects_oversized_content(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"persona_id": self.persona.pk, "content": "a" * 10_001},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "content" in response.data
+
+    def test_submit_pose_rejects_null_bytes_in_content(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"persona_id": self.persona.pk, "content": "hello\x00world"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "content" in response.data
+
+    def test_submit_pose_rejects_javascript_link_in_content(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"persona_id": self.persona.pk, "content": "[click](javascript:void(0))"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "content" in response.data
+
+    def test_submit_pose_accepts_markdown_link_content(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"persona_id": self.persona.pk, "content": "[my site](https://example.com)"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_submit_pose_accepts_mention_content(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"persona_id": self.persona.pk, "content": "@Alice waves hello"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
 
 class ActionLinksSerializerTests(APITestCase):
     """action_links field is populated by the list endpoint for POSE interactions."""


### PR DESCRIPTION
Closes #534.

## Changes

### 1. `[text](url)` markdown-link support (`formatParser.ts`)
Extends the hand-rolled tokenizer with a `markdownLink` token kind. The display text is used as `content` and the URL as `url` in the `LinkSegment`, consistent with bare-URL links. Only `http://` and `https://` URLs are matched; `javascript:` etc. are left as plain text by the parser.

### 2. Link toolbar button + Ctrl+K (`RichTextInput.tsx`)
New Link button (🔗) in the formatting toolbar after Strikethrough. Inserts `[](https://)` with cursor inside `[]` when nothing is selected, or wraps selected text as `[label](https://)` and selects the URL placeholder. Keyboard shortcut: Ctrl+K / Cmd+K.

### 3. Mention autocomplete → scene participants (`CommandInput.tsx`)
When `sceneId` is present, `CommandInput` queries scene detail via React Query (cache-shared with `SceneDetailPage` — no extra network request in normal usage) and maps `scene.participants` to `autocompleteItems`. Falls back to WS Redux `room.characters` for non-scene contexts (GameWindow).

**Decision:** Mentions persist as inline `@PersonaName` stored verbatim. Searchable by name; no FK table needed at this scope.

### 4. Server-side content validation (`PoseSubmitSerializer`)
New `validate_content()` enforces: non-blank, ≤ 10 000 chars, no null bytes, and no `[text](non-http)` links. Markdown links with `https?://` URLs pass cleanly.

## Not in scope
- WS telnet path content validation (separate concern; the pose REST path is the primary web route)
- Cross-scene mention history / notification indexing (out of scope per issue grooming)