### PR TITLE
refactor(#895): cast-dialog pull UI follow-ups — useCastPullSelection hook, gated threads, cast error surface, balance tooltips

### DIFF
--- a/frontend/src/lib/errors.test.ts
+++ b/frontend/src/lib/errors.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { extractErrorMessage, readErrorDetail } from './errors';
+
+describe('extractErrorMessage', () => {
+  it('returns the message of an Error', () => {
+    expect(extractErrorMessage(new Error('boom'))).toBe('boom');
+  });
+  it('falls back for an Error with empty message', () => {
+    expect(extractErrorMessage(new Error(''))).toBe('An unexpected error occurred.');
+  });
+  it('falls back for a non-Error value', () => {
+    expect(extractErrorMessage('nope')).toBe('An unexpected error occurred.');
+    expect(extractErrorMessage(undefined)).toBe('An unexpected error occurred.');
+  });
+});
+
+describe('readErrorDetail', () => {
+  it('throws an Error carrying the parsed {detail}', async () => {
+    const res = new Response(JSON.stringify({ detail: 'Unaffordable pull' }), { status: 400 });
+    await expect(readErrorDetail(res, 'fallback')).rejects.toThrow('Unaffordable pull');
+  });
+  it('throws the fallback when the body is not JSON', async () => {
+    const res = new Response('<html>', { status: 500 });
+    await expect(readErrorDetail(res, 'fallback')).rejects.toThrow('fallback');
+  });
+  it('throws the fallback when detail is blank', async () => {
+    const res = new Response(JSON.stringify({ detail: '   ' }), { status: 400 });
+    await expect(readErrorDetail(res, 'fallback')).rejects.toThrow('fallback');
+  });
+});

--- a/frontend/src/lib/errors.test.ts
+++ b/frontend/src/lib/errors.test.ts
@@ -12,6 +12,16 @@ describe('extractErrorMessage', () => {
     expect(extractErrorMessage('nope')).toBe('An unexpected error occurred.');
     expect(extractErrorMessage(undefined)).toBe('An unexpected error occurred.');
   });
+  it('uses custom fallback for a non-Error value', () => {
+    expect(extractErrorMessage('nope', 'Custom fallback')).toBe('Custom fallback');
+    expect(extractErrorMessage(undefined, 'Custom fallback')).toBe('Custom fallback');
+  });
+  it('uses custom fallback for an Error with empty message', () => {
+    expect(extractErrorMessage(new Error(''), 'Custom fallback')).toBe('Custom fallback');
+  });
+  it('ignores custom fallback when the Error has a message', () => {
+    expect(extractErrorMessage(new Error('real message'), 'Custom fallback')).toBe('real message');
+  });
 });
 
 describe('readErrorDetail', () => {

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared error helpers (#895). Consolidates the `extractErrorMessage` copy
+ * that was duplicated across ~10 magic/ritual dialogs, plus the api-layer
+ * `{detail}` parse-and-throw pattern (mirrors magic/api.ts `parseErrorDetail`).
+ */
+
+/** Best-effort human-readable message from an unknown thrown value. */
+export function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  return 'An unexpected error occurred.';
+}
+
+/**
+ * Parse a non-ok DRF Response's `{detail}` and throw an Error carrying it,
+ * falling back to `fallback` when the body is missing/blank/non-JSON.
+ */
+export async function readErrorDetail(res: Response, fallback: string): Promise<never> {
+  let detail = fallback;
+  try {
+    const data = (await res.json()) as { detail?: string };
+    if (typeof data.detail === 'string' && data.detail.trim()) {
+      detail = data.detail;
+    }
+  } catch {
+    // body wasn't JSON; keep the fallback
+  }
+  throw new Error(detail);
+}

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -5,9 +5,12 @@
  */
 
 /** Best-effort human-readable message from an unknown thrown value. */
-export function extractErrorMessage(error: unknown): string {
+export function extractErrorMessage(
+  error: unknown,
+  fallback = 'An unexpected error occurred.'
+): string {
   if (error instanceof Error && error.message) return error.message;
-  return 'An unexpected error occurred.';
+  return fallback;
 }
 
 /**

--- a/frontend/src/magic/__tests__/AnimaRitualEditDialog.test.tsx
+++ b/frontend/src/magic/__tests__/AnimaRitualEditDialog.test.tsx
@@ -231,8 +231,8 @@ describe('AnimaRitualEditDialog', () => {
     expect(screen.getByText('This ritual cannot be updated right now.')).toBeInTheDocument();
   });
 
-  // 7. Generic error fallback
-  it('displays generic error when error has no message', () => {
+  // 7. Per-site error fallback
+  it('displays per-site fallback error when error has no message', () => {
     const error = new Error();
     vi.mocked(ritualQueries.usePatchRitual).mockReturnValue(makeMutationError(error));
 
@@ -243,7 +243,7 @@ describe('AnimaRitualEditDialog', () => {
       </Wrapper>
     );
 
-    expect(screen.getByText('An unexpected error occurred.')).toBeInTheDocument();
+    expect(screen.getByText('Failed to update ritual')).toBeInTheDocument();
   });
 
   // 8. Cancel closes dialog without submitting

--- a/frontend/src/magic/__tests__/AnimaRitualEditDialog.test.tsx
+++ b/frontend/src/magic/__tests__/AnimaRitualEditDialog.test.tsx
@@ -243,7 +243,7 @@ describe('AnimaRitualEditDialog', () => {
       </Wrapper>
     );
 
-    expect(screen.getByText('Failed to update ritual')).toBeInTheDocument();
+    expect(screen.getByText('An unexpected error occurred.')).toBeInTheDocument();
   });
 
   // 8. Cancel closes dialog without submitting

--- a/frontend/src/magic/__tests__/SineatingRequestDialog.test.tsx
+++ b/frontend/src/magic/__tests__/SineatingRequestDialog.test.tsx
@@ -391,14 +391,14 @@ describe('SineatingRequestDialog', () => {
     expect(screen.queryByTestId('sineating-error-banner')).not.toBeInTheDocument();
   });
 
-  it('shows generic error message when error has no message', () => {
+  it('shows per-site fallback error message when error has no message', () => {
     const emptyError = new Error('');
     setupMocks({ isError: true, error: emptyError });
 
     render(<SineatingRequestDialog {...defaultProps} />, { wrapper: createWrapper() });
 
     expect(screen.getByTestId('sineating-error-banner')).toBeInTheDocument();
-    expect(screen.getByText('An unexpected error occurred.')).toBeInTheDocument();
+    expect(screen.getByText('Failed to send Sineating request')).toBeInTheDocument();
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/magic/__tests__/SineatingRequestDialog.test.tsx
+++ b/frontend/src/magic/__tests__/SineatingRequestDialog.test.tsx
@@ -398,7 +398,7 @@ describe('SineatingRequestDialog', () => {
     render(<SineatingRequestDialog {...defaultProps} />, { wrapper: createWrapper() });
 
     expect(screen.getByTestId('sineating-error-banner')).toBeInTheDocument();
-    expect(screen.getByText('Failed to send Sineating request')).toBeInTheDocument();
+    expect(screen.getByText('An unexpected error occurred.')).toBeInTheDocument();
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/magic/components/AnimaRitualEditDialog.tsx
+++ b/frontend/src/magic/components/AnimaRitualEditDialog.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { extractErrorMessage } from '@/lib/errors';
 import { usePatchRitual } from '@/rituals/queries';
 import type { RitualWithSchema } from '@/rituals/types';
 
@@ -85,15 +86,6 @@ function isValid(form: FormState): boolean {
     form.skill_id.trim().length > 0 &&
     form.check_type_id.trim().length > 0
   );
-}
-
-// ---------------------------------------------------------------------------
-// Error helper
-// ---------------------------------------------------------------------------
-
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return 'Failed to update ritual';
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/magic/components/AnimaRitualEditDialog.tsx
+++ b/frontend/src/magic/components/AnimaRitualEditDialog.tsx
@@ -151,7 +151,9 @@ export function AnimaRitualEditDialog({
   }
 
   const canSubmit = isValid(form) && !patchMutation.isPending;
-  const errorMessage = patchMutation.isError ? extractErrorMessage(patchMutation.error) : null;
+  const errorMessage = patchMutation.isError
+    ? extractErrorMessage(patchMutation.error, 'Failed to update ritual')
+    : null;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/frontend/src/magic/components/SineatingRequestDialog.tsx
+++ b/frontend/src/magic/components/SineatingRequestDialog.tsx
@@ -176,7 +176,9 @@ export function SineatingRequestDialog({
     );
   }
 
-  const errorMessage = requestMutation.isError ? extractErrorMessage(requestMutation.error) : null;
+  const errorMessage = requestMutation.isError
+    ? extractErrorMessage(requestMutation.error, 'Failed to send Sineating request')
+    : null;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/frontend/src/magic/components/SineatingRequestDialog.tsx
+++ b/frontend/src/magic/components/SineatingRequestDialog.tsx
@@ -32,6 +32,7 @@ import {
 import { searchPersonas } from '@/events/queries';
 import { fetchScenes } from '@/scenes/queries';
 import type { SceneListItem } from '@/scenes/queries';
+import { extractErrorMessage } from '@/lib/errors';
 import { useRequestSineating, useCharacterResonances } from '../queries';
 
 // ---------------------------------------------------------------------------
@@ -59,11 +60,6 @@ export interface SineatingRequestDialogProps {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return 'Failed to send Sineating request';
-}
 
 async function fetchActiveScenes(): Promise<{ results: SceneListItem[] }> {
   return (await fetchScenes('status=active')) as { results: SceneListItem[] };

--- a/frontend/src/magic/components/TechniqueBuilderForm.tsx
+++ b/frontend/src/magic/components/TechniqueBuilderForm.tsx
@@ -41,6 +41,7 @@ import type {
   DamageType,
   AppliedConditionRow,
 } from './TechniquePayloadEditors';
+import { extractErrorMessage } from '@/lib/errors';
 
 // ---------------------------------------------------------------------------
 // Types for lookup lists passed in from the page
@@ -95,15 +96,6 @@ const ACTION_CATEGORIES = [
 const TIER_OPTIONS = [1, 2, 3, 4, 5] as const;
 
 const DEBOUNCE_MS = 500;
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return 'An unexpected error occurred.';
-}
 
 // ---------------------------------------------------------------------------
 // Budget Meter

--- a/frontend/src/magic/components/sanctum/HomecomingDialog.tsx
+++ b/frontend/src/magic/components/sanctum/HomecomingDialog.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { extractErrorMessage } from '@/lib/errors';
 
 import { useHomecoming } from '../../sanctumQueries';
 import type { SanctumDetails } from '../../sanctumTypes';
@@ -27,11 +28,6 @@ export interface HomecomingDialogProps {
   sanctum: SanctumDetails;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-}
-
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return 'Failed to perform Ritual of Homecoming';
 }
 
 export function HomecomingDialog({ sanctum, open, onOpenChange }: Readonly<HomecomingDialogProps>) {

--- a/frontend/src/magic/components/sanctum/HomecomingDialog.tsx
+++ b/frontend/src/magic/components/sanctum/HomecomingDialog.tsx
@@ -84,7 +84,9 @@ export function HomecomingDialog({ sanctum, open, onOpenChange }: Readonly<Homec
             />
           </div>
           {mutation.isError ? (
-            <p className="text-sm text-destructive">{extractErrorMessage(mutation.error)}</p>
+            <p className="text-sm text-destructive">
+              {extractErrorMessage(mutation.error, 'Failed to perform Ritual of Homecoming')}
+            </p>
           ) : null}
         </div>
 

--- a/frontend/src/magic/components/sanctum/SanctumCard.tsx
+++ b/frontend/src/magic/components/sanctum/SanctumCard.tsx
@@ -22,6 +22,7 @@ import {
 import type { SanctumDetails } from '../../sanctumTypes';
 
 import { useAbsorb } from '../../sanctumQueries';
+import { extractErrorMessage } from '@/lib/errors';
 
 import { HomecomingDialog } from './HomecomingDialog';
 import { WeaveDialog } from './WeaveDialog';
@@ -35,11 +36,6 @@ function formatTimestamp(iso: string | null | undefined): string {
   const dt = new Date(iso);
   if (Number.isNaN(dt.getTime())) return 'Never';
   return dt.toLocaleString();
-}
-
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return 'Failed to absorb from this Sanctum';
 }
 
 export function SanctumCard({ sanctum }: Readonly<SanctumCardProps>) {

--- a/frontend/src/magic/components/sanctum/SanctumCard.tsx
+++ b/frontend/src/magic/components/sanctum/SanctumCard.tsx
@@ -107,7 +107,9 @@ export function SanctumCard({ sanctum }: Readonly<SanctumCardProps>) {
           </div>
         ) : null}
         {absorb.isError ? (
-          <p className="text-sm text-destructive">{extractErrorMessage(absorb.error)}</p>
+          <p className="text-sm text-destructive">
+            {extractErrorMessage(absorb.error, 'Failed to absorb from this Sanctum')}
+          </p>
         ) : null}
       </CardContent>
       <CardFooter className="flex-wrap gap-2">

--- a/frontend/src/magic/components/sanctum/WeaveDialog.tsx
+++ b/frontend/src/magic/components/sanctum/WeaveDialog.tsx
@@ -30,16 +30,12 @@ import {
 
 import { useWeaveSanctumThread } from '../../sanctumQueries';
 import type { SanctumDetails, SanctumSlotKind } from '../../sanctumTypes';
+import { extractErrorMessage } from '@/lib/errors';
 
 export interface WeaveDialogProps {
   sanctum: SanctumDetails;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-}
-
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return 'Failed to weave Sanctum thread';
 }
 
 const SLOT_LABELS: Record<SanctumSlotKind, string> = {

--- a/frontend/src/magic/components/sanctum/WeaveDialog.tsx
+++ b/frontend/src/magic/components/sanctum/WeaveDialog.tsx
@@ -85,7 +85,9 @@ export function WeaveDialog({ sanctum, open, onOpenChange }: Readonly<WeaveDialo
             </Select>
           </div>
           {mutation.isError ? (
-            <p className="text-sm text-destructive">{extractErrorMessage(mutation.error)}</p>
+            <p className="text-sm text-destructive">
+              {extractErrorMessage(mutation.error, 'Failed to weave Sanctum thread')}
+            </p>
           ) : null}
         </div>
 

--- a/frontend/src/magic/components/threads/ImbuePanel.tsx
+++ b/frontend/src/magic/components/threads/ImbuePanel.tsx
@@ -7,6 +7,7 @@
  */
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { extractErrorMessage } from '@/lib/errors';
 import { useImbueThread } from '../../queries';
 import type { ImbueResponse, Thread } from '../../types';
 
@@ -16,15 +17,6 @@ interface ImbuePanelProps {
   balance: number;
   characterSheetId: number;
   onResult?: (result: ImbueResponse) => void;
-}
-
-/**
- * Parse a user-facing error message from a mutation error.
- * Prefers `error.message` when available.
- */
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  return 'An unexpected error occurred.';
 }
 
 export function ImbuePanel({ thread, balance, characterSheetId, onResult }: ImbuePanelProps) {

--- a/frontend/src/magic/queries.ts
+++ b/frontend/src/magic/queries.ts
@@ -147,12 +147,16 @@ export function usePendingStageAdvanceOffers() {
 
 /**
  * Fetch the caller's threads (account-scoped, excluding retired).
+ *
+ * Pass ``{ enabled: false }`` to defer the fetch (e.g. until a cast dialog is
+ * open). Defaults to ``true`` so all existing callers are unaffected.
  */
-export function useThreads() {
+export function useThreads(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: magicKeys.threadList(),
     queryFn: () => api.getThreads(),
     throwOnError: true,
+    enabled: options?.enabled ?? true,
   });
 }
 

--- a/frontend/src/rituals/__tests__/RitualPerformDialog.test.tsx
+++ b/frontend/src/rituals/__tests__/RitualPerformDialog.test.tsx
@@ -285,7 +285,7 @@ describe('RitualPerformDialog', () => {
       </Wrapper>
     );
 
-    expect(screen.getByText('Failed to perform ritual')).toBeInTheDocument();
+    expect(screen.getByText('An unexpected error occurred.')).toBeInTheDocument();
   });
 
   // 9c. Shows the Error.message when there is no detail field but there is a message

--- a/frontend/src/rituals/__tests__/RitualPerformDialog.test.tsx
+++ b/frontend/src/rituals/__tests__/RitualPerformDialog.test.tsx
@@ -273,8 +273,8 @@ describe('RitualPerformDialog', () => {
     expect(screen.getByText('Test error message from server')).toBeInTheDocument();
   });
 
-  // 9b. Falls back to generic message when error has no detail field and no message
-  it('displays a generic error message when error has no detail or message', () => {
+  // 9b. Falls back to per-site message when error has no detail field and no message
+  it('displays the per-site fallback error message when error has no detail or message', () => {
     const error = new Error();
     vi.mocked(queries.usePerformRitual).mockReturnValue(makeMutationError(error));
 
@@ -285,7 +285,7 @@ describe('RitualPerformDialog', () => {
       </Wrapper>
     );
 
-    expect(screen.getByText('An unexpected error occurred.')).toBeInTheDocument();
+    expect(screen.getByText('Failed to perform ritual')).toBeInTheDocument();
   });
 
   // 9c. Shows the Error.message when there is no detail field but there is a message

--- a/frontend/src/rituals/components/RitualPerformDialog.tsx
+++ b/frontend/src/rituals/components/RitualPerformDialog.tsx
@@ -102,7 +102,9 @@ export function RitualPerformDialog({
   }
 
   const canSubmit = hasAllRequired(schema, values) && !performMutation.isPending;
-  const errorMessage = performMutation.isError ? extractErrorMessage(performMutation.error) : null;
+  const errorMessage = performMutation.isError
+    ? extractErrorMessage(performMutation.error, 'Failed to perform ritual')
+    : null;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/frontend/src/rituals/components/RitualPerformDialog.tsx
+++ b/frontend/src/rituals/components/RitualPerformDialog.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { extractErrorMessage } from '@/lib/errors';
 import { RitualForm } from './RitualForm';
 import { usePerformRitual } from '@/rituals/queries';
 import type { RitualWithSchema, RitualInputSchema, PerformRitualResponse } from '../types';
@@ -29,15 +30,6 @@ export interface RitualPerformDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess?: (response: PerformRitualResponse) => void;
-}
-
-// ---------------------------------------------------------------------------
-// Error shape helpers
-// ---------------------------------------------------------------------------
-
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return 'Failed to perform ritual';
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/rituals/components/RitualSessionDraftDialog.tsx
+++ b/frontend/src/rituals/components/RitualSessionDraftDialog.tsx
@@ -259,7 +259,9 @@ export function RitualSessionDraftDialog({
     // At least one invitee required to form a session
     invitees.length > 0;
 
-  const errorMessage = draftMutation.isError ? extractErrorMessage(draftMutation.error) : null;
+  const errorMessage = draftMutation.isError
+    ? extractErrorMessage(draftMutation.error, 'Failed to draft ritual session')
+    : null;
   const isPending = draftMutation.isPending;
 
   return (

--- a/frontend/src/rituals/components/RitualSessionDraftDialog.tsx
+++ b/frontend/src/rituals/components/RitualSessionDraftDialog.tsx
@@ -22,6 +22,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { extractErrorMessage } from '@/lib/errors';
 import { RitualForm } from './RitualForm';
 import { useDraftRitualSession } from '@/rituals/queries';
 import { searchPersonas } from '@/events/queries';
@@ -173,11 +174,6 @@ function hasAllRequired(
       if (typeof v === 'string') return v.trim().length > 0;
       return true;
     });
-}
-
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return 'Failed to draft ritual session';
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
+++ b/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
@@ -37,6 +37,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/evennia_replacements/api';
+import { extractErrorMessage } from '@/lib/errors';
 import { RitualForm } from './RitualForm';
 import { useAcceptRitualSession, useDeclineRitualSession } from '@/rituals/queries';
 import type { RitualSessionDetail } from '../api';
@@ -62,11 +63,6 @@ export interface RitualSessionResponseDialogProps {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return 'Operation failed';
-}
 
 /**
  * Extract the target_covenant id from session_kwargs.

--- a/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
+++ b/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
@@ -210,9 +210,9 @@ export function RitualSessionResponseDialog({
   const isPending = acceptMutation.isPending || declineMutation.isPending;
 
   const errorMessage = acceptMutation.isError
-    ? extractErrorMessage(acceptMutation.error)
+    ? extractErrorMessage(acceptMutation.error, 'Operation failed')
     : declineMutation.isError
-      ? extractErrorMessage(declineMutation.error)
+      ? extractErrorMessage(declineMutation.error, 'Operation failed')
       : null;
 
   return (

--- a/frontend/src/scenes/actionQueries.test.ts
+++ b/frontend/src/scenes/actionQueries.test.ts
@@ -13,6 +13,7 @@ import {
   fetchPlaces,
   joinPlace,
   leavePlace,
+  castTechnique,
 } from './actionQueries';
 
 function mockOkResponse(data: unknown) {
@@ -244,6 +245,19 @@ describe('actionQueries', () => {
       vi.mocked(apiFetch).mockResolvedValue(mockErrorResponse());
 
       await expect(leavePlace('42', 5)).rejects.toThrow('Failed to leave place');
+    });
+  });
+
+  describe('castTechnique', () => {
+    it('surfaces the backend detail on a 400', async () => {
+      vi.mocked(apiFetch).mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ detail: 'You cannot afford that pull.' }),
+      } as Response);
+
+      await expect(castTechnique('1', { initiator_persona: 1, technique_id: 2 })).rejects.toThrow(
+        'You cannot afford that pull.'
+      );
     });
   });
 });

--- a/frontend/src/scenes/actionQueries.ts
+++ b/frontend/src/scenes/actionQueries.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/evennia_replacements/api';
+import { readErrorDetail } from '@/lib/errors';
 import type {
   PlayerActionsResponse,
   ActionRequest,
@@ -170,7 +171,7 @@ export async function castTechnique(
     method: 'POST',
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error('Failed to cast technique');
+  if (!res.ok) await readErrorDetail(res, 'Failed to cast technique');
   return res.json();
 }
 

--- a/frontend/src/scenes/components/ActionPanel.test.tsx
+++ b/frontend/src/scenes/components/ActionPanel.test.tsx
@@ -61,12 +61,14 @@ vi.mock('@/store/hooks', () => ({
   ),
 }));
 
-// Mock the magic queries module — ActionPanel uses useThreads to map thread → resonance.
+// Mock the magic queries module — useCastPullSelection (called by ActionPanel) uses
+// useThreads to map thread → resonance, and useCharacterResonances for balance tooltips.
 vi.mock('@/magic/queries', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/magic/queries')>();
   return {
     ...actual,
     useThreads: vi.fn(),
+    useCharacterResonances: vi.fn(() => ({ data: undefined })),
   };
 });
 
@@ -953,5 +955,29 @@ describe('ActionPanel', () => {
     });
     const params = vi.mocked(castTechnique).mock.calls[0][1];
     expect(params).not.toHaveProperty('pull');
+  });
+
+  // -------------------------------------------------------------------------
+  // Cast error surface (#895 item 3)
+  // -------------------------------------------------------------------------
+
+  it('renders the backend detail message via role="alert" when castTechnique rejects', async () => {
+    vi.mocked(castTechnique).mockRejectedValue(
+      new Error('Insufficient anima to cast Ember Touch.')
+    );
+    const user = userEvent.setup();
+
+    await openCastDialogWithEmberTouch(user);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /cast ember touch/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /cast ember touch/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent('Insufficient anima to cast Ember Touch.');
   });
 });

--- a/frontend/src/scenes/components/ActionPanel.tsx
+++ b/frontend/src/scenes/components/ActionPanel.tsx
@@ -21,6 +21,7 @@ import type {
   AvailableEnhancement,
   CastableTechnique,
   CastResponse,
+  CastPullRequestBody,
 } from '../actionTypes';
 import type { SceneDetail, SceneParticipant } from '../types';
 import { SoulfrayWarning } from './SoulfrayWarning';
@@ -102,7 +103,7 @@ export function ActionPanel({ sceneId }: Props) {
       technique_id: number;
       target_persona?: number | null;
       strain_commitment?: number;
-      pull?: import('../actionTypes').CastPullRequestBody;
+      pull?: CastPullRequestBody;
     }) =>
       castTechnique(sceneId, {
         initiator_persona: initiatorPersonaId!,

--- a/frontend/src/scenes/components/ActionPanel.tsx
+++ b/frontend/src/scenes/components/ActionPanel.tsx
@@ -14,13 +14,12 @@ import {
 import { fetchScene, sceneKeys } from '../queries';
 import { PowerLedgerPanel } from '@/magic/components/PowerLedgerPanel';
 import { ThreadPullPicker } from '@/magic/components/threads/ThreadPullPicker';
-import { useThreads } from '@/magic/queries';
-import type { ApplicablePullsRequest, Thread } from '@/magic/types';
+import { useCastPullSelection } from '../hooks/useCastPullSelection';
+import { extractErrorMessage } from '@/lib/errors';
 import type {
   PlayerAction,
   AvailableEnhancement,
   CastableTechnique,
-  CastPullRequestBody,
   CastResponse,
 } from '../actionTypes';
 import type { SceneDetail, SceneParticipant } from '../types';
@@ -57,10 +56,6 @@ export function ActionPanel({ sceneId }: Props) {
   const [castTargetPersonaId, setCastTargetPersonaId] = useState<number | null>(null);
   const [castPickingTarget, setCastPickingTarget] = useState(false);
   const [castLedgerResult, setCastLedgerResult] = useState<CastResponse | null>(null);
-  // Thread-pull state for the cast flow (#854) — thread id → committed tier.
-  const [selectedPulls, setSelectedPulls] = useState<Record<number, 0 | 1 | 2 | 3>>({});
-  const [showInapplicablePulls, setShowInapplicablePulls] = useState(false);
-  const [pullNotice, setPullNotice] = useState<string | null>(null);
 
   const queryClient = useQueryClient();
 
@@ -92,35 +87,22 @@ export function ActionPanel({ sceneId }: Props) {
     open ? initiatorPersonaId : null
   );
 
-  // Threads — used to map a pulled thread id back to its resonance for the
-  // cast payload and to enforce the single-(resonance, tier)-group constraint.
-  const { data: threadsData } = useThreads();
-  const threadById = useMemo(() => {
-    const map = new Map<number, Thread>();
-    for (const thread of threadsData?.results ?? []) {
-      map.set(thread.id, thread);
-    }
-    return map;
-  }, [threadsData]);
-
-  // Applicability context for the thread-pull picker — only while a technique
-  // is selected in the open cast section.
-  const pullsContext = useMemo<ApplicablePullsRequest | null>(() => {
-    if (!castOpen || !selectedTechnique || characterId === null) return null;
-    return {
-      character_sheet_id: characterId,
-      technique_id: selectedTechnique.id,
-      target_persona_id: castTargetPersonaId,
-      scene_id: Number(sceneId),
-    };
-  }, [castOpen, selectedTechnique, characterId, castTargetPersonaId, sceneId]);
+  // Thread-pull selection hook — manages selectedPulls, pullNotice, pullsContext,
+  // balanceByResonanceId, and payload assembly for the cast flow (#895).
+  const pull = useCastPullSelection({
+    selectedTechnique,
+    characterId,
+    castTargetPersonaId,
+    sceneId,
+    castOpen,
+  });
 
   const performCast = useMutation({
     mutationFn: (params: {
       technique_id: number;
       target_persona?: number | null;
       strain_commitment?: number;
-      pull?: CastPullRequestBody;
+      pull?: import('../actionTypes').CastPullRequestBody;
     }) =>
       castTechnique(sceneId, {
         initiator_persona: initiatorPersonaId!,
@@ -132,8 +114,7 @@ export function ActionPanel({ sceneId }: Props) {
       setSelectedTechnique(null);
       setCastTargetPersonaId(null);
       setCastPickingTarget(false);
-      setSelectedPulls({});
-      setPullNotice(null);
+      pull.reset();
       if (data.result?.power_ledger) {
         // Immediate cast: keep the panel open showing the ledger (#859).
         setCastLedgerResult(data);
@@ -270,72 +251,21 @@ export function ActionPanel({ sceneId }: Props) {
     setSelectedTechnique(technique);
     setCastTargetPersonaId(null);
     setCastLedgerResult(null);
-    setSelectedPulls({});
-    setPullNotice(null);
-  }
-
-  /**
-   * Constrain pull selection to a single (resonance, tier) group — the cast
-   * payload's pull declaration is singular, so any newly raised pull reverts
-   * every other paid pull that disagrees on resonance or tier.
-   */
-  function handlePullsChange(next: Record<number, 0 | 1 | 2 | 3>) {
-    const changed = Object.entries(next).find(
-      ([id, tier]) => (selectedPulls[Number(id)] ?? 0) !== tier && tier > 0
-    );
-    if (changed) {
-      const changedId = Number(changed[0]);
-      const changedTier = changed[1];
-      const changedResonance = threadById.get(changedId)?.resonance;
-      if (changedResonance === undefined) {
-        // Threads cache not resolved yet — can't group by resonance; pass
-        // through unconstrained rather than reverting on undefined matches.
-        setSelectedPulls(next);
-        return;
-      }
-      let reverted = 0;
-      const constrained = { ...next };
-      for (const [idStr, tier] of Object.entries(next)) {
-        const id = Number(idStr);
-        if (id === changedId || tier === 0) continue;
-        if (tier !== changedTier || threadById.get(id)?.resonance !== changedResonance) {
-          constrained[id] = 0;
-          reverted++;
-        }
-      }
-      setPullNotice(reverted > 0 ? 'Pulls in one cast share a single resonance and tier.' : null);
-      setSelectedPulls(constrained);
-      return;
-    }
-    // Deselects pass through; a conflict notice is stale once no paid pull remains.
-    if (!Object.values(next).some((tier) => tier > 0)) {
-      setPullNotice(null);
-    }
-    setSelectedPulls(next);
+    performCast.reset();
+    pull.reset();
   }
 
   function handleCastCommit() {
     if (!selectedTechnique || initiatorPersonaId === null) return;
-    const paid = Object.entries(selectedPulls).filter(([, tier]) => tier > 0);
-    let pull: CastPullRequestBody | undefined;
-    if (paid.length > 0) {
-      const firstThread = threadById.get(Number(paid[0][0]));
-      if (!firstThread) {
-        // Don't cast without the declared pull — surface it and let the user
-        // retry once the threads cache resolves.
-        setPullNotice('Thread data is still loading — try again in a moment.');
-        return;
-      }
-      pull = {
-        resonance_id: firstThread.resonance,
-        tier: paid[0][1] as 1 | 2 | 3,
-        thread_ids: paid.map(([id]) => Number(id)),
-      };
+    const payload = pull.buildPullPayload();
+    if ('error' in payload) {
+      pull.setPullNotice(payload.error);
+      return;
     }
     performCast.mutate({
       technique_id: selectedTechnique.id,
       target_persona: castTargetPersonaId ?? null,
-      ...(pull ? { pull } : {}),
+      ...payload,
     });
   }
 
@@ -495,8 +425,8 @@ export function ActionPanel({ sceneId }: Props) {
                     setCastTargetPersonaId(null);
                     setCastPickingTarget(false);
                     setCastLedgerResult(null);
-                    setSelectedPulls({});
-                    setPullNotice(null);
+                    performCast.reset();
+                    pull.reset();
                   } else {
                     setCastLedgerResult(null);
                   }
@@ -617,19 +547,20 @@ export function ActionPanel({ sceneId }: Props) {
                       </div>
 
                       {/* Thread pulls — optional resonance surge on this cast */}
-                      {pullsContext && characterId !== null && (
+                      {pull.pullsContext && characterId !== null && (
                         <div className="border-t border-border/50 pt-2">
                           <ThreadPullPicker
                             characterSheetId={characterId}
-                            actionContext={pullsContext}
-                            selectedPulls={selectedPulls}
-                            onPullsChange={handlePullsChange}
-                            showInapplicable={showInapplicablePulls}
-                            onToggleInapplicable={setShowInapplicablePulls}
-                            onAutoRevertNotice={setPullNotice}
+                            actionContext={pull.pullsContext}
+                            selectedPulls={pull.selectedPulls}
+                            onPullsChange={pull.handlePullsChange}
+                            showInapplicable={pull.showInapplicable}
+                            onToggleInapplicable={pull.setShowInapplicable}
+                            onAutoRevertNotice={pull.setPullNotice}
+                            balanceByResonanceId={pull.balanceByResonanceId}
                           />
-                          {pullNotice && (
-                            <p className="mt-1 text-xs text-amber-400">{pullNotice}</p>
+                          {pull.pullNotice && (
+                            <p className="mt-1 text-xs text-amber-400">{pull.pullNotice}</p>
                           )}
                         </div>
                       )}
@@ -642,6 +573,11 @@ export function ActionPanel({ sceneId }: Props) {
                       >
                         {performCast.isPending ? 'Casting…' : `Cast ${selectedTechnique.name}`}
                       </Button>
+                      {performCast.isError && (
+                        <p className="mt-1 text-xs text-destructive" role="alert">
+                          {extractErrorMessage(performCast.error)}
+                        </p>
+                      )}
                     </div>
                   )}
                 </div>

--- a/frontend/src/scenes/hooks/__tests__/useCastPullSelection.test.ts
+++ b/frontend/src/scenes/hooks/__tests__/useCastPullSelection.test.ts
@@ -1,0 +1,303 @@
+/**
+ * useCastPullSelection — unit tests
+ *
+ * Mocks ``useThreads`` and ``useCharacterResonances`` from ``@/magic/queries``
+ * to avoid network/query-client overhead. Uses ``renderHook`` + ``act`` from
+ * @testing-library/react, mirroring the style in useThreading.test.ts and
+ * src/magic/__tests__/queries.test.tsx.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { useCastPullSelection } from '../useCastPullSelection';
+
+// ---------------------------------------------------------------------------
+// Mock @/magic/queries so no real network calls are made.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/magic/queries', () => ({
+  useThreads: vi.fn(),
+  useCharacterResonances: vi.fn(),
+}));
+
+import { useThreads, useCharacterResonances } from '@/magic/queries';
+
+const mockUseThreads = vi.mocked(useThreads);
+const mockUseCharacterResonances = vi.mocked(useCharacterResonances);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+/**
+ * Three test threads:
+ *   id=1 → resonance 10
+ *   id=2 → resonance 10  (same resonance as thread 1)
+ *   id=3 → resonance 20  (different resonance)
+ */
+const THREAD_1 = { id: 1, resonance: 10, name: 'Alpha' };
+const THREAD_2 = { id: 2, resonance: 10, name: 'Beta' };
+const THREAD_3 = { id: 3, resonance: 20, name: 'Gamma' };
+
+function setupThreads(threads = [THREAD_1, THREAD_2, THREAD_3]) {
+  mockUseThreads.mockReturnValue({
+    data: { results: threads },
+    isLoading: false,
+  } as ReturnType<typeof useThreads>);
+}
+
+function setupResonances(
+  resonances: Array<{ resonance: number; balance: number }> = [
+    { resonance: 10, balance: 5 },
+    { resonance: 20, balance: 3 },
+  ]
+) {
+  mockUseCharacterResonances.mockReturnValue({
+    data: resonances,
+    isLoading: false,
+  } as ReturnType<typeof useCharacterResonances>);
+}
+
+const baseParams = {
+  selectedTechnique: { id: 42, name: 'Flamecall', strain_cost: 1 } as Parameters<
+    typeof useCastPullSelection
+  >[0]['selectedTechnique'],
+  characterId: 7,
+  castTargetPersonaId: null,
+  sceneId: '99',
+  castOpen: true,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupThreads();
+  setupResonances();
+});
+
+describe('useCastPullSelection', () => {
+  // -------------------------------------------------------------------------
+  // Case 1: grouping revert + notice
+  // -------------------------------------------------------------------------
+  describe('handlePullsChange — single (resonance, tier) group enforcement', () => {
+    it('reverts conflicting paid pulls to one (resonance, tier) group', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+
+      // Raise thread 1 at tier 2 first
+      act(() => result.current.handlePullsChange({ 1: 2, 2: 0, 3: 0 }));
+      expect(result.current.selectedPulls).toEqual({ 1: 2, 2: 0, 3: 0 });
+
+      // Newly raise thread 3 (different resonance 20) — thread 3 is the anchor,
+      // thread 1 (resonance 10) disagrees so thread 1 is reverted.
+      act(() => result.current.handlePullsChange({ 1: 2, 2: 0, 3: 2 }));
+      expect(result.current.selectedPulls).toEqual({ 1: 0, 2: 0, 3: 2 });
+      expect(result.current.pullNotice).toMatch(/single resonance and tier/i);
+    });
+
+    it('reverts pulls with a different tier in the same resonance', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+
+      // Thread 1 at tier 2 (resonance 10)
+      act(() => result.current.handlePullsChange({ 1: 2, 2: 0, 3: 0 }));
+      // Thread 2 (same resonance 10) newly raised at tier 3 — different tier.
+      // Thread 2 is the anchor; thread 1 disagrees on tier so thread 1 is reverted.
+      act(() => result.current.handlePullsChange({ 1: 2, 2: 3, 3: 0 }));
+      expect(result.current.selectedPulls).toEqual({ 1: 0, 2: 3, 3: 0 });
+      expect(result.current.pullNotice).toMatch(/single resonance and tier/i);
+    });
+
+    it('allows same resonance and same tier to coexist', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+
+      // Thread 1 at tier 2
+      act(() => result.current.handlePullsChange({ 1: 2, 2: 0, 3: 0 }));
+      // Thread 2 (same resonance 10, same tier 2) — no conflict
+      act(() => result.current.handlePullsChange({ 1: 2, 2: 2, 3: 0 }));
+      expect(result.current.selectedPulls).toEqual({ 1: 2, 2: 2, 3: 0 });
+      expect(result.current.pullNotice).toBeNull();
+    });
+
+    it('clears pullNotice when all paid pulls are deselected', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+
+      // Create a conflict to set a notice
+      act(() => result.current.handlePullsChange({ 1: 2, 2: 0, 3: 0 }));
+      act(() => result.current.handlePullsChange({ 1: 2, 2: 0, 3: 2 }));
+      expect(result.current.pullNotice).not.toBeNull();
+
+      // Deselect all
+      act(() => result.current.handlePullsChange({ 1: 0, 2: 0, 3: 0 }));
+      expect(result.current.pullNotice).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 2: unresolved resonance passes through unconstrained
+  // -------------------------------------------------------------------------
+  describe('handlePullsChange — unresolved thread resonance', () => {
+    it('passes through unconstrained when the changed thread is not in the cache', () => {
+      // Only threads 1 and 2 in cache — thread 99 is unknown
+      setupThreads([THREAD_1, THREAD_2]);
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+
+      // Thread 1 at tier 2 first
+      act(() => result.current.handlePullsChange({ 1: 2 }));
+      // Thread 99 not in cache — pass through without reverting thread 1
+      act(() => result.current.handlePullsChange({ 1: 2, 99: 2 }));
+      expect(result.current.selectedPulls).toEqual({ 1: 2, 99: 2 });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 3: buildPullPayload — paid / none
+  // -------------------------------------------------------------------------
+  describe('buildPullPayload', () => {
+    it('returns { pull } with correct fields for paid pulls sharing a group', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+
+      act(() => result.current.handlePullsChange({ 1: 2, 2: 2, 3: 0 }));
+      const payload = result.current.buildPullPayload();
+      expect(payload).toEqual({
+        pull: {
+          resonance_id: 10,
+          tier: 2,
+          thread_ids: [1, 2],
+        },
+      });
+    });
+
+    it('returns {} when no paid pulls are selected', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+
+      // Leave all at tier 0
+      const payload = result.current.buildPullPayload();
+      expect(payload).toEqual({});
+    });
+
+    // -----------------------------------------------------------------------
+    // Case 4: buildPullPayload error when thread not in cache
+    // -----------------------------------------------------------------------
+    it('returns { error } when the first paid thread is not in the resolved cache', () => {
+      // Empty thread cache
+      setupThreads([]);
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+
+      // Manually set selectedPulls via handlePullsChange on a thread not in cache
+      // Since thread 99 is not in cache, the changed-thread resonance is undefined
+      // and the selection passes through unconstrained.
+      act(() => result.current.handlePullsChange({ 99: 1 }));
+      expect(result.current.selectedPulls).toEqual({ 99: 1 });
+
+      const payload = result.current.buildPullPayload();
+      expect('error' in payload).toBe(true);
+      expect((payload as { error: string }).error).toMatch(/still loading/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 5: balanceByResonanceId mapping
+  // -------------------------------------------------------------------------
+  describe('balanceByResonanceId', () => {
+    it('maps resonance id to balance from useCharacterResonances', () => {
+      setupResonances([
+        { resonance: 10, balance: 7 },
+        { resonance: 20, balance: 2 },
+      ]);
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+      expect(result.current.balanceByResonanceId).toEqual({ 10: 7, 20: 2 });
+    });
+
+    it('returns {} when resonances data is not yet available', () => {
+      mockUseCharacterResonances.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      } as ReturnType<typeof useCharacterResonances>);
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+      expect(result.current.balanceByResonanceId).toEqual({});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 6: pullsContext gating
+  // -------------------------------------------------------------------------
+  describe('pullsContext', () => {
+    it('is null when castOpen is false', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () => useCastPullSelection({ ...baseParams, castOpen: false }),
+        { wrapper }
+      );
+      expect(result.current.pullsContext).toBeNull();
+    });
+
+    it('is null when selectedTechnique is null', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () => useCastPullSelection({ ...baseParams, selectedTechnique: null }),
+        { wrapper }
+      );
+      expect(result.current.pullsContext).toBeNull();
+    });
+
+    it('is null when characterId is null', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () => useCastPullSelection({ ...baseParams, characterId: null }),
+        { wrapper }
+      );
+      expect(result.current.pullsContext).toBeNull();
+    });
+
+    it('is populated when castOpen && selectedTechnique && characterId !== null', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+      expect(result.current.pullsContext).toEqual({
+        character_sheet_id: 7,
+        technique_id: 42,
+        target_persona_id: null,
+        scene_id: 99,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // reset()
+  // -------------------------------------------------------------------------
+  describe('reset', () => {
+    it('clears selectedPulls and pullNotice', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useCastPullSelection(baseParams), { wrapper });
+
+      act(() => result.current.handlePullsChange({ 1: 2, 3: 2 }));
+      // Force a notice by triggering a conflict
+      act(() => result.current.setPullNotice('some notice'));
+      act(() => result.current.reset());
+
+      expect(result.current.selectedPulls).toEqual({});
+      expect(result.current.pullNotice).toBeNull();
+    });
+  });
+});

--- a/frontend/src/scenes/hooks/__tests__/useCastPullSelection.test.ts
+++ b/frontend/src/scenes/hooks/__tests__/useCastPullSelection.test.ts
@@ -69,9 +69,15 @@ function setupResonances(
 }
 
 const baseParams = {
-  selectedTechnique: { id: 42, name: 'Flamecall', strain_cost: 1 } as Parameters<
-    typeof useCastPullSelection
-  >[0]['selectedTechnique'],
+  selectedTechnique: {
+    id: 42,
+    name: 'Flamecall',
+    anima_cost: 1,
+    tier: 1,
+    intensity: 1,
+    control: 1,
+    hostile: false,
+  } as Parameters<typeof useCastPullSelection>[0]['selectedTechnique'],
   characterId: 7,
   castTargetPersonaId: null,
   sceneId: '99',

--- a/frontend/src/scenes/hooks/useCastPullSelection.ts
+++ b/frontend/src/scenes/hooks/useCastPullSelection.ts
@@ -1,0 +1,176 @@
+/**
+ * useCastPullSelection — manages thread-pull selection state for the cast flow.
+ *
+ * Extracted from ActionPanel.tsx (#895 item 1, 2, 4) so the cluster can be
+ * unit-tested in isolation. ActionPanel will adopt this hook in Task 4.
+ *
+ * Design notes:
+ * - Threads are fetched only while ``castOpen`` is true (gated ``useThreads``).
+ * - ``buildPullPayload`` returns ``{ error }`` instead of calling ``setPullNotice``
+ *   inline so the component owns the side-effect (brief/item 4).
+ * - ``reset()`` wipes ``selectedPulls`` and ``pullNotice``; call it after a
+ *   successful cast or when the dialog closes.
+ */
+
+import { useState, useMemo } from 'react';
+import { useThreads, useCharacterResonances } from '@/magic/queries';
+import type { Thread } from '@/magic/types';
+import type { ApplicablePullsRequest } from '@/magic/types';
+import type { CastableTechnique, CastPullRequestBody } from '@/scenes/actionTypes';
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+export interface CastPullSelection {
+  selectedPulls: Record<number, 0 | 1 | 2 | 3>;
+  showInapplicable: boolean;
+  setShowInapplicable: (next: boolean) => void;
+  pullNotice: string | null;
+  setPullNotice: (msg: string | null) => void;
+  pullsContext: ApplicablePullsRequest | null;
+  balanceByResonanceId: Record<number, number>;
+  handlePullsChange: (next: Record<number, 0 | 1 | 2 | 3>) => void;
+  /** Returns ``{ pull }`` (or ``{}``) on success, or ``{ error }`` when the
+   *  threads cache hasn't resolved for the changed thread yet. */
+  buildPullPayload: () => { pull?: CastPullRequestBody } | { error: string };
+  reset: () => void;
+}
+
+export interface UseCastPullSelectionParams {
+  selectedTechnique: CastableTechnique | null;
+  characterId: number | null;
+  castTargetPersonaId: number | null;
+  sceneId: string;
+  castOpen: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useCastPullSelection(params: UseCastPullSelectionParams): CastPullSelection {
+  const { selectedTechnique, characterId, castTargetPersonaId, sceneId, castOpen } = params;
+
+  // Pull selection state — thread id → committed tier (0 = unpaid).
+  const [selectedPulls, setSelectedPulls] = useState<Record<number, 0 | 1 | 2 | 3>>({});
+  const [showInapplicable, setShowInapplicable] = useState(false);
+  const [pullNotice, setPullNotice] = useState<string | null>(null);
+
+  // Threads — fetched only while the cast dialog is open to avoid an
+  // unnecessary warm-up fetch and to allow the gating test (brief item 6).
+  const { data: threadsData } = useThreads({ enabled: castOpen });
+  const threadById = useMemo(() => {
+    const map = new Map<number, Thread>();
+    for (const thread of threadsData?.results ?? []) {
+      map.set(thread.id, thread);
+    }
+    return map;
+  }, [threadsData]);
+
+  // Resonance balances — used by ThreadPullPicker for unaffordable-tier tooltips.
+  const { data: resonances } = useCharacterResonances(characterId ?? undefined);
+  const balanceByResonanceId = useMemo<Record<number, number>>(() => {
+    if (!resonances) return {};
+    return Object.fromEntries(resonances.map((cr) => [cr.resonance, cr.balance ?? 0]));
+  }, [resonances]);
+
+  // Applicability context for the thread-pull picker — only while a technique
+  // is selected in the open cast section.
+  const pullsContext = useMemo<ApplicablePullsRequest | null>(() => {
+    if (!castOpen || !selectedTechnique || characterId === null) return null;
+    return {
+      character_sheet_id: characterId,
+      technique_id: selectedTechnique.id,
+      target_persona_id: castTargetPersonaId,
+      scene_id: Number(sceneId),
+    };
+  }, [castOpen, selectedTechnique, characterId, castTargetPersonaId, sceneId]);
+
+  /**
+   * Constrain pull selection to a single (resonance, tier) group — the cast
+   * payload's pull declaration is singular, so any newly raised pull reverts
+   * every other paid pull that disagrees on resonance or tier.
+   *
+   * Lifted verbatim from ActionPanel.tsx:282-315.
+   */
+  function handlePullsChange(next: Record<number, 0 | 1 | 2 | 3>): void {
+    const changed = Object.entries(next).find(
+      ([id, tier]) => (selectedPulls[Number(id)] ?? 0) !== tier && tier > 0
+    );
+    if (changed) {
+      const changedId = Number(changed[0]);
+      const changedTier = changed[1];
+      const changedResonance = threadById.get(changedId)?.resonance;
+      if (changedResonance === undefined) {
+        // Threads cache not resolved yet — can't group by resonance; pass
+        // through unconstrained rather than reverting on undefined matches.
+        setSelectedPulls(next);
+        return;
+      }
+      let reverted = 0;
+      const constrained = { ...next };
+      for (const [idStr, tier] of Object.entries(next)) {
+        const id = Number(idStr);
+        if (id === changedId || tier === 0) continue;
+        if (tier !== changedTier || threadById.get(id)?.resonance !== changedResonance) {
+          constrained[id] = 0;
+          reverted++;
+        }
+      }
+      setPullNotice(reverted > 0 ? 'Pulls in one cast share a single resonance and tier.' : null);
+      setSelectedPulls(constrained);
+      return;
+    }
+    // Deselects pass through; a conflict notice is stale once no paid pull remains.
+    if (!Object.values(next).some((tier) => tier > 0)) {
+      setPullNotice(null);
+    }
+    setSelectedPulls(next);
+  }
+
+  /**
+   * Build the pull payload for ``castTechnique``.
+   *
+   * Returns:
+   * - ``{ pull: CastPullRequestBody }`` — paid group found and threads resolved.
+   * - ``{}`` — no paid pulls selected (valid; cast proceeds without a pull).
+   * - ``{ error: string }`` — paid pulls exist but the thread isn't in the cache
+   *   yet; the component should surface this and abort the cast.
+   *
+   * Adapted from ActionPanel.tsx:317-334 — returns ``{ error }`` instead of
+   * calling ``setPullNotice`` inline so the component owns that side-effect.
+   */
+  function buildPullPayload(): { pull?: CastPullRequestBody } | { error: string } {
+    const paid = Object.entries(selectedPulls).filter(([, tier]) => tier > 0);
+    if (paid.length === 0) return {};
+    const firstThread = threadById.get(Number(paid[0][0]));
+    if (!firstThread) {
+      return { error: 'Thread data is still loading — try again in a moment.' };
+    }
+    const pull: CastPullRequestBody = {
+      resonance_id: firstThread.resonance,
+      tier: paid[0][1] as 1 | 2 | 3,
+      thread_ids: paid.map(([id]) => Number(id)),
+    };
+    return { pull };
+  }
+
+  function reset(): void {
+    setSelectedPulls({});
+    setPullNotice(null);
+  }
+
+  return {
+    selectedPulls,
+    showInapplicable,
+    setShowInapplicable,
+    pullNotice,
+    setPullNotice,
+    pullsContext,
+    balanceByResonanceId,
+    handlePullsChange,
+    buildPullPayload,
+    reset,
+  };
+}

--- a/frontend/src/scenes/hooks/useCastPullSelection.ts
+++ b/frontend/src/scenes/hooks/useCastPullSelection.ts
@@ -14,8 +14,7 @@
 
 import { useState, useMemo } from 'react';
 import { useThreads, useCharacterResonances } from '@/magic/queries';
-import type { Thread } from '@/magic/types';
-import type { ApplicablePullsRequest } from '@/magic/types';
+import type { Thread, ApplicablePullsRequest } from '@/magic/types';
 import type { CastableTechnique, CastPullRequestBody } from '@/scenes/actionTypes';
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #895

## Summary

Frontend-only cleanup of ActionPanel's cast flow (all 4 reviewed items). 1) New useCastPullSelection hook (scenes/hooks/) owns the inline pull cluster — selectedPulls, pullNotice, threadById, pullsContext, the single-(resonance,tier)-group handlePullsChange, and buildPullPayload — making the grouping constraint unit-testable (15 hook tests). 2) useThreads gained an optional enabled param (default true), gated on castOpen, so non-casters no longer fetch threads or hit the throwOnError boundary. 3) castTechnique now surfaces the backend {detail}, rendered near the Cast button (role=alert), cleared on technique change/close. 4) balanceByResonanceId wired into the cast dialog's ThreadPullPicker via the existing useCharacterResonances pattern. Also consolidated the ~10x-duplicated extractErrorMessage into a shared lib/errors.ts (per-site fallbacks preserved via a fallback param) + readErrorDetail. Per-task reviews + a whole-branch Opus review all clean; 673/673 vitest, lint 0, typecheck + build OK. Follow-up #1195 filed for the api-layer parseErrorDetail sweep.

## Follow-ups filed

- #1195

## Notes

- Spec: reviewed & approved on #895 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Up to date with origin/main (unchanged since branch point 26eb4b2c); no rebase needed.

<!-- last-addressed-comment: 0 -->