### PR TITLE
Additional-target consent prompt: difficulty + combat-risk parity (follow-up #1177)

### DIFF
--- a/docs/roadmap/rp-scenes.md
+++ b/docs/roadmap/rp-scenes.md
@@ -51,7 +51,7 @@ The core RP experience — how players interact in scenes. Arx II replaces arcan
 - **Frontend:** ActionPanel, ConsentPrompt, PersonaContextMenu components
 - **Constants:** SceneActionRequestStatus, SceneActionType
 
-### Multi-Target Action Consent (#572 follow-ups) — DONE (#1177, #1178)
+### Multi-Target Action Consent (#572 follow-ups) — DONE (#1177, #1178, #1259)
 
 Two follow-ups from the #572 multi-target dispatch foundation:
 
@@ -70,6 +70,13 @@ Two follow-ups from the #572 multi-target dispatch foundation:
     every 5 s alongside the primary-request queue; renders amber consent cards for pending
     additional-target rows; Accept/Deny dispatches to
     `POST /api/action-requests/{id}/respond/` with `target_persona_id`.
+- **Additional-target combat-risk parity (#1259):** `SceneActionTargetSerializer` now
+  includes `combat_risk_level` (computed from the row's own target persona). `ConsentPrompt`
+  renders the combat-risk warning on additional-target cards, matching primary-target
+  behaviour. Per-target *difficulty* was deliberately **not** added — difficulty is
+  uniform cast-level, declared once by the initiator at dispatch via
+  `SceneActionRequest.difficulty_choice`. Removal of the now-vestigial primary-target
+  difficulty buttons in `ConsentPrompt` is tracked as a follow-up.
 
 ### Scene System (core)
 - **Models:** Scene (privacy_mode, summary fields), SceneParticipation, SceneSummaryRevision

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -256,7 +256,9 @@ Read-only listing of a player's pending additional-target consent rows (#1177).
 
 **Typical use:** `GET /api/action-targets/?scene={id}&status=pending` — fetched by `ConsentPrompt` every 5 seconds to surface the additional-target consent queue alongside the primary-request queue. Accepting or denying dispatches to `POST /api/action-requests/{id}/respond/` with `target_persona_id` set.
 
-**Response shape** (`SceneActionTargetSerializer`): `action_target_id`, `action_request_id`, `target_persona_id`, `status`, `initiator_persona`, `initiator_name`, `scene`, `action_key`, `action_template`, `technique`, `technique_name`, `pose_text`, `strain_commitment`, `created_at`.
+**Response shape** (`SceneActionTargetSerializer`): `action_target_id`, `action_request_id`, `target_persona_id`, `status`, `initiator_persona`, `initiator_name`, `scene`, `action_key`, `action_template`, `technique`, `technique_name`, `pose_text`, `strain_commitment`, `created_at`, `combat_risk_level`.
+
+`combat_risk_level` is computed from the row's own target persona — mirroring the primary-request field — so additional targets of a hostile AOE cast receive the same combat-risk warning in `ConsentPrompt` as the primary target does (#1259).
 
 ---
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -22785,7 +22785,7 @@ export interface components {
       readonly action_target_id: number;
       readonly action_request_id: number;
       readonly target_persona_id: number;
-      status?: components['schemas']['Status307Enum'];
+      readonly status: components['schemas']['Status307Enum'];
       readonly initiator_persona: number;
       readonly initiator_name: string;
       readonly scene: number;
@@ -22794,6 +22794,14 @@ export interface components {
       readonly technique: number | null;
       /** @description Human label for the enhancing technique (mirrors the request serializer). */
       readonly technique_name: string | null;
+      /**
+       * @description Risk level of the encounter this additional target would be pulled into (#1259).
+       *
+       *     Mirrors SceneActionRequestSerializer.get_combat_risk_level, re-keyed on the
+       *     row's own target_persona so each additional target of a hostile AOE cast gets
+       *     its own informed-consent warning.
+       */
+      readonly combat_risk_level: string | null;
       readonly pose_text: string;
       readonly strain_commitment: number;
       /** Format: date-time */

--- a/frontend/src/scenes/actionTypes.ts
+++ b/frontend/src/scenes/actionTypes.ts
@@ -274,5 +274,6 @@ export interface PendingActionTarget {
   technique_name: string | null;
   pose_text: string;
   strain_commitment: number;
+  combat_risk_level?: string | null;
   created_at: string;
 }

--- a/frontend/src/scenes/components/ConsentPrompt.test.tsx
+++ b/frontend/src/scenes/components/ConsentPrompt.test.tsx
@@ -311,4 +311,33 @@ describe('ConsentPrompt', () => {
       })
     );
   });
+
+  it('shows the combat-risk warning on an additional target pulled into a fight', async () => {
+    vi.mocked(fetchPendingRequests).mockResolvedValue({ results: [] });
+    vi.mocked(fetchPendingTargets).mockResolvedValue({
+      results: [
+        {
+          action_target_id: 1,
+          action_request_id: 10,
+          target_persona_id: 5,
+          status: 'pending',
+          initiator_persona: 2,
+          initiator_name: 'Caster',
+          scene: 1,
+          action_key: '',
+          action_template: null,
+          technique: 7,
+          technique_name: 'Firestorm',
+          pose_text: '',
+          strain_commitment: 0,
+          combat_risk_level: 'lethal',
+          created_at: '2026-06-20T00:00:00Z',
+        },
+      ],
+    });
+
+    render(<ConsentPrompt sceneId="1" />, { wrapper: createWrapper() });
+
+    expect(await screen.findByText(/LETHAL risk/i)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/scenes/components/ConsentPrompt.tsx
+++ b/frontend/src/scenes/components/ConsentPrompt.tsx
@@ -146,6 +146,12 @@ export function ConsentPrompt({ sceneId }: Props) {
                 {t.initiator_name} is committing {t.strain_commitment} strain.
               </p>
             )}
+            {t.combat_risk_level && (
+              <p className="mt-1 text-xs font-semibold text-red-600 dark:text-red-400">
+                The fight before you is {t.combat_risk_level.toUpperCase()} risk — accepting wades
+                your character into the combat encounter.
+              </p>
+            )}
           </div>
           <div className="flex items-center gap-1.5">
             <Button

--- a/src/schema.json
+++ b/src/schema.json
@@ -41190,7 +41190,9 @@ components:
           type: integer
           readOnly: true
         status:
-          $ref: '#/components/schemas/Status307Enum'
+          allOf:
+          - $ref: '#/components/schemas/Status307Enum'
+          readOnly: true
         initiator_persona:
           type: integer
           readOnly: true
@@ -41217,6 +41219,16 @@ components:
           description: Human label for the enhancing technique (mirrors the request
             serializer).
           readOnly: true
+        combat_risk_level:
+          type: string
+          nullable: true
+          description: |-
+            Risk level of the encounter this additional target would be pulled into (#1259).
+
+            Mirrors SceneActionRequestSerializer.get_combat_risk_level, re-keyed on the
+            row's own target_persona so each additional target of a hostile AOE cast gets
+            its own informed-consent warning.
+          readOnly: true
         pose_text:
           type: string
           readOnly: true
@@ -41232,11 +41244,13 @@ components:
       - action_request_id
       - action_target_id
       - action_template
+      - combat_risk_level
       - created_at
       - initiator_name
       - initiator_persona
       - pose_text
       - scene
+      - status
       - strain_commitment
       - target_persona_id
       - technique

--- a/src/world/scenes/action_serializers.py
+++ b/src/world/scenes/action_serializers.py
@@ -494,6 +494,7 @@ class SceneActionTargetSerializer(serializers.ModelSerializer):
         source="action_request.technique_id", read_only=True, allow_null=True
     )
     technique_name = serializers.SerializerMethodField()
+    combat_risk_level = serializers.SerializerMethodField()
     pose_text = serializers.CharField(source="action_request.pose_text", read_only=True)
     strain_commitment = serializers.IntegerField(
         source="action_request.strain_commitment", read_only=True
@@ -504,6 +505,23 @@ class SceneActionTargetSerializer(serializers.ModelSerializer):
         """Human label for the enhancing technique (mirrors the request serializer)."""
         technique = obj.action_request.technique
         return technique.name if technique is not None else None
+
+    def get_combat_risk_level(self, obj: SceneActionTarget) -> str | None:
+        """Risk level of the encounter this additional target would be pulled into (#1259).
+
+        Mirrors SceneActionRequestSerializer.get_combat_risk_level, re-keyed on the
+        row's own target_persona so each additional target of a hostile AOE cast gets
+        its own informed-consent warning.
+        """
+        request = obj.action_request
+        if obj.status != ActionRequestStatus.PENDING or not request.is_standalone_cast:
+            return None
+        if request.technique is None or not is_technique_hostile(request.technique):
+            return None
+        encounter = encounter_requiring_risk_acknowledgement(
+            request.scene, obj.target_persona.character_sheet
+        )
+        return encounter.risk_level if encounter is not None else None
 
     class Meta:
         model = SceneActionTarget
@@ -519,6 +537,24 @@ class SceneActionTargetSerializer(serializers.ModelSerializer):
             "action_template",
             "technique",
             "technique_name",
+            "combat_risk_level",
+            "pose_text",
+            "strain_commitment",
+            "created_at",
+        ]
+        read_only_fields = [
+            "action_target_id",
+            "action_request_id",
+            "target_persona_id",
+            "status",
+            "initiator_persona",
+            "initiator_name",
+            "scene",
+            "action_key",
+            "action_template",
+            "technique",
+            "technique_name",
+            "combat_risk_level",
             "pose_text",
             "strain_commitment",
             "created_at",

--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -450,7 +450,9 @@ class SceneActionTargetViewSet(viewsets.ReadOnlyModelViewSet):
                 "action_request__initiator_persona",
                 "action_request__scene",
                 "action_request__technique",
+                "action_request__technique__effect_type",
                 "target_persona",
+                "target_persona__character_sheet",
             )
             .order_by("-action_request__created_at", "id")
         )

--- a/src/world/scenes/tests/test_scene_action_request_serializer.py
+++ b/src/world/scenes/tests/test_scene_action_request_serializer.py
@@ -6,9 +6,16 @@ from django.utils import timezone
 from world.combat.constants import EncounterStatus, EncounterType, RiskLevel
 from world.combat.models import CombatEncounter
 from world.scenes.action_constants import ActionRequestStatus
-from world.scenes.action_serializers import SceneActionRequestSerializer
+from world.scenes.action_serializers import (
+    SceneActionRequestSerializer,
+    SceneActionTargetSerializer,
+)
 from world.scenes.cast_services import request_technique_cast
-from world.scenes.factories import SceneActionRequestFactory
+from world.scenes.factories import (
+    PersonaFactory,
+    SceneActionRequestFactory,
+    SceneActionTargetFactory,
+)
 from world.scenes.models import Scene
 from world.scenes.tests.cast_test_helpers import (
     CastScenarioMixin,
@@ -103,4 +110,81 @@ class SceneActionRequestSerializerRiskLevelTests(CastScenarioMixin):
         cast.request.save()
 
         data = SceneActionRequestSerializer(instance=cast.request).data
+        self.assertIsNone(data["combat_risk_level"])
+
+
+class SceneActionTargetSerializerRiskLevelTests(CastScenarioMixin):
+    """combat_risk_level surfaces per additional-target row, keyed on that row's persona (#1259).
+
+    Mirrors the primary-request behaviour: only a PENDING additional target of a
+    hostile standalone cast, whose own character still owes a risk acknowledgement,
+    carries a level.
+    """
+
+    scene: Scene
+
+    def _make_encounter(self, risk_level: str) -> CombatEncounter:
+        return CombatEncounter.objects.create(
+            room=self.scene.location,
+            scene=self.scene,
+            status=EncounterStatus.BETWEEN_ROUNDS,
+            risk_level=risk_level,
+            encounter_type=EncounterType.PARTY_COMBAT,
+        )
+
+    def _hostile_cast(self):
+        technique = make_hostile_castable_technique()
+        grant_technique(self.caster, technique)
+        return request_technique_cast(
+            scene=self.scene,
+            initiator_persona=self.caster,
+            target_persona=self.target,
+            technique=technique,
+        )
+
+    def test_pending_additional_target_serializes_encounter_risk_level(self) -> None:
+        """LETHAL feedable encounter + additional target of a gated hostile cast → 'lethal'."""
+        self._make_encounter(RiskLevel.LETHAL)
+        cast = self._hostile_cast()
+        extra = PersonaFactory()
+        row = SceneActionTargetFactory(action_request=cast.request, target_persona=extra)
+
+        data = SceneActionTargetSerializer(instance=row).data
+        self.assertEqual(data["combat_risk_level"], RiskLevel.LETHAL.value)
+
+    def test_pending_benign_additional_target_serializes_none(self) -> None:
+        """A benign (non-hostile) cast's additional target carries no risk level."""
+        self._make_encounter(RiskLevel.LETHAL)
+        technique = make_benign_castable_technique()
+        grant_technique(self.caster, technique)
+        cast = request_technique_cast(
+            scene=self.scene,
+            initiator_persona=self.caster,
+            target_persona=self.target,
+            technique=technique,
+        )
+        row = SceneActionTargetFactory(action_request=cast.request, target_persona=PersonaFactory())
+
+        data = SceneActionTargetSerializer(instance=row).data
+        self.assertIsNone(data["combat_risk_level"])
+
+    def test_resolved_additional_target_serializes_none(self) -> None:
+        """A RESOLVED additional-target row never advertises a risk level."""
+        self._make_encounter(RiskLevel.LETHAL)
+        cast = self._hostile_cast()
+        row = SceneActionTargetFactory(
+            action_request=cast.request,
+            target_persona=PersonaFactory(),
+            status=ActionRequestStatus.RESOLVED,
+        )
+
+        data = SceneActionTargetSerializer(instance=row).data
+        self.assertIsNone(data["combat_risk_level"])
+
+    def test_additional_target_with_no_gating_encounter_serializes_none(self) -> None:
+        """No feedable encounter in the scene → no risk level for the additional target."""
+        cast = self._hostile_cast()
+        row = SceneActionTargetFactory(action_request=cast.request, target_persona=PersonaFactory())
+
+        data = SceneActionTargetSerializer(instance=row).data
         self.assertIsNone(data["combat_risk_level"])


### PR DESCRIPTION
Closes #1259

## Summary

Adds combat-risk parity to the additional-target consent prompt (follow-up #1177). A new `combat_risk_level` field on `SceneActionTargetSerializer` re-keys the existing `encounter_requiring_risk_acknowledgement` engine onto each additional-target row, and `ConsentPrompt` renders the same red "this fight is X risk" warning on additional-target cards that the primary card already shows — so a player pulled into a dangerous encounter by a hostile AOE cast gives informed consent. Pure read-path reuse: no model change, no migration.

Gap 1 (per-target difficulty) was resolved by design with no code: difficulty is uniform cast-level, declared once at dispatch via `SceneActionRequest.difficulty_choice`. Code verification during design found the primary target's accept-time difficulty picker is itself non-functional (the value is dropped by `respondToRequest`), tracked as follow-up #1275.

## Follow-ups filed

- #1275

## Notes

- Spec: reviewed & approved on #1259 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto latest origin/main (clean, 3 commits replayed); regenerated api-types after sync — no schema drift.

<!-- last-addressed-comment: 0 -->