### PR TITLE
refactor(#913): converge combat BarRow onto StatBar; type fatigue zone on the wire

### DIFF
--- a/frontend/src/combat/__tests__/VitalPools.test.tsx
+++ b/frontend/src/combat/__tests__/VitalPools.test.tsx
@@ -4,7 +4,7 @@
  * Mocks useCharacterAnima. Provides encounter with participants.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { ReactNode } from 'react';
@@ -35,6 +35,19 @@ function createWrapper() {
 }
 
 const mockedUseCharacterAnima = magicQueries.useCharacterAnima as ReturnType<typeof vi.fn>;
+
+// Bars render via the shared StatBar (Radix Progress). The colored fill is the
+// indicator child of the role="progressbar" element; the fill amount is exposed
+// as aria-valuenow rather than an inline width.
+function progressFor(testId: string): HTMLElement {
+  return within(screen.getByTestId(testId)).getByRole('progressbar');
+}
+function fillIndicatorFor(testId: string): HTMLElement {
+  return progressFor(testId).firstElementChild as HTMLElement;
+}
+function fillClassesFor(testId: string): string {
+  return fillIndicatorFor(testId).className ?? '';
+}
 
 function makeParticipant(overrides: Partial<Participant> = {}): Participant {
   return {
@@ -114,7 +127,7 @@ describe('VitalPools', () => {
     expect(screen.getByTestId('vital-health-bar')).toBeInTheDocument();
     expect(screen.getByText('Health')).toBeInTheDocument();
     // 8/10 visible
-    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByTestId('vital-health-bar')).toHaveTextContent('8 / 10');
   });
 
   it('shows amber fill when health is below 50%', () => {
@@ -125,8 +138,7 @@ describe('VitalPools', () => {
     });
 
     // health = 4/10 = 40% → wounded (amber)
-    const fillBar = screen.getByTestId('vital-health-bar-fill');
-    expect(fillBar.className).toContain('bg-amber-500');
+    expect(fillClassesFor('vital-health-bar')).toContain('bg-amber-500');
   });
 
   it('shows green fill when health is at or above 50%', () => {
@@ -136,8 +148,7 @@ describe('VitalPools', () => {
       wrapper: createWrapper(),
     });
 
-    const fillBar = screen.getByTestId('vital-health-bar-fill');
-    expect(fillBar.className).toContain('bg-emerald-500');
+    expect(fillClassesFor('vital-health-bar')).toContain('bg-emerald-500');
   });
 
   it('renders the anima bar with correct values', () => {
@@ -149,7 +160,7 @@ describe('VitalPools', () => {
 
     expect(screen.getByTestId('vital-anima-bar')).toBeInTheDocument();
     expect(screen.getByText('Anima')).toBeInTheDocument();
-    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByTestId('vital-anima-bar')).toHaveTextContent('5 / 10');
   });
 
   it('renders three fatigue bars with real values', () => {
@@ -207,10 +218,14 @@ describe('VitalPools', () => {
       wrapper: createWrapper(),
     });
 
-    const physicalFill = screen.getByTestId('vital-fatigue-physical-bar-fill');
-    expect(physicalFill).toHaveStyle({ width: '100%' });
-    const socialFill = screen.getByTestId('vital-fatigue-social-bar-fill');
-    expect(socialFill).toHaveStyle({ width: '0%' });
+    // over-capacity clamps to 100% (indicator fully shown → translateX(-0%)),
+    // divide-by-zero clamps to 0% (indicator hidden → translateX(-100%)).
+    expect(fillIndicatorFor('vital-fatigue-physical-bar')).toHaveStyle({
+      transform: 'translateX(-0%)',
+    });
+    expect(fillIndicatorFor('vital-fatigue-social-bar')).toHaveStyle({
+      transform: 'translateX(-100%)',
+    });
   });
 
   it('hides fatigue bars when fatigue is null (no vitals permission)', () => {

--- a/frontend/src/combat/sections/VitalPools.tsx
+++ b/frontend/src/combat/sections/VitalPools.tsx
@@ -18,6 +18,7 @@
  * Phase 8, Task 8.2 — unified-combat-ui plan.
  */
 
+import { StatBar } from '@/components/character/StatBar';
 import { cn } from '@/lib/utils';
 import { useCharacterAnima } from '@/magic/queries';
 import type { EncounterDetail, Participant } from '../types';
@@ -55,41 +56,6 @@ export function findOwnParticipant(
   characterSheetId: number
 ): Participant | undefined {
   return participants.find((p) => p.character_sheet_id === characterSheetId);
-}
-
-// ---------------------------------------------------------------------------
-// BarRow — labelled horizontal bar
-// ---------------------------------------------------------------------------
-
-interface BarRowProps {
-  label: string;
-  current: number;
-  maximum: number;
-  /** Tailwind fill class, e.g. 'bg-primary' or 'bg-amber-500'. */
-  fillClass?: string;
-  testId?: string;
-}
-
-function BarRow({ label, current, maximum, fillClass = 'bg-primary', testId }: BarRowProps) {
-  const pct = maximum > 0 ? Math.min(100, (current / maximum) * 100) : 0;
-  return (
-    <div className="space-y-1" data-testid={testId}>
-      <div className="flex items-center justify-between">
-        <span className="text-xs text-foreground">{label}</span>
-        <span className="font-mono text-xs text-foreground">
-          {current}
-          <span className="text-muted-foreground"> / {maximum}</span>
-        </span>
-      </div>
-      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-        <div
-          className={cn('h-full rounded-full transition-all', fillClass)}
-          style={{ width: `${pct}%` }}
-          data-testid={testId !== undefined ? `${testId}-fill` : undefined}
-        />
-      </div>
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -154,42 +120,32 @@ export function VitalPools({
       {!collapsed && (
         <div className="space-y-3 border-t border-border px-3 py-2">
           {/* Health */}
-          {health !== null && maxHealth !== null ? (
-            <BarRow
-              label="Health"
-              current={health}
-              maximum={maxHealth}
-              fillClass={isWounded ? 'bg-amber-500' : 'bg-emerald-500'}
-              testId="vital-health-bar"
-            />
-          ) : (
-            <div className="space-y-1" data-testid="vital-health-bar">
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-foreground">Health</span>
-                <span className="text-xs text-muted-foreground">—</span>
-              </div>
-              <div className="h-2 w-full overflow-hidden rounded-full bg-muted" />
-            </div>
-          )}
+          <StatBar
+            label="Health"
+            valueText={health !== null && maxHealth !== null ? `${health} / ${maxHealth}` : '—'}
+            percent={healthPct !== null ? healthPct * 100 : 0}
+            fillClass={isWounded ? 'bg-amber-500' : 'bg-emerald-500'}
+            testId="vital-health-bar"
+          />
 
           {/* Anima */}
-          {!animaLoading && animaCurrent !== null && animaMaximum !== null ? (
-            <BarRow
-              label="Anima"
-              current={animaCurrent}
-              maximum={animaMaximum}
-              fillClass="bg-violet-500"
-              testId="vital-anima-bar"
-            />
-          ) : (
-            <div className="space-y-1" data-testid="vital-anima-bar">
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-foreground">Anima</span>
-                <span className="text-xs text-muted-foreground">{animaLoading ? '…' : '—'}</span>
-              </div>
-              <div className="h-2 w-full overflow-hidden rounded-full bg-muted" />
-            </div>
-          )}
+          <StatBar
+            label="Anima"
+            valueText={
+              !animaLoading && animaCurrent !== null && animaMaximum !== null
+                ? `${animaCurrent} / ${animaMaximum}`
+                : animaLoading
+                  ? '…'
+                  : '—'
+            }
+            percent={
+              animaCurrent !== null && animaMaximum !== null && animaMaximum > 0
+                ? (animaCurrent / animaMaximum) * 100
+                : 0
+            }
+            fillClass="bg-violet-500"
+            testId="vital-anima-bar"
+          />
 
           {/* Fatigue (Physical / Social / Mental) — real values from the
            * viewer's participant row. Hidden entirely when fatigue is null
@@ -199,25 +155,16 @@ export function VitalPools({
               const pool = fatigue[key];
               const current = pool?.current ?? 0;
               const capacity = pool?.capacity ?? 0;
-              const pct = capacity > 0 ? Math.min(100, Math.max(0, (current / capacity) * 100)) : 0;
-              const testId = `vital-fatigue-${key}-bar`;
+              const pct = capacity > 0 ? (current / capacity) * 100 : 0;
               return (
-                <div key={key} className="space-y-1" data-testid={testId}>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-foreground">{label} Fatigue</span>
-                    <span className="font-mono text-xs text-foreground">
-                      {current}
-                      <span className="text-muted-foreground"> / {capacity}</span>
-                    </span>
-                  </div>
-                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-                    <div
-                      className="h-full rounded-full bg-orange-500 transition-all"
-                      style={{ width: `${pct}%` }}
-                      data-testid={`${testId}-fill`}
-                    />
-                  </div>
-                </div>
+                <StatBar
+                  key={key}
+                  label={`${label} Fatigue`}
+                  valueText={`${current} / ${capacity}`}
+                  percent={pct}
+                  fillClass="bg-orange-500"
+                  testId={`vital-fatigue-${key}-bar`}
+                />
               );
             })}
         </div>

--- a/frontend/src/fatigue/fatigueQueries.ts
+++ b/frontend/src/fatigue/fatigueQueries.ts
@@ -1,22 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '@/evennia_replacements/api';
+import type { components } from '@/generated/api';
 
-export type FatigueZone = 'fresh' | 'strained' | 'tired' | 'overexerted' | 'exhausted';
-
-export interface FatiguePoolStatus {
-  current: number;
-  capacity: number;
-  percentage: number;
-  zone: FatigueZone;
-}
-
-export interface FatigueStatus {
-  physical: FatiguePoolStatus;
-  social: FatiguePoolStatus;
-  mental: FatiguePoolStatus;
-  well_rested: boolean;
-  rested_today: boolean;
-}
+// Sourced from the generated OpenAPI schema. `zone` is a ChoiceField on the wire
+// (FatiguePoolStatusSerializer), so the union is generated, not hand-written.
+export type FatigueZone = components['schemas']['ZoneEnum'];
+export type FatiguePoolStatus = components['schemas']['FatiguePoolStatus'];
+export type FatigueStatus = components['schemas']['VitalsFatigue'];
 
 export async function restCommand(): Promise<{ detail: string }> {
   const res = await apiFetch('/api/fatigue/rest/', { method: 'POST' });

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -15403,7 +15403,7 @@ export interface components {
       capacity: number;
       /** Format: double */
       percentage: number;
-      zone: string;
+      zone: components['schemas']['ZoneEnum'];
     };
     FormTrait: {
       readonly id: number;
@@ -23220,6 +23220,15 @@ export interface components {
       /** @description Slug from the window's choices payload. */
       choice: string;
     };
+    /**
+     * @description * `fresh` - Fresh
+     *     * `strained` - Strained
+     *     * `tired` - Tired
+     *     * `overexerted` - Overexerted
+     *     * `exhausted` - Exhausted
+     * @enum {string}
+     */
+    ZoneEnum: 'fresh' | 'strained' | 'tired' | 'overexerted' | 'exhausted';
     /** @description One polish category's value + derived tier label for a building. */
     _CategoryPolish: {
       category_id: number;

--- a/frontend/src/vitals/vitalsQueries.ts
+++ b/frontend/src/vitals/vitalsQueries.ts
@@ -1,15 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/evennia_replacements/api';
 import type { components } from '@/generated/api';
-import type { FatigueStatus } from '@/fatigue/fatigueQueries';
 
 export type CharacterStatus = components['schemas']['CharacterVitalsStatusEnum'];
 
-export type CharacterVitalsData = Omit<components['schemas']['CharacterVitals'], 'fatigue'> & {
-  // Generated VitalsFatigue types zone as plain string; FatigueStatus keeps the
-  // FatigueZone union that FatigueBars' Record lookups depend on.
-  fatigue: FatigueStatus;
-};
+// `fatigue.*.zone` is now a generated enum (FatiguePoolStatusSerializer's
+// ChoiceField), so the generated CharacterVitals already carries the union that
+// FatigueBars' Record lookups depend on — no hand-written override needed.
+export type CharacterVitalsData = components['schemas']['CharacterVitals'];
 
 /**
  * Fetch the vitals panel payload for a character (CharacterSheet pk).

--- a/src/schema.json
+++ b/src/schema.json
@@ -27348,7 +27348,7 @@ components:
           type: number
           format: double
         zone:
-          type: string
+          $ref: '#/components/schemas/ZoneEnum'
       required:
       - capacity
       - current
@@ -42250,6 +42250,20 @@ components:
       required:
       - choice
       - persona_id
+    ZoneEnum:
+      enum:
+      - fresh
+      - strained
+      - tired
+      - overexerted
+      - exhausted
+      type: string
+      description: |-
+        * `fresh` - Fresh
+        * `strained` - Strained
+        * `tired` - Tired
+        * `overexerted` - Overexerted
+        * `exhausted` - Exhausted
     _CategoryPolish:
       type: object
       description: One polish category's value + derived tier label for a building.

--- a/src/world/vitals/serializers.py
+++ b/src/world/vitals/serializers.py
@@ -2,6 +2,7 @@
 
 from rest_framework import serializers
 
+from world.fatigue.constants import FatigueZone
 from world.vitals.constants import (
     DERIVED_STATUS_ALIVE,
     DERIVED_STATUS_DEAD,
@@ -16,7 +17,7 @@ class FatiguePoolStatusSerializer(serializers.Serializer):
     current = serializers.IntegerField()
     capacity = serializers.IntegerField()
     percentage = serializers.FloatField()
-    zone = serializers.CharField()
+    zone = serializers.ChoiceField(choices=FatigueZone.choices)
 
 
 class VitalsFatigueSerializer(serializers.Serializer):


### PR DESCRIPTION
## Summary

Two small convergence cleanups deferred from the #521 vitals-panel review.

1. **Combat `BarRow` → shared `StatBar`.** `frontend/src/combat/sections/VitalPools.tsx` rendered its bars with a private, hand-rolled `BarRow` div-bar — the last parallel bar implementation. Every bar (health, anima, the three fatigue pools, and the empty/loading placeholders) now routes through `StatBar`, picking up the Radix `Progress` a11y semantics combat lacked. `BarRow` is deleted.
2. **Typed fatigue zone on the wire.** `FatiguePoolStatusSerializer.zone` is now a `ChoiceField` over `FatigueZone.choices`, so the generated schema carries a `ZoneEnum` union instead of `zone: string`. The hand-written `FatigueZone` / `FatiguePoolStatus` / `FatigueStatus` types in `fatigueQueries.ts` are retired in favour of generated aliases, and `vitalsQueries.ts` drops its now-unnecessary `fatigue` override. The JSON payload is unchanged (same zone strings); only the OpenAPI schema gains the enum.

## Done when

- [x] `VitalPools.tsx` renders its bars via `StatBar`; its private `BarRow` is deleted
- [x] `FatiguePoolStatusSerializer.zone` is a `ChoiceField` over the fatigue zone choices
- [x] API types regenerated (`just gen-api-types`); `FatigueZone`/`FatiguePoolStatus` hand-written types replaced by generated aliases

## Verification

- `just test-fast world.vitals` — 70 passed
- `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm build` — pass
- `pnpm exec vitest run` VitalPools + VitalsPanel — 16 passed (assertions updated for the Radix `Progress` fill: indicator transform/class instead of the old div-bar width testids)

## Notes

Design step skipped — the issue body was already a complete spec with explicit acceptance criteria and zero design surface (pure convergence). No doc updates needed: no doc describes `BarRow`, and the wire payload is byte-identical.

Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)