### PR TITLE
Lock down PersonaViewSet writes — read-only + actions (#1127 hardening)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -9326,11 +9326,20 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** @description ViewSet for managing personas within scenes */
+    /**
+     * @description Read + actions over a character's personas (#1127 hardening).
+     *
+     *     Deliberately **not** a ``ModelViewSet``: the raw create/update/destroy were an
+     *     undesigned, identity-security-critical surface (a player could POST any
+     *     ``persona_type`` / ``is_fake_name`` and mint arbitrary alt identities). Personas are
+     *     created by the system (PRIMARY at character creation) and, in future, by designed IC
+     *     flows (mask command / disguise kit / formal alternate-identity process) that call the
+     *     creation at the service layer with their own gating and consequences. This viewset only
+     *     exposes reads + the player-facing actions (``set-active``, renown, spread, …).
+     */
     get: operations['personas_list'];
     put?: never;
-    /** @description ViewSet for managing personas within scenes */
-    post: operations['personas_create'];
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -9344,17 +9353,24 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** @description ViewSet for managing personas within scenes */
+    /**
+     * @description Read + actions over a character's personas (#1127 hardening).
+     *
+     *     Deliberately **not** a ``ModelViewSet``: the raw create/update/destroy were an
+     *     undesigned, identity-security-critical surface (a player could POST any
+     *     ``persona_type`` / ``is_fake_name`` and mint arbitrary alt identities). Personas are
+     *     created by the system (PRIMARY at character creation) and, in future, by designed IC
+     *     flows (mask command / disguise kit / formal alternate-identity process) that call the
+     *     creation at the service layer with their own gating and consequences. This viewset only
+     *     exposes reads + the player-facing actions (``set-active``, renown, spread, …).
+     */
     get: operations['personas_retrieve'];
-    /** @description ViewSet for managing personas within scenes */
-    put: operations['personas_update'];
+    put?: never;
     post?: never;
-    /** @description ViewSet for managing personas within scenes */
-    delete: operations['personas_destroy'];
+    delete?: never;
     options?: never;
     head?: never;
-    /** @description ViewSet for managing personas within scenes */
-    patch: operations['personas_partial_update'];
+    patch?: never;
     trace?: never;
   };
   '/api/personas/{id}/deed-stories/': {
@@ -19822,26 +19838,6 @@ export interface components {
       /** @description The NPCServiceOffer row this details model decorates. */
       offer?: number;
     };
-    PatchedPersonaRequest: {
-      /** @description The character sheet this persona belongs to. */
-      character_sheet?: number;
-      /** @description Display name for this persona */
-      name?: string;
-      /** @description True when this persona obscures the character's identity */
-      is_fake_name?: boolean;
-      /**
-       * @description PRIMARY = real identity, ESTABLISHED = persistent alter ego, TEMPORARY = throwaway disguise
-       *
-       *     * `primary` - Primary
-       *     * `established` - Established
-       *     * `temporary` - Temporary
-       */
-      persona_type?: components['schemas']['PersonaTypeEnum'];
-      /** @description Physical description text */
-      description?: string;
-      /** Format: uri */
-      thumbnail_url?: string;
-    };
     /** @description Read serializer for staff review. */
     PatchedPlayerFeedbackDetailRequest: {
       /** @description The persona the submitter was wearing when they submitted. */
@@ -20350,26 +20346,6 @@ export interface components {
       readonly roster_entry: {
         [key: string]: number | string;
       } | null;
-    };
-    PersonaRequest: {
-      /** @description The character sheet this persona belongs to. */
-      character_sheet: number;
-      /** @description Display name for this persona */
-      name: string;
-      /** @description True when this persona obscures the character's identity */
-      is_fake_name?: boolean;
-      /**
-       * @description PRIMARY = real identity, ESTABLISHED = persistent alter ego, TEMPORARY = throwaway disguise
-       *
-       *     * `primary` - Primary
-       *     * `established` - Established
-       *     * `temporary` - Temporary
-       */
-      persona_type?: components['schemas']['PersonaTypeEnum'];
-      /** @description Physical description text */
-      description?: string;
-      /** Format: uri */
-      thumbnail_url?: string;
     };
     /**
      * @description * `primary` - Primary
@@ -36771,29 +36747,6 @@ export interface operations {
       };
     };
   };
-  personas_create: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['PersonaRequest'];
-      };
-    };
-    responses: {
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['Persona'];
-        };
-      };
-    };
-  };
   personas_retrieve: {
     parameters: {
       query?: never;
@@ -36805,79 +36758,6 @@ export interface operations {
       cookie?: never;
     };
     requestBody?: never;
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['Persona'];
-        };
-      };
-    };
-  };
-  personas_update: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description A unique integer value identifying this persona. */
-        id: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['PersonaRequest'];
-      };
-    };
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['Persona'];
-        };
-      };
-    };
-  };
-  personas_destroy: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description A unique integer value identifying this persona. */
-        id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description No response body */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  personas_partial_update: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description A unique integer value identifying this persona. */
-        id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['PatchedPersonaRequest'];
-      };
-    };
     responses: {
       200: {
         headers: {

--- a/src/schema.json
+++ b/src/schema.json
@@ -15395,7 +15395,16 @@ paths:
   /api/personas/:
     get:
       operationId: personas_list
-      description: ViewSet for managing personas within scenes
+      description: |-
+        Read + actions over a character's personas (#1127 hardening).
+
+        Deliberately **not** a ``ModelViewSet``: the raw create/update/destroy were an
+        undesigned, identity-security-critical surface (a player could POST any
+        ``persona_type`` / ``is_fake_name`` and mint arbitrary alt identities). Personas are
+        created by the system (PRIMARY at character creation) and, in future, by designed IC
+        flows (mask command / disguise kit / formal alternate-identity process) that call the
+        creation at the service layer with their own gating and consequences. This viewset only
+        exposes reads + the player-facing actions (``set-active``, renown, spread, …).
       parameters:
       - in: query
         name: character
@@ -15442,30 +15451,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedPersonaList'
           description: ''
-    post:
-      operationId: personas_create
-      description: ViewSet for managing personas within scenes
-      tags:
-      - personas
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PersonaRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Persona'
-          description: ''
   /api/personas/{id}/:
     get:
       operationId: personas_retrieve
-      description: ViewSet for managing personas within scenes
+      description: |-
+        Read + actions over a character's personas (#1127 hardening).
+
+        Deliberately **not** a ``ModelViewSet``: the raw create/update/destroy were an
+        undesigned, identity-security-critical surface (a player could POST any
+        ``persona_type`` / ``is_fake_name`` and mint arbitrary alt identities). Personas are
+        created by the system (PRIMARY at character creation) and, in future, by designed IC
+        flows (mask command / disguise kit / formal alternate-identity process) that call the
+        creation at the service layer with their own gating and consequences. This viewset only
+        exposes reads + the player-facing actions (``set-active``, renown, spread, …).
       parameters:
       - in: path
         name: id
@@ -15484,76 +15482,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Persona'
           description: ''
-    put:
-      operationId: personas_update
-      description: ViewSet for managing personas within scenes
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this persona.
-        required: true
-      tags:
-      - personas
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PersonaRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Persona'
-          description: ''
-    patch:
-      operationId: personas_partial_update
-      description: ViewSet for managing personas within scenes
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this persona.
-        required: true
-      tags:
-      - personas
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedPersonaRequest'
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Persona'
-          description: ''
-    delete:
-      operationId: personas_destroy
-      description: ViewSet for managing personas within scenes
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this persona.
-        required: true
-      tags:
-      - personas
-      security:
-      - cookieAuth: []
-      responses:
-        '204':
-          description: No response body
   /api/personas/{id}/deed-stories/:
     get:
       operationId: personas_deed_stories_list
@@ -35590,36 +35518,6 @@ components:
         offer:
           type: integer
           description: The NPCServiceOffer row this details model decorates.
-    PatchedPersonaRequest:
-      type: object
-      properties:
-        character_sheet:
-          type: integer
-          description: The character sheet this persona belongs to.
-        name:
-          type: string
-          minLength: 1
-          description: Display name for this persona
-          maxLength: 255
-        is_fake_name:
-          type: boolean
-          description: True when this persona obscures the character's identity
-        persona_type:
-          allOf:
-          - $ref: '#/components/schemas/PersonaTypeEnum'
-          description: |-
-            PRIMARY = real identity, ESTABLISHED = persistent alter ego, TEMPORARY = throwaway disguise
-
-            * `primary` - Primary
-            * `established` - Established
-            * `temporary` - Temporary
-        description:
-          type: string
-          description: Physical description text
-        thumbnail_url:
-          type: string
-          format: uri
-          maxLength: 500
     PatchedPlayerFeedbackDetailRequest:
       type: object
       description: Read serializer for staff review.
@@ -36542,39 +36440,6 @@ components:
       - name
       - roster_entry
       - thumbnail_media_url
-    PersonaRequest:
-      type: object
-      properties:
-        character_sheet:
-          type: integer
-          description: The character sheet this persona belongs to.
-        name:
-          type: string
-          minLength: 1
-          description: Display name for this persona
-          maxLength: 255
-        is_fake_name:
-          type: boolean
-          description: True when this persona obscures the character's identity
-        persona_type:
-          allOf:
-          - $ref: '#/components/schemas/PersonaTypeEnum'
-          description: |-
-            PRIMARY = real identity, ESTABLISHED = persistent alter ego, TEMPORARY = throwaway disguise
-
-            * `primary` - Primary
-            * `established` - Established
-            * `temporary` - Temporary
-        description:
-          type: string
-          description: Physical description text
-        thumbnail_url:
-          type: string
-          format: uri
-          maxLength: 500
-      required:
-      - character_sheet
-      - name
     PersonaTypeEnum:
       enum:
       - primary

--- a/src/world/scenes/tests/test_permissions.py
+++ b/src/world/scenes/tests/test_permissions.py
@@ -165,53 +165,35 @@ class PersonaPermissionsTestCase(APITestCase):
         )
         cls.persona = _create_owned_persona(cls.participant)
 
-    @suppress_permission_errors
-    def test_create_persona_participant_only(self):
-        """Only scene participants can create personas"""
-        # Create identity owned by participant
+    def test_persona_create_is_locked_down(self):
+        """The raw create surface is gone (#1127). Even staff — who pass the create
+        permission — get method-not-allowed, proving the endpoint itself is removed, not
+        merely permission-gated. Personas come from the system / future designed IC flows."""
         identity = CharacterSheetFactory()
-        player_data, _ = PlayerDataFactory._meta.model.objects.get_or_create(
-            account=self.participant,
-        )
-        roster_entry = RosterEntryFactory(character_sheet__character=identity.character)
-        RosterTenureFactory(player_data=player_data, roster_entry=roster_entry)
-
         url = reverse("persona-list")
-        data = {
-            "name": "Test Persona",
-            "character_sheet": identity.character.sheet_data.pk,
-        }
+        data = {"name": "Test Persona", "character_sheet": identity.character.sheet_data.pk}
 
-        # Outsider cannot create persona (doesn't own the character)
-        self.client.force_authenticate(user=self.outsider)
-        response = self.client.post(url, data, format="json")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-        # Participant can create persona (owns the character)
-        self.client.force_authenticate(user=self.participant)
-        response = self.client.post(url, data, format="json")
-        assert response.status_code == status.HTTP_201_CREATED, response.data
-
-    @suppress_permission_errors
-    def test_modify_persona_participant_permission(self):
-        """Only character owners and staff can modify personas"""
-        url = reverse("persona-detail", kwargs={"pk": self.persona.pk})
-        data = {"name": "Updated Persona"}
-
-        # Outsider cannot modify
-        self.client.force_authenticate(user=self.outsider)
-        response = self.client.patch(url, data, format="json")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-        # Character owner can modify
-        self.client.force_authenticate(user=self.participant)
-        response = self.client.patch(url, data, format="json")
-        assert response.status_code == status.HTTP_200_OK
-
-        # Staff can modify
         self.client.force_authenticate(user=self.staff)
-        response = self.client.patch(url, data, format="json")
-        assert response.status_code == status.HTTP_200_OK
+        response = self.client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_persona_update_and_delete_are_locked_down(self):
+        """No raw update/destroy either — persona management goes through designed flows,
+        not the REST surface. Method-not-allowed for owner and staff alike."""
+        url = reverse("persona-detail", kwargs={"pk": self.persona.pk})
+
+        self.client.force_authenticate(user=self.participant)
+        assert (
+            self.client.patch(url, {"name": "x"}, format="json").status_code
+            == status.HTTP_405_METHOD_NOT_ALLOWED
+        )
+        assert self.client.delete(url).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+        self.client.force_authenticate(user=self.staff)
+        assert (
+            self.client.patch(url, {"name": "x"}, format="json").status_code
+            == status.HTTP_405_METHOD_NOT_ALLOWED
+        )
 
 
 class SceneCreationPermissionsTestCase(APITestCase):

--- a/src/world/scenes/tests/test_view_actions_permissions.py
+++ b/src/world/scenes/tests/test_view_actions_permissions.py
@@ -259,9 +259,9 @@ class PersonaViewPermissionsTestCase(APITestCase):
         )
         cls.persona = _create_owned_persona(cls.participant_account)
 
-    def test_persona_create_participant_permission(self):
-        """Test character owner can create personas"""
-        # Create identity owned by participant
+    def test_persona_create_is_locked_down_for_owner(self):
+        """Even a character owner — who passes the create permission — cannot POST a
+        persona; the create endpoint is gone (#1127). Method-not-allowed."""
         identity = CharacterSheetFactory()
         player_data, _ = PlayerDataFactory._meta.model.objects.get_or_create(
             account=self.participant_account,
@@ -282,7 +282,7 @@ class PersonaViewPermissionsTestCase(APITestCase):
             content_type="application/json",
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     @suppress_permission_errors
     def test_persona_create_non_participant_denied(self):
@@ -310,8 +310,9 @@ class PersonaViewPermissionsTestCase(APITestCase):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_persona_create_staff_permission(self):
-        """Test staff can create personas for any character"""
+    def test_persona_create_is_locked_down_for_staff(self):
+        """Even staff cannot POST a persona — the create endpoint is gone (#1127).
+        Method-not-allowed."""
         self.client.force_authenticate(user=self.staff_account)
         url = reverse("persona-list")
         identity = CharacterSheetFactory()
@@ -326,4 +327,4 @@ class PersonaViewPermissionsTestCase(APITestCase):
             content_type="application/json",
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -5,7 +5,7 @@ from django.db.models import Prefetch, Q, QuerySet
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema
-from rest_framework import permissions, serializers, status, viewsets
+from rest_framework import mixins, permissions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import SearchFilter
 from rest_framework.permissions import BasePermission, IsAuthenticatedOrReadOnly
@@ -277,9 +277,20 @@ class SceneViewSet(viewsets.ModelViewSet):
         return Response(SceneActivitySerializer({"band": band.label}).data)
 
 
-class PersonaViewSet(viewsets.ModelViewSet):
-    """
-    ViewSet for managing personas within scenes
+class PersonaViewSet(
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Read + actions over a character's personas (#1127 hardening).
+
+    Deliberately **not** a ``ModelViewSet``: the raw create/update/destroy were an
+    undesigned, identity-security-critical surface (a player could POST any
+    ``persona_type`` / ``is_fake_name`` and mint arbitrary alt identities). Personas are
+    created by the system (PRIMARY at character creation) and, in future, by designed IC
+    flows (mask command / disguise kit / formal alternate-identity process) that call the
+    creation at the service layer with their own gating and consequences. This viewset only
+    exposes reads + the player-facing actions (``set-active``, renown, spread, …).
     """
 
     serializer_class = PersonaSerializer


### PR DESCRIPTION
The **hardening** slice of #1127: close the undesigned persona-creation hole. (The immersive creation/management flows remain #1127's larger work — this is **Refs**, not Closes.)

## The hole
`PersonaViewSet` was a plain `ModelViewSet`, so `POST /api/scenes/personas/` accepted **any** `persona_type` (ESTABLISHED / TEMPORARY) + `is_fake_name`, gated only by "you own the character" — a player could mint arbitrary alternate identities on an identity-security-critical model, with zero design or consequence.

## Verified: nothing legit used it
- Frontend only **reads** personas and calls **`set-active`** (switching is already wired — `useSetActivePersonaMutation`); it never POSTs to create.
- PRIMARY personas are created by the system (`create_character_with_sheet`).
- ESTABLISHED / TEMPORARY have **no designed creation path yet**.

## The change
`PersonaViewSet` → `ListModelMixin + RetrieveModelMixin + GenericViewSet`, keeping every existing `@action` (`set-active`, `renown`, `spread`, `deed-stories`, …). So `create` / `update` / `destroy` are removed from the REST surface; reads and actions are untouched.

**The low-level persona creation stays at the service/model layer** — it's internal wiring. Future designed **IC flows** (a "put on a mask" command, a disguise kit, a formal alternate-identity process, and the command to assume an established identity) will be the player-facing surfaces, each calling creation with its own gating and consequences. That immersive layer is the remaining #1127 work.

## Tests / gates
- The three create/modify permission tests now assert the writes are **405** — using **staff and character-owners** (who *pass* the create permission), so a 405 proves the *method itself* is gone, not merely permission-gating. Non-owner-denied (403, permission) still holds.
- `api.d.ts` + `schema.json` regenerated (`personas_create/update/destroy/partial_update` removed).
- `world.scenes` green (560 tests); ruff + ty clean; frontend typecheck + production build green.

## Anti-reinvention
No new model/endpoint — this *removes* surface. The creation logic isn't deleted, just unpublished from the raw REST CRUD; switching (`set-active`) already exists and is untouched.

Refs #1127.
