### PR TITLE
Enforce scene privacy↔room-publicness invariant globally (follow-up to #1236)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -534,7 +534,8 @@ Roleplay session recording with participant tracking, interaction logging, perso
   - `broadcast_scene_message(scene, action)` — pushes scene state to participants via WebSocket.
   - `ensure_scene_for_location(room, privacy_mode=None)` (`place_services.py`) — find-or-create the
     active scene for a room. Returns the existing active scene unchanged (caller's `privacy_mode`
-    ignored on reuse); creates a new scene with `privacy_mode` (defaults to PUBLIC) otherwise.
+    ignored on reuse); when creating, derives `privacy_mode` from the room when omitted —
+    PUBLIC if publicly listed, else PRIVATE.
   - `ensure_scene_participation(scene, character)` (`interaction_services.py`) — create a
     `SceneParticipation` for the character's account in the scene if one does not already exist.
     Public API consumed by combat to record fighters as first-class scene participants.
@@ -559,6 +560,10 @@ Roleplay session recording with participant tracking, interaction logging, perso
 - **Frontend:** `ConsentPrompt` polls both `GET /api/action-requests/?scene={id}&status=pending`
   and `GET /api/action-targets/?scene={id}&status=pending` every 5 s and renders amber consent cards for
   each; additional-target accepts/denies pass `target_persona_id` to the shared respond endpoint.
+- **Privacy ↔ room-publicness invariant (#1287):** a Scene in a publicly-listed room must be PUBLIC;
+  `Scene.save()`/`clean()` enforce this via `_validate_privacy_against_room()`;
+  `ensure_scene_for_location` derives the default. Shared helper: `room_is_publicly_listed(room)`
+  in `evennia_extensions/models.py`. See [scenes.md](scenes.md) §"Scene Privacy ↔ Room-Publicness Invariant".
 - **Integrates with:** roster (characters), stories (EpisodeScene join), instances (preservation check),
   flows (auto-logging via message_location), combat (encounter read gate + participation convergence via
   `Scene.objects.viewable_by` / `ensure_scene_participation`),

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -194,6 +194,14 @@ sceneless — the `scene__isnull=True` branch in `Interaction.objects.visible_to
 (`world/scenes/managers.py`) treats them as public-visible and this is intentional,
 unchanged behaviour.
 
+**Events obey the invariant:** `start_event` (`world/events/services.py`) enforces
+the same rule at the events chokepoint. `Event.is_public` is *calendar visibility*
+(a different axis from `RoomProfile.is_public`, which governs room listing). When
+`start_event` derives `privacy_mode` as PRIVATE (i.e. the event is not public on
+the calendar), it checks `event.location.is_public`; if the room is publicly listed,
+it raises `EventError.PRIVATE_IN_PUBLIC_ROOM` before the `Scene` is created. The
+`Scene.save()` guard remains the backstop for any path that bypasses this chokepoint.
+
 **Out of scope:**
 
 - No retroactive re-derivation: if a room's `is_public` flag flips *after* a scene

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -142,11 +142,66 @@ from world.scenes.place_services import ensure_scene_for_location
 
 # Find or create the active scene for a room.  If an active scene already
 # exists the caller's privacy_mode is ignored and the existing scene is
-# returned unchanged.  When a new scene is created, privacy_mode is applied
-# (defaults to PUBLIC when omitted).  Used by combat encounter-start to
-# guarantee every encounter carries a scene.
+# returned unchanged.  When a new scene is created, privacy_mode is derived
+# from the room when omitted — PUBLIC if the room is publicly listed, else
+# PRIVATE.  Used by combat encounter-start to guarantee every encounter
+# carries a scene.
 scene = ensure_scene_for_location(room, privacy_mode=ScenePrivacyMode.PRIVATE)
 ```
+
+### Scene Privacy ↔ Room-Publicness Invariant (#1287)
+
+**The rule (one-directional):** a `Scene` whose `location` is a publicly-listed
+room **must** have `privacy_mode == PUBLIC`. Hosting a PRIVATE or EPHEMERAL scene
+in a space anyone can enter would allow RP-leak. The constraint is one-directional:
+scenes in non-public rooms, scenes with no location, and scenes in rooms that lack
+a `RoomProfile` are completely unconstrained.
+
+**Publicness test:** a room is "publicly listed" when
+`room.room_profile.is_public` is `True`. A missing `RoomProfile` is treated as
+not-public (fail-closed), so unconfigured rooms impose no constraint.
+
+**EPHEMERAL is stricter than PRIVATE.** Both PRIVATE and EPHEMERAL are forbidden
+in publicly-listed rooms; the rule blocks anything that is not PUBLIC.
+
+**Two enforcement points:**
+
+1. `ensure_scene_for_location(room)` (`place_services.py`) — when `privacy_mode`
+   is omitted, the default is derived from the room: `PUBLIC` if
+   `room_is_publicly_listed(room)`, else `PRIVATE`. This is the creation
+   chokepoint; callers that pass an explicit mode get no derivation, but the
+   `Scene.save()` guard (below) will still fire if the mode violates the invariant.
+
+2. `Scene._validate_privacy_against_room()` wired into both `Scene.save()` and
+   `Scene.clean()` — raises `ValidationError({"privacy_mode": "..."})` when a
+   non-PUBLIC scene has a publicly-listed-room `location`. Every ORM `save()`
+   call, including serializer `.save()`, hits this guard.
+
+**Shared helper:**
+
+```python
+from evennia_extensions.models import room_is_publicly_listed
+
+room_is_publicly_listed(room) -> bool
+# Returns room.room_profile.is_public, or False when the RoomProfile is absent.
+# Single source of truth consumed by Scene validation and ensure_scene_for_location.
+```
+
+**Sceneless-interaction reconciliation:** the invariant governs scenes that
+*exist*. Combat no longer creates null-scene encounters (every encounter now
+carries a required scene). However, non-scene interactions legitimately remain
+sceneless — the `scene__isnull=True` branch in `Interaction.objects.visible_to`
+(`world/scenes/managers.py`) treats them as public-visible and this is intentional,
+unchanged behaviour.
+
+**Out of scope:**
+
+- No retroactive re-derivation: if a room's `is_public` flag flips *after* a scene
+  has been created, existing scenes are not automatically updated. The guard fires
+  only at `save()` / `clean()` time on the `Scene` instance itself.
+- `bulk_create` bypasses `save()` and therefore bypasses the guard. Do not use
+  `Scene.objects.bulk_create` to create scenes without manually enforcing the
+  invariant.
 
 ```python
 from world.scenes.interaction_services import ensure_scene_participation

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -194,13 +194,23 @@ sceneless — the `scene__isnull=True` branch in `Interaction.objects.visible_to
 (`world/scenes/managers.py`) treats them as public-visible and this is intentional,
 unchanged behaviour.
 
-**Events obey the invariant:** `start_event` (`world/events/services.py`) enforces
-the same rule at the events chokepoint. `Event.is_public` is *calendar visibility*
-(a different axis from `RoomProfile.is_public`, which governs room listing). When
-`start_event` derives `privacy_mode` as PRIVATE (i.e. the event is not public on
-the calendar), it checks `event.location.is_public`; if the room is publicly listed,
-it raises `EventError.PRIVATE_IN_PUBLIC_ROOM` before the `Scene` is created. The
-`Scene.save()` guard remains the backstop for any path that bypasses this chokepoint.
+**Events obey the invariant:** The rule is enforced at config time (create/edit)
+and at start time. `Event.is_public` is *calendar visibility* (a different axis
+from `RoomProfile.is_public`, which governs room listing).
+
+*Config time:* `Event.clean()` (wired into the admin ModelForm) and
+`_EventScheduleMixin.validate()` (shared by `EventCreateSerializer` and
+`EventUpdateSerializer`) both reject a private event (`is_public=False`) whose
+`location.is_public` is `True`. This means a GM cannot save or submit a private
+event for a publicly-listed room — they hit the error at create or edit, not at
+start.
+
+*Start time:* `start_event` (`world/events/services.py`) enforces the rule again
+as the events chokepoint. When `start_event` derives `privacy_mode` as PRIVATE
+(i.e. the event is not public on the calendar), it checks `event.location.is_public`;
+if the room is publicly listed, it raises `EventError.PRIVATE_IN_PUBLIC_ROOM` before
+the `Scene` is created. The `Scene.save()` guard remains the final backstop for any
+path that bypasses both chokepoints.
 
 **Out of scope:**
 

--- a/src/evennia_extensions/models.py
+++ b/src/evennia_extensions/models.py
@@ -6,6 +6,7 @@ This app extends Evennia's core models rather than replacing them.
 from typing import Union
 
 from allauth.account.models import EmailAddress
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.utils.functional import cached_property
 from evennia.accounts.models import AccountDB
@@ -340,6 +341,18 @@ class PlayerAllowList(SharedMemoryModel):
 # superseded by the persona-aware ``world.scenes.Block`` (block resolution lives there with the
 # Persona FKs it needs). ``PlayerAllowList`` (above) stays — it's the allow/friends list, now wired
 # by the #1271 privacy tiers.
+
+
+def room_is_publicly_listed(room: ObjectDB) -> bool:
+    """Whether a room appears in public listings. Missing RoomProfile -> not public.
+
+    Single source of truth for the scene privacy<->room-publicness invariant:
+    consumed by Scene validation, ensure_scene_for_location, and combat duels.
+    """
+    try:
+        return room.room_profile.is_public
+    except ObjectDoesNotExist:
+        return False
 
 
 class RoomProfile(SharedMemoryModel):

--- a/src/evennia_extensions/tests/test_room_profile.py
+++ b/src/evennia_extensions/tests/test_room_profile.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from evennia_extensions.factories import RoomProfileFactory
+from evennia_extensions.factories import ObjectDBFactory, RoomProfileFactory
 
 
 class RoomProfileIsOutdoorTests(TestCase):
@@ -57,3 +57,33 @@ class RoomProfileDefaultBlueprintTests(TestCase):
         rp.flush_from_cache()
         rp.refresh_from_db()
         self.assertIsNone(rp.default_blueprint_id)
+
+
+class TestRoomIsPubliclyListed(TestCase):
+    def _room(self):
+        return ObjectDBFactory(
+            db_key="Helper Room",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+
+    def test_public_profile_returns_true(self) -> None:
+        from evennia_extensions.models import room_is_publicly_listed
+
+        room = self._room()  # at_object_creation auto-creates profile, is_public defaults True
+        self.assertTrue(room_is_publicly_listed(room))
+
+    def test_non_public_profile_returns_false(self) -> None:
+        from evennia_extensions.models import room_is_publicly_listed
+
+        room = self._room()
+        room.room_profile.is_public = False
+        room.room_profile.save()
+        self.assertFalse(room_is_publicly_listed(room))
+
+    def test_missing_profile_returns_false(self) -> None:
+        from evennia_extensions.models import room_is_publicly_listed
+
+        room = self._room()
+        room.room_profile.delete()
+        room.refresh_from_db()
+        self.assertFalse(room_is_publicly_listed(room))

--- a/src/world/combat/duels.py
+++ b/src/world/combat/duels.py
@@ -47,22 +47,10 @@ if TYPE_CHECKING:
 _PVP_PARTICIPANT_COUNT = 2  # two PC participants = PvP
 
 
-def _room_is_public(room: ObjectDB) -> bool:
-    """Whether a room is publicly listed. Missing profile -> not public."""
-    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
-
-    try:
-        return room.room_profile.is_public
-    except ObjectDoesNotExist:
-        return False
-
-
 def _scene_for_duel(room: ObjectDB) -> Scene:
-    from world.scenes.constants import ScenePrivacyMode  # noqa: PLC0415
     from world.scenes.place_services import ensure_scene_for_location  # noqa: PLC0415
 
-    privacy = ScenePrivacyMode.PUBLIC if _room_is_public(room) else ScenePrivacyMode.PRIVATE
-    return ensure_scene_for_location(room, privacy_mode=privacy)
+    return ensure_scene_for_location(room)
 
 
 def assert_duel_lethality_valid(encounter: CombatEncounter) -> None:

--- a/src/world/events/models.py
+++ b/src/world/events/models.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
@@ -83,6 +84,18 @@ class Event(SharedMemoryModel):
     @property
     def is_upcoming(self) -> bool:
         return self.status == EventStatus.SCHEDULED
+
+    def _validate_privacy_against_room(self) -> None:
+        if self.is_public:
+            return
+        if self.location_id is not None and self.location.is_public:
+            raise ValidationError(
+                {"is_public": "A private event cannot be held in a publicly-listed room."}
+            )
+
+    def clean(self) -> None:
+        super().clean()
+        self._validate_privacy_against_room()
 
     # These cached_property methods serve as fallbacks when instances are accessed
     # outside the ViewSet (admin, shell, service functions). The ViewSet uses

--- a/src/world/events/serializers.py
+++ b/src/world/events/serializers.py
@@ -130,6 +130,21 @@ class _EventScheduleMixin:
             raise serializers.ValidationError(msg)
         return value
 
+    def validate(self, attrs: dict) -> dict:
+        attrs = super().validate(attrs)
+        is_public = attrs.get("is_public")  # noqa: STRING_LITERAL
+        if is_public is None:
+            is_public = self.instance.is_public if self.instance is not None else True
+        if "location" in attrs:  # noqa: STRING_LITERAL
+            location = attrs.get("location")  # noqa: STRING_LITERAL
+        else:
+            location = self.instance.location if self.instance is not None else None
+        if not is_public and location is not None and location.is_public:
+            raise serializers.ValidationError(
+                {"is_public": "A private event cannot be held in a publicly-listed room."}  # noqa: STRING_LITERAL
+            )
+        return attrs
+
 
 class EventUpdateSerializer(_EventScheduleMixin, serializers.ModelSerializer):
     """Serializer for updating events. Only mutable fields are writable."""

--- a/src/world/events/services.py
+++ b/src/world/events/services.py
@@ -145,11 +145,19 @@ def start_event(event: Event) -> Event:
     """Transition an event from SCHEDULED to ACTIVE and create a linked Scene.
 
     The Scene is created at the event's location with the event's name.
-    Privacy mode auto-derived: public events get public scenes, private events
-    get private scenes. Applies room description overlay if configured.
+    Privacy mode auto-derived: public events get public scenes; private events
+    require a non-public room (``Event.is_public`` is calendar visibility,
+    distinct from ``RoomProfile.is_public`` which governs room listing).
+    Starting a private event in a publicly-listed room is rejected with
+    ``EventError.PRIVATE_IN_PUBLIC_ROOM``. Applies room description overlay
+    if configured.
 
     Wraps scene creation + status update in a transaction. Uses
     select_for_update to prevent duplicate scenes from concurrent requests.
+
+    Raises:
+        EventError: If the event is not SCHEDULED, or if a private event is
+            attempted in a publicly-listed room.
     """
     with transaction.atomic():
         event = Event.objects.select_for_update().get(pk=event.pk)
@@ -157,6 +165,8 @@ def start_event(event: Event) -> Event:
             raise EventError(EventError.START_INVALID)
 
         privacy = ScenePrivacyMode.PUBLIC if event.is_public else ScenePrivacyMode.PRIVATE
+        if privacy != ScenePrivacyMode.PUBLIC and event.location.is_public:
+            raise EventError(EventError.PRIVATE_IN_PUBLIC_ROOM)
         Scene.objects.create(
             name=event.name,
             location=event.location.objectdb,

--- a/src/world/events/tests/test_models.py
+++ b/src/world/events/tests/test_models.py
@@ -184,6 +184,34 @@ class EventHostSocietyTest(TestCase):
         self.assertIsNone(row["host_society_id"])
 
 
+class EventCleanPrivacyTest(TestCase):
+    """Event.clean() rejects a private event in a publicly-listed room."""
+
+    def test_clean_raises_for_private_event_in_public_room(self) -> None:
+        event = EventFactory(is_public=False)
+        event.location.is_public = True
+        event.location.save()
+
+        with self.assertRaises(ValidationError) as ctx:
+            event.clean()
+
+        self.assertIn("is_public", ctx.exception.message_dict)
+
+    def test_clean_passes_for_public_event_in_public_room(self) -> None:
+        event = EventFactory(is_public=True)
+        event.location.is_public = True
+        event.location.save()
+
+        event.clean()  # must not raise
+
+    def test_clean_passes_for_private_event_in_non_public_room(self) -> None:
+        event = EventFactory(is_public=False)
+        event.location.is_public = False
+        event.location.save()
+
+        event.clean()  # must not raise
+
+
 class EventModificationModelTest(TestCase):
     def test_str(self) -> None:
         mod = EventModificationFactory()

--- a/src/world/events/tests/test_serializers.py
+++ b/src/world/events/tests/test_serializers.py
@@ -1,0 +1,107 @@
+"""Tests for event serializers — focus on config-time privacy validation."""
+
+from django.test import TestCase
+from django.utils import timezone
+
+from world.events.factories import EventFactory
+from world.events.serializers import EventCreateSerializer, EventUpdateSerializer
+
+
+def _future_dt(days: int = 1) -> str:
+    dt = timezone.now() + timezone.timedelta(days=days)
+    return dt.isoformat()
+
+
+class EventCreateSerializerPrivacyTest(TestCase):
+    """EventCreateSerializer rejects a private event in a publicly-listed room."""
+
+    def _base_payload(self, location_id: int) -> dict:
+        return {
+            "name": "Test Event",
+            "description": "A description.",
+            "location": location_id,
+            "is_public": True,
+            "scheduled_real_time": _future_dt(1),
+            "scheduled_ic_time": _future_dt(3),
+        }
+
+    def test_invalid_when_private_event_in_public_room(self) -> None:
+        """A private event whose location is publicly listed must fail validation."""
+        event = EventFactory()
+        event.location.is_public = True
+        event.location.save()
+
+        payload = self._base_payload(event.location.pk)
+        payload["is_public"] = False
+
+        serializer = EventCreateSerializer(data=payload)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("is_public", serializer.errors)
+
+    def test_valid_when_public_event_in_public_room(self) -> None:
+        """A public event in a publicly-listed room is fine."""
+        event = EventFactory()
+        event.location.is_public = True
+        event.location.save()
+
+        payload = self._base_payload(event.location.pk)
+        payload["is_public"] = True
+
+        serializer = EventCreateSerializer(data=payload)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_valid_when_private_event_in_non_public_room(self) -> None:
+        """A private event in a non-public room is fine."""
+        event = EventFactory()
+        event.location.is_public = False
+        event.location.save()
+
+        payload = self._base_payload(event.location.pk)
+        payload["is_public"] = False
+
+        serializer = EventCreateSerializer(data=payload)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+
+class EventUpdateSerializerPrivacyTest(TestCase):
+    """EventUpdateSerializer rejects flipping is_public=False when room is public."""
+
+    def test_invalid_when_flipping_to_private_in_public_room(self) -> None:
+        """Updating is_public=False on an event in a public room must fail."""
+        event = EventFactory(is_public=True)
+        event.location.is_public = True
+        event.location.save()
+
+        serializer = EventUpdateSerializer(
+            instance=event,
+            data={"is_public": False},
+            partial=True,
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("is_public", serializer.errors)
+
+    def test_valid_when_keeping_public_in_public_room(self) -> None:
+        """Updating is_public=True on a public room event is fine."""
+        event = EventFactory(is_public=True)
+        event.location.is_public = True
+        event.location.save()
+
+        serializer = EventUpdateSerializer(
+            instance=event,
+            data={"is_public": True},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_valid_when_flipping_to_private_in_non_public_room(self) -> None:
+        """Updating is_public=False on an event in a non-public room is fine."""
+        event = EventFactory(is_public=True)
+        event.location.is_public = False
+        event.location.save()
+
+        serializer = EventUpdateSerializer(
+            instance=event,
+            data={"is_public": False},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)

--- a/src/world/events/tests/test_services.py
+++ b/src/world/events/tests/test_services.py
@@ -139,8 +139,9 @@ class EventLifecycleTest(TestCase):
     def test_start_private_event_in_public_room_rejected(self) -> None:
         event = EventFactory(status=EventStatus.SCHEDULED, is_public=False)
         # event.location.is_public defaults True (publicly listed)
-        with self.assertRaises(EventError):
+        with self.assertRaises(EventError) as ctx:
             start_event(event)
+        self.assertEqual(ctx.exception.user_message, EventError.PRIVATE_IN_PUBLIC_ROOM)
         self.assertFalse(Scene.objects.filter(event=event).exists())
         event.refresh_from_db()
         self.assertEqual(event.status, EventStatus.SCHEDULED)  # transaction rolled back

--- a/src/world/events/tests/test_services.py
+++ b/src/world/events/tests/test_services.py
@@ -130,9 +130,20 @@ class EventLifecycleTest(TestCase):
 
     def test_start_private_event_creates_private_scene(self) -> None:
         event = EventFactory(status=EventStatus.SCHEDULED, is_public=False)
+        event.location.is_public = False
+        event.location.save()
         start_event(event)
         scene = Scene.objects.get(event=event)
         self.assertEqual(scene.privacy_mode, ScenePrivacyMode.PRIVATE)
+
+    def test_start_private_event_in_public_room_rejected(self) -> None:
+        event = EventFactory(status=EventStatus.SCHEDULED, is_public=False)
+        # event.location.is_public defaults True (publicly listed)
+        with self.assertRaises(EventError):
+            start_event(event)
+        self.assertFalse(Scene.objects.filter(event=event).exists())
+        event.refresh_from_db()
+        self.assertEqual(event.status, EventStatus.SCHEDULED)  # transaction rolled back
 
     def test_start_already_active_raises(self) -> None:
         event = EventFactory(status=EventStatus.SCHEDULED)

--- a/src/world/events/types.py
+++ b/src/world/events/types.py
@@ -14,6 +14,7 @@ _EVENT_ERROR_MESSAGES: dict[str, str] = {
     "INVITE_ACTIVE": "Cannot invite to an event that is active or finished.",
     "INVITE_MODIFY_ACTIVE": "Cannot modify invitations on an active or finished event.",
     "INVITE_DUPLICATE": "This target is already invited.",
+    "PRIVATE_IN_PUBLIC_ROOM": "A private event cannot be held in a publicly-listed room.",
 }
 
 
@@ -36,6 +37,7 @@ class EventError(Exception):
     INVITE_ACTIVE = _EVENT_ERROR_MESSAGES["INVITE_ACTIVE"]
     INVITE_MODIFY_ACTIVE = _EVENT_ERROR_MESSAGES["INVITE_MODIFY_ACTIVE"]
     INVITE_DUPLICATE = _EVENT_ERROR_MESSAGES["INVITE_DUPLICATE"]
+    PRIVATE_IN_PUBLIC_ROOM = _EVENT_ERROR_MESSAGES["PRIVATE_IN_PUBLIC_ROOM"]
 
     @property
     def user_message(self) -> str:

--- a/src/world/scenes/models.py
+++ b/src/world/scenes/models.py
@@ -164,6 +164,36 @@ class Scene(CachedPropertiesMixin, SharedMemoryModel):
             return True
         return any(p.account_id == account.pk for p in self.participations_cached)
 
+    def _validate_privacy_against_room(self) -> None:
+        """Enforce the scene privacy<->room-publicness invariant (#1287).
+
+        A publicly-listed room may host only PUBLIC scenes; PRIVATE/EPHEMERAL
+        scenes leak in a space anyone can enter. No location, a room with no
+        RoomProfile, and non-public rooms are unconstrained. One-directional.
+        See docs/systems/scenes.md.
+        """
+        from evennia_extensions.models import room_is_publicly_listed  # noqa: PLC0415
+
+        if self.location_id is None or self.privacy_mode == ScenePrivacyMode.PUBLIC:
+            return
+        if room_is_publicly_listed(self.location):
+            raise ValidationError(
+                {
+                    "privacy_mode": (
+                        f"A {self.get_privacy_mode_display()} scene cannot be held "
+                        "in a publicly-listed room; only PUBLIC scenes are allowed there."
+                    )
+                }
+            )
+
+    def clean(self) -> None:
+        super().clean()
+        self._validate_privacy_against_room()
+
+    def save(self, *args: object, **kwargs: object) -> None:
+        self._validate_privacy_against_room()
+        super().save(*args, **kwargs)
+
     def finish_scene(self) -> None:
         """Mark the scene as finished and stop recording new messages"""
         if not self.is_finished:

--- a/src/world/scenes/place_services.py
+++ b/src/world/scenes/place_services.py
@@ -24,12 +24,13 @@ def ensure_scene_for_location(
 
     If an active scene already exists for the room, returns it (its existing
     privacy is preserved; ``privacy_mode`` is ignored). Otherwise creates a new
-    scene with ``privacy_mode`` (defaulting to PUBLIC when not supplied).
+    scene with ``privacy_mode`` (derived from the room when not supplied).
 
     Args:
         room: The room to ensure a scene for.
         name: Optional name for a new scene. Defaults to room name.
-        privacy_mode: Privacy for a newly-created scene. Defaults to PUBLIC.
+        privacy_mode: Privacy for a newly-created scene. When omitted, derived
+            from the room — PUBLIC if publicly listed, else PRIVATE.
 
     Returns:
         The active Scene for this room.
@@ -38,11 +39,18 @@ def ensure_scene_for_location(
     if existing is not None:
         return existing
 
+    if privacy_mode is None:
+        from evennia_extensions.models import room_is_publicly_listed  # noqa: PLC0415
+
+        privacy_mode = (
+            ScenePrivacyMode.PUBLIC if room_is_publicly_listed(room) else ScenePrivacyMode.PRIVATE
+        )
+
     scene_name = name or f"Scene at {room.key}"
     scene = Scene.objects.create(
         name=scene_name,
         location=room,
-        privacy_mode=privacy_mode or ScenePrivacyMode.PUBLIC,
+        privacy_mode=privacy_mode,
     )
 
     # Auto-engage Durance covenant for room occupants when a new scene starts (Slice B §4.10)

--- a/src/world/scenes/serializers.py
+++ b/src/world/scenes/serializers.py
@@ -183,6 +183,31 @@ class SceneListSerializer(serializers.ModelSerializer):
             seen[persona.pk] = persona
         return list(seen.values())
 
+    def validate(self, attrs: dict) -> dict:
+        attrs = super().validate(attrs)
+        privacy_mode = attrs.get("privacy_mode") or (
+            self.instance.privacy_mode if self.instance is not None else None
+        )
+        location = attrs.get("location") or (
+            self.instance.location if self.instance is not None else None
+        )
+        if (
+            location is not None
+            and privacy_mode is not None
+            and privacy_mode != ScenePrivacyMode.PUBLIC
+        ):
+            from evennia_extensions.models import room_is_publicly_listed  # noqa: PLC0415
+
+            if room_is_publicly_listed(location):
+                raise serializers.ValidationError(
+                    {
+                        "privacy_mode": (
+                            "A non-public scene cannot be created in a publicly-listed room."
+                        )
+                    }
+                )
+        return attrs
+
     def get_is_owner(self, obj):
         request = self.context.get("request")
         if request and request.user.is_authenticated:

--- a/src/world/scenes/tests/test_interaction_services.py
+++ b/src/world/scenes/tests/test_interaction_services.py
@@ -663,6 +663,11 @@ class TestEphemeralInteraction(TestCase):
             db_key="Private Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )
+        # Ephemeral scenes are inherently private; the privacy↔room-publicness
+        # invariant (#1287) forbids them in a publicly-listed room, so this
+        # private room must not be publicly listed.
+        room.room_profile.is_public = False
+        room.room_profile.save()
         char_a = CharacterFactory(db_key="Alice", location=room)
         char_b = CharacterFactory(db_key="Bob", location=room)
         identity_a = CharacterSheetFactory(character=char_a)

--- a/src/world/scenes/tests/test_place_services.py
+++ b/src/world/scenes/tests/test_place_services.py
@@ -43,6 +43,8 @@ class TestEnsureSceneForLocation(TestCase):
             db_key="PrivTest",
             db_typeclass_path="typeclasses.rooms.Room",
         )
+        room.room_profile.is_public = False
+        room.room_profile.save()
         scene = ensure_scene_for_location(room, privacy_mode=ScenePrivacyMode.PRIVATE)
         self.assertEqual(scene.privacy_mode, ScenePrivacyMode.PRIVATE)
 

--- a/src/world/scenes/tests/test_place_services.py
+++ b/src/world/scenes/tests/test_place_services.py
@@ -66,6 +66,24 @@ class TestEnsureSceneForLocation(TestCase):
         self.assertEqual(first.pk, second.pk)
         self.assertEqual(second.privacy_mode, ScenePrivacyMode.PUBLIC)
 
+    def test_default_derives_public_in_public_room(self) -> None:
+        room = ObjectDBFactory(
+            db_key="PubDerive",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )  # default profile is_public=True
+        scene = ensure_scene_for_location(room)
+        self.assertEqual(scene.privacy_mode, ScenePrivacyMode.PUBLIC)
+
+    def test_default_derives_private_in_non_public_room(self) -> None:
+        room = ObjectDBFactory(
+            db_key="PrivDerive",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        room.room_profile.is_public = False
+        room.room_profile.save()
+        scene = ensure_scene_for_location(room)
+        self.assertEqual(scene.privacy_mode, ScenePrivacyMode.PRIVATE)
+
 
 class TestJoinPlace(TestCase):
     def test_join_creates_presence(self) -> None:

--- a/src/world/scenes/tests/test_scene_privacy_invariant.py
+++ b/src/world/scenes/tests/test_scene_privacy_invariant.py
@@ -1,0 +1,56 @@
+"""Scene privacy<->room-publicness invariant (#1287)."""
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from evennia_extensions.factories import ObjectDBFactory
+from world.scenes.constants import ScenePrivacyMode
+from world.scenes.models import Scene
+
+
+class TestScenePrivacyInvariant(TestCase):
+    def _room(self, *, public: bool):
+        room = ObjectDBFactory(
+            db_key="Invariant Room",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        if not public:
+            room.room_profile.is_public = False
+            room.room_profile.save()
+        return room
+
+    def test_private_scene_in_public_room_raises(self) -> None:
+        room = self._room(public=True)
+        with self.assertRaises(ValidationError):
+            Scene.objects.create(name="Leak", location=room, privacy_mode=ScenePrivacyMode.PRIVATE)
+
+    def test_ephemeral_scene_in_public_room_raises(self) -> None:
+        room = self._room(public=True)
+        with self.assertRaises(ValidationError):
+            Scene.objects.create(
+                name="Leak", location=room, privacy_mode=ScenePrivacyMode.EPHEMERAL
+            )
+
+    def test_public_scene_in_public_room_ok(self) -> None:
+        room = self._room(public=True)
+        scene = Scene.objects.create(
+            name="Fine", location=room, privacy_mode=ScenePrivacyMode.PUBLIC
+        )
+        self.assertEqual(scene.privacy_mode, ScenePrivacyMode.PUBLIC)
+
+    def test_private_scene_in_non_public_room_ok(self) -> None:
+        room = self._room(public=False)
+        scene = Scene.objects.create(
+            name="Chambers", location=room, privacy_mode=ScenePrivacyMode.PRIVATE
+        )
+        self.assertEqual(scene.privacy_mode, ScenePrivacyMode.PRIVATE)
+
+    def test_private_scene_without_location_ok(self) -> None:
+        scene = Scene.objects.create(name="Floating", privacy_mode=ScenePrivacyMode.PRIVATE)
+        self.assertIsNone(scene.location_id)
+
+    def test_clean_also_raises(self) -> None:
+        room = self._room(public=True)
+        scene = Scene(name="Leak", location=room, privacy_mode=ScenePrivacyMode.PRIVATE)
+        with self.assertRaises(ValidationError):
+            scene.clean()

--- a/src/world/scenes/tests/test_scene_serializers.py
+++ b/src/world/scenes/tests/test_scene_serializers.py
@@ -1,0 +1,63 @@
+"""Serializer-level privacy validation for scene create/update (#1299).
+
+Tests that SceneListSerializer (and SceneDetailSerializer which subclasses it)
+rejects a non-public privacy_mode paired with a publicly-listed room location,
+returning a 400-friendly ValidationError rather than letting the violation reach
+Scene.save() and 500.
+
+Built in setUp: Evennia ObjectDB instances are not deepcopyable so setUpTestData
+would break.
+"""
+
+from django.test import TestCase
+
+from evennia_extensions.factories import ObjectDBFactory
+from world.scenes.constants import ScenePrivacyMode
+from world.scenes.serializers import SceneDetailSerializer
+
+
+class TestSceneSerializerPrivacyValidation(TestCase):
+    """SceneDetailSerializer rejects non-public privacy_mode in a public room."""
+
+    def setUp(self) -> None:
+        self.public_room = ObjectDBFactory(
+            db_key="Public Room",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        self.private_room = ObjectDBFactory(
+            db_key="Private Room",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        self.private_room.room_profile.is_public = False
+        self.private_room.room_profile.save()
+
+    def _serializer(self, room, privacy_mode: str) -> SceneDetailSerializer:
+        return SceneDetailSerializer(
+            data={
+                "name": "Test Scene",
+                "location_id": room.pk,
+                "privacy_mode": privacy_mode,
+            }
+        )
+
+    def test_private_in_public_room_is_invalid(self) -> None:
+        """PRIVATE scene in a publicly-listed room → invalid, error on privacy_mode."""
+        s = self._serializer(self.public_room, ScenePrivacyMode.PRIVATE)
+        self.assertFalse(s.is_valid())
+        self.assertIn("privacy_mode", s.errors)
+
+    def test_ephemeral_in_public_room_is_invalid(self) -> None:
+        """EPHEMERAL scene in a publicly-listed room → invalid, error on privacy_mode."""
+        s = self._serializer(self.public_room, ScenePrivacyMode.EPHEMERAL)
+        self.assertFalse(s.is_valid())
+        self.assertIn("privacy_mode", s.errors)
+
+    def test_public_in_public_room_is_valid(self) -> None:
+        """PUBLIC scene in a publicly-listed room → valid."""
+        s = self._serializer(self.public_room, ScenePrivacyMode.PUBLIC)
+        self.assertTrue(s.is_valid(), s.errors)
+
+    def test_private_in_non_public_room_is_valid(self) -> None:
+        """PRIVATE scene in a non-public room → valid."""
+        s = self._serializer(self.private_room, ScenePrivacyMode.PRIVATE)
+        self.assertTrue(s.is_valid(), s.errors)


### PR DESCRIPTION
Closes #1287
Closes #1299
Closes #1300

## Summary

Enforces the scene privacy↔room-publicness invariant globally and fail-closed: a publicly-listed room may host only PUBLIC scenes (PRIVATE and EPHEMERAL are forbidden there); no-location, missing-RoomProfile, and non-public rooms are unconstrained (one-directional, per maintainer decision).

Delivered as:
- **Shared helper** `room_is_publicly_listed(room)` in `evennia_extensions/models.py` (missing profile → not public) — consolidates combat's private `_room_is_public`.
- **Fail-closed guard** `Scene._validate_privacy_against_room()` wired into `Scene.save()` (global catch for direct create / DRF serializer.save) and `Scene.clean()` (admin), raising `ValidationError`.
- **Room-aware default** in `ensure_scene_for_location` (derives PUBLIC if publicly listed else PRIVATE); combat duels collapse onto the chokepoint (`_room_is_public` removed).
- **Events obey the invariant**: a publicly-listed room cannot host a private/restricted event. Enforced at **start** (`start_event` → clean `EventError.PRIVATE_IN_PUBLIC_ROOM`, no more 500) **and at config time** (`Event.clean()` for admin + a shared `_EventScheduleMixin.validate()` covering event create/update → clean 400). `Event.is_public` is calendar visibility, a different axis from room listing.
- **Scene-create API** returns a clean **400 (not 500)** for a privacy-violating request (`SceneListSerializer.validate()`); the `Scene.save()` guard stays the backstop.
- Docs (`scenes.md` + INDEX) document the invariant, the EPHEMERAL/missing-profile rules, all enforcement points, and the sceneless-interaction reconciliation (sceneless interactions stay public-visible by design).

No new model/field/migration. Decisions confirmed with the maintainer; code-verified anti-reinvention ledger is in the issue spec.

## Scope note

The two originally-deferred items (#1299 the DRF 500→400, #1300 config-time event enforcement) were folded into this PR — both were the same defect class (DRF/admin write paths bypass `Model.clean()`, surfacing a privacy violation as a raw 500). They close with this PR.

## Verification

- 126 targeted-module tests green on the SQLite fast tier (scenes, events, combat duels, evennia_extensions). Full `scenes`/`combat` app suites run on CI's Postgres shard.
- `pre-commit run --all-files` clean (ruff, ty, custom linters, ESLint, TS, Prettier). No migrations (zero schema change). Residual-risk sweep confirms no other production path can construct a forbidden scene.

## Notes

- Spec: reviewed & approved on #1287 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (1d7ee157) cleanly — no conflicts, no migrations.

<!-- last-addressed-comment: 0 -->
