### PR TITLE
feat: gemit reach — staff/GM push vector for the public-reaction center (#1450)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -552,10 +552,11 @@ are a later slice of #1450.*
 - **Source:** `src/world/tidings/`
 - **Echo (push) vector — staff/GM gemits with reach (#1450), in `world.narrative`:**
   `broadcast_gemit` broadcasts a **hand-authored, verbatim** message (colour codes and all) to a
-  `reach` — `GemitReach` ∈ GAME_WIDE / SOCIETY / ORGANIZATION; the scoped forms carry one-or-more
-  `Gemit.reach_societies` / `reach_organizations`. Audience = sessions whose **active persona** is a
-  member of a target society/org (a TEMPORARY mask holds none, so the disguised fall out — by
-  design). History is reach-scoped so a society gemit never leaks to outsiders (staff see all).
+  `reach` — `GemitReach` ∈ GAME_WIDE / SPECIFIED; SPECIFIED carries any mix of
+  `Gemit.reach_societies` / `reach_organizations` (societies and orgs are not exclusive). Audience =
+  sessions whose **active persona** is a member of any target society/org (a TEMPORARY mask holds
+  none, so the disguised fall out — by design). History is reach-scoped so a specified gemit never
+  leaks to outsiders (staff see all).
   Faces: telnet `gemit` (`CmdGemit`, staff `perm(Admin)`) + web `POST /api/narrative/gemits/`.
 ### Consent
 OOC visibility groups and per-category social consent preferences for player-controlled

--- a/docs/systems/narrative.md
+++ b/docs/systems/narrative.md
@@ -27,8 +27,7 @@ from world.narrative.constants import GemitReach
 
 # TextChoices — how wide a gemit broadcasts (#1450):
 GemitReach.GAME_WIDE      # every online session (the classic gemit)
-GemitReach.SOCIETY        # members of the linked societies only
-GemitReach.ORGANIZATION   # members of the linked organizations only
+GemitReach.SPECIFIED      # members of any mix of the linked societies and/or organizations
 ```
 
 ---
@@ -69,8 +68,8 @@ A staff/GM real-time broadcast, persisted for retroactive (reach-scoped) viewing
 |-------|------|-------|
 | `body` | TextField | Verbatim broadcast text |
 | `reach` | CharField (`GemitReach`) | Audience scope; default `GAME_WIDE` |
-| `reach_societies` | M2M to `societies.Society` | Targets when `reach=SOCIETY` (multiple allowed) |
-| `reach_organizations` | M2M to `societies.Organization` | Targets when `reach=ORGANIZATION` (multiple allowed) |
+| `reach_societies` | M2M to `societies.Society` | Targets when `reach=SPECIFIED` (combinable with orgs) |
+| `reach_organizations` | M2M to `societies.Organization` | Targets when `reach=SPECIFIED` (combinable with societies) |
 | `sender_account` | FK to `accounts.AccountDB`, nullable | Null = system-generated |
 | `related_era` / `related_story` | FK, nullable | Optional context links |
 | `sent_at` | DateTimeField | `auto_now_add` |
@@ -122,7 +121,7 @@ def broadcast_gemit(
 ) -> Gemit
 ```
 
-Creates a `Gemit`, records its reach + targets, and pushes the green `|G[GEMIT]|n` broadcast. `GAME_WIDE` reaches every connected session; `SOCIETY` / `ORGANIZATION` reach only sessions whose **active persona** is a member of a target society/org (resolved once via `OrganizationMembership`, then matched per session — a TEMPORARY mask holds no membership, so the disguised fall out of scope by design). Push failures are swallowed so a broadcast error never rolls back the record. Faces: telnet `gemit` (`CmdGemit`, staff `perm(Admin)`) and web `POST /api/narrative/gemits/`; the gemit history list (`GemitViewSet`) is reach-scoped so a scoped gemit never leaks to non-members (staff see all).
+Creates a `Gemit`, records its reach + targets, and pushes the green `|G[GEMIT]|n` broadcast. `GAME_WIDE` reaches every connected session; `SPECIFIED` reaches only sessions whose **active persona** is a member of any target society **or** organization (the two combine freely — one gemit can target a House and a Society together), resolved once via `OrganizationMembership`, then matched per session — a TEMPORARY mask holds no membership, so the disguised fall out of scope by design. Push failures are swallowed so a broadcast error never rolls back the record. Faces: telnet `gemit` (`CmdGemit`, staff `perm(Admin)`) and web `POST /api/narrative/gemits/`; the gemit history list (`GemitViewSet`) is reach-scoped so a scoped gemit never leaks to non-members (staff see all).
 
 ---
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -16836,13 +16836,12 @@ export interface components {
        * @description Audience scope: game-wide, or the members of the linked societies / orgs.
        *
        *     * `game_wide` - Game-wide
-       *     * `society` - Society
-       *     * `organization` - Organization
+       *     * `specified` - Specified
        */
-      reach?: components['schemas']['ReachF5cEnum'];
-      /** @description When reach=SOCIETY, the societies whose members receive this gemit. */
+      reach?: components['schemas']['Reach83dEnum'];
+      /** @description SPECIFIED-reach societies whose members get this gemit (mixable with orgs). */
       reach_societies?: number[];
-      /** @description When reach=ORGANIZATION, the organizations whose members receive this gemit. */
+      /** @description For SPECIFIED reach, organizations whose members receive this gemit (may mix). */
       reach_organizations?: number[];
       /** @description Null = system-generated. */
       readonly sender_account: number | null;
@@ -16856,8 +16855,8 @@ export interface components {
     /**
      * @description Input serializer for staff POST /api/narrative/gemits/ (#1450).
      *
-     *     ``reach`` defaults to game-wide. For SOCIETY / ORGANIZATION reach, name the targets in
-     *     ``reach_societies`` / ``reach_organizations`` (validated to match the chosen reach).
+     *     ``reach`` defaults to game-wide. For SPECIFIED reach, name any combination of targets in
+     *     ``reach_societies`` and/or ``reach_organizations`` (at least one; the two are not exclusive).
      */
     GemitCreate: {
       /** @description Broadcast text. Must be at least one non-whitespace character. */
@@ -16866,13 +16865,12 @@ export interface components {
        * @description Audience scope: game-wide, or the members of the linked societies / orgs.
        *
        *     * `game_wide` - Game-wide
-       *     * `society` - Society
-       *     * `organization` - Organization
+       *     * `specified` - Specified
        */
-      reach?: components['schemas']['ReachF5cEnum'];
-      /** @description When reach=SOCIETY, the societies whose members receive this gemit. */
+      reach?: components['schemas']['Reach83dEnum'];
+      /** @description SPECIFIED-reach societies whose members get this gemit (mixable with orgs). */
       reach_societies?: number[];
-      /** @description When reach=ORGANIZATION, the organizations whose members receive this gemit. */
+      /** @description For SPECIFIED reach, organizations whose members receive this gemit (may mix). */
       reach_organizations?: number[];
       /** @description Optional: link to the era this gemit relates to. */
       related_era?: number | null;
@@ -16882,8 +16880,8 @@ export interface components {
     /**
      * @description Input serializer for staff POST /api/narrative/gemits/ (#1450).
      *
-     *     ``reach`` defaults to game-wide. For SOCIETY / ORGANIZATION reach, name the targets in
-     *     ``reach_societies`` / ``reach_organizations`` (validated to match the chosen reach).
+     *     ``reach`` defaults to game-wide. For SPECIFIED reach, name any combination of targets in
+     *     ``reach_societies`` and/or ``reach_organizations`` (at least one; the two are not exclusive).
      */
     GemitCreateRequest: {
       /** @description Broadcast text. Must be at least one non-whitespace character. */
@@ -16892,13 +16890,12 @@ export interface components {
        * @description Audience scope: game-wide, or the members of the linked societies / orgs.
        *
        *     * `game_wide` - Game-wide
-       *     * `society` - Society
-       *     * `organization` - Organization
+       *     * `specified` - Specified
        */
-      reach?: components['schemas']['ReachF5cEnum'];
-      /** @description When reach=SOCIETY, the societies whose members receive this gemit. */
+      reach?: components['schemas']['Reach83dEnum'];
+      /** @description SPECIFIED-reach societies whose members get this gemit (mixable with orgs). */
       reach_societies?: number[];
-      /** @description When reach=ORGANIZATION, the organizations whose members receive this gemit. */
+      /** @description For SPECIFIED reach, organizations whose members receive this gemit (may mix). */
       reach_organizations?: number[];
       /** @description Optional: link to the era this gemit relates to. */
       related_era?: number | null;
@@ -22508,11 +22505,10 @@ export interface components {
     RatingEnum: -2 | -1 | 0 | 1 | 2;
     /**
      * @description * `game_wide` - Game-wide
-     *     * `society` - Society
-     *     * `organization` - Organization
+     *     * `specified` - Specified
      * @enum {string}
      */
-    ReachF5cEnum: 'game_wide' | 'society' | 'organization';
+    Reach83dEnum: 'game_wide' | 'specified';
     /**
      * @description * `story_resolved` - Story resolved
      *     * `chapter_reached` - Chapter reached or passed

--- a/src/commands/gemit.py
+++ b/src/commands/gemit.py
@@ -62,13 +62,13 @@ class CmdGemit(ArxCommand):
         if "society" in switches:  # noqa: STRING_LITERAL — Evennia switch name, not a discriminator
             names, body = self._parse_targets(raw)
             societies = self._lookup_society(names)
-            self._send(body, reach=GemitReach.SOCIETY, societies=societies)
+            self._send(body, reach=GemitReach.SPECIFIED, societies=societies)
             sent = ", ".join(s.name for s in societies)
             self.msg(f"Gemit sent to the members of: |c{sent}|n.")
         elif switches & {"org", "organization"}:  # noqa: STRING_LITERAL — Evennia switch names
             names, body = self._parse_targets(raw)
             organizations = self._lookup_org(names)
-            self._send(body, reach=GemitReach.ORGANIZATION, organizations=organizations)
+            self._send(body, reach=GemitReach.SPECIFIED, organizations=organizations)
             sent = ", ".join(o.name for o in organizations)
             self.msg(f"Gemit sent to the members of: |c{sent}|n.")
         else:

--- a/src/commands/tests/test_gemit_command.py
+++ b/src/commands/tests/test_gemit_command.py
@@ -37,7 +37,7 @@ class GemitCommandTests(TestCase):
         society = SocietyFactory(name="The Compact")
         self._run("The Compact = The Compact stirs.", switches=["society"])
         gemit = Gemit.objects.get()
-        assert gemit.reach == GemitReach.SOCIETY
+        assert gemit.reach == GemitReach.SPECIFIED
         assert list(gemit.reach_societies.all()) == [society]
         assert gemit.body == "The Compact stirs."
 
@@ -45,7 +45,7 @@ class GemitCommandTests(TestCase):
         org = OrganizationFactory(name="The Wardens")
         self._run("The Wardens = Muster at dawn.", switches=["org"])
         gemit = Gemit.objects.get()
-        assert gemit.reach == GemitReach.ORGANIZATION
+        assert gemit.reach == GemitReach.SPECIFIED
         assert list(gemit.reach_organizations.all()) == [org]
 
     def test_unknown_society_is_refused(self) -> None:

--- a/src/schema.json
+++ b/src/schema.json
@@ -30082,25 +30082,24 @@ components:
             colour and all).
         reach:
           allOf:
-          - $ref: '#/components/schemas/ReachF5cEnum'
+          - $ref: '#/components/schemas/Reach83dEnum'
           description: |-
             Audience scope: game-wide, or the members of the linked societies / orgs.
 
             * `game_wide` - Game-wide
-            * `society` - Society
-            * `organization` - Organization
+            * `specified` - Specified
         reach_societies:
           type: array
           items:
             type: integer
-          description: When reach=SOCIETY, the societies whose members receive this
-            gemit.
+          description: SPECIFIED-reach societies whose members get this gemit (mixable
+            with orgs).
         reach_organizations:
           type: array
           items:
             type: integer
-          description: When reach=ORGANIZATION, the organizations whose members receive
-            this gemit.
+          description: For SPECIFIED reach, organizations whose members receive this
+            gemit (may mix).
         sender_account:
           type: integer
           readOnly: true
@@ -30128,8 +30127,8 @@ components:
       description: |-
         Input serializer for staff POST /api/narrative/gemits/ (#1450).
 
-        ``reach`` defaults to game-wide. For SOCIETY / ORGANIZATION reach, name the targets in
-        ``reach_societies`` / ``reach_organizations`` (validated to match the chosen reach).
+        ``reach`` defaults to game-wide. For SPECIFIED reach, name any combination of targets in
+        ``reach_societies`` and/or ``reach_organizations`` (at least one; the two are not exclusive).
       properties:
         body:
           type: string
@@ -30137,25 +30136,24 @@ components:
           minLength: 1
         reach:
           allOf:
-          - $ref: '#/components/schemas/ReachF5cEnum'
+          - $ref: '#/components/schemas/Reach83dEnum'
           description: |-
             Audience scope: game-wide, or the members of the linked societies / orgs.
 
             * `game_wide` - Game-wide
-            * `society` - Society
-            * `organization` - Organization
+            * `specified` - Specified
         reach_societies:
           type: array
           items:
             type: integer
-          description: When reach=SOCIETY, the societies whose members receive this
-            gemit.
+          description: SPECIFIED-reach societies whose members get this gemit (mixable
+            with orgs).
         reach_organizations:
           type: array
           items:
             type: integer
-          description: When reach=ORGANIZATION, the organizations whose members receive
-            this gemit.
+          description: For SPECIFIED reach, organizations whose members receive this
+            gemit (may mix).
         related_era:
           type: integer
           nullable: true
@@ -30171,8 +30169,8 @@ components:
       description: |-
         Input serializer for staff POST /api/narrative/gemits/ (#1450).
 
-        ``reach`` defaults to game-wide. For SOCIETY / ORGANIZATION reach, name the targets in
-        ``reach_societies`` / ``reach_organizations`` (validated to match the chosen reach).
+        ``reach`` defaults to game-wide. For SPECIFIED reach, name any combination of targets in
+        ``reach_societies`` and/or ``reach_organizations`` (at least one; the two are not exclusive).
       properties:
         body:
           type: string
@@ -30180,25 +30178,24 @@ components:
           description: Broadcast text. Must be at least one non-whitespace character.
         reach:
           allOf:
-          - $ref: '#/components/schemas/ReachF5cEnum'
+          - $ref: '#/components/schemas/Reach83dEnum'
           description: |-
             Audience scope: game-wide, or the members of the linked societies / orgs.
 
             * `game_wide` - Game-wide
-            * `society` - Society
-            * `organization` - Organization
+            * `specified` - Specified
         reach_societies:
           type: array
           items:
             type: integer
-          description: When reach=SOCIETY, the societies whose members receive this
-            gemit.
+          description: SPECIFIED-reach societies whose members get this gemit (mixable
+            with orgs).
         reach_organizations:
           type: array
           items:
             type: integer
-          description: When reach=ORGANIZATION, the organizations whose members receive
-            this gemit.
+          description: For SPECIFIED reach, organizations whose members receive this
+            gemit (may mix).
         related_era:
           type: integer
           nullable: true
@@ -40487,16 +40484,14 @@ components:
         * `0` - Neutral/No Opinion
         * `1` - Good
         * `2` - Excellent
-    ReachF5cEnum:
+    Reach83dEnum:
       enum:
       - game_wide
-      - society
-      - organization
+      - specified
       type: string
       description: |-
         * `game_wide` - Game-wide
-        * `society` - Society
-        * `organization` - Organization
+        * `specified` - Specified
     ReferencedMilestoneTypeEnum:
       enum:
       - story_resolved

--- a/src/world/narrative/constants.py
+++ b/src/world/narrative/constants.py
@@ -14,10 +14,10 @@ class NarrativeCategory(models.TextChoices):
 class GemitReach(models.TextChoices):
     """How wide a gemit broadcasts (#1450) — its audience scope.
 
-    GAME_WIDE reaches every online session (the classic gemit). SOCIETY / ORGANIZATION reach only
-    the members of the linked societies / organizations (multiple targets allowed per gemit).
+    GAME_WIDE reaches every online session (the classic gemit). SPECIFIED reaches the members of any
+    combination of the linked societies and/or organizations — the two are not mutually exclusive,
+    so one gemit can target a House (org) and a Society together.
     """
 
     GAME_WIDE = "game_wide", "Game-wide"
-    SOCIETY = "society", "Society"
-    ORGANIZATION = "organization", "Organization"
+    SPECIFIED = "specified", "Specified"

--- a/src/world/narrative/migrations/0005_gemit_reach_gemit_reach_organizations_and_more.py
+++ b/src/world/narrative/migrations/0005_gemit_reach_gemit_reach_organizations_and_more.py
@@ -19,8 +19,7 @@ class Migration(migrations.Migration):
             field=models.CharField(
                 choices=[
                     ("game_wide", "Game-wide"),
-                    ("society", "Society"),
-                    ("organization", "Organization"),
+                    ("specified", "Specified"),
                 ],
                 default="game_wide",
                 help_text="Audience scope: game-wide, or the members of the linked societies / orgs.",
@@ -32,7 +31,7 @@ class Migration(migrations.Migration):
             name="reach_organizations",
             field=models.ManyToManyField(
                 blank=True,
-                help_text="When reach=ORGANIZATION, the organizations whose members receive this gemit.",
+                help_text="For SPECIFIED reach, organizations whose members receive this gemit (may mix).",
                 related_name="gemits",
                 to="societies.organization",
             ),
@@ -42,7 +41,7 @@ class Migration(migrations.Migration):
             name="reach_societies",
             field=models.ManyToManyField(
                 blank=True,
-                help_text="When reach=SOCIETY, the societies whose members receive this gemit.",
+                help_text="SPECIFIED-reach societies whose members get this gemit (mixable with orgs).",
                 related_name="gemits",
                 to="societies.society",
             ),

--- a/src/world/narrative/models.py
+++ b/src/world/narrative/models.py
@@ -179,8 +179,8 @@ class Gemit(SharedMemoryModel):
     Persistent record so the audience can browse retroactively. Does NOT
     fan out into NarrativeMessageDelivery rows — gemit is broadcast, not
     per-recipient. ``reach`` scopes the audience: GAME_WIDE reaches every
-    online session; SOCIETY / ORGANIZATION reach only the members of the
-    linked ``reach_societies`` / ``reach_organizations`` (multiple allowed).
+    online session; SPECIFIED reaches the members of any combination of the
+    linked ``reach_societies`` and/or ``reach_organizations`` (not exclusive).
     """
 
     body = models.TextField(
@@ -196,13 +196,13 @@ class Gemit(SharedMemoryModel):
         "societies.Society",
         blank=True,
         related_name="gemits",
-        help_text="When reach=SOCIETY, the societies whose members receive this gemit.",
+        help_text="SPECIFIED-reach societies whose members get this gemit (mixable with orgs).",
     )
     reach_organizations = models.ManyToManyField(
         "societies.Organization",
         blank=True,
         related_name="gemits",
-        help_text="When reach=ORGANIZATION, the organizations whose members receive this gemit.",
+        help_text="For SPECIFIED reach, organizations whose members receive this gemit (may mix).",
     )
     sender_account = models.ForeignKey(
         "accounts.AccountDB",

--- a/src/world/narrative/serializers.py
+++ b/src/world/narrative/serializers.py
@@ -86,8 +86,8 @@ class GemitSerializer(serializers.ModelSerializer):
 class GemitCreateSerializer(serializers.ModelSerializer):
     """Input serializer for staff POST /api/narrative/gemits/ (#1450).
 
-    ``reach`` defaults to game-wide. For SOCIETY / ORGANIZATION reach, name the targets in
-    ``reach_societies`` / ``reach_organizations`` (validated to match the chosen reach).
+    ``reach`` defaults to game-wide. For SPECIFIED reach, name any combination of targets in
+    ``reach_societies`` and/or ``reach_organizations`` (at least one; the two are not exclusive).
     """
 
     body = serializers.CharField(
@@ -111,13 +111,9 @@ class GemitCreateSerializer(serializers.ModelSerializer):
         reach = attrs.get("reach", GemitReach.GAME_WIDE)
         societies = attrs.get("reach_societies") or []
         organizations = attrs.get("reach_organizations") or []
-        if reach == GemitReach.SOCIETY and not societies:
+        if reach == GemitReach.SPECIFIED and not (societies or organizations):
             raise serializers.ValidationError(
-                {"reach_societies": "Name at least one society for a society-reach gemit."}
-            )
-        if reach == GemitReach.ORGANIZATION and not organizations:
-            raise serializers.ValidationError(
-                {"reach_organizations": "Name at least one organization for an org-reach gemit."}
+                {"reach_societies": "Specify at least one society or organization."}
             )
         if reach == GemitReach.GAME_WIDE and (societies or organizations):
             msg = "A game-wide gemit takes no society or organization targets."

--- a/src/world/narrative/services.py
+++ b/src/world/narrative/services.py
@@ -137,34 +137,37 @@ def _eligible_persona_ids(
     societies: Iterable[Society],
     organizations: Iterable[Organization],
 ) -> set[int]:
-    """Persona ids whose membership puts them in a scoped gemit's audience (#1450).
+    """Persona ids whose membership puts them in a SPECIFIED gemit's audience (#1450).
 
-    SOCIETY: members of any organization belonging to a target society. ORGANIZATION: members of a
+    The union of: members of any organization belonging to a target society, plus members of a
     target organization. (Society *reputation* alone — an outsider the society merely knows of —
     does not count; internal news goes to members.) Empty for GAME_WIDE.
     """
     from world.societies.models import OrganizationMembership  # noqa: PLC0415
 
-    if reach == GemitReach.SOCIETY:
-        return set(
+    if reach == GemitReach.GAME_WIDE:
+        return set()
+    eligible: set[int] = set()
+    if societies:
+        eligible.update(
             OrganizationMembership.objects.filter(organization__society__in=societies).values_list(
                 "persona_id", flat=True
             )
         )
-    if reach == GemitReach.ORGANIZATION:
-        return set(
+    if organizations:
+        eligible.update(
             OrganizationMembership.objects.filter(organization__in=organizations).values_list(
                 "persona_id", flat=True
             )
         )
-    return set()
+    return eligible
 
 
 def _session_in_audience(session: object, eligible_persona_ids: set[int]) -> bool:
     """Whether a connected session's active-persona character is in a scoped gemit's audience.
 
     Keyed on the *active* persona (the face the character is currently wearing) — a TEMPORARY mask
-    holds no memberships, so a disguised character falls out of society/org reach, by design.
+    holds no memberships, so a disguised character falls out of a SPECIFIED gemit's reach.
     """
     from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
 
@@ -192,11 +195,11 @@ def broadcast_gemit(  # noqa: PLR0913
 ) -> Gemit:
     """Create a Gemit and push it to its ``reach`` audience in green (#1450).
 
-    GAME_WIDE pushes to every connected session (the classic gemit). SOCIETY / ORGANIZATION push
-    only to sessions whose active-persona character is a member of a target society / organization;
-    the targets are also recorded on the row so retroactive viewing stays scoped. The Gemit row
-    persists either way; push failures are swallowed so a broadcast error never rolls back the
-    record.
+    GAME_WIDE pushes to every connected session (the classic gemit). SPECIFIED pushes only to
+    sessions whose active-persona character is a member of any target society or organization (the
+    two combine freely); the targets are also recorded on the row so retroactive viewing stays
+    scoped. The Gemit row persists either way; push failures are swallowed so a broadcast error
+    never rolls back the record.
     """
     societies = list(societies or [])
     organizations = list(organizations or [])

--- a/src/world/narrative/tests/test_gemit_reach.py
+++ b/src/world/narrative/tests/test_gemit_reach.py
@@ -44,33 +44,53 @@ class GemitReachServiceTests(TestCase):
         assert gemit.reach_societies.count() == 0
         assert gemit.reach_organizations.count() == 0
 
-    def test_society_gemit_records_reach_and_targets(self) -> None:
+    def test_specified_gemit_records_reach_and_society_targets(self) -> None:
         gemit = broadcast_gemit(
             body="Compact business.",
             sender_account=None,
-            reach=GemitReach.SOCIETY,
+            reach=GemitReach.SPECIFIED,
             societies=[self.society],
         )
-        assert gemit.reach == GemitReach.SOCIETY
+        assert gemit.reach == GemitReach.SPECIFIED
         assert list(gemit.reach_societies.all()) == [self.society]
 
-    def test_org_gemit_records_reach_and_targets(self) -> None:
+    def test_specified_gemit_records_org_targets(self) -> None:
         gemit = broadcast_gemit(
             body="Org business.",
             sender_account=None,
-            reach=GemitReach.ORGANIZATION,
+            reach=GemitReach.SPECIFIED,
             organizations=[self.org],
         )
-        assert gemit.reach == GemitReach.ORGANIZATION
+        assert gemit.reach == GemitReach.SPECIFIED
         assert list(gemit.reach_organizations.all()) == [self.org]
 
+    def test_specified_gemit_can_mix_society_and_org_targets(self) -> None:
+        other_org = OrganizationFactory()
+        gemit = broadcast_gemit(
+            body="A House and a Society together.",
+            sender_account=None,
+            reach=GemitReach.SPECIFIED,
+            societies=[self.society],
+            organizations=[other_org],
+        )
+        assert gemit.reach == GemitReach.SPECIFIED
+        assert list(gemit.reach_societies.all()) == [self.society]
+        assert list(gemit.reach_organizations.all()) == [other_org]
+
     def test_eligible_persona_ids_for_society_are_its_members(self) -> None:
-        eligible = _eligible_persona_ids(GemitReach.SOCIETY, [self.society], [])
+        eligible = _eligible_persona_ids(GemitReach.SPECIFIED, [self.society], [])
         assert eligible == {self.member_persona.id}
 
     def test_eligible_persona_ids_for_organization_are_its_members(self) -> None:
-        eligible = _eligible_persona_ids(GemitReach.ORGANIZATION, [], [self.org])
+        eligible = _eligible_persona_ids(GemitReach.SPECIFIED, [], [self.org])
         assert eligible == {self.member_persona.id}
+
+    def test_eligible_persona_ids_unions_societies_and_orgs(self) -> None:
+        other_org = OrganizationFactory()
+        other_sheet = CharacterSheetFactory()
+        OrganizationMembershipFactory(organization=other_org, persona=other_sheet.primary_persona)
+        eligible = _eligible_persona_ids(GemitReach.SPECIFIED, [self.society], [other_org])
+        assert eligible == {self.member_persona.id, other_sheet.primary_persona.id}
 
     def test_game_wide_has_no_eligibility_set(self) -> None:
         assert _eligible_persona_ids(GemitReach.GAME_WIDE, [], []) == set()
@@ -117,7 +137,7 @@ class GemitHistoryScopingTests(APITestCase):
         cls.society_gemit = broadcast_gemit(
             body="Only the Compact.",
             sender_account=None,
-            reach=GemitReach.SOCIETY,
+            reach=GemitReach.SPECIFIED,
             societies=[cls.society],
         )
 

--- a/src/world/narrative/views.py
+++ b/src/world/narrative/views.py
@@ -97,8 +97,8 @@ class GemitViewSet(mixins.ListModelMixin, mixins.CreateModelMixin, viewsets.Gene
     def get_queryset(self) -> "QuerySet[Gemit]":
         """Scope the history so a scoped gemit only shows to its audience (#1450).
 
-        Staff see everything. Everyone else sees game-wide gemits plus the society/org gemits whose
-        targets a character of theirs belongs to — never another society's internal broadcasts.
+        Staff see everything. Everyone else sees game-wide gemits plus the specified gemits whose
+        society/org targets a character of theirs belongs to — never another group's internal news.
         """
         qs = super().get_queryset()
         user = cast("AccountDB", self.request.user)
@@ -106,7 +106,6 @@ class GemitViewSet(mixins.ListModelMixin, mixins.CreateModelMixin, viewsets.Gene
             return qs
         from django.db.models import Q  # noqa: PLC0415
 
-        from world.narrative.constants import GemitReach  # noqa: PLC0415
         from world.societies.models import OrganizationMembership  # noqa: PLC0415
 
         memberships = OrganizationMembership.objects.filter(
@@ -116,8 +115,8 @@ class GemitViewSet(mixins.ListModelMixin, mixins.CreateModelMixin, viewsets.Gene
         org_ids = memberships.values_list("organization_id", flat=True)
         return qs.filter(
             Q(reach=GemitReach.GAME_WIDE)
-            | Q(reach=GemitReach.SOCIETY, reach_societies__in=society_ids)
-            | Q(reach=GemitReach.ORGANIZATION, reach_organizations__in=org_ids)
+            | Q(reach=GemitReach.SPECIFIED, reach_societies__in=society_ids)
+            | Q(reach=GemitReach.SPECIFIED, reach_organizations__in=org_ids)
         ).distinct()
 
     def get_serializer_class(self) -> "type[BaseSerializer]":


### PR DESCRIPTION
## What

Implements the **echo (push) vector** of the public-reaction / scandals center — slice 2 of the #1450 epic. Staff broadcast a hand-authored gemit (verbatim, colour codes and all) to a **reach**: game-wide, one-or-more societies, or one-or-more organizations.

This is the "reach as a first-class property" + echo slice. The news-feed pull slice landed earlier (#1456); in-world criers/hubs remain a later slice.

## How

- **`GemitReach`** TextChoices (`GAME_WIDE` / `SOCIETY` / `ORGANIZATION`) on `Gemit`, with `reach_societies` / `reach_organizations` M2Ms for the scoped forms.
- **`broadcast_gemit`** gains `reach` + `societies` / `organizations`. Scoped pushes resolve the eligible persona ids once (via `OrganizationMembership`) and match per connected session by **active persona** — a TEMPORARY mask holds no membership, so the disguised fall out of scope by design.
- **`GemitViewSet.get_queryset`** is reach-scoped: non-staff see game-wide gemits plus the society/org gemits whose targets a character of theirs belongs to; staff see all. A society gemit never leaks to outsiders.
- **Faces:** telnet `gemit` (`CmdGemit`, `perm(Admin)`) + web `POST /api/narrative/gemits/` (validated against the chosen reach).

## Tests

74 tests in `world.narrative` + `commands.tests.test_gemit_command` pass (game-wide/society/org broadcast, reach-scoped history, unknown-target refusal, validation).

## Docs

Updated `docs/systems/narrative.md`, `INDEX.md`, `MODEL_MAP.md`, `commands/CLAUDE.md`; API types regenerated.

Refs #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)