### PR TITLE
Duels Phase 2: challenge inbox + outgoing affordance + completion/clash fixes (#1180, #1181, #1182)

### DIFF
--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -561,11 +561,31 @@ clamps soulfray below any death-risk stage, and never fires a `character_loss` c
 `withdraw` / `yield` / `acknowledge_risk`. **Frontend:** `combat/duels/DuelChallengeControls`
 (+ yield / acknowledge controls), reusing the existing combat round UI + dispatch.
 
+### Duels — Phase 2 (SHIPPED — 2026-06-20)
+
+**Status: SHIPPED**
+**Issues:** #1180 (inbox + prompt), #1181 (outgoing affordance), #1182 (crediting/threading fixes).
+
+- **Incoming-challenge inbox (#1180):** `GET /api/combat/duel-challenges/` —
+  `DuelChallengeViewSet` (read-only, filters/pagination/permissions) returns the caller's
+  PENDING challenges (`?role=incoming|outgoing`), scoped to played characters via
+  `played_character_sheet_ids`, reusing `DuelChallengeSerializer`. The frontend
+  `useDuelChallengeInbox` hook feeds `CombatScenePage`, replacing the
+  `hasPendingIncomingChallenge={false}` stub. Accept/decline/withdraw now accept an optional
+  `challenge_id` kwarg so the UI targets a specific challenge when a PC has several pending.
+- **Outgoing affordance (#1181):** a "Challenge to a duel" item on `PersonaContextMenu`,
+  dispatching the `challenge` registry action with the target persona id. `ChallengeAction`
+  resolves a Persona pk → character ObjectDB (web path; telnet/tests still pass ObjectDB).
+  `PersonaSerializer.allow_social_actions` mirrors the consent gate (`_tenure_blocks_actor`
+  with `category=None`) so the affordance hides for opted-out targets and for self; the
+  backend still enforces the full gate at dispatch.
+- **Crediting / threading fixes (#1182):** `_increment_completion_counters` credits a DUEL
+  win only to `encounter.duel_winner` (loss to the other duelist; abandoned duel credits
+  neither) instead of every ACTIVE participant; `commit_to_clash` threads
+  `lethal=clash.encounter.is_lethal` into `use_technique` so the non-lethal cap holds on the
+  clash path (latent today — PvP mirror surfaces never form a clash).
+
 **Still open (tracked):**
-- `GET /api/combat/duel-challenges/` inbox endpoint — the incoming-challenge accept/decline
-  prompt is wired but stubbed off until it (or a WebSocket push) ships.
-- Outgoing "challenge a co-located character" scene-UI affordance (the `challenge` action is
-  wired; only the convenience UI entry point is deferred).
 - Sheet-driven symmetric NPC duellist (the lethal variant reuses the threat-pool opponent).
 
 ### Unified Combat UI (SHIPPED — 2026-05-24)

--- a/docs/systems/consent.md
+++ b/docs/systems/consent.md
@@ -108,6 +108,14 @@ Enforcement happens in `_target_spec_for_action()`: for any social `ActionTempla
 `_social_consent_exclusions` is called with the template's `consent_category` and the
 result is wired into `TargetFilters.excluded_persona_ids`.
 
+**Read-side exposure for registry actions (#1181).** Registry actions like `challenge`
+carry no `ActionTemplate`, so they never appear in the available-actions list and get no
+computed `TargetSpec`. For these, `PersonaSerializer.allow_social_actions` surfaces the
+target's master switch (mirroring `_tenure_blocks_actor` with `category=None`, which is
+gated only by `allow_social_actions`) so the scene UI can hide the affordance for opted-out
+targets. The backend still enforces the full gate at dispatch — the serializer field is a
+UX hint, not the authority.
+
 ---
 
 ## API Endpoints (`/api/consent/`)

--- a/frontend/src/combat/api.ts
+++ b/frontend/src/combat/api.ts
@@ -23,6 +23,12 @@ import type {
 export type ConsequenceOutcome = components['schemas']['ConsequenceOutcome'];
 export type ConsequenceOutcomeModifier = components['schemas']['ConsequenceOutcomeModifier'];
 
+/** One row in the duel-challenge inbox (GET /api/combat/duel-challenges/). */
+export type DuelChallenge = components['schemas']['DuelChallenge'];
+
+/** Direction of a duel challenge relative to the requesting player. */
+export type DuelChallengeRole = 'incoming' | 'outgoing';
+
 /**
  * A single row in the outcome_display roulette wheel.
  * The backend serializes OutcomeDisplay dataclass as plain dicts.
@@ -61,6 +67,25 @@ export async function fetchEncountersForScene(sceneId: number): Promise<Encounte
   const res = await apiFetch(`/api/combat/?scene=${sceneId}`);
   if (!res.ok) throw new Error('Failed to load encounters for scene');
   const data = (await res.json()) as { results?: EncounterListItem[]; count?: number };
+  return data.results ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Duel-challenge inbox
+// ---------------------------------------------------------------------------
+
+/**
+ * List the requesting player's PENDING duel challenges.
+ * GET /api/combat/duel-challenges/[?role=incoming|outgoing]
+ *
+ * Scoped server-side to the caller's played characters. Returns the results
+ * array from the paginated response.
+ */
+export async function fetchDuelChallengeInbox(role?: DuelChallengeRole): Promise<DuelChallenge[]> {
+  const url = role ? `/api/combat/duel-challenges/?role=${role}` : '/api/combat/duel-challenges/';
+  const res = await apiFetch(url);
+  if (!res.ok) throw new Error('Failed to load duel challenges');
+  const data = (await res.json()) as { results?: DuelChallenge[]; count?: number };
   return data.results ?? [];
 }
 

--- a/frontend/src/combat/duels/DuelChallengeControls.tsx
+++ b/frontend/src/combat/duels/DuelChallengeControls.tsx
@@ -4,10 +4,11 @@
  * Three independent components surfaced by CombatTurnPanel when relevant:
  *
  * 1. DuelChallengeControls — Accept/Decline prompt for an incoming pending challenge.
- *    Backend gap: there is no /api/combat/duel-challenges/ list endpoint yet;
- *    the caller must derive `hasPendingIncomingChallenge` from other data sources
- *    (e.g. the encounter detail, a WebSocket push, or the available-actions list).
- *    Dispatches registry actions 'accept' / 'decline' via useDispatchPlayerAction.
+ *    Driven by the GET /api/combat/duel-challenges/ inbox (#1180): the caller fetches
+ *    the inbox, finds the incoming challenge for this character, and passes
+ *    `hasPendingIncomingChallenge`, `challengerName`, and the specific `challengeId`.
+ *    Dispatches registry actions 'accept' / 'decline' (threading `challenge_id`) via
+ *    useDispatchPlayerAction.
  *
  * 2. DuelYieldControls — Yield button shown while an active duel is in progress.
  *    Dispatches registry action 'yield'. Guards on `isActiveDuel` (caller derives
@@ -20,14 +21,9 @@
  *    to the frontend; the backend removes this action from availability once acked).
  *
  * All three components dispatch through useDispatchPlayerAction (the same hook
- * used by YourTurn for combat actions). No new API client functions needed.
+ * used by YourTurn for combat actions).
  *
- * Backend gap note (Task 14):
- *   A dedicated GET /api/combat/duel-challenges/ endpoint does not yet exist.
- *   The challenge prompt is driven by a caller-supplied `hasPendingIncomingChallenge`
- *   prop. Once the endpoint ships the caller can derive this via a React Query hook.
- *
- * Part of #568 — Duels feature, Task 14.
+ * Part of #568 — Duels feature, Task 14. Inbox wiring + challenge_id threading: #1180.
  */
 
 import { useState } from 'react';
@@ -38,13 +34,13 @@ import { useDispatchPlayerAction } from '@/combat/queries';
 // Dispatch helper — registry-backend action with no extra kwargs
 // ---------------------------------------------------------------------------
 
-function registryRef(key: string) {
+function registryRef(key: string, kwargs: Record<string, unknown> = {}) {
   return {
     ref: {
       backend: 'registry' as const,
       registry_key: key,
     },
-    kwargs: {} as Record<string, unknown>,
+    kwargs,
   };
 }
 
@@ -59,31 +55,47 @@ export interface DuelChallengeControlsProps {
   hasPendingIncomingChallenge: boolean;
   /** Display name of the challenger — shown in the prompt. */
   challengerName: string | null;
+  /**
+   * The specific PENDING challenge this prompt acts on. Threaded into the action
+   * kwargs as `challenge_id` so accept/decline target the intended challenge when
+   * a PC has more than one pending (#1180). Null when unknown (back-compat).
+   */
+  challengeId?: number | null;
+  /**
+   * Called after a successful accept/decline so the caller can refresh caches
+   * (e.g. invalidate the inbox + the scene's active-encounter list).
+   */
+  onResolved?: () => void;
 }
 
 /**
  * Accept/Decline prompt for an incoming duel challenge.
  *
  * Renders null when `hasPendingIncomingChallenge` is false.
- * Dispatches the 'accept' or 'decline' registry action on click.
- *
- * Backend gap: caller must supply `hasPendingIncomingChallenge` from an external
- * source (WebSocket, encounter detail, or a future challenge-inbox endpoint).
+ * Dispatches the 'accept' or 'decline' registry action (threading `challenge_id`)
+ * on click. The caller supplies the availability + identity from the
+ * GET /api/combat/duel-challenges/ inbox (#1180).
  */
 export function DuelChallengeControls({
   characterId,
   hasPendingIncomingChallenge,
   challengerName,
+  challengeId = null,
+  onResolved,
 }: DuelChallengeControlsProps) {
   const { mutateAsync, isPending } = useDispatchPlayerAction(characterId);
   const [error, setError] = useState<string | null>(null);
 
   if (!hasPendingIncomingChallenge) return null;
 
+  const challengeKwargs: Record<string, unknown> =
+    challengeId != null ? { challenge_id: challengeId } : {};
+
   async function handleAccept() {
     setError(null);
     try {
-      await mutateAsync(registryRef('accept'));
+      await mutateAsync(registryRef('accept', challengeKwargs));
+      onResolved?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to accept challenge');
     }
@@ -92,7 +104,8 @@ export function DuelChallengeControls({
   async function handleDecline() {
     setError(null);
     try {
-      await mutateAsync(registryRef('decline'));
+      await mutateAsync(registryRef('decline', challengeKwargs));
+      onResolved?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to decline challenge');
     }

--- a/frontend/src/combat/duels/__tests__/DuelChallengeControls.test.tsx
+++ b/frontend/src/combat/duels/__tests__/DuelChallengeControls.test.tsx
@@ -84,6 +84,7 @@ describe('DuelChallengeControls — pending challenge prompt', () => {
       characterId: 10,
       hasPendingIncomingChallenge: true,
       challengerName: 'Rival Knight',
+      challengeId: 42,
       ...overrides,
     };
   }
@@ -107,10 +108,52 @@ describe('DuelChallengeControls — pending challenge prompt', () => {
     expect(screen.getByTestId('duel-challenge-prompt')).toHaveTextContent('Baron Vex');
   });
 
-  it('dispatches accept action when Accept is clicked', async () => {
+  it('dispatches accept action with the threaded challenge_id and calls onResolved', async () => {
+    setupMocks();
+    const onResolved = vi.fn();
+
+    render(<DuelChallengeControls {...defaultChallengeProps({ onResolved })} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('duel-accept-btn'));
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      ref: {
+        backend: 'registry',
+        registry_key: 'accept',
+      },
+      kwargs: { challenge_id: 42 },
+    });
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+  });
+
+  it('dispatches decline action with the threaded challenge_id and calls onResolved', async () => {
+    setupMocks();
+    const onResolved = vi.fn();
+
+    render(<DuelChallengeControls {...defaultChallengeProps({ onResolved })} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('duel-decline-btn'));
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      ref: {
+        backend: 'registry',
+        registry_key: 'decline',
+      },
+      kwargs: { challenge_id: 42 },
+    });
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+  });
+
+  it('omits challenge_id from kwargs when no challengeId is provided (back-compat)', async () => {
     setupMocks();
 
-    render(<DuelChallengeControls {...defaultChallengeProps()} />, { wrapper: createWrapper() });
+    render(<DuelChallengeControls {...defaultChallengeProps({ challengeId: null })} />, {
+      wrapper: createWrapper(),
+    });
 
     await userEvent.click(screen.getByTestId('duel-accept-btn'));
 
@@ -123,20 +166,19 @@ describe('DuelChallengeControls — pending challenge prompt', () => {
     });
   });
 
-  it('dispatches decline action when Decline is clicked', async () => {
+  it('does not call onResolved when the dispatch fails', async () => {
     setupMocks();
+    mockMutateAsync.mockRejectedValueOnce(new Error('Challenge already expired'));
+    const onResolved = vi.fn();
 
-    render(<DuelChallengeControls {...defaultChallengeProps()} />, { wrapper: createWrapper() });
-
-    await userEvent.click(screen.getByTestId('duel-decline-btn'));
-
-    expect(mockMutateAsync).toHaveBeenCalledWith({
-      ref: {
-        backend: 'registry',
-        registry_key: 'decline',
-      },
-      kwargs: {},
+    render(<DuelChallengeControls {...defaultChallengeProps({ onResolved })} />, {
+      wrapper: createWrapper(),
     });
+
+    await userEvent.click(screen.getByTestId('duel-accept-btn'));
+
+    await screen.findByRole('alert');
+    expect(onResolved).not.toHaveBeenCalled();
   });
 
   it('does not render the challenge prompt when there is no pending challenge', () => {

--- a/frontend/src/combat/pages/CombatScenePage.tsx
+++ b/frontend/src/combat/pages/CombatScenePage.tsx
@@ -35,7 +35,7 @@ import type { ActionAttachmentInfo } from '@/scenes/actionTypes';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { usePendingUnlinkedActions } from '@/scenes/hooks/usePendingUnlinkedActions';
-import { useEncounterForScene } from '@/combat/queries';
+import { useEncounterForScene, useDuelChallengeInbox, combatKeys } from '@/combat/queries';
 import { CombatTurnPanel } from '@/combat/CombatTurnPanel';
 import { DeepLinkModalHost } from '@/combat/modals/DeepLinkModalHost';
 import { DuelChallengeControls } from '@/combat/duels/DuelChallengeControls';
@@ -73,6 +73,18 @@ export function CombatScenePage() {
   const characterId = activeEntry?.character_id ?? 0;
   const characterSheetId = activeEntry?.character_id ?? 0; // same pk — see MyRosterEntry type
   const personaId = activeEntry?.primary_persona_id ?? null;
+
+  // Incoming duel-challenge prompt (#1180). The inbox is scoped server-side to the
+  // account's played characters; pick the row whose challenged character is the
+  // active one. challenged.id is a CharacterSheet pk, which equals characterId.
+  const { data: incomingChallenges = [] } = useDuelChallengeInbox({
+    enabled: characterId > 0,
+    role: 'incoming',
+  });
+  const incomingChallenge = useMemo(
+    () => incomingChallenges.find((c) => c.challenged.id === characterId) ?? null,
+    [incomingChallenges, characterId]
+  );
 
   // Detached action IDs for the chip strip
   const [detachedActionIds, setDetachedActionIds] = useState<number[]>([]);
@@ -140,6 +152,15 @@ export function CombatScenePage() {
   const handleComposerModeChange = useCallback((mode: ComposerMode) => {
     setComposerMode(mode);
   }, []);
+
+  // After accepting/declining a duel challenge, refresh the inbox and the scene's
+  // active-encounter list (accept creates the encounter that should now appear).
+  const handleChallengeResolved = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: combatKeys.duelChallengesAll() }).catch(() => {});
+    queryClient
+      .invalidateQueries({ queryKey: combatKeys.encountersForScene(sceneIdNum) })
+      .catch(() => {});
+  }, [queryClient, sceneIdNum]);
 
   // ---------------------------------------------------------------------------
   // No-active-encounter empty state
@@ -227,17 +248,16 @@ export function CombatScenePage() {
             />
           ) : (
             <div className="flex flex-col gap-3">
-              {/* Duel challenge accept/decline prompt — shown when there is no active encounter
-                  yet but a pending duel challenge exists.
-                  Backend gap (#568): no /api/combat/duel-challenges/ list endpoint exists yet;
-                  hasPendingIncomingChallenge is always false until that endpoint ships and
-                  a hook populates this prop. The dispatch path (accept / decline) is wired
-                  and functional; only the availability signal is missing. */}
-              {isActive && characterId > 0 && (
+              {/* Duel challenge accept/decline prompt — shown when there is no active
+                  encounter yet but a pending incoming challenge exists for this character.
+                  Driven by the GET /api/combat/duel-challenges/ inbox (#1180). */}
+              {isActive && characterId > 0 && incomingChallenge && (
                 <DuelChallengeControls
                   characterId={characterId}
-                  hasPendingIncomingChallenge={false}
-                  challengerName={null}
+                  hasPendingIncomingChallenge={true}
+                  challengerName={incomingChallenge.challenger.name}
+                  challengeId={incomingChallenge.id}
+                  onResolved={handleChallengeResolved}
                 />
               )}
               <div

--- a/frontend/src/combat/pages/__tests__/CombatScenePage.test.tsx
+++ b/frontend/src/combat/pages/__tests__/CombatScenePage.test.tsx
@@ -42,12 +42,15 @@ vi.mock('@/combat/queries', () => ({
   useAvailableCombos: vi.fn().mockReturnValue({ data: [], isLoading: false }),
   useUpgradeCombo: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useDispatchPlayerAction: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
+  useDuelChallengeInbox: vi.fn().mockReturnValue({ data: [] }),
   combatKeys: {
     all: ['combat'],
     encounter: (id: number) => ['combat', 'encounter', id],
     encountersForScene: (id: number) => ['combat', 'encounters-for-scene', id],
     combos: (id: number) => ['combat', 'combos', id],
     availableActions: (id: number) => ['combat', 'available-actions', id],
+    duelChallengesAll: () => ['combat', 'duel-challenges'],
+    duelChallenges: (role?: string) => ['combat', 'duel-challenges', role ?? 'all'],
   },
 }));
 
@@ -279,6 +282,46 @@ describe('CombatScenePage — empty state', () => {
 
     expect(screen.getByTestId('combat-encounter-loading')).toBeInTheDocument();
     expect(screen.queryByTestId('combat-turn-panel-stub')).not.toBeInTheDocument();
+  });
+});
+
+describe('CombatScenePage — incoming duel challenge (#1180)', () => {
+  function challengeRow(challengedId: number) {
+    return {
+      id: 55,
+      challenger: { id: 20, name: 'Rival Knight' },
+      challenged: { id: challengedId, name: 'Aerande' },
+      status: 'pending',
+      created_at: '2026-06-20T00:00:00Z',
+      resolved_at: null,
+      resulting_encounter: null,
+    };
+  }
+
+  it('renders the accept/decline prompt when the inbox has a matching incoming challenge', async () => {
+    mockedUseEncounterForScene.mockReturnValue({ data: null, isLoading: false, isError: false });
+    (combatQueries.useDuelChallengeInbox as ReturnType<typeof vi.fn>).mockReturnValue({
+      // challenged.id 10 matches the active character_id from the roster mock.
+      data: [challengeRow(10)],
+    });
+
+    render(<CombatScenePage />, { wrapper: createWrapper() });
+
+    const prompt = await screen.findByTestId('duel-challenge-prompt');
+    expect(prompt).toHaveTextContent('Rival Knight');
+  });
+
+  it('does not render the prompt when no inbox challenge targets this character', () => {
+    mockedUseEncounterForScene.mockReturnValue({ data: null, isLoading: false, isError: false });
+    (combatQueries.useDuelChallengeInbox as ReturnType<typeof vi.fn>).mockReturnValue({
+      // challenged.id 999 does not match the active character_id (10).
+      data: [challengeRow(999)],
+    });
+
+    render(<CombatScenePage />, { wrapper: createWrapper() });
+
+    expect(screen.queryByTestId('duel-challenge-prompt')).not.toBeInTheDocument();
+    expect(screen.getByTestId('combat-no-encounter')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/combat/queries.ts
+++ b/frontend/src/combat/queries.ts
@@ -34,6 +34,11 @@ export const combatKeys = {
 
   consequenceOutcomes: (params: api.ConsequenceOutcomesParams) =>
     [...combatKeys.all, 'consequence-outcomes', params] as const,
+
+  duelChallengesAll: () => [...combatKeys.all, 'duel-challenges'] as const,
+
+  duelChallenges: (role?: api.DuelChallengeRole) =>
+    [...combatKeys.duelChallengesAll(), role ?? 'all'] as const,
 };
 
 /**
@@ -126,6 +131,32 @@ export function useEncounterForScene(sceneId: number): {
     isLoading: result.isLoading,
     isError: result.isError,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Duel-challenge inbox hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the requesting player's PENDING duel challenges (#1180).
+ *
+ * GET /api/combat/duel-challenges/[?role=...]. The result is scoped server-side
+ * to the caller's played characters, so the page filters by challenged.id to find
+ * the incoming challenge for the active character. Polls so an incoming challenge
+ * appears without a manual refresh; disabled via `enabled` (e.g. when no character
+ * is resolved).
+ */
+export function useDuelChallengeInbox(
+  options: { enabled?: boolean; role?: api.DuelChallengeRole } = {}
+) {
+  const { enabled = true, role } = options;
+  return useQuery({
+    queryKey: combatKeys.duelChallenges(role),
+    queryFn: () => api.fetchDuelChallengeInbox(role),
+    enabled,
+    refetchInterval: 15_000,
+    staleTime: 10_000,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -2558,6 +2558,56 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/combat/duel-challenges/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only inbox of the requesting player's PENDING duel challenges (#1180).
+     *
+     *     Lists every PENDING ``DuelChallenge`` where the caller plays either the
+     *     challenger or the challenged character, so the web UI can render the
+     *     incoming-challenge prompt (and surface a player's outgoing challenges).
+     *     ``?role=incoming|outgoing`` narrows to one side. Scoped to the caller's
+     *     played characters, so it never leaks other players' challenges.
+     */
+    get: operations['combat_duel_challenges_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/combat/duel-challenges/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only inbox of the requesting player's PENDING duel challenges (#1180).
+     *
+     *     Lists every PENDING ``DuelChallenge`` where the caller plays either the
+     *     challenger or the challenged character, so the web UI can render the
+     *     incoming-challenge prompt (and surface a player's outgoing challenges).
+     *     ``?role=incoming|outgoing`` narrows to one side. Scoped to the caller's
+     *     played characters, so it never leaks other players' challenges.
+     */
+    get: operations['combat_duel_challenges_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/conditions/capabilities/': {
     parameters: {
       query?: never;
@@ -15360,6 +15410,38 @@ export interface components {
      */
     DrawModeEnum: 'menu' | 'pool';
     /**
+     * @description Read serializer for the DuelChallenge pending-challenge inbox.
+     *
+     *     Exposes challenger/challenged identities (id + name), status, timestamps,
+     *     and the resulting_encounter FK PK. Intended for a player's incoming or
+     *     outgoing challenge list.
+     *
+     *     N+1-safe when the queryset uses ``select_related("challenger_sheet__character",
+     *     "challenged_sheet__character")``.
+     */
+    DuelChallenge: {
+      readonly id: number;
+      readonly challenger: components['schemas']['_DuelParticipantIdentity'];
+      readonly challenged: components['schemas']['_DuelParticipantIdentity'];
+      /** @default pending */
+      readonly status: components['schemas']['DuelChallengeStatusEnum'];
+      /** Format: date-time */
+      readonly created_at: string;
+      /** Format: date-time */
+      readonly resolved_at: string | null;
+      /** @description The CombatEncounter opened when the challenge was accepted. */
+      readonly resulting_encounter: number | null;
+    };
+    /**
+     * @description * `pending` - Pending
+     *     * `accepted` - Accepted
+     *     * `declined` - Declined
+     *     * `withdrawn` - Withdrawn
+     *     * `expired` - Expired
+     * @enum {string}
+     */
+    DuelChallengeStatusEnum: 'pending' | 'accepted' | 'declined' | 'withdrawn' | 'expired';
+    /**
      * @description Lightweight identity for a duel winner (CharacterSheet id + character name).
      *
      *     Exposes only what the UI needs to label the victor — the CharacterSheet PK
@@ -18704,6 +18786,21 @@ export interface components {
        */
       previous?: string | null;
       results: components['schemas']['DramaticMomentTag'][];
+    };
+    PaginatedDuelChallengeList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['DuelChallenge'][];
     };
     PaginatedEncounterListList: {
       /** @example 123 */
@@ -24508,6 +24605,17 @@ export interface components {
       /** Format: date-time */
       created_at: string;
     };
+    /**
+     * @description Compact identity for one side of a DuelChallenge (CharacterSheet id + name).
+     *
+     *     Note: CharacterSheet's primary key is the ``character`` OneToOneField, so
+     *     there is no ``.id`` attribute — ``source="pk"`` reads ``.pk`` explicitly.
+     */
+    _DuelParticipantIdentity: {
+      readonly id: number;
+      /** @description Return the character's display name from CharacterSheet.character.db_key. */
+      readonly name: string;
+    };
     /** @description Persona's fame state for the renown tab header. */
     _Fame: {
       points: number;
@@ -27823,6 +27931,59 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['OutcomeDetail'][];
+        };
+      };
+    };
+  };
+  combat_duel_challenges_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
+        /**
+         * @description Challenge direction relative to the requesting player.
+         *
+         *     * `incoming` - Incoming
+         *     * `outgoing` - Outgoing
+         */
+        role?: 'incoming' | 'outgoing';
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedDuelChallengeList'];
+        };
+      };
+    };
+  };
+  combat_duel_challenges_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this duel challenge. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['DuelChallenge'];
         };
       };
     };

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -21431,6 +21431,17 @@ export interface components {
       readonly roster_entry: {
         [key: string]: number | string;
       } | null;
+      /**
+       * @description Whether this persona's character may be targeted by social actions.
+       *
+       *     Mirrors the challenge consent gate (``_tenure_blocks_actor`` with
+       *     ``category=None``): blocked only when the active tenure's
+       *     ``SocialConsentPreference`` has ``allow_social_actions=False``. Lets the
+       *     scene UI hide/disable the duel-challenge affordance for opted-out
+       *     characters (#1181); the backend still enforces the full gate at dispatch.
+       *     Defaults to True when there is no tenure or preference row.
+       */
+      readonly allow_social_actions: boolean;
     };
     /** @description A scene persona and the Position it currently occupies (or null). */
     PersonaPosition: {

--- a/frontend/src/scenes/components/PersonaContextMenu.test.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.test.tsx
@@ -33,8 +33,18 @@ vi.mock('@/store/hooks', () => ({
   ),
 }));
 
+// Mock the combat dispatch hook (challenge affordance, #1181)
+vi.mock('@/combat/queries', () => ({
+  useDispatchPlayerAction: vi.fn(() => ({
+    mutateAsync: vi.fn(() => Promise.resolve()),
+    isPending: false,
+  })),
+  combatKeys: { duelChallengesAll: () => ['combat', 'duel-challenges'] },
+}));
+
 import { PersonaContextMenu } from './PersonaContextMenu';
 import { createActionRequest } from '../actionQueries';
+import { useDispatchPlayerAction } from '@/combat/queries';
 
 function makeAction(
   overrides: Partial<PlayerActionsResponse['results'][0]> = {}
@@ -100,6 +110,28 @@ function createWrapper(prePopulate = true) {
   if (prePopulate) {
     queryClient.setQueryData(['available-actions', 42], MOCK_ACTIONS);
   }
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+interface ScenePersonaStub {
+  id: number;
+  name: string;
+  character_sheet?: number;
+  allow_social_actions?: boolean;
+}
+
+// Wrapper that also seeds the scene cache (['scene', sceneId]) so the challenge
+// affordance can resolve the target persona's character + opt-out state (#1181).
+function createWrapperWithScene(personas: ScenePersonaStub[], prePopulateActions = true) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  if (prePopulateActions) {
+    queryClient.setQueryData(['available-actions', 42], MOCK_ACTIONS);
+  }
+  queryClient.setQueryData(['scene', '1'], { id: 1, personas });
   return function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
@@ -242,6 +274,71 @@ describe('PersonaContextMenu', () => {
         expect.objectContaining({ action_key: 'intimidate', delivery: undefined })
       );
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Challenge to a duel affordance (#1181)
+  // ---------------------------------------------------------------------------
+
+  it('dispatches the challenge action with the target persona id when clicked', async () => {
+    const user = userEvent.setup();
+    const mockMutateAsync = vi.fn(() => Promise.resolve());
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+
+    render(
+      <PersonaContextMenu personaId={10} personaName="Alice" sceneId="1">
+        <span>Alice</span>
+      </PersonaContextMenu>,
+      // Target persona belongs to character 99 (≠ viewer 42), social actions allowed.
+      { wrapper: createWrapperWithScene([{ id: 10, name: 'Alice', character_sheet: 99 }]) }
+    );
+
+    await user.click(screen.getByRole('button'));
+    const challengeItem = await screen.findByTestId('challenge-to-duel-item');
+    await user.click(challengeItem);
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      ref: { backend: 'registry', registry_key: 'challenge' },
+      kwargs: { target: 10 },
+    });
+  });
+
+  it('hides the challenge item when the target has opted out of social targeting', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PersonaContextMenu personaId={10} personaName="Alice" sceneId="1">
+        <span>Alice</span>
+      </PersonaContextMenu>,
+      {
+        wrapper: createWrapperWithScene([
+          { id: 10, name: 'Alice', character_sheet: 99, allow_social_actions: false },
+        ]),
+      }
+    );
+
+    await user.click(screen.getByRole('button'));
+    await screen.findByText('Intimidate'); // menu is open (other actions present)
+    expect(screen.queryByTestId('challenge-to-duel-item')).not.toBeInTheDocument();
+  });
+
+  it('hides the challenge item for the viewer’s own persona (no self-duel)', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PersonaContextMenu personaId={10} personaName="TestChar" sceneId="1">
+        <span>TestChar</span>
+      </PersonaContextMenu>,
+      // character_sheet 42 == the viewer's character_id from the roster mock.
+      { wrapper: createWrapperWithScene([{ id: 10, name: 'TestChar', character_sheet: 42 }]) }
+    );
+
+    await user.click(screen.getByRole('button'));
+    await screen.findByText('Intimidate');
+    expect(screen.queryByTestId('challenge-to-duel-item')).not.toBeInTheDocument();
   });
 
   it('does not show "Attach to Pose" section when onAttachAction is not provided', async () => {

--- a/frontend/src/scenes/components/PersonaContextMenu.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.tsx
@@ -11,9 +11,10 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Zap } from 'lucide-react';
+import { Swords, Zap } from 'lucide-react';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
+import { useDispatchPlayerAction, combatKeys } from '@/combat/queries';
 import { createActionRequest } from '../actionQueries';
 import type { ActionAttachmentInfo, PlayerActionsResponse, PlayerAction } from '../actionTypes';
 import type { SceneDetail } from '../types';
@@ -63,6 +64,28 @@ export function PersonaContextMenu({
     [scene, personaId]
   );
 
+  // #1181: outgoing duel-challenge affordance. Resolve the target persona to know
+  // whether it's the viewer's own character (hide for self) and whether it has
+  // opted out of social targeting (mirror the backend consent gate).
+  const targetPersona = useMemo(
+    () => (scene?.personas ?? []).find((p) => p.id === personaId) ?? null,
+    [scene, personaId]
+  );
+  const isSelfTarget = characterId !== null && targetPersona?.character_sheet === characterId;
+  // Require the target persona to be resolved from scene data: without it we know
+  // neither its character (self check) nor its opt-out state, so don't offer the duel.
+  const canChallenge =
+    characterId !== null &&
+    targetPersona !== null &&
+    !isSelfTarget &&
+    targetPersona.allow_social_actions !== false;
+
+  // Challenge dispatches via the registry path (the action carries no ActionTemplate,
+  // so it's absent from the available-actions list) with the target persona id.
+  const { mutateAsync: dispatchChallenge, isPending: isChallengePending } = useDispatchPlayerAction(
+    characterId ?? 0
+  );
+
   const [pendingWhisper, setPendingWhisper] = useState<PendingWhisper | null>(null);
 
   const performAction = useMutation({
@@ -82,8 +105,18 @@ export function PersonaContextMenu({
   // Show all prerequisite-met actions as potential targeted actions.
   const targetedActions: PlayerAction[] = (data?.results ?? []).filter((a) => a.prerequisite_met);
 
-  if (targetedActions.length === 0) {
+  // The menu is worth showing if there are targeted actions OR a challenge affordance.
+  if (targetedActions.length === 0 && !canChallenge) {
     return <>{children}</>;
+  }
+
+  function handleChallenge() {
+    dispatchChallenge({
+      ref: { backend: 'registry', registry_key: 'challenge' },
+      kwargs: { target: personaId },
+    })
+      .then(() => queryClient.invalidateQueries({ queryKey: combatKeys.duelChallengesAll() }))
+      .catch(() => {});
   }
 
   return (
@@ -95,6 +128,19 @@ export function PersonaContextMenu({
         <DropdownMenuContent>
           <DropdownMenuLabel>Actions on {personaName}</DropdownMenuLabel>
           <DropdownMenuSeparator />
+          {canChallenge && (
+            <>
+              <DropdownMenuItem
+                disabled={isChallengePending}
+                data-testid="challenge-to-duel-item"
+                onClick={handleChallenge}
+              >
+                <Swords className="mr-2 h-4 w-4" />
+                Challenge to a duel
+              </DropdownMenuItem>
+              {targetedActions.length > 0 && <DropdownMenuSeparator />}
+            </>
+          )}
           {/* Direct execute: fires the action immediately via REST, independent of
             any pose in the composer. This is a "quick action" path. The submenu
             picks the audience (#903); the plain "Default" entry sends NO delivery

--- a/frontend/src/scenes/components/PoseUnit.test.tsx
+++ b/frontend/src/scenes/components/PoseUnit.test.tsx
@@ -12,8 +12,12 @@ import { PoseUnit } from './PoseUnit';
 import type { Interaction } from '../types';
 
 // Mock @/combat/queries — used by PoseUnitDetailPanel; prevents real fetches.
+// PoseUnit also renders PersonaContextMenu, which reads useDispatchPlayerAction
+// + combatKeys for the duel-challenge affordance (#1181).
 vi.mock('@/combat/queries', () => ({
   useOutcomeDetails: vi.fn().mockReturnValue({ data: [], isLoading: false }),
+  useDispatchPlayerAction: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
+  combatKeys: { duelChallengesAll: () => ['combat', 'duel-challenges'] },
 }));
 
 // Stub PoseUnitDetailPanel with the canonical data-testid. Renders

--- a/frontend/src/scenes/types.ts
+++ b/frontend/src/scenes/types.ts
@@ -39,6 +39,14 @@ export interface ScenePersona {
   id: number;
   name: string;
   persona_type?: string;
+  /** The persona's character (CharacterSheet pk == character ObjectDB pk). */
+  character_sheet?: number;
+  /**
+   * Whether this persona's character may be socially targeted. Mirrors the
+   * challenge consent gate; the scene UI hides the duel-challenge affordance when
+   * false (#1181). Defaults to true server-side.
+   */
+  allow_social_actions?: boolean;
 }
 
 /** Compact public representation of a room position (id + name). */

--- a/src/actions/definitions/duels.py
+++ b/src/actions/definitions/duels.py
@@ -167,32 +167,53 @@ class ChallengeAction(Action):
 challenge = ChallengeAction()
 
 
-def _pending_challenge_for_challenged(actor: ObjectDB) -> DuelChallenge | None:
-    """Return the PENDING DuelChallenge where *actor* is the challenged PC, or None."""
+def _pending_challenge_for_challenged(
+    actor: ObjectDB, challenge_id: int | str | None = None
+) -> DuelChallenge | None:
+    """Return the PENDING DuelChallenge where *actor* is the challenged PC, or None.
+
+    When *challenge_id* is given (threaded from the inbox UI), scope to that
+    specific challenge — but still require it to be PENDING and directed at the
+    actor, so a stale or foreign id resolves to None rather than the wrong row.
+    Without an id, fall back to the actor's single pending incoming challenge (#1180).
+    """
     from world.combat.constants import DuelChallengeStatus  # noqa: PLC0415
     from world.combat.models import DuelChallenge  # noqa: PLC0415
 
     actor_sheet = _sheet(actor)
     if actor_sheet is None:
         return None
-    return DuelChallenge.objects.filter(
+    qs = DuelChallenge.objects.filter(
         challenged_sheet=actor_sheet,
         status=DuelChallengeStatus.PENDING,
-    ).first()
+    )
+    if challenge_id is not None:
+        qs = qs.filter(pk=challenge_id)
+    return qs.first()
 
 
-def _pending_challenge_for_challenger(actor: ObjectDB) -> DuelChallenge | None:
-    """Return the PENDING DuelChallenge where *actor* is the challenger PC, or None."""
+def _pending_challenge_for_challenger(
+    actor: ObjectDB, challenge_id: int | str | None = None
+) -> DuelChallenge | None:
+    """Return the PENDING DuelChallenge where *actor* is the challenger PC, or None.
+
+    When *challenge_id* is given, scope to that specific challenge (still requiring
+    PENDING + issued by the actor); otherwise fall back to the actor's single
+    pending outgoing challenge (#1180).
+    """
     from world.combat.constants import DuelChallengeStatus  # noqa: PLC0415
     from world.combat.models import DuelChallenge  # noqa: PLC0415
 
     actor_sheet = _sheet(actor)
     if actor_sheet is None:
         return None
-    return DuelChallenge.objects.filter(
+    qs = DuelChallenge.objects.filter(
         challenger_sheet=actor_sheet,
         status=DuelChallengeStatus.PENDING,
-    ).first()
+    )
+    if challenge_id is not None:
+        qs = qs.filter(pk=challenge_id)
+    return qs.first()
 
 
 @dataclass
@@ -223,7 +244,7 @@ class AcceptChallengeAction(Action):
                 message="You must be a real character to accept a duel challenge.",
             )
 
-        challenge = _pending_challenge_for_challenged(actor)
+        challenge = _pending_challenge_for_challenged(actor, kwargs.get("challenge_id"))
         if challenge is None:
             return ActionResult(
                 success=False,
@@ -271,7 +292,7 @@ class DeclineChallengeAction(Action):
                 message="You must be a real character to decline a duel challenge.",
             )
 
-        challenge = _pending_challenge_for_challenged(actor)
+        challenge = _pending_challenge_for_challenged(actor, kwargs.get("challenge_id"))
         if challenge is None:
             return ActionResult(
                 success=False,
@@ -319,7 +340,7 @@ class WithdrawChallengeAction(Action):
                 message="You must be a real character to withdraw a duel challenge.",
             )
 
-        challenge = _pending_challenge_for_challenger(actor)
+        challenge = _pending_challenge_for_challenger(actor, kwargs.get("challenge_id"))
         if challenge is None:
             return ActionResult(
                 success=False,

--- a/src/actions/definitions/duels.py
+++ b/src/actions/definitions/duels.py
@@ -35,6 +35,25 @@ def _sheet(actor: ObjectDB) -> CharacterSheet | None:
         return None
 
 
+def _resolve_challenge_target(target: object) -> ObjectDB | None:
+    """Resolve the ``target`` challenge kwarg to a character ObjectDB.
+
+    Telnet/test callers pass an ObjectDB directly. The web dispatch path passes a
+    Persona pk (the scene UI works in persona ids, consistent with social actions);
+    resolve it to that persona's character ObjectDB. Returns None when unresolvable.
+    """
+    from evennia.objects.models import ObjectDB  # noqa: PLC0415
+
+    if target is None or isinstance(target, ObjectDB):
+        return target
+    from world.scenes.models import Persona  # noqa: PLC0415
+
+    persona = Persona.objects.filter(pk=target).select_related("character_sheet__character").first()
+    if persona is None:
+        return None
+    return persona.character_sheet.character
+
+
 def _active_tenure(sheet: CharacterSheet) -> object | None:
     """Return the current (active) RosterTenure for *sheet*, or None."""
     try:
@@ -109,7 +128,8 @@ class ChallengeAction(Action):
         context: ActionContext | None = None,
         **kwargs: Any,
     ) -> ActionResult:
-        target: ObjectDB | None = kwargs.get("target")
+        # Resolve the target: ObjectDB (telnet/test) or a Persona pk (web dispatch).
+        target: ObjectDB | None = _resolve_challenge_target(kwargs.get("target"))
 
         # --- resolve actor sheet ---
         actor_sheet = _sheet(actor)

--- a/src/actions/tests/test_duel_actions.py
+++ b/src/actions/tests/test_duel_actions.py
@@ -88,6 +88,32 @@ class ChallengeActionConsentingTargetTests(django.test.TestCase):
         self.assertTrue(result.success, msg=result.message)
         self.assertIn("challenge_id", result.data)
 
+    def test_challenge_resolves_persona_id_target(self) -> None:
+        """The web dispatch path passes a Persona pk; the action resolves it to the
+        target's character and creates the challenge (#1181)."""
+        from actions.registry import get_action
+        from world.scenes.factories import PersonaFactory
+
+        persona = PersonaFactory(character_sheet=self.target_sheet)
+
+        result = get_action("challenge").run(self.actor, target=persona.pk)
+
+        self.assertTrue(result.success, msg=result.message)
+        challenge = DuelChallenge.objects.filter(
+            challenger_sheet=self.actor_sheet,
+            challenged_sheet=self.target_sheet,
+            status=DuelChallengeStatus.PENDING,
+        ).first()
+        self.assertIsNotNone(challenge, "Expected the persona-id target to resolve to a challenge")
+
+    def test_challenge_unresolvable_persona_id_target_fails(self) -> None:
+        """A Persona pk that doesn't exist resolves to no target → 'Challenge whom?'."""
+        from actions.registry import get_action
+
+        result = get_action("challenge").run(self.actor, target=999_999)
+
+        self.assertFalse(result.success)
+
 
 class ChallengeActionConsentBlockedTests(django.test.TestCase):
     """challenge at a target who has opted out of social actions → blocked."""

--- a/src/actions/tests/test_duel_actions.py
+++ b/src/actions/tests/test_duel_actions.py
@@ -296,6 +296,56 @@ class AcceptChallengeActionTests(django.test.TestCase):
         self.assertFalse(result.success)
 
 
+class AcceptChallengeChallengeIdTests(django.test.TestCase):
+    """A threaded challenge_id disambiguates which incoming challenge is accepted (#1180)."""
+
+    def setUp(self) -> None:
+        self.room = _make_room("MultiChallengeArena")
+        self.challenger_a, self.sheet_a = _make_pc("MultiChallengerA", self.room)
+        self.challenger_b, self.sheet_b = _make_pc("MultiChallengerB", self.room)
+        self.challenged, self.challenged_sheet = _make_pc("MultiChallenged", self.room)
+        # Two distinct PENDING incoming challenges against the same challenged PC.
+        self.challenge_a = DuelChallengeFactory(
+            challenger_sheet=self.sheet_a,
+            challenged_sheet=self.challenged_sheet,
+            room=self.room,
+        )
+        self.challenge_b = DuelChallengeFactory(
+            challenger_sheet=self.sheet_b,
+            challenged_sheet=self.challenged_sheet,
+            room=self.room,
+        )
+
+    def test_challenge_id_targets_the_intended_challenge(self) -> None:
+        from actions.registry import get_action
+
+        result = get_action("accept").run(self.challenged, challenge_id=self.challenge_b.pk)
+
+        self.assertTrue(result.success, msg=result.message)
+        self.assertEqual(result.data["challenge_id"], self.challenge_b.pk)
+        self.challenge_a.refresh_from_db()
+        self.challenge_b.refresh_from_db()
+        self.assertEqual(self.challenge_b.status, DuelChallengeStatus.ACCEPTED)
+        # The other pending challenge is left untouched.
+        self.assertEqual(self.challenge_a.status, DuelChallengeStatus.PENDING)
+
+    def test_foreign_challenge_id_is_rejected(self) -> None:
+        """A challenge_id for a challenge not directed at the actor resolves to None."""
+        from actions.registry import get_action
+
+        foreign = DuelChallengeFactory(
+            challenger_sheet=self.sheet_a,
+            challenged_sheet=self.sheet_b,
+            room=self.room,
+        )
+
+        result = get_action("accept").run(self.challenged, challenge_id=foreign.pk)
+
+        self.assertFalse(result.success)
+        foreign.refresh_from_db()
+        self.assertEqual(foreign.status, DuelChallengeStatus.PENDING)
+
+
 class DeclineChallengeActionTests(django.test.TestCase):
     """decline action: challenged PC declines → DECLINED challenge, no encounter."""
 

--- a/src/schema.json
+++ b/src/schema.json
@@ -3658,6 +3658,82 @@ paths:
                 items:
                   $ref: '#/components/schemas/OutcomeDetail'
           description: ''
+  /api/combat/duel-challenges/:
+    get:
+      operationId: combat_duel_challenges_list
+      description: |-
+        Read-only inbox of the requesting player's PENDING duel challenges (#1180).
+
+        Lists every PENDING ``DuelChallenge`` where the caller plays either the
+        challenger or the challenged character, so the web UI can render the
+        incoming-challenge prompt (and surface a player's outgoing challenges).
+        ``?role=incoming|outgoing`` narrows to one side. Scoped to the caller's
+        played characters, so it never leaks other players' challenges.
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: role
+        schema:
+          type: string
+          enum:
+          - incoming
+          - outgoing
+        description: |-
+          Challenge direction relative to the requesting player.
+
+          * `incoming` - Incoming
+          * `outgoing` - Outgoing
+      tags:
+      - combat
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedDuelChallengeList'
+          description: ''
+  /api/combat/duel-challenges/{id}/:
+    get:
+      operationId: combat_duel_challenges_retrieve
+      description: |-
+        Read-only inbox of the requesting player's PENDING duel challenges (#1180).
+
+        Lists every PENDING ``DuelChallenge`` where the caller plays either the
+        challenger or the challenged character, so the web UI can render the
+        incoming-challenge prompt (and surface a player's outgoing challenges).
+        ``?role=incoming|outgoing`` narrows to one side. Scoped to the caller's
+        played characters, so it never leaks other players' challenges.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this duel challenge.
+        required: true
+      tags:
+      - combat
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DuelChallenge'
+          description: ''
   /api/conditions/capabilities/:
     get:
       operationId: conditions_capabilities_list
@@ -27184,6 +27260,70 @@ components:
       description: |-
         * `menu` - Menu
         * `pool` - Pool
+    DuelChallenge:
+      type: object
+      description: |-
+        Read serializer for the DuelChallenge pending-challenge inbox.
+
+        Exposes challenger/challenged identities (id + name), status, timestamps,
+        and the resulting_encounter FK PK. Intended for a player's incoming or
+        outgoing challenge list.
+
+        N+1-safe when the queryset uses ``select_related("challenger_sheet__character",
+        "challenged_sheet__character")``.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        challenger:
+          allOf:
+          - $ref: '#/components/schemas/_DuelParticipantIdentity'
+          readOnly: true
+        challenged:
+          allOf:
+          - $ref: '#/components/schemas/_DuelParticipantIdentity'
+          readOnly: true
+        status:
+          allOf:
+          - $ref: '#/components/schemas/DuelChallengeStatusEnum'
+          readOnly: true
+          default: pending
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        resolved_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        resulting_encounter:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: The CombatEncounter opened when the challenge was accepted.
+      required:
+      - challenged
+      - challenger
+      - created_at
+      - id
+      - resolved_at
+      - resulting_encounter
+      - status
+    DuelChallengeStatusEnum:
+      enum:
+      - pending
+      - accepted
+      - declined
+      - withdrawn
+      - expired
+      type: string
+      description: |-
+        * `pending` - Pending
+        * `accepted` - Accepted
+        * `declined` - Declined
+        * `withdrawn` - Withdrawn
+        * `expired` - Expired
     DuelWinner:
       type: object
       description: |-
@@ -33858,6 +33998,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DramaticMomentTag'
+    PaginatedDuelChallengeList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/DuelChallenge'
     PaginatedEncounterListList:
       type: object
       required:
@@ -44700,6 +44863,24 @@ components:
       - created_at
       - id
       - title
+    _DuelParticipantIdentity:
+      type: object
+      description: |-
+        Compact identity for one side of a DuelChallenge (CharacterSheet id + name).
+
+        Note: CharacterSheet's primary key is the ``character`` OneToOneField, so
+        there is no ``.id`` attribute — ``source="pk"`` reads ``.pk`` explicitly.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          description: Return the character's display name from CharacterSheet.character.db_key.
+          readOnly: true
+      required:
+      - id
+      - name
     _Fame:
       type: object
       description: Persona's fame state for the renown tab header.

--- a/src/schema.json
+++ b/src/schema.json
@@ -38397,7 +38397,20 @@ components:
             - type: string
           nullable: true
           readOnly: true
+        allow_social_actions:
+          type: boolean
+          description: |-
+            Whether this persona's character may be targeted by social actions.
+
+            Mirrors the challenge consent gate (``_tenure_blocks_actor`` with
+            ``category=None``): blocked only when the active tenure's
+            ``SocialConsentPreference`` has ``allow_social_actions=False``. Lets the
+            scene UI hide/disable the duel-challenge affordance for opted-out
+            characters (#1181); the backend still enforces the full gate at dispatch.
+            Defaults to True when there is no tenure or preference row.
+          readOnly: true
       required:
+      - allow_social_actions
       - character_sheet
       - id
       - name

--- a/src/world/combat/clash.py
+++ b/src/world/combat/clash.py
@@ -165,8 +165,9 @@ def commit_to_clash(  # noqa: PLR0913
         character_sheet: The PC performing the contribution (CharacterSheet).
             The underlying ObjectDB is resolved internally via
             ``character_sheet.character`` for the magic pipeline calls.
-        clash: The active Clash instance this contribution belongs to (reserved for
-            future round-aggregation context; not used in v1).
+        clash: The active Clash instance this contribution belongs to. Its
+            ``encounter`` supplies the lethal flag threaded into ``use_technique``
+            so the non-lethal cap holds on the clash path (#1182).
         strain_commitment: Extra anima committed on top of the effective cost floor.
         action_slot: ``ClashActionSlot`` value (``"FOCUSED"`` or ``"PASSIVE"``);
             echoed into the returned ``ClashContributionResult`` for audit use by
@@ -272,6 +273,9 @@ def commit_to_clash(  # noqa: PLR0913
     #    reactive events, corruption, resonance environment).
     #    power_intensity_bonus folds the strain intensity into power derivation only —
     #    anima cost is unaffected by this parameter.
+    #    ``lethal`` is threaded from the encounter's risk level (consistent with
+    #    ``resolve_combat_technique``) so a non-lethal encounter caps soulfray the
+    #    same way through the clash path as through the standard technique path (#1182).
     technique_use_result = use_technique(
         character=objectdb,
         technique=technique,
@@ -280,6 +284,7 @@ def commit_to_clash(  # noqa: PLR0913
         targets=targets,
         confirm_soulfray_risk=True,
         power_intensity_bonus=power_intensity_bonus,
+        lethal=clash.encounter.is_lethal,
     )
 
     # 5. Guard against unconfirmed result (confirm_soulfray_risk=True should

--- a/src/world/combat/filters.py
+++ b/src/world/combat/filters.py
@@ -1,8 +1,13 @@
 """Filters for combat API endpoints."""
 
+from django.db.models import QuerySet
 import django_filters
 
-from world.combat.models import CombatEncounter
+from world.combat.models import CombatEncounter, DuelChallenge
+
+# Duel-inbox direction filter values (relative to the requesting player).
+_ROLE_INCOMING = "incoming"
+_ROLE_OUTGOING = "outgoing"
 
 
 class CombatEncounterFilter(django_filters.FilterSet):
@@ -14,3 +19,32 @@ class CombatEncounterFilter(django_filters.FilterSet):
     class Meta:
         model = CombatEncounter
         fields = ["scene", "status"]
+
+
+class DuelChallengeFilter(django_filters.FilterSet):
+    """Narrow the duel-challenge inbox to one direction relative to the caller.
+
+    ``role=incoming`` keeps challenges where the caller plays the challenged
+    character; ``role=outgoing`` keeps challenges the caller issued. With no
+    ``role`` the inbox returns both sides (#1180).
+    """
+
+    role = django_filters.ChoiceFilter(
+        choices=[(_ROLE_INCOMING, "Incoming"), (_ROLE_OUTGOING, "Outgoing")],
+        method="filter_role",
+        label="Challenge direction relative to the requesting player.",
+    )
+
+    class Meta:
+        model = DuelChallenge
+        fields = ["role"]
+
+    def filter_role(
+        self, queryset: QuerySet[DuelChallenge], name: str, value: str
+    ) -> QuerySet[DuelChallenge]:
+        played_ids = getattr(self.request.user, "played_character_sheet_ids", frozenset())  # noqa: GETATTR_LITERAL
+        if value == _ROLE_INCOMING:
+            return queryset.filter(challenged_sheet_id__in=played_ids)
+        if value == _ROLE_OUTGOING:
+            return queryset.filter(challenger_sheet_id__in=played_ids)
+        return queryset

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -3550,7 +3550,15 @@ def _apply_opponent_aftermath_pools(encounter: CombatEncounter, outcome: Encount
 
 
 def _increment_completion_counters(encounter: CombatEncounter, outcome: EncounterOutcome) -> None:
-    """encounters_won / encounters_lost / encounters_fled aggregates (#876 §7)."""
+    """encounters_won / encounters_lost / encounters_fled aggregates (#876 §7).
+
+    A DUEL leaves both PCs as ACTIVE participants at completion (only the loser's
+    mirror ``CombatOpponent`` is DEFEATED, never the loser's own participant row),
+    so the generic ACTIVE→won rule would credit *both* duelists with a win. For a
+    DUEL the win is credited solely to ``encounter.duel_winner`` and the loss to
+    the other duelist; an abandoned duel (no ``duel_winner``) credits neither
+    (#1182).
+    """
     from world.combat.achievement_counters import (  # noqa: PLC0415
         STAT_KEY_ENCOUNTERS_FLED,
         STAT_KEY_ENCOUNTERS_LOST,
@@ -3558,14 +3566,28 @@ def _increment_completion_counters(encounter: CombatEncounter, outcome: Encounte
         increment_combat_counter,
     )
 
+    participants = CombatParticipant.objects.filter(encounter=encounter).select_related(
+        "character_sheet"
+    )
+
+    if encounter.encounter_type == EncounterType.DUEL:
+        winner_sheet_id = encounter.duel_winner_id
+        for participant in participants:
+            if participant.status == ParticipantStatus.FLED:
+                increment_combat_counter(participant.character_sheet, STAT_KEY_ENCOUNTERS_FLED)
+            elif winner_sheet_id is None:
+                continue  # Abandoned / mutual stop — no victor; credit neither.
+            elif participant.character_sheet_id == winner_sheet_id:
+                increment_combat_counter(participant.character_sheet, STAT_KEY_ENCOUNTERS_WON)
+            else:
+                increment_combat_counter(participant.character_sheet, STAT_KEY_ENCOUNTERS_LOST)
+        return
+
     outcome_key = {
         EncounterOutcome.VICTORY: STAT_KEY_ENCOUNTERS_WON,
         EncounterOutcome.DEFEAT: STAT_KEY_ENCOUNTERS_LOST,
     }.get(outcome)
 
-    participants = CombatParticipant.objects.filter(encounter=encounter).select_related(
-        "character_sheet"
-    )
     for participant in participants:
         if participant.status == ParticipantStatus.FLED:
             increment_combat_counter(participant.character_sheet, STAT_KEY_ENCOUNTERS_FLED)

--- a/src/world/combat/tests/test_clash_commit.py
+++ b/src/world/combat/tests/test_clash_commit.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from unittest.mock import patch
 
 from django.test import TestCase
 
 from actions.factories import ActionTemplateFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.test_helpers import force_check_outcome
+from world.combat import clash as clash_module
 from world.combat.clash import commit_to_clash, outcome_to_delta
+from world.combat.constants import RiskLevel
 from world.combat.factories import ClashConfigFactory, ClashFactory, StrainConfigFactory
 from world.combat.types import ClashContributionResult
 from world.conditions.factories import ConditionTemplateFactory
@@ -266,13 +269,20 @@ class CommitToClashTests(TestCase):
     # -------------------------------------------------------------------------
 
     def test_overburn_when_strain_exceeds_pool(self) -> None:
-        """Committing more strain than the anima pool → was_overburn=True and soulfray fires."""
+        """Committing more strain than the anima pool → was_overburn=True and soulfray fires.
+
+        Overburn/soulfray is a lethal-encounter behavior: a non-lethal encounter
+        clamps the effective cost to available anima so it can never deficit. The
+        clash must therefore run in a LETHAL encounter for the overburn path to
+        fire (#1182 threads lethal=clash.encounter.is_lethal into use_technique).
+        """
         # SoulfrayConfig and ConditionTemplate needed for the soulfray accumulation path.
         SoulfrayConfigFactory(
             soulfray_threshold_ratio=Decimal("0.10"), severity_scale=5, deficit_scale=5
         )
         ConditionTemplateFactory(name=SOULFRAY_CONDITION_NAME)
 
+        lethal_clash = ClashFactory(encounter__risk_level=RiskLevel.LETHAL)
         # Give the character very little anima
         character_sheet, _anima = self._make_character_with_anima(current=2, maximum=10)
         # Technique with minimal base cost so only the strain causes overburn
@@ -282,7 +292,7 @@ class CommitToClashTests(TestCase):
             result = commit_to_clash(
                 character_sheet=character_sheet,
                 technique=technique,
-                clash=self.clash,
+                clash=lethal_clash,
                 strain_commitment=20,  # far exceeds current=2
                 action_slot="FOCUSED",
                 config_clash=self.config_clash,
@@ -404,3 +414,54 @@ class CommitToClashTests(TestCase):
             )
 
         self.assertIsNone(result.clash_interaction)
+
+
+class CommitToClashLethalFlagTests(TestCase):
+    """commit_to_clash threads lethal=clash.encounter.is_lethal into use_technique (#1182).
+
+    Latent today (PvP mirror surfaces never form a clash), but the cap must hold
+    if a non-lethal clash path is ever enabled. A spy wraps the real
+    use_technique so the rest of the pipeline runs unchanged.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.config_strain = StrainConfigFactory()
+        cls.config_clash = ClashConfigFactory()
+        cls.check_type = ActionTemplateFactory().check_type
+        cls.success_outcome = CheckOutcomeFactory(name="lethal_flag_success", success_level=1)
+
+    def _make_character_with_anima(self) -> CharacterSheetFactory:
+        sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
+        CharacterEngagementFactory(character=sheet.character)
+        return sheet
+
+    def _make_technique(self) -> object:
+        template = ActionTemplateFactory(check_type=self.check_type)
+        return TechniqueFactory(intensity=5, control=10, anima_cost=3, action_template=template)
+
+    def _captured_lethal(self, *, risk_level: str) -> bool:
+        sheet = self._make_character_with_anima()
+        technique = self._make_technique()
+        clash = ClashFactory(encounter__risk_level=risk_level)
+        with force_check_outcome(self.success_outcome):
+            with patch.object(
+                clash_module, "use_technique", wraps=clash_module.use_technique
+            ) as spy:
+                commit_to_clash(
+                    character_sheet=sheet,
+                    technique=technique,
+                    clash=clash,
+                    strain_commitment=0,
+                    action_slot="FOCUSED",
+                    config_clash=self.config_clash,
+                    config_strain=self.config_strain,
+                )
+        return spy.call_args.kwargs["lethal"]
+
+    def test_non_lethal_encounter_threads_lethal_false(self) -> None:
+        self.assertIs(self._captured_lethal(risk_level=RiskLevel.MODERATE), False)
+
+    def test_lethal_encounter_threads_lethal_true(self) -> None:
+        self.assertIs(self._captured_lethal(risk_level=RiskLevel.LETHAL), True)

--- a/src/world/combat/tests/test_duel_challenge_inbox.py
+++ b/src/world/combat/tests/test_duel_challenge_inbox.py
@@ -1,0 +1,134 @@
+"""API tests for the duel-challenge inbox endpoint (#1180).
+
+GET /api/combat/duel-challenges/ returns the requesting player's PENDING
+DuelChallenges (as challenger and/or challenged), scoped to the characters they
+currently play, with an optional ``?role=incoming|outgoing`` narrowing.
+"""
+
+from __future__ import annotations
+
+from django.db.models import Q
+from django.test import TestCase
+from evennia.utils.idmapper import models as idmapper_models
+from rest_framework import status as http_status
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import DuelChallengeStatus
+from world.combat.factories import DuelChallengeFactory
+from world.combat.models import DuelChallenge
+from world.combat.serializers import DuelChallengeSerializer
+from world.roster.factories import RosterTenureFactory
+
+_INBOX_URL = "/api/combat/duel-challenges/"
+
+
+class DuelChallengeInboxTests(TestCase):
+    """GET /api/combat/duel-challenges/ scopes to the caller's played characters."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.challenger_account = AccountFactory(username="duel_inbox_challenger")
+        cls.challenger_character = CharacterFactory(db_key="DuelInboxChallenger")
+        cls.challenger_sheet = CharacterSheetFactory(character=cls.challenger_character)
+        RosterTenureFactory(
+            roster_entry__character_sheet__character=cls.challenger_character,
+            player_data__account=cls.challenger_account,
+        )
+
+        cls.challenged_account = AccountFactory(username="duel_inbox_challenged")
+        cls.challenged_character = CharacterFactory(db_key="DuelInboxChallenged")
+        cls.challenged_sheet = CharacterSheetFactory(character=cls.challenged_character)
+        RosterTenureFactory(
+            roster_entry__character_sheet__character=cls.challenged_character,
+            player_data__account=cls.challenged_account,
+        )
+
+        # A third player uninvolved in any challenge — must see an empty inbox.
+        cls.bystander_account = AccountFactory(username="duel_inbox_bystander")
+        cls.bystander_character = CharacterFactory(db_key="DuelInboxBystander")
+        CharacterSheetFactory(character=cls.bystander_character)
+        RosterTenureFactory(
+            roster_entry__character_sheet__character=cls.bystander_character,
+            player_data__account=cls.bystander_account,
+        )
+
+    def setUp(self) -> None:
+        idmapper_models.flush_cache()
+        self.challenge = DuelChallengeFactory(
+            challenger_sheet=self.challenger_sheet,
+            challenged_sheet=self.challenged_sheet,
+            status=DuelChallengeStatus.PENDING,
+        )
+
+    def _client(self, account: object) -> APIClient:
+        client = APIClient()
+        client.force_authenticate(user=account)
+        return client
+
+    def test_requires_authentication(self) -> None:
+        response = APIClient().get(_INBOX_URL)
+        self.assertIn(
+            response.status_code,
+            (http_status.HTTP_401_UNAUTHORIZED, http_status.HTTP_403_FORBIDDEN),
+        )
+
+    def test_challenged_player_sees_incoming_challenge(self) -> None:
+        response = self._client(self.challenged_account).get(_INBOX_URL)
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 1)
+        row = results[0]
+        self.assertEqual(row["id"], self.challenge.pk)
+        self.assertEqual(row["status"], DuelChallengeStatus.PENDING)
+        self.assertEqual(row["challenger"]["id"], self.challenger_sheet.pk)
+        self.assertEqual(row["challenger"]["name"], self.challenger_character.db_key)
+        self.assertEqual(row["challenged"]["id"], self.challenged_sheet.pk)
+
+    def test_challenger_player_sees_outgoing_challenge(self) -> None:
+        response = self._client(self.challenger_account).get(_INBOX_URL)
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["id"], self.challenge.pk)
+
+    def test_bystander_sees_empty_inbox(self) -> None:
+        response = self._client(self.bystander_account).get(_INBOX_URL)
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+
+    def test_role_incoming_excludes_outgoing(self) -> None:
+        """For the challenger, ?role=incoming has no rows (their challenge is outgoing)."""
+        response = self._client(self.challenger_account).get(_INBOX_URL, {"role": "incoming"})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+
+    def test_role_outgoing_returns_outgoing(self) -> None:
+        response = self._client(self.challenger_account).get(_INBOX_URL, {"role": "outgoing"})
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["id"], self.challenge.pk)
+
+    def test_non_pending_challenge_excluded(self) -> None:
+        self.challenge.status = DuelChallengeStatus.DECLINED
+        self.challenge.save(update_fields=["status"])
+        response = self._client(self.challenged_account).get(_INBOX_URL)
+        self.assertEqual(response.data["results"], [])
+
+    def test_inbox_queryset_is_select_related(self) -> None:
+        """The inbox queryset's select_related keeps serialization N+1-free across rows."""
+        DuelChallengeFactory(
+            challenger_sheet=self.challenger_sheet,
+            challenged_sheet=CharacterSheetFactory(
+                character=CharacterFactory(db_key="DuelInboxAlt")
+            ),
+            status=DuelChallengeStatus.PENDING,
+        )
+        played_ids = self.challenger_account.played_character_sheet_ids
+        qs = (
+            DuelChallenge.objects.filter(status=DuelChallengeStatus.PENDING)
+            .filter(Q(challenger_sheet_id__in=played_ids) | Q(challenged_sheet_id__in=played_ids))
+            .select_related("challenger_sheet__character", "challenged_sheet__character")
+        )
+        with self.assertNumQueries(1):
+            data = DuelChallengeSerializer(list(qs), many=True).data
+        self.assertEqual(len(data), 2)

--- a/src/world/combat/tests/test_encounter_aftermath.py
+++ b/src/world/combat/tests/test_encounter_aftermath.py
@@ -29,6 +29,7 @@ from world.combat.constants import (
     ActionCategory,
     EncounterOutcome,
     EncounterStatus,
+    EncounterType,
     OpponentStatus,
     OpponentTier,
     ParticipantStatus,
@@ -375,6 +376,36 @@ class CompleteEncounterTests(_CompletionSeamTestBase):
         lost_def = StatDefinition.objects.get(key=STAT_KEY_ENCOUNTERS_LOST)
         self.assertEqual(active.character_sheet.stats.get(lost_def), 1)
         self.assertFalse(StatDefinition.objects.filter(key=STAT_KEY_ENCOUNTERS_WON).exists())
+
+    def test_duel_credits_only_winner_with_win_and_loser_with_loss(self) -> None:
+        """On a DUEL VICTORY both PCs are ACTIVE; only ``duel_winner`` is credited
+        a win and the other duelist a loss — not both a win (#1182)."""
+        encounter = self._make_encounter(encounter_type=EncounterType.DUEL)
+        winner = self._add_pc(encounter)
+        loser = self._add_pc(encounter)
+        encounter.duel_winner = winner.character_sheet
+        encounter.save(update_fields=["duel_winner"])
+
+        complete_encounter(encounter, outcome=EncounterOutcome.VICTORY)
+
+        won_def = StatDefinition.objects.get(key=STAT_KEY_ENCOUNTERS_WON)
+        lost_def = StatDefinition.objects.get(key=STAT_KEY_ENCOUNTERS_LOST)
+        self.assertEqual(winner.character_sheet.stats.get(won_def), 1)
+        self.assertEqual(loser.character_sheet.stats.get(won_def), 0)
+        self.assertEqual(loser.character_sheet.stats.get(lost_def), 1)
+        self.assertEqual(winner.character_sheet.stats.get(lost_def), 0)
+
+    def test_duel_without_winner_credits_neither(self) -> None:
+        """An abandoned/mutual-stop duel (no ``duel_winner``) credits no win or
+        loss even if a VICTORY outcome is recorded (#1182)."""
+        encounter = self._make_encounter(encounter_type=EncounterType.DUEL)
+        self._add_pc(encounter)
+        self._add_pc(encounter)
+
+        complete_encounter(encounter, outcome=EncounterOutcome.VICTORY)
+
+        self.assertFalse(StatDefinition.objects.filter(key=STAT_KEY_ENCOUNTERS_WON).exists())
+        self.assertFalse(StatDefinition.objects.filter(key=STAT_KEY_ENCOUNTERS_LOST).exists())
 
     def test_emits_encounter_completed(self) -> None:
         encounter = self._make_encounter()

--- a/src/world/combat/urls.py
+++ b/src/world/combat/urls.py
@@ -3,10 +3,13 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from world.combat.views import CombatEncounterViewSet
+from world.combat.views import CombatEncounterViewSet, DuelChallengeViewSet
 from world.combat.views_outcome_details import ActionOutcomeDetailsView
 
 router = DefaultRouter()
+# Register before the empty-prefix encounter route: the encounter detail regex
+# ``^(?P<pk>[^/.]+)/$`` would otherwise capture ``duel-challenges/`` as a pk.
+router.register("duel-challenges", DuelChallengeViewSet, basename="duel-challenge")
 router.register("", CombatEncounterViewSet, basename="combat-encounter")
 
 app_name = "combat"

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -17,12 +17,18 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
 from actions.errors import ActionDispatchError
 from world.character_sheets.models import CharacterSheet
-from world.combat.constants import ClashStatus, EncounterStatus, OpponentTier, ParticipantStatus
-from world.combat.filters import CombatEncounterFilter
+from world.combat.constants import (
+    ClashStatus,
+    DuelChallengeStatus,
+    EncounterStatus,
+    OpponentTier,
+    ParticipantStatus,
+)
+from world.combat.filters import CombatEncounterFilter, DuelChallengeFilter
 from world.combat.models import (
     Clash,
     CombatEncounter,
@@ -30,6 +36,7 @@ from world.combat.models import (
     CombatParticipant,
     CombatRoundAction,
     ComboDefinition,
+    DuelChallenge,
     ThreatPool,
 )
 from world.combat.permissions import (
@@ -42,6 +49,7 @@ from world.combat.serializers import (
     AddOpponentSerializer,
     AddParticipantSerializer,
     CoverSerializer,
+    DuelChallengeSerializer,
     EncounterDetailSerializer,
     EncounterListSerializer,
     JoinEncounterSerializer,
@@ -82,6 +90,36 @@ _ERR_DECLARE_FAILED = "Failed to declare action."
 _ERR_INVALID_STATUS = "Encounter is not in a valid status for this action."
 _ERR_ALREADY_COMPLETED = "Encounter is already completed."
 _ERR_COMBO_UPGRADE = "Cannot upgrade to the requested combo."
+
+
+class DuelChallengeViewSet(ReadOnlyModelViewSet):
+    """Read-only inbox of the requesting player's PENDING duel challenges (#1180).
+
+    Lists every PENDING ``DuelChallenge`` where the caller plays either the
+    challenger or the challenged character, so the web UI can render the
+    incoming-challenge prompt (and surface a player's outgoing challenges).
+    ``?role=incoming|outgoing`` narrows to one side. Scoped to the caller's
+    played characters, so it never leaks other players' challenges.
+    """
+
+    serializer_class = DuelChallengeSerializer
+    queryset = DuelChallenge.objects.none()
+    pagination_class = StandardResultsSetPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = DuelChallengeFilter
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self) -> QuerySet[DuelChallenge]:
+        user = self.request.user
+        played_ids = getattr(user, "played_character_sheet_ids", frozenset())  # noqa: GETATTR_LITERAL
+        if not played_ids:
+            return DuelChallenge.objects.none()
+        return (
+            DuelChallenge.objects.filter(status=DuelChallengeStatus.PENDING)
+            .filter(Q(challenger_sheet_id__in=played_ids) | Q(challenged_sheet_id__in=played_ids))
+            .select_related("challenger_sheet__character", "challenged_sheet__character")
+            .order_by("-created_at")
+        )
 
 
 class CombatEncounterViewSet(ModelViewSet):

--- a/src/world/scenes/serializers.py
+++ b/src/world/scenes/serializers.py
@@ -19,6 +19,7 @@ from world.scenes.models import (
 class PersonaSerializer(serializers.ModelSerializer):
     roster_entry = serializers.SerializerMethodField()
     thumbnail_media_url = serializers.SerializerMethodField()
+    allow_social_actions = serializers.SerializerMethodField()
 
     class Meta:
         model = Persona
@@ -32,13 +33,38 @@ class PersonaSerializer(serializers.ModelSerializer):
             "thumbnail_url",
             "thumbnail_media_url",
             "roster_entry",
+            "allow_social_actions",
         ]
-        read_only_fields = ["roster_entry"]
+        read_only_fields = ["roster_entry", "allow_social_actions"]
 
     def get_thumbnail_media_url(self, obj: Persona) -> str | None:
         if obj.thumbnail_id is None:
             return None
         return obj.thumbnail.cloudinary_url
+
+    def get_allow_social_actions(self, obj: Persona) -> bool:
+        """Whether this persona's character may be targeted by social actions.
+
+        Mirrors the challenge consent gate (``_tenure_blocks_actor`` with
+        ``category=None``): blocked only when the active tenure's
+        ``SocialConsentPreference`` has ``allow_social_actions=False``. Lets the
+        scene UI hide/disable the duel-challenge affordance for opted-out
+        characters (#1181); the backend still enforces the full gate at dispatch.
+        Defaults to True when there is no tenure or preference row.
+        """
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        sheet = obj.character_sheet
+        if sheet is None:
+            return True
+        try:
+            entry = sheet.roster_entry
+            tenure = entry.current_tenure if entry else None
+            if tenure is None:
+                return True
+            return tenure.social_consent_preference.allow_social_actions
+        except ObjectDoesNotExist:
+            return True
 
     def get_roster_entry(self, obj: Persona) -> dict[str, int | str] | None:
         try:

--- a/src/world/scenes/tests/test_persona_serializer.py
+++ b/src/world/scenes/tests/test_persona_serializer.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 
-from world.roster.factories import PlayerMediaFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.consent.factories import SocialConsentPreferenceFactory
+from world.roster.factories import PlayerMediaFactory, RosterEntryFactory, RosterTenureFactory
 from world.scenes.factories import PersonaFactory
 from world.scenes.serializers import PersonaSerializer
 
@@ -18,3 +20,39 @@ class PersonaSerializerThumbnailMediaUrlTestCase(TestCase):
         persona = PersonaFactory(thumbnail=media)
         data = PersonaSerializer(persona).data
         assert data["thumbnail_media_url"] == media.cloudinary_url
+
+
+class PersonaSerializerAllowSocialActionsTestCase(TestCase):
+    """allow_social_actions mirrors the challenge consent gate for the scene UI (#1181)."""
+
+    def _persona_with_tenure(self) -> tuple:
+        sheet = CharacterSheetFactory()
+        persona = PersonaFactory(character_sheet=sheet)
+        entry = RosterEntryFactory(character_sheet=sheet)
+        tenure = RosterTenureFactory(roster_entry=entry)
+        return persona, tenure
+
+    def test_defaults_true_without_tenure(self) -> None:
+        """A persona whose character has no active tenure is targetable by default."""
+        persona = PersonaFactory()
+        data = PersonaSerializer(persona).data
+        assert data["allow_social_actions"] is True
+
+    def test_true_when_tenure_has_no_preference(self) -> None:
+        """No SocialConsentPreference row → allow (default)."""
+        persona, _tenure = self._persona_with_tenure()
+        data = PersonaSerializer(persona).data
+        assert data["allow_social_actions"] is True
+
+    def test_true_when_preference_allows(self) -> None:
+        persona, tenure = self._persona_with_tenure()
+        SocialConsentPreferenceFactory(tenure=tenure, allow_social_actions=True)
+        data = PersonaSerializer(persona).data
+        assert data["allow_social_actions"] is True
+
+    def test_false_when_preference_opts_out(self) -> None:
+        """allow_social_actions=False on the active tenure → not targetable."""
+        persona, tenure = self._persona_with_tenure()
+        SocialConsentPreferenceFactory(tenure=tenure, allow_social_actions=False)
+        data = PersonaSerializer(persona).data
+        assert data["allow_social_actions"] is False


### PR DESCRIPTION
## Duels Phase 2

Closes #1180, #1181, #1182 — the three deferred follow-ups from Duels Phase 1 (#568), built together since they share the `world/combat/` + `frontend/src/combat/duels/` + scene-UI surface.

### #1180 — Incoming-challenge inbox endpoint + prompt wiring
- **Backend:** `GET /api/combat/duel-challenges/` (`DuelChallengeViewSet`, read-only, filters/pagination/permissions) returns the caller's **PENDING** challenges as challenger and/or challenged, scoped to played characters via `played_character_sheet_ids`, reusing `DuelChallengeSerializer` with `select_related`. `?role=incoming|outgoing` narrows direction. Registered **before** the empty-prefix encounter route so the encounter detail regex can't capture the literal as a pk.
- **Frontend:** a `useDuelChallengeInbox` hook feeds `CombatScenePage`, which finds the pending challenge whose challenged character is the active one and renders `DuelChallengeControls` — replacing the `hasPendingIncomingChallenge={false}` stub. Accept/decline thread the specific `challenge_id` and invalidate the inbox + scene encounter list on success.
- **Backend:** accept/decline/withdraw accept an optional `challenge_id` kwarg and resolve that specific PENDING challenge (still scoped to the actor's role) instead of an arbitrary `.first()` when a PC has multiple pending.

### #1181 — Outgoing "Challenge to a duel" affordance
- **Frontend:** a "Challenge to a duel" item on `PersonaContextMenu` (the per-persona action surface) dispatches the existing `challenge` registry action with the target persona id. Hidden for the viewer's own persona and for targets that have opted out of social targeting.
- **Backend:** `ChallengeAction` resolves a `Persona` pk target → that persona's character `ObjectDB` (the web dispatch path passes ids; telnet/tests still pass an `ObjectDB`). `PersonaSerializer.allow_social_actions` mirrors the challenge consent gate (`_tenure_blocks_actor` with `category=None` blocks only on the master `allow_social_actions` switch) so the UI can hide the affordance; the backend still enforces the full gate at dispatch.

### #1182 — DUEL completion-counter + clash lethal-flag fixes
- `_increment_completion_counters` credits a DUEL win **only** to `encounter.duel_winner` (loss to the other duelist; an abandoned duel credits neither) instead of every ACTIVE participant — both duelists stay ACTIVE at completion, so the generic rule double-credited the loser with a win.
- `commit_to_clash` threads `lethal=clash.encounter.is_lethal` into `use_technique` (consistent with `resolve_combat_technique`), so the non-lethal cap holds on the clash path. Latent today (PvP mirror surfaces never form a clash), but correct if a non-lethal clash path is ever enabled.

### Docs
- `docs/roadmap/combat.md`: new "Duels — Phase 2 (SHIPPED)" subsection; "still open" trimmed to just the sheet-driven NPC duellist.
- `docs/systems/consent.md`: note that `PersonaSerializer.allow_social_actions` surfaces the master switch for registry actions (no `ActionTemplate`/`TargetSpec`) as a UX hint.

### Testing
- Backend: new tests for the inbox endpoint (scoping, role filter, pending-only, N+1), the DUEL completion-counter split + clash lethal threading, the `challenge_id` disambiguation, persona-id target resolution, and `PersonaSerializer.allow_social_actions`. Full `world.combat` + `actions` (1618) and `world.scenes` (623) fast tiers green.
- Frontend: `DuelChallengeControls`, `CombatScenePage`, and `PersonaContextMenu` component tests (38 total) cover the prompt wiring, `challenge_id` threading, and the affordance's dispatch + hidden-for-self / hidden-when-opted-out states. `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
