### PR TITLE
fix(#520): apply DoT stage severity multiplier exactly once

### DIFF
--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -1609,17 +1609,20 @@ def _process_round_tick(
         for dot in dot_effects:
             damage = dot.base_damage
 
-            # Scale by severity
+            # effective_severity already folds in the stage multiplier, so scaling
+            # by severity and by the stage are mutually exclusive — if/elif, not two
+            # ifs, mirroring get_check_modifier / get_condition_modifier_total. (Two
+            # ifs double-applied the stage multiplier for a staged severity-scaled DoT.)
             if dot.scales_with_severity:
                 damage = damage * instance.effective_severity
+            elif instance.current_stage:
+                damage = damage * instance.current_stage.severity_multiplier
 
             # Scale by stacks
             if dot.scales_with_stacks:
                 damage = damage * instance.stacks
 
-            # Apply stage multiplier
-            if instance.current_stage:
-                damage = int(damage * instance.current_stage.severity_multiplier)
+            damage = int(damage)
 
             if damage > 0:
                 result.damage_dealt.append((dot.damage_type, damage))

--- a/src/world/conditions/tests/test_poison.py
+++ b/src/world/conditions/tests/test_poison.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.test import TestCase, tag
 
 from actions.factories import ConsequencePoolEntryFactory, ConsequencePoolFactory
@@ -96,6 +98,63 @@ class AcuteDotDamagesHealthTests(TestCase):
         self.assertEqual(self.vitals.health, 90)
 
 
+class ProcessRoundTickStageMultiplierTests(TestCase):
+    """Regression for #1117 — the staged DoT stage multiplier is applied exactly once.
+
+    ``effective_severity`` already folds in ``current_stage.severity_multiplier``, so a
+    severity-scaling staged DoT must NOT also multiply by the stage multiplier a second
+    time (that squared it: #230). The two paths are mutually exclusive (if/elif): the
+    severity path owns the multiplier via ``effective_severity``; the non-severity path
+    applies the raw stage multiplier itself.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+        cls.target = cls.sheet.character
+        cls.template = ConditionTemplateFactory(name="Staged-dot-1117")
+        # Stage-2 multiplier 2.00x; severity stays at the instance default of 1.
+        cls.stage = ConditionStageFactory(
+            condition=cls.template, stage_order=2, severity_multiplier=Decimal("2.00")
+        )
+
+    def _tick(self) -> int:
+        result = _process_round_tick(self.target, DamageTickTiming.END_OF_ROUND)
+        return sum(amt for _dt, amt in result.damage_dealt)
+
+    def test_severity_scaling_dot_applies_stage_multiplier_once(self):
+        """scales_with_severity=True: base 4 * effective_severity (1 * 2.00) = 8, not 16."""
+        ConditionDamageOverTimeFactory(
+            condition=self.template,
+            damage_type=DamageTypeFactory(name="staged-sev-true"),
+            base_damage=4,
+            tick_timing=DamageTickTiming.END_OF_ROUND,
+            is_long_term=False,
+            scales_with_severity=True,
+            scales_with_stacks=False,
+        )
+        ConditionInstanceFactory(
+            target=self.target, condition=self.template, current_stage=self.stage, severity=1
+        )
+        self.assertEqual(self._tick(), 8)
+
+    def test_non_severity_dot_applies_stage_multiplier_once(self):
+        """scales_with_severity=False: base 4 * stage multiplier 2.00 = 8 (applied once)."""
+        ConditionDamageOverTimeFactory(
+            condition=self.template,
+            damage_type=DamageTypeFactory(name="staged-sev-false"),
+            base_damage=4,
+            tick_timing=DamageTickTiming.END_OF_ROUND,
+            is_long_term=False,
+            scales_with_severity=False,
+            scales_with_stacks=False,
+        )
+        ConditionInstanceFactory(
+            target=self.target, condition=self.template, current_stage=self.stage, severity=1
+        )
+        self.assertEqual(self._tick(), 8)
+
+
 class EnsurePoisonContentTests(TestCase):
     def test_seeds_idempotently(self):
         from world.conditions.constants import (
@@ -192,12 +251,12 @@ class PoisonStagingScalesDotTests(TestCase):
 
         dmg1 = tick_damage(char1)
         dmg2 = tick_damage(char2)
-        # Staging scales the DoT: the higher stage deals strictly more damage. We assert the
-        # monotonic intent rather than an exact ratio because _process_round_tick composes the
-        # stage multiplier with effective_severity (which itself folds in the stage multiplier
-        # — preexisting #230 behavior), so a severity-scaling staged DoT does not scale by a
-        # clean 2x. The mechanic that matters here is "higher stage => more DoT".
-        self.assertGreater(dmg2, dmg1, "Stage 2 must compute more DoT than stage 1")
+        # Staging scales the DoT by exactly the stage multiplier, applied once (#1117).
+        # base_damage 4 * effective_severity (severity 1 * stage multiplier) * stacks 1:
+        # stage 1 (1.00x) => 4, stage 2 (2.00x) => 8 — a clean 2x, not the 4x that the
+        # double-applied stage multiplier (#230) produced before the fix.
+        self.assertEqual(dmg1, 4, "Stage 1 DoT = base 4 * 1.00x severity")
+        self.assertEqual(dmg2, 8, "Stage 2 DoT = base 4 * 2.00x severity (applied once)")
 
         # And the health loss through the real tick path reflects the staging.
         tick_round_for_targets([char1], timing="end")


### PR DESCRIPTION
## Summary

`_process_round_tick` (`src/world/conditions/services.py`) applied the stage
severity multiplier **twice** to a severity-scaling staged `ConditionDamageOverTime`:
once via `instance.effective_severity` (which already folds in
`current_stage.severity_multiplier`) and again via an explicit
`* current_stage.severity_multiplier` line. A stage-2 row (`2.00x`) therefore
scaled by `4x` instead of `2x` (the bug observed while writing #1050's poison
staging test — stage-2 produced 16 vs stage-1's 4).

The fix converts the two independent `if`s into an `if/elif`, mirroring the
already-correct readers `get_check_modifier` and `get_condition_modifier_total`:

- `scales_with_severity=True` → the severity path owns the multiplier via
  `effective_severity` (applied once).
- `scales_with_severity=False` → the `elif` applies the raw
  `current_stage.severity_multiplier` once (only when staged).

Pre-existing since #230; surfaced (not introduced) by #1050.

## Tests

- Tightened `PoisonStagingScalesDotTests` to assert the exact clean 2× per
  stage (stage 1 → 4, stage 2 → 8) instead of the prior directional
  `assertGreater` placeholder, and removed the stale comment documenting the
  double-application.
- Added `ProcessRoundTickStageMultiplierTests` asserting the exact per-stage
  damage for **both** `scales_with_severity=True` and `=False` staged DoT rows.
- `just test-fast world.conditions` → 280 passing.

## Notes

- Design step skipped: the issue body already contained a complete,
  team-authored fix direction; no new code surface, so no
  brainstorming/anti-reinvention pass was warranted.
- Verified the sibling long-term path (`batch_chronic_effect_tick`) does not
  share the bug — it scales by `effective_severity` once with no separate
  stage-multiplier line.
- No doc update needed: `docs/systems/conditions.md` documents
  `effective_severity` correctly and no doc described the DoT damage formula.

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
