### PR TITLE
Scene-owner surface to set round resolution mode + pose-order policy (per-scene, not just global default)

### DIFF
--- a/docs/roadmap/rp-scenes.md
+++ b/docs/roadmap/rp-scenes.md
@@ -137,6 +137,45 @@ immediate execution with pose-order ledger side-effects.
 technique cast. The unified `cast` command (`CmdDeclareTechnique`, `commands/combat.py`) replaces
 the deleted `CmdAttempt`; parses `cast <technique> [at <target>] [effort=<level>]`.
 
+### Scene Administration Command + Per-Scene Round-Mode Control — DONE (#1445)
+
+GM and co-owner tooling for scene lifecycle and round-mode adjustment, delivered as the
+`scene` command (`CmdScene`, `commands/scene.py`) and three Actions.
+
+**What shipped:**
+
+- **Co-ownership model:** all characters present at scene creation become co-owners
+  (`is_owner=True` on `SceneParticipation`); latecomers are non-owner participants
+  (anti-grab).
+- **`is_story_runner` property** on `Character` (`typeclasses/characters.py`):
+  `False` on base characters; `True` on `GMCharacter` / `StaffCharacter`
+  (`typeclasses/gm_characters.py`).
+- **Permission helper** `actor_can_administer_scene(actor, scene)` (`scene_admin_services.py`):
+  grants GM/Staff characters unconditional access; staff accounts and co-owners follow.
+- **Service functions** (`scene_admin_services.py`): `resolve_actor_account`,
+  `add_present_as_co_owners`, `finish_scene_full` (extracted from the viewset).
+- **`set_scene_round_mode`** (`round_services.py`) + `RoundModeError`: applies mode/knob
+  changes in-place; guards against DANGER rounds (immutable) and STRICT-exit with pending
+  deferred declarations.
+- **Actions:** `StartSceneAction` (key `"start_scene"`), `FinishSceneAction`
+  (key `"finish_scene"`) in `actions/definitions/scenes.py`; `SetRoundModeAction`
+  (key `"set_round_mode"`) in `actions/definitions/rounds.py`.
+  `StartRoundAction` extended: knob overrides at round creation require scene admin.
+- **Telnet:** `CmdScene` (`scene`) with subcommands `start [name]` / `finish` /
+  `round [open|pose_order|strict] [quorum=<pct>] [cap=<n>] [lock=on/off]` / `status`.
+- **Web:** `POST /api/scenes/{id}/set-round-mode/` (gated `IsSceneGMOrOwnerOrStaff`,
+  dispatches `SetRoundModeAction`).
+
+**Deferred follow-ups (filed as issues):**
+
+- DANGER → STRICT unification: DANGER rounds are currently forced to OPEN and not
+  user-settable; a future slice allows a scene admin to shift a live DANGER round into
+  the three-mode framework.
+- React round-mode control for frontend parity (linked to #1328): `scene round` is
+  telnet-only; a web panel is a follow-up.
+
+**Details:** [scenes.md](../systems/scenes.md) §"Scene Administration (#1445)"
+
 ### Positioning in Scenes — DONE (#1017)
 - **Scene API extension:** `SceneDetailSerializer` exposes `positions`, `position_adjacency`, `persona_positions` for the scene's room.
 - **Frontend:** `RoomPositionsPanel` component (`frontend/src/scenes/components/`) renders positions, persona placement, move action, and a staff "Set the stage" control. `MovementActions` extracted as a shared component (`frontend/src/combat/components/`).

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -675,6 +675,12 @@ action consent flow, and a three-mode non-combat round framework.
     - `scene_round_is_complete(scene_round) -> bool` — presence-gated: True when all present ACTIVE participants have a deferred declaration.
     - `resolve_scene_round(scene_round)` — social-only resolver: runs CHALLENGE declarations in initiative order, fires end tick, advances round.
     - `maybe_resolve_scene_round(scene_round)` — resolves iff `scene_round_is_complete` is True.
+  - **Scene administration (`scene_admin_services.py`, #1445):**
+    - `actor_can_administer_scene(actor, scene) -> bool` — permission gate; True for GM/Staff characters (`is_story_runner`), staff accounts, or scene co-owners (`is_owner=True`).
+    - `resolve_actor_account(actor) -> AccountDB | None` — controlling account for a PC actor; None for GM/Staff/NPC.
+    - `add_present_as_co_owners(scene, room)` — mark every present character with a controlling account as a co-owner at scene creation (anti-grab: latecomers are non-owners).
+    - `finish_scene_full(scene, by_account=None)` — full scene-finish orchestration: `finish_scene()` → `on_scene_finished()` → deferred fatigue resets → `broadcast_scene_message(END)`. Idempotent.
+    - `set_scene_round_mode(scene_round, *, mode, advance_quorum_pct, max_actions_per_round, per_target_repeat_lock) -> SceneRound` (`round_services.py`) — apply mode/knob changes in-place; raises `RoundModeError` for DANGER rounds (immutable) or STRICT-exit with pending declarations.
 - **Read-visibility surface (canonical):**
   - `Scene.objects.viewable_by(account)` — queryset; staff=all, auth non-staff=public OR participant,
     anonymous=public. Use in `get_queryset()` / filter chains.
@@ -700,6 +706,13 @@ action consent flow, and a three-mode non-combat round framework.
   `Scene.save()`/`clean()` enforce this via `_validate_privacy_against_room()`;
   `ensure_scene_for_location` derives the default. Shared helper: `room_is_publicly_listed(room)`
   in `evennia_extensions/models.py`. See [scenes.md](scenes.md) §"Scene Privacy ↔ Room-Publicness Invariant".
+- **Scene admin actions (#1445):**
+  - `StartSceneAction` (key `"start_scene"`, `actions/definitions/scenes.py`) — creates scene + grants co-ownership to all present PCs; records actor as non-owner participant if scene already exists.
+  - `FinishSceneAction` (key `"finish_scene"`, `actions/definitions/scenes.py`) — finishes active scene; gated by `actor_can_administer_scene`.
+  - `SetRoundModeAction` (key `"set_round_mode"`, `actions/definitions/rounds.py`) — changes mode/knobs of active round; gated by `actor_can_administer_scene`; `costs_turn=False`.
+- **`CmdScene`** (`commands/scene.py`) — telnet face for `scene start [name]` / `scene finish` / `scene round [open|pose_order|strict] [quorum=<pct>] [cap=<n>] [lock=on/off]` / `scene status`. Thin over the three Actions above; no business logic.
+- **`is_story_runner`** character property (`typeclasses/characters.py`) — `False` on base `Character`; `True` on `GMCharacter` and `StaffCharacter` (`typeclasses/gm_characters.py`); used by `actor_can_administer_scene` as the GM/Staff fast-path.
+- **New API endpoint:** `POST /api/scenes/{id}/set-round-mode/` — coarse-gated `IsSceneGMOrOwnerOrStaff`; dispatches `SetRoundModeAction`; returns updated scene detail.
 - **Integrates with:** roster (characters), stories (EpisodeScene join), instances (preservation check),
   flows (auto-logging via message_location), combat (encounter read gate + participation convergence via
   `Scene.objects.viewable_by` / `ensure_scene_participation`),

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -415,12 +415,158 @@ Read-only listing of a player's pending additional-target consent rows (#1177).
 
 ---
 
+## Scene Administration (#1445)
+
+**Source:** `src/world/scenes/scene_admin_services.py`, `src/actions/definitions/scenes.py`,
+`src/actions/definitions/rounds.py`, `src/commands/scene.py`
+
+### Co-ownership model
+
+All characters **present in the room at scene creation** become co-owners (`is_owner=True` on
+their `SceneParticipation`). Latecomers who join after the scene has started are non-owner
+participants — they cannot inadvertently acquire admin rights by entering a room mid-scene
+(anti-grab rule). A GM or staff character bypasses the ownership check entirely; they can
+administer any scene regardless of participation.
+
+### Permission helper
+
+```python
+from world.scenes.scene_admin_services import actor_can_administer_scene
+
+# True if actor may administer the scene (finish it, change round mode, etc.)
+actor_can_administer_scene(actor, scene) -> bool
+```
+
+Authorization tiers (first match wins):
+
+1. `actor.is_story_runner` — `GMCharacter` and `StaffCharacter` set this to `True`
+   (`src/typeclasses/gm_characters.py`); no account lookup is performed.
+2. The actor's controlling account is a staff user (`account.is_staff`).
+3. The actor's controlling account has `is_owner=True` on a `SceneParticipation` row for
+   this scene.
+
+```python
+from world.scenes.scene_admin_services import resolve_actor_account
+
+# Return the controlling AccountDB for actor (PC tenure path), or None for GM/Staff/NPC.
+resolve_actor_account(actor) -> AccountDB | None
+```
+
+### Service functions
+
+```python
+from world.scenes.scene_admin_services import add_present_as_co_owners
+
+# Mark every present character with a controlling account as a scene co-owner.
+# Walks room.contents; skips NPCs, props, and characters without a controlling account.
+# Called by StartSceneAction immediately after scene creation.
+add_present_as_co_owners(scene, room) -> None
+```
+
+```python
+from world.scenes.scene_admin_services import finish_scene_full
+
+# Full scene-finish orchestration. Idempotent — returns immediately if already finished.
+# Steps: scene.finish_scene() → on_scene_finished() → deferred fatigue resets →
+#        broadcast_scene_message(scene, SceneAction.END).
+# by_account is accepted for call-site symmetry but is not forwarded downstream.
+finish_scene_full(scene, by_account=None) -> None
+```
+
+### Lifecycle Actions
+
+**`StartSceneAction`** (`key="start_scene"`, `src/actions/definitions/scenes.py`)
+
+Creates a scene in the actor's current room via `ensure_scene_for_location`, then calls
+`add_present_as_co_owners` so every present PC is a co-owner. If an active scene already
+exists, the actor is recorded as a non-owner participant. Ungated — any character may invoke it.
+
+**`FinishSceneAction`** (`key="finish_scene"`, `src/actions/definitions/scenes.py`)
+
+Finishes the active scene in the actor's room. Gated by `actor_can_administer_scene` — only
+a GM character, staff account, or scene co-owner succeeds. Delegates to `finish_scene_full`
+for full orchestration.
+
+### Round-mode control
+
+```python
+from world.scenes.round_services import set_scene_round_mode, RoundModeError
+
+# Apply mode and/or knob changes to scene_round in-place.
+# Guards (both raise RoundModeError):
+#   1. DANGER rounds are autonomous — mode is fixed at OPEN, not user-settable.
+#   2. Leaving STRICT while pending non-immediate declarations exist is blocked;
+#      caller must force-resolve first.
+# Only supplied (non-None) fields are written (update_fields pattern).
+set_scene_round_mode(
+    scene_round,
+    *,
+    mode=None,                   # SceneRoundMode value (OPEN/POSE_ORDER/STRICT)
+    advance_quorum_pct=None,     # int — quorum % to advance the pose-order round
+    max_actions_per_round=None,  # int — per-participant action cap per round
+    per_target_repeat_lock=None, # bool — block repeat targeting of the same persona
+) -> SceneRound
+```
+
+**`SetRoundModeAction`** (`key="set_round_mode"`, `src/actions/definitions/rounds.py`)
+
+Changes the mode and/or knobs of the active scene round. Guard order in `execute()`:
+
+1. Actor must be in a room.
+2. The room must have an active scene (requires scene context — start one first).
+3. The actor must be a scene admin per `actor_can_administer_scene`.
+4. The room must have an active round to modify.
+5. `set_scene_round_mode` validates the mode transition (DANGER immutable; STRICT-exit blocked
+   by pending deferred declarations).
+
+`costs_turn = False` — mode changes do not consume a round action.
+
+**`StartRoundAction`** (`key="start_round"`, `src/actions/definitions/rounds.py`) — extended
+in this feature: if any knob override (`mode`, `advance_quorum_pct`, `max_actions_per_round`,
+`per_target_repeat_lock`) is supplied, the actor must be a scene admin before the round is
+created with those overrides applied at creation time.
+
+### Telnet command — `CmdScene`
+
+**Source:** `src/commands/scene.py`
+
+```
+scene                                     — show active scene + round status
+scene status                              — same
+scene start [name]                        — StartSceneAction (name optional)
+scene finish                              — FinishSceneAction
+scene round [open|pose_order|strict]      — SetRoundModeAction; any knobs optional
+         [quorum=<pct>] [cap=<n>] [lock=on/off]
+```
+
+Example: `scene round strict quorum=70 cap=2 lock=on`
+
+No business logic lives in `CmdScene` — all routing is delegated to the three Actions above.
+Mode tokens (`open` / `pose_order` / `strict`) are mapped to `SceneRoundMode` values by
+`_parse_round_args`. Lock values: `on` / `true` / `yes` / `1` → True; anything else → False.
+
+### Web endpoint
+
+`POST /api/scenes/{id}/set-round-mode/` — coarse-gated by `IsSceneGMOrOwnerOrStaff`; the
+authoritative permission check runs inside `SetRoundModeAction`. The viewset resolves the
+requesting account's active character as the action actor so that telnet and web converge on
+the same `action.run()` seam. Returns the updated scene detail on success.
+
+**Deferred follow-ups:**
+- DANGER → STRICT unification: DANGER rounds are currently forced to OPEN and not
+  user-settable; a future slice will allow a scene admin to unify a live DANGER round
+  into the three-mode framework.
+- React control for frontend parity (linked to #1328): `scene round` is telnet-only;
+  a round-mode panel in the web scene view is a follow-up.
+
+---
+
 ## Permissions
 
 | Permission Class | Used For | Rule |
 |-----------------|----------|------|
 | `IsSceneOwnerOrStaff` | Scene edit/delete | Owner participation or staff |
-| `IsSceneGMOrOwnerOrStaff` | Scene finish | GM or owner participation, or staff |
+| `IsSceneGMOrOwnerOrStaff` | Scene finish + set-round-mode | GM or owner participation, or staff |
 | `IsMessageSenderOrStaff` | Message edit/delete | Persona's account matches user AND scene is active |
 | `CanCreatePersonaInScene` | Persona creation | User must own the participation referenced |
 | `CanCreateMessageInScene` | Message creation | User must own the persona AND be a scene participant |

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -23365,6 +23365,26 @@ export interface components {
       persona_id: number;
     };
     /**
+     * @description * `open` - Open (immediate, unbounded)
+     *     * `pose_order` - Pose order (immediate, quota-gated)
+     *     * `strict` - Strict (declare, batch-resolved)
+     * @enum {string}
+     */
+    SetRoundModeRequestModeEnum: 'open' | 'pose_order' | 'strict';
+    /**
+     * @description POST body for the #1445 set-round-mode endpoint.
+     *
+     *     All fields are optional — callers may change the mode, one or more knobs, or any
+     *     combination. At least one field should be provided (the action will succeed with
+     *     a generic message if none are, because the service is a no-op update).
+     */
+    SetRoundModeRequestRequest: {
+      mode?: components['schemas']['SetRoundModeRequestModeEnum'];
+      advance_quorum_pct?: number;
+      max_actions_per_round?: number;
+      per_target_repeat_lock?: boolean;
+    };
+    /**
      * @description * `positive` - Positive
      *     * `negative` - Negative
      * @enum {string}
@@ -42166,7 +42186,7 @@ export interface operations {
     };
     requestBody?: {
       content: {
-        'application/json': components['schemas']['SceneDetailRequest'];
+        'application/json': components['schemas']['SetRoundModeRequestRequest'];
       };
     };
     responses: {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -11616,6 +11616,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/scenes/{id}/set-round-mode/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description #1445 — Set mode and/or knobs on the active scene round.
+     *
+     *     Coarse-gated by ``IsSceneGMOrOwnerOrStaff``; authoritative permission
+     *     check lives in ``SetRoundModeAction`` (ownership + scene-admin verification).
+     *     Resolves the requesting account's active character as the action's actor so
+     *     telnet and web converge on the same ``action.run()`` seam.
+     */
+    post: operations['scenes_set_round_mode_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/scenes/spotlight/': {
     parameters: {
       query?: never;
@@ -42126,6 +42150,32 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['HighlightReel'];
+        };
+      };
+    };
+  };
+  scenes_set_round_mode_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this scene. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['SceneDetailRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SceneDetail'];
         };
       };
     };

--- a/src/actions/definitions/rounds.py
+++ b/src/actions/definitions/rounds.py
@@ -16,7 +16,13 @@ from world.scenes.constants import (
     SceneRoundStartReason,
 )
 from world.scenes.models import SceneActionDeclaration, SceneRound, SceneRoundParticipant
-from world.scenes.round_services import end_scene_round, resolve_scene_round, start_scene_round
+from world.scenes.round_services import (
+    RoundModeError,
+    end_scene_round,
+    resolve_scene_round,
+    set_scene_round_mode,
+    start_scene_round,
+)
 
 # Repeated ActionResult failure messages, extracted to satisfy S1192.
 NOT_IN_A_ROOM_MESSAGE = "You are not in a room."
@@ -55,10 +61,15 @@ class StartRoundAction(Action):
     category: str = "scenes"
     target_type: TargetType = TargetType.AREA
 
-    def execute(
+    def execute(  # noqa: PLR0913
         self,
         actor: ObjectDB,
         context: ActionContext | None = None,
+        *,
+        mode: str | None = None,
+        advance_quorum_pct: int | None = None,
+        max_actions_per_round: int | None = None,
+        per_target_repeat_lock: bool | None = None,
         **kwargs: Any,
     ) -> ActionResult:
         sheet = _sheet(actor)
@@ -69,21 +80,67 @@ class StartRoundAction(Action):
         if sheet is None:
             return ActionResult(success=False, message=NO_CHARACTER_SHEET_MESSAGE)
 
+        _has_override = any(
+            v is not None
+            for v in (mode, advance_quorum_pct, max_actions_per_round, per_target_repeat_lock)
+        )
+
         rnd = _active_round_for_room(room)
         if rnd is None:
             from world.scenes.models import get_scene_round_defaults_config  # noqa: PLC0415
 
             cfg = get_scene_round_defaults_config()
-            rnd = SceneRound.objects.create(
-                room=room,
-                status=RoundStatus.DECLARING,
-                round_number=1,
-                start_reason=SceneRoundStartReason.OPT_IN,
-                mode=cfg.default_mode,
-                advance_quorum_pct=cfg.advance_quorum_pct,
-                max_actions_per_round=cfg.max_actions_per_round,
-                per_target_repeat_lock=cfg.per_target_repeat_lock,
-            )
+
+            if _has_override:
+                # Gate: overrides require an active scene + admin permission.
+                from world.scenes.models import Scene as _Scene  # noqa: PLC0415
+                from world.scenes.scene_admin_services import (  # noqa: PLC0415
+                    actor_can_administer_scene,
+                )
+
+                scene = _Scene.objects.filter(location=room, is_active=True).first()
+                if scene is None or not actor_can_administer_scene(actor, scene):
+                    return ActionResult(
+                        success=False,
+                        message=(
+                            "Only a scene GM/owner can choose the round mode at start"
+                            " (start a scene first)."
+                        ),
+                    )
+                rnd = SceneRound.objects.create(
+                    room=room,
+                    status=RoundStatus.DECLARING,
+                    round_number=1,
+                    start_reason=SceneRoundStartReason.OPT_IN,
+                    mode=mode if mode is not None else cfg.default_mode,
+                    advance_quorum_pct=(
+                        advance_quorum_pct
+                        if advance_quorum_pct is not None
+                        else cfg.advance_quorum_pct
+                    ),
+                    max_actions_per_round=(
+                        max_actions_per_round
+                        if max_actions_per_round is not None
+                        else cfg.max_actions_per_round
+                    ),
+                    per_target_repeat_lock=(
+                        per_target_repeat_lock
+                        if per_target_repeat_lock is not None
+                        else cfg.per_target_repeat_lock
+                    ),
+                    scene=scene,
+                )
+            else:
+                rnd = SceneRound.objects.create(
+                    room=room,
+                    status=RoundStatus.DECLARING,
+                    round_number=1,
+                    start_reason=SceneRoundStartReason.OPT_IN,
+                    mode=cfg.default_mode,
+                    advance_quorum_pct=cfg.advance_quorum_pct,
+                    max_actions_per_round=cfg.max_actions_per_round,
+                    per_target_repeat_lock=cfg.per_target_repeat_lock,
+                )
         elif rnd.status == RoundStatus.BETWEEN_ROUNDS:
             rnd = start_scene_round(rnd)
 
@@ -92,6 +149,82 @@ class StartRoundAction(Action):
             character_sheet=sheet,
         )
         return ActionResult(success=True, message="A round begins.")
+
+
+@dataclass
+class SetRoundModeAction(Action):
+    """Change the mode and/or knobs of the active scene round.
+
+    Only the scene's GM or a co-owner may invoke this. A guard order applies:
+    1. Actor must be in a room.
+    2. The room must have an active scene (mode control requires scene context).
+    3. The actor must be a scene admin (GM, staff, or co-owner).
+    4. The room must have an active round to modify.
+    5. The service validates the mode transition (DANGER immutable; STRICT-exit blocked by
+       pending declarations).
+    """
+
+    key: str = "set_round_mode"
+    name: str = "Set Round Mode"
+    icon: str = "sliders"
+    category: str = "scenes"
+    target_type: TargetType = TargetType.AREA
+    costs_turn: bool = False
+
+    def execute(  # noqa: PLR0911, PLR0913
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        *,
+        mode: str | None = None,
+        advance_quorum_pct: int | None = None,
+        max_actions_per_round: int | None = None,
+        per_target_repeat_lock: bool | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.scenes.models import Scene as _Scene  # noqa: PLC0415
+        from world.scenes.scene_admin_services import actor_can_administer_scene  # noqa: PLC0415
+
+        room = actor.location
+        if room is None:
+            return ActionResult(success=False, message=NOT_IN_A_ROOM_MESSAGE)
+
+        scene = _Scene.objects.filter(location=room, is_active=True).first()
+        if scene is None:
+            return ActionResult(
+                success=False,
+                message="Mode ordering needs an active scene here — start one first.",
+            )
+
+        if not actor_can_administer_scene(actor, scene):
+            return ActionResult(
+                success=False,
+                message="Only the scene's GM or an owner can set the round mode.",
+            )
+
+        rnd = _active_round_for_room(room)
+        if rnd is None:
+            return ActionResult(success=False, message="There is no active round here.")
+
+        # Opportunistically link the round to the scene if not already linked.
+        if rnd.scene_id is None:
+            rnd.scene = scene
+            rnd.save(update_fields=["scene"])
+
+        try:
+            set_scene_round_mode(
+                rnd,
+                mode=mode,
+                advance_quorum_pct=advance_quorum_pct,
+                max_actions_per_round=max_actions_per_round,
+                per_target_repeat_lock=per_target_repeat_lock,
+            )
+        except RoundModeError as exc:
+            return ActionResult(success=False, message=str(exc))
+
+        if mode is not None:
+            return ActionResult(success=True, message=f"Round mode set to {mode}.")
+        return ActionResult(success=True, message="Round settings updated.")
 
 
 @dataclass

--- a/src/actions/definitions/scenes.py
+++ b/src/actions/definitions/scenes.py
@@ -1,0 +1,118 @@
+"""Scene lifecycle actions: start/finish a scene."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from actions.base import Action
+from actions.types import ActionContext, ActionResult, TargetType
+
+# Re-use the same NOT_IN_A_ROOM_MESSAGE constant (defined in rounds.py and checked here).
+NOT_IN_A_ROOM_MESSAGE = "You are not in a room."
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from world.scenes.models import Scene
+
+
+def _active_scene_for_room(room: ObjectDB) -> Scene | None:
+    """Return the active Scene for a room, or None."""
+    from world.scenes.models import Scene as SceneModel  # noqa: PLC0415
+
+    return SceneModel.objects.filter(location=room, is_active=True).first()
+
+
+@dataclass
+class StartSceneAction(Action):
+    """Start a scene in the actor's current room.
+
+    If no active scene exists, creates one and grants co-ownership to every
+    present PC with a controlling account.  If a scene is already active, the
+    actor is recorded as a (non-owner) participant and informed.  Ungated.
+    """
+
+    key: str = "start_scene"
+    name: str = "Start Scene"
+    icon: str = "play"
+    category: str = "scenes"
+    target_type: TargetType = TargetType.AREA
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.scenes.place_services import ensure_scene_for_location  # noqa: PLC0415
+        from world.scenes.scene_admin_services import (  # noqa: PLC0415
+            add_present_as_co_owners,
+            resolve_actor_account,
+        )
+
+        room = actor.location
+        if room is None:
+            return ActionResult(success=False, message=NOT_IN_A_ROOM_MESSAGE)
+
+        scene = _active_scene_for_room(room)
+        if scene is None:
+            scene = ensure_scene_for_location(room)
+            add_present_as_co_owners(scene, room)
+            return ActionResult(success=True, message="A scene begins.")
+
+        # Scene already exists — join the actor as a non-owner participant.
+        account = resolve_actor_account(actor)
+        if account is not None:
+            from world.scenes.models import SceneParticipation  # noqa: PLC0415
+
+            SceneParticipation.objects.get_or_create(
+                scene=scene,
+                account=account,
+                defaults={"is_owner": False},
+            )
+        return ActionResult(success=True, message="A scene is already active here.")
+
+
+@dataclass
+class FinishSceneAction(Action):
+    """Finish the active scene in the actor's current room.
+
+    Gated: only the scene's GM, a co-owner, or a staff account may finish the
+    scene.  Delegates to ``finish_scene_full`` for the full orchestration.
+    """
+
+    key: str = "finish_scene"
+    name: str = "Finish Scene"
+    icon: str = "stop-circle"
+    category: str = "scenes"
+    target_type: TargetType = TargetType.AREA
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.scenes.scene_admin_services import (  # noqa: PLC0415
+            actor_can_administer_scene,
+            finish_scene_full,
+            resolve_actor_account,
+        )
+
+        room = actor.location
+        if room is None:
+            return ActionResult(success=False, message=NOT_IN_A_ROOM_MESSAGE)
+
+        scene = _active_scene_for_room(room)
+        if scene is None:
+            return ActionResult(success=False, message="There is no active scene here.")
+
+        if not actor_can_administer_scene(actor, scene):
+            return ActionResult(
+                success=False,
+                message="Only the scene's GM or an owner can finish the scene.",
+            )
+
+        finish_scene_full(scene, by_account=resolve_actor_account(actor))
+        return ActionResult(success=True, message="The scene comes to a close.")

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -62,6 +62,7 @@ from actions.definitions.rounds import (
     JoinRoundAction,
     LeaveRoundAction,
     PassRoundAction,
+    SetRoundModeAction,
     StartRoundAction,
 )
 from actions.definitions.scenes import FinishSceneAction, StartSceneAction
@@ -120,6 +121,7 @@ _ALL_ACTIONS: list[Action] = [
     DisarmTrapAction(),
     PassRoundAction(),
     ForceResolveRoundAction(),
+    SetRoundModeAction(),
     FleeAction(),
     CoverAction(),
     InterposeAction(),

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -64,6 +64,7 @@ from actions.definitions.rounds import (
     PassRoundAction,
     StartRoundAction,
 )
+from actions.definitions.scenes import FinishSceneAction, StartSceneAction
 from actions.definitions.social import (
     deceive,
     entrance,
@@ -134,6 +135,8 @@ _ALL_ACTIONS: list[Action] = [
     YieldAction(),
     AcknowledgeRiskAction(),
     CastTechniqueAction(),
+    StartSceneAction(),
+    FinishSceneAction(),
     intimidate,
     persuade,
     deceive,

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -172,6 +172,7 @@ class ActionRegistryTests(TestCase):
             "disarm_trap",
             "pass_round",
             "force_resolve_round",
+            "set_round_mode",
             "intimidate",
             "persuade",
             "deceive",

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -201,6 +201,8 @@ class ActionRegistryTests(TestCase):
             "combat_revert",
             "combat_join",
             "combat_leave",
+            "start_scene",
+            "finish_scene",
         }
         assert set(ACTIONS_BY_KEY.keys()) == expected_keys
 

--- a/src/actions/tests/test_round_mode_action.py
+++ b/src/actions/tests/test_round_mode_action.py
@@ -1,0 +1,265 @@
+"""Tests for SetRoundModeAction + StartRoundAction mode override (#1445)."""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from actions.definitions.rounds import SetRoundModeAction, StartRoundAction
+from evennia_extensions.factories import CharacterFactory, GMCharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.constants import RoundStatus, SceneRoundMode, SceneRoundStartReason
+from world.scenes.factories import SceneFactory, SceneOwnerParticipationFactory
+from world.scenes.models import SceneRound
+
+
+def _create_pc_with_account(db_key: str, location=None):
+    """Create a PC character with a live roster tenure (non-None active_account).
+
+    Returns (character, sheet, account).
+    """
+    kwargs = {"db_key": db_key}
+    if location is not None:
+        kwargs["location"] = location
+    char = CharacterFactory(**kwargs)
+    sheet = CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    account = tenure.player_data.account
+    return char, sheet, account
+
+
+def _make_room():
+    return ObjectDBFactory(
+        db_key="TestRoom",
+        db_typeclass_path="typeclasses.rooms.Room",
+    )
+
+
+def _make_active_round(room, mode=SceneRoundMode.POSE_ORDER, scene=None):
+    rnd = SceneRound.objects.create(
+        room=room,
+        status=RoundStatus.DECLARING,
+        round_number=1,
+        start_reason=SceneRoundStartReason.OPT_IN,
+        mode=mode,
+    )
+    if scene is not None:
+        rnd.scene = scene
+        rnd.save(update_fields=["scene"])
+    return rnd
+
+
+class SetRoundModeActionGateTests(TestCase):
+    """Permission gate tests for SetRoundModeAction."""
+
+    def setUp(self):
+        self.room = _make_room()
+        self.scene = SceneFactory(location=self.room, is_active=True)
+
+    def test_non_owner_pc_denied(self):
+        """A PC who is not a scene owner gets success=False."""
+        char, _sheet, _account = _create_pc_with_account("Alice", location=self.room)
+        # Not an owner — no SceneOwnerParticipation
+        _make_active_round(self.room)
+        action = SetRoundModeAction()
+        result = action.run(char, mode=SceneRoundMode.OPEN)
+        self.assertFalse(result.success)
+        self.assertIn("GM or an owner", result.message)
+
+    def test_non_owner_mode_unchanged(self):
+        """When denied, the round's mode is NOT modified."""
+        char, _sheet, _account = _create_pc_with_account("Bob", location=self.room)
+        rnd = _make_active_round(self.room, mode=SceneRoundMode.POSE_ORDER)
+        action = SetRoundModeAction()
+        action.run(char, mode=SceneRoundMode.OPEN)
+        rnd.refresh_from_db()
+        self.assertEqual(rnd.mode, SceneRoundMode.POSE_ORDER)
+
+    def test_owner_can_set_mode(self):
+        """A scene co-owner can change the round mode."""
+        char, _sheet, account = _create_pc_with_account("Carol", location=self.room)
+        SceneOwnerParticipationFactory(scene=self.scene, account=account)
+        rnd = _make_active_round(self.room, mode=SceneRoundMode.POSE_ORDER)
+        action = SetRoundModeAction()
+        result = action.run(char, mode=SceneRoundMode.OPEN)
+        self.assertTrue(result.success)
+        rnd.refresh_from_db()
+        self.assertEqual(rnd.mode, SceneRoundMode.OPEN)
+
+    def test_owner_set_mode_links_round_scene(self):
+        """A successful set_round_mode call links rnd.scene when it was None."""
+        char, _sheet, account = _create_pc_with_account("Dana", location=self.room)
+        SceneOwnerParticipationFactory(scene=self.scene, account=account)
+        rnd = _make_active_round(self.room, mode=SceneRoundMode.POSE_ORDER, scene=None)
+        self.assertIsNone(rnd.scene_id)
+        action = SetRoundModeAction()
+        result = action.run(char, mode=SceneRoundMode.OPEN)
+        self.assertTrue(result.success)
+        rnd.refresh_from_db()
+        self.assertEqual(rnd.scene_id, self.scene.pk)
+
+    def test_gm_character_can_set_mode(self):
+        """A GM (is_story_runner) character can set the round mode without account."""
+        gm = GMCharacterFactory(db_key="GMChar", location=self.room)
+        rnd = _make_active_round(self.room, mode=SceneRoundMode.POSE_ORDER)
+        action = SetRoundModeAction()
+        result = action.run(gm, mode=SceneRoundMode.OPEN)
+        self.assertTrue(result.success)
+        rnd.refresh_from_db()
+        self.assertEqual(rnd.mode, SceneRoundMode.OPEN)
+
+
+class SetRoundModeActionRefusalTests(TestCase):
+    """Refusal cases for SetRoundModeAction (no room, no scene, no round)."""
+
+    def test_no_room_returns_failure(self):
+        """Actor with no location gets NOT_IN_A_ROOM response."""
+        char, _sheet, _account = _create_pc_with_account("Eve")
+        char.location = None
+        action = SetRoundModeAction()
+        result = action.run(char, mode=SceneRoundMode.OPEN)
+        self.assertFalse(result.success)
+        self.assertIn("not in a room", result.message.lower())
+
+    def test_no_active_scene_returns_failure(self):
+        """Room has no active scene → action refuses before permission check."""
+        room = _make_room()
+        char, _sheet, _account = _create_pc_with_account("Frank", location=room)
+        # No scene created for this room
+        _make_active_round(room)
+        action = SetRoundModeAction()
+        result = action.run(char, mode=SceneRoundMode.OPEN)
+        self.assertFalse(result.success)
+        self.assertIn("scene", result.message.lower())
+
+    def test_no_active_round_returns_failure(self):
+        """Room has a scene but no active round → action refuses."""
+        room = _make_room()
+        char, _sheet, account = _create_pc_with_account("Grace", location=room)
+        scene = SceneFactory(location=room, is_active=True)
+        SceneOwnerParticipationFactory(scene=scene, account=account)
+        # No round created
+        action = SetRoundModeAction()
+        result = action.run(char, mode=SceneRoundMode.OPEN)
+        self.assertFalse(result.success)
+        self.assertIn("round", result.message.lower())
+
+    def test_danger_round_mode_change_refused(self):
+        """DANGER rounds cannot have their mode changed (service raises RoundModeError)."""
+        room = _make_room()
+        char, _sheet, account = _create_pc_with_account("Hank", location=room)
+        scene = SceneFactory(location=room, is_active=True)
+        SceneOwnerParticipationFactory(scene=scene, account=account)
+        # DANGER round — mode is forced to OPEN at creation; service guards against changes.
+        SceneRound.objects.create(
+            room=room,
+            status=RoundStatus.DECLARING,
+            round_number=1,
+            start_reason=SceneRoundStartReason.DANGER,
+        )
+        action = SetRoundModeAction()
+        result = action.run(char, mode=SceneRoundMode.POSE_ORDER)
+        self.assertFalse(result.success)
+        # The service's RoundModeError message surfaces as success=False
+        self.assertIn("danger", result.message.lower())
+
+    def test_success_message_names_new_mode(self):
+        """Success result mentions the new mode when mode was set."""
+        room = _make_room()
+        char, _sheet, account = _create_pc_with_account("Iris", location=room)
+        scene = SceneFactory(location=room, is_active=True)
+        SceneOwnerParticipationFactory(scene=scene, account=account)
+        _make_active_round(room)
+        action = SetRoundModeAction()
+        result = action.run(char, mode=SceneRoundMode.STRICT)
+        self.assertTrue(result.success)
+        self.assertIn("strict", result.message.lower())
+
+    def test_knob_only_update_without_mode(self):
+        """Updating only a knob (no mode change) → success with generic message."""
+        room = _make_room()
+        char, _sheet, account = _create_pc_with_account("Jake", location=room)
+        scene = SceneFactory(location=room, is_active=True)
+        SceneOwnerParticipationFactory(scene=scene, account=account)
+        rnd = _make_active_round(room)
+        action = SetRoundModeAction()
+        result = action.run(char, advance_quorum_pct=75)
+        self.assertTrue(result.success)
+        rnd.refresh_from_db()
+        self.assertEqual(rnd.advance_quorum_pct, 75)
+
+
+class StartRoundActionModeOverrideTests(TestCase):
+    """StartRoundAction with mode/knob override — gated by scene + admin."""
+
+    def setUp(self):
+        self.room = _make_room()
+
+    def test_no_override_starts_without_scene(self):
+        """No override → start_round works as before (no scene required)."""
+        char, _sheet, _account = _create_pc_with_account("Kim", location=self.room)
+        action = StartRoundAction()
+        result = action.run(char)
+        self.assertTrue(result.success)
+        rnd = SceneRound.objects.get(room=self.room)
+        self.assertEqual(rnd.status, RoundStatus.DECLARING)
+        self.assertIsNone(rnd.scene_id)
+
+    def test_override_denied_without_scene(self):
+        """Override without an active scene → denied."""
+        char, _sheet, _account = _create_pc_with_account("Leo", location=self.room)
+        action = StartRoundAction()
+        result = action.run(char, mode=SceneRoundMode.STRICT)
+        self.assertFalse(result.success)
+        self.assertIn("scene", result.message.lower())
+
+    def test_override_denied_for_non_owner(self):
+        """Override for a PC who is not a scene owner → denied."""
+        char, _sheet, _account = _create_pc_with_account("Mia", location=self.room)
+        # Scene exists but Mia is not an owner
+        SceneFactory(location=self.room, is_active=True)
+        action = StartRoundAction()
+        result = action.run(char, mode=SceneRoundMode.OPEN)
+        self.assertFalse(result.success)
+
+    def test_override_applied_for_owner(self):
+        """Override by a scene owner → round created with the requested mode, scene linked."""
+        char, _sheet, account = _create_pc_with_account("Nora", location=self.room)
+        scene = SceneFactory(location=self.room, is_active=True)
+        SceneOwnerParticipationFactory(scene=scene, account=account)
+        action = StartRoundAction()
+        result = action.run(char, mode=SceneRoundMode.STRICT, advance_quorum_pct=80)
+        self.assertTrue(result.success)
+        rnd = SceneRound.objects.get(room=self.room)
+        self.assertEqual(rnd.mode, SceneRoundMode.STRICT)
+        self.assertEqual(rnd.advance_quorum_pct, 80)
+        self.assertEqual(rnd.scene_id, scene.pk)
+
+    def test_override_applied_for_staff_account(self):
+        """A staff account can pass overrides — round created with correct mode."""
+        char, _sheet, account = _create_pc_with_account("Petra", location=self.room)
+        account.is_staff = True
+        account.save()
+        scene = SceneFactory(location=self.room, is_active=True)
+        action = StartRoundAction()
+        result = action.run(char, mode=SceneRoundMode.OPEN)
+        self.assertTrue(result.success)
+        rnd = SceneRound.objects.get(room=self.room)
+        self.assertEqual(rnd.mode, SceneRoundMode.OPEN)
+        self.assertEqual(rnd.scene_id, scene.pk)
+
+    def test_no_override_defaults_from_config(self):
+        """No override → config defaults copied, scene not linked."""
+        from world.scenes.models import get_scene_round_defaults_config
+
+        char, _sheet, _account = _create_pc_with_account("Owen", location=self.room)
+        cfg = get_scene_round_defaults_config()
+        action = StartRoundAction()
+        action.run(char)
+        rnd = SceneRound.objects.get(room=self.room)
+        self.assertEqual(rnd.mode, cfg.default_mode)
+        self.assertEqual(rnd.advance_quorum_pct, cfg.advance_quorum_pct)
+        self.assertEqual(rnd.max_actions_per_round, cfg.max_actions_per_round)
+        self.assertEqual(rnd.per_target_repeat_lock, cfg.per_target_repeat_lock)
+        self.assertIsNone(rnd.scene_id)

--- a/src/actions/tests/test_scene_actions.py
+++ b/src/actions/tests/test_scene_actions.py
@@ -1,0 +1,200 @@
+"""Tests for StartSceneAction and FinishSceneAction."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from actions.definitions.scenes import FinishSceneAction, StartSceneAction
+from evennia_extensions.factories import CharacterFactory, GMCharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.factories import SceneFactory, SceneOwnerParticipationFactory
+from world.scenes.models import Scene, SceneParticipation
+
+_FINISH_PATCH_BASE = "world.scenes.scene_admin_services"
+
+
+def _create_pc_with_account(db_key: str, location=None):
+    """Create a PC with an active roster tenure so active_account is non-None.
+
+    Returns (character, account).
+    """
+    kwargs: dict = {"db_key": db_key}
+    if location is not None:
+        kwargs["location"] = location
+    char = CharacterFactory(**kwargs)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    account = tenure.player_data.account
+    return char, account
+
+
+def _make_room(label: str = "Room"):
+    return ObjectDBFactory(
+        db_key=label,
+        db_typeclass_path="typeclasses.rooms.Room",
+    )
+
+
+class StartSceneActionTests(TestCase):
+    """StartSceneAction creates a scene and grants co-ownership to present PCs."""
+
+    def test_creates_scene_when_none_active(self):
+        """StartSceneAction creates an active scene in the room."""
+        room = _make_room("Room1")
+        actor, _account = _create_pc_with_account("Alice", location=room)
+
+        result = StartSceneAction().execute(actor)
+
+        assert result.success is True
+        assert Scene.objects.filter(location=room, is_active=True).exists()
+
+    def test_actor_is_co_owner_after_start(self):
+        """The actor's account becomes a co-owner of the new scene."""
+        room = _make_room("Room2")
+        actor, account = _create_pc_with_account("Bob", location=room)
+
+        StartSceneAction().execute(actor)
+
+        scene = Scene.objects.get(location=room, is_active=True)
+        assert SceneParticipation.objects.filter(
+            scene=scene, account=account, is_owner=True
+        ).exists()
+
+    def test_second_present_pc_also_becomes_co_owner(self):
+        """A second PC present in the room is also granted co-ownership."""
+        room = _make_room("Room3")
+        actor, _account_a = _create_pc_with_account("Carol", location=room)
+        _other, account_b = _create_pc_with_account("Dave", location=room)
+
+        StartSceneAction().execute(actor)
+
+        scene = Scene.objects.get(location=room, is_active=True)
+        assert SceneParticipation.objects.filter(
+            scene=scene, account=account_b, is_owner=True
+        ).exists()
+
+    def test_start_when_scene_exists_does_not_flip_ownership(self):
+        """If a scene is already active, calling start_scene does NOT change ownership."""
+        room = _make_room("Room4")
+        actor, actor_account = _create_pc_with_account("Eve", location=room)
+
+        # Create a scene where Eve is NOT an owner.
+        scene = SceneFactory(location=room, is_active=True)
+        SceneParticipation.objects.create(scene=scene, account=actor_account, is_owner=False)
+
+        result = StartSceneAction().execute(actor)
+
+        # Success message indicates scene already exists.
+        assert result.success is True
+        assert "already active" in result.message
+
+        # Ownership must NOT have been flipped.
+        participation = SceneParticipation.objects.get(scene=scene, account=actor_account)
+        assert participation.is_owner is False
+
+    def test_start_when_scene_exists_adds_actor_as_participant(self):
+        """With an existing scene, the actor is added as a non-owner participant."""
+        room = _make_room("Room5")
+        actor, actor_account = _create_pc_with_account("Frank", location=room)
+        scene = SceneFactory(location=room, is_active=True)
+
+        StartSceneAction().execute(actor)
+
+        assert SceneParticipation.objects.filter(scene=scene, account=actor_account).exists()
+
+    def test_returns_failure_when_not_in_room(self):
+        """Actor not in a room gets a failure result."""
+        actor = CharacterFactory(db_key="NoRoom")
+        actor.location = None
+
+        result = StartSceneAction().execute(actor)
+
+        assert result.success is False
+        assert "not in a room" in result.message.lower()
+
+
+class FinishSceneActionTests(TestCase):
+    """FinishSceneAction is gated by co-ownership; delegates to finish_scene_full."""
+
+    def test_non_owner_is_denied(self):
+        """A PC who is not a scene owner gets success=False."""
+        room = _make_room("Room6")
+        actor, _account = _create_pc_with_account("Grace", location=room)
+        scene = SceneFactory(location=room, is_active=True)
+        # Actor has no SceneParticipation row → not an owner.
+
+        result = FinishSceneAction().execute(actor)
+
+        assert result.success is False
+        assert scene.is_active  # scene still active
+
+    def test_scene_remains_active_when_denied(self):
+        """The scene is not deactivated when the actor lacks permission."""
+        room = _make_room("Room7")
+        actor, _account = _create_pc_with_account("Henry", location=room)
+        scene = SceneFactory(location=room, is_active=True)
+
+        FinishSceneAction().execute(actor)
+
+        scene.refresh_from_db()
+        assert scene.is_active is True
+
+    def test_owner_can_finish_scene(self):
+        """A scene owner successfully finishes the active scene."""
+        room = _make_room("Room8")
+        actor, account = _create_pc_with_account("Iris", location=room)
+        scene = SceneFactory(location=room, is_active=True)
+        SceneOwnerParticipationFactory(scene=scene, account=account)
+
+        with (
+            patch(f"{_FINISH_PATCH_BASE}.on_scene_finished"),
+            patch(f"{_FINISH_PATCH_BASE}.process_deferred_fatigue_resets"),
+            patch(f"{_FINISH_PATCH_BASE}.broadcast_scene_message"),
+        ):
+            result = FinishSceneAction().execute(actor)
+
+        assert result.success is True
+        scene.refresh_from_db()
+        assert scene.is_active is False
+
+    def test_gm_character_can_finish_scene(self):
+        """A GM character (is_story_runner=True) can finish any scene."""
+        room = _make_room("Room9")
+        gm = GMCharacterFactory(db_key="GMFinish", location=room)
+        scene = SceneFactory(location=room, is_active=True)
+
+        with (
+            patch(f"{_FINISH_PATCH_BASE}.on_scene_finished"),
+            patch(f"{_FINISH_PATCH_BASE}.process_deferred_fatigue_resets"),
+            patch(f"{_FINISH_PATCH_BASE}.broadcast_scene_message"),
+        ):
+            result = FinishSceneAction().execute(gm)
+
+        assert result.success is True
+        scene.refresh_from_db()
+        assert scene.is_active is False
+
+    def test_no_active_scene_returns_failure(self):
+        """FinishSceneAction fails when no active scene exists in the room."""
+        room = _make_room("Room10")
+        actor, _account = _create_pc_with_account("Jake", location=room)
+        # No scene created.
+
+        result = FinishSceneAction().execute(actor)
+
+        assert result.success is False
+        assert "no active scene" in result.message.lower()
+
+    def test_returns_failure_when_not_in_room(self):
+        """Actor not in a room gets a failure result."""
+        actor = CharacterFactory(db_key="NoRoomFinish")
+        actor.location = None
+
+        result = FinishSceneAction().execute(actor)
+
+        assert result.success is False
+        assert "not in a room" in result.message.lower()

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -61,6 +61,7 @@ from commands.gemit import CmdGemit
 from commands.imbue import CmdImbue
 from commands.offer_response import CmdDecline
 from commands.ritual import CmdRitual
+from commands.scene import CmdScene
 from commands.social.blocking import (
     CmdBlock,
     CmdBlockList,
@@ -178,6 +179,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdClashCommit,
             # Shared combat verbs: combat <subverb> (#1453, #1452)
             CmdCombat,
+            # Scene lifecycle telnet command (#1445)
+            CmdScene,
         )
         for command_cls in command_classes:
             self.add(command_cls())

--- a/src/commands/scene.py
+++ b/src/commands/scene.py
@@ -1,0 +1,154 @@
+"""Telnet command for scene administration.
+
+Thin telnet face of three scene-lifecycle Actions:
+    ``scene start [name]``               — StartSceneAction
+    ``scene finish``                     — FinishSceneAction
+    ``scene round <mode> [knobs]``       — SetRoundModeAction
+    ``scene`` / ``scene status``         — one-line status read-out (no action)
+    ``scene <unknown>``                  — usage message
+
+The web path calls the same actions directly. No business logic lives here.
+"""
+
+from __future__ import annotations
+
+from commands.command import ArxCommand
+from world.scenes.constants import SceneRoundMode
+
+# Maps the user's mode token to the TextChoices value.
+_MODE_TOKENS = {
+    "open": SceneRoundMode.OPEN,
+    "pose_order": SceneRoundMode.POSE_ORDER,
+    "strict": SceneRoundMode.STRICT,
+}
+_LOCK_ON = {"on", "true", "yes", "1"}
+
+_USAGE = (
+    "Usage: scene <subcommand>\n"
+    "  scene start [name]                — start a scene here\n"
+    "  scene finish                      — finish the active scene\n"
+    "  scene round [open|pose_order|strict] [quorum=<pct>] [cap=<n>] [lock=on/off]\n"
+    "  scene / scene status              — show active scene + round status"
+)
+
+
+def _parse_round_args(rest: str) -> dict:
+    """Parse ``scene round <mode> [quorum=<n>] [cap=<n>] [lock=on/off]``."""
+    tokens = rest.split()
+    out: dict = {}
+    if tokens and tokens[0].lower() in _MODE_TOKENS:
+        out["mode"] = _MODE_TOKENS[tokens[0].lower()].value
+        tokens = tokens[1:]
+    for tok in tokens:
+        if "=" not in tok:
+            continue
+        k, v = tok.split("=", 1)
+        k = k.lower()
+        if k == "quorum":  # noqa: STRING_LITERAL
+            out["advance_quorum_pct"] = int(v)
+        elif k == "cap":  # noqa: STRING_LITERAL
+            out["max_actions_per_round"] = int(v)
+        elif k == "lock":  # noqa: STRING_LITERAL
+            out["per_target_repeat_lock"] = v.lower() in _LOCK_ON
+    return out
+
+
+class CmdScene(ArxCommand):
+    """Manage a scene in your current room.
+
+    **Start a scene:**
+        ``scene start [name]``
+
+    **Finish the active scene:**
+        ``scene finish``
+
+    **Set the round mode:**
+        ``scene round [open|pose_order|strict] [quorum=<pct>] [cap=<n>] [lock=on/off]``
+        Example: ``scene round strict quorum=70 cap=2 lock=on``
+
+    **Show scene status:**
+        ``scene`` or ``scene status``
+    """
+
+    key = "scene"
+    locks = "cmd:all()"
+    action = None  # Routing is done in func(); subcommands pick their own action.
+
+    def func(self) -> None:
+        """Route the first token of self.args to the appropriate action."""
+        raw = (self.args or "").strip()
+        first = raw.split()[0].lower() if raw.split() else ""
+        rest = raw[len(first) :].strip() if first else ""
+
+        if first in ("", "status"):  # noqa: STRING_LITERAL
+            self._handle_status()
+        elif first == "start":  # noqa: STRING_LITERAL
+            self._handle_start(rest)
+        elif first == "finish":  # noqa: STRING_LITERAL
+            self._handle_finish()
+        elif first == "round":  # noqa: STRING_LITERAL
+            self._handle_round(rest)
+        else:
+            self.msg(_USAGE)
+
+    # ------------------------------------------------------------------
+    # Subcommand handlers
+    # ------------------------------------------------------------------
+
+    def _handle_start(self, rest: str) -> None:
+        """Dispatch StartSceneAction, forwarding an optional scene name."""
+        from actions.definitions.scenes import StartSceneAction  # noqa: PLC0415
+
+        kwargs = {}
+        name = rest.strip()
+        if name:
+            kwargs["name"] = name
+        result = StartSceneAction().run(actor=self.caller, **kwargs)
+        if result.message:
+            self.msg(result.message)
+
+    def _handle_finish(self) -> None:
+        """Dispatch FinishSceneAction."""
+        from actions.definitions.scenes import FinishSceneAction  # noqa: PLC0415
+
+        result = FinishSceneAction().run(actor=self.caller)
+        if result.message:
+            self.msg(result.message)
+
+    def _handle_round(self, rest: str) -> None:
+        """Parse round args and dispatch SetRoundModeAction."""
+        from actions.definitions.rounds import SetRoundModeAction  # noqa: PLC0415
+
+        try:
+            kwargs = _parse_round_args(rest)
+        except ValueError:
+            self.msg("Quorum and cap must be numbers.")
+            return
+        result = SetRoundModeAction().run(actor=self.caller, **kwargs)
+        if result.message:
+            self.msg(result.message)
+
+    def _handle_status(self) -> None:
+        """Show a one-line status for the active scene + round in this room."""
+        from world.scenes.constants import ACTIVE_SCENE_ROUND_STATUSES  # noqa: PLC0415
+        from world.scenes.models import Scene, SceneRound  # noqa: PLC0415
+
+        room = self.caller.location
+        if room is None:
+            self.msg("You are not in a room.")
+            return
+
+        scene = Scene.objects.filter(location=room, is_active=True).first()
+        if scene is None:
+            self.msg("No active scene here.")
+            return
+
+        rnd = SceneRound.objects.filter(
+            room=room,
+            status__in=ACTIVE_SCENE_ROUND_STATUSES,
+        ).first()
+
+        if rnd is None:
+            self.msg(f"Scene: {scene.name or '(unnamed)'}. No active round.")
+        else:
+            self.msg(f"Scene: {scene.name or '(unnamed)'}. Round {rnd.round_number} ({rnd.mode}).")

--- a/src/commands/tests/test_scene_command.py
+++ b/src/commands/tests/test_scene_command.py
@@ -1,0 +1,276 @@
+"""Tests for CmdScene — the thin telnet face of scene lifecycle actions.
+
+Pattern mirrors test_entrance_flourish_e2e.py: construct the command,
+set caller/args, call func(), inspect caller.msg call_args_list.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from commands.scene import CmdScene
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.constants import RoundStatus, SceneRoundMode, SceneRoundStartReason
+from world.scenes.factories import SceneFactory, SceneOwnerParticipationFactory
+from world.scenes.models import Scene, SceneRound
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_room(label: str = "CmdSceneRoom"):
+    return ObjectDBFactory(
+        db_key=label,
+        db_typeclass_path="typeclasses.rooms.Room",
+    )
+
+
+def _create_pc_with_account(db_key: str, location=None):
+    """Create a PC with a live roster tenure (active_account is non-None).
+
+    Returns (character, account).
+    """
+    kwargs = {"db_key": db_key}
+    if location is not None:
+        kwargs["location"] = location
+    char = CharacterFactory(**kwargs)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    account = tenure.player_data.account
+    return char, account
+
+
+def _run_cmd(caller, args: str) -> list[str]:
+    """Construct and run CmdScene; return all positional string messages."""
+    cmd = CmdScene()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"scene {args}".strip()
+    cmd.func()
+    return [str(c.args[0]) for c in caller.msg.call_args_list if c.args]
+
+
+# ---------------------------------------------------------------------------
+# scene start
+# ---------------------------------------------------------------------------
+
+
+class CmdSceneStartTests(TestCase):
+    """``scene start`` dispatches StartSceneAction and creates a scene."""
+
+    def setUp(self):
+        self.room = _make_room("StartRoom")
+        self.caller, _account = _create_pc_with_account("SceneStarter", location=self.room)
+        self.caller.msg = MagicMock()
+
+    def test_start_creates_active_scene(self):
+        """``scene start`` creates an active Scene in the room."""
+        _run_cmd(self.caller, "start")
+        self.assertTrue(Scene.objects.filter(location=self.room, is_active=True).exists())
+
+    def test_start_messages_caller(self):
+        """Caller receives the action's result message after start."""
+        messages = _run_cmd(self.caller, "start")
+        self.assertTrue(messages, "Expected at least one message after scene start")
+
+    def test_start_with_name_passes_name(self):
+        """``scene start My Scene Name`` still creates the scene (name kwarg forwarded)."""
+        _run_cmd(self.caller, "start My Scene Name")
+        self.assertTrue(Scene.objects.filter(location=self.room, is_active=True).exists())
+
+
+# ---------------------------------------------------------------------------
+# scene finish
+# ---------------------------------------------------------------------------
+
+
+_BROADCAST_PATCH = "world.scenes.scene_admin_services.broadcast_scene_message"
+
+
+class CmdSceneFinishTests(TestCase):
+    """``scene finish`` dispatches FinishSceneAction."""
+
+    def setUp(self):
+        self.room = _make_room("FinishRoom")
+        self.caller, self.account = _create_pc_with_account("SceneFinisher", location=self.room)
+        self.caller.msg = MagicMock()
+        self.scene = SceneFactory(location=self.room, is_active=True)
+        SceneOwnerParticipationFactory(scene=self.scene, account=self.account)
+
+    def test_finish_closes_scene(self):
+        """``scene finish`` marks the scene as finished."""
+        with patch(_BROADCAST_PATCH):
+            _run_cmd(self.caller, "finish")
+        self.scene.refresh_from_db()
+        self.assertFalse(self.scene.is_active)
+
+    def test_finish_messages_caller(self):
+        """Caller receives a confirmation message after scene finish."""
+        with patch(_BROADCAST_PATCH):
+            messages = _run_cmd(self.caller, "finish")
+        self.assertTrue(messages, "Expected at least one message after scene finish")
+
+    def test_finish_denied_for_non_owner(self):
+        """A non-owner receives a failure message and scene stays active."""
+        non_owner, _acc = _create_pc_with_account("NonOwner", location=self.room)
+        non_owner.msg = MagicMock()
+        # broadcast is never reached when the permission gate refuses.
+        _run_cmd(non_owner, "finish")
+        self.scene.refresh_from_db()
+        self.assertTrue(self.scene.is_active)
+
+
+# ---------------------------------------------------------------------------
+# scene round
+# ---------------------------------------------------------------------------
+
+
+class CmdSceneRoundTests(TestCase):
+    """``scene round <mode> [knobs]`` dispatches SetRoundModeAction."""
+
+    def setUp(self):
+        self.room = _make_room("RoundRoom")
+        self.caller, self.account = _create_pc_with_account("RoundOwner", location=self.room)
+        self.caller.msg = MagicMock()
+        self.scene = SceneFactory(location=self.room, is_active=True)
+        SceneOwnerParticipationFactory(scene=self.scene, account=self.account)
+        self.rnd = SceneRound.objects.create(
+            room=self.room,
+            status=RoundStatus.DECLARING,
+            round_number=1,
+            start_reason=SceneRoundStartReason.OPT_IN,
+            mode=SceneRoundMode.POSE_ORDER,
+            scene=self.scene,
+        )
+
+    def test_round_strict_sets_mode(self):
+        """``scene round strict`` sets the round mode to STRICT."""
+        _run_cmd(self.caller, "round strict")
+        self.rnd.refresh_from_db()
+        self.assertEqual(self.rnd.mode, SceneRoundMode.STRICT)
+
+    def test_round_strict_quorum_cap_lock_parsed(self):
+        """All optional knobs are parsed and forwarded to the action."""
+        _run_cmd(self.caller, "round strict quorum=70 cap=2 lock=on")
+        self.rnd.refresh_from_db()
+        self.assertEqual(self.rnd.mode, SceneRoundMode.STRICT)
+        self.assertEqual(self.rnd.advance_quorum_pct, 70)
+        self.assertEqual(self.rnd.max_actions_per_round, 2)
+        self.assertTrue(self.rnd.per_target_repeat_lock)
+
+    def test_round_messages_caller(self):
+        """Caller receives the action result message after mode change."""
+        messages = _run_cmd(self.caller, "round open")
+        self.assertTrue(messages, "Expected at least one message after round mode change")
+
+    def test_round_bad_quorum_shows_error(self):
+        """Non-numeric quorum value emits a friendly error; round is unchanged."""
+        _run_cmd(self.caller, "round strict quorum=abc")
+        self.rnd.refresh_from_db()
+        self.assertEqual(self.rnd.mode, SceneRoundMode.POSE_ORDER)
+        messages = [str(c.args[0]) for c in self.caller.msg.call_args_list if c.args]
+        self.assertTrue(
+            any("number" in m.lower() for m in messages),
+            f"Expected error message about numbers; got: {messages}",
+        )
+
+    def test_round_bad_cap_shows_error(self):
+        """Non-numeric cap value emits a friendly error."""
+        _run_cmd(self.caller, "round strict cap=xyz")
+        messages = [str(c.args[0]) for c in self.caller.msg.call_args_list if c.args]
+        self.assertTrue(
+            any("number" in m.lower() for m in messages),
+            f"Expected error message about numbers; got: {messages}",
+        )
+
+    def test_round_lock_off_sets_false(self):
+        """``lock=off`` parses to False."""
+        self.rnd.per_target_repeat_lock = True
+        self.rnd.save(update_fields=["per_target_repeat_lock"])
+        _run_cmd(self.caller, "round strict lock=off")
+        self.rnd.refresh_from_db()
+        self.assertFalse(self.rnd.per_target_repeat_lock)
+
+
+# ---------------------------------------------------------------------------
+# scene status / no args
+# ---------------------------------------------------------------------------
+
+
+class CmdSceneStatusTests(TestCase):
+    """``scene`` and ``scene status`` show scene + round status."""
+
+    def setUp(self):
+        self.room = _make_room("StatusRoom")
+        self.caller, _account = _create_pc_with_account("StatusPc", location=self.room)
+        self.caller.msg = MagicMock()
+
+    def test_status_no_scene_message(self):
+        """With no active scene, caller is told there's none."""
+        messages = _run_cmd(self.caller, "")
+        self.assertTrue(
+            any("no active scene" in m.lower() for m in messages),
+            f"Expected 'no active scene' message; got: {messages}",
+        )
+
+    def test_status_bare_status_subcommand(self):
+        """``scene status`` behaves the same as bare ``scene``."""
+        messages = _run_cmd(self.caller, "status")
+        self.assertTrue(
+            any("no active scene" in m.lower() for m in messages),
+            f"Expected 'no active scene' message; got: {messages}",
+        )
+
+    def test_status_shows_scene_name(self):
+        """With an active scene, status line contains the scene name."""
+        SceneFactory(location=self.room, is_active=True, name="The Great Hall")
+        messages = _run_cmd(self.caller, "")
+        self.assertTrue(
+            any("Great Hall" in m for m in messages),
+            f"Expected scene name in messages; got: {messages}",
+        )
+
+    def test_status_shows_round_info_when_active(self):
+        """With an active round, status line includes round number and mode."""
+        scene = SceneFactory(location=self.room, is_active=True, name="Round Test")
+        SceneRound.objects.create(
+            room=self.room,
+            status=RoundStatus.DECLARING,
+            round_number=2,
+            start_reason=SceneRoundStartReason.OPT_IN,
+            mode=SceneRoundMode.STRICT,
+            scene=scene,
+        )
+        messages = _run_cmd(self.caller, "")
+        self.assertTrue(
+            any("2" in m for m in messages),
+            f"Expected round number '2' in messages; got: {messages}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# unknown subcommand
+# ---------------------------------------------------------------------------
+
+
+class CmdSceneUnknownTests(TestCase):
+    """Unknown subcommand shows a usage/help message."""
+
+    def setUp(self):
+        self.room = _make_room("UnknownRoom")
+        self.caller, _account = _create_pc_with_account("UnknownPc", location=self.room)
+        self.caller.msg = MagicMock()
+
+    def test_unknown_subcommand_shows_usage(self):
+        """An unrecognized subcommand emits a usage hint."""
+        messages = _run_cmd(self.caller, "frobinate")
+        self.assertTrue(
+            any("usage" in m.lower() or "scene" in m.lower() for m in messages),
+            f"Expected usage message; got: {messages}",
+        )

--- a/src/commands/tests/test_scene_round_journey_e2e.py
+++ b/src/commands/tests/test_scene_round_journey_e2e.py
@@ -1,0 +1,242 @@
+"""E2E telnet journey: scene start → strict mode → guard → force-resolve → finish (#1445).
+
+Drives the full nine-step journey through CmdScene → actions → services,
+asserting both DB state and caller messages at each step.
+
+SQLite-compatible: no CHALLENGE/Postgres-only queries touched.
+
+DbHolder trap: all Evennia ObjectDB instances live in setUp, not setUpTestData.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from commands.scene import CmdScene
+from evennia_extensions.factories import ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.constants import RoundStatus, SceneRoundMode
+from world.scenes.models import (
+    SceneActionDeclaration,
+    SceneParticipation,
+    SceneRound,
+    SceneRoundParticipant,
+)
+
+# Patch broadcast_scene_message at the module finish_scene_full imports it from.
+_BROADCAST_PATH = "world.scenes.scene_admin_services.broadcast_scene_message"
+
+
+def _create_pc_with_account(db_key: str, location=None):
+    """Create a PC character with a live roster tenure (non-None active_account).
+
+    Returns (character, account).
+    Mirrors the helper in world/scenes/tests/test_scene_admin_services.py.
+    """
+    kwargs = {"db_key": db_key}
+    if location is not None:
+        kwargs["location"] = location
+    char = ObjectDBFactory(db_typeclass_path="typeclasses.characters.Character", **kwargs)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    account = tenure.player_data.account
+    return char, account
+
+
+def _run_scene_cmd(caller, args: str) -> list[str]:
+    """Invoke CmdScene with the given args string; return all messages sent to caller."""
+    caller.msg = MagicMock()
+    cmd = CmdScene()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"scene {args}"
+    cmd.func()
+    return [str(call.args[0]) for call in caller.msg.call_args_list if call.args]
+
+
+class SceneRoundJourneyTest(TestCase):
+    """Nine-step E2E telnet journey for the scene-round mode-gate feature (#1445)."""
+
+    def setUp(self) -> None:
+        # DbHolder trap: build all Evennia objects in setUp, never setUpTestData.
+        self.room = ObjectDBFactory(
+            db_key="JourneyRoom",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        # Owner is in the room when scene start runs → becomes co-owner.
+        self.owner, self.owner_account = _create_pc_with_account("JOwner", location=self.room)
+        # Outsider is NOT in the room during scene start; moved in after.
+        # They will be a non-owner participant for permission-denial tests.
+        self.outsider, self.outsider_account = _create_pc_with_account("JOutsider")
+
+    # ------------------------------------------------------------------
+    # Step 1: owner runs `scene start` → scene active, owner is co-owner.
+    # ------------------------------------------------------------------
+
+    def test_step_01_scene_start(self) -> None:
+        with patch(_BROADCAST_PATH):
+            msgs = _run_scene_cmd(self.owner, "start")
+
+        self.assertIn("scene begins", " ".join(msgs).lower())
+
+        from world.scenes.models import Scene
+
+        scene = Scene.objects.filter(location=self.room, is_active=True).first()
+        self.assertIsNotNone(scene, "An active scene should exist after 'scene start'")
+
+        # Owner was in the room at start → becomes a co-owner.
+        self.assertTrue(
+            SceneParticipation.objects.filter(
+                scene=scene, account=self.owner_account, is_owner=True
+            ).exists(),
+            "Owner should be a co-owner",
+        )
+
+    # ------------------------------------------------------------------
+    # Full nine-step journey in one test method.
+    # ------------------------------------------------------------------
+
+    def test_full_nine_step_journey(self) -> None:
+        """Run all nine steps in sequence; assert DB state + messages at each step."""
+
+        # ---- Step 1: owner scene start --------------------------------
+        with patch(_BROADCAST_PATH):
+            msgs = _run_scene_cmd(self.owner, "start")
+
+        self.assertIn("scene begins", " ".join(msgs).lower())
+
+        from world.scenes.models import Scene
+
+        scene = Scene.objects.filter(location=self.room, is_active=True).first()
+        self.assertIsNotNone(scene)
+        # Owner was in the room at start → co-owner.
+        self.assertTrue(
+            SceneParticipation.objects.filter(
+                scene=scene, account=self.owner_account, is_owner=True
+            ).exists(),
+            "Owner should be a co-owner",
+        )
+        # Outsider was NOT in the room → no participation row yet.
+        self.assertFalse(
+            SceneParticipation.objects.filter(scene=scene, account=self.outsider_account).exists(),
+            "Outsider (not present at start) should have no participation row",
+        )
+
+        # ---- Step 2: get an active round ------------------------------
+        # Create a DECLARING SceneRound directly (StartRoundAction requires a
+        # CharacterSheet which owner has; using the action path to stay on the
+        # action seam).
+        from actions.definitions.rounds import StartRoundAction
+
+        result = StartRoundAction().run(actor=self.owner)
+        self.assertTrue(result.success, f"StartRoundAction failed: {result.message}")
+
+        rnd = SceneRound.objects.filter(
+            room=self.room, status__in=[RoundStatus.DECLARING, RoundStatus.BETWEEN_ROUNDS]
+        ).first()
+        self.assertIsNotNone(rnd, "An active SceneRound should exist after StartRoundAction")
+
+        # ---- Step 3: owner scene round strict -------------------------
+        msgs = _run_scene_cmd(self.owner, "round strict")
+        rnd.refresh_from_db()
+        self.assertEqual(
+            rnd.mode,
+            SceneRoundMode.STRICT,
+            f"Round mode should be STRICT; got {rnd.mode}. Messages: {msgs}",
+        )
+
+        # ---- Step 4: simulate a pending (non-immediate) declaration ---
+        # We create the row directly — the guard only checks for
+        # SceneActionDeclaration(is_immediate=False) rows on this round.
+        # Using owner's participant row (created by StartRoundAction).
+        # Use (or create) the owner's participant row for the pending declaration.
+        participant, _ = SceneRoundParticipant.objects.get_or_create(
+            scene_round=rnd,
+            character_sheet=self.owner.sheet_data,
+        )
+
+        pending_decl = SceneActionDeclaration.objects.create(
+            scene_round=rnd,
+            round_number=rnd.round_number,
+            participant=participant,
+            is_immediate=False,
+            is_pass=True,  # minimal: a deferred pass is enough to trigger the guard
+        )
+
+        # ---- Step 5: owner scene round pose_order → REFUSED ----------
+        msgs = _run_scene_cmd(self.owner, "round pose_order")
+        rnd.refresh_from_db()
+
+        # The guard message should mention force-resolve.
+        full_text = " ".join(msgs).lower()
+        self.assertIn(
+            "force",
+            full_text,
+            f"Expected force-resolve guard message; got: {msgs}",
+        )
+        # Mode must still be STRICT.
+        self.assertEqual(
+            rnd.mode,
+            SceneRoundMode.STRICT,
+            "Mode must remain STRICT after guard refusal",
+        )
+
+        # ---- Step 6: force-resolve → pending declaration cleared ------
+        from actions.definitions.rounds import ForceResolveRoundAction
+
+        resolve_result = ForceResolveRoundAction().run(actor=self.owner)
+        self.assertTrue(
+            resolve_result.success, f"ForceResolveRoundAction failed: {resolve_result.message}"
+        )
+
+        # The round has been resolved; round_number is advanced (BETWEEN_ROUNDS → DECLARING
+        # via resolve_scene_round → start_scene_round). Pending declarations for the OLD
+        # round_number are deleted.
+        self.assertFalse(
+            SceneActionDeclaration.objects.filter(pk=pending_decl.pk).exists(),
+            "Pending declaration should be deleted after force-resolve",
+        )
+
+        # ---- Step 7: owner scene round pose_order → SUCCEEDS ---------
+        # After resolve, a new round with a higher round_number is in DECLARING.
+        rnd.refresh_from_db()
+        msgs = _run_scene_cmd(self.owner, "round pose_order")
+        rnd.refresh_from_db()
+        self.assertEqual(
+            rnd.mode,
+            SceneRoundMode.POSE_ORDER,
+            f"Mode should be POSE_ORDER after successful change; got {rnd.mode}. Messages: {msgs}",
+        )
+
+        # ---- Step 8: non-owner outsider tries scene round open → REFUSED ----
+        # Move outsider into the room so they have a location; they are still not a co-owner.
+        self.outsider.location = self.room
+        msgs_second = _run_scene_cmd(self.outsider, "round open")
+        rnd.refresh_from_db()
+        # Mode must not change.
+        self.assertEqual(
+            rnd.mode,
+            SceneRoundMode.POSE_ORDER,
+            "Mode should still be POSE_ORDER after non-owner attempt",
+        )
+        # Caller receives a permission-denial message.
+        denial_text = " ".join(msgs_second).lower()
+        self.assertTrue(
+            any(
+                kw in denial_text
+                for kw in ("owner", "gm", "only", "permission", "cannot", "can't", "may not")
+            ),
+            f"Expected permission-denial message for non-owner; got: {msgs_second}",
+        )
+
+        # ---- Step 9: owner scene finish → scene.is_active == False ----
+        with patch(_BROADCAST_PATH):
+            msgs = _run_scene_cmd(self.owner, "finish")
+
+        scene.refresh_from_db()
+        self.assertFalse(scene.is_active, "Scene should be inactive after 'scene finish'")
+        self.assertIn("close", " ".join(msgs).lower())

--- a/src/commands/tests/test_scene_round_journey_e2e.py
+++ b/src/commands/tests/test_scene_round_journey_e2e.py
@@ -67,11 +67,12 @@ class SceneRoundJourneyTest(TestCase):
             db_key="JourneyRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )
-        # Owner is in the room when scene start runs → becomes co-owner.
+        # Owner AND co-owner are both in the room when scene start runs → both become co-owners.
         self.owner, self.owner_account = _create_pc_with_account("JOwner", location=self.room)
-        # Outsider is NOT in the room during scene start; moved in after.
+        self.coowner, self.coowner_account = _create_pc_with_account("JCoOwner", location=self.room)
+        # Latecomer is NOT in the room during scene start; moved in after.
         # They will be a non-owner participant for permission-denial tests.
-        self.outsider, self.outsider_account = _create_pc_with_account("JOutsider")
+        self.latecomer, self.latecomer_account = _create_pc_with_account("JLatecomer")
 
     # ------------------------------------------------------------------
     # Step 1: owner runs `scene start` → scene active, owner is co-owner.
@@ -94,6 +95,13 @@ class SceneRoundJourneyTest(TestCase):
                 scene=scene, account=self.owner_account, is_owner=True
             ).exists(),
             "Owner should be a co-owner",
+        )
+        # Co-owner was also in the room at start → becomes a co-owner too (key co-ownership design).
+        self.assertTrue(
+            SceneParticipation.objects.filter(
+                scene=scene, account=self.coowner_account, is_owner=True
+            ).exists(),
+            "Second PC present at scene start should also be a co-owner",
         )
 
     # ------------------------------------------------------------------
@@ -120,16 +128,24 @@ class SceneRoundJourneyTest(TestCase):
             ).exists(),
             "Owner should be a co-owner",
         )
-        # Outsider was NOT in the room → no participation row yet.
+        # Second PC (co-owner) was also in the room at start → co-owner too
+        # (key co-ownership design point).
+        self.assertTrue(
+            SceneParticipation.objects.filter(
+                scene=scene, account=self.coowner_account, is_owner=True
+            ).exists(),
+            "Second PC present at scene start should also be a co-owner",
+        )
+        # Latecomer was NOT in the room → no participation row yet.
         self.assertFalse(
-            SceneParticipation.objects.filter(scene=scene, account=self.outsider_account).exists(),
-            "Outsider (not present at start) should have no participation row",
+            SceneParticipation.objects.filter(scene=scene, account=self.latecomer_account).exists(),
+            "Latecomer (not present at start) should have no participation row",
         )
 
         # ---- Step 2: get an active round ------------------------------
-        # Create a DECLARING SceneRound directly (StartRoundAction requires a
-        # CharacterSheet which owner has; using the action path to stay on the
-        # action seam).
+        # StartRoundAction is invoked directly here because CmdScene has no round-*start*
+        # subcommand — its `round` subcommand only sets mode on an existing round.
+        # Using StartRoundAction is intentional, not a bypass of the telnet layer.
         from actions.definitions.rounds import StartRoundAction
 
         result = StartRoundAction().run(actor=self.owner)
@@ -171,10 +187,11 @@ class SceneRoundJourneyTest(TestCase):
         msgs = _run_scene_cmd(self.owner, "round pose_order")
         rnd.refresh_from_db()
 
-        # The guard message should mention force-resolve.
+        # The guard message is the exact service text from round_services.set_scene_round_mode:
+        # "Resolve the current declarations first (force-resolve), then change the mode."
         full_text = " ".join(msgs).lower()
         self.assertIn(
-            "force",
+            "force-resolve",
             full_text,
             f"Expected force-resolve guard message; got: {msgs}",
         )
@@ -202,34 +219,53 @@ class SceneRoundJourneyTest(TestCase):
         )
 
         # ---- Step 7: owner scene round pose_order → SUCCEEDS ---------
-        # After resolve, a new round with a higher round_number is in DECLARING.
-        rnd.refresh_from_db()
+        # After force-resolve, the round may have advanced to a new row.  Re-fetch the
+        # genuinely-active round rather than asserting on the possibly-stale `rnd` object.
+        from actions.definitions.rounds import _active_round_for_room
+
         msgs = _run_scene_cmd(self.owner, "round pose_order")
-        rnd.refresh_from_db()
+        active_rnd = _active_round_for_room(self.room)
+        self.assertIsNotNone(active_rnd, "An active round should still exist after step 7")
         self.assertEqual(
-            rnd.mode,
+            active_rnd.mode,
             SceneRoundMode.POSE_ORDER,
-            f"Mode should be POSE_ORDER after successful change; got {rnd.mode}. Messages: {msgs}",
+            f"Mode should be POSE_ORDER after successful change; got {active_rnd.mode}."
+            f" Messages: {msgs}",
         )
 
-        # ---- Step 8: non-owner outsider tries scene round open → REFUSED ----
-        # Move outsider into the room so they have a location; they are still not a co-owner.
-        self.outsider.location = self.room
-        msgs_second = _run_scene_cmd(self.outsider, "round open")
-        rnd.refresh_from_db()
+        # ---- Step 8: non-owner latecomer tries scene round open → REFUSED ----
+        # Latecomer arrives AFTER scene started so they are not a co-owner.
+        # Persist their location so caller.location is non-None when the action runs.
+        self.latecomer.location = self.room
+        self.latecomer.save()
+        msgs_second = _run_scene_cmd(self.latecomer, "round open")
+        active_rnd_after_8 = _active_round_for_room(self.room)
+        self.assertIsNotNone(
+            active_rnd_after_8, "Active round should survive the non-owner attempt"
+        )
         # Mode must not change.
         self.assertEqual(
-            rnd.mode,
+            active_rnd_after_8.mode,
             SceneRoundMode.POSE_ORDER,
             "Mode should still be POSE_ORDER after non-owner attempt",
         )
-        # Caller receives a permission-denial message.
+        # Denial message must NOT indicate a missing room or missing scene (those would mean
+        # the test environment is broken, not that the permission path was exercised).
         denial_text = " ".join(msgs_second).lower()
-        self.assertTrue(
-            any(
-                kw in denial_text
-                for kw in ("owner", "gm", "only", "permission", "cannot", "can't", "may not")
-            ),
+        self.assertNotIn(
+            "not in a room",
+            denial_text,
+            "Latecomer must have a room location; 'not in a room' means location was not saved",
+        )
+        self.assertNotIn(
+            "no active scene",
+            denial_text,
+            "'no active scene' indicates wrong path — permission gate should fire first",
+        )
+        # The refusal must be the permission-denial message from SetRoundModeAction.
+        self.assertIn(
+            "only the scene",
+            denial_text,
             f"Expected permission-denial message for non-owner; got: {msgs_second}",
         )
 
@@ -239,4 +275,10 @@ class SceneRoundJourneyTest(TestCase):
 
         scene.refresh_from_db()
         self.assertFalse(scene.is_active, "Scene should be inactive after 'scene finish'")
-        self.assertIn("close", " ".join(msgs).lower())
+        # The exact success message from FinishSceneAction.execute():
+        # "The scene comes to a close."
+        self.assertIn(
+            "the scene comes to a close",
+            " ".join(msgs).lower(),
+            f"Expected finish success message; got: {msgs}",
+        )

--- a/src/schema.json
+++ b/src/schema.json
@@ -19721,6 +19721,39 @@ paths:
               schema:
                 $ref: '#/components/schemas/HighlightReel'
           description: ''
+  /api/scenes/{id}/set-round-mode/:
+    post:
+      operationId: scenes_set_round_mode_create
+      description: |-
+        #1445 — Set mode and/or knobs on the active scene round.
+
+        Coarse-gated by ``IsSceneGMOrOwnerOrStaff``; authoritative permission
+        check lives in ``SetRoundModeAction`` (ownership + scene-admin verification).
+        Resolves the requesting account's active character as the action's actor so
+        telnet and web converge on the same ``action.run()`` seam.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this scene.
+        required: true
+      tags:
+      - scenes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SceneDetailRequest'
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SceneDetail'
+          description: ''
   /api/scenes/spotlight/:
     get:
       operationId: scenes_spotlight_retrieve

--- a/src/schema.json
+++ b/src/schema.json
@@ -19744,7 +19744,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SceneDetailRequest'
+              $ref: '#/components/schemas/SetRoundModeRequestRequest'
       security:
       - cookieAuth: []
       responses:
@@ -42352,6 +42352,36 @@ components:
           minimum: 1
       required:
       - persona_id
+    SetRoundModeRequestModeEnum:
+      enum:
+      - open
+      - pose_order
+      - strict
+      type: string
+      description: |-
+        * `open` - Open (immediate, unbounded)
+        * `pose_order` - Pose order (immediate, quota-gated)
+        * `strict` - Strict (declare, batch-resolved)
+    SetRoundModeRequestRequest:
+      type: object
+      description: |-
+        POST body for the #1445 set-round-mode endpoint.
+
+        All fields are optional — callers may change the mode, one or more knobs, or any
+        combination. At least one field should be provided (the action will succeed with
+        a generic message if none are, because the service is a no-op update).
+      properties:
+        mode:
+          $ref: '#/components/schemas/SetRoundModeRequestModeEnum'
+        advance_quorum_pct:
+          type: integer
+          maximum: 100
+          minimum: 0
+        max_actions_per_round:
+          type: integer
+          minimum: 0
+        per_target_repeat_lock:
+          type: boolean
     SignEnum:
       enum:
       - positive

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -56,6 +56,9 @@ class Character(ObjectParent, DefaultCharacter):
     #: GMCharacter and StaffCharacter override this to True.
     is_mechanically_immune: bool = False
 
+    #: True only for GM/Staff "story-runner" characters; gates scene/round admin.
+    is_story_runner: bool = False
+
     state_class = CharacterState
 
     # Example typeclass defaults for item_data fallbacks

--- a/src/typeclasses/gm_characters.py
+++ b/src/typeclasses/gm_characters.py
@@ -48,6 +48,7 @@ class GMCharacter(_MechanicallyImmuneCharacterMixin, Character):
     querying the account's GMProfile.level — not by the typeclass itself.
     """
 
+    is_story_runner: bool = True
     TARGETING_REJECTION = (
         "The GM gives you a knowing look. "
         "'I appreciate the enthusiasm, but I'm just here to tell the story.'"
@@ -63,6 +64,7 @@ class StaffCharacter(_MechanicallyImmuneCharacterMixin, Character):
     authorship is tracked via GMProfile, not this typeclass.
     """
 
+    is_story_runner: bool = True
     TARGETING_REJECTION = (
         "The staff character raises an eyebrow. "
         "'Bold move. Unfortunately, I exist outside the narrative.'"

--- a/src/typeclasses/tests/test_gm_characters.py
+++ b/src/typeclasses/tests/test_gm_characters.py
@@ -55,3 +55,16 @@ class MechanicalImmunityTest(TestCase):
         staff_msg = StaffCharacter.TARGETING_REJECTION
         assert "story" in gm_msg.lower()
         assert "narrative" in staff_msg.lower()
+
+
+class IsStoryRunnerTest(TestCase):
+    """Verify the is_story_runner attribute for story administration."""
+
+    def test_base_character_is_not_story_runner(self) -> None:
+        assert Character.is_story_runner is False
+
+    def test_gm_character_is_story_runner(self) -> None:
+        assert GMCharacter.is_story_runner is True
+
+    def test_staff_character_is_story_runner(self) -> None:
+        assert StaffCharacter.is_story_runner is True

--- a/src/world/scenes/round_services.py
+++ b/src/world/scenes/round_services.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from world.scenes.constants import (
     ACTIVE_SCENE_ROUND_STATUSES,
     RoundStatus,
+    SceneRoundMode,
     SceneRoundParticipantStatus,
     SceneRoundStartReason,
 )
@@ -24,6 +25,73 @@ if TYPE_CHECKING:
     from world.character_sheets.models import CharacterSheet
 
 logger = logging.getLogger(__name__)
+
+
+class RoundModeError(ValueError):
+    """Raised when set_scene_round_mode cannot apply the requested change."""
+
+
+def set_scene_round_mode(
+    scene_round: SceneRound,
+    *,
+    mode: str | None = None,
+    advance_quorum_pct: int | None = None,
+    max_actions_per_round: int | None = None,
+    per_target_repeat_lock: bool | None = None,
+) -> SceneRound:
+    """Apply mode and/or knob changes to *scene_round* in-place.
+
+    Guard order (both raise :class:`RoundModeError`):
+
+    1. **DANGER block**: a DANGER round resolves on its own — its mode is not
+       user-settable.
+    2. **Out-of-STRICT guard**: switching *away* from STRICT while a pending
+       non-immediate declaration exists would orphan those declarations; the
+       caller must force-resolve first.
+
+    Only the supplied (non-None) fields are written; ``save(update_fields=...)``
+    touches nothing else.
+    """
+    from world.scenes.models import SceneActionDeclaration  # noqa: PLC0415
+
+    # Guard 1 — DANGER rounds resolve autonomously; mode is fixed at OPEN.
+    if scene_round.start_reason == SceneRoundStartReason.DANGER:
+        msg = "A danger round resolves on its own; its mode can't be changed."
+        raise RoundModeError(msg)
+
+    # Guard 2 — switching away from STRICT with pending deferred declarations.
+    leaving_strict = (
+        scene_round.mode == SceneRoundMode.STRICT
+        and mode is not None
+        and mode != SceneRoundMode.STRICT
+    )
+    if (
+        leaving_strict
+        and SceneActionDeclaration.objects.filter(
+            scene_round=scene_round, is_immediate=False
+        ).exists()
+    ):
+        msg = "Resolve the current declarations first (force-resolve), then change the mode."
+        raise RoundModeError(msg)
+
+    update_fields: list[str] = []
+    if mode is not None:
+        scene_round.mode = mode
+        update_fields.append("mode")
+    if advance_quorum_pct is not None:
+        scene_round.advance_quorum_pct = advance_quorum_pct
+        update_fields.append("advance_quorum_pct")
+    if max_actions_per_round is not None:
+        scene_round.max_actions_per_round = max_actions_per_round
+        update_fields.append("max_actions_per_round")
+    if per_target_repeat_lock is not None:
+        scene_round.per_target_repeat_lock = per_target_repeat_lock
+        update_fields.append("per_target_repeat_lock")
+
+    if update_fields:
+        scene_round.save(update_fields=update_fields)
+
+    return scene_round
 
 
 def actions_this_round(scene_round: SceneRound, participant: SceneRoundParticipant) -> int:

--- a/src/world/scenes/scene_admin_services.py
+++ b/src/world/scenes/scene_admin_services.py
@@ -1,9 +1,10 @@
 """Scene administration permission helpers.
 
-Three public surfaces:
+Four public surfaces:
   - ``actor_can_administer_scene`` — permission gate for admin actions.
   - ``resolve_actor_account`` — controlling account for a character actor.
   - ``add_present_as_co_owners`` — co-ownership grant for all present PCs.
+  - ``finish_scene_full`` — full scene-finish orchestration (finish, rewards, fatigue, broadcast).
 """
 
 from __future__ import annotations
@@ -12,7 +13,11 @@ from typing import TYPE_CHECKING
 
 from django.core.exceptions import ObjectDoesNotExist
 
+from world.fatigue.tasks import process_deferred_fatigue_resets
+from world.progression.services.scene_rewards import on_scene_finished
+from world.scenes.constants import SceneAction
 from world.scenes.models import Scene, SceneParticipation
+from world.scenes.services import broadcast_scene_message
 
 if TYPE_CHECKING:
     from evennia.accounts.models import AccountDB
@@ -71,3 +76,32 @@ def add_present_as_co_owners(scene: Scene, room: ObjectDB) -> None:
             account=account,
             defaults={"is_owner": True},
         )
+
+
+def finish_scene_full(scene: Scene, by_account: AccountDB | None = None) -> None:  # noqa: ARG001
+    """Run the full scene-finish orchestration.
+
+    Idempotent: returns immediately if the scene is already finished
+    (``scene.is_finished`` is True), so calling twice is safe.
+
+    Steps (in order):
+    1. ``scene.finish_scene()`` — sets ``date_finished`` + ``is_active=False``.
+    2. ``on_scene_finished(scene)`` — awards scene-completion progression rewards.
+    3. ``process_deferred_fatigue_resets`` — drains any pending fatigue-reset
+       tasks for all participant accounts.
+    4. ``broadcast_scene_message(scene, SceneAction.END)`` — pushes the END
+       event over the scene's WebSocket channel.
+
+    ``by_account`` is accepted for call-site symmetry (so both the web viewset
+    and the upcoming ``FinishSceneAction`` can pass their actor without branching)
+    but the existing orchestration did not use the requesting account, so it is
+    not forwarded to any of the above.
+    """
+    if scene.is_finished:
+        return
+
+    scene.finish_scene()
+    on_scene_finished(scene)
+    participant_account_ids = set(scene.participations.values_list("account_id", flat=True))
+    process_deferred_fatigue_resets(participant_account_ids)
+    broadcast_scene_message(scene, SceneAction.END)

--- a/src/world/scenes/scene_admin_services.py
+++ b/src/world/scenes/scene_admin_services.py
@@ -1,0 +1,73 @@
+"""Scene administration permission helpers.
+
+Three public surfaces:
+  - ``actor_can_administer_scene`` — permission gate for admin actions.
+  - ``resolve_actor_account`` — controlling account for a character actor.
+  - ``add_present_as_co_owners`` — co-ownership grant for all present PCs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.core.exceptions import ObjectDoesNotExist
+
+from world.scenes.models import Scene, SceneParticipation
+
+if TYPE_CHECKING:
+    from evennia.accounts.models import AccountDB
+    from evennia.objects.models import ObjectDB
+
+
+def resolve_actor_account(actor: ObjectDB) -> AccountDB | None:
+    """Return the controlling account for ``actor`` (PC tenure path).
+
+    Returns None for GM/Staff/NPC characters that have no roster tenure
+    linking them to a player account.
+    """
+    return actor.active_account
+
+
+def actor_can_administer_scene(actor: ObjectDB, scene: Scene) -> bool:
+    """Return True if ``actor`` may administer ``scene``.
+
+    Authorization tiers (first match wins):
+    1. ``actor.is_story_runner`` — GM/Staff characters gate as True with no
+       account lookup.
+    2. The actor's controlling account is a staff user.
+    3. The actor's controlling account is a scene co-owner (``is_owner=True``
+       on their ``SceneParticipation`` row).
+    """
+    if actor.is_story_runner:
+        return True
+    account = resolve_actor_account(actor)
+    if account is None:
+        return False
+    if account.is_staff:
+        return True
+    return scene.is_owner(account)
+
+
+def add_present_as_co_owners(scene: Scene, room: ObjectDB) -> None:
+    """Mark every present character with a controlling account as a scene co-owner.
+
+    Walks ``room.contents`` for objects with a ``sheet_data`` attribute (i.e.
+    characters with a CharacterSheet), resolves their controlling account via
+    ``character.active_account``, and ``update_or_create``s a
+    ``SceneParticipation`` row with ``is_owner=True``.  Objects without a
+    sheet (NPCs, props, etc.) and characters without a controlling account
+    (GM/Staff characters, bare NPCs) are silently skipped.
+    """
+    for obj in room.contents:
+        try:
+            obj.sheet_data  # noqa: B018 — attribute access guards NPC/prop skip
+        except (AttributeError, ObjectDoesNotExist):
+            continue
+        account = obj.active_account
+        if account is None:
+            continue
+        SceneParticipation.objects.update_or_create(
+            scene=scene,
+            account=account,
+            defaults={"is_owner": True},
+        )

--- a/src/world/scenes/serializers.py
+++ b/src/world/scenes/serializers.py
@@ -7,7 +7,7 @@ from world.areas.positioning.serializers import (
     PositionAdjacencyItemSerializer,
     PositionSummarySerializer,
 )
-from world.scenes.constants import ScenePrivacyMode
+from world.scenes.constants import ScenePrivacyMode, SceneRoundMode
 from world.scenes.models import (
     Persona,
     Scene,
@@ -417,3 +417,17 @@ class ActivePersonaResultSerializer(serializers.Serializer):
     """Result of the #981 set-active-persona endpoint — the now-worn face id."""
 
     active_persona_id = serializers.IntegerField(read_only=True)
+
+
+class SetRoundModeRequestSerializer(serializers.Serializer):
+    """POST body for the #1445 set-round-mode endpoint.
+
+    All fields are optional — callers may change the mode, one or more knobs, or any
+    combination. At least one field should be provided (the action will succeed with
+    a generic message if none are, because the service is a no-op update).
+    """
+
+    mode = serializers.ChoiceField(choices=SceneRoundMode.choices, required=False)
+    advance_quorum_pct = serializers.IntegerField(min_value=0, max_value=100, required=False)
+    max_actions_per_round = serializers.IntegerField(min_value=0, required=False)
+    per_target_repeat_lock = serializers.BooleanField(required=False)

--- a/src/world/scenes/tests/test_round_mode_services.py
+++ b/src/world/scenes/tests/test_round_mode_services.py
@@ -1,0 +1,109 @@
+"""Tests for set_scene_round_mode and RoundModeError."""
+
+from django.test import TestCase
+
+from world.scenes.constants import SceneRoundMode, SceneRoundStartReason
+from world.scenes.factories import SceneRoundFactory, SceneRoundParticipantFactory
+from world.scenes.models import SceneActionDeclaration
+from world.scenes.round_services import RoundModeError, set_scene_round_mode
+
+
+class SetSceneRoundModeTests(TestCase):
+    def test_into_strict_is_allowed_live(self):
+        """Switching an OPEN/POSE_ORDER round to STRICT is always allowed."""
+        rnd = SceneRoundFactory(mode=SceneRoundMode.POSE_ORDER)
+        result = set_scene_round_mode(rnd, mode=SceneRoundMode.STRICT)
+        rnd.refresh_from_db()
+        self.assertEqual(rnd.mode, SceneRoundMode.STRICT)
+        self.assertIs(result, rnd)
+
+    def test_change_knobs_only_allowed(self):
+        """Changing quorum/cap/lock with mode=None never triggers either guard."""
+        rnd = SceneRoundFactory(
+            mode=SceneRoundMode.STRICT,
+            advance_quorum_pct=60,
+            max_actions_per_round=1,
+            per_target_repeat_lock=False,
+        )
+        result = set_scene_round_mode(
+            rnd,
+            advance_quorum_pct=80,
+            max_actions_per_round=2,
+            per_target_repeat_lock=True,
+        )
+        rnd.refresh_from_db()
+        self.assertEqual(rnd.advance_quorum_pct, 80)
+        self.assertEqual(rnd.max_actions_per_round, 2)
+        self.assertTrue(rnd.per_target_repeat_lock)
+        # mode unchanged
+        self.assertEqual(rnd.mode, SceneRoundMode.STRICT)
+        self.assertIs(result, rnd)
+
+    def test_out_of_strict_with_pending_declaration_raises(self):
+        """Switching away from STRICT while a pending non-immediate declaration exists raises."""
+        rnd = SceneRoundFactory(mode=SceneRoundMode.STRICT)
+        participant = SceneRoundParticipantFactory(scene_round=rnd)
+        # Create a pending non-immediate declaration (deferred STRICT ledger row).
+        SceneActionDeclaration.objects.create(
+            scene_round=rnd,
+            round_number=rnd.round_number,
+            participant=participant,
+            is_immediate=False,
+            is_pass=False,
+        )
+        with self.assertRaises(RoundModeError):
+            set_scene_round_mode(rnd, mode=SceneRoundMode.POSE_ORDER)
+
+    def test_out_of_strict_without_pending_is_allowed(self):
+        """Switching away from STRICT with NO pending declarations is permitted."""
+        rnd = SceneRoundFactory(mode=SceneRoundMode.STRICT)
+        result = set_scene_round_mode(rnd, mode=SceneRoundMode.OPEN)
+        rnd.refresh_from_db()
+        self.assertEqual(rnd.mode, SceneRoundMode.OPEN)
+        self.assertIs(result, rnd)
+
+    def test_danger_round_raises(self):
+        """Any mode/knob change on a DANGER round is blocked."""
+        # DANGER rounds are forced to OPEN at creation (model.save), so start_reason is enough.
+        rnd = SceneRoundFactory(start_reason=SceneRoundStartReason.DANGER)
+        with self.assertRaises(RoundModeError):
+            set_scene_round_mode(rnd, mode=SceneRoundMode.OPEN)
+
+    def test_danger_round_raises_even_for_knob_only(self):
+        """Knob-only changes on a DANGER round are also blocked (DANGER guard fires first)."""
+        rnd = SceneRoundFactory(start_reason=SceneRoundStartReason.DANGER)
+        with self.assertRaises(RoundModeError):
+            set_scene_round_mode(rnd, advance_quorum_pct=50)
+
+    def test_only_changed_fields_saved(self):
+        """save(update_fields=...) is called with only the supplied fields (no extra writes)."""
+        rnd = SceneRoundFactory(
+            mode=SceneRoundMode.POSE_ORDER,
+            advance_quorum_pct=60,
+            max_actions_per_round=1,
+            per_target_repeat_lock=False,
+        )
+        set_scene_round_mode(rnd, advance_quorum_pct=75)
+        rnd.refresh_from_db()
+        # Only advance_quorum_pct changed; others untouched.
+        self.assertEqual(rnd.advance_quorum_pct, 75)
+        self.assertEqual(rnd.mode, SceneRoundMode.POSE_ORDER)
+        self.assertEqual(rnd.max_actions_per_round, 1)
+        self.assertFalse(rnd.per_target_repeat_lock)
+
+    def test_immediate_only_declarations_do_not_block_out_of_strict(self):
+        """Only is_immediate=False rows trigger the out-of-STRICT guard; immediate rows don't."""
+        rnd = SceneRoundFactory(mode=SceneRoundMode.STRICT)
+        participant = SceneRoundParticipantFactory(scene_round=rnd)
+        # An immediate row (POSE_ORDER/OPEN resolved action) — must NOT block.
+        SceneActionDeclaration.objects.create(
+            scene_round=rnd,
+            round_number=rnd.round_number,
+            participant=participant,
+            is_immediate=True,
+            is_pass=False,
+        )
+        result = set_scene_round_mode(rnd, mode=SceneRoundMode.POSE_ORDER)
+        rnd.refresh_from_db()
+        self.assertEqual(rnd.mode, SceneRoundMode.POSE_ORDER)
+        self.assertIs(result, rnd)

--- a/src/world/scenes/tests/test_scene_admin_services.py
+++ b/src/world/scenes/tests/test_scene_admin_services.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from evennia_extensions.factories import (
@@ -20,6 +22,7 @@ from world.scenes.models import SceneParticipation
 from world.scenes.scene_admin_services import (
     actor_can_administer_scene,
     add_present_as_co_owners,
+    finish_scene_full,
     resolve_actor_account,
 )
 
@@ -174,3 +177,63 @@ class AddPresentAsCoOwnersTests(TestCase):
         assert SceneParticipation.objects.filter(
             scene=scene, account=account_pc, is_owner=True
         ).exists()
+
+
+class FinishSceneFullTests(TestCase):
+    _PATCH_BASE = "world.scenes.scene_admin_services"
+
+    def test_sets_is_active_false_and_date_finished(self):
+        scene = SceneFactory(is_active=True)
+        assert scene.is_finished is False
+
+        with (
+            patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            finish_scene_full(scene)
+
+        scene.refresh_from_db()
+        assert scene.is_active is False
+        assert scene.date_finished is not None
+        assert scene.is_finished is True
+
+    def test_calls_on_scene_finished(self):
+        scene = SceneFactory(is_active=True)
+
+        with (
+            patch(f"{self._PATCH_BASE}.on_scene_finished") as mock_on_finished,
+            patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            finish_scene_full(scene)
+
+        mock_on_finished.assert_called_once_with(scene)
+
+    def test_idempotent_when_already_finished(self):
+        """Calling finish_scene_full on an already-finished scene is a no-op."""
+        scene = SceneFactory(is_active=True)
+        # First finish
+        with (
+            patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            finish_scene_full(scene)
+
+        scene.refresh_from_db()
+        first_date_finished = scene.date_finished
+
+        # Second call should be a no-op
+        with (
+            patch(f"{self._PATCH_BASE}.on_scene_finished") as mock_on_finished,
+            patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets") as mock_fatigue,
+            patch(f"{self._PATCH_BASE}.broadcast_scene_message") as mock_broadcast,
+        ):
+            finish_scene_full(scene)
+
+        mock_on_finished.assert_not_called()
+        mock_fatigue.assert_not_called()
+        mock_broadcast.assert_not_called()
+        scene.refresh_from_db()
+        assert scene.date_finished == first_date_finished

--- a/src/world/scenes/tests/test_scene_admin_services.py
+++ b/src/world/scenes/tests/test_scene_admin_services.py
@@ -1,0 +1,176 @@
+"""Tests for world.scenes.scene_admin_services."""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from evennia_extensions.factories import (
+    CharacterFactory,
+    GMCharacterFactory,
+    ObjectDBFactory,
+)
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.factories import (
+    SceneFactory,
+    SceneOwnerParticipationFactory,
+    SceneParticipationFactory,
+)
+from world.scenes.models import SceneParticipation
+from world.scenes.scene_admin_services import (
+    actor_can_administer_scene,
+    add_present_as_co_owners,
+    resolve_actor_account,
+)
+
+
+def _create_pc_with_account(db_key: str, location=None):
+    """Create a PC character with a live roster tenure (non-None active_account).
+
+    Returns (character, account).
+    """
+    kwargs = {"db_key": db_key}
+    if location is not None:
+        kwargs["location"] = location
+    char = CharacterFactory(**kwargs)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    account = tenure.player_data.account
+    return char, account
+
+
+class ResolveActorAccountTests(TestCase):
+    def test_returns_account_for_pc_with_tenure(self):
+        char, account = _create_pc_with_account("Alice")
+        result = resolve_actor_account(char)
+        assert result is not None
+        assert result.pk == account.pk
+
+    def test_returns_none_for_gm_character(self):
+        gm = GMCharacterFactory(db_key="GM_Test")
+        result = resolve_actor_account(gm)
+        assert result is None
+
+    def test_returns_none_for_character_without_sheet(self):
+        char = CharacterFactory(db_key="NPC_Test")
+        result = resolve_actor_account(char)
+        assert result is None
+
+
+class ActorCanAdministerSceneTests(TestCase):
+    def setUp(self):
+        self.scene = SceneFactory()
+
+    def test_owner_can_administer(self):
+        char, account = _create_pc_with_account("Alice")
+        SceneOwnerParticipationFactory(scene=self.scene, account=account)
+        assert actor_can_administer_scene(char, self.scene) is True
+
+    def test_non_owner_pc_cannot_administer(self):
+        char, account = _create_pc_with_account("Bob")
+        # Participant, not owner
+        SceneParticipationFactory(scene=self.scene, account=account)
+        assert actor_can_administer_scene(char, self.scene) is False
+
+    def test_pc_not_in_scene_cannot_administer(self):
+        char, _ = _create_pc_with_account("Carol")
+        assert actor_can_administer_scene(char, self.scene) is False
+
+    def test_staff_account_can_administer(self):
+        char, account = _create_pc_with_account("Dave")
+        account.is_staff = True
+        account.save()
+        assert actor_can_administer_scene(char, self.scene) is True
+
+    def test_story_runner_character_can_administer(self):
+        gm = GMCharacterFactory(db_key="GMRunner")
+        # GM has no account — authorized by is_story_runner alone
+        assert actor_can_administer_scene(gm, self.scene) is True
+
+
+class AddPresentAsCoOwnersTests(TestCase):
+    def test_marks_all_present_pcs_as_owners(self):
+        room = ObjectDBFactory(
+            db_key="TestRoom",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        _char_a, account_a = _create_pc_with_account("Alice", location=room)
+        _char_b, account_b = _create_pc_with_account("Bob", location=room)
+        scene = SceneFactory()
+
+        add_present_as_co_owners(scene, room)
+
+        assert SceneParticipation.objects.filter(
+            scene=scene, account=account_a, is_owner=True
+        ).exists()
+        assert SceneParticipation.objects.filter(
+            scene=scene, account=account_b, is_owner=True
+        ).exists()
+
+    def test_skips_object_without_account(self):
+        room = ObjectDBFactory(
+            db_key="TestRoom2",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        # NPC: character without a roster tenure (no active_account)
+        npc = CharacterFactory(db_key="NPC_Skip", location=room)
+        CharacterSheetFactory(character=npc)
+        # No RosterTenure -> active_account is None
+        scene = SceneFactory()
+
+        add_present_as_co_owners(scene, room)
+
+        assert SceneParticipation.objects.filter(scene=scene).count() == 0
+
+    def test_skips_object_without_sheet(self):
+        room = ObjectDBFactory(
+            db_key="TestRoom3",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        # Bare object with no sheet (e.g. a prop)
+        ObjectDBFactory(
+            db_key="Prop",
+            db_typeclass_path="typeclasses.objects.Object",
+            location=room,
+        )
+        scene = SceneFactory()
+
+        add_present_as_co_owners(scene, room)
+
+        assert SceneParticipation.objects.filter(scene=scene).count() == 0
+
+    def test_upgrades_existing_participation_to_owner(self):
+        room = ObjectDBFactory(
+            db_key="TestRoom4",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        _char, account = _create_pc_with_account("Eve", location=room)
+        scene = SceneFactory()
+        # Pre-create participation without owner flag
+        SceneParticipationFactory(scene=scene, account=account, is_owner=False)
+
+        add_present_as_co_owners(scene, room)
+
+        part = SceneParticipation.objects.get(scene=scene, account=account)
+        assert part.is_owner is True
+
+    def test_mixed_room_only_pcs_with_accounts_become_owners(self):
+        room = ObjectDBFactory(
+            db_key="TestRoom5",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        _char_pc, account_pc = _create_pc_with_account("Frank", location=room)
+        # NPC: sheet but no tenure
+        npc = CharacterFactory(db_key="NPC_Mixed", location=room)
+        CharacterSheetFactory(character=npc)
+        GMCharacterFactory(db_key="GM_Mixed", location=room)
+        scene = SceneFactory()
+
+        add_present_as_co_owners(scene, room)
+
+        # Only the real PC should be marked owner
+        assert SceneParticipation.objects.filter(scene=scene).count() == 1
+        assert SceneParticipation.objects.filter(
+            scene=scene, account=account_pc, is_owner=True
+        ).exists()

--- a/src/world/scenes/tests/test_views.py
+++ b/src/world/scenes/tests/test_views.py
@@ -4,17 +4,24 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from core_management.test_utils import suppress_permission_errors
-from evennia_extensions.factories import AccountFactory, ObjectDBFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
-from world.scenes.constants import ScenePrivacyMode
+from world.scenes.constants import (
+    RoundStatus,
+    ScenePrivacyMode,
+    SceneRoundMode,
+    SceneRoundStartReason,
+)
 from world.scenes.factories import (
     InteractionFactory,
     PersonaFactory,
     SceneFactory,
+    SceneOwnerParticipationFactory,
     SceneParticipationFactory,
+    SceneRoundFactory,
 )
-from world.scenes.models import Persona, Scene
+from world.scenes.models import Persona, Scene, SceneRound
 
 
 def _create_owned_persona(account, **persona_kwargs):
@@ -236,6 +243,99 @@ class SceneViewSetTestCase(APITestCase):
         scene.refresh_from_db()
         assert not scene.is_active
         assert scene.date_finished is not None
+
+
+def _setup_owner_with_character(account):
+    """Create a Character in a Room associated with account via RosterTenure.
+
+    Returns (character, room).  The character's location is set to the room
+    so that action.run(actor=character) can find the room's active scene.
+    """
+    room = ObjectDBFactory(
+        db_key=f"Room_{account.username}",
+        db_typeclass_path="typeclasses.rooms.Room",
+    )
+    char = CharacterFactory(location=room)
+    sheet = CharacterSheetFactory(character=char)
+    player_data, _ = PlayerDataFactory._meta.model.objects.get_or_create(account=account)
+    roster_entry = RosterEntryFactory(character_sheet=sheet)
+    RosterTenureFactory(player_data=player_data, roster_entry=roster_entry)
+    return char, room
+
+
+class SetRoundModeViewTestCase(APITestCase):
+    """Tests for POST /api/scenes/{id}/set-round-mode/ (#1445)."""
+
+    def setUp(self):
+        self.account = AccountFactory()
+        self.client.force_authenticate(user=self.account)
+        self.char, self.room = _setup_owner_with_character(self.account)
+        self.scene = SceneFactory(location=self.room, is_active=True)
+        SceneOwnerParticipationFactory(scene=self.scene, account=self.account)
+        self.round = SceneRoundFactory(
+            room=self.room,
+            scene=self.scene,
+            status=RoundStatus.DECLARING,
+            round_number=1,
+            mode=SceneRoundMode.POSE_ORDER,
+        )
+
+    def test_owner_set_mode_strict_returns_200(self):
+        """Owner POSTs mode:strict → 200 and the round mode is STRICT."""
+        url = reverse("scene-set-round-mode", kwargs={"pk": self.scene.pk})
+        response = self.client.post(url, {"mode": "strict"}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        self.round.refresh_from_db()
+        assert self.round.mode == SceneRoundMode.STRICT
+
+    def test_owner_response_contains_scene_data(self):
+        """Owner success returns the serialized scene (SceneDetailSerializer shape)."""
+        url = reverse("scene-set-round-mode", kwargs={"pk": self.scene.pk})
+        response = self.client.post(url, {"mode": "open"}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "id" in response.data
+        assert response.data["id"] == self.scene.pk
+
+    def test_non_owner_non_staff_gets_403(self):
+        """A different authenticated account that isn't a scene GM/owner gets 403."""
+        other_account = AccountFactory()
+        self.client.force_authenticate(user=other_account)
+        url = reverse("scene-set-round-mode", kwargs={"pk": self.scene.pk})
+        response = self.client.post(url, {"mode": "strict"}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_danger_round_returns_400_with_service_message(self):
+        """DANGER round → action refuses with a 400 carrying the service's message."""
+        # Replace the existing round with a DANGER round.
+        self.round.delete()
+        SceneRound.objects.create(
+            room=self.room,
+            scene=self.scene,
+            status=RoundStatus.DECLARING,
+            round_number=1,
+            start_reason=SceneRoundStartReason.DANGER,
+        )
+        url = reverse("scene-set-round-mode", kwargs={"pk": self.scene.pk})
+        response = self.client.post(url, {"mode": "strict"}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "detail" in response.data
+
+    def test_no_active_character_returns_400(self):
+        """Account with no active roster tenure → 400 'No active character.'"""
+        bare_account = AccountFactory()
+        self.client.force_authenticate(user=bare_account)
+        # Make bare_account a scene owner at the DRF permission layer so we get
+        # through IsSceneGMOrOwnerOrStaff, then hit the actor-resolution branch.
+        SceneOwnerParticipationFactory(scene=self.scene, account=bare_account)
+        url = reverse("scene-set-round-mode", kwargs={"pk": self.scene.pk})
+        response = self.client.post(url, {"mode": "open"}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["detail"] == "No active character."
 
 
 class PersonaViewSetTestCase(APITestCase):

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -272,6 +272,9 @@ class SceneViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(scene)
         return Response(serializer.data)
 
+    @extend_schema(
+        request=SetRoundModeRequestSerializer, responses=SceneDetailSerializer, tags=["scenes"]
+    )
     @action(detail=True, methods=[HTTPMethod.POST], url_path="set-round-mode")
     def set_round_mode(self, request: Request, pk: int | None = None) -> Response:
         """#1445 — Set mode and/or knobs on the active scene round.

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -48,6 +48,7 @@ from world.scenes.serializers import (
     ScenesSpotlightSerializer,
     SceneSummaryRevisionSerializer,
     SetActivePersonaRequestSerializer,
+    SetRoundModeRequestSerializer,
 )
 from world.scenes.services import ActivePersonaError, broadcast_scene_message, set_active_persona
 from world.societies.renown_serializers import (
@@ -203,8 +204,8 @@ class SceneViewSet(viewsets.ModelViewSet):
         """
         Instantiate and return the list of permissions required for this view.
         """
-        if self.action == "finish":
-            # Only scene owners/GMs or staff can finish scenes
+        if self.action in ["finish", "set_round_mode"]:
+            # Only scene owners/GMs or staff can finish scenes or set round mode
             permission_classes = [IsSceneGMOrOwnerOrStaff]
         elif self.action in ["update", "partial_update", "destroy"]:
             # Only scene owners or staff can modify/delete scenes
@@ -270,6 +271,37 @@ class SceneViewSet(viewsets.ModelViewSet):
         finish_scene_full(scene)
         serializer = self.get_serializer(scene)
         return Response(serializer.data)
+
+    @action(detail=True, methods=[HTTPMethod.POST], url_path="set-round-mode")
+    def set_round_mode(self, request: Request, pk: int | None = None) -> Response:
+        """#1445 — Set mode and/or knobs on the active scene round.
+
+        Coarse-gated by ``IsSceneGMOrOwnerOrStaff``; authoritative permission
+        check lives in ``SetRoundModeAction`` (ownership + scene-admin verification).
+        Resolves the requesting account's active character as the action's actor so
+        telnet and web converge on the same ``action.run()`` seam.
+        """
+        from actions.definitions.rounds import SetRoundModeAction  # noqa: PLC0415
+        from world.character_sheets.models import CharacterSheet  # noqa: PLC0415
+
+        scene = self.get_object()
+        serializer = SetRoundModeRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        active_sheet = CharacterSheet.objects.filter(
+            roster_entry__tenures__player_data__account=request.user,
+            roster_entry__tenures__end_date__isnull=True,
+        ).first()
+        if active_sheet is None:
+            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+
+        actor = active_sheet.character
+        result = SetRoundModeAction().run(actor=actor, **serializer.validated_data)
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+
+        response_serializer = self.get_serializer(scene)
+        return Response(response_serializer.data)
 
     @extend_schema(responses=SceneActivitySerializer, tags=["scenes"])
     @action(detail=True, methods=[HTTPMethod.GET])

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -13,8 +13,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
-from world.fatigue.tasks import process_deferred_fatigue_resets
-from world.progression.services.scene_rewards import on_scene_finished
 from world.scenes.constants import SceneAction, ScenePrivacyMode
 from world.scenes.filters import (
     PersonaFilter,
@@ -40,6 +38,7 @@ from world.scenes.permissions import (
     IsSceneOwnerOrStaff,
     ReadOnlyOrSceneParticipant,
 )
+from world.scenes.scene_admin_services import finish_scene_full
 from world.scenes.serializers import (
     ActivePersonaResultSerializer,
     HighlightReelSerializer,
@@ -268,11 +267,7 @@ class SceneViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        scene.finish_scene()
-        on_scene_finished(scene)
-        participant_account_ids = set(scene.participations.values_list("account_id", flat=True))
-        process_deferred_fatigue_resets(participant_account_ids)
-        broadcast_scene_message(scene, SceneAction.END)
+        finish_scene_full(scene)
         serializer = self.get_serializer(scene)
         return Response(serializer.data)
 


### PR DESCRIPTION
Closes #1445

## Summary

Adds a scene-administration telnet command and a per-scene round-resolution-mode control surface, so a scene's GM/Staff character or a co-owner can set the round mode + pose-order knobs per scene instead of only via the global admin default.

**Scope (expanded per design discussion):** the enabling scene-administration command was folded in — there was no telnet surface to create/finish scenes.

**What shipped:**
- `Character.is_story_runner` marker (GM/Staff characters), the real GM signal — not the dead `SceneParticipation.is_gm`.
- Scene-admin services: `actor_can_administer_scene` (GM/Staff character OR scene co-owner OR staff), `add_present_as_co_owners` (everyone present at scene **creation** co-owns it; latecomers are non-owners — anti-grab), `finish_scene_full` (extracted from the viewset; web + action now share it).
- `set_scene_round_mode` service + `RoundModeError`: live mode change with guards — DANGER blocked; leaving STRICT with pending declarations refused (force-resolve first).
- Actions `StartSceneAction`/`FinishSceneAction`/`SetRoundModeAction` + a gated `StartRoundAction` mode/knob override.
- Telnet `CmdScene`: `scene` / `scene start [name]` / `scene finish` / `scene round <open|pose_order|strict> [quorum= cap= lock=]`.
- Web `POST /api/scenes/{id}/set-round-mode/` (dispatches the action; single permission source) + regenerated schema/api types.
- Scenes have **multiple co-owners**; setting mode/finishing requires a scene + admin. DANGER stays forced-OPEN/self-resolving.

**Tests:** unit (guards, permission tiers, co-ownership), action-level refusal matrix, command parsing, web 200/403/400, and a full 9-step E2E telnet journey (start→strict→declare→guarded refusal→force-resolve→switch→latecomer denial→finish). No model fields added → no migration.

**Deferred (filed):** #1466 (unify DANGER as a STRICT specialization), #1467 (React control for web parity, #1328).

## Follow-ups filed

- #1466
- #1467

## Notes

- Spec: reviewed & approved on #1445 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: main unchanged since branch base (0 new commits, no file overlap); no rebase needed. No migrations (no model fields added).

<!-- last-addressed-comment: 0 -->