### PR TITLE
docs(skills): verify deferred follow-ups against code before filing

### DIFF
--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -156,6 +156,13 @@ ledger as a section of the spec in the issue body.** A spec without a
 code-verified ledger is not finalized. (This codifies CLAUDE.md's
 "Anti-Reinvention Pass" into the workflow.)
 
+**This pass covers any "deferred follow-ups" the spec lists, too** — a deferral
+is a proposed future surface, and listing it as "later" is not a waiver. Verify
+each deferral's premise against code; drop it if it's already built/handled, and
+write design-open items as `needs-design` questions rather than asserted work.
+Deferrals filed unverified from a spec's deferred list are the exact thing that
+later gets closed as should-not-do (#1357/#1358).
+
 Then hand off for **spec review** and exit:
 
 1. `gh issue edit <N> --remove-label status:spec-draft --add-label status:spec-review`.
@@ -230,7 +237,20 @@ On conflict (exit 4):
 Compose the PR body's substitution values (summary, follow-ups, sync
 summary). For each deferred follow-up identified during implementation,
 call `scripts/file-followup.sh <title> <body-path> <labels...>` NOW (before
-opening the PR) and collect the issue numbers. Then:
+opening the PR) and collect the issue numbers.
+
+**Before filing each follow-up, run the `verify-against-code` pass on its
+premise** (skill at `tools/skills/verify-against-code/`). A deferral is a
+proposed future surface, not exempt from the anti-reinvention pass just because
+it's "later": grep its core claim and confirm the thing it says is missing is
+genuinely `[ABSENT]` (not already `[BUILT & WIRED]` or handled by another
+surface). If the premise doesn't hold, **don't file it** — the issue would only
+die at pickup as should-not-do. If the item is really an open design choice
+rather than a code-verified scope, file it as a `needs-design` **question** that
+states the verified mechanism and labels what exists, not as a `feature`/`chore`
+that reads as ready-to-build. (This is the lesson of #1357/#1358, both filed
+unverified from a spec's deferred list and later closed as should-not-do; the
+genuine question became #1363.) Then:
 
 ```bash
 PR_SUMMARY="..." PR_RAN_OR_SKIPPED="ran" PR_SYNC_SUMMARY="..." \

--- a/tools/skills/verify-against-code/SKILL.md
+++ b/tools/skills/verify-against-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-against-code
-description: Use when a feature design, spec, or implementation plan is about to propose a new code surface (model, dataclass, enum, serializer, component, hook, helper, field, endpoint) OR wire up an existing stub (a "not wired" button/endpoint/flow), or when relying on a systems/architecture/roadmap doc's claim about what exists or doesn't — before committing the spec or writing code.
+description: Use when a feature design, spec, or implementation plan is about to propose a new code surface (model, dataclass, enum, serializer, component, hook, helper, field, endpoint) OR wire up an existing stub (a "not wired" button/endpoint/flow), or when relying on a systems/architecture/roadmap doc's claim about what exists or doesn't, OR when filing a follow-up/audit issue or writing a "deferred follow-up" into a spec (a deferral is a proposed future surface — verify its premise before it becomes a filed issue) — before committing the spec, filing the issue, or writing code.
 ---
 
 # Verify Against Code
@@ -17,6 +17,7 @@ This is the code-verified half of the Anti-Reinvention Pass (CLAUDE.md). It exis
 - An issue or stub asks you to **wire or build a user-facing action/capability** (a button, command, endpoint, or flow that accomplishes a user goal) — before wiring, verify that same capability isn't already shipped in another surface.
 - You're about to write "X doesn't exist / isn't built / needs building" — or "X already does this" — based on a doc, `INDEX.md`, `MODEL_MAP.md`, an architecture doc, or your own memory.
 - An Explore-agent summary says something is built/not-built and you haven't seen the code.
+- You're about to **file a follow-up or audit-finding issue, or write a "deferred follow-up" into a spec.** A deferral is an unverified guess about future work, captured while shipping something else — it gets the *same* pass as an in-scope surface (see "Deferrals & audit findings are not exempt" below).
 
 ## The check (per proposed surface)
 
@@ -39,6 +40,16 @@ This is the code-verified half of the Anti-Reinvention Pass (CLAUDE.md). It exis
 | `OtherThing` | BUILT, NOT WIRED | `app/models.py:200`; no caller found |
 | `NewThing` | ABSENT | grep `NewThing` → 0 hits; genuinely new |
 
+## Deferrals & audit findings are not exempt
+
+The anti-reinvention pass is easy to apply only to what you're *building now* and to wave through what you're *deferring* — a deferral feels like permission to skip scrutiny because "we're not doing it yet." That is exactly how a backlog fills with issues that get closed as should-not-do. **A deferred follow-up, and every audit finding, is a proposed future surface — it gets the same pass before it becomes a filed issue.**
+
+1. **Verify the premise against code before filing.** Run the check above on the deferral's core claim: does the thing it says is missing actually not exist (`[ABSENT]`), or is it already `[BUILT & WIRED]` / handled by another surface? Two greps at filing time kill the issue that would otherwise die at pickup. The death cases are predictable: *"X needs building"* when X already ships elsewhere, and *"map A→B"* when A already feeds the same outcome through another path (a double-count).
+
+2. **File questions as questions, not work as work.** When the premise isn't code-verified — or the item is really an open design choice ("how should X work?") rather than a scoped change — file it as a `needs-design` **question** that states the verified mechanism and labels what exists, *not* as a `feature`/`chore` that looks ready to pick up. Asserting a build (`add the mapping`, `build the state machine`) commits to a premise you haven't checked; framing a question commits to nothing but the question.
+
+If a deferral can't pass (1) and isn't worth (2), it isn't an issue — drop it, or leave it as a checklist line on the parent until someone can verify it.
+
 ## Recurring traps
 
 - A new `AvailableX` / `XDescriptor` / `XAvailability` dataclass mirroring an existing one.
@@ -49,6 +60,7 @@ This is the code-verified half of the Anti-Reinvention Pass (CLAUDE.md). It exis
 - "Derive from `x.y.category`" when no such field exists — confirm the field before designing on it.
 - **Wiring a `NOT WIRED` stub (button/endpoint/flow) for a user goal that's already `BUILT & WIRED` in another surface** — e.g. a *second* "commit to X" UI when one already works. The duplicate is at the *capability* level, not the code level, so a component-existence grep misses it: restate the issue as the user goal and grep for *that*.
 - **Recon framed around the proposed mechanism instead of the user goal.** Asking an Explore agent "where is the Commit button / how do I wire it" pre-bakes the build; ask "find EVERY surface that lets the user accomplish &lt;goal&gt; today" so an existing path surfaces.
+- **A deferred follow-up filed as a real issue without a code-verified premise.** It looks legitimate on the board, but its premise ("needs per-target combat seeds", "map resonance→aspect") was never checked against code — so it dies at pickup as should-not-do. Verify the premise at filing time; file unverified or design-open items as `needs-design` questions.
 
 ## Red flags — STOP and verify against code
 
@@ -65,9 +77,12 @@ This is the code-verified half of the Anti-Reinvention Pass (CLAUDE.md). It exis
 | "BUILT means I can reuse it" | Only BUILT & WIRED is safe reuse; BUILT-NOT-WIRED may be a stub. |
 | "The button exists but isn't wired, so wiring it is the task" | Check the *capability*: if the same user goal is wired elsewhere, wiring this is a parallel impl — delete the stub. |
 | "No time to grep" | Rebuilding an existing system costs far more than the grep. |
+| "It's just a deferral, I'll verify it later" | Later = pickup, after it has calcified as backlog and read as real work. Verify the premise now, or file it as a `needs-design` question. |
 
 ## Real-world impact
 
 In one 2026-05-29 session, four near-rebuilds traced to trusting docs over code: a `property-capability-action` architecture doc listed built-and-wired models as "Not Built," an agent summary invented a non-existent `obstacles` app, and two frontend issues assumed technique fields/flows that didn't exist (or already did). Each was caught only by reading the code.
 
 The next day, issue #555 ("wire ActiveState's Commit button to dispatch") nearly added a **second** clash-commit path — the capability was already `BUILT & WIRED` in `YourTurn`'s `ClashContributionRow`. The surface-level ledger labeled the button `BUILT, NOT WIRED` and read it as "to-do." It was caught at writing-plans, one stage *after* the anti-reinvention pass — because the pass checked the building blocks, not whether the *user goal* ("commit to a clash") was already achievable elsewhere. The capability check (step 4) + the "NOT WIRED is a yellow flag" rule exist to catch that at spec time. This skill makes that reading mandatory.
+
+In 2026-06, three deferred follow-ups from #1321 were filed at PR time straight from the spec's "deferred" list, never run through this pass. Two died on contact with the code at pickup: #1358 ("hostile FILTERED_GROUP needs per-target combat seeds") — the multi-target combat machinery already shipped in #1321 itself; and #1357 ("map resonance→aspect") — resonance already feeds the cast via `power_terms`, and `Aspect` is an orthogonal competence axis, so the mapping was redundant *and* incoherent. Both were closed as should-not-do. The genuine question #1357 gestured at was re-filed as #1363 — framed as a `needs-design` question that states the verified mechanism, not as an assertion of work. The "Deferrals & audit findings are not exempt" rule exists so deferrals get the same two greps the build surfaces get, at filing time instead of pickup.


### PR DESCRIPTION
## Why

A retrospective with the maintainer: a run of follow-up issues kept getting closed as "should-not-do." Root cause — **deferrals get a free pass on the anti-reinvention pass.** The `verify-against-code` ledger is applied rigorously to what a spec is *building*, but items written into the spec's "deferred follow-ups" list (and audit findings) are filed as real issues without ever being checked against code. They look legitimate on the board and only die at pickup.

This session, two of three #1321 deferrals died exactly this way:
- **#1358** ("hostile FILTERED_GROUP needs per-target combat seeds") — the multi-target combat machinery already shipped in #1321 itself. Closed.
- **#1357** ("map resonance→aspect") — resonance already feeds the cast via `power_terms`; `Aspect` is an orthogonal competence axis. Redundant *and* incoherent. Closed.
- The genuine question #1357 gestured at was re-filed as **#1363**, framed as a `needs-design` question rather than asserted work.

## What

A deferral / audit finding is a *proposed future surface* — it gets the **same verify pass as an in-scope surface, at filing time**, with two rules:
1. **Verify the premise against code before filing** — grep the core claim; if it's already `[BUILT & WIRED]`/handled, don't file it.
2. **File questions as questions, not work as work** — when the premise isn't code-verified or the item is an open design choice, file a `needs-design` question that states the verified mechanism, not a `feature`/`chore` that reads as ready-to-build.

### Changes
- **`verify-against-code`** — frontmatter trigger + a "When to use" bullet for filing follow-ups/deferrals; a new **"Deferrals & audit findings are not exempt"** section; trap, red-flag, and real-world-impact entries.
- **`issue-to-merged-pr`** — the design-step verify pass now explicitly covers deferrals in the spec; the file-followup step (step 5) gates each follow-up on the verify pass before `file-followup.sh`.

Docs-only (skill markdown); no code or schema impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
