### PR TITLE
Telnet journey: multi-participant ritual sessions (draft → accept/decline → fire)

### DIFF
--- a/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
+++ b/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
@@ -257,7 +257,7 @@ mechanical is web-only.
 | **Thread weave/imbue/pull** | `weave_thread` / `spend_resonance_for_imbuing` / `_for_pull` (`magic/services/`) | G1/G3 |
 | **Soul-tether & sineating** | 8 APIViews: accept/dissolve/request/respond/rescue/stage-advance (`magic/views.py:1206–1461`) | G3 |
 | **Audere / Audere Majora** | `resolve_audere_offer`; `cross_threshold` (`magic/audere*.py`) — the progression/"leveling" surface | G3 |
-| **Multi-participant rituals** | `draft_session`/`accept`/`decline`/`fire` (`magic/services/sessions.py`) | G3 |
+| **Multi-participant rituals** | `draft_session`/`accept`/`decline`/`fire` (`magic/services/sessions.py`) | **RESOLVED — #1345** |
 | **Covenant membership** | engage/disengage/leave/kick/rank; banner-call/stand-down (`covenants/services.py`) | G3 |
 | **Persona / guise** | `set_active_persona` (`scenes/services.py:86`) | G3 |
 | **Progression rewards** | `claim_kudos_for_xp`; `cast_vote`/`remove_vote`; random-scene; path-intent (`progression/views.py`) | G3 |

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -57,10 +57,15 @@ actions, backends, and service functions.
 - **`consent.py`**: `ConsentRequestCommand` (base), `CmdIntimidate`, `CmdPersuade`, `CmdDeceive`, `CmdFlirt`, `CmdPerform`, `CmdEntrance`, `CmdRestoreSense` — telnet shells for social consent-flow actions (#1337/#1338); `CmdAccept` (extended to check offer registry first; consent
   fall-through unchanged), `CmdDeny` — target responses. All call `create_action_request` / `respond_to_action_request` — the same service the web viewset calls.
 - **`ritual.py`**: `CmdRitual` (alias `perform`) — telnet face of
-  `PerformRitualAction` and multi-participant session lifecycle; parses `ritual <name> [key=value ...]` for SERVICE and
-  CEREMONY rituals, **and** `ritual sessions/draft/join/decline/fire` for session management.
-  Single-actor rituals: SERVICE rituals execute immediately; CEREMONY rituals create a
-  `PendingRitualEffect` that the matching finisher command (`weave`, `imbue`) consumes.
+  `PerformRitualAction` and multi-participant session lifecycle:
+  - `ritual <name> [k=v ...]` — single-actor ritual performance (SERVICE rituals execute
+    immediately; CEREMONY rituals create a `PendingRitualEffect` for finisher commands)
+  - `ritual sessions` — list pending sessions
+  - `ritual draft <name> invite=<char>[,<char>]` — draft a session
+  - `ritual join <id>` — accept your invitation
+  - `ritual decline <id>` — decline your invitation
+  - `ritual fire <id>` — fire the session (initiator only)
+
   Session subcommands call `draft_session` / `accept_session` / `decline_session` / `fire_session` directly.
 - **`weave.py`**: `CmdWeaveThread` (`weave`) — telnet face of `WeaveThreadAction`;
   parses `weave resonance=<name> trait=<name or id> [name=<...>]` (TRAIT anchor only — the

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -57,9 +57,11 @@ actions, backends, and service functions.
 - **`consent.py`**: `ConsentRequestCommand` (base), `CmdIntimidate`, `CmdPersuade`, `CmdDeceive`, `CmdFlirt`, `CmdPerform`, `CmdEntrance`, `CmdRestoreSense` — telnet shells for social consent-flow actions (#1337/#1338); `CmdAccept` (extended to check offer registry first; consent
   fall-through unchanged), `CmdDeny` — target responses. All call `create_action_request` / `respond_to_action_request` — the same service the web viewset calls.
 - **`ritual.py`**: `CmdRitual` (alias `perform`) — telnet face of
-  `PerformRitualAction`; parses `ritual <name> [key=value ...]` for SERVICE and
-  CEREMONY rituals. SERVICE rituals execute immediately; CEREMONY rituals create a
+  `PerformRitualAction` and multi-participant session lifecycle; parses `ritual <name> [key=value ...]` for SERVICE and
+  CEREMONY rituals, **and** `ritual sessions/draft/join/decline/fire` for session management.
+  Single-actor rituals: SERVICE rituals execute immediately; CEREMONY rituals create a
   `PendingRitualEffect` that the matching finisher command (`weave`, `imbue`) consumes.
+  Session subcommands call `draft_session` / `accept_session` / `decline_session` / `fire_session` directly.
 - **`weave.py`**: `CmdWeaveThread` (`weave`) — telnet face of `WeaveThreadAction`;
   parses `weave resonance=<name> trait=<name or id> [name=<...>]` (TRAIT anchor only — the
   reference grammar; other anchor kinds are extended by the thread-weaving journey

--- a/src/commands/ritual.py
+++ b/src/commands/ritual.py
@@ -1,46 +1,273 @@
 """Telnet command for performing magical rituals.
 
-Thin telnet face of ``actions.definitions.ritual.PerformRitualAction``. Parses
-``ritual <name> [key=value ...]`` into the action's kwargs. Supports SERVICE-kind
-rituals (Imbuing, Atonement) and CEREMONY-kind rituals (Rite of Weaving, Rite of
-Imbuing). CEREMONY rituals create a ``PendingRitualEffect`` consumed by the
-appropriate finisher command (``weave``, ``imbue``). The web path uses the same
-action via ``RitualPerformView``.
+Thin telnet face of ``actions.definitions.ritual.PerformRitualAction`` (single-actor
+path) and the session services in ``world.magic.services.sessions`` (multi-participant
+session path).
+
+Single-actor path (SERVICE/CEREMONY kind):
+    ``ritual <name>``                       — perform a ritual by name
+    ``ritual <name> key=value [key=value]``  — with ritual parameters
+
+Multi-participant session path:
+    ``ritual sessions``                              — list pending sessions
+    ``ritual draft <name> invite=<char>[,<char>]``   — draft a session
+    ``ritual join <id>``                             — accept your invitation
+    ``ritual decline <id>``                          — decline your invitation
+    ``ritual fire <id>``                             — fire the session (initiator only)
+
+The web path uses ``RitualSessionViewSet`` for sessions and ``RitualPerformView``
+for single-actor rituals — both converge on the same service functions.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from django.db.models import Q
+
 from actions.definitions.ritual import PerformRitualAction
 from commands.command import ArxCommand
 from commands.exceptions import CommandError
 
-# Telnet-friendly kwarg alias: players type ``thread=<id>`` (the pk); the action
-# / service expect the resolved ``thread`` model, and the view path uses
-# ``thread_id`` as the primitive key. Map the input token to ``thread_id`` here.
 _THREAD_KWARG = "thread"
 _THREAD_ID_KEY = "thread_id"
+_SESSION_SUBCMDS = frozenset({"sessions", "draft", "join", "decline", "fire"})
 
 
 class CmdRitual(ArxCommand):
-    """Perform a magical ritual you know.
+    """Perform a magical ritual or manage a multi-participant ritual session.
 
-    Telnet grammar:
-        ``ritual <name>``                       — perform a ritual by name
-        ``ritual <name> key=value [key=value]``  — with ritual parameters
+    **Single-actor rituals:**
+        ``ritual <name>``
+        ``ritual <name> key=value [key=value]``
+        Example: ``ritual Rite of Imbuing thread=5``
 
-    Example:
-        ``ritual Rite of Imbuing thread=5``
-
-    Trailing ``key=value`` tokens are ritual parameters; everything before the
-    first such token is the ritual name. Carried items are offered as components
-    and pruned to what the ritual requires.
+    **Multi-participant session lifecycle:**
+        ``ritual sessions``                              — list pending sessions
+        ``ritual draft <name> invite=<char>[,<char>]``   — draft a session
+        ``ritual join <id>``                             — accept your invitation
+        ``ritual decline <id>``                          — decline your invitation
+        ``ritual fire <id>``                             — fire the session (initiator only)
     """
 
     key = "ritual"
     locks = "cmd:all()"
     action = PerformRitualAction()
+
+    def func(self) -> None:
+        """Route session subcommands; fall through to single-actor action otherwise."""
+        first = (self.args or "").strip().split()[0].lower() if (self.args or "").strip() else ""
+        if first in _SESSION_SUBCMDS:
+            rest = (self.args or "").strip()[len(first) :].strip()
+            try:
+                if first == "sessions":  # noqa: STRING_LITERAL
+                    self._handle_sessions()
+                elif first == "draft":  # noqa: STRING_LITERAL
+                    self._handle_draft(rest)
+                elif first == "join":  # noqa: STRING_LITERAL
+                    self._handle_join(rest)
+                elif first == "decline":  # noqa: STRING_LITERAL
+                    self._handle_decline(rest)
+                elif first == "fire":  # noqa: STRING_LITERAL
+                    self._handle_fire(rest)
+            except CommandError as err:
+                self.caller.msg(str(err))
+        else:
+            super().func()
+
+    # ------------------------------------------------------------------
+    # Session handlers
+    # ------------------------------------------------------------------
+
+    def _handle_sessions(self) -> None:
+        """List pending sessions where caller is initiator or participant."""
+        from world.magic.models.sessions import RitualSession  # noqa: PLC0415
+
+        sheet = self.caller.sheet_data
+        qs = (
+            RitualSession.objects.filter(
+                Q(initiator=sheet) | Q(participants__character_sheet=sheet)
+            )
+            .distinct()
+            .select_related("ritual", "initiator__character")
+            .prefetch_related("participants__character_sheet__character")  # noqa: PREFETCH_STRING
+        )
+        sessions = list(qs)
+        if not sessions:
+            self.caller.msg("You have no pending ritual sessions.")
+            return
+        lines = ["|wPending ritual sessions:|n"]
+        for s in sessions:
+            participant_summary = ", ".join(
+                f"{p.character_sheet.character.db_key}:{p.state}" for p in s.participants.all()
+            )
+            lines.append(
+                f"  [#{s.pk}] {s.ritual.name}"
+                f" (by {s.initiator.character.db_key}) — {participant_summary}"
+            )
+        self.caller.msg("\n".join(lines))
+
+    def _handle_draft(self, rest: str) -> None:
+        """Draft a multi-participant session: ``draft <name> invite=<char>[,<char>]``."""
+        from datetime import timedelta  # noqa: PLC0415
+
+        from django.utils import timezone  # noqa: PLC0415
+
+        from world.magic.constants import (  # noqa: PLC0415
+            ParticipationRule,
+            RitualExecutionKind,
+        )
+        from world.magic.exceptions import (  # noqa: PLC0415
+            ParticipantCountError,
+            RitualSessionError,
+        )
+        from world.magic.models import Ritual  # noqa: PLC0415
+        from world.magic.services.sessions import draft_session  # noqa: PLC0415
+
+        # Parse: ``Ritual Name invite=char1[,char2]``
+        tokens = rest.split()
+        name_parts: list[str] = []
+        invite_names: list[str] = []
+        for token in tokens:
+            if token.startswith("invite="):
+                value = token[7:]
+                invite_names = [n.strip() for n in value.split(",") if n.strip()]
+            else:
+                name_parts.append(token)
+
+        usage = "Usage: ritual draft <ritual_name> invite=<character>[,<character>]"
+        name = " ".join(name_parts).strip()
+        if not name:
+            raise CommandError(usage)
+        if not invite_names:
+            raise CommandError(usage)
+
+        ritual = Ritual.objects.filter(
+            name__iexact=name,
+            execution_kind__in=[RitualExecutionKind.SERVICE, RitualExecutionKind.FLOW],
+            participation_rule__in=[
+                ParticipationRule.FORMATION,
+                ParticipationRule.INDUCTION,
+                ParticipationRule.BILATERAL,
+            ],
+        ).first()
+        if ritual is None:
+            msg = (
+                f"No multi-participant ritual named '{name}' found. "
+                "(Single-actor rituals use 'ritual <name>' without 'draft'.)"
+            )
+            raise CommandError(msg)
+
+        invitees = []
+        for invite_name in invite_names:
+            target = self.caller.search(invite_name)
+            if target is None:
+                msg = f"Cannot find '{invite_name}'."
+                raise CommandError(msg)
+            invitee_sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+            if invitee_sheet is None:
+                msg = f"'{invite_name}' has no character sheet."
+                raise CommandError(msg)
+            invitees.append(invitee_sheet)
+
+        initiator_sheet = self.caller.sheet_data
+        try:
+            session = draft_session(
+                ritual=ritual,
+                initiator=initiator_sheet,
+                proposed_terms="",
+                session_kwargs={},
+                invitee_sheets=invitees,
+                session_references=[],
+                initiator_participant_kwargs={},
+                initiator_references=[],
+                expires_at=timezone.now() + timedelta(hours=24),
+            )
+        except (ParticipantCountError, RitualSessionError) as exc:
+            raise CommandError(exc.user_message) from exc
+
+        invite_list = ", ".join(inv.character.db_key for inv in invitees)
+        self.caller.msg(
+            f"Ritual session #{session.pk} drafted: {ritual.name}. "
+            f"Invited: {invite_list}. "
+            f"Use 'ritual fire {session.pk}' once all have joined."
+        )
+
+    def _handle_join(self, rest: str) -> None:
+        """Accept a session invitation: ``join <id>``."""
+        from world.magic.exceptions import SessionNotInPendingError  # noqa: PLC0415
+        from world.magic.models.sessions import RitualSessionParticipant  # noqa: PLC0415
+        from world.magic.services.sessions import accept_session  # noqa: PLC0415
+
+        session_id = self._parse_session_id(rest, "Usage: ritual join <session_id>")
+        sheet = self.caller.sheet_data
+        participant = RitualSessionParticipant.objects.filter(
+            session_id=session_id,
+            character_sheet=sheet,
+        ).first()
+        if participant is None:
+            msg = f"You are not an invited participant of session #{session_id}."
+            raise CommandError(msg)
+        try:
+            accept_session(participant=participant, participant_kwargs={}, references=[])
+        except SessionNotInPendingError:
+            msg = f"You have already responded to session #{session_id}."
+            raise CommandError(msg) from None
+        self.caller.msg(f"You have joined ritual session #{session_id}.")
+
+    def _handle_decline(self, rest: str) -> None:
+        """Decline a session invitation: ``decline <id>``."""
+        from world.magic.exceptions import SessionNotInPendingError  # noqa: PLC0415
+        from world.magic.models.sessions import (  # noqa: PLC0415
+            RitualSession,
+            RitualSessionParticipant,
+        )
+        from world.magic.services.sessions import decline_session  # noqa: PLC0415
+
+        session_id = self._parse_session_id(rest, "Usage: ritual decline <session_id>")
+        sheet = self.caller.sheet_data
+        participant = RitualSessionParticipant.objects.filter(
+            session_id=session_id,
+            character_sheet=sheet,
+        ).first()
+        if participant is None:
+            msg = f"You are not an invited participant of session #{session_id}."
+            raise CommandError(msg)
+        try:
+            decline_session(participant=participant)
+        except SessionNotInPendingError:
+            msg = f"You have already responded to session #{session_id}."
+            raise CommandError(msg) from None
+        if not RitualSession.objects.filter(pk=session_id).exists():
+            self.caller.msg(
+                f"You declined session #{session_id}. The session was dissolved "
+                "— the threshold can no longer be met."
+            )
+        else:
+            self.caller.msg(f"You declined ritual session #{session_id}.")
+
+    def _handle_fire(self, rest: str) -> None:
+        """Fire a session (initiator only): ``fire <id>``."""
+        from world.magic.exceptions import ThresholdNotMetError  # noqa: PLC0415
+        from world.magic.models.sessions import RitualSession  # noqa: PLC0415
+        from world.magic.services.sessions import fire_session  # noqa: PLC0415
+
+        session_id = self._parse_session_id(rest, "Usage: ritual fire <session_id>")
+        sheet = self.caller.sheet_data
+        session = RitualSession.objects.filter(pk=session_id, initiator=sheet).first()
+        if session is None:
+            msg = f"Session #{session_id} not found or you are not its initiator."
+            raise CommandError(msg)
+        try:
+            fire_session(session=session)
+        except ThresholdNotMetError:
+            msg = f"Session #{session_id} cannot fire yet — not all participants have responded."
+            raise CommandError(msg) from None
+        self.caller.msg(f"Ritual session #{session_id} has been fired. The ritual is complete.")
+
+    # ------------------------------------------------------------------
+    # Single-actor helpers (unchanged)
+    # ------------------------------------------------------------------
 
     def resolve_action_args(self) -> dict[str, Any]:
         """Parse ``ritual <name> [k=v ...]`` into action kwargs."""
@@ -74,19 +301,13 @@ class CmdRitual(ArxCommand):
                 raise CommandError(msg)
             service_kwargs["thread"] = thread
 
-        # Pass through any remaining parsed kwargs (e.g. amount) verbatim.
         service_kwargs.update(raw_kwargs)
 
         components = self._gather_components()
         return {"ritual": ritual, "components_provided": components, **service_kwargs}
 
     def _split_name_and_kwargs(self, args: str) -> tuple[str, dict[str, int]]:
-        """Split into ritual name + trailing ``key=value`` int tokens.
-
-        Tokens are whitespace-separated. The name is everything before the first
-        ``key=value`` token; values that parse as ints are coerced (so ``thread=5``
-        yields ``thread_id``→5 via the caller). Non-int values raise CommandError.
-        """
+        """Split into ritual name + trailing ``key=value`` int tokens."""
         tokens = args.split()
         kwargs: dict[str, int] = {}
         name_parts: list[str] = []
@@ -100,7 +321,6 @@ class CmdRitual(ArxCommand):
                 except ValueError as exc:
                     msg = f"Ritual parameter '{key}' must be a number."
                     raise CommandError(msg) from exc
-                # ``thread`` is the telnet-friendly alias for the ``thread_id`` pk.
                 kwargs[_THREAD_ID_KEY if key == _THREAD_KWARG else key] = parsed
             elif in_kwargs:
                 msg = "Ritual parameters must come after the ritual name."
@@ -121,3 +341,14 @@ class CmdRitual(ArxCommand):
             if instance is not None:
                 components.append(instance)
         return components
+
+    def _parse_session_id(self, rest: str, usage_msg: str) -> int:
+        """Parse the first token of ``rest`` as an integer session pk."""
+        rest = rest.strip()
+        if not rest:
+            raise CommandError(usage_msg)
+        try:
+            return int(rest.split()[0])
+        except ValueError as exc:
+            msg = f"Session ID must be a number. {usage_msg}"
+            raise CommandError(msg) from exc

--- a/src/integration_tests/pipeline/test_ritual_session_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_ritual_session_telnet_e2e.py
@@ -1,0 +1,187 @@
+"""Telnet E2E: multi-participant ritual session lifecycle via CmdRitual (#1345).
+
+Drives the full draft → join → fire journey through CmdRitual subcommands,
+proving that the telnet surface wires correctly to the existing session
+service functions (draft_session / accept_session / fire_session).
+
+Uses RenewTheOathRitualFactory (FORMATION, ≥2 participants) with
+perform_covenant_rite patched — the covenant service is tested separately;
+here we prove the command plumbing.
+
+Error-path coverage:
+  - fire before all participants have joined → ThresholdNotMetError → caller message
+  - decline when only 2 total participants → session dissolved
+  - join a session where caller is not a participant → error message
+  - ritual sessions listing shows pending sessions
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from commands.ritual import CmdRitual
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.constants import ParticipantState
+from world.magic.factories import RenewTheOathRitualFactory
+from world.magic.models.sessions import RitualSession
+
+_PERFORM_COVENANT_RITE_PATH = "world.covenants.services.perform_covenant_rite"
+
+
+def _run(cmd_cls: type, caller: object, args: str = "") -> object:
+    """Helper: build and run a command instance."""
+    cmd = cmd_cls()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"{cmd_cls.key} {args}".strip()
+    caller.msg = MagicMock()
+    return cmd
+
+
+class RitualSessionTelnetE2ETests(TestCase):
+    """Full session lifecycle driven by CmdRitual subcommands."""
+
+    def setUp(self) -> None:
+        # Use setUp (not setUpTestData) to avoid DbHolder deepcopy issues in CI shards.
+        self.initiator = CharacterFactory(db_key="SessionInitiator")
+        self.participant = CharacterFactory(db_key="SessionParticipant")
+        self.uninvited = CharacterFactory(db_key="SessionUninvited")
+        self.initiator_sheet = CharacterSheetFactory(character=self.initiator)
+        self.participant_sheet = CharacterSheetFactory(character=self.participant)
+        self.uninvited_sheet = CharacterSheetFactory(character=self.uninvited)
+
+        self.ritual = RenewTheOathRitualFactory()
+
+    def _draft(self) -> int:
+        """Run 'ritual draft Renew the Oath invite=Participant'; return session pk."""
+        cmd = _run(CmdRitual, self.initiator, f"draft {self.ritual.name} invite=Participant")
+        cmd.caller.search = MagicMock(return_value=self.participant)
+        cmd.func()
+        return RitualSession.objects.get(ritual=self.ritual).pk
+
+    # ------------------------------------------------------------------
+    # Happy-path lifecycle
+    # ------------------------------------------------------------------
+
+    def test_full_lifecycle(self) -> None:
+        """draft → join → fire → session deleted, service called once."""
+        with patch(_PERFORM_COVENANT_RITE_PATH) as mock_rite:
+            mock_rite.return_value = MagicMock()
+
+            # 1. Initiator drafts.
+            session_pk = self._draft()
+            session = RitualSession.objects.get(pk=session_pk)
+            self.assertEqual(session.ritual, self.ritual)
+            self.assertEqual(session.initiator, self.initiator_sheet)
+            self.assertEqual(session.participants.count(), 2)
+
+            initiator_part = session.participants.get(character_sheet=self.initiator_sheet)
+            participant_part = session.participants.get(character_sheet=self.participant_sheet)
+            self.assertEqual(initiator_part.state, ParticipantState.ACCEPTED)
+            self.assertEqual(participant_part.state, ParticipantState.INVITED)
+            self.initiator.msg.assert_called()
+            self.assertIn(str(session_pk), self.initiator.msg.call_args[0][0])
+
+            # 2. Participant joins.
+            cmd = _run(CmdRitual, self.participant, f"join {session_pk}")
+            cmd.func()
+            participant_part.refresh_from_db()
+            self.assertEqual(participant_part.state, ParticipantState.ACCEPTED)
+            self.participant.msg.assert_called()
+            self.assertIn("joined", self.participant.msg.call_args[0][0])
+
+            # 3. Initiator fires.
+            cmd = _run(CmdRitual, self.initiator, f"fire {session_pk}")
+            cmd.func()
+            mock_rite.assert_called_once()
+            self.assertFalse(RitualSession.objects.filter(pk=session_pk).exists())
+            self.initiator.msg.assert_called()
+            self.assertIn("complete", self.initiator.msg.call_args[0][0])
+
+    # ------------------------------------------------------------------
+    # sessions listing
+    # ------------------------------------------------------------------
+
+    def test_sessions_listing_shows_pending_session(self) -> None:
+        """'ritual sessions' shows the session with its ID and participant states."""
+        session_pk = self._draft()
+
+        cmd = _run(CmdRitual, self.initiator, "sessions")
+        cmd.func()
+        output = self.initiator.msg.call_args[0][0]
+        self.assertIn(str(session_pk), output)
+        self.assertIn(self.ritual.name, output)
+        self.assertIn("Participant", output)
+
+    def test_sessions_listing_empty_when_none(self) -> None:
+        """'ritual sessions' with no pending sessions says so."""
+        cmd = _run(CmdRitual, self.initiator, "sessions")
+        cmd.func()
+        output = self.initiator.msg.call_args[0][0]
+        self.assertIn("no pending", output.lower())
+
+    # ------------------------------------------------------------------
+    # Error paths
+    # ------------------------------------------------------------------
+
+    def test_fire_before_participant_joins_sends_error(self) -> None:
+        """Firing before participant accepts → ThresholdNotMetError → error message."""
+        with patch(_PERFORM_COVENANT_RITE_PATH):
+            session_pk = self._draft()
+
+            # participant has NOT joined — try to fire immediately.
+            cmd = _run(CmdRitual, self.initiator, f"fire {session_pk}")
+            cmd.func()
+            output = self.initiator.msg.call_args[0][0]
+            self.assertIn("cannot fire", output.lower())
+            # Session still exists (fire was blocked).
+            self.assertTrue(RitualSession.objects.filter(pk=session_pk).exists())
+
+    def test_decline_dissolves_session_when_threshold_unachievable(self) -> None:
+        """Declining in a 2-participant FORMATION session dissolves the session."""
+        session_pk = self._draft()
+
+        cmd = _run(CmdRitual, self.participant, f"decline {session_pk}")
+        cmd.func()
+        output = self.participant.msg.call_args[0][0]
+        # Session dissolved — threshold impossible after 1 decline in FORMATION.
+        self.assertFalse(RitualSession.objects.filter(pk=session_pk).exists())
+        self.assertIn("dissolved", output.lower())
+
+    def test_join_nonexistent_session_sends_error(self) -> None:
+        """Joining a session ID with no matching participant row → error."""
+        cmd = _run(CmdRitual, self.uninvited, "join 99999")
+        cmd.func()
+        output = self.uninvited.msg.call_args[0][0]
+        self.assertIn("not an invited participant", output.lower())
+
+    def test_fire_by_non_initiator_sends_error(self) -> None:
+        """Attempting to fire a session the caller didn't initiate → error."""
+        session_pk = self._draft()
+
+        cmd = _run(CmdRitual, self.participant, f"fire {session_pk}")
+        cmd.func()
+        output = self.participant.msg.call_args[0][0]
+        self.assertIn("not found or you are not its initiator", output.lower())
+
+    def test_draft_unknown_ritual_sends_error(self) -> None:
+        """Drafting a non-existent ritual → error."""
+        cmd = _run(CmdRitual, self.initiator, "draft Rite of Nonexistent invite=Participant")
+        cmd.caller.search = MagicMock(return_value=self.participant)
+        cmd.func()
+        output = self.initiator.msg.call_args[0][0]
+        self.assertIn("No multi-participant ritual named", output)
+
+    def test_single_actor_path_unchanged(self) -> None:
+        """'ritual <name>' without a session subcommand still hits PerformRitualAction."""
+        from world.magic.factories import ImbuingRitualFactory
+
+        ImbuingRitualFactory()
+        cmd = _run(CmdRitual, self.initiator, "Rite of Imbuing")
+        with patch("actions.definitions.ritual.PerformRitualAction.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            cmd.func()
+        mock_run.assert_called_once()

--- a/tools/skills/issue-to-merged-pr/scripts/pickup-issue.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/pickup-issue.sh
@@ -53,16 +53,18 @@ fi
 # 3. Infer type from labels
 LABELS=$(jq -r '.labels[].name' <<<"$ISSUE_JSON")
 TYPE=""
-for candidate in feature fix chore refactor test docs perf performance; do
+for candidate in feature fix chore refactor test tests docs perf performance; do
   if grep -qx "$candidate" <<<"$LABELS"; then
     TYPE="$candidate"
     break
   fi
 done
-# Normalize label aliases to canonical branch-prefix types: the repo uses the
-# `performance` label, but the branch/type prefix convention is `perf`.
+# Normalize label aliases to canonical branch-prefix types.
 if [[ "$TYPE" == "performance" ]]; then
   TYPE="perf"
+fi
+if [[ "$TYPE" == "tests" ]]; then
+  TYPE="test"
 fi
 if [[ -z "$TYPE" ]]; then
   echo "ERROR: issue #$ISSUE has no recognized type label" >&2

--- a/tools/skills/running-tests/SKILL.md
+++ b/tools/skills/running-tests/SKILL.md
@@ -9,6 +9,14 @@ description: Use when running or writing tests in this repo — choosing the SQL
 
 Tests run in a **two-tier model**: a fast SQLite in-memory inner loop and a Postgres parity tier (what CI runs). **IMPORTANT: Always use `arx test` (or its `just` wrappers) to run tests.** Never use `uv run python -m`, `python manage.py test`, sourcing venvs to find binaries, or any other method.
 
+## Testing philosophy
+
+Prefer big **E2E user-journey integration tests** over many fine-grained unit tests. A single telnet-driven journey test that drives command → action → service → DB end-to-end is worth more than a dozen unit tests of individual layers. Don't create marginal unit tests that duplicate what the E2E already covers — they add maintenance cost without adding safety, and will be retired when E2E coverage matures anyway.
+
+Write focused unit tests only when logic is genuinely fiddly and wouldn't be observable from the E2E happy path: e.g. a parsing helper with multiple lookup branches, error-path exception mapping, or a pure-function edge case. When in doubt, skip the unit test and let the integration test carry the weight.
+
+**Don't assume player omniscience.** E2E journey tests should assert that the game tells the player what to do next, not just that the underlying state changed. If the game should emit a prompt ("use `flourish <resonance>` to declare your entrance"), assert that the caller received it. A journey test that only checks DB state leaves a gap: the player could be left with no idea what action is available to them, and the test wouldn't catch it.
+
 ## Two-tier model: SQLite for the inner loop, Postgres for parity
 
 Production runs Postgres exclusively. Tests run in TWO tiers:


### PR DESCRIPTION
Closes #1345

## Summary

Adds `ritual sessions/draft/join/decline/fire` subcommands to `CmdRitual` (telnet layer) plus a 9-test E2E journey suite. Session subcommands call session services directly (matching the web `RitualSessionViewSet` pattern), with the existing single-actor `ritual <name>` path unchanged via `super().func()` fallback.

## Follow-ups filed

- #1439

## Notes

- Spec: reviewed & approved on #1345 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch already up-to-date with main; no conflicts.

<!-- last-addressed-comment: 0 -->