### PR TITLE
Wire the block lift-clear cron (#1278)

### DIFF
--- a/src/world/game_clock/CLAUDE.md
+++ b/src/world/game_clock/CLAUDE.md
@@ -52,6 +52,7 @@ Tasks registered in `tasks.py` via `register_all_tasks()`, called at server star
 | Relationship weekly reset | daily sweep | relationships |
 | Form expiration cleanup | hourly | forms |
 | Condition expiration cleanup | hourly | conditions |
+| Block finalize (lifted-block clear) | hourly | scenes (#1278) |
 
 ## API Endpoints
 

--- a/src/world/game_clock/tasks.py
+++ b/src/world/game_clock/tasks.py
@@ -349,6 +349,17 @@ def register_all_tasks() -> None:
         )
     )
 
+    from world.scenes.tasks import block_finalize_task
+
+    register_task(
+        CronDefinition(
+            task_key="scenes.block_finalize",
+            callable=block_finalize_task,
+            interval=timedelta(hours=1),
+            description="Finalize player blocks whose lift grace period has elapsed (#1278).",
+        )
+    )
+
     from world.projects.services import scan_active_projects
 
     register_task(

--- a/src/world/scenes/tasks.py
+++ b/src/world/scenes/tasks.py
@@ -1,0 +1,22 @@
+"""Periodic task definitions for the scenes app."""
+
+from __future__ import annotations
+
+import logging
+
+from django.utils import timezone
+
+from world.scenes.block_services import finalize_expired_blocks
+
+logger = logging.getLogger("world.scenes.tasks")
+
+
+def block_finalize_task() -> None:
+    """Finalize blocks whose lift grace period has elapsed (#1278).
+
+    A lifted block stays active until ``pending_removal_at`` (set to a future cron tick), so a
+    player can't lift → snipe → re-block. This sweep removes the ones whose grace window has now
+    passed.
+    """
+    removed = finalize_expired_blocks(now=timezone.now())
+    logger.info("Block finalize: %d lifted blocks removed", removed)

--- a/src/world/scenes/tests/test_block_cron.py
+++ b/src/world/scenes/tests/test_block_cron.py
@@ -1,0 +1,36 @@
+"""The block-finalize cron task (#1278): removes blocks whose lift grace period has elapsed."""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from evennia_extensions.factories import AccountFactory
+from evennia_extensions.models import PlayerData
+from world.scenes.factories import PersonaFactory
+from world.scenes.models import Block
+from world.scenes.tasks import block_finalize_task
+
+
+class BlockFinalizeTaskTests(TestCase):
+    def _block(self, **kwargs):
+        owner = PlayerData.objects.get_or_create(account=AccountFactory())[0]
+        blocked = PlayerData.objects.get_or_create(account=AccountFactory())[0]
+        return Block.objects.create(
+            owner=owner,
+            blocked_player=blocked,
+            blocker_persona=PersonaFactory(),
+            blocked_persona=PersonaFactory(),
+            **kwargs,
+        )
+
+    def test_finalizes_only_blocks_past_their_grace_window(self) -> None:
+        active = self._block()  # never lifted
+        lifting = self._block(pending_removal_at=timezone.now() + timedelta(hours=1))  # in grace
+        expired = self._block(pending_removal_at=timezone.now() - timedelta(minutes=1))  # elapsed
+
+        block_finalize_task()
+
+        assert Block.objects.filter(pk=active.pk).exists()
+        assert Block.objects.filter(pk=lifting.pk).exists()
+        assert not Block.objects.filter(pk=expired.pk).exists()


### PR DESCRIPTION
The block lift-clear cron for #1278. `finalize_expired_blocks` (shipped in #1290) now runs on a
schedule, so a lifted block actually gets cleaned up after its grace window.

## What changed
- **`world/scenes/tasks.py`** — `block_finalize_task` → `finalize_expired_blocks(now)`.
- Registered in **`game_clock.register_all_tasks`** as `scenes.block_finalize` (hourly interval,
  alongside the other expiration-cleanup tasks).

## Why the grace window
Lifting a block sets `pending_removal_at` to a future tick; the block stays active until then, so
nobody can lift → get a last word in → re-block. This sweep removes the ones whose window has
passed.

Independent of #1291 (uses the already-merged `finalize_expired_blocks`).

## Tests
Active + in-grace + elapsed blocks — only the elapsed one is finalized. `game_clock` suite green
(registration intact). Wired-tasks doc updated.

Refs #1278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
