### PR TITLE
Converge the two combat-declaration paths (DeclareActionSerializer vs /dispatch/)

### DIFF
--- a/docs/architecture/unified-player-action.md
+++ b/docs/architecture/unified-player-action.md
@@ -26,8 +26,8 @@ surfaces**, each grown independently:
 3. **`world/scenes/action_availability.get_available_scene_actions`** — a third
    availability path, DB-driven via `ActionTemplate.objects.filter(category="social")`.
 4. **Combat** — entirely bespoke: `declare_action` service
-   (`src/world/combat/services.py:757`), `DeclareActionSerializer`
-   (`src/world/combat/serializers.py:355-386`), `resolve_round` view
+   (`src/world/combat/services.py:757`), ~~`DeclareActionSerializer`~~
+   (retired in #987 — see below), `resolve_round` view
    (`src/world/combat/views.py:140`).
 
 ### The two diagnostic bugs (both confirmed at the view layer; service layer is wired)
@@ -44,9 +44,12 @@ surfaces**, each grown independently:
   (`resolve_combat_technique`, `:431-483`) is fully wired and requires a
   non-optional `offense_check_type: CheckType`.
   Additionally `focused_ally_target` is hardcoded `None`
-  (`src/world/combat/views.py:290`) and **absent from
+  (`src/world/combat/views.py:290`) and **absent from the (now-retired)
   `DeclareActionSerializer`**, so no self-cast / buff / ally-target technique
-  can ever be declared — though `declare_action` accepts the parameter.
+  could ever be declared via that path — though `declare_action` accepts the
+  parameter. **Fixed in #987:** `focused_ally_target` is now accepted by the
+  unified `/dispatch/` path (`dispatch_player_action` →
+  `CombatRoundContext.record_declaration` → `_record_combat_declaration`).
 - **#2 — challenge player-resolution path missing.** `resolve_challenge`
   (`src/world/mechanics/challenge_resolution.py:46-51`) is a solid resolution
   primitive, but there is **no player-facing dispatch endpoint** that calls it.
@@ -101,7 +104,7 @@ it. Scope = "player does thing with their character."
    `offense_check_type` from `Technique.action_template.check_type`;
    `action_template` becomes **required** for combat-usable techniques (explicit
    config error, no silent no-op, no "legacy"). Add `focused_ally_target` to the
-   declare path. **This is the #1 fix.**
+   `/dispatch/` path. **This is the #1 fix.**
 4. **Combat-agnostic tempo seam** — `get_active_round_context(character)`;
    combat is the sole implementor; no general-scene provider, no plugin
    framework.
@@ -139,7 +142,7 @@ it. Scope = "player does thing with their character."
 model, and its own roadmap (`src/actions/CLAUDE.md:96-114`) names exactly these
 missing pieces ("CharacterCapabilities facade," "On-Demand Action
 Availability," generic dispatch). No new app. Challenge logic stays in
-`world/mechanics`; combat declare stays in `world/combat`. `src/actions/`
+`world/mechanics`; `declare_action` service stays in `world/combat`. `src/actions/`
 **aggregates and routes**; it does not absorb the backends.
 
 **Spine — resolved `CheckType`.** Every player action descriptor resolves to a
@@ -259,12 +262,18 @@ them costs a round is pre-existing combat-design, not this interface's concern.
 - The silent `if offense_check_type is not None` no-op guard is **deleted**. A
   combat-usable technique with no `action_template` is a configuration error
   that raises a typed exception, never a silent skip.
-- Validation that a declared technique has an `action_template` lives in
-  `DeclareActionSerializer` (validation in serializers, not services/views).
-- `focused_ally_target` is **added to `DeclareActionSerializer`**
-  (`src/world/combat/serializers.py:355-386`) and the
-  `src/world/combat/views.py:290` hardcoded `None` removed. `declare_action`
-  already accepts it.
+- Validation that a declared technique has an `action_template` is enforced by
+  `CombatRoundContext._record_combat_declaration` inside the dispatch path
+  (validation before calling `declare_action`). The former
+  `DeclareActionSerializer` and the `/api/combat/{id}/declare/` view were
+  **retired in #987**; `dispatch_player_action` →
+  `CombatRoundContext.record_declaration` → `_record_combat_declaration` is now
+  the single combat-declaration authority. [BUILT & WIRED]
+- `focused_ally_target` is now accepted through the unified
+  `/api/actions/characters/{id}/dispatch/` endpoint (the hardcoded `None` in
+  the old `src/world/combat/views.py:290` is gone with the retired view).
+  `declare_action` already accepted it; the fix was exposing it at the call
+  site. [BUILT & WIRED]
 
 ## 6. Surfaces
 
@@ -349,8 +358,9 @@ CI's fresh DB).
 | `declare_action` | `src/world/combat/services.py:757` |
 | `resolve_round` service / `_resolve_pc_action` gate | `src/world/combat/services.py:1977`, `:1720`, `:1764-1773` |
 | `resolve_combat_technique` | `src/world/combat/services.py:431-483` |
-| `resolve_round` view / hardcoded `focused_ally_target` | `src/world/combat/views.py:140-149`, `:290` |
-| `DeclareActionSerializer` (no `focused_ally_target`) | `src/world/combat/serializers.py:355-386` |
+| `resolve_round` view / hardcoded `focused_ally_target` | `src/world/combat/views.py:140-149`, `:290` (hardcoded `None` removed in #987) |
+| ~~`DeclareActionSerializer`~~ (retired in #987) | ~~`src/world/combat/serializers.py:355-386`~~ — deleted |
+| `dispatch_player_action` → `CombatRoundContext.record_declaration` → `_record_combat_declaration` (sole declaration authority) [BUILT & WIRED] | `src/actions/dispatch.py`, `src/world/combat/round_context.py` |
 | `CombatEncounter` / `CombatParticipant` / `CombatRoundAction` | `src/world/combat/models.py:27-88`, `:385-422`, `:425-518` |
 | `Technique.action_template` (nullable) | `src/world/magic/models/techniques.py:225-351` |
 | `execute_action` inputfunc | `src/server/conf/inputfuncs.py:55-121` |

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -2284,23 +2284,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/combat/{id}/declare/': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** @description Declare actions for the current round. */
-    post: operations['combat_declare_create'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/api/combat/{id}/end/': {
     parameters: {
       query?: never;
@@ -26380,32 +26363,6 @@ export interface operations {
     };
   };
   combat_cover_create: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description A unique integer value identifying this combat encounter. */
-        id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['EncounterDetailRequest'];
-      };
-    };
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['EncounterDetail'];
-        };
-      };
-    };
-  };
-  combat_declare_create: {
     parameters: {
       query?: never;
       header?: never;

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -348,10 +348,9 @@ def _combat_actions(
 
     Candidate set: techniques the character knows that are combat-usable
     (``technique.action_template is not None``).  This is the SAME gate
-    ``DeclareActionSerializer.validate`` enforces — availability surfaces
-    candidates only; authoritative per-target / passive-slot / status
-    validation happens at declare/dispatch time (``DeclareActionSerializer.validate``
-    / ``CombatRoundContext.record_declaration``).
+    the dispatch path enforces — availability surfaces candidates only;
+    authoritative per-target / passive-slot / status validation happens
+    at dispatch time (``CombatRoundContext.record_declaration``).
 
     Args:
         character: The character's ``ObjectDB`` instance.

--- a/src/schema.json
+++ b/src/schema.json
@@ -3275,33 +3275,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/EncounterDetail'
           description: ''
-  /api/combat/{id}/declare/:
-    post:
-      operationId: combat_declare_create
-      description: Declare actions for the current round.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this combat encounter.
-        required: true
-      tags:
-      - combat
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EncounterDetailRequest'
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EncounterDetail'
-          description: ''
   /api/combat/{id}/end/:
     post:
       operationId: combat_end_create

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -6,12 +6,10 @@ from typing import TYPE_CHECKING, Any, cast
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Prefetch
-from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema_field
 from evennia.accounts.models import AccountDB
 from rest_framework import serializers
 
-from actions.errors import ActionDispatchError
 from world.combat.constants import (
     NO_ROLE_SPEED_RANK,
     ActionCategory,
@@ -32,7 +30,6 @@ from world.combat.models import (
 )
 from world.conditions.serializers import ConditionInstanceSerializer
 from world.conditions.services import get_active_conditions
-from world.fatigue.constants import EffortLevel
 from world.fatigue.services import get_fatigue_capacity
 from world.magic.models import CharacterTechnique, Technique
 from world.mechanics.constants import EngagementType
@@ -1004,59 +1001,6 @@ class EncounterDetailSerializer(serializers.ModelSerializer):
 # ---------------------------------------------------------------------------
 # Write serializers
 # ---------------------------------------------------------------------------
-
-
-class DeclareActionSerializer(serializers.Serializer):
-    """Write serializer for action declaration."""
-
-    focused_action = serializers.IntegerField(
-        required=False,
-        allow_null=True,
-    )
-    focused_category = serializers.ChoiceField(
-        choices=ActionCategory.choices,
-        required=False,
-        allow_null=True,
-    )
-    effort_level = serializers.ChoiceField(
-        choices=EffortLevel.choices,
-        default=EffortLevel.MEDIUM,
-    )
-    focused_opponent_target = serializers.IntegerField(
-        required=False,
-        allow_null=True,
-    )
-    focused_ally_target = serializers.IntegerField(
-        required=False,
-        allow_null=True,
-    )
-    physical_passive = serializers.IntegerField(
-        required=False,
-        allow_null=True,
-    )
-    social_passive = serializers.IntegerField(
-        required=False,
-        allow_null=True,
-    )
-    mental_passive = serializers.IntegerField(
-        required=False,
-        allow_null=True,
-    )
-
-    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        """Validate that a focused_action technique is combat-ready."""
-        focused_action_id = attrs.get("focused_action")
-        if focused_action_id is not None:
-            technique = get_object_or_404(Technique, pk=focused_action_id)
-            if technique.action_template is None:
-                raise serializers.ValidationError(
-                    {
-                        "focused_action": ActionDispatchError(
-                            ActionDispatchError.TECHNIQUE_NOT_COMBAT_READY
-                        ).user_message,
-                    }
-                )
-        return attrs
 
 
 class RemoveParticipantSerializer(serializers.Serializer):

--- a/src/world/combat/tests/test_focused_target_dispatch.py
+++ b/src/world/combat/tests/test_focused_target_dispatch.py
@@ -29,8 +29,10 @@ from world.combat.factories import (
 from world.combat.models import CombatRoundAction
 from world.fatigue.constants import EffortLevel
 from world.magic.factories import (
+    BinaryEffectTypeFactory,
     CharacterTechniqueFactory,
     EffectTypeFactory,
+    TechniqueAppliedConditionFactory,
     TechniqueFactory,
 )
 from world.vitals.models import CharacterVitals
@@ -191,3 +193,56 @@ class TestFocusedTargetEndToEnd(django.test.TestCase):
         ).first()
         assert row is not None
         self.assertEqual(row.focused_opponent_target_id, self.opponent.pk)
+
+
+class TestFocusedAllyTargetDispatch(django.test.TestCase):
+    """Drive the REAL ``dispatch_player_action`` entry point with an ally target id."""
+
+    def setUp(self) -> None:
+        from evennia.utils.idmapper import models as idmapper_models
+
+        idmapper_models.flush_cache()
+
+        self.encounter = CombatEncounterFactory(
+            status=EncounterStatus.DECLARING,
+            round_number=1,
+        )
+        self.participant = CombatParticipantFactory(
+            encounter=self.encounter,
+            status=ParticipantStatus.ACTIVE,
+        )
+        self.sheet = self.participant.character_sheet
+        self.character = self.sheet.character
+        CharacterVitals.objects.create(
+            character_sheet=self.sheet,
+            health=100,
+            max_health=100,
+        )
+
+    def test_focused_ally_target_id_persisted(self) -> None:
+        """A self/ally-cast technique dispatched with focused_ally_target_id persists the ally."""
+        ally = CombatParticipantFactory(encounter=self.encounter, status=ParticipantStatus.ACTIVE)
+        # Buff (no base_power → no forced opponent target); one ally-kind condition row
+        technique = TechniqueFactory(
+            effect_type=BinaryEffectTypeFactory(),
+            damage_profile=False,
+            action_category=ActionCategory.PHYSICAL,
+            action_template=ActionTemplateFactory(),
+        )
+        TechniqueAppliedConditionFactory(technique=technique, target_kind="ally")
+        CharacterTechniqueFactory(character=self.sheet, technique=technique)
+
+        ref = ActionRef(
+            backend=ActionBackend.COMBAT, technique_id=technique.pk, action_slot="focused"
+        )
+        dispatch_player_action(
+            self.character,
+            ref,
+            {"effort_level": EffortLevel.MEDIUM, "focused_ally_target_id": ally.pk},
+        )
+
+        row = CombatRoundAction.objects.filter(
+            participant=self.participant, round_number=self.encounter.round_number
+        ).first()
+        assert row is not None
+        self.assertEqual(row.focused_ally_target_id, ally.pk)

--- a/src/world/combat/tests/test_views.py
+++ b/src/world/combat/tests/test_views.py
@@ -7,13 +7,14 @@ from evennia.objects.models import ObjectDB
 from rest_framework import status as http_status
 from rest_framework.test import APIClient
 
+from actions.constants import ActionBackend
 from actions.errors import ActionDispatchError
 from actions.factories import ActionTemplateFactory
 from evennia_extensions.factories import AccountFactory, CharacterFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.checks.test_helpers import force_check_outcome
-from world.combat.constants import ActionCategory, EncounterStatus, EncounterType, ParticipantStatus
+from world.combat.constants import EncounterStatus, EncounterType, ParticipantStatus
 from world.combat.factories import (
     CombatEncounterFactory,
     CombatOpponentFactory,
@@ -27,6 +28,7 @@ from world.conditions.models import ConditionInstance
 from world.magic.factories import (
     BinaryEffectTypeFactory,
     CharacterAnimaFactory,
+    CharacterTechniqueFactory,
     EffectTypeFactory,
     TechniqueAppliedConditionFactory,
     TechniqueFactory,
@@ -737,15 +739,24 @@ class DeclareAndResolveE2ETest(TestCase):
         expected_condition_template = applied_condition_row.condition
 
         # --- Step 1: Player declares the technique targeting the opponent ---
+        # CharacterTechniqueFactory links the technique to the player's sheet so the
+        # COMBAT backend ref resolves (dispatch validates against current availability).
+        CharacterTechniqueFactory(character=self.player_sheet, technique=technique)
+
         client = APIClient()
         client.force_authenticate(user=self.player_account)
         declare_response = client.post(
-            f"/api/combat/{encounter.pk}/declare/",
+            f"/api/actions/characters/{self.player_character.pk}/dispatch/",
             {
-                "focused_action": technique.pk,
-                "focused_category": ActionCategory.PHYSICAL,
-                "effort_level": "medium",
-                "focused_opponent_target": opponent.pk,
+                "ref": {
+                    "backend": ActionBackend.COMBAT,
+                    "technique_id": technique.pk,
+                    "action_slot": "focused",
+                },
+                "kwargs": {
+                    "effort_level": "medium",
+                    "focused_opponent_target_id": opponent.pk,
+                },
             },
             format="json",
         )

--- a/src/world/combat/tests/test_views.py
+++ b/src/world/combat/tests/test_views.py
@@ -26,7 +26,6 @@ from world.combat.models import CombatOpponentAction, CombatRoundAction
 from world.conditions.factories import DamageSuccessLevelMultiplierFactory
 from world.conditions.models import ConditionInstance
 from world.magic.factories import (
-    BinaryEffectTypeFactory,
     CharacterAnimaFactory,
     CharacterTechniqueFactory,
     EffectTypeFactory,
@@ -262,24 +261,6 @@ class PlayerActionTest(CombatEncounterViewSetTestBase):
         )
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertIsNone(response.data)
-
-    def test_declare_non_participant_denied(self) -> None:
-        """Account with no participant in encounter gets 403."""
-        other_account = AccountFactory(username="outsider")
-        other_char = CharacterFactory(db_key="outsiderchar")
-        CharacterSheetFactory(character=other_char)
-        RosterTenureFactory(
-            roster_entry__character_sheet__character=other_char,
-            player_data__account=other_account,
-        )
-        client = APIClient()
-        client.force_authenticate(user=other_account)
-        response = client.post(
-            f"/api/combat/{self.encounter.pk}/declare/",
-            {"effort_level": "medium"},
-            format="json",
-        )
-        self.assertEqual(response.status_code, http_status.HTTP_403_FORBIDDEN)
 
     def test_ready_toggle(self) -> None:
         """Participant can toggle ready on their action if one exists."""
@@ -531,68 +512,6 @@ class PlayerActionTest(CombatEncounterViewSetTestBase):
         )
         self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["detail"], _ERR_DECLARE_FAILED)
-
-    def test_declare_ally_target_persisted_via_endpoint(self) -> None:
-        """Declaring a self/ally-cast technique via the DRF endpoint persists focused_ally_target.
-
-        This is the TDD red test: DeclareActionSerializer has no focused_ally_target
-        field, so the view hardcodes focused_ally_target=None, dropping the ally choice.
-        The test must fail because CombatRoundAction.focused_ally_target is None instead
-        of the ally participant.
-        """
-        # Buff effect type (no base_power → no damage → no forced opponent target)
-        buff_effect_type = BinaryEffectTypeFactory()
-        # Technique with action_template so serializer validation passes,
-        # and one ally-kind condition row so target-kind validation passes
-        technique = TechniqueFactory(
-            effect_type=buff_effect_type,
-            damage_profile=False,
-            action_template=ActionTemplateFactory(check_type=CheckTypeFactory()),
-        )
-        TechniqueAppliedConditionFactory(technique=technique, target_kind="ally")
-
-        # Fresh DECLARING encounter linked to the scene so setUpTestData doesn't interfere
-        declare_encounter = CombatEncounterFactory(
-            scene=self.scene,
-            status=EncounterStatus.DECLARING,
-            round_number=1,
-        )
-        # Caster — use player_sheet so player_account's played_character_sheet_ids matches
-        caster_participant = CombatParticipantFactory(
-            encounter=declare_encounter,
-            character_sheet=self.player_sheet,
-            status=ParticipantStatus.ACTIVE,
-        )
-        CharacterVitals.objects.get_or_create(
-            character_sheet=self.player_sheet,
-            defaults={"health": 100, "max_health": 100},
-        )
-        # Ally — a second participant in the same encounter
-        ally_participant = CombatParticipantFactory(
-            encounter=declare_encounter,
-            status=ParticipantStatus.ACTIVE,
-        )
-
-        client = APIClient()
-        client.force_authenticate(user=self.player_account)
-        response = client.post(
-            f"/api/combat/{declare_encounter.pk}/declare/",
-            {
-                "focused_action": technique.pk,
-                "focused_category": "physical",
-                "effort_level": "medium",
-                "focused_ally_target": ally_participant.pk,
-            },
-            format="json",
-        )
-        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
-
-        # Reload the persisted action and assert the ally target was stored
-        action = CombatRoundAction.objects.get(
-            participant=caster_participant,
-            round_number=declare_encounter.round_number,
-        )
-        self.assertEqual(action.focused_ally_target, ally_participant)
 
 
 class StaffAccessTest(TestCase):

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -42,7 +42,6 @@ from world.combat.serializers import (
     AddOpponentSerializer,
     AddParticipantSerializer,
     CoverSerializer,
-    DeclareActionSerializer,
     EncounterDetailSerializer,
     EncounterListSerializer,
     JoinEncounterSerializer,
@@ -56,7 +55,6 @@ from world.combat.services import (
     add_opponent,
     add_participant,
     begin_declaration_phase,
-    declare_action,
     declare_cover,
     declare_flee,
     end_encounter,
@@ -70,7 +68,6 @@ from world.combat.services import (
 )
 from world.conditions.models import ConditionInstance
 from world.covenants.models import CovenantRole
-from world.magic.models import Technique
 from world.scenes.constants import PersonaType
 from world.scenes.models import Persona
 from world.stories.pagination import StandardResultsSetPagination
@@ -98,7 +95,6 @@ class CombatEncounterViewSet(ModelViewSet):
         if self.action in ("list", "retrieve"):
             return [IsAuthenticated()]
         if self.action in (
-            "declare",
             "ready",
             "my_action",
             "available_combos",
@@ -435,75 +431,6 @@ class CombatEncounterViewSet(ModelViewSet):
         return self._serialize_encounter(request, encounter)
 
     # --- Player Actions ---
-
-    @action(detail=True, methods=[HTTPMethod.POST])
-    def declare(self, request: Request, pk: int | None = None) -> Response:
-        """Declare actions for the current round."""
-        encounter = self.get_object()
-        serializer = DeclareActionSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        participant = self._get_participant(request, encounter)
-        if not participant:
-            return Response(
-                {"detail": _ERR_NOT_PARTICIPANT},
-                status=status.HTTP_403_FORBIDDEN,
-            )
-        data = serializer.validated_data
-
-        # Resolve focused action FK
-        focused_action = None
-        focused_action_id = data.get("focused_action")
-        if focused_action_id:
-            focused_action = get_object_or_404(Technique, pk=focused_action_id)
-
-        # Resolve focused opponent target FK
-        focused_opponent_target = None
-        target_id = data.get("focused_opponent_target")
-        if target_id:
-            focused_opponent_target = get_object_or_404(
-                CombatOpponent,
-                pk=target_id,
-                encounter=encounter,
-            )
-
-        # Resolve focused ally target FK
-        focused_ally_target = None
-        ally_target_id = data.get("focused_ally_target")
-        if ally_target_id:
-            focused_ally_target = get_object_or_404(
-                CombatParticipant,
-                pk=ally_target_id,
-                encounter=encounter,
-            )
-
-        # Resolve passive technique FKs
-        passive_kwargs: dict[str, Technique | None] = {}
-        for passive_field in ("physical_passive", "social_passive", "mental_passive"):
-            passive_id = data.get(passive_field)
-            if passive_id:
-                passive_kwargs[passive_field] = get_object_or_404(
-                    Technique,
-                    pk=passive_id,
-                )
-
-        try:
-            declare_action(
-                participant,
-                focused_action=focused_action,
-                focused_category=data.get("focused_category"),
-                effort_level=data["effort_level"],
-                focused_opponent_target=focused_opponent_target,
-                focused_ally_target=focused_ally_target,
-                physical_passive=passive_kwargs.get("physical_passive"),
-                social_passive=passive_kwargs.get("social_passive"),
-                mental_passive=passive_kwargs.get("mental_passive"),
-            )
-        except ValueError:
-            return Response(
-                {"detail": _ERR_DECLARE_FAILED},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        return self._serialize_encounter(request, encounter)
 
     @action(detail=True, methods=[HTTPMethod.POST])
     def ready(self, request: Request, pk: int | None = None) -> Response:


### PR DESCRIPTION
Closes #987

## Summary

Converges the two parallel combat-declaration HTTP paths onto one authority. Both always funneled into the same declare_action() service; the duplication was purely at the HTTP entry layer.

- Retired DeclareActionSerializer + the encounter declare view (/api/combat/{id}/declare/) — it had no client caller (the React combat UI and all flows use /dispatch/).
- The unified /dispatch/ path (dispatch_player_action → CombatRoundContext.record_declaration → _record_combat_declaration) is now the single combat-declaration authority. Keeper logic (declare_action, _record_combat_declaration, _resolve_focused_targets) is untouched.
- Coverage moved to the dispatch path: added focused_ally_target_id persistence (a real gap — existing dispatch tests only covered opponent targets) and migrated the declare→resolve damage/condition E2E regression to declare via /dispatch/ (still asserts 100→80 damage + condition through the HTTP endpoint).
- Removed the 2 orphaned endpoint tests + dead imports; regenerated the OpenAPI schema + frontend types (drops combat_declare_create); updated docs/architecture/unified-player-action.md to mark the surfaces retired.

Behavior note: non-participant protection shifts from a 403 membership check to a 400 UNKNOWN_ACTION_REF availability check on the dispatch path — intentional and arguably more correct (availability-based, not membership-based); covered by existing dispatch non-owner + stale-ref tests.

Tests: combat (1172) + actions (349) SQLite tiers green. (~15 pre-existing Postgres-only DISTINCT ON errors in world.combat are unrelated, verified against base.)

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #987 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto latest origin/main (5 commits) — no conflicts.

<!-- last-addressed-comment: 0 -->