### PR TITLE
Frontend: use-item UI (inventory use action)

### DIFF
--- a/docs/roadmap/items-equipment.md
+++ b/docs/roadmap/items-equipment.md
@@ -175,10 +175,16 @@ soak; thread defensive-magnitude tuning.
 
 **Branch:** `feature-509-item-interaction-service-functions-use-c`
 
-Service layer (+ a REST entry point) for using consumable items — potions, scrolls,
-charged-use items. Reuses the wired effect stack end-to-end rather than introducing new
-effect or pool primitives: effects are authored as `checks.Consequence` → `ConsequenceEffect`
-and grouped into an `actions.ConsequencePool` (the same abstraction combat clashes use).
+Service layer (+ a REST entry point) for using items with an authored on-use effect pool —
+potions, scrolls, charged-use items, and reusable magical objects. Reuses the wired effect
+stack end-to-end rather than introducing new effect or pool primitives: effects are authored
+as `checks.Consequence` → `ConsequenceEffect` and grouped into an `actions.ConsequencePool`
+(the same abstraction combat clashes use).
+
+**Usable vs Consumable:** An item is *usable* iff `ItemTemplate.on_use_pool_id is not None`.
+*Consumable* is the subset where `template.is_consumable` is True; consumables spend a charge
+per use and are destroyed at 0 charges. Non-consumable usable items are **reusable**: effects
+fire, an `ACTIVATED` ownership event is logged, no charge is spent, and the item is never destroyed.
 
 What landed:
 
@@ -194,14 +200,38 @@ What landed:
 - **Service `world/items/services/usage.py`:** `consume_item_charges` (atomic, `select_for_update`
   charge lock, `ACTIVATED`/`CONSUMED` ledger, soft/hard delete) and `use_item` (deterministic via
   `apply_pool_deterministically`, or check-gated via `select_consequence` + `apply_resolution`;
-  charge spent regardless of check outcome). Returns a `UseItemResult` dataclass.
+  consumables spend a charge regardless of check outcome; reusable items never spend charges).
+  Returns a `UseItemResult` dataclass.
 - **Typed exceptions:** `ItemNotUsable`, `NoChargesRemaining` (in `world.items.exceptions`).
 - **REST:** `POST /api/items/inventory/<pk>/use/` — a `use` action on `ItemInstanceViewSet`,
   owner-or-staff gated, `ItemError` → HTTP 400; list/retrieve filter `.in_play()`.
 
 Deferred follow-ups: use-item *Action* (`actions/definitions/`) converging on `action.run()`
 alongside equip/unequip; time-based cleanup of soft-deleted, non-lore-critical instances;
-durability-on-use (#508) integration; quantity/stack consumption; frontend "use item" UI.
+durability-on-use (#508) integration; quantity/stack consumption.
+
+## Use-Item Frontend UI (DONE, #1026)
+
+**Branch:** `feature-1026-frontend-use-item-ui`
+
+React **Use** button and inline result display wired into `ItemDetailPanel`, completing the
+player-facing loop for usable items shipped in #509.
+
+What landed:
+
+- **`is_usable` serializer field** — `ItemInstanceReadSerializer` exposes `is_usable` as a
+  `SerializerMethodField` equal to `template.on_use_pool_id is not None`. Clients gate the Use
+  button on this field; they do not inspect the template directly.
+- **`useUseItem` hook** — React Query mutation calling `POST /api/items/inventory/<pk>/use/`;
+  returns `UseItemResult` (`charges_remaining`, `consumed`, `result_text`).
+- **Use button in `ItemDetailPanel`** — rendered only when `item.is_usable`; disabled when the
+  item is consumable and `charges <= 0`. On success, shows an inline result block beneath the
+  charges line (charges remaining / consumed indicator / result text). On error, toasts the
+  backend `user_message`.
+- **Non-consumable (reusable) path** — the button is always enabled; the result block shows
+  "Used" with any authored result text and no charge counter.
+- **Generated types** — `ItemInstanceRead.is_usable` (bool) and `UseItemResult` wired into
+  the frontend API schema.
 
 ## Inventory Service Functions (DONE)
 
@@ -498,7 +528,8 @@ Explicitly NOT in this slice (parked):
 - ~~Saved outfits (Phase A)~~ — **done** (Outfit / OutfitSlot models, apply_outfit / undress / save_outfit / delete_outfit / add_outfit_slot / remove_outfit_slot services, ApplyOutfit/Undress actions, `wear outfit <name>` + `undress` telnet commands, REST CRUD, wardrobe page)
 - ~~Item stats model~~ — **done** (#508: `ItemTemplate` base combat stats — `weapon_damage_type`, `base_weapon_damage`, `base_armor_soak`, `max_durability`, gated by `gear_archetype`; `ItemInstance` derives `effective_weapon_damage` / `effective_armor_soak` / `is_broken` from quality tier and `durability`; `decrement_item_durability` service; combat wiring — armor soak in `apply_damage_to_participant`, equipped-weapon damage via `TechniqueDamageProfile.uses_equipped_weapon`, durability decremented on landed/soaked hits)
 - Visible equipment display — what others see when looking at a character; perception-layer integration into `look` output (not started)
-- Item interaction service functions — using items, consuming charges (DONE, #509)
+- ~~Item interaction service functions — using items, consuming charges~~ — **done** (#509: `use_item` service, `on_use_pool` schema, soft/hard delete, `POST /api/items/inventory/<pk>/use/`)
+- ~~Frontend "use item" UI~~ — **done** (#1026: `is_usable` serializer field, `useUseItem` hook, Use button in `ItemDetailPanel` with inline result block; reusable and consumable branches both handled)
 - Crafting integration — `OwnershipEvent.CREATED` rows written when crafted items are produced (not started; tracked under crafting roadmap)
 - ~~Outfits Phase B (Fashion)~~ — **done** (`FashionStyle` + `FashionStyleBonus` models, `Society.current_fashion_style` FK, `fashion_outfit_bonus` service, wired into `get_modifier_total` via `perceiving_society`; scene-derived society + combat surfacing delivered in Spec D PR4 / #512 via `societies_for_scene` + `collect_check_modifiers`)
 - ~~Outfits Phase C (Modeling)~~ — **done** (#514: `FashionPresentation` + peer `PresentationEndorsement`, `Event.host_society`, `prestige_from_fashion` axis, `FacetVogueMomentum` + seasonal trendsetter ceremony rewriting `Society.current_fashion_style`, `RankingType.FASHION` leaderboard reusing #676, present/judge API + event-detail UI)

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -713,8 +713,18 @@ services, and equipment-modifier integration.
   - `attach_facet_to_item(*, crafter, item_instance, facet, attachment_quality_tier) -> ItemFacet`
     — raises `FacetAlreadyAttached` / `FacetCapacityExceeded`
   - `remove_facet_from_item(*, item_facet) -> None`
+  - `use_item(item_instance, user, target=None) -> UseItemResult` — applies on-use pool effects;
+    consumables spend a charge and are destroyed at 0 (soft- or hard-delete); non-consumable
+    usable items are reusable (no charge spent, `ACTIVATED` event logged). Raises `ItemNotUsable`
+    (no `on_use_pool`) or `NoChargesRemaining` (consumable at 0 charges)
+- **Usable vs consumable:** an item is *usable* iff `template.on_use_pool_id is not None`.
+  *Consumable* is the subset where `template.is_consumable` is True; consumables spend a charge
+  per use and are destroyed at 0 charges. Non-consumable usable items are reusable.
+- **Serializer field `is_usable`:** `ItemInstanceReadSerializer` exposes `is_usable` (bool,
+  `SerializerMethodField`) — `True` iff `template.on_use_pool_id is not None`. Clients gate the
+  Use button on this field.
 - **Exceptions:** `FacetAlreadyAttached`, `FacetCapacityExceeded`, `SlotConflict`,
-  `SlotIncompatible` — all in `world.items.exceptions`
+  `SlotIncompatible`, `ItemNotUsable`, `NoChargesRemaining` — all in `world.items.exceptions`
 - **API Endpoints:**
   - `/api/items/quality-tiers/`, `/api/items/interaction-types/`, `/api/items/templates/`
     (read-only catalog)
@@ -724,9 +734,18 @@ services, and equipment-modifier integration.
     unequip route through the action layer via the WebSocket `execute_action`
     inputfunc (`{action: "equip" | "unequip", kwargs: {target_id: N, ...}}`)
     or the telnet `wear` / `remove` / `get` / `drop` commands
+  - `GET /api/items/inventory/` — read-only inventory list (`.in_play()` filtered)
+  - `POST /api/items/inventory/<pk>/use/` — use item; owner-or-staff gated; returns
+    `UseItemResult` (`charges_remaining`, `consumed`, `result_text`); `ItemError` → HTTP 400
 - **Pattern:** Templates define archetypes; instances hold per-item state. Equipment uses
   region + layer grid (unique constraint per character). Facets attach up to `facet_capacity`
   per item; worn facets feed the mechanics modifier walk (see Mechanics §EQUIPMENT_RELEVANT).
+  Usability (`is_usable`) is derived entirely from the template's `on_use_pool` FK — no
+  separate flag or type split.
+- **Frontend:** `WardrobePage` (outfits, equipped items, inventory grid, item detail drawer);
+  `ItemDetailPanel` shows a **Use** button when `item.is_usable` is true (disabled for
+  depleted consumables), calls `POST /api/items/inventory/<pk>/use/`, and renders an inline
+  result block (charges remaining / consumed / text); errors toast the backend `user_message`.
 - **Integrates with:** mechanics (equipment modifier walk via `passive_facet_bonuses` +
   `covenant_role_bonus`), magic (outfit trickle, `outfit_item_facet` ResonanceGrant FK),
   covenants (gear archetype compatibility), crafting (future: crafting recipes)

--- a/docs/systems/items.md
+++ b/docs/systems/items.md
@@ -17,7 +17,7 @@ from world.items.constants import (
                          # LEFT_LEG, RIGHT_LEG, FEET, LEFT_FINGER, RIGHT_FINGER,
                          # LEFT_EAR, RIGHT_EAR
     EquipmentLayer,      # SKIN, UNDER, BASE, OVER, OUTER, ACCESSORY
-    OwnershipEventType,  # CREATED, GIVEN, STOLEN, TRANSFERRED
+    OwnershipEventType,  # CREATED, GIVEN, STOLEN, TRANSFERRED, ACTIVATED, CONSUMED
 )
 ```
 
@@ -56,13 +56,15 @@ from world.items.constants import (
 
 ---
 
-## API Endpoints (Read-Only)
+## API Endpoints
 
 | Endpoint | ViewSet | Notes |
 |----------|---------|-------|
 | `/api/items/quality-tiers/` | `QualityTierViewSet` | List quality tiers |
 | `/api/items/interaction-types/` | `InteractionTypeViewSet` | List interaction types |
 | `/api/items/templates/` | `ItemTemplateViewSet` | List/detail with nested slots and interaction bindings |
+| `GET /api/items/inventory/` | `ItemInstanceViewSet` | Read-only inventory list; filtered to `.in_play()` |
+| `POST /api/items/inventory/<pk>/use/` | `ItemInstanceViewSet` | Use item; owner-or-staff gated; returns `UseItemResult` |
 
 ---
 
@@ -88,6 +90,31 @@ EquippedItem rows for torso, both arms, etc.). The unique constraint
 ### Ownership Ledger
 `OwnershipEvent` is append-only — ownership transitions are recorded, never deleted.
 This supports investigation mechanics, theft tracking, and provenance queries.
+
+### Usable vs Consumable Items
+An item is **usable** iff its template has an `on_use_pool` FK set (`template.on_use_pool_id is not None`).
+This is the single gate checked by `use_item` and exposed as the `is_usable` field on `ItemInstanceRead`.
+
+**Consumable** items are the *subset* of usable items where `template.is_consumable` is True:
+- Each use spends one charge (atomic `select_for_update`).
+- At 0 charges, instances with personalised data (custom name/description, non-default quality tier,
+  facets, `lore_value`, or provenance) are **soft-deleted** (`destroyed_at` marker); bare
+  template-identical throwaways are **hard-deleted** (the `CONSUMED` `OwnershipEvent` row survives
+  via `SET_NULL` on the FK).
+- `NoChargesRemaining` is raised before effects fire when `charges <= 0`.
+
+**Reusable** usable items (not consumable) apply effects on every use without spending a charge
+or ever being destroyed. An `ACTIVATED` `OwnershipEvent` is logged on each use.
+
+The `use_item` service (`world/items/services/usage.py`) dispatches both branches. Effects are
+authored as `checks.Consequence` → `ConsequenceEffect` grouped into an `actions.ConsequencePool`
+on `ItemTemplate.on_use_pool`; `on_use_check_type` and `on_use_difficulty` gate the optional
+skill check. Both consumable and reusable items return a `UseItemResult` dataclass.
+
+### is_usable Serializer Field
+`ItemInstanceReadSerializer` exposes `is_usable` (a `SerializerMethodField`) equal to
+`template.on_use_pool_id is not None`. Clients gate the **Use** button on this field; they do not
+need to inspect the template directly.
 
 ---
 
@@ -133,12 +160,10 @@ See `docs/systems/magic.md` for the full thread and ritual model lineup.
 
 ## What's Not Yet Built
 
-- **Service functions** for equip/unequip, give, pick up, drop, consume
-- **Combat stat blocks** for weapons and armor
-- **Fashion facet integration** with the magic/resonance system
-- **Visible equipment rendering** for character appearance
-- **Frontend inventory UI**
-- **Modifier source integration** with the mechanics system (equipment as modifier sources)
 - **ItemCapabilityGrant model** — links items to capabilities (parallel to TechniqueCapabilityGrant)
 - **Equipment source collector** — `_get_equipment_sources()` for `get_capability_sources_for_character()`
 - **Unified action aggregation** — frontend layer merging challenge actions, item interactions, and basic actions
+- **use-item Action class** — action-layer `UseItemAction` in `actions/definitions/` converging on
+  `action.run()` alongside equip/unequip; the REST endpoint (`POST /api/items/inventory/<pk>/use/`)
+  currently handles frontend use-item requests directly
+- **Time-based cleanup** — cron purge of soft-deleted, non-lore-critical item instances

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -5409,7 +5409,7 @@ export interface paths {
     get?: never;
     put?: never;
     /**
-     * @description Use a consumable item: apply its on-use effects (to self) and spend a charge.
+     * @description Use an item with an on-use pool: apply its effects (to self); consumables spend a charge.
      *
      *     Owner-or-staff gated. Business logic lives entirely in ``use_item``;
      *     this view resolves the actor, enforces ownership, and maps
@@ -16264,6 +16264,11 @@ export interface components {
       readonly display_description: string;
       /** @description Return the cloudinary URL for the item's display image, if any. */
       readonly display_image_url: string | null;
+      /**
+       * @description True iff use_item would proceed: the template has an on-use pool.
+       *     Mirrors the precondition in services.usage.use_item.
+       */
+      readonly is_usable: boolean;
       readonly contained_in: number;
       /** @description Stack quantity for stackable items. */
       readonly quantity: number;

--- a/frontend/src/inventory/api.ts
+++ b/frontend/src/inventory/api.ts
@@ -21,6 +21,7 @@ import type {
   OutfitSlot,
   PaginatedResponse,
   UpdateOutfitPayload,
+  UseItemResult,
 } from './types';
 
 type ItemFacetRead = components['schemas']['ItemFacetRead'];
@@ -130,6 +131,14 @@ export async function listInventory(characterId: number): Promise<ItemInstance[]
   }
   const data = (await res.json()) as PaginatedResponse<ItemInstance>;
   return data.results;
+}
+
+export async function useItem(itemId: number): Promise<UseItemResult> {
+  const res = await apiFetch(`${BASE_URL}/inventory/${itemId}/use/`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error(await readError(res, 'Failed to use item'));
+  }
+  return (await res.json()) as UseItemResult;
 }
 
 export async function listEquipped(characterId: number): Promise<EquippedItem[]> {

--- a/frontend/src/inventory/api.ts
+++ b/frontend/src/inventory/api.ts
@@ -133,7 +133,7 @@ export async function listInventory(characterId: number): Promise<ItemInstance[]
   return data.results;
 }
 
-export async function useItem(itemId: number): Promise<UseItemResult> {
+export async function postUseItem(itemId: number): Promise<UseItemResult> {
   const res = await apiFetch(`${BASE_URL}/inventory/${itemId}/use/`, { method: 'POST' });
   if (!res.ok) {
     throw new Error(await readError(res, 'Failed to use item'));

--- a/frontend/src/inventory/components/ItemDetailPanel.tsx
+++ b/frontend/src/inventory/components/ItemDetailPanel.tsx
@@ -89,6 +89,7 @@ export function ItemDetailPanel({
         {item ? (
           <>
             <ItemContent
+              key={item.id}
               item={item}
               itemFacetsQuery={itemFacetsQuery}
               facetsQuery={facetsQuery}

--- a/frontend/src/inventory/components/ItemDetailPanel.tsx
+++ b/frontend/src/inventory/components/ItemDetailPanel.tsx
@@ -187,7 +187,10 @@ function ItemContent({
   function handleUse() {
     useMutation.mutate(item.id, {
       onSuccess: (result) => setUseResult(result),
-      onError: (err) => toast.error(err instanceof Error ? err.message : 'Failed to use item.'),
+      onError: (err) => {
+        setUseResult(null);
+        toast.error(err instanceof Error ? err.message : 'Failed to use item.');
+      },
     });
   }
 

--- a/frontend/src/inventory/components/ItemDetailPanel.tsx
+++ b/frontend/src/inventory/components/ItemDetailPanel.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useState } from 'react';
-import { Hand, Package, Sparkles, Trash2, Users, X } from 'lucide-react';
+import { Hand, Package, Sparkles, Trash2, Users, X, Zap } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { toast } from 'sonner';
@@ -31,8 +31,9 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 import { useFacets } from '@/character-creation/queries';
-import type { ItemInstance } from '../types';
+import type { ItemInstance, UseItemResult } from '../types';
 import { useItemFacets, useQualityTiers, useRemoveItemFacet } from '../hooks/useItemFacets';
+import { useUseItem } from '../hooks/useUseItem';
 import { AttachFacetDialog } from './AttachFacetDialog';
 
 interface ItemDetailPanelProps {
@@ -42,6 +43,8 @@ interface ItemDetailPanelProps {
   facetLabels?: string[];
   /** True when the parent has determined this item is currently equipped. */
   isEquipped?: boolean;
+  /** Character id — required for the Use mutation; optional so existing tests compile. */
+  characterId?: number;
 
   // Sheet state
   open: boolean;
@@ -60,6 +63,7 @@ export function ItemDetailPanel({
   // facetLabels accepted for backward-compat; live data replaces it internally.
   facetLabels: _facetLabels = [],
   isEquipped = false,
+  characterId,
   open,
   onOpenChange,
   onWear,
@@ -90,6 +94,7 @@ export function ItemDetailPanel({
               facetsQuery={facetsQuery}
               tiersQuery={tiersQuery}
               isEquipped={isEquipped}
+              characterId={characterId}
               onWear={onWear}
               onRemove={onRemove}
               onDrop={onDrop}
@@ -141,6 +146,7 @@ interface ItemContentProps {
   facetsQuery: { data?: FacetRecord[] };
   tiersQuery: { data?: QualityTierRecord[] };
   isEquipped: boolean;
+  characterId?: number;
   onWear?: (itemId: number) => void;
   onRemove?: (itemId: number) => void;
   onDrop?: (itemId: number) => void;
@@ -155,6 +161,7 @@ function ItemContent({
   facetsQuery,
   tiersQuery,
   isEquipped,
+  characterId,
   onWear,
   onRemove,
   onDrop,
@@ -168,6 +175,20 @@ function ItemContent({
   const initial = item.display_name.trim().charAt(0).toUpperCase() || '?';
 
   const removeMutation = useRemoveItemFacet(item.id);
+
+  // characterId is optional on the panel; ?? -1 mirrors useInventory's sentinel.
+  // Use is only rendered when item.is_usable, and real renders always supply characterId.
+  const useMutation = useUseItem(characterId ?? -1);
+  const [useResult, setUseResult] = useState<UseItemResult | null>(null);
+  const isConsumable = item.template?.is_consumable ?? false;
+  const useDisabled = useMutation.isPending || (isConsumable && item.charges <= 0);
+
+  function handleUse() {
+    useMutation.mutate(item.id, {
+      onSuccess: (result) => setUseResult(result),
+      onError: (err) => toast.error(err instanceof Error ? err.message : 'Failed to use item.'),
+    });
+  }
 
   const liveFacets = itemFacetsQuery.data ?? [];
   const facetMap = new Map<number, FacetRecord>((facetsQuery.data ?? []).map((f) => [f.id, f]));
@@ -280,8 +301,38 @@ function ItemContent({
         )}
       </div>
 
+      {useResult && (
+        <div
+          data-testid="use-result"
+          className="mx-4 mb-2 rounded-md border bg-muted/40 p-3 text-sm text-foreground"
+        >
+          {isConsumable
+            ? useResult.destroyed
+              ? 'Consumed — last charge spent.'
+              : `Used — ${useResult.charges_remaining} charge(s) remaining.`
+            : 'Used.'}
+          {useResult.applied_effect_count > 0 && (
+            <span className="ml-1 text-muted-foreground">
+              {useResult.applied_effect_count} effect(s) applied.
+            </span>
+          )}
+        </div>
+      )}
+
       <div className="mt-auto border-t bg-muted/30 p-4">
         <div className="flex flex-wrap items-center gap-2">
+          {item.is_usable && (
+            <Button
+              size="sm"
+              variant="default"
+              onClick={handleUse}
+              disabled={useDisabled}
+              title={isConsumable && item.charges <= 0 ? 'No uses left' : undefined}
+            >
+              <Zap className="mr-1.5 h-3.5 w-3.5" />
+              Use
+            </Button>
+          )}
           {isEquipped ? (
             <Button size="sm" variant="default" onClick={() => onRemove?.(item.id)}>
               Remove

--- a/frontend/src/inventory/components/__tests__/EditOutfitDialog.test.tsx
+++ b/frontend/src/inventory/components/__tests__/EditOutfitDialog.test.tsx
@@ -62,6 +62,7 @@ function makeItem(id: number, name: string): ItemInstance {
     quantity: 1,
     charges: 0,
     is_open: false,
+    is_usable: false,
   };
 }
 

--- a/frontend/src/inventory/components/__tests__/ItemCard.test.tsx
+++ b/frontend/src/inventory/components/__tests__/ItemCard.test.tsx
@@ -38,6 +38,7 @@ function makeItem(overrides: Partial<ItemInstance> = {}): ItemInstance {
     quantity: 1,
     charges: 0,
     is_open: false,
+    is_usable: false,
     ...overrides,
   };
 }

--- a/frontend/src/inventory/components/__tests__/ItemDetailPanel.test.tsx
+++ b/frontend/src/inventory/components/__tests__/ItemDetailPanel.test.tsx
@@ -387,6 +387,39 @@ describe('ItemDetailPanel', () => {
     expect(screen.queryByTestId('use-result')).toBeNull();
   });
 
+  it('clears the use-result block when a subsequent use of the same item fails', () => {
+    let callCount = 0;
+    const mutate = vi.fn((_id, opts) => {
+      callCount += 1;
+      if (callCount === 1) {
+        opts.onSuccess({
+          charges_remaining: 2,
+          destroyed: false,
+          soft_deleted: false,
+          applied_effect_count: 0,
+        });
+      } else {
+        opts.onError(new Error('No uses left'));
+      }
+    });
+    vi.mocked(useUseItem).mockReturnValue({ mutate, isPending: false } as unknown as ReturnType<
+      typeof useUseItem
+    >);
+
+    const item = makeItem({
+      is_usable: true,
+      charges: 3,
+      template: { ...makeItem().template, is_consumable: true },
+    });
+    render(<ItemDetailPanel item={item} characterId={1} open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^use$/i }));
+    expect(screen.getByTestId('use-result')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^use$/i }));
+    expect(screen.queryByTestId('use-result')).toBeNull();
+  });
+
   it('calls removeMutation.mutate when remove button is clicked', () => {
     const mutate = vi.fn();
     vi.mocked(itemFacetsHooks.useRemoveItemFacet).mockReturnValue({

--- a/frontend/src/inventory/components/__tests__/ItemDetailPanel.test.tsx
+++ b/frontend/src/inventory/components/__tests__/ItemDetailPanel.test.tsx
@@ -17,6 +17,8 @@ vi.mock('../../hooks/useItemFacets', () => ({
   useRemoveItemFacet: vi.fn(),
 }));
 
+vi.mock('../../hooks/useUseItem', () => ({ useUseItem: vi.fn() }));
+
 vi.mock('@/character-creation/queries', () => ({
   useFacets: vi.fn(),
 }));
@@ -47,12 +49,18 @@ vi.mock('sonner', () => ({
 
 import * as itemFacetsHooks from '../../hooks/useItemFacets';
 import * as characterCreationQueries from '@/character-creation/queries';
+import { useUseItem } from '../../hooks/useUseItem';
 
 // ---------------------------------------------------------------------------
 // Default mock setup helpers
 // ---------------------------------------------------------------------------
 
 function setupDefaultMocks() {
+  vi.mocked(useUseItem).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useUseItem>);
+
   vi.mocked(itemFacetsHooks.useItemFacets).mockReturnValue({
     data: [],
     isLoading: false,
@@ -130,6 +138,7 @@ function makeItem(overrides: Partial<ItemInstance> = {}): ItemInstance {
     quantity: 1,
     charges: 0,
     is_open: false,
+    is_usable: false,
     ...overrides,
   };
 }
@@ -298,6 +307,47 @@ describe('ItemDetailPanel', () => {
     render(<ItemDetailPanel item={makeItem()} open={true} onOpenChange={vi.fn()} />);
 
     expect(screen.getByText('Facet #99')).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Use button
+  // -------------------------------------------------------------------------
+
+  it('hides the Use button when the item is not usable', () => {
+    render(
+      <ItemDetailPanel
+        item={makeItem({ is_usable: false })}
+        characterId={1}
+        open
+        onOpenChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button', { name: /^use$/i })).toBeNull();
+  });
+
+  it('disables Use for a depleted consumable', () => {
+    const item = makeItem({
+      is_usable: true,
+      charges: 0,
+      template: { ...makeItem().template, is_consumable: true },
+    });
+    render(<ItemDetailPanel item={item} characterId={1} open onOpenChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /^use$/i })).toBeDisabled();
+  });
+
+  it('calls the use mutation with the item id when Use is clicked', () => {
+    const mutate = vi.fn();
+    vi.mocked(useUseItem).mockReturnValue({ mutate, isPending: false } as unknown as ReturnType<
+      typeof useUseItem
+    >);
+    const item = makeItem({
+      is_usable: true,
+      charges: 3,
+      template: { ...makeItem().template, is_consumable: true },
+    });
+    render(<ItemDetailPanel item={item} characterId={1} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^use$/i }));
+    expect(mutate).toHaveBeenCalledWith(item.id, expect.any(Object));
   });
 
   it('calls removeMutation.mutate when remove button is clicked', () => {

--- a/frontend/src/inventory/components/__tests__/ItemDetailPanel.test.tsx
+++ b/frontend/src/inventory/components/__tests__/ItemDetailPanel.test.tsx
@@ -350,6 +350,43 @@ describe('ItemDetailPanel', () => {
     expect(mutate).toHaveBeenCalledWith(item.id, expect.any(Object));
   });
 
+  it('use-result block resets when the panel switches to a different item', () => {
+    const mutate = vi.fn((_id, opts) =>
+      opts.onSuccess({
+        charges_remaining: 2,
+        destroyed: false,
+        soft_deleted: false,
+        applied_effect_count: 1,
+      })
+    );
+    vi.mocked(useUseItem).mockReturnValue({ mutate, isPending: false } as unknown as ReturnType<
+      typeof useUseItem
+    >);
+
+    const itemA = makeItem({
+      id: 7,
+      is_usable: true,
+      charges: 3,
+      template: { ...makeItem().template, is_consumable: true },
+    });
+    const itemB = makeItem({
+      id: 99,
+      display_name: 'Iron Dagger',
+      is_usable: true,
+      charges: 3,
+      template: { ...makeItem().template, is_consumable: true },
+    });
+
+    const { rerender } = render(
+      <ItemDetailPanel item={itemA} characterId={1} open onOpenChange={vi.fn()} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^use$/i }));
+    expect(screen.getByTestId('use-result')).toBeInTheDocument();
+
+    rerender(<ItemDetailPanel item={itemB} characterId={1} open onOpenChange={vi.fn()} />);
+    expect(screen.queryByTestId('use-result')).toBeNull();
+  });
+
   it('calls removeMutation.mutate when remove button is clicked', () => {
     const mutate = vi.fn();
     vi.mocked(itemFacetsHooks.useRemoveItemFacet).mockReturnValue({

--- a/frontend/src/inventory/components/__tests__/ItemFocusView.test.tsx
+++ b/frontend/src/inventory/components/__tests__/ItemFocusView.test.tsx
@@ -74,6 +74,7 @@ function makeItem(overrides: Partial<ItemInstance> = {}): ItemInstance {
     quantity: 1,
     charges: 0,
     is_open: false,
+    is_usable: false,
     ...overrides,
   };
 }

--- a/frontend/src/inventory/components/__tests__/OutfitCard.test.tsx
+++ b/frontend/src/inventory/components/__tests__/OutfitCard.test.tsx
@@ -39,6 +39,7 @@ function makeItem(id: number, name: string, color = '#4ade80'): ItemInstance {
     quantity: 1,
     charges: 0,
     is_open: false,
+    is_usable: false,
   };
 }
 

--- a/frontend/src/inventory/components/__tests__/SaveOutfitDialog.test.tsx
+++ b/frontend/src/inventory/components/__tests__/SaveOutfitDialog.test.tsx
@@ -54,6 +54,7 @@ function makeWardrobe(id: number, name: string): ItemInstance {
     quantity: 1,
     charges: 0,
     is_open: false,
+    is_usable: false,
   };
 }
 

--- a/frontend/src/inventory/hooks/__tests__/useUseItem.test.tsx
+++ b/frontend/src/inventory/hooks/__tests__/useUseItem.test.tsx
@@ -16,7 +16,7 @@ describe('useUseItem', () => {
   it('invalidates the inventory query for the character on success', async () => {
     const qc = new QueryClient();
     const invalidate = vi.spyOn(qc, 'invalidateQueries');
-    vi.mocked(api.useItem).mockResolvedValue({
+    vi.mocked(api.postUseItem).mockResolvedValue({
       charges_remaining: 1,
       destroyed: false,
       soft_deleted: false,
@@ -27,7 +27,7 @@ describe('useUseItem', () => {
       await result.current.mutateAsync(7);
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(api.useItem).toHaveBeenCalledWith(7);
+    expect(api.postUseItem).toHaveBeenCalledWith(7);
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['inventory', 42] });
   });
 });

--- a/frontend/src/inventory/hooks/__tests__/useUseItem.test.tsx
+++ b/frontend/src/inventory/hooks/__tests__/useUseItem.test.tsx
@@ -1,0 +1,33 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import * as api from '../../api';
+import { useUseItem } from '../useUseItem';
+
+vi.mock('../../api');
+
+function createWrapper(qc: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useUseItem', () => {
+  it('invalidates the inventory query for the character on success', async () => {
+    const qc = new QueryClient();
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+    vi.mocked(api.useItem).mockResolvedValue({
+      charges_remaining: 1,
+      destroyed: false,
+      soft_deleted: false,
+      applied_effect_count: 1,
+    });
+    const { result } = renderHook(() => useUseItem(42), { wrapper: createWrapper(qc) });
+    await act(async () => {
+      await result.current.mutateAsync(7);
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.useItem).toHaveBeenCalledWith(7);
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['inventory', 42] });
+  });
+});

--- a/frontend/src/inventory/hooks/useUseItem.ts
+++ b/frontend/src/inventory/hooks/useUseItem.ts
@@ -1,11 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import * as inventoryApi from '../api';
+import { postUseItem } from '../api';
 import { inventoryKeys } from './useInventory';
 
 export function useUseItem(characterId: number) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (itemId: number) => inventoryApi.useItem(itemId),
+    mutationFn: (itemId: number) => postUseItem(itemId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: inventoryKeys.inventory(characterId) }).catch(() => {});
     },

--- a/frontend/src/inventory/hooks/useUseItem.ts
+++ b/frontend/src/inventory/hooks/useUseItem.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as inventoryApi from '../api';
+import { inventoryKeys } from './useInventory';
+
+export function useUseItem(characterId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (itemId: number) => inventoryApi.useItem(itemId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: inventoryKeys.inventory(characterId) }).catch(() => {});
+    },
+  });
+}

--- a/frontend/src/inventory/pages/WardrobePage.tsx
+++ b/frontend/src/inventory/pages/WardrobePage.tsx
@@ -271,6 +271,7 @@ export function WardrobePage() {
           if (!open) setDetailItem(null);
         }}
         isEquipped={detailItem ? equippedItemIds.has(detailItem.id) : false}
+        characterId={characterId}
       />
 
       <SaveOutfitDialog

--- a/frontend/src/inventory/pages/__tests__/WardrobePage.test.tsx
+++ b/frontend/src/inventory/pages/__tests__/WardrobePage.test.tsx
@@ -124,6 +124,7 @@ function makeItem(id: number, name: string): ItemInstance {
     quantity: 1,
     charges: 0,
     is_open: false,
+    is_usable: false,
   };
 }
 

--- a/frontend/src/inventory/types.ts
+++ b/frontend/src/inventory/types.ts
@@ -25,6 +25,7 @@ export type OutfitSlotWriteRequest = components['schemas']['OutfitSlotWriteReque
 
 export type ItemInstance = components['schemas']['ItemInstanceRead'];
 export type EquippedItem = components['schemas']['EquippedItemRead'];
+export type UseItemResult = components['schemas']['UseItemResult'];
 
 export type BodyRegion = components['schemas']['BodyRegionEnum'];
 export type EquipmentLayer = components['schemas']['EquipmentLayerEnum'];

--- a/src/schema.json
+++ b/src/schema.json
@@ -8284,7 +8284,7 @@ paths:
     post:
       operationId: items_inventory_use_create
       description: |-
-        Use a consumable item: apply its on-use effects (to self) and spend a charge.
+        Use an item with an on-use pool: apply its effects (to self); consumables spend a charge.
 
         Owner-or-staff gated. Business logic lives entirely in ``use_item``;
         this view resolves the actor, enforces ownership, and maps
@@ -29189,6 +29189,12 @@ components:
           description: Return the cloudinary URL for the item's display image, if
             any.
           readOnly: true
+        is_usable:
+          type: boolean
+          description: |-
+            True iff use_item would proceed: the template has an on-use pool.
+            Mirrors the precondition in services.usage.use_item.
+          readOnly: true
         contained_in:
           type: integer
           readOnly: true
@@ -29212,6 +29218,7 @@ components:
       - display_name
       - id
       - is_open
+      - is_usable
       - quality_tier
       - quantity
       - template

--- a/src/world/items/serializers.py
+++ b/src/world/items/serializers.py
@@ -258,6 +258,7 @@ class ItemInstanceReadSerializer(serializers.ModelSerializer):
     display_name = serializers.CharField(read_only=True)
     display_description = serializers.CharField(read_only=True)
     display_image_url = serializers.SerializerMethodField()
+    is_usable = serializers.SerializerMethodField()
     contained_in = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
@@ -269,6 +270,7 @@ class ItemInstanceReadSerializer(serializers.ModelSerializer):
             "display_name",
             "display_description",
             "display_image_url",
+            "is_usable",
             "contained_in",
             "quantity",
             "charges",
@@ -280,6 +282,11 @@ class ItemInstanceReadSerializer(serializers.ModelSerializer):
         """Return the cloudinary URL for the item's display image, if any."""
         media = obj.display_image
         return media.cloudinary_url if media else None
+
+    def get_is_usable(self, obj: ItemInstance) -> bool:
+        """True iff use_item would proceed: the template has an on-use pool.
+        Mirrors the precondition in services.usage.use_item."""
+        return obj.template.on_use_pool_id is not None
 
 
 class VisibleWornItemSerializer(serializers.Serializer):

--- a/src/world/items/services/usage.py
+++ b/src/world/items/services/usage.py
@@ -6,6 +6,7 @@ import contextlib
 
 from django.db import transaction
 from django.utils import timezone
+from evennia.objects.models import ObjectDB
 
 from world.checks.consequence_resolution import (
     apply_pool_deterministically,
@@ -82,15 +83,18 @@ def consume_item_charges(*, item_instance: ItemInstance, amount: int = 1) -> Ite
 
 
 @transaction.atomic
-def use_item(*, item_instance: ItemInstance, user, target=None) -> UseItemResult:
-    """Use a consumable: apply its on-use pool's effects (deterministic when the
-    template has no on_use_check_type, else check-gated) and spend one charge.
-    The charge is spent regardless of check outcome. user/target are ObjectDBs."""
+def use_item(
+    *, item_instance: ItemInstance, user: ObjectDB, target: ObjectDB | None = None
+) -> UseItemResult:
+    """Use an item with an on-use pool: apply its effects (deterministic when the
+    template has no on_use_check_type, else check-gated). Consumables spend one
+    charge (regardless of check outcome) and are destroyed at zero; non-consumable
+    usable items are reusable and keep their charges. user/target are ObjectDBs."""
     locked = ItemInstance.objects.select_for_update().get(pk=item_instance.pk)
     template = locked.template
-    if not template.is_consumable or template.on_use_pool_id is None:
+    if template.on_use_pool_id is None:
         raise ItemNotUsable
-    if locked.charges <= 0:
+    if template.is_consumable and locked.charges <= 0:
         raise NoChargesRemaining
 
     context = ResolutionContext(character=user, target=target)
@@ -107,11 +111,27 @@ def use_item(*, item_instance: ItemInstance, user, target=None) -> UseItemResult
         applied = apply_resolution(pending, context)
         check_result = pending.check_result
 
-    consumed = consume_item_charges(item_instance=locked, amount=1)
+    if template.is_consumable:
+        consumed = consume_item_charges(item_instance=locked, amount=1)
+        charges_remaining = consumed.charges
+        destroyed = consumed.charges == 0
+        soft_deleted = destroyed and consumed.destroyed_at is not None
+    else:
+        # Reusable on-use item: record activation, keep the item, spend no charge.
+        OwnershipEvent.objects.create(
+            item_instance=locked,
+            event_type=OwnershipEventType.ACTIVATED,
+            from_character_sheet=locked.holder_character_sheet,
+        )
+        _invalidate_caches(locked)
+        charges_remaining = locked.charges
+        destroyed = False
+        soft_deleted = False
+
     return UseItemResult(
         applied_effects=applied,
-        charges_remaining=consumed.charges,
-        destroyed=(consumed.charges == 0),
-        soft_deleted=(consumed.charges == 0 and consumed.destroyed_at is not None),
+        charges_remaining=charges_remaining,
+        destroyed=destroyed,
+        soft_deleted=soft_deleted,
         check_result=check_result,
     )

--- a/src/world/items/tests/test_item_instance_views.py
+++ b/src/world/items/tests/test_item_instance_views.py
@@ -332,3 +332,40 @@ class UseItemActionTests(TestCase):
         item = self._make_held_item(charges=0)
         response = self.client.post(f"/api/items/inventory/{item.pk}/use/", {}, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class IsUsableSerializerTests(TestCase):
+    """Tests for the is_usable field on ItemInstanceReadSerializer."""
+
+    def setUp(self) -> None:
+        self.room = ObjectDBFactory(
+            db_key="IsUsableRoom",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+
+    def _instance(self, *, template) -> ItemInstance:
+        """Build an ItemInstance with a game object at room location."""
+        obj = ObjectDBFactory(
+            db_key=f"IsUsableObj{template.pk}",
+            db_typeclass_path="typeclasses.objects.Object",
+        )
+        obj.location = self.room
+        obj.save()
+        return ItemInstanceFactory(template=template, game_object=obj, quality_tier=None)
+
+    def test_is_usable_true_when_template_has_on_use_pool(self) -> None:
+        """is_usable mirrors use_item's precondition: template has an on-use pool,
+        independent of is_consumable."""
+        from actions.factories import ConsequencePoolFactory
+        from world.items.serializers import ItemInstanceReadSerializer
+
+        usable = ItemTemplateFactory(
+            is_consumable=False, max_charges=0, on_use_pool=ConsequencePoolFactory()
+        )
+        not_usable = ItemTemplateFactory(is_consumable=True, max_charges=1, on_use_pool=None)
+        self.assertTrue(
+            ItemInstanceReadSerializer(self._instance(template=usable)).data["is_usable"]
+        )
+        self.assertFalse(
+            ItemInstanceReadSerializer(self._instance(template=not_usable)).data["is_usable"]
+        )

--- a/src/world/items/tests/test_usage_service.py
+++ b/src/world/items/tests/test_usage_service.py
@@ -192,3 +192,48 @@ class UseItemTests(TestCase):
 
         self.assertIsNotNone(result.check_result)
         self.assertEqual(result.charges_remaining, 0)
+
+    def test_non_consumable_with_pool_applies_effects_without_spending_charge(self):
+        from world.items.constants import OwnershipEventType
+        from world.items.factories import ItemTemplateFactory
+        from world.items.services.usage import use_item
+
+        template = ItemTemplateFactory(
+            is_consumable=False,
+            max_charges=0,  # DB constraint: charges (max_charges>0) require is_consumable
+            on_use_pool=self._pool_with_condition_effect(),
+            on_use_check_type=None,
+        )
+        inst = self._instance(template=template, charges=0)
+
+        result = use_item(item_instance=inst, user=self.character)
+
+        self.assertTrue(result.applied_effects)
+        self.assertFalse(result.destroyed)
+        self.assertFalse(result.soft_deleted)
+        inst.refresh_from_db()
+        self.assertTrue(
+            inst.ownership_events.filter(event_type=OwnershipEventType.ACTIVATED).exists()
+        )
+        # Reusable: a second use still works (no NoChargesRemaining).
+        use_item(item_instance=inst, user=self.character)
+
+    def test_non_consumable_use_leaves_authored_charges_untouched(self):
+        """A non-consumable template with an authored nonzero instance charge count
+        must not have its charges spent on use (guards the reusable intent)."""
+        from world.items.factories import ItemTemplateFactory
+        from world.items.services.usage import use_item
+
+        template = ItemTemplateFactory(
+            is_consumable=False,
+            max_charges=0,
+            on_use_pool=self._pool_with_condition_effect(),
+            on_use_check_type=None,
+        )
+        inst = self._instance(template=template, charges=5)
+
+        result = use_item(item_instance=inst, user=self.character)
+
+        self.assertEqual(result.charges_remaining, 5)
+        inst.refresh_from_db()
+        self.assertEqual(inst.charges, 5)

--- a/src/world/items/views.py
+++ b/src/world/items/views.py
@@ -473,7 +473,7 @@ class ItemInstanceViewSet(viewsets.ViewSet):
     @extend_schema(request=UseItemSerializer, responses=UseItemResultSerializer)
     @action(detail=True, methods=[HTTPMethod.POST], url_path="use")
     def use(self, request: Request, pk: str | None = None) -> Response:
-        """Use a consumable item: apply its on-use effects (to self) and spend a charge.
+        """Use an item with an on-use pool: apply its effects (to self); consumables spend a charge.
 
         Owner-or-staff gated. Business logic lives entirely in ``use_item``;
         this view resolves the actor, enforces ownership, and maps


### PR DESCRIPTION
Closes #1026

## Summary

Frontend use-item UI plus a backend decoupling of "usable" from "consumable".

**Backend**
- `use_item` now treats an item as usable iff its template has an on-use pool (`on_use_pool_id is not None`), independent of `is_consumable`. Consumables remain the subset that spend a charge per use and are destroyed at 0 charges (unchanged from #509). Non-consumable usable items are **reusable**: effects applied, an `ACTIVATED` ownership event logged, no charge spent, never destroyed.
- New derived `is_usable` field on `ItemInstanceReadSerializer` (N+1-free; reads the already-loaded template). API types regenerated.

**Frontend**
- `postUseItem` API fn + `useUseItem` mutation hook (invalidates the inventory query so consumed items disappear).
- A **Use** button in `ItemDetailPanel` (shown only when `is_usable`; disabled for depleted consumables) calling `POST /api/items/inventory/<pk>/use/`, with an inline result block (charges remaining / consumed / "Used") and error toasts surfacing the backend `user_message`. Result block resets across item switches and on a failed re-use.

**Docs:** items.md, INDEX.md, roadmap updated in tandem. No migration (the only charge constraint couples charges→consumable, not the pool).

**Tests:** full items app 411 pass (SQLite); frontend inventory 112 pass; `pnpm build` clean.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1026 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (cfc3d5d8). 1 intervening commit, no conflicts; it touched none of this PR's files.

<!-- last-addressed-comment: 0 -->