### PR TITLE
feat(#520,#1115): broadcast OUTCOME narration on social scene-round resolution

### DIFF
--- a/src/world/combat/interaction_services.py
+++ b/src/world/combat/interaction_services.py
@@ -253,31 +253,6 @@ def render_flee_outcome_narration(
     return f"{actor_label} tries to break away but cannot escape."
 
 
-def render_challenge_outcome_narration(
-    *,
-    actor_label: str,
-    challenge_name: str,
-    approach_name: str,
-    outcome_label: str,
-    success_level: int,
-) -> str:
-    """Render a one-line, deterministic outcome narration for a resolved challenge.
-
-    Pure function — no DB access, no randomness. Sibling of
-    ``render_action_outcome_narration`` for the challenge-resolution path. The
-    caller supplies primitives extracted from the ``ChallengeResolutionResult``
-    and the resolving participant, so this stays DB-free and unit-testable.
-
-    Examples:
-        "Kira attempts Scale the Wall (Athletics) and succeeds (Decisive Success)."
-        "Kira attempts Scale the Wall (Athletics) and fails (Failure)."
-    """
-    verb = "succeeds" if success_level > 0 else "fails"
-    return (
-        f"{actor_label} attempts {challenge_name} ({approach_name}) and {verb} ({outcome_label})."
-    )
-
-
 # Per-tier resolution clause for clash-outcome narration. Keys are
 # ``ClashResolution`` members (str-valued TextChoices, so a raw value string
 # from a resolved clash matches the same key). ``{opponent}`` is interpolated

--- a/src/world/combat/narrator.py
+++ b/src/world/combat/narrator.py
@@ -1,42 +1,5 @@
-"""Singleton 'Narrator' persona that authors combat OUTCOME interactions.
+"""Re-export shim — get_or_create_narrator_persona now lives in world.scenes.narrator."""
 
-Combat outcome lines are narration-of-result, not speech by a character.
-Every Interaction requires a persona, so outcomes are authored by a single
-shared Narrator identity created lazily on first use via the blessed
-create_character_with_sheet path. One row total, reused across encounters.
-"""
+from world.scenes.narrator import NARRATOR_PERSONA_NAME, get_or_create_narrator_persona
 
-from __future__ import annotations
-
-from world.scenes.models import Persona
-
-NARRATOR_PERSONA_NAME = "Narrator"
-
-
-def get_or_create_narrator_persona() -> Persona:
-    """Return the singleton Narrator persona, creating it on first use.
-
-    Looked up by the unique persona name. When absent, creates a Character +
-    CharacterSheet + PRIMARY Persona triple via create_character_with_sheet
-    (the same invariant-preserving path factories use), then returns its
-    persona.
-    """
-    existing = Persona.objects.filter(name=NARRATOR_PERSONA_NAME).first()
-    if existing is not None:
-        # Heal rows that predate the is_system flag (#643).
-        if not existing.is_system:
-            existing.is_system = True
-            existing.save(update_fields=["is_system"])
-        return existing
-
-    from world.character_sheets.services import (  # noqa: PLC0415
-        create_character_with_sheet,
-    )
-
-    _character, _sheet, persona = create_character_with_sheet(
-        character_key=NARRATOR_PERSONA_NAME,
-        primary_persona_name=NARRATOR_PERSONA_NAME,
-    )
-    persona.is_system = True
-    persona.save(update_fields=["is_system"])
-    return persona
+__all__ = ["NARRATOR_PERSONA_NAME", "get_or_create_narrator_persona"]

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -3503,8 +3503,8 @@ def _resolve_declared_challenges(
 
         # Broadcast a durable, Narrator-authored OUTCOME line for this challenge,
         # mirroring the per-action broadcast in _resolve_pc_action (#644).
-        from world.combat.interaction_services import (  # noqa: PLC0415
-            broadcast_action_outcome,
+        from world.combat.interaction_services import broadcast_action_outcome  # noqa: PLC0415
+        from world.scenes.interaction_services import (  # noqa: PLC0415
             render_challenge_outcome_narration,
         )
 

--- a/src/world/combat/tests/test_narrator_persona.py
+++ b/src/world/combat/tests/test_narrator_persona.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from django.test import TestCase
 
-from world.combat.narrator import NARRATOR_PERSONA_NAME, get_or_create_narrator_persona
 from world.scenes.models import Persona
+from world.scenes.narrator import NARRATOR_PERSONA_NAME, get_or_create_narrator_persona
 
 
 class NarratorPersonaTest(TestCase):

--- a/src/world/combat/tests/test_outcome_narration.py
+++ b/src/world/combat/tests/test_outcome_narration.py
@@ -4,10 +4,10 @@ from django.test import SimpleTestCase
 
 from world.combat.interaction_services import (
     render_action_outcome_narration,
-    render_challenge_outcome_narration,
     render_clash_outcome_narration,
 )
 from world.combat.types import ActionOutcome, OpponentDamageResult
+from world.scenes.interaction_services import render_challenge_outcome_narration
 
 
 def _opp_dmg(*, damage_dealt: int, defeated: bool = False) -> OpponentDamageResult:

--- a/src/world/scenes/cast_services.py
+++ b/src/world/scenes/cast_services.py
@@ -17,6 +17,7 @@ matrix:
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
@@ -29,7 +30,6 @@ from world.combat.cast_seed import (
     encounter_requiring_risk_acknowledgement,
     seed_or_feed_encounter_from_cast,
 )
-from world.combat.narrator import get_or_create_narrator_persona
 from world.combat.services import acknowledge_encounter_risk
 from world.magic.models.techniques import CharacterTechnique
 from world.magic.narration import render_cast_outcome_narration
@@ -42,6 +42,7 @@ from world.scenes.action_constants import (
 from world.scenes.action_models import SceneActionRequest, SceneCastPullDeclaration
 from world.scenes.constants import InteractionMode
 from world.scenes.interaction_services import create_interaction
+from world.scenes.narrator import get_or_create_narrator_persona
 from world.scenes.types import CastResult, EnhancedSceneActionResult
 
 if TYPE_CHECKING:
@@ -103,7 +104,7 @@ def _resolve_cast(  # noqa: PLR0913 - cohesive cast-resolution params
 
     captured: dict[str, PowerLedger] = {}
 
-    def _resolve_fn(*, power: int, ledger: PowerLedger):  # noqa: ARG001 — power is the pipeline's
+    def _resolve_fn(*, power: int, ledger: PowerLedger) -> PendingActionResolution:  # noqa: ARG001 — power is the pipeline's
         captured["ledger"] = ledger
         return start_action_resolution(
             character=character,
@@ -321,7 +322,9 @@ def resolve_accepted_cast(
 
     from world.magic.exceptions import MagicError  # noqa: PLC0415
 
-    def _resolve(pull: CastPullDeclaration | None, note: str | None):
+    def _resolve(
+        pull: CastPullDeclaration | None, note: str | None
+    ) -> tuple[EnhancedSceneActionResult, PowerLedger | None, Interaction]:
         with transaction.atomic():
             return _resolve_and_pose_cast(
                 request=action_request,
@@ -431,7 +434,7 @@ def _create_cast_request(  # noqa: PLR0913
     technique: Technique,
     status: str,
     strain_commitment: int = 0,
-    resolved_at=None,
+    resolved_at: datetime | None = None,
 ) -> SceneActionRequest:
     """Create a SceneActionRequest for a standalone cast.
 

--- a/src/world/scenes/interaction_services.py
+++ b/src/world/scenes/interaction_services.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
     from world.character_sheets.models import CharacterSheet
+    from world.scenes.models import SceneRound
 
 DELETION_WINDOW_DAYS = 30
 _ephemeral_counter = itertools.count()
@@ -805,3 +806,66 @@ def record_mutter_interaction(
         mode=InteractionMode.MUTTER,
     )
     return full, fragment
+
+
+def render_challenge_outcome_narration(
+    *,
+    actor_label: str,
+    challenge_name: str,
+    approach_name: str,
+    outcome_label: str,
+    success_level: int,
+) -> str:
+    """Render a one-line, deterministic outcome narration for a resolved challenge.
+
+    Pure function — no DB access, no randomness. The caller supplies primitives
+    extracted from the ``ChallengeResolutionResult`` and the resolving participant,
+    so this stays DB-free and unit-testable.
+
+    Examples:
+        "Kira attempts Scale the Wall (Athletics) and succeeds (Decisive Success)."
+        "Kira attempts Scale the Wall (Athletics) and fails (Failure)."
+    """
+    verb = "succeeds" if success_level > 0 else "fails"
+    return (
+        f"{actor_label} attempts {challenge_name} ({approach_name}) and {verb} ({outcome_label})."
+    )
+
+
+def broadcast_scene_outcome(
+    *,
+    scene_round: SceneRound,
+    narration: str,
+) -> Interaction | None:
+    """Persist a Narrator-authored OUTCOME interaction and broadcast it to the room.
+
+    Scene-scoped analog of ``world.combat.interaction_services.broadcast_action_outcome``.
+    Uses the scene_round's scene FK (nullable) for the scene log link and broadcasts
+    to the room via the existing WebSocket delivery path.
+
+    Returns the created Interaction, or None when narration is empty.
+    """
+    if not narration:
+        return None
+
+    from world.scenes.narrator import get_or_create_narrator_persona  # noqa: PLC0415
+
+    narrator = get_or_create_narrator_persona()
+    interaction = create_interaction(
+        persona=narrator,
+        content=narration,
+        mode=InteractionMode.OUTCOME,
+        scene=scene_round.scene,
+    )
+
+    room = scene_round.room
+    payload = _build_interaction_payload(
+        interaction_id=interaction.pk,
+        persona=narrator,
+        content=interaction.content,
+        mode=interaction.mode,
+        timestamp=interaction.timestamp.isoformat(),
+        scene_id=interaction.scene_id,
+    )
+    _broadcast_to_location(room, payload)
+    return interaction

--- a/src/world/scenes/narrator.py
+++ b/src/world/scenes/narrator.py
@@ -1,0 +1,42 @@
+"""Singleton 'Narrator' persona that authors system OUTCOME interactions.
+
+The Narrator is a scenes-layer concept: a shared system Persona that authors
+durable OUTCOME lines so they appear in the scene log. Moved here from
+world/combat/narrator so scenes-layer code can import it without a
+wrong-direction dependency.
+"""
+
+from __future__ import annotations
+
+from world.scenes.models import Persona
+
+NARRATOR_PERSONA_NAME = "Narrator"
+
+
+def get_or_create_narrator_persona() -> Persona:
+    """Return the singleton Narrator persona, creating it on first use.
+
+    Looked up by the unique persona name. When absent, creates a Character +
+    CharacterSheet + PRIMARY Persona triple via create_character_with_sheet
+    (the same invariant-preserving path factories use), then returns its
+    persona.
+    """
+    existing = Persona.objects.filter(name=NARRATOR_PERSONA_NAME).first()
+    if existing is not None:
+        # Heal rows that predate the is_system flag (#643).
+        if not existing.is_system:
+            existing.is_system = True
+            existing.save(update_fields=["is_system"])
+        return existing
+
+    from world.character_sheets.services import (  # noqa: PLC0415
+        create_character_with_sheet,
+    )
+
+    _character, _sheet, persona = create_character_with_sheet(
+        character_key=NARRATOR_PERSONA_NAME,
+        primary_persona_name=NARRATOR_PERSONA_NAME,
+    )
+    persona.is_system = True
+    persona.save(update_fields=["is_system"])
+    return persona

--- a/src/world/scenes/round_services.py
+++ b/src/world/scenes/round_services.py
@@ -257,6 +257,22 @@ def _resolve_scene_declarations(scene_round: SceneRound) -> None:
                 approach.pk,
             )
             continue
-        resolve_challenge(character, challenge_instance, approach, matching.capability_source)
+        outcome = resolve_challenge(
+            character, challenge_instance, approach, matching.capability_source
+        )
+        if outcome.check_result is not None:
+            from world.scenes.interaction_services import (  # noqa: PLC0415
+                broadcast_scene_outcome,
+                render_challenge_outcome_narration,
+            )
+
+            narration = render_challenge_outcome_narration(
+                actor_label=character.db_key,
+                challenge_name=outcome.challenge_name,
+                approach_name=outcome.approach_name,
+                outcome_label=outcome.check_result.outcome_name,
+                success_level=outcome.check_result.success_level,
+            )
+            broadcast_scene_outcome(scene_round=scene_round, narration=narration)
 
     scene_round.action_declarations.filter(round_number=scene_round.round_number).delete()

--- a/src/world/scenes/round_services.py
+++ b/src/world/scenes/round_services.py
@@ -260,7 +260,7 @@ def _resolve_scene_declarations(scene_round: SceneRound) -> None:
         outcome = resolve_challenge(
             character, challenge_instance, approach, matching.capability_source
         )
-        if outcome.check_result is not None:
+        if outcome is not None and outcome.check_result is not None:
             from world.scenes.interaction_services import (  # noqa: PLC0415
                 broadcast_scene_outcome,
                 render_challenge_outcome_narration,

--- a/src/world/scenes/tests/test_broadcast_scene_outcome.py
+++ b/src/world/scenes/tests/test_broadcast_scene_outcome.py
@@ -1,0 +1,100 @@
+"""Unit/integration tests for broadcast_scene_outcome and render_challenge_outcome_narration."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from django.test import SimpleTestCase, TestCase
+
+from world.scenes.constants import InteractionMode, RoundStatus, SceneRoundStartReason
+from world.scenes.factories import SceneRoundFactory
+from world.scenes.interaction_services import (
+    broadcast_scene_outcome,
+    render_challenge_outcome_narration,
+)
+from world.scenes.models import Interaction
+
+
+class RenderChallengeOutcomeNarrationTests(SimpleTestCase):
+    def test_success_format(self):
+        text = render_challenge_outcome_narration(
+            actor_label="Kira",
+            challenge_name="Scale the Wall",
+            approach_name="Athletics",
+            outcome_label="Decisive Success",
+            success_level=2,
+        )
+        assert text == "Kira attempts Scale the Wall (Athletics) and succeeds (Decisive Success)."
+
+    def test_failure_format(self):
+        text = render_challenge_outcome_narration(
+            actor_label="Kira",
+            challenge_name="Scale the Wall",
+            approach_name="Athletics",
+            outcome_label="Failure",
+            success_level=-1,
+        )
+        assert text == "Kira attempts Scale the Wall (Athletics) and fails (Failure)."
+
+    def test_zero_success_level_reads_as_failure(self):
+        text = render_challenge_outcome_narration(
+            actor_label="Kira",
+            challenge_name="Climb",
+            approach_name="Strength",
+            outcome_label="Marginal Failure",
+            success_level=0,
+        )
+        assert "fails" in text
+
+    def test_deterministic(self):
+        kwargs = {
+            "actor_label": "Kira",
+            "challenge_name": "Scale the Wall",
+            "approach_name": "Athletics",
+            "outcome_label": "Marginal Success",
+            "success_level": 1,
+        }
+        assert render_challenge_outcome_narration(**kwargs) == render_challenge_outcome_narration(
+            **kwargs
+        )
+
+
+class BroadcastSceneOutcomeTests(TestCase):
+    def setUp(self):
+        from evennia_extensions.factories import ObjectDBFactory
+
+        self.room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+        self.rnd = SceneRoundFactory(
+            room=self.room,
+            status=RoundStatus.DECLARING,
+            start_reason=SceneRoundStartReason.OPT_IN,
+        )
+
+    def test_creates_outcome_interaction(self):
+        broadcast_scene_outcome(scene_round=self.rnd, narration="Kira succeeds.")
+        assert Interaction.objects.filter(mode=InteractionMode.OUTCOME).count() == 1
+
+    def test_interaction_content_matches_narration(self):
+        narration = "Kira attempts Scale the Wall (Athletics) and succeeds (Decisive Success)."
+        broadcast_scene_outcome(scene_round=self.rnd, narration=narration)
+        interaction = Interaction.objects.get(mode=InteractionMode.OUTCOME)
+        assert interaction.content == narration
+
+    def test_empty_narration_returns_none_and_creates_no_interaction(self):
+        result = broadcast_scene_outcome(scene_round=self.rnd, narration="")
+        assert result is None
+        assert Interaction.objects.filter(mode=InteractionMode.OUTCOME).count() == 0
+
+    def test_broadcasts_to_room(self):
+        with mock.patch(
+            "world.scenes.interaction_services._broadcast_to_location"
+        ) as mock_broadcast:
+            broadcast_scene_outcome(scene_round=self.rnd, narration="Kira succeeds.")
+        mock_broadcast.assert_called_once()
+        room_arg = mock_broadcast.call_args[0][0]
+        assert room_arg == self.rnd.room
+
+    def test_interaction_mode_is_outcome(self):
+        result = broadcast_scene_outcome(scene_round=self.rnd, narration="Kira succeeds.")
+        assert result is not None
+        assert result.mode == InteractionMode.OUTCOME

--- a/src/world/scenes/tests/test_round_services.py
+++ b/src/world/scenes/tests/test_round_services.py
@@ -1,11 +1,14 @@
+from unittest import mock
+from unittest.mock import MagicMock
+
 from django.test import TestCase
 
 from world.character_sheets.factories import CharacterSheetFactory
 from world.conditions.constants import DurationType
 from world.conditions.factories import ConditionInstanceFactory, ConditionTemplateFactory
-from world.scenes.constants import RoundStatus, SceneRoundStartReason
+from world.scenes.constants import InteractionMode, RoundStatus, SceneRoundStartReason
 from world.scenes.factories import SceneRoundFactory, SceneRoundParticipantFactory
-from world.scenes.models import SceneActionDeclaration
+from world.scenes.models import Interaction, SceneActionDeclaration
 from world.scenes.round_services import (
     advance_scene_round,
     end_scene_round,
@@ -204,3 +207,119 @@ class SceneRoundResolutionTests(TestCase):
         assert self.rnd.status == RoundStatus.DECLARING
         assert self.rnd.round_number == 2
         assert SceneActionDeclaration.objects.filter(scene_round=self.rnd).count() == 0
+
+
+class SceneRoundOutcomeBroadcastTests(TestCase):
+    """_resolve_scene_declarations broadcasts an OUTCOME narration for each resolved challenge."""
+
+    def setUp(self):
+        from evennia_extensions.factories import ObjectDBFactory
+        from world.mechanics.factories import ChallengeApproachFactory, ChallengeInstanceFactory
+
+        self.room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+        self.rnd = SceneRoundFactory(
+            room=self.room,
+            status=RoundStatus.DECLARING,
+            round_number=1,
+            start_reason=SceneRoundStartReason.OPT_IN,
+        )
+        self.sheet = CharacterSheetFactory()
+        self.sheet.character.db_location = self.room
+        self.sheet.character.db_key = "Kira"
+        self.sheet.character.save(update_fields=["db_location", "db_key"])
+        self.participant = SceneRoundParticipantFactory(
+            scene_round=self.rnd,
+            character_sheet=self.sheet,
+            initiative_order=0,
+        )
+        self.challenge_instance = ChallengeInstanceFactory(location=self.room)
+        self.approach = ChallengeApproachFactory(
+            challenge_template=self.challenge_instance.template
+        )
+
+    def _declare_challenge(self):
+        return SceneActionDeclaration.objects.create(
+            scene_round=self.rnd,
+            round_number=self.rnd.round_number,
+            participant=self.participant,
+            challenge_instance=self.challenge_instance,
+            challenge_approach=self.approach,
+            is_pass=False,
+        )
+
+    def _fake_resolution_result(self, *, success_level: int = 1):
+        check_result = MagicMock()
+        check_result.outcome_name = "Decisive Success" if success_level > 0 else "Failure"
+        check_result.success_level = success_level
+        outcome = MagicMock()
+        outcome.challenge_name = self.challenge_instance.template.name
+        outcome.approach_name = self.approach.display_name
+        outcome.check_result = check_result
+        return outcome
+
+    def test_outcome_interaction_created_on_challenge_resolution(self):
+        self._declare_challenge()
+        fake_result = self._fake_resolution_result(success_level=1)
+        fake_action = MagicMock()
+        fake_action.challenge_instance_id = self.challenge_instance.pk
+        fake_action.approach_id = self.approach.pk
+        fake_action.capability_source = None
+        with (
+            mock.patch(
+                "world.mechanics.challenge_resolution.resolve_challenge", return_value=fake_result
+            ),
+            mock.patch(
+                "world.mechanics.services.get_available_actions", return_value=[fake_action]
+            ),
+        ):
+            resolve_scene_round(self.rnd)
+        assert Interaction.objects.filter(mode=InteractionMode.OUTCOME).count() == 1
+
+    def test_outcome_interaction_content_matches_narration(self):
+        self._declare_challenge()
+        fake_result = self._fake_resolution_result(success_level=1)
+        fake_action = MagicMock()
+        fake_action.challenge_instance_id = self.challenge_instance.pk
+        fake_action.approach_id = self.approach.pk
+        fake_action.capability_source = None
+        with (
+            mock.patch(
+                "world.mechanics.challenge_resolution.resolve_challenge", return_value=fake_result
+            ),
+            mock.patch(
+                "world.mechanics.services.get_available_actions", return_value=[fake_action]
+            ),
+        ):
+            resolve_scene_round(self.rnd)
+        interaction = Interaction.objects.get(mode=InteractionMode.OUTCOME)
+        assert "Kira" in interaction.content
+        assert "succeeds" in interaction.content
+
+    def test_no_outcome_when_check_result_is_none(self):
+        self._declare_challenge()
+        fake_result = self._fake_resolution_result()
+        fake_result.check_result = None
+        fake_action = MagicMock()
+        fake_action.challenge_instance_id = self.challenge_instance.pk
+        fake_action.approach_id = self.approach.pk
+        fake_action.capability_source = None
+        with (
+            mock.patch(
+                "world.mechanics.challenge_resolution.resolve_challenge", return_value=fake_result
+            ),
+            mock.patch(
+                "world.mechanics.services.get_available_actions", return_value=[fake_action]
+            ),
+        ):
+            resolve_scene_round(self.rnd)
+        assert Interaction.objects.filter(mode=InteractionMode.OUTCOME).count() == 0
+
+    def test_pass_declarations_produce_no_outcome_interaction(self):
+        SceneActionDeclaration.objects.create(
+            scene_round=self.rnd,
+            round_number=self.rnd.round_number,
+            participant=self.participant,
+            is_pass=True,
+        )
+        resolve_scene_round(self.rnd)
+        assert Interaction.objects.filter(mode=InteractionMode.OUTCOME).count() == 0


### PR DESCRIPTION
## Summary

- Closes #1115 (final issue in the #520 non-combat rounds epic)
- Moves `get_or_create_narrator_persona` from `world.combat.narrator` to `world.scenes.narrator` (combat re-exports for backward compat), eliminating a wrong-direction scenes→combat import in `cast_services.py`
- Adds `render_challenge_outcome_narration` (pure, DB-free) and `broadcast_scene_outcome` (scene-scoped Narrator OUTCOME broadcast analog to `broadcast_action_outcome`) to `world.scenes.interaction_services`
- Wires `_resolve_scene_declarations` in `world/scenes/round_services.py` to capture `ChallengeResolutionResult` and call `broadcast_scene_outcome` per resolved challenge (guarded on `check_result is not None` for gate-only template paths)

## Test plan

- [ ] `world/scenes/tests/test_broadcast_scene_outcome.py` — unit/integration tests for `render_challenge_outcome_narration` (pure function) and `broadcast_scene_outcome` (DB + broadcast mock)
- [ ] `SceneRoundOutcomeBroadcastTests` added to `test_round_services.py` — integration tests verifying OUTCOME Interactions are created on challenge resolution and absent on pass-only rounds
- [ ] CI full Postgres regression suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)