### PR TITLE
Surface per-target consent UI + per-target resolver side-effects (#1177, #1178)

### DIFF
--- a/docs/roadmap/rp-scenes.md
+++ b/docs/roadmap/rp-scenes.md
@@ -51,9 +51,29 @@ The core RP experience — how players interact in scenes. Arx II replaces arcan
 - **Frontend:** ActionPanel, ConsentPrompt, PersonaContextMenu components
 - **Constants:** SceneActionRequestStatus, SceneActionType
 
+### Multi-Target Action Consent (#572 follow-ups) — DONE (#1177, #1178)
+
+Two follow-ups from the #572 multi-target dispatch foundation:
+
+- **Per-target resolver invocation (#1178):** `respond_to_action_target()` now fires
+  the registered action resolver once per accepted `SceneActionTarget` row, symmetric with
+  `respond_to_action_request()`. Resolvers for multi-target actions must keep cast-level
+  side-effects idempotent across invocations.
+- **Additional-target consent UI (#1177):**
+  - `SceneActionTarget` read-only listing endpoint — `GET /api/action-targets/` (filterable
+    by `scene` and `status`); registered in scenes URL router as `action-targets`.
+  - `SceneActionTargetSerializer` — flat read payload with `action_target_id`,
+    `action_request_id`, `target_persona_id`, `initiator_name`, `scene`, `action_key`,
+    `technique_name`, `pose_text`, `strain_commitment`, `status`, `created_at`.
+  - `SceneActionTargetFilter` — `scene` + `status` django-filter FilterSet.
+  - Frontend `ConsentPrompt` extended: polls `GET /api/action-targets/?scene={id}&status=pending`
+    every 5 s alongside the primary-request queue; renders amber consent cards for pending
+    additional-target rows; Accept/Deny dispatches to
+    `POST /api/action-requests/{id}/respond/` with `target_persona_id`.
+
 ### Scene System (core)
 - **Models:** Scene (privacy_mode, summary fields), SceneParticipation, SceneSummaryRevision
-- **APIs:** SceneViewSet, PersonaViewSet, SceneSummaryRevisionViewSet, PlaceViewSet, SceneActionRequestViewSet
+- **APIs:** SceneViewSet, PersonaViewSet, SceneSummaryRevisionViewSet, PlaceViewSet, SceneActionRequestViewSet, SceneActionTargetViewSet
 - **Frontend:** Scene list/detail pages, interaction feed, action panel
 
 ### Positioning in Scenes — DONE (#1017)

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -504,8 +504,8 @@ Roleplay session recording with participant tracking, interaction logging, perso
 - **API Endpoints:** `GET/POST /api/action-requests/`, `POST /api/action-requests/{id}/respond/`,
   `GET /api/action-targets/` (read-only; filterable by `scene` + `status`; surfaces pending
   additional-target consent rows for the authenticated player's personas).
-- **Frontend:** `ConsentPrompt` polls both `GET /api/action-requests/?status=pending` and
-  `GET /api/action-targets/?status=pending` every 5 s and renders amber consent cards for
+- **Frontend:** `ConsentPrompt` polls both `GET /api/action-requests/?scene={id}&status=pending`
+  and `GET /api/action-targets/?scene={id}&status=pending` every 5 s and renders amber consent cards for
   each; additional-target accepts/denies pass `target_persona_id` to the shared respond endpoint.
 - **Integrates with:** roster (characters), stories (EpisodeScene join), instances (preservation check),
   flows (auto-logging via message_location), combat (encounter read gate via `Scene.objects.viewable_by`),

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -485,11 +485,15 @@ Character lifecycle management with web-first applications and player anonymity.
 - **Source:** `src/world/roster/`
 - **Details:** [roster.md](roster.md)
 ### Scenes
-Roleplay session recording with participant tracking and message logging.
+Roleplay session recording with participant tracking, interaction logging, persona-based identity, and social action consent flow.
 
-- **Models:** `Scene`, `SceneParticipation`, `Persona`, `SceneMessage`, `SceneMessageSupplementalData`, `SceneMessageReaction`
-- **Key Fields:** `SceneMessage.mode` (pose/emit/say/whisper/ooc), `SceneMessage.context` (public/tabletalk/private), `SceneMessage.sequence_number` (ordered), `SceneMessage.receivers` (M2M, empty=everyone)
-- **Key Functions:** `broadcast_scene_message(scene, action)` — pushes scene state to participants via websocket
+- **Models:** `Scene`, `SceneParticipation`, `Persona`, `SceneActionRequest`, `SceneActionTarget`, `SceneCastPullDeclaration`
+- **Social action consent:** `SceneActionRequest` owns the full lifecycle (dispatch → consent → resolution) for the primary target; `SceneActionTarget` rows carry additional targets, each with independent consent and result. Resolvers fire once per accepted target (primary via `respond_to_action_request`, additional via `respond_to_action_target`).
+- **Key Functions:**
+  - `create_action_request(scene, initiator_persona, target_persona, action_key, ...)` — dispatches a request; NPC additional targets auto-accept immediately.
+  - `respond_to_action_request(action_request, decision)` — primary-target consent + resolution.
+  - `respond_to_action_target(action_target, decision)` — per-additional-target consent + resolution (never touches siblings).
+  - `broadcast_scene_message(scene, action)` — pushes scene state to participants via WebSocket.
 - **Read-visibility surface (canonical):**
   - `Scene.objects.viewable_by(account)` — queryset; staff=all, auth non-staff=public OR participant,
     anonymous=public. Use in `get_queryset()` / filter chains.
@@ -497,10 +501,15 @@ Roleplay session recording with participant tracking and message logging.
     `participations_cached` (zero queries for identity-mapped scenes). Use in object-permission checks.
   - **Do not inline this logic.** `SceneViewSet`, `ReadOnlyOrSceneParticipant`, and the combat
     encounter read gate all consume these two forms.
-- **Pattern:** Messages are flat (ordered by sequence_number), no threading. `SceneMessageSupplementalData.data` (JSONField) exists as escape hatch for rich metadata without bloating main table.
-- **Note:** No `parent` FK for threading, no `message_type` beyond mode/context, no action-block concept yet. Auto-logging from in-game commands happens via `message_location()` flow service function.
+- **API Endpoints:** `GET/POST /api/action-requests/`, `POST /api/action-requests/{id}/respond/`,
+  `GET /api/action-targets/` (read-only; filterable by `scene` + `status`; surfaces pending
+  additional-target consent rows for the authenticated player's personas).
+- **Frontend:** `ConsentPrompt` polls both `GET /api/action-requests/?status=pending` and
+  `GET /api/action-targets/?status=pending` every 5 s and renders amber consent cards for
+  each; additional-target accepts/denies pass `target_persona_id` to the shared respond endpoint.
 - **Integrates with:** roster (characters), stories (EpisodeScene join), instances (preservation check),
-  flows (auto-logging via message_location), combat (encounter read gate via `Scene.objects.viewable_by`)
+  flows (auto-logging via message_location), combat (encounter read gate via `Scene.objects.viewable_by`),
+  actions (resolver registry via `get_resolver(action_key)`), consent (`SocialConsentCategory` enforcement)
 - **Source:** `src/world/scenes/`
 - **Details:** [scenes.md](scenes.md)
 ### Stories

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -121,6 +121,70 @@ broadcast_scene_message(scene, "end")     # Sets location.active_scene = None
 
 ---
 
+## Scene Action Requests
+
+Social actions within a scene require OOC consent. The `SceneActionRequest` model
+owns the full lifecycle (dispatch → consent → resolution → result recording) for
+**primary-target** requests; `SceneActionTarget` rows extend the same request to
+**additional targets**, each with its own independent consent and result.
+
+**Source:** `src/world/scenes/action_models.py`, `action_services.py`,
+`action_views.py`, `action_serializers.py`, `action_filters.py`
+
+### Models
+
+| Model | Purpose | Key Fields |
+|-------|---------|------------|
+| `SceneActionRequest` | Primary targeted (or area) social action request | `scene`, `initiator_persona`, `target_persona` (nullable), `action_key`, `action_template`, `technique`, `status` (ActionRequestStatus), `difficulty_choice`, `resolved_difficulty`, `result_interaction`, `action_interaction`, `delivery`, `pose_text`, `effort_level`, `created_at`, `resolved_at` |
+| `SceneActionTarget` | One additional non-primary target in a multi-target request | `action_request` (FK → SceneActionRequest), `target_persona`, `status`, `result_interaction`, `resolved_difficulty`, `resolved_at` |
+| `SceneCastPullDeclaration` | Paid thread-pull declared alongside a benign standalone cast | `request` (OneToOne), `resonance`, `tier`, `threads` (M2M) |
+
+`SceneActionTarget` has a `UniqueConstraint` on `(action_request, target_persona)` —
+a persona cannot appear as an additional target more than once per request.
+
+### Per-Target Resolver Semantics (#1178)
+
+When an action has a registered resolver (`action_resolvers.get_resolver(action_key)`),
+it fires **once per accepted target**:
+
+- `respond_to_action_request(action_request, decision)` — fires the resolver for the
+  primary target when the decision is ACCEPT (line ~340 in `action_services.py`).
+- `respond_to_action_target(action_target, decision)` — fires the same resolver for
+  each accepted additional target row, independently of the primary and of sibling rows.
+
+**Idempotency contract:** a resolver registered for a multi-target action is invoked
+once per accepted `SceneActionTarget`; any cast-level side-effects (e.g. anima deduction,
+kudos, renown) must therefore be idempotent with respect to invocation count across targets.
+NPC targets are auto-accepted at dispatch time via `_auto_resolve_npc_targets()`.
+
+### Key Service Functions
+
+```python
+from world.scenes.action_services import (
+    create_action_request,
+    respond_to_action_request,
+    respond_to_action_target,
+)
+
+# Create a request (primary + additional targets).
+# NPC additional targets are auto-resolved immediately.
+request = create_action_request(
+    scene=scene,
+    initiator_persona=persona,
+    target_persona=primary_target,      # None for area actions
+    action_key="intimidate",
+    additional_target_personas=[p2, p3],
+)
+
+# Primary-target consent (returns EnhancedSceneActionResult | None)
+result = respond_to_action_request(action_request=request, decision=ConsentDecision.ACCEPT)
+
+# Additional-target consent — never touches siblings or the primary status
+result = respond_to_action_target(action_target=target_row, decision=ConsentDecision.ACCEPT)
+```
+
+---
+
 ## API Endpoints
 
 ### Scenes (`/api/scenes/`)
@@ -151,6 +215,25 @@ broadcast_scene_message(scene, "end")     # Sets location.active_scene = None
 ### Reactions (`/api/reactions/`)
 - `POST /api/reactions/` - Toggle reaction (creates or removes based on existing state)
 - `DELETE /api/reactions/{id}/` - Remove reaction
+
+### Action Requests (`/api/action-requests/`)
+- `GET /api/action-requests/` - List requests where the caller is initiator or primary target
+- `POST /api/action-requests/` - Dispatch a new action request (single- or multi-target)
+- `POST /api/action-requests/{id}/respond/` - Accept or deny a primary-target request; also handles additional-target consent when `target_persona_id` is included in the payload
+
+**Filters:** `scene`, `status`, `initiator`, `target`
+
+### Action Targets (`/api/action-targets/`)
+
+Read-only listing of a player's pending additional-target consent rows (#1177).
+
+- `GET /api/action-targets/` - List `SceneActionTarget` rows where the caller controls the target persona
+
+**Filters:** `scene`, `status`
+
+**Typical use:** `GET /api/action-targets/?scene={id}&status=pending` — fetched by `ConsentPrompt` every 5 seconds to surface the additional-target consent queue alongside the primary-request queue. Accepting or denying dispatches to `POST /api/action-requests/{id}/respond/` with `target_persona_id` set.
+
+**Response shape** (`SceneActionTargetSerializer`): `action_target_id`, `action_request_id`, `target_persona_id`, `status`, `initiator_persona`, `initiator_name`, `scene`, `action_key`, `action_template`, `technique`, `technique_name`, `pose_text`, `strain_commitment`, `created_at`.
 
 ---
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -198,6 +198,40 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/action-targets/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Read-only listing of a persona's pending additional-target consent rows (#1177). */
+    get: operations['action_targets_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/action-targets/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Read-only listing of a persona's pending additional-target consent rows (#1177). */
+    get: operations['action_targets_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/actions/characters/{character_id}/available/': {
     parameters: {
       query?: never;
@@ -19576,6 +19610,21 @@ export interface components {
       previous?: string | null;
       results: components['schemas']['SceneActionRequest'][];
     };
+    PaginatedSceneActionTargetList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['SceneActionTarget'][];
+    };
     PaginatedSceneListList: {
       /** @example 123 */
       count: number;
@@ -22504,7 +22553,7 @@ export interface components {
        *     * `mutter` - Mutter (partial echo)
        */
       delivery?: components['schemas']['DeliveryEnum'] | components['schemas']['BlankEnum'];
-      readonly status: components['schemas']['SceneActionStatusEnum'];
+      readonly status: components['schemas']['Status307Enum'];
       /**
        * @description Difficulty level chosen or determined for this action
        *
@@ -22568,15 +22617,25 @@ export interface components {
       /** @description Extra anima the player commits beyond base cost. Bounded by available anima at resolution time. */
       strain_commitment?: number;
     };
-    /**
-     * @description * `pending` - Pending
-     *     * `accepted` - Accepted
-     *     * `denied` - Denied
-     *     * `resolved` - Resolved
-     *     * `expired` - Expired
-     * @enum {string}
-     */
-    SceneActionStatusEnum: 'pending' | 'accepted' | 'denied' | 'resolved' | 'expired';
+    /** @description Flat read payload for a pending additional-target consent row (#1177). */
+    SceneActionTarget: {
+      readonly action_target_id: number;
+      readonly action_request_id: number;
+      readonly target_persona_id: number;
+      status?: components['schemas']['Status307Enum'];
+      readonly initiator_persona: number;
+      readonly initiator_name: string;
+      readonly scene: number;
+      readonly action_key: string;
+      readonly action_template: number | null;
+      readonly technique: number | null;
+      /** @description Human label for the enhancing technique (mirrors the request serializer). */
+      readonly technique_name: string | null;
+      readonly pose_text: string;
+      readonly strain_commitment: number;
+      /** Format: date-time */
+      readonly created_at: string;
+    };
     /** @description A scene room's current activity band (shown before a teller commits). */
     SceneActivity: {
       readonly band: string;
@@ -23273,6 +23332,15 @@ export interface components {
       | 'approved'
       | 'denied'
       | 'withdrawn';
+    /**
+     * @description * `pending` - Pending
+     *     * `accepted` - Accepted
+     *     * `denied` - Denied
+     *     * `resolved` - Resolved
+     *     * `expired` - Expired
+     * @enum {string}
+     */
+    Status307Enum: 'pending' | 'accepted' | 'denied' | 'resolved' | 'expired';
     /**
      * @description * `declaring` - Declaring
      *     * `resolving` - Resolving
@@ -24826,6 +24894,52 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['SceneActionRequest'];
+        };
+      };
+    };
+  };
+  action_targets_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        scene?: number;
+        status?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedSceneActionTargetList'];
+        };
+      };
+    };
+  };
+  action_targets_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this scene action target. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SceneActionTarget'];
         };
       };
     };

--- a/frontend/src/scenes/actionQueries.ts
+++ b/frontend/src/scenes/actionQueries.ts
@@ -10,6 +10,7 @@ import type {
   CastPullRequestBody,
   CastRequestBody,
   CastResponse,
+  PendingActionTarget,
 } from './actionTypes';
 
 /**
@@ -86,6 +87,14 @@ export async function createActionRequest(
 export async function fetchPendingRequests(sceneId: string): Promise<{ results: ActionRequest[] }> {
   const res = await apiFetch(`/api/action-requests/?scene=${sceneId}&status=pending`);
   if (!res.ok) throw new Error('Failed to load pending requests');
+  return res.json();
+}
+
+export async function fetchPendingTargets(
+  sceneId: string
+): Promise<{ results: PendingActionTarget[] }> {
+  const res = await apiFetch(`/api/action-targets/?scene=${sceneId}&status=pending`);
+  if (!res.ok) throw new Error('Failed to load pending action targets');
   return res.json();
 }
 

--- a/frontend/src/scenes/actionTypes.ts
+++ b/frontend/src/scenes/actionTypes.ts
@@ -258,3 +258,21 @@ export interface CastResponse {
    */
   action_interaction?: number | null;
 }
+
+// Mirrors SceneActionTargetSerializer (#1177). Kept in sync with the backend.
+export interface PendingActionTarget {
+  action_target_id: number;
+  action_request_id: number;
+  target_persona_id: number;
+  status: string;
+  initiator_persona: number;
+  initiator_name: string;
+  scene: number;
+  action_key: string;
+  action_template: number | null;
+  technique: number | null;
+  technique_name: string | null;
+  pose_text: string;
+  strain_commitment: number;
+  created_at: string;
+}

--- a/frontend/src/scenes/components/ConsentPrompt.test.tsx
+++ b/frontend/src/scenes/components/ConsentPrompt.test.tsx
@@ -7,10 +7,12 @@ import type { ActionRequest } from '../actionTypes';
 
 vi.mock('../actionQueries', () => ({
   fetchPendingRequests: vi.fn(),
+  fetchPendingTargets: vi.fn(),
   respondToRequest: vi.fn(),
 }));
 
-import { fetchPendingRequests, respondToRequest } from '../actionQueries';
+import { fetchPendingRequests, fetchPendingTargets, respondToRequest } from '../actionQueries';
+import type { PendingActionTarget } from '../actionTypes';
 import { ConsentPrompt } from './ConsentPrompt';
 
 function createWrapper() {
@@ -47,6 +49,7 @@ const MOCK_REQUEST_WITH_TECHNIQUE: ActionRequest = {
 describe('ConsentPrompt', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fetchPendingTargets).mockResolvedValue({ results: [] });
   });
 
   it('shows nothing when no pending requests', async () => {
@@ -244,5 +247,68 @@ describe('ConsentPrompt', () => {
       expect(screen.getByText(/Darth Maul/)).toBeInTheDocument();
     });
     expect(screen.queryByText(/committing/i)).not.toBeInTheDocument();
+  });
+
+  const MOCK_TARGET: PendingActionTarget = {
+    action_target_id: 50,
+    action_request_id: 12,
+    target_persona_id: 99,
+    status: 'pending',
+    initiator_persona: 3,
+    initiator_name: 'Morgan',
+    scene: 42,
+    action_key: 'Hex',
+    action_template: 1,
+    technique: null,
+    technique_name: null,
+    pose_text: 'Morgan raises a hand.',
+    strain_commitment: 0,
+    created_at: '2026-03-22T12:10:00Z',
+  };
+
+  it('renders a pending additional-target prompt', async () => {
+    vi.mocked(fetchPendingRequests).mockResolvedValue({ results: [] });
+    vi.mocked(fetchPendingTargets).mockResolvedValue({ results: [MOCK_TARGET] });
+
+    render(<ConsentPrompt sceneId="42" />, { wrapper: createWrapper() });
+
+    await waitFor(() => expect(screen.getByText('Morgan')).toBeInTheDocument());
+    expect(screen.getByText('Hex')).toBeInTheDocument();
+  });
+
+  it('accepting a target calls respondToRequest with target_persona_id and no difficulty', async () => {
+    vi.mocked(fetchPendingRequests).mockResolvedValue({ results: [] });
+    vi.mocked(fetchPendingTargets).mockResolvedValue({ results: [MOCK_TARGET] });
+    vi.mocked(respondToRequest).mockResolvedValue({ status: 'resolved' });
+    const user = userEvent.setup();
+
+    render(<ConsentPrompt sceneId="42" />, { wrapper: createWrapper() });
+    await waitFor(() => expect(screen.getByText('Accept')).toBeInTheDocument());
+    await user.click(screen.getByText('Accept'));
+
+    await waitFor(() =>
+      expect(respondToRequest).toHaveBeenCalledWith('42', 12, {
+        accept: true,
+        target_persona_id: 99,
+      })
+    );
+  });
+
+  it('denying a target calls respondToRequest with accept:false + target_persona_id', async () => {
+    vi.mocked(fetchPendingRequests).mockResolvedValue({ results: [] });
+    vi.mocked(fetchPendingTargets).mockResolvedValue({ results: [MOCK_TARGET] });
+    vi.mocked(respondToRequest).mockResolvedValue({ status: 'resolved' });
+    const user = userEvent.setup();
+
+    render(<ConsentPrompt sceneId="42" />, { wrapper: createWrapper() });
+    await waitFor(() => expect(screen.getByText('Deny')).toBeInTheDocument());
+    await user.click(screen.getByText('Deny'));
+
+    await waitFor(() =>
+      expect(respondToRequest).toHaveBeenCalledWith('42', 12, {
+        accept: false,
+        target_persona_id: 99,
+      })
+    );
   });
 });

--- a/frontend/src/scenes/components/ConsentPrompt.tsx
+++ b/frontend/src/scenes/components/ConsentPrompt.tsx
@@ -1,8 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ShieldAlert, Check, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { fetchPendingRequests, respondToRequest } from '../actionQueries';
-import type { ActionRequest } from '../actionTypes';
+import { fetchPendingRequests, fetchPendingTargets, respondToRequest } from '../actionQueries';
+import type { ActionRequest, PendingActionTarget } from '../actionTypes';
 
 interface Props {
   sceneId: string;
@@ -39,9 +39,32 @@ export function ConsentPrompt({ sceneId }: Props) {
     },
   });
 
-  const requests = data?.results ?? [];
+  const { data: targetData } = useQuery({
+    queryKey: ['pending-targets', sceneId],
+    queryFn: () => fetchPendingTargets(sceneId),
+    refetchInterval: 5_000,
+  });
 
-  if (requests.length === 0) return null;
+  const respondTarget = useMutation({
+    mutationFn: ({
+      requestId,
+      targetPersonaId,
+      accept,
+    }: {
+      requestId: number;
+      targetPersonaId: number;
+      accept: boolean;
+    }) => respondToRequest(sceneId, requestId, { accept, target_persona_id: targetPersonaId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pending-targets', sceneId] });
+      queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
+    },
+  });
+
+  const requests = data?.results ?? [];
+  const targets = targetData?.results ?? [];
+
+  if (requests.length === 0 && targets.length === 0) return null;
 
   return (
     <div className="space-y-2">
@@ -100,6 +123,61 @@ export function ConsentPrompt({ sceneId }: Props) {
                 {opt.label}
               </Button>
             ))}
+          </div>
+        </div>
+      ))}
+      {targets.map((t: PendingActionTarget) => (
+        <div
+          key={`target-${t.action_target_id}`}
+          className="flex items-center gap-3 rounded-md border border-amber-500/50 bg-amber-50 px-4 py-3 dark:bg-amber-950/30"
+        >
+          <ShieldAlert className="h-5 w-5 shrink-0 text-amber-600" />
+          <div className="flex-1">
+            <p className="text-sm font-medium">
+              <span className="font-semibold">{t.initiator_name}</span> wants to use{' '}
+              <span className="font-semibold">
+                {t.action_key}
+                {t.technique_name ? ` (${t.technique_name})` : ''}
+              </span>{' '}
+              on your character.
+            </p>
+            {t.strain_commitment > 0 && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t.initiator_name} is committing {t.strain_commitment} strain.
+              </p>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() =>
+                respondTarget.mutate({
+                  requestId: t.action_request_id,
+                  targetPersonaId: t.target_persona_id,
+                  accept: false,
+                })
+              }
+              disabled={respondTarget.isPending}
+            >
+              <X className="mr-1 h-3.5 w-3.5" />
+              Deny
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() =>
+                respondTarget.mutate({
+                  requestId: t.action_request_id,
+                  targetPersonaId: t.target_persona_id,
+                  accept: true,
+                })
+              }
+              disabled={respondTarget.isPending}
+            >
+              <Check className="mr-1 h-3.5 w-3.5" />
+              Accept
+            </Button>
           </div>
         </div>
       ))}

--- a/src/schema.json
+++ b/src/schema.json
@@ -270,6 +270,60 @@ paths:
               schema:
                 $ref: '#/components/schemas/SceneActionRequest'
           description: ''
+  /api/action-targets/:
+    get:
+      operationId: action_targets_list
+      description: Read-only listing of a persona's pending additional-target consent
+        rows (#1177).
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - in: query
+        name: scene
+        schema:
+          type: number
+      - in: query
+        name: status
+        schema:
+          type: string
+      tags:
+      - action-targets
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSceneActionTargetList'
+          description: ''
+  /api/action-targets/{id}/:
+    get:
+      operationId: action_targets_retrieve
+      description: Read-only listing of a persona's pending additional-target consent
+        rows (#1177).
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this scene action target.
+        required: true
+      tags:
+      - action-targets
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SceneActionTarget'
+          description: ''
   /api/actions/characters/{character_id}/available/:
     get:
       operationId: actions_characters_available_list
@@ -35251,6 +35305,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SceneActionRequest'
+    PaginatedSceneActionTargetList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SceneActionTarget'
     PaginatedSceneListList:
       type: object
       required:
@@ -40723,7 +40800,7 @@ components:
           - $ref: '#/components/schemas/BlankEnum'
         status:
           allOf:
-          - $ref: '#/components/schemas/SceneActionStatusEnum'
+          - $ref: '#/components/schemas/Status307Enum'
           readOnly: true
         difficulty_choice:
           allOf:
@@ -40844,20 +40921,71 @@ components:
       required:
       - initiator_persona
       - scene
-    SceneActionStatusEnum:
-      enum:
-      - pending
-      - accepted
-      - denied
-      - resolved
-      - expired
-      type: string
-      description: |-
-        * `pending` - Pending
-        * `accepted` - Accepted
-        * `denied` - Denied
-        * `resolved` - Resolved
-        * `expired` - Expired
+    SceneActionTarget:
+      type: object
+      description: Flat read payload for a pending additional-target consent row (#1177).
+      properties:
+        action_target_id:
+          type: integer
+          readOnly: true
+        action_request_id:
+          type: integer
+          readOnly: true
+        target_persona_id:
+          type: integer
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/Status307Enum'
+        initiator_persona:
+          type: integer
+          readOnly: true
+        initiator_name:
+          type: string
+          readOnly: true
+        scene:
+          type: integer
+          readOnly: true
+        action_key:
+          type: string
+          readOnly: true
+        action_template:
+          type: integer
+          readOnly: true
+          nullable: true
+        technique:
+          type: integer
+          readOnly: true
+          nullable: true
+        technique_name:
+          type: string
+          nullable: true
+          description: Human label for the enhancing technique (mirrors the request
+            serializer).
+          readOnly: true
+        pose_text:
+          type: string
+          readOnly: true
+        strain_commitment:
+          type: integer
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - action_key
+      - action_request_id
+      - action_target_id
+      - action_template
+      - created_at
+      - initiator_name
+      - initiator_persona
+      - pose_text
+      - scene
+      - strain_commitment
+      - target_persona_id
+      - technique
+      - technique_name
     SceneActivity:
       type: object
       description: A scene room's current activity band (shown before a teller commits).
@@ -42302,6 +42430,20 @@ components:
         * `approved` - Approved
         * `denied` - Denied
         * `withdrawn` - Withdrawn
+    Status307Enum:
+      enum:
+      - pending
+      - accepted
+      - denied
+      - resolved
+      - expired
+      type: string
+      description: |-
+        * `pending` - Pending
+        * `accepted` - Accepted
+        * `denied` - Denied
+        * `resolved` - Resolved
+        * `expired` - Expired
     Status4e6Enum:
       enum:
       - declaring

--- a/src/world/scenes/action_filters.py
+++ b/src/world/scenes/action_filters.py
@@ -2,7 +2,7 @@
 
 import django_filters
 
-from world.scenes.action_models import SceneActionRequest
+from world.scenes.action_models import SceneActionRequest, SceneActionTarget
 
 
 class SceneActionRequestFilter(django_filters.FilterSet):
@@ -14,3 +14,12 @@ class SceneActionRequestFilter(django_filters.FilterSet):
     class Meta:
         model = SceneActionRequest
         fields = ["scene", "status", "initiator", "target"]
+
+
+class SceneActionTargetFilter(django_filters.FilterSet):
+    scene = django_filters.NumberFilter(field_name="action_request__scene_id")
+    status = django_filters.CharFilter(field_name="status")
+
+    class Meta:
+        model = SceneActionTarget
+        fields = ["scene", "status"]

--- a/src/world/scenes/action_resolvers.py
+++ b/src/world/scenes/action_resolvers.py
@@ -4,6 +4,9 @@ Generic seam: each app that wants to add post-resolution side-effects to
 SceneActionRequests registers a callable here.
 
 A resolver runs after respond_to_action_request() resolves an accepted SceneActionRequest.
+For multi-target casts the resolver is also invoked by respond_to_action_target()
+once per accepted additional target. Resolvers registered for multi-target actions
+must therefore keep cast-level (non-idempotent) side-effects target-scoped/idempotent.
 """
 
 from __future__ import annotations

--- a/src/world/scenes/action_serializers.py
+++ b/src/world/scenes/action_serializers.py
@@ -8,7 +8,7 @@ from rest_framework import serializers
 from world.combat.cast_seed import encounter_requiring_risk_acknowledgement
 from world.magic.services.hostility import is_technique_hostile
 from world.scenes.action_constants import ActionDelivery, ActionRequestStatus, ConsentDecision
-from world.scenes.action_models import SceneActionRequest
+from world.scenes.action_models import SceneActionRequest, SceneActionTarget
 
 
 def _cap_fury_by_provocation(attrs: dict) -> dict:
@@ -471,3 +471,55 @@ class EnhancedSceneActionResultSerializer(serializers.Serializer):
             return None
         payload = getattr(action_request, "_anima_recovery_payload", None)  # noqa: GETATTR_LITERAL
         return AnimaRecoverySerializer(payload).data if payload is not None else None
+
+
+class SceneActionTargetSerializer(serializers.ModelSerializer):
+    """Flat read payload for a pending additional-target consent row (#1177)."""
+
+    action_target_id = serializers.IntegerField(source="id", read_only=True)
+    action_request_id = serializers.IntegerField(read_only=True)
+    target_persona_id = serializers.IntegerField(read_only=True)
+    initiator_persona = serializers.IntegerField(
+        source="action_request.initiator_persona_id", read_only=True
+    )
+    initiator_name = serializers.CharField(
+        source="action_request.initiator_persona.name", read_only=True
+    )
+    scene = serializers.IntegerField(source="action_request.scene_id", read_only=True)
+    action_key = serializers.CharField(source="action_request.action_key", read_only=True)
+    action_template = serializers.IntegerField(
+        source="action_request.action_template_id", read_only=True, allow_null=True
+    )
+    technique = serializers.IntegerField(
+        source="action_request.technique_id", read_only=True, allow_null=True
+    )
+    technique_name = serializers.SerializerMethodField()
+    pose_text = serializers.CharField(source="action_request.pose_text", read_only=True)
+    strain_commitment = serializers.IntegerField(
+        source="action_request.strain_commitment", read_only=True
+    )
+    created_at = serializers.DateTimeField(source="action_request.created_at", read_only=True)
+
+    def get_technique_name(self, obj: SceneActionTarget) -> str | None:
+        """Human label for the enhancing technique (mirrors the request serializer)."""
+        technique = obj.action_request.technique
+        return technique.name if technique is not None else None
+
+    class Meta:
+        model = SceneActionTarget
+        fields = [
+            "action_target_id",
+            "action_request_id",
+            "target_persona_id",
+            "status",
+            "initiator_persona",
+            "initiator_name",
+            "scene",
+            "action_key",
+            "action_template",
+            "technique",
+            "technique_name",
+            "pose_text",
+            "strain_commitment",
+            "created_at",
+        ]

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -517,9 +517,14 @@ def respond_to_action_target(
                 update_fields=["status", "resolved_at", "resolved_difficulty", "result_interaction"]
             )
             _award_acceptance_kudos_for_persona(action_request, action_target.target_persona)
-            # Resolver invocation is intentionally omitted here: no multi-target resolvers
-            # exist yet (#572). When they do, wire get_resolver(action_key)(action_request, result)
-            # in this block analogous to respond_to_action_request.
+            # Per-target resolver invocation (#1178): fire the registered resolver for
+            # THIS target's result, symmetric with respond_to_action_request (:340).
+            # Runs once per accepted target; resolvers registered for multi-target
+            # actions must keep cast-level side-effects idempotent. result is None only
+            # for hostile consent-accepts (empty action_key → no resolver).
+            resolver = get_resolver(action_request.action_key)
+            if resolver is not None and result is not None:
+                resolver(action_request, result)
         return result
     return None
 

--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -21,7 +21,7 @@ from actions.registry import get_action
 from actions.types import TargetType
 from world.magic.exceptions import MagicError
 from world.scenes.action_constants import ActionRequestStatus, DifficultyChoice
-from world.scenes.action_filters import SceneActionRequestFilter
+from world.scenes.action_filters import SceneActionRequestFilter, SceneActionTargetFilter
 from world.scenes.action_models import SceneActionRequest, SceneActionTarget
 from world.scenes.action_serializers import (
     CastableTechniqueSerializer,
@@ -29,6 +29,7 @@ from world.scenes.action_serializers import (
     EnhancedSceneActionResultSerializer,
     SceneActionRequestCreateSerializer,
     SceneActionRequestSerializer,
+    SceneActionTargetSerializer,
     TechniqueCastCreateSerializer,
 )
 from world.scenes.action_services import (
@@ -426,3 +427,30 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
 
         techniques = [ct.technique for ct in char_techniques]
         return Response(CastableTechniqueSerializer(techniques, many=True).data)
+
+
+class SceneActionTargetViewSet(viewsets.ReadOnlyModelViewSet):
+    """Read-only listing of a persona's pending additional-target consent rows (#1177)."""
+
+    serializer_class = SceneActionTargetSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = SceneActionRequestPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = SceneActionTargetFilter
+    http_method_names = ["get"]
+
+    def get_queryset(self) -> QuerySet[SceneActionTarget]:
+        persona_ids = get_account_personas(self.request)
+        if not persona_ids:
+            return SceneActionTarget.objects.none()
+        return (
+            SceneActionTarget.objects.filter(target_persona_id__in=persona_ids)
+            .select_related(
+                "action_request",
+                "action_request__initiator_persona",
+                "action_request__scene",
+                "action_request__technique",
+                "target_persona",
+            )
+            .order_by("-action_request__created_at", "id")
+        )

--- a/src/world/scenes/tests/test_action_services.py
+++ b/src/world/scenes/tests/test_action_services.py
@@ -858,3 +858,66 @@ class MultiTargetE2ETests(TestCase):
         self.assertEqual(pc_a_row.status, ActionRequestStatus.RESOLVED)
         pc_b_row.refresh_from_db()
         self.assertEqual(pc_b_row.status, ActionRequestStatus.DENIED)
+
+
+class TestPerTargetResolverIntegration(TestCase):
+    """The resolver registry fires once per accepted additional target (#1178)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.scene = SceneFactory()
+        cls.initiator = PersonaFactory()
+        cls.action_template = ActionTemplateFactory()
+
+    def setUp(self) -> None:
+        self.award_kudos_patcher = patch("world.scenes.action_services.award_kudos")
+        self.mock_award_kudos = self.award_kudos_patcher.start()
+
+    def tearDown(self) -> None:
+        self.award_kudos_patcher.stop()
+
+    def _make_request(self, action_key: str) -> "SceneActionRequest":
+        from world.scenes.action_models import SceneActionRequest
+
+        request = SceneActionRequestFactory(
+            scene=self.scene,
+            initiator_persona=self.initiator,
+            action_key=action_key,
+            status=ActionRequestStatus.PENDING,
+        )
+        SceneActionRequest.objects.filter(pk=request.pk).update(
+            action_template=self.action_template
+        )
+        request.action_template = self.action_template
+        return request
+
+    @patch("world.scenes.action_services.start_action_resolution")
+    def test_resolver_fires_for_accepted_additional_target(self, mock_resolve: MagicMock) -> None:
+        mock_resolve.return_value = _make_pending_resolution(success=True)
+        captured: list[tuple[int, object]] = []
+
+        def fake_resolver(request, outcome):
+            captured.append((request.pk, outcome))
+
+        register_resolver("test_target_resolver", fake_resolver)
+        self.addCleanup(lambda: _RESOLVER_REGISTRY.pop("test_target_resolver", None))
+
+        request = self._make_request("test_target_resolver")
+        accepted = SceneActionTargetFactory(action_request=request)
+        denied = SceneActionTargetFactory(action_request=request)
+
+        result = respond_to_action_target(action_target=accepted, decision=ConsentDecision.ACCEPT)
+        respond_to_action_target(action_target=denied, decision=ConsentDecision.DENY)
+
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0][0], request.pk)
+        self.assertIs(captured[0][1], result)  # resolver gets THIS target's result
+
+    @patch("world.scenes.action_services.start_action_resolution")
+    def test_no_resolver_registered_is_noop(self, mock_resolve: MagicMock) -> None:
+        mock_resolve.return_value = _make_pending_resolution(success=True)
+        request = self._make_request("unregistered_target_action")
+        row = SceneActionTargetFactory(action_request=request)
+
+        result = respond_to_action_target(action_target=row, decision=ConsentDecision.ACCEPT)
+        self.assertIsNotNone(result)  # must not raise

--- a/src/world/scenes/tests/test_action_views.py
+++ b/src/world/scenes/tests/test_action_views.py
@@ -1009,3 +1009,70 @@ class PerTargetRespondTestCase(APITestCase):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data["detail"] == "Unable to process this action request."
+
+
+class TestSceneActionTargetViewSet(APITestCase):
+    """GET /api/action-targets/ lists the requester's pending additional-target rows (#1177)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.account = AccountFactory()
+        cls.character = CharacterFactory()
+        cls.roster_entry = RosterEntryFactory(character_sheet__character=cls.character)
+        cls.player_data = PlayerDataFactory(account=cls.account)
+        cls.tenure = RosterTenureFactory(
+            player_data=cls.player_data,
+            roster_entry=cls.roster_entry,
+        )
+        cls.identity = CharacterSheetFactory(character=cls.character)
+        cls.my_persona = cls.identity.primary_persona
+
+        cls.other_account = AccountFactory()
+        cls.other_character = CharacterFactory()
+        cls.other_roster_entry = RosterEntryFactory(character_sheet__character=cls.other_character)
+        cls.other_player_data = PlayerDataFactory(account=cls.other_account)
+        cls.other_tenure = RosterTenureFactory(
+            player_data=cls.other_player_data,
+            roster_entry=cls.other_roster_entry,
+        )
+        cls.other_identity = CharacterSheetFactory(character=cls.other_character)
+        cls.other_persona = cls.other_identity.primary_persona
+
+        cls.scene = SceneFactory()
+
+    def setUp(self) -> None:
+        self.client.force_authenticate(user=self.account)
+
+    def test_lists_only_my_pending_target_rows(self) -> None:
+        request = SceneActionRequestFactory(scene=self.scene, initiator_persona=self.other_persona)
+        mine = SceneActionTargetFactory(
+            action_request=request,
+            target_persona=self.my_persona,
+            status=ActionRequestStatus.PENDING,
+        )
+        SceneActionTargetFactory(  # someone else's row — must not appear
+            action_request=request,
+            target_persona=self.other_persona,
+            status=ActionRequestStatus.PENDING,
+        )
+
+        resp = self.client.get(f"/api/action-targets/?scene={self.scene.pk}&status=pending")
+
+        self.assertEqual(resp.status_code, 200)
+        ids = [r["action_target_id"] for r in resp.json()["results"]]
+        self.assertEqual(ids, [mine.pk])
+        row = resp.json()["results"][0]
+        self.assertEqual(row["target_persona_id"], self.my_persona.pk)
+        self.assertEqual(row["initiator_name"], self.other_persona.name)
+        self.assertIn("action_key", row)
+        self.assertIn("pose_text", row)
+
+    def test_status_filter_excludes_resolved(self) -> None:
+        request = SceneActionRequestFactory(scene=self.scene, initiator_persona=self.other_persona)
+        SceneActionTargetFactory(
+            action_request=request,
+            target_persona=self.my_persona,
+            status=ActionRequestStatus.RESOLVED,
+        )
+        resp = self.client.get(f"/api/action-targets/?scene={self.scene.pk}&status=pending")
+        self.assertEqual(resp.json()["results"], [])

--- a/src/world/scenes/urls.py
+++ b/src/world/scenes/urls.py
@@ -1,7 +1,7 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from world.scenes.action_views import SceneActionRequestViewSet
+from world.scenes.action_views import SceneActionRequestViewSet, SceneActionTargetViewSet
 from world.scenes.interaction_views import (
     InteractionFavoriteViewSet,
     InteractionReactionViewSet,
@@ -39,6 +39,11 @@ router.register(
     r"action-requests",
     SceneActionRequestViewSet,
     basename="sceneactionrequest",
+)
+router.register(
+    r"action-targets",
+    SceneActionTargetViewSet,
+    basename="sceneactiontarget",
 )
 router.register(
     r"reaction-windows",


### PR DESCRIPTION
Closes #1177

## Summary

Two #572 multi-target-dispatch follow-ups, in one branch.

**#1178 — per-target resolver side-effects.** `respond_to_action_target` now fires the registered action resolver once per accepted additional target, symmetric with the primary path (`respond_to_action_request`), inside the same `transaction.atomic()` block and guarded for the no-resolver / `None`-result cases. NPC additional targets inherit it through the shared path (no double-fire). Resolver contract documented: invoked once per accepted target; cast-level side-effects must be idempotent. **Closes #1178.**

**#1177 — additional-target consent queue.** New read-only `GET /api/action-targets/?scene={id}&status=pending` endpoint (`SceneActionTargetViewSet` + serializer + filter; pagination/permissions/filters per repo standards; account-owned-persona privacy filter via `get_account_personas`). `ConsentPrompt` renders pending additional-target rows as an **Accept/Deny-only** section, reusing the already-wired `respondToRequest(target_persona_id)` mutation.

Docs (scenes system doc + `INDEX.md` + roadmap) updated; API types regenerated. Tests cover the per-target resolver fire-count (fires for accepted, not denied), endpoint ownership/status filtering, and the ConsentPrompt accept/deny payloads. Built spec-first (brainstorm → code-verified anti-reinvention ledger → subagent-driven execution → per-task + whole-branch review).

## Follow-ups filed

- #1259

## Notes

- Spec: reviewed & approved on #1177 (in the issue body)
- Brainstorm/plan: ran (brainstorming + ephemeral plan, subagent-driven execution; final whole-branch review: ready to merge)
- Sync-with-main: rebased onto origin/main cleanly — no conflicts, no migration collisions

<!-- last-addressed-comment: 0 -->