### PR TITLE
Cover-bio display: read bio from the presented persona's profile (#1270, slice 2)

### DIFF
--- a/docs/systems/character_sheets.md
+++ b/docs/systems/character_sheets.md
@@ -10,7 +10,7 @@ CharacterSheet is the single anchor for all character-related data.
 
 `CharacterSheet` is OneToOne to ObjectDB (`primary_key=True` — shares pk), holding demographics/appearance fields. Every playable character has one.
 
-The **narrative bio** (concept, real_concept, quote, personality, background, obituary) was sliced out into a separate **`Profile`** model (#1270) so a cover identity can present its own bio. The sheet owns one `true_profile` (its real bio), and the PRIMARY persona points at it. `CharacterSheet` keeps read/write forwarding properties (`sheet.concept` → `true_profile.concept`, with a `save()` cascade), so existing reads/writes are unchanged — bio just lives on the profile now. Lineage FKs (family/heritage/tarot/origin) and the cover-bio *display* + authoring flow are follow-up slices.
+The **narrative bio** (concept, real_concept, quote, personality, background, obituary) was sliced out into a separate **`Profile`** model (#1270) so a cover identity can present its own bio. The sheet owns one `true_profile` (its real bio), and the PRIMARY persona points at it. `CharacterSheet` keeps read/write forwarding properties (`sheet.concept` → `true_profile.concept`, with a `save()` cascade), so existing reads/writes are unchanged — bio just lives on the profile now. **Cover-bio display is wired** (#1270 slice 2): the profile serializer reads concept/quote/story from the *presented* persona's profile (`_presented_bio_profile`) — the real `true_profile` when revealed, a cover persona's own authored profile when presenting one, else blank (never the real bio for a non-revealed face). Lineage FKs (family/heritage/tarot/origin) and the cover-bio *authoring* form are the remaining follow-up slices.
 
 ## Privacy Tiers (#1271)
 

--- a/src/world/character_sheets/serializers.py
+++ b/src/world/character_sheets/serializers.py
@@ -17,7 +17,7 @@ from evennia.objects.models import ObjectDB
 from rest_framework import serializers
 from rest_framework.request import Request
 
-from world.character_sheets.models import CharacterSheet
+from world.character_sheets.models import CharacterSheet, Profile
 from world.character_sheets.services import can_edit_character_sheet
 from world.character_sheets.types import (
     SHEET_VISIBILITY_RANK,
@@ -125,17 +125,22 @@ def _build_identity(
     *,
     display_name: str | None = None,
     reveal_identity: bool = True,
+    bio_profile: Profile | None = None,
 ) -> IdentitySection:
-    """Build the identity section (#1109-aware).
+    """Build the identity section (#1109/#1270-aware).
 
     ``display_name`` is the name resolved for the viewer (the presented persona / sdesc / reveal);
-    defaults to the character's key. When ``reveal_identity`` is False — a non-privileged viewer
-    of a character presenting an anonymous face — only the presented name and the physically
-    observable traits (age, gender, pronouns, species) are returned; every identifying / lore
-    field (real fullname, concept, quote, family, heritage, tarot, origin, path) is withheld.
+    defaults to the character's key. ``bio_profile`` is the **presented face's** bio (#1270): the
+    real ``true_profile`` for a revealed identity, a cover persona's own (fabricated) profile when
+    presenting an anonymous face that has authored one, or None (concept/quote blank). When
+    ``reveal_identity`` is False — a non-privileged viewer of an anonymous face — the **lineage**
+    fields (real fullname, family, heritage, tarot, origin, path) are still withheld, but the
+    presented face's own concept/quote DO show (a cover identity reads as a real person).
     """
     character = sheet.character
     name = display_name if display_name is not None else character.db_key
+    concept = bio_profile.concept if bio_profile is not None else ""
+    quote = bio_profile.quote if bio_profile is not None else ""
 
     pronouns = PronounsData(
         subject=sheet.pronoun_subject,
@@ -147,8 +152,8 @@ def _build_identity(
         return IdentitySection(
             name=name,
             fullname=name,
-            concept="",
-            quote="",
+            concept=concept,
+            quote=quote,
             age=sheet.age,
             gender=_id_name_or_null(sheet.gender, name_field="display_name"),
             pronouns=pronouns,
@@ -171,8 +176,8 @@ def _build_identity(
     return IdentitySection(
         name=name,
         fullname=fullname,
-        concept=sheet.concept,
-        quote=sheet.quote,
+        concept=concept,
+        quote=quote,
         age=sheet.age,
         gender=_id_name_or_null(sheet.gender, name_field="display_name"),
         pronouns=pronouns,
@@ -212,6 +217,28 @@ def _resolve_active_persona(sheet: CharacterSheet) -> Persona | None:
     if active_id is not None:
         return next((p for p in personas if p.pk == active_id), None)
     return next((p for p in personas if p.persona_type == PersonaType.PRIMARY), None)
+
+
+def _presented_bio_profile(
+    sheet: CharacterSheet, active: Persona | None, *, reveal_identity: bool
+) -> Profile | None:
+    """The bio (concept/quote/story) source for the presented face (#1270).
+
+    - **Revealed** (owner/staff/primary-public/discovered) → the real ``true_profile``.
+    - **Anonymous face with its own authored cover profile** → that cover profile (a fabricated
+      bio shown as if real, so the cover doesn't out itself with an empty one).
+    - **Anonymous face with no cover profile** → None (concept/quote/story blank). Never the real
+      ``true_profile`` for a non-revealed face — that would de-anonymize.
+    """
+    if reveal_identity:
+        return sheet.true_profile
+    if (
+        active is not None
+        and active.profile_id is not None
+        and active.profile_id != sheet.true_profile_id
+    ):
+        return active.profile
+    return None
 
 
 def _viewer_is_privileged(sheet: CharacterSheet, user: Any) -> bool:
@@ -644,11 +671,18 @@ _STORY_SELECT_RELATED: tuple[str, ...] = ("true_profile",)  # #1270 — backgrou
 _STORY_PREFETCH_RELATED: tuple[str | Prefetch, ...] = ()
 
 
-def _build_story(sheet: CharacterSheet) -> StorySection:
-    """Build the story section from CharacterSheet text fields."""
+def _build_story(*, bio_profile: Profile | None = None) -> StorySection:
+    """Build the story section from the presented face's bio profile (#1270).
+
+    ``bio_profile`` is the real ``true_profile`` for a revealed identity, a cover persona's own
+    (fabricated) profile when presenting one, or None (empty story) — so a cover shows its own
+    story and a bare anonymous figure shows nothing.
+    """
+    if bio_profile is None:
+        return StorySection(background="", personality="")
     return StorySection(
-        background=sheet.background,
-        personality=sheet.personality,
+        background=bio_profile.background,
+        personality=bio_profile.personality,
     )
 
 
@@ -679,7 +713,7 @@ _PERSONAS_SELECT_RELATED: tuple[str, ...] = ()
 _PERSONAS_PREFETCH_RELATED: tuple[str | Prefetch, ...] = (
     Prefetch(
         "personas",
-        queryset=Persona.objects.select_related("thumbnail").prefetch_related(
+        queryset=Persona.objects.select_related("thumbnail", "profile").prefetch_related(
             # Each persona's per-trait descriptors, so the appearance builder can
             # overlay the active face's descriptors at zero extra queries.
             Prefetch(
@@ -870,12 +904,18 @@ class CharacterSheetSerializer(serializers.Serializer):
         show_skills = _section_visible(access, sheet.skills_visibility)
         show_magic = _section_visible(access, sheet.magic_visibility)
         show_goals = _section_visible(access, sheet.goals_visibility)
+        # #1270 — bio (concept/quote/story) reads from the presented face's profile: the real
+        # one when revealed, a cover persona's own when presenting one, else blank.
+        bio_profile = _presented_bio_profile(sheet, active, reveal_identity=reveal_identity)
 
         return {
             "id": sheet.pk,
             "can_edit": can_edit_character_sheet(user, roster_entry) if user else False,
             "identity": _build_identity(
-                sheet, display_name=display_name, reveal_identity=reveal_identity
+                sheet,
+                display_name=display_name,
+                reveal_identity=reveal_identity,
+                bio_profile=bio_profile,
             ),
             "appearance": _build_appearance(sheet),
             "stats": _build_stats(sheet) if show_stats else {},
@@ -883,13 +923,8 @@ class CharacterSheetSerializer(serializers.Serializer):
             "path": _build_path_detail(sheet),
             "distinctions": _build_distinctions(sheet, privileged=privileged),
             "magic": _build_magic(sheet) if show_magic else None,
-            # Story is public by default, but withheld from a non-revealed (anonymous /
-            # hidden-link) figure — a cover identity's fake story is a future Guise Sheet.
-            "story": (
-                _build_story(sheet)
-                if reveal_identity
-                else StorySection(background="", personality="")
-            ),
+            # Story reads from the presented face's profile (cover identities show their own).
+            "story": _build_story(bio_profile=bio_profile),
             "goals": _build_goals(sheet) if show_goals else [],
             "personas": _build_personas(
                 sheet,

--- a/src/world/character_sheets/tests/test_profile_identity_privacy.py
+++ b/src/world/character_sheets/tests/test_profile_identity_privacy.py
@@ -157,6 +157,32 @@ class ProfileIdentityPrivacyTests(APITestCase):
         # identity in parens so it is never ambiguous which character the mask belongs to.
         assert data["identity"]["name"] == f"stag mask ({sheet.primary_persona.name})"
 
+    def test_cover_persona_with_its_own_profile_shows_the_cover_bio(self) -> None:
+        # #1270 slice 2 — a cover face that has authored its own profile reads as a real person:
+        # its fabricated bio shows, NOT the real one, NOT blank. Lineage stays withheld.
+        from world.character_sheets.factories import ProfileFactory
+
+        sheet = self._character_sheet(AccountFactory(), fake_active=True)  # presents "stag mask"
+        cover = sheet.active_persona
+        cover.profile = ProfileFactory(concept="A kindly merchant", background="Sells fine silks.")
+        cover.save()
+        viewer = AccountFactory()
+        self._character_sheet(viewer)
+
+        data = self._get(sheet, viewer).data
+        assert data["identity"]["concept"] == "A kindly merchant"  # the cover's own bio
+        assert data["story"]["background"] == "Sells fine silks."
+        assert data["identity"]["family"] is None  # the real lineage stays hidden
+
+    def test_anonymous_face_without_a_cover_profile_still_redacts_bio(self) -> None:
+        # No authored cover profile → the real bio is never shown to a non-owner (no de-anon).
+        sheet = self._character_sheet(AccountFactory(), fake_active=True)  # mask, no own profile
+        viewer = AccountFactory()
+        self._character_sheet(viewer)
+        data = self._get(sheet, viewer).data
+        assert data["identity"]["concept"] == ""
+        assert data["story"]["background"] == ""
+
     def _distinction_names(self, data) -> set[str]:
         return {d["name"] for d in data["distinctions"]}
 

--- a/src/world/character_sheets/tests/test_viewset.py
+++ b/src/world/character_sheets/tests/test_viewset.py
@@ -2107,7 +2107,7 @@ class TestPrefetchCompleteness(TestCase):
     def test_story_zero_queries(self) -> None:
         sheet = self._get_sheet()
         with self.assertNumQueries(0):
-            _build_story(sheet)
+            _build_story(bio_profile=sheet.true_profile)
 
     def test_goals_zero_queries(self) -> None:
         sheet = self._get_sheet()


### PR DESCRIPTION
The cover-identity **display payoff** for #1270. The profile serializer reads concept/quote/story
from the *presented* face's profile, not always the sheet's real one.

## What changed
- **`_presented_bio_profile(sheet, active, reveal_identity)`** — the bio source:
  - **Revealed** (owner/staff/primary-public/discovered) → the real `true_profile`.
  - **Anonymous face with its own authored profile** → that cover profile (fabricated bio, shown
    as if real — so a cover doesn't out itself with an empty bio).
  - **Anonymous face, no cover profile** → None (concept/quote/story blank). **Never the real bio
    for a non-revealed face** — no de-anonymization.
- `_build_identity` / `_build_story` take a `bio_profile` source. **Lineage** (family/heritage/
  tarot/origin) stays sheet-based + reveal-gated — moving it to Profile is slice 3.
- Persona prefetch now `select_related("profile")` → query-free.

## Behaviour-preserving
No cover profiles exist until the authoring form, so today this is identical to #1269: revealed →
real bio, bare anonymous → redacted. The logic is just ready for cover profiles.

## Tests
A cover with its own profile shows the cover bio (not real, not blank); a bare mask still redacts.
`world.character_sheets` green (237); query budget unchanged. ruff clean; 2 pre-existing ty
diagnostics unchanged.

## Remaining #1270
Lineage FK move (slice 3) and the cover-bio **authoring** form (player-facing — for your input).

Refs #1270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)