### PR TITLE
Targeting model cleanups: AppliedConditionResult relocation, serializer read-only + schema fidelity (follow-up to #1321)

### DIFF
--- a/docs/architecture/combat-conditions.md
+++ b/docs/architecture/combat-conditions.md
@@ -129,7 +129,7 @@ world/combat/
 │   ├── _build_affected_targets    ← NEW helper: target_kind → ObjectDB list
 │   └── _resolve_pc_action         ← updated: removes "base_power None" no-op
 ├── types.py
-│   ├── AppliedConditionResult     ← NEW
+│   ├── AppliedConditionResult     ← NEW (later relocated to conditions/types.py, #1359)
 │   └── CombatTechniqueResolution  ← extend with applied_conditions list
 ├── typeclasses/
 │   └── combat_npc.py              ← NEW: CombatNPC typeclass
@@ -662,11 +662,11 @@ class CombatTechniqueResolver:
 ### Types
 
 ```python
-# world/combat/types.py
+# world/conditions/types.py  (relocated from combat/types.py — #1359)
 
 @dataclass(frozen=True)
 class AppliedConditionResult:
-    """Per-condition apply outcome from CombatTechniqueResolver._apply_conditions."""
+    """Per-condition apply outcome from a technique cast (combat or standalone)."""
     target: ObjectDB
     condition: ConditionTemplate
     severity_applied: int

--- a/docs/architecture/non-clash-casting.md
+++ b/docs/architecture/non-clash-casting.md
@@ -46,7 +46,8 @@ in `world/scenes/cast_services.py:request_technique_cast` uses a three-way split
 `apply_technique_conditions` (`world/magic/services/condition_application.py`) — extracted from
 combat's `_apply_conditions`. Standalone casts now apply technique-authored conditions to resolved
 targets via `_resolve_and_pose_cast`. Both combat and standalone paths call the same function;
-`AppliedConditionResult` (return type) still lives in `world/combat/types.py` as a known follow-up.
+`AppliedConditionResult` (return type) lives in `world/conditions/types.py` — the neutral condition
+layer both combat and magic import directly (no deferred import).
 
 ---
 

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -179,7 +179,8 @@ Lives on `world/conditions/models.py:ConditionCategory`.
 — extracted from combat's `_apply_conditions`; used by **both** combat and standalone
 cast paths. Callers build `targets_by_kind` before calling; the service iterates
 `TechniqueAppliedCondition` rows and batches them via `bulk_apply_conditions`.
-(`AppliedConditionResult` still lives in `world/combat/types.py` — a known follow-up.)
+(`AppliedConditionResult` lives in `world/conditions/types.py` — the neutral condition
+layer both combat and magic depend on; no deferred import needed.)
 
 **AoE — combat** (`world/combat/models.py:CombatRoundActionTarget`):
 New join table. For AREA and FILTERED_GROUP techniques, each targeted `CombatOpponent`
@@ -193,9 +194,11 @@ technique's `target_spec`, built by `_target_spec_for_technique_action` in
 `actions/player_interface.py`. `TargetSpec`/`TargetType`/`TargetKind`/`TargetFilters`
 (all in `actions/types.py` and `actions/constants.py`) were **reused** — not reinvented.
 
-**Deferred follow-ups:** standalone hostile/behavior-altering FILTERED_GROUP multi-consent;
-relocate `AppliedConditionResult`; resonance→aspect mapping (all magic checks still use
-the Arcana aspect).
+**Scope notes:** standalone behavior-altering multi-target casts stay guarded by
+`InvalidCastTarget` — per-target consent for multiple PCs is intentionally unsupported
+(#1358 closed); hostile multi-target routes through combat's existing `CombatRoundActionTarget`
+path. Magic checks use a single placeholder Arcana aspect; how `Aspect` should apply to
+magic checks at all is an open design question (#1363).
 
 ### Motif System
 
@@ -817,7 +820,7 @@ execute_flow("cast_power", context={
 - **ConditionCategory.alters_behavior** — behavior-altering categories (compulsion, charm, fear) require
   the target's consent; capability/stat categories resolve immediately including on other PCs.
 - **apply_technique_conditions** lives in `world/magic/services/condition_application.py` — shared by
-  both combat and standalone cast paths. `AppliedConditionResult` (its return type) still lives in
-  `world/combat/types.py` as a known follow-up to relocate.
+  both combat and standalone cast paths. `AppliedConditionResult` (its return type) lives in
+  `world/conditions/types.py`, the neutral condition layer both combat and magic import directly.
 - **CombatRoundActionTarget** — new combat join table for AoE/multi-target technique actions (AREA and
   FILTERED_GROUP). SINGLE/SELF actions continue to use `CombatRoundAction.focused_opponent_target`.

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -189,7 +189,7 @@ export interface paths {
      *     Requires ?initiator_persona=<id> query param. Returns only techniques
      *     with an action_template (castable standalone) known by that character.
      */
-    get: operations['action_requests_castable_techniques_retrieve'];
+    get: operations['action_requests_castable_techniques_list'];
     put?: never;
     post?: never;
     delete?: never;
@@ -14009,6 +14009,38 @@ export interface components {
       readonly name: string;
       readonly description: string;
     };
+    /**
+     * @description Nested pull declaration on the cast endpoint (#854).
+     *
+     *     Field shapes mirror ThreadPullCommitRequestSerializer
+     *     (world/magic/serializers.py).
+     */
+    CastPullRequestRequest: {
+      resonance_id: number;
+      tier: number;
+      thread_ids: number[];
+    };
+    /** @description Serializes a Technique for the castable-techniques list endpoint. */
+    CastableTechnique: {
+      id: number;
+      name: string;
+      anima_cost: number;
+      tier: number;
+      intensity: number;
+      control: number;
+      readonly hostile: boolean;
+      target_type: string;
+      reach: string;
+      /**
+       * @description Derive and serialize the TargetSpec for this technique.
+       *
+       *     Returns None for SELF-targeting techniques (no picker needed). For other
+       *     cardinalities, returns the same shape as actions.serializers.TargetSpecSerializer.
+       */
+      readonly target_spec: {
+        [key: string]: unknown;
+      } | null;
+    };
     /** @description Nested serializer for challenge approaches. */
     ChallengeApproach: {
       readonly id: number;
@@ -21344,15 +21376,6 @@ export interface components {
       /** @description The cantrip template this technique was created from, if any. */
       source_cantrip?: number | null;
       /**
-       * @description Per-technique target cardinality (how many / how selected). Relationship (self/ally/enemy) is derived from condition target_kinds + hostility, not stored here.
-       *
-       *     * `self` - Self
-       *     * `single` - Single Target
-       *     * `area` - Area
-       *     * `filtered_group` - Filtered Group
-       */
-      target_type?: components['schemas']['TechniqueTargetTypeEnum'];
-      /**
        * @description Positional reach: which positions this technique can target (SAME=melee, ADJACENT=reach, ANY=ranged).
        *
        *     * `same` - Same position
@@ -22957,41 +22980,6 @@ export interface components {
       delivery: components['schemas']['DeliveryEnum'] | components['schemas']['BlankEnum'];
       delivery_receiver_ids?: number[];
     };
-    SceneActionRequestRequest: {
-      /** @description The scene where this action takes place */
-      scene: number;
-      /** @description The persona performing the action */
-      initiator_persona: number;
-      /** @description The persona being targeted. Null for area actions (to the room) or standalone technique casts. */
-      target_persona?: number | null;
-      /** @description Key identifying the action type (e.g., 'intimidate', 'persuade') */
-      action_key?: string;
-      /** @description Data-driven action template if applicable */
-      action_template?: number | null;
-      /** @description Technique used for this action, if any */
-      technique?: number | null;
-      /**
-       * @description Resolved audience routing for the result echo (#903). Blank = resolve from the template's default_delivery at resolution time.
-       *
-       *     * `pose` - Pose (whole room)
-       *     * `whisper` - Whisper (target only)
-       *     * `table_talk` - Table talk (your place)
-       *     * `mutter` - Mutter (partial echo)
-       */
-      delivery?: components['schemas']['DeliveryEnum'] | components['schemas']['BlankEnum'];
-      /**
-       * @description Plausibility band chosen by the defender at consent.
-       *
-       *     * `trivial` - Trivial
-       *     * `easy` - Easy
-       *     * `normal` - Normal
-       *     * `hard` - Hard
-       *     * `daunting` - Daunting
-       */
-      difficulty_choice?: components['schemas']['DifficultyChoiceEnum'];
-      /** @description Extra anima the player commits beyond base cost. Bounded by available anima at resolution time. */
-      strain_commitment?: number;
-    };
     /** @description Flat read payload for a pending additional-target consent row (#1177). */
     SceneActionTarget: {
       readonly action_target_id: number;
@@ -24252,7 +24240,7 @@ export interface components {
        *     * `area` - Area
        *     * `filtered_group` - Filtered Group
        */
-      target_type?: components['schemas']['TechniqueTargetTypeEnum'];
+      readonly target_type: components['schemas']['TechniqueTargetTypeEnum'];
       /**
        * @description Positional reach: which positions this technique can target (SAME=melee, ADJACENT=reach, ANY=ranged).
        *
@@ -24262,15 +24250,20 @@ export interface components {
        */
       reach?: components['schemas']['ReachEnum'];
       readonly tier: number;
-      /**
-       * @description Derive and serialize the TargetSpec for this technique.
-       *
-       *     Returns None for SELF-targeting techniques (no picker needed). For other
-       *     cardinalities, returns the same shape as TargetSpecSerializer.
-       */
-      readonly target_spec: {
-        [key: string]: unknown;
-      } | null;
+      readonly target_spec: components['schemas']['TargetSpec'];
+    };
+    /** @description Validate input for the standalone technique cast endpoint. */
+    TechniqueCastCreateRequest: {
+      scene: number;
+      initiator_persona: number;
+      technique_id: number;
+      target_persona?: number | null;
+      target_persona_ids?: number[] | null;
+      /** @default 0 */
+      strain_commitment: number;
+      fury_commitment_id?: number | null;
+      fury_anchor_id?: number | null;
+      pull?: components['schemas']['CastPullRequestRequest'] | null;
     };
     /** @description Serializer for Technique records with intensity and control stats. */
     TechniqueRequest: {
@@ -24295,15 +24288,6 @@ export interface components {
       description?: string;
       /** @description The cantrip template this technique was created from, if any. */
       source_cantrip?: number | null;
-      /**
-       * @description Per-technique target cardinality (how many / how selected). Relationship (self/ally/enemy) is derived from condition target_kinds + hostility, not stored here.
-       *
-       *     * `self` - Self
-       *     * `single` - Single Target
-       *     * `area` - Area
-       *     * `filtered_group` - Filtered Group
-       */
-      target_type?: components['schemas']['TechniqueTargetTypeEnum'];
       /**
        * @description Positional reach: which positions this technique can target (SAME=melee, ADJACENT=reach, ANY=ranged).
        *
@@ -25309,11 +25293,11 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['SceneActionRequestRequest'];
+        'application/json': components['schemas']['TechniqueCastCreateRequest'];
       };
     };
     responses: {
-      200: {
+      201: {
         headers: {
           [name: string]: unknown;
         };
@@ -25323,9 +25307,16 @@ export interface operations {
       };
     };
   };
-  action_requests_castable_techniques_retrieve: {
+  action_requests_castable_techniques_list: {
     parameters: {
-      query?: never;
+      query: {
+        initiator?: number;
+        /** @description Persona id (owned by the requester) to list castable techniques for. */
+        initiator_persona: number;
+        scene?: number;
+        status?: string;
+        target?: number;
+      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -25337,7 +25328,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['SceneActionRequest'];
+          'application/json': components['schemas']['CastableTechnique'][];
         };
       };
     };

--- a/src/schema.json
+++ b/src/schema.json
@@ -240,12 +240,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SceneActionRequestRequest'
+              $ref: '#/components/schemas/TechniqueCastCreateRequest'
         required: true
       security:
       - cookieAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
@@ -253,12 +253,36 @@ paths:
           description: ''
   /api/action-requests/castable-techniques/:
     get:
-      operationId: action_requests_castable_techniques_retrieve
+      operationId: action_requests_castable_techniques_list
       description: |-
         List techniques the given persona can cast standalone.
 
         Requires ?initiator_persona=<id> query param. Returns only techniques
         with an action_template (castable standalone) known by that character.
+      parameters:
+      - in: query
+        name: initiator
+        schema:
+          type: number
+      - in: query
+        name: initiator_persona
+        schema:
+          type: integer
+        description: Persona id (owned by the requester) to list castable techniques
+          for.
+        required: true
+      - in: query
+        name: scene
+        schema:
+          type: number
+      - in: query
+        name: status
+        schema:
+          type: string
+      - in: query
+        name: target
+        schema:
+          type: number
       tags:
       - action-requests
       security:
@@ -268,7 +292,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SceneActionRequest'
+                type: array
+                items:
+                  $ref: '#/components/schemas/CastableTechnique'
           description: ''
   /api/action-targets/:
     get:
@@ -24013,6 +24039,73 @@ components:
       - description
       - id
       - name
+    CastPullRequestRequest:
+      type: object
+      description: |-
+        Nested pull declaration on the cast endpoint (#854).
+
+        Field shapes mirror ThreadPullCommitRequestSerializer
+        (world/magic/serializers.py).
+      properties:
+        resonance_id:
+          type: integer
+        tier:
+          type: integer
+          maximum: 3
+          minimum: 1
+        thread_ids:
+          type: array
+          items:
+            type: integer
+          maxItems: 20
+      required:
+      - resonance_id
+      - thread_ids
+      - tier
+    CastableTechnique:
+      type: object
+      description: Serializes a Technique for the castable-techniques list endpoint.
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        anima_cost:
+          type: integer
+        tier:
+          type: integer
+        intensity:
+          type: integer
+        control:
+          type: integer
+        hostile:
+          type: boolean
+          readOnly: true
+        target_type:
+          type: string
+        reach:
+          type: string
+        target_spec:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: |-
+            Derive and serialize the TargetSpec for this technique.
+
+            Returns None for SELF-targeting techniques (no picker needed). For other
+            cardinalities, returns the same shape as actions.serializers.TargetSpecSerializer.
+          readOnly: true
+      required:
+      - anima_cost
+      - control
+      - hostile
+      - id
+      - intensity
+      - name
+      - reach
+      - target_spec
+      - target_type
+      - tier
     ChallengeApproach:
       type: object
       description: Nested serializer for challenge approaches.
@@ -38221,16 +38314,6 @@ components:
           type: integer
           nullable: true
           description: The cantrip template this technique was created from, if any.
-        target_type:
-          allOf:
-          - $ref: '#/components/schemas/TechniqueTargetTypeEnum'
-          description: |-
-            Per-technique target cardinality (how many / how selected). Relationship (self/ally/enemy) is derived from condition target_kinds + hostility, not stored here.
-
-            * `self` - Self
-            * `single` - Single Target
-            * `area` - Area
-            * `filtered_group` - Filtered Group
         reach:
           allOf:
           - $ref: '#/components/schemas/ReachEnum'
@@ -41557,63 +41640,6 @@ components:
       - action_key
       - initiator_persona
       - scene
-    SceneActionRequestRequest:
-      type: object
-      properties:
-        scene:
-          type: integer
-          description: The scene where this action takes place
-        initiator_persona:
-          type: integer
-          description: The persona performing the action
-        target_persona:
-          type: integer
-          nullable: true
-          description: The persona being targeted. Null for area actions (to the room)
-            or standalone technique casts.
-        action_key:
-          type: string
-          description: Key identifying the action type (e.g., 'intimidate', 'persuade')
-          maxLength: 100
-        action_template:
-          type: integer
-          nullable: true
-          description: Data-driven action template if applicable
-        technique:
-          type: integer
-          nullable: true
-          description: Technique used for this action, if any
-        delivery:
-          description: |-
-            Resolved audience routing for the result echo (#903). Blank = resolve from the template's default_delivery at resolution time.
-
-            * `pose` - Pose (whole room)
-            * `whisper` - Whisper (target only)
-            * `table_talk` - Table talk (your place)
-            * `mutter` - Mutter (partial echo)
-          oneOf:
-          - $ref: '#/components/schemas/DeliveryEnum'
-          - $ref: '#/components/schemas/BlankEnum'
-        difficulty_choice:
-          allOf:
-          - $ref: '#/components/schemas/DifficultyChoiceEnum'
-          description: |-
-            Plausibility band chosen by the defender at consent.
-
-            * `trivial` - Trivial
-            * `easy` - Easy
-            * `normal` - Normal
-            * `hard` - Hard
-            * `daunting` - Daunting
-        strain_commitment:
-          type: integer
-          maximum: 2147483647
-          minimum: 0
-          description: Extra anima the player commits beyond base cost. Bounded by
-            available anima at resolution time.
-      required:
-      - initiator_persona
-      - scene
     SceneActionTarget:
       type: object
       description: Flat read payload for a pending additional-target consent row (#1177).
@@ -44211,6 +44237,7 @@ components:
         target_type:
           allOf:
           - $ref: '#/components/schemas/TechniqueTargetTypeEnum'
+          readOnly: true
           description: |-
             Per-technique target cardinality (how many / how selected). Relationship (self/ally/enemy) is derived from condition target_kinds + hostility, not stored here.
 
@@ -44231,14 +44258,8 @@ components:
           type: integer
           readOnly: true
         target_spec:
-          type: object
-          additionalProperties: {}
-          nullable: true
-          description: |-
-            Derive and serialize the TargetSpec for this technique.
-
-            Returns None for SELF-targeting techniques (no picker needed). For other
-            cardinalities, returns the same shape as TargetSpecSerializer.
+          allOf:
+          - $ref: '#/components/schemas/TargetSpec'
           readOnly: true
       required:
       - anima_cost
@@ -44248,7 +44269,44 @@ components:
       - name
       - style
       - target_spec
+      - target_type
       - tier
+    TechniqueCastCreateRequest:
+      type: object
+      description: Validate input for the standalone technique cast endpoint.
+      properties:
+        scene:
+          type: integer
+        initiator_persona:
+          type: integer
+        technique_id:
+          type: integer
+        target_persona:
+          type: integer
+          nullable: true
+        target_persona_ids:
+          type: array
+          items:
+            type: integer
+          nullable: true
+        strain_commitment:
+          type: integer
+          minimum: 0
+          default: 0
+        fury_commitment_id:
+          type: integer
+          nullable: true
+        fury_anchor_id:
+          type: integer
+          nullable: true
+        pull:
+          allOf:
+          - $ref: '#/components/schemas/CastPullRequestRequest'
+          nullable: true
+      required:
+      - initiator_persona
+      - scene
+      - technique_id
     TechniqueRequest:
       type: object
       description: Serializer for Technique records with intensity and control stats.
@@ -44300,16 +44358,6 @@ components:
           type: integer
           nullable: true
           description: The cantrip template this technique was created from, if any.
-        target_type:
-          allOf:
-          - $ref: '#/components/schemas/TechniqueTargetTypeEnum'
-          description: |-
-            Per-technique target cardinality (how many / how selected). Relationship (self/ally/enemy) is derived from condition target_kinds + hostility, not stored here.
-
-            * `self` - Self
-            * `single` - Single Target
-            * `area` - Area
-            * `filtered_group` - Filtered Group
         reach:
           allOf:
           - $ref: '#/components/schemas/ReachEnum'

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from world.combat.models import ClashConfig, StrainConfig
     from world.combat.types import WeaponContribution
     from world.conditions.models import ConditionTemplate, DamageType
+    from world.conditions.types import AppliedConditionResult
     from world.covenants.models import CovenantRole
     from world.items.models import ItemInstance
     from world.magic.models import Technique, TechniqueDamageProfile
@@ -97,7 +98,6 @@ from world.combat.models import (
 )
 from world.combat.types import (
     ActionOutcome,
-    AppliedConditionResult,
     AvailableCombo,
     ClashRoundResult,
     CombatTechniqueResolution,

--- a/src/world/combat/tests/test_combat_technique_resolver.py
+++ b/src/world/combat/tests/test_combat_technique_resolver.py
@@ -325,8 +325,7 @@ class ApplyConditionsTests(TestCase):
 
     def test_applies_enemy_targeted_condition(self) -> None:
         """A ENEMY-kind row lands on the focused opponent's ObjectDB."""
-        from world.combat.types import AppliedConditionResult
-        from world.conditions.types import ApplyConditionResult
+        from world.conditions.types import AppliedConditionResult, ApplyConditionResult
 
         self._make_applied_condition_row(
             condition=self.cond_a,

--- a/src/world/combat/types.py
+++ b/src/world/combat/types.py
@@ -11,8 +11,6 @@ from world.vitals.types import DamageConsequenceResult
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from evennia.objects.models import ObjectDB
-
     from world.character_sheets.models import CharacterSheet
     from world.checks.models import Consequence
     from world.checks.types import CheckResult
@@ -25,7 +23,8 @@ if TYPE_CHECKING:
         CombatRoundAction,
         ComboDefinition,
     )
-    from world.conditions.models import ConditionTemplate, DamageType
+    from world.conditions.models import DamageType
+    from world.conditions.types import AppliedConditionResult
     from world.magic.models import Affinity
     from world.magic.models.techniques import Technique
     from world.magic.types import TechniqueUseResult
@@ -122,17 +121,6 @@ class RoundResolutionResult:
 def _empty_ledger() -> PowerLedger:
     """Return an empty PowerLedger suitable as a default for CombatTechniqueResolution."""
     return PowerLedger(entries=(), total=0)
-
-
-@dataclass(frozen=True)
-class AppliedConditionResult:
-    """Per-condition apply outcome from CombatTechniqueResolver._apply_conditions."""
-
-    target: ObjectDB
-    condition: ConditionTemplate
-    severity_applied: int
-    duration_rounds: int | None
-    success: bool
 
 
 @dataclass(frozen=True)

--- a/src/world/conditions/types.py
+++ b/src/world/conditions/types.py
@@ -49,6 +49,17 @@ class BulkConditionApplication:
     stack_count: int = 1
 
 
+@dataclass(frozen=True)
+class AppliedConditionResult:
+    """Per-condition apply outcome from a technique cast (combat or standalone)."""
+
+    target: "ObjectDB"
+    condition: "ConditionTemplate"
+    severity_applied: int
+    duration_rounds: int | None
+    success: bool
+
+
 @dataclass
 class ApplyConditionResult:
     """Result of attempting to apply a condition."""

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
+from actions.serializers import TargetSpecSerializer
 from world.character_sheets.models import CharacterSheet
 
 if TYPE_CHECKING:
@@ -227,7 +228,9 @@ class TechniqueSerializer(serializers.ModelSerializer):
             "tier",
             "target_spec",
         ]
+        read_only_fields = ["target_type"]
 
+    @extend_schema_field(TargetSpecSerializer)
     def get_target_spec(self, obj: Technique) -> dict | None:
         """Derive and serialize the TargetSpec for this technique.
 

--- a/src/world/magic/services/condition_application.py
+++ b/src/world/magic/services/condition_application.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from world.conditions.services import bulk_apply_conditions
+from world.conditions.types import AppliedConditionResult, BulkConditionApplication
 
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
-    from world.combat.types import AppliedConditionResult
     from world.magic.models.techniques import Technique
 
 
@@ -55,9 +55,6 @@ def apply_technique_conditions(
         submitted, in the same order.  Empty list when no rows pass the SL gate
         or all resolved target lists are empty.
     """
-    from world.combat.types import AppliedConditionResult  # noqa: PLC0415
-    from world.conditions.types import BulkConditionApplication  # noqa: PLC0415
-
     rows = list(technique.condition_applications.select_related("condition").all())
     if not rows:
         return []

--- a/src/world/magic/tests/test_condition_application.py
+++ b/src/world/magic/tests/test_condition_application.py
@@ -14,9 +14,8 @@ from django.test import TestCase
 from django.test.utils import tag
 
 from world.character_sheets.factories import CharacterSheetFactory
-from world.combat.types import AppliedConditionResult
 from world.conditions.factories import ConditionTemplateFactory
-from world.conditions.types import ApplyConditionResult
+from world.conditions.types import AppliedConditionResult, ApplyConditionResult
 from world.magic.factories import (
     GiftFactory,
     TechniqueAppliedConditionFactory,

--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError as DRFValidationError
@@ -294,6 +294,10 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
 
         return Response(response_data)
 
+    @extend_schema(
+        request=TechniqueCastCreateSerializer,
+        responses={201: SceneActionRequestSerializer},
+    )
     @action(detail=False, methods=[HTTPMethod.POST], url_path="cast")
     def cast(self, request: Request) -> Response:  # noqa: C901, PLR0911
         """Submit a standalone technique cast.
@@ -406,7 +410,24 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
 
         return Response(response_data, status=status.HTTP_201_CREATED)
 
-    @action(detail=False, methods=[HTTPMethod.GET], url_path="castable-techniques")
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "initiator_persona",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="Persona id (owned by the requester) to list castable techniques for.",
+            ),
+        ],
+        responses={200: CastableTechniqueSerializer(many=True)},
+    )
+    @action(
+        detail=False,
+        methods=[HTTPMethod.GET],
+        url_path="castable-techniques",
+        pagination_class=None,
+    )
     def castable_techniques(self, request: Request) -> Response:
         """List techniques the given persona can cast standalone.
 


### PR DESCRIPTION
Closes #1359

## Summary

Four low-risk cleanups from the #1321 review (no new behavior, no model changes):

1. **Relocate `AppliedConditionResult`** from `world.combat.types` to the neutral `world.conditions.types` (the condition layer both combat and magic already depend on), and drop the magic→combat deferred import in `condition_application.py`. `combat.types`/`combat.services` now reference it via `TYPE_CHECKING`; importers updated.
2. **`Technique.target_type` read-only** on `TechniqueSerializer` (authored cardinality should not be player-writeable).
3. **Cast-endpoint schema fidelity** — added `@extend_schema` to the `cast` action (`request=TechniqueCastCreateSerializer`) and `castable-techniques` (now a bare `CastableTechnique[]` via `pagination_class=None`, plus the required `initiator_persona` query param) so the generated TS client stops typing them as `SceneActionRequest`.
4. **Typed `get_target_spec`** via `@extend_schema_field(TargetSpecSerializer)` so `api.d.ts` emits the named `TargetSpec` type instead of `{ [key: string]: unknown } | null`.

Regenerated `src/schema.json` + `frontend/src/generated/api.d.ts`, and updated the magic/combat docs that pointed `AppliedConditionResult` at `combat/types.py`.

Verification: `world.magic.tests.test_condition_application`, `world.combat.tests.test_combat_technique_resolver`, `world.scenes.tests.test_action_views`, `world.scenes.tests.test_cast_targeting`, `world.magic.tests.test_technique_targeting` all green on the SQLite tier; `ty`, full pre-commit, and frontend `tsc` pass.

Note: the sibling follow-ups #1357 (resonance→aspect) and #1358 (multi-target consent) were closed during triage as ill-premised; the genuine open question they surfaced is filed as #1363 (how `Aspect` should apply to magic checks).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1359 (in the issue body)
- Brainstorm/plan: skipped (chore — design step skipped per the issue-to-merged-pr rules; the code-verified ledger is embedded in the #1359 spec)
- Sync-with-main: Rebased onto origin/main (a71f6028, Character Secrets slice 2); no conflicts. `just gen-api-types` re-run on top of main produced no drift.

<!-- last-addressed-comment: 0 -->