### PR TITLE
feat: sheet/standing + sheet/covenant telnet sections

### DIFF
--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -112,8 +112,13 @@ actions, backends, and service functions.
   character; locked layers "Unknown"); `renown` (`sheet/renown`, #676 — your prestige / fame tier /
   society standing, via `build_renown_payload`, mirroring the web `RenownPanel`); `relationship`
   (`sheet/relationship`, — your regard toward others, a qualitative warm/cold/neutral read of
-  `CharacterRelationship.affection`, mirroring the web `RelationshipsSection`). Each is thin over
-  its app's data. Add a section: a renderer + a registry entry (+ `SECTION_NAMES`).
+  `CharacterRelationship.affection`, mirroring the web `RelationshipsSection`); `standing`
+  (`sheet/standing` — your **organizational** positions: org memberships with rank titles + org
+  reputations, scoped to active persona; distinct from `renown`, which holds fame / prestige /
+  *society* reputation); `covenant` (`sheet/covenant` — your covenant membership(s), role, rank,
+  and which you're *engaged* in, from `CharacterCovenantRole`; read-only). Each is thin over its
+  app's data. Add a section: a renderer + a registry entry (+ `SECTION_NAMES`). *Web tabs for
+  standing/covenant are a follow-up — the "which contextual center owns this" call is open (#1446).*
 
 ### Social Commands (`social/`)
 - **`blocking.py`**: `CmdBlock`/`CmdUnblock`/`CmdShareBlock`/`CmdMute`/`CmdUnmute`/`CmdBlockList`

--- a/src/commands/account/sheet_sections.py
+++ b/src/commands/account/sheet_sections.py
@@ -178,6 +178,82 @@ def _format_relationships(relationships: list) -> list[str]:
     return lines
 
 
+def _render_standing_section(command: Command) -> list[str]:
+    """The standing section: your formal positions in organizations (societies app).
+
+    Your **organizational** standing — org memberships (with rank titles) and org reputations —
+    scoped to your active persona. Distinct from ``sheet/renown`` (fame / prestige / *society*
+    reputation); this is the formal-position view. Society standing lives on the renown section.
+    """
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+    from world.societies.models import (  # noqa: PLC0415
+        OrganizationMembership,
+        OrganizationReputation,
+    )
+
+    viewer = _viewer_sheet(command)
+    persona = active_persona_for_sheet(viewer)
+    memberships = list(
+        OrganizationMembership.objects.filter(persona=persona)
+        .select_related("organization", "organization__org_type")
+        .order_by("rank", "organization__name")
+    )
+    reputations = list(
+        OrganizationReputation.objects.filter(persona=persona)
+        .select_related("organization")
+        .order_by("organization__name")
+    )
+    return _format_standing(memberships, reputations)
+
+
+def _format_standing(memberships: list, reputations: list) -> list[str]:
+    if not memberships and not reputations:
+        return ["You hold no organizational standing."]
+    lines = ["|wYour standing:|n"]
+    if memberships:
+        lines.append("  Memberships:")
+        for membership in memberships:
+            title = membership.organization.get_rank_title(membership.rank)
+            lines.append(f"    {membership.organization.name}: {title} (rank {membership.rank})")
+    if reputations:
+        lines.append("  Reputation:")
+        lines.extend(
+            f"    {reputation.organization.name}: {reputation.get_tier().value.title()}"
+            for reputation in reputations
+        )
+    return lines
+
+
+def _render_covenant_section(command: Command) -> list[str]:
+    """The covenant section: your covenant membership(s) and role (covenants app).
+
+    Each active covenant assignment with its role, rank, and which one you're currently *engaged*
+    in. Read-only — joining/role changes are covenant actions, not a sheet view.
+    """
+    from world.covenants.models import CharacterCovenantRole  # noqa: PLC0415
+
+    viewer = _viewer_sheet(command)
+    assignments = list(
+        CharacterCovenantRole.objects.filter(character_sheet=viewer, left_at__isnull=True)
+        .select_related("covenant", "covenant_role", "rank")
+        .order_by("covenant__name")
+    )
+    return _format_covenant(assignments)
+
+
+def _format_covenant(assignments: list) -> list[str]:
+    if not assignments:
+        return ["You belong to no covenant."]
+    lines = ["|wYour covenant:|n"]
+    for assignment in assignments:
+        rank = f", {assignment.rank.name}" if assignment.rank_id else ""
+        engaged = " |g[engaged]|n" if assignment.engaged else ""
+        name = assignment.covenant.name
+        role = assignment.covenant_role.name
+        lines.append(f"  {name}: {role}{rank}{engaged}")
+    return lines
+
+
 # Switch name → renderer. Add a section by writing a renderer and registering it here (and in
 # SECTION_NAMES for the overview footer). Aliases (secret/secrets) map to the same renderer.
 SHEET_SECTIONS: dict[str, Callable[..., list[str]]] = {
@@ -186,7 +262,10 @@ SHEET_SECTIONS: dict[str, Callable[..., list[str]]] = {
     "renown": _render_renown_section,
     "relationship": _render_relationships_section,
     "relationships": _render_relationships_section,
+    "standing": _render_standing_section,
+    "standings": _render_standing_section,
+    "covenant": _render_covenant_section,
 }
 
 # Canonical section names shown in the bare-``sheet`` footer (deduped; one per real section).
-SECTION_NAMES: tuple[str, ...] = ("secret", "renown", "relationship")
+SECTION_NAMES: tuple[str, ...] = ("secret", "renown", "relationship", "standing", "covenant")

--- a/src/commands/account/tests/test_sheet_sections.py
+++ b/src/commands/account/tests/test_sheet_sections.py
@@ -82,3 +82,44 @@ class SheetSecretSectionTests(TestCase):
 
     def test_relationships_section_empty(self) -> None:
         assert "no relationships" in self._run("", switches=["relationship"]).lower()
+
+    def test_standing_section_lists_org_memberships_and_reputation(self) -> None:
+        from world.societies.factories import (
+            OrganizationFactory,
+            OrganizationMembershipFactory,
+            OrganizationReputationFactory,
+        )
+
+        persona = self.viewer_sheet.primary_persona
+        OrganizationMembershipFactory(
+            organization=OrganizationFactory(name="The Wardens"), persona=persona, rank=2
+        )
+        OrganizationReputationFactory(
+            organization=OrganizationFactory(name="The Guild"), persona=persona, value=600
+        )
+        out = self._run("", switches=["standing"])
+        assert "The Wardens" in out
+        assert "The Guild" in out
+        assert "Honored" in out
+
+    def test_standing_section_empty(self) -> None:
+        assert "no organizational standing" in self._run("", switches=["standing"]).lower()
+
+    def test_covenant_section_lists_your_covenant(self) -> None:
+        from world.covenants.factories import (
+            CharacterCovenantRoleFactory,
+            CovenantFactory,
+            CovenantRoleFactory,
+        )
+
+        CharacterCovenantRoleFactory(
+            character_sheet=self.viewer_sheet,
+            covenant=CovenantFactory(name="The Ashen Circle"),
+            covenant_role=CovenantRoleFactory(name="Vanguard"),
+        )
+        out = self._run("", switches=["covenant"])
+        assert "The Ashen Circle" in out
+        assert "Vanguard" in out
+
+    def test_covenant_section_empty(self) -> None:
+        assert "no covenant" in self._run("", switches=["covenant"]).lower()


### PR DESCRIPTION
## What

Two more sections off the character-sheet hub, mirroring the established `secret`/`renown`/`relationship` pattern — read-only, thin over each app's data, scoped to the **active persona**:

- **`sheet/standing`** — your formal **organizational** positions: org memberships (with rank titles) + org reputations. Deliberately **distinct from `sheet/renown`** (which already holds fame / prestige / *society* reputation) so we don't duplicate the society-standing view.
- **`sheet/covenant`** — your covenant membership(s), role, rank, and which you're *engaged* in, from `CharacterCovenantRole`.

## Deliberately deferred (flagged, not guessed)

**Web tabs** for standing/covenant, and the **"which contextual center owns this"** IA call (#1446 — does *standing* fold into Renown? is *covenant* its own center or a sheet tab?). The telnet sections are the safe, concrete deliverable; the web/IA decision is yours, so I didn't guess at new web API surface unsupervised. The covenants frontend today is browse-only (no character-sheet membership view), so there's a genuine gap to fill once the IA call is made.

## Tests / checks

- 4 new tests (memberships + reputation, covenant, both empty states); 11 green in the sheet-section suite.
- No model changes / no migration. ruff + ty clean. Docs: `commands/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)