### PR TITLE
Converge build_crossing_world onto a renown-bearing threshold default

### DIFF
--- a/src/world/magic/tests/majora_fixtures.py
+++ b/src/world/magic/tests/majora_fixtures.py
@@ -28,6 +28,7 @@ from world.magic.factories import IntensityTierFactory
 from world.mechanics.constants import EngagementType
 from world.mechanics.engagement import CharacterEngagement
 from world.progression.models import CharacterPathHistory
+from world.societies.constants import RenownMagnitude, RenownReach, RenownRisk
 
 
 def build_majora_world(  # noqa: PLR0913 — fixture knobs are keyword-only by design
@@ -116,6 +117,12 @@ def build_majora_world(  # noqa: PLR0913 — fixture knobs are keyword-only by d
         requires_active_audere=True,
         vision_text=vision_text,
         manifestation_text=manifestation_text,
+        # Renown-bearing default so a crossing mints a deed, converging with
+        # ``ensure_audere_majora_threshold`` (#1205). ``fire_renown_award`` only
+        # mints a LegendEntry when risk != NONE.
+        magnitude=RenownMagnitude.HIGH,
+        risk=RenownRisk.HIGH,
+        reach=RenownReach.REGIONAL,
     )
 
     prospect_path = PathFactory(name=f"Prospect_{boundary_level}{suffix}", stage=PathStage.PROSPECT)

--- a/src/world/magic/tests/test_audere_majora_deed.py
+++ b/src/world/magic/tests/test_audere_majora_deed.py
@@ -21,16 +21,8 @@ from world.magic.tests.majora_fixtures import build_crossing_world
 from world.scenes.constants import PersonaType
 from world.scenes.factories import SceneFactory
 from world.scenes.models import Persona
-from world.societies.constants import DeedKnowledgeSource, RenownMagnitude, RenownReach, RenownRisk
+from world.societies.constants import DeedKnowledgeSource
 from world.societies.models import PersonaDeedKnowledge
-
-
-def _set_deed_risk(threshold) -> None:
-    """Stamp non-NONE renown fields on a threshold so a crossing mints a legend deed."""
-    threshold.risk = RenownRisk.HIGH
-    threshold.magnitude = RenownMagnitude.HIGH
-    threshold.reach = RenownReach.REGIONAL
-    threshold.save(update_fields=["risk", "magnitude", "reach"])
 
 
 class MintCrossingDeedWithWitnessesTests(TestCase):
@@ -48,8 +40,6 @@ class MintCrossingDeedWithWitnessesTests(TestCase):
             cls.puissant_path,
             cls.offer,
         ) = build_crossing_world(boundary_level=30, suffix="_deed_mint")
-        _set_deed_risk(cls.threshold)
-
         # Active scene at the crosser's location.
         cls.scene = SceneFactory(location=cls.character.location, is_active=True)
 
@@ -99,8 +89,6 @@ class MintCrossingDeedWitnessesRecordedTests(TestCase):
             cls.puissant_path,
             cls.offer,
         ) = build_crossing_world(boundary_level=31, suffix="_deed_wit")
-        _set_deed_risk(cls.threshold)
-
         # Scene at the crosser's location.
         cls.scene = SceneFactory(location=cls.character.location, is_active=True)
 
@@ -168,8 +156,6 @@ class MintCrossingDeedNoPrimaryPersonaTests(TestCase):
             cls.puissant_path,
             cls.offer,
         ) = build_crossing_world(boundary_level=32, suffix="_deed_nopersona")
-        _set_deed_risk(cls.threshold)
-
         # Remove the PRIMARY persona so _mint_crossing_deed hits the no-op branch.
         Persona.objects.filter(character_sheet=cls.sheet, persona_type=PersonaType.PRIMARY).delete()
         # Bust the cached_property.
@@ -203,7 +189,6 @@ class MintCrossingDeedNoSceneTests(TestCase):
             cls.puissant_path,
             cls.offer,
         ) = build_crossing_world(boundary_level=33, suffix="_deed_noscene")
-        _set_deed_risk(cls.threshold)
         # Deliberately no active scene at cls.character.location.
 
     def test_deed_minted_with_zero_witnesses(self):
@@ -237,7 +222,6 @@ class ResolveOfferAcceptMintsDeedE2ETests(TestCase):
             cls.chosen_path,
             cls.offer,
         ) = build_crossing_world(boundary_level=34, suffix="_deed_e2e")
-        _set_deed_risk(cls.threshold)
 
     def test_resolve_accept_mints_deed_end_to_end(self):
         result = resolve_audere_majora_offer(


### PR DESCRIPTION
Closes #1205

## Summary

Converge the Audere Majora test-fixture builders on a single renown-bearing threshold default (#1205). `build_majora_world` (which `build_crossing_world` delegates to) now authors non-NONE renown fields (`magnitude=HIGH, risk=HIGH, reach=REGIONAL`) on the `AudereMajoraThreshold` it creates, matching the sibling `ensure_audere_majora_threshold` factory helper. Because `fire_renown_award` only mints a `LegendEntry` when `risk != NONE`, every deed test previously had to locally stamp risk via the `_set_deed_risk` bridge helper; that bridge and its five call sites are now removed. Test-only change — no production code, models, or docs affected. Verified no caller depends on the prior no-deed/NONE path.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1205 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: Branch was up to date with origin/main; no conflicts.

<!-- last-addressed-comment: 0 -->