### PR TITLE
Magic blocker: no technique is castable out of the box (CG-minted technique has no action_template)

### DIFF
--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -20,7 +20,7 @@ disagree, this doc and the code win.
 | Pose / narration into the scene | ✅ wired | `world/scenes/cast_services.py:create_cast_outcome_pose` → `world/magic/narration.py` |
 | Logging — `SceneActionRequest` + `Interaction` + power ledger | ✅ wired | `world/scenes/action_models.py`; `cast_services.py:persist_power_ledger` |
 | Resonance / progression feedback | ✅ by design | earned from RP perception (endorsements), **not** from casting — see "By design" below |
-| **A real character actually being able to cast** | ❌ **blocked** | **see #1306** |
+| **A real character actually being able to cast** | ✅ wired | `#1306` — shared template + per-character check; see below |
 
 The backend cast→pose→log→outcome loop is fully wired and resolves end-to-end (verified
 by tracing + a throwaway smoke test). The remaining frontier is **assembly, content, and
@@ -31,12 +31,16 @@ integration**, not engine mechanics.
 Ordered by priority. These are the gaps between "the engine works" and "a player can do
 magic." Each is a filed issue — work these, not micro-hardening tickets.
 
-1. **🔴 #1306 — nothing is castable out of the box** (`priority:now`). Standalone cast
-   rejects any technique with no `action_template` (`cast_services.py:418`); the CG
-   cantrip→technique path (`character_creation/services.py:_finalize_cantrip_gift_and_technique`
-   → `magic/services/technique_builder.py:create_technique`) never sets one, and 0 seeded
-   techniques have one. The cast button fails for every real character. **This is the
-   one blocker that gates playable magic.**
+1. **✅ #1306 — RESOLVED: every technique is now castable** (`priority:now` → done).
+   `create_technique` defaults `action_template` to the shared **Technique Cast**
+   `ActionTemplate` seeded by `seeds_cast.ensure_technique_cast_content()`. Cast
+   resolution rolls the **caster's own per-character magic check**
+   (`ensure_character_magic_check_type` / `get_character_cast_check` in
+   `seeds_checks.py` / `services/anima.py`); the same check is used by the anima ritual
+   (wired via `provision_player_anima_ritual`). A graded **"Magic: Technique Cast"**
+   `ConsequencePool` routes outcomes. No schema migration required.
+   Remaining follow-ups (filed as issues): technique designer (player picks a pool from
+   a curated catalog) and targeting model (validity + AoE + frontend picker).
 2. **🟠 #1307 — seed produces no playable character or scene** (`priority:next`). The
    "Big Button" (`world/seeds/database.py:seed_dev_database`, #651) seeds rules content
    only — 0 CharacterSheets / Personas / Scenes. Needs a playable-slice path (demo
@@ -65,11 +69,24 @@ before treating any as a bug:
 - **Non-combat thread pulls are passive-only** (VITAL_BONUS inactive outside combat) —
   Resonance Spec §7.4.
 
-## Open design question carried by #1306
+## Design resolution — #1306 (castability, RESOLVED)
 
-Is castability (the `action_template`) auto-provisioned per technique, shared per
-effect-type/style, or authored staff content? The cast gate keys on a per-technique FK
-today (`world/magic/models/techniques.py:362`). Resolve this in #1306's spec.
+**Was:** Is castability (the `action_template`) auto-provisioned per technique, shared
+per effect-type/style, or authored staff content?
+
+**Resolved:** A single shared **Technique Cast** `ActionTemplate` is seeded by
+`seeds_cast.ensure_technique_cast_content()`. `create_technique` defaults `action_template`
+to it; the per-technique FK remains as a staff-only override. Cast resolution rolls the
+**caster's own per-character magic check** (synthesized from their stat + skill via
+`ensure_character_magic_check_type`), not a technique-level authored check. Outcomes route
+through a graded **"Magic: Technique Cast"** `ConsequencePool`. The anima ritual and
+technique casts always share the same personal check (`provision_player_anima_ritual`
+in `services/anima.py`).
+
+Deferred to follow-up issues: technique designer (player selects a consequence pool
+from a curated catalog built on `ConsequencePool.parent`); targeting model (targeting
+validity enforcement + AoE + frontend picker); optional resonance→aspect mapping for the
+per-character check (today all magic checks use the Arcana aspect).
 
 ## Deeper design & history
 

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -145,7 +145,7 @@ Powers, affinities, auras, resonances, threads-as-currency, rituals, and Mage Sc
     `get_character_cast_check(character)` (`services/anima.py`) — resolves the
     per-character CheckType for cast resolution.
     `get_character_anima_ritual(character)` (`services/anima.py`) — retrieves the
-    character's `CharacterAnimaRitual`.
+    character's personal SCENE_ACTION `Ritual` (their anima ritual).
     `provision_player_anima_ritual(...)` (`services/anima.py`) — updated to point
     `RitualCheckConfig.check_type` at the per-character check so ritual and technique
     casts roll the same personal check.

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -133,6 +133,22 @@ Powers, affinities, auras, resonances, threads-as-currency, rituals, and Mage Sc
     issues `ResonanceGrant` rows (source=OUTFIT_TRICKLE, `outfit_item_facet` typed FK)
     for each worn item with matching facets; `resonance_daily_tick()` now calls this
     alongside residence trickle
+  - Standalone casting (#1306):
+    `ensure_technique_cast_content()` (`seeds_cast.py`) — idempotent seed: shared
+    "Technique Cast" `ActionTemplate` + fallback `CheckType` + graded "Magic: Technique
+    Cast" `ConsequencePool`; called by the magic dev seed.
+    `get_standalone_cast_template()` (`seeds_cast.py`) — retrieves the shared
+    ActionTemplate; used as default by `create_technique`.
+    `ensure_character_magic_check_type(character_sheet, *, stat, skill)` (`seeds_checks.py`)
+    — synthesizes a per-character `CheckType` (name from `character_magic_check_type_name()`)
+    for the character's stat + skill.
+    `get_character_cast_check(character)` (`services/anima.py`) — resolves the
+    per-character CheckType for cast resolution.
+    `get_character_anima_ritual(character)` (`services/anima.py`) — retrieves the
+    character's `CharacterAnimaRitual`.
+    `provision_player_anima_ritual(...)` (`services/anima.py`) — updated to point
+    `RitualCheckConfig.check_type` at the per-character check so ritual and technique
+    casts roll the same personal check.
   - Dramatic moment tagging (#1139):
     `create_dramatic_moment_tag(*, character_sheet, moment_type, tagged_by, scene, interaction=None) -> DramaticMomentTag`
     — validates resonance claim + per-scene cap; atomically creates tag, calls

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -131,7 +131,7 @@ per-technique via the FK. Key surfaces:
 | `get_standalone_cast_template()` | `seeds_cast.py` | Retrieves the shared ActionTemplate; called by `create_technique` default |
 | `ensure_character_magic_check_type(character_sheet, *, stat, skill)` | `seeds_checks.py` | Synthesizes a per-character `CheckType` (pattern: `character_magic_check_type_name()`) for that character's stat + skill |
 | `get_character_cast_check(character)` | `services/anima.py` | Resolves the per-character check type for cast resolution |
-| `get_character_anima_ritual(character)` | `services/anima.py` | Retrieves the character's `CharacterAnimaRitual` |
+| `get_character_anima_ritual(character)` | `services/anima.py` | Retrieves the character's personal SCENE_ACTION `Ritual` (their anima ritual) |
 | `provision_player_anima_ritual(...)` | `services/anima.py` | Points `RitualCheckConfig.check_type` at the per-character check so ritual and technique casts share the same roll |
 
 Cast resolution (`world/scenes/cast_services.py:_resolve_cast`) passes the caster's personal

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -118,6 +118,26 @@ Mechanical fields are hidden from the player — they only see name, description
 archetype grouping, and optional facet selection. Filtered by Path (cantrip's style
 must be in Path's allowed_styles).
 
+### Standalone Casting — Shared Template + Per-Character Check (#1306) [BUILT & WIRED]
+
+`create_technique` (`services/technique_builder.py`) defaults `action_template` to the
+shared **Technique Cast** `ActionTemplate` seeded by `seeds_cast.ensure_technique_cast_content()`,
+so every technique (including CG cantrips) is castable standalone. Staff may override
+per-technique via the FK. Key surfaces:
+
+| Surface | Location | Purpose |
+|---------|----------|---------|
+| `ensure_technique_cast_content()` | `seeds_cast.py` | Idempotent seed: shared ActionTemplate + fallback CheckType + "Magic: Technique Cast" ConsequencePool |
+| `get_standalone_cast_template()` | `seeds_cast.py` | Retrieves the shared ActionTemplate; called by `create_technique` default |
+| `ensure_character_magic_check_type(character_sheet, *, stat, skill)` | `seeds_checks.py` | Synthesizes a per-character `CheckType` (pattern: `character_magic_check_type_name()`) for that character's stat + skill |
+| `get_character_cast_check(character)` | `services/anima.py` | Resolves the per-character check type for cast resolution |
+| `get_character_anima_ritual(character)` | `services/anima.py` | Retrieves the character's `CharacterAnimaRitual` |
+| `provision_player_anima_ritual(...)` | `services/anima.py` | Points `RitualCheckConfig.check_type` at the per-character check so ritual and technique casts share the same roll |
+
+Cast resolution (`world/scenes/cast_services.py:_resolve_cast`) passes the caster's personal
+check into `start_action_resolution` via the `check_type` override (optional kwarg added to
+`src/actions/services.py`). No schema migration — all seeded via `ensure_technique_cast_content()`.
+
 ### Motif System
 
 | Model | Purpose | Key Fields |

--- a/src/actions/services.py
+++ b/src/actions/services.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from actions.models import ConsequencePool
     from actions.models.action_templates import ActionTemplate, ActionTemplateGate
     from actions.models.consequence_pools import ConsequencePoolEntry
+    from world.checks.models import CheckType
     from world.checks.types import CheckResult
     from world.mechanics.types import AppliedEffect
 
@@ -78,12 +79,14 @@ def _entries_to_weighted(
 # ---------------------------------------------------------------------------
 
 
-def start_action_resolution(
+def start_action_resolution(  # noqa: PLR0913
     character: ObjectDB,
     template: ActionTemplate,
     target_difficulty: int,
     context: ResolutionContext,
     extra_modifiers: int = 0,
+    *,
+    check_type: CheckType | None = None,
 ) -> PendingActionResolution:
     """Start an action resolution pipeline and run it to completion or pause.
 
@@ -133,7 +136,11 @@ def start_action_resolution(
                 return pending
 
     pending.current_phase = ResolutionPhase.MAIN_PENDING
-    main_result = _run_main_step(character, template, target_difficulty, context, extra_modifiers)
+    # Override applies to the immediate main step (SINGLE pipeline); GATED continuation
+    # via advance_resolution keeps template.check_type — no cast uses GATED.
+    main_result = _run_main_step(
+        character, template, target_difficulty, context, extra_modifiers, check_type=check_type
+    )
     pending.main_result = main_result
     pending.current_phase = ResolutionPhase.MAIN_RESOLVED
 
@@ -241,16 +248,18 @@ def _run_gate(
     )
 
 
-def _run_main_step(
+def _run_main_step(  # noqa: PLR0913
     character: ObjectDB,
     template: ActionTemplate,
     difficulty: int,
     context: ResolutionContext,
     extra_modifiers: int = 0,
+    *,
+    check_type: CheckType | None = None,
 ) -> StepResult:
     """Run the main resolution step."""
     check_result = perform_check(
-        character, template.check_type, difficulty, extra_modifiers=extra_modifiers
+        character, check_type or template.check_type, difficulty, extra_modifiers=extra_modifiers
     )
 
     if template.consequence_pool is None:

--- a/src/actions/tests/test_resolution_check_override.py
+++ b/src/actions/tests/test_resolution_check_override.py
@@ -1,0 +1,93 @@
+"""Tests for the check_type override seam in the action resolver (Task 4).
+
+Verifies that start_action_resolution / _run_main_step honour an optional
+check_type override for the immediate (SINGLE pipeline) main step, and fall
+back to template.check_type when no override is supplied.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from actions.constants import Pipeline, ResolutionPhase
+from actions.factories import ActionTemplateFactory
+from actions.services import start_action_resolution
+from world.checks.factories import CheckCategoryFactory, CheckTypeFactory
+from world.checks.types import ResolutionContext
+
+
+class CheckOverrideTests(TestCase):
+    """Verify the check_type override param is honoured on the SINGLE pipeline."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        category = CheckCategoryFactory(name="OverrideCat")
+        cls.template_check = CheckTypeFactory(name="TemplateCheck", category=category)
+        cls.override_check = CheckTypeFactory(name="CasterOverrideCheck", category=category)
+        cls.template = ActionTemplateFactory(
+            name="Override Test Template",
+            pipeline=Pipeline.SINGLE,
+            check_type=cls.template_check,
+            consequence_pool=None,
+        )
+
+    @patch("actions.services.perform_check")
+    def test_override_check_type_used_when_provided(self, mock_perform_check: MagicMock) -> None:
+        """When check_type is provided, the override check_type is rolled."""
+        from world.checks.types import CheckResult
+
+        fake_result = MagicMock(spec=CheckResult)
+        fake_result.check_type = self.override_check
+        fake_result.outcome = None
+        mock_perform_check.return_value = fake_result
+
+        character = MagicMock()
+        character.pk = 1
+        context = MagicMock(spec=ResolutionContext)
+        context.challenge_instance = None
+
+        result = start_action_resolution(
+            character, self.template, 10, context, check_type=self.override_check
+        )
+
+        assert result.current_phase == ResolutionPhase.COMPLETE
+        assert result.main_result is not None
+
+        # Verify perform_check was called with the OVERRIDE check type, not template.check_type
+        call_args = mock_perform_check.call_args
+        used_check_type = call_args[0][1]  # positional arg 1: check_type
+        assert used_check_type is self.override_check, (
+            f"Expected override check type {self.override_check!r} "
+            f"but perform_check was called with {used_check_type!r}"
+        )
+        assert used_check_type is not self.template_check, (
+            "perform_check should NOT have used template.check_type when override was provided"
+        )
+
+    @patch("actions.services.perform_check")
+    def test_template_check_type_used_when_no_override(self, mock_perform_check: MagicMock) -> None:
+        """When no check_type override is provided, template.check_type is used."""
+        from world.checks.types import CheckResult
+
+        fake_result = MagicMock(spec=CheckResult)
+        fake_result.check_type = self.template_check
+        fake_result.outcome = None
+        mock_perform_check.return_value = fake_result
+
+        character = MagicMock()
+        character.pk = 1
+        context = MagicMock(spec=ResolutionContext)
+        context.challenge_instance = None
+
+        result = start_action_resolution(character, self.template, 10, context)
+
+        assert result.current_phase == ResolutionPhase.COMPLETE
+        assert result.main_result is not None
+
+        # Verify perform_check was called with template.check_type
+        call_args = mock_perform_check.call_args
+        used_check_type = call_args[0][1]  # positional arg 1: check_type
+        assert used_check_type is self.template_check, (
+            f"Expected template check type {self.template_check!r} "
+            f"but perform_check was called with {used_check_type!r}"
+        )

--- a/src/integration_tests/game_content/magic.py
+++ b/src/integration_tests/game_content/magic.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
     from actions.models import ActionEnhancement
+    from actions.models.action_templates import ActionTemplate
     from actions.models.consequence_pools import ConsequencePool
     from integration_tests.game_content.combat import FleeSeedResult, PenetrationContestResult
     from world.classes.models import Path
@@ -2203,6 +2204,8 @@ class MagicDevSeedResult:
     check-scoped ModifierTarget seeded by seed_penetration_contest() (#767).
     ``flee`` holds the flee CheckType, ModifierTarget, and FleeConfig singleton
     seeded by seed_flee_check() (#878).
+    ``technique_cast_template`` is the shared Technique Cast ActionTemplate seeded
+    by ensure_technique_cast_content() (#1306).
     """
 
     config: MagicConfigResult
@@ -2214,6 +2217,7 @@ class MagicDevSeedResult:
     penetration: PenetrationContestResult
     flee: FleeSeedResult
     magic_checks: MagicCheckContentResult
+    technique_cast_template: ActionTemplate
 
 
 def seed_facet_thread_unlock() -> FacetThreadUnlockResult:
@@ -2318,6 +2322,9 @@ def seed_magic_dev() -> MagicDevSeedResult:
     penetration = seed_penetration_contest()
     flee = seed_flee_check()
     magic_checks = MagicContent.seed_magic_checks()
+    from world.magic.seeds_cast import ensure_technique_cast_content  # noqa: PLC0415
+
+    technique_cast_template = ensure_technique_cast_content()
 
     return MagicDevSeedResult(
         config=config,
@@ -2329,4 +2336,5 @@ def seed_magic_dev() -> MagicDevSeedResult:
         penetration=penetration,
         flee=flee,
         magic_checks=magic_checks,
+        technique_cast_template=technique_cast_template,
     )

--- a/src/world/character_creation/tests/test_services.py
+++ b/src/world/character_creation/tests/test_services.py
@@ -1412,18 +1412,14 @@ class FinalizeRitualKnowledgeTests(FinalizationTestMixin, TestCase):
         assert "RitualKTest" in ritual.name
 
     def test_finalize_creates_ritual_check_config(self) -> None:
-        """finalize_character creates RitualCheckConfig with the seeded default check_type."""
+        """finalize_character creates RitualCheckConfig pointing at the per-character CheckType."""
         from world.magic.constants import RitualExecutionKind
         from world.magic.models.ritual_check_config import RitualCheckConfig
         from world.magic.models.rituals import Ritual
-        from world.magic.seeds_checks import (
-            ANIMA_RESTORATION_CHECK_TYPE_NAME,
-            ensure_magic_check_types,
-        )
+        from world.magic.seeds_checks import character_magic_check_type_name
 
-        ensure_magic_check_types()
         draft = self._create_complete_draft()
-        finalize_character(draft, add_to_roster=True)
+        character = finalize_character(draft, add_to_roster=True)
 
         ritual = Ritual.objects.filter(
             author_account=self.account,
@@ -1433,9 +1429,9 @@ class FinalizeRitualKnowledgeTests(FinalizationTestMixin, TestCase):
         config = RitualCheckConfig.objects.filter(ritual=ritual).first()
         assert config is not None, "Expected a RitualCheckConfig for the player anima ritual"
         assert config.check_type is not None, (
-            "Provisioning should default check_type to the seeded Anima Restoration row"
+            "Provisioning should wire check_type to the per-character CheckType"
         )
-        assert config.check_type.name == ANIMA_RESTORATION_CHECK_TYPE_NAME
+        assert config.check_type.name == character_magic_check_type_name(character.sheet_data)
 
     def test_finalize_creates_ritual_knowledge_row(self) -> None:
         """finalize_character creates CharacterRitualKnowledge for the player anima ritual."""

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -60,7 +60,7 @@ The magic system for Arx II. Power flows from identity and connection.
 
 `services/technique_builder.py` provides a three-layer authoring stack:
 
-**Unrestricted core** — `build_technique(design, *, creator)` writes a `Technique` + payload rows (`TechniqueCapabilityGrant`, `TechniqueDamageProfile`, `TechniqueAppliedCondition`) + restriction attachments in one `transaction.atomic`. No gating, no character binding. `create_technique(...)` is the extracted low-level row writer shared with cantrip finalization.
+**Unrestricted core** — `build_technique(design, *, creator)` writes a `Technique` + payload rows (`TechniqueCapabilityGrant`, `TechniqueDamageProfile`, `TechniqueAppliedCondition`) + restriction attachments in one `transaction.atomic`. No gating, no character binding. `create_technique(...)` is the extracted low-level row writer shared with cantrip finalization. When `action_template` is omitted (the default), `create_technique` resolves it to the shared **Technique Cast** `ActionTemplate` seeded by `seeds_cast.py` via `get_standalone_cast_template()` — so every technique is castable standalone out of the box. Staff may pass an explicit template FK to override on a per-technique basis.
 
 **Policy layer** — `price_design(design, *, config, budget)` is a pure function that itemizes power cost per dimension and subtracts restriction refunds, returning a `TechniqueCostBreakdown`. It always runs for every author — the breakdown is informational for staff and a gate for players. `AuthoringPolicy` subclasses answer three knobs:
 - `StaffPolicy` — `enforced=False`; budget is advisory; any tier allowed.
@@ -86,6 +86,35 @@ The magic system for Arx II. Power flows from identity and connection.
 
 **Note:** During character creation, the magic stage uses a simplified cantrip selection
 system. Anima rituals are set up post-CG. CharacterAnimaRitual references Resonance directly.
+
+### Standalone Casting (#1306)
+
+Every technique now carries an `action_template` FK (defaulted by `create_technique`) so
+casting never hard-fails with "no template." The resolution chain:
+
+- **Shared "Technique Cast" ActionTemplate** — seeded idempotently by
+  `seeds_cast.ensure_technique_cast_content()`, called from the magic dev seed.
+  Retrieved at runtime via `get_standalone_cast_template()`. Staff may override
+  on a per-technique basis via the `action_template` FK; `None` (omit the kwarg)
+  always resolves to this shared template.
+- **Per-character magic check** — every caster rolls *their own* magic check, not a
+  technique-level authored check. `ensure_character_magic_check_type(character_sheet, *, stat, skill)`
+  (`seeds_checks.py`) synthesizes a `CheckType` named after the character (pattern
+  `character_magic_check_type_name(character_sheet)`) that weights the character's
+  personal stat + skill. `get_character_cast_check(character)` (`services/anima.py`)
+  resolves this check type for use by the cast pipeline.
+- **Anima ritual alignment** — `provision_player_anima_ritual` (`services/anima.py`)
+  points the anima ritual's `RitualCheckConfig.check_type` at the same per-character
+  check type, so the anima ritual and technique casts always roll the same personal check.
+  Use `get_character_anima_ritual(character)` to retrieve the anima ritual row.
+- **Graded consequence pool** — a single "Magic: Technique Cast" `ConsequencePool`
+  (seeded by `seeds_cast.py`) routes graded outcomes (critical/success/partial/failure/
+  critical-failure) through the shared consequence machinery. No per-technique pool is
+  required.
+
+Follow-ups deferred to later issues: technique designer (players pick a consequence pool
+from a curated catalog), targeting model (targeting validity + AoE + per-technique target
+constraints + frontend target picker), and the optional resonance→aspect mapping.
 
 ### Cantrips (Character Creation)
 - `Cantrip` - Staff-curated technique templates for CG magic stage selection

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -81,11 +81,12 @@ The magic system for Arx II. Power flows from identity and connection.
 **Frontend** — `TechniqueBuilderForm` with `mode: "staff" | "player"`. Staff mode shows the budget meter informationally without blocking; player mode gates submit on `within_budget`. `usePriceTechnique` (debounced `POST .../price/`) drives the live budget meter; `useAuthorTechnique` handles submission.
 
 ### Anima Recovery
-- `CharacterAnimaRitual` - Personalized recovery ritual (stat + skill + resonance)
+- `Ritual` (execution_kind=SCENE_ACTION) + `RitualCheckConfig` sidecar - Personalized recovery ritual (stat + skill + resonance + check_type)
 - `AnimaRitualPerformance` - Historical record of ritual performances
 
 **Note:** During character creation, the magic stage uses a simplified cantrip selection
-system. Anima rituals are set up post-CG. CharacterAnimaRitual references Resonance directly.
+system. Anima rituals are set up post-CG. The player-authored `Ritual` row (SCENE_ACTION)
+carries check configuration via its `RitualCheckConfig` sidecar (stat, skill, resonance, check_type).
 
 ### Standalone Casting (#1306)
 
@@ -108,9 +109,8 @@ casting never hard-fails with "no template." The resolution chain:
   check type, so the anima ritual and technique casts always roll the same personal check.
   Use `get_character_anima_ritual(character)` to retrieve the anima ritual row.
 - **Graded consequence pool** — a single "Magic: Technique Cast" `ConsequencePool`
-  (seeded by `seeds_cast.py`) routes graded outcomes (critical/success/partial/failure/
-  critical-failure) through the shared consequence machinery. No per-technique pool is
-  required.
+  (seeded by `seeds_cast.py`) routes graded outcomes (failure / partial success / success)
+  through the shared consequence machinery. No per-technique pool is required.
 
 Follow-ups deferred to later issues: technique designer (players pick a consequence pool
 from a curated catalog), targeting model (targeting validity + AoE + per-technique target

--- a/src/world/magic/seeds_cast.py
+++ b/src/world/magic/seeds_cast.py
@@ -1,0 +1,120 @@
+"""Idempotent seed for the shared standalone technique-cast scaffolding (#1306)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+TECHNIQUE_CAST_TEMPLATE_NAME = "Technique Cast"
+TECHNIQUE_CAST_CHECK_TYPE_NAME = "Technique Cast"
+TECHNIQUE_CAST_POOL_NAME = "Magic: Technique Cast"
+
+# (outcome_tier_name, label, weight)
+_CAST_CONSEQUENCES = [
+    ("Failure", "The cast falters.", 1),
+    ("Partial Success", "The cast lands, imperfectly.", 1),
+    ("Success", "The cast lands cleanly.", 1),
+]
+# fallback check trait composition (tuning placeholder; staff-tunable)
+_FALLBACK_TRAITS = [("willpower", "1.00"), ("occult", "1.00")]
+
+
+def _ensure_fallback_check_type():
+    from world.checks.models import CheckType, CheckTypeAspect, CheckTypeTrait  # noqa: PLC0415
+    from world.magic.seeds_checks import (  # noqa: PLC0415
+        _ensure_arcana_aspect,
+        ensure_magic_check_category,
+        ensure_magic_skills,
+    )
+    from world.traits.models import Trait, TraitType  # noqa: PLC0415
+
+    ensure_magic_skills()  # ensures occult Trait/Skill exist
+    category = ensure_magic_check_category()
+    arcana = _ensure_arcana_aspect()
+    check_type, _ = CheckType.objects.get_or_create(
+        name=TECHNIQUE_CAST_CHECK_TYPE_NAME,
+        category=category,
+        defaults={
+            "description": "Fallback check for casting a technique standalone.",
+            "is_active": True,
+        },
+    )
+    for trait_name, weight in _FALLBACK_TRAITS:
+        trait = Trait.objects.filter(name=trait_name).first()
+        if trait is None:
+            trait, _ = Trait.objects.get_or_create(
+                name=trait_name, defaults={"trait_type": TraitType.STAT, "is_public": True}
+            )
+        CheckTypeTrait.objects.get_or_create(
+            check_type=check_type, trait=trait, defaults={"weight": Decimal(weight)}
+        )
+    CheckTypeAspect.objects.get_or_create(
+        check_type=check_type, aspect=arcana, defaults={"weight": Decimal("1.00")}
+    )
+    return check_type
+
+
+def _ensure_cast_pool():
+    from actions.models import ConsequencePool, ConsequencePoolEntry  # noqa: PLC0415
+    from world.checks.models import Consequence  # noqa: PLC0415
+    from world.traits.factories import CheckOutcomeFactory  # noqa: PLC0415
+
+    pool, _ = ConsequencePool.objects.get_or_create(
+        name=TECHNIQUE_CAST_POOL_NAME,
+        defaults={"description": "Graded outcomes for a standalone technique cast."},
+    )
+    for outcome_name, label, weight in _CAST_CONSEQUENCES:
+        outcome = CheckOutcomeFactory(name=outcome_name)
+        consequence, _ = Consequence.objects.get_or_create(
+            outcome_tier=outcome,
+            label=label,
+            defaults={"weight": weight, "character_loss": False},
+        )
+        ConsequencePoolEntry.objects.get_or_create(
+            pool=pool,
+            consequence=consequence,
+            defaults={"weight_override": None, "is_excluded": False},
+        )
+    return pool
+
+
+def ensure_technique_cast_content():
+    """Idempotent: seed the fallback CheckType, graded ConsequencePool, and ActionTemplate.
+
+    Returns the ActionTemplate row (created or pre-existing). FK re-wiring ensures the
+    template is correctly linked even when called on a pre-existing row.
+    """
+    from actions.constants import ActionTargetType, Pipeline  # noqa: PLC0415
+    from actions.models import ActionTemplate  # noqa: PLC0415
+
+    check_type = _ensure_fallback_check_type()
+    pool = _ensure_cast_pool()
+    template, _ = ActionTemplate.objects.get_or_create(
+        name=TECHNIQUE_CAST_TEMPLATE_NAME,
+        defaults={
+            "check_type": check_type,
+            "consequence_pool": pool,
+            "category": "magic",
+            "pipeline": Pipeline.SINGLE,
+            "target_type": ActionTargetType.SELF,
+            "description": "Standalone resolution spec for casting a technique.",
+        },
+    )
+    # get_or_create won't update FKs on a pre-existing row — ensure wiring.
+    changed = []
+    if template.check_type_id != check_type.pk:
+        template.check_type = check_type
+        changed.append("check_type")
+    if template.consequence_pool_id != pool.pk:
+        template.consequence_pool = pool
+        changed.append("consequence_pool")
+    if changed:
+        template.save(update_fields=changed)
+    return template
+
+
+def get_standalone_cast_template():
+    """Return the shared Technique Cast ActionTemplate, seeding it if absent."""
+    from actions.models import ActionTemplate  # noqa: PLC0415
+
+    template = ActionTemplate.objects.filter(name=TECHNIQUE_CAST_TEMPLATE_NAME).first()
+    return template or ensure_technique_cast_content()

--- a/src/world/magic/seeds_checks.py
+++ b/src/world/magic/seeds_checks.py
@@ -280,6 +280,48 @@ def ensure_ritual_check_configs(
     return configs
 
 
+def character_magic_check_type_name(character_sheet) -> str:
+    """Stable, per-character CheckType name (natural key with the Magic category)."""
+    return f"Magic Check — sheet {character_sheet.pk}"
+
+
+def ensure_character_magic_check_type(character_sheet, *, stat, skill):
+    """Synthesize/return a per-character magic CheckType from stat + skill (+ Arcana).
+
+    The character's signature check: rolled by their Anima Ritual AND their
+    technique casts. Idempotent; weights are tuning placeholders (staff-tunable).
+    """
+    from decimal import Decimal  # noqa: PLC0415
+
+    from world.checks.models import (  # noqa: PLC0415
+        CheckType,
+        CheckTypeAspect,
+        CheckTypeTrait,
+    )
+
+    category = ensure_magic_check_category()
+    arcana = _ensure_arcana_aspect()
+    name = character_magic_check_type_name(character_sheet)
+    check_type, _ = CheckType.objects.get_or_create(
+        name=name,
+        category=category,
+        defaults={
+            "description": "A character's personal magic check (anima ritual + casting).",
+            "is_active": True,
+        },
+    )
+    CheckTypeTrait.objects.get_or_create(
+        check_type=check_type, trait=stat, defaults={"weight": Decimal("1.00")}
+    )
+    CheckTypeTrait.objects.get_or_create(
+        check_type=check_type, trait=skill.trait, defaults={"weight": Decimal("1.00")}
+    )
+    CheckTypeAspect.objects.get_or_create(
+        check_type=check_type, aspect=arcana, defaults={"weight": Decimal("1.00")}
+    )
+    return check_type
+
+
 def ensure_magic_check_content() -> MagicCheckContentResult:
     """Umbrella: skills + check types + ritual configs. Safe to call repeatedly."""
     skills = ensure_magic_skills()

--- a/src/world/magic/services/__init__.py
+++ b/src/world/magic/services/__init__.py
@@ -26,7 +26,12 @@ from world.magic.services.alterations import (
     staff_clear_alteration,
     validate_alteration_resolution,
 )
-from world.magic.services.anima import deduct_anima, provision_player_anima_ritual
+from world.magic.services.anima import (
+    deduct_anima,
+    get_character_anima_ritual,
+    get_character_cast_check,
+    provision_player_anima_ritual,
+)
 from world.magic.services.aura import (
     calculate_affinity_breakdown,
     get_aura_percentages,
@@ -94,6 +99,8 @@ __all__ = [
     # anima
     "deduct_anima",
     "get_aura_percentages",
+    "get_character_anima_ritual",
+    "get_character_cast_check",
     "get_library_entries",
     "get_runtime_technique_stats",
     "get_soulfray_warning",

--- a/src/world/magic/services/anima.py
+++ b/src/world/magic/services/anima.py
@@ -56,6 +56,29 @@ _SUCCESS_LEVEL = 1
 _PARTIAL_LEVEL = 0
 
 
+def get_character_anima_ritual(character):  # noqa: OBJECTDB_PARAM — Evennia character
+    """The character's authored SCENE_ACTION ritual (with check_config), or None."""
+    from world.magic.constants import RitualExecutionKind  # noqa: PLC0415
+    from world.magic.models.rituals import Ritual  # noqa: PLC0415
+
+    return (
+        Ritual.objects.filter(
+            author_account=character.db_account,
+            execution_kind=RitualExecutionKind.SCENE_ACTION,
+        )
+        .select_related("check_config")
+        .first()
+    )
+
+
+def get_character_cast_check(character):  # noqa: OBJECTDB_PARAM — Evennia character
+    """The CheckType a character's technique casts roll, or None for fallback."""
+    ritual = get_character_anima_ritual(character)
+    if ritual is None or not hasattr(ritual, "check_config"):
+        return None
+    return ritual.check_config.check_type
+
+
 @transaction.atomic
 def perform_anima_ritual(
     character_sheet: CharacterSheet,
@@ -68,7 +91,6 @@ def perform_anima_ritual(
     with leftover budget. Crit always tops anima to max regardless.
     """
     from world.checks.services import perform_check  # noqa: PLC0415
-    from world.magic.constants import RitualExecutionKind  # noqa: PLC0415
     from world.magic.exceptions import (  # noqa: PLC0415
         CharacterEngagedForRitual,
         NoRitualConfigured,
@@ -76,24 +98,16 @@ def perform_anima_ritual(
         RitualScenePrerequisiteFailed,
     )
     from world.magic.models.anima import AnimaRitualPerformance  # noqa: PLC0415
-    from world.magic.models.rituals import Ritual  # noqa: PLC0415
     from world.mechanics.engagement import CharacterEngagement  # noqa: PLC0415
 
-    ritual = (
-        Ritual.objects.filter(
-            author_account=character_sheet.character.db_account,
-            execution_kind=RitualExecutionKind.SCENE_ACTION,
-        )
-        .select_related("check_config")
-        .first()
-    )
+    character = character_sheet.character
+    ritual = get_character_anima_ritual(character)
     if ritual is None or not hasattr(ritual, "check_config"):
         raise NoRitualConfigured
 
     config = ritual.check_config
     if config.check_type is None:
         raise NoRitualConfigured
-    character = character_sheet.character
 
     if CharacterEngagement.objects.filter(character=character).exists():
         raise CharacterEngagedForRitual

--- a/src/world/magic/services/anima.py
+++ b/src/world/magic/services/anima.py
@@ -277,22 +277,13 @@ def provision_player_anima_ritual(
         author_account=account,
     )
 
-    # 4. Create the config. check_type defaults to the seeded Anima Restoration
-    # CheckType; resonance is left null for the player to set. Provisioning never
-    # blocks finalization — an unseeded environment just leaves check_type NULL.
-    from world.checks.models import CheckType  # noqa: PLC0415
+    # 4. Synthesize the character's personal magic check (#1306) — rolled by this
+    # ritual AND by the character's technique casts. Idempotent.
     from world.magic.seeds_checks import (  # noqa: PLC0415
-        ANIMA_RESTORATION_CHECK_TYPE_NAME,
+        ensure_character_magic_check_type,
     )
 
-    check_type = CheckType.objects.filter(name=ANIMA_RESTORATION_CHECK_TYPE_NAME).first()
-    if check_type is None:
-        logger.warning(
-            "provision_player_anima_ritual: %r CheckType not seeded; leaving "
-            "check_type NULL for character %s",
-            ANIMA_RESTORATION_CHECK_TYPE_NAME,
-            character.pk,
-        )
+    check_type = ensure_character_magic_check_type(character_sheet, stat=stat_trait, skill=skill)
 
     RitualCheckConfig.objects.create(
         ritual=ritual,

--- a/src/world/magic/services/technique_builder.py
+++ b/src/world/magic/services/technique_builder.py
@@ -64,9 +64,17 @@ def create_technique(  # noqa: PLR0913
     action_category,
     description,
     source_cantrip=None,
+    action_template=None,
 ) -> Technique:
     """Low-level Technique row writer. Shared by cantrip finalization and
-    build_technique. Does NOT create a CharacterTechnique."""
+    build_technique. Does NOT create a CharacterTechnique.
+
+    Defaults action_template to the shared 'Technique Cast' template so every
+    technique is castable standalone; pass an explicit template to override."""
+    if action_template is None:
+        from world.magic.seeds_cast import get_standalone_cast_template  # noqa: PLC0415
+
+        action_template = get_standalone_cast_template()
     return Technique.objects.create(
         name=name,
         gift=gift,
@@ -80,6 +88,7 @@ def create_technique(  # noqa: PLR0913
         description=description,
         source_cantrip=source_cantrip,
         creator=creator,
+        action_template=action_template,
     )
 
 

--- a/src/world/magic/tests/test_character_cast_check.py
+++ b/src/world/magic/tests/test_character_cast_check.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.seeds_checks import (
+    MAGIC_CHECK_CATEGORY_NAME,
+    ensure_character_magic_check_type,
+)
+from world.skills.factories import SkillFactory
+from world.traits.factories import TraitFactory
+from world.traits.models import TraitType
+
+
+class CharacterMagicCheckTypeTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+        cls.other = CharacterSheetFactory()
+        cls.willpower = TraitFactory(name="willpower", trait_type=TraitType.STAT)
+        cls.skill = SkillFactory(trait__name="ritualism")
+
+    def test_synthesizes_per_character_check_weighted_on_stat_and_skill(self):
+        ct = ensure_character_magic_check_type(self.sheet, stat=self.willpower, skill=self.skill)
+        self.assertEqual(ct.category.name, MAGIC_CHECK_CATEGORY_NAME)
+        trait_names = {t.trait.name for t in ct.traits.all()}
+        self.assertEqual(trait_names, {"willpower", "ritualism"})
+        self.assertTrue(ct.aspects.filter(aspect__name="Arcana").exists())
+
+    def test_distinct_rows_per_character_and_idempotent(self):
+        a1 = ensure_character_magic_check_type(self.sheet, stat=self.willpower, skill=self.skill)
+        a2 = ensure_character_magic_check_type(self.sheet, stat=self.willpower, skill=self.skill)
+        b = ensure_character_magic_check_type(self.other, stat=self.willpower, skill=self.skill)
+        self.assertEqual(a1.pk, a2.pk)
+        self.assertNotEqual(a1.pk, b.pk)

--- a/src/world/magic/tests/test_character_cast_check.py
+++ b/src/world/magic/tests/test_character_cast_check.py
@@ -200,3 +200,131 @@ class ProvisionUsesPerCharacterCheckTests(TestCase):
             config.check_type.name,
             character_magic_check_type_name(sheet),
         )
+
+
+class GetCharacterCastCheckTests(TestCase):
+    """Tests for get_character_cast_check resolver."""
+
+    @classmethod
+    def setUpTestData(cls):
+        for stat_name in _PROVISION_STATS:
+            Trait.objects.get_or_create(
+                name=stat_name,
+                defaults={"trait_type": TraitType.STAT, "description": stat_name},
+            )
+        Roster.objects.get_or_create(name="Available Characters")
+
+        realm = Realm.objects.create(name="CastCheck Realm", description="Test")
+        area = StartingArea.objects.create(
+            name="CastCheck Area",
+            description="Test",
+            realm=realm,
+            access_level=StartingArea.AccessLevel.ALL,
+        )
+        species = Species.objects.create(name="CastCheck Species", description="Test")
+        gender, _ = Gender.objects.get_or_create(
+            key="castcheck_gender",
+            defaults={"display_name": "CastCheck Gender"},
+        )
+        tarot = TarotCard.objects.create(
+            name="CastCheck Fool",
+            arcana_type=ArcanaType.MAJOR,
+            rank=98,
+            latin_name="Fatui2",
+        )
+        beginnings = Beginnings.objects.create(
+            name="CastCheck Beginnings",
+            description="Test",
+            starting_area=area,
+            trust_required=0,
+            is_active=True,
+            family_known=False,
+        )
+        beginnings.allowed_species.add(species)
+        height_band = HeightBand.objects.create(
+            name="cc_band",
+            display_name="CastCheck Band",
+            min_inches=5000,
+            max_inches=5100,
+            weight_min=None,
+            weight_max=None,
+            is_cg_selectable=True,
+        )
+        build = Build.objects.create(
+            name="cc_build",
+            display_name="CastCheck Build",
+            weight_factor=Decimal("1.0"),
+            is_cg_selectable=True,
+        )
+        path = PathFactory(name="CastCheck Path", stage=PathStage.PROSPECT, minimum_level=1)
+        TechniqueStyleFactory()
+        EffectTypeFactory()
+        ResonanceFactory()
+        tradition = TraditionFactory()
+        cls.skill = SkillFactory(trait__name="CCProvisionMelee")
+        cantrip = CantripFactory(requires_facet=False)
+
+        cls.area = area
+        cls.beginnings = beginnings
+        cls.species = species
+        cls.gender = gender
+        cls.tarot = tarot
+        cls.height_band = height_band
+        cls.build = build
+        cls.path = path
+        cls.tradition = tradition
+        cls.cantrip = cantrip
+
+    def setUp(self):
+        CharacterSheet.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        Trait.flush_instance_cache()
+
+    def test_returns_none_without_ritual(self):
+        from world.magic.services.anima import get_character_cast_check
+
+        sheet = CharacterSheetFactory()
+        self.assertIsNone(get_character_cast_check(sheet.character))
+
+    def test_returns_per_character_check_after_provision(self):
+        from world.character_creation.models import CharacterDraft
+        from world.magic.services.anima import get_character_cast_check
+
+        account = AccountDB.objects.create(username=f"castcheck_run_{id(self)}")
+        draft = CharacterDraft.objects.create(
+            account=account,
+            selected_area=self.area,
+            selected_beginnings=self.beginnings,
+            selected_species=self.species,
+            selected_gender=self.gender,
+            selected_path=self.path,
+            selected_tradition=self.tradition,
+            age=25,
+            height_band=self.height_band,
+            height_inches=5050,
+            build=self.build,
+            draft_data={
+                "first_name": "CastCheck",
+                "description": "A test character",
+                "stats": _PROVISION_STATS,
+                "lineage_is_orphan": True,
+                "tarot_card_name": self.tarot.name,
+                "tarot_reversed": False,
+                "traits_complete": True,
+                "selected_cantrip_id": self.cantrip.id,
+                "skills": {str(self.skill.pk): 20},
+            },
+        )
+
+        character = finalize_character(draft, add_to_roster=True)
+        sheet = character.sheet_data
+
+        # Puppet the character to the account so db_account is set,
+        # mirroring the runtime path where get_character_anima_ritual queries
+        # author_account=character.db_account.
+        character.db_account = account
+        character.save(update_fields=["db_account"])
+
+        ct = get_character_cast_check(sheet.character)
+        self.assertIsNotNone(ct)
+        self.assertEqual(ct.name, character_magic_check_type_name(sheet))

--- a/src/world/magic/tests/test_character_cast_check.py
+++ b/src/world/magic/tests/test_character_cast_check.py
@@ -1,13 +1,38 @@
-from django.test import TestCase
+from decimal import Decimal
 
+from django.test import TestCase
+from evennia.accounts.models import AccountDB
+
+from world.character_creation.models import Beginnings, StartingArea
+from world.character_creation.services import finalize_character
 from world.character_sheets.factories import CharacterSheetFactory
+from world.character_sheets.models import CharacterSheet, Gender
+from world.classes.factories import PathFactory
+from world.classes.models import PathStage
+from world.forms.models import Build, HeightBand
+from world.magic.constants import RitualExecutionKind
+from world.magic.factories import (
+    CantripFactory,
+    EffectTypeFactory,
+    ResonanceFactory,
+    TechniqueStyleFactory,
+    TraditionFactory,
+)
+from world.magic.models.ritual_check_config import RitualCheckConfig
+from world.magic.models.rituals import Ritual
 from world.magic.seeds_checks import (
     MAGIC_CHECK_CATEGORY_NAME,
+    character_magic_check_type_name,
     ensure_character_magic_check_type,
 )
+from world.realms.models import Realm
+from world.roster.models import Roster
 from world.skills.factories import SkillFactory
+from world.species.models import Species
+from world.tarot.constants import ArcanaType
+from world.tarot.models import TarotCard
 from world.traits.factories import TraitFactory
-from world.traits.models import TraitType
+from world.traits.models import CharacterTraitValue, Trait, TraitType
 
 
 class CharacterMagicCheckTypeTests(TestCase):
@@ -31,3 +56,147 @@ class CharacterMagicCheckTypeTests(TestCase):
         b = ensure_character_magic_check_type(self.other, stat=self.willpower, skill=self.skill)
         self.assertEqual(a1.pk, a2.pk)
         self.assertNotEqual(a1.pk, b.pk)
+
+
+_PROVISION_STATS = {
+    "strength": 2,
+    "agility": 2,
+    "stamina": 2,
+    "charm": 2,
+    "presence": 2,
+    "composure": 2,
+    "intellect": 2,
+    "wits": 2,
+    "stability": 2,
+    "luck": 2,
+    "perception": 2,
+    "willpower": 2,
+}
+
+
+class ProvisionUsesPerCharacterCheckTests(TestCase):
+    """Provisioned anima ritual's check_config points to the per-character CheckType."""
+
+    @classmethod
+    def setUpTestData(cls):
+        for stat_name in _PROVISION_STATS:
+            Trait.objects.get_or_create(
+                name=stat_name,
+                defaults={"trait_type": TraitType.STAT, "description": stat_name},
+            )
+        Roster.objects.get_or_create(name="Available Characters")
+
+        realm = Realm.objects.create(name="ProvisionCheck Realm", description="Test")
+        area = StartingArea.objects.create(
+            name="ProvisionCheck Area",
+            description="Test",
+            realm=realm,
+            access_level=StartingArea.AccessLevel.ALL,
+        )
+        species = Species.objects.create(name="ProvisionCheck Species", description="Test")
+        gender, _ = Gender.objects.get_or_create(
+            key="provisioncheck_gender",
+            defaults={"display_name": "ProvisionCheck Gender"},
+        )
+        tarot = TarotCard.objects.create(
+            name="ProvCheck Fool",
+            arcana_type=ArcanaType.MAJOR,
+            rank=99,
+            latin_name="Fatui",
+        )
+        beginnings = Beginnings.objects.create(
+            name="ProvisionCheck Beginnings",
+            description="Test",
+            starting_area=area,
+            trust_required=0,
+            is_active=True,
+            family_known=False,
+        )
+        beginnings.allowed_species.add(species)
+        height_band = HeightBand.objects.create(
+            name="pc_band",
+            display_name="ProvisionCheck Band",
+            min_inches=4000,
+            max_inches=4100,
+            weight_min=None,
+            weight_max=None,
+            is_cg_selectable=True,
+        )
+        build = Build.objects.create(
+            name="pc_build",
+            display_name="ProvisionCheck Build",
+            weight_factor=Decimal("1.0"),
+            is_cg_selectable=True,
+        )
+        path = PathFactory(name="ProvisionCheck Path", stage=PathStage.PROSPECT, minimum_level=1)
+        TechniqueStyleFactory()
+        EffectTypeFactory()
+        ResonanceFactory()
+        tradition = TraditionFactory()
+
+        # Skill needed so provision_player_anima_ritual doesn't log + skip.
+        cls.skill = SkillFactory(trait__name="PCProvisionMelee")
+
+        cantrip = CantripFactory(requires_facet=False)
+        cls.area = area
+        cls.beginnings = beginnings
+        cls.species = species
+        cls.gender = gender
+        cls.tarot = tarot
+        cls.height_band = height_band
+        cls.build = build
+        cls.path = path
+        cls.tradition = tradition
+        cls.cantrip = cantrip
+
+    def setUp(self):
+        CharacterSheet.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        Trait.flush_instance_cache()
+
+    def test_provisioned_ritual_uses_per_character_check_type(self):
+        """provision_player_anima_ritual wires check_type to the per-character CheckType."""
+        from world.character_creation.models import CharacterDraft
+
+        account = AccountDB.objects.create(username=f"provcheck_run_{id(self)}")
+        draft = CharacterDraft.objects.create(
+            account=account,
+            selected_area=self.area,
+            selected_beginnings=self.beginnings,
+            selected_species=self.species,
+            selected_gender=self.gender,
+            selected_path=self.path,
+            selected_tradition=self.tradition,
+            age=25,
+            height_band=self.height_band,
+            height_inches=4050,
+            build=self.build,
+            draft_data={
+                "first_name": "ProvCheck",
+                "description": "A test character",
+                "stats": _PROVISION_STATS,
+                "lineage_is_orphan": True,
+                "tarot_card_name": self.tarot.name,
+                "tarot_reversed": False,
+                "traits_complete": True,
+                "selected_cantrip_id": self.cantrip.id,
+                "skills": {str(self.skill.pk): 20},
+            },
+        )
+
+        character = finalize_character(draft, add_to_roster=True)
+        sheet = character.sheet_data
+
+        ritual = Ritual.objects.filter(
+            author_account=account,
+            execution_kind=RitualExecutionKind.SCENE_ACTION,
+        ).first()
+        self.assertIsNotNone(ritual, "Expected a SCENE_ACTION Ritual authored by the account")
+
+        config = RitualCheckConfig.objects.filter(ritual=ritual).first()
+        self.assertIsNotNone(config)
+        self.assertIsNotNone(config.check_type)
+        self.assertEqual(
+            config.check_type.name,
+            character_magic_check_type_name(sheet),
+        )

--- a/src/world/magic/tests/test_seeds_cast.py
+++ b/src/world/magic/tests/test_seeds_cast.py
@@ -1,0 +1,26 @@
+"""Tests for the shared standalone technique-cast seed scaffolding (#1306)."""
+
+from django.test import TestCase
+
+from actions.constants import Pipeline
+from world.magic.seeds_cast import (
+    TECHNIQUE_CAST_POOL_NAME,
+    ensure_technique_cast_content,
+    get_standalone_cast_template,
+)
+
+
+class TechniqueCastSeedTests(TestCase):
+    def test_seeds_template_with_check_and_graded_pool(self):
+        template = ensure_technique_cast_content()
+        self.assertEqual(template.category, "magic")
+        self.assertEqual(template.pipeline, Pipeline.SINGLE)
+        self.assertIsNotNone(template.check_type)
+        self.assertEqual(template.consequence_pool.name, TECHNIQUE_CAST_POOL_NAME)
+        self.assertGreaterEqual(template.consequence_pool.entries.count(), 3)
+
+    def test_idempotent_and_get_returns_same_row(self):
+        a = ensure_technique_cast_content()
+        b = ensure_technique_cast_content()
+        self.assertEqual(a.pk, b.pk)
+        self.assertEqual(get_standalone_cast_template().pk, a.pk)

--- a/src/world/magic/tests/test_technique_builder_service.py
+++ b/src/world/magic/tests/test_technique_builder_service.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from actions.factories import ActionTemplateFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.exceptions import TechniqueBudgetExceeded
 from world.magic.factories import (
@@ -15,6 +16,7 @@ from world.magic.models import (
     TechniqueBudgetConfig,
     TechniqueTierBudget,
 )
+from world.magic.seeds_cast import TECHNIQUE_CAST_TEMPLATE_NAME
 from world.magic.services.technique_builder import (
     PlayerPolicy,
     StaffPolicy,
@@ -342,3 +344,41 @@ class CapabilityConditionPricingLineTests(TestCase):
             + 2 * cfg.condition_duration_unit_cost
         )
         assert bd.gross_cost == intensity_cost + control_cost + cap_line_cost + cond_line_cost
+
+
+# =============================================================================
+# §10 create_technique default action_template (#1306)
+# =============================================================================
+
+
+class CreateTechniqueDefaultActionTemplateTests(TestCase):
+    """create_technique should default action_template to the shared cast template."""
+
+    def _minimal_kwargs(self):
+        sheet = CharacterSheetFactory()
+        return {
+            "creator": sheet,
+            "name": "Test Cantrip",
+            "gift": GiftFactory(creator=sheet),
+            "style": TechniqueStyleFactory(),
+            "effect_type": EffectTypeFactory(),
+            "intensity": 1,
+            "control": 1,
+            "anima_cost": 1,
+            "level": 1,
+            "action_category": "physical",
+            "description": "",
+        }
+
+    def test_create_technique_defaults_shared_cast_template(self):
+        """No action_template arg → seeds and assigns the shared cast template."""
+        tech = create_technique(**self._minimal_kwargs())
+        self.assertIsNotNone(tech.action_template)
+        self.assertEqual(tech.action_template.name, TECHNIQUE_CAST_TEMPLATE_NAME)
+
+    def test_explicit_action_template_wins(self):
+        """Explicit action_template overrides the default; the shared template is not used."""
+        custom = ActionTemplateFactory(name="Bespoke Cast")
+        tech = create_technique(**self._minimal_kwargs(), action_template=custom)
+        self.assertEqual(tech.action_template_id, custom.pk)
+        self.assertEqual(tech.action_template.name, "Bespoke Cast")

--- a/src/world/scenes/cast_services.py
+++ b/src/world/scenes/cast_services.py
@@ -100,10 +100,15 @@ def _resolve_cast(  # noqa: PLR0913 - cohesive cast-resolution params
     (BASE + ENVIRONMENT stages), and the ``FuryResolution`` (None if no fury).
     """
     from world.magic.services import use_technique  # noqa: PLC0415
+    from world.magic.services.anima import get_character_cast_check  # noqa: PLC0415
     from world.magic.services.cast_threads import applicable_threads_for_cast  # noqa: PLC0415
 
     action_template = technique.action_template
     context = ResolutionContext(character=character, target=target)
+
+    # The cast rolls the CASTER'S personal magic check (their anima-ritual check);
+    # falls back to the template's own check (None) when no ritual is provisioned.
+    cast_check = get_character_cast_check(character)
 
     from world.magic.services.fury import run_fury_for_action  # noqa: PLC0415
 
@@ -125,6 +130,7 @@ def _resolve_cast(  # noqa: PLR0913 - cohesive cast-resolution params
             template=action_template,
             target_difficulty=difficulty,
             context=context,
+            check_type=cast_check,
         )
 
     technique_result = use_technique(

--- a/src/world/scenes/tests/test_cast_per_character_check.py
+++ b/src/world/scenes/tests/test_cast_per_character_check.py
@@ -1,0 +1,238 @@
+"""End-to-end regression for #1306: a CG-finalized character can cast a cantrip
+technique standalone, and the cast rolls the CASTER'S per-character magic check.
+
+Issue #1306: standalone casts previously raised "Technique is not castable
+standalone" because cantrip-derived techniques carried no action_template, and
+even once they did, the cast rolled the template's fallback check rather than the
+character's personal anima-ritual check.
+
+This suite proves both halves of the fix on a real finalized character:
+
+1. ``request_technique_cast`` for a self-target cast RESOLVES (no ValidationError).
+2. The resolution rolls ``get_character_cast_check(character)`` — the per-character
+   CheckType named ``character_magic_check_type_name(sheet)`` — NOT the shared
+   "Technique Cast" fallback. Verified by spying the ``check_type`` argument passed
+   into ``start_action_resolution``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import patch
+
+from django.test import TestCase
+from evennia import create_object
+from evennia.accounts.models import AccountDB
+
+from world.character_creation.models import Beginnings, CharacterDraft, StartingArea
+from world.character_creation.services import finalize_character
+from world.character_sheets.models import CharacterSheet, Gender
+from world.classes.factories import PathFactory
+from world.classes.models import PathStage
+from world.forms.models import Build, HeightBand
+from world.magic.factories import (
+    CantripFactory,
+    EffectTypeFactory,
+    ResonanceFactory,
+    TechniqueStyleFactory,
+    TraditionFactory,
+)
+from world.magic.models import CharacterTechnique
+from world.magic.seeds_cast import TECHNIQUE_CAST_CHECK_TYPE_NAME
+from world.magic.seeds_checks import character_magic_check_type_name
+from world.magic.services.anima import get_character_cast_check
+from world.realms.models import Realm
+from world.roster.models import Roster
+from world.scenes import cast_services
+from world.scenes.cast_services import request_technique_cast
+from world.scenes.factories import PersonaFactory, SceneFactory
+from world.skills.factories import SkillFactory
+from world.species.models import Species
+from world.tarot.constants import ArcanaType
+from world.tarot.models import TarotCard
+from world.traits.factories import CheckSystemSetupFactory
+from world.traits.models import CharacterTraitValue, Trait, TraitType
+
+_STATS = {
+    "strength": 2,
+    "agility": 2,
+    "stamina": 2,
+    "charm": 2,
+    "presence": 2,
+    "composure": 2,
+    "intellect": 2,
+    "wits": 2,
+    "stability": 2,
+    "luck": 2,
+    "perception": 2,
+    "willpower": 2,
+}
+
+
+class CastUsesPerCharacterCheckTests(TestCase):
+    """A finalized character casts a cantrip technique using their personal check."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # Full check system (outcomes/charts/ranks + stat traits) so perform_check
+        # can resolve and so the cast pipeline runs end-to-end.
+        CheckSystemSetupFactory.create()
+        for stat_name in _STATS:
+            Trait.objects.get_or_create(
+                name=stat_name,
+                defaults={"trait_type": TraitType.STAT, "description": stat_name},
+            )
+        Roster.objects.get_or_create(name="Available Characters")
+
+        realm = Realm.objects.create(name="CastPC Realm", description="Test")
+        cls.area = StartingArea.objects.create(
+            name="CastPC Area",
+            description="Test",
+            realm=realm,
+            access_level=StartingArea.AccessLevel.ALL,
+        )
+        cls.species = Species.objects.create(name="CastPC Species", description="Test")
+        cls.gender, _ = Gender.objects.get_or_create(
+            key="castpc_gender",
+            defaults={"display_name": "CastPC Gender"},
+        )
+        cls.tarot = TarotCard.objects.create(
+            name="CastPC Fool",
+            arcana_type=ArcanaType.MAJOR,
+            rank=97,
+            latin_name="FatuiPC",
+        )
+        cls.beginnings = Beginnings.objects.create(
+            name="CastPC Beginnings",
+            description="Test",
+            starting_area=cls.area,
+            trust_required=0,
+            is_active=True,
+            family_known=False,
+        )
+        cls.beginnings.allowed_species.add(cls.species)
+        cls.height_band = HeightBand.objects.create(
+            name="castpc_band",
+            display_name="CastPC Band",
+            min_inches=6000,
+            max_inches=6100,
+            weight_min=None,
+            weight_max=None,
+            is_cg_selectable=True,
+        )
+        cls.build = Build.objects.create(
+            name="castpc_build",
+            display_name="CastPC Build",
+            weight_factor=Decimal("1.0"),
+            is_cg_selectable=True,
+        )
+        cls.path = PathFactory(name="CastPC Path", stage=PathStage.PROSPECT, minimum_level=1)
+        TechniqueStyleFactory()
+        EffectTypeFactory()
+        ResonanceFactory()
+        cls.tradition = TraditionFactory()
+        # Skill so provision_player_anima_ritual finds a default and doesn't skip.
+        cls.skill = SkillFactory(trait__name="CastPCRitualism")
+        cls.cantrip = CantripFactory(requires_facet=False)
+
+    def setUp(self) -> None:
+        CharacterSheet.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        Trait.flush_instance_cache()
+
+    def _finalize_caster(self) -> tuple[object, CharacterSheet, AccountDB]:
+        """Run a full CG finalization, returning (character, sheet, account).
+
+        Sets ``character.db_account`` to model the logged-in/runtime state — the
+        cast-check resolver keys on ``character.db_account`` and ``finalize_character``
+        does not puppet the character (Task 3 finding).
+        """
+        account = AccountDB.objects.create(username=f"castpc_run_{id(self)}")
+        draft = CharacterDraft.objects.create(
+            account=account,
+            selected_area=self.area,
+            selected_beginnings=self.beginnings,
+            selected_species=self.species,
+            selected_gender=self.gender,
+            selected_path=self.path,
+            selected_tradition=self.tradition,
+            age=25,
+            height_band=self.height_band,
+            height_inches=6050,
+            build=self.build,
+            draft_data={
+                "first_name": "CastPC",
+                "description": "A test character",
+                "stats": _STATS,
+                "lineage_is_orphan": True,
+                "tarot_card_name": self.tarot.name,
+                "tarot_reversed": False,
+                "traits_complete": True,
+                "selected_cantrip_id": self.cantrip.id,
+                "skills": {str(self.skill.pk): 20},
+            },
+        )
+        character = finalize_character(draft, add_to_roster=True)
+        sheet = character.sheet_data
+        # Model the runtime/logged-in state: the resolver queries
+        # author_account=character.db_account.
+        character.db_account = account
+        character.save(update_fields=["db_account"])
+        return character, sheet, account
+
+    def test_finalized_character_casts_with_personal_check(self) -> None:
+        """A CG-finalized character can self-cast their cantrip technique, and the
+        cast rolls their per-character magic check rather than the fallback."""
+        character, sheet, _account = self._finalize_caster()
+
+        # The cantrip finalized into a real Technique with the default cast template.
+        char_technique = CharacterTechnique.objects.filter(character=sheet).first()
+        self.assertIsNotNone(
+            char_technique, "Finalized character should know a cantrip-derived technique"
+        )
+        technique = char_technique.technique
+        self.assertIsNotNone(
+            technique.action_template_id,
+            "Cantrip-derived technique must carry the default cast template (Task 6)",
+        )
+
+        # The personal check exists and is what we expect the cast to roll.
+        personal_check = get_character_cast_check(character)
+        self.assertIsNotNone(
+            personal_check, "Finalized character must have a per-character cast check"
+        )
+        expected_name = character_magic_check_type_name(sheet)
+        self.assertEqual(personal_check.name, expected_name)
+
+        # A persona on this finalized sheet, in an active scene, to cast through.
+        room = create_object("typeclasses.rooms.Room", key="CastPC Room", nohome=True)
+        scene = SceneFactory(location=room)
+        caster_persona = PersonaFactory(character_sheet=sheet)
+
+        # Spy the real start_action_resolution (``wraps`` keeps the cast resolving)
+        # to capture the check_type forwarded — proving the per-character override
+        # was applied rather than the template fallback.
+        with patch.object(
+            cast_services,
+            "start_action_resolution",
+            wraps=cast_services.start_action_resolution,
+        ) as spy:
+            # CORE REGRESSION: a self-target cast must RESOLVE (no
+            # "Technique is not castable standalone" ValidationError).
+            cast_result = request_technique_cast(
+                scene=scene,
+                initiator_persona=caster_persona,
+                target_persona=None,
+                technique=technique,
+            )
+
+        self.assertIsNotNone(cast_result)
+        self.assertIsNotNone(cast_result.result, "Immediate self-cast should return a result")
+
+        # The cast rolled the CASTER'S per-character check, not the shared fallback.
+        spy.assert_called_once()
+        rolled = spy.call_args.kwargs.get("check_type")
+        self.assertIsNotNone(rolled, "cast must forward an explicit per-character check_type")
+        self.assertEqual(rolled.pk, personal_check.pk)
+        self.assertEqual(rolled.name, expected_name)
+        self.assertNotEqual(rolled.name, TECHNIQUE_CAST_CHECK_TYPE_NAME)


### PR DESCRIPTION
Closes #1306

## Summary

Fixes the magic playable-loop blocker: no technique was castable out of the box because CG-minted cantrip-techniques had no `action_template` and the standalone cast hard-rejects a null one.

**What changed (no schema migration — service + seed code over existing models):**
- **Castable by default:** `create_technique` now defaults `action_template` to a single shared, seeded **"Technique Cast"** `ActionTemplate` (new `world/magic/seeds_cast.py`, wired into the magic dev seed). The per-technique FK is preserved as a staff override.
- **Per-character magic check (the heart of it):** a caster's techniques roll **their own** check — the one their Anima Ritual defines — not a homogenized global check. `provision_player_anima_ritual` now synthesizes a per-character `CheckType` (stat + skill + Arcana aspect) and points `RitualCheckConfig.check_type` at it, closing the old 'stat/skill are inert hints' gap so the anima ritual *and* casting roll the same personal check.
- **Resolver seam:** `get_character_cast_check` resolves the caster's check; `start_action_resolution`/`_run_main_step` gained an optional `check_type` override; `_resolve_cast` passes the caster's check (falling back to the template's check when un-provisioned).
- **Graded outcomes:** a base "Magic: Technique Cast" `ConsequencePool` (Failure / Partial Success / Success), seeded for future per-technique inheritance.

**Why one shared template is enough:** verified during design — per-technique variation lives on the Technique (effects/payload), the event/flow layer (`TECHNIQUE_CAST` events + `has_property` triggers), and runtime routing (target + hostility); `ActionTemplate.target_type` isn't even read in the cast path. The shared template is pure resolution scaffolding.

**Tests:** an end-to-end regression finalizes a real CG character and proves the cantrip-technique cast resolves *and* rolls the per-character check (non-tautological). Each change is TDD'd; docs updated in tandem (magic CLAUDE.md, systems/magic.md, INDEX, roadmap; MODEL_MAP regen — no diff).

**Out of scope → follow-ups:** technique designer #1320, targeting model #1321, seed-spine hardening #1322.

## Follow-ups filed

- #1320
- #1321
- #1322

## Notes

- Spec: reviewed & approved on #1306 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto origin/main (427acbc5) — no conflicts, no migration collisions. No schema migration in this branch.

<!-- last-addressed-comment: 0 -->