### PR TITLE
fix(#909): harden get_modifier_breakdown against null distinction_effect rows

### DIFF
--- a/docs/systems/mechanics.md
+++ b/docs/systems/mechanics.md
@@ -94,6 +94,10 @@ breakdown = get_modifier_breakdown(character, modifier_target)
 # get_modifier_breakdown applies these rules:
 # 1. Amplifying sources: add their amplifies_sources_by bonus to all OTHER sources
 # 2. Immunity: if any source grants_immunity_to_negative, all negative final values are blocked
+# 3. Orphaned rows (source.distinction_effect is null — SET_NULL after the effect template
+#    is deleted, or a future non-distinction source type) are skipped: they contribute
+#    nothing and are not listed in sources, since their amplifier/immunity/label semantics
+#    are gone.
 
 breakdown = get_modifier_breakdown(character, modifier_target)
 breakdown.total            # Final stacked value after amplification/immunity

--- a/src/world/mechanics/services.py
+++ b/src/world/mechanics/services.py
@@ -82,13 +82,22 @@ def get_modifier_breakdown(character, modifier_target: ModifierTarget) -> Modifi
     Returns:
         ModifierBreakdown with sources, calculations, and total
     """
-    # Get all modifiers for this character and target
-    modifiers = CharacterModifier.objects.filter(
-        character=character,
-        target=modifier_target,
-    ).select_related("source__distinction_effect__distinction")
+    # Get all modifiers for this character and target. Materialize once: the rows are
+    # iterated twice below, so a bare ``.exists()`` pre-check would add a needless query.
+    modifiers = list(
+        CharacterModifier.objects.filter(
+            character=character,
+            target=modifier_target,
+        ).select_related("source__distinction_effect__distinction")
+    )
 
-    if not modifiers.exists():
+    # Skip orphaned rows whose source has lost its distinction_effect (it is nullable:
+    # SET_NULL when the effect template is deleted, or a future non-distinction source
+    # type). Such a row has no amplifier/immunity/label semantics left, so it contributes
+    # nothing rather than crashing on a None dereference (issue #909).
+    modifiers = [mod for mod in modifiers if mod.source.distinction_effect is not None]
+
+    if not modifiers:
         return ModifierBreakdown(
             modifier_target_name=modifier_target.name,
             sources=[],

--- a/src/world/mechanics/tests/test_services.py
+++ b/src/world/mechanics/tests/test_services.py
@@ -8,7 +8,11 @@ from world.distinctions.factories import (
     DistinctionEffectFactory,
     DistinctionFactory,
 )
-from world.mechanics.factories import ModifierTargetFactory
+from world.mechanics.factories import (
+    CharacterModifierFactory,
+    ModifierSourceFactory,
+    ModifierTargetFactory,
+)
 from world.mechanics.models import CharacterModifier
 from world.mechanics.services import (
     covenant_role_bonus,
@@ -60,6 +64,61 @@ class TestGetModifierBreakdown(TestCase):
         assert len(breakdown.sources) == 1
         assert breakdown.sources[0].source_name == "Attractive"
         assert breakdown.sources[0].base_value == 10
+
+    def test_null_effect_source_is_ignored(self):
+        """A modifier whose source has a null distinction_effect is skipped, not crashed on.
+
+        ModifierSource.distinction_effect is nullable (SET_NULL when the effect template
+        is deleted, or a future non-distinction source type). Such an orphaned modifier
+        has lost its amplifier/immunity/label semantics, so the breakdown must ignore it
+        rather than dereference None (issue #909).
+        """
+        # A valid distinction modifier worth +5.
+        distinction = DistinctionFactory(name="Attractive")
+        DistinctionEffectFactory(
+            distinction=distinction,
+            target=self.allure,
+            value_per_rank=5,
+        )
+        char_distinction = CharacterDistinctionFactory(
+            character=self.character.character,
+            distinction=distinction,
+            rank=1,
+        )
+        create_distinction_modifiers(char_distinction)
+
+        # An orphaned modifier on the same target whose source has no distinction_effect.
+        CharacterModifierFactory(
+            character=self.character,
+            target=self.allure,
+            value=7,
+            source=ModifierSourceFactory(),
+        )
+
+        breakdown = get_modifier_breakdown(self.character, self.allure)
+
+        # Orphan contributes nothing and is not listed; only the valid +5 remains.
+        assert breakdown.total == 5
+        assert len(breakdown.sources) == 1
+        assert breakdown.sources[0].source_name == "Attractive"
+        assert breakdown.has_immunity is False
+        assert breakdown.negatives_blocked == 0
+
+    def test_only_null_effect_source_returns_empty(self):
+        """When every modifier row is orphaned, the breakdown is empty (no crash)."""
+        CharacterModifierFactory(
+            character=self.character,
+            target=self.allure,
+            value=9,
+            source=ModifierSourceFactory(),
+        )
+
+        breakdown = get_modifier_breakdown(self.character, self.allure)
+
+        assert breakdown.total == 0
+        assert breakdown.sources == []
+        assert breakdown.has_immunity is False
+        assert breakdown.negatives_blocked == 0
 
     def test_multiple_modifiers_sum(self):
         """Multiple modifiers are summed together."""


### PR DESCRIPTION
## Summary

`ModifierSource.distinction_effect` is nullable (`null=True, on_delete=SET_NULL`). A `CharacterModifier` whose source row has a null `distinction_effect` made `get_modifier_breakdown()` raise `AttributeError` on the unguarded `mod.source.distinction_effect` dereference.

Such orphaned rows arise when the `DistinctionEffect` **template** is deleted (SET_NULL, while `character_distinction` keeps the source alive — the source's own `CharacterModifier` rows are CASCADE so they survive), or for a future non-distinction source type. Since #767 routes check resolution through this function for any check type with a linked `ModifierTarget`, the latent crash's blast radius now includes combat-path check resolution, not just magic technique math.

## Changes

- **Skip orphaned rows** in `get_modifier_breakdown()`: a row whose `source.distinction_effect` is null contributes nothing and is not listed in `breakdown.sources`, since its amplifier/immunity/label semantics are gone. (Decision per issue: ignore rather than contribute-with-generic-label.)
- **Perf**: materialize the queryset once with `list()` and early-return on empty, dropping the extra query from the prior `.exists()`-then-iterate pattern.
- **Tests**: `test_null_effect_source_is_ignored` (orphan mixed with a valid +5 modifier → total 5, orphan absent from sources) and `test_only_null_effect_source_returns_empty` (all-orphan → empty breakdown, no crash).
- **Docs**: note the orphan-skip rule in `docs/systems/mechanics.md`.

## Notes

- Design step: **skipped** — small, well-specified hardening fix; the fix was already laid out in the issue. The one open product decision (ignore vs. contribute-with-generic-label) was confirmed as *ignore*.
- Verification: `just test-fast world.mechanics` → 321 passing; ruff + ty clean on changed files.

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)