### PR TITLE
feat(#774): multi-alt character picker for technique authoring

### DIFF
--- a/frontend/src/magic/__tests__/CharacterAuthorSelect.test.tsx
+++ b/frontend/src/magic/__tests__/CharacterAuthorSelect.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import type { MyRosterEntry } from '@/roster/types';
+import { CharacterAuthorSelect } from '../components/CharacterAuthorSelect';
+
+function makeEntry(overrides: Partial<MyRosterEntry> & { character_id: number }): MyRosterEntry {
+  return {
+    id: overrides.character_id,
+    name: `Character ${overrides.character_id}`,
+    profile_picture_url: null,
+    primary_persona_id: null,
+    active_persona_id: null,
+    ...overrides,
+  };
+}
+
+describe('CharacterAuthorSelect', () => {
+  it('renders nothing when the account plays no characters', () => {
+    const { container } = render(
+      <CharacterAuthorSelect entries={[]} value={null} onChange={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a single-character account (zero-click)', () => {
+    const entries = [makeEntry({ character_id: 7, name: 'Solo' })];
+    const { container } = render(
+      <CharacterAuthorSelect entries={entries} value={7} onChange={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a selector with one option per character when the account has >1', () => {
+    const entries = [
+      makeEntry({ character_id: 1, name: 'Alice' }),
+      makeEntry({ character_id: 2, name: 'Bob' }),
+    ];
+    render(<CharacterAuthorSelect entries={entries} value={1} onChange={vi.fn()} />);
+    // The trigger reflects the selected character's name.
+    expect(screen.getByRole('combobox')).toHaveTextContent('Alice');
+  });
+
+  it('emits the chosen character_id when a different character is picked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const entries = [
+      makeEntry({ character_id: 1, name: 'Alice' }),
+      makeEntry({ character_id: 2, name: 'Bob' }),
+    ];
+    render(<CharacterAuthorSelect entries={entries} value={1} onChange={onChange} />);
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByRole('option', { name: 'Bob' }));
+
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+});

--- a/frontend/src/magic/__tests__/TechniqueBuilderPage.test.tsx
+++ b/frontend/src/magic/__tests__/TechniqueBuilderPage.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MyRosterEntry } from '@/roster/types';
+import { TechniqueBuilderPage } from '../pages/TechniqueBuilderPage';
+
+// --- Capture the props the page hands to the (mocked) form ------------------
+const formProps = vi.fn();
+vi.mock('../components/TechniqueBuilderForm', () => ({
+  TechniqueBuilderForm: (props: { characterId?: number }) => {
+    formProps(props);
+    return <div data-testid="form" data-character-id={props.characterId ?? 'none'} />;
+  },
+}));
+
+// --- Roster hook is the source of the account's played characters -----------
+const useMyRosterEntriesQuery = vi.fn();
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: () => useMyRosterEntriesQuery(),
+}));
+
+// --- Stub the lookup-list data sources so the page clears its loading gate --
+vi.mock('@/store/hooks', () => ({ useAccount: () => ({ is_staff: false }) }));
+vi.mock('@/character-creation/queries', () => ({
+  useTechniqueStyles: () => ({ data: [], isLoading: false }),
+  useEffectTypes: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/character-creation/api', () => ({ getGifts: () => Promise.resolve([]) }));
+vi.mock('@/conditions/queries', () => ({ useDamageTypes: () => ({ data: [], isLoading: false }) }));
+vi.mock('@/evennia_replacements/api', () => ({
+  apiFetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
+}));
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
+
+function entry(character_id: number, name: string): MyRosterEntry {
+  return {
+    id: character_id,
+    name,
+    character_id,
+    profile_picture_url: null,
+    primary_persona_id: null,
+    active_persona_id: null,
+  };
+}
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <TechniqueBuilderPage />
+    </QueryClientProvider>
+  );
+}
+
+describe('TechniqueBuilderPage alt wiring (#774)', () => {
+  beforeEach(() => {
+    formProps.mockClear();
+    useMyRosterEntriesQuery.mockReset();
+  });
+
+  it('passes the single character id to the form without showing a selector', async () => {
+    useMyRosterEntriesQuery.mockReturnValue({ data: [entry(7, 'Solo')] });
+    renderPage();
+
+    const form = await screen.findByTestId('form');
+    expect(form).toHaveAttribute('data-character-id', '7');
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('shows a selector for multi-alt accounts and defaults to the first character', async () => {
+    useMyRosterEntriesQuery.mockReturnValue({
+      data: [entry(1, 'Alice'), entry(2, 'Bob')],
+    });
+    renderPage();
+
+    const form = await screen.findByTestId('form');
+    expect(form).toHaveAttribute('data-character-id', '1');
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('forwards the picked character id to the form when an alt is selected', async () => {
+    const user = userEvent.setup();
+    useMyRosterEntriesQuery.mockReturnValue({
+      data: [entry(1, 'Alice'), entry(2, 'Bob')],
+    });
+    renderPage();
+
+    await screen.findByTestId('form');
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByRole('option', { name: 'Bob' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('form')).toHaveAttribute('data-character-id', '2')
+    );
+  });
+});

--- a/frontend/src/magic/components/CharacterAuthorSelect.tsx
+++ b/frontend/src/magic/components/CharacterAuthorSelect.tsx
@@ -1,0 +1,62 @@
+/**
+ * CharacterAuthorSelect — alt picker for technique authoring (#774).
+ *
+ * Accounts that play more than one character must disambiguate which character
+ * is authoring a technique; the backend validates the chosen `character_id`
+ * against the account's owned set (TechniqueViewSet._resolve_owned_character).
+ *
+ * Renders nothing for accounts with 0 or 1 played characters so single-character
+ * players keep the zero-click flow (the backend's single-character fallback
+ * resolves the acting character on its own).
+ */
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { MyRosterEntry } from '@/roster/types';
+
+interface Props {
+  /** The account's played characters (from useMyRosterEntriesQuery). */
+  entries: MyRosterEntry[];
+  /** Currently selected CharacterSheet PK, or null when none chosen yet. */
+  value: number | null;
+  /** Called with the chosen CharacterSheet PK. */
+  onChange: (characterId: number) => void;
+}
+
+export function CharacterAuthorSelect({ entries, value, onChange }: Props) {
+  // Single-character (or empty) accounts: no disambiguation needed.
+  if (entries.length <= 1) return null;
+
+  return (
+    <div className="mb-6 w-72 space-y-1">
+      <label htmlFor="technique-author-character" className="text-sm font-medium">
+        Authoring as
+      </label>
+      <Select
+        value={value != null ? String(value) : ''}
+        onValueChange={(val) => onChange(Number(val))}
+      >
+        <SelectTrigger id="technique-author-character">
+          <SelectValue placeholder="Select a character" />
+        </SelectTrigger>
+        <SelectContent>
+          {entries.map((entry) => (
+            <SelectItem key={entry.character_id} value={String(entry.character_id)}>
+              {entry.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs text-muted-foreground">
+        You play multiple characters — choose which one is authoring this technique.
+      </p>
+    </div>
+  );
+}
+
+export default CharacterAuthorSelect;

--- a/frontend/src/magic/pages/TechniqueBuilderPage.tsx
+++ b/frontend/src/magic/pages/TechniqueBuilderPage.tsx
@@ -14,6 +14,7 @@
  * isStaff is read from the Redux account store (same pattern as CharacterCreationPage).
  */
 
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/evennia_replacements/api';
@@ -23,7 +24,9 @@ import { useTechniqueStyles, useEffectTypes } from '@/character-creation/queries
 import { getGifts } from '@/character-creation/api';
 import type { components } from '@/generated/api';
 import { useDamageTypes } from '@/conditions/queries';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { TechniqueBuilderForm } from '../components/TechniqueBuilderForm';
+import { CharacterAuthorSelect } from '../components/CharacterAuthorSelect';
 import type { CapabilityType } from '../components/TechniquePayloadEditors';
 
 // ---------------------------------------------------------------------------
@@ -55,6 +58,12 @@ export function TechniqueBuilderPage() {
   const navigate = useNavigate();
   const account = useAccount();
   const isStaff = account?.is_staff ?? false;
+
+  // Acting character (#774): multi-alt accounts pick which character authors;
+  // single-character accounts fall through to the backend's auto-resolution.
+  const { data: rosterEntries = [] } = useMyRosterEntriesQuery();
+  const [pickedCharacterId, setPickedCharacterId] = useState<number | null>(null);
+  const effectiveCharacterId = pickedCharacterId ?? rosterEntries[0]?.character_id;
 
   // Lookup lists
   const { data: giftsData = [], isLoading: giftsLoading } = useQuery({
@@ -112,6 +121,12 @@ export function TechniqueBuilderPage() {
         </p>
       </div>
 
+      <CharacterAuthorSelect
+        entries={rosterEntries}
+        value={effectiveCharacterId ?? null}
+        onChange={setPickedCharacterId}
+      />
+
       <TechniqueBuilderForm
         mode={isStaff ? 'staff' : 'player'}
         gifts={gifts}
@@ -120,6 +135,7 @@ export function TechniqueBuilderPage() {
         capabilities={capabilitiesData}
         damageTypes={damageTypesData}
         conditions={conditions}
+        characterId={effectiveCharacterId}
         onSuccess={() => navigate('/threads')}
       />
     </div>


### PR DESCRIPTION
## Summary

Closes #774. Wires the page-level character picker that the form↔backend seam was already built for, so accounts that play multiple characters can disambiguate which character is authoring a technique.

Before this change, `TechniqueBuilderPage` never passed a `characterId`, so multi-alt players always fell through to the backend's single-character auto-resolution (`TechniqueViewSet._resolve_owned_character`) — ambiguous for accounts with more than one active tenure.

## Changes

- **`CharacterAuthorSelect`** (new) — presentational Radix `Select` of the account's played characters. Renders **nothing** for 0/1-character accounts (single-character players keep the zero-click flow); shows the picker only when the account plays more than one character.
- **`TechniqueBuilderPage`** — reads the account's characters via `useMyRosterEntriesQuery`, defaults the acting character to the first played character, lets multi-alt players override it, and passes the resolved `character_id` to `TechniqueBuilderForm` (which already forwards it to the `price`/`author` endpoints).

## Done when (from #774)

- [x] `TechniqueBuilderPage` renders a character selector when the account has >1 active tenure.
- [x] The selected `characterId` is passed to `TechniqueBuilderForm` and included in the request body.
- [x] Single-character accounts keep the current zero-click behavior (no selector shown).

## Testing

- `CharacterAuthorSelect.test.tsx` — hides for 0/1 entries, renders an option per character for >1, emits the chosen `character_id` on pick.
- `TechniqueBuilderPage.test.tsx` — single-char passes the id with no selector; multi-alt shows the selector defaulting to the first character; picking an alt forwards the new id to the form.
- `pnpm typecheck`, `pnpm lint`, `pnpm build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)