### PR TITLE
docs(audit): broad-pass telnet inventory + deep-trace corrections (#1328)

### DIFF
--- a/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
+++ b/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
@@ -185,3 +185,64 @@ web. Minimal fix: a `CmdDeclareAction` plus a GM-only `start encounter` for test
   for *all* player actions), or remain a distinct viewset that telnet shells call directly?
 - For combat/magic seed prerequisites, which belong in a shared **combat seed module** so the
   E2E is writable without bespoke per-test wiring?
+
+---
+
+## Broad-pass inventory (follow-up sweep)
+
+The four loops above were a *deep* trace. This section is the *broad* pass the original
+scope deferred: a full sweep of the DRF surface (every `router.register`, `APIView`, and
+`@action`) to find player-facing mutations with no telnet command. **Result: ~150
+player-facing API mutations; only ~7 have any telnet command** (`wear`, `undress`, `use`,
+`+block`/`+unblock`/`+mute`/`+unmute`, plus `say`/`pose`/`emit` via actions). Everything
+mechanical is web-only.
+
+### Two corrections to the deep trace above
+
+1. **Combat was under-counted.** Loop 4 traced only *declare* and *clash-commit* (through
+   `dispatch_player_action`). But `CombatEncounterViewSet` exposes ~13 *additional* direct
+   `@action`→service player surfaces with no telnet path that **will not** be reached by the
+   `dispatch_player_action` routing fix: `flee` (`declare_flee`, `combat/services.py:926`),
+   `cover` (`declare_cover` `:975`), `interpose` (`declare_interpose` `:1028`), `yield`
+   (`duels.yield_duel:303`), `join`/`leave` (`:852`/`:886`), `ready`, `upgrade_combo`/
+   `revert_combo` (`:2523`/`:2642`). These need their own thin shells (family 3), not just
+   the dispatch reroute.
+2. **The dispatch-routing keystone is now its own issue** (foundation), not just the bullet
+   in "Cross-cutting conclusions #1".
+
+### Web-only clusters with no telnet surface (by domain)
+
+| Domain | Representative web-only surfaces (seam) | Class |
+|---|---|---|
+| **Social consent** | `create_action_request` / `respond_to_action_request` (`scenes/action_views.py:55/195`) | G1/G3 |
+| **Entrance + flourish** | `EntranceAction`; `resolve_entry_flourish_offer` (`magic/entry_flourish.py`) | G1/G3 |
+| **Resonance endorsements** | pose / scene-entry / style (`magic/views.py:1053+`); fashion `FashionJudgementViewSet` (`items/views.py:1280`) | G3 |
+| **Interaction reactions** | `InteractionFavorite` / `InteractionReaction` / reaction windows (`scenes/`) | G3 |
+| **Thread weave/imbue/pull** | `weave_thread` / `spend_resonance_for_imbuing` / `_for_pull` (`magic/services/`) | G1/G3 |
+| **Soul-tether & sineating** | 8 APIViews: accept/dissolve/request/respond/rescue/stage-advance (`magic/views.py:1206–1461`) | G3 |
+| **Audere / Audere Majora** | `resolve_audere_offer`; `cross_threshold` (`magic/audere*.py`) — the progression/"leveling" surface | G3 |
+| **Multi-participant rituals** | `draft_session`/`accept`/`decline`/`fire` (`magic/services/sessions.py`) | G3 |
+| **Covenant membership** | engage/disengage/leave/kick/rank; banner-call/stand-down (`covenants/services.py`) | G3 |
+| **Persona / guise** | `set_active_persona` (`scenes/services.py:86`) | G3 |
+| **Progression rewards** | `claim_kudos_for_xp`; `cast_vote`/`remove_vote`; random-scene; path-intent (`progression/views.py`) | G3 |
+| **Missions** | resolve/abandon/group_pick/group_vote (`missions/views.py:497+`) | G3 |
+| **Journals & goals** | `create_journal_entry`/`respond`; `CharacterGoalViewSet` (`journals/`, `goals/`) | G3 |
+
+### Two named surfaces that don't map to code
+
+- **Soulfray combat-consent** — no dedicated surface found (neither telnet nor web). Soulfray
+  severity accumulates as a runtime side-effect of casting (`techniques.py:525`); entry appears
+  automatic at Warp stage 3. Whether an explicit consent gate is intended is an open design
+  question, tracked separately.
+- **"Ritual of the Durance"** — no ritual by that name exists. "Durance" is a *covenant type*
+  (`Covenant of the Durance`, the default/standing covenant). Level advancement actually rides
+  **thread Imbuing** and **Audere Majora crossing**. Naming reconciliation tracked separately.
+
+### Disposition
+
+Tracked as journey-shaped children of the umbrella issue (telnet commands + one user-journey
+E2E each, which then retires the unit tests it covers): two **foundation** issues (dispatch
+routing; consent-flow / direct-viewset strategy), the per-domain **journey** issues above, and
+two **design-clarification** issues (soulfray consent; durance naming). Existing combat (scope
+widened), ritual-as-Action, and non-combat-cast journeys are reconciled into the same set. See
+the umbrella issue for the live child map.


### PR DESCRIPTION
## What
Completes the deferred **broad pass** of the telnet-driveability audit (#1328). The original doc deep-traced four loops; this appends a full DRF-surface sweep.

## Findings added to the audit doc
- **~150 player-facing API mutations; only ~7 have any telnet command.** Per-domain table of web-only clusters (social consent, endorsements, interaction reactions, threads, soul-tether/sineating, Audere/Majora, ritual sessions, covenants, persona, progression, missions, journals).
- **Two corrections to the deep trace:** (1) combat was under-counted — `CombatEncounterViewSet` has ~13 direct `@action`→service surfaces (flee/cover/interpose/yield/join/leave/combo) the dispatch-routing fix will *not* reach; (2) the dispatch-routing keystone is now its own foundation issue.
- **Two named surfaces that don't map to code:** soulfray combat-consent (no surface found) and "Ritual of the Durance" (no such ritual — "Durance" is a covenant type; leveling = imbuing + Audere Majora).

## Disposition
Filed as journey-shaped children of #1328: foundation #1336/#1337, journeys #1338–#1350, clarifications #1351/#1352; existing #1330 (combat scope widened), #1331 (merged), #1332 reconciled.

Docs-only change. Refs #1328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)