### PR TITLE
Telnet foundation: strategy for consent-flow & direct-viewset systems (resolve #1328 open questions)

### DIFF
--- a/docs/architecture/unified-player-action.md
+++ b/docs/architecture/unified-player-action.md
@@ -340,7 +340,69 @@ CI's fresh DB).
 - Whether specific registry actions (e.g., equip) should cost a combat round —
   pre-existing combat-design question, untouched here.
 
-## 10. Verified Source Anchors
+## 10. Telnet Convergence Convention — Three Player-Action Families (ratified #1337)
+
+Sections 1–9 design **Family 1**: the unified `dispatch_player_action()` interface
+and its three dispatch backends (REGISTRY / CHALLENGE / COMBAT). That is the seam
+for *most* player actions, but it is not the only one. The
+[telnet-driveability audit](../audits/2026-06-21-telnet-driveability-ui-parity.md)
+identified **three distinct player-action dispatch families**, each with its own
+shared seam. The invariant — ratified in #1337 — is that **telnet converges with
+the web on each family's own seam; there is never a forked telnet-only path**. The
+correct seam differs by family; "use `action.run()`" is *not* the universal answer.
+
+### Family 1 — Unified dispatch (REGISTRY / CHALLENGE / COMBAT)
+
+- **Seam:** `dispatch_player_action()` (`src/actions/player_interface.py`). Routes by
+  backend: REGISTRY → `action.run()`, CHALLENGE → `resolve_challenge()`, COMBAT →
+  `declare_action()` (deferred, resolved by `resolve_round()`).
+- **Telnet face:** `DispatchCommand` (`src/commands/command.py`) carries an
+  `ActionRef` to `dispatch_player_action()` — the same entry the web's
+  `DispatchActionView` uses. Pure-REGISTRY actions may instead use the simpler
+  `ArxCommand` → `action.run()` shim (REGISTRY is the one backend `action.run()`
+  reaches directly). Worked examples: `CmdDeclareTechnique` (combat cast/declare).
+
+### Family 2 — Consent (two-party targeted social actions)
+
+- **Seam: the consent SERVICE functions** `create_action_request()` /
+  `respond_to_action_request()` (`src/world/scenes/action_services.py`) — **not**
+  `action.run()` or `dispatch_player_action()`. The web's `SceneActionRequestViewSet`
+  calls exactly these services; telnet calls the same ones.
+- **Telnet face:** `ConsentRequestCommand` / `CmdIntimidate` (request half) plus the
+  generic `CmdAccept` / `CmdDeny` (response half), all in `src/commands/consent.py`.
+- **Why it stays at the service seam (not resolution / `action.run()`):** consent is
+  an inherently **two-party async protocol** — request, then a *separate* accept/deny
+  by the target — whose response half cannot be a single dispatch call. Whether an
+  action "needs consent" is a property of `ActionTemplate.consent_category`, not of
+  the `Action`. Convergence here is at the **service seam**, deliberately *before*
+  resolution; a naive telnet command calling `action.run()` would resolve
+  immediately and skip consent — a different semantic than the web.
+
+### Family 3 — Direct-viewset player mutations (weave / pull / endorse / membership …)
+
+- **Seam: a real `Action` on `action.run()`** (the #1331 ritual-as-Action template).
+  Where the web historically reached a service directly through a dedicated viewset,
+  the convention is to introduce a real `Action`, then re-point the web serializer at
+  `action.run()` so web + telnet converge on the same action machinery
+  (prerequisites, AP/fatigue, enhancements, events).
+- **Worked example:** `WeaveThreadAction` (`src/actions/definitions/threads.py`). The
+  web `ThreadSerializer.create()` (`src/world/magic/serializers.py`) now calls
+  `WeaveThreadAction().run(...)` instead of `weave_thread()` directly; the telnet face
+  is `CmdWeaveThread` (`src/commands/weave.py`). (Ritual performance — imbue/pull via
+  `PerformRitualAction`, #1331 — is the other landed instance of this family.)
+- **Family-3 classification rule (verbatim):** *a player-facing state mutation with
+  costs/prerequisites becomes an `Action`; GM/system-only surfaces (e.g.
+  `resolve_round`, encounter setup) stay raw services with no player UI.*
+
+### Summary
+
+| Family | Seam (telnet == web) | Telnet face | Why this seam |
+|---|---|---|---|
+| 1 — Unified dispatch | `dispatch_player_action()` | `DispatchCommand` (or `ArxCommand`→`action.run()` for pure REGISTRY) | One entry routes REGISTRY/CHALLENGE/COMBAT by backend |
+| 2 — Consent | `create_action_request()` / `respond_to_action_request()` services | `ConsentRequestCommand`/`CmdIntimidate` + `CmdAccept`/`CmdDeny` | Two-party async protocol; response half can't be one dispatch call; "needs consent" lives on `ActionTemplate.consent_category` |
+| 3 — Direct-viewset mutation | a real `Action` via `action.run()` | `CmdWeaveThread` (worked: `WeaveThreadAction`) | Player mutation with costs/prerequisites; GM/system-only surfaces stay raw services |
+
+## 11. Verified Source Anchors
 
 | Concept | Location |
 |---|---|

--- a/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
+++ b/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
@@ -32,6 +32,16 @@ The docstring at `src/actions/base.py:25-26` — *"Commands (telnet) and the web
 both call `action.run()`"* — is therefore **misleading**: it is true only for REGISTRY
 actions. Magic and combat never touch `action.run()`. **Fix-on-sight target.**
 
+> **[ALREADY CORRECT — audit claim stale, verified #1337]** The `Action` class
+> docstring (`src/actions/base.py`, ~lines 27–33) **already** describes the real seam
+> and the three dispatch backends; it no longer says telnet calls `action.run()`
+> universally. It reads: *"`action.run()` is the entry point for the **REGISTRY** path
+> only. … the web frontend and telnet `DispatchCommand`s instead call
+> `dispatch_player_action()`, which routes by backend: REGISTRY → `action.run()`,
+> CHALLENGE → `resolve_challenge()`, COMBAT → `declare_action()`/`resolve_round()`.
+> Magic and combat actions never reach `action.run()` directly."* No fix is needed; the
+> "fix-on-sight" call above is itself stale. (History preserved; do not act on it.)
+
 ### There are three web dispatch families; telnet implements a slice of one
 
 | # | Web dispatch family | Entry | Reaches | Telnet today |
@@ -162,8 +172,12 @@ web. Minimal fix: a `CmdDeclareAction` plus a GM-only `start encounter` for test
    `weave_thread`/`spend_resonance_for_*` for threads) — not `action.run()`.
 3. **No magic/combat story is telnet-driveable today**, so none can yet serve as a telnet E2E
    regression. The service-layer pipeline tests remain the only proof for those loops.
-4. **The `action.run` docstring is stale** and should be corrected to describe the real
-   `dispatch_player_action` seam and the three dispatch families.
+4. ~~**The `action.run` docstring is stale** and should be corrected to describe the real
+   `dispatch_player_action` seam and the three dispatch families.~~
+   **[ALREADY CORRECT — audit claim stale, verified #1337]** The `Action` docstring
+   (`src/actions/base.py`, ~lines 27–33) already describes the REGISTRY-only role of
+   `action.run()` and the three backends routed by `dispatch_player_action()`. No
+   correction is needed.
 
 ## Recommended direction (for the build phase, not yet ratified)
 
@@ -179,10 +193,25 @@ web. Minimal fix: a `CmdDeclareAction` plus a GM-only `start encounter` for test
 
 ## Open questions (for design)
 
-- Should thread imbue/pull and similar direct-viewset mutations **become actions** (so
-  prerequisites/AP/enhancements/events apply uniformly), or stay plain service calls?
-- Should the **consent flow be reachable through `dispatch_player_action`** (a unified entry
-  for *all* player actions), or remain a distinct viewset that telnet shells call directly?
+- **RESOLVED (#1337):** Should thread imbue/pull and similar direct-viewset mutations
+  **become actions** (so prerequisites/AP/enhancements/events apply uniformly), or stay
+  plain service calls? **Answer:** they become **real `Action`s on `action.run()`** (the
+  #1331 ritual template). The classification rule: *a player-facing state mutation with
+  costs/prerequisites becomes an `Action`; GM/system-only surfaces (e.g. `resolve_round`,
+  encounter setup) stay raw services with no player UI.* Worked example: `WeaveThreadAction`
+  (`src/actions/definitions/threads.py`); `ThreadSerializer.create()` now calls
+  `action.run()` so web + telnet converge (`CmdWeaveThread`, `src/commands/weave.py`). See
+  Family 3 in [unified-player-action.md](../architecture/unified-player-action.md#10-telnet-convergence-convention--three-player-action-families-ratified-1337).
+- **RESOLVED (#1337):** Should the **consent flow be reachable through
+  `dispatch_player_action`** (a unified entry for *all* player actions), or remain a distinct
+  viewset that telnet shells call directly? **Answer:** it stays at the **consent SERVICE
+  seam** — telnet's `ConsentRequestCommand`/`CmdIntimidate` + generic `CmdAccept`/`CmdDeny`
+  (`src/commands/consent.py`) call the same `create_action_request()` /
+  `respond_to_action_request()` services the `SceneActionRequestViewSet` calls — **not**
+  `dispatch_player_action()`/`action.run()`. Consent is an inherently two-party async
+  protocol whose response half can't be a single dispatch call, and "needs consent" is a
+  property of `ActionTemplate.consent_category`, not the Action. See Family 2 in
+  [unified-player-action.md](../architecture/unified-player-action.md#10-telnet-convergence-convention--three-player-action-families-ratified-1337).
 - For combat/magic seed prerequisites, which belong in a shared **combat seed module** so the
   E2E is writable without bespoke per-test wiring?
 

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1266,6 +1266,10 @@ Self-contained game actions that own prerequisites, execution, and events.
 - **Prerequisites:** `get_prerequisites()` is load-bearing; `run()` calls `check_availability()` against post-enhancement kwargs. Prerequisites read action-specific kwargs via `context["kwargs"]`. Shipped: `StaffOnlyPrerequisite`, `HoldsItemPrerequisite`, `ItemUsablePrerequisite`, `OnUseTargetPrerequisite`.
 - **Integrates with:** service functions (direct calls), commands (telnet compatibility), flows (future: complex triggers)
 - **Not Yet Built:** `SyntheticAction` model, event emission, `CharacterCapabilities` facade, on-demand availability endpoint
+- **Telnet convergence convention (ratified #1337):** the three player-action dispatch
+  families and the seam each telnet command must converge on with the web — Family 1
+  `dispatch_player_action()`, Family 2 consent services, Family 3 a real `Action` on
+  `action.run()`. See [unified-player-action.md §10](../architecture/unified-player-action.md#10-telnet-convergence-convention--three-player-action-families-ratified-1337).
 - **Source:** `src/actions/`
 
 ### Flows
@@ -1298,6 +1302,10 @@ Thin telnet compatibility layer that delegates to Actions.
 - **Pattern:** Telnet text → `command.func()` → `resolve_action_args()` → `action.run()`. Web bypasses commands entirely.
 - **Frontend Integration:** `ArxCommand.to_payload()` builds descriptors from action metadata. `serialize_cmdset()` aggregates for room state.
 - **Non-action commands:** CmdIC, CmdCharacters, CmdAccount, CmdSheet, CmdPage, builder commands
+- **Dispatch families (#1337):** `DispatchCommand` (Family 1 → `dispatch_player_action()`),
+  consent commands `ConsentRequestCommand`/`CmdAccept`/`CmdDeny` (Family 2 → consent
+  services), `CmdWeaveThread` (Family 3 → `WeaveThreadAction.run()`). See
+  [unified-player-action.md §10](../architecture/unified-player-action.md#10-telnet-convergence-convention--three-player-action-families-ratified-1337).
 - **Source:** `src/commands/`
 - **Details:** [commands.md](commands.md)
 ### Behaviors

--- a/src/actions/definitions/threads.py
+++ b/src/actions/definitions/threads.py
@@ -1,0 +1,67 @@
+"""Thread-weaving as a real Action (telnet + web converge on action.run()).
+
+Wraps the ``weave_thread`` service so the cross-cutting ``action.run`` machinery
+(prerequisites, AP/fatigue, enhancements, events) applies uniformly — the #1331
+ritual template applied to a direct-viewset mutation (#1337).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from actions.base import Action
+from actions.types import ActionResult, TargetType
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from actions.types import ActionContext
+
+
+@dataclass
+class WeaveThreadAction(Action):
+    """Create a new Thread anchored to a target the actor is unlocked for."""
+
+    key: str = "weave_thread"
+    name: str = "Weave Thread"
+    icon: str = "link"
+    category: str = "magic"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        """Validate eligibility (in the service) and create the thread."""
+        from world.covenants.exceptions import CovenantRoleNeverHeldError  # noqa: PLC0415
+        from world.magic.exceptions import (  # noqa: PLC0415
+            MantleNotClearedError,
+            WeavingUnlockMissing,
+        )
+        from world.magic.services import weave_thread  # noqa: PLC0415
+
+        sheet = actor.sheet_data
+        try:
+            thread = weave_thread(
+                character_sheet=sheet,
+                target_kind=kwargs["target_kind"],
+                target=kwargs["target"],
+                resonance=kwargs["resonance"],
+                name=kwargs.get("name", ""),
+                description=kwargs.get("description", ""),
+            )
+        except (
+            WeavingUnlockMissing,
+            CovenantRoleNeverHeldError,
+            MantleNotClearedError,
+        ) as exc:
+            return ActionResult(success=False, message=exc.user_message)
+
+        return ActionResult(
+            success=True,
+            message=f"You weave a new thread channeling {thread.resonance}.",
+            data={"thread": thread},
+        )

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -56,6 +56,7 @@ from actions.definitions.social import (
     persuade,
     restore_sense,
 )
+from actions.definitions.threads import WeaveThreadAction
 from actions.definitions.traps import DisarmTrapAction
 from actions.types import TargetType
 
@@ -88,6 +89,7 @@ _ALL_ACTIONS: list[Action] = [
     MoveToPositionAction(),
     SetTheStageAction(),
     PerformRitualAction(),
+    WeaveThreadAction(),
     StartRoundAction(),
     JoinRoundAction(),
     LeaveRoundAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -186,6 +186,7 @@ class ActionRegistryTests(TestCase):
             "acknowledge_risk",
             "restore_sense",
             "perform_ritual",
+            "weave_thread",
         }
         assert set(ACTIONS_BY_KEY.keys()) == expected_keys
 

--- a/src/actions/tests/test_weave_thread_action.py
+++ b/src/actions/tests/test_weave_thread_action.py
@@ -1,0 +1,51 @@
+"""Tests for WeaveThreadAction — the action.run() seam over weave_thread (#1337)."""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from actions.definitions.threads import WeaveThreadAction
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.constants import TargetKind
+from world.magic.factories import (
+    CharacterThreadWeavingUnlockFactory,
+    ResonanceFactory,
+    ThreadWeavingUnlockFactory,
+)
+from world.traits.factories import TraitFactory
+
+
+class WeaveThreadActionTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory()
+        cls.trait = TraitFactory()
+        unlock = ThreadWeavingUnlockFactory(target_kind=TargetKind.TRAIT, unlock_trait=cls.trait)
+        CharacterThreadWeavingUnlockFactory(character=cls.sheet, unlock=unlock, xp_spent=100)
+
+    def test_run_creates_thread_and_returns_it_in_data(self) -> None:
+        action = WeaveThreadAction()
+        result = action.run(
+            actor=self.sheet.character,
+            target_kind=TargetKind.TRAIT,
+            target=self.trait,
+            resonance=self.resonance,
+            name="Test Weave",
+        )
+        self.assertTrue(result.success, result.message)
+        thread = result.data["thread"]
+        self.assertEqual(thread.owner, self.sheet)
+        self.assertEqual(thread.resonance, self.resonance)
+
+    def test_run_returns_failure_when_unlock_missing(self) -> None:
+        other_sheet = CharacterSheetFactory()
+        action = WeaveThreadAction()
+        result = action.run(
+            actor=other_sheet.character,
+            target_kind=TargetKind.TRAIT,
+            target=self.trait,
+            resonance=self.resonance,
+        )
+        self.assertFalse(result.success)
+        self.assertTrue(result.message)

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -51,6 +51,10 @@ actions, backends, and service functions.
 - **`door.py`**: `CmdLock`, `CmdUnlock` (stubs pending LockAction/UnlockAction)
 - **`ritual.py`**: `CmdRitual` (alias `perform`) — telnet face of
   `PerformRitualAction`; parses `ritual <name> [key=value ...]` for SERVICE rituals
+- **`weave.py`**: `CmdWeaveThread` (`weave`) — telnet face of `WeaveThreadAction`;
+  parses `weave resonance=<name> trait=<id> [name=<...>]` (TRAIT anchor only — the
+  reference grammar; other anchor kinds are extended by the thread-weaving journey
+  issue). Proves the direct-viewset→Action telnet pattern (#1337)
 - **`evennia_overrides/builder.py`**: `CmdDig`, `CmdOpen`, `CmdLink`, `CmdUnlink` (Evennia overrides)
 
 ### Account Commands (`account/`)

--- a/src/commands/consent.py
+++ b/src/commands/consent.py
@@ -6,15 +6,16 @@ via ``CmdAccept``/``CmdDeny`` (Task 6). Telnet calls the SAME service functions
 the web viewset calls (``create_action_request`` / ``respond_to_action_request``)
 — convergence at the service seam, not ``action.run()``.
 
-``SceneActionRequestViewSet.create`` resolves ``scene``, ``initiator_persona``,
-and ``target_persona`` from explicit ids in the request payload (the web client
-already knows them). Telnet has no payload — so the command resolves the same
-three objects from the caller's location and a typed target name, then hands
-the IDENTICAL ``create_action_request(scene, initiator_persona, target_persona,
-action_key)`` call. The persona resolution itself reuses
-``active_persona_for_sheet`` (the same "which face is this character on right
-now" helper the request-level web resolver uses), so both faces are honoured
-identically.
+Convergence is at the **service seam**, not the resolution. The web viewset
+resolves ``scene`` / ``initiator_persona`` / ``target_persona`` from explicit
+ids in the POST payload (the web client already picked which face it is acting
+as). Telnet has no payload, so it *derives* the same three objects from the
+caller's location and a typed target name — scene via the location's active
+scene, personas via ``active_persona_for_sheet`` (the caller's currently
+presented face). The two paths therefore differ in how they obtain the
+arguments, but hand the identical
+``create_action_request(scene, initiator_persona, target_persona, action_key)``
+call to the shared service — which owns all consent logic.
 """
 
 from __future__ import annotations
@@ -69,9 +70,10 @@ class ConsentRequestCommand(ArxCommand):
         """Resolve (active Scene, initiator Persona) for the caller.
 
         The scene is the active scene at the caller's location; the persona is
-        the face the caller is currently presenting (``active_persona_for_sheet``
-        — the same resolver the web request path gates on). Raises
-        ``CommandError`` on either miss so the command surfaces a clean message.
+        the face the caller is currently presenting (``active_persona_for_sheet``).
+        The web viewset instead takes these from explicit payload ids; telnet
+        derives them. Raises ``CommandError`` on either miss so the command
+        surfaces a clean message.
         """
         from world.scenes.interaction_services import _get_active_scene  # noqa: PLC0415
 

--- a/src/commands/consent.py
+++ b/src/commands/consent.py
@@ -1,0 +1,119 @@
+"""Telnet consent flow — thin shells over the consent service (#1337).
+
+Targeted social actions are an inherently two-party protocol: the initiator
+opens a PENDING ``SceneActionRequest`` (this base); the target accepts/denies
+via ``CmdAccept``/``CmdDeny`` (Task 6). Telnet calls the SAME service functions
+the web viewset calls (``create_action_request`` / ``respond_to_action_request``)
+— convergence at the service seam, not ``action.run()``.
+
+``SceneActionRequestViewSet.create`` resolves ``scene``, ``initiator_persona``,
+and ``target_persona`` from explicit ids in the request payload (the web client
+already knows them). Telnet has no payload — so the command resolves the same
+three objects from the caller's location and a typed target name, then hands
+the IDENTICAL ``create_action_request(scene, initiator_persona, target_persona,
+action_key)`` call. The persona resolution itself reuses
+``active_persona_for_sheet`` (the same "which face is this character on right
+now" helper the request-level web resolver uses), so both faces are honoured
+identically.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from world.scenes.models import Persona, Scene
+
+
+class ConsentRequestCommand(ArxCommand):
+    """Base for telnet commands that open a consent request.
+
+    Subclasses set ``action_key`` (the registry action key, e.g. "intimidate").
+    Resolves the caller's active scene + persona and the named target's persona,
+    then calls ``create_action_request`` — the same service the consent viewset
+    calls. All consent logic stays in the service; this is a thin shell.
+
+    Usage:
+        <key> <character>
+    """
+
+    action_key: ClassVar[str] = ""
+    locks = "cmd:all()"
+    action = None
+
+    def func(self) -> None:
+        from world.scenes.action_services import create_action_request  # noqa: PLC0415
+
+        try:
+            scene, initiator_persona = self._resolve_scene_and_initiator()
+            target_persona = self._resolve_target_persona()
+        except CommandError as err:
+            self.msg(str(err))
+            return
+
+        request = create_action_request(
+            scene=scene,
+            initiator_persona=initiator_persona,
+            target_persona=target_persona,
+            action_key=self.action_key,
+        )
+        self.msg(
+            f"You move to {self.action_key} {target_persona.name}. "
+            f"Awaiting their response (request #{request.pk})."
+        )
+
+    def _resolve_scene_and_initiator(self) -> tuple[Scene, Persona]:
+        """Resolve (active Scene, initiator Persona) for the caller.
+
+        The scene is the active scene at the caller's location; the persona is
+        the face the caller is currently presenting (``active_persona_for_sheet``
+        — the same resolver the web request path gates on). Raises
+        ``CommandError`` on either miss so the command surfaces a clean message.
+        """
+        from world.scenes.interaction_services import _get_active_scene  # noqa: PLC0415
+
+        scene = _get_active_scene(getattr(self.caller, "location", None))  # noqa: GETATTR_LITERAL
+        if scene is None:
+            msg = "You are not in an active scene."
+            raise CommandError(msg)
+
+        initiator_persona = self._persona_for(self.caller, "You have no character identity.")
+        return scene, initiator_persona
+
+    def _resolve_target_persona(self) -> Persona:
+        """Resolve the target persona from ``self.args`` (a character name).
+
+        Searches near the caller for the named character, then takes their
+        active persona. Raises ``CommandError`` on a missing name or sheet.
+        """
+        name = self.require_args(f"Whom do you want to {self.action_key or 'target'}?")
+        target = self.search_or_raise(name)
+        return self._persona_for(target, f"{target} has no character identity.")
+
+    def _persona_for(self, character: object, missing_msg: str) -> Persona:
+        """Active persona for ``character``; ``CommandError(missing_msg)`` on miss."""
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        if sheet is None:
+            raise CommandError(missing_msg)
+        try:
+            return active_persona_for_sheet(sheet)
+        except ObjectDoesNotExist as exc:
+            raise CommandError(missing_msg) from exc
+
+
+class CmdIntimidate(ConsentRequestCommand):
+    """Attempt to intimidate another character (they must accept or deny).
+
+    Usage:
+        intimidate <character>
+    """
+
+    key = "intimidate"
+    action_key = "intimidate"

--- a/src/commands/consent.py
+++ b/src/commands/consent.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING, ClassVar
 
 from commands.command import ArxCommand
 from commands.exceptions import CommandError
+from world.scenes.action_constants import ActionRequestStatus, ConsentDecision
+from world.scenes.action_models import SceneActionRequest
 
 if TYPE_CHECKING:
     from world.scenes.models import Persona, Scene
@@ -119,3 +121,85 @@ class CmdIntimidate(ConsentRequestCommand):
 
     key = "intimidate"
     action_key = "intimidate"
+
+
+_NO_PENDING_MSG = "You have no pending action to respond to."
+
+
+class _RespondCommand(ArxCommand):
+    """Base for telnet commands that answer a pending consent request.
+
+    Subclasses set ``decision`` (a ``ConsentDecision`` value). Resolves the
+    caller's pending ``SceneActionRequest`` — by id when ``self.args`` is a
+    digit, else the most-recent PENDING request targeting the caller's active
+    persona — then forwards the decision to ``respond_to_action_request``, the
+    SAME service the consent viewset calls. All consent + resolution logic stays
+    in the service; this is a thin shell.
+
+    Usage:
+        <key> [request_id]
+    """
+
+    decision: ClassVar[str] = ""
+    locks = "cmd:all()"
+    action = None
+
+    def func(self) -> None:
+        from world.scenes.action_services import respond_to_action_request  # noqa: PLC0415
+
+        request = self._resolve_pending_request()
+        if request is None:
+            self.msg(_NO_PENDING_MSG)
+            return
+        respond_to_action_request(action_request=request, decision=self.decision)
+        verb = "accept" if self.decision == ConsentDecision.ACCEPT else "deny"
+        self.msg(f"You {verb} the action against you.")
+
+    def _resolve_pending_request(self) -> SceneActionRequest | None:
+        """Most-recent PENDING request targeting the caller (or by id arg).
+
+        Resolves the caller's active persona, then the latest PENDING
+        ``SceneActionRequest`` whose ``target_persona`` is that persona. When
+        ``self.args`` is a digit, looks up by pk (still constrained to the
+        caller as target). Returns None when nothing matches.
+        """
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        if sheet is None:
+            return None
+        try:
+            persona = active_persona_for_sheet(sheet)
+        except ObjectDoesNotExist:
+            return None
+        qs = SceneActionRequest.objects.filter(
+            target_persona=persona, status=ActionRequestStatus.PENDING
+        )
+        args = self.args.strip() if self.args else ""
+        if args.isdigit():
+            return qs.filter(pk=int(args)).first()
+        return qs.order_by("-id").first()
+
+
+class CmdAccept(_RespondCommand):
+    """Accept a pending action targeting you.
+
+    Usage:
+        accept [request_id]
+    """
+
+    key = "accept"
+    decision = ConsentDecision.ACCEPT
+
+
+class CmdDeny(_RespondCommand):
+    """Deny a pending action targeting you.
+
+    Usage:
+        deny [request_id]
+    """
+
+    key = "deny"
+    decision = ConsentDecision.DENY

--- a/src/commands/consent.py
+++ b/src/commands/consent.py
@@ -48,6 +48,13 @@ class ConsentRequestCommand(ArxCommand):
     action = None
 
     def func(self) -> None:
+        # ValidationError is imported as DjangoValidationError to avoid colliding
+        # with DRF's ValidationError; the service raises Django's (e.g. technique
+        # validation or a TABLE_TALK delivery without a place). Subclasses that
+        # pass a technique/delivery can trip it, so the base converts it to a
+        # clean message rather than a raw traceback — mirroring the web viewset.
+        from django.core.exceptions import ValidationError as DjangoValidationError  # noqa: PLC0415
+
         from world.scenes.action_services import create_action_request  # noqa: PLC0415
 
         try:
@@ -57,12 +64,17 @@ class ConsentRequestCommand(ArxCommand):
             self.msg(str(err))
             return
 
-        request = create_action_request(
-            scene=scene,
-            initiator_persona=initiator_persona,
-            target_persona=target_persona,
-            action_key=self.action_key,
-        )
+        try:
+            request = create_action_request(
+                scene=scene,
+                initiator_persona=initiator_persona,
+                target_persona=target_persona,
+                action_key=self.action_key,
+            )
+        except DjangoValidationError as err:
+            self.msg("; ".join(err.messages))
+            return
+
         self.msg(
             f"You move to {self.action_key} {target_persona.name}. "
             f"Awaiting their response (request #{request.pk})."

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -21,6 +21,7 @@ from commands.account.character_switching import CmdCharacters, CmdIC
 from commands.account.prompt_reply import CmdPromptReply
 from commands.account.sheet import CmdSheet
 from commands.combat import CmdDeclareTechnique
+from commands.consent import CmdIntimidate
 from commands.door import CmdLock, CmdUnlock
 from commands.evennia_overrides.builder import CmdDig, CmdLink, CmdOpen, CmdUnlink
 from commands.evennia_overrides.communication import (
@@ -111,6 +112,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdUnlock())
         self.add(CmdRitual())
         self.add(CmdWeaveThread())
+        self.add(CmdIntimidate())
         self.add(CmdDig())
         self.add(CmdOpen())
         self.add(CmdLink())

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -52,6 +52,7 @@ from commands.social.blocking import (
     CmdUnblock,
     CmdUnmute,
 )
+from commands.weave import CmdWeaveThread
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -109,6 +110,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdLock())
         self.add(CmdUnlock())
         self.add(CmdRitual())
+        self.add(CmdWeaveThread())
         self.add(CmdDig())
         self.add(CmdOpen())
         self.add(CmdLink())

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -21,7 +21,7 @@ from commands.account.character_switching import CmdCharacters, CmdIC
 from commands.account.prompt_reply import CmdPromptReply
 from commands.account.sheet import CmdSheet
 from commands.combat import CmdDeclareTechnique
-from commands.consent import CmdIntimidate
+from commands.consent import CmdAccept, CmdDeny, CmdIntimidate
 from commands.door import CmdLock, CmdUnlock
 from commands.evennia_overrides.builder import CmdDig, CmdLink, CmdOpen, CmdUnlink
 from commands.evennia_overrides.communication import (
@@ -113,6 +113,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdRitual())
         self.add(CmdWeaveThread())
         self.add(CmdIntimidate())
+        self.add(CmdAccept())
+        self.add(CmdDeny())
         self.add(CmdDig())
         self.add(CmdOpen())
         self.add(CmdLink())

--- a/src/commands/tests/test_consent_commands.py
+++ b/src/commands/tests/test_consent_commands.py
@@ -1,0 +1,109 @@
+"""Tests for the telnet consent-initiate commands (#1337).
+
+``CmdIntimidate`` is the worked example of ``ConsentRequestCommand``: a thin
+telnet shell that resolves the caller's active scene + persona and the named
+target's persona, then opens a PENDING ``SceneActionRequest`` via the SAME
+``create_action_request`` service the web viewset calls. These tests build a
+scene with both characters present (mirroring the consent viewset's persona
+wiring) and assert the row lands in PENDING with the right personas.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.consent import CmdIntimidate, ConsentRequestCommand
+from evennia_extensions.factories import ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.scenes.action_constants import ActionRequestStatus
+from world.scenes.action_models import SceneActionRequest
+from world.scenes.factories import SceneFactory
+
+
+class CmdIntimidateTests(TestCase):
+    """Initiator runs ``intimidate <target>``; a PENDING request is created."""
+
+    def setUp(self) -> None:
+        # Evennia ObjectDB fixtures must be built in setUp, not setUpTestData:
+        # the idmapper's DbHolder is un-deepcopyable, so the classmethod
+        # snapshot machinery raises copy.Error (the DbHolder setUpTestData trap).
+        self.room = ObjectDBFactory(
+            db_key="Hall",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        self.initiator_char = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+        self.target_char = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+        # CharacterSheet is the source of truth; primary_persona is the face.
+        self.initiator_sheet = CharacterSheetFactory(character=self.initiator_char)
+        self.target_sheet = CharacterSheetFactory(character=self.target_char)
+        self.initiator_persona = self.initiator_sheet.primary_persona
+        self.target_persona = self.target_sheet.primary_persona
+        # The active scene is resolved off the caller's location.
+        self.scene = SceneFactory(is_active=True, location=self.room)
+        # Bust the per-location active-scene cache (SharedMemory identity map).
+        if hasattr(self.room, "_active_scene_cache"):
+            del self.room._active_scene_cache
+
+    def _run(self, caller: object, args: str) -> CmdIntimidate:
+        cmd = CmdIntimidate()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.raw_string = f"intimidate {args}"
+        caller.msg = MagicMock()
+        cmd.func()
+        return cmd
+
+    def test_intimidate_creates_pending_request(self) -> None:
+        cmd = self._run(self.initiator_char, self.target_char.key)
+
+        req = SceneActionRequest.objects.get(initiator_persona=self.initiator_persona)
+        self.assertEqual(req.status, ActionRequestStatus.PENDING)
+        self.assertEqual(req.target_persona, self.target_persona)
+        self.assertEqual(req.action_key, "intimidate")
+        self.assertEqual(req.scene, self.scene)
+        cmd.caller.msg.assert_called()
+
+    def test_no_args_reports_error_and_creates_nothing(self) -> None:
+        cmd = self._run(self.initiator_char, "")
+
+        self.assertFalse(SceneActionRequest.objects.exists())
+        cmd.caller.msg.assert_called()
+
+    def test_no_active_scene_reports_error(self) -> None:
+        loner = ObjectDBFactory(
+            db_key="Cleo",
+            db_typeclass_path="typeclasses.characters.Character",
+        )
+        target = ObjectDBFactory(
+            db_key="Dax",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=loner.location,
+        )
+        CharacterSheetFactory(character=loner)
+        CharacterSheetFactory(character=target)
+
+        cmd = self._run(loner, target.key)
+
+        self.assertFalse(SceneActionRequest.objects.exists())
+        cmd.caller.msg.assert_called()
+
+    def test_unknown_target_reports_error(self) -> None:
+        cmd = self._run(self.initiator_char, "Nobody")
+
+        self.assertFalse(SceneActionRequest.objects.exists())
+        cmd.caller.msg.assert_called()
+
+    def test_action_key_class_attr_drives_request(self) -> None:
+        """The base reads ``action_key`` from the subclass — no hardcoding."""
+        self.assertEqual(CmdIntimidate.action_key, "intimidate")
+        self.assertTrue(issubclass(CmdIntimidate, ConsentRequestCommand))

--- a/src/commands/tests/test_consent_commands.py
+++ b/src/commands/tests/test_consent_commands.py
@@ -10,16 +10,16 @@ wiring) and assert the row lands in PENDING with the right personas.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
-from commands.consent import CmdIntimidate, ConsentRequestCommand
+from commands.consent import CmdAccept, CmdDeny, CmdIntimidate, ConsentRequestCommand
 from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
-from world.scenes.action_constants import ActionRequestStatus
+from world.scenes.action_constants import ActionRequestStatus, ConsentDecision
 from world.scenes.action_models import SceneActionRequest
-from world.scenes.factories import SceneFactory
+from world.scenes.factories import SceneActionRequestFactory, SceneFactory
 
 
 class CmdIntimidateTests(TestCase):
@@ -107,3 +107,99 @@ class CmdIntimidateTests(TestCase):
         """The base reads ``action_key`` from the subclass — no hardcoding."""
         self.assertEqual(CmdIntimidate.action_key, "intimidate")
         self.assertTrue(issubclass(CmdIntimidate, ConsentRequestCommand))
+
+
+class RespondCommandTests(TestCase):
+    """Defender runs ``accept`` / ``deny``; the pending request is resolved.
+
+    These exercise the thin shell's two jobs — resolving the caller's pending
+    ``SceneActionRequest`` and forwarding the right ``ConsentDecision`` to
+    ``respond_to_action_request`` (the SAME service the consent viewset calls).
+    The deny path lands DENIED via the real service; the accept path's full
+    resolution pipeline is the service's own concern (covered in scenes tests),
+    so here we assert the command calls the service with ACCEPT.
+    """
+
+    def setUp(self) -> None:
+        # DbHolder trap: Evennia ObjectDB fixtures must be built in setUp.
+        self.room = ObjectDBFactory(
+            db_key="Hall",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        self.initiator_char = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+        self.target_char = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+        self.initiator_sheet = CharacterSheetFactory(character=self.initiator_char)
+        self.target_sheet = CharacterSheetFactory(character=self.target_char)
+        self.initiator_persona = self.initiator_sheet.primary_persona
+        self.target_persona = self.target_sheet.primary_persona
+        self.scene = SceneFactory(is_active=True, location=self.room)
+
+    def _make_pending(self) -> SceneActionRequest:
+        return SceneActionRequestFactory(
+            scene=self.scene,
+            initiator_persona=self.initiator_persona,
+            target_persona=self.target_persona,
+            status=ActionRequestStatus.PENDING,
+        )
+
+    def _run(self, cmd_cls: type, caller: object, args: str = "") -> object:
+        cmd = cmd_cls()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.raw_string = f"{cmd_cls.key} {args}".strip()
+        caller.msg = MagicMock()
+        cmd.func()
+        return cmd
+
+    def test_deny_marks_request_denied(self) -> None:
+        req = self._make_pending()
+
+        cmd = self._run(CmdDeny, self.target_char)
+
+        req.refresh_from_db()
+        self.assertEqual(req.status, ActionRequestStatus.DENIED)
+        cmd.caller.msg.assert_called()
+
+    def test_accept_forwards_accept_decision_for_pending_request(self) -> None:
+        req = self._make_pending()
+
+        with patch("world.scenes.action_services.respond_to_action_request") as respond:
+            cmd = self._run(CmdAccept, self.target_char)
+
+        respond.assert_called_once()
+        kwargs = respond.call_args.kwargs
+        self.assertEqual(kwargs["action_request"], req)
+        self.assertEqual(kwargs["decision"], ConsentDecision.ACCEPT)
+        cmd.caller.msg.assert_called()
+
+    def test_accept_by_id_arg_resolves_that_request(self) -> None:
+        req = self._make_pending()
+
+        with patch("world.scenes.action_services.respond_to_action_request") as respond:
+            self._run(CmdAccept, self.target_char, args=str(req.pk))
+
+        self.assertEqual(respond.call_args.kwargs["action_request"], req)
+
+    def test_no_pending_request_reports_cleanly(self) -> None:
+        with patch("world.scenes.action_services.respond_to_action_request") as respond:
+            cmd = self._run(CmdAccept, self.target_char)
+
+        respond.assert_not_called()
+        cmd.caller.msg.assert_called()
+
+    def test_respond_uses_most_recent_pending_for_caller(self) -> None:
+        self._make_pending()
+        newest = self._make_pending()
+
+        with patch("world.scenes.action_services.respond_to_action_request") as respond:
+            self._run(CmdAccept, self.target_char)
+
+        self.assertEqual(respond.call_args.kwargs["action_request"], newest)

--- a/src/commands/tests/test_weave_command.py
+++ b/src/commands/tests/test_weave_command.py
@@ -1,0 +1,64 @@
+"""Tests for CmdWeaveThread — the thin telnet shell over WeaveThreadAction (#1337)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.weave import CmdWeaveThread
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.constants import TargetKind
+from world.magic.factories import (
+    CharacterThreadWeavingUnlockFactory,
+    ResonanceFactory,
+    ThreadWeavingUnlockFactory,
+)
+from world.magic.models import Thread
+from world.traits.factories import TraitFactory
+
+
+class CmdWeaveThreadTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory(name="Embers")
+        cls.trait = TraitFactory()
+        unlock = ThreadWeavingUnlockFactory(target_kind=TargetKind.TRAIT, unlock_trait=cls.trait)
+        CharacterThreadWeavingUnlockFactory(character=cls.sheet, unlock=unlock, xp_spent=100)
+
+    def setUp(self) -> None:
+        self.character = self.sheet.character
+        self.character.msg = MagicMock()
+
+    def _run(self, args: str) -> None:
+        cmd = CmdWeaveThread()
+        cmd.caller = self.character
+        cmd.args = args
+        cmd.raw_string = f"weave {args}"
+        cmd.func()
+
+    def test_weave_creates_thread(self) -> None:
+        self._run(f"resonance=Embers trait={self.trait.pk}")
+        self.assertTrue(Thread.objects.filter(owner=self.sheet, resonance=self.resonance).exists())
+        self.character.msg.assert_called()
+
+    def test_weave_passes_optional_name(self) -> None:
+        self._run(f"resonance=Embers trait={self.trait.pk} name=My Bright Thread")
+        thread = Thread.objects.get(owner=self.sheet, resonance=self.resonance)
+        self.assertEqual(thread.name, "My Bright Thread")
+
+    def test_unknown_resonance_reports_error(self) -> None:
+        self._run(f"resonance=Nope trait={self.trait.pk}")
+        self.assertFalse(Thread.objects.filter(owner=self.sheet).exists())
+        self.character.msg.assert_called()
+
+    def test_missing_trait_reports_error(self) -> None:
+        self._run("resonance=Embers")
+        self.assertFalse(Thread.objects.filter(owner=self.sheet).exists())
+        self.character.msg.assert_called()
+
+    def test_unknown_trait_reports_error(self) -> None:
+        self._run("resonance=Embers trait=99999")
+        self.assertFalse(Thread.objects.filter(owner=self.sheet).exists())
+        self.character.msg.assert_called()

--- a/src/commands/weave.py
+++ b/src/commands/weave.py
@@ -1,0 +1,109 @@
+"""Telnet ``weave`` command — the thin shell over WeaveThreadAction (#1337).
+
+Thin telnet face of ``actions.definitions.threads.WeaveThreadAction``. Parses
+``weave resonance=<name> trait=<trait_id> [name=<thread name>]`` into the action's
+kwargs and delegates; all eligibility/creation logic lives in the action + the
+``weave_thread`` service. The web path uses the same action via the thread viewset.
+
+Reference-grammar scope: the worked example supports the **TRAIT** anchor only
+(``trait=<id>``). Other anchor kinds (covenant role, facet, mantle, technique,
+relationship track/capstone, sanctum) are extended by the thread-weaving journey
+issue — this command is the direct-viewset→Action telnet pattern proof.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from actions.definitions.threads import WeaveThreadAction
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+# Telnet kwarg tokens players type (``key=value``); ``name`` greedily consumes the
+# rest of the line so thread names may contain spaces.
+_RESONANCE_KWARG = "resonance"
+_TRAIT_KWARG = "trait"
+_NAME_KWARG = "name"
+
+
+class CmdWeaveThread(ArxCommand):
+    """Weave a new thread anchored to a trait you are unlocked for.
+
+    Telnet grammar (TRAIT anchor only; the journey issue extends other kinds):
+        ``weave resonance=<name> trait=<trait_id>``
+        ``weave resonance=<name> trait=<trait_id> name=<thread name>``
+
+    Example:
+        ``weave resonance=Embers trait=5 name=Ember of the First Hearth``
+
+    ``resonance`` and ``trait`` are required; ``name`` is optional and captures
+    the rest of the line (so it may contain spaces). The thread's resonance and
+    trait anchor are resolved here; everything else is the action's concern.
+    """
+
+    key = "weave"
+    locks = "cmd:all()"
+    action = WeaveThreadAction()
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        """Parse ``weave resonance=<name> trait=<id> [name=<...>]`` into action kwargs."""
+        from world.magic.constants import TargetKind  # noqa: PLC0415
+        from world.magic.models import Resonance  # noqa: PLC0415
+        from world.traits.models import Trait  # noqa: PLC0415
+
+        args = self.require_args(
+            "Weave what? (weave resonance=<name> trait=<id> [name=<thread name>])"
+        )
+        parsed = self._parse_kwargs(args)
+
+        resonance_name = parsed.get(_RESONANCE_KWARG, "").strip()
+        if not resonance_name:
+            msg = "Specify a resonance: resonance=<name>."
+            raise CommandError(msg)
+        resonance = Resonance.objects.filter(name__iexact=resonance_name).first()
+        if resonance is None:
+            msg = f"There is no resonance called '{resonance_name}'."
+            raise CommandError(msg)
+
+        trait_id = parsed.get(_TRAIT_KWARG, "").strip()
+        if not trait_id:
+            msg = "Specify a trait anchor: trait=<id>."
+            raise CommandError(msg)
+        if not trait_id.isdigit():
+            msg = "The trait anchor must be a numeric id: trait=<id>."
+            raise CommandError(msg)
+        trait = Trait.objects.filter(pk=int(trait_id)).first()
+        if trait is None:
+            msg = f"There is no trait with id {trait_id}."
+            raise CommandError(msg)
+
+        return {
+            "target_kind": TargetKind.TRAIT,
+            "target": trait,
+            "resonance": resonance,
+            "name": parsed.get(_NAME_KWARG, "").strip(),
+        }
+
+    @staticmethod
+    def _parse_kwargs(args: str) -> dict[str, str]:
+        """Parse ``key=value`` tokens, left to right.
+
+        ``resonance`` and ``trait`` are single whitespace-delimited tokens; once a
+        ``name=`` token is seen, the remainder of the line (including spaces) is its
+        value, so thread names may contain spaces.
+        """
+        out: dict[str, str] = {}
+        tokens = args.split()
+        index = 0
+        while index < len(tokens):
+            token = tokens[index]
+            if "=" not in token:
+                index += 1
+                continue
+            key, _, value = token.partition("=")
+            if key == _NAME_KWARG:
+                out[_NAME_KWARG] = " ".join([value, *tokens[index + 1 :]]).strip()
+                break
+            out[key] = value
+            index += 1
+        return out

--- a/src/integration_tests/pipeline/test_consent_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_consent_telnet_e2e.py
@@ -1,0 +1,175 @@
+"""Telnet E2E: intimidate -> accept resolves the consent flow (#1337).
+
+Proves a telnet two-party social action reaches the SAME consent services the
+web viewset uses (``create_action_request`` / ``respond_to_action_request``) and
+drives them through to full resolution.
+
+The web equivalent is ``world/scenes/tests/test_targeted_action_e2e.py``
+(``TargetedActionE2EWithStrainTests``): it POSTs the action-request endpoints to
+exercise create -> respond. This test reuses the SAME fixture shape (scene +
+two characters/personas + the "Intimidate" ``ActionTemplate``) but derives the
+arguments the telnet way — scene from the caller's room, personas from
+``active_persona_for_sheet`` — and drives the real ``CmdIntimidate`` /
+``CmdAccept`` commands.
+
+``respond_to_action_request`` does NOT merely flip status to ACCEPTED: on accept
+it runs the full standard-action resolution (``_resolve_standard_action`` ->
+``start_action_resolution``) to a terminal RESOLVED state and records a result
+``Interaction``. We patch ``start_action_resolution`` (exactly as the web test
+patches it) so the check-roll infrastructure is stubbed while every other
+service step — status transition, result-interaction creation, fatigue/accrual —
+runs for real. A plain (no-technique) intimidate is used so resolution never
+touches the Postgres-only ``apply_condition`` (DISTINCT ON) path, keeping the
+test on the SQLite fast tier.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from evennia.objects.models import ObjectDB
+from evennia.utils.idmapper import models as idmapper_models
+
+from actions.constants import ResolutionPhase
+from actions.factories import ActionTemplateFactory
+from actions.types import PendingActionResolution, StepResult
+from commands.consent import CmdAccept, CmdIntimidate
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.scenes.action_constants import ActionRequestStatus
+from world.scenes.action_models import SceneActionRequest
+from world.scenes.factories import SceneFactory
+
+
+def _make_pending_resolution() -> PendingActionResolution:
+    """Minimal PendingActionResolution standing in for start_action_resolution.
+
+    Mirrors ``test_targeted_action_e2e._make_pending_resolution``: a COMPLETE
+    resolution with a success check result, enough for ``_create_result_interaction``
+    to read ``success_level`` / ``outcome_name`` and record the Interaction.
+    """
+    check_result = MagicMock()
+    check_result.success_level = 1
+    check_result.outcome_name = "Success"
+    check_result.outcome = None
+    main_result = StepResult(
+        step_label="main",
+        check_result=check_result,
+        consequence_id=None,
+    )
+    return PendingActionResolution(
+        template_id=1,
+        character_id=1,
+        target_difficulty=10,
+        resolution_context_data={"character_id": 1, "challenge_instance_id": None},
+        current_phase=ResolutionPhase.COMPLETE,
+        main_result=main_result,
+    )
+
+
+def _make_character_in_room(room: ObjectDB) -> ObjectDB:
+    """Create a Character placed in ``room`` (so caller.search finds peers there)."""
+    char = CharacterFactory()
+    char.location = room
+    char.save()
+    return char
+
+
+class ConsentTelnetE2ETests(TestCase):
+    """Telnet ``intimidate`` -> ``accept`` drives the real consent services.
+
+    Uses ``setUp`` (not ``setUpTestData``) for the ObjectDB-bearing fixtures:
+    Django's ``setUpTestData`` deepcopy machinery cannot copy DbHolder /
+    SharedMemoryModel instances (copy.Error in CI shard runs — see project
+    memory + the combat-cast telnet E2E).
+    """
+
+    def setUp(self) -> None:
+        # Flush the SharedMemoryModel identity map to avoid stale PK-recycled
+        # instances leaking from a prior test (see project memory).
+        idmapper_models.flush_cache()
+
+        # Patch accrue: the consent service awards good-sport kudos on accept,
+        # which would otherwise need the social_engagement KudosSourceCategory +
+        # GameWeek seeded. Mirrors the web E2E.
+        self.accrue_patcher = patch("world.scenes.action_services.accrue")
+        self.mock_accrue = self.accrue_patcher.start()
+        self.addCleanup(self.accrue_patcher.stop)
+
+        # Room both characters share; the scene is located here so the telnet
+        # command's _get_active_scene(location) finds it.
+        self.room = ObjectDB.objects.create(
+            db_key="TestRoom",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+
+        # The "Intimidate" ActionTemplate: create_action_request resolves the
+        # template by the registry intimidate action's template_name ("Intimidate"),
+        # and the accept path requires it to run _resolve_standard_action. (The web
+        # test attaches a template manually because its create endpoint does not
+        # accept one; the telnet create path resolves it automatically by name.)
+        self.action_template = ActionTemplateFactory(name="Intimidate")
+
+        # Scene located in the room and active, so it is the room's active scene.
+        self.scene = SceneFactory(location=self.room, is_active=True)
+
+        # --- Initiator: character + sheet + primary persona, placed in the room ---
+        self.initiator_char = _make_character_in_room(self.room)
+        self.initiator_sheet = CharacterSheetFactory(character=self.initiator_char)
+        self.initiator_persona = self.initiator_sheet.primary_persona
+
+        # --- Target: character + sheet + primary persona, placed in the room ---
+        self.target_char = _make_character_in_room(self.room)
+        self.target_sheet = CharacterSheetFactory(character=self.target_char)
+        self.target_persona = self.target_sheet.primary_persona
+
+    @patch("world.scenes.action_services.start_action_resolution")
+    def test_intimidate_then_accept_resolves(self, mock_resolve: MagicMock) -> None:
+        """Telnet intimidate creates a PENDING request; accept resolves it end-to-end."""
+        mock_resolve.return_value = _make_pending_resolution()
+
+        # Mock only caller.msg — drive the real commands and real services.
+        self.initiator_char.msg = MagicMock()
+        self.target_char.msg = MagicMock()
+
+        # ----------------------------------------------------------------------
+        # 1) Initiator intimidates the target by name (telnet CmdIntimidate).
+        # ----------------------------------------------------------------------
+        initiate = CmdIntimidate()
+        initiate.caller = self.initiator_char
+        initiate.args = self.target_char.key
+        initiate.raw_string = f"intimidate {self.target_char.key}"
+        initiate.func()
+
+        # A real PENDING request exists with the correct initiator/target personas.
+        request = SceneActionRequest.objects.get(initiator_persona=self.initiator_persona)
+        self.assertEqual(request.status, ActionRequestStatus.PENDING)
+        self.assertEqual(request.target_persona, self.target_persona)
+        self.assertEqual(request.action_key, "intimidate")
+        # create_action_request resolved the template by the registry action's name.
+        self.assertEqual(request.action_template, self.action_template)
+        self.initiator_char.msg.assert_called()
+
+        # ----------------------------------------------------------------------
+        # 2) Target accepts (telnet CmdAccept) — drives full resolution.
+        # ----------------------------------------------------------------------
+        accept = CmdAccept()
+        accept.caller = self.target_char
+        accept.args = ""
+        accept.func()
+
+        # ----------------------------------------------------------------------
+        # 3) The request resolved end-to-end: RESOLVED (no longer PENDING) AND a
+        #    real downstream artifact of resolution — the result Interaction —
+        #    exists. Mirrors the web E2E's post-accept assertions (sans strain).
+        # ----------------------------------------------------------------------
+        request.refresh_from_db()
+        self.assertEqual(request.status, ActionRequestStatus.RESOLVED)
+        self.assertIsNotNone(request.resolved_at)
+        self.assertIsNotNone(
+            request.result_interaction,
+            "accept must record a result Interaction via the full resolution path",
+        )
+        self.assertEqual(request.result_interaction.persona, self.initiator_persona)
+        self.target_char.msg.assert_called()

--- a/src/integration_tests/pipeline/test_weave_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_weave_telnet_e2e.py
@@ -1,0 +1,53 @@
+"""Telnet E2E: ``weave`` creates a Thread identically to the web path (#1337).
+
+One focused test: a player types ``weave resonance=<name> trait=<id> name=<...>``
+and a ``Thread`` is woven through the full telnet path
+(``CmdWeaveThread.func()`` → ``resolve_action_args()`` → ``WeaveThreadAction.run()``
+→ ``weave_thread``), exactly as the web viewset reaches the same action.
+
+Sparse by design — the web side of the same action is covered by the weave
+viewset/serializer tests; this proves the direct-viewset → Action telnet pattern.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.weave import CmdWeaveThread
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.constants import TargetKind
+from world.magic.factories import (
+    CharacterThreadWeavingUnlockFactory,
+    ResonanceFactory,
+    ThreadWeavingUnlockFactory,
+)
+from world.magic.models import Thread
+from world.traits.factories import TraitFactory
+
+
+class WeaveTelnetE2ETests(TestCase):
+    """Weaving runs end-to-end from the telnet command."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory(name="Embers")
+        cls.trait = TraitFactory()
+        unlock = ThreadWeavingUnlockFactory(target_kind=TargetKind.TRAIT, unlock_trait=cls.trait)
+        CharacterThreadWeavingUnlockFactory(character=cls.sheet, unlock=unlock, xp_spent=100)
+
+    def test_weave_via_telnet_creates_thread(self) -> None:
+        character = self.sheet.character
+        character.msg = MagicMock()
+        cmd = CmdWeaveThread()
+        cmd.caller = character
+        cmd.args = f"resonance=Embers trait={self.trait.pk} name=First"
+        cmd.raw_string = f"weave {cmd.args}"
+
+        cmd.func()
+
+        thread = Thread.objects.get(owner=self.sheet, resonance=self.resonance)
+        self.assertEqual(thread.name, "First")
+        character.msg.assert_called()

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -865,12 +865,13 @@ class ThreadSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(msg) from exc
 
     def create(self, validated_data: dict) -> Thread:
-        """Delegate thread creation to ``weave_thread``."""
-        from world.magic.exceptions import (  # noqa: PLC0415
-            MantleNotClearedError,
-            WeavingUnlockMissing,
-        )
-        from world.magic.services import weave_thread  # noqa: PLC0415
+        """Delegate thread creation to ``WeaveThreadAction`` (telnet + web converge).
+
+        The action wraps the ``weave_thread`` service (still the source of truth)
+        so the web POST path runs through the same ``action.run()`` machinery as
+        telnet. Eligibility failures surface as a 400 with the action's message.
+        """
+        from actions.definitions.threads import WeaveThreadAction  # noqa: PLC0415
 
         # character_sheet_id was replaced by the CharacterSheet instance in
         # validate_character_sheet_id — pop it before building kwargs.
@@ -878,19 +879,17 @@ class ThreadSerializer(serializers.ModelSerializer):
         target = validated_data.pop("_target")
         validated_data.pop("target_id", None)
 
-        from world.covenants.exceptions import CovenantRoleNeverHeldError  # noqa: PLC0415
-
-        try:
-            return weave_thread(
-                character_sheet=character_sheet,
-                target_kind=validated_data["target_kind"],
-                target=target,
-                resonance=validated_data["resonance"],
-                name=validated_data.get("name", ""),
-                description=validated_data.get("description", ""),
-            )
-        except (WeavingUnlockMissing, CovenantRoleNeverHeldError, MantleNotClearedError) as exc:
-            raise serializers.ValidationError({"detail": exc.user_message}) from exc
+        result = WeaveThreadAction().run(
+            actor=character_sheet.character,
+            target_kind=validated_data["target_kind"],
+            target=target,
+            resonance=validated_data["resonance"],
+            name=validated_data.get("name", ""),
+            description=validated_data.get("description", ""),
+        )
+        if not result.success:
+            raise serializers.ValidationError({"detail": result.message})
+        return result.data["thread"]
 
 
 class RitualCheckConfigSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Closes #1337

## Summary

Ratifies the telnet-foundation F2 convention (resolving #1328's two open questions) and ships one worked reference per family.

**Decisions ratified:**
1. **Consent flow → converge at the service seam.** Telnet calls the same `create_action_request`/`respond_to_action_request` services the consent viewset calls — NOT `action.run()`/`dispatch_player_action()` (consent is an inherently two-party protocol; 'needs consent' is an `ActionTemplate.consent_category` property, not an Action property).
2. **Direct-viewset player mutations → become real Actions** on `action.run()` (the #1331 ritual template), resolving the imbue-is-Action vs weave/pull-is-service asymmetry. Family-3 rule: a player-facing state mutation with costs/prereqs becomes an Action; GM/system-only surfaces stay raw services.

**Reference scaffolding:**
- **Family 3:** `WeaveThreadAction` wraps the unchanged `weave_thread` service; `ThreadSerializer.create()` re-pointed to `action.run()` so web+telnet converge; telnet `CmdWeaveThread`; a weave telnet E2E.
- **Family 2:** `ConsentRequestCommand` + `CmdIntimidate` (initiate) and generic `CmdAccept`/`CmdDeny` (respond) over the consent services; a consent telnet E2E (intimidate→accept→resolved).
- **Docs:** architecture doc §10 (the three families + verbatim classification rule); audit doc open-questions marked RESOLVED + the stale 'action.run docstring' claim annotated ALREADY CORRECT (it already described the three families — the audit's fix-on-sight item was itself stale).

Per-domain conversions (pull, endorsements, covenant membership, full social set) stay with their journey issues, which now have a ratified contract. Built via subagent-driven development with per-task spec+quality review and a clean final whole-branch review (Ready to merge: Yes).

## Follow-ups filed

- #1370

## Notes

- Spec: reviewed & approved on #1337 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main cleanly (10 commits, no conflicts, no migration collision). Post-rebase: actions 418, commands 97, both telnet E2Es green; pre-commit --all-files EXIT=0.

<!-- last-addressed-comment: 0 -->