### PR TITLE
Sheet sections: sheet/renown (the second section)

### DIFF
--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -101,9 +101,11 @@ actions, backends, and service functions.
   baseline for a character and sections (secrets, and — as built — renown, relationships, society
   standings, covenant, magic) hang off it. Add a section: write a renderer in `sheet_sections.py`
   and register it in `SHEET_SECTIONS` — **don't** add a standalone `+command`.
-- **`sheet_sections.py`**: the `sheet/<section>` renderers + `SHEET_SECTIONS` registry. `secret`
-  (`sheet/secret [character]`, #1334) is the first — your own secrets, or the ones you know about
-  a character; thin over `world.secrets.services`, locked layers render "Unknown".
+- **`sheet_sections.py`**: the `sheet/<section>` renderers + `SHEET_SECTIONS` registry. Sections:
+  `secret` (`sheet/secret [character]`, #1334 — your own secrets, or the ones you know about a
+  character; locked layers "Unknown") and `renown` (`sheet/renown`, #676 — your prestige / fame
+  tier / society standing, via `build_renown_payload`, mirroring the web `RenownPanel`). Each is
+  thin over its app's services. Add a section: a renderer + a registry entry (+ `SECTION_NAMES`).
 
 ### Social Commands (`social/`)
 - **`blocking.py`**: `CmdBlock`/`CmdUnblock`/`CmdShareBlock`/`CmdMute`/`CmdUnmute`/`CmdBlockList`

--- a/src/commands/account/sheet_sections.py
+++ b/src/commands/account/sheet_sections.py
@@ -100,12 +100,46 @@ def _render_known(held_rows: QuerySet[SecretKnowledge]) -> list[str]:
     return lines
 
 
+def _render_renown_section(command: Command) -> list[str]:
+    """The renown section: your standing — prestige, fame tier, society reputations (#676).
+
+    Mirrors the web Renown tab (the owner's ``RenownPanel``) for your active character. Viewing
+    another character's renown *card* (tiers only, from their perspective) is a follow-up.
+    """
+    from world.societies.renown_serializers import build_renown_payload  # noqa: PLC0415
+
+    viewer = _viewer_sheet(command)
+    return _format_renown(build_renown_payload(viewer.primary_persona))
+
+
+def _format_renown(payload: dict) -> list[str]:
+    fame = payload["fame"]
+    prestige = payload["prestige"]
+    lines = [
+        f"|wRenown — {payload['persona_name']}|n",
+        f"  Fame: {fame['tier_label']} ({fame['points']} pts)",
+        (
+            f"  Prestige: {prestige['total']}  (deeds {prestige['deeds']}, orgs {prestige['orgs']},"
+            f" dwellings {prestige['dwellings']}, items {prestige['items']},"
+            f" fashion {prestige['fashion']})"
+        ),
+    ]
+    reputation = payload["reputation"]
+    if reputation:
+        lines.append("  Standing:")
+        lines.extend(f"    {row['society_name']}: {row['tier']}" for row in reputation)
+    else:
+        lines.append("  Standing: none recorded.")
+    return lines
+
+
 # Switch name → renderer. Add a section by writing a renderer and registering it here (and in
 # SECTION_NAMES for the overview footer). Aliases (secret/secrets) map to the same renderer.
 SHEET_SECTIONS: dict[str, Callable[..., list[str]]] = {
     "secret": _render_secret_section,
     "secrets": _render_secret_section,
+    "renown": _render_renown_section,
 }
 
 # Canonical section names shown in the bare-``sheet`` footer (deduped; one per real section).
-SECTION_NAMES: tuple[str, ...] = ("secret",)
+SECTION_NAMES: tuple[str, ...] = ("secret", "renown")

--- a/src/commands/account/tests/test_sheet_sections.py
+++ b/src/commands/account/tests/test_sheet_sections.py
@@ -45,3 +45,17 @@ class SheetSecretSectionTests(TestCase):
     def test_secret_section_without_an_active_character(self) -> None:
         self.caller.puppet = None
         assert "no active character" in self._run("").lower()
+
+    def test_renown_section_shows_fame_and_prestige(self) -> None:
+        out = self._run("", switches=["renown"])
+        assert "Renown" in out
+        assert "Fame:" in out
+        assert "Prestige:" in out
+
+    def test_renown_section_lists_society_standing(self) -> None:
+        from world.societies.factories import SocietyReputationFactory
+
+        SocietyReputationFactory(
+            persona=self.viewer_sheet.primary_persona, society__name="The Compact", value=600
+        )
+        assert "The Compact" in self._run("", switches=["renown"])


### PR DESCRIPTION
## What

Continues the `sheet/<section>` architecture (from #1437) with **renown** as the second section, mirroring the web Renown tab. The sheet hub now has `secret` + `renown`.

- `sheet/renown` shows the active character's standing — **fame tier**, **prestige** (total + the five-axis breakdown), and **society reputations** — via `world.societies.renown_serializers.build_renown_payload`, the same builder the web `RenownPanel` uses.
- Registered in `SHEET_SECTIONS` + `SECTION_NAMES`. Demonstrates that adding a section is a small renderer + a registry entry — the pattern the remaining sections (relationships, society/org standings, covenant, magic) will follow.
- Viewing **another** character's renown *card* (tiers only, from the viewer's perspective — the web `RenownCardPanel`) is the natural follow-up.

## Tests

`commands/account/tests/test_sheet_sections.py` — `sheet/renown` shows fame + prestige, and lists society standing. `commands.account` suite green; ruff/ty clean.

## Stacking

**Stacked on #1437** (the sheet-section architecture + the secret section), which is currently in the merge queue. Until it lands, this PR's diff includes #1437's commits; I'll rebase onto `main` once #1437 merges so it shows only the renown changes.

Refs #1334, #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)