### PR TITLE
Frictionless scene start: let a player begin or auto-join a castable scene without staff setup

### DIFF
--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -149,6 +149,38 @@ from world.scenes.place_services import ensure_scene_for_location
 scene = ensure_scene_for_location(room, privacy_mode=ScenePrivacyMode.PRIVATE)
 ```
 
+### Frictionless / Implicit Scene Start + Auto-Close (#1309)
+
+Players should never have to manually open a scene before they can act. The
+lifecycle is bookended around `ensure_scene_for_location` (the get-or-create
+primitive above):
+
+- **Start-or-join on action.** `start_or_join_scene(room, *, owner_account=None,
+  name=None, privacy_mode=None)` (`place_services.py`) wraps
+  `ensure_scene_for_location_created` (which returns a `(scene, created)` tuple).
+  When *this* call created the scene and an `owner_account` is supplied, that
+  account is recorded as the scene owner via a `SceneParticipation(is_owner=True)`
+  (mirroring `SceneViewSet.perform_create`). If the scene already existed, no owner
+  is changed — the actor simply joins. It is idempotent: a second actor in the same
+  room joins the **same** scene and is **not** made owner. Privacy is auto-derived
+  from room publicness (PUBLIC if publicly listed, else PRIVATE), honoring the
+  invariant below.
+
+  Wired at the player action seams that previously dead-ended with a 404 when no
+  active scene existed: `SceneActionRequestViewSet.create` and the
+  `…/cast` action (`action_views.py`) — both now take an **optional** `scene`
+  field; when omitted they resolve the scene from the initiator persona's current
+  room via `_resolve_action_scene`. `record_interaction` (`interaction_services.py`)
+  likewise implicitly starts a scene when a pose lands in a room with no active
+  scene (owner = the posing character's account).
+
+- **Auto-close when the room empties.** `maybe_finish_empty_scene(room, *,
+  leaving=None)` (`interaction_services.py`) is called from
+  `Room.at_object_leave` (a thin Evennia-hook delegator). It finds the room's
+  active scene and calls `scene.finish_scene()` when no scene-participating
+  character remains present (walking `room.contents`, excluding `leaving` — which
+  may still be in contents at hook time). Returns the finished `Scene` or `None`.
+
 ### Scene Privacy ↔ Room-Publicness Invariant (#1287)
 
 **The rule (one-directional):** a `Scene` whose `location` is a publicly-listed

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -22941,7 +22941,7 @@ export interface components {
       readonly resolved_at: string | null;
     };
     SceneActionRequestCreateRequest: {
-      scene: number;
+      scene?: number | null;
       initiator_persona: number;
       target_persona?: number;
       target_persona_ids?: number[];

--- a/src/schema.json
+++ b/src/schema.json
@@ -41515,6 +41515,7 @@ components:
       properties:
         scene:
           type: integer
+          nullable: true
         initiator_persona:
           type: integer
         target_persona:
@@ -41556,7 +41557,6 @@ components:
       required:
       - action_key
       - initiator_persona
-      - scene
     SceneActionRequestRequest:
       type: object
       properties:

--- a/src/typeclasses/rooms.py
+++ b/src/typeclasses/rooms.py
@@ -117,4 +117,7 @@ class Room(ObjectParent, DefaultRoom):
             **kwargs: Arbitrary keyword arguments.
         """
         super().at_object_leave(obj, target_location, **kwargs)
+        from world.scenes.interaction_services import maybe_finish_empty_scene
+
+        maybe_finish_empty_scene(self, leaving=obj)
         self._broadcast_room_state(exclude=obj)

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -41,6 +41,13 @@ Captures and manages roleplay sessions with participant tracking, interaction re
 - Participation-based access control
 - Privacy controls for disguised participation
 
+### `place_services.py`
+- **`ensure_scene_for_location(room, *, name, privacy_mode)`**: get-or-create the room's active scene; privacy auto-derived from room publicness when omitted (PUBLIC if publicly listed, else PRIVATE). Thin wrapper over `ensure_scene_for_location_created`, which returns `(scene, created)`.
+- **`start_or_join_scene(room, *, owner_account, name, privacy_mode)`**: frictionless scene start (#1309). Get-or-creates the active scene; records `owner_account` as `SceneParticipation(is_owner=True)` ONLY when this call created the scene (a later actor just joins, no owner change). Idempotent.
+
+### `interaction_services.py`
+- **`maybe_finish_empty_scene(room, *, leaving=None)`**: auto-close (#1309). Finishes the room's active scene when no scene-participating character remains present (walks `room.contents`, excluding `leaving`, which may still be in contents at the `at_object_leave` hook). Called from `Room.at_object_leave`. Implicit scene start on a pose lives in `record_interaction`'s no-active-scene branch.
+
 ## Key Classes
 
 - **`Scene`**: Contains participants and interactions

--- a/src/world/scenes/action_serializers.py
+++ b/src/world/scenes/action_serializers.py
@@ -205,7 +205,9 @@ def _validate_cast_pull(attrs: dict) -> dict:
 class TechniqueCastCreateSerializer(serializers.Serializer):
     """Validate input for the standalone technique cast endpoint."""
 
-    scene = serializers.IntegerField()
+    # Frictionless scene start (#1309): omit ``scene`` to implicitly start/join
+    # the scene at the initiator's current room.
+    scene = serializers.IntegerField(required=False, allow_null=True)
     initiator_persona = serializers.IntegerField()
     technique_id = serializers.IntegerField()
     target_persona = serializers.IntegerField(required=False, allow_null=True)
@@ -347,7 +349,9 @@ class SceneActionRequestSerializer(serializers.ModelSerializer):
 
 
 class SceneActionRequestCreateSerializer(serializers.Serializer):
-    scene = serializers.IntegerField()
+    # Frictionless scene start (#1309): omit ``scene`` to implicitly start/join
+    # the scene at the initiator's current room.
+    scene = serializers.IntegerField(required=False, allow_null=True)
     initiator_persona = serializers.IntegerField()
     target_persona = serializers.IntegerField(required=False)
     target_persona_ids = serializers.ListField(

--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -46,6 +46,44 @@ from world.scenes.models import Persona, Scene
 # SonarCloud smell (python:S1192).
 _NO_PERSONAS_DETAIL = "No personas found for your account."
 _INITIATOR_NOT_FOUND_DETAIL = "Initiator persona not found for your account."
+_NO_LOCATION_DETAIL = "Initiator has no location to start a scene in."
+
+
+def _resolve_action_scene(
+    *,
+    scene_id: int | None,
+    initiator_persona: Persona,
+    account: Any,
+) -> Scene | Response:
+    """Resolve the scene for an action request / cast.
+
+    Frictionless scene start (#1309): when ``scene_id`` is given, fetch that
+    active scene (404 if missing). When omitted, implicitly start-or-join the
+    scene at the initiator's current room, recording ``account`` as owner if
+    this call created it.
+
+    Returns the resolved ``Scene`` on success, or a DRF ``Response`` carrying the
+    error to return to the caller.
+    """
+    if scene_id is not None:
+        try:
+            return Scene.objects.get(pk=scene_id, is_active=True)
+        except Scene.DoesNotExist:
+            return Response(
+                {"detail": "Active scene not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+    from world.scenes.place_services import start_or_join_scene  # noqa: PLC0415
+
+    character = initiator_persona.character_sheet.character
+    location = getattr(character, "location", None)  # noqa: GETATTR_LITERAL
+    if location is None:
+        return Response(
+            {"detail": _NO_LOCATION_DETAIL},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    return start_or_join_scene(location, owner_account=account)
 
 
 class SceneActionRequestPagination(PageNumberPagination):
@@ -101,7 +139,7 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        scene_id = serializer.validated_data["scene"]
+        scene_id = serializer.validated_data.get("scene")
         initiator_persona_id = serializer.validated_data["initiator_persona"]
         action_key = serializer.validated_data["action_key"]
         target_ids: list[int] = serializer.validated_data["target_ids"]
@@ -125,14 +163,6 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
         if cardinality == TargetType.SELF and target_ids:
             raise DRFValidationError({"target_persona_ids": "This action targets the caster only."})
 
-        try:
-            scene = Scene.objects.get(pk=scene_id, is_active=True)
-        except Scene.DoesNotExist:
-            return Response(
-                {"detail": "Active scene not found."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-
         # Caller must explicitly specify which persona initiates the action.
         if initiator_persona_id not in persona_ids:
             return Response(
@@ -140,6 +170,14 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         initiator_persona = get_object_or_404(Persona, pk=initiator_persona_id)
+
+        scene = _resolve_action_scene(
+            scene_id=scene_id,
+            initiator_persona=initiator_persona,
+            account=request.user,
+        )
+        if isinstance(scene, Response):
+            return scene
 
         primary_id = target_ids[0] if target_ids else None
         target_persona = (
@@ -316,7 +354,7 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
             )
 
         vd = serializer.validated_data
-        scene_id = vd["scene"]
+        scene_id = vd.get("scene")
         initiator_persona_id = vd["initiator_persona"]
         technique_id = vd["technique_id"]
         target_persona_id = vd.get("target_persona")
@@ -334,20 +372,20 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
                 threads=tuple(pull_data["threads"]),
             )
 
-        try:
-            scene = Scene.objects.get(pk=scene_id, is_active=True)
-        except Scene.DoesNotExist:
-            return Response(
-                {"detail": "Active scene not found."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-
         if initiator_persona_id not in persona_ids:
             return Response(
                 {"detail": _INITIATOR_NOT_FOUND_DETAIL},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         initiator_persona = get_object_or_404(Persona, pk=initiator_persona_id)
+
+        scene = _resolve_action_scene(
+            scene_id=scene_id,
+            initiator_persona=initiator_persona,
+            account=request.user,
+        )
+        if isinstance(scene, Response):
+            return scene
 
         target_persona: Persona | None = None
         if target_persona_id is not None:

--- a/src/world/scenes/interaction_services.py
+++ b/src/world/scenes/interaction_services.py
@@ -63,6 +63,54 @@ def invalidate_active_scene_cache(location: ObjectDB) -> None:
         del location._active_scene_cache  # noqa: SLF001
 
 
+def maybe_finish_empty_scene(
+    room: ObjectDB,
+    *,
+    leaving: ObjectDB | None = None,
+) -> Scene | None:
+    """Auto-close the room's active scene when no participating character remains.
+
+    Frictionless scene end (#1309): when a character leaves a room, finish the
+    active scene if no scene-participating character is still present. The
+    leaving object is excluded — at the ``at_object_leave`` hook it may still be
+    in ``room.contents``.
+
+    Args:
+        room: The room the character is leaving.
+        leaving: The departing object, excluded from the presence check.
+
+    Returns:
+        The finished Scene, or None if there was no active scene or a
+        participant is still present.
+    """
+    if room is None:
+        return None
+
+    scene = Scene.objects.filter(location=room, is_active=True).first()
+    if scene is None:
+        return None
+
+    participant_account_ids = set(scene.participations.values_list("account_id", flat=True))
+
+    for obj in room.contents:
+        if obj is leaving:
+            continue
+        # A character sheet marks a real character (skip items, exits, etc.).
+        try:
+            sheet = obj.sheet_data
+        except (AttributeError, ObjectDoesNotExist):
+            continue
+        if sheet is None:
+            continue
+        account_id = _get_account_for_character(obj.pk)
+        if account_id is not None and account_id in participant_account_ids:
+            return None  # a participating character is still present
+
+    scene.finish_scene()
+    invalidate_active_scene_cache(room)
+    return scene
+
+
 def reassign_persona_interactions(
     *,
     source_persona: Persona,
@@ -653,6 +701,20 @@ def record_interaction(  # noqa: PLR0913 - all fields needed for interaction cre
 
     if scene is None:
         scene = _get_active_scene(character.location)
+
+    # Frictionless scene start (#1309): a pose in a room with no active scene
+    # implicitly starts one (owner = the posing character's account).
+    if scene is None and character.location is not None:
+        from world.scenes.place_services import start_or_join_scene  # noqa: PLC0415
+
+        account_id = _get_account_for_character(character.pk)
+        owner_account = None
+        if account_id is not None:
+            from evennia.accounts.models import AccountDB  # noqa: PLC0415
+
+            owner_account = AccountDB.objects.filter(pk=account_id).first()
+        scene = start_or_join_scene(character.location, owner_account=owner_account)
+        invalidate_active_scene_cache(character.location)
 
     # Ephemeral scenes: push in real-time but never persist
     if scene is not None and scene.privacy_mode == ScenePrivacyMode.EPHEMERAL:

--- a/src/world/scenes/place_services.py
+++ b/src/world/scenes/place_services.py
@@ -9,6 +9,7 @@ from world.scenes.models import Scene
 from world.scenes.place_models import Place, PlacePresence
 
 if TYPE_CHECKING:
+    from evennia.accounts.models import AccountDB
     from evennia.objects.models import ObjectDB
 
     from world.scenes.models import Persona
@@ -22,6 +23,21 @@ def ensure_scene_for_location(
 ) -> Scene:
     """Get or create an active scene for the given room.
 
+    Thin wrapper over :func:`ensure_scene_for_location_created` that discards the
+    created-signal for callers that only need the scene.
+    """
+    scene, _created = ensure_scene_for_location_created(room, name=name, privacy_mode=privacy_mode)
+    return scene
+
+
+def ensure_scene_for_location_created(
+    room: ObjectDB,
+    *,
+    name: str | None = None,
+    privacy_mode: ScenePrivacyMode | None = None,
+) -> tuple[Scene, bool]:
+    """Get or create an active scene for the given room, reporting newness.
+
     If an active scene already exists for the room, returns it (its existing
     privacy is preserved; ``privacy_mode`` is ignored). Otherwise creates a new
     scene with ``privacy_mode`` (derived from the room when not supplied).
@@ -33,11 +49,12 @@ def ensure_scene_for_location(
             from the room — PUBLIC if publicly listed, else PRIVATE.
 
     Returns:
-        The active Scene for this room.
+        A ``(scene, created)`` tuple. ``created`` is True only when this call
+        created the scene (so the caller may set an owner on it).
     """
     existing = Scene.objects.filter(location=room, is_active=True).first()
     if existing is not None:
-        return existing
+        return existing, False
 
     if privacy_mode is None:
         from evennia_extensions.models import room_is_publicly_listed  # noqa: PLC0415
@@ -61,6 +78,47 @@ def ensure_scene_for_location(
         if sheet is not None:
             evaluate_scene_engagement(character_sheet=sheet, room=room)
 
+    return scene, True
+
+
+def start_or_join_scene(
+    room: ObjectDB,
+    *,
+    owner_account: AccountDB | None = None,
+    name: str | None = None,
+    privacy_mode: ScenePrivacyMode | None = None,
+) -> Scene:
+    """Implicitly start a scene in ``room`` (or join the existing one).
+
+    Frictionless scene start (#1309): when a player acts in a room with no
+    active scene, get-or-create one. When *this* call created the scene and an
+    ``owner_account`` is supplied, that account is recorded as the scene owner
+    (mirrors :meth:`SceneViewSet.perform_create`). If the scene already existed,
+    no owner is changed — the actor simply joins.
+
+    Idempotent: a second actor in the same room joins the same scene and is not
+    made owner.
+
+    Args:
+        room: The room to start/join a scene in.
+        owner_account: The acting player's account. Recorded as owner only on
+            create. When None, no owner participation is written.
+        name: Optional name for a newly-created scene.
+        privacy_mode: Privacy for a newly-created scene (derived from the room
+            when omitted).
+
+    Returns:
+        The active Scene for this room.
+    """
+    from world.scenes.models import SceneParticipation  # noqa: PLC0415
+
+    scene, created = ensure_scene_for_location_created(room, name=name, privacy_mode=privacy_mode)
+    if created and owner_account is not None:
+        SceneParticipation.objects.get_or_create(
+            scene=scene,
+            account=owner_account,
+            defaults={"is_owner": True},
+        )
     return scene
 
 

--- a/src/world/scenes/tests/test_implicit_scene_start.py
+++ b/src/world/scenes/tests/test_implicit_scene_start.py
@@ -1,0 +1,130 @@
+"""Integration tests for frictionless / implicit scene start + auto-close (#1309).
+
+Covers the lifecycle bookends wired around the existing
+``ensure_scene_for_location`` primitive:
+
+- ``start_or_join_scene``: a player acting in a room with no active scene
+  auto-creates one (becoming owner) with privacy derived from room publicness;
+  a second actor in the same room joins the SAME scene and is NOT owner.
+- ``maybe_finish_empty_scene``: when the last participating character leaves the
+  room the scene auto-finishes; with another occupant still present it stays open.
+"""
+
+from django.test import TestCase
+
+from evennia_extensions.factories import AccountFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import (
+    PlayerDataFactory,
+    RosterEntryFactory,
+    RosterTenureFactory,
+)
+from world.scenes.constants import ScenePrivacyMode
+from world.scenes.interaction_services import (
+    ensure_scene_participation,
+    maybe_finish_empty_scene,
+)
+from world.scenes.models import SceneParticipation
+from world.scenes.place_services import start_or_join_scene
+
+
+def _make_room(*, key: str, public: bool = True):
+    room = ObjectDBFactory(db_key=key, db_typeclass_path="typeclasses.rooms.Room")
+    if not public:
+        room.room_profile.is_public = False
+        room.room_profile.save()
+    return room
+
+
+def _player_in_room(room, *, account):
+    """A character placed in ``room`` whose roster tenure points at ``account``."""
+    sheet = CharacterSheetFactory()
+    entry = RosterEntryFactory(character_sheet=sheet)
+    RosterTenureFactory(
+        player_data=PlayerDataFactory(account=account),
+        roster_entry=entry,
+    )
+    sheet.character.db_location = room
+    sheet.character.save(update_fields=["db_location"])
+    return sheet.character
+
+
+class ImplicitSceneStartTest(TestCase):
+    """A player acting with no active scene auto-creates-or-joins one."""
+
+    def test_first_actor_creates_and_owns_public_scene(self) -> None:
+        room = _make_room(key="PublicTavern", public=True)
+        account = AccountFactory()
+
+        scene = start_or_join_scene(room, owner_account=account)
+
+        assert scene.pk is not None
+        assert scene.is_active is True
+        assert scene.location == room
+        assert scene.privacy_mode == ScenePrivacyMode.PUBLIC
+        assert SceneParticipation.objects.filter(
+            scene=scene, account=account, is_owner=True
+        ).exists()
+
+    def test_unlisted_room_creates_private_scene(self) -> None:
+        room = _make_room(key="HiddenCellar", public=False)
+        account = AccountFactory()
+
+        scene = start_or_join_scene(room, owner_account=account)
+
+        assert scene.privacy_mode == ScenePrivacyMode.PRIVATE
+
+    def test_second_actor_joins_same_scene_and_is_not_owner(self) -> None:
+        room = _make_room(key="SharedTavern", public=True)
+        owner_account = AccountFactory()
+        joiner_account = AccountFactory()
+
+        first = start_or_join_scene(room, owner_account=owner_account)
+        second = start_or_join_scene(room, owner_account=joiner_account)
+
+        # Same scene (idempotent get-or-create).
+        assert first.pk == second.pk
+        # The joiner did NOT override the original owner and is not an owner.
+        assert not SceneParticipation.objects.filter(
+            scene=first, account=joiner_account, is_owner=True
+        ).exists()
+        assert SceneParticipation.objects.filter(scene=first, is_owner=True).count() == 1
+
+
+class AutoCloseEmptySceneTest(TestCase):
+    """The room emptying auto-finishes its active scene."""
+
+    def test_scene_finishes_when_last_participant_leaves(self) -> None:
+        room = _make_room(key="EmptyingRoom", public=True)
+        account = AccountFactory()
+        character = _player_in_room(room, account=account)
+
+        scene = start_or_join_scene(room, owner_account=account)
+        ensure_scene_participation(scene, character)
+
+        # The only participant is leaving — exclude them from the presence check.
+        finished = maybe_finish_empty_scene(room, leaving=character)
+
+        assert finished is not None
+        assert finished.pk == scene.pk
+        scene.refresh_from_db()
+        assert scene.is_active is False
+        assert scene.date_finished is not None
+
+    def test_scene_stays_open_with_another_occupant_present(self) -> None:
+        room = _make_room(key="StillBusyRoom", public=True)
+        leaver_account = AccountFactory()
+        stayer_account = AccountFactory()
+        leaver = _player_in_room(room, account=leaver_account)
+        stayer = _player_in_room(room, account=stayer_account)
+
+        scene = start_or_join_scene(room, owner_account=leaver_account)
+        ensure_scene_participation(scene, leaver)
+        ensure_scene_participation(scene, stayer)
+
+        finished = maybe_finish_empty_scene(room, leaving=leaver)
+
+        assert finished is None
+        scene.refresh_from_db()
+        assert scene.is_active is True
+        assert scene.date_finished is None


### PR DESCRIPTION
Closes #1309

## Summary

Frictionless / implicit scene start: wire the existing `ensure_scene_for_location` primitive into the player action seams that previously dead-ended on a missing active scene (auto-create-or-join; the triggering player owns the scene only when their action created it; privacy auto-derived from room publicness, honoring the #1301 invariant). Plus an auto-close-when-empty bookend: a new `maybe_finish_empty_scene` service hooked into `Room.at_object_leave`. All changes live in `world/scenes/` + `typeclasses/rooms.py` — no `actions`/`commands`/`world.magic`/`world.combat` edits (non-interfering with the parallel sessions). Sparse tests per request.

## Follow-ups filed

- #1361

## Notes

- Spec: reviewed & approved on #1309 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto origin/main; no conflicts, no API-schema drift; no migration (no model change).

<!-- last-addressed-comment: 0 -->