### PR TITLE
test: persona-level edge cases for the tidings feed (#1450)

### DIFF
--- a/src/commands/tests/test_tidings_command.py
+++ b/src/commands/tests/test_tidings_command.py
@@ -24,6 +24,7 @@ class TidingsCommandTests(TestCase):
         SocietyReputationFactory(persona=self.persona, society=self.society, value=300)
 
     def _run(self, args: str = "") -> str:
+        self.caller.msg.reset_mock()  # so each call reads only this run's output, not accumulated
         cmd = CmdTidings()
         cmd.caller = self.caller
         cmd.args = args
@@ -43,4 +44,46 @@ class TidingsCommandTests(TestCase):
         assert "consorts with the abyss" in out
 
     def test_empty_when_nothing_circulating(self) -> None:
+        assert "no tidings circulating" in self._run().lower()
+
+    def test_feed_follows_the_active_persona(self) -> None:
+        """Switching the active face changes the tidings — scoping is persona-level, not char."""
+        from world.scenes.constants import PersonaType
+        from world.scenes.factories import PersonaFactory
+        from world.scenes.services import set_active_persona
+
+        deed_primary = LegendEntryFactory(title="deed of my true face")
+        deed_primary.societies_aware.add(self.society)
+
+        alt = PersonaFactory(
+            character_sheet=self.entry.character_sheet, persona_type=PersonaType.ESTABLISHED
+        )
+        alt_society = SocietyFactory(name="The Hollow")
+        SocietyReputationFactory(persona=alt, society=alt_society, value=200)
+        deed_alt = LegendEntryFactory(title="deed of my other face")
+        deed_alt.societies_aware.add(alt_society)
+
+        out_primary = self._run()
+        assert "deed of my true face" in out_primary
+        assert "deed of my other face" not in out_primary
+
+        set_active_persona(self.entry.character_sheet, alt)
+        out_alt = self._run()
+        assert "deed of my other face" in out_alt
+        assert "deed of my true face" not in out_alt
+
+    def test_masked_persona_sees_no_tidings(self) -> None:
+        """A TEMPORARY mask holds no memberships, so a disguised character's feed is empty."""
+        from world.scenes.constants import PersonaType
+        from world.scenes.factories import PersonaFactory
+        from world.scenes.services import set_active_persona
+
+        deed = LegendEntryFactory(title="known to my true face")
+        deed.societies_aware.add(self.society)
+
+        mask = PersonaFactory(
+            character_sheet=self.entry.character_sheet, persona_type=PersonaType.TEMPORARY
+        )
+        set_active_persona(self.entry.character_sheet, mask)
+
         assert "no tidings circulating" in self._run().lower()


### PR DESCRIPTION
## What

Hardening the shipped **tidings** vector around the **active-persona scoping** you flagged. The headline: **no weird edge case** — the behaviour is correct — and these lock it in as regression tests.

- **The feed follows the ACTIVE persona** — switching the face a character is wearing changes their tidings (persona-level, not character-level). A character with a primary persona in society A and an established alt in society B sees A's deeds as the primary and B's deeds as the alt.
- **A TEMPORARY mask holds no society/org memberships**, so a disguised character's feed is empty even when their true face has tidings — consistent with the gemit push side (#1458).

Also fixes the command test helper to reset the caller mock per run (so a second invocation in one test reads only its own output, not the accumulated call list).

## Note on scope

Tidings has no migration and no M2M, so the SQLite tier is authoritative here (the PG-parity M2M gotcha applied to the gemit migration, validated in #1458). Broader full-stack parity / doc audit is available as a follow-up, but I focused this pass on the specific persona-scoping concern.

Refs #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)