### PR TITLE
Player endorsement UI — SceneEntryEndorsement + PoseEndorsement buttons in scene view

### DIFF
--- a/docs/architecture/resonance-gain.md
+++ b/docs/architecture/resonance-gain.md
@@ -678,6 +678,28 @@ Standard DRF ModelSerializers. `PoseEndorsement` serializer exposes
 until settled. `SceneEntryEndorsement` serializer exposes
 `granted_amount` as read-only (captured at creation).
 
+### 4.4 Scene interaction read surface (implemented — #1138)
+
+The existing `GET /api/interactions/?scene=<id>` response was extended to nest
+endorsement state directly on each `Interaction` row, so the scene view does not
+need a separate endorsement fetch. Fields added to `InteractionListSerializer`:
+
+| Field | Type | Description |
+|---|---|---|
+| `pose_kind` | `string` | STANDARD / ENTRY / DEPARTURE — identifies endorsable entry poses |
+| `endorsee_sheet_id` | `int \| null` | The pose author's CharacterSheet id — used to filter own poses |
+| `endorsable_resonances` | `[{id, name}]` | The author's claimed resonances — the endorsement picker source |
+| `pose_endorsers` | `[{persona_id, persona_name, thumbnail_url, resonance_id}]` | Who endorsed this pose and for which resonance |
+| `my_pose_endorsement` | `{id, resonance_id, settled: bool} \| null` | Viewer's own endorsement on this pose (null if none) |
+| `entry_endorsers` | `[{persona_id, persona_name, thumbnail_url, resonance_id}]` | Who endorsed this entry (ENTRY poses only) |
+| `entry_endorsed_by_me` | `bool` | Whether the viewer has endorsed this entry (ENTRY poses only) |
+
+**Frontend:** `EndorsementControl` component (in `frontend/src/scenes/components/`) mounts
+in `PoseUnit` next to `ReactionsFooter`. It shows an endorsement picker (source:
+`endorsable_resonances`), endorser badges (`pose_endorsers` / `entry_endorsers`), and
+retract affordance for unsettled pose endorsements. ENTRY poses render two controls:
+one for pose endorsement and one for scene-entry endorsement.
+
 ---
 
 ## 5. Gain Surface Rules Summary

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -46,6 +46,16 @@ Powers, affinities, auras, resonances, threads-as-currency, rituals, and Mage Sc
   - **Resonance-environment interaction (2026-05-16):** `AffinityInteraction` (9-row
     tuning table; gains `consequence_pool` FK), `ResonanceEnvironmentConfig` (singleton),
     `ResonanceAlignmentBoonTier` (authored ALIGNED boon tiers per affinity/magnitude band)
+  - **Spec C Resonance Gain (endorsements + audit — #1138):** `ResonanceGainConfig`
+    (singleton pk=1 tuning surface), `PoseEndorsement` (weekly deferred; `endorser_sheet`
+    FK, `resonance` FK (PROTECT), `persona_snapshot` FK to `scenes.Persona` (SET_NULL),
+    unique `(endorser_sheet, interaction)`), `SceneEntryEndorsement` (immediate flat
+    grant; same FK shape, unique `(endorser_sheet, endorsee_sheet, scene)`),
+    `ResonanceGrant` (universal audit ledger — discriminator `source` + typed source FKs).
+    Read surface: `InteractionListSerializer` now nests `pose_kind`, `endorsee_sheet_id`,
+    `endorsable_resonances`, `pose_endorsers`/`my_pose_endorsement`,
+    `entry_endorsers`/`entry_endorsed_by_me` on every `GET /api/interactions/?scene=<id>`
+    row. Frontend: `EndorsementControl` in `PoseUnit` (`frontend/src/scenes/components/`).
 - **Handlers:**
   - `character.threads` (`CharacterThreadHandler`) — cached thread list,
     `passive_vital_bonuses(vital_target)` for tier-0 VITAL_BONUS
@@ -120,6 +130,9 @@ Powers, affinities, auras, resonances, threads-as-currency, rituals, and Mage Sc
   - `POST /api/magic/rituals/perform/` — dispatches PerformRitualAction
     (resolves primitive `thread_id` → Thread instance for Imbuing)
   - `GET /api/magic/teaching-offers/` — ThreadWeavingTeachingOffer listing
+  - `POST /api/magic/pose-endorsements/` + `DELETE .../pose-endorsements/{id}/` — create/retract pose endorsement (Spec C)
+  - `POST /api/magic/scene-entry-endorsements/` — create entry endorsement; fires `grant_resonance` synchronously (Spec C)
+  - `GET /api/magic/resonance-grants/` — paginated audit ledger (Spec C)
 - **Source:** `src/world/magic/`
 - **Details:** [magic.md](magic.md) · cast lifecycle (How Magic Works):
   [technique-use-pipeline.md](../architecture/technique-use-pipeline.md) · power ledger +

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -16262,6 +16262,15 @@ export interface components {
       visibility?: components['schemas']['VisibilityF91Enum'];
       /** Format: date-time */
       readonly timestamp: string;
+      /**
+       * @description Classifies the pose as standard, entry, or departure. Set by the +enter command (future) or scene-entry hook. Spec C reads ENTRY to filter scene-entry-endorsement targets.
+       *
+       *     * `standard` - Standard
+       *     * `entry` - Entry
+       *     * `departure` - Departure
+       */
+      pose_kind?: components['schemas']['PoseKindEnum'];
+      readonly endorsee_sheet_id: number;
       readonly is_favorited: boolean;
       /** @description Aggregate emoji counts with reacted-by-current-user flag. */
       readonly reactions: {
@@ -16282,6 +16291,47 @@ export interface components {
       readonly place_name: string | null;
       readonly target_persona_ids: number[];
       readonly action_links: components['schemas']['InteractionActionLink'][];
+      /**
+       * @description List of resonances claimed by the endorsee (pose author).
+       *
+       *     Reads from the prefetched ``persona__character_sheet__resonances``
+       *     path (set up in ``interaction_views.get_queryset``) via the
+       *     ``cached_resonances`` to_attr. Falls back to a live query if the attr
+       *     is absent (e.g. serializer used outside the view's queryset pipeline).
+       */
+      readonly endorsable_resonances: {
+        [key: string]: unknown;
+      }[];
+      /**
+       * @description List of peers who endorsed this pose, with persona info.
+       *
+       *     Reads ``obj.cached_endorsements`` (Prefetch(to_attr=...) set by the
+       *     view queryset). Each endorser's primary persona is pre-loaded via
+       *     ``cached_primary_persona`` (another nested Prefetch).
+       */
+      readonly pose_endorsers: {
+        [key: string]: unknown;
+      }[];
+      /**
+       * @description Return the viewer's own endorsement for this pose, or None.
+       *
+       *     Checks ``character_sheet_ids`` from context (viewer's sheet PKs) against
+       *     each cached endorsement's ``endorser_sheet_id``.
+       */
+      readonly my_pose_endorsement: {
+        [key: string]: unknown;
+      } | null;
+      /**
+       * @description List of peers who gave this character a scene-entry endorsement.
+       *
+       *     Only non-empty for ENTRY poses. Reads ``scene_entry_endorsements`` from
+       *     context (populated by the view's ``get_serializer_context``).
+       */
+      readonly entry_endorsers: {
+        [key: string]: unknown;
+      }[];
+      /** @description True when the viewer has given this character a scene-entry endorsement. */
+      readonly entry_endorsed_by_me: boolean;
       readonly receivers: components['schemas']['InteractionReceiver'][];
     };
     InteractionFavorite: {
@@ -16331,6 +16381,15 @@ export interface components {
       visibility?: components['schemas']['VisibilityF91Enum'];
       /** Format: date-time */
       readonly timestamp: string;
+      /**
+       * @description Classifies the pose as standard, entry, or departure. Set by the +enter command (future) or scene-entry hook. Spec C reads ENTRY to filter scene-entry-endorsement targets.
+       *
+       *     * `standard` - Standard
+       *     * `entry` - Entry
+       *     * `departure` - Departure
+       */
+      pose_kind?: components['schemas']['PoseKindEnum'];
+      readonly endorsee_sheet_id: number;
       readonly is_favorited: boolean;
       /** @description Aggregate emoji counts with reacted-by-current-user flag. */
       readonly reactions: {
@@ -16351,6 +16410,47 @@ export interface components {
       readonly place_name: string | null;
       readonly target_persona_ids: number[];
       readonly action_links: components['schemas']['InteractionActionLink'][];
+      /**
+       * @description List of resonances claimed by the endorsee (pose author).
+       *
+       *     Reads from the prefetched ``persona__character_sheet__resonances``
+       *     path (set up in ``interaction_views.get_queryset``) via the
+       *     ``cached_resonances`` to_attr. Falls back to a live query if the attr
+       *     is absent (e.g. serializer used outside the view's queryset pipeline).
+       */
+      readonly endorsable_resonances: {
+        [key: string]: unknown;
+      }[];
+      /**
+       * @description List of peers who endorsed this pose, with persona info.
+       *
+       *     Reads ``obj.cached_endorsements`` (Prefetch(to_attr=...) set by the
+       *     view queryset). Each endorser's primary persona is pre-loaded via
+       *     ``cached_primary_persona`` (another nested Prefetch).
+       */
+      readonly pose_endorsers: {
+        [key: string]: unknown;
+      }[];
+      /**
+       * @description Return the viewer's own endorsement for this pose, or None.
+       *
+       *     Checks ``character_sheet_ids`` from context (viewer's sheet PKs) against
+       *     each cached endorsement's ``endorser_sheet_id``.
+       */
+      readonly my_pose_endorsement: {
+        [key: string]: unknown;
+      } | null;
+      /**
+       * @description List of peers who gave this character a scene-entry endorsement.
+       *
+       *     Only non-empty for ENTRY poses. Reads ``scene_entry_endorsements`` from
+       *     context (populated by the view's ``get_serializer_context``).
+       */
+      readonly entry_endorsers: {
+        [key: string]: unknown;
+      }[];
+      /** @description True when the viewer has given this character a scene-entry endorsement. */
+      readonly entry_endorsed_by_me: boolean;
     };
     InteractionListRequest: {
       /** @description Scene container if one was active */
@@ -16379,6 +16479,14 @@ export interface components {
        *     * `very_private` - Very Private
        */
       visibility?: components['schemas']['VisibilityF91Enum'];
+      /**
+       * @description Classifies the pose as standard, entry, or departure. Set by the +enter command (future) or scene-entry hook. Spec C reads ENTRY to filter scene-entry-endorsement targets.
+       *
+       *     * `standard` - Standard
+       *     * `entry` - Entry
+       *     * `departure` - Departure
+       */
+      pose_kind?: components['schemas']['PoseKindEnum'];
     };
     /** @description One eligible offer in the interaction state response. */
     InteractionOffer: {
@@ -20936,6 +21044,13 @@ export interface components {
       interaction: number;
       resonance: number;
     };
+    /**
+     * @description * `standard` - Standard
+     *     * `entry` - Entry
+     *     * `departure` - Departure
+     * @enum {string}
+     */
+    PoseKindEnum: 'standard' | 'entry' | 'departure';
     /**
      * @description Read-only serializer for a single PositionAdjacency entry.
      *

--- a/frontend/src/scenes/__tests__/endorsements.test.ts
+++ b/frontend/src/scenes/__tests__/endorsements.test.ts
@@ -1,0 +1,102 @@
+import { vi } from 'vitest';
+
+vi.mock('@/evennia_replacements/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/evennia_replacements/api';
+import {
+  createPoseEndorsement,
+  deletePoseEndorsement,
+  createSceneEntryEndorsement,
+} from '../queries';
+
+function mockOkResponse(data: unknown) {
+  return { ok: true, status: 200, json: () => Promise.resolve(data) } as Response;
+}
+
+function mockNoContentResponse() {
+  return { ok: true, status: 204 } as Response;
+}
+
+function mockErrorResponse(status = 400) {
+  return { ok: false, status } as Response;
+}
+
+describe('endorsement API functions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createPoseEndorsement', () => {
+    it('POSTs to /api/magic/pose-endorsements/ with interaction + resonance body', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockOkResponse({ id: 1, resonance_id: 5 }));
+
+      const result = await createPoseEndorsement({ interaction: 42, resonance: 5 });
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/magic/pose-endorsements/', {
+        method: 'POST',
+        body: JSON.stringify({ interaction: 42, resonance: 5 }),
+      });
+      expect(result).toEqual({ id: 1, resonance_id: 5 });
+    });
+
+    it('throws on error response', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockErrorResponse());
+
+      await expect(createPoseEndorsement({ interaction: 42, resonance: 5 })).rejects.toThrow(
+        'Failed to endorse pose'
+      );
+    });
+  });
+
+  describe('deletePoseEndorsement', () => {
+    it('DELETEs /api/magic/pose-endorsements/<id>/', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockNoContentResponse());
+
+      await deletePoseEndorsement(7);
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/magic/pose-endorsements/7/', {
+        method: 'DELETE',
+      });
+    });
+
+    it('does not throw on 204', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockNoContentResponse());
+
+      await expect(deletePoseEndorsement(7)).resolves.not.toThrow();
+    });
+
+    it('throws on error response', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockErrorResponse(403));
+
+      await expect(deletePoseEndorsement(7)).rejects.toThrow('Failed to retract endorsement');
+    });
+  });
+
+  describe('createSceneEntryEndorsement', () => {
+    it('POSTs to /api/magic/scene-entry-endorsements/ with endorsee_sheet + scene + resonance', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockOkResponse({ id: 3 }));
+
+      const result = await createSceneEntryEndorsement({
+        endorsee_sheet: 10,
+        scene: 99,
+        resonance: 5,
+      });
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/magic/scene-entry-endorsements/', {
+        method: 'POST',
+        body: JSON.stringify({ endorsee_sheet: 10, scene: 99, resonance: 5 }),
+      });
+      expect(result).toEqual({ id: 3 });
+    });
+
+    it('throws on error response', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockErrorResponse());
+
+      await expect(
+        createSceneEntryEndorsement({ endorsee_sheet: 10, scene: 99, resonance: 5 })
+      ).rejects.toThrow('Failed to endorse entry');
+    });
+  });
+});

--- a/frontend/src/scenes/components/EndorsementControl.tsx
+++ b/frontend/src/scenes/components/EndorsementControl.tsx
@@ -12,8 +12,11 @@
  * Hidden entirely when:
  *   - endorsable_resonances is empty (nothing to endorse with)
  *   - the pose belongs to the viewer (self-endorsement guard)
- *   - mode === 'WHISPER' or visibility === 'VERY_PRIVATE'
+ *   - mode === 'whisper' or visibility === 'very_private'
  *   - kind='entry' and endorsee_sheet_id is null (impossible in practice but typed)
+ *
+ * For kind='entry': shows a display-only "Endorsed ✓" indicator when
+ * entry_endorsed_by_me is true (entry endorsements are permanent — no retract).
  */
 
 import { useMemo } from 'react';
@@ -92,8 +95,8 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
   if (
     interaction.endorsable_resonances.length === 0 ||
     isSelfPose ||
-    interaction.mode === 'WHISPER' ||
-    interaction.visibility === 'VERY_PRIVATE'
+    interaction.mode === 'whisper' ||
+    interaction.visibility === 'very_private'
   ) {
     return null;
   }
@@ -128,6 +131,7 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
   const isPending = isPose ? createPose.isPending : createEntry.isPending;
   const myEndorsement = isPose ? interaction.my_pose_endorsement : null;
   const isEndorsed = myEndorsement != null;
+  const isEntryEndorsedByMe = !isPose && interaction.entry_endorsed_by_me;
   const label = isPose ? 'Endorse' : 'Endorse entry';
 
   return (
@@ -149,6 +153,14 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
         >
           Retract
         </button>
+      ) : isEntryEndorsedByMe ? (
+        /* Entry endorsements are permanent — no retract affordance, just a display indicator. */
+        <span
+          data-testid="entry-endorsed-indicator"
+          className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-300"
+        >
+          Endorsed ✓
+        </span>
       ) : (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/frontend/src/scenes/components/EndorsementControl.tsx
+++ b/frontend/src/scenes/components/EndorsementControl.tsx
@@ -13,6 +13,7 @@
  *   - endorsable_resonances is empty (nothing to endorse with)
  *   - the pose belongs to the viewer (self-endorsement guard)
  *   - mode === 'WHISPER' or visibility === 'VERY_PRIVATE'
+ *   - kind='entry' and endorsee_sheet_id is null (impossible in practice but typed)
  */
 
 import { useMemo } from 'react';
@@ -74,10 +75,16 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
     [myRosterEntries, activeCharacterName]
   );
 
-  // Mutation hooks
+  // Mutation hooks — must be called unconditionally before any early return.
   const createPose = useCreatePoseEndorsement(sceneId);
   const deletePose = useDeletePoseEndorsement(sceneId);
   const createEntry = useCreateSceneEntryEndorsement(sceneId);
+
+  // Map resonance id → name for badge tooltips — memoized, unconditional.
+  const resonanceMap = useMemo(
+    () => new Map(interaction.endorsable_resonances.map((r) => [r.id, r.name])),
+    [interaction.endorsable_resonances]
+  );
 
   // ----- Guard conditions — render nothing --------------------------------
   const isSelfPose = viewerPersonaId != null && interaction.persona.id === viewerPersonaId;
@@ -91,22 +98,26 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
     return null;
   }
 
+  // endorsee_sheet_id is typed number | null; for kind='entry' it must be present.
+  // If it's somehow null (impossible in practice but typed), hide rather than coerce.
+  if (kind === 'entry' && interaction.endorsee_sheet_id == null) {
+    return null;
+  }
+
   // ----- Data for this kind -----------------------------------------------
   const isPose = kind === 'pose';
   const endorsers: EndorserBadge[] = isPose
     ? interaction.pose_endorsers
     : interaction.entry_endorsers;
 
-  // Map resonance id → name for badge tooltips
-  const resonanceMap = new Map(interaction.endorsable_resonances.map((r) => [r.id, r.name]));
-
   // ----- Handlers ---------------------------------------------------------
   function handlePickResonance(resonanceId: number) {
     if (isPose) {
       createPose.mutate({ interaction: interaction.id, resonance: resonanceId });
     } else {
+      // endorsee_sheet_id is guaranteed non-null here by the guard above.
       createEntry.mutate({
-        endorsee_sheet: interaction.endorsee_sheet_id as number,
+        endorsee_sheet: interaction.endorsee_sheet_id!,
         scene: Number(sceneId),
         resonance: resonanceId,
       });
@@ -162,7 +173,7 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
       {/* Endorser badges */}
       {endorsers.map((badge) => (
         <BadgeChip
-          key={badge.persona_id}
+          key={`${badge.persona_id}-${badge.resonance_id}`}
           badge={badge}
           resonanceName={resonanceMap.get(badge.resonance_id) ?? String(badge.resonance_id)}
         />

--- a/frontend/src/scenes/components/EndorsementControl.tsx
+++ b/frontend/src/scenes/components/EndorsementControl.tsx
@@ -1,0 +1,172 @@
+/**
+ * EndorsementControl (#1138) — resonance-picker + endorser badge strip for
+ * both pose endorsements (weekly PoseEndorsement) and scene-entry endorsements
+ * (immediate SceneEntryEndorsement). Mounts inside PoseUnit.
+ *
+ * Props:
+ *   interaction — the full Interaction payload including endorsement state.
+ *   sceneId     — forwarded to mutation hooks for cache invalidation.
+ *   kind        — 'pose' | 'entry'; drives which mutation fires and which
+ *                 badge list / retract affordance is shown.
+ *
+ * Hidden entirely when:
+ *   - endorsable_resonances is empty (nothing to endorse with)
+ *   - the pose belongs to the viewer (self-endorsement guard)
+ *   - mode === 'WHISPER' or visibility === 'VERY_PRIVATE'
+ */
+
+import { useMemo } from 'react';
+import { useAppSelector } from '@/store/hooks';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  useCreatePoseEndorsement,
+  useDeletePoseEndorsement,
+  useCreateSceneEntryEndorsement,
+} from '../queries';
+import type { Interaction, EndorserBadge } from '../types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface EndorsementControlProps {
+  interaction: Interaction;
+  sceneId: string;
+  kind: 'pose' | 'entry';
+}
+
+// ---------------------------------------------------------------------------
+// Endorser badge chip
+// ---------------------------------------------------------------------------
+
+interface BadgeChipProps {
+  badge: EndorserBadge;
+  resonanceName: string;
+}
+
+function BadgeChip({ badge, resonanceName }: BadgeChipProps) {
+  return (
+    <span
+      title={`${badge.persona_name} endorsed with ${resonanceName}`}
+      className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-xs text-amber-700 dark:text-amber-300"
+    >
+      {badge.persona_name}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// EndorsementControl
+// ---------------------------------------------------------------------------
+
+export function EndorsementControl({ interaction, sceneId, kind }: EndorsementControlProps) {
+  // Resolve the viewer's active persona to detect self-pose.
+  const activeCharacterName = useAppSelector((state) => state.game.active);
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
+  const viewerPersonaId = useMemo(
+    () => myRosterEntries.find((e) => e.name === activeCharacterName)?.primary_persona_id ?? null,
+    [myRosterEntries, activeCharacterName]
+  );
+
+  // Mutation hooks
+  const createPose = useCreatePoseEndorsement(sceneId);
+  const deletePose = useDeletePoseEndorsement(sceneId);
+  const createEntry = useCreateSceneEntryEndorsement(sceneId);
+
+  // ----- Guard conditions — render nothing --------------------------------
+  const isSelfPose = viewerPersonaId != null && interaction.persona.id === viewerPersonaId;
+
+  if (
+    interaction.endorsable_resonances.length === 0 ||
+    isSelfPose ||
+    interaction.mode === 'WHISPER' ||
+    interaction.visibility === 'VERY_PRIVATE'
+  ) {
+    return null;
+  }
+
+  // ----- Data for this kind -----------------------------------------------
+  const isPose = kind === 'pose';
+  const endorsers: EndorserBadge[] = isPose
+    ? interaction.pose_endorsers
+    : interaction.entry_endorsers;
+
+  // Map resonance id → name for badge tooltips
+  const resonanceMap = new Map(interaction.endorsable_resonances.map((r) => [r.id, r.name]));
+
+  // ----- Handlers ---------------------------------------------------------
+  function handlePickResonance(resonanceId: number) {
+    if (isPose) {
+      createPose.mutate({ interaction: interaction.id, resonance: resonanceId });
+    } else {
+      createEntry.mutate({
+        endorsee_sheet: interaction.endorsee_sheet_id as number,
+        scene: Number(sceneId),
+        resonance: resonanceId,
+      });
+    }
+  }
+
+  // ----- Render -----------------------------------------------------------
+  const isPending = isPose ? createPose.isPending : createEntry.isPending;
+  const myEndorsement = isPose ? interaction.my_pose_endorsement : null;
+  const isEndorsed = myEndorsement != null;
+  const label = isPose ? 'Endorse' : 'Endorse entry';
+
+  return (
+    <div
+      data-testid={`endorsement-control-${kind}`}
+      className="mt-1 flex flex-wrap items-center gap-1.5"
+    >
+      {/* Resonance picker or retract affordance */}
+      {isEndorsed ? (
+        <button
+          type="button"
+          disabled={myEndorsement.settled || deletePose.isPending}
+          onClick={() => deletePose.mutate(myEndorsement.id)}
+          className={`rounded-full border px-2 py-0.5 text-xs transition-colors ${
+            myEndorsement.settled
+              ? 'cursor-not-allowed border-muted-foreground/20 opacity-50'
+              : 'border-amber-500 bg-amber-500/10 font-medium hover:bg-amber-500/20'
+          }`}
+        >
+          Retract
+        </button>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              disabled={isPending}
+              className="rounded-full border border-muted-foreground/30 px-2 py-0.5 text-xs transition-colors hover:border-amber-500/60 disabled:opacity-50"
+            >
+              {label}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            {interaction.endorsable_resonances.map((r) => (
+              <DropdownMenuItem key={r.id} onClick={() => handlePickResonance(r.id)}>
+                {r.name}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+
+      {/* Endorser badges */}
+      {endorsers.map((badge) => (
+        <BadgeChip
+          key={badge.persona_id}
+          badge={badge}
+          resonanceName={resonanceMap.get(badge.resonance_id) ?? String(badge.resonance_id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/scenes/components/PoseUnit.test.tsx
+++ b/frontend/src/scenes/components/PoseUnit.test.tsx
@@ -26,10 +26,21 @@ vi.mock('./PoseUnitDetailPanel', () => ({
 }));
 
 // Stub EndorsementControl so PoseUnit mount tests can assert presence/absence
-// without pulling in endorsement hook machinery.
+// without pulling in endorsement hook machinery. The stub renders data-* attributes
+// carrying the forwarded mode and visibility so tests can verify prop forwarding.
 vi.mock('./EndorsementControl', () => ({
-  EndorsementControl: ({ kind }: { kind: string }) => (
-    <div data-testid={`endorsement-control-${kind}`} />
+  EndorsementControl: ({
+    kind,
+    interaction,
+  }: {
+    kind: string;
+    interaction: { mode: string; visibility: string };
+  }) => (
+    <div
+      data-testid={`endorsement-control-${kind}`}
+      data-mode={interaction.mode}
+      data-visibility={interaction.visibility}
+    />
   ),
 }));
 
@@ -468,24 +479,38 @@ describe('PoseUnit endorsement control mounting', () => {
     expect(screen.getByTestId('endorsement-control-pose')).toBeInTheDocument();
   });
 
-  it('WHISPER pose renders NO endorsement controls (guarded by EndorsementControl itself)', () => {
-    // The EndorsementControl stub renders regardless of visibility — the real
-    // component guards; PoseUnit just passes props through. We test here that
-    // PoseUnit still renders the control element (guard lives in EndorsementControl).
-    // This test verifies props are passed so the real component can guard.
-    const interaction = makeInteraction({
-      mode: 'WHISPER',
-      pose_kind: 'STANDARD',
-    });
+  // WHISPER and VERY_PRIVATE suppression is tested at the correct layer:
+  // EndorsementControl.test.tsx covers "hides for WHISPER mode" and "hides for
+  // VERY_PRIVATE visibility". PoseUnit's only responsibility is to mount
+  // EndorsementControl and forward the interaction prop — the control self-hides.
+  // The tests below verify that PoseUnit does pass the interaction's mode/visibility
+  // through to EndorsementControl, so the real component receives the data it needs
+  // to apply its own guard.
 
+  it('WHISPER pose: PoseUnit forwards interaction with mode=WHISPER to EndorsementControl', () => {
+    const interaction = makeInteraction({ mode: 'WHISPER', pose_kind: 'STANDARD' });
     render(
       <Wrapper>
         <PoseUnit interaction={interaction} sceneId="1" />
       </Wrapper>
     );
 
-    // WHISPER is treated as a pose-mode interaction by PoseUnit branch logic;
-    // the control is rendered (guard lives inside EndorsementControl).
-    expect(screen.getByTestId('endorsement-control-pose')).toBeInTheDocument();
+    // The stub renders data-mode from the forwarded interaction prop.
+    // If PoseUnit passes the right interaction, the real EndorsementControl will
+    // see mode='WHISPER' and return null — suppression tested in EndorsementControl.test.tsx.
+    const control = screen.getByTestId('endorsement-control-pose');
+    expect(control).toHaveAttribute('data-mode', 'WHISPER');
+  });
+
+  it('VERY_PRIVATE pose: PoseUnit forwards interaction with visibility=VERY_PRIVATE to EndorsementControl', () => {
+    const interaction = makeInteraction({ visibility: 'VERY_PRIVATE', pose_kind: 'STANDARD' });
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    const control = screen.getByTestId('endorsement-control-pose');
+    expect(control).toHaveAttribute('data-visibility', 'VERY_PRIVATE');
   });
 });

--- a/frontend/src/scenes/components/PoseUnit.test.tsx
+++ b/frontend/src/scenes/components/PoseUnit.test.tsx
@@ -60,7 +60,7 @@ function makeInteraction(overrides: Partial<Interaction> = {}): Interaction {
     receiver_persona_ids: [],
     target_persona_ids: [],
     action_links: [],
-    pose_kind: 'STANDARD',
+    pose_kind: 'standard',
     endorsee_sheet_id: 20,
     endorsable_resonances: [{ id: 5, name: 'Courage' }],
     pose_endorsers: [],
@@ -419,7 +419,7 @@ describe('PoseUnit endorsement control mounting', () => {
   it('ENTRY pose renders TWO endorsement controls (pose + entry)', () => {
     const interaction = makeInteraction({
       mode: 'pose',
-      pose_kind: 'ENTRY',
+      pose_kind: 'entry',
     });
 
     render(
@@ -435,7 +435,7 @@ describe('PoseUnit endorsement control mounting', () => {
   it('STANDARD pose renders ONE endorsement control (pose only)', () => {
     const interaction = makeInteraction({
       mode: 'pose',
-      pose_kind: 'STANDARD',
+      pose_kind: 'standard',
     });
 
     render(
@@ -467,7 +467,7 @@ describe('PoseUnit endorsement control mounting', () => {
   it('standalone ACTION branch also renders an endorsement control', () => {
     const interaction = makeInteraction({
       mode: 'action',
-      pose_kind: 'STANDARD',
+      pose_kind: 'standard',
     });
 
     render(
@@ -487,8 +487,8 @@ describe('PoseUnit endorsement control mounting', () => {
   // through to EndorsementControl, so the real component receives the data it needs
   // to apply its own guard.
 
-  it('WHISPER pose: PoseUnit forwards interaction with mode=WHISPER to EndorsementControl', () => {
-    const interaction = makeInteraction({ mode: 'WHISPER', pose_kind: 'STANDARD' });
+  it('whisper pose: PoseUnit forwards interaction with mode=whisper to EndorsementControl', () => {
+    const interaction = makeInteraction({ mode: 'whisper', pose_kind: 'standard' });
     render(
       <Wrapper>
         <PoseUnit interaction={interaction} sceneId="1" />
@@ -497,13 +497,13 @@ describe('PoseUnit endorsement control mounting', () => {
 
     // The stub renders data-mode from the forwarded interaction prop.
     // If PoseUnit passes the right interaction, the real EndorsementControl will
-    // see mode='WHISPER' and return null — suppression tested in EndorsementControl.test.tsx.
+    // see mode='whisper' and return null — suppression tested in EndorsementControl.test.tsx.
     const control = screen.getByTestId('endorsement-control-pose');
-    expect(control).toHaveAttribute('data-mode', 'WHISPER');
+    expect(control).toHaveAttribute('data-mode', 'whisper');
   });
 
-  it('VERY_PRIVATE pose: PoseUnit forwards interaction with visibility=VERY_PRIVATE to EndorsementControl', () => {
-    const interaction = makeInteraction({ visibility: 'VERY_PRIVATE', pose_kind: 'STANDARD' });
+  it('very_private pose: PoseUnit forwards interaction with visibility=very_private to EndorsementControl', () => {
+    const interaction = makeInteraction({ visibility: 'very_private', pose_kind: 'standard' });
     render(
       <Wrapper>
         <PoseUnit interaction={interaction} sceneId="1" />
@@ -511,6 +511,6 @@ describe('PoseUnit endorsement control mounting', () => {
     );
 
     const control = screen.getByTestId('endorsement-control-pose');
-    expect(control).toHaveAttribute('data-visibility', 'VERY_PRIVATE');
+    expect(control).toHaveAttribute('data-visibility', 'very_private');
   });
 });

--- a/frontend/src/scenes/components/PoseUnit.test.tsx
+++ b/frontend/src/scenes/components/PoseUnit.test.tsx
@@ -25,6 +25,14 @@ vi.mock('./PoseUnitDetailPanel', () => ({
   ),
 }));
 
+// Stub EndorsementControl so PoseUnit mount tests can assert presence/absence
+// without pulling in endorsement hook machinery.
+vi.mock('./EndorsementControl', () => ({
+  EndorsementControl: ({ kind }: { kind: string }) => (
+    <div data-testid={`endorsement-control-${kind}`} />
+  ),
+}));
+
 function makeInteraction(overrides: Partial<Interaction> = {}): Interaction {
   return {
     id: 1,
@@ -41,6 +49,13 @@ function makeInteraction(overrides: Partial<Interaction> = {}): Interaction {
     receiver_persona_ids: [],
     target_persona_ids: [],
     action_links: [],
+    pose_kind: 'STANDARD',
+    endorsee_sheet_id: 20,
+    endorsable_resonances: [{ id: 5, name: 'Courage' }],
+    pose_endorsers: [],
+    my_pose_endorsement: null,
+    entry_endorsers: [],
+    entry_endorsed_by_me: false,
     ...overrides,
   };
 }
@@ -378,5 +393,99 @@ describe('PoseUnit outcome mode', () => {
     expect(screen.queryByTitle('Double-click to add as target')).toBeNull();
     expect(screen.queryByTestId('pose-unit')).toBeNull();
     expect(screen.queryByTestId('pose-unit-action-standalone')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Endorsement control mounting (#1138)
+// ---------------------------------------------------------------------------
+
+describe('PoseUnit endorsement control mounting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ENTRY pose renders TWO endorsement controls (pose + entry)', () => {
+    const interaction = makeInteraction({
+      mode: 'pose',
+      pose_kind: 'ENTRY',
+    });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('endorsement-control-pose')).toBeInTheDocument();
+    expect(screen.getByTestId('endorsement-control-entry')).toBeInTheDocument();
+  });
+
+  it('STANDARD pose renders ONE endorsement control (pose only)', () => {
+    const interaction = makeInteraction({
+      mode: 'pose',
+      pose_kind: 'STANDARD',
+    });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('endorsement-control-pose')).toBeInTheDocument();
+    expect(screen.queryByTestId('endorsement-control-entry')).toBeNull();
+  });
+
+  it('OUTCOME branch renders NO endorsement controls', () => {
+    const interaction = makeInteraction({
+      mode: 'outcome',
+      persona: { id: 99, name: 'Narrator', thumbnail_url: '' },
+    });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('endorsement-control-pose')).toBeNull();
+    expect(screen.queryByTestId('endorsement-control-entry')).toBeNull();
+  });
+
+  it('standalone ACTION branch also renders an endorsement control', () => {
+    const interaction = makeInteraction({
+      mode: 'action',
+      pose_kind: 'STANDARD',
+    });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('endorsement-control-pose')).toBeInTheDocument();
+  });
+
+  it('WHISPER pose renders NO endorsement controls (guarded by EndorsementControl itself)', () => {
+    // The EndorsementControl stub renders regardless of visibility — the real
+    // component guards; PoseUnit just passes props through. We test here that
+    // PoseUnit still renders the control element (guard lives in EndorsementControl).
+    // This test verifies props are passed so the real component can guard.
+    const interaction = makeInteraction({
+      mode: 'WHISPER',
+      pose_kind: 'STANDARD',
+    });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    // WHISPER is treated as a pose-mode interaction by PoseUnit branch logic;
+    // the control is rendered (guard lives inside EndorsementControl).
+    expect(screen.getByTestId('endorsement-control-pose')).toBeInTheDocument();
   });
 });

--- a/frontend/src/scenes/components/PoseUnit.tsx
+++ b/frontend/src/scenes/components/PoseUnit.tsx
@@ -152,8 +152,10 @@ export function PoseUnit({ interaction, sceneId, onAddTarget, onAttachAction }: 
         </button>
         {expanded && <PoseUnitDetailPanel actionInteractionIds={[interaction.id]} />}
         <ReactionsFooter interaction={interaction} sceneId={sceneId} />
+        {/* Standalone ACTION rows are authored content (claimed resonances) and
+            are endorsable per spec — this is intentional, not a slip. */}
         <EndorsementControl interaction={interaction} sceneId={sceneId} kind="pose" />
-        {interaction.pose_kind === 'ENTRY' && (
+        {interaction.pose_kind === 'entry' && (
           <EndorsementControl interaction={interaction} sceneId={sceneId} kind="entry" />
         )}
       </div>
@@ -232,7 +234,7 @@ export function PoseUnit({ interaction, sceneId, onAddTarget, onAttachAction }: 
       <ReactionStrip windows={interaction.reaction_windows ?? []} sceneId={sceneId} />
       <ReactionsFooter interaction={interaction} sceneId={sceneId} />
       <EndorsementControl interaction={interaction} sceneId={sceneId} kind="pose" />
-      {interaction.pose_kind === 'ENTRY' && (
+      {interaction.pose_kind === 'entry' && (
         <EndorsementControl interaction={interaction} sceneId={sceneId} kind="entry" />
       )}
     </div>

--- a/frontend/src/scenes/components/PoseUnit.tsx
+++ b/frontend/src/scenes/components/PoseUnit.tsx
@@ -18,6 +18,7 @@ import { FormattedContent } from '@/components/FormattedContent';
 import { PersonaContextMenu } from './PersonaContextMenu';
 import { ActionResult } from './ActionResult';
 import { ReactionStrip } from './ReactionStrip';
+import { EndorsementControl } from './EndorsementControl';
 import { postInteractionReaction } from '../queries';
 import type { Interaction, ActionLink } from '../types';
 import type { ActionAttachmentInfo } from '../actionTypes';
@@ -151,6 +152,10 @@ export function PoseUnit({ interaction, sceneId, onAddTarget, onAttachAction }: 
         </button>
         {expanded && <PoseUnitDetailPanel actionInteractionIds={[interaction.id]} />}
         <ReactionsFooter interaction={interaction} sceneId={sceneId} />
+        <EndorsementControl interaction={interaction} sceneId={sceneId} kind="pose" />
+        {interaction.pose_kind === 'ENTRY' && (
+          <EndorsementControl interaction={interaction} sceneId={sceneId} kind="entry" />
+        )}
       </div>
     );
   }
@@ -226,6 +231,10 @@ export function PoseUnit({ interaction, sceneId, onAddTarget, onAttachAction }: 
 
       <ReactionStrip windows={interaction.reaction_windows ?? []} sceneId={sceneId} />
       <ReactionsFooter interaction={interaction} sceneId={sceneId} />
+      <EndorsementControl interaction={interaction} sceneId={sceneId} kind="pose" />
+      {interaction.pose_kind === 'ENTRY' && (
+        <EndorsementControl interaction={interaction} sceneId={sceneId} kind="entry" />
+      )}
     </div>
   );
 }

--- a/frontend/src/scenes/components/SceneMessages.test.tsx
+++ b/frontend/src/scenes/components/SceneMessages.test.tsx
@@ -27,7 +27,7 @@ function makeInteraction(overrides: Partial<Interaction> = {}): Interaction {
     receiver_persona_ids: [],
     target_persona_ids: [],
     action_links: [],
-    pose_kind: 'STANDARD',
+    pose_kind: 'standard',
     endorsee_sheet_id: null,
     endorsable_resonances: [],
     pose_endorsers: [],

--- a/frontend/src/scenes/components/SceneMessages.test.tsx
+++ b/frontend/src/scenes/components/SceneMessages.test.tsx
@@ -27,6 +27,13 @@ function makeInteraction(overrides: Partial<Interaction> = {}): Interaction {
     receiver_persona_ids: [],
     target_persona_ids: [],
     action_links: [],
+    pose_kind: 'STANDARD',
+    endorsee_sheet_id: null,
+    endorsable_resonances: [],
+    pose_endorsers: [],
+    my_pose_endorsement: null,
+    entry_endorsers: [],
+    entry_endorsed_by_me: false,
     ...overrides,
   };
 }

--- a/frontend/src/scenes/components/__tests__/EndorsementControl.test.tsx
+++ b/frontend/src/scenes/components/__tests__/EndorsementControl.test.tsx
@@ -1,0 +1,323 @@
+/**
+ * Tests for EndorsementControl (#1138) — resonance-picker + endorsement badge strip
+ * for both pose and scene-entry endorsements.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import type { Interaction } from '../../types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockCreatePoseEndorsement = vi.fn();
+const mockDeletePoseEndorsement = vi.fn();
+const mockCreateSceneEntryEndorsement = vi.fn();
+
+vi.mock('../../queries', () => ({
+  useCreatePoseEndorsement: (_sceneId: string) => ({
+    mutate: mockCreatePoseEndorsement,
+    isPending: false,
+  }),
+  useDeletePoseEndorsement: (_sceneId: string) => ({
+    mutate: mockDeletePoseEndorsement,
+    isPending: false,
+  }),
+  useCreateSceneEntryEndorsement: (_sceneId: string) => ({
+    mutate: mockCreateSceneEntryEndorsement,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: vi.fn(() => ({
+    data: [
+      {
+        id: 1,
+        name: 'ViewerChar',
+        character_id: 42,
+        profile_picture_url: null,
+        primary_persona_id: 7,
+        active_persona_id: 7,
+      },
+    ],
+  })),
+}));
+
+vi.mock('@/store/hooks', () => ({
+  useAppSelector: vi.fn((selector: (state: unknown) => unknown) =>
+    selector({ game: { active: 'ViewerChar' }, auth: {} })
+  ),
+}));
+
+import { EndorsementControl } from '../EndorsementControl';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function makeInteraction(overrides: Partial<Interaction> = {}): Interaction {
+  return {
+    id: 1,
+    persona: { id: 10, name: 'Alice' },
+    content: 'Alice enters.',
+    mode: 'pose',
+    visibility: 'default',
+    timestamp: '2026-01-01T00:00:00Z',
+    scene: 1,
+    reactions: [],
+    is_favorited: false,
+    place: null,
+    place_name: null,
+    receiver_persona_ids: [],
+    target_persona_ids: [],
+    action_links: [],
+    pose_kind: 'ENTRY',
+    endorsee_sheet_id: 20,
+    endorsable_resonances: [
+      { id: 5, name: 'Courage' },
+      { id: 6, name: 'Wisdom' },
+    ],
+    pose_endorsers: [],
+    my_pose_endorsement: null,
+    entry_endorsers: [],
+    entry_endorsed_by_me: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: kind="pose"
+// ---------------------------------------------------------------------------
+
+describe('EndorsementControl — kind="pose"', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows an Endorse button', () => {
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="pose" />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByRole('button', { name: /endorse/i })).toBeInTheDocument();
+  });
+
+  it('clicking Endorse opens a picker listing endorsable_resonances', async () => {
+    const user = userEvent.setup();
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="pose" />, {
+      wrapper: createWrapper(),
+    });
+    await user.click(screen.getByRole('button', { name: /endorse/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Courage')).toBeInTheDocument();
+      expect(screen.getByText('Wisdom')).toBeInTheDocument();
+    });
+  });
+
+  it('selecting a resonance calls pose mutation with { interaction, resonance }', async () => {
+    const user = userEvent.setup();
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="pose" />, {
+      wrapper: createWrapper(),
+    });
+    await user.click(screen.getByRole('button', { name: /endorse/i }));
+    await waitFor(() => screen.getByText('Courage'));
+    await user.click(screen.getByText('Courage'));
+    expect(mockCreatePoseEndorsement).toHaveBeenCalledWith({ interaction: 1, resonance: 5 });
+  });
+
+  it('shows endorsed state + retract affordance when my_pose_endorsement is set and settled=false', () => {
+    render(
+      <EndorsementControl
+        interaction={makeInteraction({
+          my_pose_endorsement: { id: 99, resonance_id: 5, settled: false },
+        })}
+        sceneId="1"
+        kind="pose"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(screen.getByRole('button', { name: /retract/i })).toBeInTheDocument();
+  });
+
+  it('retract button calls delete with endorsement id', async () => {
+    const user = userEvent.setup();
+    render(
+      <EndorsementControl
+        interaction={makeInteraction({
+          my_pose_endorsement: { id: 99, resonance_id: 5, settled: false },
+        })}
+        sceneId="1"
+        kind="pose"
+      />,
+      { wrapper: createWrapper() }
+    );
+    await user.click(screen.getByRole('button', { name: /retract/i }));
+    expect(mockDeletePoseEndorsement).toHaveBeenCalledWith(99);
+  });
+
+  it('retract is disabled when settled=true', () => {
+    render(
+      <EndorsementControl
+        interaction={makeInteraction({
+          my_pose_endorsement: { id: 99, resonance_id: 5, settled: true },
+        })}
+        sceneId="1"
+        kind="pose"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(screen.getByRole('button', { name: /retract/i })).toBeDisabled();
+  });
+
+  it('renders pose_endorsers badges', () => {
+    render(
+      <EndorsementControl
+        interaction={makeInteraction({
+          pose_endorsers: [
+            { persona_id: 11, persona_name: 'Bob', thumbnail_url: '', resonance_id: 5 },
+          ],
+        })}
+        sceneId="1"
+        kind="pose"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(screen.getByTitle('Bob endorsed with Courage')).toBeInTheDocument();
+  });
+
+  it('hides entirely when endorsable_resonances is empty', () => {
+    const { container } = render(
+      <EndorsementControl
+        interaction={makeInteraction({ endorsable_resonances: [] })}
+        sceneId="1"
+        kind="pose"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides when the pose belongs to the viewer (self-pose)', () => {
+    // persona.id === 7 which is the viewer's primary_persona_id
+    const { container } = render(
+      <EndorsementControl
+        interaction={makeInteraction({ persona: { id: 7, name: 'ViewerChar' } })}
+        sceneId="1"
+        kind="pose"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides for WHISPER mode', () => {
+    const { container } = render(
+      <EndorsementControl
+        interaction={makeInteraction({ mode: 'WHISPER' })}
+        sceneId="1"
+        kind="pose"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides for VERY_PRIVATE visibility', () => {
+    const { container } = render(
+      <EndorsementControl
+        interaction={makeInteraction({ visibility: 'VERY_PRIVATE' })}
+        sceneId="1"
+        kind="pose"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: kind="entry"
+// ---------------------------------------------------------------------------
+
+describe('EndorsementControl — kind="entry"', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows an Endorse entry button', () => {
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="entry" />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByRole('button', { name: /endorse entry/i })).toBeInTheDocument();
+  });
+
+  it('selecting a resonance calls entry mutation with { endorsee_sheet, scene, resonance }', async () => {
+    const user = userEvent.setup();
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="entry" />, {
+      wrapper: createWrapper(),
+    });
+    await user.click(screen.getByRole('button', { name: /endorse entry/i }));
+    await waitFor(() => screen.getByText('Courage'));
+    await user.click(screen.getByText('Courage'));
+    expect(mockCreateSceneEntryEndorsement).toHaveBeenCalledWith({
+      endorsee_sheet: 20,
+      scene: 1,
+      resonance: 5,
+    });
+  });
+
+  it('shows entry_endorsers badges', () => {
+    render(
+      <EndorsementControl
+        interaction={makeInteraction({
+          entry_endorsers: [
+            { persona_id: 12, persona_name: 'Carol', thumbnail_url: '', resonance_id: 6 },
+          ],
+        })}
+        sceneId="1"
+        kind="entry"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(screen.getByTitle('Carol endorsed with Wisdom')).toBeInTheDocument();
+  });
+
+  it('does NOT show a retract button for entry endorsements', () => {
+    render(
+      <EndorsementControl
+        interaction={makeInteraction({
+          my_pose_endorsement: { id: 99, resonance_id: 5, settled: false },
+        })}
+        sceneId="1"
+        kind="entry"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(screen.queryByRole('button', { name: /retract/i })).toBeNull();
+  });
+
+  it('hides entirely when endorsable_resonances is empty', () => {
+    const { container } = render(
+      <EndorsementControl
+        interaction={makeInteraction({ endorsable_resonances: [] })}
+        sceneId="1"
+        kind="entry"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/scenes/components/__tests__/EndorsementControl.test.tsx
+++ b/frontend/src/scenes/components/__tests__/EndorsementControl.test.tsx
@@ -85,7 +85,7 @@ function makeInteraction(overrides: Partial<Interaction> = {}): Interaction {
     receiver_persona_ids: [],
     target_persona_ids: [],
     action_links: [],
-    pose_kind: 'ENTRY',
+    pose_kind: 'entry',
     endorsee_sheet_id: 20,
     endorsable_resonances: [
       { id: 5, name: 'Courage' },
@@ -223,10 +223,10 @@ describe('EndorsementControl — kind="pose"', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('hides for WHISPER mode', () => {
+  it('hides for whisper mode', () => {
     const { container } = render(
       <EndorsementControl
-        interaction={makeInteraction({ mode: 'WHISPER' })}
+        interaction={makeInteraction({ mode: 'whisper' })}
         sceneId="1"
         kind="pose"
       />,
@@ -235,10 +235,10 @@ describe('EndorsementControl — kind="pose"', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('hides for VERY_PRIVATE visibility', () => {
+  it('hides for very_private visibility', () => {
     const { container } = render(
       <EndorsementControl
-        interaction={makeInteraction({ visibility: 'VERY_PRIVATE' })}
+        interaction={makeInteraction({ visibility: 'very_private' })}
         sceneId="1"
         kind="pose"
       />,
@@ -319,6 +319,21 @@ describe('EndorsementControl — kind="entry"', () => {
       { wrapper: createWrapper() }
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  it('shows endorsed indicator (not picker) when entry_endorsed_by_me=true', () => {
+    render(
+      <EndorsementControl
+        interaction={makeInteraction({ entry_endorsed_by_me: true })}
+        sceneId="1"
+        kind="entry"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(screen.getByTestId('entry-endorsed-indicator')).toBeInTheDocument();
+    // No "Endorse entry" button — endorsement is permanent, no retract.
+    expect(screen.queryByRole('button', { name: /endorse entry/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /retract/i })).toBeNull();
   });
 
   it('hides and fires no mutation when endorsee_sheet_id is null (safe null guard)', async () => {

--- a/frontend/src/scenes/components/__tests__/EndorsementControl.test.tsx
+++ b/frontend/src/scenes/components/__tests__/EndorsementControl.test.tsx
@@ -320,4 +320,23 @@ describe('EndorsementControl — kind="entry"', () => {
     );
     expect(container.firstChild).toBeNull();
   });
+
+  it('hides and fires no mutation when endorsee_sheet_id is null (safe null guard)', async () => {
+    // endorsee_sheet_id is typed number | null; the component must not cast it
+    // unsafely when null — it should return null instead of firing a bad mutation.
+    const user = userEvent.setup();
+    const { container } = render(
+      <EndorsementControl
+        interaction={makeInteraction({ endorsee_sheet_id: null })}
+        sceneId="1"
+        kind="entry"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(container.firstChild).toBeNull();
+    // No mutation should have been attempted.
+    expect(mockCreateSceneEntryEndorsement).not.toHaveBeenCalled();
+    // Suppress unused variable warning — user is needed for async setup but no interaction fires.
+    void user;
+  });
 });

--- a/frontend/src/scenes/hooks/__tests__/useThreading.test.ts
+++ b/frontend/src/scenes/hooks/__tests__/useThreading.test.ts
@@ -18,6 +18,13 @@ function makeInteraction(overrides: Partial<Interaction> = {}): Interaction {
     place_name: null,
     receiver_persona_ids: [],
     target_persona_ids: [],
+    pose_kind: 'STANDARD',
+    endorsee_sheet_id: null,
+    endorsable_resonances: [],
+    pose_endorsers: [],
+    my_pose_endorsement: null,
+    entry_endorsers: [],
+    entry_endorsed_by_me: false,
     ...overrides,
   };
 }

--- a/frontend/src/scenes/hooks/__tests__/useThreading.test.ts
+++ b/frontend/src/scenes/hooks/__tests__/useThreading.test.ts
@@ -18,7 +18,7 @@ function makeInteraction(overrides: Partial<Interaction> = {}): Interaction {
     place_name: null,
     receiver_persona_ids: [],
     target_persona_ids: [],
-    pose_kind: 'STANDARD',
+    pose_kind: 'standard',
     endorsee_sheet_id: null,
     endorsable_resonances: [],
     pose_endorsers: [],

--- a/frontend/src/scenes/hooks/useSceneInteractions.ts
+++ b/frontend/src/scenes/hooks/useSceneInteractions.ts
@@ -23,6 +23,14 @@ export function wsPayloadToInteraction(payload: InteractionWsPayload): Interacti
     place_name: payload.place_name,
     receiver_persona_ids: payload.receiver_persona_ids ?? [],
     target_persona_ids: payload.target_persona_ids ?? [],
+    // Endorsement fields are not present in WS payloads; initialise as empty.
+    pose_kind: 'STANDARD',
+    endorsee_sheet_id: null,
+    endorsable_resonances: [],
+    pose_endorsers: [],
+    my_pose_endorsement: null,
+    entry_endorsers: [],
+    entry_endorsed_by_me: false,
   };
 }
 

--- a/frontend/src/scenes/hooks/useSceneInteractions.ts
+++ b/frontend/src/scenes/hooks/useSceneInteractions.ts
@@ -24,7 +24,7 @@ export function wsPayloadToInteraction(payload: InteractionWsPayload): Interacti
     receiver_persona_ids: payload.receiver_persona_ids ?? [],
     target_persona_ids: payload.target_persona_ids ?? [],
     // Endorsement fields are not present in WS payloads; initialise as empty.
-    pose_kind: 'STANDARD',
+    pose_kind: 'standard',
     endorsee_sheet_id: null,
     endorsable_resonances: [],
     pose_endorsers: [],

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -1,3 +1,4 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '@/evennia_replacements/api';
 
 // ---------------------------------------------------------------------------
@@ -144,4 +145,56 @@ export async function reactToWindow(
     const detail = Array.isArray(data?.detail) ? data.detail[0] : data?.detail;
     throw new Error(detail || 'Failed to react');
   }
+}
+
+export async function createPoseEndorsement(body: { interaction: number; resonance: number }) {
+  const res = await apiFetch('/api/magic/pose-endorsements/', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error('Failed to endorse pose');
+  return res.json();
+}
+
+export async function deletePoseEndorsement(id: number) {
+  const res = await apiFetch(`/api/magic/pose-endorsements/${id}/`, { method: 'DELETE' });
+  if (!res.ok && res.status !== 204) throw new Error('Failed to retract endorsement');
+}
+
+export async function createSceneEntryEndorsement(body: {
+  endorsee_sheet: number;
+  scene: number;
+  resonance: number;
+}) {
+  const res = await apiFetch('/api/magic/scene-entry-endorsements/', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error('Failed to endorse entry');
+  return res.json();
+}
+
+export function useCreatePoseEndorsement(sceneId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { interaction: number; resonance: number }) => createPoseEndorsement(body),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
+  });
+}
+
+export function useDeletePoseEndorsement(sceneId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => deletePoseEndorsement(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
+  });
+}
+
+export function useCreateSceneEntryEndorsement(sceneId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { endorsee_sheet: number; scene: number; resonance: number }) =>
+      createSceneEntryEndorsement(body),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
+  });
 }

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -158,7 +158,7 @@ export async function createPoseEndorsement(body: { interaction: number; resonan
 
 export async function deletePoseEndorsement(id: number) {
   const res = await apiFetch(`/api/magic/pose-endorsements/${id}/`, { method: 'DELETE' });
-  if (!res.ok && res.status !== 204) throw new Error('Failed to retract endorsement');
+  if (!res.ok) throw new Error('Failed to retract endorsement');
 }
 
 export async function createSceneEntryEndorsement(body: {
@@ -177,7 +177,7 @@ export async function createSceneEntryEndorsement(body: {
 export function useCreatePoseEndorsement(sceneId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (body: { interaction: number; resonance: number }) => createPoseEndorsement(body),
+    mutationFn: createPoseEndorsement,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
   });
 }
@@ -185,7 +185,7 @@ export function useCreatePoseEndorsement(sceneId: string) {
 export function useDeletePoseEndorsement(sceneId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => deletePoseEndorsement(id),
+    mutationFn: deletePoseEndorsement,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
   });
 }
@@ -193,8 +193,7 @@ export function useDeletePoseEndorsement(sceneId: string) {
 export function useCreateSceneEntryEndorsement(sceneId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (body: { endorsee_sheet: number; scene: number; resonance: number }) =>
-      createSceneEntryEndorsement(body),
+    mutationFn: createSceneEntryEndorsement,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
   });
 }

--- a/frontend/src/scenes/types.ts
+++ b/frontend/src/scenes/types.ts
@@ -157,7 +157,8 @@ export interface Interaction {
   target_persona_ids: number[];
   /** ACTION Interactions linked to this POSE (populated only for POSE-mode rows). */
   action_links?: ActionLink[];
-  pose_kind: string;
+  /** Classifies the pose for entry-endorsement filtering. Matches PoseKind TextChoices (lowercase wire format). */
+  pose_kind: 'standard' | 'entry' | 'departure';
   endorsee_sheet_id: number | null;
   endorsable_resonances: { id: number; name: string }[];
   pose_endorsers: EndorserBadge[];

--- a/frontend/src/scenes/types.ts
+++ b/frontend/src/scenes/types.ts
@@ -78,6 +78,13 @@ export interface InteractionPersona {
   thumbnail_url?: string;
 }
 
+export interface EndorserBadge {
+  persona_id: number;
+  persona_name: string;
+  thumbnail_url: string;
+  resonance_id: number;
+}
+
 export interface InteractionReaction {
   emoji: string;
   count: number;
@@ -150,4 +157,11 @@ export interface Interaction {
   target_persona_ids: number[];
   /** ACTION Interactions linked to this POSE (populated only for POSE-mode rows). */
   action_links?: ActionLink[];
+  pose_kind: string;
+  endorsee_sheet_id: number | null;
+  endorsable_resonances: { id: number; name: string }[];
+  pose_endorsers: EndorserBadge[];
+  my_pose_endorsement: { id: number; resonance_id: number; settled: boolean } | null;
+  entry_endorsers: EndorserBadge[];
+  entry_endorsed_by_me: boolean;
 }

--- a/src/schema.json
+++ b/src/schema.json
@@ -29084,6 +29084,18 @@ components:
           type: string
           format: date-time
           readOnly: true
+        pose_kind:
+          allOf:
+          - $ref: '#/components/schemas/PoseKindEnum'
+          description: |-
+            Classifies the pose as standard, entry, or departure. Set by the +enter command (future) or scene-entry hook. Spec C reads ENTRY to filter scene-entry-endorsement targets.
+
+            * `standard` - Standard
+            * `entry` - Entry
+            * `departure` - Departure
+        endorsee_sheet_id:
+          type: integer
+          readOnly: true
         is_favorited:
           type: boolean
           readOnly: true
@@ -29135,6 +29147,57 @@ components:
           items:
             $ref: '#/components/schemas/InteractionActionLink'
           readOnly: true
+        endorsable_resonances:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: |-
+            List of resonances claimed by the endorsee (pose author).
+
+            Reads from the prefetched ``persona__character_sheet__resonances``
+            path (set up in ``interaction_views.get_queryset``) via the
+            ``cached_resonances`` to_attr. Falls back to a live query if the attr
+            is absent (e.g. serializer used outside the view's queryset pipeline).
+          readOnly: true
+        pose_endorsers:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: |-
+            List of peers who endorsed this pose, with persona info.
+
+            Reads ``obj.cached_endorsements`` (Prefetch(to_attr=...) set by the
+            view queryset). Each endorser's primary persona is pre-loaded via
+            ``cached_primary_persona`` (another nested Prefetch).
+          readOnly: true
+        my_pose_endorsement:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: |-
+            Return the viewer's own endorsement for this pose, or None.
+
+            Checks ``character_sheet_ids`` from context (viewer's sheet PKs) against
+            each cached endorsement's ``endorser_sheet_id``.
+          readOnly: true
+        entry_endorsers:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: |-
+            List of peers who gave this character a scene-entry endorsement.
+
+            Only non-empty for ENTRY poses. Reads ``scene_entry_endorsements`` from
+            context (populated by the view's ``get_serializer_context``).
+          readOnly: true
+        entry_endorsed_by_me:
+          type: boolean
+          description: True when the viewer has given this character a scene-entry
+            endorsement.
+          readOnly: true
         receivers:
           type: array
           items:
@@ -29143,10 +29206,16 @@ components:
       required:
       - action_links
       - content
+      - endorsable_resonances
+      - endorsee_sheet_id
+      - entry_endorsed_by_me
+      - entry_endorsers
       - id
       - is_favorited
+      - my_pose_endorsement
       - persona
       - place_name
+      - pose_endorsers
       - reaction_windows
       - reactions
       - receiver_persona_ids
@@ -29236,6 +29305,18 @@ components:
           type: string
           format: date-time
           readOnly: true
+        pose_kind:
+          allOf:
+          - $ref: '#/components/schemas/PoseKindEnum'
+          description: |-
+            Classifies the pose as standard, entry, or departure. Set by the +enter command (future) or scene-entry hook. Spec C reads ENTRY to filter scene-entry-endorsement targets.
+
+            * `standard` - Standard
+            * `entry` - Entry
+            * `departure` - Departure
+        endorsee_sheet_id:
+          type: integer
+          readOnly: true
         is_favorited:
           type: boolean
           readOnly: true
@@ -29287,13 +29368,70 @@ components:
           items:
             $ref: '#/components/schemas/InteractionActionLink'
           readOnly: true
+        endorsable_resonances:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: |-
+            List of resonances claimed by the endorsee (pose author).
+
+            Reads from the prefetched ``persona__character_sheet__resonances``
+            path (set up in ``interaction_views.get_queryset``) via the
+            ``cached_resonances`` to_attr. Falls back to a live query if the attr
+            is absent (e.g. serializer used outside the view's queryset pipeline).
+          readOnly: true
+        pose_endorsers:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: |-
+            List of peers who endorsed this pose, with persona info.
+
+            Reads ``obj.cached_endorsements`` (Prefetch(to_attr=...) set by the
+            view queryset). Each endorser's primary persona is pre-loaded via
+            ``cached_primary_persona`` (another nested Prefetch).
+          readOnly: true
+        my_pose_endorsement:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: |-
+            Return the viewer's own endorsement for this pose, or None.
+
+            Checks ``character_sheet_ids`` from context (viewer's sheet PKs) against
+            each cached endorsement's ``endorser_sheet_id``.
+          readOnly: true
+        entry_endorsers:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: |-
+            List of peers who gave this character a scene-entry endorsement.
+
+            Only non-empty for ENTRY poses. Reads ``scene_entry_endorsements`` from
+            context (populated by the view's ``get_serializer_context``).
+          readOnly: true
+        entry_endorsed_by_me:
+          type: boolean
+          description: True when the viewer has given this character a scene-entry
+            endorsement.
+          readOnly: true
       required:
       - action_links
       - content
+      - endorsable_resonances
+      - endorsee_sheet_id
+      - entry_endorsed_by_me
+      - entry_endorsers
       - id
       - is_favorited
+      - my_pose_endorsement
       - persona
       - place_name
+      - pose_endorsers
       - reaction_windows
       - reactions
       - receiver_persona_ids
@@ -29336,6 +29474,15 @@ components:
 
             * `default` - Default
             * `very_private` - Very Private
+        pose_kind:
+          allOf:
+          - $ref: '#/components/schemas/PoseKindEnum'
+          description: |-
+            Classifies the pose as standard, entry, or departure. Set by the +enter command (future) or scene-entry hook. Spec C reads ENTRY to filter scene-entry-endorsement targets.
+
+            * `standard` - Standard
+            * `entry` - Entry
+            * `departure` - Departure
       required:
       - content
     InteractionOffer:
@@ -37598,6 +37745,16 @@ components:
       required:
       - interaction
       - resonance
+    PoseKindEnum:
+      enum:
+      - standard
+      - entry
+      - departure
+      type: string
+      description: |-
+        * `standard` - Standard
+        * `entry` - Entry
+        * `departure` - Departure
     PositionAdjacencyItem:
       type: object
       description: |-

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -216,11 +216,12 @@ optional OneToOne FK back to ModifierTarget for modifier system integration.
   `scene_entry_grant`, `residence_daily_trickle_per_resonance`, etc. Lazy-created via
   `get_resonance_gain_config()`.
 - `PoseEndorsement` - Unsettled endorsement of a pose; settles at weekly tick. FK to
-  `endorser_sheet`, M2M to `Resonance`. Unique per `(endorser_sheet, interaction)`.
-  Captures `persona_snapshot` (CharField) for masquerade audit. Fields: `created_at`,
-  `settled_at` (NULL until weekly settlement).
+  `endorser_sheet`, single `resonance` FK (PROTECT). Unique per `(endorser_sheet, interaction)`.
+  Captures `persona_snapshot` (FK to `scenes.Persona`, SET_NULL) for masquerade audit. Fields:
+  `created_at`, `settled_at` (NULL until weekly settlement).
 - `SceneEntryEndorsement` - Immediate flat grant for endorsing a character's scene entry
-  pose. FK `endorser_sheet`, FK `endorsee_sheet`, FK `scene`, M2M `resonance`. Unique per
+  pose. FK `endorser_sheet`, FK `endorsee_sheet`, FK `scene`, single `resonance` FK (PROTECT).
+  Captures `persona_snapshot` (FK to `scenes.Persona`, SET_NULL) for masquerade audit. Unique per
   `(endorser_sheet, endorsee_sheet, scene)`. Fires `grant_resonance` synchronously on creation.
 - `ResonanceGrant` - Universal audit ledger. Discriminator `source` (TextChoice: POSE_ENDORSEMENT,
   SCENE_ENTRY, ROOM_RESIDENCE, OUTFIT_ITEM, STAFF_GRANT) + typed FKs: `source_room_profile`,

--- a/src/world/scenes/interaction_serializers.py
+++ b/src/world/scenes/interaction_serializers.py
@@ -93,6 +93,14 @@ class InteractionListSerializer(serializers.ModelSerializer):
         read_only=True,
         source="cached_action_links",
     )
+    endorsee_sheet_id = serializers.IntegerField(
+        source="persona.character_sheet_id", read_only=True
+    )
+    endorsable_resonances = serializers.SerializerMethodField()
+    pose_endorsers = serializers.SerializerMethodField()
+    my_pose_endorsement = serializers.SerializerMethodField()
+    entry_endorsers = serializers.SerializerMethodField()
+    entry_endorsed_by_me = serializers.SerializerMethodField()
 
     class Meta:
         model = Interaction
@@ -105,6 +113,8 @@ class InteractionListSerializer(serializers.ModelSerializer):
             "mode",
             "visibility",
             "timestamp",
+            "pose_kind",
+            "endorsee_sheet_id",
             "is_favorited",
             "reactions",
             "reaction_windows",
@@ -112,6 +122,11 @@ class InteractionListSerializer(serializers.ModelSerializer):
             "place_name",
             "target_persona_ids",
             "action_links",
+            "endorsable_resonances",
+            "pose_endorsers",
+            "my_pose_endorsement",
+            "entry_endorsers",
+            "entry_endorsed_by_me",
         ]
 
     def get_persona(self, obj: Interaction) -> PersonaPayload:
@@ -240,6 +255,93 @@ class InteractionListSerializer(serializers.ModelSerializer):
             ReactionAggregation(emoji=emoji, count=count, reacted=emoji in user_reacted)
             for emoji, count in counts.items()
         ]
+
+    def get_endorsable_resonances(self, obj: Interaction) -> list[dict]:
+        """List of resonances claimed by the endorsee (pose author).
+
+        Reads from the prefetched ``persona__character_sheet__resonances``
+        path (set up in ``interaction_views.get_queryset``) via the
+        ``cached_resonances`` to_attr. Falls back to a live query if the attr
+        is absent (e.g. serializer used outside the view's queryset pipeline).
+        """
+        sheet = obj.persona.character_sheet
+        if sheet is None:
+            return []
+        resonances = getattr(sheet, "cached_resonances", None)  # noqa: GETATTR_LITERAL
+        if resonances is None:
+            resonances = list(sheet.resonances.select_related("resonance"))
+        return [{"id": cr.resonance_id, "name": cr.resonance.name} for cr in resonances]
+
+    def get_pose_endorsers(self, obj: Interaction) -> list[dict]:
+        """List of peers who endorsed this pose, with persona info.
+
+        Reads ``obj.cached_endorsements`` (Prefetch(to_attr=...) set by the
+        view queryset). Each endorser's primary persona is pre-loaded via
+        ``cached_primary_persona`` (another nested Prefetch).
+        """
+        out = []
+        for e in getattr(obj, "cached_endorsements", []):  # noqa: GETATTR_LITERAL
+            persona = next(iter(e.endorser_sheet.cached_primary_persona), None)
+            if persona is None:
+                continue
+            out.append(
+                {
+                    "persona_id": persona.pk,
+                    "persona_name": persona.name,
+                    "thumbnail_url": persona.thumbnail_url or "",
+                    "resonance_id": e.resonance_id,
+                }
+            )
+        return out
+
+    def get_my_pose_endorsement(self, obj: Interaction) -> dict | None:
+        """Return the viewer's own endorsement for this pose, or None.
+
+        Checks ``character_sheet_ids`` from context (viewer's sheet PKs) against
+        each cached endorsement's ``endorser_sheet_id``.
+        """
+        sheet_ids: set[int] = self.context.get("character_sheet_ids", set())
+        for e in getattr(obj, "cached_endorsements", []):  # noqa: GETATTR_LITERAL
+            if e.endorser_sheet_id in sheet_ids:
+                return {
+                    "id": e.pk,
+                    "resonance_id": e.resonance_id,
+                    "settled": e.settled_at is not None,
+                }
+        return None
+
+    def _entry_rows(self, obj: Interaction) -> list:
+        """Return scene-entry endorsement rows for ENTRY poses only."""
+        if obj.pose_kind != PoseKind.ENTRY:
+            return []
+        sheet_id = obj.persona.character_sheet_id
+        return self.context.get("scene_entry_endorsements", {}).get(sheet_id, [])
+
+    def get_entry_endorsers(self, obj: Interaction) -> list[dict]:
+        """List of peers who gave this character a scene-entry endorsement.
+
+        Only non-empty for ENTRY poses. Reads ``scene_entry_endorsements`` from
+        context (populated by the view's ``get_serializer_context``).
+        """
+        out = []
+        for r in self._entry_rows(obj):
+            persona = next(iter(r.endorser_sheet.cached_primary_persona), None)
+            if persona is None:
+                continue
+            out.append(
+                {
+                    "persona_id": persona.pk,
+                    "persona_name": persona.name,
+                    "thumbnail_url": persona.thumbnail_url or "",
+                    "resonance_id": r.resonance_id,
+                }
+            )
+        return out
+
+    def get_entry_endorsed_by_me(self, obj: Interaction) -> bool:
+        """True when the viewer has given this character a scene-entry endorsement."""
+        sheet_ids: set[int] = self.context.get("character_sheet_ids", set())
+        return any(r.endorser_sheet_id in sheet_ids for r in self._entry_rows(obj))
 
 
 class InteractionDetailSerializer(InteractionListSerializer):

--- a/src/world/scenes/interaction_views.py
+++ b/src/world/scenes/interaction_views.py
@@ -16,9 +16,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
+from world.magic.models import CharacterResonance, PoseEndorsement, SceneEntryEndorsement
 from world.scenes.constants import (
     InteractionMode,
     InteractionVisibility,
+    PersonaType,
     PoseKind,
     ReactionWindowKind,
     ScenePrivacyMode,
@@ -92,6 +94,30 @@ class InteractionViewSet(
         # Per-viewer my_reaction on reaction windows (#904) — context, never
         # Prefetch(to_attr) on the shared instances.
         context["persona_ids"] = set(get_account_personas(self.request))
+        # Viewer's character sheet PKs — used for my_pose_endorsement and
+        # entry_endorsed_by_me (#1138).
+        context["character_sheet_ids"] = (
+            {e.character_sheet_id for e in entries} if entries else set()
+        )
+        # Scene-entry endorsements indexed by endorsee_sheet_id — loaded once
+        # per list request, keyed by the scene query param (#1138).
+        scene_id = self.request.query_params.get("scene")  # noqa: USE_FILTERSET
+        entry_map: dict[int, list] = {}
+        if scene_id:
+            rows = (
+                SceneEntryEndorsement.objects.filter(scene_id=scene_id)
+                .select_related("endorser_sheet", "resonance")
+                .prefetch_related(
+                    Prefetch(
+                        "endorser_sheet__personas",
+                        queryset=Persona.objects.filter(persona_type=PersonaType.PRIMARY),
+                        to_attr="cached_primary_persona",
+                    )
+                )
+            )
+            for r in rows:
+                entry_map.setdefault(r.endorsee_sheet_id, []).append(r)
+        context["scene_entry_endorsements"] = entry_map
         return context
 
     def get_queryset(self) -> QuerySet[Interaction]:
@@ -107,6 +133,24 @@ class InteractionViewSet(
             "scene",
             "place",
         ).prefetch_related(
+            Prefetch(
+                "persona__character_sheet__resonances",
+                queryset=CharacterResonance.objects.select_related("resonance"),
+                to_attr="cached_resonances",
+            ),
+            Prefetch(
+                "endorsements",
+                queryset=PoseEndorsement.objects.select_related(
+                    "endorser_sheet", "resonance"
+                ).prefetch_related(
+                    Prefetch(
+                        "endorser_sheet__personas",
+                        queryset=Persona.objects.filter(persona_type=PersonaType.PRIMARY),
+                        to_attr="cached_primary_persona",
+                    )
+                ),
+                to_attr="cached_endorsements",
+            ),
             Prefetch(
                 "target_personas",
                 queryset=Persona.objects.all(),
@@ -343,6 +387,7 @@ class InteractionViewSet(
         interaction.cached_favorites = []
         interaction.cached_reactions = []
         interaction.cached_action_links = []
+        interaction.cached_endorsements = []
         # ENTRY poses opened a window above; let the serializer query it (no
         # cached attr) so the fresh response includes the reactable strip.
         interaction.cached_reaction_windows = None

--- a/src/world/scenes/tests/test_interaction_serializers.py
+++ b/src/world/scenes/tests/test_interaction_serializers.py
@@ -1,0 +1,339 @@
+"""TDD tests for endorsement-related fields on InteractionListSerializer (#1138).
+
+Tests cover Tasks 1-4 of Phase A:
+  Task 1: pose_kind + endorsee_sheet_id
+  Task 2: endorsable_resonances
+  Task 3: pose_endorsers + my_pose_endorsement
+  Task 4: entry_endorsers + entry_endorsed_by_me
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.db.models import Prefetch
+from django.test import TestCase
+from evennia.utils.idmapper import models as idmapper_models
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.factories import (
+    CharacterResonanceFactory,
+    PoseEndorsementFactory,
+    ResonanceFactory,
+    SceneEntryEndorsementFactory,
+)
+from world.scenes.constants import PoseKind
+from world.scenes.factories import InteractionFactory, SceneFactory
+from world.scenes.interaction_serializers import InteractionListSerializer
+
+
+def _make_context(
+    user_pk: int | None = None,
+    persona_ids: set | None = None,
+    roster_entry_ids: set | None = None,
+    character_sheet_ids: set | None = None,
+    scene_entry_endorsements: dict | None = None,
+) -> dict:
+    """Build a minimal serializer context."""
+    mock_request = MagicMock()
+    mock_request.user.pk = user_pk
+    mock_request.user.is_authenticated = user_pk is not None
+    return {
+        "request": mock_request,
+        "persona_ids": persona_ids or set(),
+        "roster_entry_ids": roster_entry_ids or set(),
+        "character_sheet_ids": character_sheet_ids or set(),
+        "scene_entry_endorsements": scene_entry_endorsements or {},
+    }
+
+
+def _set_empty_cached_attrs(interaction) -> None:
+    """Set all cached_* attrs to empty so serializer doesn't try to query."""
+    interaction.cached_receivers = []
+    interaction.cached_target_personas = []
+    interaction.cached_favorites = []
+    interaction.cached_reactions = []
+    interaction.cached_action_links = []
+    interaction.cached_endorsements = []
+    interaction.cached_reaction_windows = None
+
+
+class Task1PoseKindEndorseeSheetIdTests(TestCase):
+    """Task 1: pose_kind + endorsee_sheet_id exposed on InteractionListSerializer."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        idmapper_models.flush_cache()
+        cls.sheet = CharacterSheetFactory()
+        cls.persona = cls.sheet.primary_persona
+        cls.entry_pose = InteractionFactory(persona=cls.persona, pose_kind=PoseKind.ENTRY)
+        cls.standard_pose = InteractionFactory(persona=cls.persona, pose_kind=PoseKind.STANDARD)
+
+    def setUp(self) -> None:
+        idmapper_models.flush_cache()
+
+    def test_pose_kind_entry(self) -> None:
+        interaction = self.entry_pose
+        _set_empty_cached_attrs(interaction)
+        data = InteractionListSerializer(interaction, context=_make_context()).data
+        assert data["pose_kind"] == "entry"
+
+    def test_pose_kind_standard(self) -> None:
+        interaction = self.standard_pose
+        _set_empty_cached_attrs(interaction)
+        data = InteractionListSerializer(interaction, context=_make_context()).data
+        assert data["pose_kind"] == "standard"
+
+    def test_endorsee_sheet_id_matches_persona_character_sheet(self) -> None:
+        interaction = self.entry_pose
+        _set_empty_cached_attrs(interaction)
+        data = InteractionListSerializer(interaction, context=_make_context()).data
+        assert data["endorsee_sheet_id"] == self.sheet.pk
+
+
+class Task2EndorsableResonancesTests(TestCase):
+    """Task 2: endorsable_resonances lists the endorsee's claimed resonances."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        idmapper_models.flush_cache()
+        cls.sheet = CharacterSheetFactory()
+        cls.persona = cls.sheet.primary_persona
+        cls.r1 = ResonanceFactory()
+        cls.r2 = ResonanceFactory()
+        cls.cr1 = CharacterResonanceFactory(character_sheet=cls.sheet, resonance=cls.r1)
+        cls.cr2 = CharacterResonanceFactory(character_sheet=cls.sheet, resonance=cls.r2)
+        cls.entry_pose = InteractionFactory(persona=cls.persona, pose_kind=PoseKind.ENTRY)
+
+    def setUp(self) -> None:
+        idmapper_models.flush_cache()
+
+    def test_endorsable_resonances_lists_all_claimed(self) -> None:
+        from world.magic.models import CharacterResonance
+        from world.scenes.models import Interaction
+
+        interaction = (
+            Interaction.objects.select_related("persona__character_sheet").prefetch_related(
+                Prefetch(
+                    "persona__character_sheet__resonances",
+                    queryset=CharacterResonance.objects.select_related("resonance"),
+                    to_attr="cached_resonances",
+                )
+            )
+        ).get(pk=self.entry_pose.pk)
+        _set_empty_cached_attrs(interaction)
+
+        data = InteractionListSerializer(interaction, context=_make_context()).data
+        resonance_list = data["endorsable_resonances"]
+        assert isinstance(resonance_list, list)
+        returned_ids = {r["id"] for r in resonance_list}
+        assert self.r1.pk in returned_ids
+        assert self.r2.pk in returned_ids
+        for entry in resonance_list:
+            assert "id" in entry
+            assert "name" in entry
+
+    def test_endorsable_resonances_empty_when_none_claimed(self) -> None:
+        from world.scenes.models import Interaction
+
+        bare_sheet = CharacterSheetFactory()
+        interaction = InteractionFactory(persona=bare_sheet.primary_persona)
+        interaction = Interaction.objects.select_related("persona__character_sheet").get(
+            pk=interaction.pk
+        )
+        _set_empty_cached_attrs(interaction)
+        # No cached_resonances attr — serializer falls back to live query (empty).
+        data = InteractionListSerializer(interaction, context=_make_context()).data
+        assert data["endorsable_resonances"] == []
+
+
+class Task3PoseEndorsersMyPoseEndorsementTests(TestCase):
+    """Task 3: pose_endorsers + my_pose_endorsement."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        idmapper_models.flush_cache()
+        cls.alice_sheet = CharacterSheetFactory()
+        cls.alice_persona = cls.alice_sheet.primary_persona
+        cls.bob_sheet = CharacterSheetFactory()
+        cls.bob_persona = cls.bob_sheet.primary_persona
+        cls.resonance = ResonanceFactory()
+        cls.entry_pose = InteractionFactory(persona=cls.alice_persona, pose_kind=PoseKind.ENTRY)
+        cls.endorsement = PoseEndorsementFactory(
+            endorser_sheet=cls.bob_sheet,
+            endorsee_sheet=cls.alice_sheet,
+            interaction=cls.entry_pose,
+            resonance=cls.resonance,
+        )
+
+    def setUp(self) -> None:
+        idmapper_models.flush_cache()
+
+    def _get_endorsement_with_cache(self):
+        """Return the endorsement with cached_primary_persona set on endorser_sheet."""
+        from world.magic.models import PoseEndorsement
+
+        endorsement = PoseEndorsement.objects.select_related("endorser_sheet", "resonance").get(
+            pk=self.endorsement.pk
+        )
+        endorsement.endorser_sheet.cached_primary_persona = [self.bob_persona]
+        return endorsement
+
+    def test_pose_endorsers_list_with_third_party_viewer(self) -> None:
+        """A non-participant viewer sees the endorser list."""
+        interaction = self.entry_pose
+        _set_empty_cached_attrs(interaction)
+        endorsement = self._get_endorsement_with_cache()
+        interaction.cached_endorsements = [endorsement]
+
+        data = InteractionListSerializer(
+            interaction, context=_make_context(character_sheet_ids=set())
+        ).data
+        endorsers = data["pose_endorsers"]
+        assert len(endorsers) == 1
+        assert endorsers[0]["persona_id"] == self.bob_persona.pk
+        assert endorsers[0]["persona_name"] == self.bob_persona.name
+        assert endorsers[0]["resonance_id"] == self.resonance.pk
+
+    def test_my_pose_endorsement_when_bob_is_viewer(self) -> None:
+        """When Bob views, my_pose_endorsement shows Bob's endorsement."""
+        interaction = self.entry_pose
+        _set_empty_cached_attrs(interaction)
+        endorsement = self._get_endorsement_with_cache()
+        interaction.cached_endorsements = [endorsement]
+
+        data = InteractionListSerializer(
+            interaction,
+            context=_make_context(character_sheet_ids={self.bob_sheet.pk}),
+        ).data
+        my_endorsement = data["my_pose_endorsement"]
+        assert my_endorsement is not None
+        assert my_endorsement["id"] == endorsement.pk
+        assert my_endorsement["resonance_id"] == self.resonance.pk
+        # settled_at is None → settled should be False
+        assert my_endorsement["settled"] is False
+
+    def test_my_pose_endorsement_none_when_alice_is_viewer(self) -> None:
+        """Alice did not endorse her own pose, so my_pose_endorsement is None."""
+        interaction = self.entry_pose
+        _set_empty_cached_attrs(interaction)
+        endorsement = self._get_endorsement_with_cache()
+        interaction.cached_endorsements = [endorsement]
+
+        data = InteractionListSerializer(
+            interaction,
+            context=_make_context(character_sheet_ids={self.alice_sheet.pk}),
+        ).data
+        assert data["my_pose_endorsement"] is None
+
+    def test_pose_endorsers_empty_when_no_endorsements(self) -> None:
+        interaction = self.entry_pose
+        _set_empty_cached_attrs(interaction)
+        interaction.cached_endorsements = []
+        data = InteractionListSerializer(interaction, context=_make_context()).data
+        assert data["pose_endorsers"] == []
+        assert data["my_pose_endorsement"] is None
+
+
+class Task4EntryEndorsersTests(TestCase):
+    """Task 4: entry_endorsers + entry_endorsed_by_me."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        idmapper_models.flush_cache()
+        cls.alice_sheet = CharacterSheetFactory()
+        cls.alice_persona = cls.alice_sheet.primary_persona
+        cls.bob_sheet = CharacterSheetFactory()
+        cls.bob_persona = cls.bob_sheet.primary_persona
+        cls.resonance = ResonanceFactory()
+        cls.scene = SceneFactory()
+        cls.entry_pose = InteractionFactory(
+            persona=cls.alice_persona, pose_kind=PoseKind.ENTRY, scene=cls.scene
+        )
+        cls.standard_pose = InteractionFactory(
+            persona=cls.alice_persona, pose_kind=PoseKind.STANDARD, scene=cls.scene
+        )
+        cls.endorsement = SceneEntryEndorsementFactory(
+            endorser_sheet=cls.bob_sheet,
+            endorsee_sheet=cls.alice_sheet,
+            scene=cls.scene,
+            resonance=cls.resonance,
+        )
+
+    def setUp(self) -> None:
+        idmapper_models.flush_cache()
+
+    def _build_entry_map(self):
+        """Build a scene_entry_endorsements dict with the endorsement loaded."""
+        from world.magic.models import SceneEntryEndorsement
+
+        row = SceneEntryEndorsement.objects.select_related("endorser_sheet", "resonance").get(
+            pk=self.endorsement.pk
+        )
+        row.endorser_sheet.cached_primary_persona = [self.bob_persona]
+        return {self.alice_sheet.pk: [row]}
+
+    def test_entry_endorsers_has_bob(self) -> None:
+        """Third-party viewer sees Bob's entry endorsement for Alice's entry pose."""
+        interaction = self.entry_pose
+        _set_empty_cached_attrs(interaction)
+        entry_map = self._build_entry_map()
+
+        data = InteractionListSerializer(
+            interaction,
+            context=_make_context(
+                character_sheet_ids=set(),
+                scene_entry_endorsements=entry_map,
+            ),
+        ).data
+        endorsers = data["entry_endorsers"]
+        assert len(endorsers) == 1
+        assert endorsers[0]["persona_id"] == self.bob_persona.pk
+        assert endorsers[0]["persona_name"] == self.bob_persona.name
+        assert endorsers[0]["resonance_id"] == self.resonance.pk
+
+    def test_entry_endorsed_by_me_true_for_bob(self) -> None:
+        """Bob's viewer context → entry_endorsed_by_me is True for Alice's entry pose."""
+        interaction = self.entry_pose
+        _set_empty_cached_attrs(interaction)
+        entry_map = self._build_entry_map()
+
+        data = InteractionListSerializer(
+            interaction,
+            context=_make_context(
+                character_sheet_ids={self.bob_sheet.pk},
+                scene_entry_endorsements=entry_map,
+            ),
+        ).data
+        assert data["entry_endorsed_by_me"] is True
+
+    def test_entry_endorsed_by_me_false_for_alice(self) -> None:
+        """Alice (endorsee) did not endorse herself, so entry_endorsed_by_me is False."""
+        interaction = self.entry_pose
+        _set_empty_cached_attrs(interaction)
+        entry_map = self._build_entry_map()
+
+        data = InteractionListSerializer(
+            interaction,
+            context=_make_context(
+                character_sheet_ids={self.alice_sheet.pk},
+                scene_entry_endorsements=entry_map,
+            ),
+        ).data
+        assert data["entry_endorsed_by_me"] is False
+
+    def test_standard_pose_returns_empty_for_entry_endorsement_fields(self) -> None:
+        """STANDARD poses always return empty entry_endorsers and False entry_endorsed_by_me."""
+        interaction = self.standard_pose
+        _set_empty_cached_attrs(interaction)
+        entry_map = self._build_entry_map()
+
+        data = InteractionListSerializer(
+            interaction,
+            context=_make_context(
+                character_sheet_ids={self.bob_sheet.pk},
+                scene_entry_endorsements=entry_map,
+            ),
+        ).data
+        assert data["entry_endorsers"] == []
+        assert data["entry_endorsed_by_me"] is False

--- a/src/world/scenes/tests/test_interaction_views.py
+++ b/src/world/scenes/tests/test_interaction_views.py
@@ -9,8 +9,18 @@ from rest_framework.test import APITestCase
 from core_management.test_utils import suppress_permission_errors
 from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.factories import (
+    PoseEndorsementFactory,
+    ResonanceFactory,
+    SceneEntryEndorsementFactory,
+)
 from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
-from world.scenes.constants import InteractionMode, InteractionVisibility, ScenePrivacyMode
+from world.scenes.constants import (
+    InteractionMode,
+    InteractionVisibility,
+    PoseKind,
+    ScenePrivacyMode,
+)
 from world.scenes.factories import (
     InteractionFactory,
     InteractionReceiverFactory,
@@ -755,3 +765,105 @@ class WithoutPoseLinkFilterTests(APITestCase):
         result_ids = {r["id"] for r in response.data["results"]}
         assert unlinked_action.pk in result_ids
         assert linked_action.pk in result_ids
+
+
+class InteractionListQueryBudgetTests(APITestCase):
+    """Task 5 — pin the query budget for GET /api/interactions/?scene=<id>.
+
+    A fixed N-query budget ensures the endorsement prefetches don't introduce
+    N+1 queries as endorsements scale. If the budget creeps, either a prefetch
+    path is broken or a new one is needed.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia.utils.idmapper import models as idmapper_models
+
+        idmapper_models.flush_cache()
+
+        # Build the requesting user's full identity chain.
+        cls.account = AccountFactory()
+        cls.character = CharacterFactory()
+        cls.roster_entry = RosterEntryFactory(character_sheet__character=cls.character)
+        cls.player_data = PlayerDataFactory(account=cls.account)
+        cls.tenure = RosterTenureFactory(
+            player_data=cls.player_data,
+            roster_entry=cls.roster_entry,
+        )
+        cls.sheet = CharacterSheetFactory(character=cls.character)
+        cls.persona = cls.sheet.primary_persona
+
+        # Build two additional "NPC" sheets as authors of poses.
+        cls.alice_sheet = CharacterSheetFactory()
+        cls.alice_persona = cls.alice_sheet.primary_persona
+        cls.bob_sheet = CharacterSheetFactory()
+        cls.bob_persona = cls.bob_sheet.primary_persona
+
+        # Scene with a mix of ENTRY and STANDARD poses.
+        cls.scene = SceneFactory()
+        cls.resonance = ResonanceFactory()
+
+        # ENTRY pose by Alice.
+        cls.entry_pose = InteractionFactory(
+            persona=cls.alice_persona,
+            pose_kind=PoseKind.ENTRY,
+            scene=cls.scene,
+        )
+        # STANDARD pose by Bob.
+        cls.standard_pose = InteractionFactory(
+            persona=cls.bob_persona,
+            pose_kind=PoseKind.STANDARD,
+            scene=cls.scene,
+        )
+        # Another ENTRY pose by Bob.
+        cls.bob_entry_pose = InteractionFactory(
+            persona=cls.bob_persona,
+            pose_kind=PoseKind.ENTRY,
+            scene=cls.scene,
+        )
+
+        # Several PoseEndorsements across multiple endorsers.
+        cls.endorsement_a = PoseEndorsementFactory(
+            endorser_sheet=cls.bob_sheet,
+            endorsee_sheet=cls.alice_sheet,
+            interaction=cls.entry_pose,
+            resonance=cls.resonance,
+        )
+        cls.endorsement_b = PoseEndorsementFactory(
+            endorser_sheet=cls.sheet,
+            endorsee_sheet=cls.alice_sheet,
+            interaction=cls.entry_pose,
+            resonance=cls.resonance,
+        )
+        # SceneEntryEndorsements for the ENTRY poses.
+        cls.scene_entry_a = SceneEntryEndorsementFactory(
+            endorser_sheet=cls.bob_sheet,
+            endorsee_sheet=cls.alice_sheet,
+            scene=cls.scene,
+            resonance=cls.resonance,
+        )
+        cls.scene_entry_b = SceneEntryEndorsementFactory(
+            endorser_sheet=cls.sheet,
+            endorsee_sheet=cls.bob_sheet,
+            scene=cls.scene,
+            resonance=cls.resonance,
+        )
+
+    def setUp(self) -> None:
+        from evennia.utils.idmapper import models as idmapper_models
+
+        idmapper_models.flush_cache()
+        self.client.force_authenticate(user=self.account)
+
+    def test_interaction_list_query_budget_is_constant(self) -> None:
+        """GET ?scene=<id> must not produce N+1 queries as endorsement count grows.
+
+        Query budget pinned after initial observation. If this test fails with a
+        higher count, check whether a new prefetch path is needed.
+        """
+        url = reverse("interaction-list")
+        # Run once to observe the count, then assert.
+        with self.assertNumQueries(48):
+            response = self.client.get(url, {"scene": self.scene.pk})
+        assert response.status_code == 200
+        assert len(response.data["results"]) == 3

--- a/src/world/scenes/tests/test_interaction_views.py
+++ b/src/world/scenes/tests/test_interaction_views.py
@@ -867,3 +867,83 @@ class InteractionListQueryBudgetTests(APITestCase):
             response = self.client.get(url, {"scene": self.scene.pk})
         assert response.status_code == 200
         assert len(response.data["results"]) == 3
+
+    def test_interaction_list_query_budget_does_not_scale_with_endorser_count(self) -> None:
+        """Query count must stay constant as endorser count grows (endorsement prefetches
+        must not degenerate into N+1 queries per endorser).
+
+        Uses the same interaction count as the small dataset (3 interactions) but with
+        5+ endorsers per pose instead of 2, then asserts the same 48-query budget.
+        If this fails with a higher count, an endorser-prefetch path is broken.
+        """
+        from evennia.utils.idmapper import models as idmapper_models
+
+        idmapper_models.flush_cache()
+
+        # Five extra endorser sheets (more than the 2 in the small dataset).
+        extra_sheets = [CharacterSheetFactory() for _ in range(5)]
+        extra_personas = [s.primary_persona for s in extra_sheets]
+
+        dense_scene = SceneFactory()
+        dense_resonance = ResonanceFactory()
+
+        # Same interaction structure as the small dataset: 1 ENTRY + 1 STANDARD + 1 ENTRY.
+        dense_entry_a = InteractionFactory(
+            persona=extra_personas[0],
+            pose_kind=PoseKind.ENTRY,
+            scene=dense_scene,
+        )
+        dense_standard = InteractionFactory(
+            persona=extra_personas[1],
+            pose_kind=PoseKind.STANDARD,
+            scene=dense_scene,
+        )
+        dense_entry_b = InteractionFactory(
+            persona=extra_personas[2],
+            pose_kind=PoseKind.ENTRY,
+            scene=dense_scene,
+        )
+
+        # 5 PoseEndorsements on each ENTRY pose (vs. 2 in the small dataset).
+        for endorser_sheet in extra_sheets[1:]:
+            PoseEndorsementFactory(
+                endorser_sheet=endorser_sheet,
+                endorsee_sheet=extra_sheets[0],
+                interaction=dense_entry_a,
+                resonance=dense_resonance,
+            )
+            PoseEndorsementFactory(
+                endorser_sheet=endorser_sheet,
+                endorsee_sheet=extra_sheets[2],
+                interaction=dense_entry_b,
+                resonance=dense_resonance,
+            )
+        # Also endorse the STANDARD pose.
+        for endorser_sheet in extra_sheets[1:]:
+            PoseEndorsementFactory(
+                endorser_sheet=endorser_sheet,
+                endorsee_sheet=extra_sheets[1],
+                interaction=dense_standard,
+                resonance=dense_resonance,
+            )
+
+        # 5+ SceneEntryEndorsements (vs. 2 in the small dataset).
+        for endorser_sheet in extra_sheets[1:]:
+            SceneEntryEndorsementFactory(
+                endorser_sheet=endorser_sheet,
+                endorsee_sheet=extra_sheets[0],
+                scene=dense_scene,
+                resonance=dense_resonance,
+            )
+            SceneEntryEndorsementFactory(
+                endorser_sheet=endorser_sheet,
+                endorsee_sheet=extra_sheets[2],
+                scene=dense_scene,
+                resonance=dense_resonance,
+            )
+
+        url = reverse("interaction-list")
+        with self.assertNumQueries(48):
+            response = self.client.get(url, {"scene": dense_scene.pk})
+        assert response.status_code == 200
+        assert len(response.data["results"]) == 3  # same count as small dataset


### PR DESCRIPTION
Closes #1138

## Summary

Wires the player **endorsement** surfaces into the scene view (closes the last gap from Resonance Pivot Spec C — the write API shipped earlier; the frontend + read surface did not).

**What players get**
- **Endorse pose** (weekly-settling `PoseEndorsement`) and **Endorse entry** (immediate `SceneEntryEndorsement`) controls on poses in the scene view. Entry poses surface **both** (double-dipping by design, per #544).
- A resonance picker offering the target's **claimed** resonances (the rule the backend enforces).
- Endorsement state reflected in the UI: endorser personas (mirroring public reactions) + the viewer's own endorsed/retract state.

**Backend (read surface only — no new models, no migrations, no new endpoints)**
Nests into the existing scene interaction read (`InteractionListSerializer`), mirroring `reactions`: `pose_kind`, `endorsee_sheet_id`, `endorsable_resonances`, `pose_endorsers`/`my_pose_endorsement`, `entry_endorsers`/`entry_endorsed_by_me`. Prefetched / context-mapped so the read stays N+1-safe (query budget pinned, constant w.r.t. endorser count). Privacy is correct-by-construction — these fields are only reachable through the scene read's existing visibility filter, and endorsers are surfaced as primary personas only (no account/sheet/masquerade leak).

**Frontend**
`EndorsementControl` component (Radix dropdown picker) mounted in `PoseUnit`, with hooks in `scenes/queries.ts`. Hidden on the viewer's own pose, on whispers, and on very-private interactions.

**Docs:** corrected stale `magic/CLAUDE.md` endorsement-model descriptions; recorded the read surface + UI in `docs/architecture/resonance-gain.md` and `docs/systems/INDEX.md`.

**Tests:** backend serializer + view tests incl. viewer-scoping and a query-budget guard; 65 frontend tests (component guards, picker, retract gating, entry double-control). A multi-agent review caught and fixed a critical enum-casing bug (frontend compared UPPERCASE vs the lowercase wire format — entry controls would never have rendered); `pose_kind` is now a literal-union type so the bug class is compile-prevented.

**Notes for reviewer (out of scope, not blocking):**
- `Interaction.mode`/`visibility` left typed as `string` (narrowing to literal unions rippled into unrelated files); only `pose_kind` was narrowed.
- Testing surfaced what appears to be a **pre-existing** per-interaction-count N+1 in the base interaction serializer (independent of endorsements). Flagging for awareness — candidate for a separate follow-up.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1138 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (c52af24a); no conflicts. API types regenerated post-rebase — no drift.

<!-- last-addressed-comment: 0 -->