### PR TITLE
Annotate plain-Serializer respond endpoints with @extend_schema (Audere + soul-tether sweep)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -12518,6 +12518,22 @@ export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
     /**
+     * @description Write serializer for forming a Soul Tether (Spec B §12).
+     *
+     *     ``actor_sheet_id`` identifies the character sheet of the requesting account.
+     *     ``partner_sheet_id`` identifies the partner's character sheet.
+     *     ``sinner_role`` determines which side (SINNER or SINEATER) the initiator holds.
+     *     ``resonance_id`` selects the resonance for the Sinner's Thread.
+     *     ``writeup`` is the narrative description of the bond (20+ chars).
+     */
+    AcceptSoulTetherRequest: {
+      actor_sheet_id: number;
+      partner_sheet_id: number;
+      sinner_role: components['schemas']['SinnerRoleEnum'];
+      resonance_id: number;
+      writeup: string;
+    };
+    /**
      * @description Serializer for accepting a ThreadWeavingTeachingOffer (Spec A §6.1).
      *
      *     Optional ``learner_sheet_id`` disambiguates the learner when the requesting
@@ -12756,6 +12772,34 @@ export interface components {
      * @enum {string}
      */
     AssistantGMClaimStatusEnum: 'requested' | 'approved' | 'rejected' | 'cancelled' | 'completed';
+    /** @description Read serializer for AudereMajoraCrossingResult dataclass. */
+    AudereMajoraCrossingResult: {
+      accepted: boolean;
+      level_before: number;
+      level_after: number;
+      chosen_path_name: string;
+      advisory_text: string;
+      declaration_interaction_id: number | null;
+    };
+    /** @description Write serializer for the player's Crossing decision. accept=false declines. */
+    AudereMajoraRespondRequest: {
+      offer_id: number;
+      accept: boolean;
+      path_id?: number | null;
+      declaration_text?: string;
+    };
+    /** @description Read serializer for AudereOfferResult (audere.py dataclass). */
+    AudereOfferResult: {
+      accepted: boolean;
+      intensity_bonus_applied: number;
+      anima_pool_expanded_by: number;
+      advisory_text: string;
+    };
+    /** @description Write serializer for the player's Audere decision. accept=false declines. */
+    AudereRespondRequest: {
+      offer_id: number;
+      accept: boolean;
+    };
     /** @description Read-only serializer for AvailableEnhancement (technique enhancement option). */
     AvailableEnhancement: {
       readonly technique_id: number;
@@ -14384,6 +14428,16 @@ export interface components {
      * @enum {string}
      */
     DiscoveryTypeEnum: 'obvious' | 'discoverable';
+    /**
+     * @description Write serializer for dissolving a Soul Tether (Spec B §13).
+     *
+     *     Either party may dissolve; ``actor_sheet_id`` is validated for ownership.
+     *     ``relationship_id`` is the PK of *either* directional CharacterRelationship row.
+     */
+    DissolveRequest: {
+      actor_sheet_id: number;
+      relationship_id: number;
+    };
     /** @description Serializer for DistinctionCategory lookup records. */
     DistinctionCategory: {
       readonly id: number;
@@ -14642,6 +14696,14 @@ export interface components {
      * @enum {string}
      */
     EffortLevelEnum: 'very_low' | 'low' | 'medium' | 'high' | 'extreme';
+    /** @description Read serializer for a single eligible crossing path. */
+    EligiblePath: {
+      id: number;
+      name: string;
+      stage: number;
+      stage_display: string;
+      description: string;
+    };
     /** @description Full encounter state with covenant-filtered action visibility. */
     EncounterDetail: {
       readonly id: number;
@@ -20197,8 +20259,7 @@ export interface components {
       readonly advisory_text: string;
       /** @description Fixed risk copy (approved verbatim). */
       readonly risk_text: string;
-      /** @description Eligible child paths serialized through EligiblePathSerializer. */
-      readonly eligible_paths: unknown[];
+      readonly eligible_paths: components['schemas']['EligiblePath'][];
       /** @description Return the PathIntent's intended_path_id if it is among eligible paths, else None. */
       readonly intended_path_id: number | null;
       /** Format: date-time */
@@ -21001,6 +21062,16 @@ export interface components {
      * @enum {string}
      */
     RequiredOutcomeEnum: 'unsatisfied' | 'success' | 'failure' | 'expired' | 'pending_gm_review';
+    /** @description Read serializer for RescueOutcome payloads. */
+    RescueOutcome: {
+      severity_reduced: number;
+      sinner_stage_at_start: number;
+      sinner_stage_at_end: number;
+      sineater_strain_taken: number;
+      protagonism_lock_lifted: boolean;
+      /** @description Return the SoulTetherRescue audit row PK. */
+      readonly audit_row_id: number;
+    };
     /**
      * @description * `destroy` - Destroy (removed for everyone)
      *     * `personal` - Personal (resolved for this character only)
@@ -21723,6 +21794,21 @@ export interface components {
      * @enum {string}
      */
     SignEnum: 'positive' | 'negative';
+    /** @description Read serializer for SineatingOffer payloads returned by the request endpoint. */
+    SineatingOffer: {
+      /** @description Return sinner_sheet PK. */
+      readonly sinner_sheet_id: number;
+      /** @description Return sineater_sheet PK. */
+      readonly sineater_sheet_id: number;
+      /** @description Return resonance PK. */
+      readonly resonance_id: number;
+      max_units_offered: number;
+      anima_cost_per_unit: number;
+      fatigue_cost_per_unit: number;
+      current_hollow: number;
+      hollow_max: number;
+      sineater_current_strain_stage: number;
+    };
     /**
      * @description Sineater-facing view of a pending Sineating offer (inbox UI).
      *
@@ -21743,6 +21829,40 @@ export interface components {
       readonly created_at: string;
     };
     /**
+     * @description Write serializer for Sinner-initiated Sineating request (Spec B §7).
+     *
+     *     Returns a ``SineatingOffer`` that the Sineater can accept or decline via
+     *     the respond endpoint.
+     */
+    SineatingRequestRequest: {
+      actor_sheet_id: number;
+      sineater_sheet_id: number;
+      resonance_id: number;
+      max_units: number;
+      scene_id: number;
+    };
+    /**
+     * @description Write serializer for the Sineater's response to a Sineating request (Spec B §7).
+     *
+     *     The pending offer row is the canonical source of truth for scene, resonance,
+     *     and units cap — the caller only needs to identify the pair and supply their choice.
+     *     ``units_accepted=0`` means decline.
+     */
+    SineatingRespondRequest: {
+      sinner_sheet_id: number;
+      sineater_sheet_id: number;
+      units_accepted: number;
+    };
+    /** @description Read serializer for SineatingResult payloads. */
+    SineatingResult: {
+      units_accepted: number;
+      declined: boolean;
+      new_hollow_current: number;
+      new_lifetime_helped: number;
+      /** @description Return the audit Sineating row PK. */
+      readonly audit_row_id: number;
+    };
+    /**
      * @description * `money` - Money
      *     * `legend_points` - Legend Points
      *     * `resonance` - Resonance
@@ -21752,6 +21872,12 @@ export interface components {
      * @enum {string}
      */
     SinkEnum: 'money' | 'legend_points' | 'resonance' | 'rumor' | 'crime_watch' | 'beat';
+    /**
+     * @description * `SINNER` - SINNER
+     *     * `SINEATER` - SINEATER
+     * @enum {string}
+     */
+    SinnerRoleEnum: 'SINNER' | 'SINEATER';
     /** @description Nested serializer for situation challenge links. */
     SituationChallengeLink: {
       challenge_template: number;
@@ -21842,6 +21968,45 @@ export interface components {
     SocietySearch: {
       id: number;
       name: string;
+    };
+    SoulTetherAcceptResponse: {
+      capstone_id: number;
+    };
+    /**
+     * @description Read serializer for GET /api/magic/soul-tether/{relationship_id}/.
+     *
+     *     Returns tether state: Hollow current/max, Thread levels, Sineater stats,
+     *     and role information. Accepts a CharacterRelationship (either direction).
+     */
+    SoulTetherDetail: {
+      readonly relationship_id: number;
+      readonly is_soul_tether: boolean;
+      readonly soul_tether_role: string;
+      /** @description Return the Sinner's CharacterSheet PK. */
+      readonly sinner_sheet_id: number | null;
+      /** @description Return the Sineater's CharacterSheet PK. */
+      readonly sineater_sheet_id: number | null;
+      /** @description Return the Sinner's current Hollow capacity (from the capstone Thread). */
+      readonly hollow_current: number;
+      /** @description Return the Sinner's Hollow maximum (thread.level * 10). */
+      readonly hollow_max: number;
+      /** @description Return the Sineater's total lifetime_helped across all resonances for this bond. */
+      readonly sineater_lifetime_helped: number;
+      /** @description Return the Sinner's highest corruption stage across all resonances. */
+      readonly sinner_corruption_stage: number;
+      /** @description Return the Sineater's current Tether Strain severity (or 0 if none). */
+      readonly sineater_strain_stage: number;
+    };
+    /**
+     * @description Write serializer for the rescue ritual (Spec B §9).
+     *
+     *     The Sineater performs the ritual on the Sinner. Both must be in the same scene.
+     */
+    SoulTetherRescueRequest: {
+      actor_sheet_id: number;
+      sinner_sheet_id: number;
+      resonance_id: number;
+      scene_id: number;
     };
     /**
      * @description * `SINEATER` - Sineater
@@ -21953,6 +22118,26 @@ export interface components {
       readonly base_value: number;
       /** Format: date-time */
       readonly created_at: string;
+    };
+    /** @description Read serializer for StageAdvanceBonusResult payloads (Task 1.7). */
+    StageAdvanceBonusResult: {
+      offer_id: string;
+      units_committed: number;
+      hollow_drained: number;
+      strain_severity_added: number;
+      declined: boolean;
+    };
+    /**
+     * @description Write serializer for the Sineater's response to a stage-advance prompt (Spec B §8.1).
+     *
+     *     The pending offer row is the canonical source of truth for resonance, max units,
+     *     and expiry — the caller only needs to identify the pair and supply their choice.
+     *     ``units_committed=0`` means decline.
+     */
+    StageAdvanceRespondRequest: {
+      sinner_sheet_id: number;
+      sineater_sheet_id: number;
+      units_committed: number;
     };
     /**
      * @description * `1` - Prospect
@@ -31127,14 +31312,19 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['AudereMajoraRespondRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['AudereMajoraCrossingResult'];
+        };
       };
     };
   };
@@ -31190,14 +31380,19 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['AudereRespondRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['AudereOfferResult'];
+        };
       };
     };
   };
@@ -32757,12 +32952,13 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['SoulTetherDetail'];
+        };
       };
     };
   };
@@ -32773,14 +32969,19 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['AcceptSoulTetherRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
-      200: {
+      201: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['SoulTetherAcceptResponse'];
+        };
       };
     };
   };
@@ -32791,10 +32992,14 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['DissolveRequest'];
+      };
+    };
     responses: {
       /** @description No response body */
-      200: {
+      204: {
         headers: {
           [name: string]: unknown;
         };
@@ -32809,14 +33014,19 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SoulTetherRescueRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['RescueOutcome'];
+        };
       };
     };
   };
@@ -32872,14 +33082,19 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SineatingRequestRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['SineatingOffer'];
+        };
       };
     };
   };
@@ -32890,14 +33105,19 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SineatingRespondRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['SineatingResult'];
+        };
       };
     };
   };
@@ -32953,14 +33173,19 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['StageAdvanceRespondRequest'];
+      };
+    };
     responses: {
-      /** @description No response body */
       200: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['StageAdvanceBonusResult'];
+        };
       };
     };
   };

--- a/frontend/src/magic/CLAUDE.md
+++ b/frontend/src/magic/CLAUDE.md
@@ -58,21 +58,28 @@ TypeScript types for the magic module.
 
 - `getTierCaps(pending)` — returns the typed `AlterationTierCaps` for a `PendingAlteration`. `tier_caps` is a `SerializerMethodField` → generated as an untyped dict; always use this helper instead of casting the raw field.
 
-**Local types** (the generated schema leaves these as `content?: never`):
+**Soul Tether / Audere respond + detail re-exports** (generated via `@extend_schema`, #920 —
+these endpoints use plain `serializers.Serializer` classes, now annotated so drf-spectacular
+emits real components; re-exported instead of hand-rolled so they can't drift):
 
-- `SoulTetherDetail` — response shape for `GET /api/magic/soul-tether/{relationship_id}/`
-  (from `SoulTetherDetailSerializer`; fields: relationship_id, is_soul_tether, soul_tether_role,
-  sinner/sineater sheet ids, hollow_current/max, sineater_lifetime_helped, corruption/strain stages)
-- `DissolveRequest` — `{ actor_sheet_id, relationship_id }`
-- `SineatingRequest` — body for POST sineating/request/ (`actor_sheet_id`, `sineater_sheet_id`,
-  `resonance_id`, `max_units`, `scene_id`)
-- `SineatingOffer` — response from sineating/request/ (SineatingOfferSerializer shape)
-- `SineatingRespondRequest` — `{ sinner_sheet_id, sineater_sheet_id, units_accepted }` (0=decline)
-- `SineatingResult` — response from sineating/respond/ (SineatingResultSerializer shape)
-- `RescueRequest` — body for POST rescue/ (`actor_sheet_id`, `sinner_sheet_id`, `resonance_id`, `scene_id`)
-- `RescueOutcome` — response from rescue/ (RescueOutcomeSerializer shape)
-- `StageAdvanceRespondRequest` — `{ sinner_sheet_id, sineater_sheet_id, units_committed }` (0=decline)
-- `StageAdvanceBonusResult` — response from stage-advance/respond/ (StageAdvanceBonusResultSerializer shape)
+- `SoulTetherDetail` — `components['schemas']['SoulTetherDetail']` — response for
+  `GET /api/magic/soul-tether/{relationship_id}/`
+- `DissolveRequest` — `components['schemas']['DissolveRequest']`
+- `SineatingRequest` — `components['schemas']['SineatingRequestRequest']` (request body → "Request" suffix)
+- `SineatingOffer` — `components['schemas']['SineatingOffer']`
+- `SineatingRespondRequest` — `components['schemas']['SineatingRespondRequest']` (units_accepted=0 declines)
+- `SineatingResult` — `components['schemas']['SineatingResult']`
+- `RescueRequest` — `components['schemas']['SoulTetherRescueRequest']`
+- `RescueOutcome` — `components['schemas']['RescueOutcome']`
+- `StageAdvanceRespondRequest` — `components['schemas']['StageAdvanceRespondRequest']` (units_committed=0 declines)
+- `StageAdvanceBonusResult` — `components['schemas']['StageAdvanceBonusResult']`
+- `AudereRespondRequest` / `AudereOfferResult` — `audere/respond/` request + result
+- `AudereMajoraRespondRequest` / `AudereMajoraCrossingResult` — `audere-majora/respond/` request + result
+- `EligiblePath` / `PendingAudereMajoraOffer` / `PaginatedPendingAudereMajoraOfferList` —
+  the Crossing offer list (`eligible_paths` typed via `@extend_schema_field` on the serializer)
+
+**Local types** (no 1:1 serializer to re-export):
+
 - `WeaveThreadRequest` — body for POST /threads/ (weave new thread)
 - `PatchThreadRequest` — `{ name?, description? }` for PATCH /threads/{id}/
 - `ImbueRequest` — `{ ritual_id, character_sheet_id, kwargs: { thread_id, amount } }`
@@ -333,14 +340,14 @@ for removal once the hub/detail pages are confirmed stable.
 - **NOT here:** Soul Tether _formation_ (acceptance) goes through
   `POST /api/magic/rituals/perform/` via `usePerformRitual` in the rituals module.
 - **Backend:** `world.magic` — services/soul_tether.py, views.py, urls.py
-- **Serializer mapping:**
-  - `SoulTetherDetailSerializer` → `SoulTetherDetail` (local type, not in generated schema)
-  - `SineatingOfferSerializer` → `SineatingOffer` (local type)
-  - `SineatingResultSerializer` → `SineatingResult` (local type)
-  - `RescueOutcomeSerializer` → `RescueOutcome` (local type)
-  - `StageAdvanceBonusResultSerializer` → `StageAdvanceBonusResult` (local type)
-  - `SineatingPendingOfferSerializer` → `SineatingPendingOffer` (generated schema)
-  - `PendingStageAdvanceOfferSerializer` → `PendingStageAdvanceOffer` (generated schema)
+- **Serializer mapping** (all generated via `@extend_schema`, #920):
+  - `SoulTetherDetailSerializer` → `SoulTetherDetail`
+  - `SineatingOfferSerializer` → `SineatingOffer`
+  - `SineatingResultSerializer` → `SineatingResult`
+  - `RescueOutcomeSerializer` → `RescueOutcome`
+  - `StageAdvanceBonusResultSerializer` → `StageAdvanceBonusResult`
+  - `SineatingPendingOfferSerializer` → `SineatingPendingOffer`
+  - `PendingStageAdvanceOfferSerializer` → `PendingStageAdvanceOffer`
 - **Consumers (Phase 3 Tasks 3.2–3.7):** SoulTetherPanel, SineatingInbox,
   SineatingRespondDialog, StageAdvanceInbox, RescueDialog, DissolveDialog
 
@@ -370,11 +377,11 @@ action. `useAlterationLibrary(id).data` is `AlterationLibraryEntry[]`, not a pag
 wrapper. The `@extend_schema` decorator on the backend makes the generated schema reflect
 this accurately.
 
-**`SoulTetherDetail` is a local type, NOT in the generated schema.**
-The generated `magic_soul_tether_retrieve` operation has `content?: never` because
-`SoulTetherDetailSerializer` derives from `serializers.Serializer`, not a ModelSerializer,
-and drf-spectacular cannot infer the response shape. The fields are taken directly from
-`SoulTetherDetailSerializer` field declarations.
+**`SoulTetherDetail` is now generated (#920), re-exported — do not hand-roll it.**
+`SoulTetherDetailView.get` carries `@extend_schema(responses={200: SoulTetherDetailSerializer})`,
+so `components['schemas']['SoulTetherDetail']` exists. Same pattern for every soul-tether /
+Audere respond + detail endpoint: annotate the view (or `@extend_schema_field` a method field),
+run `just gen-api-types`, and re-export — never re-introduce a hand-rolled mirror that can drift.
 
 **`soul_tether_role` is a string, not a union.**
 The `SoulTetherRole` TextChoices (`ABYSSAL` / `CELESTIAL`) are not exposed in the generated

--- a/frontend/src/magic/types.ts
+++ b/frontend/src/magic/types.ts
@@ -3,9 +3,10 @@
  *
  * Re-exports generated schemas for Thread, CharacterResonance, SineatingPendingOffer,
  * PendingStageAdvanceOffer, Ritual, ThreadWeavingTeachingOffer, and related list types.
- * Local types cover request bodies and response shapes that the generated schema left
- * as `content?: never` (e.g. soul-tether detail, sineating offer response, rescue
- * outcome, thread hub summary, pull preview/commit).
+ * The soul-tether / Audere / Audere Majora respond + detail endpoints are now annotated
+ * with `@extend_schema` (#920), so their request/response shapes are re-exported from the
+ * generated schema too. The few remaining local types cover shapes with no 1:1 serializer
+ * (e.g. TetherBond, ImbueRequest/Response, the alteration-resolve union, technique design).
  */
 
 import type { components } from '@/generated/api';
@@ -32,128 +33,31 @@ export type PaginatedPendingStageAdvanceOfferList =
   components['schemas']['PaginatedPendingStageAdvanceOfferList'];
 
 // ---------------------------------------------------------------------------
-// Soul Tether detail response
+// Soul Tether respond/detail endpoints — generated via @extend_schema (#920)
 //
-// The generated schema for GET /api/magic/soul-tether/{relationship_id}/
-// has `content?: never` — drf-spectacular does not know the response shape
-// because SoulTetherDetailSerializer derives from serializers.Serializer, not
-// a model. We declare the shape manually from SoulTetherDetailSerializer.
+// These endpoints use plain `serializers.Serializer` classes. With
+// `@extend_schema` on each view, drf-spectacular now emits proper request and
+// response components, so we re-export the generated shapes instead of
+// hand-rolling them (which could drift from the backend serializers).
 // ---------------------------------------------------------------------------
 
-export interface SoulTetherDetail {
-  relationship_id: number;
-  is_soul_tether: boolean;
-  soul_tether_role: string; // 'ABYSSAL' | 'CELESTIAL' from SoulTetherRole choices
-  sinner_sheet_id: number | null;
-  sineater_sheet_id: number | null;
-  hollow_current: number;
-  hollow_max: number;
-  sineater_lifetime_helped: number;
-  sinner_corruption_stage: number;
-  sineater_strain_stage: number;
-}
+export type SoulTetherDetail = components['schemas']['SoulTetherDetail'];
+export type DissolveRequest = components['schemas']['DissolveRequest'];
 
-// ---------------------------------------------------------------------------
-// Dissolve request body
-// ---------------------------------------------------------------------------
+// SineatingRequestSerializer is a request body, so the generated component
+// carries drf-spectacular's "Request" suffix (→ SineatingRequestRequest).
+export type SineatingRequest = components['schemas']['SineatingRequestRequest'];
+export type SineatingOffer = components['schemas']['SineatingOffer'];
 
-export interface DissolveRequest {
-  actor_sheet_id: number;
-  relationship_id: number;
-}
+export type SineatingRespondRequest = components['schemas']['SineatingRespondRequest'];
+export type SineatingResult = components['schemas']['SineatingResult'];
 
-// ---------------------------------------------------------------------------
-// Sineating request body + offer response
-//
-// POST /api/magic/soul-tether/sineating/request/ accepts SineatingRequestSerializer.
-// It returns a SineatingOffer which drf-spectacular marks as no body (the view uses
-// a plain Serializer). We type the response from SineatingOfferSerializer.
-// ---------------------------------------------------------------------------
+// RescueRequest maps to the generated SoulTetherRescueRequest component.
+export type RescueRequest = components['schemas']['SoulTetherRescueRequest'];
+export type RescueOutcome = components['schemas']['RescueOutcome'];
 
-export interface SineatingRequest {
-  actor_sheet_id: number;
-  sineater_sheet_id: number;
-  resonance_id: number;
-  max_units: number;
-  scene_id: number;
-}
-
-export interface SineatingOffer {
-  sinner_sheet_id: number;
-  sineater_sheet_id: number;
-  resonance_id: number;
-  max_units_offered: number;
-  anima_cost_per_unit: number;
-  fatigue_cost_per_unit: number;
-  current_hollow: number;
-  hollow_max: number;
-  sineater_current_strain_stage: number;
-}
-
-// ---------------------------------------------------------------------------
-// Sineating respond body + result response
-//
-// POST /api/magic/soul-tether/sineating/respond/ accepts SineatingRespondSerializer.
-// Response shape from SineatingResultSerializer.
-// ---------------------------------------------------------------------------
-
-export interface SineatingRespondRequest {
-  sinner_sheet_id: number;
-  sineater_sheet_id: number;
-  units_accepted: number; // 0 = decline
-}
-
-export interface SineatingResult {
-  units_accepted: number;
-  declined: boolean;
-  new_hollow_current: number;
-  new_lifetime_helped: number;
-  audit_row_id: number;
-}
-
-// ---------------------------------------------------------------------------
-// Rescue request + outcome
-//
-// POST /api/magic/soul-tether/rescue/ accepts SoulTetherRescueSerializer.
-// Response shape from RescueOutcomeSerializer.
-// ---------------------------------------------------------------------------
-
-export interface RescueRequest {
-  actor_sheet_id: number;
-  sinner_sheet_id: number;
-  resonance_id: number;
-  scene_id: number;
-}
-
-export interface RescueOutcome {
-  severity_reduced: number;
-  sinner_stage_at_start: number;
-  sinner_stage_at_end: number;
-  sineater_strain_taken: number;
-  protagonism_lock_lifted: boolean;
-  audit_row_id: number;
-}
-
-// ---------------------------------------------------------------------------
-// Stage-advance respond request + result
-//
-// POST /api/magic/soul-tether/stage-advance/respond/ accepts StageAdvanceRespondSerializer.
-// Response shape from StageAdvanceBonusResultSerializer.
-// ---------------------------------------------------------------------------
-
-export interface StageAdvanceRespondRequest {
-  sinner_sheet_id: number;
-  sineater_sheet_id: number;
-  units_committed: number; // 0 = decline
-}
-
-export interface StageAdvanceBonusResult {
-  offer_id: string;
-  units_committed: number;
-  hollow_drained: number;
-  strain_severity_added: number;
-  declined: boolean;
-}
+export type StageAdvanceRespondRequest = components['schemas']['StageAdvanceRespondRequest'];
+export type StageAdvanceBonusResult = components['schemas']['StageAdvanceBonusResult'];
 
 // ---------------------------------------------------------------------------
 // Tether bond — returned by getMyTetherBonds / useMyTetherBonds
@@ -398,85 +302,27 @@ export type PendingAudereOffer = components['schemas']['PendingAudereOffer'];
 export type PaginatedPendingAudereOfferList =
   components['schemas']['PaginatedPendingAudereOfferList'];
 
-/** Body for POST /api/magic/audere/respond/. accept=false declines. */
-export interface AudereRespondRequest {
-  offer_id: number;
-  accept: boolean;
-}
-
-/**
- * Response from audere/respond/ (AudereOfferResultSerializer — plain
- * Serializer, not in generated schema).
- */
-export interface AudereOfferResult {
-  accepted: boolean;
-  intensity_bonus_applied: number;
-  anima_pool_expanded_by: number;
-  advisory_text: string;
-}
+// Body for POST /api/magic/audere/respond/ (accept=false declines) + result.
+// Generated via @extend_schema on AudereRespondView (#920).
+export type AudereRespondRequest = components['schemas']['AudereRespondRequest'];
+export type AudereOfferResult = components['schemas']['AudereOfferResult'];
 
 // ---------------------------------------------------------------------------
-// Audere Majora (Crossing offer), #543
+// Audere Majora (Crossing offer), #543 — generated shapes (#920)
+//
+// The PendingAudereMajoraOfferViewSet is auto-detected by drf-spectacular;
+// `eligible_paths` is now typed via @extend_schema_field on the serializer's
+// get_eligible_paths, so the whole offer (and its paginated list) re-export
+// cleanly. The respond endpoint is annotated via @extend_schema.
 // ---------------------------------------------------------------------------
 
-/** One eligible crossing path returned by GET /api/magic/audere-majora/pending/. */
-export interface EligiblePath {
-  id: number;
-  name: string;
-  stage: number;
-  stage_display: string;
-  description: string;
-}
+export type EligiblePath = components['schemas']['EligiblePath'];
+export type PendingAudereMajoraOffer = components['schemas']['PendingAudereMajoraOffer'];
+export type PaginatedPendingAudereMajoraOfferList =
+  components['schemas']['PaginatedPendingAudereMajoraOfferList'];
 
-/**
- * A pending Audere Majora crossing offer.
- * Returned (paginated) by GET /api/magic/audere-majora/pending/.
- */
-export interface PendingAudereMajoraOffer {
-  id: number;
-  character_sheet_id: number;
-  character_name: string;
-  fired_intensity: number;
-  soulfray_stage_order: number;
-  boundary_level: number;
-  target_stage_display: string;
-  vision_text: string;
-  advisory_text: string;
-  risk_text: string;
-  eligible_paths: EligiblePath[];
-  intended_path_id: number | null;
-  created_at: string;
-}
-
-/** Paginated wrapper for PendingAudereMajoraOffer list. */
-export interface PaginatedPendingAudereMajoraOfferList {
-  count: number;
-  next: string | null;
-  previous: string | null;
-  results: PendingAudereMajoraOffer[];
-}
-
-/** Body for POST /api/magic/audere-majora/respond/. accept=false declines. */
-export interface AudereMajoraRespondRequest {
-  offer_id: number;
-  accept: boolean;
-  path_id?: number | null;
-  declaration_text?: string;
-}
-
-/**
- * Response from audere-majora/respond/ (AudereMajoraCrossingResultSerializer —
- * plain Serializer, not in generated schema).
- */
-export interface AudereMajoraCrossingResult {
-  accepted: boolean;
-  level_before: number;
-  level_after: number;
-  chosen_path_name: string;
-  advisory_text: string;
-  /** null on decline and on no-scene crossings. */
-  declaration_interaction_id: number | null;
-}
+export type AudereMajoraRespondRequest = components['schemas']['AudereMajoraRespondRequest'];
+export type AudereMajoraCrossingResult = components['schemas']['AudereMajoraCrossingResult'];
 
 /** A declared path intent as returned by GET /api/progression/path-intent/. */
 export interface PathIntentDetail {

--- a/src/schema.json
+++ b/src/schema.json
@@ -8985,11 +8985,21 @@ paths:
         the result.
       tags:
       - magic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AudereMajoraRespondRequest'
+        required: true
       security:
       - cookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AudereMajoraCrossingResult'
+          description: ''
   /api/magic/audere/pending/:
     get:
       operationId: magic_audere_pending_list
@@ -9058,11 +9068,21 @@ paths:
         result.
       tags:
       - magic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AudereRespondRequest'
+        required: true
       security:
       - cookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AudereOfferResult'
+          description: ''
   /api/magic/character-anima/:
     get:
       operationId: magic_character_anima_list
@@ -10983,28 +11003,48 @@ paths:
       - cookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SoulTetherDetail'
+          description: ''
   /api/magic/soul-tether/accept/:
     post:
       operationId: magic_soul_tether_accept_create
       description: Validate and dispatch accept_soul_tether; return capstone PK.
       tags:
       - magic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AcceptSoulTetherRequest'
+        required: true
       security:
       - cookieAuth: []
       responses:
-        '200':
-          description: No response body
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SoulTetherAcceptResponse'
+          description: ''
   /api/magic/soul-tether/dissolve/:
     post:
       operationId: magic_soul_tether_dissolve_create
       description: Validate and dispatch dissolve_soul_tether; return 204 on success.
       tags:
       - magic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DissolveRequest'
+        required: true
       security:
       - cookieAuth: []
       responses:
-        '200':
+        '204':
           description: No response body
   /api/magic/soul-tether/rescue/:
     post:
@@ -11013,11 +11053,21 @@ paths:
         payload.
       tags:
       - magic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SoulTetherRescueRequest'
+        required: true
       security:
       - cookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RescueOutcome'
+          description: ''
   /api/magic/soul-tether/sineating/pending/:
     get:
       operationId: magic_soul_tether_sineating_pending_list
@@ -11087,22 +11137,42 @@ paths:
       description: Validate and dispatch request_sineating; return offer payload.
       tags:
       - magic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SineatingRequestRequest'
+        required: true
       security:
       - cookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SineatingOffer'
+          description: ''
   /api/magic/soul-tether/sineating/respond/:
     post:
       operationId: magic_soul_tether_sineating_respond_create
       description: Re-validate offer + dispatch resolve_sineating; return result payload.
       tags:
       - magic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SineatingRespondRequest'
+        required: true
       security:
       - cookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SineatingResult'
+          description: ''
   /api/magic/soul-tether/stage-advance/pending/:
     get:
       operationId: magic_soul_tether_stage_advance_pending_list
@@ -11176,11 +11246,21 @@ paths:
       description: Validate offer + dispatch resolve; return result payload.
       tags:
       - magic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StageAdvanceRespondRequest'
+        required: true
       security:
       - cookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageAdvanceBonusResult'
+          description: ''
   /api/magic/style-presentation-endorsements/:
     post:
       operationId: magic_style_presentation_endorsements_create
@@ -21158,6 +21238,35 @@ paths:
           description: ''
 components:
   schemas:
+    AcceptSoulTetherRequest:
+      type: object
+      description: |-
+        Write serializer for forming a Soul Tether (Spec B §12).
+
+        ``actor_sheet_id`` identifies the character sheet of the requesting account.
+        ``partner_sheet_id`` identifies the partner's character sheet.
+        ``sinner_role`` determines which side (SINNER or SINEATER) the initiator holds.
+        ``resonance_id`` selects the resonance for the Sinner's Thread.
+        ``writeup`` is the narrative description of the bond (20+ chars).
+      properties:
+        actor_sheet_id:
+          type: integer
+        partner_sheet_id:
+          type: integer
+        sinner_role:
+          $ref: '#/components/schemas/SinnerRoleEnum'
+        resonance_id:
+          type: integer
+        writeup:
+          type: string
+          minLength: 20
+          maxLength: 4000
+      required:
+      - actor_sheet_id
+      - partner_sheet_id
+      - resonance_id
+      - sinner_role
+      - writeup
     AcceptTeachingOfferRequest:
       type: object
       description: |-
@@ -21670,6 +21779,77 @@ components:
         * `rejected` - Rejected
         * `cancelled` - Cancelled
         * `completed` - Completed
+    AudereMajoraCrossingResult:
+      type: object
+      description: Read serializer for AudereMajoraCrossingResult dataclass.
+      properties:
+        accepted:
+          type: boolean
+        level_before:
+          type: integer
+        level_after:
+          type: integer
+        chosen_path_name:
+          type: string
+        advisory_text:
+          type: string
+        declaration_interaction_id:
+          type: integer
+          nullable: true
+      required:
+      - accepted
+      - advisory_text
+      - chosen_path_name
+      - declaration_interaction_id
+      - level_after
+      - level_before
+    AudereMajoraRespondRequest:
+      type: object
+      description: Write serializer for the player's Crossing decision. accept=false
+        declines.
+      properties:
+        offer_id:
+          type: integer
+        accept:
+          type: boolean
+        path_id:
+          type: integer
+          nullable: true
+        declaration_text:
+          type: string
+          maxLength: 4000
+      required:
+      - accept
+      - offer_id
+    AudereOfferResult:
+      type: object
+      description: Read serializer for AudereOfferResult (audere.py dataclass).
+      properties:
+        accepted:
+          type: boolean
+        intensity_bonus_applied:
+          type: integer
+        anima_pool_expanded_by:
+          type: integer
+        advisory_text:
+          type: string
+      required:
+      - accepted
+      - advisory_text
+      - anima_pool_expanded_by
+      - intensity_bonus_applied
+    AudereRespondRequest:
+      type: object
+      description: Write serializer for the player's Audere decision. accept=false
+        declines.
+      properties:
+        offer_id:
+          type: integer
+        accept:
+          type: boolean
+      required:
+      - accept
+      - offer_id
     AvailableEnhancement:
       type: object
       description: Read-only serializer for AvailableEnhancement (technique enhancement
@@ -25203,6 +25383,21 @@ components:
       description: |-
         * `obvious` - Obvious (visible if capability met)
         * `discoverable` - Discoverable (must be learned)
+    DissolveRequest:
+      type: object
+      description: |-
+        Write serializer for dissolving a Soul Tether (Spec B §13).
+
+        Either party may dissolve; ``actor_sheet_id`` is validated for ownership.
+        ``relationship_id`` is the PK of *either* directional CharacterRelationship row.
+      properties:
+        actor_sheet_id:
+          type: integer
+        relationship_id:
+          type: integer
+      required:
+      - actor_sheet_id
+      - relationship_id
     DistinctionCategory:
       type: object
       description: Serializer for DistinctionCategory lookup records.
@@ -25824,6 +26019,26 @@ components:
         * `medium` - Medium Effort
         * `high` - High Effort
         * `extreme` - Extreme Effort
+    EligiblePath:
+      type: object
+      description: Read serializer for a single eligible crossing path.
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        stage:
+          type: integer
+        stage_display:
+          type: string
+        description:
+          type: string
+      required:
+      - description
+      - id
+      - name
+      - stage
+      - stage_display
     EncounterDetail:
       type: object
       description: Full encounter state with covenant-filtered action visibility.
@@ -36115,8 +36330,8 @@ components:
           readOnly: true
         eligible_paths:
           type: array
-          items: {}
-          description: Eligible child paths serialized through EligiblePathSerializer.
+          items:
+            $ref: '#/components/schemas/EligiblePath'
           readOnly: true
         intended_path_id:
           type: integer
@@ -37811,6 +38026,31 @@ components:
         * `failure` - Failure
         * `expired` - Expired
         * `pending_gm_review` - Pending GM review
+    RescueOutcome:
+      type: object
+      description: Read serializer for RescueOutcome payloads.
+      properties:
+        severity_reduced:
+          type: integer
+        sinner_stage_at_start:
+          type: integer
+        sinner_stage_at_end:
+          type: integer
+        sineater_strain_taken:
+          type: integer
+        protagonism_lock_lifted:
+          type: boolean
+        audit_row_id:
+          type: integer
+          description: Return the SoulTetherRescue audit row PK.
+          readOnly: true
+      required:
+      - audit_row_id
+      - protagonism_lock_lifted
+      - severity_reduced
+      - sineater_strain_taken
+      - sinner_stage_at_end
+      - sinner_stage_at_start
     ResolutionTypeEnum:
       enum:
       - destroy
@@ -39299,6 +39539,45 @@ components:
       description: |-
         * `positive` - Positive
         * `negative` - Negative
+    SineatingOffer:
+      type: object
+      description: Read serializer for SineatingOffer payloads returned by the request
+        endpoint.
+      properties:
+        sinner_sheet_id:
+          type: integer
+          description: Return sinner_sheet PK.
+          readOnly: true
+        sineater_sheet_id:
+          type: integer
+          description: Return sineater_sheet PK.
+          readOnly: true
+        resonance_id:
+          type: integer
+          description: Return resonance PK.
+          readOnly: true
+        max_units_offered:
+          type: integer
+        anima_cost_per_unit:
+          type: integer
+        fatigue_cost_per_unit:
+          type: integer
+        current_hollow:
+          type: integer
+        hollow_max:
+          type: integer
+        sineater_current_strain_stage:
+          type: integer
+      required:
+      - anima_cost_per_unit
+      - current_hollow
+      - fatigue_cost_per_unit
+      - hollow_max
+      - max_units_offered
+      - resonance_id
+      - sineater_current_strain_stage
+      - sineater_sheet_id
+      - sinner_sheet_id
     SineatingPendingOffer:
       type: object
       description: |-
@@ -39349,6 +39628,73 @@ components:
       - sinner_persona_name
       - sinner_sheet_id
       - units_offered
+    SineatingRequestRequest:
+      type: object
+      description: |-
+        Write serializer for Sinner-initiated Sineating request (Spec B §7).
+
+        Returns a ``SineatingOffer`` that the Sineater can accept or decline via
+        the respond endpoint.
+      properties:
+        actor_sheet_id:
+          type: integer
+        sineater_sheet_id:
+          type: integer
+        resonance_id:
+          type: integer
+        max_units:
+          type: integer
+          minimum: 1
+        scene_id:
+          type: integer
+      required:
+      - actor_sheet_id
+      - max_units
+      - resonance_id
+      - scene_id
+      - sineater_sheet_id
+    SineatingRespondRequest:
+      type: object
+      description: |-
+        Write serializer for the Sineater's response to a Sineating request (Spec B §7).
+
+        The pending offer row is the canonical source of truth for scene, resonance,
+        and units cap — the caller only needs to identify the pair and supply their choice.
+        ``units_accepted=0`` means decline.
+      properties:
+        sinner_sheet_id:
+          type: integer
+        sineater_sheet_id:
+          type: integer
+        units_accepted:
+          type: integer
+          minimum: 0
+      required:
+      - sineater_sheet_id
+      - sinner_sheet_id
+      - units_accepted
+    SineatingResult:
+      type: object
+      description: Read serializer for SineatingResult payloads.
+      properties:
+        units_accepted:
+          type: integer
+        declined:
+          type: boolean
+        new_hollow_current:
+          type: integer
+        new_lifetime_helped:
+          type: integer
+        audit_row_id:
+          type: integer
+          description: Return the audit Sineating row PK.
+          readOnly: true
+      required:
+      - audit_row_id
+      - declined
+      - new_hollow_current
+      - new_lifetime_helped
+      - units_accepted
     SinkEnum:
       enum:
       - money
@@ -39365,6 +39711,14 @@ components:
         * `rumor` - Rumor
         * `crime_watch` - Crime Watch
         * `beat` - Beat
+    SinnerRoleEnum:
+      enum:
+      - SINNER
+      - SINEATER
+      type: string
+      description: |-
+        * `SINNER` - SINNER
+        * `SINEATER` - SINEATER
     SituationChallengeLink:
       type: object
       description: Nested serializer for situation challenge links.
@@ -39600,6 +39954,94 @@ components:
       required:
       - id
       - name
+    SoulTetherAcceptResponse:
+      type: object
+      properties:
+        capstone_id:
+          type: integer
+      required:
+      - capstone_id
+    SoulTetherDetail:
+      type: object
+      description: |-
+        Read serializer for GET /api/magic/soul-tether/{relationship_id}/.
+
+        Returns tether state: Hollow current/max, Thread levels, Sineater stats,
+        and role information. Accepts a CharacterRelationship (either direction).
+      properties:
+        relationship_id:
+          type: integer
+          readOnly: true
+        is_soul_tether:
+          type: boolean
+          readOnly: true
+        soul_tether_role:
+          type: string
+          readOnly: true
+        sinner_sheet_id:
+          type: integer
+          nullable: true
+          description: Return the Sinner's CharacterSheet PK.
+          readOnly: true
+        sineater_sheet_id:
+          type: integer
+          nullable: true
+          description: Return the Sineater's CharacterSheet PK.
+          readOnly: true
+        hollow_current:
+          type: integer
+          description: Return the Sinner's current Hollow capacity (from the capstone
+            Thread).
+          readOnly: true
+        hollow_max:
+          type: integer
+          description: Return the Sinner's Hollow maximum (thread.level * 10).
+          readOnly: true
+        sineater_lifetime_helped:
+          type: integer
+          description: Return the Sineater's total lifetime_helped across all resonances
+            for this bond.
+          readOnly: true
+        sinner_corruption_stage:
+          type: integer
+          description: Return the Sinner's highest corruption stage across all resonances.
+          readOnly: true
+        sineater_strain_stage:
+          type: integer
+          description: Return the Sineater's current Tether Strain severity (or 0
+            if none).
+          readOnly: true
+      required:
+      - hollow_current
+      - hollow_max
+      - is_soul_tether
+      - relationship_id
+      - sineater_lifetime_helped
+      - sineater_sheet_id
+      - sineater_strain_stage
+      - sinner_corruption_stage
+      - sinner_sheet_id
+      - soul_tether_role
+    SoulTetherRescueRequest:
+      type: object
+      description: |-
+        Write serializer for the rescue ritual (Spec B §9).
+
+        The Sineater performs the ritual on the Sinner. Both must be in the same scene.
+      properties:
+        actor_sheet_id:
+          type: integer
+        sinner_sheet_id:
+          type: integer
+        resonance_id:
+          type: integer
+        scene_id:
+          type: integer
+      required:
+      - actor_sheet_id
+      - resonance_id
+      - scene_id
+      - sinner_sheet_id
     SoulTetherRoleEnum:
       enum:
       - SINEATER
@@ -39820,6 +40262,46 @@ components:
       - created_at
       - id
       - title
+    StageAdvanceBonusResult:
+      type: object
+      description: Read serializer for StageAdvanceBonusResult payloads (Task 1.7).
+      properties:
+        offer_id:
+          type: string
+        units_committed:
+          type: integer
+        hollow_drained:
+          type: integer
+        strain_severity_added:
+          type: integer
+        declined:
+          type: boolean
+      required:
+      - declined
+      - hollow_drained
+      - offer_id
+      - strain_severity_added
+      - units_committed
+    StageAdvanceRespondRequest:
+      type: object
+      description: |-
+        Write serializer for the Sineater's response to a stage-advance prompt (Spec B §8.1).
+
+        The pending offer row is the canonical source of truth for resonance, max units,
+        and expiry — the caller only needs to identify the pair and supply their choice.
+        ``units_committed=0`` means decline.
+      properties:
+        sinner_sheet_id:
+          type: integer
+        sineater_sheet_id:
+          type: integer
+        units_committed:
+          type: integer
+          minimum: 0
+      required:
+      - sineater_sheet_id
+      - sinner_sheet_id
+      - units_committed
     StageEnum:
       enum:
       - 1

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -9,6 +9,7 @@ Affinities and Resonances are proper domain models in the magic app.
 
 from typing import TYPE_CHECKING
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from world.character_sheets.models import CharacterSheet
@@ -2333,6 +2334,7 @@ class PendingAudereMajoraOfferSerializer(_PendingOfferCharacterMixin, serializer
             )
         return cache[pk]
 
+    @extend_schema_field(EligiblePathSerializer(many=True))
     def get_eligible_paths(self, obj: object) -> list:
         """Eligible child paths serialized through EligiblePathSerializer."""
         paths = self._eligible_paths_for_obj(obj)
@@ -2365,12 +2367,14 @@ class AudereMajoraRespondSerializer(serializers.Serializer):
     offer_id = serializers.IntegerField()
     accept = serializers.BooleanField()
     path_id = serializers.IntegerField(required=False, allow_null=True)
+    # No `default=""`: the validate()/create() `.get(..., "")` fallbacks already
+    # cover omission, and a default would make drf-spectacular mark the field
+    # required in the generated request schema (decline call-sites omit it).
     declaration_text = serializers.CharField(
         required=False,
         allow_blank=True,
         max_length=4000,
         trim_whitespace=True,
-        default="",
     )
 
     def validate_offer_id(self, value: int):

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -18,10 +18,10 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, inline_serializer
 from evennia.accounts.models import AccountDB
 from evennia.objects.models import ObjectDB
-from rest_framework import mixins, status, viewsets
+from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.filters import OrderingFilter, SearchFilter
@@ -79,11 +79,16 @@ from world.magic.models import (
 )
 from world.magic.permissions import IsRitualAuthorOrStaff, IsThreadOwner
 from world.magic.serializers import (
+    AcceptSoulTetherSerializer,
     AcceptTeachingOfferResponseSerializer,
     AcceptTeachingOfferSerializer,
     AlterationResolutionResponseSerializer,
     AlterationResolutionSerializer,
     ApplicablePullsRequestSerializer,
+    AudereMajoraCrossingResultSerializer,
+    AudereMajoraRespondSerializer,
+    AudereOfferResultSerializer,
+    AudereRespondSerializer,
     CantripSerializer,
     CharacterAnimaSerializer,
     CharacterAuraSerializer,
@@ -91,6 +96,7 @@ from world.magic.serializers import (
     CharacterResonanceSerializer,
     CrossXPLockResponseSerializer,
     CrossXPLockSerializer,
+    DissolveSerializer,
     EffectTypeSerializer,
     FacetSerializer,
     FacetTreeSerializer,
@@ -101,6 +107,7 @@ from world.magic.serializers import (
     PendingAlterationSerializer,
     PoseEndorsementSerializer,
     ProgressionStageSerializer,
+    RescueOutcomeSerializer,
     ResonanceGrantSerializer,
     RestrictionSerializer,
     RitualPatchSerializer,
@@ -110,6 +117,14 @@ from world.magic.serializers import (
     RitualSessionDraftSerializer,
     RoomBriefSerializer,
     SceneEntryEndorsementSerializer,
+    SineatingOfferSerializer,
+    SineatingRequestSerializer,
+    SineatingRespondSerializer,
+    SineatingResultSerializer,
+    SoulTetherDetailSerializer,
+    SoulTetherRescueSerializer,
+    StageAdvanceBonusResultSerializer,
+    StageAdvanceRespondSerializer,
     StylePresentationEndorsementSerializer,
     TechniqueDesignSerializer,
     TechniqueSerializer,
@@ -1200,10 +1215,17 @@ class SoulTetherAcceptView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=AcceptSoulTetherSerializer,
+        responses={
+            201: inline_serializer(
+                name="SoulTetherAcceptResponse",
+                fields={"capstone_id": serializers.IntegerField()},
+            )
+        },
+    )
     def post(self, request: Request) -> Response:
         """Validate and dispatch accept_soul_tether; return capstone PK."""
-        from world.magic.serializers import AcceptSoulTetherSerializer  # noqa: PLC0415
-
         serializer = AcceptSoulTetherSerializer(
             data=request.data,
             context={"request": request},
@@ -1224,9 +1246,9 @@ class SoulTetherDetailView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(responses={200: SoulTetherDetailSerializer})
     def get(self, request: Request, relationship_id: int) -> Response:
         """Fetch and serialise the tether state for the given relationship."""
-        from world.magic.serializers import SoulTetherDetailSerializer  # noqa: PLC0415
         from world.relationships.models import CharacterRelationship  # noqa: PLC0415
 
         rel = get_object_or_404(CharacterRelationship, pk=relationship_id, is_soul_tether=True)
@@ -1246,13 +1268,12 @@ class SineatingRequestView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=SineatingRequestSerializer,
+        responses={200: SineatingOfferSerializer},
+    )
     def post(self, request: Request) -> Response:
         """Validate and dispatch request_sineating; return offer payload."""
-        from world.magic.serializers import (  # noqa: PLC0415
-            SineatingOfferSerializer,
-            SineatingRequestSerializer,
-        )
-
         serializer = SineatingRequestSerializer(
             data=request.data,
             context={"request": request},
@@ -1277,13 +1298,12 @@ class SineatingRespondView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=SineatingRespondSerializer,
+        responses={200: SineatingResultSerializer},
+    )
     def post(self, request: Request) -> Response:
         """Re-validate offer + dispatch resolve_sineating; return result payload."""
-        from world.magic.serializers import (  # noqa: PLC0415
-            SineatingRespondSerializer,
-            SineatingResultSerializer,
-        )
-
         serializer = SineatingRespondSerializer(
             data=request.data,
             context={"request": request},
@@ -1307,13 +1327,12 @@ class SoulTetherRescueView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=SoulTetherRescueSerializer,
+        responses={200: RescueOutcomeSerializer},
+    )
     def post(self, request: Request) -> Response:
         """Validate and dispatch perform_soul_tether_rescue; return outcome payload."""
-        from world.magic.serializers import (  # noqa: PLC0415
-            RescueOutcomeSerializer,
-            SoulTetherRescueSerializer,
-        )
-
         serializer = SoulTetherRescueSerializer(
             data=request.data,
             context={"request": request},
@@ -1337,10 +1356,9 @@ class SoulTetherDissolveView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(request=DissolveSerializer, responses={204: None})
     def post(self, request: Request) -> Response:
         """Validate and dispatch dissolve_soul_tether; return 204 on success."""
-        from world.magic.serializers import DissolveSerializer  # noqa: PLC0415
-
         serializer = DissolveSerializer(
             data=request.data,
             context={"request": request},
@@ -1435,13 +1453,12 @@ class StageAdvanceRespondView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=StageAdvanceRespondSerializer,
+        responses={200: StageAdvanceBonusResultSerializer},
+    )
     def post(self, request: Request) -> Response:
         """Validate offer + dispatch resolve; return result payload."""
-        from world.magic.serializers import (  # noqa: PLC0415
-            StageAdvanceBonusResultSerializer,
-            StageAdvanceRespondSerializer,
-        )
-
         serializer = StageAdvanceRespondSerializer(
             data=request.data,
             context={"request": request},
@@ -1522,13 +1539,12 @@ class AudereRespondView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=AudereRespondSerializer,
+        responses={200: AudereOfferResultSerializer},
+    )
     def post(self, request: Request) -> Response:
         """Validate ownership + dispatch resolve_audere_offer; return the result."""
-        from world.magic.serializers import (  # noqa: PLC0415
-            AudereOfferResultSerializer,
-            AudereRespondSerializer,
-        )
-
         return _dispatch_respond(request, AudereRespondSerializer, AudereOfferResultSerializer)
 
 
@@ -1570,13 +1586,12 @@ class AudereMajoraRespondView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=AudereMajoraRespondSerializer,
+        responses={200: AudereMajoraCrossingResultSerializer},
+    )
     def post(self, request: Request) -> Response:
         """Validate ownership + dispatch resolve_audere_majora_offer; return the result."""
-        from world.magic.serializers import (  # noqa: PLC0415
-            AudereMajoraCrossingResultSerializer,
-            AudereMajoraRespondSerializer,
-        )
-
         return _dispatch_respond(
             request, AudereMajoraRespondSerializer, AudereMajoraCrossingResultSerializer
         )


### PR DESCRIPTION
Closes #920

## Summary

Annotates the plain-`serializers.Serializer` Audere / soul-tether / Audere-Majora respond + detail endpoints with `@extend_schema` so drf-spectacular emits real request/response components instead of `requestBody?: never` + contentless 200s.

Backend: 9 views decorated (AudereRespondView is the issue's primary; SoulTetherAcceptView gets an inline 201 response); respond-view serializers hoisted to the module-top import block; `get_eligible_paths` annotated via `@extend_schema_field(EligiblePathSerializer(many=True))` so `eligible_paths` types as `EligiblePath[]`; dropped a redundant `default=""` on `declaration_text` that was forcing the field required in the schema.

Frontend: regenerated `schema.json` + `api.d.ts`; `magic/types.ts` now re-exports the generated shapes instead of hand-rolled interfaces (SoulTetherDetail, Dissolve/Sineating/Rescue/StageAdvance/Audere request+result, EligiblePath, PendingAudereMajoraOffer + paginated list). Docs in `frontend/src/magic/CLAUDE.md` updated.

Verification: 1942 magic backend tests pass (sqlite fast tier); frontend `pnpm typecheck`, `pnpm build` (tsc -b + vite), and 324 magic vitest tests pass; `ty` adds zero new diagnostics; all pre-commit hooks green.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #920 (in the issue body)
- Brainstorm/plan: skipped (chore — spec fully specified in the issue body)
- Sync-with-main: Branched fresh from origin/main; sync reported up to date (no rebase needed).

<!-- last-addressed-comment: 0 -->