### PR TITLE
Fashion bonus: derive perceiving society from scene context

### DIFF
--- a/docs/roadmap/items-equipment.md
+++ b/docs/roadmap/items-equipment.md
@@ -99,11 +99,47 @@ What shipped:
   double-count)
 - **Scene-derived perceiving society** — `Area.dominant_society` FK +
   `societies_for_scene(scene)` (permissive: all societies sharing the area's realm,
-  unless the area names one); combat takes the **max** `fashion_outfit_bonus` across
-  relevant societies; `ModifierSourceKind.FASHION` provenance value
+  unless the area names one); the seam takes the **max** `fashion_outfit_bonus` across
+  relevant societies; `ModifierSourceKind.FASHION` provenance value. (The engine
+  shipped here; the **combat consumers that actually supply `scene=` were wired in
+  #750** — see the section below. Until then fashion was always 0 in combat and
+  defense bypassed the seam entirely.)
 - **Integration test** — craft → wear → combat for a mantle-bearing item, end-to-end
   through the real services (clearance → gated weave → equip → `collect_check_modifiers`)
 - **Typed exception** — `MantleNotClearedError` in `world.magic.exceptions`
+
+## Combat passes the scene-derived perceiving society (DONE, #750)
+
+Spec D PR4 built the engine (`societies_for_scene`, `Area.dominant_society`, the
+`max`-across-societies fold in `_character_and_equipment_contributions`, and a
+`scene=` parameter on `collect_check_modifiers`) but the **combat consumers never
+supplied a `scene`**, so the fashion bonus was always 0 in combat and defense
+never used the modifier seam at all. #750 closes that consumer-side gap:
+
+- **Every participant combat check derives its perceiving society from scene
+  context** — offense, penetration, flee, and environmental checks pass
+  `scene=encounter.scene`; the clash contribution passes `scene=clash.encounter.scene`
+  (`world/combat/services.py`, `world/combat/clash.py`). No signature/plumbing
+  changes — each site reads the scene from its in-scope encounter/clash.
+- **Defense now joins the seam (the headline).** `resolve_npc_attack` previously
+  rolled the defender's check with **zero modifiers**; it now routes through
+  `collect_check_modifiers(participant.character_sheet, check_type,
+  scene=participant.encounter.scene)` and feeds `extra_modifiers` into the roll.
+  Fashion **and** covenant-role/equipment-walk **and** persistent
+  `CharacterModifier`s **and** conditions now all reach defense — so a character
+  whose attire matches the perceiving society's vogue is genuinely harder to
+  hit/kill (durability from vibe).
+- **Capability vs. content:** the bonus is nonzero only where a defensive
+  `CheckType` has a scoped `modifier_target` with authored `FashionStyleBonus`
+  rows. The wiring ships the capability; an integration fixture
+  (`combat/tests/test_defense.py::DefensiveFashionWiringTests`) proves the path
+  end-to-end. Broad authoring is seed content.
+- **Threads already cut damage post-defense** (`apply_damage_reduction_from_threads`),
+  so durability-from-investment now spans threads (damage reduction) +
+  fashion/covenant (defensive check bonus).
+
+Follow-ups filed: covenant-role gating whether a character benefits from armor
+soak; thread defensive-magnitude tuning.
 
 ## Item Interaction Service Functions — Use / Consume Charges (DONE, #509)
 

--- a/src/world/checks/CLAUDE.md
+++ b/src/world/checks/CLAUDE.md
@@ -34,6 +34,20 @@ The checks app defines types of checks (Stealth, Diplomacy, Perception, etc.) an
 3. Extra modifiers from caller (goals, magic, combat, conditions)
 4. Total points -> CheckRank -> ResultChart -> roll 1-100 -> outcome
 
+## The modifier seam — `collect_check_modifiers(sheet, check_type, *, scene=None, ...)`
+
+Central aggregator (`services.py`) that gathers condition / rollmod / scene /
+equipment / CHARACTER / equipment-walk / **fashion** contributions into one
+`ModifierBreakdown`. Pass `scene=` to enable the **perception-relative fashion
+bonus**: `_character_and_equipment_contributions` resolves the perceiving
+societies via `world.areas.services.societies_for_scene(scene)`
+(`Area.dominant_society`, else all societies sharing the realm) and takes the
+**max** `fashion_outfit_bonus` across them. Society-blind callers pass no
+`scene` and are unaffected. Combat funnels every participant check (offense,
+penetration, flee, environmental, clash, **and defense** via `resolve_npc_attack`)
+through this seam with `scene=encounter.scene`, so fashion/covenant/conditions
+apply uniformly to attack and defense (#750/#512).
+
 ## Integration Points
 
 - **Traits app**: Uses PointConversionRange, CheckRank, ResultChart, CheckOutcome

--- a/src/world/combat/clash.py
+++ b/src/world/combat/clash.py
@@ -243,6 +243,7 @@ def commit_to_clash(  # noqa: PLR0913
     breakdown = collect_check_modifiers(
         character_sheet,
         check_type,
+        scene=clash.encounter.scene,
         extra_contributions=extra_contributions,
     )
     check_extra_modifiers = breakdown.total

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -268,6 +268,7 @@ class CombatTechniqueResolver:
         breakdown = collect_check_modifiers(
             self.participant.character_sheet,
             self.offense_check_type,
+            scene=self.participant.encounter.scene,
             extra_contributions=extra_contributions,
         )
         extra_modifiers = breakdown.total
@@ -491,6 +492,7 @@ class CombatTechniqueResolver:
         pen_breakdown = collect_check_modifiers(
             self.participant.character_sheet,
             pen_check_type,
+            scene=self.participant.encounter.scene,
         )
         pen_result = perform_check(
             caster,
@@ -2772,6 +2774,7 @@ def _resolve_flee(
     breakdown = collect_check_modifiers(
         participant.character_sheet,
         config.check_type,
+        scene=encounter.scene,
         extra_contributions=extra_contributions,
     )
 
@@ -3434,7 +3437,7 @@ def _apply_aftermath_rules(
     for participant in affected:
         sheet = participant.character_sheet
         character = sheet.character
-        breakdown = collect_check_modifiers(sheet, rule.check_type)
+        breakdown = collect_check_modifiers(sheet, rule.check_type, scene=encounter.scene)
         pending = select_consequence(
             character,
             rule.check_type,

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -2565,7 +2565,23 @@ def resolve_npc_attack(
                 ),
             )
 
-    result: CheckResult = perform_check_fn(character, check_type)
+    # Route the defensive check through the shared modifier seam so it honors
+    # every character-side source — fashion (perception-relative, scene-derived),
+    # covenant-role / equipment-walk, persistent CharacterModifiers, and
+    # conditions — exactly as the offense roll does (#750, #512). The perceiving
+    # society is derived from the encounter's scene; ``collect_check_modifiers``
+    # self-limits (a fashion bonus only lands when ``check_type`` has a scoped
+    # modifier_target and the scene's society has a matching in-vogue style).
+    breakdown = collect_check_modifiers(
+        participant.character_sheet,
+        check_type,
+        scene=participant.encounter.scene,
+    )
+    result: CheckResult = perform_check_fn(
+        character,
+        check_type,
+        extra_modifiers=breakdown.total,
+    )
 
     multiplier = _damage_multiplier_for_success(result.success_level)
     base_damage = opponent_action.threat_entry.base_damage

--- a/src/world/combat/tests/test_combat_technique_resolver.py
+++ b/src/world/combat/tests/test_combat_technique_resolver.py
@@ -169,6 +169,37 @@ class CombatTechniqueResolverRollCheckTests(TestCase):
         # so extra_modifiers == 5 with no separate additive term.
         self.assertEqual(mock_perform.call_args.kwargs["extra_modifiers"], 5)
 
+    def test_offense_passes_encounter_scene(self) -> None:
+        """The offense roll hands the encounter's scene to collect_check_modifiers,
+        so the perceiving society (and thus the fashion bonus) is derived from
+        scene context (#750)."""
+        from world.checks import services as checks_services
+        from world.scenes.factories import SceneFactory
+
+        resolver = _build_resolver()
+        scene = SceneFactory()
+        resolver.participant.encounter.scene = scene
+        resolver.participant.encounter.save(update_fields=["scene"])
+
+        captured: dict = {}
+        real_collect = checks_services.collect_check_modifiers
+
+        def _spy_collect(sheet, check_type, **kwargs):
+            captured["scene"] = kwargs.get("scene")
+            return real_collect(sheet, check_type, **kwargs)
+
+        with (
+            patch("world.combat.services.perform_check") as mock_perform,
+            patch(
+                "world.combat.services.collect_check_modifiers",
+                side_effect=_spy_collect,
+            ),
+        ):
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolver._roll_check()
+
+        self.assertEqual(captured["scene"], scene)
+
 
 class CombatTechniqueResolverApplyDamageTests(TestCase):
     @classmethod

--- a/src/world/combat/tests/test_defense.py
+++ b/src/world/combat/tests/test_defense.py
@@ -150,3 +150,151 @@ class ResolveNpcAttackTests(TestCase):
         )
         vitals = CharacterVitals.objects.get(character_sheet=self.sheet)
         self.assertEqual(vitals.health, 200 - result.final_damage)
+
+
+class DefensiveFashionWiringTests(TestCase):
+    """resolve_npc_attack routes the defensive check through collect_check_modifiers
+    so a scene-derived fashion bonus reaches the defender's roll (#750).
+
+    The whole point: a character whose attire matches the perceiving society's
+    vogue is harder to hit/kill. Defense previously rolled with zero modifiers,
+    making this structurally impossible.
+
+    Uses setUp (not setUpTestData) for the same DbHolder reason as
+    ResolveNpcAttackTests, and because the area-room / fashion chain are simplest
+    to build per-test.
+    """
+
+    def setUp(self) -> None:
+        from evennia.objects.models import ObjectDB
+
+        from evennia_extensions.factories import CharacterFactory
+        from evennia_extensions.models import RoomProfile
+        from world.areas.constants import AreaLevel
+        from world.areas.factories import AreaFactory
+        from world.checks.factories import CheckTypeFactory
+        from world.items.constants import BodyRegion, EquipmentLayer
+        from world.items.factories import (
+            EquippedItemFactory,
+            FashionStyleBonusFactory,
+            FashionStyleFactory,
+            ItemFacetFactory,
+            ItemInstanceFactory,
+            ItemTemplateFactory,
+            QualityTierFactory,
+            TemplateSlotFactory,
+        )
+        from world.magic.factories import FacetFactory
+        from world.mechanics.factories import ModifierTargetFactory
+        from world.realms.models import Realm
+        from world.scenes.factories import SceneFactory
+        from world.societies.factories import SocietyFactory
+
+        RoomProfile.flush_instance_cache()
+
+        # --- fashion chain: an item carrying an in-vogue facet, worn by the PC ---
+        quality = QualityTierFactory(name="DefenseCommon", stat_multiplier=1.0)
+        facet = FacetFactory(name="DefenseFacetIn")
+        template = ItemTemplateFactory(name="DefenseTestItem")
+        TemplateSlotFactory(
+            template=template,
+            body_region=BodyRegion.TORSO,
+            equipment_layer=EquipmentLayer.BASE,
+        )
+        item = ItemInstanceFactory(template=template, quality_tier=quality)
+        ItemFacetFactory(item_instance=item, facet=facet, attachment_quality_tier=quality)
+        character = CharacterFactory(db_key="DefenseChar")
+        EquippedItemFactory(
+            character=character,
+            item_instance=item,
+            body_region=BodyRegion.TORSO,
+            equipment_layer=EquipmentLayer.BASE,
+        )
+        self.sheet = CharacterSheetFactory(character=character)
+
+        # --- a defensive CheckType with a scoped ModifierTarget (so fashion lands) ---
+        self.check_type = CheckTypeFactory(name="DefenseCheck")
+        self.target = ModifierTargetFactory(name="DefenseTarget", target_check_type=self.check_type)
+
+        # --- style puts the facet in vogue; society adopts the style ---
+        style = FashionStyleFactory(name="DefenseStyle")
+        style.in_vogue_facets.add(facet)
+        FashionStyleBonusFactory(fashion_style=style, target=self.target, weight=1)
+        realm = Realm.objects.create(name="DefenseRealm")
+        self.society = SocietyFactory(
+            name="DefenseSociety", realm=realm, current_fashion_style=style
+        )
+
+        # --- scene located in an area dominated by that society ---
+        area = AreaFactory(
+            name="Defense Ward",
+            level=AreaLevel.WARD,
+            realm=realm,
+            dominant_society=self.society,
+        )
+        area_room = ObjectDB.objects.create(
+            db_key="Defense Room",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        RoomProfile.objects.update_or_create(objectdb=area_room, defaults={"area": area})
+        self.scene = SceneFactory(location=area_room)
+
+        # --- encounter wired to the scene ---
+        self.encounter = CombatEncounterFactory(
+            status=EncounterStatus.DECLARING,
+            round_number=1,
+            scene=self.scene,
+        )
+        pool = ThreatPoolFactory()
+        entry = ThreatPoolEntryFactory(pool=pool, base_damage=100)
+        opponent = CombatOpponentFactory(encounter=self.encounter, threat_pool=pool)
+        self.participant = CombatParticipantFactory(
+            encounter=self.encounter,
+            character_sheet=self.sheet,
+        )
+        CharacterVitals.objects.create(character_sheet=self.sheet, health=200, max_health=200)
+        self.npc_action = CombatOpponentAction.objects.create(
+            opponent=opponent,
+            round_number=1,
+            threat_entry=entry,
+        )
+        self.npc_action.targets.add(self.participant)
+
+    def _spy(self) -> tuple:
+        """A perform_check spy that records the extra_modifiers it was handed."""
+        captured: dict = {}
+
+        def spy(character, check_type, *args, **kwargs) -> MagicMock:
+            captured["extra_modifiers"] = kwargs.get("extra_modifiers", 0)
+            result = MagicMock()
+            result.success_level = 0
+            return result
+
+        return spy, captured
+
+    def test_defense_receives_scene_fashion_bonus(self) -> None:
+        """The defensive roll is handed the fashion bonus derived from the scene."""
+        from world.items.constants import FASHION_MATCH_BASE
+
+        spy, captured = self._spy()
+        resolve_npc_attack(
+            self.npc_action,
+            self.participant,
+            self.check_type,
+            perform_check_fn=spy,
+        )
+        self.assertEqual(captured["extra_modifiers"], FASHION_MATCH_BASE)
+
+    def test_defense_without_scene_has_no_fashion(self) -> None:
+        """With no scene on the encounter, no fashion bonus reaches the roll."""
+        self.encounter.scene = None
+        self.encounter.save(update_fields=["scene"])
+
+        spy, captured = self._spy()
+        resolve_npc_attack(
+            self.npc_action,
+            self.participant,
+            self.check_type,
+            perform_check_fn=spy,
+        )
+        self.assertEqual(captured["extra_modifiers"], 0)

--- a/src/world/combat/tests/test_reactive_integration.py
+++ b/src/world/combat/tests/test_reactive_integration.py
@@ -627,7 +627,7 @@ class AttackPreResolveCancellationTest(TestCase):
         mock_check = MagicMock()
         mock_check.success_level = 0  # miss → 0 damage
 
-        def fake_check(char, ct):
+        def fake_check(char, ct, **kwargs):
             return mock_check
 
         try:
@@ -661,7 +661,7 @@ class AttackPreResolveCancellationTest(TestCase):
         mock_check = MagicMock()
         mock_check.success_level = -2  # critical hit → should be big damage if not cancelled
 
-        def fake_check(char, ct):
+        def fake_check(char, ct, **kwargs):
             return mock_check
 
         resolve_npc_attack(action, participant, check_type, perform_check_fn=fake_check)


### PR DESCRIPTION
Closes #750

## Summary

Wires the scene-derived perceiving society into every participant combat check and fixes the defensive check to use the modifier seam, so fashion/covenant/conditions confer real combat durability — not just better offense.

What changed:
- **Defense joins the modifier seam (headline).** `resolve_npc_attack` previously rolled the defender's check with zero modifiers; it now routes through `collect_check_modifiers(participant.character_sheet, check_type, scene=participant.encounter.scene)` and feeds `extra_modifiers` into the roll. Fashion, covenant-role/equipment-walk, persistent CharacterModifiers, and conditions now all reach defense — so attire matching the perceiving society's vogue makes a character harder to hit/kill.
- **All other participant checks pass scene.** Offense, penetration, flee, environmental (`scene=encounter.scene`) and the clash contribution (`scene=clash.encounter.scene`). No signature/plumbing changes — each site reads the scene from its in-scope encounter/clash.
- The engine (societies_for_scene, Area.dominant_society, max-across-societies, the `scene=` seam) was already built; this is the consumer-side wiring #750 owns.

Design decisions (answers to the issue's open questions) and a code-verified anti-reinvention ledger are in the issue body spec.

Capability vs. content: the fashion bonus is nonzero only where a defensive CheckType has a scoped modifier_target with authored FashionStyleBonus rows. The wiring ships the capability; `combat/tests/test_defense.py::DefensiveFashionWiringTests` proves the path end-to-end. Broad authoring is seed content.

Tests: 1250 combat+checks fast-tier tests pass (SQLite); added defensive-fashion and offense-scene wiring tests.

## Follow-ups filed

- #1174
- #1175

## Notes

- Spec: reviewed & approved on #750 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto origin/main (4 commits, no conflicts).

<!-- last-addressed-comment: 0 -->