### PR TITLE
feat: room editor web panel — owner edits a room in the game view (#1472)

### DIFF
--- a/frontend/src/game/api/roomEditor.ts
+++ b/frontend/src/game/api/roomEditor.ts
@@ -1,0 +1,40 @@
+import { apiFetch } from '@/evennia_replacements/api';
+
+export interface RoomEditInput {
+  name?: string;
+  description?: string;
+  is_public?: boolean;
+}
+
+/**
+ * Dispatch the `edit_room` REGISTRY action for `characterId`, editing the room
+ * the character is currently standing in (#1470). Owner-gated server-side.
+ *
+ * Returns the action's human-readable result message (e.g. "Room updated." or
+ * the reason an edit was refused). Throws on a dispatch-level error (4xx) with
+ * the server's `detail`.
+ */
+export async function editRoom(characterId: number, input: RoomEditInput): Promise<string> {
+  const res = await apiFetch(`/api/actions/characters/${characterId}/dispatch/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      ref: { backend: 'registry', registry_key: 'edit_room' },
+      kwargs: input,
+    }),
+  });
+  if (!res.ok) {
+    let detail = 'Failed to update the room.';
+    try {
+      const data = (await res.json()) as { detail?: string };
+      if (typeof data.detail === 'string' && data.detail.trim()) {
+        detail = data.detail;
+      }
+    } catch {
+      // body wasn't JSON; keep the generic message
+    }
+    throw new Error(detail);
+  }
+  const data = (await res.json()) as { message?: string | null };
+  return data.message ?? 'Room updated.';
+}

--- a/frontend/src/game/components/FocusPanel.test.tsx
+++ b/frontend/src/game/components/FocusPanel.test.tsx
@@ -69,6 +69,8 @@ function makeRoomData(): RoomData {
     ],
     objects: [],
     exits: [],
+    is_owner: false,
+    is_public: false,
   };
 }
 

--- a/frontend/src/game/components/FocusPanel.tsx
+++ b/frontend/src/game/components/FocusPanel.tsx
@@ -116,6 +116,7 @@ export function FocusPanel({ focus, roomCharacter, roomData, sceneData }: FocusP
       body = (
         <RoomPanel
           character={roomCharacter}
+          characterId={observerId}
           room={roomData}
           scene={sceneData}
           onCharacterClick={onCharacterClickFromRoom}

--- a/frontend/src/game/components/RoomPanel.tsx
+++ b/frontend/src/game/components/RoomPanel.tsx
@@ -1,14 +1,17 @@
+import { useState } from 'react';
 import { useGameSocket } from '@/hooks/useGameSocket';
 import { useMutation } from '@tanstack/react-query';
 import { startScene, finishScene } from '@/scenes/queries';
 import { useAppDispatch } from '@/store/hooks';
 import { setSessionScene } from '@/store/gameSlice';
 import type { RoomStateObject, SceneSummary } from '@/hooks/types';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { RoomHeader } from './room-panel/RoomHeader';
 import { RoomDescription } from './room-panel/RoomDescription';
 import { CharactersList } from './room-panel/CharactersList';
 import { ExitsList } from './room-panel/ExitsList';
 import { ObjectsList } from './room-panel/ObjectsList';
+import { RoomEditorPanel } from './room-panel/RoomEditorPanel';
 
 export interface RoomData {
   id: number;
@@ -18,18 +21,29 @@ export interface RoomData {
   characters: RoomStateObject[];
   objects: RoomStateObject[];
   exits: RoomStateObject[];
+  is_owner: boolean;
+  is_public: boolean;
 }
 
 interface RoomPanelProps {
   character: string | null;
+  /** The active puppet's ObjectDB pk, for owner-gated room editing (#1470). */
+  characterId?: number | null;
   room: RoomData | null;
   scene: SceneSummary | null;
   onCharacterClick?: (character: RoomStateObject) => void;
 }
 
-export function RoomPanel({ character, room, scene, onCharacterClick }: RoomPanelProps) {
+export function RoomPanel({
+  character,
+  characterId,
+  room,
+  scene,
+  onCharacterClick,
+}: RoomPanelProps) {
   const { send } = useGameSocket();
   const dispatch = useAppDispatch();
+  const [editOpen, setEditOpen] = useState(false);
 
   const start = useMutation({
     mutationFn: () => {
@@ -75,7 +89,30 @@ export function RoomPanel({ character, room, scene, onCharacterClick }: RoomPane
         onEndScene={() => end.mutate()}
         isStartPending={start.isPending}
         isEndPending={end.isPending}
+        canEdit={Boolean(room.is_owner) && characterId != null}
+        onEditRoom={() => setEditOpen(true)}
       />
+
+      {room.is_owner && characterId != null && (
+        <Dialog open={editOpen} onOpenChange={setEditOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Edit room</DialogTitle>
+            </DialogHeader>
+            <RoomEditorPanel
+              characterId={characterId}
+              initialName={room.name}
+              initialDescription={room.description}
+              initialIsPublic={Boolean(room.is_public)}
+              onSaved={() => {
+                setEditOpen(false);
+                send(character, 'look');
+              }}
+              onCancel={() => setEditOpen(false)}
+            />
+          </DialogContent>
+        </Dialog>
+      )}
 
       {room.thumbnail_url && (
         <div className="border-b">

--- a/frontend/src/game/components/room-panel/RoomEditorPanel.test.tsx
+++ b/frontend/src/game/components/room-panel/RoomEditorPanel.test.tsx
@@ -1,0 +1,55 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { editRoom } from '@/game/api/roomEditor';
+import { RoomEditorPanel } from './RoomEditorPanel';
+
+vi.mock('@/game/api/roomEditor', () => ({ editRoom: vi.fn() }));
+
+function renderPanel(overrides: Partial<Parameters<typeof RoomEditorPanel>[0]> = {}) {
+  const onSaved = vi.fn();
+  const onCancel = vi.fn();
+  renderWithProviders(
+    <RoomEditorPanel
+      characterId={42}
+      initialName="Hall"
+      initialDescription="Old desc."
+      initialIsPublic={false}
+      onSaved={onSaved}
+      onCancel={onCancel}
+      {...overrides}
+    />
+  );
+  return { onSaved, onCancel };
+}
+
+describe('RoomEditorPanel', () => {
+  it('dispatches edit_room with the edited fields and calls onSaved on success', async () => {
+    vi.mocked(editRoom).mockResolvedValue('Room updated.');
+    const { onSaved } = renderPanel();
+
+    const nameInput = screen.getByLabelText('Room name');
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'The Solar');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(editRoom).toHaveBeenCalledWith(42, expect.objectContaining({ name: 'The Solar' }));
+      expect(onSaved).toHaveBeenCalled();
+    });
+  });
+
+  it('does not call onSaved when the edit is refused', async () => {
+    vi.mocked(editRoom).mockRejectedValue(new Error("You don't own this room."));
+    const { onSaved } = renderPanel();
+
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(editRoom).toHaveBeenCalled();
+    });
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/game/components/room-panel/RoomEditorPanel.tsx
+++ b/frontend/src/game/components/room-panel/RoomEditorPanel.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { editRoom } from '@/game/api/roomEditor';
+
+interface RoomEditorPanelProps {
+  characterId: number;
+  initialName: string;
+  initialDescription: string;
+  initialIsPublic: boolean;
+  /** Called after a successful save (e.g. to close the dialog + refresh the room). */
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Owner-facing room editor (#1470): edit the current room's name, description,
+ * and public/private listing. Renders inside a dialog hosted by RoomPanel, shown
+ * only when the viewer's active persona owns the room. Submits via the `edit_room`
+ * action dispatch; ownership + the public-toggle guard are enforced server-side.
+ */
+export function RoomEditorPanel({
+  characterId,
+  initialName,
+  initialDescription,
+  initialIsPublic,
+  onSaved,
+  onCancel,
+}: RoomEditorPanelProps) {
+  const [name, setName] = useState(initialName);
+  const [description, setDescription] = useState(initialDescription);
+  const [isPublic, setIsPublic] = useState(initialIsPublic);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      editRoom(characterId, { name: name.trim(), description, is_public: isPublic }),
+    onSuccess: (message) => {
+      toast.success(message);
+      onSaved();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    mutation.mutate();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="room-name">Room name</Label>
+        <Input id="room-name" value={name} onChange={(e) => setName(e.target.value)} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="room-description">Description</Label>
+        <Textarea
+          id="room-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={6}
+        />
+      </div>
+      <div className="flex items-center gap-3">
+        <Switch id="room-public" checked={isPublic} onCheckedChange={setIsPublic} />
+        <Label htmlFor="room-public">Public — listed on where; only public scenes here</Label>
+      </div>
+      <div className="flex gap-3">
+        <Button type="submit" disabled={!name.trim() || mutation.isPending}>
+          {mutation.isPending ? 'Saving…' : 'Save'}
+        </Button>
+        <Button type="button" variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/game/components/room-panel/RoomHeader.tsx
+++ b/frontend/src/game/components/room-panel/RoomHeader.tsx
@@ -10,6 +10,9 @@ interface RoomHeaderProps {
   onEndScene: () => void;
   isStartPending: boolean;
   isEndPending: boolean;
+  /** Show the "Edit" affordance — true only when the viewer owns this room (#1470). */
+  canEdit?: boolean;
+  onEditRoom?: () => void;
 }
 
 export function RoomHeader({
@@ -19,10 +22,19 @@ export function RoomHeader({
   onEndScene,
   isStartPending,
   isEndPending,
+  canEdit = false,
+  onEditRoom,
 }: RoomHeaderProps) {
   return (
     <div className="border-b px-3 py-2">
-      <h3 className="text-sm font-semibold">{name}</h3>
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">{name}</h3>
+        {canEdit && onEditRoom && (
+          <Button variant="ghost" size="sm" className="h-5 px-1 text-xs" onClick={onEditRoom}>
+            Edit
+          </Button>
+        )}
+      </div>
       {scene ? (
         <div className="mt-1 flex items-center gap-2">
           <Link to={`/scenes/${scene.id}`}>

--- a/frontend/src/hooks/__tests__/handleRoomStatePayload.test.ts
+++ b/frontend/src/hooks/__tests__/handleRoomStatePayload.test.ts
@@ -71,6 +71,8 @@ describe('handleRoomStatePayload', () => {
           characters: [],
           objects: payload.objects,
           exits: payload.exits,
+          is_owner: false,
+          is_public: false,
         },
       });
       expect(mockDispatch).toHaveBeenCalledTimes(3);
@@ -389,6 +391,8 @@ describe('handleRoomStatePayload', () => {
           characters: [],
           objects: [],
           exits: [],
+          is_owner: false,
+          is_public: false,
         },
       });
     });
@@ -480,6 +484,8 @@ describe('handleRoomStatePayload', () => {
           characters: [],
           objects: [],
           exits: [],
+          is_owner: false,
+          is_public: false,
         },
       });
     });
@@ -563,6 +569,8 @@ describe('handleRoomStatePayload', () => {
           characters: [],
           objects,
           exits,
+          is_owner: false,
+          is_public: false,
         },
       });
 

--- a/frontend/src/hooks/handleRoomStatePayload.ts
+++ b/frontend/src/hooks/handleRoomStatePayload.ts
@@ -20,6 +20,8 @@ export function handleRoomStatePayload(
         characters: payload.characters ?? [],
         objects: payload.objects,
         exits: payload.exits,
+        is_owner: payload.room.is_owner ?? false,
+        is_public: payload.room.is_public ?? false,
       },
     })
   );

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -88,6 +88,10 @@ export interface RoomStateObject {
   thumbnail_url: string | null;
   commands: string[];
   description?: string;
+  /** Whether the viewing character's active persona owns this room (#1470). */
+  is_owner?: boolean;
+  /** Whether the room is publicly listed (the editor's privacy toggle state). */
+  is_public?: boolean;
 }
 
 export interface RoomStatePayload {

--- a/frontend/src/store/__tests__/gameSlice.test.ts
+++ b/frontend/src/store/__tests__/gameSlice.test.ts
@@ -39,6 +39,8 @@ interface RoomData {
   characters: RoomStateObject[];
   objects: RoomStateObject[];
   exits: RoomStateObject[];
+  is_owner: boolean;
+  is_public: boolean;
 }
 
 interface Session {
@@ -91,6 +93,8 @@ const createRoomData = (
   characters: [],
   objects,
   exits,
+  is_owner: false,
+  is_public: false,
 });
 
 const createRoomStateObject = (

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -16,6 +16,8 @@ interface RoomData {
   characters: RoomStateObject[];
   objects: RoomStateObject[];
   exits: RoomStateObject[];
+  is_owner: boolean;
+  is_public: boolean;
 }
 
 interface Session {

--- a/src/flows/service_functions/serializers/room_state.py
+++ b/src/flows/service_functions/serializers/room_state.py
@@ -222,6 +222,28 @@ class RoomStatePayloadSerializer(serializers.Serializer):
             "theme": realm.theme,
         }
 
+    def _is_room_owner(self, caller: BaseState, room: BaseState) -> bool:
+        """Whether the caller's ACTIVE persona owns this room (#1470 editor gate).
+
+        Active persona, never primary — gating on primary would leak alt ownership.
+        """
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        from world.locations.services import is_owner  # noqa: PLC0415
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        try:
+            sheet = caller.obj.sheet_data
+        except (AttributeError, ObjectDoesNotExist):
+            return False
+        return is_owner(active_persona_for_sheet(sheet), room.obj)
+
+    def _is_room_public(self, room: BaseState) -> bool:
+        """Whether the room is publicly listed (the editor's privacy toggle state)."""
+        from evennia_extensions.models import room_is_publicly_listed  # noqa: PLC0415
+
+        return room_is_publicly_listed(room.obj)
+
     def to_representation(self, instance):
         """Convert room state data to structured payload."""
         if isinstance(instance, dict):
@@ -236,6 +258,8 @@ class RoomStatePayloadSerializer(serializers.Serializer):
         room_data["description"] = room.description
         room_data["ancestry"] = self._get_ancestry(room)
         room_data["realm"] = self._get_realm(room)
+        room_data["is_owner"] = self._is_room_owner(caller, room)
+        room_data["is_public"] = self._is_room_public(room)
 
         # Serialize characters, objects, and exits
         characters, objects, exits = self._serialize_contents(room, caller)

--- a/src/flows/tests/test_room_state_serializer.py
+++ b/src/flows/tests/test_room_state_serializer.py
@@ -126,6 +126,11 @@ class RoomStateSerializerCharacterSplitTests(TestCase):
         payload = build_room_state_payload(self.caller_state, self.room_state)
         assert "description" in payload["room"]
 
+    def test_room_data_includes_is_owner_false_for_non_owner(self):
+        """Room payload carries an is_owner flag (#1470); False without ownership."""
+        payload = build_room_state_payload(self.caller_state, self.room_state)
+        assert payload["room"]["is_owner"] is False
+
     def test_exits_still_in_exits(self):
         """Exits should still appear in the 'exits' list."""
         payload = build_room_state_payload(self.caller_state, self.room_state)


### PR DESCRIPTION
The web UI for the room editor (#1470 backend merged in #1473). The #1472 "needs a host page" split **dissolved** once the host was found: the GamePage **RoomPanel** already renders the current room, so the editor lives there behind an owner-gated button — no new page/route needed.

## What
- **Room-state payload** gains a viewer-scoped **`is_owner`** (resolved via the **active** persona — never `primary`, per the alt-leak rule) and **`is_public`**, added in the `room_state` DRF serializer (no api-types regen).
- **`RoomEditorPanel`** — name / description / public-private toggle; submits via the existing `edit_room` action dispatch (`postDispatchAction` shape). Hosted in **`RoomPanel`** behind an **"Edit"** button in `RoomHeader` shown only when `room.is_owner`; refreshes the room (`look`) on save. `FocusPanel` passes the resolved `character_id`.
- Ownership + the public-toggle scene guard are enforced **server-side** (the panel surfaces the action's message).

## Anti-reinvention
Reuses the GamePage room view, the action-dispatch endpoint, `is_owner`, and the existing shadcn form primitives (Input/Textarea/Switch/Dialog) — no new page, route, ViewSet, or privacy model. The `is_owner`/`is_public` additions ride the existing room serializer.

## Tests / gates
- `RoomEditorPanel` mutation test (vitest); `is_owner` room-payload test (backend, 10 pass).
- `pnpm build` ✓ (the real FE gate — caught + fixed two stale `RoomData` test fixtures), typecheck ✓, eslint ✓.

Closes #1472
Refs #670, #1470

🤖 Generated with [Claude Code](https://claude.com/claude-code)