### PR TITLE
docs(#1328): backend-journey coverage audit (telnet as the E2E harness)

### DIFF
--- a/docs/architecture/unified-player-action.md
+++ b/docs/architecture/unified-player-action.md
@@ -5,6 +5,20 @@
 **Domain:** Core (Tehom) — action interface, magic-in-combat, challenge resolution
 **Branch:** `unified-action-interface`
 
+## The principle (read this first, plain language)
+
+A player has a **small, shared set of commands**. Whether they click a button on the web or type
+a command in telnet, both simply **express the intent to use an action**. Whether that action
+**happens now, waits its turn, or is blocked** is decided by **context — generally the rules of the
+active scene** (see the scene-round modes in §4 / `SceneRound.mode`: OPEN, POSE_ORDER, STRICT,
+added in #1351). **Combat is one specialization of this** (it always defers), not a separate system.
+
+Both interfaces should express that intent through the **same** path, so a backend (telnet) test of
+a journey also proves the web path. Where the web currently reaches something by an older,
+separate path, that's a **frontend-follows-the-backend** fixup to do afterward — not a different
+design. Everything below is the implementation detail behind this one idea; if the jargon ever
+seems to contradict this principle, the principle wins.
+
 ## 1. Problem & Context
 
 A player's character can currently take actions through **four disconnected

--- a/docs/architecture/unified-player-action.md
+++ b/docs/architecture/unified-player-action.md
@@ -153,8 +153,11 @@ the keystone correction above.
 **Descriptor — `PlayerAction` dataclass** (carries model instances, not bare
 PKs; types in `src/actions/types.py`):
 
-- `backend`: `CHALLENGE | COMBAT | REGISTRY` (TextChoices in
-  `src/actions/constants.py`)
+- `backend`: `CHALLENGE | COMBAT | REGISTRY | SCENE_ADAPTIVE` (TextChoices in
+  `src/actions/constants.py`). `SCENE_ADAPTIVE` was added in #1351 for actions
+  that work both in and out of a combat round (technique casts); see the
+  "SCENE_ADAPTIVE Backend" section of `src/actions/CLAUDE.md` for its dispatch
+  flow (anti-spam floor, `round_declaration` deferral, soulfray-pending gate).
 - `check_type`: the resolved `CheckType` instance (always present; the unifying
   anchor, sourced per-backend per the keystone correction)
 - `action_template`: the `ActionTemplate` instance or `None` (present for
@@ -190,6 +193,10 @@ on the next read with no special path.
   capability_source)`.
 - `COMBAT` → `declare_action(participant, …)`.
 - `REGISTRY` → `get_action(key).run(actor, **kwargs)`.
+- `SCENE_ADAPTIVE` (#1351) → anti-spam check, then `get_action(key)`; inside a
+  combat round `action.round_declaration(ctx, …)` may defer it as a COMBAT
+  declaration, otherwise `action.run(actor, **kwargs)` runs immediately (with a
+  POSE_ORDER quorum / repeat-block check from the active scene round).
 - Immediate vs. declaration-gated is decided by the tempo seam (§4), not the
   backend.
 

--- a/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
+++ b/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
@@ -1,10 +1,19 @@
 # Telnet-Driveability & UI Dispatch-Parity Audit
 
-**Date:** 2026-06-21
+**Date:** 2026-06-21 — **refreshed 2026-06-23** against post-#1351 code.
 **Tracking issue:** [#1328](https://github.com/Arx-Game/arxii/issues/1328)
 **Scope of this pass:** deep trace of the four priority loops — **magic casting, combat,
 thread weaving, social scenes**. Remaining L1 stories (character creation, relationships,
 codex, journals, progression, world clock) are a later broad pass.
+
+> **Refresh note (2026-06-23).** The original 2026-06-21 trace concluded that *"the genuine
+> UI-shared seam is `dispatch_player_action()`, and the telnet layer does not call it."* **That
+> thesis is now obsolete.** Three PRs landed since: **#1337/#1338** (social-consent telnet
+> shells), **#1342** (thread weave/imbue/pull as real `Action`s), and **#1351** (the unified
+> scene-adaptive `cast` + a fourth `SCENE_ADAPTIVE` dispatch backend). Telnet now reaches the
+> dispatcher and `action.run()` across most of the four loops, and **a telnet E2E test already
+> exists for nearly every one** (see "Existing telnet E2E coverage" below). This refresh rewrites
+> every loop table against current code and re-scopes the follow-on to the genuine residual gaps.
 
 ## Why this audit exists
 
@@ -15,270 +24,229 @@ relies on an architectural invariant: **a telnet command and a web view are inte
 UIs over the same code underneath.** If that holds, "works in telnet" ⟹ "works for web
 players." This audit measures where it actually holds — and where it doesn't.
 
-## Headline finding
+## Headline finding (refreshed)
 
-**The genuine UI-shared seam is `dispatch_player_action()`, not `action.run()`** — and the
-telnet layer does not call it.
+**Telnet now drives the dispatcher and `action.run()` across most of the four loops; the
+question has shifted from "can telnet reach it?" to "*where* do telnet and web converge — and is
+that point high enough to make a telnet E2E a valid web proxy?"**
 
-- The web's single dispatch endpoint `DispatchActionView` (`src/actions/views.py:48`) calls
-  `dispatch_player_action()` (`src/actions/player_interface.py:78`), which routes by backend:
-  - `REGISTRY` → `action.run()` (`player_interface.py:113` → `_dispatch_registry` `:150`)
-  - `CHALLENGE` → `resolve_challenge()` (`player_interface.py:117` → `_dispatch_immediate_challenge` `:193`)
-  - `COMBAT` → record a declaration (`_dispatch_clash_contribution` `:546`), resolved later by `resolve_round()`
-- Telnet commands instead call `self.action.run()` **directly** (`src/commands/command.py:140`).
-  That only reaches the `REGISTRY` path. There is **no telnet route to CHALLENGE or COMBAT**.
+There are now **four** dispatch backends (`actions/constants.py:61-64`): `REGISTRY`, `CHALLENGE`,
+`COMBAT`, and `SCENE_ADAPTIVE` (new in #1351). The web write path is `DispatchActionView`
+(`actions/views.py:48`) → `dispatch_player_action()` (`actions/player_interface.py:78`). Telnet
+reaches the same dispatcher through `DispatchCommand` (`commands/command.py`), or `action.run()`
+directly through `ArxCommand`, or — for a few domains — a shared **service** function.
 
-The docstring at `src/actions/base.py:25-26` — *"Commands (telnet) and the web dispatcher
-both call `action.run()`"* — is therefore **misleading**: it is true only for REGISTRY
-actions. Magic and combat never touch `action.run()`. **Fix-on-sight target.**
+The convergence point now **varies by loop**, and that is the whole story:
 
-> **[ALREADY CORRECT — audit claim stale, verified #1337]** The `Action` class
-> docstring (`src/actions/base.py`, ~lines 27–33) **already** describes the real seam
-> and the three dispatch backends; it no longer says telnet calls `action.run()`
-> universally. It reads: *"`action.run()` is the entry point for the **REGISTRY** path
-> only. … the web frontend and telnet `DispatchCommand`s instead call
-> `dispatch_player_action()`, which routes by backend: REGISTRY → `action.run()`,
-> CHALLENGE → `resolve_challenge()`, COMBAT → `declare_action()`/`resolve_round()`.
-> Magic and combat actions never reach `action.run()` directly."* No fix is needed; the
-> "fix-on-sight" call above is itself stale. (History preserved; do not act on it.)
+| Convergence altitude | Loops | Telnet E2E proves web? |
+|---|---|---|
+| **`action.run()` on the *same* Action** | say/pose (REGISTRY), thread weave, thread pull | **Yes** — identical code below the command |
+| **`dispatch_player_action` → same declaration service** | combat technique declaration | **Yes** — both reach `record_declaration`/`declare_action` |
+| **shared *service* only (UIs wrap it differently)** | magic standalone cast, thread imbue, social consent | **Partly** — proves the service & below, *not* each UI's wrapper |
+| **web-only (no telnet)** | combat clash-commit + ~8 PC combat actions, teaching-unlock acquisition | **N/A** — gap |
 
-### There are three web dispatch families; telnet implements a slice of one
-
-| # | Web dispatch family | Entry | Reaches | Telnet today |
-|---|---|---|---|---|
-| 1 | **Unified action dispatch** | `dispatch_player_action()` | REGISTRY→`action.run`, CHALLENGE→`resolve_challenge`, COMBAT→`declare_action`/`resolve_round`→`use_technique` | REGISTRY via `ArxCommand` → `self.action.run()`; COMBAT via `DispatchCommand` → `dispatch_player_action()` (`CmdDeclareTechnique`); non-combat magic via `ArxCommand` → `request_technique_cast` (`CmdAttempt`, RESOLVED #1332) |
-| 2 | **Consent flow** | `SceneActionRequestViewSet` (`action_views.py:55`) → `create_action_request`/`respond_to_action_request` (`action_services.py:150/304`) → `start_action_resolution` | Targeted social actions (intimidate, persuade, …) with accept/deny gating | ❌ none |
-| 3 | **Direct viewset→service** | dedicated viewsets/views → service fn (no action, no dispatcher) | thread weave/imbue/pull, rituals, outfits, narrative | ❌ none |
+The two service-only magic/thread cases are the subtle ones #1351/#1342 introduced and are the
+main residual findings of this refresh (see Loops 2 and 3).
 
 ## Gap classification
 
 | Class | Meaning | Fix |
 |---|---|---|
-| **G0 Converged** | Telnet command exists; web uses the *same* seam | None — telnet E2E is a valid web proxy today |
+| **G0 Converged** | Telnet command exists; web uses the *same* seam (action **or** a shared service) | None — telnet E2E is a valid web proxy today |
 | **G1 Missing shell** | Web seam exists; no telnet command drives it | Add a thin command that calls the *same* seam |
-| **G2 Divergent dispatch** | Telnet path and web path would be *different code* | Unify the seam |
-| **G3 View-only** | Web reaches a service that has no action/dispatch layer (or a GM/system-only surface) | Decide if a player-facing telnet surface is wanted; if so, call the same service |
+| **G2 Divergent dispatch** | Telnet and web reach the goal through *different* actions/wrappers, converging only at a lower service | Decide whether to unify the upper wrapper, or accept the service as the contract |
+| **G3 View-only / GM-only** | Web reaches a service with no action layer, or a GM/system-only surface | Decide if a player-facing telnet surface is wanted; if so, call the same service |
 | **G4 Not buildable** | Story can't run end-to-end yet (missing seed/service) | Backend/seed gap → its own task |
-
-> **Important nuance on G2:** for magic and combat the underlying *service* seam already
-> converges (web reaches `use_technique`/`resolve_challenge` through `dispatch_player_action`).
-> The divergence is only that **telnet doesn't call `dispatch_player_action` at all**. So the
-> fix is not "make magic an Action subclass" (a large, risky refactor) — it is "let telnet
-> commands call `dispatch_player_action()`, the same entry the web uses."
 
 ---
 
 ## Loop 1 — Social scenes
 
-Freeform RP converges; mechanical social actions do not.
+Freeform RP and mechanical social actions both converge now. The consent flow gained telnet
+shells in #1337/#1338, closing the gaps the original audit flagged.
 
 | Step | Telnet | Web dispatch | Same code? | Existing test | Class |
 |---|---|---|---|---|---|
-| Say text | `CmdSay` (`commands/evennia_overrides/communication.py:26`) | `dispatch_player_action`→REGISTRY→`SayAction.execute` | **YES** (both `action.run`) | `test_dispatch_social_round.py` | **G0** |
-| Pose | `CmdPose` (`communication.py:160`) | same as above → `PoseAction.execute` | **YES** | `test_dispatch_social_round.py` | **G0** |
-| Initiate social action (intimidate/…) | ❌ none | `SceneActionRequestViewSet.create` → `create_action_request` (`action_services.py:150`) | **NO** — web uses the *consent flow*, not `dispatch_player_action` | `test_targeted_action_e2e.py` | **G1** |
-| Target accept/deny | ❌ none | `…/respond/` → `respond_to_action_request` (`:304`) | **NO** — no telnet consent surface | `test_targeted_action_e2e.py` | **G1** |
-| Resolve + apply consequence | ❌ (only via consent path) | `respond_to_action_request` → `start_action_resolution` (`:470`) | resolution seam *is* shared; telnet can't reach it | `test_targeted_action_e2e.py` | **G3** |
+| Say text | `CmdSay` (`commands/evennia_overrides/communication.py:26`) | `DispatchActionView`→`dispatch_player_action`→REGISTRY→`SayAction.run` (`player_interface.py:176`) | **YES** (both `action.run`) | `commands/tests/test_dispatchers.py` | **G0** |
+| Pose | `CmdPose` (`communication.py:160`) | same → `PoseAction.run` | **YES** | `commands/tests/test_dispatchers.py` | **G0** |
+| Initiate social action (intimidate/persuade/deceive/flirt/perform/entrance/…) | `CmdIntimidate`/`CmdPersuade`/`CmdDeceive`/`CmdFlirt`/`CmdPerform`/`CmdEntrance`/`CmdRestoreSense` (`commands/consent.py:114-194`) → `create_action_request` | `SceneActionRequestViewSet.create` (`action_views.py:118`) → `create_action_request` (`scenes/action_services.py:150`) | **YES** — same service (the ratified consent SERVICE seam, #1337) | `commands/tests/test_social_consent_e2e.py`, `integration_tests/pipeline/test_consent_telnet_e2e.py` | **G0** |
+| Target accept/deny | `CmdAccept`/`CmdDeny` (`commands/consent.py:251/298`) → `respond_to_action_request` | `…/respond/` (`action_views.py:204`) → `respond_to_action_request` (`scenes/action_services.py:335`) | **YES** — same service | `test_social_consent_e2e.py` | **G0** |
+| Resolve + apply consequence | (via accept) → `start_action_resolution` | same → `start_action_resolution` | **YES** — shared resolution pipeline | `integration_tests/pipeline/test_social_pipeline.py` | **G0** |
 
-**Trap:** the 8 social-action singletons exist (`actions/definitions/social.py`) and a naive
-telnet command calling `action.run()` would resolve **immediately, skipping consent** — a
-different semantic than the web. A telnet command must call `create_action_request()` (then a
-telnet accept/deny calls `respond_to_action_request()`), matching the web consent flow.
-
-**Verdict:** say/pose are telnet-driveable E2E today (G0). Mechanical social actions are
-web-only; the minimal fix is telnet `intimidate`/`accept`/`deny` shells over the consent flow.
+**Verdict:** social scenes are fully telnet-driveable (G0 throughout). Convergence is the consent
+**service** seam by design (#1337): consent is an inherently two-party async protocol whose
+response half can't be a single dispatch call, so telnet and web both call
+`create_action_request` / `respond_to_action_request` directly rather than routing through
+`action.run()`. This was the original audit's biggest correction and is now settled.
 
 ---
 
 ## Loop 2 — Magic casting
 
-100% web-only; never uses `action.run()`; the seam is `dispatch_player_action()`.
+The unified scene-adaptive `cast` (#1351) made **telnet** ride a real `Action`. The **web
+standalone-cast endpoint still does not** — it is the one place in this loop where the two UIs
+converge only at the service.
 
 | Step | Telnet | Web dispatch | Same code? | Existing test | Class |
 |---|---|---|---|---|---|
-| See available techniques | ❌ none | `get_player_actions` / `_combat_actions` (`player_interface.py`) | N/A | — | G3 |
-| Declare cast (non-combat) | ✅ `attempt` (`CmdAttempt`, `commands/magic.py` — `ArxCommand`) | `SceneCastViewSet` → `request_technique_cast` → `use_technique` (`techniques.py:702`) | **YES** — both call `request_technique_cast` (same seam) | `test_noncombat_cast_telnet_e2e.py` | **RESOLVED (#1332)** |
-| Declare cast (combat) | `cast`/`declare` (`commands/combat.py` — `CmdDeclareTechnique(DispatchCommand)`) | `dispatch_player_action`→COMBAT→`declare_action` (`combat/services.py:1494`) | **YES** — telnet calls `dispatch_player_action` (same seam) | `test_combat_ui_integration.py`, `test_combat_cast_telnet_e2e.py`, `test_combat_commands.py` | **G0** |
-| Check + resonance env + effects | N/A (service) | `resolve_round`→`resolve_combat_technique` (`:707`)→`use_technique` (`techniques.py:702`) | **YES** — fully shared service orchestration | `test_magic_story_pipeline.py` | **G0** |
-| Perform ritual | ✅ `ritual`/`perform` (`CmdRitual`) | `RitualPerformView` → `PerformRitualAction.run()` | **YES** — both converge on `perform_ritual` action | `test_ritual_telnet_e2e.py` | **RESOLVED (#1331)** |
+| Standalone cast (in *and* out of combat) | `cast`/`declare` (`CmdDeclareTechnique`, `commands/combat.py:32`, a `DispatchCommand`) → `dispatch_player_action`(SCENE_ADAPTIVE) → `CastTechniqueAction.run` (`actions/definitions/cast.py:30`, key `cast_technique`) → `request_technique_cast` | `SceneActionRequestViewSet.cast` (`action_views.py:322`) → `request_technique_cast` (`scenes/cast_services.py:558`) **directly** | **NO at the action level / YES at the service** — web bypasses `dispatch_player_action` *and* `CastTechniqueAction`; both meet at `request_technique_cast` | `integration_tests/pipeline/test_noncombat_cast_telnet_e2e.py`, `test_combat_cast_telnet_e2e.py` | **G2** |
+| Combat declaration of the cast | same `cast` command — inside a DECLARING round `CastTechniqueAction.round_declaration` (`cast.py:117`) builds a COMBAT declaration | `dispatch_player_action`(COMBAT) → `record_declaration` → `declare_action` (`combat/services.py:1658`) | **YES** — both reach `record_declaration`/`declare_action` | `test_combat_cast_telnet_e2e.py`, `commands/tests/test_combat_commands.py` | **G0** |
+| Check + resonance env + effects | N/A (service) | `resolve_round` → `resolve_combat_technique` → `use_technique` | **YES** — shared service orchestration | `world/magic/tests/integration/test_magic_story_pipeline.py` | **G0** |
+| Perform ritual (SERVICE/FLOW) | `ritual`/`perform` (`CmdRitual`, `commands/ritual.py`) → `PerformRitualAction.run` | `RitualPerformView` (`magic/views.py:907`) → `PerformRitualAction.run` | **YES** — both via `perform_ritual` action | `test_ritual_telnet_e2e.py` | **G0** (RESOLVED #1331) |
+| Multi-participant ritual session | `ritual draft/join/decline/fire` (`CmdRitual`) → `draft_session`/`accept_session`/`decline_session`/`fire_session` | session viewset → same services | **YES** — same services | `test_ritual_session_telnet_e2e.py` | **G0** (RESOLVED #1345) |
 
-> **Rituals (RESOLVED, #1331):** ritual performance is now a real `Action`
-> (`actions/definitions/ritual.py`, key `perform_ritual`). The standalone
-> `world.magic.actions.PerformRitualAction` executor was deleted; telnet
-> (`CmdRitual`) and web (`RitualPerformView`) both call
-> `PerformRitualAction.run()`, so the G3 "web bypasses actions" gap is closed for
-> SERVICE + FLOW rituals. (Anima/SCENE_ACTION rituals dispatch elsewhere and are
-> out of scope.)
+**The G2 cast finding (new since the audit).** #1351 introduced `SCENE_ADAPTIVE` →
+`CastTechniqueAction`, giving the **telnet** cast anti-spam gating, POSE_ORDER quorum advancement,
+`round_declaration` combat-deferral, and the soulfray-consent `PendingCast` re-dispatch
+(`accept soulfray`). The **web** `cast` endpoint (`SceneActionRequestViewSet.cast`) calls
+`request_technique_cast` directly and gets *none* of that wrapper — it returns a
+`SceneActionRequest` for the frontend to handle soulfray its own way. So:
 
-**Verdict:** combat declare is telnet-driveable (G0) — `cast`/`declare`
-(`CmdDeclareTechnique`) calls `dispatch_player_action()` with a COMBAT `ActionRef`, the same
-seam the web uses. Non-combat declare is now also G0 (RESOLVED, #1332) — `attempt`
-(`CmdAttempt`, `commands/magic.py`) is a thin `ArxCommand` shell that calls
-`request_technique_cast()` directly, the same entry point the web viewset uses. The deep
-orchestration (`use_technique`, ~15 steps: anima, soulfray, resonance environment, conditions,
-story beats, achievements) is already service-tested.
+- A telnet cast E2E (`test_noncombat_cast_telnet_e2e.py`) proves `request_technique_cast` **and
+  below**, plus the telnet wrapper — **but not** the web endpoint's wrapper.
+- `CastTechniqueAction` is effectively **`[BUILT, NOT WIRED]` for the web**: it exists and is wired
+  for telnet only. The `cast.py` docstring previously claimed both UIs converge on the action;
+  that was corrected in this refresh.
 
-> **Note on dispatch path:** the spec for #1332 proposed CHALLENGE via `DispatchCommand`,
-> but CHALLENGE requires `challenge_instance_id` (it's for dungeon puzzles). Non-combat
-> magic casts route through `request_technique_cast` → `use_technique` — no CHALLENGE
-> backend involved. `CmdAttempt` is an `ArxCommand`, not a `DispatchCommand`.
+Whether the web cast endpoint *should* route through `dispatch_player_action(SCENE_ADAPTIVE)` (to
+inherit anti-spam/pose-order/soulfray uniformly) or whether anti-spam/pose-order are legitimately
+telnet-pacing concerns the web handles differently is a **design question**, not an obvious bug —
+see Follow-on.
+
+**Verdict:** combat declaration, ritual performance, and ritual sessions are G0. Standalone cast
+is G2 — telnet rides the action, web rides the service. The deep orchestration (`use_technique`:
+anima, soulfray, resonance environment, conditions, story beats, achievements) is shared and
+service-tested.
 
 ---
 
 ## Loop 3 — Thread weaving
 
-100% web-only; mostly **direct viewset→service** (family 3) — does not even reach
-`dispatch_player_action`.
+#1342 turned weave/imbue/pull into real `Action`s. Weave and pull are now genuine `action.run()`
+convergence (G0); imbue converges only at the service (G2); teaching-unlock acquisition is still
+web-only (G1).
 
 | Step | Telnet | Web dispatch | Same code? | Existing test | Class |
 |---|---|---|---|---|---|
-| Acquire THREAD WEAVING unlock | ❌ none | `teaching-offers/{id}/accept/` → `accept_thread_weaving_unlock` (`services/threads.py:548`) | service-only | `test_thread_weaving_acquisition.py` | **G1** |
-| Weave a thread | ❌ none | `ThreadViewSet.create` → `weave_thread` (`services/threads.py:298`) | service-only | `test_resonance_services.py` | **G1** |
-| Imbue (spend resonance, advance level) | ✅ `ritual Rite of Imbuing thread=<id> amount=<n>` (`CmdRitual`) | `RitualPerformView` → `PerformRitualAction.run()` → `spend_resonance_for_imbuing` | **YES** — both via `perform_ritual` action | `test_ritual_telnet_e2e.py` | **RESOLVED (#1331)** |
-| Pull thread (in combat) | ❌ none | `ThreadPullCommitView` → `spend_resonance_for_pull` (`services/resonance.py:588`) | service-only | `test_thread_pull_pipeline.py` | **G3** |
+| Acquire THREAD WEAVING unlock | ❌ none | `teaching-offers/{id}/accept/` → `accept_thread_weaving_unlock` (`magic/services/threads.py`) | service-only; no telnet | `magic/tests/test_teaching_offer_accept_view.py` | **G1** |
+| Weave a thread | `CmdWeaveThread` (`commands/weave.py:29`) → `WeaveThreadAction.run` (`actions/definitions/threads.py:23`) | `ThreadSerializer.create` (`magic/serializers.py:867`) → `WeaveThreadAction.run` | **YES** — same action | `commands/tests/test_weave_command.py`, `integration_tests/pipeline/test_weave_telnet_e2e.py` | **G0** (RESOLVED #1342) |
+| Imbue (spend resonance, advance level) | `imbue` (`CmdImbue`, `commands/imbue.py`) → `ImbueAction.run` (`actions/definitions/imbue.py:23`) → `spend_resonance_for_imbuing` (`magic/services/resonance.py:221`) | `RitualPerformView` → `PerformRitualAction.run` → (Rite of Imbuing CEREMONY service) → `spend_resonance_for_imbuing` | **NO at the action level / YES at the service** — telnet uses the `ImbueAction` *finisher*; web resolves imbuing through `PerformRitualAction`; both meet at `spend_resonance_for_imbuing` | `commands/tests/test_imbue_cmd.py`, `integration_tests/pipeline/test_weave_imbue_pull_journey_e2e.py` | **G2** |
+| Pull thread (in combat) | `pull` (`CmdPull`, `commands/pull.py:28`) → `PullThreadAction.run` (`actions/definitions/pull.py:25`) → `spend_resonance_for_pull` (`magic/services/resonance.py:588`) | `ThreadPullCommitView` → `ThreadPullCommitRequestSerializer.create` → `PullThreadAction.run` | **YES** — same action | `commands/tests/test_pull_cmd.py`, `test_weave_imbue_pull_journey_e2e.py` | **G0** (RESOLVED #1342) |
 
-**Verdict:** not telnet-driveable. The web path is *not an action* — it's viewsets calling
-services directly. The services are self-contained convergence points; telnet shells can call
-the **same services** for real parity. **Open question:** should imbue/pull be actions so the
-cross-cutting `action.run` machinery (prerequisites, AP/fatigue, enhancements, events) applies
-uniformly — or are they legitimately plain service calls? (See Open questions.)
+**The G2 imbue finding (new since the audit).** Imbuing uses a **ceremony/finisher** split: a
+player performs the *Rite of Imbuing* CEREMONY ritual (which creates a `PendingRitualEffect`), then
+a **finisher** advances the thread. Telnet's finisher is `ImbueAction` (gated by a
+`PendingRitualEffectPrerequisite`, `commands/imbue.py` → `actions/definitions/imbue.py`); the web
+resolves the same end through `PerformRitualAction`'s CEREMONY service path. Two different actions
+for one user goal, converging at `spend_resonance_for_imbuing`. This is a parallel-implementation
+smell worth a deliberate decision (unify on one finisher action vs. accept the service as the
+contract) — flagged in Follow-on, not asserted as a fix.
+
+**Verdict:** weave and pull are telnet-driveable at the action seam (G0). Imbue is G2 (service
+convergence). Teaching-unlock acquisition is the lone untouched G1 (no telnet shell yet).
 
 ---
 
 ## Loop 4 — Combat
 
-100% web-only; declarations go through `dispatch_player_action` (COMBAT, deferred), resolution
-is GM/system-triggered.
+Technique **declaration** converges (G0) via the #1351 SCENE_ADAPTIVE reshaping. Clash-commit and
+the bundle of other PC combat actions remain web-only (G1); round resolution and encounter setup
+are correctly GM/system-only (G3).
 
 | Step | Telnet | Web dispatch | Same code? | Existing test | Class |
 |---|---|---|---|---|---|
-| GM starts encounter | ❌ none | `CombatEncounterViewSet.create` + `begin_declaration_phase` (`combat/services.py:1451`) | GM/system surface | `test_duels_integration.py` | G3 (correct) |
-| Player declares technique/passives | ❌ none | `dispatch_player_action`→COMBAT→`record_declaration`→`declare_action` (`combat/services.py:1494`) → `CombatRoundAction` row | seam converges; no telnet | `test_combat_ui_integration.py` | **G1** |
-| Commit to clash | ❌ none | `dispatch_player_action`→`_dispatch_clash_contribution` (`player_interface.py:546`) | seam converges; no telnet | `test_combat_ui_integration.py` | **G1** |
-| GM resolves round | ❌ none | `…/resolve_round/` → `resolve_round` (`combat/services.py:3997`) → `use_technique` | service-only, GM-triggered | `test_duels_integration.py` | G3 (correct) |
-| NPC selection / damage / conditions | N/A | threat-pool selection + damage services (internal to `resolve_round`) | service-only | `test_agency_integration.py` | G3 (correct) |
+| GM starts encounter | ❌ none (GM) | `CombatEncounterViewSet` → `begin_declaration_phase` (`combat/services.py:1424`) | GM/system surface | `world/combat/tests/.../test_duels_integration.py` | **G3** (correct) |
+| Player declares technique | `cast`/`declare` (`CmdDeclareTechnique`) → SCENE_ADAPTIVE → `round_declaration` → `record_declaration` (`combat/round_context.py:101→197`) → `declare_action` (`combat/services.py:1658`) | `DispatchActionView`→`dispatch_player_action`(COMBAT) → `record_declaration` → `declare_action` | **YES** — both reach `record_declaration`/`declare_action` | `test_combat_cast_telnet_e2e.py`, `test_combat_ui_integration.py` | **G0** |
+| Commit to clash | ❌ none | `dispatch_player_action` → `_dispatch_clash_contribution` (`player_interface.py:627`) → `declare_clash_contribution` (`combat/services.py:4693`) | seam converges; no telnet shell | `test_combat_ui_integration.py` | **G1** |
+| GM resolves round | ❌ none (GM) | `…/resolve_round/` → `resolve_round` (`combat/services.py:4454`) → `use_technique` | service-only, GM-triggered | `test_duels_integration.py` | **G3** (correct) |
+| Other PC combat actions: `flee`/`cover`/`interpose`/`join`/`leave`/`ready`/`upgrade_combo`/`revert_combo` | ❌ none | `CombatEncounterViewSet` `@action`s → `declare_flee` (`combat/services.py:1004`), `declare_cover` (`:1053`), `declare_interpose` (`:1106`), join/leave/ready/combo services | seam converges; no telnet shells | `test_duels_integration.py`, `test_agency_integration.py` | **G1** |
+| NPC selection / damage / conditions | N/A | threat-pool selection + damage services (internal to `resolve_round`) | service-only | `test_agency_integration.py` | **G3** (correct) |
 
 **Seed prerequisites (gate the test, G4 until met):** `CharacterVitals`, `CovenantRole`
-(auto-assigned if absent), `ThreatPool`/`ThreatPoolEntry`, and `Technique.action_template.check_type`
-populated. Factories exist for most.
+(auto-assigned if absent), `ThreatPool`/`ThreatPoolEntry`, and
+`Technique.action_template.check_type` populated. Factories exist for most;
+`test_combat_cast_telnet_e2e.py` already wires a working seed.
 
-**Verdict:** player declarations are the only missing player surface (G1); resolution is
-correctly GM/system-only (G3). Combat is deferred (declare-then-resolve), so a telnet
-`declare` command calling `dispatch_player_action()` records a declaration exactly like the
-web. Minimal fix: a `CmdDeclareAction` plus a GM-only `start encounter` for test setup.
-
----
-
-## Cross-cutting conclusions
-
-1. **`dispatch_player_action()` is the seam to standardize on.** Routing telnet commands
-   through it (instead of `self.action.run()` directly) instantly extends telnet to the
-   CHALLENGE and COMBAT backends with no per-domain refactor.
-2. **Consent-flow and direct-viewset systems need telnet shells that call the same
-   service/flow** (`create_action_request`/`respond_to_action_request` for social;
-   `weave_thread`/`spend_resonance_for_*` for threads) — not `action.run()`.
-3. **No magic/combat story is telnet-driveable today**, so none can yet serve as a telnet E2E
-   regression. The service-layer pipeline tests remain the only proof for those loops.
-4. ~~**The `action.run` docstring is stale** and should be corrected to describe the real
-   `dispatch_player_action` seam and the three dispatch families.~~
-   **[ALREADY CORRECT — audit claim stale, verified #1337]** The `Action` docstring
-   (`src/actions/base.py`, ~lines 27–33) already describes the REGISTRY-only role of
-   `action.run()` and the three backends routed by `dispatch_player_action()`. No
-   correction is needed.
-
-## Recommended direction (for the build phase, not yet ratified)
-
-- **Adopt `dispatch_player_action()` as the canonical "what any UI calls" seam.** Add a thin
-  telnet base that calls it (carrying an `ActionRef`), so telnet rides the same backend
-  routing as the web.
-- **Pilot the first telnet-driven E2E on one loop** end-to-end, proving the pattern, then
-  template it across the others. (Loop choice is the next open decision — magic is the north
-  star but needs the most new surface; social/combat reuse `dispatch_player_action` most
-  directly.)
-- **Retire duplicative unit tests only after** a loop has a real telnet/web-seam E2E covering
-  the behavior — and keep fast unit tests where they localize failures the E2E cannot.
-
-## Open questions (for design)
-
-- **RESOLVED (#1337):** Should thread imbue/pull and similar direct-viewset mutations
-  **become actions** (so prerequisites/AP/enhancements/events apply uniformly), or stay
-  plain service calls? **Answer:** they become **real `Action`s on `action.run()`** (the
-  #1331 ritual template). The classification rule: *a player-facing state mutation with
-  costs/prerequisites becomes an `Action`; GM/system-only surfaces (e.g. `resolve_round`,
-  encounter setup) stay raw services with no player UI.* Worked example: `WeaveThreadAction`
-  (`src/actions/definitions/threads.py`); `ThreadSerializer.create()` now calls
-  `action.run()` so web + telnet converge (`CmdWeaveThread`, `src/commands/weave.py`). See
-  Family 3 in [unified-player-action.md](../architecture/unified-player-action.md#10-telnet-convergence-convention--three-player-action-families-ratified-1337).
-- **RESOLVED (#1337):** Should the **consent flow be reachable through
-  `dispatch_player_action`** (a unified entry for *all* player actions), or remain a distinct
-  viewset that telnet shells call directly? **Answer:** it stays at the **consent SERVICE
-  seam** — telnet's `ConsentRequestCommand`/`CmdIntimidate` + generic `CmdAccept`/`CmdDeny`
-  (`src/commands/consent.py`) call the same `create_action_request()` /
-  `respond_to_action_request()` services the `SceneActionRequestViewSet` calls — **not**
-  `dispatch_player_action()`/`action.run()`. Consent is an inherently two-party async
-  protocol whose response half can't be a single dispatch call, and "needs consent" is a
-  property of `ActionTemplate.consent_category`, not the Action. See Family 2 in
-  [unified-player-action.md](../architecture/unified-player-action.md#10-telnet-convergence-convention--three-player-action-families-ratified-1337).
-- For combat/magic seed prerequisites, which belong in a shared **combat seed module** so the
-  E2E is writable without bespoke per-test wiring?
+**Verdict:** technique declaration is G0 (the `cast` command reaches `declare_action` exactly like
+the web COMBAT backend). The residual G1 surface is clash-commit plus the ~8 other PC combat
+actions — each needs its own thin telnet shell calling the same service. Resolution and setup stay
+GM/system-only (G3).
 
 ---
 
-## Broad-pass inventory (follow-up sweep)
+## Existing telnet E2E coverage (Deliverable 3 — already substantial)
 
-The four loops above were a *deep* trace. This section is the *broad* pass the original
-scope deferred: a full sweep of the DRF surface (every `router.register`, `APIView`, and
-`@action`) to find player-facing mutations with no telnet command. **Result: ~150
-player-facing API mutations; only ~7 have any telnet command** (`wear`, `undress`, `use`,
-`+block`/`+unblock`/`+mute`/`+unmute`, plus `say`/`pose`/`emit` via actions). Everything
-mechanical is web-only.
+The original audit said "no magic/combat story is telnet-driveable today." That is now false.
+`src/integration_tests/pipeline/` already contains telnet-driven (`execute_cmd`-level) journey
+tests for most loops:
 
-### Two corrections to the deep trace above
-
-1. **Combat was under-counted.** Loop 4 traced only *declare* and *clash-commit* (through
-   `dispatch_player_action`). But `CombatEncounterViewSet` exposes ~13 *additional* direct
-   `@action`→service player surfaces with no telnet path that **will not** be reached by the
-   `dispatch_player_action` routing fix: `flee` (`declare_flee`, `combat/services.py:926`),
-   `cover` (`declare_cover` `:975`), `interpose` (`declare_interpose` `:1028`), `yield`
-   (`duels.yield_duel:303`), `join`/`leave` (`:852`/`:886`), `ready`, `upgrade_combo`/
-   `revert_combo` (`:2523`/`:2642`). These need their own thin shells (family 3), not just
-   the dispatch reroute.
-2. **The dispatch-routing keystone is now its own issue** (foundation), not just the bullet
-   in "Cross-cutting conclusions #1".
-
-### Web-only clusters with no telnet surface (by domain)
-
-| Domain | Representative web-only surfaces (seam) | Class |
+| Loop | Telnet E2E test | Covers |
 |---|---|---|
-| **Social consent** | `create_action_request` / `respond_to_action_request` (`scenes/action_views.py:55/195`) | G1/G3 |
-| **Entrance + flourish** | `EntranceAction`; `resolve_entry_flourish_offer` (`magic/entry_flourish.py`) | G1/G3 |
-| **Resonance endorsements** | pose / scene-entry / style (`magic/views.py:1053+`); fashion `FashionJudgementViewSet` (`items/views.py:1280`) | **RESOLVED — #1340** |
-| **Interaction reactions** | `InteractionFavorite` / `InteractionReaction` / reaction windows (`scenes/`) | G3 |
-| **Thread weave/imbue/pull** | `weave_thread` / `spend_resonance_for_imbuing` / `_for_pull` (`magic/services/`) | G1/G3 |
-| **Soul-tether & sineating** | 8 APIViews: accept/dissolve/request/respond/rescue/stage-advance (`magic/views.py:1206–1461`) | G3 |
-| **Audere / Audere Majora** | `resolve_audere_offer`; `cross_threshold` (`magic/audere*.py`) — the progression/"leveling" surface | G3 |
-| **Multi-participant rituals** | `draft_session`/`accept`/`decline`/`fire` (`magic/services/sessions.py`) | **RESOLVED — #1345** |
-| **Covenant membership** | engage/disengage/leave/kick/rank; banner-call/stand-down (`covenants/services.py`) | G3 |
-| **Persona / guise** | `set_active_persona` (`scenes/services.py:86`) | G3 |
-| **Progression rewards** | `claim_kudos_for_xp`; `cast_vote`/`remove_vote`; random-scene; path-intent (`progression/views.py`) | G3 |
-| **Missions** | resolve/abandon/group_pick/group_vote (`missions/views.py:497+`) | G3 |
-| **Journals & goals** | `create_journal_entry`/`respond`; `CharacterGoalViewSet` (`journals/`, `goals/`) | G3 |
+| Magic cast (non-combat) | `test_noncombat_cast_telnet_e2e.py` | `cast` (SCENE_ADAPTIVE) → anima debit, OUTCOME interaction, `TECHNIQUE_CAST` event |
+| Magic cast (combat) | `test_combat_cast_telnet_e2e.py` | `cast` inside a DECLARING round → combat declaration |
+| Ritual | `test_ritual_telnet_e2e.py` | `ritual`/`perform` → `PerformRitualAction` |
+| Ritual session | `test_ritual_session_telnet_e2e.py` | `ritual draft/join/decline/fire` |
+| Thread weave+imbue+pull | `test_weave_imbue_pull_journey_e2e.py`, `test_weave_telnet_e2e.py` | full ceremony/finisher journey |
+| Social consent | `test_consent_telnet_e2e.py` | intimidate/accept/deny |
+| Challenge dispatch | `test_challenge_dispatch_telnet_e2e.py` | CHALLENGE backend |
+| Endorsement | `test_endorsement_journey_e2e.py` | pose/entry/style endorse (#1340) |
+| Audere / Durance | `test_audere_telnet_e2e.py`, `test_durance_e2e.py` | progression surfaces |
 
-### Two named surfaces that don't map to code
+So Deliverable 3 is mostly **done**; the remaining E2E work is narrow (clash-commit + PC combat
+actions once shells exist, and a web-vs-telnet parity assertion for the two G2 cases).
 
-- **Soulfray combat-consent** — no dedicated surface found (neither telnet nor web). Soulfray
-  severity accumulates as a runtime side-effect of casting (`techniques.py:525`); entry appears
-  automatic at Warp stage 3. Whether an explicit consent gate is intended is an open design
-  question, tracked separately.
-- **"Ritual of the Durance"** — no ritual by that name exists. "Durance" is a *covenant type*
-  (`Covenant of the Durance`, the default/standing covenant). Level advancement actually rides
-  **thread Imbuing** and **Audere Majora crossing**. Naming reconciliation tracked separately.
+## Cross-cutting conclusions (refreshed)
 
-### Disposition
+1. **Telnet has caught up to the dispatcher.** `DispatchCommand` lets telnet reach SCENE_ADAPTIVE,
+   COMBAT, and CHALLENGE; the social/thread loops converge at shared services. The original "telnet
+   never calls `dispatch_player_action`" finding is retired.
+2. **Convergence altitude is the remaining variable.** Most loops now converge at `action.run()` or
+   the declaration service (telnet E2E = valid web proxy). **Two cases converge only at the
+   service** — magic standalone cast (G2) and thread imbue (G2) — because each UI wraps the service
+   differently. A telnet E2E there proves the service, not the web wrapper.
+3. **Residual G1 surface is small and combat-shaped:** clash-commit and ~8 PC combat actions
+   (flee/cover/interpose/join/leave/ready/upgrade_combo/revert_combo), plus teaching-unlock
+   acquisition. Each is a thin shell over an existing service.
+4. **Telnet E2E coverage already exists** for nearly every loop (table above); the umbrella's
+   Deliverable 3 is largely complete.
 
-Tracked as journey-shaped children of the umbrella issue (telnet commands + one user-journey
-E2E each, which then retires the unit tests it covers): two **foundation** issues (dispatch
-routing; consent-flow / direct-viewset strategy), the per-domain **journey** issues above, and
-two **design-clarification** issues (soulfray consent; durance naming). Existing combat (scope
-widened), ritual-as-Action, and non-combat-cast journeys are reconciled into the same set. See
-the umbrella issue for the live child map.
+## Follow-on (re-scoped 2026-06-23)
+
+Verified against current code; premises checked per `verify-against-code`. Distinguishes scoped
+work from open design questions.
+
+**Design questions (file as `needs-design`, not as ready work):**
+
+1. **Web standalone-cast vs `CastTechniqueAction` (the G2 cast).** Should
+   `SceneActionRequestViewSet.cast` route through `dispatch_player_action(SCENE_ADAPTIVE)` so the
+   web inherits anti-spam / POSE_ORDER quorum / soulfray-`PendingCast` uniformly — or are those
+   telnet-pacing concerns the web legitimately handles its own way? Today `CastTechniqueAction` is
+   wired for telnet only. *Premise verified:* `action_views.py:392` calls `request_technique_cast`
+   directly; `cast.py` is reached only by `CmdDeclareTechnique`.
+2. **Imbue finisher unification (the G2 imbue).** Telnet uses `ImbueAction`; web resolves imbuing
+   through `PerformRitualAction`. One user goal, two actions, converging at
+   `spend_resonance_for_imbuing`. Unify on a single finisher action, or ratify the service as the
+   contract? *Premise verified:* `actions/definitions/imbue.py:23` vs the CEREMONY path in
+   `actions/definitions/ritual.py`.
+
+**Scoped work (thin shells over existing services — G1):**
+
+3. **Combat PC-action telnet shells:** clash-commit (`declare_clash_contribution`,
+   `combat/services.py:4693`) and flee/cover/interpose/join/leave/ready/upgrade_combo/revert_combo
+   (`CombatEncounterViewSet` `@action`s → their `declare_*`/encounter services). Each is a
+   `DispatchCommand` or thin service shell, then a telnet assertion in `test_duels_integration`'s
+   journey form.
+4. **Teaching-unlock telnet shell:** a command over `accept_thread_weaving_unlock`
+   (`magic/services/threads.py`) so the thread-weaving journey is driveable from acquisition.
+
+**Verification work (close the G2 proof gap):**
+
+5. For the two G2 cases, add a **web-path assertion** alongside the existing telnet E2E (POST the
+   web cast / ritual-imbue endpoint and assert the same service outcome) so the parity is proven on
+   *both* wrappers, not just inferred from the shared service.
+
+**Likely already closed (verify before filing anything):** the original Disposition listed
+per-domain journey children and two foundation issues (dispatch routing; consent strategy). The
+dispatch-routing keystone shipped as #1351 (SCENE_ADAPTIVE); the consent strategy was ratified in
+#1337; weave/imbue/pull shipped in #1342. Reconcile the umbrella's child map against this refresh
+before opening new issues — most of the original deep-trace gaps are resolved.

--- a/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
+++ b/docs/audits/2026-06-21-telnet-driveability-ui-parity.md
@@ -1,252 +1,101 @@
-# Telnet-Driveability & UI Dispatch-Parity Audit
+# Telnet Backend-Journey Coverage
 
-**Date:** 2026-06-21 — **refreshed 2026-06-23** against post-#1351 code.
+**Date:** 2026-06-21 — **rewritten 2026-06-23** (post-#1351) around the backend-journey principle.
 **Tracking issue:** [#1328](https://github.com/Arx-Game/arxii/issues/1328)
-**Scope of this pass:** deep trace of the four priority loops — **magic casting, combat,
-thread weaving, social scenes**. Remaining L1 stories (character creation, relationships,
-codex, journals, progression, world clock) are a later broad pass.
+**Loops covered deep:** magic casting, combat, thread weaving, social scenes. Other journeys
+(missions, covenant, persona, progression, journals) get the broad pass at the end.
 
-> **Refresh note (2026-06-23).** The original 2026-06-21 trace concluded that *"the genuine
-> UI-shared seam is `dispatch_player_action()`, and the telnet layer does not call it."* **That
-> thesis is now obsolete.** Three PRs landed since: **#1337/#1338** (social-consent telnet
-> shells), **#1342** (thread weave/imbue/pull as real `Action`s), and **#1351** (the unified
-> scene-adaptive `cast` + a fourth `SCENE_ADAPTIVE` dispatch backend). Telnet now reaches the
-> dispatcher and `action.run()` across most of the four loops, and **a telnet E2E test already
-> exists for nearly every one** (see "Existing telnet E2E coverage" below). This refresh rewrites
-> every loop table against current code and re-scopes the follow-on to the genuine residual gaps.
+## Why this doc exists (the principle)
 
-## Why this audit exists
+Telnet is **not** an interface we're investing in for its own sake — it's **pure backend**, which
+makes it the ideal way to write full **end-to-end tests of user journeys**. Every journey is one
+question: **"Can a player do X?"** — perform a major ritual, fight through a combat sequence, run a
+mission, drive a social scene.
 
-The goal is to make **telnet a first-class end-to-end testing surface** for whole user
-stories. Telnet is pure backend, so driving a story through telnet commands yields a full
-`command → … → service-function` integration test with no frontend in the loop. The premise
-relies on an architectural invariant: **a telnet command and a web view are interchangeable
-UIs over the same code underneath.** If that holds, "works in telnet" ⟹ "works for web
-players." This audit measures where it actually holds — and where it doesn't.
+The ordering that keeps this coherent: **get the journey working end-to-end in the backend first
+(proven by a telnet test); the frontend can always be made to follow.** Sometimes a frontend piece
+will need to be **re-pointed afterward** — e.g. the web's "cast" still uses an older path instead
+of the shared one #1351 introduced. That's a follow-the-backend fixup, **not** a reason the journey
+"doesn't work."
 
-## Headline finding (refreshed)
+So the real question this doc answers is **"which important player journeys work end-to-end in the
+backend today, and which don't yet?"** — not "do telnet and web match." Where the web is on an
+older path, it's a **frontend-follows** note, listed but never counted as a blocker.
 
-**Telnet now drives the dispatcher and `action.run()` across most of the four loops; the
-question has shifted from "can telnet reach it?" to "*where* do telnet and web converge — and is
-that point high enough to make a telnet E2E a valid web proxy?"**
+### How to read the tables
 
-There are now **four** dispatch backends (`actions/constants.py:61-64`): `REGISTRY`, `CHALLENGE`,
-`COMBAT`, and `SCENE_ADAPTIVE` (new in #1351). The web write path is `DispatchActionView`
-(`actions/views.py:48`) → `dispatch_player_action()` (`actions/player_interface.py:78`). Telnet
-reaches the same dispatcher through `DispatchCommand` (`commands/command.py`), or `action.run()`
-directly through `ArxCommand`, or — for a few domains — a shared **service** function.
+- **End-to-end in backend?** — can a player drive the whole journey start-to-finish with backend
+  commands today? (Yes / Partial / No.)
+- **Telnet test** — the integration test that proves it (in `src/integration_tests/pipeline/`).
+- **Backend gap** — the missing piece a player can't yet drive (the work that matters).
+- **Frontend follows** — where the web reaches the same journey by an older path that should be
+  re-pointed later (secondary).
 
-The convergence point now **varies by loop**, and that is the whole story:
+> One shared path underneath: a player command (telnet) and a web action both express *intent to
+> use an action*, and the active scene's rules decide whether it happens now, waits its turn, or is
+> blocked (`SceneRound` mode OPEN / POSE_ORDER / STRICT, #1351). Combat is one specialization of
+> that, not a separate thing. See `docs/architecture/unified-player-action.md`.
 
-| Convergence altitude | Loops | Telnet E2E proves web? |
+---
+
+## The four priority journeys
+
+| Journey ("can a player…") | End-to-end in backend? | Telnet test | Backend gap | Frontend follows |
+|---|---|---|---|---|
+| **Cast a technique** (in or out of a scene) | **Yes** | `test_noncombat_cast_telnet_e2e.py`, `test_combat_cast_telnet_e2e.py` | — | Web cast uses an older path (`SceneActionRequestViewSet.cast` → `request_technique_cast` directly) instead of the shared scene-adaptive cast. Re-point afterward — already routed here by #1351's own follow-up and tracked in #1444. |
+| **Perform a ritual** (incl. multi-person sessions) | **Yes** | `test_ritual_telnet_e2e.py`, `test_ritual_session_telnet_e2e.py` | — | Web and backend already share the ritual path. |
+| **Weave → imbue → pull a thread** | **Mostly** | `test_weave_imbue_pull_journey_e2e.py`, `test_weave_telnet_e2e.py` | **Acquiring the unlock**: no backend command to accept the teaching offer that grants thread-weaving, so the journey can't be driven from the very start. | Web imbue uses an older path (`PerformRitualAction`) vs the backend's imbue finisher; same end result. Re-point afterward. |
+| **Fight a combat sequence** | **Partial** | `test_combat_cast_telnet_e2e.py` (declaring a technique only) | **The rest of a player's combat moves have no backend command**: commit to a clash, flee, take cover, interpose, join/leave, ready, combo up/down. A player can declare a technique but can't drive a full fight. **This is the biggest real gap.** | Web has these (encounter viewset); they're not yet drivable in the backend, so not yet testable end-to-end. |
+| **Drive a social scene** | **Yes** | `test_consent_telnet_e2e.py`, `test_social_pipeline.py` | — | Say/pose and the targeted social actions (intimidate, accept/deny) share the same backend path web uses. |
+
+**Reading the combat row:** GM-only steps (start an encounter, resolve a round, add opponents)
+are correctly not player-drivable and out of scope — a player never does them. The gap is only the
+*player's own* moves beyond "declare a technique."
+
+---
+
+## Beyond the four loops (broad pass)
+
+These journeys mostly have **no backend command yet**, so they can't be driven or tested
+end-to-end. Each already has a tracking issue (the "Telnet journey:" children of #1328):
+
+| Journey | Backend command today | Tracking |
 |---|---|---|
-| **`action.run()` on the *same* Action** | say/pose (REGISTRY), thread weave, thread pull | **Yes** — identical code below the command |
-| **`dispatch_player_action` → same declaration service** | combat technique declaration | **Yes** — both reach `record_declaration`/`declare_action` |
-| **shared *service* only (UIs wrap it differently)** | magic standalone cast, thread imbue, social consent | **Partly** — proves the service & below, *not* each UI's wrapper |
-| **web-only (no telnet)** | combat clash-commit + ~8 PC combat actions, teaching-unlock acquisition | **N/A** — gap |
+| Missions (resolve a beat, abandon, group pick/vote) | none | #1349 |
+| Covenant membership (engage/leave/kick/rank, banner-call) | none | #1346 |
+| Persona / guise switching | none | #1347 |
+| Progression rewards (claim kudos, vote, random-scene, path-intent) | none | #1348 |
+| Journals & goals authoring | none | #1350 |
+| Interaction reactions & favorites | none | #1341 |
+| Entry flourish (resolve a pending offer) | none | #1246 |
 
-The two service-only magic/thread cases are the subtle ones #1351/#1342 introduced and are the
-main residual findings of this refresh (see Loops 2 and 3).
+A player-facing state change with costs/prerequisites should become a real action driven the same
+way casts and weaves are, so a backend command and the web both reach it; GM/system-only steps stay
+backend services with no player command.
 
-## Gap classification
+## What to do next
 
-| Class | Meaning | Fix |
-|---|---|---|
-| **G0 Converged** | Telnet command exists; web uses the *same* seam (action **or** a shared service) | None — telnet E2E is a valid web proxy today |
-| **G1 Missing shell** | Web seam exists; no telnet command drives it | Add a thin command that calls the *same* seam |
-| **G2 Divergent dispatch** | Telnet and web reach the goal through *different* actions/wrappers, converging only at a lower service | Decide whether to unify the upper wrapper, or accept the service as the contract |
-| **G3 View-only / GM-only** | Web reaches a service with no action layer, or a GM/system-only surface | Decide if a player-facing telnet surface is wanted; if so, call the same service |
-| **G4 Not buildable** | Story can't run end-to-end yet (missing seed/service) | Backend/seed gap → its own task |
+**Real backend work — these unblock testable journeys:**
 
----
+1. **Combat player moves** — give a player backend commands for clash-commit, flee, cover,
+   interpose, join/leave, ready, combo up/down (over the existing combat services), so a full fight
+   is drivable and a combat journey test can exist. *Largest gap; needs its own issue or a widened
+   combat-journey issue.*
+2. **Thread-weaving unlock** — a backend command to accept the teaching offer, so the weave→imbue→pull
+   journey is drivable from acquisition.
+3. **The broad-pass journeys** above — each child issue adds the backend command(s) + one journey test.
 
-## Loop 1 — Social scenes
+**Frontend-follows fixups — do after the backend journey works, never a blocker:**
 
-Freeform RP and mechanical social actions both converge now. The consent flow gained telnet
-shells in #1337/#1338, closing the gaps the original audit flagged.
+4. **Web cast** → move onto the shared scene-adaptive cast path (tracked in #1444 under #1328).
+5. **Web imbue** → converge on the same imbue path the backend uses.
 
-| Step | Telnet | Web dispatch | Same code? | Existing test | Class |
-|---|---|---|---|---|---|
-| Say text | `CmdSay` (`commands/evennia_overrides/communication.py:26`) | `DispatchActionView`→`dispatch_player_action`→REGISTRY→`SayAction.run` (`player_interface.py:176`) | **YES** (both `action.run`) | `commands/tests/test_dispatchers.py` | **G0** |
-| Pose | `CmdPose` (`communication.py:160`) | same → `PoseAction.run` | **YES** | `commands/tests/test_dispatchers.py` | **G0** |
-| Initiate social action (intimidate/persuade/deceive/flirt/perform/entrance/…) | `CmdIntimidate`/`CmdPersuade`/`CmdDeceive`/`CmdFlirt`/`CmdPerform`/`CmdEntrance`/`CmdRestoreSense` (`commands/consent.py:114-194`) → `create_action_request` | `SceneActionRequestViewSet.create` (`action_views.py:118`) → `create_action_request` (`scenes/action_services.py:150`) | **YES** — same service (the ratified consent SERVICE seam, #1337) | `commands/tests/test_social_consent_e2e.py`, `integration_tests/pipeline/test_consent_telnet_e2e.py` | **G0** |
-| Target accept/deny | `CmdAccept`/`CmdDeny` (`commands/consent.py:251/298`) → `respond_to_action_request` | `…/respond/` (`action_views.py:204`) → `respond_to_action_request` (`scenes/action_services.py:335`) | **YES** — same service | `test_social_consent_e2e.py` | **G0** |
-| Resolve + apply consequence | (via accept) → `start_action_resolution` | same → `start_action_resolution` | **YES** — shared resolution pipeline | `integration_tests/pipeline/test_social_pipeline.py` | **G0** |
+**Already done — don't redo:** telnet journey tests already exist for cast, rituals, ritual
+sessions, thread weave/imbue/pull, social consent, challenges, endorsements, and progression
+(`src/integration_tests/pipeline/`). Most working journeys are already covered; the gaps above are
+the remainder.
 
-**Verdict:** social scenes are fully telnet-driveable (G0 throughout). Convergence is the consent
-**service** seam by design (#1337): consent is an inherently two-party async protocol whose
-response half can't be a single dispatch call, so telnet and web both call
-`create_action_request` / `respond_to_action_request` directly rather than routing through
-`action.run()`. This was the original audit's biggest correction and is now settled.
-
----
-
-## Loop 2 — Magic casting
-
-The unified scene-adaptive `cast` (#1351) made **telnet** ride a real `Action`. The **web
-standalone-cast endpoint still does not** — it is the one place in this loop where the two UIs
-converge only at the service.
-
-| Step | Telnet | Web dispatch | Same code? | Existing test | Class |
-|---|---|---|---|---|---|
-| Standalone cast (in *and* out of combat) | `cast`/`declare` (`CmdDeclareTechnique`, `commands/combat.py:32`, a `DispatchCommand`) → `dispatch_player_action`(SCENE_ADAPTIVE) → `CastTechniqueAction.run` (`actions/definitions/cast.py:30`, key `cast_technique`) → `request_technique_cast` | `SceneActionRequestViewSet.cast` (`action_views.py:322`) → `request_technique_cast` (`scenes/cast_services.py:558`) **directly** | **NO at the action level / YES at the service** — web bypasses `dispatch_player_action` *and* `CastTechniqueAction`; both meet at `request_technique_cast` | `integration_tests/pipeline/test_noncombat_cast_telnet_e2e.py`, `test_combat_cast_telnet_e2e.py` | **G2** |
-| Combat declaration of the cast | same `cast` command — inside a DECLARING round `CastTechniqueAction.round_declaration` (`cast.py:117`) builds a COMBAT declaration | `dispatch_player_action`(COMBAT) → `record_declaration` → `declare_action` (`combat/services.py:1658`) | **YES** — both reach `record_declaration`/`declare_action` | `test_combat_cast_telnet_e2e.py`, `commands/tests/test_combat_commands.py` | **G0** |
-| Check + resonance env + effects | N/A (service) | `resolve_round` → `resolve_combat_technique` → `use_technique` | **YES** — shared service orchestration | `world/magic/tests/integration/test_magic_story_pipeline.py` | **G0** |
-| Perform ritual (SERVICE/FLOW) | `ritual`/`perform` (`CmdRitual`, `commands/ritual.py`) → `PerformRitualAction.run` | `RitualPerformView` (`magic/views.py:907`) → `PerformRitualAction.run` | **YES** — both via `perform_ritual` action | `test_ritual_telnet_e2e.py` | **G0** (RESOLVED #1331) |
-| Multi-participant ritual session | `ritual draft/join/decline/fire` (`CmdRitual`) → `draft_session`/`accept_session`/`decline_session`/`fire_session` | session viewset → same services | **YES** — same services | `test_ritual_session_telnet_e2e.py` | **G0** (RESOLVED #1345) |
-
-**The G2 cast finding (new since the audit).** #1351 introduced `SCENE_ADAPTIVE` →
-`CastTechniqueAction`, giving the **telnet** cast anti-spam gating, POSE_ORDER quorum advancement,
-`round_declaration` combat-deferral, and the soulfray-consent `PendingCast` re-dispatch
-(`accept soulfray`). The **web** `cast` endpoint (`SceneActionRequestViewSet.cast`) calls
-`request_technique_cast` directly and gets *none* of that wrapper — it returns a
-`SceneActionRequest` for the frontend to handle soulfray its own way. So:
-
-- A telnet cast E2E (`test_noncombat_cast_telnet_e2e.py`) proves `request_technique_cast` **and
-  below**, plus the telnet wrapper — **but not** the web endpoint's wrapper.
-- `CastTechniqueAction` is effectively **`[BUILT, NOT WIRED]` for the web**: it exists and is wired
-  for telnet only. The `cast.py` docstring previously claimed both UIs converge on the action;
-  that was corrected in this refresh.
-
-Whether the web cast endpoint *should* route through `dispatch_player_action(SCENE_ADAPTIVE)` (to
-inherit anti-spam/pose-order/soulfray uniformly) or whether anti-spam/pose-order are legitimately
-telnet-pacing concerns the web handles differently is a **design question**, not an obvious bug —
-see Follow-on.
-
-**Verdict:** combat declaration, ritual performance, and ritual sessions are G0. Standalone cast
-is G2 — telnet rides the action, web rides the service. The deep orchestration (`use_technique`:
-anima, soulfray, resonance environment, conditions, story beats, achievements) is shared and
-service-tested.
-
----
-
-## Loop 3 — Thread weaving
-
-#1342 turned weave/imbue/pull into real `Action`s. Weave and pull are now genuine `action.run()`
-convergence (G0); imbue converges only at the service (G2); teaching-unlock acquisition is still
-web-only (G1).
-
-| Step | Telnet | Web dispatch | Same code? | Existing test | Class |
-|---|---|---|---|---|---|
-| Acquire THREAD WEAVING unlock | ❌ none | `teaching-offers/{id}/accept/` → `accept_thread_weaving_unlock` (`magic/services/threads.py`) | service-only; no telnet | `magic/tests/test_teaching_offer_accept_view.py` | **G1** |
-| Weave a thread | `CmdWeaveThread` (`commands/weave.py:29`) → `WeaveThreadAction.run` (`actions/definitions/threads.py:23`) | `ThreadSerializer.create` (`magic/serializers.py:867`) → `WeaveThreadAction.run` | **YES** — same action | `commands/tests/test_weave_command.py`, `integration_tests/pipeline/test_weave_telnet_e2e.py` | **G0** (RESOLVED #1342) |
-| Imbue (spend resonance, advance level) | `imbue` (`CmdImbue`, `commands/imbue.py`) → `ImbueAction.run` (`actions/definitions/imbue.py:23`) → `spend_resonance_for_imbuing` (`magic/services/resonance.py:221`) | `RitualPerformView` → `PerformRitualAction.run` → (Rite of Imbuing CEREMONY service) → `spend_resonance_for_imbuing` | **NO at the action level / YES at the service** — telnet uses the `ImbueAction` *finisher*; web resolves imbuing through `PerformRitualAction`; both meet at `spend_resonance_for_imbuing` | `commands/tests/test_imbue_cmd.py`, `integration_tests/pipeline/test_weave_imbue_pull_journey_e2e.py` | **G2** |
-| Pull thread (in combat) | `pull` (`CmdPull`, `commands/pull.py:28`) → `PullThreadAction.run` (`actions/definitions/pull.py:25`) → `spend_resonance_for_pull` (`magic/services/resonance.py:588`) | `ThreadPullCommitView` → `ThreadPullCommitRequestSerializer.create` → `PullThreadAction.run` | **YES** — same action | `commands/tests/test_pull_cmd.py`, `test_weave_imbue_pull_journey_e2e.py` | **G0** (RESOLVED #1342) |
-
-**The G2 imbue finding (new since the audit).** Imbuing uses a **ceremony/finisher** split: a
-player performs the *Rite of Imbuing* CEREMONY ritual (which creates a `PendingRitualEffect`), then
-a **finisher** advances the thread. Telnet's finisher is `ImbueAction` (gated by a
-`PendingRitualEffectPrerequisite`, `commands/imbue.py` → `actions/definitions/imbue.py`); the web
-resolves the same end through `PerformRitualAction`'s CEREMONY service path. Two different actions
-for one user goal, converging at `spend_resonance_for_imbuing`. This is a parallel-implementation
-smell worth a deliberate decision (unify on one finisher action vs. accept the service as the
-contract) — flagged in Follow-on, not asserted as a fix.
-
-**Verdict:** weave and pull are telnet-driveable at the action seam (G0). Imbue is G2 (service
-convergence). Teaching-unlock acquisition is the lone untouched G1 (no telnet shell yet).
-
----
-
-## Loop 4 — Combat
-
-Technique **declaration** converges (G0) via the #1351 SCENE_ADAPTIVE reshaping. Clash-commit and
-the bundle of other PC combat actions remain web-only (G1); round resolution and encounter setup
-are correctly GM/system-only (G3).
-
-| Step | Telnet | Web dispatch | Same code? | Existing test | Class |
-|---|---|---|---|---|---|
-| GM starts encounter | ❌ none (GM) | `CombatEncounterViewSet` → `begin_declaration_phase` (`combat/services.py:1424`) | GM/system surface | `world/combat/tests/.../test_duels_integration.py` | **G3** (correct) |
-| Player declares technique | `cast`/`declare` (`CmdDeclareTechnique`) → SCENE_ADAPTIVE → `round_declaration` → `record_declaration` (`combat/round_context.py:101→197`) → `declare_action` (`combat/services.py:1658`) | `DispatchActionView`→`dispatch_player_action`(COMBAT) → `record_declaration` → `declare_action` | **YES** — both reach `record_declaration`/`declare_action` | `test_combat_cast_telnet_e2e.py`, `test_combat_ui_integration.py` | **G0** |
-| Commit to clash | ❌ none | `dispatch_player_action` → `_dispatch_clash_contribution` (`player_interface.py:627`) → `declare_clash_contribution` (`combat/services.py:4693`) | seam converges; no telnet shell | `test_combat_ui_integration.py` | **G1** |
-| GM resolves round | ❌ none (GM) | `…/resolve_round/` → `resolve_round` (`combat/services.py:4454`) → `use_technique` | service-only, GM-triggered | `test_duels_integration.py` | **G3** (correct) |
-| Other PC combat actions: `flee`/`cover`/`interpose`/`join`/`leave`/`ready`/`upgrade_combo`/`revert_combo` | ❌ none | `CombatEncounterViewSet` `@action`s → `declare_flee` (`combat/services.py:1004`), `declare_cover` (`:1053`), `declare_interpose` (`:1106`), join/leave/ready/combo services | seam converges; no telnet shells | `test_duels_integration.py`, `test_agency_integration.py` | **G1** |
-| NPC selection / damage / conditions | N/A | threat-pool selection + damage services (internal to `resolve_round`) | service-only | `test_agency_integration.py` | **G3** (correct) |
-
-**Seed prerequisites (gate the test, G4 until met):** `CharacterVitals`, `CovenantRole`
-(auto-assigned if absent), `ThreatPool`/`ThreatPoolEntry`, and
-`Technique.action_template.check_type` populated. Factories exist for most;
-`test_combat_cast_telnet_e2e.py` already wires a working seed.
-
-**Verdict:** technique declaration is G0 (the `cast` command reaches `declare_action` exactly like
-the web COMBAT backend). The residual G1 surface is clash-commit plus the ~8 other PC combat
-actions — each needs its own thin telnet shell calling the same service. Resolution and setup stay
-GM/system-only (G3).
-
----
-
-## Existing telnet E2E coverage (Deliverable 3 — already substantial)
-
-The original audit said "no magic/combat story is telnet-driveable today." That is now false.
-`src/integration_tests/pipeline/` already contains telnet-driven (`execute_cmd`-level) journey
-tests for most loops:
-
-| Loop | Telnet E2E test | Covers |
-|---|---|---|
-| Magic cast (non-combat) | `test_noncombat_cast_telnet_e2e.py` | `cast` (SCENE_ADAPTIVE) → anima debit, OUTCOME interaction, `TECHNIQUE_CAST` event |
-| Magic cast (combat) | `test_combat_cast_telnet_e2e.py` | `cast` inside a DECLARING round → combat declaration |
-| Ritual | `test_ritual_telnet_e2e.py` | `ritual`/`perform` → `PerformRitualAction` |
-| Ritual session | `test_ritual_session_telnet_e2e.py` | `ritual draft/join/decline/fire` |
-| Thread weave+imbue+pull | `test_weave_imbue_pull_journey_e2e.py`, `test_weave_telnet_e2e.py` | full ceremony/finisher journey |
-| Social consent | `test_consent_telnet_e2e.py` | intimidate/accept/deny |
-| Challenge dispatch | `test_challenge_dispatch_telnet_e2e.py` | CHALLENGE backend |
-| Endorsement | `test_endorsement_journey_e2e.py` | pose/entry/style endorse (#1340) |
-| Audere / Durance | `test_audere_telnet_e2e.py`, `test_durance_e2e.py` | progression surfaces |
-
-So Deliverable 3 is mostly **done**; the remaining E2E work is narrow (clash-commit + PC combat
-actions once shells exist, and a web-vs-telnet parity assertion for the two G2 cases).
-
-## Cross-cutting conclusions (refreshed)
-
-1. **Telnet has caught up to the dispatcher.** `DispatchCommand` lets telnet reach SCENE_ADAPTIVE,
-   COMBAT, and CHALLENGE; the social/thread loops converge at shared services. The original "telnet
-   never calls `dispatch_player_action`" finding is retired.
-2. **Convergence altitude is the remaining variable.** Most loops now converge at `action.run()` or
-   the declaration service (telnet E2E = valid web proxy). **Two cases converge only at the
-   service** — magic standalone cast (G2) and thread imbue (G2) — because each UI wraps the service
-   differently. A telnet E2E there proves the service, not the web wrapper.
-3. **Residual G1 surface is small and combat-shaped:** clash-commit and ~8 PC combat actions
-   (flee/cover/interpose/join/leave/ready/upgrade_combo/revert_combo), plus teaching-unlock
-   acquisition. Each is a thin shell over an existing service.
-4. **Telnet E2E coverage already exists** for nearly every loop (table above); the umbrella's
-   Deliverable 3 is largely complete.
-
-## Follow-on (re-scoped 2026-06-23)
-
-Verified against current code; premises checked per `verify-against-code`. Distinguishes scoped
-work from open design questions.
-
-**Design questions (file as `needs-design`, not as ready work):**
-
-1. **Web standalone-cast vs `CastTechniqueAction` (the G2 cast).** Should
-   `SceneActionRequestViewSet.cast` route through `dispatch_player_action(SCENE_ADAPTIVE)` so the
-   web inherits anti-spam / POSE_ORDER quorum / soulfray-`PendingCast` uniformly — or are those
-   telnet-pacing concerns the web legitimately handles its own way? Today `CastTechniqueAction` is
-   wired for telnet only. *Premise verified:* `action_views.py:392` calls `request_technique_cast`
-   directly; `cast.py` is reached only by `CmdDeclareTechnique`.
-2. **Imbue finisher unification (the G2 imbue).** Telnet uses `ImbueAction`; web resolves imbuing
-   through `PerformRitualAction`. One user goal, two actions, converging at
-   `spend_resonance_for_imbuing`. Unify on a single finisher action, or ratify the service as the
-   contract? *Premise verified:* `actions/definitions/imbue.py:23` vs the CEREMONY path in
-   `actions/definitions/ritual.py`.
-
-**Scoped work (thin shells over existing services — G1):**
-
-3. **Combat PC-action telnet shells:** clash-commit (`declare_clash_contribution`,
-   `combat/services.py:4693`) and flee/cover/interpose/join/leave/ready/upgrade_combo/revert_combo
-   (`CombatEncounterViewSet` `@action`s → their `declare_*`/encounter services). Each is a
-   `DispatchCommand` or thin service shell, then a telnet assertion in `test_duels_integration`'s
-   journey form.
-4. **Teaching-unlock telnet shell:** a command over `accept_thread_weaving_unlock`
-   (`magic/services/threads.py`) so the thread-weaving journey is driveable from acquisition.
-
-**Verification work (close the G2 proof gap):**
-
-5. For the two G2 cases, add a **web-path assertion** alongside the existing telnet E2E (POST the
-   web cast / ritual-imbue endpoint and assert the same service outcome) so the parity is proven on
-   *both* wrappers, not just inferred from the shared service.
-
-**Likely already closed (verify before filing anything):** the original Disposition listed
-per-domain journey children and two foundation issues (dispatch routing; consent strategy). The
-dispatch-routing keystone shipped as #1351 (SCENE_ADAPTIVE); the consent strategy was ratified in
-#1337; weave/imbue/pull shipped in #1342. Reconcile the umbrella's child map against this refresh
-before opening new issues — most of the original deep-trace gaps are resolved.
+> **Note for the next pass:** several of the original deep-trace "gaps" were already resolved in
+> #1331 / #1337 / #1342 / #1351 before this rewrite. Reconcile the #1328 child map against this doc
+> before filing anything new — most of the early findings are closed, and a few (like web-cast
+> parity) are already tracked. Don't re-file them.

--- a/src/actions/definitions/cast.py
+++ b/src/actions/definitions/cast.py
@@ -1,7 +1,11 @@
 """CastTechniqueAction — SCENE_ADAPTIVE action for standalone technique casts.
 
-Both telnet (``commands.magic.CmdAttempt``) and the web dispatch path converge
-here for standalone technique casts. The action:
+Reached by the **telnet** ``cast``/``declare`` command (``commands.combat.CmdDeclareTechnique``)
+via ``dispatch_player_action(SCENE_ADAPTIVE)``. The **web** standalone-cast endpoint
+(``world.scenes.action_views.SceneActionRequestViewSet.cast``) does NOT route through this
+action — it calls ``request_technique_cast`` directly. So telnet and web converge at the
+``request_technique_cast`` **service**, not at ``action.run()``; this action's anti-spam,
+pose-order, and soulfray-pending machinery is telnet-only today. The action:
 
 1. Resolves the active scene, initiator persona, technique, and optional target.
 2. Calls ``request_technique_cast``.


### PR DESCRIPTION
## What

Rewrites the #1328 audit around the **backend-journey principle**, and records that principle in plain language at the top of `docs/architecture/unified-player-action.md`. Part of #1328 — does **not** close it.

## The principle

Telnet isn't a target interface — it's *pure backend*, which makes it the ideal driver for **end-to-end tests of user journeys** ("can a player do X?"). Get a journey working end-to-end in the backend first; the frontend can always be made to follow (sometimes re-pointed afterward, like web cast). So the audit's question is **"which important journeys work end-to-end in the backend, and which don't yet?"** — not telnet-vs-web parity. A player command and a web action both express *intent to act*; the active scene's rules decide now / deferred / blocked (#1351). Combat is one specialization of that.

## Journey status (four priority loops)

- **Cast a technique** — works end-to-end (telnet-tested). Frontend follow-up: web cast still on an older path → re-point (#1444).
- **Perform a ritual / session** — works end-to-end.
- **Weave → imbue → pull a thread** — works, except *acquiring the unlock* has no backend command yet.
- **Fight a combat sequence** — partial: declaring a technique works, but clash-commit / flee / cover / interpose / join / leave / ready / combo have no backend command. **Biggest gap.**
- **Drive a social scene** — works end-to-end.

Broad-pass journeys (missions, covenant, persona, progression, journals, reactions) mostly have no backend command yet; tracked as #1341–1350.

## Next

- **Real backend work:** combat player moves; thread-weaving unlock command; the broad-pass children (each = backend command + one journey test).
- **Frontend-follows (not blockers):** web cast (#1444), web imbue.
- **Already done:** telnet journey tests exist for cast, rituals, sessions, weave/imbue/pull, social consent, challenges, endorsements.

_(Supersedes the earlier jargon-heavy "dispatch-parity / gap-class" framing on this branch — that obscured the principle and re-posed already-decided work as open questions.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
