### PR TITLE
Frontend: React control for scene round resolution mode (web parity for #1445)

### DIFF
--- a/docs/roadmap/rp-scenes.md
+++ b/docs/roadmap/rp-scenes.md
@@ -166,13 +166,24 @@ GM and co-owner tooling for scene lifecycle and round-mode adjustment, delivered
 - **Web:** `POST /api/scenes/{id}/set-round-mode/` (gated `IsSceneGMOrOwnerOrStaff`,
   dispatches `SetRoundModeAction`).
 
-**Deferred follow-ups (filed as issues):**
+**Deferred follow-up:**
 
 - DANGER → STRICT unification: DANGER rounds are currently forced to OPEN and not
   user-settable; a future slice allows a scene admin to shift a live DANGER round into
   the three-mode framework.
-- React round-mode control for frontend parity (linked to #1328): `scene round` is
-  telnet-only; a web panel is a follow-up.
+
+### Web Round-Mode Control — DONE (#1467, parity for #1445)
+
+Frontend parity for `scene round` (telnet):
+
+- **`active_round` read field** on `SceneDetailSerializer` — `SceneRoundSerializer` (read-only)
+  nested under the scene detail. Fields: `mode`, `advance_quorum_pct`, `max_actions_per_round`,
+  `per_target_repeat_lock`, `status`, `round_number`, `is_danger`. `null` when no active round.
+- **`active_round_for_room(room) -> SceneRound | None`** promoted to a public service in
+  `round_services.py` (was a private action helper); consumed by `SceneDetailSerializer.get_active_round`.
+- **`RoundSettingsDialog`** (`frontend/src/scenes/components/RoundSettingsDialog.tsx`) — GM/owner/
+  staff-gated React dialog; reads `active_round` from the scene detail and dispatches
+  `useSetRoundMode` → `POST /api/scenes/{id}/set-round-mode/`. Wired into `SceneHeader.tsx`.
 
 **Details:** [scenes.md](../systems/scenes.md) §"Scene Administration (#1445)"
 

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -669,6 +669,9 @@ action consent flow, and a three-mode non-combat round framework.
     Public API consumed by combat to record fighters as first-class scene participants.
   - **Round framework (`round_services.py`, #1351):**
     - `get_scene_round_defaults_config() -> SceneRoundDefaultsConfig` (`models.py`) — get-or-create the singleton config.
+    - `active_round_for_room(room) -> SceneRound | None` — public service; returns the active
+      (non-completed) round for a room, or None. One-active-round-per-room constraint makes
+      `.first()` unambiguous. Consumed by `SceneDetailSerializer.get_active_round` (#1467).
     - `actions_this_round(scene_round, participant) -> int` — declaration count for a participant.
     - `distinct_actors_this_round(scene_round) -> int` — distinct participants with declarations this round.
     - `record_pose_order_action(scene_round, participant, target_persona=None)` — write an `is_immediate=True` ledger row.
@@ -713,7 +716,14 @@ action consent flow, and a three-mode non-combat round framework.
   - `SetRoundModeAction` (key `"set_round_mode"`, `actions/definitions/rounds.py`) — changes mode/knobs of active round; gated by `actor_can_administer_scene`; `costs_turn=False`.
 - **`CmdScene`** (`commands/scene.py`) — telnet face for `scene start [name]` / `scene finish` / `scene round [open|pose_order|strict] [quorum=<pct>] [cap=<n>] [lock=on/off]` / `scene status`. Thin over the three Actions above; no business logic.
 - **`is_story_runner`** character property (`typeclasses/characters.py`) — `False` on base `Character`; `True` on `GMCharacter` and `StaffCharacter` (`typeclasses/gm_characters.py`); used by `actor_can_administer_scene` as the GM/Staff fast-path.
-- **New API endpoint:** `POST /api/scenes/{id}/set-round-mode/` — coarse-gated `IsSceneGMOrOwnerOrStaff`; dispatches `SetRoundModeAction`; returns updated scene detail.
+- **API endpoint:** `POST /api/scenes/{id}/set-round-mode/` — coarse-gated `IsSceneGMOrOwnerOrStaff`; dispatches `SetRoundModeAction`; returns updated scene detail.
+- **`active_round` read field on `SceneDetailSerializer`** (#1467): nullable nested field serialized by
+  `SceneRoundSerializer` (read-only). Exposes `mode`, `advance_quorum_pct`, `max_actions_per_round`,
+  `per_target_repeat_lock`, `status`, `round_number`, `is_danger`. `null` when no location or no active round.
+- **`RoundSettingsDialog`** (React, `frontend/src/scenes/components/RoundSettingsDialog.tsx`, #1467):
+  GM/owner/staff-gated (`viewer_can_gm && is_active`) dialog for setting round mode and knobs;
+  consumes `active_round` from the scene detail and dispatches `useSetRoundMode` →
+  `POST /api/scenes/{id}/set-round-mode/`. Wired into `SceneHeader.tsx`.
 - **Integrates with:** roster (characters), stories (EpisodeScene join), instances (preservation check),
   flows (auto-logging via message_location), combat (encounter read gate + participation convergence via
   `Scene.objects.viewable_by` / `ensure_scene_participation`),

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -487,6 +487,18 @@ Finishes the active scene in the actor's room. Gated by `actor_can_administer_sc
 a GM character, staff account, or scene co-owner succeeds. Delegates to `finish_scene_full`
 for full orchestration.
 
+### Round-mode service — active_round_for_room
+
+```python
+from world.scenes.round_services import active_round_for_room
+
+# Return the active (non-completed) SceneRound for a room, or None.
+# Relies on the one-active-scene-round-per-room DB constraint, so .first() is
+# unambiguous.  Public service — promoted from the private _active_round_for_room
+# helper that was previously inlined in SetRoundModeAction (#1467).
+active_round_for_room(room) -> SceneRound | None
+```
+
 ### Round-mode control
 
 ```python
@@ -552,12 +564,45 @@ authoritative permission check runs inside `SetRoundModeAction`. The viewset res
 requesting account's active character as the action actor so that telnet and web converge on
 the same `action.run()` seam. Returns the updated scene detail on success.
 
-**Deferred follow-ups:**
+**Deferred follow-up:**
 - DANGER → STRICT unification: DANGER rounds are currently forced to OPEN and not
   user-settable; a future slice will allow a scene admin to unify a live DANGER round
   into the three-mode framework.
-- React control for frontend parity (linked to #1328): `scene round` is telnet-only;
-  a round-mode panel in the web scene view is a follow-up.
+
+### Web round-mode control — RoundSettingsDialog (#1467)
+
+`RoundSettingsDialog` (`frontend/src/scenes/components/RoundSettingsDialog.tsx`) is the
+React-side parity for `scene round` (telnet, #1445).
+
+**Gate:** rendered only when `scene.viewer_can_gm && scene.is_active`; matches the backend
+`IsSceneGMOrOwnerOrStaff` coarse gate on `POST /api/scenes/{id}/set-round-mode/`.
+
+**Behaviour:**
+- When `scene.active_round` is `null` (no active round), the dialog body shows an
+  informational message; Save is disabled.
+- When a round exists, the dialog exposes mode (Select), advance quorum % (Input),
+  max actions per round (Input), and repeat-target lock (Switch). The mode selector is
+  disabled when `active_round.is_danger` is true (DANGER rounds stay in OPEN mode).
+- On Save, dispatches `useSetRoundMode` → `POST /api/scenes/{id}/set-round-mode/` with a
+  `SetRoundModePayload`; closes the dialog on success.
+
+**Wire-point:** `RoundSettingsDialog` is rendered by `SceneHeader.tsx` alongside the
+Edit and End Scene buttons.
+
+**Read-side serialization:** `SceneDetailSerializer` exposes `active_round` as a nullable
+nested field serialized by `SceneRoundSerializer` (read-only). Fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `mode` | string | `SceneRoundMode` value (`open` / `pose_order` / `strict`) |
+| `advance_quorum_pct` | int | % of distinct actors needed to advance a POSE_ORDER round |
+| `max_actions_per_round` | int | Per-participant action cap per round |
+| `per_target_repeat_lock` | bool | Block repeat targeting of the same persona |
+| `status` | string | `RoundStatus` value |
+| `round_number` | int | Current round counter |
+| `is_danger` | bool | Derived: `True` when `start_reason == DANGER` |
+
+`active_round` is `null` when the scene has no location or no active round exists.
 
 ---
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -23200,7 +23200,7 @@ export interface components {
       readonly positions: components['schemas']['PositionSummary'][];
       readonly position_adjacency: components['schemas']['PositionAdjacencyItem'][];
       readonly persona_positions: components['schemas']['PersonaPosition'][];
-      readonly active_round: components['schemas']['SceneRound'];
+      readonly active_round: components['schemas']['SceneRound'] | null;
     };
     /** @description Full scene representation with personas */
     SceneDetailRequest: {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -18402,6 +18402,13 @@ export interface components {
      */
     MissionVisibilityEnum: 'open' | 'restricted';
     /**
+     * @description * `open` - Open (immediate, unbounded)
+     *     * `pose_order` - Pose order (immediate, quota-gated)
+     *     * `strict` - Strict (declare, batch-resolved)
+     * @enum {string}
+     */
+    Mode081Enum: 'open' | 'pose_order' | 'strict';
+    /**
      * @description * `pose` - Pose
      *     * `emit` - Emit
      *     * `say` - Say
@@ -23193,6 +23200,7 @@ export interface components {
       readonly positions: components['schemas']['PositionSummary'][];
       readonly position_adjacency: components['schemas']['PositionAdjacencyItem'][];
       readonly persona_positions: components['schemas']['PersonaPosition'][];
+      readonly active_round: components['schemas']['SceneRound'];
     };
     /** @description Full scene representation with personas */
     SceneDetailRequest: {
@@ -23269,6 +23277,16 @@ export interface components {
       }[];
       readonly is_owner: string;
       readonly viewer_can_gm: boolean;
+    };
+    /** @description Read-only view of a scene's active round, for the round-settings control (#1467). */
+    SceneRound: {
+      mode?: components['schemas']['Mode081Enum'];
+      advance_quorum_pct?: number;
+      max_actions_per_round?: number;
+      per_target_repeat_lock?: boolean;
+      status?: components['schemas']['Status4e6Enum'];
+      round_number?: number;
+      readonly is_danger: boolean;
     };
     SceneSummaryRevision: {
       readonly id: number;
@@ -23361,13 +23379,6 @@ export interface components {
       persona_id: number;
     };
     /**
-     * @description * `open` - Open (immediate, unbounded)
-     *     * `pose_order` - Pose order (immediate, quota-gated)
-     *     * `strict` - Strict (declare, batch-resolved)
-     * @enum {string}
-     */
-    SetRoundModeRequestModeEnum: 'open' | 'pose_order' | 'strict';
-    /**
      * @description POST body for the #1445 set-round-mode endpoint.
      *
      *     All fields are optional — callers may change the mode, one or more knobs, or any
@@ -23375,7 +23386,7 @@ export interface components {
      *     a generic message if none are, because the service is a no-op update).
      */
     SetRoundModeRequestRequest: {
-      mode?: components['schemas']['SetRoundModeRequestModeEnum'];
+      mode?: components['schemas']['Mode081Enum'];
       advance_quorum_pct?: number;
       max_actions_per_round?: number;
       per_target_repeat_lock?: boolean;

--- a/frontend/src/scenes/components/RoundSettingsDialog.test.tsx
+++ b/frontend/src/scenes/components/RoundSettingsDialog.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi } from 'vitest';
+import { RoundSettingsDialog } from './RoundSettingsDialog';
+import type { SceneDetail, SceneRoundState } from '../types';
+
+// Mock the queries module so no real network calls happen
+vi.mock('../queries', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../queries')>();
+  return {
+    ...original,
+    setRoundMode: vi.fn().mockResolvedValue({}),
+  };
+});
+
+function renderWith(scene: SceneDetail) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RoundSettingsDialog scene={scene} />
+    </QueryClientProvider>
+  );
+}
+
+const base: SceneDetail = {
+  id: 1,
+  name: 'S',
+  description: '',
+  date_started: '',
+  participants: [],
+  is_active: true,
+  is_owner: true,
+  viewer_can_gm: true,
+  positions: [],
+  position_adjacency: [],
+  persona_positions: [],
+  active_round: null,
+} as unknown as SceneDetail;
+
+const activeRound: SceneRoundState = {
+  mode: 'pose_order',
+  advance_quorum_pct: 60,
+  max_actions_per_round: 1,
+  per_target_repeat_lock: false,
+  status: 'open',
+  round_number: 1,
+  is_danger: false,
+};
+
+describe('RoundSettingsDialog', () => {
+  it('shows the trigger for a GM/owner of an active scene', () => {
+    renderWith({ ...base, active_round: null });
+    expect(screen.getByRole('button', { name: /round settings/i })).toBeInTheDocument();
+  });
+
+  it('renders nothing when the viewer cannot GM', () => {
+    const { container } = renderWith({ ...base, viewer_can_gm: false, active_round: null });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the scene is not active', () => {
+    const { container } = renderWith({ ...base, is_active: false, active_round: null });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('Save is disabled in the no-active-round state', async () => {
+    // Radix Dialog sets pointer-events: none on <body> while closed;
+    // disable the userEvent pointer-events guard so we can click in jsdom.
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderWith({ ...base, active_round: null });
+
+    // Open the dialog
+    await user.click(screen.getByRole('button', { name: /round settings/i }));
+
+    // Wait for the dialog content to appear
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('shows the "no active round" message when active_round is null', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderWith({ ...base, active_round: null });
+
+    await user.click(screen.getByRole('button', { name: /round settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/no active round/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows the mode select when there is an active round', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderWith({ ...base, active_round: activeRound });
+
+    await user.click(screen.getByRole('button', { name: /round settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/mode/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/scenes/components/RoundSettingsDialog.test.tsx
+++ b/frontend/src/scenes/components/RoundSettingsDialog.test.tsx
@@ -102,4 +102,23 @@ describe('RoundSettingsDialog', () => {
       expect(screen.getByLabelText(/mode/i)).toBeInTheDocument();
     });
   });
+
+  it('disables the mode select when the active round is a danger round', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const dangerRound: SceneRoundState = {
+      ...activeRound,
+      mode: 'open',
+      is_danger: true,
+    };
+    renderWith({ ...base, active_round: dangerRound });
+
+    await user.click(screen.getByRole('button', { name: /round settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/mode/i)).toBeInTheDocument();
+    });
+
+    const trigger = screen.getByLabelText(/mode/i);
+    expect(trigger).toHaveAttribute('disabled');
+  });
 });

--- a/frontend/src/scenes/components/RoundSettingsDialog.test.tsx
+++ b/frontend/src/scenes/components/RoundSettingsDialog.test.tsx
@@ -103,7 +103,7 @@ describe('RoundSettingsDialog', () => {
     });
   });
 
-  it('disables the mode select when the active round is a danger round', async () => {
+  it('disables the mode select and Save button when the active round is a danger round', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     const dangerRound: SceneRoundState = {
       ...activeRound,
@@ -120,5 +120,7 @@ describe('RoundSettingsDialog', () => {
 
     const trigger = screen.getByLabelText(/mode/i);
     expect(trigger).toHaveAttribute('disabled');
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
   });
 });

--- a/frontend/src/scenes/components/RoundSettingsDialog.tsx
+++ b/frontend/src/scenes/components/RoundSettingsDialog.tsx
@@ -107,7 +107,7 @@ export function RoundSettingsDialog({ scene }: { scene: SceneDetail }) {
               </Select>
               {modeLocked && (
                 <p className="text-xs text-muted-foreground">
-                  Danger rounds stay in Open mode and cannot be changed.
+                  Danger rounds resolve on their own and can&apos;t be reconfigured.
                 </p>
               )}
             </div>
@@ -121,6 +121,7 @@ export function RoundSettingsDialog({ scene }: { scene: SceneDetail }) {
                 max={100}
                 value={quorum}
                 onChange={(e) => setQuorum(Number(e.target.value))}
+                disabled={modeLocked}
               />
             </div>
 
@@ -132,18 +133,28 @@ export function RoundSettingsDialog({ scene }: { scene: SceneDetail }) {
                 min={0}
                 value={maxActions}
                 onChange={(e) => setMaxActions(Number(e.target.value))}
+                disabled={modeLocked}
               />
             </div>
 
             <div className="flex items-center justify-between">
               <Label htmlFor="round-repeat-lock">Lock repeat actions on the same target</Label>
-              <Switch id="round-repeat-lock" checked={repeatLock} onCheckedChange={setRepeatLock} />
+              <Switch
+                id="round-repeat-lock"
+                checked={repeatLock}
+                onCheckedChange={setRepeatLock}
+                disabled={modeLocked}
+              />
             </div>
           </div>
         )}
 
         <DialogFooter>
-          <Button type="button" onClick={handleSave} disabled={noRound || mutation.isPending}>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={noRound || modeLocked || mutation.isPending}
+          >
             Save
           </Button>
         </DialogFooter>

--- a/frontend/src/scenes/components/RoundSettingsDialog.tsx
+++ b/frontend/src/scenes/components/RoundSettingsDialog.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import type { SceneDetail, SceneRoundModeValue } from '../types';
+import { useSetRoundMode, type SetRoundModePayload } from '../queries';
+
+const MODE_OPTIONS: { value: SceneRoundModeValue; label: string }[] = [
+  { value: 'open', label: 'Open — every action resolves immediately' },
+  { value: 'pose_order', label: 'Pose order — quorum advances the round' },
+  { value: 'strict', label: 'Strict — declare, then resolve together' },
+];
+
+export function RoundSettingsDialog({ scene }: { scene: SceneDetail }) {
+  const [open, setOpen] = useState(false);
+  const round = scene.active_round;
+  const mutation = useSetRoundMode(String(scene.id));
+
+  const [mode, setMode] = useState<SceneRoundModeValue>(round?.mode ?? 'pose_order');
+  const [quorum, setQuorum] = useState<number>(round?.advance_quorum_pct ?? 60);
+  const [maxActions, setMaxActions] = useState<number>(round?.max_actions_per_round ?? 1);
+  const [repeatLock, setRepeatLock] = useState<boolean>(round?.per_target_repeat_lock ?? false);
+
+  // Re-sync local form state whenever the dialog opens or the round changes.
+  useEffect(() => {
+    if (round) {
+      setMode(round.mode);
+      setQuorum(round.advance_quorum_pct);
+      setMaxActions(round.max_actions_per_round);
+      setRepeatLock(round.per_target_repeat_lock);
+    }
+  }, [round, open]);
+
+  if (!scene.viewer_can_gm || !scene.is_active) return null;
+
+  const noRound = round === null;
+  const modeLocked = round?.is_danger ?? false;
+
+  function handleSave() {
+    const payload: SetRoundModePayload = {
+      advance_quorum_pct: quorum,
+      max_actions_per_round: maxActions,
+      per_target_repeat_lock: repeatLock,
+    };
+    if (!modeLocked) payload.mode = mode;
+    mutation.mutate(payload, { onSuccess: () => setOpen(false) });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          Round settings
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Round settings</DialogTitle>
+          <DialogDescription>Control how this scene&apos;s rounds resolve.</DialogDescription>
+        </DialogHeader>
+
+        {noRound ? (
+          <p className="text-sm text-muted-foreground">
+            There is no active round in this scene. Start a round before configuring it.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <Label htmlFor="round-mode">Mode</Label>
+              <Select
+                value={mode}
+                onValueChange={(v) => setMode(v as SceneRoundModeValue)}
+                disabled={modeLocked}
+              >
+                <SelectTrigger id="round-mode">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MODE_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {modeLocked && (
+                <p className="text-xs text-muted-foreground">
+                  Danger rounds stay in Open mode and cannot be changed.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <Label htmlFor="round-quorum">Advance quorum (%)</Label>
+              <Input
+                id="round-quorum"
+                type="number"
+                min={0}
+                max={100}
+                value={quorum}
+                onChange={(e) => setQuorum(Number(e.target.value))}
+              />
+            </div>
+
+            <div className="space-y-1">
+              <Label htmlFor="round-max-actions">Max actions per round</Label>
+              <Input
+                id="round-max-actions"
+                type="number"
+                min={0}
+                value={maxActions}
+                onChange={(e) => setMaxActions(Number(e.target.value))}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <Label htmlFor="round-repeat-lock">Lock repeat actions on the same target</Label>
+              <Switch id="round-repeat-lock" checked={repeatLock} onCheckedChange={setRepeatLock} />
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" onClick={handleSave} disabled={noRound || mutation.isPending}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/scenes/components/RoundSettingsDialog.tsx
+++ b/frontend/src/scenes/components/RoundSettingsDialog.tsx
@@ -45,6 +45,11 @@ export function RoundSettingsDialog({ scene }: { scene: SceneDetail }) {
       setQuorum(round.advance_quorum_pct);
       setMaxActions(round.max_actions_per_round);
       setRepeatLock(round.per_target_repeat_lock);
+    } else {
+      setMode('pose_order');
+      setQuorum(60);
+      setMaxActions(1);
+      setRepeatLock(false);
     }
   }, [round, open]);
 

--- a/frontend/src/scenes/components/SceneHeader.tsx
+++ b/frontend/src/scenes/components/SceneHeader.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { SubmitButton } from '@/components/SubmitButton';
+import { RoundSettingsDialog } from './RoundSettingsDialog';
 
 interface Props {
   scene?: SceneDetail;
@@ -95,6 +96,7 @@ export function SceneHeader({ scene, onRefresh }: Props) {
               Refresh
             </Button>
           )}
+          <RoundSettingsDialog scene={scene} />
         </div>
       )}
       {scene.is_active && (

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '@/evennia_replacements/api';
-import type { HighlightReel, Interaction } from './types';
+import type { HighlightReel, Interaction, SceneRoundModeValue } from './types';
 
 // ---------------------------------------------------------------------------
 // Query key factory
@@ -28,6 +28,7 @@ export type {
   SceneDetail,
   Interaction,
   HighlightReel,
+  SceneRoundModeValue,
 } from './types';
 
 export async function fetchScenes(params: string) {
@@ -63,6 +64,25 @@ export async function updateScene(id: string, data: { name?: string; description
 export async function finishScene(id: string) {
   const res = await apiFetch(`/api/scenes/${id}/finish/`, { method: 'POST' });
   if (!res.ok) throw new Error('Failed to finish scene');
+  return res.json();
+}
+
+export interface SetRoundModePayload {
+  mode?: SceneRoundModeValue;
+  advance_quorum_pct?: number;
+  max_actions_per_round?: number;
+  per_target_repeat_lock?: boolean;
+}
+
+export async function setRoundMode(id: string, payload: SetRoundModePayload) {
+  const res = await apiFetch(`/api/scenes/${id}/set-round-mode/`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const data = (await res.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(data?.detail || 'Failed to set round mode');
+  }
   return res.json();
 }
 
@@ -243,5 +263,13 @@ export function useCreateSceneEntryEndorsement(sceneId: string) {
   return useMutation({
     mutationFn: createSceneEntryEndorsement,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
+  });
+}
+
+export function useSetRoundMode(sceneId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: SetRoundModePayload) => setRoundMode(sceneId, payload),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene', sceneId] }),
   });
 }

--- a/frontend/src/scenes/types.ts
+++ b/frontend/src/scenes/types.ts
@@ -67,6 +67,21 @@ export interface PersonaPosition {
   position: PositionSummary | null;
 }
 
+/** Round resolution mode wire values (matches SceneRoundMode TextChoices). */
+export type SceneRoundModeValue = 'open' | 'pose_order' | 'strict';
+
+/** The scene's active round state, for the round-settings control (#1467). */
+export interface SceneRoundState {
+  mode: SceneRoundModeValue;
+  advance_quorum_pct: number;
+  max_actions_per_round: number;
+  per_target_repeat_lock: boolean;
+  status: string;
+  round_number: number;
+  /** DANGER rounds are forced to OPEN and are immutable — the form locks the mode field. */
+  is_danger: boolean;
+}
+
 export interface SceneDetail extends SceneListItem {
   is_active: boolean;
   is_owner: boolean;
@@ -80,6 +95,8 @@ export interface SceneDetail extends SceneListItem {
   position_adjacency: PositionAdjacencyItem[];
   /** Current position for each persona in the scene (#1017). */
   persona_positions: PersonaPosition[];
+  /** Active scene round (#1467); null when no round is in progress. */
+  active_round: SceneRoundState | null;
 }
 
 export interface InteractionPersona {

--- a/src/actions/definitions/rounds.py
+++ b/src/actions/definitions/rounds.py
@@ -18,6 +18,7 @@ from world.scenes.constants import (
 from world.scenes.models import SceneActionDeclaration, SceneRound, SceneRoundParticipant
 from world.scenes.round_services import (
     RoundModeError,
+    active_round_for_room,
     end_scene_round,
     resolve_scene_round,
     set_scene_round_mode,
@@ -44,7 +45,7 @@ def _sheet(actor: ObjectDB) -> CharacterSheet | None:
 
 def _active_round_for_room(room: ObjectDB) -> SceneRound | None:
     """Return the active (non-completed) SceneRound for a room, or None."""
-    return SceneRound.objects.filter(room=room, status__in=ACTIVE_SCENE_ROUND_STATUSES).first()
+    return active_round_for_room(room)
 
 
 @dataclass

--- a/src/schema.json
+++ b/src/schema.json
@@ -42028,6 +42028,7 @@ components:
         active_round:
           allOf:
           - $ref: '#/components/schemas/SceneRound'
+          nullable: true
           readOnly: true
       required:
       - active_round

--- a/src/schema.json
+++ b/src/schema.json
@@ -33227,6 +33227,16 @@ components:
       description: |-
         * `open` - Open
         * `restricted` - Restricted
+    Mode081Enum:
+      enum:
+      - open
+      - pose_order
+      - strict
+      type: string
+      description: |-
+        * `open` - Open (immediate, unbounded)
+        * `pose_order` - Pose order (immediate, quota-gated)
+        * `strict` - Strict (declare, batch-resolved)
     Mode8baEnum:
       enum:
       - pose
@@ -42015,7 +42025,12 @@ components:
           items:
             $ref: '#/components/schemas/PersonaPosition'
           readOnly: true
+        active_round:
+          allOf:
+          - $ref: '#/components/schemas/SceneRound'
+          readOnly: true
       required:
+      - active_round
       - date_started
       - id
       - is_owner
@@ -42174,6 +42189,34 @@ components:
       - name
       - participants
       - viewer_can_gm
+    SceneRound:
+      type: object
+      description: Read-only view of a scene's active round, for the round-settings
+        control (#1467).
+      properties:
+        mode:
+          $ref: '#/components/schemas/Mode081Enum'
+        advance_quorum_pct:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        max_actions_per_round:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        per_target_repeat_lock:
+          type: boolean
+        status:
+          $ref: '#/components/schemas/Status4e6Enum'
+        round_number:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        is_danger:
+          type: boolean
+          readOnly: true
+      required:
+      - is_danger
     SceneSummaryRevision:
       type: object
       properties:
@@ -42347,16 +42390,6 @@ components:
           minimum: 1
       required:
       - persona_id
-    SetRoundModeRequestModeEnum:
-      enum:
-      - open
-      - pose_order
-      - strict
-      type: string
-      description: |-
-        * `open` - Open (immediate, unbounded)
-        * `pose_order` - Pose order (immediate, quota-gated)
-        * `strict` - Strict (declare, batch-resolved)
     SetRoundModeRequestRequest:
       type: object
       description: |-
@@ -42367,7 +42400,7 @@ components:
         a generic message if none are, because the service is a no-op update).
       properties:
         mode:
-          $ref: '#/components/schemas/SetRoundModeRequestModeEnum'
+          $ref: '#/components/schemas/Mode081Enum'
         advance_quorum_pct:
           type: integer
           maximum: 100

--- a/src/world/scenes/round_services.py
+++ b/src/world/scenes/round_services.py
@@ -94,6 +94,15 @@ def set_scene_round_mode(
     return scene_round
 
 
+def active_round_for_room(room: ObjectDB) -> SceneRound | None:
+    """Return the active (non-completed) SceneRound for a room, or None.
+
+    One active round per room (the ``one_active_scene_round_per_room`` constraint),
+    so ``.first()`` is unambiguous.
+    """
+    return SceneRound.objects.filter(room=room, status__in=ACTIVE_SCENE_ROUND_STATUSES).first()
+
+
 def actions_this_round(scene_round: SceneRound, participant: SceneRoundParticipant) -> int:
     """Return the number of action declarations for a participant in the current round."""
     return scene_round.action_declarations.filter(

--- a/src/world/scenes/serializers.py
+++ b/src/world/scenes/serializers.py
@@ -326,7 +326,7 @@ class SceneDetailSerializer(SceneListSerializer):
             result.append({"persona_id": persona.pk, "position": position})
         return result
 
-    @extend_schema_field(SceneRoundSerializer)
+    @extend_schema_field(SceneRoundSerializer(allow_null=True))
     def get_active_round(self, obj: Scene) -> dict | None:
         if obj.location is None:
             return None

--- a/src/world/scenes/serializers.py
+++ b/src/world/scenes/serializers.py
@@ -7,11 +7,12 @@ from world.areas.positioning.serializers import (
     PositionAdjacencyItemSerializer,
     PositionSummarySerializer,
 )
-from world.scenes.constants import ScenePrivacyMode, SceneRoundMode
+from world.scenes.constants import ScenePrivacyMode, SceneRoundMode, SceneRoundStartReason
 from world.scenes.models import (
     Persona,
     Scene,
     SceneParticipation,
+    SceneRound,
     SceneSummaryRevision,
 )
 
@@ -222,6 +223,27 @@ class SceneListSerializer(serializers.ModelSerializer):
         return bool(user.is_staff or obj.is_gm(user) or obj.is_owner(user))
 
 
+class SceneRoundSerializer(serializers.ModelSerializer):
+    """Read-only view of a scene's active round, for the round-settings control (#1467)."""
+
+    is_danger = serializers.SerializerMethodField()
+
+    class Meta:
+        model = SceneRound
+        fields = [
+            "mode",
+            "advance_quorum_pct",
+            "max_actions_per_round",
+            "per_target_repeat_lock",
+            "status",
+            "round_number",
+            "is_danger",
+        ]
+
+    def get_is_danger(self, obj: SceneRound) -> bool:
+        return obj.start_reason == SceneRoundStartReason.DANGER
+
+
 class SceneDetailSerializer(SceneListSerializer):
     """Full scene representation with personas"""
 
@@ -229,6 +251,7 @@ class SceneDetailSerializer(SceneListSerializer):
     positions = serializers.SerializerMethodField()
     position_adjacency = serializers.SerializerMethodField()
     persona_positions = serializers.SerializerMethodField()
+    active_round = serializers.SerializerMethodField()
 
     class Meta(SceneListSerializer.Meta):
         model = Scene
@@ -241,6 +264,7 @@ class SceneDetailSerializer(SceneListSerializer):
             "positions",
             "position_adjacency",
             "persona_positions",
+            "active_round",
         ]
         extra_kwargs = {"name": {"required": False}}
 
@@ -301,6 +325,15 @@ class SceneDetailSerializer(SceneListSerializer):
                         position = PositionSummarySerializer(pos).data
             result.append({"persona_id": persona.pk, "position": position})
         return result
+
+    @extend_schema_field(SceneRoundSerializer)
+    def get_active_round(self, obj: Scene) -> dict | None:
+        if obj.location is None:
+            return None
+        from world.scenes.round_services import active_round_for_room  # noqa: PLC0415
+
+        rnd = active_round_for_room(obj.location)
+        return SceneRoundSerializer(rnd).data if rnd is not None else None
 
 
 class ScenesSpotlightSerializer(serializers.Serializer):

--- a/src/world/scenes/tests/test_round_mode_services.py
+++ b/src/world/scenes/tests/test_round_mode_services.py
@@ -1,10 +1,11 @@
-"""Tests for set_scene_round_mode and RoundModeError."""
+"""Tests for set_scene_round_mode, RoundModeError, and active_round_for_room."""
 
 from django.test import TestCase
 
-from world.scenes.constants import SceneRoundMode, SceneRoundStartReason
+from evennia_extensions.factories import ObjectDBFactory
+from world.scenes.constants import RoundStatus, SceneRoundMode, SceneRoundStartReason
 from world.scenes.factories import SceneRoundFactory, SceneRoundParticipantFactory
-from world.scenes.models import SceneActionDeclaration
+from world.scenes.models import SceneActionDeclaration, SceneRound
 from world.scenes.round_services import RoundModeError, set_scene_round_mode
 
 
@@ -107,3 +108,23 @@ class SetSceneRoundModeTests(TestCase):
         rnd.refresh_from_db()
         self.assertEqual(rnd.mode, SceneRoundMode.POSE_ORDER)
         self.assertIs(result, rnd)
+
+
+class ActiveRoundForRoomTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.room = ObjectDBFactory()
+
+    def test_active_round_for_room_returns_active_round(self):
+        from world.scenes.round_services import active_round_for_room
+
+        rnd = SceneRound.objects.create(room=self.room, start_reason=SceneRoundStartReason.OPT_IN)
+        self.assertEqual(active_round_for_room(self.room), rnd)
+
+    def test_active_round_for_room_none_when_only_completed(self):
+        from world.scenes.round_services import active_round_for_room
+
+        SceneRound.objects.create(
+            room=self.room, start_reason=SceneRoundStartReason.OPT_IN, status=RoundStatus.COMPLETED
+        )
+        self.assertIsNone(active_round_for_room(self.room))

--- a/src/world/scenes/tests/test_round_mode_services.py
+++ b/src/world/scenes/tests/test_round_mode_services.py
@@ -6,7 +6,7 @@ from evennia_extensions.factories import ObjectDBFactory
 from world.scenes.constants import RoundStatus, SceneRoundMode, SceneRoundStartReason
 from world.scenes.factories import SceneRoundFactory, SceneRoundParticipantFactory
 from world.scenes.models import SceneActionDeclaration, SceneRound
-from world.scenes.round_services import RoundModeError, set_scene_round_mode
+from world.scenes.round_services import RoundModeError, active_round_for_room, set_scene_round_mode
 
 
 class SetSceneRoundModeTests(TestCase):
@@ -116,14 +116,10 @@ class ActiveRoundForRoomTests(TestCase):
         cls.room = ObjectDBFactory()
 
     def test_active_round_for_room_returns_active_round(self):
-        from world.scenes.round_services import active_round_for_room
-
         rnd = SceneRound.objects.create(room=self.room, start_reason=SceneRoundStartReason.OPT_IN)
         self.assertEqual(active_round_for_room(self.room), rnd)
 
     def test_active_round_for_room_none_when_only_completed(self):
-        from world.scenes.round_services import active_round_for_room
-
         SceneRound.objects.create(
             room=self.room, start_reason=SceneRoundStartReason.OPT_IN, status=RoundStatus.COMPLETED
         )

--- a/src/world/scenes/tests/test_views.py
+++ b/src/world/scenes/tests/test_views.py
@@ -337,6 +337,45 @@ class SetRoundModeViewTestCase(APITestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data["detail"] == "No active character."
 
+    def test_scene_detail_active_round_null_when_none(self):
+        self.round.delete()
+        self.client.force_authenticate(self.account)
+        resp = self.client.get(f"/api/scenes/{self.scene.id}/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(resp.data["active_round"])
+
+    def test_scene_detail_active_round_payload(self):
+        self.round.delete()
+        rnd = SceneRound.objects.create(
+            room=self.scene.location,
+            scene=self.scene,
+            mode=SceneRoundMode.STRICT,
+            advance_quorum_pct=50,
+            max_actions_per_round=2,
+            per_target_repeat_lock=True,
+            start_reason=SceneRoundStartReason.OPT_IN,
+        )
+        self.client.force_authenticate(self.account)
+        resp = self.client.get(f"/api/scenes/{self.scene.id}/")
+        ar = resp.data["active_round"]
+        self.assertEqual(ar["mode"], SceneRoundMode.STRICT)
+        self.assertEqual(ar["advance_quorum_pct"], 50)
+        self.assertEqual(ar["max_actions_per_round"], 2)
+        self.assertTrue(ar["per_target_repeat_lock"])
+        self.assertEqual(ar["round_number"], rnd.round_number)
+        self.assertFalse(ar["is_danger"])
+
+    def test_scene_detail_active_round_is_danger(self):
+        self.round.delete()
+        SceneRound.objects.create(
+            room=self.scene.location,
+            scene=self.scene,
+            start_reason=SceneRoundStartReason.DANGER,
+        )
+        self.client.force_authenticate(self.account)
+        resp = self.client.get(f"/api/scenes/{self.scene.id}/")
+        self.assertTrue(resp.data["active_round"]["is_danger"])
+
 
 class PersonaViewSetTestCase(APITestCase):
     def setUp(self):


### PR DESCRIPTION
Closes #1467

## Summary

Adds the web (React) control for setting a scene round's resolution mode + pose-order knobs — parity for the backend shipped in #1445.

- **Frontend:** a GM/owner/staff-gated `RoundSettingsDialog` (a shadcn Dialog launched from a *Round settings* button beside *End Scene* in `SceneHeader`). Mode `Select` + quorum / max-actions number inputs + a repeat-lock `Switch`, pre-filled from the current round. Self-gates on `viewer_can_gm && is_active`; shows a clear empty state (Save disabled) when there is no active round; fully locks the form on a DANGER round (which the engine resolves autonomously). Posts via a new `setRoundMode` / `useSetRoundMode` to the pre-existing `/api/scenes/{id}/set-round-mode/` endpoint.
- **Backend read-side:** a read-only `SceneRoundSerializer` and a nullable `active_round` field on the scene detail API, reusing a promoted public `active_round_for_room` service (the action's old private helper now delegates to it). Regenerated `schema.json` + `api.d.ts`.
- **No permission-model changes.** Gated on the existing per-scene `viewer_can_gm`; the authoritative check stays in `SetRoundModeAction`. Per scope discussion, the broader 'which GM owns a scene / story-runner vs scoped check' reconciliation is intentionally out of scope and not filed.

Whole-branch reviewed (READY TO MERGE); SQLite fast tier green for scenes (766) + actions (501), frontend dialog tests 7/7, `pre-commit --all-files` clean.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1467 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main cleanly — no conflicts, no migration collisions.

<!-- last-addressed-comment: 0 -->