### PR TITLE
Relationships center: sheet/relationship telnet section + own web tab

### DIFF
--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -49,6 +49,7 @@ export function CharacterSheetPage() {
       <Tabs defaultValue="sheet" className="space-y-4">
         <TabsList>
           <TabsTrigger value="sheet">Sheet</TabsTrigger>
+          <TabsTrigger value="relationships">Relationships</TabsTrigger>
           <TabsTrigger value="renown">Renown</TabsTrigger>
           <TabsTrigger value="secrets">Secrets</TabsTrigger>
         </TabsList>
@@ -73,10 +74,6 @@ export function CharacterSheetPage() {
             vocation={entry.character.vocation}
             socialRank={entry.character.social_rank}
           />
-          <RelationshipsSection
-            relationships={entry.character.relationships}
-            characterSheetId={entry.character.id}
-          />
           <GalleriesSection galleries={entry.character.galleries} />
           {entry.can_apply && <CharacterApplicationForm entryId={entry.id} />}
           {isMyCharacter && (
@@ -84,6 +81,13 @@ export function CharacterSheetPage() {
               <MessagesSection />
             </div>
           )}
+        </TabsContent>
+
+        <TabsContent value="relationships" className="space-y-4">
+          <RelationshipsSection
+            relationships={entry.character.relationships}
+            characterSheetId={entry.character.id}
+          />
         </TabsContent>
 
         <TabsContent value="renown" className="space-y-4">

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -109,9 +109,11 @@ actions, backends, and service functions.
   and register it in `SHEET_SECTIONS` — **don't** add a standalone `+command`.
 - **`sheet_sections.py`**: the `sheet/<section>` renderers + `SHEET_SECTIONS` registry. Sections:
   `secret` (`sheet/secret [character]`, #1334 — your own secrets, or the ones you know about a
-  character; locked layers "Unknown") and `renown` (`sheet/renown`, #676 — your prestige / fame
-  tier / society standing, via `build_renown_payload`, mirroring the web `RenownPanel`). Each is
-  thin over its app's services. Add a section: a renderer + a registry entry (+ `SECTION_NAMES`).
+  character; locked layers "Unknown"); `renown` (`sheet/renown`, #676 — your prestige / fame tier /
+  society standing, via `build_renown_payload`, mirroring the web `RenownPanel`); `relationship`
+  (`sheet/relationship`, — your regard toward others, a qualitative warm/cold/neutral read of
+  `CharacterRelationship.affection`, mirroring the web `RelationshipsSection`). Each is thin over
+  its app's data. Add a section: a renderer + a registry entry (+ `SECTION_NAMES`).
 
 ### Social Commands (`social/`)
 - **`blocking.py`**: `CmdBlock`/`CmdUnblock`/`CmdShareBlock`/`CmdMute`/`CmdUnmute`/`CmdBlockList`

--- a/src/commands/account/sheet_sections.py
+++ b/src/commands/account/sheet_sections.py
@@ -133,13 +133,60 @@ def _format_renown(payload: dict) -> list[str]:
     return lines
 
 
+def _render_relationships_section(command: Command) -> list[str]:
+    """The relationships section: your regard toward others (relationships app).
+
+    Mirrors the web Relationships tab for your active character — each relationship with a
+    qualitative read of its affection (warm / cold / neutral) + status. Numeric points stay OOC.
+    """
+    from django.db.models import Prefetch  # noqa: PLC0415
+
+    from world.relationships.models import (  # noqa: PLC0415
+        CharacterRelationship,
+        RelationshipTrackProgress,
+    )
+
+    viewer = _viewer_sheet(command)
+    relationships = (
+        CharacterRelationship.objects.filter(source=viewer)
+        .select_related("target__character")
+        .prefetch_related(
+            Prefetch(
+                "track_progress",
+                queryset=RelationshipTrackProgress.objects.select_related("track"),
+                to_attr="cached_track_progress",
+            )
+        )
+        .order_by("-updated_at")
+    )
+    return _format_relationships(list(relationships))
+
+
+def _format_relationships(relationships: list) -> list[str]:
+    if not relationships:
+        return ["You have no relationships recorded."]
+    lines = ["|wYour relationships:|n"]
+    for relationship in relationships:
+        target = relationship.target.character.db_key
+        affection = relationship.affection
+        tone = "|gwarm|n" if affection > 0 else ("|rcold|n" if affection < 0 else "neutral")
+        status = " (pending)" if relationship.is_pending else ""
+        tether = (
+            f" |m[tether: {relationship.soul_tether_role}]|n" if relationship.is_soul_tether else ""
+        )
+        lines.append(f"  {target}: {tone}{status}{tether}")
+    return lines
+
+
 # Switch name → renderer. Add a section by writing a renderer and registering it here (and in
 # SECTION_NAMES for the overview footer). Aliases (secret/secrets) map to the same renderer.
 SHEET_SECTIONS: dict[str, Callable[..., list[str]]] = {
     "secret": _render_secret_section,
     "secrets": _render_secret_section,
     "renown": _render_renown_section,
+    "relationship": _render_relationships_section,
+    "relationships": _render_relationships_section,
 }
 
 # Canonical section names shown in the bare-``sheet`` footer (deduped; one per real section).
-SECTION_NAMES: tuple[str, ...] = ("secret", "renown")
+SECTION_NAMES: tuple[str, ...] = ("secret", "renown", "relationship")

--- a/src/commands/account/tests/test_sheet_sections.py
+++ b/src/commands/account/tests/test_sheet_sections.py
@@ -59,3 +59,26 @@ class SheetSecretSectionTests(TestCase):
             persona=self.viewer_sheet.primary_persona, society__name="The Compact", value=600
         )
         assert "The Compact" in self._run("", switches=["renown"])
+
+    def test_relationships_section_lists_your_relationships(self) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.relationships.constants import TrackSign
+        from world.relationships.factories import (
+            CharacterRelationshipFactory,
+            RelationshipTrackFactory,
+            RelationshipTrackProgressFactory,
+        )
+
+        target = CharacterSheetFactory(character__db_key="Brennan")
+        relationship = CharacterRelationshipFactory(source=self.viewer_sheet, target=target)
+        RelationshipTrackProgressFactory(
+            relationship=relationship,
+            track=RelationshipTrackFactory(sign=TrackSign.POSITIVE),
+            developed_points=50,
+        )
+        out = self._run("", switches=["relationship"])
+        assert "Brennan" in out
+        assert "warm" in out
+
+    def test_relationships_section_empty(self) -> None:
+        assert "no relationships" in self._run("", switches=["relationship"]).lower()


### PR DESCRIPTION
## What

Builds out the **Relationships** contextual center (from the centers map, #1446) on both faces.

- **Telnet** — a `relationship` sheet section (`sheet/relationship`) listing your regard toward others: a qualitative **warm / cold / neutral** read of `CharacterRelationship.affection` + status (pending / soul-tether). Numeric points stay OOC. Registered in `SHEET_SECTIONS` + `SECTION_NAMES`, the third section after `secret` and `renown`.
- **Web** — promoted the existing `RelationshipsSection` out of the bundled "Sheet" tab into its **own "Relationships" tab** on `CharacterSheetPage`, alongside Renown / Secrets — its own findable center.

## Anti-reinvention

The web UI and read API already existed (`RelationshipsSection`, `CharacterRelationshipViewSet`) — this just gives relationships its own tab and adds the telnet face. No new models/serializers.

## Why

Relationships is one of the **three centers a secret→grievance event surfaces in** (secrets / public-reaction / relationships) — so this is also groundwork for that event appearing where it belongs once the scandals feed lands. Per the sheet-is-the-hub + contextual-centers principles.

## Tests

`commands/account/tests/test_sheet_sections.py` — `sheet/relationship` lists your relationships (warm read) + empty state. Backend section suite (7) green; FE typecheck / eslint / `pnpm build` / roster tests green; ruff/ty clean.

Refs #1446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)