### PR TITLE
Combat verbs as shared actions: flee/cover/interpose/ready/join/leave/combo + telnet combat namespace (#1453, #1452)

### DIFF
--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -284,6 +284,14 @@ to defend better but drain your pools faster). Focus stays on PCs as active agen
   carries a required scene, so scene visibility subsumes participant membership. Effect/power-ledger
   details are separately gated by `combat.permissions.can_view_encounter_effects` (staff, scene
   GM, or encounter participant — stricter than scene visibility by design).
+- **Shared combat verbs (SHIPPED — #1453/#1452):** flee, cover, interpose, ready, join, leave,
+  combo upgrade/revert, and yield are real `Action`s in `actions/definitions/combat_maneuvers.py`
+  (keys `combat_flee`/`combat_cover`/`combat_interpose`/`combat_ready`/`combat_join`/`combat_leave`/
+  `combat_combo`/`combat_revert`; yield reuses `YieldAction`). The web player-action endpoints now
+  dispatch through these via `dispatch_player_action` (the bypass is gone; REST contract unchanged),
+  and telnet reaches them through the `combat <subverb>` namespace (`CmdCombat`). The only new
+  service is `toggle_action_ready` (extracted from the inline `ready` toggle). Verbs are namespaced
+  rather than bare top-level keys to avoid exit/channel/alias collisions.
 - **Round pacing:** Timed mode (default, configurable minutes with auto-resolve), Ready mode (all players mark ready), Manual mode (GM triggers). Timer task runs every 30 seconds via game clock scheduler
 - **Participation:** PCs in the room can self-join active encounters. Flee resolves as a graded check at round resolution with authored tier difficulty, ally cover bonuses, and pool-routed failure consequences (#878)
 - **Tests:** 599 tests across combat, vitals, conditions, mechanics, checks, and covenants

--- a/src/actions/CLAUDE.md
+++ b/src/actions/CLAUDE.md
@@ -32,7 +32,14 @@ They do not use the command system, dispatchers, or handlers.
   action.run() seam for SERVICE/FLOW ritual performance shared by telnet
   `CmdRitual` and the web `RitualPerformView`, #1331;
   `cast.py` — `CastTechniqueAction`, key `"cast_technique"`, the SCENE_ADAPTIVE
-  seam for standalone technique casts — see "SCENE_ADAPTIVE Backend" below)
+  seam for standalone technique casts — see "SCENE_ADAPTIVE Backend" below;
+  `combat_maneuvers.py` (#1453/#1452) — the non-cast/non-clash combat verbs as REGISTRY
+  actions: `FleeAction`/`CoverAction`/`InterposeAction`/`ReadyAction`/`UpgradeComboAction`/
+  `RevertComboAction`/`JoinEncounterAction`/`LeaveEncounterAction` (keys prefixed `combat_`).
+  Each `execute()` resolves the actor's active `CombatParticipant`/encounter and calls the
+  existing combat service; shared by telnet `CmdCombat` (`combat <subverb>`) and the web
+  `CombatEncounterViewSet`. `yield` is not here — `YieldAction` (`duels.py`) is reused. The one
+  new service is `toggle_action_ready`, extracted from the inline web `ready` toggle)
 
 ## SCENE_ADAPTIVE Backend (#1351)
 

--- a/src/actions/definitions/combat_maneuvers.py
+++ b/src/actions/definitions/combat_maneuvers.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
     from world.character_sheets.models import CharacterSheet
-    from world.combat.models import CombatParticipant, CombatRoundAction
+    from world.combat.models import CombatEncounter, CombatParticipant, CombatRoundAction
 
 
 def _sheet(actor: ObjectDB) -> CharacterSheet | None:
@@ -113,3 +113,276 @@ class FleeAction(Action):
         except ValueError as err:
             return ActionResult(success=False, message=str(err))
         return ActionResult(success=True, message="You declare a desperate flee.")
+
+
+@dataclass
+class CoverAction(Action):
+    """Cover an ally — passives-only, auto-ready (wraps ``declare_cover``)."""
+
+    key: str = "combat_cover"
+    name: str = "Cover"
+    icon: str = "shield"
+    category: str = "combat"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SINGLE
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        ally_participant_id: int | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.combat.constants import EncounterStatus  # noqa: PLC0415
+        from world.combat.services import declare_cover  # noqa: PLC0415
+
+        participant = _active_combat_participant(actor, {EncounterStatus.DECLARING})
+        if participant is None:
+            return ActionResult(success=False, message="You are not in an active combat round.")
+        if ally_participant_id is None:
+            return ActionResult(success=False, message="Cover requires an ally to protect.")
+        ally = _resolve_ally(participant, ally_participant_id)
+        if ally is None:
+            return ActionResult(success=False, message="No such ally in this encounter.")
+        try:
+            declare_cover(participant, ally)
+        except ValueError as err:
+            return ActionResult(success=False, message=str(err))
+        return ActionResult(success=True, message="You move to cover your ally.")
+
+
+@dataclass
+class InterposeAction(Action):
+    """Interpose to guard an ally (or any ally) — passives-only (wraps ``declare_interpose``)."""
+
+    key: str = "combat_interpose"
+    name: str = "Interpose"
+    icon: str = "shield-half"
+    category: str = "combat"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SINGLE
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        ally_participant_id: int | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.combat.constants import EncounterStatus  # noqa: PLC0415
+        from world.combat.services import declare_interpose  # noqa: PLC0415
+
+        participant = _active_combat_participant(actor, {EncounterStatus.DECLARING})
+        if participant is None:
+            return ActionResult(success=False, message="You are not in an active combat round.")
+        ally = _resolve_ally(participant, ally_participant_id)
+        if ally_participant_id is not None and ally is None:
+            return ActionResult(success=False, message="No such ally in this encounter.")
+        try:
+            declare_interpose(participant, ally)
+        except ValueError as err:
+            return ActionResult(success=False, message=str(err))
+        return ActionResult(success=True, message="You stand ready to interpose.")
+
+
+@dataclass
+class ReadyAction(Action):
+    """Toggle your declared action's ready flag (wraps ``toggle_action_ready``)."""
+
+    key: str = "combat_ready"
+    name: str = "Ready"
+    icon: str = "check"
+    category: str = "combat"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.combat.constants import EncounterStatus  # noqa: PLC0415
+        from world.combat.services import toggle_action_ready  # noqa: PLC0415
+
+        participant = _active_combat_participant(actor, {EncounterStatus.DECLARING})
+        if participant is None:
+            return ActionResult(success=False, message="You are not in an active combat round.")
+        action = _current_round_action(participant)
+        if action is None:
+            return ActionResult(success=False, message="You have not declared an action yet.")
+        toggle_action_ready(action)
+        if action.is_ready:
+            return ActionResult(success=True, message="You are ready.")
+        return ActionResult(success=True, message="You are no longer ready.")
+
+
+@dataclass
+class UpgradeComboAction(Action):
+    """Chain your declared action into a combo (#1452, wraps ``upgrade_action_to_combo``)."""
+
+    key: str = "combat_combo"
+    name: str = "Combo"
+    icon: str = "layers"
+    category: str = "combat"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        combo_id: int | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.combat.constants import EncounterStatus  # noqa: PLC0415
+        from world.combat.models import ComboDefinition  # noqa: PLC0415
+        from world.combat.services import upgrade_action_to_combo  # noqa: PLC0415
+
+        participant = _active_combat_participant(actor, {EncounterStatus.DECLARING})
+        if participant is None:
+            return ActionResult(success=False, message="You are not in an active combat round.")
+        action = _current_round_action(participant)
+        if action is None:
+            return ActionResult(success=False, message="You have not declared an action yet.")
+        combo = ComboDefinition.objects.filter(pk=combo_id).first() if combo_id else None
+        if combo is None:
+            return ActionResult(success=False, message="No such combo.")
+        try:
+            upgrade_action_to_combo(action, combo)
+        except ValueError as err:
+            return ActionResult(success=False, message=str(err))
+        # Changing the declared action un-readies it (mirrors the former inline view logic).
+        action.is_ready = False
+        action.save(update_fields=["is_ready"])
+        return ActionResult(success=True, message=f"You chain into {combo.name}.")
+
+
+@dataclass
+class RevertComboAction(Action):
+    """Revert a combo upgrade on your declared action (wraps ``revert_combo_upgrade``)."""
+
+    key: str = "combat_revert"
+    name: str = "Revert Combo"
+    icon: str = "undo"
+    category: str = "combat"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.combat.constants import EncounterStatus  # noqa: PLC0415
+        from world.combat.services import revert_combo_upgrade  # noqa: PLC0415
+
+        participant = _active_combat_participant(actor, {EncounterStatus.DECLARING})
+        if participant is None:
+            return ActionResult(success=False, message="You are not in an active combat round.")
+        action = _current_round_action(participant)
+        if action is None:
+            return ActionResult(success=False, message="You have not declared an action yet.")
+        try:
+            revert_combo_upgrade(action)
+        except ValueError as err:
+            return ActionResult(success=False, message=str(err))
+        action.is_ready = False
+        action.save(update_fields=["is_ready"])
+        return ActionResult(success=True, message="You revert the combo.")
+
+
+def _active_encounter_in_room(actor: ObjectDB) -> CombatEncounter | None:
+    """Return the newest joinable encounter in *actor*'s room, or None (telnet join path)."""
+    from world.combat.constants import EncounterStatus  # noqa: PLC0415
+    from world.combat.models import CombatEncounter  # noqa: PLC0415
+
+    room = actor.location
+    if room is None:
+        return None
+    return (
+        CombatEncounter.objects.filter(
+            room=room,
+            status__in={EncounterStatus.DECLARING, EncounterStatus.BETWEEN_ROUNDS},
+        )
+        .order_by("-created_at")
+        .first()
+    )
+
+
+@dataclass
+class JoinEncounterAction(Action):
+    """Join an active combat encounter (wraps ``join_encounter``).
+
+    ``encounter_id`` / ``character_sheet_id`` are supplied by the web (the URL pk
+    and the request-validated sheet); telnet omits both and the encounter is the
+    one in the caller's room, joined as the caller's own character.
+    """
+
+    key: str = "combat_join"
+    name: str = "Join Combat"
+    icon: str = "user-plus"
+    category: str = "combat"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        encounter_id: int | None = None,
+        character_sheet_id: int | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.character_sheets.models import CharacterSheet  # noqa: PLC0415
+        from world.combat.models import CombatEncounter  # noqa: PLC0415
+        from world.combat.services import join_encounter  # noqa: PLC0415
+
+        if character_sheet_id is not None:
+            sheet = CharacterSheet.objects.filter(pk=character_sheet_id).first()
+        else:
+            sheet = _sheet(actor)
+        if sheet is None:
+            return ActionResult(success=False, message="You have no character to join with.")
+
+        if encounter_id is not None:
+            encounter = CombatEncounter.objects.filter(pk=encounter_id).first()
+        else:
+            encounter = _active_encounter_in_room(actor)
+        if encounter is None:
+            return ActionResult(success=False, message="There is no encounter to join here.")
+
+        try:
+            join_encounter(encounter, sheet)
+        except ValueError as err:
+            return ActionResult(success=False, message=str(err))
+        return ActionResult(success=True, message="You join the fight.")
+
+
+@dataclass
+class LeaveEncounterAction(Action):
+    """Leave an open encounter between rounds (wraps ``leave_encounter``)."""
+
+    key: str = "combat_leave"
+    name: str = "Leave Combat"
+    icon: str = "user-minus"
+    category: str = "combat"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.combat.constants import EncounterStatus  # noqa: PLC0415
+        from world.combat.services import leave_encounter  # noqa: PLC0415
+
+        participant = _active_combat_participant(actor, {EncounterStatus.BETWEEN_ROUNDS})
+        if participant is None:
+            return ActionResult(
+                success=False,
+                message="You are not in an encounter you can leave right now.",
+            )
+        try:
+            leave_encounter(participant)
+        except ValueError as err:
+            return ActionResult(success=False, message=str(err))
+        return ActionResult(success=True, message="You withdraw from the fight.")

--- a/src/actions/definitions/combat_maneuvers.py
+++ b/src/actions/definitions/combat_maneuvers.py
@@ -1,0 +1,115 @@
+"""Combat maneuver actions on the shared dispatch seam (#1453, #1452).
+
+Each verb a player can take in a fight that is not a technique cast or a clash
+commit — flee, cover, interpose, ready, join/leave the encounter, and the combo
+upgrade/revert — is a real ``Action`` here. Telnet (``CmdCombat``) and the web
+``CombatEncounterViewSet`` both reach them through ``dispatch_player_action``;
+each ``execute()`` resolves the actor's combat state and calls the existing
+service. No new game logic lives here.
+
+``yield`` is intentionally absent: ``YieldAction`` (``definitions/duels.py``)
+already exists and is reused by the ``combat yield`` subverb.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from django.core.exceptions import ObjectDoesNotExist
+
+from actions.base import Action
+from actions.constants import ActionCategory
+from actions.types import ActionContext, ActionResult, TargetType
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from world.character_sheets.models import CharacterSheet
+    from world.combat.models import CombatParticipant, CombatRoundAction
+
+
+def _sheet(actor: ObjectDB) -> CharacterSheet | None:
+    """Return *actor*'s CharacterSheet, or None if absent."""
+    try:
+        return actor.sheet_data
+    except (AttributeError, ObjectDoesNotExist):
+        return None
+
+
+def _active_combat_participant(
+    actor: ObjectDB,
+    statuses: set[str],
+) -> CombatParticipant | None:
+    """Return *actor*'s ACTIVE participant whose encounter is in *statuses*, newest first."""
+    from world.combat.constants import ParticipantStatus  # noqa: PLC0415
+    from world.combat.models import CombatParticipant  # noqa: PLC0415
+
+    sheet = _sheet(actor)
+    if sheet is None:
+        return None
+    return (
+        CombatParticipant.objects.filter(
+            character_sheet=sheet,
+            status=ParticipantStatus.ACTIVE,
+            encounter__status__in=statuses,
+        )
+        .select_related("encounter")
+        .order_by("-encounter__created_at")
+        .first()
+    )
+
+
+def _resolve_ally(
+    participant: CombatParticipant,
+    ally_participant_id: int | None,
+) -> CombatParticipant | None:
+    """Resolve an ally pk to a CombatParticipant scoped to *participant*'s encounter."""
+    if ally_participant_id is None:
+        return None
+    from world.combat.models import CombatParticipant  # noqa: PLC0415
+
+    return CombatParticipant.objects.filter(
+        pk=ally_participant_id,
+        encounter=participant.encounter,
+    ).first()
+
+
+def _current_round_action(participant: CombatParticipant) -> CombatRoundAction | None:
+    """Return *participant*'s CombatRoundAction for its encounter's current round, or None."""
+    from world.combat.models import CombatRoundAction  # noqa: PLC0415
+
+    return CombatRoundAction.objects.filter(
+        participant=participant,
+        round_number=participant.encounter.round_number,
+    ).first()
+
+
+@dataclass
+class FleeAction(Action):
+    """Declare a desperate flee — passives-only, auto-ready (wraps ``declare_flee``)."""
+
+    key: str = "combat_flee"
+    name: str = "Flee"
+    icon: str = "running"
+    category: str = "combat"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.combat.constants import EncounterStatus  # noqa: PLC0415
+        from world.combat.services import declare_flee  # noqa: PLC0415
+
+        participant = _active_combat_participant(actor, {EncounterStatus.DECLARING})
+        if participant is None:
+            return ActionResult(success=False, message="You are not in an active combat round.")
+        try:
+            declare_flee(participant)
+        except ValueError as err:
+            return ActionResult(success=False, message=str(err))
+        return ActionResult(success=True, message="You declare a desperate flee.")

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from actions.base import Action
 from actions.definitions.cast import CastTechniqueAction
+from actions.definitions.combat_maneuvers import FleeAction
 from actions.definitions.communication import (
     MutterAction,
     PemitAction,
@@ -111,6 +112,7 @@ _ALL_ACTIONS: list[Action] = [
     DisarmTrapAction(),
     PassRoundAction(),
     ForceResolveRoundAction(),
+    FleeAction(),
     ChallengeAction(),
     AcceptChallengeAction(),
     DeclineChallengeAction(),

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 from actions.base import Action
 from actions.definitions.cast import CastTechniqueAction
-from actions.definitions.combat_maneuvers import FleeAction
+from actions.definitions.combat_maneuvers import (
+    CoverAction,
+    FleeAction,
+    InterposeAction,
+    JoinEncounterAction,
+    LeaveEncounterAction,
+    ReadyAction,
+    RevertComboAction,
+    UpgradeComboAction,
+)
 from actions.definitions.communication import (
     MutterAction,
     PemitAction,
@@ -113,6 +122,13 @@ _ALL_ACTIONS: list[Action] = [
     PassRoundAction(),
     ForceResolveRoundAction(),
     FleeAction(),
+    CoverAction(),
+    InterposeAction(),
+    ReadyAction(),
+    UpgradeComboAction(),
+    RevertComboAction(),
+    JoinEncounterAction(),
+    LeaveEncounterAction(),
     ChallengeAction(),
     AcceptChallengeAction(),
     DeclineChallengeAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -194,6 +194,14 @@ class ActionRegistryTests(TestCase):
             "endorse_scene_entry",
             "endorse_style_presentation",
             "cast_technique",
+            "combat_flee",
+            "combat_cover",
+            "combat_interpose",
+            "combat_ready",
+            "combat_combo",
+            "combat_revert",
+            "combat_join",
+            "combat_leave",
         }
         assert set(ACTIONS_BY_KEY.keys()) == expected_keys
 

--- a/src/actions/tests/test_combat_maneuvers.py
+++ b/src/actions/tests/test_combat_maneuvers.py
@@ -1,0 +1,57 @@
+"""Tests for combat maneuver actions (#1453, #1452).
+
+These drive the actions through ``Action.run()`` — the same lifecycle the telnet
+command and web viewset reach via ``dispatch_player_action`` — so they cover the
+full shared seam, not just the service call.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from actions.definitions.combat_maneuvers import FleeAction
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import CombatManeuver, EncounterStatus, ParticipantStatus
+from world.combat.factories import CombatEncounterFactory, CombatParticipantFactory
+from world.combat.models import CombatRoundAction
+from world.vitals.models import CharacterVitals
+
+
+class CombatManeuverActionTestBase(TestCase):
+    """Shared fixture: a player character active in a DECLARING encounter."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.character = CharacterFactory(db_key="maneuverchar")
+        cls.sheet = CharacterSheetFactory(character=cls.character)
+        cls.encounter = CombatEncounterFactory(
+            status=EncounterStatus.DECLARING,
+            round_number=1,
+        )
+        cls.participant = CombatParticipantFactory(
+            encounter=cls.encounter,
+            character_sheet=cls.sheet,
+            status=ParticipantStatus.ACTIVE,
+        )
+        CharacterVitals.objects.get_or_create(
+            character_sheet=cls.sheet,
+            defaults={"health": 50, "max_health": 100},
+        )
+
+
+class FleeActionTest(CombatManeuverActionTestBase):
+    def test_flee_declares_flee_maneuver(self) -> None:
+        result = FleeAction().run(self.character)
+        self.assertTrue(result.success, result.message)
+        action = CombatRoundAction.objects.get(
+            participant=self.participant,
+            round_number=self.encounter.round_number,
+        )
+        self.assertEqual(action.maneuver, CombatManeuver.FLEE)
+
+    def test_flee_fails_when_not_in_combat(self) -> None:
+        loner = CharacterFactory(db_key="lonerchar")
+        CharacterSheetFactory(character=loner)
+        result = FleeAction().run(loner)
+        self.assertFalse(result.success)

--- a/src/actions/tests/test_combat_maneuvers.py
+++ b/src/actions/tests/test_combat_maneuvers.py
@@ -9,12 +9,27 @@ from __future__ import annotations
 
 from django.test import TestCase
 
-from actions.definitions.combat_maneuvers import FleeAction
+from actions.definitions.combat_maneuvers import (
+    CoverAction,
+    FleeAction,
+    InterposeAction,
+    JoinEncounterAction,
+    LeaveEncounterAction,
+    ReadyAction,
+    RevertComboAction,
+    UpgradeComboAction,
+)
 from evennia_extensions.factories import CharacterFactory
 from world.character_sheets.factories import CharacterSheetFactory
-from world.combat.constants import CombatManeuver, EncounterStatus, ParticipantStatus
+from world.combat.constants import (
+    CombatManeuver,
+    EncounterStatus,
+    EncounterType,
+    ParticipantStatus,
+)
 from world.combat.factories import CombatEncounterFactory, CombatParticipantFactory
-from world.combat.models import CombatRoundAction
+from world.combat.models import CombatParticipant, CombatRoundAction
+from world.combat.services import declare_flee
 from world.vitals.models import CharacterVitals
 
 
@@ -54,4 +69,158 @@ class FleeActionTest(CombatManeuverActionTestBase):
         loner = CharacterFactory(db_key="lonerchar")
         CharacterSheetFactory(character=loner)
         result = FleeAction().run(loner)
+        self.assertFalse(result.success)
+
+
+class CoverInterposeActionTest(CombatManeuverActionTestBase):
+    def _ally_participant(self) -> CombatParticipant:
+        ally_sheet = CharacterSheetFactory(character=CharacterFactory(db_key="allychar"))
+        return CombatParticipantFactory(
+            encounter=self.encounter,
+            character_sheet=ally_sheet,
+            status=ParticipantStatus.ACTIVE,
+        )
+
+    def test_cover_declares_cover_for_ally(self) -> None:
+        ally = self._ally_participant()
+        result = CoverAction().run(self.character, ally_participant_id=ally.pk)
+        self.assertTrue(result.success, result.message)
+        action = CombatRoundAction.objects.get(participant=self.participant, round_number=1)
+        self.assertEqual(action.maneuver, CombatManeuver.COVER)
+        self.assertEqual(action.focused_ally_target_id, ally.pk)
+
+    def test_cover_without_ally_fails(self) -> None:
+        result = CoverAction().run(self.character)
+        self.assertFalse(result.success)
+
+    def test_cover_foreign_ally_fails(self) -> None:
+        other_enc = CombatEncounterFactory(status=EncounterStatus.DECLARING, round_number=1)
+        foreign = CombatParticipantFactory(
+            encounter=other_enc,
+            character_sheet=CharacterSheetFactory(character=CharacterFactory(db_key="foreign")),
+            status=ParticipantStatus.ACTIVE,
+        )
+        result = CoverAction().run(self.character, ally_participant_id=foreign.pk)
+        self.assertFalse(result.success)
+
+    def test_interpose_without_ally_guards_any(self) -> None:
+        result = InterposeAction().run(self.character)
+        self.assertTrue(result.success, result.message)
+        action = CombatRoundAction.objects.get(participant=self.participant, round_number=1)
+        self.assertEqual(action.maneuver, CombatManeuver.INTERPOSE)
+        self.assertIsNone(action.focused_ally_target_id)
+
+
+class ReadyActionTest(CombatManeuverActionTestBase):
+    def test_ready_toggles_declared_action(self) -> None:
+        declare_flee(self.participant)  # creates a round action with is_ready=True
+        result = ReadyAction().run(self.character)
+        self.assertTrue(result.success, result.message)
+        action = CombatRoundAction.objects.get(participant=self.participant, round_number=1)
+        self.assertFalse(action.is_ready)
+        ReadyAction().run(self.character)
+        action.refresh_from_db()
+        self.assertTrue(action.is_ready)
+
+    def test_ready_without_declared_action_fails(self) -> None:
+        result = ReadyAction().run(self.character)
+        self.assertFalse(result.success)
+
+
+class ComboActionTest(CombatManeuverActionTestBase):
+    def test_combo_unknown_id_fails(self) -> None:
+        declare_flee(self.participant)
+        result = UpgradeComboAction().run(self.character, combo_id=999999)
+        self.assertFalse(result.success)
+
+    def test_combo_without_declared_action_fails(self) -> None:
+        result = UpgradeComboAction().run(self.character, combo_id=1)
+        self.assertFalse(result.success)
+
+    def test_revert_is_idempotent_with_no_combo(self) -> None:
+        declare_flee(self.participant)  # no combo upgrade present
+        result = RevertComboAction().run(self.character)
+        self.assertTrue(result.success, result.message)
+        action = CombatRoundAction.objects.get(participant=self.participant, round_number=1)
+        self.assertIsNone(action.combo_upgrade_id)
+
+    def test_revert_without_declared_action_fails(self) -> None:
+        result = RevertComboAction().run(self.character)
+        self.assertFalse(result.success)
+
+
+class JoinLeaveActionTest(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.encounter = CombatEncounterFactory(
+            encounter_type=EncounterType.OPEN_ENCOUNTER,
+            status=EncounterStatus.DECLARING,
+            round_number=1,
+        )
+        cls.character = CharacterFactory(db_key="joinerchar")
+        cls.sheet = CharacterSheetFactory(character=cls.character)
+
+    def test_join_adds_active_participant(self) -> None:
+        result = JoinEncounterAction().run(self.character, encounter_id=self.encounter.pk)
+        self.assertTrue(result.success, result.message)
+        self.assertTrue(
+            CombatParticipant.objects.filter(
+                encounter=self.encounter,
+                character_sheet=self.sheet,
+                status=ParticipantStatus.ACTIVE,
+            ).exists()
+        )
+
+    def test_double_join_fails(self) -> None:
+        JoinEncounterAction().run(self.character, encounter_id=self.encounter.pk)
+        result = JoinEncounterAction().run(self.character, encounter_id=self.encounter.pk)
+        self.assertFalse(result.success)
+
+    def test_join_no_encounter_here_fails(self) -> None:
+        result = JoinEncounterAction().run(self.character)  # no id, no room encounter
+        self.assertFalse(result.success)
+
+    def test_leave_between_rounds_removes_participant(self) -> None:
+        between = CombatEncounterFactory(
+            encounter_type=EncounterType.OPEN_ENCOUNTER,
+            status=EncounterStatus.BETWEEN_ROUNDS,
+            round_number=1,
+        )
+        leaver = CharacterFactory(db_key="leaverchar")
+        leaver_sheet = CharacterSheetFactory(character=leaver)
+        CombatParticipantFactory(
+            encounter=between,
+            character_sheet=leaver_sheet,
+            status=ParticipantStatus.ACTIVE,
+        )
+        # A second participant so the encounter isn't abandoned out from under the assert.
+        CombatParticipantFactory(
+            encounter=between,
+            character_sheet=CharacterSheetFactory(character=CharacterFactory(db_key="stayer")),
+            status=ParticipantStatus.ACTIVE,
+        )
+        result = LeaveEncounterAction().run(leaver)
+        self.assertTrue(result.success, result.message)
+        self.assertFalse(
+            CombatParticipant.objects.filter(
+                encounter=between,
+                character_sheet=leaver_sheet,
+                status=ParticipantStatus.ACTIVE,
+            ).exists()
+        )
+
+    def test_leave_while_declaring_fails(self) -> None:
+        declaring = CombatEncounterFactory(
+            encounter_type=EncounterType.OPEN_ENCOUNTER,
+            status=EncounterStatus.DECLARING,
+            round_number=1,
+        )
+        mover = CharacterFactory(db_key="moverchar")
+        mover_sheet = CharacterSheetFactory(character=mover)
+        CombatParticipantFactory(
+            encounter=declaring,
+            character_sheet=mover_sheet,
+            status=ParticipantStatus.ACTIVE,
+        )
+        result = LeaveEncounterAction().run(mover)
         self.assertFalse(result.success)

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -108,6 +108,15 @@ actions, backends, and service functions.
     which calls `declare_clash_contribution` (writes a `ClashContributionDeclaration`
     consumed by `_resolve_clashes` in the round post-pass). `strain=<n>` commits
     extra anima beyond the technique's base cost (default 0).
+- **`combat_maneuvers.py`**: `CmdCombat` (`combat`, #1453/#1452) — the shared-verb
+  namespace. One command routes a leading subverb (`combat flee` / `cover <ally>` /
+  `interpose [ally]` / `join` / `leave` / `ready` / `combo <name>` / `revert` / `yield`)
+  to a REGISTRY `ActionRef` and dispatches through `dispatch_player_action` — the same
+  seam the web `CombatEncounterViewSet` uses. Bare `combat` prints a status hub (mirrors
+  `CmdSheet`). Verbs are namespaced — not bare top-level keys — to avoid exit/channel/alias
+  collisions (mirrors `CmdRitual`'s `ritual <subverb>` routing). Each verb wraps an existing
+  combat service via its Action in `actions/definitions/combat_maneuvers.py`; `yield` reuses
+  the existing `YieldAction`.
 - **`pull.py`**: `CmdPull` (`pull`) — resonance pull command with optional `preview`
   mode; parses `pull [preview] resonance=<name> tier=<1-3> thread=<name|id>[,...]
   [trait=<name>] [technique=<name>]`. Preview mode returns cost estimate without

--- a/src/commands/combat_maneuvers.py
+++ b/src/commands/combat_maneuvers.py
@@ -1,0 +1,159 @@
+"""Combat maneuver telnet command — the ``combat <subverb>`` namespace (#1453, #1452).
+
+A single command routes the non-cast/non-clash combat verbs (flee, cover,
+interpose, join, leave, ready, combo, revert, yield) through the shared
+``dispatch_player_action`` seam — the same path the web uses. The verbs live
+under the ``combat`` namespace rather than as bare top-level keys because broad
+one-word keys (``join``/``leave``/``ready``/``cover``/``revert``) collide with
+room exits, channels, and aliases. Mirrors ``CmdRitual`` (subverb routing) and
+``CmdSheet`` (the section-hub pattern).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from actions.constants import ActionBackend
+from commands.combat import _CombatCommandMixin
+from commands.command import DispatchCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from actions.types import ActionRef
+
+# subverb -> registry action key. ``yield`` reuses the existing YieldAction.
+_SUBVERBS: dict[str, str] = {
+    "flee": "combat_flee",
+    "cover": "combat_cover",
+    "interpose": "combat_interpose",
+    "join": "combat_join",
+    "leave": "combat_leave",
+    "ready": "combat_ready",
+    "combo": "combat_combo",
+    "revert": "combat_revert",
+    "yield": "yield",
+}
+
+# subverbs that take a single name argument.
+_ALLY_SUBVERBS = {"cover", "interpose"}
+
+
+class CmdCombat(_CombatCommandMixin, DispatchCommand):
+    """Take a combat action other than casting or clashing.
+
+    Usage:
+        combat                      — show your combat status + available actions
+        combat flee                 — declare a desperate flee this round
+        combat cover <ally>         — cover an ally's escape
+        combat interpose [ally]     — guard an ally (or any ally) from harm
+        combat join                 — join the fight in your room
+        combat leave                — leave an open encounter between rounds
+        combat ready                — toggle your declared action as ready
+        combat combo <name>         — chain your declared action into a combo
+        combat revert               — undo a combo upgrade
+        combat yield                — concede a duel
+    """
+
+    key = "combat"
+    locks = "cmd:all()"
+
+    _subverb: str = ""
+    _rest: str = ""
+
+    def func(self) -> None:
+        """Route the leading subverb; bare ``combat`` shows the status hub."""
+        raw = (self.args or "").strip()
+        if not raw:
+            self._show_status_hub()
+            return
+        parts = raw.split(maxsplit=1)
+        self._subverb = parts[0].lower()
+        self._rest = parts[1].strip() if len(parts) > 1 else ""
+        if self._subverb not in _SUBVERBS:
+            options = ", ".join(_SUBVERBS)
+            self.msg(f"Unknown combat action '{self._subverb}'. Try: {options}.")
+            return
+        super().func()  # resolve_action_ref + resolve_action_args + dispatch
+
+    def resolve_action_ref(self) -> ActionRef:
+        """Build a REGISTRY ActionRef for the parsed subverb."""
+        from actions.types import ActionRef  # noqa: PLC0415
+
+        return ActionRef(backend=ActionBackend.REGISTRY, registry_key=_SUBVERBS[self._subverb])
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        """Resolve name arguments (ally / combo) into dispatch kwargs."""
+        if self._subverb == "cover":  # noqa: STRING_LITERAL
+            return {"ally_participant_id": self._resolve_ally_pk(self._require_rest("an ally"))}
+        if self._subverb == "interpose":  # noqa: STRING_LITERAL
+            ally = self._resolve_ally_pk(self._rest) if self._rest else None
+            return {"ally_participant_id": ally}
+        if self._subverb == "combo":  # noqa: STRING_LITERAL
+            return {"combo_id": self._resolve_combo_pk(self._require_rest("a combo name"))}
+        return {}
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _require_rest(self, what: str) -> str:
+        if not self._rest:
+            msg = f"Usage: combat {self._subverb} <{what}>."
+            raise CommandError(msg)
+        return self._rest
+
+    def _resolve_ally_pk(self, name: str) -> int:
+        """Return the pk of the active ally named *name* in the caller's encounter."""
+        from world.combat.constants import ParticipantStatus  # noqa: PLC0415
+        from world.combat.models import CombatParticipant  # noqa: PLC0415
+
+        participant = self._combat_participant_or_none()
+        if participant is None:
+            msg = "You are not in an active combat round."
+            raise CommandError(msg)
+        matches = list(
+            CombatParticipant.objects.filter(
+                encounter=participant.encounter,
+                status=ParticipantStatus.ACTIVE,
+                character_sheet__character__db_key__iexact=name,
+            )
+        )
+        if not matches:
+            msg = f"No active ally named '{name}' in this encounter."
+            raise CommandError(msg)
+        if len(matches) > 1:
+            msg = f"More than one ally named '{name}' — be more specific."
+            raise CommandError(msg)
+        return matches[0].pk
+
+    def _resolve_combo_pk(self, name: str) -> int:
+        from world.combat.models import ComboDefinition  # noqa: PLC0415
+
+        combo = ComboDefinition.objects.filter(name__iexact=name).first()
+        if combo is None:
+            msg = f"No combo named '{name}'."
+            raise CommandError(msg)
+        return combo.pk
+
+    def _show_status_hub(self) -> None:
+        """Print the caller's current declared action plus the available subverbs."""
+        lines = [
+            "|wCombat actions|n: "
+            "flee, cover <ally>, interpose [ally], join, leave, ready, "
+            "combo <name>, revert, yield"
+        ]
+        participant = self._combat_participant_or_none()
+        if participant is None:
+            lines.append("You are not currently declaring in combat.")
+        else:
+            from world.combat.models import CombatRoundAction  # noqa: PLC0415
+
+            action = CombatRoundAction.objects.filter(
+                participant=participant,
+                round_number=participant.encounter.round_number,
+            ).first()
+            if action is None:
+                lines.append("You have not declared an action this round.")
+            else:
+                ready = "ready" if action.is_ready else "not ready"
+                maneuver = action.maneuver or "action"
+                lines.append(f"Declared: {maneuver} ({ready}).")
+        self.msg("\n".join(lines))

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -21,6 +21,7 @@ from commands.account.character_switching import CmdCharacters, CmdIC
 from commands.account.prompt_reply import CmdPromptReply
 from commands.account.sheet import CmdSheet
 from commands.combat import CmdClashCommit, CmdDeclareTechnique
+from commands.combat_maneuvers import CmdCombat
 from commands.consent import (
     CmdAccept,
     CmdDeceive,
@@ -177,6 +178,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdDeclareTechnique,
             # Clash contribution (#1451)
             CmdClashCommit,
+            # Shared combat verbs: combat <subverb> (#1453, #1452)
+            CmdCombat,
         )
         for command_cls in command_classes:
             self.add(command_cls())

--- a/src/commands/tests/test_combat_maneuvers_command.py
+++ b/src/commands/tests/test_combat_maneuvers_command.py
@@ -1,0 +1,103 @@
+"""Unit tests for CmdCombat — the ``combat <subverb>`` namespace (#1453, #1452).
+
+Verify subverb routing, REGISTRY ref construction, name-argument resolution, and
+the bare-``combat`` status hub, mirroring the mock-caller style of
+``test_combat_commands.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from actions.constants import ActionBackend
+from actions.types import ActionResult, DispatchResult
+from commands.combat_maneuvers import CmdCombat
+from commands.exceptions import CommandError
+
+_DISPATCH = "commands.command.dispatch_player_action"
+
+
+def _make_cmd(args: str) -> CmdCombat:
+    cmd = CmdCombat()
+    cmd.caller = MagicMock()
+    cmd.args = args
+    cmd.raw_string = f"combat {args}"
+    cmd.cmdname = "combat"
+    return cmd
+
+
+class CmdCombatRoutingTests(TestCase):
+    def test_flee_builds_registry_ref(self) -> None:
+        cmd = _make_cmd("flee")
+        cmd._subverb = "flee"
+        ref = cmd.resolve_action_ref()
+        self.assertEqual(ref.backend, ActionBackend.REGISTRY)
+        self.assertEqual(ref.registry_key, "combat_flee")
+
+    def test_yield_reuses_existing_yield_action(self) -> None:
+        cmd = _make_cmd("yield")
+        cmd._subverb = "yield"
+        ref = cmd.resolve_action_ref()
+        self.assertEqual(ref.registry_key, "yield")
+
+    def test_unknown_subverb_messages_and_does_not_dispatch(self) -> None:
+        cmd = _make_cmd("frobnicate")
+        with patch(_DISPATCH) as dispatch:
+            cmd.func()
+        dispatch.assert_not_called()
+        cmd.caller.msg.assert_called()
+
+    def test_flee_dispatches_registry_ref_through_func(self) -> None:
+        cmd = _make_cmd("flee")
+        result = DispatchResult(
+            backend=ActionBackend.REGISTRY,
+            deferred=False,
+            detail=ActionResult(success=True, message="You flee."),
+        )
+        with patch(_DISPATCH, return_value=result) as dispatch:
+            cmd.func()
+        dispatch.assert_called_once()
+        _, ref, kwargs = dispatch.call_args.args
+        self.assertEqual(ref.registry_key, "combat_flee")
+        self.assertEqual(kwargs, {})
+
+    def test_bare_combat_shows_status_hub(self) -> None:
+        cmd = _make_cmd("")
+        with patch.object(cmd, "_combat_participant_or_none", return_value=None):
+            cmd.func()
+        cmd.caller.msg.assert_called_once()
+        self.assertIn("Combat actions", cmd.caller.msg.call_args.args[0])
+
+
+class CmdCombatArgResolutionTests(TestCase):
+    def test_cover_resolves_ally_kwarg(self) -> None:
+        cmd = _make_cmd("cover Bob")
+        cmd._subverb, cmd._rest = "cover", "Bob"
+        with patch.object(cmd, "_resolve_ally_pk", return_value=5):
+            kwargs = cmd.resolve_action_args()
+        self.assertEqual(kwargs, {"ally_participant_id": 5})
+
+    def test_cover_without_ally_raises(self) -> None:
+        cmd = _make_cmd("cover")
+        cmd._subverb, cmd._rest = "cover", ""
+        with self.assertRaises(CommandError):
+            cmd.resolve_action_args()
+
+    def test_interpose_without_ally_passes_none(self) -> None:
+        cmd = _make_cmd("interpose")
+        cmd._subverb, cmd._rest = "interpose", ""
+        self.assertEqual(cmd.resolve_action_args(), {"ally_participant_id": None})
+
+    def test_combo_resolves_combo_kwarg(self) -> None:
+        cmd = _make_cmd("combo Whirlwind")
+        cmd._subverb, cmd._rest = "combo", "Whirlwind"
+        with patch.object(cmd, "_resolve_combo_pk", return_value=3):
+            kwargs = cmd.resolve_action_args()
+        self.assertEqual(kwargs, {"combo_id": 3})
+
+    def test_flee_takes_no_args(self) -> None:
+        cmd = _make_cmd("flee")
+        cmd._subverb, cmd._rest = "flee", ""
+        self.assertEqual(cmd.resolve_action_args(), {})

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -1050,6 +1050,17 @@ def declare_flee(participant: CombatParticipant) -> CombatRoundAction:
     return action
 
 
+def toggle_action_ready(action: CombatRoundAction) -> CombatRoundAction:
+    """Flip the ready flag on a round action and persist it.
+
+    Extracted from the inline toggle that lived in the web ``ready`` endpoint so
+    both the telnet/web shared ``ReadyAction`` and any caller use one code path.
+    """
+    action.is_ready = not action.is_ready
+    action.save(update_fields=["is_ready"])
+    return action
+
+
 def declare_cover(
     participant: CombatParticipant,
     ally: CombatParticipant,

--- a/src/world/combat/tests/test_combat_maneuvers_e2e.py
+++ b/src/world/combat/tests/test_combat_maneuvers_e2e.py
@@ -1,0 +1,125 @@
+"""E2E: combat verbs through the shared dispatch seam (#1453, #1452).
+
+Each test dispatches a verb's REGISTRY ``ActionRef`` via ``dispatch_player_action``
+— the exact path both telnet (``CmdCombat``) and the web viewset use — and asserts
+real encounter state, proving telnet/web convergence end to end.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from actions.constants import ActionBackend
+from actions.player_interface import dispatch_player_action
+from actions.types import ActionRef
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import (
+    CombatManeuver,
+    EncounterStatus,
+    EncounterType,
+    ParticipantStatus,
+)
+from world.combat.factories import CombatEncounterFactory, CombatParticipantFactory
+from world.combat.models import CombatParticipant, CombatRoundAction
+from world.vitals.models import CharacterVitals
+
+
+def _ref(registry_key: str) -> ActionRef:
+    return ActionRef(backend=ActionBackend.REGISTRY, registry_key=registry_key)
+
+
+class CombatManeuverDispatchE2E(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.encounter = CombatEncounterFactory(
+            status=EncounterStatus.DECLARING,
+            round_number=1,
+        )
+        cls.char = CharacterFactory(db_key="e2echar")
+        cls.sheet = CharacterSheetFactory(character=cls.char)
+        cls.participant = CombatParticipantFactory(
+            encounter=cls.encounter,
+            character_sheet=cls.sheet,
+            status=ParticipantStatus.ACTIVE,
+        )
+        CharacterVitals.objects.get_or_create(
+            character_sheet=cls.sheet,
+            defaults={"health": 50, "max_health": 100},
+        )
+
+    def _round_action(self) -> CombatRoundAction:
+        return CombatRoundAction.objects.get(participant=self.participant, round_number=1)
+
+    def test_flee_then_ready_toggle(self) -> None:
+        result = dispatch_player_action(self.char, _ref("combat_flee"), {})
+        self.assertTrue(result.detail.success, result.detail.message)
+        action = self._round_action()
+        self.assertEqual(action.maneuver, CombatManeuver.FLEE)
+        self.assertTrue(action.is_ready)  # flee auto-readies
+        dispatch_player_action(self.char, _ref("combat_ready"), {})
+        action.refresh_from_db()
+        self.assertFalse(action.is_ready)
+
+    def test_cover_targets_ally(self) -> None:
+        ally = CombatParticipantFactory(
+            encounter=self.encounter,
+            character_sheet=CharacterSheetFactory(character=CharacterFactory(db_key="e2eally")),
+            status=ParticipantStatus.ACTIVE,
+        )
+        result = dispatch_player_action(
+            self.char, _ref("combat_cover"), {"ally_participant_id": ally.pk}
+        )
+        self.assertTrue(result.detail.success, result.detail.message)
+        action = self._round_action()
+        self.assertEqual(action.maneuver, CombatManeuver.COVER)
+        self.assertEqual(action.focused_ally_target_id, ally.pk)
+
+    def test_interpose_no_target(self) -> None:
+        result = dispatch_player_action(self.char, _ref("combat_interpose"), {})
+        self.assertTrue(result.detail.success, result.detail.message)
+        action = self._round_action()
+        self.assertEqual(action.maneuver, CombatManeuver.INTERPOSE)
+        self.assertIsNone(action.focused_ally_target_id)
+
+
+class JoinLeaveDispatchE2E(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.encounter = CombatEncounterFactory(
+            encounter_type=EncounterType.OPEN_ENCOUNTER,
+            status=EncounterStatus.BETWEEN_ROUNDS,
+            round_number=1,
+        )
+        # An anchor participant so the leave does not abandon the encounter.
+        CombatParticipantFactory(
+            encounter=cls.encounter,
+            character_sheet=CharacterSheetFactory(character=CharacterFactory(db_key="anchore2e")),
+            status=ParticipantStatus.ACTIVE,
+        )
+        cls.joiner = CharacterFactory(db_key="joindispatch")
+        cls.joiner_sheet = CharacterSheetFactory(character=cls.joiner)
+
+    def test_join_then_leave(self) -> None:
+        joined = dispatch_player_action(
+            self.joiner,
+            _ref("combat_join"),
+            {"encounter_id": self.encounter.pk, "character_sheet_id": self.joiner_sheet.pk},
+        )
+        self.assertTrue(joined.detail.success, joined.detail.message)
+        self.assertTrue(
+            CombatParticipant.objects.filter(
+                encounter=self.encounter,
+                character_sheet=self.joiner_sheet,
+                status=ParticipantStatus.ACTIVE,
+            ).exists()
+        )
+        left = dispatch_player_action(self.joiner, _ref("combat_leave"), {})
+        self.assertTrue(left.detail.success, left.detail.message)
+        self.assertFalse(
+            CombatParticipant.objects.filter(
+                encounter=self.encounter,
+                character_sheet=self.joiner_sheet,
+                status=ParticipantStatus.ACTIVE,
+            ).exists()
+        )

--- a/src/world/combat/tests/test_combat_maneuvers_e2e.py
+++ b/src/world/combat/tests/test_combat_maneuvers_e2e.py
@@ -123,3 +123,16 @@ class JoinLeaveDispatchE2E(TestCase):
                 status=ParticipantStatus.ACTIVE,
             ).exists()
         )
+
+    def test_join_resolves_room_encounter_without_id(self) -> None:
+        """Telnet path: no ids — encounter resolves from the actor's room, sheet from the actor."""
+        self.joiner.location = self.encounter.room
+        result = dispatch_player_action(self.joiner, _ref("combat_join"), {})
+        self.assertTrue(result.detail.success, result.detail.message)
+        self.assertTrue(
+            CombatParticipant.objects.filter(
+                encounter=self.encounter,
+                character_sheet=self.joiner_sheet,
+                status=ParticipantStatus.ACTIVE,
+            ).exists()
+        )

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from evennia.accounts.models import AccountDB
+from evennia.objects.models import ObjectDB
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -19,7 +20,10 @@ from rest_framework.response import Response
 from rest_framework.serializers import Serializer
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
+from actions.constants import ActionBackend
 from actions.errors import ActionDispatchError
+from actions.player_interface import dispatch_player_action
+from actions.types import ActionRef, ActionResult, DispatchResult
 from world.character_sheets.models import CharacterSheet
 from world.combat.constants import (
     ClashStatus,
@@ -64,17 +68,10 @@ from world.combat.services import (
     add_opponent,
     add_participant,
     begin_declaration_phase,
-    declare_cover,
-    declare_flee,
-    declare_interpose,
     end_encounter,
-    join_encounter,
-    leave_encounter,
     remove_participant,
     resolve_round,
-    revert_combo_upgrade,
     run_combo_detection,
-    upgrade_action_to_combo,
 )
 from world.conditions.models import ConditionInstance
 from world.covenants.models import CovenantRole
@@ -505,8 +502,7 @@ class CombatEncounterViewSet(ModelViewSet):
                 {"detail": _ERR_NO_ACTION},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        current_action.is_ready = not current_action.is_ready
-        current_action.save(update_fields=["is_ready"])
+        self._dispatch_combat_action(participant.character_sheet.character, "combat_ready")
         return self._serialize_encounter(request, encounter)
 
     @action(detail=True, methods=[HTTPMethod.GET])
@@ -557,22 +553,23 @@ class CombatEncounterViewSet(ModelViewSet):
         serializer = UpgradeComboSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         combo_id = serializer.validated_data["combo_id"]
-        combo = get_object_or_404(ComboDefinition, pk=combo_id)
+        get_object_or_404(ComboDefinition, pk=combo_id)
         current_action = self._current_round_action(participant, encounter)
         if not current_action:
             return Response(
                 {"detail": _ERR_NO_ACTION},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        try:
-            upgrade_action_to_combo(current_action, combo)
-        except ValueError:
+        result = self._dispatch_combat_action(
+            participant.character_sheet.character,
+            "combat_combo",
+            {"combo_id": combo_id},
+        )
+        if not self._action_succeeded(result):
             return Response(
                 {"detail": _ERR_COMBO_UPGRADE},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        current_action.is_ready = False
-        current_action.save(update_fields=["is_ready"])
         return self._serialize_encounter(request, encounter)
 
     @action(detail=True, methods=[HTTPMethod.POST])
@@ -591,9 +588,7 @@ class CombatEncounterViewSet(ModelViewSet):
                 {"detail": _ERR_NO_ACTION},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        revert_combo_upgrade(current_action)
-        current_action.is_ready = False
-        current_action.save(update_fields=["is_ready"])
+        self._dispatch_combat_action(participant.character_sheet.character, "combat_revert")
         return self._serialize_encounter(request, encounter)
 
     # --- Participation ---
@@ -623,15 +618,24 @@ class CombatEncounterViewSet(ModelViewSet):
                 status=status.HTTP_403_FORBIDDEN,
             )
         sheet = get_object_or_404(CharacterSheet, pk=sheet_pk)
-        try:
-            new_participant = join_encounter(encounter, sheet)
-        except ValueError:
+        result = self._dispatch_combat_action(
+            sheet.character,
+            "combat_join",
+            {"encounter_id": encounter.pk, "character_sheet_id": sheet.pk},
+        )
+        if not self._action_succeeded(result):
             return Response(
                 {"detail": _ERR_ALREADY_JOINED},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        # Update cached participant list in-place
-        encounter.participants_cached.append(new_participant)
+        # Refresh the cached participant list with the newly-created row.
+        new_participant = CombatParticipant.objects.filter(
+            encounter=encounter,
+            character_sheet=sheet,
+            status=ParticipantStatus.ACTIVE,
+        ).first()
+        if new_participant is not None:
+            encounter.participants_cached.append(new_participant)
         return self._serialize_encounter(request, encounter)
 
     @action(detail=True, methods=[HTTPMethod.POST])
@@ -648,9 +652,8 @@ class CombatEncounterViewSet(ModelViewSet):
                 {"detail": _ERR_NOT_PARTICIPANT},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        try:
-            declare_flee(participant)
-        except ValueError:
+        result = self._dispatch_combat_action(participant.character_sheet.character, "combat_flee")
+        if not self._action_succeeded(result):
             return Response(
                 {"detail": _ERR_DECLARE_FAILED},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -671,9 +674,8 @@ class CombatEncounterViewSet(ModelViewSet):
                 {"detail": _ERR_NOT_PARTICIPANT},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        try:
-            leave_encounter(participant)
-        except ValueError:
+        result = self._dispatch_combat_action(participant.character_sheet.character, "combat_leave")
+        if not self._action_succeeded(result):
             return Response(
                 {"detail": _ERR_INVALID_STATUS},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -703,9 +705,12 @@ class CombatEncounterViewSet(ModelViewSet):
         serializer.is_valid(raise_exception=True)
         ally_id = serializer.validated_data["ally_participant_id"]
         ally = get_object_or_404(CombatParticipant, pk=ally_id, encounter=encounter)
-        try:
-            declare_cover(participant, ally)
-        except ValueError:
+        result = self._dispatch_combat_action(
+            participant.character_sheet.character,
+            "combat_cover",
+            {"ally_participant_id": ally.pk},
+        )
+        if not self._action_succeeded(result):
             return Response(
                 {"detail": _ERR_DECLARE_FAILED},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -736,9 +741,12 @@ class CombatEncounterViewSet(ModelViewSet):
             if ally_id is not None
             else None
         )
-        try:
-            declare_interpose(participant, ally)
-        except ValueError:
+        result = self._dispatch_combat_action(
+            participant.character_sheet.character,
+            "combat_interpose",
+            {"ally_participant_id": ally.pk if ally is not None else None},
+        )
+        if not self._action_succeeded(result):
             return Response(
                 {"detail": _ERR_DECLARE_FAILED},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -833,3 +841,22 @@ class CombatEncounterViewSet(ModelViewSet):
             ),
             None,
         )
+
+    def _dispatch_combat_action(
+        self,
+        actor: ObjectDB,
+        registry_key: str,
+        action_kwargs: dict | None = None,
+    ) -> DispatchResult:
+        """Run a registry combat action through the shared ``dispatch_player_action`` seam.
+
+        The web and telnet now converge on the same Action; the viewset keeps its
+        request-scoped ownership/participant checks and serialized-encounter contract.
+        """
+        ref = ActionRef(backend=ActionBackend.REGISTRY, registry_key=registry_key)
+        return dispatch_player_action(actor, ref, action_kwargs or {})
+
+    @staticmethod
+    def _action_succeeded(result: DispatchResult) -> bool:
+        """True when a REGISTRY dispatch ran its action and it reported success."""
+        return isinstance(result.detail, ActionResult) and result.detail.success


### PR DESCRIPTION
## What & why

Converts the combat "verbs" a player takes in a fight — **flee, cover, interpose, ready, join, leave, combo upgrade/revert, and yield** — into real `Action`s on the shared `dispatch_player_action` seam, so telnet and the web reach them through the **same** path. The web's one-off `CombatEncounterViewSet` endpoints previously bypassed the action machinery and telnet couldn't do these at all; now the bypass is **converted** (not mirrored) and telnet has parity.

Closes #1453
Closes #1452

## Approach

- **New actions** in `actions/definitions/combat_maneuvers.py` (`FleeAction`, `CoverAction`, `InterposeAction`, `ReadyAction`, `UpgradeComboAction`, `RevertComboAction`, `JoinEncounterAction`, `LeaveEncounterAction`; keys prefixed `combat_`). Each `execute()` resolves the actor's active `CombatParticipant`/encounter and calls the **existing** combat service — no new game logic. `yield` reuses the existing `YieldAction`.
- **Telnet surface is a `combat <subverb>` namespace** (`CmdCombat`): `combat flee` / `cover <ally>` / `interpose [ally]` / `join` / `leave` / `ready` / `combo <name>` / `revert` / `yield`; bare `combat` is a status hub. Namespaced rather than bare top-level keys (`join`/`leave`/`ready`/…) to avoid exit/channel/alias collisions — mirrors `CmdRitual`/`CmdSheet`. `cast`/`clash` stay top-level.
- **Web convergence:** the 8 viewset player-action endpoints now dispatch through these actions via `dispatch_player_action`. **REST contract unchanged** (same status codes + serialized-encounter JSON); the 28 existing view tests pass against the rewired endpoints.
- **One new service:** `toggle_action_ready`, *extracted* from the inline `is_ready` toggle that lived in the `ready` endpoint. The `is_ready=False` reset on combo upgrade/revert (formerly inline in the views) now lives single-sourced in the actions.

## Anti-reinvention notes

- `JoinRoundAction`/`LeaveRoundAction` (`actions/definitions/rounds.py`) operate on the **generic `SceneRound`** layer (`SceneRoundParticipant`), **not** `CombatEncounter` — so they are not duplicates; combat join/leave needs encounter-specific actions. The `combat join` namespace also disambiguates the two at the player surface.
- The combo services (`upgrade_action_to_combo` / `revert_combo_upgrade`) are plain setters with no validation/`ValueError` — confirmed against code; the spec's inferred "compatibility" prerequisites don't exist. Combo *compatibility* validation is therefore out of scope here (it isn't built anywhere yet).

## Tests

- `actions/tests/test_combat_maneuvers.py` — each action through `Action.run()` (17 tests).
- `commands/tests/test_combat_maneuvers_command.py` — `CmdCombat` routing/parsing/hub (10 tests).
- `world/combat/tests/test_combat_maneuvers_e2e.py` — every verb through `dispatch_player_action`, the shared telnet/web seam, incl. telnet room-resolution join (5 tests).
- `world/combat/tests/test_views.py` (28) + `test_combos.py` (24) — green against the rewired endpoints.

Local: `just test-fast` SQLite tier green for `actions`, `commands`, `world.combat` touched modules; full `pre-commit run --all-files` clean. No new models or migrations.

## Notes for review

- No frontend changes — REST contract preserved; the separate frontend-parity audit is #1328.
- Ephemeral plan (worktree-only, gitignored) drove the build; spec lives in #1453's body (approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
