### PR TITLE
Apply effort modifier to technique-enhanced social actions (coordinate with #520)

### DIFF
--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -249,7 +249,10 @@ owns the full lifecycle (dispatch → consent → resolution → result recordin
   default `"medium"`). This is forwarded from `create_action_request` → stored on
   `SceneActionRequest.effort_level`. At resolution `_resolve_action_against_persona`
   reads `EFFORT_CHECK_MODIFIER[effort_level]` and adds it to the check pool, then
-  charges the initiator social fatigue via `apply_fatigue`.
+  charges the initiator social fatigue via `apply_fatigue`. This applies on **both**
+  the plain and the technique-enhanced (`_resolve_enhanced_action` → `use_technique`)
+  branches (#1293): effort is a check-roll modifier, orthogonal to the technique's
+  anima/intensity/fury levers (which scale cast power).
 - **Defender authors difficulty** via a plausibility band (`DifficultyChoice`) at consent
   time — not the initiator. The defender's choice is stored as `difficulty_choice` on
   the per-target row (`DefenderConsentFields.difficulty_choice`, default `NORMAL`).

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -449,6 +449,11 @@ def _resolve_action_against_persona(
     target_character = target_persona.character_sheet.character
     context = ResolutionContext(character=character, target=target_character)
 
+    # Effort is a check-roll modifier (not a difficulty delta) applied on BOTH the
+    # technique-enhanced and plain branches (#1293). It is orthogonal to the
+    # technique's anima/intensity/fury levers, which scale cast power; the effort
+    # cost axis is charged separately by apply_fatigue below.
+    check_modifiers = EFFORT_CHECK_MODIFIER.get(action_request.effort_level, 0)
     if action_request.technique is not None:
         result = _resolve_enhanced_action(
             character=character,
@@ -457,6 +462,7 @@ def _resolve_action_against_persona(
             action_key=action_request.action_key,
             difficulty=difficulty,
             context=context,
+            effort_modifier=check_modifiers,
             strain_commitment=action_request.strain_commitment,
             fury_commitment=action_request.fury_commitment,
             fury_anchor=action_request.fury_anchor,
@@ -466,7 +472,6 @@ def _resolve_action_against_persona(
         # technique-cast-only mechanic (spec: intensity rides power_intensity_bonus
         # inside use_technique). The serializer rejects fury_commitment_id on
         # plain actions, so fury_commitment is always None here.
-        check_modifiers = EFFORT_CHECK_MODIFIER.get(action_request.effort_level, 0)
         action_resolution = start_action_resolution(
             character=character,
             template=action_template,
@@ -683,6 +688,7 @@ def _resolve_enhanced_action(  # noqa: PLR0913
     action_key: str,
     difficulty: int,
     context: ResolutionContext,
+    effort_modifier: int = 0,
     strain_commitment: int = 0,
     fury_commitment: FuryTier | None = None,
     fury_anchor: CharacterSheet | None = None,
@@ -701,6 +707,9 @@ def _resolve_enhanced_action(  # noqa: PLR0913
         action_key: The action key (e.g. "flirt").
         difficulty: The resolved numeric difficulty.
         context: Resolution context carrying character data.
+        effort_modifier: The EFFORT_CHECK_MODIFIER for the action's effort level,
+            applied as a check-roll modifier (extra_modifiers) on the inner
+            start_action_resolution — parity with the plain/area branches (#1293).
         strain_commitment: Optional extra anima the caster commits beyond the
             technique's baseline cost. Forwarded to use_technique so the cost
             calculation accounts for the strain.
@@ -731,6 +740,7 @@ def _resolve_enhanced_action(  # noqa: PLR0913
             template=action_template,
             target_difficulty=difficulty,
             context=context,
+            extra_modifiers=effort_modifier,
         ),
         confirm_soulfray_risk=True,
         strain_commitment=strain_commitment,

--- a/src/world/scenes/tests/test_fury_threading.py
+++ b/src/world/scenes/tests/test_fury_threading.py
@@ -19,6 +19,7 @@ from actions.factories import ActionTemplateFactory
 from actions.types import PendingActionResolution, StepResult
 from world.checks.test_helpers import force_check_outcome
 from world.conditions.factories import ConditionInstanceFactory
+from world.fatigue.constants import EFFORT_CHECK_MODIFIER, EffortLevel
 from world.magic.factories import (
     BerserkConditionTemplateFactory,
     CharacterAnimaFactory,
@@ -428,3 +429,73 @@ class BerserkAppliedOnLostControlTests(TestCase):
             call_kwargs.args[1] if call_kwargs.args else call_kwargs.kwargs.get("condition")
         )
         self.assertEqual(applied_template, ConditionTemplate.get_by_name("Berserk"))
+
+
+# ---------------------------------------------------------------------------
+# #1293: effort modifier threads into the technique-enhanced check roll
+# ---------------------------------------------------------------------------
+
+
+class EffortThreadsIntoTechniqueCheckTests(TestCase):
+    """A technique-enhanced action applies EFFORT_CHECK_MODIFIER to its check roll.
+
+    Parity with the plain/area branches, which already pass the effort modifier as
+    ``extra_modifiers`` to ``start_action_resolution``. The ``use_technique`` mock
+    invokes the passed ``resolve_fn`` so the inner lambda's call is captured.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.scene, cls.initiator, cls.anchor, cls.tier, cls.cfg = _setup_fury_fixture()
+        cls.action_template = ActionTemplateFactory()
+        cls.technique = TechniqueFactory(
+            action_template=cls.action_template,
+            damage_profile=False,
+        )
+
+    def setUp(self) -> None:
+        self.accrue_patcher = patch("world.scenes.action_services.accrue")
+        self.accrue_patcher.start()
+
+    def tearDown(self) -> None:
+        self.accrue_patcher.stop()
+
+    def _extra_modifiers_for_effort(self, effort_level: str) -> int:
+        pending = _make_pending_resolution(success_level=1)
+
+        def fake_use_technique(*, resolve_fn, **_kwargs):
+            resolve_fn(power=1, ledger=None)
+            return _make_technique_use_result(pending)
+
+        request = SceneActionRequestFactory(
+            scene=self.scene,
+            initiator_persona=self.initiator,
+            target_persona=self.anchor,
+            action_key="intimidate",
+            technique=self.technique,
+            effort_level=effort_level,
+        )
+        request.action_template = self.action_template
+        request.save(update_fields=["action_template"])
+
+        with (
+            patch("world.scenes.action_services.start_action_resolution") as mock_resolve,
+            patch("world.magic.services.use_technique", side_effect=fake_use_technique),
+        ):
+            mock_resolve.return_value = pending
+            respond_to_action_request(action_request=request, decision=ConsentDecision.ACCEPT)
+
+        self.assertTrue(mock_resolve.called, "start_action_resolution was not invoked")
+        return mock_resolve.call_args.kwargs["extra_modifiers"]
+
+    def test_high_effort_threads_positive_check_modifier(self) -> None:
+        self.assertEqual(
+            self._extra_modifiers_for_effort(EffortLevel.HIGH),
+            EFFORT_CHECK_MODIFIER[EffortLevel.HIGH],
+        )
+
+    def test_very_low_effort_threads_negative_check_modifier(self) -> None:
+        self.assertEqual(
+            self._extra_modifiers_for_effort(EffortLevel.VERY_LOW),
+            EFFORT_CHECK_MODIFIER[EffortLevel.VERY_LOW],
+        )


### PR DESCRIPTION
Closes #1293

## Summary

Thread the effort check modifier (`EFFORT_CHECK_MODIFIER`) into the technique-enhanced social-action branch so effort affects technique casts the same way it already affects plain and area actions. `_resolve_action_against_persona` now computes the modifier once and passes it to both branches; `_resolve_enhanced_action` forwards it as `extra_modifiers` into the inner `start_action_resolution`. Effort is a check-roll modifier, orthogonal to the technique's anima/intensity/fury power levers, and the effort cost axis was already charged for both branches via `apply_fatigue` — so this is coherent composition, not naive stacking with #520 (closed). Adds technique-branch threading tests (high → +2, very_low → −3) and updates docs/systems/scenes.md.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1293 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main cleanly; no conflicts.

<!-- last-addressed-comment: 0 -->