### PR TITLE
Character Secrets slice 3: the secret-tab display (#1334)

### DIFF
--- a/docs/systems/secrets.md
+++ b/docs/systems/secrets.md
@@ -7,11 +7,11 @@ loop.
 **Source:** `src/world/secrets/`
 **Umbrella issue / design:** #1334
 
-> **Build status:** Slices 1–2 built — the content model + authoring (slice 1) and **discovery**
-> (slice 2: the per-knower held/partial-knowledge record + the SECRET clue-target wiring). The
-> profile secret-tab display, action-anchored minting (blackmail/murder/affair/crime → Secret +
-> Evidence), the Deed↔Secret cross-link, the #1269 distinction migration, and the CG nudge are
-> **later slices** of #1334.
+> **Build status:** Slices 1–3 built — content model + authoring (slice 1), **discovery**
+> (slice 2: the held/partial-knowledge record + the SECRET clue-target), and the **secret-tab
+> display** (slice 3: the known-secrets API + the React tab, locked layers shown as "Unknown").
+> Action-anchored minting (blackmail/murder/affair/crime → Secret + Evidence), the Deed↔Secret
+> cross-link, the #1269 distinction migration, and the CG nudge are **later slices** of #1334.
 
 ---
 
@@ -78,6 +78,20 @@ gained a `SECRET` `target_kind` + `target_secret` FK (#1334); `grant_clue_target
 secret's fact via `grant_secret_knowledge`, and `target_already_known` reflects held knowledge.
 So a planted/searched SECRET clue grants the secret on acquisition exactly like a CODEX or RESCUE
 clue.
+
+## Display — the secret tab
+
+`GET /api/secrets/known/?subject=<CharacterSheet pk>` returns the secrets the **viewer's
+account** holds about that character (newest first), paginated. `KnownSecretViewSet` scopes to
+`RosterEntry.objects.for_account` and the serializer renders each held secret with locked layers
+as **"Unknown"**: the fact (`content`) always shows, but `category` / `consequences` read
+"Unknown" when the viewer hasn't unlocked that layer *or* the secret leaves it unplaced. The
+frontend `SecretsTab` (a tab on `CharacterSheetPage`) renders the list; Radix unmounts inactive
+tab content, so the query only fires when the tab is opened.
+
+> Scope note: the tab is account-aggregate (any of the viewer's characters' knowledge) — an OOC
+> "what you've learned about this person" view. Knowledge itself stays roster-scoped; narrowing
+> the tab to the active character is a possible refinement.
 
 ## Boundary with Codex
 

--- a/docs/systems/secrets.md
+++ b/docs/systems/secrets.md
@@ -81,17 +81,19 @@ clue.
 
 ## Display — the secret tab
 
-`GET /api/secrets/known/?subject=<CharacterSheet pk>` returns the secrets the **viewer's
-account** holds about that character (newest first), paginated. `KnownSecretViewSet` scopes to
-`RosterEntry.objects.for_account` and the serializer renders each held secret with locked layers
-as **"Unknown"**: the fact (`content`) always shows, but `category` / `consequences` read
-"Unknown" when the viewer hasn't unlocked that layer *or* the secret leaves it unplaced. The
-frontend `SecretsTab` (a tab on `CharacterSheetPage`) renders the list; Radix unmounts inactive
-tab content, so the query only fires when the tab is opened.
+`GET /api/secrets/known/?subject=<CharacterSheet pk>&viewer=<RosterEntry pk>` returns the secrets
+the **active viewing character** holds about that subject (newest first), paginated. The
+serializer renders each held secret with locked layers as **"Unknown"**: the fact (`content`)
+always shows, but `category` / `consequences` read "Unknown" when the viewer hasn't unlocked that
+layer *or* the secret leaves it unplaced. The frontend `SecretsTab` (a tab on
+`CharacterSheetPage`) renders the list; Radix unmounts inactive tab content, so the query only
+fires when the tab is opened.
 
-> Scope note: the tab is account-aggregate (any of the viewer's characters' knowledge) — an OOC
-> "what you've learned about this person" view. Knowledge itself stays roster-scoped; narrowing
-> the tab to the active character is a possible refinement.
+> **IC scope invariant:** IC knowledge scopes to the **active character**, never the account.
+> `KnownSecretViewSet` scopes to the single `viewer` RosterEntry the caller passes, validated
+> via `RosterEntry.objects.for_account` (so the param can't reach another account's knowledge);
+> no/unowned `viewer` → no secrets. The frontend resolves the active character from
+> `state.game.active`. An alt knowing a secret never surfaces it while you play a different face.
 
 ## Boundary with Codex
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -11653,6 +11653,40 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/secrets/known/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description A viewer's known secrets — the data behind the profile secret tab (#1334). */
+    get: operations['secrets_known_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/secrets/known/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description A viewer's known secrets — the data behind the profile secret tab (#1334). */
+    get: operations['secrets_known_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/session-requests/': {
     parameters: {
       query?: never;
@@ -17544,6 +17578,20 @@ export interface components {
       compass_rooms: string[];
       compass_anywhere: boolean;
     };
+    /** @description One known secret, from the viewer's side, with locked layers shown as "Unknown". */
+    KnownSecret: {
+      readonly id: number;
+      readonly level: string;
+      readonly content: string;
+      readonly provenance: string;
+      /** Format: date-time */
+      readonly found_at: string;
+      readonly subject: string;
+      readonly second_party: string | null;
+      readonly category: string;
+      readonly consequences: string;
+      readonly author: string;
+    };
     LedgerRow: {
       id: number;
       amount: number;
@@ -19440,6 +19488,21 @@ export interface components {
       /** Format: uri */
       previous: string | null;
       results: components['schemas']['JournalEntry'][];
+    };
+    PaginatedKnownSecretList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['KnownSecret'][];
     };
     PaginatedMissionCategoryList: {
       /** @example 123 */
@@ -42051,6 +42114,49 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['SceneDetail'];
+        };
+      };
+    };
+  };
+  secrets_known_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedKnownSecretList'];
+        };
+      };
+    };
+  };
+  secrets_known_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['KnownSecret'];
         };
       };
     };

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -42123,6 +42123,7 @@ export interface operations {
       query?: {
         /** @description A page number within the paginated result set. */
         page?: number;
+        subject?: number;
       };
       header?: never;
       path?: never;
@@ -42145,7 +42146,8 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        id: string;
+        /** @description A unique integer value identifying this Secret knowledge. */
+        id: number;
       };
       cookie?: never;
     };

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -13,6 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { RenownPanel } from '@/renown/components/RenownPanel';
 import { RenownCardPanel } from '@/renown/components/RenownCardPanel';
 import { VitalsPanel } from '@/vitals/components/VitalsPanel';
+import { SecretsTab } from '@/secrets/components/SecretsTab';
 
 export function CharacterSheetPage() {
   const { id } = useParams();
@@ -44,6 +45,7 @@ export function CharacterSheetPage() {
         <TabsList>
           <TabsTrigger value="sheet">Sheet</TabsTrigger>
           <TabsTrigger value="renown">Renown</TabsTrigger>
+          <TabsTrigger value="secrets">Secrets</TabsTrigger>
         </TabsList>
 
         <TabsContent value="sheet" className="space-y-4">
@@ -88,6 +90,13 @@ export function CharacterSheetPage() {
               viewerPersonaId={viewerPersonaId}
             />
           )}
+        </TabsContent>
+
+        <TabsContent value="secrets" className="space-y-4">
+          {/* The character sheet shares its pk with the ObjectDB, so character.id is the
+              CharacterSheet pk the secret-tab API filters by. Radix unmounts inactive tab
+              content, so the query only fires when this tab is opened. */}
+          <SecretsTab subjectId={entry.character.id} />
         </TabsContent>
       </Tabs>
     </div>

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'react-router-dom';
+import { useAppSelector } from '@/store/hooks';
 import { useRosterEntryQuery, useMyRosterEntriesQuery } from '../queries';
 import {
   CharacterPortrait,
@@ -27,6 +28,10 @@ export function CharacterSheetPage() {
   // persona from their first owned character. Null when the viewer has
   // no characters → the backend returns the anonymous subset.
   const viewerPersonaId = myEntries?.[0]?.primary_persona_id ?? null;
+  // For the Secrets tab: IC knowledge scopes to the ACTIVE character (never the account), so
+  // resolve the active character's roster entry. Null when no character is active → no secrets.
+  const activeCharacterName = useAppSelector((state) => state.game.active);
+  const viewerEntryId = myEntries?.find((e) => e.name === activeCharacterName)?.id ?? null;
 
   if (isLoading) return <p className="p-4">Loading...</p>;
   if (!entry) return <p className="p-4">Character not found.</p>;
@@ -96,7 +101,7 @@ export function CharacterSheetPage() {
           {/* The character sheet shares its pk with the ObjectDB, so character.id is the
               CharacterSheet pk the secret-tab API filters by. Radix unmounts inactive tab
               content, so the query only fires when this tab is opened. */}
-          <SecretsTab subjectId={entry.character.id} />
+          <SecretsTab subjectId={entry.character.id} viewerId={viewerEntryId} />
         </TabsContent>
       </Tabs>
     </div>

--- a/frontend/src/secrets/__tests__/SecretsTab.test.tsx
+++ b/frontend/src/secrets/__tests__/SecretsTab.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * SecretsTab (#1334) — the secret tab renders known secrets, and any layer the viewer hasn't
+ * unlocked (which the backend returns as "Unknown") shows as such. Mocks the query hook so the
+ * tab sees its data synchronously.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SecretsTab } from '../components/SecretsTab';
+import type { KnownSecret } from '../types';
+
+vi.mock('@/secrets/queries', () => ({
+  useKnownSecretsQuery: vi.fn(),
+}));
+
+import { useKnownSecretsQuery } from '@/secrets/queries';
+
+const mockQuery = vi.mocked(useKnownSecretsQuery);
+
+function mockResults(results: KnownSecret[]): void {
+  mockQuery.mockReturnValue({
+    data: { count: results.length, next: null, previous: null, results },
+    isLoading: false,
+    isError: false,
+  } as ReturnType<typeof useKnownSecretsQuery>);
+}
+
+function secret(overrides: Partial<KnownSecret>): KnownSecret {
+  return {
+    id: 1,
+    level: 'Carefully Kept',
+    content: 'A fact.',
+    provenance: 'GM/Staff authored (canon)',
+    found_at: '2026-06-22T00:00:00Z',
+    subject: 'Lady Vyper',
+    second_party: null,
+    category: 'Scandal',
+    consequences: 'Execution if proven.',
+    author: 'GM/Staff',
+    ...overrides,
+  };
+}
+
+describe('SecretsTab', () => {
+  it('shows a known secret with its fact and level', () => {
+    mockResults([secret({ content: 'She poisoned the duke.', level: 'Dangerous Secret' })]);
+    render(<SecretsTab subjectId={5} />);
+    expect(screen.getByText('She poisoned the duke.')).toBeInTheDocument();
+    expect(screen.getByText('Dangerous Secret')).toBeInTheDocument();
+  });
+
+  it('renders locked layers as "Unknown"', () => {
+    mockResults([secret({ category: 'Unknown', consequences: 'Unknown' })]);
+    render(<SecretsTab subjectId={5} />);
+    // Both the category and consequences layers read "Unknown".
+    expect(screen.getAllByText('Unknown')).toHaveLength(2);
+  });
+
+  it('shows the unlocked values when the viewer knows the layers', () => {
+    mockResults([secret({ category: 'Scandal', consequences: 'Execution if proven.' })]);
+    render(<SecretsTab subjectId={5} />);
+    expect(screen.getByText('Scandal')).toBeInTheDocument();
+    expect(screen.getByText('Execution if proven.')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when no secrets are known', () => {
+    mockResults([]);
+    render(<SecretsTab subjectId={5} />);
+    expect(screen.getByText(/know no secrets/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/secrets/__tests__/SecretsTab.test.tsx
+++ b/frontend/src/secrets/__tests__/SecretsTab.test.tsx
@@ -44,28 +44,34 @@ function secret(overrides: Partial<KnownSecret>): KnownSecret {
 describe('SecretsTab', () => {
   it('shows a known secret with its fact and level', () => {
     mockResults([secret({ content: 'She poisoned the duke.', level: 'Dangerous Secret' })]);
-    render(<SecretsTab subjectId={5} />);
+    render(<SecretsTab subjectId={5} viewerId={7} />);
     expect(screen.getByText('She poisoned the duke.')).toBeInTheDocument();
     expect(screen.getByText('Dangerous Secret')).toBeInTheDocument();
   });
 
   it('renders locked layers as "Unknown"', () => {
     mockResults([secret({ category: 'Unknown', consequences: 'Unknown' })]);
-    render(<SecretsTab subjectId={5} />);
+    render(<SecretsTab subjectId={5} viewerId={7} />);
     // Both the category and consequences layers read "Unknown".
     expect(screen.getAllByText('Unknown')).toHaveLength(2);
   });
 
   it('shows the unlocked values when the viewer knows the layers', () => {
     mockResults([secret({ category: 'Scandal', consequences: 'Execution if proven.' })]);
-    render(<SecretsTab subjectId={5} />);
+    render(<SecretsTab subjectId={5} viewerId={7} />);
     expect(screen.getByText('Scandal')).toBeInTheDocument();
     expect(screen.getByText('Execution if proven.')).toBeInTheDocument();
   });
 
   it('shows an empty state when no secrets are known', () => {
     mockResults([]);
-    render(<SecretsTab subjectId={5} />);
+    render(<SecretsTab subjectId={5} viewerId={7} />);
     expect(screen.getByText(/know no secrets/i)).toBeInTheDocument();
+  });
+
+  it('prompts to pick a character when none is active', () => {
+    mockResults([]);
+    render(<SecretsTab subjectId={5} viewerId={null} />);
+    expect(screen.getByText(/select a character/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/secrets/api.ts
+++ b/frontend/src/secrets/api.ts
@@ -1,0 +1,12 @@
+/** Character Secrets REST calls (#1334): the viewer's known secrets about a character. */
+import { apiFetch } from '@/evennia_replacements/api';
+
+import type { PaginatedKnownSecretList } from './types';
+
+export async function listKnownSecrets(subjectId: number): Promise<PaginatedKnownSecretList> {
+  const res = await apiFetch(`/api/secrets/known/?subject=${subjectId}`);
+  if (!res.ok) {
+    throw new Error('Failed to load secrets');
+  }
+  return res.json() as Promise<PaginatedKnownSecretList>;
+}

--- a/frontend/src/secrets/api.ts
+++ b/frontend/src/secrets/api.ts
@@ -3,8 +3,12 @@ import { apiFetch } from '@/evennia_replacements/api';
 
 import type { PaginatedKnownSecretList } from './types';
 
-export async function listKnownSecrets(subjectId: number): Promise<PaginatedKnownSecretList> {
-  const res = await apiFetch(`/api/secrets/known/?subject=${subjectId}`);
+/** Secrets the active viewing character (`viewerId`, a RosterEntry pk) knows about `subjectId`. */
+export async function listKnownSecrets(
+  subjectId: number,
+  viewerId: number
+): Promise<PaginatedKnownSecretList> {
+  const res = await apiFetch(`/api/secrets/known/?subject=${subjectId}&viewer=${viewerId}`);
   if (!res.ok) {
     throw new Error('Failed to load secrets');
   }

--- a/frontend/src/secrets/components/SecretsTab.tsx
+++ b/frontend/src/secrets/components/SecretsTab.tsx
@@ -1,0 +1,55 @@
+import { useKnownSecretsQuery } from '../queries';
+import type { KnownSecret } from '../types';
+
+const UNKNOWN = 'Unknown';
+
+/** One partial-knowledge layer. The backend renders unlocked/unplaced layers as "Unknown"; we
+ * style that muted so it reads as a deliberate gap, not missing data. */
+function Layer({ label, value }: { label: string; value: string }) {
+  const isUnknown = value === UNKNOWN;
+  return (
+    <div className="text-sm">
+      <span className="font-medium">{label}: </span>
+      <span className={isUnknown ? 'italic text-muted-foreground' : ''}>{value}</span>
+    </div>
+  );
+}
+
+function SecretCard({ secret }: { secret: KnownSecret }) {
+  return (
+    <div className="space-y-1 rounded-md border p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {secret.level}
+        </span>
+        <span className="text-xs text-muted-foreground">{secret.author}</span>
+      </div>
+      <p>{secret.content}</p>
+      {secret.second_party && <Layer label="Also implicates" value={secret.second_party} />}
+      <Layer label="Category" value={secret.category} />
+      <Layer label="Consequences" value={secret.consequences} />
+    </div>
+  );
+}
+
+/** The secret tab on a character's profile: the secrets the viewer knows about this person,
+ * with any layer they haven't unlocked shown as "Unknown" (#1334). */
+export function SecretsTab({ subjectId }: { subjectId: number }) {
+  const { data, isLoading, isError } = useKnownSecretsQuery(subjectId);
+
+  if (isLoading) return <p className="text-muted-foreground">Loading…</p>;
+  if (isError) return <p className="text-destructive">Failed to load secrets.</p>;
+
+  const secrets = data?.results ?? [];
+  if (secrets.length === 0) {
+    return <p className="text-muted-foreground">You know no secrets about this person.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {secrets.map((secret) => (
+        <SecretCard key={secret.id} secret={secret} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/secrets/components/SecretsTab.tsx
+++ b/frontend/src/secrets/components/SecretsTab.tsx
@@ -32,11 +32,23 @@ function SecretCard({ secret }: { secret: KnownSecret }) {
   );
 }
 
-/** The secret tab on a character's profile: the secrets the viewer knows about this person,
- * with any layer they haven't unlocked shown as "Unknown" (#1334). */
-export function SecretsTab({ subjectId }: { subjectId: number }) {
-  const { data, isLoading, isError } = useKnownSecretsQuery(subjectId);
+/** The secret tab on a character's profile: the secrets the **active viewing character** knows
+ * about this person, with any layer they haven't unlocked shown as "Unknown" (#1334). IC
+ * knowledge is per active character — `viewerId` is the viewer's active RosterEntry, or null. */
+export function SecretsTab({
+  subjectId,
+  viewerId,
+}: {
+  subjectId: number;
+  viewerId: number | null;
+}) {
+  const { data, isLoading, isError } = useKnownSecretsQuery(subjectId, viewerId);
 
+  if (viewerId === null) {
+    return (
+      <p className="text-muted-foreground">Select a character to see the secrets they know.</p>
+    );
+  }
   if (isLoading) return <p className="text-muted-foreground">Loading…</p>;
   if (isError) return <p className="text-destructive">Failed to load secrets.</p>;
 

--- a/frontend/src/secrets/queries.ts
+++ b/frontend/src/secrets/queries.ts
@@ -4,13 +4,16 @@ import { useQuery } from '@tanstack/react-query';
 import { listKnownSecrets } from './api';
 
 export const secretKeys = {
-  known: (subjectId: number) => ['secrets', 'known', subjectId] as const,
+  known: (subjectId: number, viewerId: number) =>
+    ['secrets', 'known', subjectId, viewerId] as const,
 };
 
-export function useKnownSecretsQuery(subjectId: number) {
+/** Secrets the active viewing character (`viewerId`) knows about `subjectId`. Disabled until
+ * there's an active character — IC knowledge is per character, never account-wide. */
+export function useKnownSecretsQuery(subjectId: number, viewerId: number | null) {
   return useQuery({
-    queryKey: secretKeys.known(subjectId),
-    queryFn: () => listKnownSecrets(subjectId),
-    enabled: Number.isFinite(subjectId),
+    queryKey: secretKeys.known(subjectId, viewerId ?? 0),
+    queryFn: () => listKnownSecrets(subjectId, viewerId as number),
+    enabled: Number.isFinite(subjectId) && viewerId != null,
   });
 }

--- a/frontend/src/secrets/queries.ts
+++ b/frontend/src/secrets/queries.ts
@@ -1,0 +1,16 @@
+/** React Query hooks for the secret tab (#1334). */
+import { useQuery } from '@tanstack/react-query';
+
+import { listKnownSecrets } from './api';
+
+export const secretKeys = {
+  known: (subjectId: number) => ['secrets', 'known', subjectId] as const,
+};
+
+export function useKnownSecretsQuery(subjectId: number) {
+  return useQuery({
+    queryKey: secretKeys.known(subjectId),
+    queryFn: () => listKnownSecrets(subjectId),
+    enabled: Number.isFinite(subjectId),
+  });
+}

--- a/frontend/src/secrets/types.ts
+++ b/frontend/src/secrets/types.ts
@@ -1,0 +1,5 @@
+/** Character Secrets API types (#1334), from the generated OpenAPI schema. */
+import type { components } from '@/generated/api';
+
+export type KnownSecret = components['schemas']['KnownSecret'];
+export type PaginatedKnownSecretList = components['schemas']['PaginatedKnownSecretList'];

--- a/src/schema.json
+++ b/src/schema.json
@@ -19760,6 +19760,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/SceneDetail'
           description: ''
+  /api/secrets/known/:
+    get:
+      operationId: secrets_known_list
+      description: A viewer's known secrets — the data behind the profile secret tab
+        (#1334).
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      tags:
+      - secrets
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedKnownSecretList'
+          description: ''
+  /api/secrets/known/{id}/:
+    get:
+      operationId: secrets_known_retrieve
+      description: A viewer's known secrets — the data behind the profile secret tab
+        (#1334).
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - secrets
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnownSecret'
+          description: ''
   /api/session-requests/:
     get:
       operationId: session_requests_list
@@ -31682,6 +31727,54 @@ components:
       - status
       - summary
       - template_name
+    KnownSecret:
+      type: object
+      description: One known secret, from the viewer's side, with locked layers shown
+        as "Unknown".
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        level:
+          type: string
+          readOnly: true
+        content:
+          type: string
+          readOnly: true
+        provenance:
+          type: string
+          readOnly: true
+        found_at:
+          type: string
+          format: date-time
+          readOnly: true
+        subject:
+          type: string
+          readOnly: true
+        second_party:
+          type: string
+          nullable: true
+          readOnly: true
+        category:
+          type: string
+          readOnly: true
+        consequences:
+          type: string
+          readOnly: true
+        author:
+          type: string
+          readOnly: true
+      required:
+      - author
+      - category
+      - consequences
+      - content
+      - found_at
+      - id
+      - level
+      - provenance
+      - second_party
+      - subject
     LedgerRow:
       type: object
       properties:
@@ -35174,6 +35267,29 @@ components:
       - next
       - previous
       - results
+    PaginatedKnownSecretList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/KnownSecret'
     PaginatedMissionCategoryList:
       type: object
       required:

--- a/src/schema.json
+++ b/src/schema.json
@@ -19772,6 +19772,10 @@ paths:
         description: A page number within the paginated result set.
         schema:
           type: integer
+      - in: query
+        name: subject
+        schema:
+          type: number
       tags:
       - secrets
       security:
@@ -19792,7 +19796,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this Secret knowledge.
         required: true
       tags:
       - secrets

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path("api/currency/", include("world.currency.urls")),
     path("api/events/", include("world.events.urls")),
     path("api/combat/", include("world.combat.urls")),
+    path("api/secrets/", include("world.secrets.urls")),
     path("api/fatigue/", include("world.fatigue.urls")),
     path("api/vitals/", include("world.vitals.urls")),
     path("api/areas/", include("world.areas.urls")),

--- a/src/world/secrets/filters.py
+++ b/src/world/secrets/filters.py
@@ -1,0 +1,15 @@
+"""Filters for the secret-tab API (#1334)."""
+
+import django_filters
+
+from world.secrets.models import SecretKnowledge
+
+
+class KnownSecretFilter(django_filters.FilterSet):
+    """Filter a viewer's known secrets — by ``subject`` (a CharacterSheet pk) for one tab."""
+
+    subject = django_filters.NumberFilter(field_name="secret__subject_sheet_id")
+
+    class Meta:
+        model = SecretKnowledge
+        fields = ["subject"]

--- a/src/world/secrets/serializers.py
+++ b/src/world/secrets/serializers.py
@@ -1,0 +1,52 @@
+"""Serializers for the secret tab (#1334) — a viewer's known secrets about a character.
+
+Renders a ``SecretKnowledge`` (a held secret) into the tab shape. The fact (``content``) is
+always shown — holding the row *is* the fact layer — but any partial-knowledge layer the viewer
+hasn't unlocked (``category``, ``consequences``), and any layer the secret itself leaves
+unplaced, renders as **"Unknown"** (a first-class state, not a blank).
+"""
+
+from rest_framework import serializers
+
+# Runtime import (not TYPE_CHECKING): drf-spectacular calls get_type_hints() on the method
+# fields, which evaluates the ``obj: SecretKnowledge`` annotations — they must resolve at runtime.
+from world.secrets.models import SecretKnowledge
+
+UNKNOWN = "Unknown"
+
+
+class KnownSecretSerializer(serializers.Serializer):
+    """One known secret, from the viewer's side, with locked layers shown as "Unknown"."""
+
+    id = serializers.IntegerField(source="secret_id", read_only=True)
+    level = serializers.CharField(source="secret.get_level_display", read_only=True)
+    content = serializers.CharField(source="secret.content", read_only=True)
+    provenance = serializers.CharField(source="secret.get_provenance_display", read_only=True)
+    found_at = serializers.DateTimeField(read_only=True)
+    subject = serializers.SerializerMethodField()
+    second_party = serializers.SerializerMethodField()
+    category = serializers.SerializerMethodField()
+    consequences = serializers.SerializerMethodField()
+    author = serializers.SerializerMethodField()
+
+    def get_subject(self, obj: SecretKnowledge) -> str:
+        return obj.secret.subject_sheet.character.db_key
+
+    def get_second_party(self, obj: SecretKnowledge) -> str | None:
+        other = obj.secret.second_party_sheet
+        return other.character.db_key if other is not None else None
+
+    def get_category(self, obj: SecretKnowledge) -> str:
+        secret = obj.secret
+        if obj.knows_category and secret.category_id is not None:
+            return secret.category.name
+        return UNKNOWN
+
+    def get_consequences(self, obj: SecretKnowledge) -> str:
+        if obj.knows_consequences and obj.secret.consequences:
+            return obj.secret.consequences
+        return UNKNOWN
+
+    def get_author(self, obj: SecretKnowledge) -> str:
+        persona = obj.secret.author_persona
+        return persona.name if persona is not None else "GM/Staff"

--- a/src/world/secrets/tests/test_secret_tab_api.py
+++ b/src/world/secrets/tests/test_secret_tab_api.py
@@ -1,0 +1,109 @@
+"""Secret-tab API (#1334) — a viewer's known secrets, with locked layers shown as "Unknown".
+
+The load-bearing display rule (Apostate): a known secret shows its fact, but any partial-knowledge
+layer the viewer hasn't unlocked — and any layer the secret leaves unplaced — reads "Unknown".
+"""
+
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory
+from evennia_extensions.models import PlayerData
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.secrets.constants import SecretLevel, SecretProvenance
+from world.secrets.factories import SecretCategoryFactory, SecretFactory
+from world.secrets.services import grant_secret_knowledge
+
+URL = "/api/secrets/known/"
+
+
+class SecretTabAPITests(APITestCase):
+    def _viewer_with_character(self):
+        account = AccountFactory()
+        player_data, _ = PlayerData.objects.get_or_create(account=account)
+        entry = RosterEntryFactory()
+        RosterTenureFactory(player_data=player_data, roster_entry=entry)
+        return account, entry
+
+    def setUp(self) -> None:
+        self.account, self.knower = self._viewer_with_character()
+        self.subject = RosterEntryFactory().character_sheet
+        self.category = SecretCategoryFactory(name="Scandal")
+        self.client.force_authenticate(user=self.account)
+
+    def _results(self, **params):
+        return self.client.get(URL, params).data["results"]
+
+    def test_known_secret_appears_on_the_subject_tab(self) -> None:
+        secret = SecretFactory(
+            subject_sheet=self.subject, content="She poisoned the duke.", category=self.category
+        )
+        grant_secret_knowledge(roster_entry=self.knower, secret=secret)
+        results = self._results(subject=self.subject.pk)
+        assert len(results) == 1
+        assert results[0]["content"] == "She poisoned the duke."
+
+    def test_locked_layers_render_unknown(self) -> None:
+        secret = SecretFactory(
+            subject_sheet=self.subject,
+            category=self.category,
+            consequences="Execution if proven.",
+        )
+        # Knows the fact only — not the category or consequences.
+        grant_secret_knowledge(roster_entry=self.knower, secret=secret)
+        row = self._results(subject=self.subject.pk)[0]
+        assert row["category"] == "Unknown"
+        assert row["consequences"] == "Unknown"
+        assert row["content"]  # the fact itself is shown
+
+    def test_unlocked_layers_render_the_real_values(self) -> None:
+        secret = SecretFactory(
+            subject_sheet=self.subject,
+            category=self.category,
+            consequences="Execution if proven.",
+        )
+        grant_secret_knowledge(
+            roster_entry=self.knower, secret=secret, knows_category=True, knows_consequences=True
+        )
+        row = self._results(subject=self.subject.pk)[0]
+        assert row["category"] == "Scandal"
+        assert row["consequences"] == "Execution if proven."
+
+    def test_unplaced_category_is_unknown_even_when_the_layer_is_unlocked(self) -> None:
+        # The secret itself has no category → Unknown even to a knower who has the category layer.
+        secret = SecretFactory(subject_sheet=self.subject, category=None)
+        grant_secret_knowledge(roster_entry=self.knower, secret=secret, knows_category=True)
+        row = self._results(subject=self.subject.pk)[0]
+        assert row["category"] == "Unknown"
+
+    def test_a_secret_you_do_not_know_is_not_listed(self) -> None:
+        SecretFactory(subject_sheet=self.subject, content="Unknown to the viewer.")
+        assert self._results(subject=self.subject.pk) == []
+
+    def test_subject_filter_scopes_to_one_person(self) -> None:
+        other_subject = RosterEntryFactory().character_sheet
+        mine = SecretFactory(subject_sheet=self.subject)
+        theirs = SecretFactory(subject_sheet=other_subject)
+        grant_secret_knowledge(roster_entry=self.knower, secret=mine)
+        grant_secret_knowledge(roster_entry=self.knower, secret=theirs)
+        ids = {r["id"] for r in self._results(subject=self.subject.pk)}
+        assert ids == {mine.pk}
+
+    def test_author_attribution_player_vs_gm(self) -> None:
+        player_secret = SecretFactory(
+            subject_sheet=self.subject,
+            provenance=SecretProvenance.PLAYER_FLAVOR,
+            level=SecretLevel.UNCOMMON_KNOWLEDGE,
+            author_persona=self.subject.primary_persona,
+        )
+        gm_secret = SecretFactory(
+            subject_sheet=self.subject, provenance=SecretProvenance.GM_AUTHORED, author_persona=None
+        )
+        grant_secret_knowledge(roster_entry=self.knower, secret=player_secret)
+        grant_secret_knowledge(roster_entry=self.knower, secret=gm_secret)
+        authors = {r["id"]: r["author"] for r in self._results(subject=self.subject.pk)}
+        assert authors[player_secret.pk] == self.subject.primary_persona.name
+        assert authors[gm_secret.pk] == "GM/Staff"
+
+    def test_requires_authentication(self) -> None:
+        self.client.force_authenticate(user=None)
+        assert self.client.get(URL).status_code in (401, 403)

--- a/src/world/secrets/tests/test_secret_tab_api.py
+++ b/src/world/secrets/tests/test_secret_tab_api.py
@@ -17,12 +17,15 @@ URL = "/api/secrets/known/"
 
 
 class SecretTabAPITests(APITestCase):
-    def _viewer_with_character(self):
-        account = AccountFactory()
+    def _add_character(self, account):
         player_data, _ = PlayerData.objects.get_or_create(account=account)
         entry = RosterEntryFactory()
         RosterTenureFactory(player_data=player_data, roster_entry=entry)
-        return account, entry
+        return entry
+
+    def _viewer_with_character(self):
+        account = AccountFactory()
+        return account, self._add_character(account)
 
     def setUp(self) -> None:
         self.account, self.knower = self._viewer_with_character()
@@ -31,6 +34,8 @@ class SecretTabAPITests(APITestCase):
         self.client.force_authenticate(user=self.account)
 
     def _results(self, **params):
+        # IC knowledge scopes to the active character; default the viewer to the test's knower.
+        params.setdefault("viewer", self.knower.pk)
         return self.client.get(URL, params).data["results"]
 
     def test_known_secret_appears_on_the_subject_tab(self) -> None:
@@ -103,6 +108,30 @@ class SecretTabAPITests(APITestCase):
         authors = {r["id"]: r["author"] for r in self._results(subject=self.subject.pk)}
         assert authors[player_secret.pk] == self.subject.primary_persona.name
         assert authors[gm_secret.pk] == "GM/Staff"
+
+    def test_scoped_to_the_active_character_not_the_account(self) -> None:
+        # A second character on the SAME account knows a secret. Viewing as the first character
+        # must NOT surface it — IC knowledge is per active character, never account-aggregate.
+        alt = self._add_character(self.account)
+        secret = SecretFactory(subject_sheet=self.subject)
+        grant_secret_knowledge(roster_entry=alt, secret=secret)
+        assert self._results(subject=self.subject.pk, viewer=self.knower.pk) == []
+        # Viewing as the alt, it shows.
+        ids = {r["id"] for r in self._results(subject=self.subject.pk, viewer=alt.pk)}
+        assert ids == {secret.pk}
+
+    def test_no_active_character_returns_empty(self) -> None:
+        secret = SecretFactory(subject_sheet=self.subject)
+        grant_secret_knowledge(roster_entry=self.knower, secret=secret)
+        # No viewer → no secrets (never an account-wide aggregate).
+        assert self.client.get(URL, {"subject": self.subject.pk}).data["results"] == []
+
+    def test_cannot_view_as_another_accounts_character(self) -> None:
+        _, other_entry = self._viewer_with_character()
+        secret = SecretFactory(subject_sheet=self.subject)
+        grant_secret_knowledge(roster_entry=other_entry, secret=secret)
+        # Passing a roster entry the requester doesn't own → empty (for_account confines it).
+        assert self._results(subject=self.subject.pk, viewer=other_entry.pk) == []
 
     def test_requires_authentication(self) -> None:
         self.client.force_authenticate(user=None)

--- a/src/world/secrets/urls.py
+++ b/src/world/secrets/urls.py
@@ -1,0 +1,10 @@
+"""URL configuration for the secrets API (#1334)."""
+
+from rest_framework.routers import DefaultRouter
+
+from world.secrets.views import KnownSecretViewSet
+
+router = DefaultRouter()
+router.register("known", KnownSecretViewSet, basename="known-secret")
+
+urlpatterns = router.urls

--- a/src/world/secrets/views.py
+++ b/src/world/secrets/views.py
@@ -1,0 +1,54 @@
+"""Secret-tab API (#1334) — the viewer's known secrets about a character.
+
+Read-only: returns the ``SecretKnowledge`` the viewer's account holds (newest first), filterable
+by ``subject`` (a CharacterSheet pk) for one person's tab. Scoped to the account's roster entries
+— an OOC "what you've learned about this person" view; knowledge itself stays roster-scoped.
+Locked partial-knowledge layers render as "Unknown" in the serializer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import ReadOnlyModelViewSet
+
+from world.roster.models import RosterEntry
+from world.secrets.filters import KnownSecretFilter
+from world.secrets.models import SecretKnowledge
+from world.secrets.serializers import KnownSecretSerializer
+
+if TYPE_CHECKING:
+    from django.db.models import QuerySet
+
+
+class SecretsPagination(PageNumberPagination):
+    page_size = 50
+
+
+class KnownSecretViewSet(ReadOnlyModelViewSet):
+    """A viewer's known secrets — the data behind the profile secret tab (#1334)."""
+
+    serializer_class = KnownSecretSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = SecretsPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = KnownSecretFilter
+
+    def get_queryset(self) -> QuerySet[SecretKnowledge]:
+        # Subquery (not a list) so the __in stays a single indexed query; the names come from the
+        # prefetched character so the serializer never queries per row.
+        own_entries = RosterEntry.objects.for_account(self.request.user)
+        return (
+            SecretKnowledge.objects.filter(roster_entry__in=own_entries)
+            .select_related(
+                "secret",
+                "secret__category",
+                "secret__author_persona",
+                "secret__subject_sheet__character",
+                "secret__second_party_sheet__character",
+            )
+            .order_by("-found_at")
+        )

--- a/src/world/secrets/views.py
+++ b/src/world/secrets/views.py
@@ -1,9 +1,10 @@
-"""Secret-tab API (#1334) — the viewer's known secrets about a character.
+"""Secret-tab API (#1334) — the active character's known secrets about a character.
 
-Read-only: returns the ``SecretKnowledge`` the viewer's account holds (newest first), filterable
-by ``subject`` (a CharacterSheet pk) for one person's tab. Scoped to the account's roster entries
-— an OOC "what you've learned about this person" view; knowledge itself stays roster-scoped.
-Locked partial-knowledge layers render as "Unknown" in the serializer.
+Read-only: returns the ``SecretKnowledge`` the **active viewing character** holds (newest first),
+filterable by ``subject`` (a CharacterSheet pk) for one person's tab. IC knowledge is scoped to
+the active character the caller passes (``viewer`` = a RosterEntry pk), **never** the account —
+``for_account`` confines it to the caller's own characters so the param can't reach another
+account's knowledge. Locked partial-knowledge layers render as "Unknown" in the serializer.
 """
 
 from __future__ import annotations
@@ -38,11 +39,11 @@ class KnownSecretViewSet(ReadOnlyModelViewSet):
     filterset_class = KnownSecretFilter
 
     def get_queryset(self) -> QuerySet[SecretKnowledge]:
-        # Subquery (not a list) so the __in stays a single indexed query; the names come from the
-        # prefetched character so the serializer never queries per row.
-        own_entries = RosterEntry.objects.for_account(self.request.user)
+        viewer = self._viewer_entry()
+        if viewer is None:
+            return SecretKnowledge.objects.none()
         return (
-            SecretKnowledge.objects.filter(roster_entry__in=own_entries)
+            SecretKnowledge.objects.filter(roster_entry=viewer)
             .select_related(
                 "secret",
                 "secret__category",
@@ -52,3 +53,16 @@ class KnownSecretViewSet(ReadOnlyModelViewSet):
             )
             .order_by("-found_at")
         )
+
+    def _viewer_entry(self) -> RosterEntry | None:
+        """The active (viewing) character, validated as owned by the requester (#1334).
+
+        IC knowledge scopes to the active character, never the account: the caller passes which of
+        their characters is viewing (``viewer`` = a RosterEntry pk); ``for_account`` confines the
+        lookup to their own, so the param can never reach another account's knowledge. No (or an
+        unowned) ``viewer`` → no secrets, rather than an account-wide aggregate.
+        """
+        raw = self.request.query_params.get("viewer")  # noqa: use_filterset — auth scope, not a filter
+        if not raw or not raw.isdigit():
+            return None
+        return RosterEntry.objects.for_account(self.request.user).filter(pk=int(raw)).first()


### PR DESCRIPTION
## What

Slice 3 of the Character Secrets epic (#1334) — the **secret-tab display**. A character's profile
gains a **Secrets** tab showing the secrets *the viewer knows* about that person, with any
partial-knowledge layer they haven't unlocked rendered as **"Unknown"** (per @ApostateCD).

## Backend

- `GET /api/secrets/known/?subject=<CharacterSheet pk>` — `KnownSecretViewSet` returns the
  `SecretKnowledge` the viewer's account holds (newest first, paginated), scoped via
  `RosterEntry.objects.for_account`. Query-free serialization (`select_related`).
- `KnownSecretSerializer` renders **locked or unplaced** layers (`category`, `consequences`) as
  `"Unknown"`; the fact (`content`) always shows. Author = the narrating persona's name, or
  `"GM/Staff"`.
- Regenerated `api.d.ts` (`KnownSecret` + `PaginatedKnownSecretList`).

## Frontend

- `secrets/{types,api,queries}.ts` + `SecretsTab`, wired as a tab on `CharacterSheetPage`. Radix
  unmounts inactive tab content, so the query fires only when the tab is opened. `"Unknown"`
  layers render muted, so they read as a deliberate gap.

## Scope note (flagged)

The tab is **account-aggregate** — secrets known by *any* of the viewer's characters (an OOC
"what you've learned about this person" view). Knowledge stays roster-scoped; narrowing to the
active character is a possible refinement if you'd prefer strict IC accuracy.

## Tests

8 API tests (locked→Unknown, unlocked→values, unplaced-category→Unknown, subject scoping, author
attribution, auth) + 4 React tests. Backend 21 green; FE typecheck + lint + **build** + tests green.

## Next

Action-anchored minting (→ Secret + Evidence), the Deed↔Secret cross-link, the #1269 distinction
migration, the CG nudge, and the level-names / category workshop pass.

Refs #1334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)