### PR TITLE
feat: room editor MVP — owner edits a room's name, description & public/private (#1470)

### DIFF
--- a/src/actions/CLAUDE.md
+++ b/src/actions/CLAUDE.md
@@ -39,7 +39,10 @@ They do not use the command system, dispatchers, or handlers.
   Each `execute()` resolves the actor's active `CombatParticipant`/encounter and calls the
   existing combat service; shared by telnet `CmdCombat` (`combat <subverb>`) and the web
   `CombatEncounterViewSet`. `yield` is not here — `YieldAction` (`duels.py`) is reused. The one
-  new service is `toggle_action_ready`, extracted from the inline web `ready` toggle)
+  new service is `toggle_action_ready`, extracted from the inline web `ready` toggle;
+  `locations.py` — `RoomEditAction`, key `"edit_room"` (#1470), owner-gated
+  (`IsRoomOwnerPrerequisite`) edit of the current room's name/description/public-listing via
+  `world.locations.services.set_room_display_data`; shared by telnet `CmdManageRoom` + web dispatch)
 
 ## SCENE_ADAPTIVE Backend (#1351)
 

--- a/src/actions/definitions/locations.py
+++ b/src/actions/definitions/locations.py
@@ -1,0 +1,70 @@
+"""Player-facing room editing actions (#1470) — the room-editor MVP seam.
+
+``RoomEditAction`` lets a room **owner** edit the room they're standing in: its
+display name, description, and public/private listing. It is the single seam both
+telnet (``CmdManageRoom``) and the web (action-dispatch + ``RoomEditorPanel``)
+call. Ownership is gated by ``IsRoomOwnerPrerequisite``; the write + the
+public-toggle guard live in ``world.locations.services.set_room_display_data``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from evennia.objects.models import ObjectDB
+
+from actions.base import Action
+from actions.constants import ActionCategory
+from actions.prerequisites import IsRoomOwnerPrerequisite, Prerequisite
+from actions.types import ActionResult, TargetType
+
+if TYPE_CHECKING:
+    from actions.types import ActionContext
+
+
+@dataclass
+class RoomEditAction(Action):
+    """Owner edits the room they're standing in: name, description, public/private.
+
+    Operates on ``actor.location`` (the room the actor is in). Each field is
+    optional — only those supplied are changed.
+    """
+
+    key: str = "edit_room"
+    name: str = "Edit Room"
+    icon: str = "home"
+    category: str = "locations"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SELF
+
+    def get_prerequisites(self) -> list[Prerequisite]:
+        return [IsRoomOwnerPrerequisite()]
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.locations.services import (  # noqa: PLC0415
+            RoomEditError,
+            set_room_display_data,
+        )
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        room = actor.location
+        if room is None:
+            return ActionResult(success=False, message="You're not in a room.")
+        persona = active_persona_for_sheet(actor.sheet_data)
+        try:
+            set_room_display_data(
+                room=room,
+                persona=persona,
+                name=kwargs.get("name"),
+                description=kwargs.get("description"),
+                is_public=kwargs.get("is_public"),
+            )
+        except RoomEditError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        return ActionResult(success=True, message="Room updated.")

--- a/src/actions/prerequisites.py
+++ b/src/actions/prerequisites.py
@@ -51,6 +51,34 @@ class StaffOnlyPrerequisite(Prerequisite):
 
 
 @dataclass
+class IsRoomOwnerPrerequisite(Prerequisite):
+    """The actor's active persona must own the room they're standing in (#1470)."""
+
+    def is_met(
+        self,
+        actor: ObjectDB,
+        target: ObjectDB | None = None,
+        context: dict | None = None,
+    ) -> tuple[bool, str]:
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        from world.locations.services import is_owner  # noqa: PLC0415
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        room = actor.location
+        if room is None:
+            return False, "You're not in a room."
+        try:
+            sheet = actor.sheet_data
+        except (AttributeError, ObjectDoesNotExist):
+            return False, "Only characters can edit rooms."
+        persona = active_persona_for_sheet(sheet)
+        if is_owner(persona, room):
+            return True, ""
+        return False, "You don't own this room."
+
+
+@dataclass
 class HoldsItemPrerequisite(Prerequisite):
     """The actor must be holding the item passed as ``kwargs['item']``."""
 

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -45,6 +45,7 @@ from actions.definitions.items import (
     UnequipAction,
     UseItemAction,
 )
+from actions.definitions.locations import RoomEditAction
 from actions.definitions.movement import (
     DropAction,
     GetAction,
@@ -96,6 +97,7 @@ _ALL_ACTIONS: list[Action] = [
     GiveAction(),
     EquipAction(),
     UnequipAction(),
+    RoomEditAction(),
     PutInAction(),
     TakeOutAction(),
     ActivatePermitAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -153,6 +153,7 @@ class ActionRegistryTests(TestCase):
             "give",
             "equip",
             "unequip",
+            "edit_room",
             "put_in",
             "take_out",
             "apply_outfit",

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -145,6 +145,11 @@ actions, backends, and service functions.
   to a *reach*: `gemit <msg>` (game-wide), `gemit/society <a>,<b> = <msg>`, or `gemit/org <a>,<b> =
   <msg>` (members of those societies/orgs, by active persona). No body is ever generated. Player/
   covenant-targeted story emits are a separate, non-public tool — not this command.
+- **`locations.py`**: `CmdManageRoom` (`manageroom`, #1470) — owner-gated room editor.
+  Thin over `RoomEditAction` (key `edit_room`): `manageroom/name <name>`,
+  `manageroom/desc <text>`, `manageroom/public <yes|no>`. Edits the room the caller
+  is standing in; ownership is gated by `IsRoomOwnerPrerequisite`, writes live in
+  `world.locations.services.set_room_display_data`. No business logic in the command.
 - **`evennia_overrides/builder.py`**: `CmdDig`, `CmdOpen`, `CmdLink`, `CmdUnlink` (Evennia overrides)
 
 ### Account Commands (`account/`)

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -59,6 +59,7 @@ from commands.evennia_overrides.perception import CmdInventory, CmdLook
 from commands.fashion import CmdJudgePresentation
 from commands.gemit import CmdGemit
 from commands.imbue import CmdImbue
+from commands.locations import CmdManageRoom
 from commands.offer_response import CmdDecline
 from commands.ritual import CmdRitual
 from commands.scene import CmdScene
@@ -181,6 +182,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdCombat,
             # Scene lifecycle telnet command (#1445)
             CmdScene,
+            # #1470 — owner-gated room editor (name/description/public-private).
+            CmdManageRoom,
         )
         for command_cls in command_classes:
             self.add(command_cls())

--- a/src/commands/locations.py
+++ b/src/commands/locations.py
@@ -1,0 +1,61 @@
+"""Telnet ``manageroom`` command (#1470) — the room-editor MVP, owner-gated.
+
+Thin over ``RoomEditAction`` (the same seam the web action-dispatch calls). A room
+owner standing in their room edits its name, description, or public/private
+listing. No business logic here — ownership gating + the writes live in the action
+and ``world.locations.services.set_room_display_data``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from actions.definitions.locations import RoomEditAction
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+_USAGE = (
+    "Usage:\n"
+    "  manageroom/name <new name>\n"
+    "  manageroom/desc <description>\n"
+    "  manageroom/public <yes|no>"
+)
+
+_AFFIRMATIVE = frozenset({"yes", "y", "true", "on", "1", "public"})
+
+
+class CmdManageRoom(ArxCommand):
+    """Edit a room you own — its name, description, or public/private listing.
+
+    You must be standing in a room you own.
+
+    Usage:
+      manageroom/name <new name>
+      manageroom/desc <description>
+      manageroom/public <yes|no>
+    """
+
+    key = "manageroom"
+    locks = "cmd:all()"
+    help_category = "Building"
+    action = RoomEditAction()
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        switches = set(self.switches or [])
+        args = (self.args or "").strip()
+        if "name" in switches:  # noqa: STRING_LITERAL — Evennia switch name, not a discriminator
+            if not args:
+                msg = "Give the new room name."
+                raise CommandError(msg)
+            return {"name": args}
+        if switches & {"desc", "description"}:  # noqa: STRING_LITERAL — Evennia switch names
+            if not args:
+                msg = "Give the new description."
+                raise CommandError(msg)
+            return {"description": args}
+        if "public" in switches:  # noqa: STRING_LITERAL — Evennia switch name
+            if not args:
+                msg = "Use 'manageroom/public <yes|no>'."
+                raise CommandError(msg)
+            return {"is_public": args.lower() in _AFFIRMATIVE}
+        raise CommandError(_USAGE)

--- a/src/commands/tests/test_manageroom_command.py
+++ b/src/commands/tests/test_manageroom_command.py
@@ -1,0 +1,36 @@
+"""manageroom command (#1470) — switch parsing into RoomEditAction kwargs."""
+
+from django.test import TestCase
+
+from commands.exceptions import CommandError
+from commands.locations import CmdManageRoom
+
+
+class ManageRoomParseTests(TestCase):
+    def _parse(self, switches: list[str], args: str) -> dict:
+        cmd = CmdManageRoom()
+        cmd.switches = switches
+        cmd.args = args
+        return cmd.resolve_action_args()
+
+    def test_name_switch_trims_and_returns_name(self) -> None:
+        assert self._parse(["name"], "  The Solar  ") == {"name": "The Solar"}
+
+    def test_desc_switch_returns_description(self) -> None:
+        assert self._parse(["desc"], "Warm light, worn rugs.") == {
+            "description": "Warm light, worn rugs."
+        }
+
+    def test_public_yes_is_true(self) -> None:
+        assert self._parse(["public"], "yes") == {"is_public": True}
+
+    def test_public_no_is_false(self) -> None:
+        assert self._parse(["public"], "no") == {"is_public": False}
+
+    def test_no_switch_raises_usage(self) -> None:
+        with self.assertRaises(CommandError):
+            self._parse([], "anything")
+
+    def test_name_requires_a_value(self) -> None:
+        with self.assertRaises(CommandError):
+            self._parse(["name"], "")

--- a/src/world/locations/CLAUDE.md
+++ b/src/world/locations/CLAUDE.md
@@ -421,3 +421,21 @@ stories.
 Same `_validate_location_kwargs` shape as the lifecycle helpers —
 exactly one of `area` or `room_profile`. Raises `ValueError` on
 violation.
+
+## Owner-facing room editing (#1470)
+
+`set_room_display_data(*, room, persona, name=None, description=None, is_public=None)`
+is the owner-gated MVP seam for a player editing a room they own — the first
+player-facing write over `RoomProfile` / `ObjectDisplayData`. It:
+
+- re-checks `is_owner(persona, room)` as a hard boundary (raises `RoomEditError`,
+  which carries a player-facing `user_message` — never surface `str(exc)`);
+- refuses to flip `is_public`→True while a non-public scene is live in the room
+  (`_has_active_non_public_scene`, the inverse of the #1287 scene-privacy invariant);
+- writes name → `ObjectDisplayData.longname`, description → `permanent_description`,
+  listing → `RoomProfile.is_public`; idempotent, only supplied fields change.
+
+Callers: `actions.definitions.locations.RoomEditAction` (key `edit_room`), gated by
+`actions.prerequisites.IsRoomOwnerPrerequisite`. Faces: telnet `CmdManageRoom`
+(`manageroom/name|desc|public`) and the web action-dispatch endpoint. The React
+room-editor panel is a follow-up (needs a room-management host page).

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -981,3 +981,74 @@ def cleanup_decayed_modifiers(now: datetime | None = None) -> int:
         if to_delete_ids:
             LocationValueModifier.objects.filter(pk__in=to_delete_ids).delete()
         return len(to_delete_ids)
+
+
+# ---------------------------------------------------------------------------
+# Owner-facing room editing (#1470) — the player room-editor MVP seam
+# ---------------------------------------------------------------------------
+
+
+class RoomEditError(Exception):
+    """A room edit was refused; carries a player-facing ``user_message``.
+
+    Never surface ``str(exc)`` to API responses — use ``exc.user_message``.
+    """
+
+    def __init__(self, user_message: str) -> None:
+        super().__init__(user_message)
+        self.user_message = user_message
+
+
+def _has_active_non_public_scene(room: DefaultObject) -> bool:
+    """Whether an active, non-PUBLIC scene is running in this room.
+
+    The inverse of the #1287 scene-privacy invariant: a publicly-listed room may
+    host only PUBLIC scenes, so a room cannot be *made* public while a
+    PRIVATE/EPHEMERAL scene is live in it.
+    """
+    from world.scenes.constants import ScenePrivacyMode  # noqa: PLC0415
+    from world.scenes.models import Scene  # noqa: PLC0415
+
+    return (
+        Scene.objects.filter(location=room, is_active=True)
+        .exclude(privacy_mode=ScenePrivacyMode.PUBLIC)
+        .exists()
+    )
+
+
+def set_room_display_data(
+    *,
+    room: DefaultObject,
+    persona: Persona,
+    name: str | None = None,
+    description: str | None = None,
+    is_public: bool | None = None,
+) -> None:
+    """Owner-gated edit of a room's display name, description, and public listing.
+
+    Re-checks ownership as a hard boundary (the action prerequisite is the primary
+    UX gate). Refuses to make a room public while a non-public scene is active in
+    it. Writes name → ``ObjectDisplayData.longname``, description →
+    ``permanent_description``, listing → ``RoomProfile.is_public``. Idempotent;
+    only the provided fields are touched.
+    """
+    from evennia_extensions.models import ObjectDisplayData  # noqa: PLC0415
+
+    if not is_owner(persona, room):
+        msg = "You don't own this room."
+        raise RoomEditError(msg)
+    if is_public is True and _has_active_non_public_scene(room):
+        msg = "A non-public scene is happening here; it must end before the room can be public."
+        raise RoomEditError(msg)
+
+    if name is not None or description is not None:
+        display, _ = ObjectDisplayData.objects.get_or_create(object=room)
+        if name is not None:
+            display.longname = name
+        if description is not None:
+            display.permanent_description = description
+        display.save()
+    if is_public is not None:
+        profile, _ = RoomProfile.objects.get_or_create(objectdb=room)
+        profile.is_public = is_public
+        profile.save(update_fields=["is_public"])

--- a/src/world/locations/tests/test_room_editor.py
+++ b/src/world/locations/tests/test_room_editor.py
@@ -1,0 +1,102 @@
+"""Room-editor MVP (#1470) — owner-gated name/description/public-private edits.
+
+Covers the ``set_room_display_data`` service (writes + owner gate + the
+public-toggle scene-privacy guard) and the ``IsRoomOwnerPrerequisite`` gate.
+"""
+
+from django.test import TestCase
+
+from actions.prerequisites import IsRoomOwnerPrerequisite
+from evennia_extensions.factories import RoomProfileFactory
+from evennia_extensions.models import ObjectDisplayData, RoomProfile
+from world.areas.constants import AreaLevel
+from world.areas.factories import AreaFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.locations.constants import HolderType, LocationParentType
+from world.locations.models import LocationOwnership
+from world.locations.services import RoomEditError, set_room_display_data
+from world.scenes.constants import ScenePrivacyMode
+from world.scenes.factories import PersonaFactory, SceneFactory
+
+
+def _own_room(profile, persona) -> LocationOwnership:
+    return LocationOwnership.objects.create(
+        parent_type=LocationParentType.ROOM,
+        room_profile=profile,
+        holder_type=HolderType.PERSONA,
+        holder_persona=persona,
+    )
+
+
+class SetRoomDisplayDataTests(TestCase):
+    def setUp(self) -> None:
+        self.ward = AreaFactory(level=AreaLevel.WARD)
+        self.profile = RoomProfileFactory(area=self.ward)
+        self.room = self.profile.objectdb
+        self.owner = PersonaFactory()
+        _own_room(self.profile, self.owner)
+
+    def test_owner_sets_name_description_and_privacy(self) -> None:
+        set_room_display_data(
+            room=self.room,
+            persona=self.owner,
+            name="The Great Hall",
+            description="Lofty and lamplit.",
+            is_public=False,
+        )
+        display = ObjectDisplayData.objects.get(object=self.room)
+        assert display.longname == "The Great Hall"
+        assert display.permanent_description == "Lofty and lamplit."
+        assert RoomProfile.objects.get(objectdb=self.room).is_public is False
+
+    def test_only_supplied_fields_change(self) -> None:
+        ObjectDisplayData.objects.create(
+            object=self.room, longname="Old", permanent_description="Old desc."
+        )
+        set_room_display_data(room=self.room, persona=self.owner, name="New")
+        display = ObjectDisplayData.objects.get(object=self.room)
+        assert display.longname == "New"
+        assert display.permanent_description == "Old desc."
+
+    def test_non_owner_is_refused(self) -> None:
+        stranger = PersonaFactory()
+        with self.assertRaises(RoomEditError):
+            set_room_display_data(room=self.room, persona=stranger, name="Hijacked")
+        assert not ObjectDisplayData.objects.filter(object=self.room).exists()
+
+    def test_cannot_make_public_while_a_non_public_scene_is_active(self) -> None:
+        self.profile.is_public = False
+        self.profile.save(update_fields=["is_public"])
+        SceneFactory(location=self.room, privacy_mode=ScenePrivacyMode.PRIVATE, is_active=True)
+        with self.assertRaises(RoomEditError):
+            set_room_display_data(room=self.room, persona=self.owner, is_public=True)
+        assert RoomProfile.objects.get(objectdb=self.room).is_public is False
+
+    def test_can_make_public_with_no_active_private_scene(self) -> None:
+        self.profile.is_public = False
+        self.profile.save(update_fields=["is_public"])
+        set_room_display_data(room=self.room, persona=self.owner, is_public=True)
+        assert RoomProfile.objects.get(objectdb=self.room).is_public is True
+
+
+class IsRoomOwnerPrerequisiteTests(TestCase):
+    def setUp(self) -> None:
+        self.ward = AreaFactory(level=AreaLevel.WARD)
+        self.profile = RoomProfileFactory(area=self.ward)
+        self.room = self.profile.objectdb
+
+    def test_owner_standing_in_their_room_is_met(self) -> None:
+        sheet = CharacterSheetFactory()
+        _own_room(self.profile, sheet.primary_persona)
+        character = sheet.character
+        character.location = self.room
+        met, _msg = IsRoomOwnerPrerequisite().is_met(character)
+        assert met is True
+
+    def test_non_owner_is_refused(self) -> None:
+        sheet = CharacterSheetFactory()
+        character = sheet.character
+        character.location = self.room
+        met, msg = IsRoomOwnerPrerequisite().is_met(character)
+        assert met is False
+        assert "own" in msg.lower()


### PR DESCRIPTION
The foundation slice of the #670 player room/building editor. A room **owner** standing in a room they own edits its **name**, **description**, and **public/private** listing — through the action layer (telnet + the existing web action-dispatch endpoint).

## What
- **`RoomEditAction`** (key `edit_room`, `actions/definitions/locations.py`), gated by the new **`IsRoomOwnerPrerequisite`** — the first action to wire `locations.is_owner`.
- **`set_room_display_data`** service (`world/locations/services.py`): writes name → `ObjectDisplayData.longname`, description → `permanent_description`, listing → `RoomProfile.is_public`. Re-checks ownership as a hard boundary; **refuses to make a room public while a non-public scene is live** (the #1287 scene-privacy invariant, inverted). Typed `RoomEditError` carries a player-facing `user_message`.
- **Telnet `CmdManageRoom`** (`manageroom/name|desc|public`), registered in the cmdset.

## Anti-reinvention
No new models, no new ViewSet, no parallel privacy/ownership logic — it's the missing **player seam** over `RoomProfile.is_public`, `ObjectDisplayData`, `is_owner`, the generic `DispatchActionView`, and the #1287 invariant. (Full code-verified ledger in #1470's body.)

## Tests
13 backend tests (service writes, owner gate, the public-toggle scene-privacy guard, prerequisite gating, command parsing).

## Scope split
The **React `RoomEditorPanel`** is deferred to **#1472** — verified during implementation that **no room-management page exists** to host it (only event/magic components touch rooms), so an unhosted panel would be a NOT-WIRED stub. The edit capability is already web-reachable via the action-dispatch endpoint.

## Docs
Updated `world/locations/CLAUDE.md`, `commands/CLAUDE.md`, `actions/CLAUDE.md`.

Closes #1470
Refs #670, #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)