### PR TITLE
docs(#976): NPC clash contributions are authored-flat by design

### DIFF
--- a/docs/architecture/clash-design.md
+++ b/docs/architecture/clash-design.md
@@ -158,8 +158,10 @@ round. This mirrors the `CombatPull` / `CombatPullResolvedEffect` audit pattern.
      (see `outcome_to_delta` and `ClashConfig`). Power sets the magnitude; the check
      outcome is the quality gate.
    - Sum PC deltas; compute the NPC delta from the threat pattern (NPC-side
-     contributions remain on the `npc_delta` model — power-driving the NPC side is a
-     known follow-up); apply the affinity tilt (§8).
+     contributions remain on the `npc_delta` model — the NPC side stays authored-flat
+     **by design**: clash is PvE-asymmetric per the design pillars, so the NPC pushes an authored
+     magnitude rather than a power-scaled one; power-driving it was considered and
+     declined in #976); apply the affinity tilt (§8).
    - Write `ClashRound` + `ClashContribution` rows; update `clash.progress`.
    - Fire `per_round_consequence_pool` if set (visible incremental feedback).
    - Threshold check → if crossed, resolve (fire `resolution_consequence_pool`, set


### PR DESCRIPTION
## What

Records the resolution of #976: the NPC side of a clash **stays authored-flat by design** — it is not an unfinished symmetry.

#858 made PC clash contributions power-driven (`round(power × quality × scale)`) and left the NPC side deriving its per-round push from authored `ThreatPoolEntry` fields, flagged in `clash-design.md` as a "known follow-up." That follow-up (#976) asked whether to power-drive the NPC side for a symmetric contest.

Decision: **no.** Clash is PvE-asymmetric (a core design pillar): PCs push with power-scaled, quality-modulated, strain-escalating force; the NPC pushes an authored magnitude. Bosses are fixed walls by intent, not by omission.

## Change

- `docs/architecture/clash-design.md` — retire the "known follow-up" hedge on the NPC-delta step; state the authored-flat asymmetry is by design and reference the PvE-asymmetric pillar.

No code changes; `npc_round_contribution` / `aggregate_clash_round` are unchanged.

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)