### PR TITLE
fix(#1162): convert silent suppress(Exception) best-effort hooks to log-and-continue

### DIFF
--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -329,32 +329,38 @@ class Character(ObjectParent, DefaultCharacter):
             # to the destination may hand this character a mission. The cheap
             # "is this a trigger room?" query short-circuits for ordinary rooms.
             # Best-effort — an optional mission hook must never break movement.
-            with contextlib.suppress(Exception):
+            try:
                 from world.missions.services.trigger_dispatch import (
                     maybe_dispatch_on_enter,
                 )
 
                 maybe_dispatch_on_enter(self, self.location)
+            except Exception:
+                logger.exception("Mission trigger dispatch failed on room entry")
 
             # Dramatic traps (#1051): an armed trap the entrant has not yet
             # resolved runs its detection check on arrival. Same room-bound
             # rationale as mission dispatch — the cheap ``traps`` query short-
             # circuits ordinary rooms. Best-effort — never break movement.
-            with contextlib.suppress(Exception):
+            try:
                 from world.room_features.trap_services import (
                     check_room_traps_on_entry,
                 )
 
                 check_room_traps_on_entry(self, self.location)
+            except Exception:
+                logger.exception("Trap detection failed on room entry")
 
             # Fame reactions (#881): a room with authored FameReactionLine
             # rows may react to a notable arrival — bystanders see the
             # observer line, the arriver their own register. Optional
             # flavor; best-effort, never breaks movement.
-            with contextlib.suppress(Exception):
+            try:
                 from world.societies.fame_reactions import maybe_emit_fame_reaction
 
                 maybe_emit_fame_reaction(self, self.location)
+            except Exception:
+                logger.exception("Fame reaction failed on room entry")
 
             # Passive clue triggers (#1160): a room may reveal a clue to an eligible
             # entrant — no search needed (who you are / where you are). This is an

--- a/src/typeclasses/mixins.py
+++ b/src/typeclasses/mixins.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 from typing import TYPE_CHECKING, Self, Union
 
 from django.utils.functional import cached_property
@@ -9,6 +10,8 @@ from flows.trigger_handler import TriggerHandler
 
 if TYPE_CHECKING:
     from evennia.objects.objects import DefaultObject
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_GENDER = "neutral"
 
@@ -136,12 +139,14 @@ class ObjectParent:
         # bound to this object may hand the examiner a mission. The cheap
         # giver lookup short-circuits for ordinary objects. Best-effort — an
         # optional mission hook must never break a look.
-        with contextlib.suppress(Exception):
+        try:
             from world.missions.services.trigger_dispatch import (
                 maybe_dispatch_on_examine,
             )
 
             maybe_dispatch_on_examine(observer, self)
+        except Exception:
+            logger.exception("Mission dispatch failed on examine")
         return True
 
     def return_appearance(self, looker: "DefaultObject | None", **kwargs) -> str:
@@ -183,7 +188,6 @@ def _maybe_render_ranking_display(obj, looker) -> str | None:
         display = obj.ranking_display
     except (AttributeError, RankingDisplay.DoesNotExist):
         return None
-    import contextlib
 
     # #981: gate the board on the looker's ACTIVE face (the telnet mirror of
     # RankingDisplayViewSet) so examining a board while wearing an alt's face is

--- a/src/world/missions/services/trigger_dispatch.py
+++ b/src/world/missions/services/trigger_dispatch.py
@@ -18,7 +18,7 @@ room-bound giver), wrapped so a dispatch hiccup never breaks movement/look.
 
 from __future__ import annotations
 
-import contextlib
+import logging
 from typing import TYPE_CHECKING, cast
 
 from django.db.models import Q
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
 
     from typeclasses.characters import Character
     from world.missions.models import MissionTemplate
+
+logger = logging.getLogger(__name__)
 
 # Default re-offer cooldown when a drawn template carries no cooldown of its own.
 _DEFAULT_COOLDOWN = timezone.timedelta(hours=12)
@@ -146,10 +148,12 @@ def _write_cooldown(
 
 def _announce(character: ObjectDB, template: MissionTemplate) -> None:
     """Tell the player a mission hook found them (best-effort; never fatal)."""
-    with contextlib.suppress(Exception):
+    try:
         send_narrative_message(
             recipients=[character.sheet_data],
             body=f"Something here pulls you toward a task — {template.name}.",
             category=NarrativeCategory.HAPPENSTANCE,
             ooc_note=f"Surfaced by a trigger giver (template #{template.pk}).",
         )
+    except Exception:
+        logger.exception("Failed to announce mission %s to %s", template.pk, character)

--- a/src/world/narrative/services.py
+++ b/src/world/narrative/services.py
@@ -16,6 +16,7 @@ online sessions and persists a Gemit record for retroactive viewing.
 from __future__ import annotations
 
 from collections.abc import Generator, Iterable
+import logging
 from typing import TYPE_CHECKING
 
 from django.db import transaction
@@ -36,6 +37,8 @@ if TYPE_CHECKING:
 
     from world.character_sheets.models import CharacterSheet
     from world.stories.models import BeatCompletion, EpisodeResolution, Era, Story
+
+logger = logging.getLogger(__name__)
 
 
 def send_narrative_message(  # noqa: PLR0913
@@ -156,8 +159,8 @@ def broadcast_gemit(
 
         for session in SESSION_HANDLER.get_sessions():
             session.msg(text=(formatted, {}), type="gemit")
-    except Exception:  # noqa: BLE001, S110
-        pass
+    except Exception:
+        logger.exception("Failed to broadcast gemit %s to sessions", gemit.pk)
     return gemit
 
 

--- a/src/world/stories/services/tables.py
+++ b/src/world/stories/services/tables.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import contextlib
+import logging
 
 from django.db import transaction
 from django.utils import timezone
@@ -13,6 +13,8 @@ from world.gm.models import GMProfile, GMTable
 from world.stories.constants import StoryGMOfferStatus, StoryScope
 from world.stories.exceptions import StoryGMOfferError
 from world.stories.models import Story, StoryGMOffer
+
+logger = logging.getLogger(__name__)
 
 # Notification kind constants for _send_offer_notification — internal identifiers only.
 _KIND_CREATED = "created"
@@ -183,7 +185,7 @@ def _send_offer_notification(offer: StoryGMOffer, *, kind: str) -> None:
     else:
         return  # Unknown kind — ignore.
 
-    with contextlib.suppress(Exception):  # notification is best-effort; don't block the offer
+    try:  # notification is best-effort; don't block the offer, but log a real failure
         send_narrative_message(
             recipients=[character_sheet],
             body=body,
@@ -191,3 +193,5 @@ def _send_offer_notification(offer: StoryGMOffer, *, kind: str) -> None:
             sender_account=sender,
             related_story=story,
         )
+    except Exception:
+        logger.exception("Failed to send story-offer notification for story %s", story.pk)


### PR DESCRIPTION
## #1162 — convert silent `suppress(Exception)` best-effort hooks to log-and-continue

Audit follow-up to TehomCD's review on #1161. A best-effort hook that swallows *all*
exceptions keeps the action from breaking — but a real fault (a DB/connection error, a
bug) then **vanishes silently**. Each site below now does `try/except Exception:
logger.exception(...)` and continues, so failures land in logs instead of disappearing.

### Converted
- **`typeclasses/characters.py`** `at_post_move` — mission ROOM_TRIGGER dispatch (#729),
  traps (#1051), fame reactions (#881). *(The clue-trigger block was already fixed in #1161.)*
- **`typeclasses/mixins.py`** — mission ENVIRONMENTAL_DETAIL dispatch on examine (#729).
- **`world/missions/services/trigger_dispatch.py`** `_announce` — mission grant notification.
- **`world/stories/services/tables.py`** — story-offer notification.
- **`world/narrative/services.py`** `broadcast_gemit` — the `session.msg` loop (was `except: pass`).

### Left as-is (assessed)
- Narrow `suppress(SpecificError)` (e.g. `suppress(RosterEntry.DoesNotExist)`) — correct,
  not a silent-fail.
- `cli/arx.py` (×3) — CLI-tool fallbacks, intentional and noqa'd, not game-facing hooks.

### Behaviour
Each keeps continuing (still best-effort), now logs via a module `logger`. No behaviour
change on the happy path; full touched-app suites green (1564 tests), `ty` clean.

### Note — stacked on #1161
The `characters.py` conversions need the module `logger` introduced in #1161, so this
branch sits on it; the diff includes #1161 until it merges, after which I'll rebase onto
main. Net-new here is the audit.

Closes #1162.
