### PR TITLE
Per-viewer persona display: sdesc + discovery reveal + self-ownership (#1109)

### DIFF
--- a/src/world/scenes/interaction_serializers.py
+++ b/src/world/scenes/interaction_serializers.py
@@ -115,12 +115,38 @@ class InteractionListSerializer(serializers.ModelSerializer):
         ]
 
     def get_persona(self, obj: Interaction) -> PersonaPayload:
-        p = obj.persona
-        return PersonaPayload(
-            id=p.pk,
-            name=p.name,
-            thumbnail_url=p.thumbnail_url or "",
+        # Per-viewer name resolution (#1109): own faces and named-public faces render real;
+        # discovered anonymous faces reveal "<real> (as <mask>)"; undiscovered anonymous faces
+        # render a composed sdesc. Resolved once for the whole page (see _persona_display_map).
+        name, _is_discovered = self._persona_display_map().get(
+            obj.persona_id, (obj.persona.name, False)
         )
+        return PersonaPayload(
+            id=obj.persona_id,
+            name=name,
+            thumbnail_url=obj.persona.thumbnail_url or "",
+        )
+
+    def _persona_display_map(self) -> dict[int, tuple[str, bool]]:
+        """Cache the page's persona-display resolution on the shared context (O(1) queries)."""
+        cached = self.context.get("_persona_display_map")
+        if cached is not None:
+            return cached
+        from world.scenes.persona_display import build_persona_display_map  # noqa: PLC0415
+
+        if self.parent is not None:
+            rows = list(self.parent.instance or [])
+        elif self.instance is not None:
+            rows = [self.instance]
+        else:
+            rows = []
+        display_map = build_persona_display_map(
+            [row.persona for row in rows],
+            viewer_persona_ids=set(self.context.get("persona_ids", set())),
+            viewer_sheet_ids=set(self.context.get("viewer_sheet_ids", set())),
+        )
+        self.context["_persona_display_map"] = display_map
+        return display_map
 
     def get_receiver_persona_ids(self, obj: Interaction) -> list[int]:
         return [r.persona_id for r in obj.cached_receivers]

--- a/src/world/scenes/interaction_views.py
+++ b/src/world/scenes/interaction_views.py
@@ -86,6 +86,9 @@ class InteractionViewSet(
         context = super().get_serializer_context()
         entries = get_account_roster_entries(self.request)
         context["roster_entry_ids"] = {e.pk for e in entries} if entries else set()
+        # The viewer's own character sheets — who their PersonaDiscovery rows belong to,
+        # for per-viewer persona-name resolution (#1109).
+        context["viewer_sheet_ids"] = {e.character_sheet_id for e in entries} if entries else set()
         # Per-viewer my_reaction on reaction windows (#904) — context, never
         # Prefetch(to_attr) on the shared instances.
         context["persona_ids"] = set(get_account_personas(self.request))
@@ -99,6 +102,7 @@ class InteractionViewSet(
         base_qs = Interaction.objects.select_related(
             "persona__character_sheet",
             "persona__character_sheet__roster_entry",
+            "persona__character_sheet__gender",  # #1109: apparent gender for anonymous sdesc
             "persona",
             "scene",
             "place",

--- a/src/world/scenes/persona_display.py
+++ b/src/world/scenes/persona_display.py
@@ -26,18 +26,24 @@ if TYPE_CHECKING:
 
     from world.scenes.models import Persona
 
-# PLACEHOLDER — the spec'd anonymous-face short description format (#1109). Apparent gender
-# comes from the character's real gender; non-binary / unset render as "person". The mask
-# label is the player-authored persona name. Player-facing wording, kept simple and editable.
+# Apparent gender for the anonymous-face short description (#1109): from the character's real
+# gender; non-binary / unset render as "person". (A slice-3 disguise that conceals gender will
+# force "person" regardless — e.g. a feature-concealing robe.)
 _GENDER_NOUN = {"male": "man", "female": "woman"}
 
 
 def compose_sdesc(persona: Persona) -> str:
-    """An anonymous face's short description: ``"a man/woman/person in a <mask name>"``."""
+    """An anonymous face's short description: ``"a man/woman/person wearing a <mask name>"``.
+
+    This is the *mask* case — the mask label is the player-authored persona name. Slice 3
+    (disguises) will let other concealment types supply their own phrasing and conceal traits
+    (e.g. ``"a person wearing a feature-concealing robe"``), continuing into the trait-driven
+    auto-description; for now an anonymous persona is rendered as a worn mask.
+    """
     sheet = persona.character_sheet
     gender_key = sheet.gender.key if sheet.gender_id is not None else None
     noun = _GENDER_NOUN.get(gender_key, "person")
-    return f"a {noun} in a {persona.name}"
+    return f"a {noun} wearing a {persona.name}"
 
 
 def build_persona_display_map(

--- a/src/world/scenes/persona_display.py
+++ b/src/world/scenes/persona_display.py
@@ -1,0 +1,79 @@
+"""Per-viewer persona display resolution (#1109, slice 2).
+
+How a persona's name renders to a given viewer:
+
+- **Your own faces** — any persona on a character_sheet your account currently plays — and
+  **named public faces** render by their real name. You are never restricted from your own
+  identities (the owning player always sees the truth).
+- **Anonymous faces** (`is_fake_name`) you have **discovered** (via any of your characters)
+  render as ``"<real> (as <mask>)"``.
+- **Anonymous faces** you have not discovered render as a composed **sdesc**.
+
+``build_persona_display_map`` resolves a whole page of personas in O(1) discovery queries, so
+the interaction feed stays query-bounded.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.db.models import Q
+
+from world.scenes.models import PersonaDiscovery
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from world.scenes.models import Persona
+
+# PLACEHOLDER — the spec'd anonymous-face short description format (#1109). Apparent gender
+# comes from the character's real gender; non-binary / unset render as "person". The mask
+# label is the player-authored persona name. Player-facing wording, kept simple and editable.
+_GENDER_NOUN = {"male": "man", "female": "woman"}
+
+
+def compose_sdesc(persona: Persona) -> str:
+    """An anonymous face's short description: ``"a man/woman/person in a <mask name>"``."""
+    sheet = persona.character_sheet
+    gender_key = sheet.gender.key if sheet.gender_id is not None else None
+    noun = _GENDER_NOUN.get(gender_key, "person")
+    return f"a {noun} in a {persona.name}"
+
+
+def build_persona_display_map(
+    personas: Iterable[Persona],
+    *,
+    viewer_persona_ids: set[int],
+    viewer_sheet_ids: set[int],
+) -> dict[int, tuple[str, bool]]:
+    """Map each persona's pk -> ``(display_name, is_discovered)`` for one viewer (#1109).
+
+    One discovery query covers every anonymous, non-owned persona in ``personas``. Owned and
+    named-public personas resolve to their real name with no query.
+    """
+    unique = {p.pk: p for p in personas}
+    # Owned faces are never restricted — resolved as the real name without a discovery lookup.
+    fake_ids = [p.pk for p in unique.values() if p.is_fake_name and p.pk not in viewer_persona_ids]
+
+    revealed: dict[int, Persona] = {}
+    if fake_ids and viewer_sheet_ids:
+        rows = PersonaDiscovery.objects.filter(
+            Q(persona_id__in=fake_ids) | Q(linked_to_id__in=fake_ids),
+            discovered_by_id__in=viewer_sheet_ids,
+        ).select_related("persona", "linked_to")
+        for discovery in rows:
+            # A discovery links two faces; map the masked one to the other (the revealed one).
+            if discovery.persona_id in fake_ids:
+                revealed[discovery.persona_id] = discovery.linked_to
+            if discovery.linked_to_id in fake_ids:
+                revealed[discovery.linked_to_id] = discovery.persona
+
+    display: dict[int, tuple[str, bool]] = {}
+    for persona in unique.values():
+        if persona.pk in viewer_persona_ids or not persona.is_fake_name:
+            display[persona.pk] = (persona.name, False)
+        elif persona.pk in revealed:
+            display[persona.pk] = (f"{revealed[persona.pk].name} (as {persona.name})", True)
+        else:
+            display[persona.pk] = (compose_sdesc(persona), False)
+    return display

--- a/src/world/scenes/tests/test_persona_display.py
+++ b/src/world/scenes/tests/test_persona_display.py
@@ -41,15 +41,15 @@ class ComposeSdescTests(TestCase):
 
         sheet.gender = _gender("male")
         sheet.save(update_fields=["gender"])
-        assert compose_sdesc(mask) == "a man in a stag mask"
+        assert compose_sdesc(mask) == "a man wearing a stag mask"
 
         sheet.gender = _gender("female")
         sheet.save(update_fields=["gender"])
-        assert compose_sdesc(mask) == "a woman in a stag mask"
+        assert compose_sdesc(mask) == "a woman wearing a stag mask"
 
         sheet.gender = _gender("nonbinary")
         sheet.save(update_fields=["gender"])
-        assert compose_sdesc(mask) == "a person in a stag mask"
+        assert compose_sdesc(mask) == "a person wearing a stag mask"
 
 
 class PersonaDisplayApiTests(APITestCase):
@@ -75,7 +75,7 @@ class PersonaDisplayApiTests(APITestCase):
         _played_character(viewer)
         self.client.force_authenticate(user=viewer)
         response = self.client.get(reverse("interaction-list"))
-        assert self._persona_name(response, pose.pk) == "a man in a stag mask"
+        assert self._persona_name(response, pose.pk) == "a man wearing a stag mask"
 
     def test_owner_is_never_restricted_from_their_own_face(self) -> None:
         owner = AccountFactory()

--- a/src/world/scenes/tests/test_persona_display.py
+++ b/src/world/scenes/tests/test_persona_display.py
@@ -1,0 +1,150 @@
+"""Per-viewer persona display resolution (#1109): sdesc, discovery reveal, self-ownership."""
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory
+from world.character_sheets.models import Gender
+from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
+from world.scenes.constants import InteractionMode, ScenePrivacyMode
+from world.scenes.factories import (
+    InteractionFactory,
+    PersonaDiscoveryFactory,
+    PersonaFactory,
+    SceneFactory,
+)
+from world.scenes.persona_display import compose_sdesc
+
+
+def _gender(key):
+    return Gender.objects.get_or_create(key=key, defaults={"display_name": key.title()})[0]
+
+
+def _played_character(account, *, gender_key="male"):
+    roster_entry = RosterEntryFactory()
+    player_data = PlayerDataFactory(account=account)
+    RosterTenureFactory(player_data=player_data, roster_entry=roster_entry)
+    sheet = roster_entry.character_sheet
+    sheet.gender = _gender(gender_key)
+    sheet.save(update_fields=["gender"])
+    return roster_entry
+
+
+class ComposeSdescTests(TestCase):
+    def test_gender_noun_mapping(self) -> None:
+        roster_entry = RosterEntryFactory()
+        sheet = roster_entry.character_sheet
+        mask = PersonaFactory(character_sheet=sheet, is_fake_name=True, name="stag mask")
+
+        sheet.gender = _gender("male")
+        sheet.save(update_fields=["gender"])
+        assert compose_sdesc(mask) == "a man in a stag mask"
+
+        sheet.gender = _gender("female")
+        sheet.save(update_fields=["gender"])
+        assert compose_sdesc(mask) == "a woman in a stag mask"
+
+        sheet.gender = _gender("nonbinary")
+        sheet.save(update_fields=["gender"])
+        assert compose_sdesc(mask) == "a person in a stag mask"
+
+
+class PersonaDisplayApiTests(APITestCase):
+    def _persona_name(self, response, interaction_pk):
+        for row in response.data["results"]:
+            if row["id"] == interaction_pk:
+                return row["persona"]["name"]
+        return None
+
+    def _public_pose_by(self, persona):
+        scene = SceneFactory(privacy_mode=ScenePrivacyMode.PUBLIC)
+        return InteractionFactory(persona=persona, mode=InteractionMode.POSE, scene=scene)
+
+    def test_non_owner_sees_an_anonymous_face_as_an_sdesc(self) -> None:
+        owner = AccountFactory()
+        roster_entry = _played_character(owner, gender_key="male")
+        mask = PersonaFactory(
+            character_sheet=roster_entry.character_sheet, is_fake_name=True, name="stag mask"
+        )
+        pose = self._public_pose_by(mask)
+
+        viewer = AccountFactory()
+        _played_character(viewer)
+        self.client.force_authenticate(user=viewer)
+        response = self.client.get(reverse("interaction-list"))
+        assert self._persona_name(response, pose.pk) == "a man in a stag mask"
+
+    def test_owner_is_never_restricted_from_their_own_face(self) -> None:
+        owner = AccountFactory()
+        roster_entry = _played_character(owner)
+        mask = PersonaFactory(
+            character_sheet=roster_entry.character_sheet, is_fake_name=True, name="stag mask"
+        )
+        pose = self._public_pose_by(mask)
+
+        self.client.force_authenticate(user=owner)
+        response = self.client.get(reverse("interaction-list"))
+        # The owning player sees the real persona name, never the anonymized sdesc.
+        assert self._persona_name(response, pose.pk) == "stag mask"
+
+    def test_a_viewer_who_discovered_the_link_sees_the_reveal(self) -> None:
+        owner = AccountFactory()
+        roster_entry = _played_character(owner)
+        sheet = roster_entry.character_sheet
+        mask = PersonaFactory(character_sheet=sheet, is_fake_name=True, name="stag mask")
+        pose = self._public_pose_by(mask)
+
+        viewer = AccountFactory()
+        viewer_entry = _played_character(viewer)
+        PersonaDiscoveryFactory(
+            persona=mask,
+            linked_to=sheet.primary_persona,
+            discovered_by=viewer_entry.character_sheet,
+        )
+
+        self.client.force_authenticate(user=viewer)
+        response = self.client.get(reverse("interaction-list"))
+        assert self._persona_name(response, pose.pk) == (
+            f"{sheet.primary_persona.name} (as stag mask)"
+        )
+
+    def test_a_named_public_face_renders_by_name_to_everyone(self) -> None:
+        owner = AccountFactory()
+        roster_entry = _played_character(owner)
+        named = roster_entry.character_sheet.primary_persona  # not fake
+        pose = self._public_pose_by(named)
+
+        viewer = AccountFactory()
+        _played_character(viewer)
+        self.client.force_authenticate(user=viewer)
+        response = self.client.get(reverse("interaction-list"))
+        assert self._persona_name(response, pose.pk) == named.name
+
+    def test_display_resolution_is_batched_not_n_plus_one(self) -> None:
+        """The per-viewer resolution adds ONE discovery query for the whole page, and reads the
+        apparent gender from the (prefetched) select_related — never per anonymous persona."""
+        viewer = AccountFactory()
+        _played_character(viewer)
+        for i in range(8):
+            owner = AccountFactory()
+            entry = _played_character(owner)
+            mask = PersonaFactory(
+                character_sheet=entry.character_sheet, is_fake_name=True, name=f"mask {i}"
+            )
+            self._public_pose_by(mask)
+
+        self.client.force_authenticate(user=viewer)
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(reverse("interaction-list"))
+        assert response.status_code == 200
+
+        sql = [q["sql"].lower() for q in ctx.captured_queries]
+        discovery_queries = [s for s in sql if "personadiscovery" in s]
+        gender_queries = [s for s in sql if "character_sheets_gender" in s]
+        # One discovery query for all 8 masks; gender comes via select_related — neither grows
+        # per anonymous persona (8 masks must not mean 8 of either).
+        assert len(discovery_queries) <= 1, f"discovery not batched: {len(discovery_queries)}"
+        assert len(gender_queries) <= 1, f"gender resolved per-row (N+1): {len(gender_queries)}"


### PR DESCRIPTION
The **player-facing half of appearance slice 2** (#1109) — how a persona's name renders to a viewer in the scene feed. Completes the slice alongside #1218 (privacy invariants) and #1223 (perception-accurate access).

## What a viewer sees
- **Own faces** (any persona on a character_sheet their account currently plays) and **named public faces** → the real name. **The owning player is never restricted from their own identities** — ownership overrides every sdesc/discovery rule (your steer).
- **Anonymous faces** (`is_fake_name`) the viewer has **discovered** (via any of their characters) → `"<real> (as <mask>)"`.
- **Anonymous faces** otherwise → a composed **sdesc**: `"a man/woman/person in a <mask name>"` — apparent gender from the character's real gender (non-binary / unset → "person"), mask label = the player-authored persona name.

## Implementation
- `persona_display.build_persona_display_map` resolves a whole page in **one** discovery query; the format/gender map is `PLACEHOLDER`-tagged (player-facing wording, editable).
- Gender rides in via a `select_related` added to the interaction queryset; the serializer caches the display map on the shared context — **no N+1**.
- The viewer's own character-sheet ids ride in the serializer context for the discovery lookup.

## Tests
gender noun mapping (male→man / female→woman / nonbinary→person); non-owner sees sdesc; **owner sees real name (self-ownership)**; discoverer sees the reveal; named face renders by name to all; and a batching guard — discovery + gender each stay **one query for a page of 8 masks**.

`world.scenes` green (580); ruff + ty clean; no API-types drift (the `persona` payload shape is unchanged).

## Note / deferred
Wired into the **scene-feed** (interaction list/detail) — the in-scene context. The same resolution would also apply to the broader **look / room-contents / profile** rendering (telnet `item_data`, web appearance serializer); that's a separate surface and a natural follow-up. The sdesc wording is intentionally minimal + PLACEHOLDER-tagged for your voice pass.

Refs #1109.
