### PR TITLE
docs: document the Investigation & Discovery system (post-ship)

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -82,6 +82,7 @@ limits, IC-vs-UI placement, etc. — see [`design-tenets.md`](design-tenets.md).
 | [Events](events.md) | **MVP complete** | Scheduled RP gatherings, calendar, invitations, room modifications |
 | [Stories & GM Tables](stories-gm.md) | in-progress | Story arcs, GM tables, trust tiers, time reconciliation |
 | [Codex & Knowledge](codex.md) | in-progress | Lore repository, character-scoped knowledge, research, secrets |
+| [Investigation & Discovery](investigation-discovery.md) | in-progress | Clue model, room search, passive triggers, collaborative research projects, gating, rescue-as-clue — core loop shipped; trigger sources + journal UI remain |
 | [Journals & Expression](journals.md) | in-progress | IC writing, praises/retorts, freeform tags, weekly XP rewards |
 | [Societies & Organizations](societies.md) | in-progress | Societies, organizations, reputation, legend, alter egos |
 | [Achievements & Discoveries](achievements.md) | in-progress | Achievement tracking, first-to-discover, stat tracking, chains |

--- a/docs/roadmap/investigation-discovery.md
+++ b/docs/roadmap/investigation-discovery.md
@@ -1,0 +1,51 @@
+# Investigation & Discovery
+
+**Status:** in-progress — core loop shipped. Epic: #1143. System doc:
+[`docs/systems/investigation_and_discovery.md`](../systems/investigation_and_discovery.md).
+
+## Why this matters
+
+Mystery and investigation are the core loop — Arx 1's clue/research system was its most
+beloved feature. Arx 2 is built around incremental discovery: hidden lore as a puzzle-box,
+clues that always point at something real, and a discovery spine that lore, missions, and
+rescues all reuse rather than each reinventing.
+
+## The model
+
+A **clue is a pointer** on three independent axes: a **target** (codex entry / mission /
+rescue-a-captive; never empty), an **acquisition** (room search or passive trigger), and a
+**resolution** (granted automatically, or won through a collaborative research project).
+Every player-facing detail — clue text, difficulties, eligibility, research magnitudes — is
+**authored data**, never agent-generated; code ships the mechanism, GMs fill the menu.
+
+## Shipped
+
+- **Clue model** (#1144) — Target-polymorphic pointer; absorbs the old codex `CodexClue`.
+- **Investigation skill + Search/Research CheckTypes** (#1145) — seed data.
+- **`search` action + declarative AP/fatigue cost on the `Action` base** (#1154 A/B).
+- **Eligibility gating** (#1154 C) — predicate access layer over the skill check.
+- **RESEARCH project kind** (#1146) — collaborative, AP-funded, floored progress, cron setbacks.
+- **Rescue-as-clue** (#931 / #1159) — capture plants a discoverable rescue clue; closes the
+  captivity arc.
+- **Passive enter-room triggers** (#1160 slice A) — clues revealed on entry by precondition.
+
+## Remaining
+
+- **More trigger sources** (#1160) — item-acquisition / resonance / past-life soul-tie. Needs
+  a verify-against-code pass on which predicate leaves exist before designing (likely a
+  "flag the holes" moment — resonance probably exists, soul-tie may not).
+- **Clue journal UI** — the web surface where players see held clues, known-target flags, and
+  pursue research. Frontend; wants a UX design pass.
+- **Secret / scandal target kinds** — the social-information targets; informational shapes not
+  yet settled (deliberately stubbed in the discriminator).
+- **Error-handling service** (#1164) — replace the interim log-and-continue in the trigger
+  hooks with a Sentry-style report + user-facing error, per TehomCD's review.
+
+## Design principles
+
+- **No red herrings, no empty clues** — a clue always points at something real; a known
+  target is surfaced ("you already know this"), not hidden.
+- **Two-layer gating** — capability (the skill check) *and* access (an eligibility predicate);
+  magic/threads raise effective capability so gifts light up options without per-gift wiring.
+- **Reuse the spine** — search → acquire → resolve is one machine; rescue and research are
+  consumers, not parallel systems.

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -287,6 +287,33 @@ Lore storage and character knowledge tracking.
 - **Integrates with:** action_points (teaching costs), consent (visibility), character_creation (starting knowledge)
 - **Source:** `src/world/codex/`
 - **Details:** [codex.md](codex.md)
+
+### Investigation & Discovery
+The mystery core loop: a clue points at something worth finding (codex entry, mission, or a
+held captive to rescue); players acquire clues by **searching** a room or via passive
+**triggers**, then resolve them automatically or through a collaborative **research project**.
+
+- **Models:** `Clue` (DiscriminatorMixin — `target_kind` ∈ CODEX / MISSION / RESCUE + a
+  per-kind FK; never exists without a target), `CharacterClue` (held-clue, roster-scoped),
+  `RoomClue` (search-anchored placement + `detect_difficulty` + `eligibility_rule`),
+  `ClueTrigger` (passive on-entry placement + `eligibility_rule`), `ResearchProjectDetails`
+  (the clue a `ProjectKind.RESEARCH` project researches toward)
+- **Key functions (`world/clues/services.py`, `research.py`):** `acquire_clue`,
+  `target_already_known`, `search_room` (Search check per hidden clue), `grant_clue_target`
+  (AUTOMATIC resolution — codex KNOWN / rescue mission), `maybe_grant_clue_triggers`
+  (on room entry), `plant_rescue_clue` / `clear_rescue_clues` (#931), `start_research_project`
+  / `contribute_research` (floored CHECK→progress) / `resolve_research` (RESEARCH handler)
+- **Action:** `SearchAction` (`actions/definitions/investigation.py`) — AP + mental fatigue
+  via the declarative cost on the `Action` base; rolls the seeded "Search" CheckType
+- **Two-layer gating:** the detect (skill) check *and* an `eligibility_rule` predicate on
+  each placement (access layer; empty rule = open to anyone)
+- **Integrates with:** codex (codex-target grant via `add_progress`), missions
+  (`grant_rescue_mission`, mission target), projects (RESEARCH kind), captivity (RESCUE
+  clues planted on capture / cleared on resolution), predicates (eligibility), checks
+  (`perform_check`), actions (search), narrative (trigger notification), typeclasses
+  (`Character.at_post_move` trigger hook)
+- **Source:** `src/world/clues/`
+- **Details:** [investigation_and_discovery.md](investigation_and_discovery.md)
 ### Consent
 OOC visibility groups for player-controlled content sharing.
 

--- a/docs/systems/investigation_and_discovery.md
+++ b/docs/systems/investigation_and_discovery.md
@@ -1,0 +1,96 @@
+# Investigation & Discovery
+
+The mystery core loop, built as one reusable spine over existing systems. Players
+discover hidden things — lore (codex entries), missions, and held captives to rescue —
+by **acquiring clues** and **resolving** them. Lives in `src/world/clues/`. Epic: #1143.
+
+## The model: a clue is a pointer, on three independent axes
+
+A `Clue` is a pointer defined by three orthogonal things:
+
+1. **Target** — *what it points at.* `target_kind` (DiscriminatorMixin) ∈ `CODEX` /
+   `MISSION` / `RESCUE`, with a matching per-kind FK (`target_codex_entry`,
+   `target_mission`, `target_captivity`). **Invariant:** a clue cannot save without a
+   target (`clean()` enforces exactly one) — no red herrings, no empty clues. The target
+   also drives the "you already know this" flag (`target_already_known`) — a known-target
+   clue is surfaced, not hidden.
+2. **Acquisition** — *how you come to hold it.* A room **search** (`RoomClue` + the Search
+   action) or a passive **trigger** (`ClueTrigger`, fired on room entry). Both record the
+   holding via `CharacterClue` (roster-scoped, idempotent `acquire_clue`).
+3. **Resolution** — *how holding it becomes having the target.* `resolution_mode` ∈
+   `AUTOMATIC` (granted on acquisition — `grant_clue_target`) or `RESEARCH` (won through a
+   collaborative research project).
+
+## Acquisition surfaces
+
+- **Search (active):** `RoomClue` anchors a clue to a room with a `detect_difficulty`.
+  `SearchAction` (`actions/definitions/investigation.py`) charges AP + mental fatigue (via
+  the declarative cost on the `Action` base) and calls `search_room`, which rolls the
+  seeded **Search** CheckType (Perception+Investigation) against each hidden clue's
+  difficulty and acquires the ones spotted.
+- **Trigger (passive):** `ClueTrigger` anchors a clue to a room; `maybe_grant_clue_triggers`
+  fires from `Character.at_post_move` (alongside the mission ROOM_TRIGGER dispatch) and
+  grants eligible, not-yet-held clues with no roll — the world reveals it because of who you
+  are / where you are. The player is told via the clue's authored description
+  (`send_narrative_message`).
+
+## Resolution paths
+
+- **AUTOMATIC** (`grant_clue_target`): CODEX → the character learns the entry
+  (`CharacterCodexKnowledge.add_progress`, firing the codex KNOWN reactivity hook); RESCUE →
+  the finder is handed the rescue mission (`grant_rescue_mission`, captive as
+  `rescue_target`).
+- **RESEARCH** (`world/clues/research.py`): a `ProjectKind.RESEARCH` project (on the shared
+  `world/projects` framework) targeting a clue. Contributors spend AP to make Research rolls
+  (`contribute_research`); progress scales with the outcome, **floored at 0** (a failed help
+  never detracts). A weekly cron setback (`apply_research_setbacks`) is the only negative.
+  On completion, `resolve_research` grants the clue's target to every contributor.
+
+## Two-layer gating
+
+Every placement gates on two independent things (via `world.predicates`; the epic's "gating
+is layered"):
+
+- **Capability / skill** — the detect (Search) check, against `detect_difficulty`.
+- **Access** — an `eligibility_rule` predicate (`JSONField`, same shape as
+  `MissionTemplate.visibility_rule`) on `RoomClue` / `ClueTrigger`. Empty `{}` = open to
+  anyone (the clue default, unlike missions' default-locked); a rule restricts on identity /
+  org / resonance / species via `world.predicates`.
+
+## Rescue-as-clue (#931)
+
+Capture plants discovery, reusing the whole spine. Authored at mission-design time: the
+CAPTURE consequence effect and `CaptivityConfig` carry the rescue clue's name / description /
+detect difficulty + the rescue mission template (override-then-default). On capture,
+`_apply_capture` stamps `Captivity.rescue_template` and `plant_rescue_clue`s a RESCUE clue at
+the capture site; allies who `search` there are handed the rescue. `resolve_captivity` calls
+`clear_rescue_clues` when the captive is freed.
+
+## Build constraint (authoring vs. mechanism)
+
+Everything player-facing is **authored data**, never agent-generated: clue text, detect
+difficulties, eligibility rules, research magnitudes, the Search/Research CheckTypes, and the
+Investigation skill are all staff-editable rows (admin), with sane defaults. Code ships the
+mechanism + schema; *which* clues exist and *how much* each adds are deferred to author
+passes.
+
+## Reuse ledger (what this is built on)
+
+| Concern | Reuses |
+|---|---|
+| Clue → codex pointer | absorbed the old `codex.CodexClue` (now generalized `Clue`) |
+| Hidden room-anchored findable | mirrors `room_features.Trap` |
+| Research projects | `world/projects` `Project`/`Contribution` + a `RESEARCH` kind |
+| Check resolution | `perform_check` + data `CheckType`/`CheckTypeTrait` |
+| AP / fatigue | declarative cost on `Action` base → `ActionPointPool` + fatigue pipeline |
+| Access gating | `world/predicates` rule trees |
+| Rescue grant | `missions.grant_rescue_mission` (#1134) |
+| Player notification | `narrative.send_narrative_message` |
+
+## Status
+
+Shipped: clue model, Investigation skill + CheckTypes (seed), search action + declarative
+cost, eligibility gating, RESEARCH kind, rescue-as-clue (closes #931), passive enter-room
+triggers. Remaining (see `docs/roadmap/investigation-discovery.md`): more trigger sources
+(item / resonance / soul-tie), the clue journal UI, and the error-handling service (#1164)
+that replaces the interim log-and-continue in the trigger hooks.


### PR DESCRIPTION
Documentation catch-up for the shipped clue/search/research/trigger pillar (#1143) — closes the reinvention risk per CLAUDE.md's 'Completing a Unit of Work'. Adds the systems INDEX section + a detailed system doc + a roadmap domain doc/row. Docs-only.