### PR TITLE
fix(sonarcloud): resolve 50 high-severity issues across 31 files

### DIFF
--- a/frontend/src/scenes/components/DramaticMomentTagDialog.tsx
+++ b/frontend/src/scenes/components/DramaticMomentTagDialog.tsx
@@ -59,7 +59,7 @@ export function DramaticMomentTagDialog({
         interaction: interactionId,
       }),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] });
+      queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] });
       onClose();
       setSelectedTypeId('');
     },

--- a/src/actions/definitions/rounds.py
+++ b/src/actions/definitions/rounds.py
@@ -210,9 +210,9 @@ class PassRoundAction(Action):
         room = actor.location
 
         if room is None:
-            return ActionResult(success=False, message="You are not in a room.")
+            return ActionResult(success=False, message=NOT_IN_A_ROOM_MESSAGE)
         if sheet is None:
-            return ActionResult(success=False, message="No character sheet found.")
+            return ActionResult(success=False, message=NO_CHARACTER_SHEET_MESSAGE)
 
         rnd = _active_round_for_room(room)
         if rnd is None:
@@ -264,7 +264,7 @@ class ForceResolveRoundAction(Action):
         room = actor.location
 
         if room is None:
-            return ActionResult(success=False, message="You are not in a room.")
+            return ActionResult(success=False, message=NOT_IN_A_ROOM_MESSAGE)
 
         rnd = _active_round_for_room(room)
         if rnd is None:

--- a/src/actions/definitions/social.py
+++ b/src/actions/definitions/social.py
@@ -77,7 +77,7 @@ class IntimidateAction(_SocialTemplateAction):
     name: str = "Intimidate"
     icon: str = "skull"
     template_name: str = "Intimidate"
-    description = "Coerce through force of presence, threats, or physical dominance."
+    description: str = "Coerce through force of presence, threats, or physical dominance."
 
 
 @dataclass
@@ -86,7 +86,7 @@ class PersuadeAction(_SocialTemplateAction):
     name: str = "Persuade"
     icon: str = "handshake"
     template_name: str = "Persuade"
-    description = "Convince through reasoned argument, charm, and social grace."
+    description: str = "Convince through reasoned argument, charm, and social grace."
 
 
 @dataclass
@@ -95,7 +95,7 @@ class DeceiveAction(_SocialTemplateAction):
     name: str = "Deceive"
     icon: str = "mask"
     template_name: str = "Deceive"
-    description = "Mislead through misdirection, half-truths, or outright lies."
+    description: str = "Mislead through misdirection, half-truths, or outright lies."
 
 
 @dataclass
@@ -104,7 +104,7 @@ class FlirtAction(_SocialTemplateAction):
     name: str = "Flirt"
     icon: str = "heart"
     template_name: str = "Flirt"
-    description = "Beguile through charm, allure, and romantic suggestion."
+    description: str = "Beguile through charm, allure, and romantic suggestion."
 
 
 @dataclass
@@ -113,7 +113,7 @@ class PerformAction(_SocialTemplateAction):
     name: str = "Perform"
     icon: str = "music"
     template_name: str = "Perform"
-    description = "Captivate an audience through music, oration, or storytelling."
+    description: str = "Captivate an audience through music, oration, or storytelling."
 
 
 @dataclass
@@ -122,7 +122,7 @@ class EntranceAction(_SocialTemplateAction):
     name: str = "Entrance"
     icon: str = "sparkles"
     template_name: str = "Entrance"
-    description = "Command attention through sheer force of personality on entering."
+    description: str = "Command attention through sheer force of personality on entering."
 
     def execute(
         self,
@@ -184,7 +184,7 @@ class RestoreSenseAction(_SocialTemplateAction):
     name: str = "Restore to Sense"
     icon: str = "heart-pulse"
     template_name: str = "Restore to Sense"
-    description = "Talk a berserk ally down through force of personality and connection."
+    description: str = "Talk a berserk ally down through force of personality and connection."
 
     def dispatch_effects(
         self,

--- a/src/actions/models/effect_configs.py
+++ b/src/actions/models/effect_configs.py
@@ -12,6 +12,9 @@ from evennia.utils.idmapper.models import SharedMemoryModel
 
 from actions.constants import TransformType
 
+CHECK_TYPE_FK = "checks.CheckType"
+CONDITION_TEMPLATE_FK = "conditions.ConditionTemplate"
+
 
 class BaseEffectConfig(models.Model):
     """Abstract base for all effect config models.
@@ -82,13 +85,13 @@ class ConditionOnCheckConfig(BaseEffectConfig, SharedMemoryModel):
     """
 
     check_type = models.ForeignKey(
-        "checks.CheckType",
+        CHECK_TYPE_FK,
         on_delete=models.CASCADE,
         related_name="+",
         help_text="Attacker's check type (weighted trait combination).",
     )
     resistance_check_type = models.ForeignKey(
-        "checks.CheckType",
+        CHECK_TYPE_FK,
         on_delete=models.CASCADE,
         null=True,
         blank=True,
@@ -101,7 +104,7 @@ class ConditionOnCheckConfig(BaseEffectConfig, SharedMemoryModel):
         help_text="Fixed difficulty fallback for NPCs/missions.",
     )
     condition = models.ForeignKey(
-        "conditions.ConditionTemplate",
+        CONDITION_TEMPLATE_FK,
         on_delete=models.CASCADE,
         related_name="+",
         help_text="Condition to apply on successful check.",
@@ -109,7 +112,7 @@ class ConditionOnCheckConfig(BaseEffectConfig, SharedMemoryModel):
     severity = models.PositiveIntegerField(default=1)
     duration_rounds = models.PositiveIntegerField(null=True, blank=True)
     immunity_condition = models.ForeignKey(
-        "conditions.ConditionTemplate",
+        CONDITION_TEMPLATE_FK,
         on_delete=models.CASCADE,
         null=True,
         blank=True,
@@ -145,13 +148,13 @@ class RemoveConditionOnCheckConfig(BaseEffectConfig, SharedMemoryModel):
     """
 
     check_type = models.ForeignKey(
-        "checks.CheckType",
+        CHECK_TYPE_FK,
         on_delete=models.CASCADE,
         related_name="+",
         help_text="Attacker's check type (weighted trait combination).",
     )
     resistance_check_type = models.ForeignKey(
-        "checks.CheckType",
+        CHECK_TYPE_FK,
         on_delete=models.CASCADE,
         null=True,
         blank=True,
@@ -164,7 +167,7 @@ class RemoveConditionOnCheckConfig(BaseEffectConfig, SharedMemoryModel):
         help_text="Fixed difficulty fallback for NPCs/missions.",
     )
     condition = models.ForeignKey(
-        "conditions.ConditionTemplate",
+        CONDITION_TEMPLATE_FK,
         on_delete=models.CASCADE,
         related_name="+",
         help_text="Condition to remove on successful check.",

--- a/src/actions/prerequisites.py
+++ b/src/actions/prerequisites.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+CANNOT_BE_USED_MESSAGE = "That can't be used."
+CANNOT_SEE_MESSAGE = "You can't see that."
+
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
@@ -97,13 +100,50 @@ class ItemUsablePrerequisite(Prerequisite):
         item_obj = (context or {}).get("kwargs", {}).get("item")
         instance = resolve_item_instance(item_obj) if item_obj is not None else None
         if instance is None:
-            return False, "That can't be used."
+            return False, CANNOT_BE_USED_MESSAGE
         template = instance.template
         if not template.is_usable:
-            return False, "That can't be used."
+            return False, CANNOT_BE_USED_MESSAGE
         if template.is_consumable and instance.charges <= 0:
             return False, "There are no uses left."
         return True, ""
+
+
+def _check_item_target(actor: ObjectDB, target: ObjectDB) -> tuple[bool, str]:
+    """Validate an ITEM-kind on-use target: must be a resolvable, reachable, visible item."""
+    from actions.definitions.item_helpers import resolve_item_instance  # noqa: PLC0415
+    from flows.object_states.item_state import ItemState  # noqa: PLC0415
+
+    target_instance = resolve_item_instance(target)
+    if target_instance is None:
+        return False, "You can't use that on that."
+    if not ItemState(target_instance, context=None).is_reachable_by(actor):
+        return False, "That isn't within reach."
+    if not _is_visible_to(actor, target):
+        return False, CANNOT_SEE_MESSAGE
+    return True, ""
+
+
+def _check_character_target(actor: ObjectDB, target: ObjectDB) -> tuple[bool, str]:
+    """Validate a CHARACTER-kind on-use target: must be a character present and visible."""
+    if not target.is_typeclass("typeclasses.characters.Character", exact=False):
+        return False, "That can only be used on a character."
+    if target.location != actor.location:
+        return False, "They aren't here."
+    if not _is_visible_to(actor, target):
+        return False, CANNOT_SEE_MESSAGE
+    return True, ""
+
+
+def _check_room_target(actor: ObjectDB, target: ObjectDB) -> tuple[bool, str]:
+    """Validate a ROOM-kind on-use target: must be a room the actor occupies and can see."""
+    if not target.is_typeclass("typeclasses.rooms.Room", exact=False):
+        return False, "That can only be used on a place."
+    if actor.location not in (target.location, target):
+        return False, "They aren't here."
+    if not _is_visible_to(actor, target):
+        return False, CANNOT_SEE_MESSAGE
+    return True, ""
 
 
 @dataclass
@@ -114,7 +154,7 @@ class OnUseTargetPrerequisite(Prerequisite):
     external target of that kind is required, reachable, and visible.
     """
 
-    def is_met(  # noqa: C901,PLR0911,PLR0912
+    def is_met(  # noqa: PLR0911
         self,
         actor: ObjectDB,
         target: ObjectDB | None = None,
@@ -122,12 +162,11 @@ class OnUseTargetPrerequisite(Prerequisite):
     ) -> tuple[bool, str]:
         from actions.constants import TargetKind  # noqa: PLC0415
         from actions.definitions.item_helpers import resolve_item_instance  # noqa: PLC0415
-        from flows.object_states.item_state import ItemState  # noqa: PLC0415
 
         item_obj = (context or {}).get("kwargs", {}).get("item")
         instance = resolve_item_instance(item_obj) if item_obj is not None else None
         if instance is None:
-            return False, "That can't be used."
+            return False, CANNOT_BE_USED_MESSAGE
         kind = instance.template.on_use_target_kind
 
         if kind is None:
@@ -138,34 +177,12 @@ class OnUseTargetPrerequisite(Prerequisite):
         if target is None:
             return False, "Use it on what?"
 
-        # Kind match: ITEM targets use ItemState.is_reachable_by.
         if kind == TargetKind.ITEM:
-            target_instance = resolve_item_instance(target)
-            if target_instance is None:
-                return False, "You can't use that on that."
-            if not ItemState(target_instance, context=None).is_reachable_by(actor):
-                return False, "That isn't within reach."
-            if not _is_visible_to(actor, target):
-                return False, "You can't see that."
-            return True, ""
-
+            return _check_item_target(actor, target)
         if kind == TargetKind.CHARACTER:
-            if not target.is_typeclass("typeclasses.characters.Character", exact=False):
-                return False, "That can only be used on a character."
-            if target.location != actor.location:
-                return False, "They aren't here."
-            if not _is_visible_to(actor, target):
-                return False, "You can't see that."
-            return True, ""
-
+            return _check_character_target(actor, target)
         if kind == TargetKind.ROOM:
-            if not target.is_typeclass("typeclasses.rooms.Room", exact=False):
-                return False, "That can only be used on a place."
-            if actor.location not in (target.location, target):
-                return False, "They aren't here."
-            if not _is_visible_to(actor, target):
-                return False, "You can't see that."
-            return True, ""
+            return _check_room_target(actor, target)
 
         # TargetKind.PERSONA and any future unhandled kinds — fail closed.
         return False, "That can't be used on that."

--- a/src/commands/social/blocking.py
+++ b/src/commands/social/blocking.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from world.scenes.models import Persona
 
 _NO_IDENTITY = "You have no character identity to act with."
+_LOCK_ALL = "cmd:all()"
 
 
 def _caller_persona(command: ArxCommand) -> Persona:
@@ -46,7 +47,7 @@ class CmdBlock(ArxCommand):
     """
 
     key = "+block"
-    locks = "cmd:all()"
+    locks = _LOCK_ALL
     action = None
 
     def func(self) -> None:
@@ -86,7 +87,7 @@ class CmdUnblock(ArxCommand):
     """
 
     key = "+unblock"
-    locks = "cmd:all()"
+    locks = _LOCK_ALL
     action = None
 
     def func(self) -> None:
@@ -116,7 +117,7 @@ class CmdShareBlock(ArxCommand):
     """
 
     key = "+shareblock"
-    locks = "cmd:all()"
+    locks = _LOCK_ALL
     action = None
 
     def func(self) -> None:
@@ -146,7 +147,7 @@ class CmdMute(ArxCommand):
     """
 
     key = "+mute"
-    locks = "cmd:all()"
+    locks = _LOCK_ALL
     action = None
 
     def func(self) -> None:
@@ -178,7 +179,7 @@ class CmdUnmute(ArxCommand):
     """
 
     key = "+unmute"
-    locks = "cmd:all()"
+    locks = _LOCK_ALL
     action = None
 
     def func(self) -> None:
@@ -203,7 +204,7 @@ class CmdBlockList(ArxCommand):
     """
 
     key = "+blocklist"
-    locks = "cmd:all()"
+    locks = _LOCK_ALL
     action = None
 
     def func(self) -> None:

--- a/src/world/captivity/models.py
+++ b/src/world/captivity/models.py
@@ -24,6 +24,8 @@ from evennia.utils.idmapper.models import SharedMemoryModel
 
 from world.captivity.constants import CaptivityStatus
 
+_MISSION_TEMPLATE_FK = "missions.MissionTemplate"
+
 
 class Captivity(SharedMemoryModel):
     """One character's imprisonment and how it ends."""
@@ -77,7 +79,7 @@ class Captivity(SharedMemoryModel):
         help_text="The one-shot demand contract surfaced on the captor-debtor's books.",
     )
     rescue_template = models.ForeignKey(
-        "missions.MissionTemplate",
+        _MISSION_TEMPLATE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -125,7 +127,7 @@ class CaptivityConfig(SharedMemoryModel):
     """
 
     captive_template = models.ForeignKey(
-        "missions.MissionTemplate",
+        _MISSION_TEMPLATE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -136,7 +138,7 @@ class CaptivityConfig(SharedMemoryModel):
         ),
     )
     rescue_template = models.ForeignKey(
-        "missions.MissionTemplate",
+        _MISSION_TEMPLATE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/src/world/checks/factories.py
+++ b/src/world/checks/factories.py
@@ -133,37 +133,42 @@ _ENTRANCE_TEMPLATE_NAME = "Entrance"
 # Pool name prefix for social consequence pools.
 _SOCIAL_POOL_PREFIX = "Social"
 
+# CheckOutcome tier names used in consequence pool entries.
+_OUTCOME_FAILURE = "Failure"
+_OUTCOME_PARTIAL = "Partial Success"
+_OUTCOME_SUCCESS = "Success"
+
 # (action_name, outcome_tier_name, label, weight)
 _SOCIAL_POOL_CONSEQUENCES: dict[str, list[tuple[str, str, int]]] = {
     "Intimidate": [
-        ("Failure", "Intimidation falls flat", 1),
-        ("Partial Success", "Target rattled but holds firm", 2),
-        ("Success", "Target cowed and compliant", 1),
+        (_OUTCOME_FAILURE, "Intimidation falls flat", 1),
+        (_OUTCOME_PARTIAL, "Target rattled but holds firm", 2),
+        (_OUTCOME_SUCCESS, "Target cowed and compliant", 1),
     ],
     "Persuade": [
-        ("Failure", "Argument dismissed outright", 1),
-        ("Partial Success", "Target intrigued but unconvinced", 2),
-        ("Success", "Target fully persuaded", 1),
+        (_OUTCOME_FAILURE, "Argument dismissed outright", 1),
+        (_OUTCOME_PARTIAL, "Target intrigued but unconvinced", 2),
+        (_OUTCOME_SUCCESS, "Target fully persuaded", 1),
     ],
     "Deceive": [
-        ("Failure", "Lie detected immediately", 1),
-        ("Partial Success", "Partial deception holds", 2),
-        ("Success", "Target completely deceived", 1),
+        (_OUTCOME_FAILURE, "Lie detected immediately", 1),
+        (_OUTCOME_PARTIAL, "Partial deception holds", 2),
+        (_OUTCOME_SUCCESS, "Target completely deceived", 1),
     ],
     "Flirt": [
-        ("Failure", "Advance rebuffed", 1),
-        ("Partial Success", "Interest piqued but guarded", 2),
-        ("Success", "Charm lands completely", 1),
+        (_OUTCOME_FAILURE, "Advance rebuffed", 1),
+        (_OUTCOME_PARTIAL, "Interest piqued but guarded", 2),
+        (_OUTCOME_SUCCESS, "Charm lands completely", 1),
     ],
     "Perform": [
-        ("Failure", "Performance falls flat", 1),
-        ("Partial Success", "Audience politely attentive", 2),
-        ("Success", "Audience captivated", 1),
+        (_OUTCOME_FAILURE, "Performance falls flat", 1),
+        (_OUTCOME_PARTIAL, "Audience politely attentive", 2),
+        (_OUTCOME_SUCCESS, "Audience captivated", 1),
     ],
     "Entrance": [
-        ("Failure", "Entrance goes unnoticed", 1),
-        ("Partial Success", "Attention caught briefly", 2),
-        ("Success", "All eyes arrested", 1),
+        (_OUTCOME_FAILURE, "Entrance goes unnoticed", 1),
+        (_OUTCOME_PARTIAL, "Attention caught briefly", 2),
+        (_OUTCOME_SUCCESS, "All eyes arrested", 1),
     ],
 }
 

--- a/src/world/clues/services.py
+++ b/src/world/clues/services.py
@@ -168,6 +168,25 @@ def clear_rescue_clues(captivity: Captivity) -> None:
     Clue.objects.filter(target_captivity=captivity).delete()
 
 
+def _placement_passes_eligibility(
+    placement: RoomClue,
+    character: ObjectDB,
+    context_holder: list,
+) -> bool:
+    """Return True if character passes the placement's eligibility gate.
+
+    ``context_holder`` is a one-element list used to lazily build and cache the
+    predicate context across calls within a single search sweep.
+    """
+    from world.predicates.predicates import evaluate  # noqa: PLC0415
+
+    if not placement.eligibility_rule:
+        return True
+    if not context_holder:
+        context_holder.append(_predicate_context(character))
+    return evaluate(placement.eligibility_rule, context_holder[0])
+
+
 def search_room(
     character: ObjectDB,
     room_profile: RoomProfile,
@@ -181,7 +200,6 @@ def search_room(
     Returns the clues found this search (empty if the searcher has no roster entry).
     """
     from world.checks.services import perform_check  # noqa: PLC0415
-    from world.predicates.predicates import evaluate  # noqa: PLC0415
 
     roster_entry = _roster_entry_for(character)
     if roster_entry is None:
@@ -190,7 +208,7 @@ def search_room(
         CharacterClue.objects.filter(roster_entry=roster_entry).values_list("clue_id", flat=True)
     )
     found: list[Clue] = []
-    context = None  # CharacterPredicateContext, built lazily only when a clue is gated
+    context_holder: list = []
     placements = RoomClue.objects.filter(room_profile=room_profile, is_active=True).select_related(
         "clue"
     )
@@ -198,13 +216,8 @@ def search_room(
         clue = placement.clue
         if clue.pk in held_ids:
             continue
-        # Access gate: a placement may restrict WHO can discover it (identity / org /
-        # resonance) via a predicate rule. Empty rule = open to anyone (the default).
-        if placement.eligibility_rule:
-            if context is None:
-                context = _predicate_context(character)
-            if not evaluate(placement.eligibility_rule, context):
-                continue
+        if not _placement_passes_eligibility(placement, character, context_holder):
+            continue
         result = perform_check(
             character, search_check_type, target_difficulty=placement.detect_difficulty
         )

--- a/src/world/combat/factories.py
+++ b/src/world/combat/factories.py
@@ -61,6 +61,7 @@ from world.magic.constants import EffectKind
 # multiple factories below. Centralized to avoid the duplicated-literal
 # SonarCloud smell (python:S1192).
 _CHARACTER_SHEET_FACTORY = "world.character_sheets.factories.CharacterSheetFactory"
+_ROOM_TYPECLASS = "typeclasses.rooms.Room"
 
 
 class CombatEncounterFactory(factory_django.DjangoModelFactory):
@@ -77,7 +78,7 @@ class CombatEncounterFactory(factory_django.DjangoModelFactory):
     def room(self) -> object:
         from evennia import create_object
 
-        return create_object("typeclasses.rooms.Room", key="Test Combat Room", nohome=True)
+        return create_object(_ROOM_TYPECLASS, key="Test Combat Room", nohome=True)
 
     @factory.lazy_attribute
     def scene(self) -> object:
@@ -833,7 +834,7 @@ class DuelChallengeFactory(factory_django.DjangoModelFactory):
     def room(self) -> object:
         from evennia import create_object
 
-        return create_object("typeclasses.rooms.Room", key="Duel Challenge Room", nohome=True)
+        return create_object(_ROOM_TYPECLASS, key="Duel Challenge Room", nohome=True)
 
 
 class PvpDuelFactory:
@@ -867,7 +868,7 @@ class PvpDuelFactory:
         if challenged_sheet is None:
             challenged_sheet = CharacterSheetFactory()
         if room is None:
-            room = create_object("typeclasses.rooms.Room", key="Duel Room", nohome=True)
+            room = create_object(_ROOM_TYPECLASS, key="Duel Room", nohome=True)
         return create_pvp_duel(challenger_sheet, challenged_sheet, room, risk_level=risk_level)
 
 
@@ -910,7 +911,7 @@ class LethalDuelFactory:
         if pc_sheet is None:
             pc_sheet = CharacterSheetFactory()
         if room is None:
-            room = create_object("typeclasses.rooms.Room", key="Lethal Duel Room", nohome=True)
+            room = create_object(_ROOM_TYPECLASS, key="Lethal Duel Room", nohome=True)
         if opponent_kwargs is None:
             opponent_kwargs = {
                 "name": "Dueling Master",

--- a/src/world/combat/models.py
+++ b/src/world/combat/models.py
@@ -55,6 +55,7 @@ CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
 TECHNIQUE_MODEL = "magic.Technique"
 COMBAT_PARTICIPANT_MODEL = "combat.CombatParticipant"
 COMBAT_ENCOUNTER_MODEL = "combat.CombatEncounter"
+OBJECTS_OBJECTDB_MODEL = "objects.ObjectDB"
 
 
 class CombatEncounter(SharedMemoryModel):
@@ -71,7 +72,7 @@ class CombatEncounter(SharedMemoryModel):
         related_name="combat_encounters",
     )
     room = models.ForeignKey(
-        "objects.ObjectDB",
+        OBJECTS_OBJECTDB_MODEL,
         on_delete=models.PROTECT,
         related_name="combat_encounters",
         null=True,
@@ -369,7 +370,7 @@ class CombatOpponent(SharedMemoryModel):
         "instead; this is the fallback when persona is None.",
     )
     objectdb = models.ForeignKey(
-        "objects.ObjectDB",
+        OBJECTS_OBJECTDB_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -2206,7 +2207,7 @@ class DuelChallenge(SharedMemoryModel):
         help_text="The PC who was challenged.",
     )
     room = models.ForeignKey(
-        "objects.ObjectDB",
+        OBJECTS_OBJECTDB_MODEL,
         on_delete=models.PROTECT,
         related_name="duel_challenges",
         null=True,

--- a/src/world/combat/round_context.py
+++ b/src/world/combat/round_context.py
@@ -256,6 +256,35 @@ class CombatRoundContext(RoundContext):
                 [CombatRoundActionTarget(action=action, opponent=opp) for opp in aoe_opponents]
             )
 
+    def _resolve_aoe_opponents(
+        self,
+        opponent_ids: list[int],
+    ) -> list[CombatOpponent]:
+        """Validate and order the AoE opponent id list against this encounter.
+
+        Raises ActionDispatchError(UNKNOWN_ACTION_REF) if any id is not in this encounter.
+        """
+        resolved = list(
+            CombatOpponent.objects.filter(pk__in=opponent_ids, encounter=self._encounter)
+        )
+        resolved_map = {o.pk: o for o in resolved}
+        ordered: list[CombatOpponent] = []
+        for oid in opponent_ids:
+            if oid not in resolved_map:
+                raise ActionDispatchError(ActionDispatchError.UNKNOWN_ACTION_REF)
+            ordered.append(resolved_map[oid])
+        return ordered
+
+    def _resolve_single_opponent(self, opponent_id: int) -> CombatOpponent:
+        """Resolve a single CombatOpponent PK scoped to this encounter.
+
+        Raises ActionDispatchError(UNKNOWN_ACTION_REF) if the id is not found.
+        """
+        try:
+            return CombatOpponent.objects.get(pk=opponent_id, encounter=self._encounter)
+        except CombatOpponent.DoesNotExist as exc:
+            raise ActionDispatchError(ActionDispatchError.UNKNOWN_ACTION_REF) from exc
+
     def _resolve_focused_targets(
         self,
         kwargs: dict[str, Any],
@@ -288,34 +317,16 @@ class CombatRoundContext(RoundContext):
         """
         opponent: CombatOpponent | None = kwargs.get("focused_opponent_target")
         opponent_ids: list[int] | None = kwargs.get("focused_opponent_target_ids")
-
         aoe_opponents: list[CombatOpponent] = []
 
         if opponent_ids:
-            # AoE / FILTERED_GROUP dispatch: validate each id in this encounter.
-            resolved = list(
-                CombatOpponent.objects.filter(
-                    pk__in=opponent_ids,
-                    encounter=self._encounter,
-                )
-            )
-            resolved_map = {o.pk: o for o in resolved}
-            for oid in opponent_ids:
-                if oid not in resolved_map:
-                    raise ActionDispatchError(ActionDispatchError.UNKNOWN_ACTION_REF)
-                aoe_opponents.append(resolved_map[oid])
+            aoe_opponents = self._resolve_aoe_opponents(opponent_ids)
             if aoe_opponents and opponent is None:
                 opponent = aoe_opponents[0]
         else:
             opponent_id = kwargs.get("focused_opponent_target_id")
             if opponent is None and opponent_id is not None:
-                try:
-                    opponent = CombatOpponent.objects.get(
-                        pk=opponent_id,
-                        encounter=self._encounter,
-                    )
-                except CombatOpponent.DoesNotExist as exc:
-                    raise ActionDispatchError(ActionDispatchError.UNKNOWN_ACTION_REF) from exc
+                opponent = self._resolve_single_opponent(opponent_id)
 
         ally: CombatParticipant | None = kwargs.get("focused_ally_target")
         ally_id = kwargs.get("focused_ally_target_id")

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
     from actions.models.consequence_pools import ConsequencePool
+    from flows.events.payloads import DamageSource
     from typeclasses.characters import Character
     from world.character_sheets.models import CharacterSheet
     from world.checks.models import CheckType
@@ -351,6 +352,43 @@ class CombatTechniqueResolver:
         primary = self.action.focused_opponent_target
         return [primary] if primary is not None else []
 
+    def _apply_profiles_to_target(  # noqa: PLR0913
+        self,
+        target: CombatOpponent,
+        profiles: list[TechniqueDamageProfile],
+        weapon: WeaponContribution | None,
+        *,
+        sl: int,
+        multiplier: Decimal,
+        eff_intensity: int,
+    ) -> tuple[list[OpponentDamageResult], bool]:
+        """Apply each damage profile to a single target, returning results and weapon-hit flag.
+
+        Skips profiles that deal zero damage and aborts early if the target is
+        defeated mid-loop (can happen when a preceding profile triggers a kill).
+        """
+        results: list[OpponentDamageResult] = []
+        weapon_landed = False
+        for profile in profiles:
+            scaled, profile_damage_type = self._profile_damage(
+                profile, weapon, sl=sl, multiplier=multiplier, eff_intensity=eff_intensity
+            )
+            if scaled <= 0:
+                continue
+            target.refresh_from_db()
+            if target.status == OpponentStatus.DEFEATED:
+                break
+            results.append(
+                apply_damage_to_opponent(
+                    target,
+                    scaled,
+                    damage_type=profile_damage_type,
+                    source_sheet=self.participant.character_sheet,
+                )
+            )
+            weapon_landed = weapon_landed or (profile.uses_equipped_weapon and weapon is not None)
+        return results, weapon_landed
+
     def _apply_damage(
         self, check_result: CheckResult, *, eff_intensity: int
     ) -> list[OpponentDamageResult]:
@@ -389,35 +427,20 @@ class CombatTechniqueResolver:
 
         attacker = self.participant.character_sheet.character
         weapon = effective_weapon_profile(attacker)
-        weapon_landed = False
+        any_weapon_landed = False
 
         results: list[OpponentDamageResult] = []
         for target in targets:
             target.refresh_from_db()
             if target.status == OpponentStatus.DEFEATED:
                 continue
-            for profile in profiles:
-                scaled, profile_damage_type = self._profile_damage(
-                    profile, weapon, sl=sl, multiplier=multiplier, eff_intensity=eff_intensity
-                )
-                if scaled <= 0:
-                    continue
-                target.refresh_from_db()
-                if target.status == OpponentStatus.DEFEATED:
-                    break
-                results.append(
-                    apply_damage_to_opponent(
-                        target,
-                        scaled,
-                        damage_type=profile_damage_type,
-                        source_sheet=self.participant.character_sheet,
-                    )
-                )
-                weapon_landed = weapon_landed or (
-                    profile.uses_equipped_weapon and weapon is not None
-                )
+            target_results, weapon_landed = self._apply_profiles_to_target(
+                target, profiles, weapon, sl=sl, multiplier=multiplier, eff_intensity=eff_intensity
+            )
+            results.extend(target_results)
+            any_weapon_landed = any_weapon_landed or weapon_landed
 
-        if weapon_landed:
+        if any_weapon_landed:
             _wear_equipped_weapon(attacker)
         return results
 
@@ -1136,6 +1159,74 @@ def declare_interpose(
     return action
 
 
+def _resolve_opponent_stat_fields(  # noqa: PLR0913
+    block: object | None,
+    *,
+    soak_value: int | None,
+    probing_threshold: int | None,
+    swarm_count: int | None,
+    body_toughness: int | None,
+    bodies_per_attack: int | None,
+    barrier_strength: int | None,
+) -> tuple[int, int | None, int | None, int | None, int | None, int | None]:
+    """Return resolved (soak, probing, swarm, body_toughness, bodies_per_attack, barrier)
+    from either the auto-scaling block or manual-mode defaults."""
+    if block is not None:
+        return (
+            soak_value if soak_value is not None else block.soak_value,
+            probing_threshold if probing_threshold is not None else block.probing_threshold,
+            swarm_count if swarm_count is not None else block.swarm_count,
+            body_toughness if body_toughness is not None else block.body_toughness,
+            bodies_per_attack if bodies_per_attack is not None else block.bodies_per_attack,
+            barrier_strength if barrier_strength is not None else block.barrier_strength,
+        )
+    return (
+        soak_value if soak_value is not None else 0,
+        probing_threshold,
+        swarm_count,
+        body_toughness,
+        bodies_per_attack,
+        barrier_strength,
+    )
+
+
+def _resolve_objectdb_for_opponent(
+    encounter: CombatEncounter,
+    name: str,
+    persona: Persona | None,
+    existing_objectdb: ObjectDB | None,
+) -> tuple[object, bool]:
+    """Resolve the ObjectDB and ephemeral flag for a new CombatOpponent.
+
+    Three sources (checked in order):
+    - existing_objectdb: pre-existing OD — not ephemeral, must be a Character.
+    - persona: reuses persona's character OD — not ephemeral.
+    - neither: creates a fresh CombatNPC in encounter.room — ephemeral.
+    """
+    from evennia.utils.create import create_object  # noqa: PLC0415
+
+    from typeclasses.characters import Character  # noqa: PLC0415
+    from world.combat.typeclasses.combat_npc import CombatNPC  # noqa: PLC0415
+
+    if existing_objectdb is not None:
+        if not isinstance(existing_objectdb, Character):
+            msg = (
+                f"existing_objectdb must be a Character typeclass instance "
+                f"(got {type(existing_objectdb).__name__}). "
+                f"Combat damage paths require character.conditions handler access."
+            )
+            raise TypeError(msg)
+        return existing_objectdb, False
+
+    if persona is not None:
+        return persona.character_sheet.character, False
+
+    if encounter.room is None:
+        msg = "Cannot create ephemeral CombatNPC: encounter has no room."
+        raise ValueError(msg)
+    return create_object(CombatNPC, key=name, location=encounter.room, nohome=True), True
+
+
 def add_opponent(  # noqa: PLR0913 - opponent creation requires all stat fields
     encounter: CombatEncounter,
     *,
@@ -1169,73 +1260,34 @@ def add_opponent(  # noqa: PLR0913 - opponent creation requires all stat fields
     automatic ``BossPhase`` creation for BOSS-tier opponents (manual mode also
     creates no phases, since no block is computed).
     """
-    from evennia.utils.create import create_object  # noqa: PLC0415
-
-    from typeclasses.characters import Character  # noqa: PLC0415
     from world.combat.scaling import compute_opponent_stat_block  # noqa: PLC0415
-    from world.combat.typeclasses.combat_npc import CombatNPC  # noqa: PLC0415
 
-    # --- Resolve scaling block when max_health is omitted ---
-    # The formula is triggered by an absent max_health — the primary signal that
-    # the caller wants auto-scaling.  Callers that pass max_health explicitly are
-    # in "manual mode": any unspecified secondary stats fall back to their
-    # pre-scaling defaults (soak=0, probing=None, etc.), preserving backward
-    # compatibility for existing call sites that never seeded OpponentTierTemplate.
+    # The formula is triggered by an absent max_health (auto-scaling mode).
+    # Callers that pass max_health explicitly are in "manual mode": omitted
+    # secondary stats fall back to their legacy defaults (soak=0, etc.).
     block = compute_opponent_stat_block(tier, encounter) if max_health is None else None
-
     resolved_max_health: int = max_health if max_health is not None else block.max_health
-    resolved_soak: int
-    resolved_probing: int | None
-    resolved_swarm: int | None
-    resolved_body_toughness: int | None
-    resolved_bodies_per_attack: int | None
-    resolved_barrier_strength: int | None
 
-    if block is not None:
-        # Auto-scaling mode: fill every omitted field from the formula.
-        resolved_soak = soak_value if soak_value is not None else block.soak_value
-        resolved_probing = (
-            probing_threshold if probing_threshold is not None else block.probing_threshold
-        )
-        resolved_swarm = swarm_count if swarm_count is not None else block.swarm_count
-        resolved_body_toughness = (
-            body_toughness if body_toughness is not None else block.body_toughness
-        )
-        resolved_bodies_per_attack = (
-            bodies_per_attack if bodies_per_attack is not None else block.bodies_per_attack
-        )
-        resolved_barrier_strength = (
-            barrier_strength if barrier_strength is not None else block.barrier_strength
-        )
-    else:
-        # Manual mode: caller provided max_health; apply legacy defaults for unspecified fields.
-        resolved_soak = soak_value if soak_value is not None else 0
-        resolved_probing = probing_threshold
-        resolved_swarm = swarm_count
-        resolved_body_toughness = body_toughness
-        resolved_bodies_per_attack = bodies_per_attack
-        resolved_barrier_strength = barrier_strength
+    (
+        resolved_soak,
+        resolved_probing,
+        resolved_swarm,
+        resolved_body_toughness,
+        resolved_bodies_per_attack,
+        resolved_barrier_strength,
+    ) = _resolve_opponent_stat_fields(
+        block,
+        soak_value=soak_value,
+        probing_threshold=probing_threshold,
+        swarm_count=swarm_count,
+        body_toughness=body_toughness,
+        bodies_per_attack=bodies_per_attack,
+        barrier_strength=barrier_strength,
+    )
 
-    if existing_objectdb is not None and not isinstance(existing_objectdb, Character):
-        msg = (
-            f"existing_objectdb must be a Character typeclass instance "
-            f"(got {type(existing_objectdb).__name__}). "
-            f"Combat damage paths require character.conditions handler access."
-        )
-        raise TypeError(msg)
-
-    if existing_objectdb is not None:
-        objectdb = existing_objectdb
-        is_ephemeral = False
-    elif persona is not None:
-        objectdb = persona.character_sheet.character
-        is_ephemeral = False
-    else:
-        if encounter.room is None:
-            msg = "Cannot create ephemeral CombatNPC: encounter has no room."
-            raise ValueError(msg)
-        objectdb = create_object(CombatNPC, key=name, location=encounter.room, nohome=True)
-        is_ephemeral = True
+    objectdb, is_ephemeral = _resolve_objectdb_for_opponent(
+        encounter, name, persona, existing_objectdb
+    )
 
     opp = CombatOpponent(
         encounter=encounter,
@@ -2208,6 +2260,48 @@ def _resolve_passive_actions(
                 _apply_passive_technique(passive, action.participant, encounter)
 
 
+def _emit_post_damage_events(  # noqa: PLR0913
+    *,
+    character: Character,
+    room: ObjectDB | None,
+    effective_damage: int,
+    damage_type: DamageType | None,
+    damage_source: DamageSource,
+    health_after: int,
+    knockout_eligible: bool,
+    was_in_knockout_band: bool,
+    death_eligible: bool,
+    force_death: bool,
+) -> None:
+    """Emit DAMAGE_APPLIED, CHARACTER_INCAPACITATED, and CHARACTER_KILLED events post-save.
+
+    Called after vitals.save(); no-op when room is None (unlocated characters).
+    """
+    if room is None:
+        return
+    applied_payload = DamageAppliedPayload(
+        target=character,
+        amount_dealt=effective_damage,
+        damage_type=damage_type,
+        source=damage_source,
+        hp_after=health_after,
+    )
+    emit_event(EventName.DAMAGE_APPLIED, applied_payload, location=room)
+
+    will_emit_death_gate = death_eligible or force_death
+    if knockout_eligible and not was_in_knockout_band and not will_emit_death_gate:
+        emit_event(
+            EventName.CHARACTER_INCAPACITATED,
+            CharacterIncapacitatedPayload(
+                character=character,
+                source_event=EventName.DAMAGE_PRE_APPLY,
+            ),
+            location=room,
+        )
+    if will_emit_death_gate:
+        _emit_death_gate(character, room)
+
+
 def apply_damage_to_participant(  # noqa: PLR0913
     participant: CombatParticipant,
     damage: int,
@@ -2330,40 +2424,18 @@ def apply_damage_to_participant(  # noqa: PLR0913
     # call sites are pre-threaded.
     del source_sheet
 
-    # --- DAMAGE_APPLIED (post-save, frozen) ---
-    applied_payload = DamageAppliedPayload(
-        target=character,
-        amount_dealt=effective_damage,
+    _emit_post_damage_events(
+        character=character,
+        room=room,
+        effective_damage=effective_damage,
         damage_type=pre_payload.damage_type,
-        source=damage_source,
-        hp_after=health_after,
+        damage_source=damage_source,
+        health_after=health_after,
+        knockout_eligible=knockout_eligible,
+        was_in_knockout_band=was_in_knockout_band,
+        death_eligible=death_eligible,
+        force_death=force_death,
     )
-    if room is not None:
-        emit_event(
-            EventName.DAMAGE_APPLIED,
-            applied_payload,
-            location=room,
-        )
-
-        # --- Incapacitation / death gates ---
-        # CHARACTER_INCAPACITATED marks the dramatic beat (the fall), not
-        # per-hit at-risk status: it fires only on the transition INTO the
-        # knockout band, and never alongside the death gate — one narrative
-        # beat, one event. knockout_eligible itself stays per-hit for the
-        # survivability-check pipeline (process_damage_consequences).
-        will_emit_death_gate = death_eligible or force_death
-        if knockout_eligible and not was_in_knockout_band and not will_emit_death_gate:
-            emit_event(
-                EventName.CHARACTER_INCAPACITATED,
-                CharacterIncapacitatedPayload(
-                    character=character,
-                    source_event=EventName.DAMAGE_PRE_APPLY,
-                ),
-                location=room,
-            )
-
-        if will_emit_death_gate:
-            _emit_death_gate(character, room)
 
     return ParticipantDamageResult(
         damage_dealt=effective_damage,
@@ -3142,6 +3214,50 @@ def _resolve_flee(
     return outcome
 
 
+def _record_and_broadcast_pc_action(  # noqa: PLR0913
+    *,
+    participant: CombatParticipant,
+    action: CombatRoundAction,
+    technique: Technique,
+    target: CombatOpponent | None,
+    outcome: ActionOutcome,
+    combat_result: CombatTechniqueResult | None,
+) -> None:
+    """Record the ACTION-mode Interaction and broadcast the outcome narration."""
+    from world.combat.interaction_services import (  # noqa: PLC0415
+        broadcast_action_outcome,
+        create_action_interaction,
+        render_action_declaration_label,
+        render_action_outcome_narration,
+    )
+    from world.scenes.interaction_services import push_interaction  # noqa: PLC0415
+
+    interaction = create_action_interaction(
+        participant=participant,
+        round_number=action.round_number,
+        summary_label=render_action_declaration_label(action),
+    )
+    if interaction is not None:
+        action.interaction = interaction
+        action.interaction_timestamp = interaction.timestamp
+        action.save(update_fields=["interaction", "interaction_timestamp"])
+        push_interaction(interaction)
+        if combat_result is not None:
+            from world.scenes.power_ledger_services import persist_power_ledger  # noqa: PLC0415
+
+            persist_power_ledger(interaction=interaction, ledger=combat_result.power_ledger)
+
+    target_label = target.name if target is not None else None
+    narration = render_action_outcome_narration(
+        actor_label=str(participant),
+        technique_name=technique.name,
+        target_label=target_label,
+        outcome=outcome,
+        power_ledger=combat_result.power_ledger if combat_result is not None else None,
+    )
+    broadcast_action_outcome(encounter=participant.encounter, narration=narration)
+
+
 def _resolve_pc_action(
     participant: CombatParticipant,
     action: CombatRoundAction,
@@ -3231,43 +3347,14 @@ def _resolve_pc_action(
         action.effort_level,
     )
 
-    # Create the ACTION-mode Interaction, link it, and broadcast it live.
-    from world.combat.interaction_services import (  # noqa: PLC0415
-        broadcast_action_outcome,
-        create_action_interaction,
-        render_action_declaration_label,
-        render_action_outcome_narration,
-    )
-    from world.scenes.interaction_services import push_interaction  # noqa: PLC0415
-
-    interaction = create_action_interaction(
+    _record_and_broadcast_pc_action(
         participant=participant,
-        round_number=action.round_number,
-        summary_label=render_action_declaration_label(action),
-    )
-    if interaction is not None:
-        action.interaction = interaction
-        action.interaction_timestamp = interaction.timestamp
-        action.save(update_fields=["interaction", "interaction_timestamp"])
-        push_interaction(interaction)
-        if combat_result is not None:
-            from world.scenes.power_ledger_services import persist_power_ledger  # noqa: PLC0415
-
-            persist_power_ledger(interaction=interaction, ledger=combat_result.power_ledger)
-
-    # Broadcast a durable, Narrator-authored OUTCOME line for this action.
-    # The power_ledger is threaded from the combat resolver (magic pipeline) so
-    # narration can fold in ward/environment drama clauses. Combo paths and
-    # unconfirmed casts produce no ledger (combat_result is None).
-    target_label = target.name if target is not None else None
-    narration = render_action_outcome_narration(
-        actor_label=str(participant),
-        technique_name=technique.name,
-        target_label=target_label,
+        action=action,
+        technique=technique,
+        target=target,
         outcome=outcome,
-        power_ledger=combat_result.power_ledger if combat_result is not None else None,
+        combat_result=combat_result,
     )
-    broadcast_action_outcome(encounter=participant.encounter, narration=narration)
 
     return outcome
 
@@ -4199,6 +4286,27 @@ def _try_interpose(
         )
 
 
+def _bind_interpose_challenges_any_ally(
+    template: object,
+    room: object,
+    interposer_participant_id: int,
+    active_participants_by_id: dict[int, CombatParticipant],
+) -> None:
+    """Bind a ChallengeInstance to every active participant except the interposer."""
+    from world.mechanics.models import ChallengeInstance  # noqa: PLC0415
+
+    for part_id, part in active_participants_by_id.items():
+        if part_id == interposer_participant_id:
+            continue
+        ally_char = part.character_sheet.character
+        ChallengeInstance.objects.get_or_create(
+            template=template,
+            target_object=ally_char,
+            is_active=True,
+            defaults={"location": room, "is_revealed": True},
+        )
+
+
 def _ensure_interpose_challenges(
     encounter: CombatEncounter,
     pc_actions: dict[int, CombatRoundAction],
@@ -4247,15 +4355,6 @@ def _ensure_interpose_challenges(
     # select_related prevents N+1 when accessing .character_sheet.character below.
     active_participants_by_id: dict[int, CombatParticipant] | None = None
 
-    def _get_active_participants() -> dict[int, CombatParticipant]:
-        return {
-            p.pk: p
-            for p in CombatParticipant.objects.filter(
-                encounter=encounter,
-                status=ParticipantStatus.ACTIVE,
-            ).select_related("character_sheet__character")
-        }
-
     for action in interpose_actions:
         interposer_participant_id = action.participant_id
 
@@ -4271,17 +4370,16 @@ def _ensure_interpose_challenges(
         else:
             # Any-ally path: bind to every active participant except the interposer.
             if active_participants_by_id is None:
-                active_participants_by_id = _get_active_participants()
-            for part_id, part in active_participants_by_id.items():
-                if part_id == interposer_participant_id:
-                    continue
-                ally_char = part.character_sheet.character
-                ChallengeInstance.objects.get_or_create(
-                    template=template,
-                    target_object=ally_char,
-                    is_active=True,
-                    defaults={"location": room, "is_revealed": True},
-                )
+                active_participants_by_id = {
+                    p.pk: p
+                    for p in CombatParticipant.objects.filter(
+                        encounter=encounter,
+                        status=ParticipantStatus.ACTIVE,
+                    ).select_related("character_sheet__character")
+                }
+            _bind_interpose_challenges_any_ally(
+                template, room, interposer_participant_id, active_participants_by_id
+            )
 
 
 def apply_interpose_outcome(

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -2252,6 +2252,35 @@ def decay_all_conditions_tick() -> DecayTickSummary:
     )
 
 
+def _compute_chronic_damage(instance: "ConditionInstance") -> int:
+    """Sum long-term DoT damage for one condition instance.
+
+    Applies per-row severity and stacks scaling; rows that resolve to ≤0 are ignored.
+    """
+    total = 0
+    long_term_rows = ConditionDamageOverTime.objects.filter(
+        condition=instance.condition,
+        is_long_term=True,
+    )
+    for dot in long_term_rows:
+        damage = dot.base_damage
+        if dot.scales_with_severity:
+            damage = int(damage * instance.effective_severity)
+        if dot.scales_with_stacks:
+            damage = damage * instance.stacks
+        if damage > 0:
+            total += damage
+    return total
+
+
+def _chronic_tick_sheet(instance: "ConditionInstance") -> "object | None":
+    """Return the character sheet for the instance's target, or None if absent."""
+    try:
+        return instance.target.sheet_data
+    except ObjectDoesNotExist:
+        return None
+
+
 def batch_chronic_effect_tick() -> ChronicTickSummary:
     """Scheduler entry point. Advance long-term (chronic) DoT by one tick.
 
@@ -2291,28 +2320,12 @@ def batch_chronic_effect_tick() -> ChronicTickSummary:
     for instance in instances:
         summary.examined += 1
 
-        try:
-            sheet = instance.target.sheet_data
-        except ObjectDoesNotExist:
-            sheet = None
+        sheet = _chronic_tick_sheet(instance)
         if sheet is not None and get_active_round_context(sheet) is not None:
             summary.active_round_skipped += 1
             continue
 
-        total = 0
-        long_term_rows = ConditionDamageOverTime.objects.filter(
-            condition=instance.condition,
-            is_long_term=True,
-        )
-        for dot in long_term_rows:
-            damage = dot.base_damage
-            if dot.scales_with_severity:
-                damage = int(damage * instance.effective_severity)
-            if dot.scales_with_stacks:
-                damage = damage * instance.stacks
-            if damage > 0:
-                total += damage
-
+        total = _compute_chronic_damage(instance)
         if total > 0 and sheet is not None:
             removed = apply_clamped_chronic_damage(sheet, total)
             if removed > 0:

--- a/src/world/consent/factories.py
+++ b/src/world/consent/factories.py
@@ -13,6 +13,8 @@ from world.consent.models import (
     SocialConsentWhitelist,
 )
 
+_ROSTER_TENURE_FACTORY = "world.roster.factories.RosterTenureFactory"
+
 
 class ConsentGroupFactory(DjangoModelFactory):
     """Factory for creating ConsentGroup instances."""
@@ -20,7 +22,7 @@ class ConsentGroupFactory(DjangoModelFactory):
     class Meta:
         model = ConsentGroup
 
-    owner = factory.SubFactory("world.roster.factories.RosterTenureFactory")
+    owner = factory.SubFactory(_ROSTER_TENURE_FACTORY)
     name = factory.Sequence(lambda n: f"Group {n}")
 
 
@@ -31,7 +33,7 @@ class ConsentGroupMemberFactory(DjangoModelFactory):
         model = ConsentGroupMember
 
     group = factory.SubFactory(ConsentGroupFactory)
-    tenure = factory.SubFactory("world.roster.factories.RosterTenureFactory")
+    tenure = factory.SubFactory(_ROSTER_TENURE_FACTORY)
 
 
 class SocialConsentCategoryFactory(DjangoModelFactory):
@@ -48,7 +50,7 @@ class SocialConsentPreferenceFactory(DjangoModelFactory):
     class Meta:
         model = SocialConsentPreference
 
-    tenure = factory.SubFactory("world.roster.factories.RosterTenureFactory")
+    tenure = factory.SubFactory(_ROSTER_TENURE_FACTORY)
     allow_social_actions = True
 
 
@@ -65,8 +67,8 @@ class SocialConsentWhitelistFactory(DjangoModelFactory):
     class Meta:
         model = SocialConsentWhitelist
 
-    owner_tenure = factory.SubFactory("world.roster.factories.RosterTenureFactory")
-    allowed_tenure = factory.SubFactory("world.roster.factories.RosterTenureFactory")
+    owner_tenure = factory.SubFactory(_ROSTER_TENURE_FACTORY)
+    allowed_tenure = factory.SubFactory(_ROSTER_TENURE_FACTORY)
     category = factory.SubFactory(SocialConsentCategoryFactory)
 
 

--- a/src/world/covenants/factories.py
+++ b/src/world/covenants/factories.py
@@ -30,6 +30,8 @@ from world.covenants.models import (
 )
 from world.items.constants import GearArchetype
 
+CHARACTER_SHEET_FACTORY = "world.character_sheets.factories.CharacterSheetFactory"
+
 if TYPE_CHECKING:
     from world.conditions.models import CapabilityType
     from world.magic.models import Resonance
@@ -147,7 +149,7 @@ class CharacterCovenantRoleFactory(factory_django.DjangoModelFactory):
     class Meta:
         model = CharacterCovenantRole
 
-    character_sheet = factory.SubFactory("world.character_sheets.factories.CharacterSheetFactory")
+    character_sheet = factory.SubFactory(CHARACTER_SHEET_FACTORY)
     covenant = factory.SubFactory(CovenantFactory)
     covenant_role = factory.SubFactory(CovenantRoleFactory)
     rank = factory.LazyAttribute(lambda o: CovenantRankFactory(covenant=o.covenant))
@@ -237,8 +239,8 @@ class MentorBondFactory(factory_django.DjangoModelFactory):
         model = MentorBond
 
     covenant = factory.SubFactory(CovenantFactory)
-    mentor_sheet = factory.SubFactory("world.character_sheets.factories.CharacterSheetFactory")
-    sidekick_sheet = factory.SubFactory("world.character_sheets.factories.CharacterSheetFactory")
+    mentor_sheet = factory.SubFactory(CHARACTER_SHEET_FACTORY)
+    sidekick_sheet = factory.SubFactory(CHARACTER_SHEET_FACTORY)
     adjusted_party = MentorBondAdjusted.SIDEKICK
     dissolved_at = None
 

--- a/src/world/covenants/models.py
+++ b/src/world/covenants/models.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 # Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
 ACCOUNT_DB_MODEL = "accounts.AccountDB"
+COVENANT_MODEL = "covenants.Covenant"
 COVENANT_ROLE_MODEL = "covenants.CovenantRole"
 CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
 CONDITION_TEMPLATE_MODEL = "conditions.ConditionTemplate"
@@ -265,6 +266,43 @@ class CovenantRole(SharedMemoryModel):
             ),
         ]
 
+    def _clean_subrole(self) -> None:
+        if self.unlock_thread_level == 0:
+            raise ValidationError(
+                {"unlock_thread_level": "Sub-roles must have unlock_thread_level > 0."}
+            )
+        parent = self.parent_role
+        if parent.covenant_type != self.covenant_type:
+            raise ValidationError(
+                {"covenant_type": "Sub-role covenant_type must match parent_role.covenant_type."}
+            )
+        if parent.archetype != self.archetype:
+            raise ValidationError(
+                {"archetype": "Sub-role archetype must match parent_role.archetype."}
+            )
+        if parent.parent_role_id is not None:
+            raise ValidationError(
+                {"parent_role": "Sub-sub-roles are not allowed (single-depth only)."}
+            )
+
+    def _clean_primary_role(self) -> None:
+        if self.discovery_achievement_id is not None or self.codex_entry_id is not None:
+            raise ValidationError(
+                {
+                    "discovery_achievement": (
+                        "Only sub-roles may set discovery_achievement / codex_entry."
+                    )
+                }
+            )
+        if self.unlock_thread_level != 0:
+            raise ValidationError(
+                {
+                    "unlock_thread_level": (
+                        "Primary roles (no parent_role/resonance) must have unlock_thread_level=0."
+                    )
+                }
+            )
+
     def clean(self) -> None:
         super().clean()
         has_parent = self.parent_role_id is not None
@@ -279,47 +317,9 @@ class CovenantRole(SharedMemoryModel):
             raise ValidationError({"parent_role": msg, "resonance": msg})
 
         if has_parent and has_resonance:
-            # Sub-role rules
-            if self.unlock_thread_level == 0:
-                raise ValidationError(
-                    {"unlock_thread_level": "Sub-roles must have unlock_thread_level > 0."}
-                )
-            parent = self.parent_role
-            if parent.covenant_type != self.covenant_type:
-                raise ValidationError(
-                    {
-                        "covenant_type": (
-                            "Sub-role covenant_type must match parent_role.covenant_type."
-                        )
-                    }
-                )
-            if parent.archetype != self.archetype:
-                raise ValidationError(
-                    {"archetype": "Sub-role archetype must match parent_role.archetype."}
-                )
-            if parent.parent_role_id is not None:
-                raise ValidationError(
-                    {"parent_role": "Sub-sub-roles are not allowed (single-depth only)."}
-                )
-        # Primary role rules
+            self._clean_subrole()
         else:
-            if self.discovery_achievement_id is not None or self.codex_entry_id is not None:
-                raise ValidationError(
-                    {
-                        "discovery_achievement": (
-                            "Only sub-roles may set discovery_achievement / codex_entry."
-                        )
-                    }
-                )
-            if self.unlock_thread_level != 0:
-                raise ValidationError(
-                    {
-                        "unlock_thread_level": (
-                            "Primary roles (no parent_role/resonance) must have"
-                            " unlock_thread_level=0."
-                        )
-                    }
-                )
+            self._clean_primary_role()
 
     def __str__(self) -> str:
         return f"{self.name} ({self.get_covenant_type_display()})"
@@ -362,7 +362,7 @@ class CovenantRank(SharedMemoryModel):
     """
 
     covenant = models.ForeignKey(
-        "covenants.Covenant",
+        COVENANT_MODEL,
         on_delete=models.CASCADE,
         related_name="ranks",
     )
@@ -423,7 +423,7 @@ class CharacterCovenantRole(SharedMemoryModel):
         related_name="character_assignments",
     )
     covenant = models.ForeignKey(
-        "covenants.Covenant",
+        COVENANT_MODEL,
         on_delete=models.PROTECT,
         related_name="memberships",
     )
@@ -698,7 +698,7 @@ class CovenantRiteInstance(SharedMemoryModel):
         related_name="instances",
     )
     covenant = models.ForeignKey(
-        "covenants.Covenant",
+        COVENANT_MODEL,
         on_delete=models.PROTECT,
         related_name="rite_instances",
     )
@@ -833,7 +833,7 @@ class MentorBond(SharedMemoryModel):
     """
 
     covenant = models.ForeignKey(
-        "covenants.Covenant",
+        COVENANT_MODEL,
         on_delete=models.CASCADE,
         related_name="mentor_bonds",
     )

--- a/src/world/forms/factories.py
+++ b/src/world/forms/factories.py
@@ -22,6 +22,8 @@ from world.forms.models import (
 )
 from world.species.factories import SpeciesFactory
 
+_TRAIT_SELF_REF = "..trait"
+
 
 class HeightBandFactory(factory.django.DjangoModelFactory):
     class Meta:
@@ -101,7 +103,9 @@ class CharacterFormValueFactory(factory.django.DjangoModelFactory):
 
     form = factory.SubFactory(CharacterFormFactory)
     trait = factory.SubFactory(FormTraitFactory)
-    option = factory.SubFactory(FormTraitOptionFactory, trait=factory.SelfAttribute("..trait"))
+    option = factory.SubFactory(
+        FormTraitOptionFactory, trait=factory.SelfAttribute(_TRAIT_SELF_REF)
+    )
     natural_option = factory.SelfAttribute("option")
 
 
@@ -120,7 +124,9 @@ class TemporaryFormChangeFactory(factory.django.DjangoModelFactory):
 
     character = factory.SubFactory(CharacterFactory)
     trait = factory.SubFactory(FormTraitFactory)
-    option = factory.SubFactory(FormTraitOptionFactory, trait=factory.SelfAttribute("..trait"))
+    option = factory.SubFactory(
+        FormTraitOptionFactory, trait=factory.SelfAttribute(_TRAIT_SELF_REF)
+    )
     source_type = SourceType.SYSTEM
     source_id = None
     duration_type = DurationType.UNTIL_REMOVED
@@ -145,8 +151,12 @@ class AppearanceChangeLogFactory(factory.django.DjangoModelFactory):
     form = factory.SubFactory(CharacterFormFactory)
     persona = factory.SubFactory("world.scenes.factories.PersonaFactory")
     trait = factory.SubFactory(FormTraitFactory)
-    from_option = factory.SubFactory(FormTraitOptionFactory, trait=factory.SelfAttribute("..trait"))
-    to_option = factory.SubFactory(FormTraitOptionFactory, trait=factory.SelfAttribute("..trait"))
+    from_option = factory.SubFactory(
+        FormTraitOptionFactory, trait=factory.SelfAttribute(_TRAIT_SELF_REF)
+    )
+    to_option = factory.SubFactory(
+        FormTraitOptionFactory, trait=factory.SelfAttribute(_TRAIT_SELF_REF)
+    )
     from_text = ""
     to_text = "Crimson"
     actor_persona = factory.SelfAttribute("persona")

--- a/src/world/forms/models.py
+++ b/src/world/forms/models.py
@@ -7,6 +7,8 @@ from evennia.utils.idmapper.models import SharedMemoryModel
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.species.models import Species
 
+SCENES_PERSONA_FK = "scenes.Persona"
+
 
 class TraitType(models.TextChoices):
     COLOR = "color", "Color"
@@ -386,7 +388,7 @@ class PersonaTraitDescriptor(SharedMemoryModel):
     """
 
     persona = models.ForeignKey(
-        "scenes.Persona",
+        SCENES_PERSONA_FK,
         on_delete=models.CASCADE,
         related_name="trait_descriptors",
         help_text="The presented face this descriptor belongs to.",
@@ -427,7 +429,7 @@ class AppearanceChangeLog(SharedMemoryModel):
         help_text="The real form whose trait was edited.",
     )
     persona = models.ForeignKey(
-        "scenes.Persona",
+        SCENES_PERSONA_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -446,7 +448,7 @@ class AppearanceChangeLog(SharedMemoryModel):
     from_text = models.CharField(max_length=120, blank=True, help_text="Prior descriptor.")
     to_text = models.CharField(max_length=120, blank=True, help_text="New descriptor.")
     actor_persona = models.ForeignKey(
-        "scenes.Persona",
+        SCENES_PERSONA_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/src/world/items/models.py
+++ b/src/world/items/models.py
@@ -30,6 +30,7 @@ from world.items.constants import (
 # duplicated-literal SonarCloud smell (python:S1192).
 _CHARACTER_SHEET_FK = "character_sheets.CharacterSheet"
 _PERSONA_FK = "scenes.Persona"
+_ITEM_INSTANCE_FK = "items.ItemInstance"
 SOCIETY_MODEL = "societies.Society"
 CHECK_TYPE_MODEL = "checks.CheckType"
 FACET_MODEL = "magic.Facet"
@@ -942,7 +943,7 @@ class ItemFacet(ItemAttachment):
     """
 
     item_instance = models.ForeignKey(
-        "items.ItemInstance",
+        _ITEM_INSTANCE_FK,
         on_delete=models.CASCADE,
         related_name="item_facets",
     )
@@ -973,7 +974,7 @@ class ItemStyle(ItemAttachment):
     """
 
     item_instance = models.ForeignKey(
-        "items.ItemInstance",
+        _ITEM_INSTANCE_FK,
         on_delete=models.CASCADE,
         related_name="item_styles",
     )
@@ -1328,7 +1329,7 @@ class Mantle(SharedMemoryModel):
     """
 
     item_instance = models.OneToOneField(
-        "items.ItemInstance",
+        _ITEM_INSTANCE_FK,
         on_delete=models.PROTECT,
         related_name="mantle",
         help_text="The unique ItemInstance that is this Mantle.",

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -1489,7 +1489,7 @@ class EntryFlourishRecordFactory(factory.django.DjangoModelFactory):
         model = "magic.EntryFlourishRecord"
 
     character_sheet = factory.SubFactory("world.character_sheets.factories.CharacterSheetFactory")
-    resonance = factory.SubFactory("world.magic.factories.ResonanceFactory")
+    resonance = factory.SubFactory(ResonanceFactory)
     scene = None
     granted_amount = 10
 
@@ -1501,7 +1501,7 @@ class DramaticMomentTypeFactory(factory.django.DjangoModelFactory):
 
     label = factory.Sequence(lambda n: f"DramaticMomentType{n}")
     description = factory.Faker("sentence")
-    resonance = factory.SubFactory("world.magic.factories.ResonanceFactory")
+    resonance = factory.SubFactory(ResonanceFactory)
     resonance_amount = 15
     magnitude = "small"
     risk = "none"
@@ -1779,7 +1779,7 @@ class SineatingFactory(factory.django.DjangoModelFactory):
     sineater_sheet = factory.SubFactory("world.character_sheets.factories.CharacterSheetFactory")
     relationship = factory.SubFactory("world.relationships.factories.CharacterRelationshipFactory")
     scene = None
-    resonance = factory.SubFactory("world.magic.factories.ResonanceFactory")
+    resonance = factory.SubFactory(ResonanceFactory)
     units_offered = 5
     units_accepted = 5
     anima_cost = 10
@@ -1796,7 +1796,7 @@ class SoulTetherRescueFactory(factory.django.DjangoModelFactory):
     sineater_sheet = factory.SubFactory("world.character_sheets.factories.CharacterSheetFactory")
     relationship = factory.SubFactory("world.relationships.factories.CharacterRelationshipFactory")
     scene = None
-    resonance = factory.SubFactory("world.magic.factories.ResonanceFactory")
+    resonance = factory.SubFactory(ResonanceFactory)
     sinner_stage_at_start = 4
     sinner_stage_at_end = 3
     severity_reduced = 5

--- a/src/world/magic/models/endorsement.py
+++ b/src/world/magic/models/endorsement.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+CHARACTER_SHEET_FK = "character_sheets.CharacterSheet"
+RESONANCE_FK = "magic.Resonance"
+SCENE_FK = "scenes.Scene"
+
 
 class EndorsementBase(SharedMemoryModel):
     """Shared identity fields for peer-endorsement records (#514).
@@ -17,12 +21,12 @@ class EndorsementBase(SharedMemoryModel):
     """
 
     endorser_sheet = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_FK,
         on_delete=models.CASCADE,
         related_name="%(class)s_given",
     )
     endorsee_sheet = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_FK,
         on_delete=models.CASCADE,
         related_name="%(class)s_received",
     )
@@ -60,7 +64,7 @@ class PoseEndorsement(EndorsementBase):
         "with partitioned table",
     )
     resonance = models.ForeignKey(
-        "magic.Resonance",
+        RESONANCE_FK,
         on_delete=models.PROTECT,
     )
     settled_at = models.DateTimeField(null=True, blank=True, db_index=True)
@@ -98,7 +102,7 @@ class SceneEntryEndorsement(EndorsementBase):
     """
 
     scene = models.ForeignKey(
-        "scenes.Scene",
+        SCENE_FK,
         on_delete=models.CASCADE,
         related_name="entry_endorsements",
     )
@@ -119,7 +123,7 @@ class SceneEntryEndorsement(EndorsementBase):
         "FK with partitioned table",
     )
     resonance = models.ForeignKey(
-        "magic.Resonance",
+        RESONANCE_FK,
         on_delete=models.PROTECT,
     )
     granted_amount = models.PositiveIntegerField(
@@ -180,12 +184,12 @@ class StylePresentationEndorsement(EndorsementBase):
     """
 
     scene = models.ForeignKey(
-        "scenes.Scene",
+        SCENE_FK,
         on_delete=models.CASCADE,
         related_name="style_presentation_endorsements",
     )
     resonance = models.ForeignKey(
-        "magic.Resonance",
+        RESONANCE_FK,
         on_delete=models.PROTECT,
     )
     granted_amount = models.PositiveIntegerField(
@@ -218,17 +222,17 @@ class EntryFlourishRecord(SharedMemoryModel):
     """
 
     character_sheet = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_FK,
         on_delete=models.CASCADE,
         related_name="entry_flourish_records",
     )
     resonance = models.ForeignKey(
-        "magic.Resonance",
+        RESONANCE_FK,
         on_delete=models.PROTECT,
         related_name="entry_flourish_records",
     )
     scene = models.ForeignKey(
-        "scenes.Scene",
+        SCENE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/src/world/magic/services/gain.py
+++ b/src/world/magic/services/gain.py
@@ -121,6 +121,8 @@ def get_resonance_gain_config() -> ResonanceGainConfig:
 
 
 ROOM_RESONANCE_TAG_SOURCE = "tag_room_resonance"
+_ERR_ALT_ENDORSE = "Cannot endorse an alt character"
+_ERR_RESONANCE_UNCLAIMED = "Endorsee has not claimed this resonance"
 
 
 @transaction.atomic
@@ -260,7 +262,7 @@ def create_pose_endorsement(  # noqa: C901
         and endorsee_account is not None
         and endorser_account == endorsee_account
     ):
-        msg = "Cannot endorse an alt character"
+        msg = _ERR_ALT_ENDORSE
         raise EndorsementValidationError(msg)
 
     if interaction.mode == InteractionMode.WHISPER:
@@ -278,7 +280,7 @@ def create_pose_endorsement(  # noqa: C901
     if not CharacterResonance.objects.filter(
         character_sheet=endorsee_sheet, resonance=resonance
     ).exists():
-        msg = "Endorsee has not claimed this resonance"
+        msg = _ERR_RESONANCE_UNCLAIMED
         raise EndorsementValidationError(msg)
 
     existing = PoseEndorsement.objects.filter(
@@ -411,7 +413,7 @@ def create_scene_entry_endorsement(
         and endorsee_account is not None
         and endorser_account == endorsee_account
     ):
-        msg = "Cannot endorse an alt character"
+        msg = _ERR_ALT_ENDORSE
         raise EndorsementValidationError(msg)
 
     if endorser_account is None:
@@ -424,7 +426,7 @@ def create_scene_entry_endorsement(
     if not CharacterResonance.objects.filter(
         character_sheet=endorsee_sheet, resonance=resonance
     ).exists():
-        msg = "Endorsee has not claimed this resonance"
+        msg = _ERR_RESONANCE_UNCLAIMED
         raise EndorsementValidationError(msg)
 
     # Find the endorsee's entry pose in this scene.
@@ -570,7 +572,7 @@ def create_style_presentation_endorsement(
         and endorsee_account is not None
         and endorser_account == endorsee_account
     ):
-        msg = "Cannot endorse an alt character"
+        msg = _ERR_ALT_ENDORSE
         raise EndorsementValidationError(msg)
 
     if not _endorser_can_see_scene(endorser_account, scene):
@@ -580,7 +582,7 @@ def create_style_presentation_endorsement(
     if not CharacterResonance.objects.filter(
         character_sheet=endorsee_sheet, resonance=resonance
     ).exists():
-        msg = "Endorsee has not claimed this resonance"
+        msg = _ERR_RESONANCE_UNCLAIMED
         raise EndorsementValidationError(msg)
 
     if not _endorsee_wears_bound_style(endorsee_sheet, resonance):

--- a/src/world/mechanics/effect_handlers.py
+++ b/src/world/mechanics/effect_handlers.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SKIP_ATTACK = "Attack system not yet implemented."
+_NO_SHEET_DESCRIPTION = "Target has no character sheet"
+_NO_SHEET_SKIP_REASON = "Target has no CharacterSheet"
 
 # Role constants for _resolve_position — discriminate named-lookup variants.
 _ROLE_DESTINATION = "destination"
@@ -381,9 +383,9 @@ def _apply_magical_scars(
     except (AttributeError, ObjectDoesNotExist):
         return AppliedEffect(
             effect_type=EffectType.MAGICAL_SCARS,
-            description="Target has no character sheet",
+            description=_NO_SHEET_DESCRIPTION,
             applied=False,
-            skip_reason="Target has no CharacterSheet",
+            skip_reason=_NO_SHEET_SKIP_REASON,
         )
 
     affinity, resonance = _derive_alteration_origin(target)
@@ -453,9 +455,9 @@ def _apply_capture(
     except (AttributeError, ObjectDoesNotExist):
         return AppliedEffect(
             effect_type=EffectType.CAPTURE,
-            description="Target has no character sheet",
+            description=_NO_SHEET_DESCRIPTION,
             applied=False,
-            skip_reason="Target has no CharacterSheet",
+            skip_reason=_NO_SHEET_SKIP_REASON,
         )
 
     # Per-capture override layered over the one CaptivityConfig default — cell flavor,
@@ -742,9 +744,9 @@ def _apply_escape_captivity(
     except (AttributeError, ObjectDoesNotExist):
         return AppliedEffect(
             effect_type=EffectType.ESCAPE_CAPTIVITY,
-            description="Target has no character sheet",
+            description=_NO_SHEET_DESCRIPTION,
             applied=False,
-            skip_reason="Target has no CharacterSheet",
+            skip_reason=_NO_SHEET_SKIP_REASON,
         )
 
     if not escape_captivity(sheet):

--- a/src/world/scenes/action_models.py
+++ b/src/world/scenes/action_models.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from world.scenes.models import Persona
 
 _PERSONA_MODEL = "scenes.Persona"
+_INTERACTION_MODEL = "scenes.Interaction"
 
 
 class DefenderConsentFields(models.Model):
@@ -204,7 +205,7 @@ class SceneActionRequest(CommittingDeclaration, DefenderConsentFields, SharedMem
         db_index=True,
     )
     result_interaction = models.OneToOneField(
-        "scenes.Interaction",
+        _INTERACTION_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -213,7 +214,7 @@ class SceneActionRequest(CommittingDeclaration, DefenderConsentFields, SharedMem
         help_text="The interaction recording the result of this action",
     )
     action_interaction = models.OneToOneField(
-        "scenes.Interaction",
+        _INTERACTION_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -281,7 +282,7 @@ class SceneActionTarget(DefenderConsentFields, SharedMemoryModel):
         db_index=True,
     )
     result_interaction = models.OneToOneField(
-        "scenes.Interaction",
+        _INTERACTION_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -301,6 +301,37 @@ def _snapshot_kwargs_from_ritual(ritual_id: int) -> dict[str, object]:
     }
 
 
+def _compute_difficulty_override_for_primary(
+    action_request: SceneActionRequest,
+    resist_effort: str,
+) -> int | None:
+    """Compute the difficulty override for the primary target, applying resist fatigue if needed.
+
+    Returns None when there is no primary target (area/standalone-cast requests).
+    """
+    if action_request.target_persona is None:
+        return None
+    from actions.constants import ActionCategory  # noqa: PLC0415
+    from world.checks.services import compute_resist_increment  # noqa: PLC0415
+    from world.fatigue.services import apply_fatigue  # noqa: PLC0415
+
+    base = DIFFICULTY_VALUES[action_request.difficulty_choice]
+    if resist_effort:
+        increment = compute_resist_increment(
+            action_request.target_persona.character_sheet.character,
+            resist_effort,
+        )
+        apply_fatigue(
+            action_request.target_persona.character_sheet,
+            ActionCategory.SOCIAL,
+            RESIST_FATIGUE_BASE,
+            resist_effort,
+        )
+    else:
+        increment = 0
+    return base + increment
+
+
 def respond_to_action_request(
     *,
     action_request: SceneActionRequest,
@@ -361,29 +392,9 @@ def respond_to_action_request(
 
                 result = resolve_accepted_cast(action_request)
             else:
-                # Compute resistance increment and charge defender fatigue when
-                # resist_effort is declared and there is a primary target.
-                difficulty_override: int | None = None
-                if action_request.target_persona is not None:
-                    from actions.constants import ActionCategory  # noqa: PLC0415
-                    from world.checks.services import compute_resist_increment  # noqa: PLC0415
-                    from world.fatigue.services import apply_fatigue  # noqa: PLC0415
-
-                    base = DIFFICULTY_VALUES[action_request.difficulty_choice]
-                    if resist_effort:
-                        increment = compute_resist_increment(
-                            action_request.target_persona.character_sheet.character,
-                            resist_effort,
-                        )
-                        apply_fatigue(
-                            action_request.target_persona.character_sheet,
-                            ActionCategory.SOCIAL,
-                            RESIST_FATIGUE_BASE,
-                            resist_effort,
-                        )
-                    else:
-                        increment = 0
-                    difficulty_override = base + increment
+                difficulty_override = _compute_difficulty_override_for_primary(
+                    action_request, resist_effort
+                )
                 result = _resolve_standard_action(
                     action_request, difficulty_override=difficulty_override
                 )

--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -86,10 +86,36 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
             .order_by("-created_at")
         )
 
+    @staticmethod
+    def _validate_cardinality(action_key: str, target_ids: list[int]) -> None:
+        """Raise DRFValidationError if target_ids conflict with the action's target_type."""
+        registered_action = get_action(action_key)
+        cardinality = (
+            registered_action.target_type if registered_action is not None else TargetType.SINGLE
+        )
+        if cardinality == TargetType.SINGLE and len(target_ids) > 1:
+            raise DRFValidationError(
+                {"target_persona_ids": "This action targets a single persona."}
+            )
+        if cardinality in (TargetType.AREA, TargetType.FILTERED_GROUP) and not target_ids:
+            raise DRFValidationError(
+                {"target_persona_ids": "This action requires at least one target."}
+            )
+        if cardinality == TargetType.SELF and target_ids:
+            raise DRFValidationError({"target_persona_ids": "This action targets the caster only."})
+
+    @staticmethod
+    def _resolve_delivery_receivers(receiver_ids: list[int]) -> tuple[list[Persona], bool]:
+        """Return (resolved_personas, all_found). ``all_found`` is False if any id is missing."""
+        if not receiver_ids:
+            return [], True
+        delivery_receivers = list(Persona.objects.filter(pk__in=receiver_ids))
+        return delivery_receivers, len(delivery_receivers) == len(set(receiver_ids))
+
     @extend_schema(
         request=SceneActionRequestCreateSerializer, responses=SceneActionRequestSerializer
     )
-    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: C901
+    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Create a new action request."""
         serializer = SceneActionRequestCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -107,23 +133,7 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
         target_ids: list[int] = serializer.validated_data["target_ids"]
         effort_level: str = serializer.validated_data["effort_level"]
 
-        # Cardinality validation: enforce the action's target_type against the
-        # normalised target_ids list.  Unknown / unregistered actions default to
-        # SINGLE (conservative — avoids silent multi-target dispatch).
-        registered_action = get_action(action_key)
-        cardinality = (
-            registered_action.target_type if registered_action is not None else TargetType.SINGLE
-        )
-        if cardinality == TargetType.SINGLE and len(target_ids) > 1:
-            raise DRFValidationError(
-                {"target_persona_ids": "This action targets a single persona."}
-            )
-        if cardinality in (TargetType.AREA, TargetType.FILTERED_GROUP) and not target_ids:
-            raise DRFValidationError(
-                {"target_persona_ids": "This action requires at least one target."}
-            )
-        if cardinality == TargetType.SELF and target_ids:
-            raise DRFValidationError({"target_persona_ids": "This action targets the caster only."})
+        self._validate_cardinality(action_key, target_ids)
 
         try:
             scene = Scene.objects.get(pk=scene_id, is_active=True)
@@ -158,14 +168,12 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
 
         delivery = serializer.validated_data.get("delivery", "")
         receiver_ids = serializer.validated_data.get("delivery_receiver_ids", [])
-        delivery_receivers: list[Persona] = []
-        if receiver_ids:
-            delivery_receivers = list(Persona.objects.filter(pk__in=receiver_ids))
-            if len(delivery_receivers) != len(set(receiver_ids)):
-                return Response(
-                    {"detail": "One or more delivery receivers not found."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+        delivery_receivers, all_found = self._resolve_delivery_receivers(receiver_ids)
+        if not all_found:
+            return Response(
+                {"detail": "One or more delivery receivers not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         try:
             action_request = create_action_request(
@@ -294,6 +302,19 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
 
         return Response(response_data)
 
+    @staticmethod
+    def _resolve_supplied_personas(
+        target_persona_ids: list[int] | None,
+    ) -> tuple[list[Persona] | None, bool]:
+        """Resolve FILTERED_GROUP picker ids to Persona objects.
+
+        Returns ``(resolved, all_found)``. ``resolved`` is None when no ids supplied.
+        """
+        if target_persona_ids is None:
+            return None, True
+        supplied = list(Persona.objects.filter(pk__in=target_persona_ids))
+        return supplied, len(supplied) == len(set(target_persona_ids))
+
     @extend_schema(
         request=TechniqueCastCreateSerializer,
         responses={201: SceneActionRequestSerializer},
@@ -324,7 +345,6 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
         initiator_persona_id = vd["initiator_persona"]
         technique_id = vd["technique_id"]
         target_persona_id = vd.get("target_persona")
-        target_persona_ids: list[int] | None = vd.get("target_persona_ids") or None
         strain_commitment = vd.get("strain_commitment", 0) or 0
 
         cast_pull = None
@@ -358,14 +378,13 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
             target_persona = get_object_or_404(Persona, pk=target_persona_id)
 
         # Resolve the FILTERED_GROUP picker list, if provided.
-        supplied_personas: list[Persona] | None = None
-        if target_persona_ids is not None:
-            supplied_personas = list(Persona.objects.filter(pk__in=target_persona_ids))
-            if len(supplied_personas) != len(set(target_persona_ids)):
-                return Response(
-                    {"detail": "One or more target personas not found."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+        raw_target_ids: list[int] | None = vd.get("target_persona_ids") or None
+        supplied_personas, all_found = self._resolve_supplied_personas(raw_target_ids)
+        if not all_found:
+            return Response(
+                {"detail": "One or more target personas not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         technique = get_object_or_404(Technique, pk=technique_id)
 

--- a/src/world/scenes/cast_services.py
+++ b/src/world/scenes/cast_services.py
@@ -431,7 +431,112 @@ def resolve_accepted_cast(
     return result  # result.power_ledger is already set from _resolve_cast
 
 
-def request_technique_cast(  # noqa: PLR0913, C901 - cohesive cast-routing params
+def _guard_area_consent(technique: Technique) -> None:
+    """Raise InvalidCastTarget when a behavior-altering AREA cast would expand without consent."""
+    from actions.constants import ActionTargetType  # noqa: PLC0415
+
+    if technique.target_type != ActionTargetType.AREA or not cast_requires_consent(technique):
+        return
+    if derive_target_relationship(technique) == ConditionTargetKind.ALLY:
+        # TODO(#1321 follow-up): mass-consent state machine for AREA behavior-altering
+        # techniques; per-target consent is not yet supported for multi-target casts.
+        msg = (
+            "Multi-target behavior-altering AREA casts are not yet supported; "
+            "obtain individual consent before casting."
+        )
+        raise InvalidCastTarget(msg)
+
+
+def _route_filtered_group_cast(  # noqa: PLR0913
+    *,
+    scene: Scene,
+    initiator_persona: Persona,
+    technique: Technique,
+    strain_commitment: int,
+    fury_commitment: FuryTier | None,
+    fury_anchor: CharacterSheet | None,
+    cast_pull: CastPullDeclaration | None,
+    supplied_personas: list[Persona],
+) -> CastResult:
+    """Route a FILTERED_GROUP cast that has a player-supplied persona list.
+
+    Raises InvalidCastTarget for hostile or behavior-altering cases (deferred paths).
+    """
+    if is_technique_hostile(technique):
+        # TODO(#1321 follow-up): multi-target hostile FILTERED_GROUP needs
+        # per-target combat seeds; not yet supported.
+        msg = (
+            "Multi-target hostile FILTERED_GROUP casts are not yet supported standalone; "
+            "use combat targeting instead."
+        )
+        raise InvalidCastTarget(msg)
+    if cast_requires_consent(technique):
+        # TODO(#1321 follow-up): behavior-altering FILTERED_GROUP requires a
+        # per-target consent state machine; not yet supported.
+        msg = (
+            "Multi-target behavior-altering FILTERED_GROUP casts are not yet supported; "
+            "obtain individual consent before casting."
+        )
+        raise InvalidCastTarget(msg)
+    return _route_immediate_cast(
+        scene=scene,
+        initiator_persona=initiator_persona,
+        target_persona=None,  # no single primary target; resolve_targets uses supplied_personas
+        technique=technique,
+        strain_commitment=strain_commitment,
+        fury_commitment=fury_commitment,
+        fury_anchor=fury_anchor,
+        cast_pull=cast_pull,
+        supplied_personas=supplied_personas,
+    )
+
+
+def _route_other_pc_cast(  # noqa: PLR0913
+    *,
+    scene: Scene,
+    initiator_persona: Persona,
+    target_persona: Persona,
+    technique: Technique,
+    strain_commitment: int,
+    fury_commitment: FuryTier | None,
+    fury_anchor: CharacterSheet | None,
+    cast_pull: CastPullDeclaration | None,
+) -> CastResult:
+    """Route a cast directed at another PC (not the caster's own sheet)."""
+    if is_technique_hostile(technique):
+        if cast_pull is not None:
+            msg = "Pulls cannot be declared on hostile casts."
+            raise ValidationError(msg)
+        return _route_hostile_cast(
+            scene=scene,
+            initiator_persona=initiator_persona,
+            target_persona=target_persona,
+            technique=technique,
+        )
+    if cast_requires_consent(technique):
+        return _route_benign_cast(
+            scene=scene,
+            initiator_persona=initiator_persona,
+            target_persona=target_persona,
+            technique=technique,
+            strain_commitment=strain_commitment,
+            fury_commitment=fury_commitment,
+            fury_anchor=fury_anchor,
+            cast_pull=cast_pull,
+        )
+    return _route_immediate_cast(
+        scene=scene,
+        initiator_persona=initiator_persona,
+        target_persona=target_persona,
+        technique=technique,
+        strain_commitment=strain_commitment,
+        fury_commitment=fury_commitment,
+        fury_anchor=fury_anchor,
+        cast_pull=cast_pull,
+    )
+
+
+def request_technique_cast(  # noqa: PLR0913
     *,
     scene: Scene,
     initiator_persona: Persona,
@@ -493,45 +598,12 @@ def request_technique_cast(  # noqa: PLR0913, C901 - cohesive cast-routing param
         target_personas=[target_persona] if target_persona is not None else [],
     )
 
-    # AREA technique that requires consent: guard before the immediate route.
-    # Hostile AREA routes to combat; SELF AREA only hits the caster — both safe.
-    # Only behavior-altering ALLY-expanding AREA is the hole: resolve_targets would
-    # silently expand to all other scene personas with no consent step.
-    if technique.target_type == ActionTargetType.AREA and cast_requires_consent(technique):
-        relationship = derive_target_relationship(technique)
-        if relationship == ConditionTargetKind.ALLY:
-            # TODO(#1321 follow-up): mass-consent state machine for AREA behavior-altering
-            # techniques; per-target consent is not yet supported for multi-target casts.
-            msg = (
-                "Multi-target behavior-altering AREA casts are not yet supported; "
-                "obtain individual consent before casting."
-            )
-            raise InvalidCastTarget(msg)
+    _guard_area_consent(technique)
 
-    # FILTERED_GROUP with a player-supplied list: guard the deferred cases, then
-    # resolve immediately for the benign capability / stat-buff path.
     if supplied_personas is not None and technique.target_type == ActionTargetType.FILTERED_GROUP:
-        if is_technique_hostile(technique):
-            # TODO(#1321 follow-up): multi-target hostile FILTERED_GROUP needs
-            # per-target combat seeds; not yet supported.
-            msg = (
-                "Multi-target hostile FILTERED_GROUP casts are not yet supported standalone; "
-                "use combat targeting instead."
-            )
-            raise InvalidCastTarget(msg)
-        if cast_requires_consent(technique):
-            # TODO(#1321 follow-up): behavior-altering FILTERED_GROUP requires a
-            # per-target consent state machine; not yet supported.
-            msg = (
-                "Multi-target behavior-altering FILTERED_GROUP casts are not yet supported; "
-                "obtain individual consent before casting."
-            )
-            raise InvalidCastTarget(msg)
-        # Benign, consent-free FILTERED_GROUP → resolve immediately with the full list.
-        return _route_immediate_cast(
+        return _route_filtered_group_cast(
             scene=scene,
             initiator_persona=initiator_persona,
-            target_persona=None,  # no single primary target; resolve_targets uses supplied_personas
             technique=technique,
             strain_commitment=strain_commitment,
             fury_commitment=fury_commitment,
@@ -546,29 +618,7 @@ def request_technique_cast(  # noqa: PLR0913, C901 - cohesive cast-routing param
         target_persona is not None
         and target_persona.character_sheet_id != initiator_persona.character_sheet_id
     ):
-        if is_technique_hostile(technique):
-            if cast_pull is not None:
-                msg = "Pulls cannot be declared on hostile casts."
-                raise ValidationError(msg)
-            return _route_hostile_cast(
-                scene=scene,
-                initiator_persona=initiator_persona,
-                target_persona=target_persona,
-                technique=technique,
-            )
-        if cast_requires_consent(technique):
-            return _route_benign_cast(
-                scene=scene,
-                initiator_persona=initiator_persona,
-                target_persona=target_persona,
-                technique=technique,
-                strain_commitment=strain_commitment,
-                fury_commitment=fury_commitment,
-                fury_anchor=fury_anchor,
-                cast_pull=cast_pull,
-            )
-        # Benign but no consent required (capability/stat buffs) → immediate resolution.
-        return _route_immediate_cast(
+        return _route_other_pc_cast(
             scene=scene,
             initiator_persona=initiator_persona,
             target_persona=target_persona,

--- a/src/world/scenes/models.py
+++ b/src/world/scenes/models.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 # Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
 CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
 INTERACTION_MODEL = "scenes.Interaction"
+PLAYER_DATA_MODEL = "evennia_extensions.PlayerData"
 
 
 class Scene(CachedPropertiesMixin, SharedMemoryModel):
@@ -529,13 +530,13 @@ class Block(SharedMemoryModel):
     """
 
     owner = models.ForeignKey(
-        "evennia_extensions.PlayerData",
+        PLAYER_DATA_MODEL,
         on_delete=models.CASCADE,
         related_name="blocks_made",
         help_text="The player who created the block (the blocker).",
     )
     blocked_player = models.ForeignKey(
-        "evennia_extensions.PlayerData",
+        PLAYER_DATA_MODEL,
         on_delete=models.CASCADE,
         related_name="blocks_received",
         help_text="The player being blocked.",
@@ -598,7 +599,7 @@ class Mute(SharedMemoryModel):
     """
 
     owner = models.ForeignKey(
-        "evennia_extensions.PlayerData",
+        PLAYER_DATA_MODEL,
         on_delete=models.CASCADE,
         related_name="mutes_made",
         help_text="The player who muted (the muter).",

--- a/src/world/scenes/persona_display.py
+++ b/src/world/scenes/persona_display.py
@@ -48,6 +48,39 @@ def compose_sdesc(persona: Persona) -> str:
     return f"a {noun} wearing a {persona.name}"
 
 
+def _build_revealed_map(
+    fake_ids: list[int],
+    viewer_sheet_ids: set[int],
+) -> dict[int, Persona]:
+    """Query PersonaDiscovery rows and return a mapping of fake persona pk → revealed persona."""
+    if not fake_ids or not viewer_sheet_ids:
+        return {}
+    rows = PersonaDiscovery.objects.filter(
+        Q(persona_id__in=fake_ids) | Q(linked_to_id__in=fake_ids),
+        discovered_by_id__in=viewer_sheet_ids,
+    ).select_related("persona", "linked_to")
+    revealed: dict[int, Persona] = {}
+    for discovery in rows:
+        if discovery.persona_id in fake_ids:
+            revealed[discovery.persona_id] = discovery.linked_to
+        if discovery.linked_to_id in fake_ids:
+            revealed[discovery.linked_to_id] = discovery.persona
+    return revealed
+
+
+def _resolve_single_display(
+    persona: Persona,
+    viewer_persona_ids: set[int],
+    revealed: dict[int, Persona],
+) -> tuple[str, bool]:
+    """Return ``(display_name, is_discovered)`` for one persona given the revealed map."""
+    if persona.pk in viewer_persona_ids or not persona.is_fake_name:
+        return persona.name, False
+    if persona.pk in revealed:
+        return f"{persona.name} ({revealed[persona.pk].name})", True
+    return compose_sdesc(persona), False
+
+
 def build_persona_display_map(
     personas: Iterable[Persona],
     *,
@@ -62,29 +95,11 @@ def build_persona_display_map(
     unique = {p.pk: p for p in personas}
     # Owned faces are never restricted — resolved as the real name without a discovery lookup.
     fake_ids = [p.pk for p in unique.values() if p.is_fake_name and p.pk not in viewer_persona_ids]
-
-    revealed: dict[int, Persona] = {}
-    if fake_ids and viewer_sheet_ids:
-        rows = PersonaDiscovery.objects.filter(
-            Q(persona_id__in=fake_ids) | Q(linked_to_id__in=fake_ids),
-            discovered_by_id__in=viewer_sheet_ids,
-        ).select_related("persona", "linked_to")
-        for discovery in rows:
-            # A discovery links two faces; map the masked one to the other (the revealed one).
-            if discovery.persona_id in fake_ids:
-                revealed[discovery.persona_id] = discovery.linked_to
-            if discovery.linked_to_id in fake_ids:
-                revealed[discovery.linked_to_id] = discovery.persona
-
-    display: dict[int, tuple[str, bool]] = {}
-    for persona in unique.values():
-        if persona.pk in viewer_persona_ids or not persona.is_fake_name:
-            display[persona.pk] = (persona.name, False)
-        elif persona.pk in revealed:
-            display[persona.pk] = (f"{persona.name} ({revealed[persona.pk].name})", True)
-        else:
-            display[persona.pk] = (compose_sdesc(persona), False)
-    return display
+    revealed = _build_revealed_map(fake_ids, viewer_sheet_ids)
+    return {
+        persona.pk: _resolve_single_display(persona, viewer_persona_ids, revealed)
+        for persona in unique.values()
+    }
 
 
 def resolve_display_for_viewer(

--- a/src/world/seeds/checks.py
+++ b/src/world/seeds/checks.py
@@ -49,6 +49,9 @@ _CHECK_RANKS: tuple[tuple[int, int, str], ...] = (
     (3, 50, "Expert"),
 )
 
+# CheckOutcome tier name constants — referenced in both _OUTCOMES and the band tuples.
+_OUTCOME_PARTIAL_SUCCESS = "Partial Success"
+
 # --- Outcome catalog (name -> success_level) ---
 # Initial sane defaults aligned with the integration-test setup. "Critical
 # Failure" is included so the magic cluster's backfire consequence pools (which
@@ -57,7 +60,7 @@ _CHECK_RANKS: tuple[tuple[int, int, str], ...] = (
 _OUTCOMES: tuple[tuple[str, int], ...] = (
     ("Critical Failure", -2),
     ("Failure", -1),
-    ("Partial Success", 0),
+    (_OUTCOME_PARTIAL_SUCCESS, 0),
     ("Success", 1),
     ("Critical Success", 2),
 )
@@ -73,12 +76,12 @@ _EASY_BANDS: tuple[tuple[str, int, int], ...] = (
 )
 _EVEN_BANDS: tuple[tuple[str, int, int], ...] = (
     ("Failure", 1, 40),
-    ("Partial Success", 41, 60),
+    (_OUTCOME_PARTIAL_SUCCESS, 41, 60),
     ("Success", 61, 100),
 )
 _HARD_BANDS: tuple[tuple[str, int, int], ...] = (
     ("Failure", 1, 70),
-    ("Partial Success", 71, 85),
+    (_OUTCOME_PARTIAL_SUCCESS, 71, 85),
     ("Success", 86, 100),
 )
 _CHARTS: tuple[tuple[int, tuple[tuple[str, int, int], ...]], ...] = (


### PR DESCRIPTION
## Summary

- **S1192** (duplicate string literal): extracted repeated literals to module-level constants across actions, magic, covenants, combat, scenes, forms, and misc apps — 28 files touched
- **S3776** (cognitive complexity): refactored 15 over-limit functions by extracting well-named private helpers; no `# NOSONAR` suppressions used, all reductions are structural
- **S8514** (missing dataclass type annotations): added Python 3.13 type annotations to 7 attributes in `actions/definitions/social.py`
- **S3735** (TypeScript `void` operator): removed `void` from `DramaticMomentTagDialog.tsx:62`

One `ty` type error introduced by the `combat/services.py` complexity refactor (`DamageSource`/`ObjectDB` parameter types on the extracted `_emit_post_damage_events` helper) was caught and fixed before commit.

## Test plan

- [ ] CI fast-SQLite tier passes for all touched apps
- [ ] CI Postgres parity tier passes
- [ ] SonarCloud new-code quality gate clears on this branch

Closes #1376
Closes #1377
Closes #1378
Closes #1379
Closes #1380
Closes #1381
Closes #1382
Closes #1383
Closes #1384
Closes #1385
Closes #1386
Closes #1387
Closes #1388
Closes #1389
Closes #1390
Closes #1391
Closes #1392
Closes #1393
Closes #1394
Closes #1395
Closes #1396
Closes #1397
Closes #1398
Closes #1399
Closes #1400
Closes #1401
Closes #1402
Closes #1403
Closes #1404
Closes #1405
Closes #1406
Closes #1407
Closes #1408
Closes #1409
Closes #1410
Closes #1411
Closes #1412
Closes #1413
Closes #1414
Closes #1415
Closes #1416
Closes #1417
Closes #1418
Closes #1419
Closes #1420
Closes #1421
Closes #1422
Closes #1423
Closes #1424
Closes #1425

🤖 Generated with [Claude Code](https://claude.com/claude-code)