### PR TITLE
Time-based cleanup of soft-deleted non-lore-critical items

### DIFF
--- a/docs/roadmap/items-equipment.md
+++ b/docs/roadmap/items-equipment.md
@@ -200,8 +200,44 @@ What landed:
   owner-or-staff gated, `ItemError` → HTTP 400; list/retrieve filter `.in_play()`.
 
 Deferred follow-ups: use-item *Action* (`actions/definitions/`) converging on `action.run()`
-alongside equip/unequip; time-based cleanup of soft-deleted, non-lore-critical instances;
-durability-on-use (#508) integration; quantity/stack consumption; frontend "use item" UI.
+alongside equip/unequip; durability-on-use (#508) integration; quantity/stack consumption;
+frontend "use item" UI.
+
+## Time-Based Cleanup of Soft-Deleted Items (DONE, #1025)
+
+**Branch:** `feature-1025-time-based-cleanup-of-soft-deleted-non-l`
+
+Closes the deferred cleanup follow-up from #509: non-lore-critical soft-deleted items are
+now automatically hard-purged after a configurable grace period.
+
+What landed:
+
+- **`is_lore_critical` predicate** on `ItemInstance` (`world/items/models.py`) — returns
+  `True` if the item must never be auto-purged: `lore_value != 0`, OR has attached facets
+  (`ItemFacet` rows), OR has transfer provenance (a GIVEN, STOLEN, or TRANSFERRED
+  `OwnershipEvent`). Cosmetic-only data (custom name, quality tier) is deliberately *not*
+  lore-critical so throway cosmetics are still eligible for purge.
+- **`PROVENANCE_EVENT_TYPES`** frozenset in `world/items/constants.py` — `{GIVEN, STOLEN,
+  TRANSFERRED}` — the transfer-event guard shared by the predicate and the cleanup query.
+- **`hard_delete_item_instance(item_instance)` shared helper** in
+  `world/items/services/usage.py` — convergence of the destruction-at-0-charges path
+  (#509) and the cleanup path (#1025). Deletes ledger rows first, then the game object
+  (CASCADE) or instance row directly; no dangling FKs possible. Previously, bare-throwaway
+  destruction left a `CONSUMED` ledger row with `item_instance=NULL`; that dangling-row
+  behavior is now retired for hard-delete paths.
+- **`purge_expired_soft_deleted_items(*, grace=None) -> int`** in
+  `world/items/services/cleanup.py` — queries `destroyed_at < cutoff AND lore_value=0
+  AND facets=0 AND transfer_provenance=0`, calls `hard_delete_item_instance` for each,
+  returns the count purged. Wraps everything in `@transaction.atomic`.
+- **`ITEM_SOFT_DELETE_GRACE_DAYS`** in `settings.py` — defaults to 30, configurable via
+  the `ITEM_SOFT_DELETE_GRACE_DAYS` env var. Passed as `timedelta(days=N)` to the
+  cleanup service.
+- **`items.soft_delete_cleanup` daily cron task** in `world/items/tasks.py` — registered
+  with `world.game_clock.task_registry` via `register_all_tasks()`; runs every 24 hours;
+  logs the purge count.
+- **Tests** — lore-critical items are retained forever; past-grace non-lore-critical items
+  are purged; within-grace items are retained; no-op when nothing eligible; no orphaned
+  ledger rows after purge.
 
 ## Inventory Service Functions (DONE)
 

--- a/docs/roadmap/items-equipment.md
+++ b/docs/roadmap/items-equipment.md
@@ -235,7 +235,10 @@ What landed:
   `world/items/services/cleanup.py` — queries `destroyed_at < cutoff AND lore_value=0
   AND facets=0 AND transfer_provenance=0`, then purges each via a per-item savepoint so one
   PROTECT-referenced row can't wedge the batch (Mantle / ProjectContribution rows are also
-  excluded at the query level); returns the count purged.
+  excluded at the query level); returns the count purged. **In-world safety guard:** an
+  otherwise-eligible row whose `game_object` still has a location (a half-undelete) is never
+  purged — it is logged at WARNING for staff to resolve, so the cron can't delete a game
+  object out from under a live room.
 - **`ITEM_SOFT_DELETE_GRACE_DAYS`** in `settings.py` — defaults to 30, configurable via
   the `ITEM_SOFT_DELETE_GRACE_DAYS` env var. Passed as `timedelta(days=N)` to the
   cleanup service.

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -702,7 +702,9 @@ services, and equipment-modifier integration.
 - **New fields on `ItemTemplate` (Spec D PR1):** `facet_capacity` (max attachable facets,
   default 0), `gear_archetype` (CharField, `GearArchetype` enum choices)
 - **Enums:** `BodyRegion` (17 body regions), `EquipmentLayer` (skin/under/base/over/outer/
-  accessory), `OwnershipEventType` (created/given/stolen/transferred), `GearArchetype`
+  accessory), `OwnershipEventType` (created/given/stolen/transferred/activated/consumed),
+  `GearArchetype`; `PROVENANCE_EVENT_TYPES` frozenset (GIVEN/STOLEN/TRANSFERRED — transfer
+  provenance used by the lore-critical predicate)
 - **Handlers:**
   - `character.equipped_items` (`CharacterEquipmentHandler`) — `iter()`,
     `iter_item_facets()`, `item_facets_for(facet)`, `invalidate()`
@@ -713,6 +715,17 @@ services, and equipment-modifier integration.
   - `attach_facet_to_item(*, crafter, item_instance, facet, attachment_quality_tier) -> ItemFacet`
     — raises `FacetAlreadyAttached` / `FacetCapacityExceeded`
   - `remove_facet_from_item(*, item_facet) -> None`
+  - `hard_delete_item_instance(item_instance) -> None` (`world/items/services/usage.py`) —
+    deletes the whole footprint: ledger rows then game_object/instance; no dangling FKs
+  - `purge_expired_soft_deleted_items(*, grace=None) -> int` (`world/items/services/cleanup.py`)
+    — hard-deletes soft-deleted, non-lore-critical items past the grace period; called
+    by the `items.soft_delete_cleanup` daily cron task (#1025)
+- **Predicates on `ItemInstance`:**
+  - `differs_from_template` — True if instance has any per-instance data (custom name/desc,
+    lore_value, quality_tier, facets, or non-CREATED provenance); gates soft- vs. hard-delete
+    at 0 charges
+  - `is_lore_critical` — True if the item must never be auto-purged: `lore_value != 0`,
+    OR has facets, OR has GIVEN/STOLEN/TRANSFERRED provenance
 - **Exceptions:** `FacetAlreadyAttached`, `FacetCapacityExceeded`, `SlotConflict`,
   `SlotIncompatible` — all in `world.items.exceptions`
 - **API Endpoints:**

--- a/docs/systems/items.md
+++ b/docs/systems/items.md
@@ -146,8 +146,17 @@ Runs daily as the `items.soft_delete_cleanup` cron task (registered in
    days, configurable via the `ITEM_SOFT_DELETE_GRACE_DAYS` env var, default **30**).
 2. Queries all `ItemInstance` rows with `destroyed_at < cutoff` **and**
    `lore_value=0` **and** zero attached facets **and** zero transfer-provenance events
-   (GIVEN/STOLEN/TRANSFERRED).
-3. Calls `hard_delete_item_instance` for each, returning the count purged.
+   (GIVEN/STOLEN/TRANSFERRED), excluding PROTECT-referenced rows (Mantle /
+   ProjectContribution).
+3. Calls `hard_delete_item_instance` for each out-of-world row in its own savepoint,
+   returning the count purged.
+
+**In-world safety guard:** a soft-deleted item must never be in the game world. Any
+otherwise-eligible row whose `game_object` still has a location (e.g. a half-undelete
+that moved the object back into play but left `destroyed_at` set) is **not** purged —
+it is logged at WARNING for staff to resolve (clear `destroyed_at` to truly undelete,
+or pull it back out of the world). This prevents the cron from deleting a game object
+out from under a live room.
 
 Lore-critical items (`is_lore_critical=True`) are never eligible and remain as
 soft-deleted rows indefinitely, available for staff recovery.

--- a/docs/systems/items.md
+++ b/docs/systems/items.md
@@ -45,7 +45,7 @@ from world.items.constants import (
 
 | Model | Purpose | Key Fields |
 |-------|---------|------------|
-| `ItemInstance` | A specific item in the game world | `template` (FK, PROTECT), `game_object` (OneToOne to ObjectDB), `custom_name`, `custom_description`, `quality_tier` (FK), `quantity`, `charges`, `is_open`, `owner` (FK to AccountDB), `crafter` (FK to AccountDB) |
+| `ItemInstance` | A specific item in the game world | `template` (FK, PROTECT), `game_object` (OneToOne to ObjectDB), `custom_name`, `custom_description`, `quality_tier` (FK), `quantity`, `charges`, `is_open`, `holder_character_sheet` (FK to CharacterSheet), `crafter_character_sheet` (FK to CharacterSheet), `lore_value`, `destroyed_at` |
 | `EquippedItem` | Tracks equipped item at a body slot | `character` (FK to ObjectDB), `item_instance` (FK), `body_region`, `equipment_layer`. Unique on (character, body_region, equipment_layer) |
 
 ### Economy & History
@@ -53,7 +53,7 @@ from world.items.constants import (
 | Model | Purpose | Key Fields |
 |-------|---------|------------|
 | `OwnershipEvent` | Ownership transition ledger (append-only during play; purged alongside non-lore-critical items on cleanup) | `item_instance` (FK, SET_NULL), `event_type`, `from_character_sheet` (FK), `to_character_sheet` (FK), `notes`, `created_at` |
-| `CurrencyBalance` | Per-account gold balance | `account` (OneToOne to AccountDB), `gold` |
+| `CurrencyBalance` | Per-character gold balance | `character` (OneToOne to ObjectDB), `gold` |
 
 ---
 

--- a/docs/systems/items.md
+++ b/docs/systems/items.md
@@ -17,7 +17,8 @@ from world.items.constants import (
                          # LEFT_LEG, RIGHT_LEG, FEET, LEFT_FINGER, RIGHT_FINGER,
                          # LEFT_EAR, RIGHT_EAR
     EquipmentLayer,      # SKIN, UNDER, BASE, OVER, OUTER, ACCESSORY
-    OwnershipEventType,  # CREATED, GIVEN, STOLEN, TRANSFERRED
+    OwnershipEventType,  # CREATED, GIVEN, STOLEN, TRANSFERRED, ACTIVATED, CONSUMED
+    PROVENANCE_EVENT_TYPES,  # frozenset {GIVEN, STOLEN, TRANSFERRED} — transfer provenance
 )
 ```
 
@@ -51,7 +52,7 @@ from world.items.constants import (
 
 | Model | Purpose | Key Fields |
 |-------|---------|------------|
-| `OwnershipEvent` | Append-only ownership transition ledger | `item_instance` (FK), `event_type`, `from_account` (FK), `to_account` (FK), `notes`, `created_at` |
+| `OwnershipEvent` | Ownership transition ledger (append-only during play; purged alongside non-lore-critical items on cleanup) | `item_instance` (FK, SET_NULL), `event_type`, `from_character_sheet` (FK), `to_character_sheet` (FK), `notes`, `created_at` |
 | `CurrencyBalance` | Per-account gold balance | `account` (OneToOne to AccountDB), `gold` |
 
 ---
@@ -86,8 +87,81 @@ EquippedItem rows for torso, both arms, etc.). The unique constraint
 `(character, body_region, equipment_layer)` enforces one item per slot.
 
 ### Ownership Ledger
-`OwnershipEvent` is append-only — ownership transitions are recorded, never deleted.
-This supports investigation mechanics, theft tracking, and provenance queries.
+`OwnershipEvent` is append-only during normal play — ownership transitions are
+recorded, not overwritten. However, the soft-delete cleanup path (see "Destruction &
+soft-delete lifecycle" below) hard-deletes the entire footprint of non-lore-critical
+items, **including their ledger rows**. Ledger rows are therefore permanent only for
+lore-critical items (those with `lore_value`, facets, or transfer provenance — i.e.
+items that have changed hands). Bare throwaway consumables' CREATED/ACTIVATED/CONSUMED
+rows are removed alongside the item on purge. This supports investigation mechanics,
+theft tracking, and provenance queries for items that matter.
+
+---
+
+## Destruction & soft-delete lifecycle
+
+Items move through three states:
+
+| State | Meaning | How to query |
+|-------|---------|--------------|
+| **In play** | Active, in the game world | `ItemInstance.objects.in_play()` (`destroyed_at IS NULL`) |
+| **Soft-deleted (recoverable)** | Removed from play but row retained | `destroyed_at IS NOT NULL` |
+| **Purged** | Row hard-deleted; gone permanently | — (no row) |
+
+### Predicates on ItemInstance
+
+**`differs_from_template`** (property) — `True` if the instance carries any
+per-instance data worth preserving: a `custom_name`, `custom_description`, `lore_value`,
+non-default `quality_tier`, any attached facets, or any `OwnershipEvent` beyond
+`CREATED`. Used by `consume_item_charges` to decide soft-delete vs. hard-delete at
+0 charges.
+
+**`is_lore_critical`** (property) — a tighter subset; `True` only if the item must
+*never* be auto-purged. Conditions: `lore_value` is nonzero, OR the item has facets,
+OR it has transfer provenance (a `GIVEN`, `STOLEN`, or `TRANSFERRED` ownership event
+in `PROVENANCE_EVENT_TYPES`). Cosmetic-only data (custom name, quality tier) is not
+lore-critical: those items can be purged once the grace period expires.
+
+### Shared deletion helper
+
+`hard_delete_item_instance(item_instance)` in
+`world/items/services/usage.py` removes the instance's complete footprint in one
+call: it deletes all `OwnershipEvent` rows for the item first (so no ledger row is
+left with a null FK), then deletes the `game_object` (whose CASCADE removes the
+`ItemInstance` row) or the `ItemInstance` row directly if there is no game object.
+This helper is used by both the destruction-at-0-charges path and the time-based
+cleanup, so there is no second code path that could leave dangling rows.
+
+### Time-based cleanup of soft-deleted items
+
+**Service:** `purge_expired_soft_deleted_items(*, grace=None)` in
+`world/items/services/cleanup.py`
+
+Runs daily as the `items.soft_delete_cleanup` cron task (registered in
+`world/items/tasks.py`). On each run it:
+
+1. Computes a cutoff: `now() - grace` (default: `settings.ITEM_SOFT_DELETE_GRACE_DAYS`
+   days, configurable via the `ITEM_SOFT_DELETE_GRACE_DAYS` env var, default **30**).
+2. Queries all `ItemInstance` rows with `destroyed_at < cutoff` **and**
+   `lore_value=0` **and** zero attached facets **and** zero transfer-provenance events
+   (GIVEN/STOLEN/TRANSFERRED).
+3. Calls `hard_delete_item_instance` for each, returning the count purged.
+
+Lore-critical items (`is_lore_critical=True`) are never eligible and remain as
+soft-deleted rows indefinitely, available for staff recovery.
+
+**Configuration:**
+
+```python
+# src/server/conf/settings.py (default)
+ITEM_SOFT_DELETE_GRACE_DAYS = env.int("ITEM_SOFT_DELETE_GRACE_DAYS", default=30)
+```
+
+Override via `.env`:
+
+```
+ITEM_SOFT_DELETE_GRACE_DAYS=14
+```
 
 ---
 

--- a/src/server/conf/settings.py
+++ b/src/server/conf/settings.py
@@ -184,6 +184,10 @@ SITE_URL = env("SITE_URL", default="https://arxmush.org")
 GITHUB_ISSUE_REPO = env("GITHUB_ISSUE_REPO", default="Arx-Game/arxii")
 GITHUB_ISSUE_TOKEN = env("GITHUB_ISSUE_TOKEN", default=env("GH_TOKEN", default=""))
 
+# Days a soft-deleted, non-lore-critical ItemInstance lingers (recoverable)
+# before the daily cleanup hard-deletes it (#1025).
+ITEM_SOFT_DELETE_GRACE_DAYS = env.int("ITEM_SOFT_DELETE_GRACE_DAYS", default=30)
+
 # Django Allauth configuration
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",

--- a/src/world/items/constants.py
+++ b/src/world/items/constants.py
@@ -56,6 +56,19 @@ class OwnershipEventType(models.TextChoices):
     CONSUMED = "consumed", "Consumed"  # item destroyed by use (e.g. permit absorbed into project)
 
 
+# Ownership events that represent the item changing hands — the lore-relevant
+# provenance the soft-delete cleanup must never destroy (#1025). Deliberately
+# excludes CREATED (origin) and ACTIVATED/CONSUMED (every consumed item has
+# these, so counting them would make the purge a no-op).
+PROVENANCE_EVENT_TYPES = frozenset(
+    {
+        OwnershipEventType.GIVEN,
+        OwnershipEventType.STOLEN,
+        OwnershipEventType.TRANSFERRED,
+    }
+)
+
+
 class GearArchetype(models.TextChoices):
     """Gear categorization for covenant role compatibility.
 

--- a/src/world/items/models.py
+++ b/src/world/items/models.py
@@ -17,7 +17,13 @@ from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
-from world.items.constants import BodyRegion, EquipmentLayer, GearArchetype, OwnershipEventType
+from world.items.constants import (
+    PROVENANCE_EVENT_TYPES,
+    BodyRegion,
+    EquipmentLayer,
+    GearArchetype,
+    OwnershipEventType,
+)
 
 # Cross-app FK strings used by multiple fields below. Centralized to avoid the
 # duplicated-literal SonarCloud smell (python:S1192).
@@ -631,6 +637,18 @@ class ItemInstance(SharedMemoryModel):
         if self.cached_item_facets:
             return True
         return self.ownership_events.exclude(event_type=OwnershipEventType.CREATED).exists()
+
+    @property
+    def is_lore_critical(self) -> bool:
+        """True if this instance must never be auto-purged by the soft-delete
+        cleanup: it carries material ``lore_value``, facets, or transfer
+        provenance (it changed hands). Subset of ``differs_from_template`` —
+        cosmetic-only data (custom name / quality tier) is NOT lore-critical."""
+        if self.lore_value:
+            return True
+        if self.cached_item_facets:
+            return True
+        return self.ownership_events.filter(event_type__in=PROVENANCE_EVENT_TYPES).exists()
 
     def _quality_multiplier(self) -> Decimal:
         if self.quality_tier is None:

--- a/src/world/items/services/cleanup.py
+++ b/src/world/items/services/cleanup.py
@@ -1,0 +1,43 @@
+"""Service: time-based cleanup of soft-deleted, non-lore-critical items (#1025)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.db import transaction
+from django.db.models import Count, Q
+from django.utils import timezone
+
+from world.items.constants import PROVENANCE_EVENT_TYPES
+from world.items.models import ItemInstance
+from world.items.services.usage import hard_delete_item_instance
+
+
+@transaction.atomic
+def purge_expired_soft_deleted_items(*, grace: timedelta | None = None) -> int:
+    """Hard-delete soft-deleted ItemInstance rows that are past the grace
+    period AND not lore-critical (no facets, no transfer provenance, no
+    ``lore_value``). Deletes each row's whole footprint via
+    ``hard_delete_item_instance`` (no dangling FKs). Returns the count purged.
+
+    ``grace`` defaults to ``settings.ITEM_SOFT_DELETE_GRACE_DAYS`` days."""
+    if grace is None:
+        grace = timedelta(days=settings.ITEM_SOFT_DELETE_GRACE_DAYS)
+    cutoff = timezone.now() - grace
+
+    eligible = list(
+        ItemInstance.objects.filter(destroyed_at__lt=cutoff, lore_value=0)
+        .annotate(
+            facet_count=Count("item_facets", distinct=True),
+            transfer_count=Count(
+                "ownership_events",
+                filter=Q(ownership_events__event_type__in=PROVENANCE_EVENT_TYPES),
+                distinct=True,
+            ),
+        )
+        .filter(facet_count=0, transfer_count=0)
+    )
+    for instance in eligible:
+        hard_delete_item_instance(instance)
+    return len(eligible)

--- a/src/world/items/services/cleanup.py
+++ b/src/world/items/services/cleanup.py
@@ -3,31 +3,39 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import logging
 
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Count, Q
+from django.db.models import Count, ProtectedError, Q
 from django.utils import timezone
 
 from world.items.constants import PROVENANCE_EVENT_TYPES
 from world.items.models import ItemInstance
 from world.items.services.usage import hard_delete_item_instance
 
+logger = logging.getLogger(__name__)
 
-@transaction.atomic
+
 def purge_expired_soft_deleted_items(*, grace: timedelta | None = None) -> int:
     """Hard-delete soft-deleted ItemInstance rows that are past the grace
     period AND not lore-critical (no facets, no transfer provenance, no
     ``lore_value``). Deletes each row's whole footprint via
     ``hard_delete_item_instance`` (no dangling FKs). Returns the count purged.
 
-    ``grace`` defaults to ``settings.ITEM_SOFT_DELETE_GRACE_DAYS`` days."""
+    ``grace`` defaults to ``settings.ITEM_SOFT_DELETE_GRACE_DAYS`` days.
+
+    PROTECT-referenced instances (those with a Mantle or ProjectContribution
+    FK) are excluded from the eligibility queryset. Additionally, each deletion
+    runs in its own savepoint so that any unexpected ProtectedError from a
+    future FK addition skips that row instead of aborting the whole batch."""
     if grace is None:
         grace = timedelta(days=settings.ITEM_SOFT_DELETE_GRACE_DAYS)
     cutoff = timezone.now() - grace
 
     eligible = list(
         ItemInstance.objects.filter(destroyed_at__lt=cutoff, lore_value=0)
+        .filter(mantle__isnull=True, project_contributions__isnull=True)
         .annotate(
             facet_count=Count("item_facets", distinct=True),
             transfer_count=Count(
@@ -38,6 +46,17 @@ def purge_expired_soft_deleted_items(*, grace: timedelta | None = None) -> int:
         )
         .filter(facet_count=0, transfer_count=0)
     )
+    purged = 0
     for instance in eligible:
-        hard_delete_item_instance(instance)
-    return len(eligible)
+        try:
+            with transaction.atomic():
+                hard_delete_item_instance(instance)
+            purged += 1
+        except ProtectedError:
+            logger.warning(
+                "purge_expired_soft_deleted_items: skipping ItemInstance pk=%s — "
+                "ProtectedError (PROTECT FK still references this row); "
+                "exclude it from the eligibility filter to suppress this warning.",
+                instance.pk,
+            )
+    return purged

--- a/src/world/items/services/cleanup.py
+++ b/src/world/items/services/cleanup.py
@@ -25,6 +25,12 @@ def purge_expired_soft_deleted_items(*, grace: timedelta | None = None) -> int:
 
     ``grace`` defaults to ``settings.ITEM_SOFT_DELETE_GRACE_DAYS`` days.
 
+    A soft-deleted item must never be in the game world. Any otherwise-eligible
+    instance whose ``game_object`` still has a location (e.g. a half-undelete
+    that moved the object back into play but left ``destroyed_at`` set) is NOT
+    purged — it is logged for staff to resolve (clear ``destroyed_at`` to truly
+    undelete it, or pull it back out of the world).
+
     PROTECT-referenced instances (those with a Mantle or ProjectContribution
     FK) are excluded from the eligibility queryset. Additionally, each deletion
     runs in its own savepoint so that any unexpected ProtectedError from a
@@ -36,6 +42,7 @@ def purge_expired_soft_deleted_items(*, grace: timedelta | None = None) -> int:
     eligible = list(
         ItemInstance.objects.filter(destroyed_at__lt=cutoff, lore_value=0)
         .filter(mantle__isnull=True, project_contributions__isnull=True)
+        .select_related("game_object")
         .annotate(
             facet_count=Count("item_facets", distinct=True),
             transfer_count=Count(
@@ -46,8 +53,28 @@ def purge_expired_soft_deleted_items(*, grace: timedelta | None = None) -> int:
         )
         .filter(facet_count=0, transfer_count=0)
     )
-    purged = 0
+
+    # Safety guard: a soft-deleted item must not be in the game world. If its
+    # game_object has a location, someone re-homed it without clearing
+    # destroyed_at (a half-undelete) — never purge it; surface it instead.
+    in_world = []
+    purgeable = []
     for instance in eligible:
+        if instance.game_object_id is not None and instance.game_object.db_location_id is not None:
+            in_world.append(instance)
+        else:
+            purgeable.append(instance)
+    if in_world:
+        logger.warning(
+            "purge_expired_soft_deleted_items: %d soft-deleted item(s) are in the game "
+            "world while flagged for deletion (pks=%s); NOT purging. Resolve by clearing "
+            "destroyed_at to undelete, or removing them from the world.",
+            len(in_world),
+            [instance.pk for instance in in_world],
+        )
+
+    purged = 0
+    for instance in purgeable:
         try:
             with transaction.atomic():
                 hard_delete_item_instance(instance)

--- a/src/world/items/services/usage.py
+++ b/src/world/items/services/usage.py
@@ -6,6 +6,7 @@ import contextlib
 
 from django.db import transaction
 from django.utils import timezone
+from evennia.objects.models import ObjectDB
 
 from world.checks.consequence_resolution import (
     apply_pool_deterministically,
@@ -18,6 +19,20 @@ from world.items.constants import OwnershipEventType
 from world.items.exceptions import ItemNotUsable, NoChargesRemaining
 from world.items.models import EquippedItem, ItemInstance, OwnershipEvent
 from world.items.types import UseItemResult
+
+
+def hard_delete_item_instance(item_instance: ItemInstance) -> None:
+    """Permanently remove an instance and its whole footprint: its own ledger
+    rows first (so no OwnershipEvent is orphaned to a null FK), then the backing
+    game_object if present (CASCADE removes the row) else the row directly.
+
+    Used by both the destruction-at-0-charges path (#509) and the time-based
+    soft-delete cleanup (#1025). Caller owns the transaction."""
+    item_instance.ownership_events.all().delete()
+    if item_instance.game_object_id is not None:
+        item_instance.game_object.delete()  # CASCADE removes the ItemInstance row
+    else:
+        item_instance.delete()
 
 
 def _invalidate_caches(item_instance: ItemInstance) -> None:
@@ -68,21 +83,16 @@ def consume_item_charges(*, item_instance: ItemInstance, amount: int = 1) -> Ite
                 notes="Consumed — final charge spent (preserved).",
             )
         else:
-            OwnershipEvent.objects.create(
-                item_instance=locked,
-                event_type=OwnershipEventType.CONSUMED,
-                from_character_sheet=locked.holder_character_sheet,
-                notes=f"Consumed and destroyed: {locked.display_name} ({locked.template.name}).",
-            )
-            if locked.game_object_id is not None:
-                locked.game_object.delete()  # CASCADE removes the ItemInstance row
-            else:
-                locked.delete()
+            # Bare throwaway: nothing worth preserving — remove the whole
+            # footprint (no dangling CONSUMED row). #1025 convergence.
+            hard_delete_item_instance(locked)
     return locked
 
 
 @transaction.atomic
-def use_item(*, item_instance: ItemInstance, user, target=None) -> UseItemResult:
+def use_item(
+    *, item_instance: ItemInstance, user: ObjectDB, target: ObjectDB | None = None
+) -> UseItemResult:
     """Use a consumable: apply its on-use pool's effects (deterministic when the
     template has no on_use_check_type, else check-gated) and spend one charge.
     The charge is spent regardless of check outcome. user/target are ObjectDBs."""

--- a/src/world/items/tasks.py
+++ b/src/world/items/tasks.py
@@ -1,4 +1,4 @@
-"""Periodic tasks for the fashion / trendsetter system (Outfits Phase C, #514).
+"""Periodic tasks for the items app (fashion/trendsetter + soft-delete cleanup).
 
 Registered with ``world.game_clock.task_registry`` at server startup via the
 aggregator in ``world.game_clock.tasks.register_all_tasks``.
@@ -6,10 +6,12 @@ aggregator in ``world.game_clock.tasks.register_all_tasks``.
 
 from __future__ import annotations
 
+from datetime import timedelta
 import logging
 
 from world.game_clock.task_registry import CronDefinition, register_task
 from world.items.constants import FASHION_SEASON_INTERVAL, FASHION_VOGUE_DECAY_INTERVAL
+from world.items.services.cleanup import purge_expired_soft_deleted_items
 from world.items.services.trendsetter import (
     run_all_trendsetter_ceremonies,
     vogue_momentum_decay_tick,
@@ -27,6 +29,12 @@ def trendsetter_ceremony_task() -> None:
 def vogue_momentum_decay_task() -> None:
     """Cron entry: decay all positive facet-vogue momentum toward zero."""
     vogue_momentum_decay_tick()
+
+
+def soft_delete_cleanup_task() -> None:
+    """Cron entry: purge expired soft-deleted, non-lore-critical items (#1025)."""
+    purged = purge_expired_soft_deleted_items()
+    logger.info("Soft-delete cleanup: purged %d expired item instance(s)", purged)
 
 
 def register_all_tasks() -> None:
@@ -51,6 +59,17 @@ def register_all_tasks() -> None:
             description=(
                 "Decay every positive FacetVogueMomentum toward zero, mirroring "
                 "the renown fame-decay cadence (Outfits Phase C, #514)."
+            ),
+        )
+    )
+    register_task(
+        CronDefinition(
+            task_key="items.soft_delete_cleanup",
+            callable=soft_delete_cleanup_task,
+            interval=timedelta(days=1),
+            description=(
+                "Hard-delete soft-deleted, non-lore-critical ItemInstance rows "
+                "past the configured grace period (#1025)."
             ),
         )
     )

--- a/src/world/items/tests/test_cleanup_service.py
+++ b/src/world/items/tests/test_cleanup_service.py
@@ -1,0 +1,94 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+
+class PurgeExpiredSoftDeletedItemsTests(TestCase):
+    """purge_expired_soft_deleted_items() — #1025."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from evennia_extensions.factories import ObjectDBFactory
+        from world.items.factories import ItemInstanceFactory
+
+        cls.ItemInstanceFactory = ItemInstanceFactory
+        cls.ObjectDBFactory = ObjectDBFactory
+
+    def _soft_deleted(self, *, age_days: int, **kw):
+        when = timezone.now() - timedelta(days=age_days)
+        return self.ItemInstanceFactory(
+            quality_tier=None,
+            game_object=self.ObjectDBFactory(),
+            destroyed_at=when,
+            **kw,
+        )
+
+    def test_non_lore_critical_past_grace_is_purged(self):
+        from world.items.models import ItemInstance, OwnershipEvent
+        from world.items.services.cleanup import purge_expired_soft_deleted_items
+
+        inst = self._soft_deleted(age_days=40, custom_name="Plain Phial")
+        OwnershipEvent.objects.create(item_instance=inst, event_type="consumed")
+        pk = inst.pk
+
+        purged = purge_expired_soft_deleted_items(grace=timedelta(days=30))
+
+        self.assertEqual(purged, 1)
+        self.assertFalse(ItemInstance.objects.filter(pk=pk).exists())
+        self.assertFalse(OwnershipEvent.objects.exists())  # no orphan rows
+
+    def test_within_grace_is_retained(self):
+        from world.items.models import ItemInstance
+        from world.items.services.cleanup import purge_expired_soft_deleted_items
+
+        inst = self._soft_deleted(age_days=5, custom_name="Recent Phial")
+        purged = purge_expired_soft_deleted_items(grace=timedelta(days=30))
+        self.assertEqual(purged, 0)
+        self.assertTrue(ItemInstance.objects.filter(pk=inst.pk).exists())
+
+    def test_lore_value_survives_forever(self):
+        from world.items.models import ItemInstance
+        from world.items.services.cleanup import purge_expired_soft_deleted_items
+
+        inst = self._soft_deleted(age_days=400, lore_value=3)
+        purge_expired_soft_deleted_items(grace=timedelta(days=30))
+        self.assertTrue(ItemInstance.objects.filter(pk=inst.pk).exists())
+
+    def test_facet_survives_forever(self):
+        from world.items.factories import ItemFacetFactory
+        from world.items.models import ItemInstance
+        from world.items.services.cleanup import purge_expired_soft_deleted_items
+
+        inst = self._soft_deleted(age_days=400)
+        ItemFacetFactory(item_instance=inst)
+        purge_expired_soft_deleted_items(grace=timedelta(days=30))
+        self.assertTrue(ItemInstance.objects.filter(pk=inst.pk).exists())
+
+    def test_transfer_provenance_survives_forever(self):
+        from world.items.models import ItemInstance, OwnershipEvent
+        from world.items.services.cleanup import purge_expired_soft_deleted_items
+
+        inst = self._soft_deleted(age_days=400)
+        OwnershipEvent.objects.create(item_instance=inst, event_type="given")
+        purge_expired_soft_deleted_items(grace=timedelta(days=30))
+        self.assertTrue(ItemInstance.objects.filter(pk=inst.pk).exists())
+
+    def test_in_play_items_never_purged(self):
+        from world.items.models import ItemInstance
+        from world.items.services.cleanup import purge_expired_soft_deleted_items
+
+        inst = self.ItemInstanceFactory(quality_tier=None)  # destroyed_at=None
+        purge_expired_soft_deleted_items(grace=timedelta(days=30))
+        self.assertTrue(ItemInstance.objects.filter(pk=inst.pk).exists())
+
+    def test_default_grace_from_settings(self):
+        from django.test import override_settings
+
+        from world.items.models import ItemInstance
+        from world.items.services.cleanup import purge_expired_soft_deleted_items
+
+        inst = self._soft_deleted(age_days=40, custom_name="Plain")
+        with override_settings(ITEM_SOFT_DELETE_GRACE_DAYS=30):
+            purge_expired_soft_deleted_items()  # no grace arg → settings
+        self.assertFalse(ItemInstance.objects.filter(pk=inst.pk).exists())

--- a/src/world/items/tests/test_cleanup_service.py
+++ b/src/world/items/tests/test_cleanup_service.py
@@ -92,3 +92,57 @@ class PurgeExpiredSoftDeletedItemsTests(TestCase):
         with override_settings(ITEM_SOFT_DELETE_GRACE_DAYS=30):
             purge_expired_soft_deleted_items()  # no grace arg → settings
         self.assertFalse(ItemInstance.objects.filter(pk=inst.pk).exists())
+
+    def test_mantle_referenced_instance_excluded_sibling_purged(self):
+        """A Mantle-referenced instance is excluded; a plain sibling is purged."""
+        from world.items.factories import MantleFactory
+        from world.items.models import ItemInstance
+        from world.items.services.cleanup import purge_expired_soft_deleted_items
+
+        protected_inst = self._soft_deleted(age_days=40, custom_name="Mantle Item")
+        plain_inst = self._soft_deleted(age_days=40, custom_name="Plain Item")
+        # Attach a Mantle to the protected instance so it has a PROTECT FK.
+        MantleFactory(item_instance=protected_inst)
+
+        purged = purge_expired_soft_deleted_items(grace=timedelta(days=30))
+
+        self.assertEqual(purged, 1)
+        # The plain sibling must be gone.
+        self.assertFalse(ItemInstance.objects.filter(pk=plain_inst.pk).exists())
+        # The Mantle-referenced instance must survive.
+        self.assertTrue(ItemInstance.objects.filter(pk=protected_inst.pk).exists())
+
+    def test_per_item_protected_error_skips_row_not_whole_batch(self):
+        """A ProtectedError on one item skips it; the next item is still purged."""
+        from unittest.mock import patch
+
+        from django.db.models import ProtectedError
+
+        from world.items.models import ItemInstance
+        from world.items.services.cleanup import purge_expired_soft_deleted_items
+
+        inst_a = self._soft_deleted(age_days=40, custom_name="Protected A")
+        inst_b = self._soft_deleted(age_days=40, custom_name="Plain B")
+        pk_a = inst_a.pk
+        pk_b = inst_b.pk
+
+        call_count = {"n": 0}
+
+        def _side_effect(instance):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                msg = "test ProtectedError"
+                raise ProtectedError(msg, set())
+
+        with patch(
+            "world.items.services.cleanup.hard_delete_item_instance",
+            side_effect=_side_effect,
+        ):
+            purged = purge_expired_soft_deleted_items(grace=timedelta(days=30))
+
+        # Only one deletion succeeded (the second call).
+        self.assertEqual(purged, 1)
+        # Both rows still exist in the DB because the mock never actually deleted.
+        # The key invariant is that no exception escaped the function.
+        self.assertTrue(ItemInstance.objects.filter(pk=pk_a).exists())
+        self.assertTrue(ItemInstance.objects.filter(pk=pk_b).exists())

--- a/src/world/items/tests/test_cleanup_service.py
+++ b/src/world/items/tests/test_cleanup_service.py
@@ -47,6 +47,25 @@ class PurgeExpiredSoftDeletedItemsTests(TestCase):
         self.assertEqual(purged, 0)
         self.assertTrue(ItemInstance.objects.filter(pk=inst.pk).exists())
 
+    def test_in_world_item_not_purged_and_warns(self):
+        # Half-undelete: the game_object was moved back into the world but
+        # destroyed_at is still set. Never purge an in-world item — warn instead.
+        from world.items.models import ItemInstance
+        from world.items.services.cleanup import purge_expired_soft_deleted_items
+
+        in_world = self._soft_deleted(age_days=40, custom_name="Re-homed Phial")
+        in_world.game_object.db_location = self.ObjectDBFactory()
+        in_world.game_object.save()
+        plain = self._soft_deleted(age_days=40, custom_name="Plain Phial")
+
+        with self.assertLogs("world.items.services.cleanup", level="WARNING") as logs:
+            purged = purge_expired_soft_deleted_items(grace=timedelta(days=30))
+
+        self.assertEqual(purged, 1)  # only the plain, out-of-world item
+        self.assertTrue(ItemInstance.objects.filter(pk=in_world.pk).exists())
+        self.assertFalse(ItemInstance.objects.filter(pk=plain.pk).exists())
+        self.assertTrue(any(str(in_world.pk) in line for line in logs.output))
+
     def test_lore_value_survives_forever(self):
         from world.items.models import ItemInstance
         from world.items.services.cleanup import purge_expired_soft_deleted_items

--- a/src/world/items/tests/test_models.py
+++ b/src/world/items/tests/test_models.py
@@ -439,3 +439,49 @@ class ItemTemplateUseFieldsTests(TestCase):
         from world.items.factories import ItemInstanceFactory
 
         self.assertIsNone(ItemInstanceFactory().destroyed_at)
+
+
+class IsLoreCriticalTests(TestCase):
+    """ItemInstance.is_lore_critical — the never-purge predicate (#1025)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from world.items.factories import ItemInstanceFactory
+
+        cls.ItemInstanceFactory = ItemInstanceFactory
+
+    def test_bare_instance_is_not_lore_critical(self):
+        inst = self.ItemInstanceFactory(quality_tier=None)
+        self.assertFalse(inst.is_lore_critical)
+
+    def test_lore_value_makes_it_lore_critical(self):
+        inst = self.ItemInstanceFactory(quality_tier=None, lore_value=5)
+        self.assertTrue(inst.is_lore_critical)
+
+    def test_facet_makes_it_lore_critical(self):
+        from world.items.factories import ItemFacetFactory
+
+        inst = self.ItemInstanceFactory(quality_tier=None)
+        _ = inst.cached_item_facets  # populate cache before the facet is added
+        ItemFacetFactory(item_instance=inst)
+        del inst.cached_item_facets  # invalidate so is_lore_critical re-queries
+        self.assertTrue(inst.is_lore_critical)
+
+    def test_transfer_provenance_makes_it_lore_critical(self):
+        from world.items.constants import OwnershipEventType
+        from world.items.models import OwnershipEvent
+
+        inst = self.ItemInstanceFactory(quality_tier=None)
+        OwnershipEvent.objects.create(item_instance=inst, event_type=OwnershipEventType.GIVEN)
+        self.assertTrue(inst.is_lore_critical)
+
+    def test_activated_and_consumed_events_are_not_provenance(self):
+        # A consumed item ALWAYS has ACTIVATED + CONSUMED events; those must
+        # NOT count as lore-critical or the cleanup is a silent no-op.
+        from world.items.constants import OwnershipEventType
+        from world.items.models import OwnershipEvent
+
+        inst = self.ItemInstanceFactory(quality_tier=None)
+        OwnershipEvent.objects.create(item_instance=inst, event_type=OwnershipEventType.ACTIVATED)
+        OwnershipEvent.objects.create(item_instance=inst, event_type=OwnershipEventType.CONSUMED)
+        self.assertFalse(inst.is_lore_critical)

--- a/src/world/items/tests/test_tasks.py
+++ b/src/world/items/tests/test_tasks.py
@@ -1,0 +1,43 @@
+"""Test that the soft-delete cleanup cron task registers at startup (#1025).
+
+Task 4 wires :func:`soft_delete_cleanup_task` into the game_clock
+scheduler with task_key ``items.soft_delete_cleanup`` and a 1-day interval.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from world.game_clock.task_registry import (
+    clear_registry,
+    get_registered_tasks,
+)
+from world.game_clock.tasks import register_all_tasks
+
+
+class SoftDeleteCleanupTaskRegistrationTests(TestCase):
+    """``items.soft_delete_cleanup`` is registered after register_all_tasks() runs."""
+
+    def setUp(self) -> None:
+        clear_registry()
+
+    def tearDown(self) -> None:
+        clear_registry()
+
+    def test_cleanup_task_is_registered(self) -> None:
+        register_all_tasks()
+        keys = {t.task_key for t in get_registered_tasks()}
+        self.assertIn("items.soft_delete_cleanup", keys)
+
+    def test_cleanup_task_has_daily_interval(self) -> None:
+        register_all_tasks()
+        task = next(t for t in get_registered_tasks() if t.task_key == "items.soft_delete_cleanup")
+        self.assertEqual(task.interval, timedelta(days=1))
+
+    def test_cleanup_task_callable_invokes_service(self) -> None:
+        from world.items.tasks import soft_delete_cleanup_task
+
+        with patch("world.items.tasks.purge_expired_soft_deleted_items", return_value=3) as mocked:
+            soft_delete_cleanup_task()
+        mocked.assert_called_once_with()

--- a/src/world/items/tests/test_usage_service.py
+++ b/src/world/items/tests/test_usage_service.py
@@ -39,8 +39,9 @@ class ConsumeItemChargesTests(TestCase):
         with self.assertRaises(NoChargesRemaining):
             consume_item_charges(item_instance=self._consumable(charges=0))
 
-    def test_hard_delete_bare_instance_at_zero(self):
-        from world.items.constants import OwnershipEventType
+    def test_hard_delete_bare_instance_removes_whole_footprint(self):
+        # #1025: perma-delete of a bare throwaway now removes its ledger rows
+        # too — no dangling CONSUMED row with a nulled FK.
         from world.items.models import ItemInstance, OwnershipEvent
         from world.items.services.usage import consume_item_charges
 
@@ -49,16 +50,19 @@ class ConsumeItemChargesTests(TestCase):
         pk = inst.pk
         consume_item_charges(item_instance=inst, amount=1)
         self.assertFalse(ItemInstance.objects.filter(pk=pk).exists())
-        # The CONSUMED event survives the hard-delete via SET_NULL: its
-        # item_instance FK is nulled, but the ledger row persists. Read the
-        # FK column straight from the DB via .values() — the idmapper-cached
-        # event object isn't touched by the DB-side cascade.
-        fk = (
-            OwnershipEvent.objects.filter(event_type=OwnershipEventType.CONSUMED)
-            .values_list("item_instance_id", flat=True)
-            .get()
-        )
-        self.assertIsNone(fk)
+        self.assertFalse(OwnershipEvent.objects.exists())
+
+    def test_hard_delete_helper_removes_instance_and_ledger(self):
+        from world.items.constants import OwnershipEventType
+        from world.items.models import ItemInstance, OwnershipEvent
+        from world.items.services.usage import hard_delete_item_instance
+
+        inst = self._consumable(charges=0)
+        OwnershipEvent.objects.create(item_instance=inst, event_type=OwnershipEventType.CONSUMED)
+        pk = inst.pk
+        hard_delete_item_instance(inst)
+        self.assertFalse(ItemInstance.objects.filter(pk=pk).exists())
+        self.assertFalse(OwnershipEvent.objects.exists())
 
     def test_soft_delete_when_prior_ownership_event_exists(self):
         from world.items.constants import OwnershipEventType


### PR DESCRIPTION
Closes #1025

## Summary

Adds time-based cleanup of soft-deleted, non-lore-critical `ItemInstance` rows (follow-up to #509).

- **`ItemInstance.is_lore_critical`** — never-purge predicate: `lore_value > 0` OR facets OR **transfer** provenance (`GIVEN`/`STOLEN`/`TRANSFERRED` only). `ACTIVATED`/`CONSUMED` are deliberately excluded — every consumed item has those, so counting them would make the sweep a silent no-op.
- **Shared `hard_delete_item_instance()` helper** — removes an instance's whole footprint (its ledger rows, then `game_object` CASCADE / direct delete) with **no dangling FKs**. Used by both the destruction-at-0 path (retiring #509's old nulled-`CONSUMED`-row behavior) and the new cleanup.
- **`purge_expired_soft_deleted_items()`** — daily `items.soft_delete_cleanup` cron task sweeps soft-deleted, past-grace, non-lore-critical rows. Grace = `ITEM_SOFT_DELETE_GRACE_DAYS` (.env, default 30). Per-item savepointed and skips PROTECT-referenced rows (Mantle / ProjectContribution) so one bad row can't wedge the batch.
- Soft-delete itself is unchanged: rows + FKs stay intact, just filtered; only the time-delayed purge removes them. No new migration. Docs updated in tandem. 426 items tests green.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1025 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main @ cfc3d5d8 (#1218) — no overlap with our files; clean.

<!-- last-addressed-comment: 0 -->