### PR TITLE
Verify/harden the full covenant induction UI round-trip (draft → accept → fire)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1096,6 +1096,12 @@ These two axes are orthogonal — never re-merge them.
   `viewer_capabilities.can_invite` is true (read from the first member row of the
   `character-roles` endpoint). The induction `RitualSessionDraftDialog` sets the
   COVENANT reference so `assert_initiator_can_induct` can validate rank at draft time.
+  `RitualSessionResponseDialog` renders `candidate_only` participant fields (role picker),
+  resolves the COVENANT reference from `session.session_references` to filter the role
+  picker, and converts `emits_reference: "COVENANT_ROLE"` into a typed reference on
+  accept — completing the draft → accept-with-role → fire → `CharacterCovenantRole`
+  round-trip. Covered by `RitualInductionRoundTripTests` (backend) + `RitualSessionPages`
+  component tests (frontend).
 - **Integrates with:** magic (COVENANT_ROLE Thread anchor cap = `current_level × 10`;
   `MentorsVowRitualFactory`; `Ritual.draft_validator_path` for induction gate;
   `spend_resonance_for_imbuing` hooks `fire_subrole_discoveries` after each imbue),

--- a/docs/systems/covenants.md
+++ b/docs/systems/covenants.md
@@ -159,6 +159,29 @@ axes are orthogonal — never re-merge them.
   participant is mentor vs. sidekick based on band position, and calls
   `establish_mentor_bond`.
 
+## Induction Round-Trip
+
+The covenant induction flow is wired end-to-end through the UI:
+
+1. **Draft** — initiator opens `RitualSessionDraftDialog`; the COVENANT reference is
+   set so `assert_initiator_can_induct` can validate the initiator's rank at draft time.
+2. **Candidate accepts with role** — `RitualSessionResponseDialog` renders the
+   `candidate_only` `CovenantRolePickerField` (from `input_schema.participant_fields`),
+   resolves the COVENANT reference from `session.session_references` to populate the
+   role picker's `covenant_type` filter, and converts the `emits_reference: "COVENANT_ROLE"`
+   field value into a typed `RitualSessionReference` in the accept request's `references`
+   array.
+3. **Initiator fires** — `POST /api/magic/ritual-sessions/{id}/fire/` dispatches the
+   induction service function, which reads the COVENANT_ROLE reference and calls
+   `assign_covenant_role` to create the `CharacterCovenantRole` row.
+
+**Test coverage:** `RitualInductionRoundTripTests`
+(`src/world/magic/tests/test_session_views.py`) covers the full draft → accept-with-role
+→ fire → `CharacterCovenantRole` created backend path. Frontend component tests in
+`frontend/src/rituals/__tests__/RitualSessionPages.test.tsx` cover the role-picker
+rendering, `emits_reference` → `references` conversion on accept, and `candidate_only`
+field hiding for the initiator.
+
 ## Enums / Constants
 
 - **`MentorBondAdjusted`** (`TextChoices` in `world.covenants.constants`) —

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -22491,6 +22491,7 @@ export interface components {
       readonly created_at: string;
       readonly participants: components['schemas']['RitualSessionParticipantSummary'][];
       readonly session_references: string;
+      readonly participant_fields: string;
     };
     /**
      * @description Write-only serializer for POST /api/rituals/sessions/ (draft a session).

--- a/frontend/src/rituals/CLAUDE.md
+++ b/frontend/src/rituals/CLAUDE.md
@@ -63,6 +63,55 @@ Unit tests for the query hooks. Uses vi.fn mocks of `api.*` (no msw).
 - **Consumers:** `RitualForm` (Task 2.4), `RitualPerformDialog` (Task 2.5),
   `RitualsListPage` (Task 2.6)
 
+## Ritual Session UI (Induction and Multi-Participant Rituals)
+
+### `RitualSessionDetailPage` / `RitualSessionResponseDialog`
+
+`RitualSessionDetailPage` fetches the session via `useRitualSessionDetail` and passes
+`participantFieldsSchema` (parsed from `session.participant_fields`, the serialized
+`input_schema.participant_fields` blob) down to `RitualSessionResponseDialog`.
+
+`RitualSessionResponseDialog` handles the invitee accept / decline flow with an optional
+participant-fields form:
+
+- **`participantFieldsSchema`** prop — `RitualInputSchema | null`. When provided, Accept
+  renders a `RitualForm` for the fields the participant must fill in before accepting.
+- **`applies_to` gating** — fields with `applies_to === "candidate_only"` are hidden from
+  the session initiator (`participantId === session.initiator_id`). The `effectiveSchema`
+  reflects only the fields the current viewer should fill in.
+- **`emits_reference` conversion** — on accept, any field with `emits_reference` is NOT
+  sent in `participant_kwargs`; instead it becomes an entry in the `references` array
+  (`{ kind: emits_reference, ref_<kind>_id: value }`). Currently wired kinds:
+  `COVENANT_ROLE → ref_covenant_role_id`, `COVENANT → ref_covenant_id`.
+- **`depends_on` path resolution** — `CovenantRolePickerField` declares
+  `depends_on: "session.target_covenant.covenant_type"`. The dialog resolves this by:
+  1. Reading the `COVENANT`-kind entry from `session.session_references` (primary path).
+  2. Falling back to `session_kwargs.target_covenant` for older sessions.
+  3. Fetching `GET /api/covenants/covenants/{id}/` to get `covenant_type`.
+  4. Injecting the resolved value into `formValues` under the full
+     `"session.target_covenant.covenant_type"` key — so `CovenantRolePickerField`
+     reads it via `formValues[field.depends_on]` with no changes to the field component.
+
+### `RitualField` descriptors (extended)
+
+Two optional fields on `RitualField` gate the induction participant flow:
+
+| Field             | Type                     | Meaning                                                                                                                      |
+| ----------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `emits_reference` | `string` (ReferenceKind) | Field value is sent as a typed `RitualSessionReference` on accept (not in `participant_kwargs`). Example: `"COVENANT_ROLE"`. |
+| `applies_to`      | `string`                 | Audience gate for rendering. `"candidate_only"` hides the field from the session initiator.                                  |
+
+These are defined in `RitualField` in `types.ts` and used by `RitualSessionResponseDialog`.
+The `participant_fields` schema lives in `input_schema.participant_fields` on the backend
+`Ritual` model and is exposed by `RitualSessionDetailSerializer.participant_fields`.
+
+### Test coverage
+
+- `frontend/src/rituals/__tests__/RitualSessionPages.test.tsx` — component tests for
+  `RitualSessionResponseDialog` covering: role-picker rendering from `participantFieldsSchema`,
+  `emits_reference` → `references` conversion on accept, and `candidate_only` field hiding
+  for the initiator.
+
 ## Common Gotchas
 
 **`Ritual.input_schema` is `unknown` in the generated types.** Cast the ritual to

--- a/frontend/src/rituals/__tests__/RitualSessionPages.test.tsx
+++ b/frontend/src/rituals/__tests__/RitualSessionPages.test.tsx
@@ -21,8 +21,18 @@ import { RitualSessionInboxPage } from '../pages/RitualSessionInboxPage';
 import { RitualSessionDetailPage } from '../pages/RitualSessionDetailPage';
 import { RitualSessionDraftDialog } from '../components/RitualSessionDraftDialog';
 import { RitualSessionResponseDialog } from '../components/RitualSessionResponseDialog';
-import type { RitualWithSchema } from '../types';
+import type { RitualWithSchema, RitualInputSchema } from '../types';
 import type { RitualSessionList, RitualSessionDetail } from '../api';
+
+// ---------------------------------------------------------------------------
+// Mock apiFetch (used by CovenantRolePickerField and useTargetCovenantType)
+// ---------------------------------------------------------------------------
+
+vi.mock('@/evennia_replacements/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/evennia_replacements/api';
 
 // ---------------------------------------------------------------------------
 // Mock react-query hooks (rituals)
@@ -123,6 +133,7 @@ const sampleSessionDetail: RitualSessionDetail = {
     },
   ],
   session_references: '',
+  participant_fields: '',
 };
 
 const sampleRitual: RitualWithSchema = {
@@ -528,5 +539,140 @@ describe('RitualSessionResponseDialog', () => {
         expect.objectContaining({ onSuccess: expect.any(Function) })
       );
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Induction accept: covenant_role_picker → COVENANT_ROLE reference
+  // ---------------------------------------------------------------------------
+
+  /**
+   * participant_fields schema for a covenant induction ritual:
+   * - chosen_covenant_role: covenant_role_picker
+   *   emits_reference: "COVENANT_ROLE"
+   *   applies_to: "candidate_only"
+   *   depends_on: "session.target_covenant.covenant_type"
+   *   required: true
+   */
+  const inductionParticipantFieldsSchema: RitualInputSchema = {
+    fields: [
+      {
+        name: 'chosen_covenant_role',
+        label: 'Covenant Role',
+        type: 'covenant_role_picker',
+        emits_reference: 'COVENANT_ROLE',
+        applies_to: 'candidate_only',
+        depends_on: 'session.target_covenant.covenant_type',
+        required: true,
+      },
+    ],
+  };
+
+  const COVENANT_ID = 55;
+  const SESSION_ID = 1;
+
+  // Session with a COVENANT session-reference so the dialog can resolve covenant_type
+  const inductionSession: RitualSessionDetail = {
+    ...sampleSessionDetail,
+    id: SESSION_ID,
+    // Cast: runtime shape is reference array, generated type is string
+    session_references: [{ kind: 'COVENANT', ref_covenant_id: COVENANT_ID }] as unknown as string,
+  };
+
+  it('renders covenant role picker as candidate and accept emits COVENANT_ROLE reference', async () => {
+    // Stub apiFetch for covenant detail + roles list
+    vi.mocked(apiFetch).mockImplementation((url: string) => {
+      if (url === `/api/covenants/covenants/${COVENANT_ID}/`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ id: COVENANT_ID, covenant_type: 'DURANCE', name: 'Test Covenant' }),
+        } as Response);
+      }
+      if (url.includes('/api/covenants/roles/')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 7, name: 'Adept', covenant_type: 'DURANCE' }],
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    const acceptMutate = vi.fn();
+    mockUseAcceptRitualSession.mockReturnValue({ ...idleMutation, mutate: acceptMutate });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RitualSessionResponseDialog
+            session={inductionSession}
+            // participantId 42 is NOT the initiator (99), so candidate_only field shows
+            participantId={42}
+            open={true}
+            onOpenChange={vi.fn()}
+            participantFieldsSchema={inductionParticipantFieldsSchema}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Assertion 1: the role picker combobox renders
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+
+    // Wait for covenant_type to resolve and the roles query to load, enabling the combobox
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).not.toBeDisabled();
+    });
+
+    // Drive the Radix Select: open the dropdown and pick 'Adept'
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(await screen.findByText('Adept'));
+
+    // Click Accept (button enabled once the required field has a value)
+    await waitFor(() => {
+      expect(screen.getByTestId('accept-button')).not.toBeDisabled();
+    });
+    await userEvent.click(screen.getByTestId('accept-button'));
+
+    // Assertion 2: accept mutation was called with the COVENANT_ROLE reference
+    await waitFor(() => {
+      expect(acceptMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: SESSION_ID,
+          body: expect.objectContaining({
+            references: [{ kind: 'COVENANT_ROLE', ref_covenant_role_id: 7 }],
+          }),
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  it('hides chosen_covenant_role picker when rendered as the initiator', () => {
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    // inductionSession.initiator_id is 99; render as participant 99 (the initiator)
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <RitualSessionResponseDialog
+            session={inductionSession}
+            participantId={99}
+            open={true}
+            onOpenChange={vi.fn()}
+            participantFieldsSchema={inductionParticipantFieldsSchema}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Assertion 3: applies_to=candidate_only gate hides the picker from the initiator
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.queryByText('Covenant Role')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
+++ b/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
@@ -79,11 +79,9 @@ export interface RitualSessionResponseDialogProps {
  * but at runtime it's an array of reference objects.
  */
 function targetCovenantIdFromRefs(session: RitualSessionDetail): number | null {
-  const refs =
-    (session.session_references as unknown as Array<{
-      kind: string;
-      ref_covenant_id?: number;
-    }>) ?? [];
+  const raw = session.session_references as unknown;
+  if (!Array.isArray(raw)) return null;
+  const refs = raw as Array<{ kind: string; ref_covenant_id?: number }>;
   const covRef = refs.find((r) => r.kind === 'COVENANT' && r.ref_covenant_id != null);
   return covRef?.ref_covenant_id ?? null;
 }

--- a/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
+++ b/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
@@ -15,14 +15,23 @@
  *
  * --- depends_on path resolution ---
  * CovenantRolePickerField has `depends_on: "session.target_covenant.covenant_type"`.
- * RitualSessionDetail.session_kwargs contains `target_covenant` as a covenant PK (number).
  * We resolve this path by:
- *   1. Extracting target_covenant_id from session_kwargs (cast to unknown→Record).
+ *   1. Reading the COVENANT-kind entry from session.session_references (the primary path for
+ *      induction sessions). Falls back to extracting target_covenant from session_kwargs for
+ *      older sessions that stored it there.
  *   2. Fetching GET /api/covenants/covenants/{id}/ to get covenant_type.
  *   3. Injecting the resolved value into formValues under the full depends_on key
  *      "session.target_covenant.covenant_type" before passing to RitualForm.
  * CovenantRolePickerField reads formValues[field.depends_on] — the key is the full path
  * string, so no changes are needed to CovenantRolePickerField itself.
+ *
+ * --- applies_to gating ---
+ * Fields with applies_to === "candidate_only" are hidden from the initiator. The
+ * effectiveSchema reflects only the fields the viewer should fill in.
+ *
+ * --- emits_reference ---
+ * On accept, fields with emits_reference are sent as typed references entries (not
+ * participant_kwargs). COVENANT_ROLE → ref_covenant_role_id; COVENANT → ref_covenant_id.
  */
 
 import { useState } from 'react';
@@ -65,7 +74,22 @@ export interface RitualSessionResponseDialogProps {
 // ---------------------------------------------------------------------------
 
 /**
- * Extract the target_covenant id from session_kwargs.
+ * Resolve target_covenant id from the session-level COVENANT reference.
+ * session_references is typed as `string` in the generated schema (SerializerMethodField),
+ * but at runtime it's an array of reference objects.
+ */
+function targetCovenantIdFromRefs(session: RitualSessionDetail): number | null {
+  const refs =
+    (session.session_references as unknown as Array<{
+      kind: string;
+      ref_covenant_id?: number;
+    }>) ?? [];
+  const covRef = refs.find((r) => r.kind === 'COVENANT' && r.ref_covenant_id != null);
+  return covRef?.ref_covenant_id ?? null;
+}
+
+/**
+ * Extract the target_covenant id from session_kwargs (legacy fallback).
  * session_kwargs is typed as `unknown` in the generated schema.
  * We defensively cast and look for a `target_covenant` number field.
  */
@@ -91,8 +115,10 @@ async function fetchCovenant(id: number): Promise<Covenant> {
   return res.json() as Promise<Covenant>;
 }
 
-function useTargetCovenantType(sessionKwargs: unknown): string | null {
-  const covenantId = extractTargetCovenantId(sessionKwargs);
+function useTargetCovenantType(session: RitualSessionDetail): string | null {
+  // Prefer the session-level COVENANT reference; fall back to session_kwargs for older sessions.
+  const covenantId =
+    targetCovenantIdFromRefs(session) ?? extractTargetCovenantId(session.session_kwargs);
 
   const { data } = useQuery({
     queryKey: ['covenants', 'detail', covenantId],
@@ -130,7 +156,16 @@ export function RitualSessionResponseDialog({
   // We fetch the target covenant's type and inject it into formValues under the full
   // depends_on key. CovenantRolePickerField reads formValues[field.depends_on] which
   // is the full string "session.target_covenant.covenant_type" — so the key must match.
-  const targetCovenantType = useTargetCovenantType(session.session_kwargs);
+  const targetCovenantType = useTargetCovenantType(session);
+
+  // Gate fields by applies_to: the initiator does not see candidate_only fields.
+  const isInitiator = participantId === session.initiator_id;
+  const visibleFields = (participantFieldsSchema?.fields ?? []).filter(
+    (f) => !(f.applies_to === 'candidate_only' && isInitiator)
+  );
+  const effectiveSchema = participantFieldsSchema
+    ? { ...participantFieldsSchema, fields: visibleFields }
+    : participantFieldsSchema;
 
   /**
    * Build the formValues passed to RitualForm, injecting the resolved covenant_type
@@ -145,9 +180,7 @@ export function RitualSessionResponseDialog({
 
   function resetForm() {
     setParticipantValues(
-      participantFieldsSchema
-        ? Object.fromEntries(participantFieldsSchema.fields.map((f) => [f.name, null]))
-        : {}
+      effectiveSchema ? Object.fromEntries(effectiveSchema.fields.map((f) => [f.name, null])) : {}
     );
     acceptMutation.reset();
     declineMutation.reset();
@@ -167,11 +200,25 @@ export function RitualSessionResponseDialog({
     });
   }
 
+  // Maps emits_reference kind to the correct id key for the reference object.
+  const REF_ID_KEY: Record<string, 'ref_covenant_id' | 'ref_covenant_role_id'> = {
+    COVENANT: 'ref_covenant_id',
+    COVENANT_ROLE: 'ref_covenant_role_id',
+  };
+
   function handleAccept() {
-    // Build participant_kwargs from form values; filter out null values
+    // Split form values: fields with emits_reference become references entries;
+    // remaining non-null values go into participant_kwargs.
     const participant_kwargs: Record<string, unknown> = {};
+    const references: Array<Record<string, unknown>> = [];
+    const fieldByName = new Map((effectiveSchema?.fields ?? []).map((f) => [f.name, f]));
     for (const [k, v] of Object.entries(participantValues)) {
-      if (v !== null && v !== undefined) {
+      if (v === null || v === undefined) continue;
+      const emits = fieldByName.get(k)?.emits_reference;
+      if (emits) {
+        const idKey = REF_ID_KEY[emits];
+        if (idKey) references.push({ kind: emits, [idKey]: v });
+      } else {
         participant_kwargs[k] = v;
       }
     }
@@ -182,6 +229,7 @@ export function RitualSessionResponseDialog({
         body: {
           participant_kwargs:
             Object.keys(participant_kwargs).length > 0 ? participant_kwargs : undefined,
+          references: references.length > 0 ? references : undefined,
         },
       },
       {
@@ -193,12 +241,12 @@ export function RitualSessionResponseDialog({
     );
   }
 
-  const hasSchema = participantFieldsSchema && participantFieldsSchema.fields.length > 0;
+  const hasSchema = effectiveSchema && effectiveSchema.fields.length > 0;
 
   // Required-field validation: all required participant_fields must have a value
   const canAccept = !hasSchema
     ? true
-    : participantFieldsSchema.fields
+    : effectiveSchema.fields
         .filter((f) => f.required === true)
         .every((f) => {
           const v = participantValues[f.name];
@@ -246,7 +294,7 @@ export function RitualSessionResponseDialog({
               Your choices (required to accept):
             </p>
             <RitualForm
-              schema={participantFieldsSchema}
+              schema={effectiveSchema}
               values={formValuesWithResolved}
               onChange={setParticipantValues}
               disabled={isPending}

--- a/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
+++ b/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
@@ -34,7 +34,7 @@
  * participant_kwargs). COVENANT_ROLE → ref_covenant_role_id; COVENANT → ref_covenant_id.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -131,6 +131,16 @@ function useTargetCovenantType(session: RitualSessionDetail): string | null {
 }
 
 // ---------------------------------------------------------------------------
+// Module-level constants
+// ---------------------------------------------------------------------------
+
+/** Maps emits_reference kind to the correct id key for the reference object. */
+const REF_ID_KEY: Record<string, 'ref_covenant_id' | 'ref_covenant_role_id'> = {
+  COVENANT: 'ref_covenant_id',
+  COVENANT_ROLE: 'ref_covenant_role_id',
+};
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -142,11 +152,22 @@ export function RitualSessionResponseDialog({
   participantFieldsSchema,
   onSuccess,
 }: RitualSessionResponseDialogProps) {
+  // Gate fields by applies_to: the initiator does not see candidate_only fields.
+  // Hoisted above useState so the initial seed uses the same filtered field set.
+  const isInitiator = participantId === session.initiator_id;
+  const effectiveSchema = useMemo(() => {
+    if (!participantFieldsSchema) return participantFieldsSchema;
+    const visibleFields = participantFieldsSchema.fields.filter(
+      (f) => !(f.applies_to === 'candidate_only' && isInitiator)
+    );
+    return { ...participantFieldsSchema, fields: visibleFields };
+  }, [participantFieldsSchema, isInitiator]);
+
   const [participantValues, setParticipantValues] = useState<
     Record<string, string | number | null>
   >(() => {
-    if (!participantFieldsSchema) return {};
-    return Object.fromEntries(participantFieldsSchema.fields.map((f) => [f.name, null]));
+    if (!effectiveSchema) return {};
+    return Object.fromEntries(effectiveSchema.fields.map((f) => [f.name, null]));
   });
 
   const acceptMutation = useAcceptRitualSession();
@@ -157,15 +178,6 @@ export function RitualSessionResponseDialog({
   // depends_on key. CovenantRolePickerField reads formValues[field.depends_on] which
   // is the full string "session.target_covenant.covenant_type" — so the key must match.
   const targetCovenantType = useTargetCovenantType(session);
-
-  // Gate fields by applies_to: the initiator does not see candidate_only fields.
-  const isInitiator = participantId === session.initiator_id;
-  const visibleFields = (participantFieldsSchema?.fields ?? []).filter(
-    (f) => !(f.applies_to === 'candidate_only' && isInitiator)
-  );
-  const effectiveSchema = participantFieldsSchema
-    ? { ...participantFieldsSchema, fields: visibleFields }
-    : participantFieldsSchema;
 
   /**
    * Build the formValues passed to RitualForm, injecting the resolved covenant_type
@@ -199,12 +211,6 @@ export function RitualSessionResponseDialog({
       },
     });
   }
-
-  // Maps emits_reference kind to the correct id key for the reference object.
-  const REF_ID_KEY: Record<string, 'ref_covenant_id' | 'ref_covenant_role_id'> = {
-    COVENANT: 'ref_covenant_id',
-    COVENANT_ROLE: 'ref_covenant_role_id',
-  };
 
   function handleAccept() {
     // Split form values: fields with emits_reference become references entries;

--- a/frontend/src/rituals/pages/RitualSessionDetailPage.tsx
+++ b/frontend/src/rituals/pages/RitualSessionDetailPage.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/rituals/queries';
 import { RitualSessionResponseDialog } from '../components/RitualSessionResponseDialog';
 import type { RitualSessionDetail } from '../api';
+import type { RitualInputSchema } from '../types';
 
 // ---------------------------------------------------------------------------
 // Loading skeleton
@@ -291,6 +292,12 @@ function RitualSessionDetailInner({ sessionId }: DetailInnerProps) {
             <RitualSessionResponseDialog
               session={session}
               participantId={characterSheetId}
+              participantFieldsSchema={
+                session.participant_fields &&
+                (session.participant_fields as unknown as RitualInputSchema['fields']).length > 0
+                  ? { fields: session.participant_fields as unknown as RitualInputSchema['fields'] }
+                  : null
+              }
               open={respondOpen}
               onOpenChange={setRespondOpen}
               onSuccess={() => {

--- a/frontend/src/rituals/types.ts
+++ b/frontend/src/rituals/types.ts
@@ -40,6 +40,14 @@ export interface RitualField {
   depends_on?: string;
   /** Hint for server-side filtering when fetching options (e.g. "initiator_active_memberships"). */
   filter?: string;
+  /**
+   * When set, this field's value is emitted as a typed RitualSessionReference
+   * on accept (instead of staying in participant_kwargs). Value is a
+   * ReferenceKind, e.g. "COVENANT_ROLE".
+   */
+  emits_reference?: string;
+  /** Audience gate — e.g. "candidate_only" renders only to non-initiator participants. */
+  applies_to?: string;
 }
 
 export interface FieldProps {

--- a/src/schema.json
+++ b/src/schema.json
@@ -40614,12 +40614,16 @@ components:
         session_references:
           type: string
           readOnly: true
+        participant_fields:
+          type: string
+          readOnly: true
       required:
       - created_at
       - expires_at
       - id
       - initiator_id
       - initiator_name
+      - participant_fields
       - participants
       - participation_rule
       - proposed_terms

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -2398,6 +2398,7 @@ class CovenantInductionRitualFactory(factory.django.DjangoModelFactory):
                     "type": "covenant_role_picker",
                     "depends_on": "session.target_covenant.covenant_type",
                     "applies_to": "candidate_only",
+                    "emits_reference": "COVENANT_ROLE",
                     "required": True,
                 },
             ],

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -2885,6 +2885,7 @@ class RitualSessionDetailSerializer(serializers.ModelSerializer):
         source="participants_cached", many=True, read_only=True
     )
     session_references = serializers.SerializerMethodField()
+    participant_fields = serializers.SerializerMethodField()
 
     class Meta:
         model = RitualSession
@@ -2900,6 +2901,7 @@ class RitualSessionDetailSerializer(serializers.ModelSerializer):
             "created_at",
             "participants",
             "session_references",
+            "participant_fields",
         ]
         read_only_fields = fields
 
@@ -2934,6 +2936,14 @@ class RitualSessionDetailSerializer(serializers.ModelSerializer):
                 entry["ref_covenant_role_id"] = ref.ref_covenant_role_id
             result.append(entry)
         return result
+
+    def get_participant_fields(self, obj: object) -> list[dict[str, object]]:
+        """Return the ritual's authored participant_fields blob (or [])."""
+        schema = getattr(obj.ritual, "input_schema", None)  # noqa: GETATTR_LITERAL
+        if not isinstance(schema, dict):
+            return []
+        fields = schema.get("participant_fields", [])
+        return fields if isinstance(fields, list) else []
 
 
 # Error messages for RitualSessionDraftSerializer.

--- a/src/world/magic/tests/test_session_views.py
+++ b/src/world/magic/tests/test_session_views.py
@@ -518,6 +518,100 @@ class RitualSessionCancelTests(TestCase):
         self.assertEqual(response.status_code, 403)
 
 
+class RitualInductionRoundTripTests(TestCase):
+    """Integration: draft → candidate accepts with COVENANT_ROLE ref → fire → membership row."""
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    def test_draft_accept_fire_creates_membership(self) -> None:
+        from world.covenants.constants import CovenantType
+        from world.covenants.factories import (
+            CovenantFactory,
+            CovenantRankFactory,
+            CovenantRoleFactory,
+        )
+        from world.covenants.models import CharacterCovenantRole
+        from world.covenants.services import add_member
+
+        # --- participants ---
+        _, initiator_account, initiator_sheet = _make_tenure_with_account()
+        _, candidate_account, candidate_sheet = _make_tenure_with_account()
+
+        # --- covenant + roles (both DURANCE to match CovenantFactory default) ---
+        covenant = CovenantFactory(covenant_type=CovenantType.DURANCE)
+        initiator_role = CovenantRoleFactory(covenant_type=CovenantType.DURANCE)
+        candidate_role = CovenantRoleFactory(covenant_type=CovenantType.DURANCE)
+
+        # Pre-create the rank ladder so add_member's _ensure_base_rank picks up the
+        # member rank (highest tier = lowest authority).  The initiator will be
+        # promoted to the manager rank afterward so can_invite_to_covenant passes.
+        manager_rank = CovenantRankFactory(
+            covenant=covenant,
+            can_invite=True,
+            can_kick=True,
+            can_manage_ranks=True,
+            tier=1,
+        )
+        CovenantRankFactory(covenant=covenant, can_invite=False, tier=2)
+
+        # add_member assigns the base rank (tier=2, no can_invite).
+        initiator_ccr = add_member(
+            covenant=covenant,
+            character_sheet=initiator_sheet,
+            role=initiator_role,
+        )
+        # Promote initiator to the manager rank (can_invite=True).
+        initiator_ccr.rank = manager_rank
+        initiator_ccr.save(update_fields=["rank"])
+
+        ritual = _make_induction_ritual()
+
+        # --- step 1: initiator drafts with session-level COVENANT ref ---
+        self.client.force_authenticate(user=initiator_account)
+        draft = self.client.post(
+            "/api/magic/rituals/sessions/",
+            {
+                "ritual_id": ritual.pk,
+                "invitee_ids": [candidate_sheet.pk],
+                "session_references": [{"kind": "COVENANT", "ref_covenant_id": covenant.pk}],
+                "expires_at": _future_dt(),
+            },
+            format="json",
+        )
+        self.assertEqual(draft.status_code, 201, draft.data)
+        session_id = draft.data["id"]
+
+        # --- step 2: candidate accepts with COVENANT_ROLE ref ---
+        self.client.force_authenticate(user=candidate_account)
+        accept = self.client.post(
+            f"/api/magic/rituals/sessions/{session_id}/accept/",
+            {
+                "participant_kwargs": {},
+                "references": [
+                    {"kind": "COVENANT_ROLE", "ref_covenant_role_id": candidate_role.pk}
+                ],
+            },
+            format="json",
+        )
+        self.assertEqual(accept.status_code, 200, accept.data)
+
+        # --- step 3: initiator fires ---
+        self.client.force_authenticate(user=initiator_account)
+        fire = self.client.post(
+            f"/api/magic/rituals/sessions/{session_id}/fire/", {}, format="json"
+        )
+        self.assertEqual(fire.status_code, 200, fire.data)
+        self.assertEqual(fire.data["result_kind"], "membership")
+
+        # --- assert: CCR row was created for the candidate ---
+        membership = CharacterCovenantRole.objects.get(
+            character_sheet=candidate_sheet,
+            covenant=covenant,
+        )
+        self.assertEqual(membership.covenant_role_id, candidate_role.pk)
+
+
 class RitualSessionDetailParticipantFieldsTests(TestCase):
     """GET /api/magic/rituals/sessions/{id}/ exposes participant_fields."""
 

--- a/src/world/magic/tests/test_session_views.py
+++ b/src/world/magic/tests/test_session_views.py
@@ -630,3 +630,5 @@ class RitualSessionDetailParticipantFieldsTests(TestCase):
         fields = response.data["participant_fields"]
         names = {f["name"] for f in fields}
         self.assertIn("chosen_covenant_role", names)
+        role_field = next(f for f in fields if f["name"] == "chosen_covenant_role")
+        self.assertEqual(role_field["emits_reference"], "COVENANT_ROLE")

--- a/src/world/magic/tests/test_session_views.py
+++ b/src/world/magic/tests/test_session_views.py
@@ -516,3 +516,23 @@ class RitualSessionCancelTests(TestCase):
         self.client.force_authenticate(user=inv_account)
         response = self.client.delete(f"/api/magic/rituals/sessions/{session.pk}/")
         self.assertEqual(response.status_code, 403)
+
+
+class RitualSessionDetailParticipantFieldsTests(TestCase):
+    """GET /api/magic/rituals/sessions/{id}/ exposes participant_fields."""
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    def test_detail_exposes_participant_fields_for_induction(self) -> None:
+        from world.magic.factories import RitualSessionFactory
+
+        _, account, sheet = _make_tenure_with_account()
+        ritual = _make_induction_ritual()
+        session = RitualSessionFactory(ritual=ritual, initiator=sheet)
+        self.client.force_authenticate(user=account)
+        response = self.client.get(f"/api/magic/rituals/sessions/{session.pk}/")
+        self.assertEqual(response.status_code, 200)
+        fields = response.data["participant_fields"]
+        names = {f["name"] for f in fields}
+        self.assertIn("chosen_covenant_role", names)


### PR DESCRIPTION
Closes #1261

## Summary

Fixes the covenant induction UI round-trip (draft → candidate accepts with a chosen role → initiator fires → CharacterCovenantRole created), which the backend supported but the UI broke at three integration seams.

What changed:
- Expose participant_fields on RitualSessionDetailSerializer (the role-picker schema).
- New additive RitualField descriptors: emits_reference (field value → typed RitualSessionReference on accept) and applies_to (audience gate; candidate_only hides from the initiator); authored emits_reference: COVENANT_ROLE on the induction role field.
- RitualSessionDetailPage now passes participantFieldsSchema; RitualSessionResponseDialog resolves the role-picker covenant-type from the session-level COVENANT reference (was session_kwargs), gates candidate_only fields to non-initiators, and converts emits_reference fields into the accept references array.

Tests: RitualInductionRoundTripTests (backend, no-mock draft→accept→fire→membership) + new RitualSessionResponseDialog component tests (picker renders, accept emits the COVENANT_ROLE reference, candidate-only gate). Docs updated in tandem (rituals/CLAUDE.md, covenants.md, INDEX.md).

Anti-reinvention: only new surfaces are the one serializer field and two additive RitualField descriptors; everything else reuses existing reference plumbing (_parse_reference_specs, RitualSessionReferenceSpec, accept references path).

Out of scope (follow-up #1313): the FORMATION covenant-creation ritual shares the same role-picker field and has the same latent reference gap, but its semantics differ (all founders need a role, so candidate_only would be wrong) and it needs its own tests — captured in #1313, not fixed here.

## Follow-ups filed

- #1313

## Notes

- Spec: reviewed & approved on #1261 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased 8 commits cleanly onto origin/main; no conflicts, no migration collisions.

<!-- last-addressed-comment: 0 -->