### PR TITLE
feat(#564): Open Encounters Phase 1 — drop-in/drop-out PvE combat

### DIFF
--- a/frontend/src/combat/CombatTurnPanel.tsx
+++ b/frontend/src/combat/CombatTurnPanel.tsx
@@ -15,7 +15,13 @@ import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { AudereOfferGate } from '@/magic/components/AudereOfferGate';
 import { AudereMajoraOfferGate } from '@/magic/components/AudereMajoraOfferGate';
-import { useAvailableActions, useCombatEncounter, useConsequenceOutcomes } from './queries';
+import {
+  useAvailableActions,
+  useCombatEncounter,
+  useConsequenceOutcomes,
+  useJoinMutation,
+  useLeaveMutation,
+} from './queries';
 import { YourTurn } from './sections/YourTurn';
 import { ResonanceBudget } from './sections/ResonanceBudget';
 import { VitalPools, findOwnParticipant } from './sections/VitalPools';
@@ -148,6 +154,12 @@ export function CombatTurnPanel({
   const isParticipant = encounter.is_participant;
   const roundNumber = encounter.round_number ?? 0;
 
+  const isOpenEncounter = encounter.encounter_type === 'open_encounter';
+  const isBetweenRounds = encounter.status === 'between_rounds';
+
+  const { mutate: joinEncounter, isPending: isJoining } = useJoinMutation(encounterId);
+  const { mutate: leaveEncounter, isPending: isLeaving } = useLeaveMutation(encounterId);
+
   // Audere active strip — the viewer's own participant row (matched by
   // character_sheet_id) carries the Audere condition in active_conditions while
   // the breakthrough is live. active_conditions entries are ConditionInstances
@@ -199,6 +211,28 @@ export function CombatTurnPanel({
           Audere
         </div>
       ) : null}
+
+      {/* Open Encounter join/leave — only between rounds */}
+      {isOpenEncounter && isBetweenRounds && !isParticipant && (
+        <button
+          data-testid="open-encounter-join-btn"
+          onClick={() => joinEncounter(characterSheetId)}
+          disabled={isJoining}
+          className="w-full rounded-md border border-border bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {isJoining ? 'Joining…' : 'Join Encounter'}
+        </button>
+      )}
+      {isOpenEncounter && isBetweenRounds && isParticipant && (
+        <button
+          data-testid="open-encounter-leave-btn"
+          onClick={() => leaveEncounter()}
+          disabled={isLeaving}
+          className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm text-muted-foreground hover:bg-muted/80 disabled:opacity-50"
+        >
+          {isLeaving ? 'Leaving…' : 'Leave Encounter'}
+        </button>
+      )}
 
       {/* §2 — Section order: YourTurn → ResonanceBudget → VitalPools →
           CombatantsList → ActiveState → RoundFlow */}

--- a/frontend/src/combat/CombatTurnPanel.tsx
+++ b/frontend/src/combat/CombatTurnPanel.tsx
@@ -99,6 +99,10 @@ export function CombatTurnPanel({
   // Collapse state — all sections start expanded.
   const [collapsed, setCollapsed] = useState<Record<SectionName, boolean>>(DEFAULT_COLLAPSE_STATE);
 
+  // Open Encounter join/leave mutations — must be called unconditionally (rules of hooks).
+  const { mutate: joinEncounter, isPending: isJoining } = useJoinMutation(encounterId);
+  const { mutate: leaveEncounter, isPending: isLeaving } = useLeaveMutation(encounterId);
+
   function toggleSection(section: SectionName) {
     setCollapsed((prev) => ({ ...prev, [section]: !prev[section] }));
   }
@@ -157,9 +161,6 @@ export function CombatTurnPanel({
   const isOpenEncounter = encounter.encounter_type === 'open_encounter';
   const isBetweenRounds = encounter.status === 'between_rounds';
 
-  const { mutate: joinEncounter, isPending: isJoining } = useJoinMutation(encounterId);
-  const { mutate: leaveEncounter, isPending: isLeaving } = useLeaveMutation(encounterId);
-
   // Audere active strip — the viewer's own participant row (matched by
   // character_sheet_id) carries the Audere condition in active_conditions while
   // the breakthrough is live. active_conditions entries are ConditionInstances
@@ -215,6 +216,7 @@ export function CombatTurnPanel({
       {/* Open Encounter join/leave — only between rounds */}
       {isOpenEncounter && isBetweenRounds && !isParticipant && (
         <button
+          type="button"
           data-testid="open-encounter-join-btn"
           onClick={() => joinEncounter(characterSheetId)}
           disabled={isJoining}
@@ -225,6 +227,7 @@ export function CombatTurnPanel({
       )}
       {isOpenEncounter && isBetweenRounds && isParticipant && (
         <button
+          type="button"
           data-testid="open-encounter-leave-btn"
           onClick={() => leaveEncounter()}
           disabled={isLeaving}

--- a/frontend/src/combat/__tests__/CombatTurnPanel.test.tsx
+++ b/frontend/src/combat/__tests__/CombatTurnPanel.test.tsx
@@ -38,6 +38,8 @@ vi.mock('@/combat/queries', () => ({
     isError: false,
   }),
   useEndEncounter: vi.fn(),
+  useJoinMutation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+  useLeaveMutation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   combatKeys: {
     all: ['combat'],
     encounter: (id: number) => ['combat', 'encounter', id],
@@ -204,6 +206,14 @@ beforeEach(() => {
     isPending: false,
   });
   (combatQueries.useEndEncounter as ReturnType<typeof vi.fn>).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  (combatQueries.useJoinMutation as ReturnType<typeof vi.fn>).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  (combatQueries.useLeaveMutation as ReturnType<typeof vi.fn>).mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
   });
@@ -485,5 +495,56 @@ describe('CombatTurnPanel — encounter outcome banner (#876)', () => {
     });
 
     expect(screen.getByRole('status')).toHaveTextContent('Abandoned');
+  });
+});
+
+describe('CombatTurnPanel — Open Encounter join/leave', () => {
+  it('shows Join button for non-participant in open encounter between rounds', () => {
+    mockEncounter({
+      encounter_type: 'open_encounter',
+      status: 'between_rounds',
+      is_participant: false,
+    });
+    render(<CombatTurnPanel encounterId={1} characterId={10} characterSheetId={100} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByTestId('open-encounter-join-btn')).toBeInTheDocument();
+  });
+
+  it('shows Leave button for participant in open encounter between rounds', () => {
+    mockEncounter({
+      encounter_type: 'open_encounter',
+      status: 'between_rounds',
+      is_participant: true,
+    });
+    render(<CombatTurnPanel encounterId={1} characterId={10} characterSheetId={100} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByTestId('open-encounter-leave-btn')).toBeInTheDocument();
+  });
+
+  it('hides both buttons for party_combat encounters', () => {
+    mockEncounter({
+      encounter_type: 'party_combat',
+      status: 'between_rounds',
+      is_participant: false,
+    });
+    render(<CombatTurnPanel encounterId={1} characterId={10} characterSheetId={100} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByTestId('open-encounter-join-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('open-encounter-leave-btn')).not.toBeInTheDocument();
+  });
+
+  it('hides join button when encounter is not between_rounds', () => {
+    mockEncounter({
+      encounter_type: 'open_encounter',
+      status: 'declaring',
+      is_participant: false,
+    });
+    render(<CombatTurnPanel encounterId={1} characterId={10} characterSheetId={100} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByTestId('open-encounter-join-btn')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/combat/api.ts
+++ b/frontend/src/combat/api.ts
@@ -105,6 +105,69 @@ export async function postUpgradeCombo(
 }
 
 // ---------------------------------------------------------------------------
+// Join encounter (player self-join)
+// ---------------------------------------------------------------------------
+
+/**
+ * Player self-joins an Open Encounter.
+ * POST /api/combat/{encounterId}/join/
+ * Body: { character_sheet_id: number }
+ * 400 if already joined; 403 if not in encounter room.
+ */
+export async function postJoin(
+  encounterId: number,
+  characterSheetId: number
+): Promise<EncounterDetail> {
+  const res = await apiFetch(`/api/combat/${encounterId}/join/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ character_sheet_id: characterSheetId }),
+  });
+  if (!res.ok) {
+    let detail = 'Failed to join encounter';
+    try {
+      const data = (await res.json()) as { detail?: string };
+      if (typeof data.detail === 'string' && data.detail.trim()) {
+        detail = data.detail;
+      }
+    } catch {
+      // body wasn't JSON; keep generic
+    }
+    throw new Error(detail);
+  }
+  return res.json() as Promise<EncounterDetail>;
+}
+
+// ---------------------------------------------------------------------------
+// Leave encounter (player voluntary exit)
+// ---------------------------------------------------------------------------
+
+/**
+ * Player voluntarily leaves an Open Encounter between rounds.
+ * POST /api/combat/{encounterId}/leave/
+ * No body required. 400 if not between_rounds; 403 non-participant.
+ */
+export async function postLeave(encounterId: number): Promise<EncounterDetail> {
+  const res = await apiFetch(`/api/combat/${encounterId}/leave/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    let detail = 'Failed to leave encounter';
+    try {
+      const data = (await res.json()) as { detail?: string };
+      if (typeof data.detail === 'string' && data.detail.trim()) {
+        detail = data.detail;
+      }
+    } catch {
+      // body wasn't JSON; keep generic
+    }
+    throw new Error(detail);
+  }
+  return res.json() as Promise<EncounterDetail>;
+}
+
+// ---------------------------------------------------------------------------
 // Flee declaration
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/combat/queries.ts
+++ b/frontend/src/combat/queries.ts
@@ -259,6 +259,30 @@ export function useFleeMutation(encounterId: number) {
 }
 
 // ---------------------------------------------------------------------------
+// Join / Leave mutation hooks (Open Encounters)
+// ---------------------------------------------------------------------------
+
+/**
+ * Player self-joins an Open Encounter.
+ * POST /api/combat/{encounterId}/join/
+ * Arg: characterSheetId (number). Invalidates encounter key on success.
+ */
+export function useJoinMutation(encounterId: number) {
+  return useEncounterMutation(encounterId, (characterSheetId: number) =>
+    api.postJoin(encounterId, characterSheetId)
+  );
+}
+
+/**
+ * Player voluntarily leaves an Open Encounter between rounds.
+ * POST /api/combat/{encounterId}/leave/
+ * Invalidates encounter key on success.
+ */
+export function useLeaveMutation(encounterId: number) {
+  return useEncounterMutation(encounterId, () => api.postLeave(encounterId));
+}
+
+// ---------------------------------------------------------------------------
 // End encounter mutation hook (GM only)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -2360,6 +2360,28 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/combat/{id}/leave/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description Player voluntarily leaves an Open Encounter between rounds.
+     *
+     *     Only valid in BETWEEN_ROUNDS status. If the departing player is the last
+     *     active participant, the encounter completes as ABANDONED.
+     */
+    post: operations['combat_leave_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/combat/{id}/my_action/': {
     parameters: {
       query?: never;
@@ -25835,6 +25857,32 @@ export interface operations {
     };
   };
   combat_join_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this combat encounter. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['EncounterDetailRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['EncounterDetail'];
+        };
+      };
+    };
+  };
+  combat_leave_create: {
     parameters: {
       query?: never;
       header?: never;

--- a/src/schema.json
+++ b/src/schema.json
@@ -3390,6 +3390,37 @@ paths:
               schema:
                 $ref: '#/components/schemas/EncounterDetail'
           description: ''
+  /api/combat/{id}/leave/:
+    post:
+      operationId: combat_leave_create
+      description: |-
+        Player voluntarily leaves an Open Encounter between rounds.
+
+        Only valid in BETWEEN_ROUNDS status. If the departing player is the last
+        active participant, the encounter completes as ABANDONED.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this combat encounter.
+        required: true
+      tags:
+      - combat
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EncounterDetailRequest'
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncounterDetail'
+          description: ''
   /api/combat/{id}/my_action/:
     get:
       operationId: combat_my_action_retrieve

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -866,6 +866,33 @@ def join_encounter(
     return participant
 
 
+@transaction.atomic
+def leave_encounter(participant: CombatParticipant) -> None:
+    """Allow a participant to voluntarily leave an Open Encounter between rounds.
+
+    Unlike flee (a check-gated exit), this is unconditional. If the departing
+    participant is the last active player, the encounter completes as ABANDONED.
+
+    Raises ValueError when the encounter is not in BETWEEN_ROUNDS status.
+    """
+    enc = CombatEncounter.objects.select_for_update().get(pk=participant.encounter_id)
+    if enc.status != EncounterStatus.BETWEEN_ROUNDS:
+        msg = (
+            f"Cannot leave: encounter status is "
+            f"'{enc.get_status_display()}', expected 'Between Rounds'."
+        )
+        raise ValueError(msg)
+
+    remove_participant(participant)
+
+    any_active = CombatParticipant.objects.filter(
+        encounter=enc,
+        status=ParticipantStatus.ACTIVE,
+    ).exists()
+    if not any_active:
+        complete_encounter(enc, outcome=EncounterOutcome.ABANDONED)
+
+
 def declare_flee(participant: CombatParticipant) -> CombatRoundAction:
     """Declare intent to flee -- passives-only maneuver, auto-ready.
 
@@ -3226,7 +3253,7 @@ def complete_encounter(encounter: CombatEncounter, *, outcome: EncounterOutcome)
 
 
 def end_encounter(encounter: CombatEncounter) -> CombatEncounter:
-    """GM force-end: completes as ABANDONED (#876 §8) — the sole ABANDONED producer."""
+    """GM force-end: completes as ABANDONED (#876 §8)."""
     complete_encounter(encounter, outcome=EncounterOutcome.ABANDONED)
     return encounter
 

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -65,6 +65,7 @@ from world.combat.constants import (
     CombatManeuver,
     EncounterOutcome,
     EncounterStatus,
+    EncounterType,
     OpponentStatus,
     OpponentTier,
     ParticipantStatus,
@@ -873,7 +874,10 @@ def leave_encounter(participant: CombatParticipant) -> None:
     Unlike flee (a check-gated exit), this is unconditional. If the departing
     participant is the last active participant, the encounter completes as ABANDONED.
 
-    Raises ValueError when the encounter is not in BETWEEN_ROUNDS status.
+    Raises ValueError when:
+    - the encounter is not in BETWEEN_ROUNDS status,
+    - the encounter type is not OPEN_ENCOUNTER, or
+    - the participant is not ACTIVE.
     """
     enc = CombatEncounter.objects.select_for_update().get(pk=participant.encounter_id)
     if enc.status != EncounterStatus.BETWEEN_ROUNDS:
@@ -882,7 +886,14 @@ def leave_encounter(participant: CombatParticipant) -> None:
             f"'{enc.get_status_display()}', expected 'Between Rounds'."
         )
         raise ValueError(msg)
-
+    if enc.encounter_type != EncounterType.OPEN_ENCOUNTER:
+        msg = (
+            f"Cannot leave: encounter type is "
+            f"'{enc.get_encounter_type_display()}', expected 'Open Encounter'."
+        )
+        raise ValueError(msg)
+    # Re-read participant under the same transaction lock to avoid stale status reads.
+    participant = CombatParticipant.objects.select_for_update().get(pk=participant.pk)
     if participant.status != ParticipantStatus.ACTIVE:
         msg = f"Cannot leave: participant status is '{participant.status}'."
         raise ValueError(msg)

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -871,7 +871,7 @@ def leave_encounter(participant: CombatParticipant) -> None:
     """Allow a participant to voluntarily leave an Open Encounter between rounds.
 
     Unlike flee (a check-gated exit), this is unconditional. If the departing
-    participant is the last active player, the encounter completes as ABANDONED.
+    participant is the last active participant, the encounter completes as ABANDONED.
 
     Raises ValueError when the encounter is not in BETWEEN_ROUNDS status.
     """
@@ -881,6 +881,10 @@ def leave_encounter(participant: CombatParticipant) -> None:
             f"Cannot leave: encounter status is "
             f"'{enc.get_status_display()}', expected 'Between Rounds'."
         )
+        raise ValueError(msg)
+
+    if participant.status != ParticipantStatus.ACTIVE:
+        msg = f"Cannot leave: participant status is '{participant.status}'."
         raise ValueError(msg)
 
     remove_participant(participant)

--- a/src/world/combat/tests/test_services.py
+++ b/src/world/combat/tests/test_services.py
@@ -17,6 +17,7 @@ from world.combat.constants import (
     CombatManeuver,
     EncounterOutcome,
     EncounterStatus,
+    EncounterType,
     OpponentStatus,
     OpponentTier,
     ParticipantStatus,
@@ -376,7 +377,10 @@ class LeaveEncounterTest(TestCase):
     """Tests for leave_encounter service function."""
 
     def _make_between_rounds_encounter(self) -> tuple:
-        encounter = CombatEncounterFactory(status=EncounterStatus.BETWEEN_ROUNDS)
+        encounter = CombatEncounterFactory(
+            status=EncounterStatus.BETWEEN_ROUNDS,
+            encounter_type=EncounterType.OPEN_ENCOUNTER,
+        )
         CombatOpponentFactory(encounter=encounter)
         participant = CombatParticipantFactory(
             encounter=encounter,
@@ -405,7 +409,10 @@ class LeaveEncounterTest(TestCase):
         assert encounter.outcome == EncounterOutcome.ABANDONED
 
     def test_leave_with_other_participants_encounter_continues(self) -> None:
-        encounter = CombatEncounterFactory(status=EncounterStatus.BETWEEN_ROUNDS)
+        encounter = CombatEncounterFactory(
+            status=EncounterStatus.BETWEEN_ROUNDS,
+            encounter_type=EncounterType.OPEN_ENCOUNTER,
+        )
         CombatOpponentFactory(encounter=encounter)
         leaver = CombatParticipantFactory(encounter=encounter, status=ParticipantStatus.ACTIVE)
         _stayer = CombatParticipantFactory(encounter=encounter, status=ParticipantStatus.ACTIVE)
@@ -418,6 +425,16 @@ class LeaveEncounterTest(TestCase):
         participant.status = ParticipantStatus.REMOVED
         participant.save(update_fields=["status"])
         with pytest.raises(ValueError, match="participant status"):
+            leave_encounter(participant)
+
+    def test_leave_blocked_when_party_combat(self) -> None:
+        encounter = CombatEncounterFactory(
+            status=EncounterStatus.BETWEEN_ROUNDS,
+            encounter_type=EncounterType.PARTY_COMBAT,
+        )
+        CombatOpponentFactory(encounter=encounter)
+        participant = CombatParticipantFactory(encounter=encounter, status=ParticipantStatus.ACTIVE)
+        with pytest.raises(ValueError, match="Open Encounter"):
             leave_encounter(participant)
 
 

--- a/src/world/combat/tests/test_services.py
+++ b/src/world/combat/tests/test_services.py
@@ -15,6 +15,7 @@ from world.checks.types import CheckResult
 from world.combat.constants import (
     ActionCategory,
     CombatManeuver,
+    EncounterOutcome,
     EncounterStatus,
     OpponentStatus,
     OpponentTier,
@@ -44,6 +45,7 @@ from world.combat.services import (
     declare_flee,
     get_flee_config,
     join_encounter,
+    leave_encounter,
     resolve_round,
     select_npc_actions,
 )
@@ -368,6 +370,48 @@ class JoinEncounterTest(TestCase):
         sheet = CharacterSheetFactory()
         participant = join_encounter(encounter, sheet)
         assert participant.status == ParticipantStatus.ACTIVE
+
+
+class LeaveEncounterTest(TestCase):
+    """Tests for leave_encounter service function."""
+
+    def _make_between_rounds_encounter(self) -> tuple:
+        encounter = CombatEncounterFactory(status=EncounterStatus.BETWEEN_ROUNDS)
+        CombatOpponentFactory(encounter=encounter)
+        participant = CombatParticipantFactory(
+            encounter=encounter,
+            status=ParticipantStatus.ACTIVE,
+        )
+        return encounter, participant
+
+    def test_leave_marks_participant_removed(self) -> None:
+        _encounter, participant = self._make_between_rounds_encounter()
+        leave_encounter(participant)
+        participant.refresh_from_db()
+        assert participant.status == ParticipantStatus.REMOVED
+
+    def test_leave_blocked_when_not_between_rounds(self) -> None:
+        encounter = CombatEncounterFactory(status=EncounterStatus.DECLARING, round_number=1)
+        CombatOpponentFactory(encounter=encounter)
+        participant = CombatParticipantFactory(encounter=encounter)
+        with pytest.raises(ValueError, match="Between Rounds"):
+            leave_encounter(participant)
+
+    def test_leave_last_participant_triggers_abandoned(self) -> None:
+        encounter, participant = self._make_between_rounds_encounter()
+        leave_encounter(participant)
+        encounter.refresh_from_db()
+        assert encounter.status == EncounterStatus.COMPLETED
+        assert encounter.outcome == EncounterOutcome.ABANDONED
+
+    def test_leave_with_other_participants_encounter_continues(self) -> None:
+        encounter = CombatEncounterFactory(status=EncounterStatus.BETWEEN_ROUNDS)
+        CombatOpponentFactory(encounter=encounter)
+        leaver = CombatParticipantFactory(encounter=encounter, status=ParticipantStatus.ACTIVE)
+        _stayer = CombatParticipantFactory(encounter=encounter, status=ParticipantStatus.ACTIVE)
+        leave_encounter(leaver)
+        encounter.refresh_from_db()
+        assert encounter.status == EncounterStatus.BETWEEN_ROUNDS
 
 
 class DeclareFleeTest(TestCase):

--- a/src/world/combat/tests/test_services.py
+++ b/src/world/combat/tests/test_services.py
@@ -413,6 +413,13 @@ class LeaveEncounterTest(TestCase):
         encounter.refresh_from_db()
         assert encounter.status == EncounterStatus.BETWEEN_ROUNDS
 
+    def test_leave_already_removed_raises(self) -> None:
+        _encounter, participant = self._make_between_rounds_encounter()
+        participant.status = ParticipantStatus.REMOVED
+        participant.save(update_fields=["status"])
+        with pytest.raises(ValueError, match="participant status"):
+            leave_encounter(participant)
+
 
 class DeclareFleeTest(TestCase):
     """Tests for declare_flee service function."""

--- a/src/world/combat/tests/test_views.py
+++ b/src/world/combat/tests/test_views.py
@@ -805,3 +805,38 @@ class DeclareAndResolveE2ETest(TestCase):
                 "Condition application via the API resolve path may be broken."
             ),
         )
+
+
+class LeaveViewTest(CombatEncounterViewSetTestBase):
+    """Tests for POST /api/combat/{id}/leave/."""
+
+    def setUp(self) -> None:
+        self.encounter.status = EncounterStatus.BETWEEN_ROUNDS
+        self.encounter.save(update_fields=["status"])
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.player_account)
+
+    def test_leave_removes_participant(self) -> None:
+        response = self.client.post(f"/api/combat/{self.encounter.pk}/leave/")
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.participant.refresh_from_db()
+        self.assertEqual(self.participant.status, ParticipantStatus.REMOVED)
+
+    def test_leave_returns_encounter_json(self) -> None:
+        response = self.client.post(f"/api/combat/{self.encounter.pk}/leave/")
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertIn("id", response.data)
+
+    def test_leave_blocked_for_non_participant(self) -> None:
+        outsider = AccountFactory(username="outsider_leave")
+        non_participant_client = APIClient()
+        non_participant_client.force_authenticate(user=outsider)
+        response = non_participant_client.post(f"/api/combat/{self.encounter.pk}/leave/")
+        self.assertEqual(response.status_code, http_status.HTTP_403_FORBIDDEN)
+
+    def test_leave_returns_400_when_not_between_rounds(self) -> None:
+        self.encounter.status = EncounterStatus.DECLARING
+        self.encounter.round_number = 1
+        self.encounter.save(update_fields=["status", "round_number"])
+        response = self.client.post(f"/api/combat/{self.encounter.pk}/leave/")
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)

--- a/src/world/combat/tests/test_views.py
+++ b/src/world/combat/tests/test_views.py
@@ -13,7 +13,7 @@ from evennia_extensions.factories import AccountFactory, CharacterFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.checks.test_helpers import force_check_outcome
-from world.combat.constants import ActionCategory, EncounterStatus, ParticipantStatus
+from world.combat.constants import ActionCategory, EncounterStatus, EncounterType, ParticipantStatus
 from world.combat.factories import (
     CombatEncounterFactory,
     CombatOpponentFactory,
@@ -812,7 +812,8 @@ class LeaveViewTest(CombatEncounterViewSetTestBase):
 
     def setUp(self) -> None:
         self.encounter.status = EncounterStatus.BETWEEN_ROUNDS
-        self.encounter.save(update_fields=["status"])
+        self.encounter.encounter_type = EncounterType.OPEN_ENCOUNTER
+        self.encounter.save(update_fields=["status", "encounter_type"])
         self.client = APIClient()
         self.client.force_authenticate(user=self.player_account)
 

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -56,6 +56,7 @@ from world.combat.services import (
     declare_flee,
     end_encounter,
     join_encounter,
+    leave_encounter,
     remove_participant,
     resolve_round,
     revert_combo_upgrade,
@@ -100,6 +101,7 @@ class CombatEncounterViewSet(ModelViewSet):
             "revert_combo",
             "flee",
             "cover",
+            "leave",
         ):
             return [IsAuthenticated(), IsEncounterParticipant()]
         if self.action == "join":
@@ -597,6 +599,32 @@ class CombatEncounterViewSet(ModelViewSet):
                 {"detail": _ERR_DECLARE_FAILED},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        return self._serialize_encounter(request, encounter)
+
+    @action(detail=True, methods=[HTTPMethod.POST])
+    def leave(self, request: Request, pk: int | None = None) -> Response:
+        """Player voluntarily leaves an Open Encounter between rounds.
+
+        Only valid in BETWEEN_ROUNDS status. If the departing player is the last
+        active participant, the encounter completes as ABANDONED.
+        """
+        encounter = self.get_object()
+        participant = self._get_participant(request, encounter)
+        if not participant:
+            return Response(
+                {"detail": _ERR_NOT_PARTICIPANT},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        try:
+            leave_encounter(participant)
+        except ValueError:
+            return Response(
+                {"detail": _ERR_INVALID_STATUS},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        encounter.participants_cached = [
+            p for p in encounter.participants_cached if p.pk != participant.pk
+        ]
         return self._serialize_encounter(request, encounter)
 
     @action(detail=True, methods=[HTTPMethod.POST])


### PR DESCRIPTION
## Summary

Closes #564

Wires `encounter_type=OPEN_ENCOUNTER` end-to-end for Phase 1 (PvE only; PvP deferred). No new models — the data layer was already complete. Three new surfaces:

- **`leave_encounter(participant)`** service (`combat/services.py`): voluntary exit between rounds; auto-completes the encounter as ABANDONED if the last active participant leaves. Guards `OPEN_ENCOUNTER` type + `BETWEEN_ROUNDS` status + `ACTIVE` participant status; re-reads participant row under `select_for_update()` to close concurrent-leave TOCTOU.
- **`POST /api/combat/{id}/leave/`** endpoint (`combat/views.py`): guarded by `IsEncounterParticipant`, mirrors the existing `flee` action pattern, returns serialised encounter.
- **Join/Leave buttons in `CombatTurnPanel`**: shown only for `encounter_type === "open_encounter"` in `between_rounds` status; hidden for `party_combat`. Join calls existing `POST /join/` endpoint; Leave calls new `/leave/`. Hooks placed before early returns (Rules of Hooks).

Spec ran (verified against code, approved via `spec:approved` label). Design skip: No — spec posted on issue #564.

## Test plan

- [ ] `just test-fast world.combat` — 6 new service tests, 4 new view tests, all pass (966 total)
- [ ] `pnpm exec vitest run frontend/src/combat/__tests__/CombatTurnPanel.test.tsx` — 4 new UI tests pass (19 total)
- [ ] `pnpm typecheck && pnpm build` — 0 type errors, build succeeds
- [ ] CI (Postgres parity) green

<!-- last-addressed-comment: 0 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)