### PR TITLE
chore(skills): fix four workflow-friction-audit findings

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -29,6 +29,7 @@ Modern React application with TypeScript, Vite, and Tailwind CSS powering the Ar
 - **Never use file path patterns in `manualChunks` for app code** — only split `node_modules` into vendor chunks. App code splitting creates circular chunk dependencies that work in Vite dev mode but crash in production (`Cannot access 'x' before initialization`). For feature-based splitting, use `React.lazy(() => import('./SomePage'))` at the route level instead
 - **After any Vite config change, test the production build end-to-end** — run `pnpm build`, then verify the app loads on the Django/TwistedWeb server (port 4001). Vite dev mode (port 3000) resolves ESM imports differently and will not catch circular chunk dependencies or static file serving issues
 - **`pnpm build` succeeding does not mean the app works** — the build only checks that code compiles. Module evaluation order, CORS on static files, and asset path rewriting are only testable against the production server
+- **pnpm `overrides` live in `pnpm-workspace.yaml`, not `package.json`** — under pnpm v11 the `package.json` `pnpm.overrides`/`onlyBuiltDependencies` fields are ignored. Edit `frontend/pnpm-workspace.yaml` (authoritative), keep the `package.json` `pnpm` block mirrored, and confirm `git diff --stat pnpm-lock.yaml` is non-empty before running build/tests — otherwise the override silently had no effect
 
 ### Development
 

--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -240,6 +240,11 @@ PR_SUMMARY="..." PR_RAN_OR_SKIPPED="ran" PR_SYNC_SUMMARY="..." \
 The PR body references the approved spec via `Closes #<issue>` — the spec lives
 in the issue body, so there is no spec-file link to pass.
 
+**Before pushing, run `uv run pre-commit run --all-files`** — this matches CI's
+`pre-commit` job exactly. Committing with hooks only checks *changed* files, so
+ruff-format / Prettier / the custom linters can still reflow or flag untouched files
+that CI then rejects. Running the full pass locally avoids a wasted CI round-trip.
+
 ### 6. CI watch
 
 > ⚠️ **NEVER use Opus for CI watch or any looping/polling phase.** The watch
@@ -300,7 +305,11 @@ NEW_MAX=<max comment id you addressed>
 BODY=$(gh pr view <pr> --json body --jq .body)
 # -E (ERE) so [0-9]+ works on both GNU sed (Linux) and BSD sed (macOS).
 NEW_BODY=$(sed -E "s/<!-- last-addressed-comment: [0-9]+ -->/<!-- last-addressed-comment: $NEW_MAX -->/" <<<"$BODY")
-printf '%s' "$NEW_BODY" | gh pr edit <pr> --body-file -
+# Use the REST API, not `gh pr edit`: `gh pr edit` fetches the deprecated
+# Projects-classic `projectCards` field and now errors out, silently leaving the
+# body unchanged. REST PATCH is unaffected.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+printf '%s' "$NEW_BODY" | gh api -X PATCH "repos/$REPO/pulls/<pr>" -F body=@-
 ```
 
 #### Takeaway evaluation

--- a/tools/skills/issue-to-merged-pr/scripts/pickup-issue.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/pickup-issue.sh
@@ -53,15 +53,20 @@ fi
 # 3. Infer type from labels
 LABELS=$(jq -r '.labels[].name' <<<"$ISSUE_JSON")
 TYPE=""
-for candidate in feature fix chore refactor test docs perf; do
+for candidate in feature fix chore refactor test docs perf performance; do
   if grep -qx "$candidate" <<<"$LABELS"; then
     TYPE="$candidate"
     break
   fi
 done
+# Normalize label aliases to canonical branch-prefix types: the repo uses the
+# `performance` label, but the branch/type prefix convention is `perf`.
+if [[ "$TYPE" == "performance" ]]; then
+  TYPE="perf"
+fi
 if [[ -z "$TYPE" ]]; then
   echo "ERROR: issue #$ISSUE has no recognized type label" >&2
-  echo "(expected one of: feature, fix, chore, refactor, test, docs, perf)." >&2
+  echo "(expected one of: feature, fix, chore, refactor, test, docs, perf/performance)." >&2
   echo "Labels found: $LABELS" >&2
   exit 1
 fi


### PR DESCRIPTION
Landed from the 2026-06-20 workflow-friction-audit (5 logged entries, grouped into 4 fixes):

1. **`pickup-issue.sh` rejected the `performance` label** — its type loop only matched `perf`, so every performance-labelled issue failed pickup (hit on #1248). Now accepts `performance` and normalizes it to the `perf` branch-prefix type.
2. **`gh pr edit` no-ops on Projects-classic deprecation** — the step-8 PR-body marker bump now uses `gh api -X PATCH repos/$REPO/pulls/<pr>` instead of `gh pr edit` (which fetches the deprecated `projectCards` field and silently leaves the body unchanged).
3. **Local pre-push lint gate too narrow** (2 entries) — SKILL.md step 5 now says to run `uv run pre-commit run --all-files` before pushing, matching CI's `pre-commit` job (commit-with-hooks only checks changed files).
4. **pnpm overrides authoritative file** — `frontend/CLAUDE.md` notes overrides live in `pnpm-workspace.yaml`, not `package.json`, under pnpm v11.

No code/behavior change — skill scripts + docs only.