### PR TITLE
fix(#1172): make social actions live-dispatchable on the consent path

### DIFF
--- a/docs/architecture/scene-magic-enhancement.md
+++ b/docs/architecture/scene-magic-enhancement.md
@@ -70,10 +70,14 @@ gives all social actions:
 - `ConsequenceEffect` application (conditions, property changes, etc.)
 - Character loss filtering (always applied)
 
-The six existing social actions (intimidate, persuade, deceive, flirt,
-perform, entrance) each have an `ActionTemplate` with `check_type` and
-`consequence_pool` FKs. The consequence pools determine what happens
-on success/failure — these are authored content, not code concerns.
+The seven social actions (intimidate, persuade, deceive, flirt,
+perform, entrance, and `restore_sense` — the #567 Restore-to-Sense
+ally-recovery action) each have an `ActionTemplate` with `check_type`
+(and, for most, a `consequence_pool`) FK. The consequence pools
+determine what happens on success/failure — these are authored content,
+not code concerns. `restore_sense` additionally carries a
+`RemoveConditionOnCheckConfig` dispatched via `Action.dispatch_effects`
+(see #1172).
 
 `resolve_scene_action()` remains available for any future callers that
 need the lightweight path but is no longer used by scene actions.
@@ -118,10 +122,14 @@ pattern.
 
 **ActionTemplate must be non-null:** `start_action_resolution()`
 requires a valid `ActionTemplate` with `check_type` FK.
-`create_action_request()` must validate that an `ActionTemplate`
-exists for the given `action_key` at creation time, rejecting the
-request early if not. This prevents null `action_template` from
-reaching the resolution pipeline.
+`create_action_request()` resolves and persists `action_template` at
+creation time from the registry action's `template_name`
+(`Action.template_name` → `ActionTemplate.objects.filter(name=…)`,
+#1172) — an `ActionTemplate` has only a unique `name`, no key/slug
+column. Action keys without a registry-backed template (standalone
+casts, rituals) leave `action_template` null and resolve via their own
+pipeline. This is what makes social actions live-dispatchable on the
+consent path.
 
 **How the technique modifies the action check:** The technique's
 runtime stats (intensity, control) can feed `extra_modifiers` into

--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -777,8 +777,10 @@ integration test suite.
   check (Composure/Willpower, per `FuryConfig`) decides lucid-vs-Berserk; lost control applies
   a Berserk `ConditionTemplate` (severity by tier, decays over rounds). Audited on
   `Interaction.fury_committed` + the `CommittingDeclaration` mixin (clash + non-clash). Fury is
-  restricted to technique casts. The "Restore to Sense" ally-recovery action is authored +
-  effect-tested but its live player dispatch is deferred (social-action dispatch gap — #1172).
+  restricted to technique casts. The "Restore to Sense" ally-recovery action is authored,
+  effect-tested, and **live-dispatchable** on the scene consent path (#1172): accepting the
+  request fires its `RemoveConditionOnCheckConfig`, removing the target ally's Berserk
+  condition end-to-end.
 - **Frontend / web UI** — the backend is complete; the declaration panel and round-by-round
   clash visibility UI is a follow-up.
 

--- a/src/actions/base.py
+++ b/src/actions/base.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from actions.constants import ActionCategory, TargetKind
     from actions.models import ActionEnhancement
     from actions.types import TargetFilters
+    from flows.scene_data_manager import SceneDataManager
 
 
 @dataclass
@@ -71,6 +72,13 @@ class Action:
     intent_event: str | None = None
     result_event: str | None = None
 
+    # Name of the ActionTemplate this action resolves through, if any. Set by
+    # registry-backed, data-driven actions (the social actions) so the scene
+    # layer can map a request's ``action_key`` back to its ActionTemplate — an
+    # ActionTemplate has only a unique ``name``, no key/slug column (#1172).
+    # Empty for actions that are not ActionTemplate-backed.
+    template_name: str = ""
+
     objectdb_target_kwargs: ClassVar[frozenset[str]] = frozenset()
 
     def get_prerequisites(self) -> list[Prerequisite]:
@@ -100,6 +108,26 @@ class Action:
             Structured result of the action.
         """
         raise NotImplementedError
+
+    def dispatch_effects(
+        self,
+        actor: ObjectDB,
+        target: ObjectDB | None = None,
+        scene_data: SceneDataManager | None = None,
+    ) -> None:
+        """Dispatch this action's inherent, target-gated effect configs.
+
+        Default no-op. Actions with built-in effects (e.g. the social
+        ``RestoreSenseAction`` removing a Berserk condition) override this to
+        dispatch their ``ActionEnhancement`` effect configs against *target*.
+
+        Called from two places so the effects fire exactly once regardless of
+        dispatch route: the action's own ``execute()`` (the registry/``run()``
+        path) and the scene consent resolution (``_resolve_action_against_persona``
+        in ``world.scenes.action_services``), which resolves the check chain
+        directly and never reaches ``execute()``. A single live dispatch only
+        ever travels one of those routes, so there is no double-application.
+        """
 
     def check_availability(
         self,

--- a/src/actions/definitions/social.py
+++ b/src/actions/definitions/social.py
@@ -3,44 +3,63 @@
 Each singleton exposes ``target_kind = TargetKind.PERSONA`` so the frontend knows
 to prompt for a persona target. The ``execute()`` path goes through
 ``start_action_resolution`` which resolves the linked ActionTemplate's check chain.
+
+These are real ``Action`` subclasses (#1172): the registry dispatch path and the
+scene consent path both rely on the ``Action`` interface (``run()`` / ``execute()`` /
+``dispatch_effects()``). Inherent target effects (e.g. RestoreSense removing a
+Berserk condition) live in ``dispatch_effects`` so they fire exactly once whether
+the action is driven through ``run()`` or through the scene consent resolution.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
 
+from actions.base import Action
 from actions.constants import ActionCategory, TargetKind
 from actions.types import TargetFilters, TargetType
 
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
-    from actions.base import ActionContext
-    from actions.types import ActionResult
+    from actions.types import ActionContext, ActionResult
+    from flows.scene_data_manager import SceneDataManager
 
 
-class _SocialTemplateAction:
+@dataclass
+class _SocialTemplateAction(Action):
     """Base for social ActionTemplate-driven actions.
 
-    Subclasses MUST set ``key``, ``name``, ``description``, ``template_name``.
-    Not a subclass of ``Action`` (which is a dataclass with required positional
-    fields); instead it exposes the same interface as class attributes so the
-    registry and player_interface can treat it identically to an ``Action``.
+    Subclasses set ``key``, ``name``, ``icon``, and ``template_name``. The
+    common social defaults (PERSONA single target, social category, turn cost)
+    are supplied here so concrete classes only declare what differs.
     """
 
-    template_name: str = ""
+    category: str = "social"
     target_type: TargetType = TargetType.SINGLE
-    target_kind: TargetKind = TargetKind.PERSONA
-    target_filters: TargetFilters = TargetFilters(in_same_scene=True, exclude_self=True)
-    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_kind: TargetKind | None = TargetKind.PERSONA
+    target_filters: TargetFilters | None = field(
+        default_factory=lambda: TargetFilters(in_same_scene=True, exclude_self=True)
+    )
+    action_category: ActionCategory | None = ActionCategory.SOCIAL
     costs_turn: bool = True
-    intent_event: str | None = None
-    result_event: str | None = None
 
-    def execute(self, actor: ObjectDB, context: ActionContext, **kwargs) -> ActionResult:
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
         from actions.models import ActionTemplate  # noqa: PLC0415
         from actions.services import start_action_resolution  # noqa: PLC0415
         from world.checks.types import ResolutionContext  # noqa: PLC0415
+
+        # Dispatch any inherent target effects first (no-op for plain social
+        # actions; RestoreSense removes Berserk here). On this path a single
+        # dispatch only runs through execute(), never the consent path too.
+        scene_data = context.scene_data if context is not None else None
+        self.dispatch_effects(actor, kwargs.get("target"), scene_data)
 
         template = ActionTemplate.objects.get(name=self.template_name)
         resolution_ctx = ResolutionContext(action_context=context)
@@ -52,60 +71,65 @@ class _SocialTemplateAction:
         )
 
 
+@dataclass
 class IntimidateAction(_SocialTemplateAction):
-    key = "intimidate"
-    name = "Intimidate"
+    key: str = "intimidate"
+    name: str = "Intimidate"
+    icon: str = "skull"
+    template_name: str = "Intimidate"
     description = "Coerce through force of presence, threats, or physical dominance."
-    icon = "skull"
-    template_name = "Intimidate"
-    category = "social"
 
 
+@dataclass
 class PersuadeAction(_SocialTemplateAction):
-    key = "persuade"
-    name = "Persuade"
+    key: str = "persuade"
+    name: str = "Persuade"
+    icon: str = "handshake"
+    template_name: str = "Persuade"
     description = "Convince through reasoned argument, charm, and social grace."
-    icon = "handshake"
-    template_name = "Persuade"
-    category = "social"
 
 
+@dataclass
 class DeceiveAction(_SocialTemplateAction):
-    key = "deceive"
-    name = "Deceive"
+    key: str = "deceive"
+    name: str = "Deceive"
+    icon: str = "mask"
+    template_name: str = "Deceive"
     description = "Mislead through misdirection, half-truths, or outright lies."
-    icon = "mask"
-    template_name = "Deceive"
-    category = "social"
 
 
+@dataclass
 class FlirtAction(_SocialTemplateAction):
-    key = "flirt"
-    name = "Flirt"
+    key: str = "flirt"
+    name: str = "Flirt"
+    icon: str = "heart"
+    template_name: str = "Flirt"
     description = "Beguile through charm, allure, and romantic suggestion."
-    icon = "heart"
-    template_name = "Flirt"
-    category = "social"
 
 
+@dataclass
 class PerformAction(_SocialTemplateAction):
-    key = "perform"
-    name = "Perform"
+    key: str = "perform"
+    name: str = "Perform"
+    icon: str = "music"
+    template_name: str = "Perform"
     description = "Captivate an audience through music, oration, or storytelling."
-    icon = "music"
-    template_name = "Perform"
-    category = "social"
 
 
+@dataclass
 class EntranceAction(_SocialTemplateAction):
-    key = "entrance"
-    name = "Entrance"
+    key: str = "entrance"
+    name: str = "Entrance"
+    icon: str = "sparkles"
+    template_name: str = "Entrance"
     description = "Command attention through sheer force of personality on entering."
-    icon = "sparkles"
-    template_name = "Entrance"
-    category = "social"
 
-    def execute(self, actor: ObjectDB, context: ActionContext, **kwargs) -> ActionResult:
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
         from actions.models import ActionTemplate  # noqa: PLC0415
         from actions.services import start_action_resolution  # noqa: PLC0415
         from world.checks.types import ResolutionContext  # noqa: PLC0415
@@ -150,53 +174,53 @@ class EntranceAction(_SocialTemplateAction):
             )
 
 
+@dataclass
 class RestoreSenseAction(_SocialTemplateAction):
-    key = "restore_sense"
-    name = "Restore to Sense"
+    key: str = "restore_sense"
+    name: str = "Restore to Sense"
+    icon: str = "heart-pulse"
+    template_name: str = "Restore to Sense"
     description = "Talk a berserk ally down through force of personality and connection."
-    icon = "heart-pulse"
-    template_name = "Restore to Sense"
-    category = "social"
 
-    def execute(self, actor: ObjectDB, context: ActionContext, **kwargs) -> ActionResult:
+    def dispatch_effects(
+        self,
+        actor: ObjectDB,
+        target: ObjectDB | None = None,
+        scene_data: SceneDataManager | None = None,
+    ) -> None:
+        """Dispatch the RemoveConditionOnCheckConfig wired to ``restore_sense``.
+
+        The factory seeds a ``RemoveConditionOnCheckConfig`` on an
+        ``ActionEnhancement`` keyed ``base_action_key="restore_sense"``;
+        ``apply_effects`` dispatches it to ``handle_remove_condition_on_check``,
+        which rolls a check against *target* and removes the Berserk condition on
+        success. Called by ``execute()`` (registry/``run()`` path) and by the
+        scene consent resolution.
+        """
         from actions.effects.registry import apply_effects  # noqa: PLC0415
-        from actions.models import ActionEnhancement, ActionTemplate  # noqa: PLC0415
-        from actions.services import start_action_resolution  # noqa: PLC0415
+        from actions.models import ActionEnhancement  # noqa: PLC0415
         from actions.types import (  # noqa: PLC0415
             ActionContext as _ActionContext,
             ActionResult as _ActionResult,
         )
         from flows.scene_data_manager import SceneDataManager  # noqa: PLC0415
-        from world.checks.types import ResolutionContext  # noqa: PLC0415
 
-        # Build an ActionContext for the effect dispatch (RemoveConditionOnCheckConfig).
-        sdm = SceneDataManager()
-        sdm.initialize_state_for_object(actor)
-        target = kwargs.get("target")
+        sdm = scene_data
+        if sdm is None:
+            sdm = SceneDataManager()
+            sdm.initialize_state_for_object(actor)
+
         effect_ctx = _ActionContext(
-            action=self,  # type: ignore[arg-type]
+            action=self,
             actor=actor,
             target=target,
-            kwargs=kwargs,
+            kwargs={},
             scene_data=sdm,
             result=_ActionResult(success=True),
         )
 
-        # Dispatch all ActionEnhancements wired to "restore_sense".
-        # The factory seeds a RemoveConditionOnCheckConfig on one of these enhancements;
-        # apply_effects dispatches it to handle_remove_condition_on_check.
-        for enh in ActionEnhancement.objects.filter(base_action_key="restore_sense"):
+        for enh in ActionEnhancement.objects.filter(base_action_key=self.key):
             apply_effects(enh, effect_ctx)
-
-        # Run the standard social template resolution (check + consequence pool).
-        template = ActionTemplate.objects.get(name=self.template_name)
-        resolution_ctx = ResolutionContext(action_context=context)
-        return start_action_resolution(
-            character=actor,
-            template=template,
-            target_difficulty=0,
-            context=resolution_ctx,
-        )
 
 
 # Module-level singletons — registered in actions/registry.py

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -875,11 +875,16 @@ def _scene_actions(character: ObjectDB) -> list[PlayerAction]:
     """
     del character  # placeholder for per-character filtering in a follow-up PR
     from actions.models import ActionTemplate  # noqa: PLC0415
+    from actions.registry import SOCIAL_ACTIONS_BY_TEMPLATE_NAME  # noqa: PLC0415
 
     templates = list(ActionTemplate.objects.filter(category=_SOCIAL_CATEGORY))
     result: list[PlayerAction] = []
     for template in templates:
-        action_key = template.name.lower()
+        # Derive the dispatch key from the registry singleton, not name.lower():
+        # multi-word templates ("Restore to Sense") have a distinct registry key
+        # ("restore_sense") that a slug transform cannot reproduce (#1172).
+        social_action = SOCIAL_ACTIONS_BY_TEMPLATE_NAME.get(template.name)
+        action_key = social_action.key if social_action is not None else template.name.lower()
         ref = ActionRef(
             backend=ActionBackend.REGISTRY,
             registry_key=action_key,
@@ -1034,12 +1039,17 @@ def _enhancements_for_action(
 
 
 def _resolve_action_key(action: PlayerAction) -> str:
-    """Return the action key for *action* used to find ActionEnhancement rows."""
+    """Return the action key for *action* used to find ActionEnhancement rows.
+
+    Prefer the dispatch ref's ``registry_key``: for social actions it is the
+    canonical registry key (e.g. ``restore_sense``), whereas ``template.name.lower()``
+    would yield ``restore to sense`` and miss the ``base_action_key`` index (#1172).
+    """
+    if action.ref.registry_key:
+        return action.ref.registry_key
     template = action.action_template
     if template is not None:
         return template.name.lower()
-    if action.ref.registry_key:
-        return action.ref.registry_key
     return ""
 
 

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -59,8 +59,7 @@ from actions.definitions.traps import DisarmTrapAction
 from actions.types import TargetType
 
 # All base action instances. Each is a singleton — actions are stateless.
-# Social singletons are plain classes (not Action subclasses) but share the same interface.
-_ALL_ACTIONS: list[Action] = [  # type: ignore[list-item]
+_ALL_ACTIONS: list[Action] = [
     LookAction(),
     LookAtItemAction(),
     InventoryAction(),
@@ -116,6 +115,17 @@ ACTIONS_BY_KEY: dict[str, Action] = {a.key: a for a in _ALL_ACTIONS}
 ACTIONS_BY_TARGET_TYPE: dict[TargetType, list[Action]] = {}
 for _action in _ALL_ACTIONS:
     ACTIONS_BY_TARGET_TYPE.setdefault(_action.target_type, []).append(_action)
+
+# Social ActionTemplate-backed singletons indexed by their ``template_name``.
+# An ActionTemplate has only a unique ``name`` (no key/slug column), so the scene
+# layer uses this map to translate a template name back to its registry action —
+# both to derive the dispatch ``action_key`` (#1172: "Restore to Sense" → the
+# "restore_sense" key, which a naive ``name.lower()`` would mangle) and to resolve
+# the ActionTemplate for a consent request.
+SOCIAL_ACTIONS_BY_TEMPLATE_NAME: dict[str, Action] = {
+    a.template_name: a
+    for a in (intimidate, persuade, deceive, flirt, perform, entrance, restore_sense)
+}
 
 
 def get_action(key: str) -> Action | None:

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -2910,8 +2910,9 @@ class _RestoreToSenseActionTemplateFactory:
 
     The ActionEnhancement source is an authored "Restore to Sense" Technique
     so the DB constraint (exactly one source FK non-null) is satisfied.  The
-    enhancement is voluntary (is_involuntary=False) — RestoreSenseAction.execute()
-    queries by base_action_key and dispatches apply_effects explicitly.
+    enhancement is voluntary (is_involuntary=False) — RestoreSenseAction.dispatch_effects()
+    queries by base_action_key and dispatches apply_effects explicitly (on both the
+    registry/run() path and the scene consent path, #1172).
 
     Idempotent: uses get_or_create on ActionTemplate name, ActionEnhancement
     variant_name, and RemoveConditionOnCheckConfig(enhancement, condition).

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -105,6 +105,45 @@ def _validate_technique_enhancement(
         raise ValidationError(msg)
 
 
+def _action_template_for_key(action_key: str) -> ActionTemplate | None:
+    """Resolve the ActionTemplate a registry social action resolves through.
+
+    The consent path runs the template's check chain, so a targeted social request
+    needs its ``action_template`` set at creation. Registry social singletons carry
+    the template's ``name`` via ``Action.template_name``; action_keys without one
+    (standalone casts, rituals) yield None and leave the request template-less —
+    unchanged behaviour (#1172).
+    """
+    from actions.models import ActionTemplate  # noqa: PLC0415
+    from actions.registry import get_action  # noqa: PLC0415
+
+    action_obj = get_action(action_key)
+    if action_obj is None or not action_obj.template_name:
+        return None
+    return ActionTemplate.objects.filter(name=action_obj.template_name).first()
+
+
+def _dispatch_action_effects(
+    action_request: SceneActionRequest,
+    actor: ObjectDB,
+    target: ObjectDB,
+) -> None:
+    """Fire the request's registry action's inherent target effects (#1172).
+
+    The consent path resolves the template's check chain via ``start_action_resolution``
+    but never reaches the ``Action``'s ``execute()``; social actions with built-in
+    effects (RestoreSense's ``RemoveConditionOnCheckConfig``) dispatch them here so
+    the effect fires on the live player path. No-op for actions without inherent
+    effects and for non-registry action_keys (standalone casts, rituals).
+    """
+    from actions.registry import get_action  # noqa: PLC0415
+
+    action_obj = get_action(action_request.action_key)
+    if action_obj is None:
+        return
+    action_obj.dispatch_effects(actor, target)
+
+
 def create_action_request(  # noqa: PLR0913
     *,
     scene: Scene,
@@ -191,6 +230,7 @@ def create_action_request(  # noqa: PLR0913
         initiator_persona=initiator_persona,
         target_persona=target_persona,
         action_key=action_key,
+        action_template=_action_template_for_key(action_key),
         difficulty_choice=difficulty_choice,
         status=ActionRequestStatus.PENDING,
         technique=technique,
@@ -363,6 +403,11 @@ def _resolve_action_against_persona(
             action_key=action_request.action_key,
             fury_committed=None,
         )
+
+    # Dispatch the action's inherent target effects (e.g. RestoreSense removing a
+    # Berserk condition). The check chain above resolves the action; this is where
+    # data-driven condition effects reach the live player path (#1172).
+    _dispatch_action_effects(action_request, character, target_character)
 
     result_interaction = _create_result_interaction(
         action_request=action_request,

--- a/src/world/scenes/tests/test_restore_sense_consent_e2e.py
+++ b/src/world/scenes/tests/test_restore_sense_consent_e2e.py
@@ -1,0 +1,191 @@
+"""Live-path coverage for social-action dispatch — the Fury Restore-to-Sense loop (#1172).
+
+Social actions were not dispatchable on the live player path: ``_scene_actions``
+emitted a mangled slug for multi-word templates, ``create_action_request`` never set
+``action_template``, and the consent resolution bypassed the action's effect dispatch.
+These tests pin the three fixes:
+
+1. ``_scene_actions`` emits the canonical registry key ("restore_sense"), not
+   ``template.name.lower()`` ("restore to sense").
+2. ``create_action_request`` resolves and persists the ActionTemplate from the
+   registry action's ``template_name``.
+3. End-to-end (``@tag("postgres")``): accepting a Restore-to-Sense request removes
+   the Berserk condition from the target ally via the consent path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, tag
+
+from actions.constants import ResolutionPhase
+from actions.factories import ActionTemplateFactory
+from actions.player_interface import _scene_actions
+from actions.types import PendingActionResolution, StepResult
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import CheckCategoryFactory, CheckTypeFactory
+from world.conditions.services import apply_condition, has_condition
+from world.magic.factories import (
+    BerserkConditionTemplateFactory,
+    RestoreToSenseActionTemplateFactory,
+)
+from world.scenes.action_constants import ConsentDecision
+from world.scenes.action_services import create_action_request, respond_to_action_request
+from world.scenes.factories import PersonaFactory, SceneFactory
+
+
+def _make_pending_resolution(*, success: bool = True) -> PendingActionResolution:
+    """Minimal PendingActionResolution so the mocked check chain has a main_result."""
+    check_result = MagicMock()
+    check_result.success_level = 1 if success else -1
+    check_result.outcome_name = "Success" if success else "Failure"
+    check_result.outcome = None
+    main_result = StepResult(step_label="main", check_result=check_result, consequence_id=None)
+    return PendingActionResolution(
+        template_id=1,
+        character_id=1,
+        target_difficulty=10,
+        resolution_context_data={"character_id": 1, "challenge_instance_id": None},
+        current_phase=ResolutionPhase.COMPLETE,
+        main_result=main_result,
+    )
+
+
+class SceneActionsSlugTests(TestCase):
+    """``_scene_actions`` keys multi-word social templates by their registry key (#1172)."""
+
+    def test_multi_word_template_uses_registry_key_not_name_lower(self) -> None:
+        ActionTemplateFactory(name="Restore to Sense", category="social", consequence_pool=None)
+
+        actions = _scene_actions(MagicMock())
+        restore = next(
+            (
+                a
+                for a in actions
+                if a.action_template and a.action_template.name == "Restore to Sense"
+            ),
+            None,
+        )
+        self.assertIsNotNone(restore, "Restore to Sense not surfaced by _scene_actions")
+        # name.lower() would yield "restore to sense" (spaces) and miss get_action().
+        self.assertEqual(restore.ref.registry_key, "restore_sense")
+
+    def test_single_word_template_still_resolves(self) -> None:
+        ActionTemplateFactory(name="Intimidate", category="social", consequence_pool=None)
+
+        actions = _scene_actions(MagicMock())
+        intimidate = next(
+            (a for a in actions if a.action_template and a.action_template.name == "Intimidate"),
+            None,
+        )
+        self.assertIsNotNone(intimidate)
+        self.assertEqual(intimidate.ref.registry_key, "intimidate")
+
+
+class CreateActionRequestTemplateResolutionTests(TestCase):
+    """``create_action_request`` resolves ``action_template`` from the registry action (#1172)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.scene = SceneFactory()
+        cls.initiator = PersonaFactory()
+        cls.target = PersonaFactory()
+
+    def test_social_action_key_resolves_template(self) -> None:
+        template = ActionTemplateFactory(
+            name="Restore to Sense", category="social", consequence_pool=None
+        )
+        request = create_action_request(
+            scene=self.scene,
+            initiator_persona=self.initiator,
+            target_persona=self.target,
+            action_key="restore_sense",
+        )
+        self.assertEqual(request.action_template_id, template.pk)
+
+    def test_unseeded_template_leaves_request_template_less(self) -> None:
+        # No "Intimidate" ActionTemplate seeded → resolution returns None, unchanged.
+        request = create_action_request(
+            scene=self.scene,
+            initiator_persona=self.initiator,
+            target_persona=self.target,
+            action_key="intimidate",
+        )
+        self.assertIsNone(request.action_template_id)
+
+    def test_unregistered_action_key_leaves_request_template_less(self) -> None:
+        request = create_action_request(
+            scene=self.scene,
+            initiator_persona=self.initiator,
+            target_persona=self.target,
+            action_key="anima_ritual",
+        )
+        self.assertIsNone(request.action_template_id)
+
+
+@tag("postgres")
+class RestoreSenseConsentE2ETests(TestCase):
+    """End-to-end: accepting a Restore-to-Sense request removes Berserk (#1172 / #567).
+
+    Tagged ``postgres`` because ``remove_condition`` walks active conditions via
+    ``DISTINCT ON`` — Postgres-only.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.berserk = BerserkConditionTemplateFactory()
+        cls.check_cat = CheckCategoryFactory(name="Social")
+        cls.check_type = CheckTypeFactory(name="Willpower", category=cls.check_cat)
+        # Seeds the "Restore to Sense" template + ActionEnhancement +
+        # RemoveConditionOnCheckConfig(condition=berserk).
+        RestoreToSenseActionTemplateFactory(check_type=cls.check_type)
+
+        cls.initiator_character = CharacterFactory()
+        cls.initiator_sheet = CharacterSheetFactory(character=cls.initiator_character)
+        cls.initiator_persona = cls.initiator_sheet.primary_persona
+
+        cls.target_character = CharacterFactory()
+        cls.target_sheet = CharacterSheetFactory(character=cls.target_character)
+        cls.target_persona = cls.target_sheet.primary_persona
+
+        cls.scene = SceneFactory(is_active=True)
+
+    def setUp(self) -> None:
+        self.award_kudos_patcher = patch("world.scenes.action_services.award_kudos")
+        self.award_kudos_patcher.start()
+        self.addCleanup(self.award_kudos_patcher.stop)
+
+    @patch("actions.effects.conditions.perform_check")
+    @patch("world.scenes.action_services.start_action_resolution")
+    def test_accepting_restore_sense_removes_berserk(
+        self, mock_resolve: MagicMock, mock_check: MagicMock
+    ) -> None:
+        # The talk-down check (consent template) and the remove-condition check both
+        # succeed so the effect fires.
+        mock_resolve.return_value = _make_pending_resolution(success=True)
+        mock_check.return_value = MagicMock(success_level=1)
+
+        apply_condition(self.target_character, self.berserk)
+        self.assertTrue(
+            has_condition(self.target_character, self.berserk),
+            "precondition: target should be Berserk before Restore to Sense",
+        )
+
+        request = create_action_request(
+            scene=self.scene,
+            initiator_persona=self.initiator_persona,
+            target_persona=self.target_persona,
+            action_key="restore_sense",
+        )
+        # The fix makes create resolve the template — no manual attach (cf. the old
+        # test_targeted_action_e2e which had to set request.action_template by hand).
+        self.assertEqual(request.action_template.name, "Restore to Sense")
+
+        respond_to_action_request(action_request=request, decision=ConsentDecision.ACCEPT)
+
+        self.assertFalse(
+            has_condition(self.target_character, self.berserk),
+            "Berserk should be removed from the target after Restore to Sense resolves",
+        )

--- a/src/world/scenes/tests/test_scene_action_integration.py
+++ b/src/world/scenes/tests/test_scene_action_integration.py
@@ -142,14 +142,20 @@ class TestSceneActionIntegration(_BaseActionIntegrationTest):
         assert request.resolved_difficulty == 60  # HARD = 60
 
     def test_request_without_template_raises(self) -> None:
-        """Requests with no action_template raise ValueError."""
+        """A request whose action_key resolves no ActionTemplate still raises ValueError.
+
+        ``create_action_request`` now auto-resolves ``action_template`` from a
+        registry social action's ``template_name`` (#1172), so a registered key
+        like ``intimidate`` is no longer template-less. An unregistered key has no
+        template, so the consent resolution guard must still reject it.
+        """
         request = create_action_request(
             scene=self.scene,
             initiator_persona=self.initiator,
             target_persona=self.target,
-            action_key="intimidate",
+            action_key="unregistered_action",
         )
-        # action_template is None by default
+        self.assertIsNone(request.action_template_id)
 
         with self.assertRaises(ValueError):
             respond_to_action_request(


### PR DESCRIPTION
## Summary

Social actions (incl. `RestoreSenseAction`) were not dispatchable on the live
player path, blocking the Fury **"Restore to Sense"** loop (#567) from removing a
Berserk condition end-to-end. The live path for a targeted social action is the
**consent flow** — frontend `POST /api/action-requests/` → `create_action_request`
→ `respond_to_action_request` → `_resolve_standard_action` — and it was broken in
three compounding ways. All three are fixed here.

### What was broken (verified against code)

1. **`_SocialTemplateAction` was not an `Action` subclass** and had no `run()`, so
   the registry dispatch path `AttributeError`'d on it.
2. **Slug mismatch** — `_scene_actions` emitted `template.name.lower()` →
   `"restore to sense"`, but the registry key is `"restore_sense"`. A naive slug
   transform can't bridge it (`"restore_to_sense"` ≠ `"restore_sense"`); only the
   singleton's `template_name` links template → key.
3. **Consent path never set `action_template` and never ran the effects** —
   `create_action_request` stored only `action_key`, so `_resolve_action_against_persona`
   would `ValueError` on a null template, and even once resolved it called
   `start_action_resolution(template)` directly, never reaching the action's
   effect dispatch.

### Fix

- `_SocialTemplateAction` + concrete social classes are now real `@dataclass`
  `Action` subclasses (gain `run()`). Inherent target effects move to a shared
  `Action.dispatch_effects` hook (no-op by default; `RestoreSenseAction` overrides
  it with the `RemoveConditionOnCheckConfig` dispatch). It fires **exactly once**
  whether the action runs via `run()`/`execute()` or via the consent path — a
  single live dispatch only travels one route. `template_name` is promoted to a
  base `Action` field so the scene layer can map `action_key` → `ActionTemplate`.
- `_scene_actions` derives `action_key` from `SOCIAL_ACTIONS_BY_TEMPLATE_NAME`;
  `_resolve_action_key` prefers `ref.registry_key` so enhancement lookup uses the
  canonical `base_action_key` for multi-word actions too.
- `create_action_request` resolves + persists `action_template` from the registry
  action's `template_name`; `_resolve_action_against_persona` dispatches the
  action's effects on the consent resolution.

## Done when (from the issue)

- [x] Social actions (incl. `RestoreSenseAction`) are dispatchable on the live
  player path — consent path routed through the action's effects + `run()` added.
- [x] `_scene_actions` slug handles multi-word names (registry-key map, not raw
  `name.lower()`).
- [x] The Fury "Restore to Sense" loop removes a Berserk condition from a target
  ally end-to-end on the live path — `@tag("postgres")` integration test.

## Testing

- SQLite unit coverage: `_scene_actions` slug = `restore_sense`; multi-word vs
  single-word; `create_action_request` template resolution (social key resolves,
  unseeded/unregistered keys stay template-less).
- `@tag("postgres")` end-to-end: accepting a Restore-to-Sense request removes the
  target ally's Berserk condition via the consent path.
- Full `actions` app (378) + `world.scenes.tests.test_action_services` (25) pass
  on the SQLite tier; `ruff` + project-wide `ty` clean. The postgres-tagged e2e
  runs on CI (local Postgres test DB is held by a parallel worktree session).

## Docs

`docs/architecture/scene-magic-enhancement.md` (action_template resolution + the
seven social actions), `docs/roadmap/combat.md` (#567 Restore-to-Sense now
live-dispatchable), and the RestoreSense factory docstring updated in tandem.

Closes #1172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
