### PR TITLE
Look/room-contents render the presented persona per viewer (#1109)

### DIFF
--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -178,14 +178,7 @@ class BaseState:
             if pk is not None:
                 looker_state = self.context.get_state_by_pk(pk)
 
-        base = self.name
-        if self.fake_name:
-            if looker_state is None:
-                base = self.fake_name
-            else:
-                pk = looker_state.obj.pk
-                if pk != self.obj.pk and pk not in self.real_name_viewers:
-                    base = self.fake_name
+        base = self._base_display_name(looker_state)
 
         prefix = self.name_prefix
         suffix = self.name_suffix
@@ -196,6 +189,23 @@ class BaseState:
             suffix = self.name_suffix_map.get(pk, suffix)
 
         return f"{prefix}{base}{suffix}"
+
+    def _base_display_name(self, looker_state: "BaseState | None") -> str:
+        """The bare name ``looker_state`` sees, before prefix/suffix.
+
+        Subclasses override to resolve identity (e.g. ``CharacterState`` renders the presented
+        persona — real name / discovery reveal / anonymous sdesc — per viewer).
+        """
+        base = self.name
+        if self.fake_name and (
+            looker_state is None
+            or (
+                looker_state.obj.pk != self.obj.pk
+                and looker_state.obj.pk not in self.real_name_viewers
+            )
+        ):
+            base = self.fake_name
+        return base
 
     def get_extra_display_name_info(self, **kwargs: Kwargs) -> str:
         return ""

--- a/src/flows/object_states/character_state.py
+++ b/src/flows/object_states/character_state.py
@@ -27,6 +27,62 @@ class CharacterState(BaseState):
         return {}
 
     # ------------------------------------------------------------------
+    # Identity rendering (#1109) — the look / room-contents / examine name
+    # ------------------------------------------------------------------
+
+    def _base_display_name(self, looker_state: "BaseState | None") -> str:
+        """Render this character's presented persona, resolved per viewer (#1109).
+
+        The active face renders by real name to its owner and for any named-public face; a viewer
+        who has discovered an anonymous face sees the reveal ("Real (as Mask)"); otherwise an
+        anonymous face renders as a composed sdesc ("a man wearing a stag mask"). Falls back to the
+        default name when there is no sheet/persona (NPCs, objects mid-setup).
+        """
+        resolved = self._presented_persona_name(looker_state)
+        if resolved is not None:
+            return resolved
+        return super()._base_display_name(looker_state)
+
+    def _presented_persona_name(self, looker_state: "BaseState | None") -> str | None:
+        from world.scenes.models import Persona  # noqa: PLC0415
+        from world.scenes.persona_display import resolve_display_for_viewer  # noqa: PLC0415
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        sheet = getattr(self.obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        if sheet is None:
+            return None
+        try:
+            persona = active_persona_for_sheet(sheet)
+        except Persona.DoesNotExist:
+            return None
+        viewer_persona_ids, viewer_sheet_ids = (
+            looker_state._viewer_persona_context()  # noqa: SLF001 — same-class look context
+            if isinstance(looker_state, CharacterState)
+            else (set(), set())
+        )
+        name, _is_discovered = resolve_display_for_viewer(
+            persona,
+            viewer_persona_ids=viewer_persona_ids,
+            viewer_sheet_ids=viewer_sheet_ids,
+        )
+        return name
+
+    def _viewer_persona_context(self) -> tuple[set[int], set[int]]:
+        """This looker's account's ``(owned_persona_ids, owned_sheet_ids)``, cached for the look.
+
+        Cached on the state so listing a room's occupants resolves the looker's context once, not
+        once per occupant.
+        """
+        if getattr(self, "_viewer_persona_ctx", None) is None:  # noqa: GETATTR_LITERAL
+            from world.scenes.persona_display import viewer_context_for_account  # noqa: PLC0415
+
+            account = self.obj.db_account
+            self._viewer_persona_ctx = (
+                viewer_context_for_account(account) if account is not None else (set(), set())
+            )
+        return self._viewer_persona_ctx
+
+    # ------------------------------------------------------------------
     # Permission helpers
     # ------------------------------------------------------------------
 

--- a/src/flows/tests/test_look_persona_display.py
+++ b/src/flows/tests/test_look_persona_display.py
@@ -1,0 +1,99 @@
+"""Look / room-contents identity rendering through the persona resolver (#1109).
+
+`CharacterState.get_display_name(looker=...)` is the funnel for telnet room contents, telnet
+look-at, and the web room-state list. A character renders as their presented persona, resolved
+per viewer: own faces / named-public faces by real name, discovered anonymous faces as the
+reveal, undiscovered anonymous faces as a composed sdesc.
+"""
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from evennia_extensions.factories import AccountFactory
+from world.character_sheets.models import Gender
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.factories import PersonaDiscoveryFactory, PersonaFactory
+
+
+def _gender(key):
+    return Gender.objects.get_or_create(key=key, defaults={"display_name": key.title()})[0]
+
+
+class LookPersonaDisplayTests(TestCase):
+    def setUp(self) -> None:
+        self.context = MagicMock()
+
+    def _played(self, account, *, fake_active=False, gender_key="male"):
+        """A tenure'd character; optionally presenting an anonymous mask as its active face."""
+        from evennia_extensions.models import PlayerData
+
+        roster_entry = RosterEntryFactory()
+        player_data, _ = PlayerData.objects.get_or_create(account=account)
+        RosterTenureFactory(player_data=player_data, roster_entry=roster_entry)
+        sheet = roster_entry.character_sheet
+        sheet.gender = _gender(gender_key)
+        character = sheet.character
+        character.db_account = account
+        character.save()
+        if fake_active:
+            mask = PersonaFactory(character_sheet=sheet, is_fake_name=True, name="stag mask")
+            sheet.active_persona = mask
+        sheet.save()
+        return character, sheet
+
+    def _state(self, character):
+        from flows.object_states.character_state import CharacterState
+
+        return CharacterState(character, context=self.context)
+
+    def test_non_owner_sees_a_masked_character_as_an_sdesc(self) -> None:
+        target, _sheet = self._played(AccountFactory(), fake_active=True, gender_key="male")
+        looker, _ = self._played(AccountFactory())
+
+        name = self._state(target).get_display_name(looker=self._state(looker))
+        assert name == "a man wearing a stag mask"
+
+    def test_owner_account_is_never_restricted_from_their_own_masked_face(self) -> None:
+        owner = AccountFactory()
+        target, _sheet = self._played(owner, fake_active=True)
+        # A second character on the SAME account looking — owns the face, sees it real.
+        looker, _ = self._played(owner)
+
+        name = self._state(target).get_display_name(looker=self._state(looker))
+        assert name == "stag mask"
+
+    def test_looking_at_your_own_masked_self_shows_the_real_face(self) -> None:
+        owner = AccountFactory()
+        target, _sheet = self._played(owner, fake_active=True)
+
+        target_state = self._state(target)
+        assert target_state.get_display_name(looker=target_state) == "stag mask"
+
+    def test_a_viewer_who_discovered_the_link_sees_the_reveal(self) -> None:
+        target, sheet = self._played(AccountFactory(), fake_active=True)
+        looker, looker_sheet = self._played(AccountFactory())
+        PersonaDiscoveryFactory(
+            persona=sheet.active_persona,
+            linked_to=sheet.primary_persona,
+            discovered_by=looker_sheet,
+        )
+
+        name = self._state(target).get_display_name(looker=self._state(looker))
+        assert name == f"{sheet.primary_persona.name} (as stag mask)"
+
+    def test_a_normal_unmasked_character_renders_their_name(self) -> None:
+        target, sheet = self._played(AccountFactory(), fake_active=False)
+        looker, _ = self._played(AccountFactory())
+
+        name = self._state(target).get_display_name(looker=self._state(looker))
+        # A named (non-fake) primary persona renders by name, never an sdesc.
+        assert "wearing a" not in name
+        assert name == sheet.primary_persona.name
+
+    def test_no_sheet_character_falls_back_to_default_name(self) -> None:
+        from evennia_extensions.factories import CharacterFactory
+
+        bare = CharacterFactory(db_key="Bare NPC")  # no CharacterSheet
+        looker, _ = self._played(AccountFactory())
+        assert self._state(bare).get_display_name(looker=self._state(looker)) == "Bare NPC"

--- a/src/world/scenes/persona_display.py
+++ b/src/world/scenes/persona_display.py
@@ -19,12 +19,12 @@ from typing import TYPE_CHECKING
 
 from django.db.models import Q
 
-from world.scenes.models import PersonaDiscovery
+from world.scenes.models import Persona, PersonaDiscovery
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from world.scenes.models import Persona
+    from evennia.accounts.models import AccountDB
 
 # Apparent gender for the anonymous-face short description (#1109): from the character's real
 # gender; non-binary / unset render as "person". (A slice-3 disguise that conceals gender will
@@ -83,3 +83,54 @@ def build_persona_display_map(
         else:
             display[persona.pk] = (compose_sdesc(persona), False)
     return display
+
+
+def resolve_display_for_viewer(
+    persona: Persona,
+    *,
+    viewer_persona_ids: set[int],
+    viewer_sheet_ids: set[int],
+) -> tuple[str, bool]:
+    """Resolve one persona's ``(display_name, is_discovered)`` for one viewer (#1109).
+
+    The single-target form of ``build_persona_display_map`` — for the look / room-contents
+    paths, which resolve one character at a time. Own faces and named-public faces render real;
+    a discovered anonymous face reveals; otherwise the composed sdesc. One discovery query, and
+    only for an anonymous, non-owned face.
+    """
+    if persona.pk in viewer_persona_ids or not persona.is_fake_name:
+        return persona.name, False
+    if viewer_sheet_ids:
+        discovery = (
+            PersonaDiscovery.objects.filter(
+                Q(persona_id=persona.pk) | Q(linked_to_id=persona.pk),
+                discovered_by_id__in=viewer_sheet_ids,
+            )
+            .select_related("persona", "linked_to")
+            .first()
+        )
+        if discovery is not None:
+            linked = (
+                discovery.linked_to if discovery.persona_id == persona.pk else discovery.persona
+            )
+            return f"{linked.name} (as {persona.name})", True
+    return compose_sdesc(persona), False
+
+
+def viewer_context_for_account(account: AccountDB) -> tuple[set[int], set[int]]:
+    """The viewer's ``(owned_persona_ids, owned_sheet_ids)`` for a look (no request) (#1109).
+
+    Owned = personas on the character sheets the account *currently* plays. Both sets feed
+    ``resolve_display_for_viewer`` — owned for self-ownership, sheets for the discovery lookup.
+    """
+    from world.roster.models import RosterEntry  # noqa: PLC0415
+
+    sheet_ids = set(
+        RosterEntry.objects.for_account(account).values_list("character_sheet_id", flat=True)
+    )
+    if not sheet_ids:
+        return set(), set()
+    persona_ids = set(
+        Persona.objects.filter(character_sheet_id__in=sheet_ids).values_list("id", flat=True)
+    )
+    return persona_ids, sheet_ids


### PR DESCRIPTION
Extends the slice-2 per-viewer identity resolution (#1233, scene feed) to the **look / room-contents / examine** surfaces — the broader follow-up I flagged. All three route through one funnel, so this fixes them together.

## What renders now
When you look at a room or a character, each character renders as their **presented persona** (`active_persona_for_sheet`), resolved for *you*:
- **Own faces** (any persona on a character_sheet your account currently plays) + **named-public faces** → real name. Self-ownership holds at the account level — you're never restricted from your own faces, even looking from a *different* character of yours.
- **A discovered anonymous face** → `"<real> (as <mask>)"`.
- **An undiscovered anonymous face** → the composed sdesc `"a man wearing a stag mask"`.
- NPCs / sheetless objects → the default name (unchanged).

## How (one leverage point)
`BaseState.get_display_name(looker=...)` is the shared funnel for **telnet room contents, telnet look-at, and the web room-state occupant list**. It now delegates the bare name to a `_base_display_name(looker)` hook (default = legacy behaviour); `CharacterState` overrides it to run the persona resolver.
- New `persona_display.resolve_display_for_viewer` (single-target) + `viewer_context_for_account` (the looker's owned persona/sheet ids).
- The looker's context is **cached on the state**, so a room of N occupants resolves it once, not per occupant.

## Tests
non-owner sees sdesc; owner (another of their characters) sees real; self sees real; discoverer sees the reveal; normal unmasked character renders their name; sheetless NPC falls back. `flows + scenes + typeclasses` green (**915**); ruff + ty clean; **no API drift** (same `name` field, resolved differently).

## Deferred (separate, riskier surface)
The web **character-sheet profile** name + persona list (`_build_identity` / `_build_personas`) is viewer-agnostic today — a sheet GET on an anonymous face would leak the real name + every alt. That needs viewer threading **plus a fail-closed boundary**, so it's its own PR, not a name swap.

Refs #1109.
