### PR TITLE
Reconcile RoundSettingsDialog danger lock with #1466 (danger is now a reconfigurable STRICT round)

### DIFF
--- a/docs/roadmap/rp-scenes.md
+++ b/docs/roadmap/rp-scenes.md
@@ -183,11 +183,10 @@ Frontend parity for `scene round` (telnet):
   staff-gated React dialog; reads `active_round` from the scene detail and dispatches
   `useSetRoundMode` → `POST /api/scenes/{id}/set-round-mode/`. Wired into `SceneHeader.tsx`.
 
-**Deferred follow-up — reconcile the web danger lock with #1466:** `RoundSettingsDialog`
-still locks danger rounds (`modeLocked = is_danger`, "Danger rounds resolve on their own
-and can't be reconfigured"). #1466 retired the forced-OPEN self-resolving danger path, so
-the web control should let a scene admin reconfigure a live danger round's knobs (linked to
-#1328 web/telnet parity).
+**Web danger lock reconciled — DONE (#1476):** `RoundSettingsDialog` no longer locks
+danger rounds. Since #1466 a danger round is an ordinary STRICT round, so the dialog lets
+a scene admin reconfigure a live danger round's knobs/mode like any other round (web/telnet
+parity, #1328). `is_danger` now only drives a non-blocking informational note.
 
 **Details:** [scenes.md](../systems/scenes.md) §"Scene Administration (#1445)"
 

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -576,8 +576,12 @@ React-side parity for `scene round` (telnet, #1445).
 - When `scene.active_round` is `null` (no active round), the dialog body shows an
   informational message; Save is disabled.
 - When a round exists, the dialog exposes mode (Select), advance quorum % (Input),
-  max actions per round (Input), and repeat-target lock (Switch). The mode selector is
-  currently disabled when `active_round.is_danger` is true (`modeLocked`).
+  max actions per round (Input), and repeat-target lock (Switch). All controls are
+  editable for every round, including danger rounds — since #1466 a danger round is an
+  ordinary STRICT round and `set_scene_round_mode` accepts knob/mode changes for it like
+  any other round (web/telnet parity, #1328, #1476). When `active_round.is_danger` is
+  true the dialog shows a non-blocking informational note explaining the round was started
+  by an unfolding peril and auto-ends when it clears; it does **not** lock anything.
 - On Save, dispatches `useSetRoundMode` → `POST /api/scenes/{id}/set-round-mode/` with a
   `SetRoundModePayload`; closes the dialog on success.
 
@@ -599,12 +603,8 @@ nested field serialized by `SceneRoundSerializer` (read-only). Fields:
 
 `active_round` is `null` when the scene has no location or no active round exists.
 
-**Deferred follow-up — frontend/backend reconciliation:** `RoundSettingsDialog` still
-locks danger rounds (`modeLocked = is_danger`, "Danger rounds resolve on their own and
-can't be reconfigured"). That copy and lock predate #1466, which retired the forced-OPEN
-self-resolving danger path — danger is now a STRICT, reconfigurable scene round. The web
-control should be updated to allow reconfiguring a danger round's knobs (linked to #1328
-web/telnet parity).
+The `is_danger` field remains a read-side hint: the dialog uses it only to show the
+informational note above, never to disable controls (#1476 cleared the old danger lock).
 
 ---
 

--- a/frontend/src/scenes/components/RoundSettingsDialog.test.tsx
+++ b/frontend/src/scenes/components/RoundSettingsDialog.test.tsx
@@ -103,11 +103,12 @@ describe('RoundSettingsDialog', () => {
     });
   });
 
-  it('disables the mode select and Save button when the active round is a danger round', async () => {
+  it('lets a GM reconfigure a danger round (mode select and Save enabled)', async () => {
+    // After #1466 a danger round is an ordinary STRICT round: fully reconfigurable.
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     const dangerRound: SceneRoundState = {
       ...activeRound,
-      mode: 'open',
+      mode: 'strict',
       is_danger: true,
     };
     renderWith({ ...base, active_round: dangerRound });
@@ -119,8 +120,11 @@ describe('RoundSettingsDialog', () => {
     });
 
     const trigger = screen.getByLabelText(/mode/i);
-    expect(trigger).toHaveAttribute('disabled');
+    expect(trigger).not.toHaveAttribute('disabled');
 
-    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
+
+    // The danger context note is shown, but it never locks the controls.
+    expect(screen.getByText(/started by an unfolding danger/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/scenes/components/RoundSettingsDialog.tsx
+++ b/frontend/src/scenes/components/RoundSettingsDialog.tsx
@@ -56,15 +56,17 @@ export function RoundSettingsDialog({ scene }: { scene: SceneDetail }) {
   if (!scene.viewer_can_gm || !scene.is_active) return null;
 
   const noRound = round === null;
-  const modeLocked = round?.is_danger ?? false;
+  // A danger round is an ordinary STRICT round (#1466): fully reconfigurable, just
+  // started by an unfolding peril. We surface that context but never lock the controls.
+  const isDanger = round?.is_danger ?? false;
 
   function handleSave() {
     const payload: SetRoundModePayload = {
+      mode,
       advance_quorum_pct: quorum,
       max_actions_per_round: maxActions,
       per_target_repeat_lock: repeatLock,
     };
-    if (!modeLocked) payload.mode = mode;
     mutation.mutate(payload, { onSuccess: () => setOpen(false) });
   }
 
@@ -87,13 +89,16 @@ export function RoundSettingsDialog({ scene }: { scene: SceneDetail }) {
           </p>
         ) : (
           <div className="space-y-4">
+            {isDanger && (
+              <p className="text-xs text-muted-foreground">
+                This round was started by an unfolding danger. It resolves each round and ends on
+                its own once the peril clears — but you can still adjust its settings below.
+              </p>
+            )}
+
             <div className="space-y-1">
               <Label htmlFor="round-mode">Mode</Label>
-              <Select
-                value={mode}
-                onValueChange={(v) => setMode(v as SceneRoundModeValue)}
-                disabled={modeLocked}
-              >
+              <Select value={mode} onValueChange={(v) => setMode(v as SceneRoundModeValue)}>
                 <SelectTrigger id="round-mode">
                   <SelectValue />
                 </SelectTrigger>
@@ -105,11 +110,6 @@ export function RoundSettingsDialog({ scene }: { scene: SceneDetail }) {
                   ))}
                 </SelectContent>
               </Select>
-              {modeLocked && (
-                <p className="text-xs text-muted-foreground">
-                  Danger rounds resolve on their own and can&apos;t be reconfigured.
-                </p>
-              )}
             </div>
 
             <div className="space-y-1">
@@ -121,7 +121,6 @@ export function RoundSettingsDialog({ scene }: { scene: SceneDetail }) {
                 max={100}
                 value={quorum}
                 onChange={(e) => setQuorum(Number(e.target.value))}
-                disabled={modeLocked}
               />
             </div>
 
@@ -133,28 +132,18 @@ export function RoundSettingsDialog({ scene }: { scene: SceneDetail }) {
                 min={0}
                 value={maxActions}
                 onChange={(e) => setMaxActions(Number(e.target.value))}
-                disabled={modeLocked}
               />
             </div>
 
             <div className="flex items-center justify-between">
               <Label htmlFor="round-repeat-lock">Lock repeat actions on the same target</Label>
-              <Switch
-                id="round-repeat-lock"
-                checked={repeatLock}
-                onCheckedChange={setRepeatLock}
-                disabled={modeLocked}
-              />
+              <Switch id="round-repeat-lock" checked={repeatLock} onCheckedChange={setRepeatLock} />
             </div>
           </div>
         )}
 
         <DialogFooter>
-          <Button
-            type="button"
-            onClick={handleSave}
-            disabled={noRound || modeLocked || mutation.isPending}
-          >
+          <Button type="button" onClick={handleSave} disabled={noRound || mutation.isPending}>
             Save
           </Button>
         </DialogFooter>


### PR DESCRIPTION
Closes #1476

## Summary

Since #1466 (merged via #1474) a danger round is an ordinary STRICT `SceneRound(start_reason=DANGER)`: reconfigurable, resolved at presence-gated resolution, and auto-ending when the peril clears. The web `RoundSettingsDialog` still treated it as the retired forced-OPEN self-resolving type, disabling the mode selector and every knob via `modeLocked = is_danger`.

This drops the blanket lock so **mode / advance quorum / action cap / repeat-lock / Save are editable for danger rounds like any other round** (web/telnet parity, #1328), matching the backend `set_scene_round_mode` after #1466. `is_danger` now only drives a **non-blocking informational note**. The danger unit test is inverted to assert the controls are enabled, and the deferred-follow-up notes in `docs/systems/scenes.md` and `docs/roadmap/rp-scenes.md` are cleared.

Frontend checks: `pnpm typecheck`, `eslint`, `vitest run` (7 passing), and `pnpm build` all green.

## Follow-ups filed

(none)

## Notes

- Spec: design skipped — backend-determined bug fix (the fully-open behavior is fixed by #1466); implemented directly per the issue body's "at minimum" directive
- Brainstorm/plan: skipped — backend-determined bug fix; the design (fully open, no danger special-case) is fixed by #1466
- Sync-with-main: branch is on top of origin/main @ 3f101969 (#1474); already current, no rebase needed

<!-- last-addressed-comment: 0 -->