### PR TITLE
Plummet/catch polish: catcher-in-chasm landing, approach-arg fallback, trigger-name constant (post-#1228)

### DIFF
--- a/docs/systems/areas.md
+++ b/docs/systems/areas.md
@@ -327,9 +327,12 @@ through `_dispatch_immediate_challenge`, since `is_declaration_open` is False in
 round), then translates the graded outcome through `resolve_catch(faller, catcher,
 resolution_result)`:
 
-- **clean catch** (a SUCCESS check outcome, or any `ResolutionType.DESTROY` resolution):
-  `end_plummet(faller, caught=True)` (no impact) **and** `force_move_to_position(faller, ...)`
-  to the catcher's safe non-CHASM position;
+- **clean catch** (a SUCCESS check outcome, or any `ResolutionType.DESTROY` resolution): set
+  the faller down on the catcher's safe non-CHASM position, or — when the catcher is themselves
+  in a CHASM and has none — fall back to the room's PRIMARY ground (`_primary_landing_for`,
+  mirroring `leave_aerial`'s ground fallback), then `end_plummet`. `caught` reflects whether the
+  faller was actually placed, so a caught faller is never left in the pit while the narration
+  claims a safe landing (#1284);
 - **partial** (a neutral / zero-success outcome that did not destroy the challenge): soften —
   decrement the accumulated `Plummeting` `ConditionInstance.severity` (floored at 0) — but let
   the descent continue;

--- a/src/world/areas/positioning/constants.py
+++ b/src/world/areas/positioning/constants.py
@@ -38,3 +38,10 @@ FLY_CAPABILITY_NAME: str = "fly"
 TELEPORT_CAPABILITY_NAME: str = "teleport"
 TELEKINESIS_CAPABILITY_NAME: str = "telekinesis"
 ACROBATICS_CAPABILITY_NAME: str = "acrobatics"
+
+
+# FELL → plummet wiring identity key (#1228). Shared by the room-owned
+# TriggerDefinition and its FlowDefinition (both named ``fall_to_plummet``),
+# seeded by ``wire_fall_triggers`` and located by ``install_fall_triggers``.
+# Hoisted here so the trigger/flow name has a single source of truth (#1284).
+FALL_TRIGGER_NAME: str = "fall_to_plummet"

--- a/src/world/areas/positioning/factories.py
+++ b/src/world/areas/positioning/factories.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import factory
 import factory.django
 
-from world.areas.positioning.constants import PositionKind
+from world.areas.positioning.constants import FALL_TRIGGER_NAME, PositionKind
 from world.areas.positioning.models import (
     BlueprintEdge,
     BlueprintPosition,
@@ -269,7 +269,7 @@ def _build_plummet_flow() -> object:
     from flows.factories import FlowStepDefinitionFactory
     from flows.models import FlowDefinition
 
-    flow, _ = FlowDefinition.objects.get_or_create(name="fall_to_plummet")
+    flow, _ = FlowDefinition.objects.get_or_create(name=FALL_TRIGGER_NAME)
     if not flow.steps.exists():
         FlowStepDefinitionFactory(
             flow=flow,
@@ -291,7 +291,7 @@ class FallToPlummetTriggerDefinitionFactory(factory.django.DjangoModelFactory):
         model = "flows.TriggerDefinition"
         django_get_or_create = ("name",)
 
-    name = "fall_to_plummet"
+    name = FALL_TRIGGER_NAME
     event_name = "fell"  # EventName.FELL value
     flow_definition = factory.LazyFunction(_build_plummet_flow)
     priority = 50

--- a/src/world/areas/positioning/plummet.py
+++ b/src/world/areas/positioning/plummet.py
@@ -31,6 +31,7 @@ from django.conf import settings
 from world.areas.positioning.constants import (
     CATCH_THE_FALLER_NAME,
     FALL_DAMAGE_TYPE_NAME,
+    FALL_TRIGGER_NAME,
     PLUMMETING_CONDITION_NAME,
 )
 
@@ -254,6 +255,22 @@ def _safe_position_for(catcher: ObjectDB) -> Position | None:  # noqa: OBJECTDB_
     return pos
 
 
+def _primary_landing_for(faller: ObjectDB) -> Position | None:  # noqa: OBJECTDB_PARAM
+    """The PRIMARY ground position of the faller's room, or None.
+
+    Mirrors ``leave_aerial``'s ground fallback: a CHASM's vertical stack bottoms
+    out at the room's PRIMARY position, so it is the natural place to set a caught
+    faller down when the catcher offers no safe position of their own.
+    """
+    from world.areas.positioning.constants import PositionKind  # noqa: PLC0415
+    from world.areas.positioning.models import Position  # noqa: PLC0415
+
+    room = faller.location
+    if room is None:
+        return None
+    return Position.objects.filter(room=room, kind=PositionKind.PRIMARY).first()
+
+
 def resolve_catch(
     faller: ObjectDB,  # noqa: OBJECTDB_PARAM
     catcher: ObjectDB,  # noqa: OBJECTDB_PARAM
@@ -286,10 +303,15 @@ def resolve_catch(
     if is_clean_catch:
         from world.areas.positioning.services import force_move_to_position  # noqa: PLC0415
 
-        end_plummet(faller, caught=True)
-        safe = _safe_position_for(catcher)
-        if safe is not None:
-            force_move_to_position(faller, safe)
+        # Prefer the catcher's own safe spot; if the catcher is themselves in a
+        # CHASM (no safe position), set the faller down on the room's PRIMARY
+        # ground instead of leaving them in the pit. ``caught`` then reflects
+        # whether the faller was actually placed safely, so the narration stays
+        # honest even in the pathological no-safe-position-anywhere case (#1284).
+        landing = _safe_position_for(catcher) or _primary_landing_for(faller)
+        if landing is not None:
+            force_move_to_position(faller, landing)
+        end_plummet(faller, caught=landing is not None)
         return
 
     if success_level == 0:
@@ -358,17 +380,20 @@ _ERR_NO_CATCH_APPROACH = "No catch approach is available to this catcher for thi
 
 
 def _select_catch_action(catch_actions: list[AvailableAction], approach: str) -> AvailableAction:
-    """Pick the catch AvailableAction matching *approach* (capability name)."""
+    """Pick the catch AvailableAction matching *approach* (capability name).
+
+    Matches on the capability behind the approach's ``ChallengeApproach``
+    (``application.capability.name``), which is always populated, rather than the
+    ``capability_source.capability_name`` — that is empty for condition-sourced
+    capabilities, so source-name matching would silently return the wrong approach
+    when a catcher qualifies for several (#1284).
+    """
     for action in catch_actions:
-        source = action.capability_source
-        if source is not None and source.capability_name == approach:
+        approach_row = action.resolved_challenge_approach
+        if approach_row is not None and approach_row.application.capability.name == approach:
             return action
-    # Fall back to the first available catch action when the name does not match
-    # (e.g. condition-sourced sources carry an empty capability_name).
+    # Fall back to the first available catch action when the name does not match.
     return catch_actions[0]
-
-
-FALL_TRIGGER_NAME = "fall_to_plummet"
 
 
 def install_fall_triggers(room: ObjectDB) -> None:  # noqa: OBJECTDB_PARAM

--- a/src/world/areas/positioning/tests/test_catch_action.py
+++ b/src/world/areas/positioning/tests/test_catch_action.py
@@ -183,6 +183,29 @@ class CatchActionTests(TestCase):
             "clean catch should clear the bound catch challenge",
         )
 
+    def test_resolve_catch_catcher_in_chasm_lands_faller_on_primary(self) -> None:
+        # The catcher is themselves standing in the CHASM, so they have no safe
+        # position. The clean catch must still set the faller down somewhere safe
+        # (the room's PRIMARY ground) rather than leaving them in the pit while
+        # the narration claims they were set down safely (#1284 / M2).
+        self._start_plummet()
+        force_move_to_position(self.catcher, self.top_chasm)
+        result = self._result_for(success_level=1, resolution_type=ResolutionType.DESTROY)
+
+        resolve_catch(self.faller, self.catcher, result)
+
+        self.assertFalse(self._is_plummeting(), "clean catch should end the plummet")
+        self.assertEqual(
+            position_of(self.faller),
+            self.ground,
+            "faller must fall back to the room's PRIMARY position, not stay in the chasm",
+        )
+        self.assertNotEqual(
+            position_of(self.faller).kind,
+            PositionKind.CHASM,
+            "a 'caught' faller must never be left in the chasm",
+        )
+
     def test_resolve_catch_partial_softens_but_continues(self) -> None:
         self._start_plummet()
         # Pre-accumulate some depth so the decrement is observable.
@@ -277,3 +300,49 @@ class CatchActionTests(TestCase):
         catcher_actions = get_available_actions(self.catcher, self.room)
         catcher_catch = [a for a in catcher_actions if a.challenge_name == "Catch the Faller"]
         self.assertTrue(catcher_catch, "the telekinetic catcher is offered the catch approach")
+
+
+class SelectCatchActionTests(TestCase):
+    """``_select_catch_action`` honors the requested approach (#1284 / M3).
+
+    Condition-sourced capabilities carry an empty ``capability_source.capability_name``,
+    so the selector must identify the approach by the capability behind its
+    ``ChallengeApproach`` (``application.capability.name``) — not the source name —
+    or it silently returns the wrong approach when a catcher qualifies for several.
+
+    Pure stubs, no DB: the selector only reads ``capability_source`` and
+    ``resolved_challenge_approach.application.capability.name``.
+    """
+
+    @staticmethod
+    def _action(capability_name: str, *, source_name: str):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            capability_source=SimpleNamespace(capability_name=source_name),
+            resolved_challenge_approach=SimpleNamespace(
+                application=SimpleNamespace(capability=SimpleNamespace(name=capability_name))
+            ),
+        )
+
+    def test_matches_requested_approach_when_source_name_is_empty(self) -> None:
+        from world.areas.positioning.plummet import _select_catch_action
+
+        # Both sources are condition-granted → empty capability_name; the requested
+        # approach is NOT the first in the list, so the old [0] fallback would miss.
+        telekinesis = self._action("telekinesis", source_name="")
+        acrobatics = self._action("acrobatics", source_name="")
+
+        chosen = _select_catch_action([telekinesis, acrobatics], "acrobatics")
+
+        self.assertIs(chosen, acrobatics, "selector must honor the requested approach")
+
+    def test_falls_back_to_first_action_when_no_approach_matches(self) -> None:
+        from world.areas.positioning.plummet import _select_catch_action
+
+        fly = self._action("fly", source_name="")
+        teleport = self._action("teleport", source_name="")
+
+        chosen = _select_catch_action([fly, teleport], "telekinesis")
+
+        self.assertIs(chosen, fly, "unmatched approach falls back to the first available action")


### PR DESCRIPTION
Closes #1284

## Summary

Three deferred polish items from #1228's whole-branch review, all in `positioning/plummet.py` — no correctness blockers, all small robustness/quality fixes:

- **M2 — catcher-in-chasm landing.** `resolve_catch` now falls back to the room's PRIMARY ground (`_primary_landing_for`, mirroring `leave_aerial`) when the catcher is themselves in a CHASM and has no safe position, instead of leaving a "caught" faller in the pit while the narration claims a safe landing. `caught=` now reflects whether the faller was actually placed, keeping the narration honest.
- **M3 — approach-arg matching.** `_select_catch_action` matches the requested approach by its `ChallengeApproach` capability (`application.capability.name`, always populated) instead of the often-empty `capability_source.capability_name`, so a multi-capability catcher no longer silently falls back to the wrong approach.
- **M4 — trigger-name constant.** Hoisted `FALL_TRIGGER_NAME` into `positioning/constants.py` (single source of truth for the `fall_to_plummet` trigger/flow identity); used by `plummet.py` and `factories.py`.

## Tests
- New: catcher-in-chasm landing test (M2) + two `_select_catch_action` selector unit tests (M3).
- Catch suite (10 tests) green on the PG parity tier; trigger-install suite (4 tests) green; selector unit tests green on the fast tier.

## Docs
- `docs/systems/areas.md` clean-catch bullet updated for the PRIMARY-ground fallback and honest `caught=` semantics.

## Notes
Design step skipped: tech-debt with a fully-prescriptive issue body (explicit per-item fixes + Done-when checklist), so the issue body served as the spec.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1284 (in the issue body)
- Brainstorm/plan: skipped (tech-debt; issue body was a complete prescriptive spec)
- Sync-with-main: Rebased onto origin/main cleanly; no conflicts.

<!-- last-addressed-comment: 0 -->