### PR TITLE
Telnet combat-cast L0: DispatchCommand base + cast/declare command (#1330)

### DIFF
--- a/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
+++ b/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
@@ -88,7 +88,7 @@ web-only; the minimal fix is telnet `intimidate`/`accept`/`deny` shells over the
 |---|---|---|---|---|---|
 | See available techniques | ❌ none | `get_player_actions` / `_combat_actions` (`player_interface.py`) | N/A | — | G3 |
 | Declare cast (non-combat) | ❌ none | `dispatch_player_action`→CHALLENGE→`resolve_challenge` (`challenge_resolution.py`) | seam converges; no telnet | — | **G1** |
-| Declare cast (combat) | `cast`/`declare` (`commands/combat.py` — `CmdDeclareTechnique(DispatchCommand)`) | `dispatch_player_action`→COMBAT→`declare_action` (`combat/services.py:1494`) | **YES** — telnet calls `dispatch_player_action` (same seam) | `test_combat_ui_integration.py`, `test_cmd_declare_technique.py` | **G0** |
+| Declare cast (combat) | `cast`/`declare` (`commands/combat.py` — `CmdDeclareTechnique(DispatchCommand)`) | `dispatch_player_action`→COMBAT→`declare_action` (`combat/services.py:1494`) | **YES** — telnet calls `dispatch_player_action` (same seam) | `test_combat_ui_integration.py`, `test_combat_cast_telnet_e2e.py`, `test_combat_commands.py` | **G0** |
 | Check + resonance env + effects | N/A (service) | `resolve_round`→`resolve_combat_technique` (`:707`)→`use_technique` (`techniques.py:702`) | **YES** — fully shared service orchestration | `test_magic_story_pipeline.py` | **G0** |
 | Perform ritual | ✅ `ritual`/`perform` (`CmdRitual`) | `RitualPerformView` → `PerformRitualAction.run()` | **YES** — both converge on `perform_ritual` action | `test_ritual_telnet_e2e.py` | **RESOLVED (#1331)** |
 

--- a/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
+++ b/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
@@ -36,7 +36,7 @@ actions. Magic and combat never touch `action.run()`. **Fix-on-sight target.**
 
 | # | Web dispatch family | Entry | Reaches | Telnet today |
 |---|---|---|---|---|
-| 1 | **Unified action dispatch** | `dispatch_player_action()` | REGISTRY→`action.run`, CHALLENGE→`resolve_challenge`, COMBAT→`declare_action`/`resolve_round`→`use_technique` | Only REGISTRY, and only via `self.action.run()` (bypassing the dispatcher) |
+| 1 | **Unified action dispatch** | `dispatch_player_action()` | REGISTRY→`action.run`, CHALLENGE→`resolve_challenge`, COMBAT→`declare_action`/`resolve_round`→`use_technique` | REGISTRY via `ArxCommand` → `self.action.run()`; COMBAT via `DispatchCommand` → `dispatch_player_action()` (`CmdDeclareTechnique`); CHALLENGE still G1 (#1332) |
 | 2 | **Consent flow** | `SceneActionRequestViewSet` (`action_views.py:55`) → `create_action_request`/`respond_to_action_request` (`action_services.py:150/304`) → `start_action_resolution` | Targeted social actions (intimidate, persuade, …) with accept/deny gating | ❌ none |
 | 3 | **Direct viewset→service** | dedicated viewsets/views → service fn (no action, no dispatcher) | thread weave/imbue/pull, rituals, outfits, narrative | ❌ none |
 
@@ -88,7 +88,7 @@ web-only; the minimal fix is telnet `intimidate`/`accept`/`deny` shells over the
 |---|---|---|---|---|---|
 | See available techniques | ❌ none | `get_player_actions` / `_combat_actions` (`player_interface.py`) | N/A | — | G3 |
 | Declare cast (non-combat) | ❌ none | `dispatch_player_action`→CHALLENGE→`resolve_challenge` (`challenge_resolution.py`) | seam converges; no telnet | — | **G1** |
-| Declare cast (combat) | ❌ none | `dispatch_player_action`→COMBAT→`declare_action` (`combat/services.py:1494`) | seam converges; no telnet | `test_combat_ui_integration.py` | **G1** |
+| Declare cast (combat) | `cast`/`declare` (`commands/combat.py` — `CmdDeclareTechnique(DispatchCommand)`) | `dispatch_player_action`→COMBAT→`declare_action` (`combat/services.py:1494`) | **YES** — telnet calls `dispatch_player_action` (same seam) | `test_combat_ui_integration.py`, `test_cmd_declare_technique.py` | **G0** |
 | Check + resonance env + effects | N/A (service) | `resolve_round`→`resolve_combat_technique` (`:707`)→`use_technique` (`techniques.py:702`) | **YES** — fully shared service orchestration | `test_magic_story_pipeline.py` | **G0** |
 | Perform ritual | ✅ `ritual`/`perform` (`CmdRitual`) | `RitualPerformView` → `PerformRitualAction.run()` | **YES** — both converge on `perform_ritual` action | `test_ritual_telnet_e2e.py` | **RESOLVED (#1331)** |
 
@@ -100,11 +100,11 @@ web-only; the minimal fix is telnet `intimidate`/`accept`/`deny` shells over the
 > SERVICE + FLOW rituals. (Anima/SCENE_ACTION rituals dispatch elsewhere and are
 > out of scope.)
 
-**Verdict:** cast→outcome cannot be driven via telnet today (no `cast`/`attempt` command).
-The deep orchestration (`use_technique`, ~15 steps: anima, soulfray, resonance environment,
-conditions, story beats, achievements) is already service-tested. Minimal fix: telnet
-`cast`/`attempt` commands that call `dispatch_player_action()` with a COMBAT/CHALLENGE
-`ActionRef` — riding the exact path the web uses.
+**Verdict:** combat declare is now telnet-driveable (G0) — `cast`/`declare`
+(`CmdDeclareTechnique`) calls `dispatch_player_action()` with a COMBAT `ActionRef`, the same
+seam the web uses. Non-combat (CHALLENGE) declare remains G1 (#1332). The deep
+orchestration (`use_technique`, ~15 steps: anima, soulfray, resonance environment, conditions,
+story beats, achievements) is already service-tested.
 
 ---
 

--- a/src/actions/base.py
+++ b/src/actions/base.py
@@ -22,8 +22,15 @@ class Action:
     """A self-contained action definition.
 
     Actions own their full lifecycle: prerequisites, intent event emission,
-    execution, and result event emission. Commands (telnet) and the web
-    dispatcher both call ``action.run()`` — the action handles everything.
+    execution, and result event emission.
+
+    ``action.run()`` is the entry point for the **REGISTRY** path only.  Plain
+    telnet :class:`~commands.command.ArxCommand` s call it directly; the web
+    frontend and telnet :class:`~commands.command.DispatchCommand` s instead call
+    ``dispatch_player_action()``, which routes by backend: REGISTRY →
+    ``action.run()``, CHALLENGE → ``resolve_challenge()``, COMBAT →
+    ``declare_action()``/``resolve_round()``.  Magic and combat actions never
+    reach ``action.run()`` directly.
 
     Subclasses override ``get_prerequisites()`` and ``execute()`` to define
     what the action checks and does.

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -7,20 +7,41 @@ and service functions.
 ## Architecture
 
 Commands exist for telnet compatibility only. The web frontend bypasses
-commands entirely and calls `action.run()` directly.
+commands entirely and calls `dispatch_player_action()`.
 
 ```
-Telnet: text → command.parse() → command.func() → action.run()
-Web:    frontend → websocket → action dispatcher → action.run()
+Telnet (ArxCommand):      text → command.parse() → command.func() → action.run()
+Telnet (DispatchCommand): text → command.parse() → command.func() → dispatch_player_action()
+Web:                      frontend → websocket → action dispatcher → dispatch_player_action()
 ```
+
+`dispatch_player_action()` routes by backend: REGISTRY → `action.run()`,
+CHALLENGE → `resolve_challenge()`, COMBAT → `declare_action()`/`resolve_round()`.
+Use `DispatchCommand` whenever the command must reach a CHALLENGE or COMBAT backend.
 
 ## Key Files
 
 ### `command.py`
-- **`ArxCommand`**: Base command class
+- **`ArxCommand`**: Base command class for REGISTRY actions
   - `action`: The Action instance this command delegates to
   - `resolve_action_args()`: Override to parse telnet text into action kwargs
   - `func()`: Calls `resolve_action_args()` → `action.run()` → sends result to caller
+- **`DispatchCommand(ArxCommand)`**: Base class for commands that ride the player-action dispatcher
+  - `resolve_action_ref()`: Override to return an `ActionRef` (backend + params)
+  - `resolve_action_args()`: Override to return extra kwargs passed alongside the ref
+  - `func()`: Calls `dispatch_player_action(caller, ref, kwargs)` — the same seam the web uses
+  - `_report_dispatch_result()`: Sends the caller a deferred-round confirmation or inline result
+
+### When to subclass `DispatchCommand` vs `ArxCommand`
+
+| Use | Base class |
+|---|---|
+| REGISTRY action (most look/say/move/item commands) | `ArxCommand` |
+| CHALLENGE backend (magic attempt, non-combat skill check) | `DispatchCommand` |
+| COMBAT backend (technique declaration into the current round) | `DispatchCommand` |
+
+Both bases stay thin: no business logic in commands — all behavior lives in
+actions, backends, and service functions.
 
 ### Command Files
 - **`evennia_overrides/perception.py`**: `CmdLook`, `CmdInventory`

--- a/src/commands/combat.py
+++ b/src/commands/combat.py
@@ -43,8 +43,9 @@ class CmdDeclareTechnique(DispatchCommand):
 
     _technique_name: str | None = None
     _target_name: str | None = None
-    _effort: str | None = None
+    _effort: str = "medium"
     _parsed: bool = False
+    _participant: CombatParticipant | None = None
 
     # --------------------------------------------------------------------------
 
@@ -65,7 +66,8 @@ class CmdDeclareTechnique(DispatchCommand):
         # Strip off effort=<level> if present (rightmost keyword=value pair).
         effort_str: str = EffortLevel.MEDIUM
         if _EFFORT_PREFIX in raw.lower():
-            parts = raw.rsplit(_EFFORT_PREFIX, 1)
+            # Split case-insensitively so "Effort=HIGH" is handled correctly.
+            parts = re.split(re.escape(_EFFORT_PREFIX), raw, flags=re.IGNORECASE)
             raw = parts[0].strip()
             effort_val = parts[1].strip().lower()
             valid_values = {v.value for v in EffortLevel}
@@ -160,17 +162,25 @@ class CmdDeclareTechnique(DispatchCommand):
         from world.combat.constants import OpponentStatus  # noqa: PLC0415
         from world.combat.models import CombatOpponent  # noqa: PLC0415
 
-        participant = self._active_participant()
+        # Reuse the participant cached by resolve_action_ref; fall back to querying.
+        participant = (
+            self._participant if self._participant is not None else self._active_participant()
+        )
         name = self._target_name
-        opponent = CombatOpponent.objects.filter(
-            encounter=participant.encounter,
-            status=OpponentStatus.ACTIVE,
-            name__iexact=name,
-        ).first()
-        if opponent is None:
+        matches = list(
+            CombatOpponent.objects.filter(
+                encounter=participant.encounter,
+                status=OpponentStatus.ACTIVE,
+                name__iexact=name,
+            )
+        )
+        if not matches:
             msg = f"No active opponent named '{name}' in this encounter."
             raise CommandError(msg)
-        return opponent.pk
+        if len(matches) > 1:
+            msg = f"More than one opponent named '{name}' — be more specific."
+            raise CommandError(msg)
+        return matches[0].pk
 
     # -- DispatchCommand interface ---------------------------------------------
 
@@ -179,11 +189,17 @@ class CmdDeclareTechnique(DispatchCommand):
 
         Parses args on the first call and caches the results so
         ``resolve_action_args`` can reuse them without re-parsing.
+
+        Raises:
+            CommandError: If the caller is not in an active DECLARING combat round.
         """
         from actions.constants import ActionBackend  # noqa: PLC0415
         from actions.types import ActionRef  # noqa: PLC0415
 
         self._parse_args()
+        # Gate ALL casts (targeted and untargeted) on an active DECLARING round.
+        # Cache the participant so _resolve_opponent_target_id can reuse it.
+        self._participant = self._active_participant()
         technique_id = self._resolve_technique_id()
         return ActionRef(backend=ActionBackend.COMBAT, technique_id=technique_id)
 

--- a/src/commands/combat.py
+++ b/src/commands/combat.py
@@ -1,0 +1,203 @@
+"""Combat-related telnet commands — thin adapters over the COMBAT dispatch backend.
+
+Commands here parse text input from telnet clients and delegate entirely to
+``dispatch_player_action``. No business logic lives here; validation and round
+gating are the dispatcher's job.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from commands.command import DispatchCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from actions.types import ActionRef
+    from world.combat.models import CombatParticipant
+
+# Keyword prefix used to parse effort=<level> from command args.
+_EFFORT_PREFIX = "effort="
+
+
+class CmdDeclareTechnique(DispatchCommand):
+    """Declare a technique for the current combat round.
+
+    Usage:
+        cast <technique> [at <target>] [effort=<level>]
+        declare <technique> [at <target>] [effort=<level>]
+
+    Declare which technique you will cast this round. Optionally focus
+    a specific opponent target with ``at <name>`` and set your effort
+    level with ``effort=<level>`` (very_low/low/medium/high/extreme;
+    defaults to medium).
+
+    You must be in an active combat round (DECLARING phase) to use this.
+    """
+
+    key = "cast"
+    aliases = ["declare"]
+    locks = "cmd:all()"
+
+    # -- Parsed state cached on first call to resolve_action_ref ---------------
+
+    _technique_name: str | None = None
+    _target_name: str | None = None
+    _effort: str | None = None
+    _parsed: bool = False
+
+    # --------------------------------------------------------------------------
+
+    def _parse_args(self) -> None:
+        """Parse ``self.args`` once; cache technique name, optional target, effort."""
+        if self._parsed:
+            return
+
+        import re  # noqa: PLC0415
+
+        from world.fatigue.constants import EffortLevel  # noqa: PLC0415
+
+        raw = (self.args or "").strip()
+        if not raw:
+            msg = "Usage: cast <technique> [at <target>] [effort=<level>]"
+            raise CommandError(msg)
+
+        # Strip off effort=<level> if present (rightmost keyword=value pair).
+        effort_str: str = EffortLevel.MEDIUM
+        if _EFFORT_PREFIX in raw.lower():
+            parts = raw.rsplit(_EFFORT_PREFIX, 1)
+            raw = parts[0].strip()
+            effort_val = parts[1].strip().lower()
+            valid_values = {v.value for v in EffortLevel}
+            if effort_val not in valid_values:
+                choices = "/".join(sorted(valid_values))
+                msg = f"Invalid effort level '{effort_val}'. Choose from: {choices}"
+                raise CommandError(msg)
+            effort_str = effort_val
+
+        # Split on " at " (case-insensitive) to separate technique from optional target.
+        match = re.match(r"^(.+?)\s+at\s+(.+)$", raw, flags=re.IGNORECASE)
+        if match:
+            self._technique_name = match.group(1).strip()
+            self._target_name = match.group(2).strip()
+        else:
+            self._technique_name = raw.strip()
+            self._target_name = None
+
+        if not self._technique_name:
+            msg = "Usage: cast <technique> [at <target>] [effort=<level>]"
+            raise CommandError(msg)
+
+        self._effort = effort_str
+        self._parsed = True
+
+    # -- Resolution helpers ----------------------------------------------------
+
+    def _active_participant(self) -> CombatParticipant:
+        """Return the caller's active CombatParticipant in a DECLARING encounter.
+
+        Raises:
+            CommandError: If no active DECLARING combat is found.
+        """
+        from world.combat.constants import EncounterStatus, ParticipantStatus  # noqa: PLC0415
+        from world.combat.models import CombatParticipant  # noqa: PLC0415
+
+        participant = (
+            CombatParticipant.objects.filter(
+                character_sheet=self.caller.sheet_data,
+                status=ParticipantStatus.ACTIVE,
+                encounter__status=EncounterStatus.DECLARING,
+            )
+            .select_related("encounter")
+            .order_by("-encounter__created_at")
+            .first()
+        )
+        if participant is None:
+            msg = "You are not in an active combat round."
+            raise CommandError(msg)
+        return participant
+
+    def _resolve_technique_id(self) -> int:
+        """Return the pk of the technique named by ``self._technique_name``.
+
+        Matches case-insensitively against ``Technique.name`` for techniques
+        the caller knows (via ``CharacterTechnique``).
+
+        Raises:
+            CommandError: If no matching known technique is found.
+        """
+        from world.magic.models import CharacterTechnique  # noqa: PLC0415
+
+        name = self._technique_name or ""
+        ct = (
+            CharacterTechnique.objects.filter(
+                character=self.caller.sheet_data,
+                technique__name__iexact=name,
+            )
+            .select_related("technique")
+            .first()
+        )
+        if ct is None:
+            msg = f"You don't know a technique called '{name}'."
+            raise CommandError(msg)
+        return ct.technique_id
+
+    def _resolve_opponent_target_id(self) -> int | None:
+        """Return the pk of the CombatOpponent named by ``self._target_name``.
+
+        Scoped to the caller's active encounter so stale/cross-encounter ids
+        cannot be targeted.
+
+        Returns ``None`` when no target name was provided (untargeted cast).
+
+        Raises:
+            CommandError: If a target name was given but no matching active
+                opponent was found.
+        """
+        if not self._target_name:
+            return None
+
+        from world.combat.constants import OpponentStatus  # noqa: PLC0415
+        from world.combat.models import CombatOpponent  # noqa: PLC0415
+
+        participant = self._active_participant()
+        name = self._target_name
+        opponent = CombatOpponent.objects.filter(
+            encounter=participant.encounter,
+            status=OpponentStatus.ACTIVE,
+            name__iexact=name,
+        ).first()
+        if opponent is None:
+            msg = f"No active opponent named '{name}' in this encounter."
+            raise CommandError(msg)
+        return opponent.pk
+
+    # -- DispatchCommand interface ---------------------------------------------
+
+    def resolve_action_ref(self) -> ActionRef:
+        """Build a COMBAT ``ActionRef`` for the declared technique.
+
+        Parses args on the first call and caches the results so
+        ``resolve_action_args`` can reuse them without re-parsing.
+        """
+        from actions.constants import ActionBackend  # noqa: PLC0415
+        from actions.types import ActionRef  # noqa: PLC0415
+
+        self._parse_args()
+        technique_id = self._resolve_technique_id()
+        return ActionRef(backend=ActionBackend.COMBAT, technique_id=technique_id)
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        """Return dispatch kwargs for the COMBAT backend.
+
+        Keys:
+            effort_level: EffortLevel value string (default ``"medium"``).
+            focused_opponent_target_id: CombatOpponent pk, omitted when no
+                ``at <target>`` was given.
+        """
+        self._parse_args()
+        opp_id = self._resolve_opponent_target_id()
+        kwargs: dict[str, Any] = {"effort_level": self._effort}
+        if opp_id is not None:
+            kwargs["focused_opponent_target_id"] = opp_id
+        return kwargs

--- a/src/commands/combat.py
+++ b/src/commands/combat.py
@@ -77,11 +77,12 @@ class CmdDeclareTechnique(DispatchCommand):
                 raise CommandError(msg)
             effort_str = effort_val
 
-        # Split on " at " (case-insensitive) to separate technique from optional target.
-        match = re.match(r"^(.+?)\s+at\s+(.+)$", raw, flags=re.IGNORECASE)
-        if match:
-            self._technique_name = match.group(1).strip()
-            self._target_name = match.group(2).strip()
+        # Split on the first " at " (case-insensitive) to separate technique from
+        # the optional target. A literal search avoids a backtracking-prone regex.
+        at_index = raw.lower().find(" at ")
+        if at_index != -1:
+            self._technique_name = raw[:at_index].strip()
+            self._target_name = raw[at_index + len(" at ") :].strip()
         else:
             self._technique_name = raw.strip()
             self._target_name = None

--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -9,12 +9,14 @@ from evennia.commands.command import Command
 
 from actions.errors import ActionDispatchError
 from actions.player_interface import dispatch_player_action
+from actions.result_extraction import extract_dispatch_message_data
 from actions.types import ActionResult
 from commands.consts import HelpFileViewMode
 from commands.descriptors import CommandDescriptor
 from commands.exceptions import CommandError
 from commands.frontend_types import FrontendDescriptor
 from commands.types import Kwargs
+from world.mechanics.types import ChallengeResolutionResult
 
 if TYPE_CHECKING:
     from actions.base import Action
@@ -232,5 +234,7 @@ class DispatchCommand(ArxCommand):
         if result.deferred:
             self.msg("You ready your action for this round.")
             return
-        if isinstance(result.detail, ActionResult) and result.detail.message:
-            self.msg(result.detail.message)
+        if isinstance(result.detail, (ActionResult, ChallengeResolutionResult)):
+            message, _ = extract_dispatch_message_data(result.detail)
+            if message:
+                self.msg(message)

--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING, Any
 
 from evennia.commands.command import Command
 
+from actions.errors import ActionDispatchError
+from actions.player_interface import dispatch_player_action
+from actions.types import ActionResult
 from commands.consts import HelpFileViewMode
 from commands.descriptors import CommandDescriptor
 from commands.exceptions import CommandError
@@ -15,6 +18,7 @@ from commands.types import Kwargs
 
 if TYPE_CHECKING:
     from actions.base import Action
+    from actions.types import ActionRef, DispatchResult
 
 
 class ArxCommand(Command):
@@ -189,3 +193,44 @@ class ArxCommand(Command):
             descriptors=descriptors,
         )
         return descriptor.to_dict()
+
+
+class DispatchCommand(ArxCommand):
+    """Telnet base for commands that route through the player-action dispatcher.
+
+    Unlike :class:`ArxCommand` (which calls ``action.run()`` directly — the
+    REGISTRY path), this builds an :class:`~actions.types.ActionRef` and calls
+    ``dispatch_player_action()``, the same seam the web frontend uses. That lets
+    a telnet command ride the CHALLENGE/COMBAT backends (round-gated
+    declarations) with no per-domain refactor. Subclasses override
+    :meth:`resolve_action_ref` and :meth:`resolve_action_args`.
+    """
+
+    def resolve_action_ref(self) -> ActionRef:
+        """Build the typed dispatch reference. Override in subclasses."""
+        raise NotImplementedError
+
+    def func(self) -> None:
+        """Execute the command by routing through the player-action dispatcher."""
+        try:
+            ref = self.resolve_action_ref()
+            kwargs = self.resolve_action_args()
+            result = dispatch_player_action(self.caller, ref, kwargs)
+        except ActionDispatchError as err:
+            self.msg(err.user_message)
+            return
+        except CommandError as err:
+            self.msg(str(err))
+            self.msg(
+                command_error={"error": str(err), "command": self.raw_string or ""},
+            )
+            return
+        self._report_dispatch_result(result)
+
+    def _report_dispatch_result(self, result: DispatchResult) -> None:
+        """Send a user-facing confirmation for the dispatched action."""
+        if result.deferred:
+            self.msg("You ready your action for this round.")
+            return
+        if isinstance(result.detail, ActionResult) and result.detail.message:
+            self.msg(result.detail.message)

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -20,6 +20,7 @@ from commands.account.account_info import CmdAccount
 from commands.account.character_switching import CmdCharacters, CmdIC
 from commands.account.prompt_reply import CmdPromptReply
 from commands.account.sheet import CmdSheet
+from commands.combat import CmdDeclareTechnique
 from commands.door import CmdLock, CmdUnlock
 from commands.evennia_overrides.builder import CmdDig, CmdLink, CmdOpen, CmdUnlink
 from commands.evennia_overrides.communication import (
@@ -119,6 +120,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdMute())
         self.add(CmdUnmute())
         self.add(CmdBlockList())
+        # Combat commands
+        self.add(CmdDeclareTechnique())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/src/commands/tests/test_combat_commands.py
+++ b/src/commands/tests/test_combat_commands.py
@@ -23,7 +23,9 @@ def _make_cmd(args):
 class CmdDeclareTechniqueTests(TestCase):
     def test_builds_combat_ref_for_known_technique(self) -> None:
         cmd = _make_cmd("Firebolt at Mook")
+        participant = MagicMock()
         with (
+            patch.object(cmd, "_active_participant", return_value=participant),
             patch.object(cmd, "_resolve_technique_id", return_value=42) as mt,
             patch.object(cmd, "_resolve_opponent_target_id", return_value=7),
         ):
@@ -42,10 +44,54 @@ class CmdDeclareTechniqueTests(TestCase):
 
     def test_effort_override_parsed(self) -> None:
         cmd = _make_cmd("Firebolt at Mook effort=high")
+        participant = MagicMock()
         with (
+            patch.object(cmd, "_active_participant", return_value=participant),
             patch.object(cmd, "_resolve_technique_id", return_value=1),
             patch.object(cmd, "_resolve_opponent_target_id", return_value=2),
         ):
             cmd.resolve_action_ref()
             kwargs = cmd.resolve_action_args()
         self.assertEqual(kwargs["effort_level"], "high")
+
+    def test_mixed_case_effort_parsed(self) -> None:
+        """Mixed-case 'Effort=HIGH' must not raise IndexError and must parse correctly."""
+        cmd = _make_cmd("Firebolt at Mook Effort=HIGH")
+        participant = MagicMock()
+        with (
+            patch.object(cmd, "_active_participant", return_value=participant),
+            patch.object(cmd, "_resolve_technique_id", return_value=1),
+            patch.object(cmd, "_resolve_opponent_target_id", return_value=2),
+        ):
+            cmd.resolve_action_ref()
+            kwargs = cmd.resolve_action_args()
+        self.assertEqual(kwargs["effort_level"], "high")
+
+    def test_untargeted_cast_without_active_round_raises(self) -> None:
+        """cast Firebolt (no target) must gate on active participant."""
+        cmd = _make_cmd("Firebolt")
+        no_round = CommandError("You are not in an active combat round.")
+        with patch.object(cmd, "_active_participant", side_effect=no_round):
+            with self.assertRaises(CommandError):
+                cmd.resolve_action_ref()
+
+    def test_ambiguous_opponent_name_raises(self) -> None:
+        """Two opponents with the same name must raise CommandError."""
+        cmd = _make_cmd("Firebolt at Mook")
+        opp1 = MagicMock()
+        opp1.pk = 1
+        opp2 = MagicMock()
+        opp2.pk = 2
+
+        # Set up participant mock so _active_participant doesn't hit the DB.
+        participant = MagicMock()
+        participant.encounter = MagicMock()
+
+        with (
+            patch.object(cmd, "_resolve_technique_id", return_value=99),
+            patch.object(cmd, "_active_participant", return_value=participant),
+            patch("world.combat.models.CombatOpponent") as MockOpponent,
+        ):
+            MockOpponent.objects.filter.return_value = [opp1, opp2]
+            with self.assertRaises(CommandError):
+                cmd.resolve_action_args()

--- a/src/commands/tests/test_combat_commands.py
+++ b/src/commands/tests/test_combat_commands.py
@@ -1,0 +1,51 @@
+"""Unit tests for CmdDeclareTechnique (thin telnet shell over the COMBAT dispatcher)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from actions.constants import ActionBackend
+from commands.combat import CmdDeclareTechnique
+from commands.exceptions import CommandError
+
+
+def _make_cmd(args):
+    cmd = CmdDeclareTechnique()
+    cmd.caller = MagicMock()
+    cmd.args = args
+    cmd.raw_string = f"cast {args}"
+    cmd.cmdname = "cast"
+    return cmd
+
+
+class CmdDeclareTechniqueTests(TestCase):
+    def test_builds_combat_ref_for_known_technique(self) -> None:
+        cmd = _make_cmd("Firebolt at Mook")
+        with (
+            patch.object(cmd, "_resolve_technique_id", return_value=42) as mt,
+            patch.object(cmd, "_resolve_opponent_target_id", return_value=7),
+        ):
+            ref = cmd.resolve_action_ref()
+            kwargs = cmd.resolve_action_args()
+        mt.assert_called_once()
+        self.assertEqual(ref.backend, ActionBackend.COMBAT)
+        self.assertEqual(ref.technique_id, 42)
+        self.assertEqual(kwargs["focused_opponent_target_id"], 7)
+        self.assertEqual(kwargs["effort_level"], "medium")
+
+    def test_blank_args_raises(self) -> None:
+        cmd = _make_cmd("")
+        with self.assertRaises(CommandError):
+            cmd.resolve_action_ref()
+
+    def test_effort_override_parsed(self) -> None:
+        cmd = _make_cmd("Firebolt at Mook effort=high")
+        with (
+            patch.object(cmd, "_resolve_technique_id", return_value=1),
+            patch.object(cmd, "_resolve_opponent_target_id", return_value=2),
+        ):
+            cmd.resolve_action_ref()
+            kwargs = cmd.resolve_action_args()
+        self.assertEqual(kwargs["effort_level"], "high")

--- a/src/commands/tests/test_combat_commands.py
+++ b/src/commands/tests/test_combat_commands.py
@@ -95,3 +95,13 @@ class CmdDeclareTechniqueTests(TestCase):
             MockOpponent.objects.filter.return_value = [opp1, opp2]
             with self.assertRaises(CommandError):
                 cmd.resolve_action_args()
+
+
+class CmdsetRegistrationTests(TestCase):
+    def test_cast_command_registered(self) -> None:
+        from commands.default_cmdsets import CharacterCmdSet
+
+        cmdset = CharacterCmdSet()
+        cmdset.at_cmdset_creation()
+        keys = {c.key for c in cmdset.commands}
+        self.assertIn("cast", keys)

--- a/src/commands/tests/test_dispatch_command.py
+++ b/src/commands/tests/test_dispatch_command.py
@@ -52,7 +52,7 @@ class DispatchCommandTests(TestCase):
         with patch("commands.command.dispatch_player_action") as mock_dispatch:
             mock_dispatch.return_value = DispatchResult(backend=ActionBackend.COMBAT, deferred=True)
             cmd.func()
-        self.caller.msg.assert_called()
+        self.caller.msg.assert_called_with("You ready your action for this round.")
 
     def test_dispatch_error_shows_user_message(self) -> None:
         cmd = _make_cmd(_ProbeDispatchCommand, self.caller)
@@ -60,3 +60,10 @@ class DispatchCommandTests(TestCase):
             mock_dispatch.side_effect = ActionDispatchError(ActionDispatchError.UNKNOWN_ACTION_REF)
             cmd.func()
         self.caller.msg.assert_called_with("That action is no longer available.")
+
+    def test_dispatch_error_unknown_code_shows_fallback(self) -> None:
+        cmd = _make_cmd(_ProbeDispatchCommand, self.caller)
+        with patch("commands.command.dispatch_player_action") as mock_dispatch:
+            mock_dispatch.side_effect = ActionDispatchError("totally_unknown_code")
+            cmd.func()
+        self.caller.msg.assert_called_with("That action could not be completed.")

--- a/src/commands/tests/test_dispatch_command.py
+++ b/src/commands/tests/test_dispatch_command.py
@@ -1,0 +1,62 @@
+"""Tests for the DispatchCommand telnet base (rides dispatch_player_action)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from actions.constants import ActionBackend
+from actions.errors import ActionDispatchError
+from actions.types import ActionRef, DispatchResult
+from commands.command import DispatchCommand
+
+
+class _ProbeDispatchCommand(DispatchCommand):
+    key = "probe"
+
+    def resolve_action_ref(self) -> ActionRef:
+        return ActionRef(backend=ActionBackend.REGISTRY, registry_key="probe")
+
+    def resolve_action_args(self) -> dict:
+        return {"foo": "bar"}
+
+
+def _make_cmd(cls, caller, args=""):
+    cmd = cls()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"{cmd.key} {args}"
+    cmd.cmdname = cmd.key
+    return cmd
+
+
+class DispatchCommandTests(TestCase):
+    def setUp(self) -> None:
+        self.caller = MagicMock()
+
+    def test_func_calls_dispatcher_with_ref_and_kwargs(self) -> None:
+        cmd = _make_cmd(_ProbeDispatchCommand, self.caller)
+        with patch("commands.command.dispatch_player_action") as mock_dispatch:
+            mock_dispatch.return_value = DispatchResult(
+                backend=ActionBackend.REGISTRY, deferred=True
+            )
+            cmd.func()
+        ref = mock_dispatch.call_args.args[1]
+        kwargs = mock_dispatch.call_args.args[2]
+        self.assertEqual(ref.backend, ActionBackend.REGISTRY)
+        self.assertEqual(kwargs, {"foo": "bar"})
+
+    def test_deferred_result_reports_to_caller(self) -> None:
+        cmd = _make_cmd(_ProbeDispatchCommand, self.caller)
+        with patch("commands.command.dispatch_player_action") as mock_dispatch:
+            mock_dispatch.return_value = DispatchResult(backend=ActionBackend.COMBAT, deferred=True)
+            cmd.func()
+        self.caller.msg.assert_called()
+
+    def test_dispatch_error_shows_user_message(self) -> None:
+        cmd = _make_cmd(_ProbeDispatchCommand, self.caller)
+        with patch("commands.command.dispatch_player_action") as mock_dispatch:
+            mock_dispatch.side_effect = ActionDispatchError(ActionDispatchError.UNKNOWN_ACTION_REF)
+            cmd.func()
+        self.caller.msg.assert_called_with("That action is no longer available.")

--- a/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
@@ -1,0 +1,212 @@
+"""Telnet-driven combat cast E2E (#1330 L0): cast command → resolve_round → use_technique.
+
+Proves that the full pipeline works:
+  CmdDeclareTechnique.func()
+    → dispatch_player_action(COMBAT)
+    → CombatRoundContext.record_declaration()
+    → declare_action() [writes CombatRoundAction]
+  resolve_round(encounter)
+    → resolve_combat_technique()
+    → use_technique() [deducts anima, applies damage]
+
+Setup mirrors _setup_pc_attacking_mook from
+world/combat/tests/test_combat_magic_integration.py but builds the encounter
+in DECLARING status (dispatch_player_action requires is_declaration_open=True)
+and wires a CharacterTechnique row so the command can resolve the technique by name.
+
+DISTINCT-ON / AreaClosure SQLite limitations:
+  The dispatch path calls get_player_actions() → _combat_actions(), which may
+  trigger apply_condition / AreaClosure PG-only SQL.  The test is tagged
+  @tag("postgres") so it runs on CI's PG shard and is skipped by the SQLite
+  fast tier.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from evennia.objects.models import ObjectDB
+from evennia.utils.idmapper import models as idmapper_models
+
+from commands.combat import CmdDeclareTechnique
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import (
+    ActionCategory,
+    EncounterStatus,
+    OpponentTier,
+)
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+    ThreatPoolEntryFactory,
+    ThreatPoolFactory,
+)
+from world.combat.models import CombatRoundAction
+from world.combat.services import resolve_round
+from world.conditions.factories import DamageSuccessLevelMultiplierFactory
+from world.magic.factories import (
+    CharacterAnimaFactory,
+    EffectTypeFactory,
+    GiftFactory,
+    TechniqueFactory,
+)
+from world.magic.models import CharacterTechnique
+from world.magic.seeds_cast import ensure_technique_cast_content
+from world.mechanics.factories import CharacterEngagementFactory
+from world.vitals.models import CharacterVitals
+
+
+def _make_cmd(caller: ObjectDB, args: str) -> CmdDeclareTechnique:
+    """Build a CmdDeclareTechnique instance wired to *caller* with *args*."""
+    cmd = CmdDeclareTechnique()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"cast {args}"
+    cmd.cmdname = "cast"
+    return cmd
+
+
+class CombatCastTelnetE2ETests(TestCase):
+    """Telnet cast command drives declare → resolve_round → damage pipeline.
+
+    Uses setUp (not setUpTestData) for ObjectDB objects: Django's setUpTestData
+    deepcopy machinery cannot copy DbHolder / SharedMemoryModel instances (would
+    raise copy.Error in CI shard runs — see project memory).
+
+    SQLite tier: passes cleanly.  The dispatch path through get_player_actions()
+    → _combat_actions() does not trigger DISTINCT ON or the AreaClosure
+    materialized view in this scenario (no apply_condition calls on the
+    DECLARING-phase hot path), so no @tag("postgres") is required.
+    """
+
+    def setUp(self) -> None:
+        # Flush SharedMemoryModel identity-map cache to prevent PK recycling
+        # from a prior test leaking stale instances (see project memory).
+        idmapper_models.flush_cache()
+
+        # -- Damage multiplier rows (needed for resolve_round to deal damage) --
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=2, multiplier=Decimal("1.00"), label="Full"
+        )
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=1, multiplier=Decimal("0.50"), label="Partial"
+        )
+
+        # -- ActionTemplate: required so _combat_actions surfaces the technique --
+        self.action_template = ensure_technique_cast_content()
+
+        # -- Encounter: DECLARING so dispatch_player_action accepts a declaration --
+        self.encounter = CombatEncounterFactory(
+            status=EncounterStatus.DECLARING,
+            round_number=1,
+        )
+
+        # -- Threat pool for the mook opponent --
+        pool = ThreatPoolFactory()
+        ThreatPoolEntryFactory(pool=pool, base_damage=30)
+
+        # -- Mook opponent --
+        self.opponent = CombatOpponentFactory(
+            encounter=self.encounter,
+            tier=OpponentTier.MOOK,
+            health=50,
+            max_health=50,
+            threat_pool=pool,
+        )
+        self.opponent_name = self.opponent.name
+
+        # -- PC participant: sheet → character → vitals/anima/engagement/room --
+        self.sheet = CharacterSheetFactory()
+        self.participant = CombatParticipantFactory(
+            encounter=self.encounter,
+            character_sheet=self.sheet,
+        )
+        CharacterVitals.objects.create(
+            character_sheet=self.sheet,
+            health=100,
+            max_health=100,
+        )
+        # CharacterAnima.character FK → ObjectDB (the game object, not the sheet)
+        self.character = self.sheet.character
+        self.anima = CharacterAnimaFactory(
+            character=self.character,
+            current=20,
+            maximum=20,
+        )
+        CharacterEngagementFactory(character=self.character)
+
+        # Place the character in a room so location-dependent queries don't fail.
+        room = ObjectDB.objects.create(
+            db_key="TestRoom",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        self.character.location = room
+        self.character.save()
+
+        # -- Technique: must have action_template so _combat_actions surfaces it --
+        self.technique = TechniqueFactory(
+            gift=GiftFactory(),
+            effect_type=EffectTypeFactory(name="Attack E2E", base_power=20),
+            intensity=5,
+            control=10,
+            anima_cost=3,
+            action_category=ActionCategory.PHYSICAL,
+            action_template=self.action_template,
+        )
+
+        # -- CharacterTechnique: links the sheet to the technique --
+        # Required for both:
+        #   • CmdDeclareTechnique._resolve_technique_id (looks up by name on
+        #     CharacterTechnique rows filtered by character=caller.sheet_data)
+        #   • _combat_actions (filters CharacterTechnique.objects.filter(
+        #       character=sheet, technique__action_template__isnull=False))
+        CharacterTechnique.objects.create(
+            character=self.sheet,
+            technique=self.technique,
+        )
+
+    def test_cast_command_declares_then_resolves_and_deducts_anima(self) -> None:
+        """cast → declaration row → resolve_round → damage applied + anima spent."""
+        anima_before = self.anima.current
+
+        # Step 1: drive the telnet command (declares via dispatch_player_action).
+        cmd = _make_cmd(
+            self.character,
+            f"{self.technique.name} at {self.opponent_name}",
+        )
+        cmd.func()
+
+        # Step 2: assert a CombatRoundAction row was recorded for this participant + round.
+        action = CombatRoundAction.objects.get(
+            participant=self.participant,
+            round_number=1,
+        )
+        self.assertEqual(
+            action.focused_action_id,
+            self.technique.pk,
+            "focused_action should be the declared technique",
+        )
+
+        # Step 3: resolve the round (patching perform_check to return SL=2).
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolve_round(self.encounter)
+
+        # Step 4a: anima was spent (current ≤ before, floor is 0).
+        self.anima.refresh_from_db()
+        self.assertLessEqual(
+            self.anima.current,
+            anima_before,
+            "anima should have been deducted (or stayed the same if control offset cost to 0)",
+        )
+
+        # Step 4b: the mook took damage.
+        self.opponent.refresh_from_db()
+        self.assertLess(
+            self.opponent.health,
+            self.opponent.max_health,
+            "opponent health should have decreased after resolve_round",
+        )

--- a/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
@@ -14,11 +14,10 @@ world/combat/tests/test_combat_magic_integration.py but builds the encounter
 in DECLARING status (dispatch_player_action requires is_declaration_open=True)
 and wires a CharacterTechnique row so the command can resolve the technique by name.
 
-DISTINCT-ON / AreaClosure SQLite limitations:
-  The dispatch path calls get_player_actions() → _combat_actions(), which may
-  trigger apply_condition / AreaClosure PG-only SQL.  The test is tagged
-  @tag("postgres") so it runs on CI's PG shard and is skipped by the SQLite
-  fast tier.
+SQLite tier: runs cleanly.  The dispatch path through get_player_actions()
+→ _combat_actions() does not trigger DISTINCT ON or the AreaClosure materialized
+view in this scenario (no apply_condition calls on the DECLARING-phase hot path),
+so no @tag("postgres") is required.
 """
 
 from __future__ import annotations
@@ -152,7 +151,7 @@ class CombatCastTelnetE2ETests(TestCase):
             effect_type=EffectTypeFactory(name="Attack E2E", base_power=20),
             intensity=5,
             control=10,
-            anima_cost=3,
+            anima_cost=10,
             action_category=ActionCategory.PHYSICAL,
             action_template=self.action_template,
         )
@@ -195,12 +194,14 @@ class CombatCastTelnetE2ETests(TestCase):
             mock_perform.return_value = MagicMock(success_level=2)
             resolve_round(self.encounter)
 
-        # Step 4a: anima was spent (current ≤ before, floor is 0).
+        # Step 4a: anima was spent (current < before).
+        # effective cost = max(anima_cost - (control - intensity), 0)
+        #                = max(10 - (10 - 5), 0) = 5 > 0, so deduction is guaranteed.
         self.anima.refresh_from_db()
-        self.assertLessEqual(
+        self.assertLess(
             self.anima.current,
             anima_before,
-            "anima should have been deducted (or stayed the same if control offset cost to 0)",
+            "anima must be deducted: effective cost=5 (anima_cost=10, control=10, intensity=5)",
         )
 
         # Step 4b: the mook took damage.


### PR DESCRIPTION
## #1330 L0 — telnet→dispatcher command base + first combat-cast rider

Part of **#1330** (the layered telnet combat-round journey). This is **L0**: the reusable seam + the first rider. L1–L4 (effort/target/passive/strain kwargs, thread-pull, combo, + unit-test retirements) follow as increments; L5–L6 (soulfray/fury *wiring*) are their own child specs. **Does not close #1330.**

### What this adds
- **`DispatchCommand(ArxCommand)`** (`src/commands/command.py`) — a telnet base whose `func()` builds an `ActionRef` (`resolve_action_ref()` hook) and calls **`dispatch_player_action()`**, the *same* seam the web frontend uses, then reports the `DispatchResult` (deferred for round declarations) and surfaces `ActionDispatchError.user_message`/`CommandError` without tracebacks. (Plain `ArxCommand` still calls `action.run()` directly — the REGISTRY path.)
- **`CmdDeclareTechnique(DispatchCommand)`** (`src/commands/combat.py`, key `cast`/`declare`, registered in `CharacterCmdSet`) — parses `cast <technique> [at <target>] [effort=<level>]`, gates on the caller's active **DECLARING** `CombatParticipant`, resolves technique + opponent by name, and dispatches an `ActionRef(backend=COMBAT, technique_id=…)`. Thin adapter — all routing/validation stays in the dispatcher/services.
- **Telnet cast E2E** (`src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py`) — drives the real `cast` command → asserts a `CombatRoundAction` is declared → `resolve_round` (with `perform_check` mocked) → asserts anima is deducted (effective cost 5, strict `assertLess`) and the opponent takes damage. Proves the cast→outcome loop runs through the same code the web uses.
- **Docs:** corrected `Action.run` docstring (`src/actions/base.py`), documented the `DispatchCommand` pattern (`src/commands/CLAUDE.md`), and ticked the telnet-driveability audit (Loop 2 combat-declare **G1 → G0**).

### Why it matters
Combat cast becomes telnet-driveable through the converged `dispatch_player_action` seam (the audit's prescribed fix — no per-domain Action refactor). The `DispatchCommand` base is the foundation **#1332** (non-combat / CHALLENGE cast E2E) reuses; the immediate-result guard already handles the future CHALLENGE rider.

### Testing
- `commands` fast tier: **82/82** green.
- Telnet cast E2E: green on the SQLite fast tier (the DECLARING-phase dispatch path avoids the PG-only `DISTINCT ON`/`AreaClosure` SQL).
- `uv run pre-commit run --all-files`: **all hooks pass** (ruff, ty, custom linters, migrations, shard-coverage, ESLint/TS/Prettier).

### Notes
- Reviewed via subagent-driven development (per-task spec+quality review + a whole-branch review on the most capable model). The whole-branch review confirmed the security boundary is correctly backstopped by the dispatcher (the thin command's name-resolution is not the authority — `dispatch_player_action` re-validates the `technique_id` and enforces the round gate).
- Opponent-only targeting is the deliberate L0 scope; ally/passive targeting is L1.
