### PR TITLE
stage_crossing milestones render ELIGIBLE for crossings already made

### DIFF
--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -141,6 +141,11 @@ authoring is separate.
   recurring at each crossing), 11 codex entries (resonance/motif public, rest gated), and
   `PathCodexGrant` rows for all active Prospect paths. `PathCodexGrant` is now consumed at
   CG finalize via `_finalize_path_codex_grants` (mirrors the tradition grant).
+- `stage_crossing` milestones (#1007) resolve as a retrospective journey record, not a
+  CTA: LOCKED while the stage is ahead, ALREADY_HAVE once reached (read from current path
+  stage, so it covers every crossing mechanism — the level-3 crossing, Audere Majora, or
+  staff action — not just `AudereMajoraCrossing` receipts), and never ELIGIBLE. Resolved
+  ahead of the Mage-Scars / protagonism spend locks, which only gate spendable advancement.
 
 ## What's Needed for MVP
 

--- a/src/world/magic/services/progression_dashboard.py
+++ b/src/world/magic/services/progression_dashboard.py
@@ -110,17 +110,31 @@ def _already_have(kind: str, prefetched: _Prefetched) -> bool:
         return prefetched.anima_exists
     if kind == MagicMilestoneKind.SECOND_GIFT:
         return prefetched.gift_count >= 2  # noqa: PLR2004 — "second" gift is domain meaning
-    # TECHNIQUE_DEVELOPMENT, STAGE_CROSSING, and any future kinds default to False
+    # TECHNIQUE_DEVELOPMENT and any future kinds default to False. STAGE_CROSSING is
+    # resolved earlier in _resolve_eligibility (purely on path stage) and never
+    # reaches here.
     return False
 
 
-def _resolve_eligibility(
+def _resolve_eligibility(  # noqa: PLR0911
     sheet: CharacterSheet,
     milestone: MagicProgressionMilestone,
     current_stage: int,
     prefetched: _Prefetched,
 ) -> tuple[str, list[str], int | None]:
     """Compute eligibility, missing requirements list, and xp_cost for a KNOWN milestone."""
+    if milestone.kind == MagicMilestoneKind.STAGE_CROSSING:
+        # A crossing is a retrospective journey record, not a dashboard CTA: it is
+        # performed in play (the level-3 Prospect->Potential crossing, an Audere
+        # Majora crossing, or staff action), never from this dashboard. So it is
+        # LOCKED while the stage is ahead and ALREADY_HAVE once reached (by any
+        # mechanism — reached-ness reads from current path stage), and is never
+        # ELIGIBLE. Resolved before the Mage-Scars / protagonism spend locks below:
+        # those gate spendable advancement, which a past crossing is not.
+        if current_stage < milestone.stage:
+            stage_label = PathStage(milestone.stage).label
+            return MilestoneEligibility.LOCKED, [f"Reach {stage_label}"], None
+        return MilestoneEligibility.ALREADY_HAVE, [], None
     if has_pending_alterations(sheet):
         return MilestoneEligibility.LOCKED, ["Resolve your Mage Scars first"], None
     if sheet.is_protagonism_locked:

--- a/src/world/magic/tests/test_progression_dashboard.py
+++ b/src/world/magic/tests/test_progression_dashboard.py
@@ -226,6 +226,97 @@ class ProgressionDashboardTests(TestCase):
             assert sv.milestones == []
 
 
+class StageCrossingMilestoneTests(TestCase):
+    """stage_crossing milestones are a retrospective journey record.
+
+    They are LOCKED while the stage is ahead and ALREADY_HAVE once it is reached
+    (by any mechanism), and are never ELIGIBLE — a crossing is performed in play,
+    not from the dashboard. "Reached" is derived from the character's current path
+    stage, not from AudereMajoraCrossing receipts (the level-3 Prospect->Potential
+    crossing mints no receipt, and Audere thresholds only exist at 5/10/15/20).
+    """
+
+    def setUp(self):
+        self.sheet = CharacterSheetFactory()
+
+    def _set_current_stage(self, stage):
+        """Advance the character's path stage by writing a CharacterPathHistory row."""
+        from world.classes.factories import PathFactory
+        from world.progression.factories import CharacterPathHistoryFactory
+
+        path = PathFactory(name=f"Test Path Stage {int(stage)}", stage=stage)
+        CharacterPathHistoryFactory(character=self.sheet.character, path=path)
+
+    def _crossing_milestone(self, stage):
+        """Create a KNOWN (public) stage_crossing milestone at the destination stage."""
+        from world.codex.factories import CodexEntryFactory
+        from world.magic.factories import MagicProgressionMilestoneFactory
+
+        entry = CodexEntryFactory(
+            is_public=True, name=f"Crossing to {int(stage)}", summary="A crossing."
+        )
+        return MagicProgressionMilestoneFactory(
+            stage=stage, kind=MagicMilestoneKind.STAGE_CROSSING, codex_entry=entry
+        )
+
+    def _crossing_view(self, stage):
+        from world.magic.services.progression_dashboard import build_progression_dashboard
+
+        result = build_progression_dashboard(self.sheet)
+        stage_view = next(sv for sv in result if sv.stage == stage)
+        assert len(stage_view.milestones) == 1
+        return stage_view.milestones[0]
+
+    def test_crossing_ahead_of_current_stage_is_locked(self):
+        """current_stage < milestone.stage → LOCKED with a 'Reach <Stage>' hint."""
+        from world.classes.models import PathStage
+
+        # Character stays at the default Prospect (stage 1).
+        self._crossing_milestone(PathStage.PUISSANT)
+        mv = self._crossing_view(PathStage.PUISSANT)
+        assert mv.eligibility == MilestoneEligibility.LOCKED
+        assert "Puissant" in mv.missing[0]
+
+    def test_crossing_at_current_stage_is_already_have(self):
+        """current_stage == milestone.stage → ALREADY_HAVE (the crossing was made)."""
+        from world.classes.models import PathStage
+
+        self._set_current_stage(PathStage.POTENTIAL)
+        self._crossing_milestone(PathStage.POTENTIAL)
+        mv = self._crossing_view(PathStage.POTENTIAL)
+        assert mv.eligibility == MilestoneEligibility.ALREADY_HAVE
+        assert mv.missing == []
+
+    def test_crossing_below_current_stage_is_already_have(self):
+        """current_stage > milestone.stage → ALREADY_HAVE (crossing long passed)."""
+        from world.classes.models import PathStage
+
+        self._set_current_stage(PathStage.PUISSANT)
+        self._crossing_milestone(PathStage.POTENTIAL)
+        mv = self._crossing_view(PathStage.POTENTIAL)
+        assert mv.eligibility == MilestoneEligibility.ALREADY_HAVE
+
+    def test_reached_crossing_is_never_eligible(self):
+        """A reached crossing is ALREADY_HAVE, never ELIGIBLE (it is not a dashboard CTA)."""
+        from world.classes.models import PathStage
+
+        self._set_current_stage(PathStage.POTENTIAL)
+        self._crossing_milestone(PathStage.POTENTIAL)
+        mv = self._crossing_view(PathStage.POTENTIAL)
+        assert mv.eligibility != MilestoneEligibility.ELIGIBLE
+
+    def test_reached_crossing_with_pending_alterations_stays_already_have(self):
+        """The retrospective record is not gated by the Mage-Scars spend lock."""
+        from world.classes.models import PathStage
+        from world.magic.factories import PendingAlterationFactory
+
+        self._set_current_stage(PathStage.POTENTIAL)
+        self._crossing_milestone(PathStage.POTENTIAL)
+        PendingAlterationFactory(character=self.sheet)
+        mv = self._crossing_view(PathStage.POTENTIAL)
+        assert mv.eligibility == MilestoneEligibility.ALREADY_HAVE
+
+
 # =============================================================================
 # Progression Dashboard API endpoint tests
 # =============================================================================


### PR DESCRIPTION
Closes #1007

## Summary

Resolve `stage_crossing` progression-dashboard milestones as a retrospective journey record — **LOCKED** while the stage is ahead, **ALREADY_HAVE** once reached, **never ELIGIBLE**. Previously `_resolve_eligibility` had no `stage_crossing` branch, so a milestone defaulted to ELIGIBLE once its destination stage was reached, advertising a crossing already made as a still-available to-do.

"Reached" derives from the character's current path stage (mechanism-agnostic), not from `AudereMajoraCrossing` receipts — the level-3 Prospect→Potential crossing mints no receipt and Audere thresholds exist only at 5/10/15/20, so a receipt check would leave several crossings stuck on ELIGIBLE. Resolved ahead of the Mage-Scars / protagonism spend locks, which only gate spendable advancement.

One new branch in `_resolve_eligibility` + a stale-comment fix; no new surfaces, no matrix change. Tests: LOCKED-ahead, ALREADY_HAVE at/below stage, never-ELIGIBLE, and ALREADY_HAVE-despite-pending-alterations. Roadmap doc updated.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1007 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto origin/main; no conflicts.

<!-- last-addressed-comment: 0 -->