### PR TITLE
Pin slice-2 privacy invariants as tests (#1109, non-player-facing half)

### DIFF
--- a/src/world/forms/tests/test_descriptor_privacy_invariant.py
+++ b/src/world/forms/tests/test_descriptor_privacy_invariant.py
@@ -1,0 +1,57 @@
+"""The descriptor privacy invariant (#1109, slice 2).
+
+> A descriptor is authored independently per persona and never auto-attaches from another
+> persona of the same character — blank by default, no "copy from my real face" pre-fill,
+> no template that carries it over.
+
+Outing-by-descriptor is only possible when one distinctive string lands on two personas of
+the *same* character. The structural absence of any copy/pre-fill path makes accidental
+cross-persona sameness impossible; deliberate reuse (a chosen tell) stays available because
+each descriptor is authored explicitly. These tests pin that guarantee.
+"""
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.forms.factories import FormTraitFactory, PersonaTraitDescriptorFactory
+from world.forms.models import PersonaTraitDescriptor
+from world.scenes.factories import PersonaFactory
+
+
+class DescriptorPrivacyInvariantTests(TestCase):
+    def test_a_new_persona_is_born_with_no_descriptors(self) -> None:
+        sheet = CharacterSheetFactory()
+        # The PRIMARY persona created with the sheet carries no descriptors.
+        assert not PersonaTraitDescriptor.objects.filter(persona=sheet.primary_persona).exists()
+        # A freshly created sibling persona is likewise blank.
+        sibling = PersonaFactory(character_sheet=sheet)
+        assert not PersonaTraitDescriptor.objects.filter(persona=sibling).exists()
+
+    def test_a_sibling_descriptor_never_attaches_to_another_face(self) -> None:
+        """Bob's "Rusty Auburn" must never bleed onto Robert — the core outing guard."""
+        sheet = CharacterSheetFactory()
+        bob = sheet.primary_persona
+        trait = FormTraitFactory()
+        PersonaTraitDescriptorFactory(persona=bob, trait=trait, text="Rusty Auburn")
+
+        # Creating Robert on the same body copies nothing.
+        robert = PersonaFactory(character_sheet=sheet)
+
+        assert not PersonaTraitDescriptor.objects.filter(persona=robert).exists()
+        # Bob keeps his; Robert has none for that trait — no cross-persona sameness.
+        assert PersonaTraitDescriptor.objects.get(persona=bob, trait=trait).text == "Rusty Auburn"
+        assert not PersonaTraitDescriptor.objects.filter(persona=robert, trait=trait).exists()
+
+    def test_deliberate_reuse_is_allowed_because_each_is_authored_explicitly(self) -> None:
+        """A chosen tell (the same descriptor on two faces) is permitted — only the
+        accidental/default carry-over is structurally impossible. Authoring each on purpose
+        is the supported path, so the same string can appear twice when intended."""
+        sheet = CharacterSheetFactory()
+        bob = sheet.primary_persona
+        robert = PersonaFactory(character_sheet=sheet)
+        trait = FormTraitFactory()
+
+        PersonaTraitDescriptorFactory(persona=bob, trait=trait, text="a livid scar")
+        PersonaTraitDescriptorFactory(persona=robert, trait=trait, text="a livid scar")
+
+        assert PersonaTraitDescriptor.objects.filter(trait=trait, text="a livid scar").count() == 2

--- a/src/world/scenes/tests/test_persona_freeze.py
+++ b/src/world/scenes/tests/test_persona_freeze.py
@@ -1,0 +1,32 @@
+"""Recorded scenes freeze the presented persona (#1109, slice 2).
+
+A logged interaction stores the face the actor wore *at that moment* and never re-resolves
+to their current active persona. Without this, switching faces later would retroactively
+out someone — a scene where Robert acted would silently become a scene where Bob acted.
+"""
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.scenes.factories import InteractionFactory, PersonaFactory
+from world.scenes.interaction_serializers import InteractionListSerializer
+from world.scenes.services import set_active_persona
+
+
+class RecordedPersonaFreezeTests(TestCase):
+    def test_interaction_persona_is_frozen_after_a_later_face_switch(self) -> None:
+        sheet = CharacterSheetFactory()
+        acted_as = sheet.primary_persona  # the face worn when the line was posed
+        interaction = InteractionFactory(persona=acted_as)
+
+        # The actor later switches to a different face of the same character.
+        other_face = PersonaFactory(character_sheet=sheet)
+        set_active_persona(sheet, other_face)
+
+        interaction.refresh_from_db()
+        # The record never re-resolves to the current active persona.
+        assert interaction.persona_id == acted_as.pk
+        # And the display reads the frozen face, not the face worn now.
+        payload = InteractionListSerializer().get_persona(interaction)
+        assert payload["name"] == acted_as.name
+        assert payload["name"] != other_face.name


### PR DESCRIPTION
**Autonomous slice while you were out** — the *non-player-facing* half of slice 2 (#1109). Locks in two identity-security invariants as tests; the player-facing half is scoped below and **awaits your input** (I didn't invent any player-visible prose/behavior).

## What this does
Both guarantees already hold structurally on `main`; these tests pin them so the rest of slice 2 can't silently regress them.

- **Descriptor privacy invariant** (`world/forms`) — a persona is born with no descriptors, and a sibling persona's descriptor never auto-attaches to another face of the same character (the Bob "Rusty Auburn" → Robert outing guard). Verified against code first: no descriptor-copy/pre-fill path exists, and `create_character_with_sheet` attaches nothing. Deliberate reuse (a chosen tell) stays available — only accidental carry-over is impossible.
- **Recorded-scene persona freeze** (`world/scenes`) — a logged interaction stores the face worn *then* and never re-resolves to the actor's current active persona after a later switch. Asserted at the model (frozen FK) and display (serializer reads the stored persona) levels.

Pure tests, no behavior change. `world.forms` + `world.scenes` green; ruff + ty clean.

## Verify-against-code findings (the slice-2 map)
| Sub-feature | State on main | This PR |
|---|---|---|
| Descriptor privacy invariant | already enforced structurally | **pinned with tests** ✅ |
| Recorded-scene freeze | already wired (`Interaction.persona` stored + read frozen) | **pinned with tests** ✅ |
| `PersonaDiscovery` render wiring | resolver `resolve_persona_display` exists (`interaction_services.py:720`) but is **only used in tests**, not wired into rendering; viewer is not threaded into the appearance/interaction render path | **deferred — player-facing** 🚩 |
| Anonymous face → composed sdesc | **ABSENT** — no sdesc composer exists (the design doc was optimistic; "machinery exists" is not true on main) | **deferred — player-facing** 🚩 |

## Deferred — needs your input (player-facing)
Two decisions a player would see, which I'm not guessing on:
1. **Anonymous-face display.** Today the resolver shows an anonymous persona's authored `name` (e.g. "Stag Mask"). Slice 2 calls for a *composed sdesc* ("a man in a stag mask") built from form traits — that's new player-visible prose + a composition format. **Decision:** is v1 just the player-authored persona name, or a trait-composed sdesc (and if so, what shape)?
2. **PersonaDiscovery in logs = whose discovery applies?** Wiring per-viewer name resolution into interaction display changes what a player sees, and needs a rule for *which* viewing character's discoveries apply when an account reads a scene log.

I've written both up in detail on the issue.

Refs #1109.
