### PR TITLE
fix(#964): make TriggerHandler cache rollback-safe via on_commit invalidation

### DIFF
--- a/docs/architecture/reactive-layer-foundation.md
+++ b/docs/architecture/reactive-layer-foundation.md
@@ -31,10 +31,12 @@ system, not of magic.
   the subject's trigger handler) and `ROOM` scope (delivered to the room's
   trigger handler). Authors pick the scope that matches "where does this
   trigger live."
-- **Populate once, mutate in place.** Each `TriggerHandler` is a
+- **Populate once, invalidate on commit.** Each `TriggerHandler` is a
   `cached_property` on a typeclass. It reads its Trigger rows on first
-  access, then is kept in sync via explicit service-function hooks when
-  conditions apply/remove or stages change. No repeated queries.
+  access, then is dropped and lazily re-read when service-function hooks
+  fire as conditions apply/remove or stages change. Invalidation defers to
+  `transaction.on_commit`, so a rolled-back trigger install/removal never
+  corrupts the cache (#964).
 - **In-memory flow execution.** `FlowExecution` is not a model. Flow state
   lives in Python objects. Player prompts suspend via Twisted Deferreds
   held in a module-level dict; timeouts fire default branches.
@@ -129,10 +131,15 @@ Handler responsibilities:
   returns cancellation/propagation state.
 - **Sync hooks:** `on_trigger_added(trigger)`, `on_trigger_removed(pk)`,
   `on_stage_changed(condition, new_stage)`. Called by service functions
-  that apply conditions, remove them, or advance stages. Mutate the
-  handler's in-memory structures in place. Never re-query.
-- **Invalidation:** handlers do not invalidate. They stay in sync via the
-  explicit hooks above. This is the SharedMemoryModel-trusting pattern.
+  that apply conditions, remove them, or advance stages. The add/remove
+  hooks route through `invalidate()`; `on_stage_changed` is a no-op
+  (`_is_active` re-checks stage at dispatch time).
+- **Invalidation:** `invalidate()` registers a `transaction.on_commit`
+  callback that drops the populated index so the next `triggers_for()`
+  re-reads committed rows. Deferring to commit keeps the cache rollback-safe
+  (#964): unlike the synchronous `.invalidate()` on sibling read-caches
+  (`ConditionHandler` et al.), a phantom trigger would *double-fire*, so
+  trigger dispatch must never see uncommitted or rolled-back rows.
 
 Different typeclasses may have different handler subclasses (e.g., rooms
 might do additional filtering for line-of-sight triggers).
@@ -538,8 +545,9 @@ All tests use FactoryBoy — no fixture data required. Tests live in
 - All 29 integration tests pass without fixture data, using only factories.
 - `ConditionInstance` removal cascades all associated `Trigger` rows
   (tested via DB assertion).
-- Handler `cached_property` populates once; sync hooks mutate in-memory
-  state without re-query (tested via query-count assertion).
+- Handler `cached_property` populates once and serves reads without re-query
+  (tested via query-count assertion); sync hooks invalidate on commit and the
+  next read re-populates.
 - AE attacks produce N parallel FlowStacks (one per PERSONAL target) plus
   one ROOM FlowStack; depth cap applies per-stack.
 - Combat arithmetic is NOT duplicated in the reactive layer — all damage

--- a/docs/systems/flows.md
+++ b/docs/systems/flows.md
@@ -52,13 +52,13 @@ PRE-event payloads are mutable dataclasses. `MODIFY_PAYLOAD` flow steps can amen
 - `source_stage` — optional. Makes the trigger active only while the source condition is at that stage.
 - `additional_filter_condition` — JSON DSL evaluated per dispatch; restricts which payloads match. **This is how you express self-vs-target-vs-bystander semantics** — there is no `scope` field. See Filter Idioms below.
 
-Service functions install triggers from `ConditionTemplate.reactive_triggers` (M2M to `TriggerDefinition`) when `apply_condition` runs and call `handler.on_trigger_added(...)` to keep the cached handler in sync.
+Service functions install triggers from `ConditionTemplate.reactive_triggers` (M2M to `TriggerDefinition`) when `apply_condition` runs and call `handler.on_trigger_added(...)` to invalidate the cached handler (on commit) so the next read re-picks up the new row.
 
 ### TriggerHandler (per-owner cache)
 
 Installed as `cached_property` on Character/Room/Object via `ObjectParent`. First access populates from the DB once and joins event/flow/condition/stage in a single query. Subsequent calls are O(active triggers for event_name) with zero queries.
 
-The handler is a **pure provider**: its sole public method is `triggers_for(event_name) -> list[Trigger]`. It does not dispatch. `emit_event` queries the handler on every owner in the location walk, concatenates results, priority-sorts globally, and dispatches itself. Sync hooks (`on_trigger_added`, `on_trigger_removed`, `on_stage_changed`) keep the cache fresh — service functions must call them after persisting the row.
+The handler is a **pure provider**: its sole public method is `triggers_for(event_name) -> list[Trigger]`. It does not dispatch. `emit_event` queries the handler on every owner in the location walk, concatenates results, priority-sorts globally, and dispatches itself. Sync hooks (`on_trigger_added`, `on_trigger_removed`, `on_stage_changed`) keep the cache fresh — service functions must call them after persisting the row. The add/remove hooks call `invalidate()`, which registers a `transaction.on_commit` callback to drop the cache; the next read re-populates from committed rows. Deferring to commit makes the cache rollback-safe (#964) — a phantom trigger would double-fire, so the cache must never retain an uncommitted or rolled-back row. (Within a `TestCase`, wrap install-then-dispatch in `transaction.captureOnCommitCallbacks(execute=True)`.)
 
 ### Filter DSL
 

--- a/src/flows/tests/test_trigger_handler/test_rollback_sync.py
+++ b/src/flows/tests/test_trigger_handler/test_rollback_sync.py
@@ -1,0 +1,81 @@
+"""Cache-vs-transaction-rollback safety for TriggerHandler (#964).
+
+The handler's sync hooks must not corrupt the in-memory cache when the
+enclosing transaction rolls back: a rolled-back install must not leave a
+phantom trigger, and a rolled-back removal must not drop a live one. The
+contract is that ``on_trigger_added`` / ``on_trigger_removed`` defer their
+cache invalidation to ``transaction.on_commit``.
+"""
+
+from django.db import transaction
+from django.test import TestCase
+
+from flows.constants import EventName
+from flows.trigger_handler import TriggerHandler
+from world.conditions.factories import ReactiveConditionFactory
+
+
+class _ForceRollback(Exception):
+    """Sentinel raised inside an atomic block to trigger a rollback."""
+
+
+class TriggerHandlerRollbackTests(TestCase):
+    def test_rolled_back_install_leaves_no_phantom(self) -> None:
+        # Pre-populate the handler with one DAMAGE_APPLIED trigger; the
+        # ATTACK_LANDED bucket starts empty.
+        existing = ReactiveConditionFactory(event_name=EventName.DAMAGE_APPLIED)
+        character = existing.obj
+        handler = TriggerHandler(owner=character)
+        self.assertEqual(len(handler.triggers_for("attack_landed")), 0)
+
+        # Install an ATTACK_LANDED trigger inside a transaction that rolls back.
+        with self.assertRaises(_ForceRollback):
+            with transaction.atomic():
+                new = ReactiveConditionFactory(
+                    event_name=EventName.ATTACK_LANDED,
+                    target=character,
+                )
+                handler.on_trigger_added(new)
+                raise _ForceRollback
+
+        # The never-committed row must not be in the cache.
+        self.assertEqual(
+            len(handler.triggers_for("attack_landed")),
+            0,
+            "phantom trigger leaked into the cache after rollback",
+        )
+
+    def test_rolled_back_removal_keeps_live_trigger(self) -> None:
+        existing = ReactiveConditionFactory(event_name=EventName.ATTACK_LANDED)
+        character = existing.obj
+        handler = TriggerHandler(owner=character)
+        self.assertEqual(len(handler.triggers_for("attack_landed")), 1)
+
+        with self.assertRaises(_ForceRollback):
+            with transaction.atomic():
+                handler.on_trigger_removed(existing.pk)
+                raise _ForceRollback
+
+        # The removal never committed, so the live trigger must remain.
+        self.assertEqual(
+            len(handler.triggers_for("attack_landed")),
+            1,
+            "live trigger vanished from the cache after a rolled-back removal",
+        )
+
+    def test_committed_install_is_visible_after_commit(self) -> None:
+        # Positive control: an install that commits is visible once the
+        # on_commit callbacks run.
+        existing = ReactiveConditionFactory(event_name=EventName.DAMAGE_APPLIED)
+        character = existing.obj
+        handler = TriggerHandler(owner=character)
+        self.assertEqual(len(handler.triggers_for("attack_landed")), 0)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            new = ReactiveConditionFactory(
+                event_name=EventName.ATTACK_LANDED,
+                target=character,
+            )
+            handler.on_trigger_added(new)
+
+        self.assertEqual(len(handler.triggers_for("attack_landed")), 1)

--- a/src/flows/trigger_handler.py
+++ b/src/flows/trigger_handler.py
@@ -88,17 +88,33 @@ class TriggerHandler:
 
     # ---- sync hooks (called by service functions) ----
 
+    def invalidate(self) -> None:
+        """Drop the cache on commit so the next access re-reads from the DB.
+
+        Defers to ``transaction.on_commit`` rather than mutating ``_by_event``
+        in place. This makes the cache rollback-safe (#964): if the enclosing
+        transaction rolls back, the callback is discarded and a never-committed
+        trigger never enters the cache; in autocommit the callback runs at once.
+
+        Sibling cached handlers (``ConditionHandler.invalidate`` et al.) drop
+        their cache synchronously, but trigger dispatch must be rollback-safe —
+        a phantom trigger *double-fires* (actively wrong), whereas a stale
+        read-cache merely re-queries and self-heals on the next mutation.
+        """
+        from django.db import transaction  # noqa: PLC0415
+
+        transaction.on_commit(self._reset)
+
+    def _reset(self) -> None:
+        """Clear the populated index so the next ``triggers_for`` re-reads."""
+        self._by_event.clear()
+        self._populated = False
+
     def on_trigger_added(self, trigger: "Trigger") -> None:
-        if not self._populated:
-            return  # lazy — will populate on first use
-        event_name = trigger.trigger_definition.event_name
-        self._by_event[event_name].append(trigger)
+        self.invalidate()
 
     def on_trigger_removed(self, trigger_pk: int) -> None:
-        if not self._populated:
-            return
-        for event_name, triggers in self._by_event.items():
-            self._by_event[event_name] = [t for t in triggers if t.pk != trigger_pk]
+        self.invalidate()
 
     def on_stage_changed(self, condition_pk: int, new_stage: Any) -> None:
         """No structural change — ``_is_active`` re-checks on each dispatch."""

--- a/src/world/combat/tests/test_escalation_integration.py
+++ b/src/world/combat/tests/test_escalation_integration.py
@@ -274,7 +274,10 @@ class BondedSpikeRealDamagePathTests(TestCase):
         self.assertEqual(engagement_a.intensity_modifier, 0)
 
         # The real escalating round start installs the room spike triggers.
-        begin_declaration_phase(self.encounter)
+        # The handler invalidates on commit (#964), so run the on_commit
+        # callbacks here to drop the stale cache before the dispatch below.
+        with self.captureOnCommitCallbacks(execute=True):
+            begin_declaration_phase(self.encounter)
         for name in ESCALATION_SPIKE_TRIGGER_NAMES:
             self.assertTrue(
                 Trigger.objects.filter(

--- a/src/world/magic/services/soul_tether.py
+++ b/src/world/magic/services/soul_tether.py
@@ -436,10 +436,17 @@ def dissolve_soul_tether(
                 condition__name="Soul Tether Active",
             ).delete()
 
+            # Invalidate the Sinner's in-memory TriggerHandler so the
+            # cascade-deleted Trigger rows leave the cache on commit (#964).
+            trigger_handler = getattr(sinner_sheet.character, "trigger_handler", None)  # noqa: GETATTR_LITERAL
+            if trigger_handler is not None:
+                trigger_handler.invalidate()
+
     # NOTE: lifetime_helped on CharacterResonance persists (§13 — permanent record).
     # NOTE: TetherStrain ConditionInstance on the Sineater persists (decays naturally).
     # NOTE: Sineating and SoulTetherRescue audit rows persist (immutable history).
-    # NOTE: Trigger rows are cascade-deleted with ConditionInstance; no manual cleanup needed.
+    # NOTE: Trigger rows are cascade-deleted with ConditionInstance; invalidate() above
+    #       drops them from the in-memory cache on commit.
     # TODO: Phase 15 — emit SOUL_TETHER_DISSOLVED reactive event when event infrastructure
     #   supports cross-character location resolution.
 

--- a/src/world/magic/tests/test_soul_tether_services.py
+++ b/src/world/magic/tests/test_soul_tether_services.py
@@ -1558,6 +1558,26 @@ class DissolveSoulTetherSingleTests(TestCase):
         rel_in = CharacterRelationship.objects.get(source=self.sineater, target=self.sinner)
         self.assertEqual(rel_in.soul_tether_role, "")
 
+    def test_dissolution_invalidates_trigger_handler_cache(self) -> None:
+        # Populate the Sinner's handler so it caches the tether redirect trigger.
+        handler = self.sinner.character.trigger_handler
+        self.assertGreater(
+            len(handler.triggers_for("corruption_accruing")),
+            0,
+            "tether redirect trigger should be cached before dissolution",
+        )
+
+        # Dissolution cascade-deletes the Trigger rows; the cache must drop them
+        # on commit (#964), not keep dispatching phantom triggers.
+        with self.captureOnCommitCallbacks(execute=True):
+            self._dissolve()
+
+        self.assertEqual(
+            len(handler.triggers_for("corruption_accruing")),
+            0,
+            "dissolve left a stale tether trigger in the cache",
+        )
+
     def test_sinner_thread_retired_at_set(self) -> None:
         # Capture thread PK before dissolution so we can re-query by PK afterward.
         # Use .values() to avoid SharedMemoryModel identity-map returning a cached


### PR DESCRIPTION
## Summary

Makes the `TriggerHandler` in-memory cache rollback-safe. `on_trigger_added` / `on_trigger_removed` mutated the `_by_event` index **synchronously inside `transaction.atomic` blocks**, so a rollback left the cache out of sync with the DB — a **phantom trigger** (dispatches a never-committed row; a retry then double-appends → double-fire) or a **missing live trigger**. `dissolve_soul_tether` never invalidated at all, leaving a stale populated cache.

Closes #964.

## Changes

- **`flows/trigger_handler.py`** — new `invalidate()` registers a `transaction.on_commit` callback that clears `_by_event` and `_populated`; the next `triggers_for()` lazily re-reads committed rows. On rollback the callback is discarded, so a never-committed row never enters the cache. `on_trigger_added` / `on_trigger_removed` now route through `invalidate()` (signatures unchanged — the three call sites are untouched).
- **`world/magic/services/soul_tether.py`** — `dissolve_soul_tether` invalidates the Sinner's handler after the cascade delete (the issue's "dissolve never invalidates" bug).
- The method name follows the codebase-wide handler `.invalidate()` convention. The on-commit deferral (vs the *synchronous* sibling read-caches like `ConditionHandler`) is deliberate and documented: a phantom **trigger** double-fires (actively wrong), whereas a stale read-cache merely re-queries.

## Tests

- `flows/tests/test_trigger_handler/test_rollback_sync.py` (new) — a rolled-back install leaves no phantom; a rolled-back removal keeps the live trigger; a committed install is visible after commit. Both rollback tests fail on `main`, pass here.
- `test_soul_tether_services.py` — dissolve invalidates the cached tether triggers.
- `test_escalation_integration.py` — wraps its install in `transaction.captureOnCommitCallbacks(execute=True)`, since `on_commit` does not fire inside `TestCase`'s outer transaction.

Swept locally (sqlite fast tier): `flows`, `combat`, `conditions`, `vitals`, `checks`, `scenes`, and the magic trigger/soul-tether modules — all green (~2500 tests).

## Docs

`docs/architecture/reactive-layer-foundation.md` and `docs/systems/flows.md` updated for the on-commit invalidation contract (the old "mutate in place / handlers do not invalidate" wording was the pre-fix design).

## Notes

- Anti-reinvention: reuses the existing handler-`invalidate()` convention + the existing `_populate()`/`_populated` machinery; no new models/fields/enums/endpoints. Converging *all* sibling handlers onto a shared rollback-safe base is noted in the issue spec as a possible follow-up, intentionally out of scope here.
- Spec (with the anti-reinvention ledger) lives in the issue body; design was approved via `spec:approved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
