### PR TITLE
Swarm target-fanning + #875 test-coverage polish

### DIFF
--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -279,7 +279,11 @@ Full design: `docs/plans/2026-04-05-party-combat-design.md`
   scales attritionally — `select_npc_actions` emits
   `clamp(ceil(swarm_count / bodies_per_attack), 1, acting_PCs)` attacks/round
   (the one-action-per-opponent unique constraint was dropped; `resolve_round`
-  resolves every swarm action). **Hero Killer** is unbeatable: damage never sets
+  resolves every swarm action). Those attacks **fan across distinct PCs**
+  (#983): single-target selection rotates round-robin per attack, so a swarm
+  spreads over the party rather than dogpiling the first PC — realizing the
+  intent behind capping the count at acting-PC count. **Hero Killer** is
+  unbeatable: damage never sets
   DEFEATED, `_classify_encounter_outcome` forbids VICTORY while one is present, so
   the only resolution is fleeing (FLED via the existing flee pipeline). A derived
   `CombatEncounter.forced_escape` property drives a "you must run" banner in the

--- a/frontend/src/combat/__tests__/CombatTurnPanel.test.tsx
+++ b/frontend/src/combat/__tests__/CombatTurnPanel.test.tsx
@@ -499,6 +499,32 @@ describe('CombatTurnPanel — encounter outcome banner (#876)', () => {
   });
 });
 
+describe('CombatTurnPanel — forced escape banner wiring (#983)', () => {
+  it('renders the ForcedEscapeBanner in live panel state when forced_escape is true', () => {
+    mockEncounter({ is_participant: true, forced_escape: true });
+
+    render(<CombatTurnPanel encounterId={1} characterId={10} characterSheetId={100} />, {
+      wrapper: createWrapper(),
+    });
+
+    const banner = screen.getByRole('alert');
+    expect(banner).toHaveTextContent(/you must run/i);
+    // Wired into the live panel alongside the normal sections, not in place of them.
+    expect(screen.getByTestId('round-flow-section')).toBeInTheDocument();
+  });
+
+  it('does not render the ForcedEscapeBanner when forced_escape is false', () => {
+    mockEncounter({ is_participant: true, forced_escape: false });
+
+    render(<CombatTurnPanel encounterId={1} characterId={10} characterSheetId={100} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByText(/you must run/i)).not.toBeInTheDocument();
+  });
+});
+
 describe('CombatTurnPanel — Open Encounter join/leave', () => {
   it('shows Join button for non-participant in open encounter between rounds', () => {
     mockEncounter({

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -1540,8 +1540,16 @@ def _get_eligible_entries(
 def _select_targets(
     entry: ThreatPoolEntry,
     active_participants: list[CombatParticipant],
+    rotation: int = 0,
 ) -> list[CombatParticipant]:
-    """Select targets for a threat pool entry from active participants."""
+    """Select targets for a threat pool entry from active participants.
+
+    ``rotation`` offsets the deterministic (non-random, non-health-sorted)
+    selection so a swarm's successive attacks fan across distinct PCs rather
+    than dogpiling the first one (#983). It is a no-op for the ALL, RANDOM, and
+    LOWEST_HEALTH modes, which already spread across or intentionally focus the
+    party on their own terms.
+    """
     if not active_participants:
         return []
 
@@ -1577,8 +1585,12 @@ def _select_targets(
 
     # TODO: SPECIFIC_ROLE should prioritize tank covenant role (aggro system)
     # TODO: HIGHEST_THREAT should use a threat tracking mechanic (not yet built)
-    # Placeholder: pick first active participants by DB order
-    return list(active_participants[:count])
+    # Placeholder: pick active participants by DB order, rotated so a swarm's
+    # successive attacks fan across distinct PCs instead of all landing on the
+    # first one (#983).
+    offset = rotation % len(active_participants)
+    rotated = active_participants[offset:] + active_participants[:offset]
+    return list(rotated[:count])
 
 
 def _batch_fetch_cooldown_data(
@@ -1701,10 +1713,10 @@ def select_npc_actions(
         else:
             n_attacks = 1
 
-        for _ in range(n_attacks):
+        for attack_index in range(n_attacks):
             weights = [e.weight for e in eligible]
             chosen = random.choices(eligible, weights=weights, k=1)[0]  # noqa: S311
-            targets = _select_targets(chosen, active_participants)
+            targets = _select_targets(chosen, active_participants, rotation=attack_index)
             action = CombatOpponentAction.objects.create(
                 opponent=opponent,
                 round_number=encounter.round_number,

--- a/src/world/combat/tests/test_hero_killer.py
+++ b/src/world/combat/tests/test_hero_killer.py
@@ -1,7 +1,10 @@
 """Hero Killer tier (#875): unbeatable, victory-blocked, escape-only."""
 
 from django.test import TestCase
+from rest_framework.test import APIClient
 
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.constants import EncounterOutcome, OpponentStatus, ParticipantStatus
 from world.combat.factories import (
     CombatEncounterFactory,
@@ -9,6 +12,8 @@ from world.combat.factories import (
     HeroKillerOpponentFactory,
 )
 from world.combat.services import _classify_encounter_outcome, apply_damage_to_opponent
+from world.roster.factories import RosterTenureFactory
+from world.scenes.factories import SceneFactory, SceneParticipationFactory
 
 
 class HeroKillerDamageTests(TestCase):
@@ -48,3 +53,51 @@ class HeroKillerEscapeArcTests(TestCase):
         CombatParticipantFactory(encounter=encounter, status=ParticipantStatus.FLED)
         self.assertEqual(_classify_encounter_outcome(encounter), EncounterOutcome.FLED)
         self.assertTrue(encounter.forced_escape)
+
+
+class ForcedEscapeSerializerTests(TestCase):
+    """EncounterDetailSerializer emits forced_escape in the API payload (#983).
+
+    The model property is covered by ForcedEscapeFlagTests; this asserts the
+    serializer contract — that the detail endpoint actually surfaces the flag,
+    so the frontend's ForcedEscapeBanner has live state to react to.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.account = AccountFactory(username="forced_escape_player")
+        cls.character = CharacterFactory(db_key="forcedescapechar")
+        cls.sheet = CharacterSheetFactory(character=cls.character)
+        cls.tenure = RosterTenureFactory(
+            roster_entry__character_sheet__character=cls.character,
+            player_data__account=cls.account,
+        )
+        cls.scene = SceneFactory()
+        SceneParticipationFactory(scene=cls.scene, account=cls.account, is_gm=False)
+
+    def setUp(self) -> None:
+        # Fresh encounter per test — the SharedMemoryModel identity map would
+        # otherwise leak cached prefetch attrs across tests.
+        self.encounter = CombatEncounterFactory(scene=self.scene)
+        CombatParticipantFactory(encounter=self.encounter, character_sheet=self.sheet)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.account)
+
+    def _get_detail(self) -> dict:
+        response = self.client.get(f"/api/combat/{self.encounter.pk}/")
+        self.assertEqual(response.status_code, 200)
+        return response.data  # type: ignore[return-value]
+
+    def test_forced_escape_true_with_active_hero_killer(self) -> None:
+        HeroKillerOpponentFactory(encounter=self.encounter)
+
+        data = self._get_detail()
+
+        self.assertIn("forced_escape", data)
+        self.assertTrue(data["forced_escape"])
+
+    def test_forced_escape_false_without_hero_killer(self) -> None:
+        data = self._get_detail()
+
+        self.assertIn("forced_escape", data)
+        self.assertFalse(data["forced_escape"])

--- a/src/world/combat/tests/test_swarm.py
+++ b/src/world/combat/tests/test_swarm.py
@@ -88,6 +88,34 @@ class SwarmOffenseTests(TestCase):
         swarm_actions = [a for a in actions if a.opponent_id == swarm.pk]
         self.assertEqual(len(swarm_actions), 2)
 
+    def test_swarm_fans_attacks_across_distinct_pcs(self):
+        """A swarm's multiple actions spread over distinct PCs, not one (#983).
+
+        The default threat entry targets SINGLE/SPECIFIC_ROLE, which resolves
+        deterministically; before fanning, every swarm action piled onto the
+        same first PC. With ≥2 acting PCs and ≥2 attacks, each action should
+        land on a distinct PC.
+        """
+        encounter = CombatEncounterFactory(status=EncounterStatus.DECLARING)
+        pool = ThreatPoolFactory()
+        ThreatPoolEntryFactory(pool=pool)
+        # 30 bodies / 6 per attack = 5 raw, capped at 3 acting PCs → 3 actions.
+        swarm = SwarmOpponentFactory(
+            encounter=encounter,
+            swarm_count=30,
+            bodies_per_attack=6,
+            threat_pool=pool,
+        )
+        participants = [CombatParticipantFactory(encounter=encounter) for _ in range(3)]
+
+        actions = select_npc_actions(encounter)
+
+        swarm_actions = [a for a in actions if a.opponent_id == swarm.pk]
+        self.assertEqual(len(swarm_actions), 3)
+        # Each action is single-target; collect the one PC each hit.
+        targeted_ids = {a.targets.get().pk for a in swarm_actions}
+        self.assertEqual(targeted_ids, {p.pk for p in participants})
+
 
 class SwarmResolutionTests(TestCase):
     """End-to-end: a multi-action swarm resolves multiple attacks per round (#875).


### PR DESCRIPTION
Closes #983

## Summary

Swarm attacks now fan across distinct PCs instead of all landing on the first one. `select_npc_actions` passes a per-attack rotation index into `_select_targets`, which round-robins the deterministic (SINGLE/SPECIFIC_ROLE) selection across the active party — realizing the intent behind capping a swarm's attack count at acting-PC count. No-op for ALL/RANDOM/LOWEST_HEALTH modes. Also closes the two deferred #875 coverage gaps: a backend test that `EncounterDetailSerializer` emits `forced_escape` (with and without an active Hero Killer), and a `CombatTurnPanel` wiring test that the `ForcedEscapeBanner` renders from live `forced_escape` state. Roadmap updated.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #983 (in the issue body)
- Brainstorm/plan: skipped (well-specified test-coverage polish from #875 with acceptance criteria already in the issue body; per user direction)
- Sync-with-main: Rebased onto origin/main cleanly (no conflicts).

<!-- last-addressed-comment: 0 -->