### PR TITLE
Telnet-driven non-combat cast: CmdAttempt → request_technique_cast E2E (#1332)

### DIFF
--- a/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
+++ b/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
@@ -46,7 +46,7 @@ actions. Magic and combat never touch `action.run()`. **Fix-on-sight target.**
 
 | # | Web dispatch family | Entry | Reaches | Telnet today |
 |---|---|---|---|---|
-| 1 | **Unified action dispatch** | `dispatch_player_action()` | REGISTRY→`action.run`, CHALLENGE→`resolve_challenge`, COMBAT→`declare_action`/`resolve_round`→`use_technique` | REGISTRY via `ArxCommand` → `self.action.run()`; COMBAT via `DispatchCommand` → `dispatch_player_action()` (`CmdDeclareTechnique`); CHALLENGE still G1 (#1332) |
+| 1 | **Unified action dispatch** | `dispatch_player_action()` | REGISTRY→`action.run`, CHALLENGE→`resolve_challenge`, COMBAT→`declare_action`/`resolve_round`→`use_technique` | REGISTRY via `ArxCommand` → `self.action.run()`; COMBAT via `DispatchCommand` → `dispatch_player_action()` (`CmdDeclareTechnique`); non-combat magic via `ArxCommand` → `request_technique_cast` (`CmdAttempt`, RESOLVED #1332) |
 | 2 | **Consent flow** | `SceneActionRequestViewSet` (`action_views.py:55`) → `create_action_request`/`respond_to_action_request` (`action_services.py:150/304`) → `start_action_resolution` | Targeted social actions (intimidate, persuade, …) with accept/deny gating | ❌ none |
 | 3 | **Direct viewset→service** | dedicated viewsets/views → service fn (no action, no dispatcher) | thread weave/imbue/pull, rituals, outfits, narrative | ❌ none |
 
@@ -97,7 +97,7 @@ web-only; the minimal fix is telnet `intimidate`/`accept`/`deny` shells over the
 | Step | Telnet | Web dispatch | Same code? | Existing test | Class |
 |---|---|---|---|---|---|
 | See available techniques | ❌ none | `get_player_actions` / `_combat_actions` (`player_interface.py`) | N/A | — | G3 |
-| Declare cast (non-combat) | ❌ none | `dispatch_player_action`→CHALLENGE→`resolve_challenge` (`challenge_resolution.py`) | seam converges; no telnet | — | **G1** |
+| Declare cast (non-combat) | ✅ `attempt` (`CmdAttempt`, `commands/magic.py` — `ArxCommand`) | `SceneCastViewSet` → `request_technique_cast` → `use_technique` (`techniques.py:702`) | **YES** — both call `request_technique_cast` (same seam) | `test_noncombat_cast_telnet_e2e.py` | **RESOLVED (#1332)** |
 | Declare cast (combat) | `cast`/`declare` (`commands/combat.py` — `CmdDeclareTechnique(DispatchCommand)`) | `dispatch_player_action`→COMBAT→`declare_action` (`combat/services.py:1494`) | **YES** — telnet calls `dispatch_player_action` (same seam) | `test_combat_ui_integration.py`, `test_combat_cast_telnet_e2e.py`, `test_combat_commands.py` | **G0** |
 | Check + resonance env + effects | N/A (service) | `resolve_round`→`resolve_combat_technique` (`:707`)→`use_technique` (`techniques.py:702`) | **YES** — fully shared service orchestration | `test_magic_story_pipeline.py` | **G0** |
 | Perform ritual | ✅ `ritual`/`perform` (`CmdRitual`) | `RitualPerformView` → `PerformRitualAction.run()` | **YES** — both converge on `perform_ritual` action | `test_ritual_telnet_e2e.py` | **RESOLVED (#1331)** |
@@ -110,11 +110,18 @@ web-only; the minimal fix is telnet `intimidate`/`accept`/`deny` shells over the
 > SERVICE + FLOW rituals. (Anima/SCENE_ACTION rituals dispatch elsewhere and are
 > out of scope.)
 
-**Verdict:** combat declare is now telnet-driveable (G0) — `cast`/`declare`
+**Verdict:** combat declare is telnet-driveable (G0) — `cast`/`declare`
 (`CmdDeclareTechnique`) calls `dispatch_player_action()` with a COMBAT `ActionRef`, the same
-seam the web uses. Non-combat (CHALLENGE) declare remains G1 (#1332). The deep
+seam the web uses. Non-combat declare is now also G0 (RESOLVED, #1332) — `attempt`
+(`CmdAttempt`, `commands/magic.py`) is a thin `ArxCommand` shell that calls
+`request_technique_cast()` directly, the same entry point the web viewset uses. The deep
 orchestration (`use_technique`, ~15 steps: anima, soulfray, resonance environment, conditions,
 story beats, achievements) is already service-tested.
+
+> **Note on dispatch path:** the spec for #1332 proposed CHALLENGE via `DispatchCommand`,
+> but CHALLENGE requires `challenge_instance_id` (it's for dungeon puzzles). Non-combat
+> magic casts route through `request_technique_cast` → `use_technique` — no CHALLENGE
+> backend involved. `CmdAttempt` is an `ArxCommand`, not a `DispatchCommand`.
 
 ---
 

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -37,7 +37,8 @@ Use `DispatchCommand` whenever the command must reach a CHALLENGE or COMBAT back
 | Use | Base class |
 |---|---|
 | REGISTRY action (most look/say/move/item commands) | `ArxCommand` |
-| CHALLENGE backend (magic attempt, non-combat skill check) | `DispatchCommand` |
+| CHALLENGE backend (dungeon puzzle challenges — requires `challenge_instance_id`) | `DispatchCommand` |
+| Non-combat magic cast (`attempt`) — calls `request_technique_cast` directly | `ArxCommand` |
 | COMBAT backend (technique declaration into the current round) | `DispatchCommand` |
 
 Both bases stay thin: no business logic in commands — all behavior lives in
@@ -66,6 +67,10 @@ actions, backends, and service functions.
 - **`imbue.py`**: `CmdImbue` (`imbue`) — finisher for the Rite of Imbuing CEREMONY;
   parses `imbue thread=<name|id> amount=<n>`. Requires an active `PendingRitualEffect`
   for Rite of Imbuing; calls `spend_resonance_for_imbuing` to advance thread level.
+- **`magic.py`**: `CmdAttempt` (`attempt`) — non-combat technique cast shell (#1332); thin
+  `ArxCommand` that parses `attempt <technique> [at <target>]`, resolves the persona via
+  `persona_for_character`, and calls `request_technique_cast` (the same service the web
+  viewset calls). No business logic; does NOT use CHALLENGE backend.
 - **`pull.py`**: `CmdPull` (`pull`) — resonance pull command with optional `preview`
   mode; parses `pull [preview] resonance=<name> tier=<1-3> thread=<name|id>[,...]
   [trait=<name>] [technique=<name>]`. Preview mode returns cost estimate without

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -57,6 +57,7 @@ from commands.evennia_overrides.movement import CmdDrop, CmdGet, CmdGive, CmdHom
 from commands.evennia_overrides.perception import CmdInventory, CmdLook
 from commands.fashion import CmdJudgePresentation
 from commands.imbue import CmdImbue
+from commands.magic import CmdAttempt
 from commands.offer_response import CmdDecline
 from commands.pull import CmdPull
 from commands.ritual import CmdRitual
@@ -169,6 +170,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdSineater,
             # Combat commands
             CmdDeclareTechnique,
+            # Non-combat magic cast (#1332)
+            CmdAttempt,
         )
         for command_cls in command_classes:
             self.add(command_cls())

--- a/src/commands/magic.py
+++ b/src/commands/magic.py
@@ -1,0 +1,133 @@
+"""Non-combat technique cast command."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.core.exceptions import ValidationError
+
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from world.scenes.models import Persona
+
+
+_USAGE = "Usage: attempt <technique> [at <target>]"
+
+
+class CmdAttempt(ArxCommand):
+    """Attempt to cast a non-combat technique.
+
+    Usage:
+        attempt <technique> [at <target>]
+
+    Requires an active scene in your location. Consent, hostility, and
+    targeting logic live in cast_services — this command is a thin parse/
+    dispatch shell.
+    """
+
+    key = "attempt"
+
+    _technique_name: str | None = None
+    _target_name: str | None = None
+    _parsed: bool = False
+
+    def _parse_args(self) -> None:
+        if self._parsed:
+            return
+        raw = (self.args or "").strip()
+        if not raw:
+            raise CommandError(_USAGE)
+        at_index = raw.lower().find(" at ")
+        if at_index != -1:
+            self._technique_name = raw[:at_index].strip()
+            self._target_name = raw[at_index + len(" at ") :].strip()
+        else:
+            self._technique_name = raw.strip()
+            self._target_name = None
+        if not self._technique_name:
+            raise CommandError(_USAGE)
+        self._parsed = True
+
+    def _resolve_technique_id(self) -> int:
+        from world.magic.models import CharacterTechnique  # noqa: PLC0415
+
+        name = self._technique_name or ""
+        ct = (
+            CharacterTechnique.objects.filter(
+                character=self.caller.sheet_data,
+                technique__name__iexact=name,
+            )
+            .select_related("technique")
+            .first()
+        )
+        if ct is None:
+            msg = f"You don't know a technique called '{name}'."
+            raise CommandError(msg)
+        return ct.technique_id
+
+    def _resolve_target_persona(self) -> Persona | None:
+        if not self._target_name:
+            return None
+        from world.scenes.models import Persona  # noqa: PLC0415
+
+        persona = Persona.objects.filter(name__iexact=self._target_name).first()
+        if persona is None:
+            msg = f"No persona named '{self._target_name}' found."
+            raise CommandError(msg)
+        return persona
+
+    def _dispatch(self) -> str:
+        """Core dispatch; raises CommandError or ValidationError on failure."""
+        from world.magic.models import Technique  # noqa: PLC0415
+        from world.scenes.cast_services import request_technique_cast  # noqa: PLC0415
+        from world.scenes.models import Scene  # noqa: PLC0415
+        from world.scenes.services import (  # noqa: PLC0415
+            MissingPrimaryPersonaError,
+            persona_for_character,
+        )
+
+        self._parse_args()
+
+        location = self.caller.location
+        if location is None:
+            msg = "You must be somewhere to cast a technique."
+            raise CommandError(msg)
+
+        scene = Scene.objects.filter(location=location, is_active=True).first()
+        if scene is None:
+            msg = "There is no active scene here."
+            raise CommandError(msg)
+
+        try:
+            persona = persona_for_character(self.caller)
+        except MissingPrimaryPersonaError:
+            msg = "You don't have a primary persona."
+            raise CommandError(msg)  # noqa: B904
+
+        technique_id = self._resolve_technique_id()
+        technique = Technique.objects.get(pk=technique_id)
+        target_persona = self._resolve_target_persona()
+
+        cast_result = request_technique_cast(
+            scene=scene,
+            initiator_persona=persona,
+            target_persona=target_persona,
+            technique=technique,
+        )
+        if cast_result.result is not None:
+            return "Your technique resolves."
+        return "Your cast is pending."
+
+    def func(self) -> None:
+        try:
+            message = self._dispatch()
+        except CommandError as exc:
+            self.msg(str(exc))
+            return
+        except ValidationError as exc:
+            messages = exc.messages if hasattr(exc, "messages") else [str(exc)]
+            self.msg("; ".join(messages))
+            return
+        self.msg(message)

--- a/src/integration_tests/pipeline/test_noncombat_cast_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_noncombat_cast_telnet_e2e.py
@@ -1,0 +1,160 @@
+"""Telnet-driven non-combat cast E2E (#1332): CmdAttempt → use_technique.
+
+Proves the full pipeline:
+  CmdAttempt.func()
+    → request_technique_cast(scene, persona, technique)
+    → _resolve_cast()
+    → use_technique()
+    → anima deducted, OUTCOME Interaction written to scene, TECHNIQUE_CAST emitted
+
+Setup uses setUp (not setUpTestData) for all ObjectDB objects to avoid copy.Error
+in CI shard runs (DbHolder deepcopy trap — see project memory).
+
+perform_check is patched to return SL=2 (full success) for determinism,
+matching the pattern in test_combat_cast_telnet_e2e.py.
+
+SQLite tier: passes cleanly. The benign self-cast path through request_technique_cast
+→ _resolve_cast → use_technique does not invoke DISTINCT ON (no apply_condition
+on the self-cast benign path), so no @tag("postgres") is needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from evennia import create_object
+from evennia.utils.idmapper import models as idmapper_models
+
+from actions.factories import ActionTemplateFactory
+from commands.magic import CmdAttempt
+from flows.constants import EventName
+from world.magic.factories import BinaryEffectTypeFactory, CharacterAnimaFactory, TechniqueFactory
+from world.scenes.constants import InteractionMode
+from world.scenes.factories import PersonaFactory, SceneFactory
+from world.scenes.models import Interaction
+from world.scenes.tests.cast_test_helpers import grant_technique
+from world.traits.factories import CheckSystemSetupFactory
+from world.vitals.models import CharacterVitals
+
+
+def _make_attempt_cmd(caller, args: str) -> CmdAttempt:
+    """Build a CmdAttempt wired to *caller* with *args*."""
+    cmd = CmdAttempt()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"attempt {args}"
+    cmd.cmdname = "attempt"
+    return cmd
+
+
+class NoncombatCastTelnetE2ETests(TestCase):
+    """CmdAttempt.func() drives the full non-combat cast pipeline.
+
+    Uses setUp (not setUpTestData) for ObjectDB objects to avoid the
+    DbHolder deepcopy trap in CI shard runs.
+    """
+
+    def setUp(self) -> None:
+        idmapper_models.flush_cache()
+        CheckSystemSetupFactory.create()
+
+        self.room = create_object("typeclasses.rooms.Room", key="CastTestRoom", nohome=True)
+        self.scene = SceneFactory(location=self.room)
+
+        self.persona = PersonaFactory()
+        self.character = self.persona.character_sheet.character
+        self.character.db_location = self.room
+        self.character.save()
+
+        # anima_cost=20 ensures effective_cost > 0 even with the unengaged social-safety
+        # bonus (+10 control) applied by _get_social_safety_bonus(). Without this, the
+        # delta formula floors at 0 and deduct_anima is called with 0 — no deduction.
+        self.technique = TechniqueFactory(
+            anima_cost=20,
+            effect_type=BinaryEffectTypeFactory(),
+            damage_profile=False,
+            action_template=ActionTemplateFactory(),
+        )
+        grant_technique(self.persona, self.technique)
+
+        CharacterVitals.objects.create(
+            character_sheet=self.persona.character_sheet,
+            health=50,
+            max_health=50,
+            base_max_health=50,
+        )
+        self.anima = CharacterAnimaFactory(
+            character=self.character,
+            current=20,
+            maximum=30,
+        )
+
+        self._check_patcher = patch(
+            "actions.services.perform_check",
+            return_value=MagicMock(
+                success_level=2,
+                outcome=MagicMock(name="Success"),
+                outcome_name="Success",
+            ),
+        )
+        self._check_patcher.start()
+        self._accrue_patcher = patch("world.scenes.action_services.accrue")
+        self._accrue_patcher.start()
+
+    def tearDown(self) -> None:
+        self._check_patcher.stop()
+        self._accrue_patcher.stop()
+
+    def test_attempt_command_deducts_anima(self) -> None:
+        """CmdAttempt drives use_technique which deducts anima."""
+        anima_before = self.anima.current
+
+        cmd = _make_attempt_cmd(self.character, self.technique.name)
+        cmd.func()
+
+        self.anima.refresh_from_db()
+        self.assertLess(
+            self.anima.current,
+            anima_before,
+            "anima.current must decrease: use_technique deducts the technique's anima cost",
+        )
+
+    def test_attempt_command_writes_outcome_interaction(self) -> None:
+        """CmdAttempt causes a Narrator OUTCOME Interaction to be written to the scene."""
+        cmd = _make_attempt_cmd(self.character, self.technique.name)
+        cmd.func()
+
+        self.assertTrue(
+            Interaction.objects.filter(
+                scene=self.scene,
+                mode=InteractionMode.OUTCOME,
+            ).exists(),
+            "An OUTCOME Interaction must exist in the scene after a resolved cast",
+        )
+
+    def test_attempt_command_emits_technique_cast_event(self) -> None:
+        """CmdAttempt causes TECHNIQUE_CAST to be emitted via emit_event.
+
+        Patches world.magic.services.techniques.emit_event because techniques.py
+        binds emit_event at import time; patching flows.emit.emit_event alone
+        would not intercept calls made via that module-level binding.
+        """
+        from flows.emit import emit_event as _real_emit_event
+        import world.magic.services.techniques as _techniques_mod
+
+        with patch.object(
+            _techniques_mod,
+            "emit_event",
+            wraps=_real_emit_event,
+        ) as mock_emit:
+            cmd = _make_attempt_cmd(self.character, self.technique.name)
+            cmd.func()
+
+        technique_cast_calls = [
+            c for c in mock_emit.call_args_list if c.args and c.args[0] == EventName.TECHNIQUE_CAST
+        ]
+        self.assertTrue(
+            len(technique_cast_calls) >= 1,
+            f"emit_event must be called with TECHNIQUE_CAST; calls: {mock_emit.call_args_list}",
+        )


### PR DESCRIPTION
## Summary

- Adds `CmdAttempt` (`attempt <technique> [at <target>]`) — a thin `ArxCommand` shell that resolves the caster's primary persona and calls `request_technique_cast()` directly (the same service entry point the web viewset uses)
- Adds `NoncombatCastTelnetE2ETests` (3 tests) proving the full pipeline: anima deducted, OUTCOME Interaction written, TECHNIQUE_CAST emitted
- Updates `docs/audits/2026-06-21-telnet-driveability-ui-parity.md` (Loop 2 non-combat row → RESOLVED, G0) and `src/commands/CLAUDE.md` (adds `magic.py` entry, corrects CHALLENGE vs ArxCommand table)

## Architecture note

The issue spec proposed CHALLENGE backend via `DispatchCommand`, but CHALLENGE requires `challenge_instance_id` (dungeon puzzles). Non-combat magic casts route through `request_technique_cast` → `use_technique` — no CHALLENGE backend involved. `CmdAttempt` is an `ArxCommand`, not a `DispatchCommand`.

## Test plan

- [x] `just test-fast integration_tests.pipeline.test_noncombat_cast_telnet_e2e` — 3/3 pass
- [x] `just test-fast integration_tests` — 4 pre-existing failures, no new regressions
- [x] `uv run pre-commit run --all-files` — all hooks pass

## Notes

Design ran; spec posted to issue and approved by org member before implementation.

Closes #1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)