### PR TITLE
Telnet journey: persona / guise switching (set-active identity)

### DIFF
--- a/docs/roadmap/rp-scenes.md
+++ b/docs/roadmap/rp-scenes.md
@@ -190,6 +190,25 @@ parity, #1328). `is_danger` now only drives a non-blocking informational note.
 
 **Details:** [scenes.md](../systems/scenes.md) §"Scene Administration (#1445)"
 
+### Persona Telnet Switch + Shared set-active Path — DONE (#1347)
+
+Web/telnet parity for active-persona management. Before this, `PersonaViewSet.set_active`
+called `set_active_persona` directly (bypassing `action.run()`); telnet had no way to switch.
+
+- **`SetActivePersonaAction`** (key `"set_active_persona"`, REGISTRY, `target_type=SELF`,
+  kwarg `persona_id`) in `actions/definitions/personas.py` — validates persona ownership,
+  wraps `world.scenes.services.set_active_persona` (still the sole mutator).
+- **`PersonaViewSet.set_active`** now routes through `dispatch_player_action` → the action
+  instead of calling the service directly. API request/response unchanged.
+- **`CmdPersona`** (`persona`, alias `wear-face`) in `commands/persona.py` — thin
+  `DispatchCommand`; bare `persona`/`persona list` renders the caller's faces (active marked
+  `◄ active`); `persona <name>` or `wear-face <name>` dispatches the action.
+- **E2E:** `src/integration_tests/pipeline/test_persona_telnet_e2e.py` (telnet list/switch,
+  web/telnet parity, negative cases).
+- **Scope boundary:** pose/sdesc reflection of the presented persona remains **#1109**.
+
+**Details:** [appearance_and_identity.md](../systems/appearance_and_identity.md) §"Layer 1 — Persona"
+
 ### Positioning in Scenes — DONE (#1017)
 - **Scene API extension:** `SceneDetailSerializer` exposes `positions`, `position_adjacency`, `persona_positions` for the scene's room.
 - **Frontend:** `RoomPositionsPanel` component (`frontend/src/scenes/components/`) renders positions, persona placement, move action, and a staff "Set the stage" control. `MovementActions` extracted as a shared component (`frontend/src/combat/components/`).

--- a/docs/systems/appearance_and_identity.md
+++ b/docs/systems/appearance_and_identity.md
@@ -74,6 +74,17 @@ artist changes persona with an *identical* body; a curse changes the body and
   auto-attached across personas** (see *Privacy invariant*). It is *not* on the form
   value — one shared form must be able to carry different descriptors per persona.
 - Active face resolves via `active_persona_for_sheet` (**#1044**).
+- **Switching the active face** flows through `SetActivePersonaAction` (key
+  `"set_active_persona"`, `actions/definitions/personas.py`, **#1347**) — a REGISTRY
+  action with `target_type=SELF` and kwarg `persona_id`. Both the web
+  (`PersonaViewSet.set_active`) and telnet (`CmdPersona` / `wear-face` alias,
+  `commands/persona.py`) route through `dispatch_player_action` → `action.run()`;
+  `world.scenes.services.set_active_persona` remains the sole mutator underneath.
+  Bare `persona`/`persona list` on telnet renders the caller's own personas and marks
+  the active one; `persona <name>` or `wear-face <name>` triggers the switch.
+  **Scope boundary:** the pose/sdesc read-path (`record_interaction` /
+  `_characters_to_active_personas`) is **not** changed here — making poses reflect the
+  presented persona (with privacy/discovery/freeze) is **#1109**'s scope.
 
 ## Layer 2 — Form (physical body, REAL)
 
@@ -199,7 +210,7 @@ path copies a descriptor from a sibling persona.
 
 | Surface | Verdict | Evidence |
 |---|---|---|
-| `Persona` + `active_persona` resolution | **BUILT & WIRED** | `world/scenes/models.py`; `active_persona_for_sheet` (#1044) |
+| `Persona` + `active_persona` resolution | **BUILT & WIRED** | `world/scenes/models.py`; `active_persona_for_sheet` (#1044); set-active wired via `SetActivePersonaAction` (web + telnet, #1347) |
 | `PersonaDiscovery` | **BUILT** | `world/scenes` (per scenes guide) |
 | `CharacterForm` / `FormType` (TRUE/ALTERNATE/DISGUISE) / `CharacterFormState` / `switch_form` / `get_apparent_form` | **BUILT, partly wired** | `world/forms/models.py:202-302`, `services.py:18-64`; wired to a forms API endpoint, **not** to character-appearance rendering (`_build_appearance` reads the TRUE form) |
 | `DurationType` + `TemporaryFormChange` | **BUILT** | `world/forms/models.py:215-318` — covers shapeshift/overlay durations |

--- a/src/actions/CLAUDE.md
+++ b/src/actions/CLAUDE.md
@@ -42,7 +42,12 @@ They do not use the command system, dispatchers, or handlers.
   new service is `toggle_action_ready`, extracted from the inline web `ready` toggle;
   `locations.py` — `RoomEditAction`, key `"edit_room"` (#1470), owner-gated
   (`IsRoomOwnerPrerequisite`) edit of the current room's name/description/public-listing via
-  `world.locations.services.set_room_display_data`; shared by telnet `CmdManageRoom` + web dispatch)
+  `world.locations.services.set_room_display_data`; shared by telnet `CmdManageRoom` + web dispatch;
+  `personas.py` — `SetActivePersonaAction`, key `"set_active_persona"` (#1347), REGISTRY backend,
+  `target_type=SELF`, kwarg `persona_id`; the single action.run() path for set-active shared by
+  telnet `CmdPersona` and the web `PersonaViewSet.set_active`. Validates the persona belongs to
+  the actor's own sheet; wraps `world.scenes.services.set_active_persona` (the sole mutator).
+  Pose/sdesc reflection of the active persona is #1109's scope, not this action.)
 
 ## SCENE_ADAPTIVE Backend (#1351)
 

--- a/src/actions/definitions/personas.py
+++ b/src/actions/definitions/personas.py
@@ -1,0 +1,62 @@
+"""Identity actions — the ``set_active_persona`` REGISTRY action (#1347).
+
+Wraps ``world.scenes.services.set_active_persona`` (the sole mutator of
+``CharacterSheet.active_persona``) so telnet (``CmdPersona``) and the web
+``PersonaViewSet.set_active`` share one ``action.run()`` path instead of the web
+calling the service directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from actions.base import Action
+from actions.types import ActionResult, TargetType
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from actions.types import ActionContext
+
+
+@dataclass
+class SetActivePersonaAction(Action):
+    """Switch the actor's active persona (identity they present as).
+
+    The ``persona_id`` kwarg must be the pk of a ``Persona`` owned by the
+    actor's sheet. A foreign or unknown id returns a uniform failure message
+    to avoid leaking identity information.
+    """
+
+    key: str = "set_active_persona"
+    name: str = "Wear Face"
+    icon: str = "mask"
+    category: str = "identity"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.scenes.models import Persona  # noqa: PLC0415
+        from world.scenes.services import ActivePersonaError, set_active_persona  # noqa: PLC0415
+
+        uniform = "That isn't one of this character's identities."
+        sheet = actor.sheet_data
+        persona = Persona.objects.filter(
+            pk=kwargs.get("persona_id"), character_sheet_id=sheet.pk
+        ).first()
+        if persona is None:
+            return ActionResult(success=False, message=uniform)
+        try:
+            set_active_persona(sheet, persona)
+        except ActivePersonaError:
+            return ActionResult(success=False, message=uniform)
+        return ActionResult(
+            success=True,
+            message=f"You present as {persona.name}.",
+            data={"active_persona_id": persona.pk},
+        )

--- a/src/actions/definitions/personas.py
+++ b/src/actions/definitions/personas.py
@@ -44,17 +44,16 @@ class SetActivePersonaAction(Action):
         from world.scenes.models import Persona  # noqa: PLC0415
         from world.scenes.services import ActivePersonaError, set_active_persona  # noqa: PLC0415
 
-        uniform = "That isn't one of this character's identities."
         sheet = actor.sheet_data
         persona = Persona.objects.filter(
             pk=kwargs.get("persona_id"), character_sheet_id=sheet.pk
         ).first()
         if persona is None:
-            return ActionResult(success=False, message=uniform)
+            return ActionResult(success=False, message=ActivePersonaError.user_message)
         try:
             set_active_persona(sheet, persona)
         except ActivePersonaError:
-            return ActionResult(success=False, message=uniform)
+            return ActionResult(success=False, message=ActivePersonaError.user_message)
         return ActionResult(
             success=True,
             message=f"You present as {persona.name}.",

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -55,6 +55,7 @@ from actions.definitions.movement import (
 )
 from actions.definitions.outfits import ApplyOutfitAction, UndressAction
 from actions.definitions.perception import InventoryAction, LookAction, LookAtItemAction
+from actions.definitions.personas import SetActivePersonaAction
 from actions.definitions.positioning import MoveToPositionAction, SetTheStageAction
 from actions.definitions.ritual import PerformRitualAction
 from actions.definitions.rounds import (
@@ -98,6 +99,7 @@ _ALL_ACTIONS: list[Action] = [
     EquipAction(),
     UnequipAction(),
     RoomEditAction(),
+    SetActivePersonaAction(),
     PutInAction(),
     TakeOutAction(),
     ActivatePermitAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -205,6 +205,7 @@ class ActionRegistryTests(TestCase):
             "combat_leave",
             "start_scene",
             "finish_scene",
+            "set_active_persona",
         }
         assert set(ACTIONS_BY_KEY.keys()) == expected_keys
 

--- a/src/actions/tests/test_personas.py
+++ b/src/actions/tests/test_personas.py
@@ -1,0 +1,38 @@
+"""Tests for SetActivePersonaAction (#1347)."""
+
+from django.test import TestCase
+
+from actions.definitions.personas import SetActivePersonaAction
+from world.character_sheets.factories import CharacterSheetFactory
+from world.scenes.constants import PersonaType
+from world.scenes.factories import PersonaFactory
+from world.scenes.services import active_persona_for_sheet
+
+
+class SetActivePersonaActionTests(TestCase):
+    def setUp(self) -> None:
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        self.alt = PersonaFactory(
+            character_sheet=self.sheet, persona_type=PersonaType.ESTABLISHED, name="Alt Face"
+        )
+
+    def test_switches_to_owned_persona(self) -> None:
+        result = SetActivePersonaAction().run(actor=self.character, persona_id=self.alt.pk)
+        self.assertTrue(result.success)
+        self.sheet.refresh_from_db()
+        self.assertEqual(active_persona_for_sheet(self.sheet), self.alt)
+        self.assertEqual(result.data["active_persona_id"], self.alt.pk)
+
+    def test_rejects_foreign_persona_uniform_message(self) -> None:
+        other = CharacterSheetFactory()
+        foreign = other.primary_persona
+        result = SetActivePersonaAction().run(actor=self.character, persona_id=foreign.pk)
+        self.assertFalse(result.success)
+        self.assertIn("isn't one of this character's identities", result.message)
+        self.sheet.refresh_from_db()
+        self.assertEqual(active_persona_for_sheet(self.sheet), self.sheet.primary_persona)
+
+    def test_rejects_unknown_id(self) -> None:
+        result = SetActivePersonaAction().run(actor=self.character, persona_id=999999)
+        self.assertFalse(result.success)

--- a/src/actions/tests/test_personas.py
+++ b/src/actions/tests/test_personas.py
@@ -6,7 +6,7 @@ from actions.definitions.personas import SetActivePersonaAction
 from world.character_sheets.factories import CharacterSheetFactory
 from world.scenes.constants import PersonaType
 from world.scenes.factories import PersonaFactory
-from world.scenes.services import active_persona_for_sheet
+from world.scenes.services import ActivePersonaError, active_persona_for_sheet
 
 
 class SetActivePersonaActionTests(TestCase):
@@ -36,3 +36,4 @@ class SetActivePersonaActionTests(TestCase):
     def test_rejects_unknown_id(self) -> None:
         result = SetActivePersonaAction().run(actor=self.character, persona_id=999999)
         self.assertFalse(result.success)
+        self.assertEqual(result.message, ActivePersonaError.user_message)

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -150,6 +150,13 @@ actions, backends, and service functions.
   `manageroom/desc <text>`, `manageroom/public <yes|no>`. Edits the room the caller
   is standing in; ownership is gated by `IsRoomOwnerPrerequisite`, writes live in
   `world.locations.services.set_room_display_data`. No business logic in the command.
+- **`persona.py`**: `CmdPersona` (`persona`, alias `wear-face`, #1347) — list own
+  personas or switch the active one. Bare `persona`/`persona list` renders all the
+  caller's personas (marking the active one `◄ active`). `persona <name>`/`wear-face
+  <name>` resolves the name among the caller's own faces and dispatches `SetActivePersonaAction`
+  (key `"set_active_persona"`, REGISTRY backend) through `dispatch_player_action` — the same
+  seam the web `PersonaViewSet.set_active` uses. Pose/sdesc reflection of the presented
+  persona is #1109's scope, not this command.
 - **`evennia_overrides/builder.py`**: `CmdDig`, `CmdOpen`, `CmdLink`, `CmdUnlink` (Evennia overrides)
 
 ### Account Commands (`account/`)

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -61,6 +61,7 @@ from commands.gemit import CmdGemit
 from commands.imbue import CmdImbue
 from commands.locations import CmdManageRoom
 from commands.offer_response import CmdDecline
+from commands.persona import CmdPersona
 from commands.ritual import CmdRitual
 from commands.scene import CmdScene
 from commands.social.blocking import (
@@ -184,6 +185,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdScene,
             # #1470 — owner-gated room editor (name/description/public-private).
             CmdManageRoom,
+            # #1347 — list faces + wear-face active persona switch.
+            CmdPersona,
         )
         for command_cls in command_classes:
             self.add(command_cls())

--- a/src/commands/persona.py
+++ b/src/commands/persona.py
@@ -1,0 +1,95 @@
+"""Persona telnet command — list faces + wear-face switch (#1347).
+
+A single command renders the caller's owned personas (bare ``persona`` or
+``persona list``) or switches the active persona (``persona <name>``). The
+switch path dispatches through ``dispatch_player_action`` — the same seam the
+web PersonaViewSet uses — routing to the REGISTRY ``set_active_persona`` action.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from actions.constants import ActionBackend
+from commands.command import DispatchCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from actions.types import ActionRef
+
+
+class CmdPersona(DispatchCommand):
+    """List or switch your active face.
+
+    Usage:
+        persona              — list your personas; marks the active one
+        persona list         — same as bare ``persona``
+        persona <name>       — switch your active face to the named persona
+        wear-face <name>     — alias for persona <name>
+    """
+
+    key = "persona"
+    aliases = ["wear-face"]
+    locks = "cmd:all()"
+
+    _name: str = ""
+
+    def func(self) -> None:
+        """Route: bare/list → listing; named → DispatchCommand dispatch."""
+        raw = (self.args or "").strip()
+        if not raw or raw.lower() == "list":  # noqa: STRING_LITERAL
+            self._show_listing()
+            return
+        self._name = raw
+        super().func()  # resolve_action_ref + resolve_action_args + dispatch
+
+    def resolve_action_ref(self) -> ActionRef:
+        """Build a REGISTRY ActionRef for ``set_active_persona``."""
+        from actions.types import ActionRef  # noqa: PLC0415
+
+        return ActionRef(backend=ActionBackend.REGISTRY, registry_key="set_active_persona")
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        """Resolve ``self._name`` to a Persona pk scoped to the caller's sheet."""
+        from world.scenes.models import Persona  # noqa: PLC0415
+
+        sheet = self.caller.sheet_data
+        matches = list(
+            Persona.objects.filter(
+                character_sheet_id=sheet.pk,
+                name__iexact=self._name,
+            )
+        )
+        if not matches:
+            available = ", ".join(
+                p.name for p in Persona.objects.filter(character_sheet_id=sheet.pk)
+            )
+            msg = f"No persona named '{self._name}'. Available: {available}."
+            raise CommandError(msg)
+        if len(matches) > 1:
+            names = ", ".join(p.name for p in matches)
+            msg = f"Multiple personas match '{self._name}': {names}. Be more specific."
+            raise CommandError(msg)
+        return {"persona_id": matches[0].pk}
+
+    # -- helpers ------------------------------------------------------------------
+
+    def _show_listing(self) -> None:
+        """Render the caller's personas, marking the active one."""
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        sheet = self.caller.sheet_data
+        active = active_persona_for_sheet(sheet)
+        personas = list(sheet.personas.all())
+        if not personas:
+            self.msg("You have no personas.")
+            return
+        lines = []
+        for persona in personas:
+            ptype = persona.get_persona_type_display()
+            ftier = persona.get_fame_tier_display()
+            label = f"{persona.name} ({ptype}, {ftier})"
+            if persona.pk == active.pk:
+                label += " ◄ active"
+            lines.append(label)
+        self.msg("\n".join(lines))

--- a/src/commands/persona.py
+++ b/src/commands/persona.py
@@ -89,7 +89,7 @@ class CmdPersona(DispatchCommand):
             ptype = persona.get_persona_type_display()
             ftier = persona.get_fame_tier_display()
             label = f"{persona.name} ({ptype}, {ftier})"
-            if persona.pk == active.pk:
+            if active is not None and persona.pk == active.pk:
                 label += " ◄ active"
             lines.append(label)
         self.msg("\n".join(lines))

--- a/src/commands/tests/test_persona_command.py
+++ b/src/commands/tests/test_persona_command.py
@@ -72,6 +72,19 @@ class CmdPersonaTests(TestCase):
         with self.assertRaises(CommandError):
             cmd.resolve_action_args()
 
+    def test_ambiguous_case_collision_raises(self) -> None:
+        """Two own personas whose names differ only in case → CommandError (>1 iexact match)."""
+        PersonaFactory(
+            character_sheet=self.sheet, persona_type=PersonaType.ESTABLISHED, name="Echo"
+        )
+        PersonaFactory(
+            character_sheet=self.sheet, persona_type=PersonaType.ESTABLISHED, name="echo"
+        )
+        cmd = _cmd(self.character, "echo")
+        cmd._name = "echo"
+        with self.assertRaises(CommandError):
+            cmd.resolve_action_args()
+
     def test_case_insensitive_name_match(self) -> None:
         """Matching is case-insensitive."""
         cmd = _cmd(self.character, "alt face")

--- a/src/commands/tests/test_persona_command.py
+++ b/src/commands/tests/test_persona_command.py
@@ -1,0 +1,96 @@
+"""Unit tests for CmdPersona — list faces + wear-face switch (#1347).
+
+Mirrors src/commands/tests/test_combat_commands.py +
+src/commands/tests/test_dispatch_command.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from actions.constants import ActionBackend
+from actions.types import ActionResult, DispatchResult
+from commands.exceptions import CommandError
+from commands.persona import CmdPersona
+from world.character_sheets.factories import CharacterSheetFactory
+from world.scenes.constants import PersonaType
+from world.scenes.factories import PersonaFactory
+
+
+def _cmd(caller, args=""):
+    cmd = CmdPersona()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"persona {args}".strip()
+    cmd.cmdname = "persona"
+    return cmd
+
+
+class CmdPersonaTests(TestCase):
+    def setUp(self) -> None:
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        self.character.msg = MagicMock()
+        self.alt = PersonaFactory(
+            character_sheet=self.sheet, persona_type=PersonaType.ESTABLISHED, name="Alt Face"
+        )
+
+    def test_bare_lists_personas_marks_active(self) -> None:
+        _cmd(self.character).func()
+        sent = "\n".join(str(c.args[0]) for c in self.character.msg.call_args_list)
+        self.assertIn("Alt Face", sent)
+        self.assertIn(self.sheet.primary_persona.name, sent)
+        self.assertIn("active", sent)
+
+    def test_list_arg_lists_personas(self) -> None:
+        """'persona list' also shows the listing."""
+        _cmd(self.character, "list").func()
+        sent = "\n".join(str(c.args[0]) for c in self.character.msg.call_args_list)
+        self.assertIn("Alt Face", sent)
+        self.assertIn("active", sent)
+
+    def test_named_dispatches_set_active(self) -> None:
+        cmd = _cmd(self.character, "Alt Face")
+        with patch("commands.command.dispatch_player_action") as disp:
+            disp.return_value = DispatchResult(
+                backend=ActionBackend.REGISTRY,
+                deferred=False,
+                detail=ActionResult(success=True, message="ok"),
+            )
+            cmd.func()
+        ref = disp.call_args.args[1]
+        kwargs = disp.call_args.args[2]
+        self.assertEqual(ref.backend, ActionBackend.REGISTRY)
+        self.assertEqual(ref.registry_key, "set_active_persona")
+        self.assertEqual(kwargs, {"persona_id": self.alt.pk})
+
+    def test_unknown_name_raises(self) -> None:
+        cmd = _cmd(self.character, "Nobody")
+        cmd._name = "Nobody"
+        with self.assertRaises(CommandError):
+            cmd.resolve_action_args()
+
+    def test_case_insensitive_name_match(self) -> None:
+        """Matching is case-insensitive."""
+        cmd = _cmd(self.character, "alt face")
+        with patch("commands.command.dispatch_player_action") as disp:
+            disp.return_value = DispatchResult(
+                backend=ActionBackend.REGISTRY,
+                deferred=False,
+                detail=ActionResult(success=True, message="ok"),
+            )
+            cmd.func()
+        kwargs = disp.call_args.args[2]
+        self.assertEqual(kwargs, {"persona_id": self.alt.pk})
+
+
+class CmdPersonaCmdsetRegistrationTests(TestCase):
+    def test_persona_command_registered(self) -> None:
+        from commands.default_cmdsets import CharacterCmdSet
+
+        cmdset = CharacterCmdSet()
+        cmdset.at_cmdset_creation()
+        keys = {c.key for c in cmdset.commands}
+        self.assertIn("persona", keys)

--- a/src/commands/tests/test_persona_command.py
+++ b/src/commands/tests/test_persona_command.py
@@ -86,6 +86,29 @@ class CmdPersonaTests(TestCase):
         self.assertEqual(kwargs, {"persona_id": self.alt.pk})
 
 
+class CmdPersonaActiveNoneTests(TestCase):
+    """Listing must not crash when active_persona_for_sheet returns None."""
+
+    def setUp(self) -> None:
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        self.character.msg = MagicMock()
+        PersonaFactory(
+            character_sheet=self.sheet, persona_type=PersonaType.ESTABLISHED, name="Alt Face"
+        )
+
+    def test_listing_does_not_crash_when_active_is_none(self) -> None:
+        """No AttributeError when active_persona_for_sheet returns None."""
+        with patch(
+            "world.scenes.services.active_persona_for_sheet",  # noqa: STRING_LITERAL
+            return_value=None,
+        ):
+            _cmd(self.character).func()
+        sent = "\n".join(str(c.args[0]) for c in self.character.msg.call_args_list)
+        self.assertIn("Alt Face", sent)
+        self.assertNotIn("active", sent)
+
+
 class CmdPersonaCmdsetRegistrationTests(TestCase):
     def test_persona_command_registered(self) -> None:
         from commands.default_cmdsets import CharacterCmdSet

--- a/src/integration_tests/pipeline/test_persona_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_persona_telnet_e2e.py
@@ -23,7 +23,6 @@ from evennia.utils.idmapper import models as idmapper_models
 from actions.constants import ActionBackend
 from actions.player_interface import dispatch_player_action
 from actions.types import ActionRef
-from commands.exceptions import CommandError
 from commands.persona import CmdPersona
 from world.character_sheets.factories import CharacterSheetFactory
 from world.scenes.constants import PersonaType
@@ -72,7 +71,7 @@ class PersonaTelnetE2ETests(TestCase):
         primary_name = self.sheet.primary_persona.name
         self.assertIn(primary_name, sent, "primary persona should appear in listing")
         self.assertIn("Alt Face", sent, "alt persona should appear in listing")
-        self.assertIn("active", sent, "active marker should appear in listing")
+        self.assertIn(" ◄ active", sent, "active marker should appear in listing")
 
         self.character.msg.reset_mock()
 
@@ -124,24 +123,41 @@ class PersonaTelnetE2ETests(TestCase):
     def test_foreign_persona_rejected_via_telnet(self) -> None:
         """A persona from another sheet is rejected; active persona is unchanged.
 
-        ``CmdPersona.func()`` catches ``CommandError`` and messages the caller,
-        so we assert the raise by calling ``resolve_action_args()`` directly
-        (mirroring how ``test_persona_command.py`` tests the unknown-name path).
+        ``CmdPersona.func()`` sets ``self._name`` then calls ``super().func()``
+        (``DispatchCommand.func()``), which catches ``CommandError`` from
+        ``resolve_action_args()`` and sends the message to the caller via
+        ``self.msg()`` — no exception propagates to the caller.  This test
+        exercises the full real telnet path rather than calling
+        ``resolve_action_args()`` directly.
         """
         other_sheet = CharacterSheetFactory()
         foreign_name = other_sheet.primary_persona.name
 
-        primary_before = self.sheet.primary_persona
+        primary_pk = self.sheet.primary_persona.pk
 
         cmd = _cmd(self.character, foreign_name)
-        cmd._name = foreign_name
+        # Full real telnet path — func() must NOT raise; DispatchCommand.func()
+        # catches CommandError and routes it to self.msg().
+        cmd.func()
 
-        with self.assertRaises(CommandError, msg="foreign persona name should raise CommandError"):
-            cmd.resolve_action_args()
+        # Caller must have been messaged with the error.
+        self.assertTrue(
+            self.character.msg.called,
+            "msg should have been called with an error after foreign-name rejection",
+        )
+        sent = " ".join(
+            str(call.args[0]) for call in self.character.msg.call_args_list if call.args
+        )
+        self.assertIn(
+            foreign_name,
+            sent,
+            "error message should mention the unrecognised persona name",
+        )
 
+        # DB state unchanged: active persona pk is still the primary's pk.
         self.sheet.refresh_from_db()
         self.assertEqual(
-            active_persona_for_sheet(self.sheet),
-            primary_before,
-            "active persona must be unchanged after rejected switch",
+            active_persona_for_sheet(self.sheet).pk,
+            primary_pk,
+            "active persona pk must be unchanged after rejected switch",
         )

--- a/src/integration_tests/pipeline/test_persona_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_persona_telnet_e2e.py
@@ -1,0 +1,147 @@
+"""Telnet E2E: persona switching end-to-end journey (#1347).
+
+Covers three scenarios:
+  1. ``persona`` (bare list) renders both personas with the active marker, then
+     ``persona Alt Face`` switches via the full telnet path and DB state reflects it.
+  2. Web-seam parity: ``dispatch_player_action`` (REGISTRY, ``set_active_persona``)
+     reaches identical DB state — proves telnet + web converge on one Action.
+  3. A foreign persona (from another character's sheet) is rejected via telnet and
+     leaves the active persona unchanged.
+
+setUp uses plain ``TestCase`` (not EvenniaTest) + factories, mirroring
+``test_combat_cast_telnet_e2e.py``. ``idmapper_models.flush_cache()`` is called in
+setUp to prevent PK-recycling flakiness from prior tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+from evennia.utils.idmapper import models as idmapper_models
+
+from actions.constants import ActionBackend
+from actions.player_interface import dispatch_player_action
+from actions.types import ActionRef
+from commands.exceptions import CommandError
+from commands.persona import CmdPersona
+from world.character_sheets.factories import CharacterSheetFactory
+from world.scenes.constants import PersonaType
+from world.scenes.factories import PersonaFactory
+from world.scenes.services import active_persona_for_sheet
+
+
+def _cmd(character, args=""):
+    """Build a ``CmdPersona`` instance wired to *character* with *args*."""
+    cmd = CmdPersona()
+    cmd.caller = character
+    cmd.args = args
+    cmd.raw_string = f"persona {args}".strip()
+    cmd.cmdname = "persona"
+    return cmd
+
+
+class PersonaTelnetE2ETests(TestCase):
+    """Full persona-switching journey from the telnet command.
+
+    Uses setUp (not setUpTestData) for ObjectDB-backed objects: Django's
+    setUpTestData deepcopy machinery cannot copy DbHolder / SharedMemoryModel
+    instances (would raise copy.Error in CI shard runs — see project memory).
+    """
+
+    def setUp(self) -> None:
+        # Flush SharedMemoryModel identity-map cache to prevent PK recycling
+        # from a prior test leaking stale instances (see project memory).
+        idmapper_models.flush_cache()
+
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        self.character.msg = MagicMock()
+        self.alt = PersonaFactory(
+            character_sheet=self.sheet,
+            persona_type=PersonaType.ESTABLISHED,
+            name="Alt Face",
+        )
+
+    def test_telnet_list_then_switch(self) -> None:
+        """Bare ``persona`` lists both names + active marker; ``persona Alt Face`` switches."""
+        # Step 1: bare listing — both personas visible, active marker present.
+        _cmd(self.character).func()
+
+        sent = "\n".join(str(call.args[0]) for call in self.character.msg.call_args_list)
+        primary_name = self.sheet.primary_persona.name
+        self.assertIn(primary_name, sent, "primary persona should appear in listing")
+        self.assertIn("Alt Face", sent, "alt persona should appear in listing")
+        self.assertIn("active", sent, "active marker should appear in listing")
+
+        self.character.msg.reset_mock()
+
+        # Step 2: switch to alt via telnet.
+        _cmd(self.character, "Alt Face").func()
+
+        self.sheet.refresh_from_db()
+        self.assertEqual(
+            active_persona_for_sheet(self.sheet),
+            self.alt,
+            "active persona should be 'Alt Face' after switch",
+        )
+        self.assertEqual(
+            self.sheet.active_persona_id,
+            self.alt.pk,
+            "active_persona_id should match alt pk",
+        )
+
+    def test_web_telnet_parity(self) -> None:
+        """dispatch_player_action (web seam) reaches the same DB state as telnet.
+
+        1. Switch to alt via telnet.
+        2. Revert to primary via the web seam (dispatch_player_action REGISTRY).
+        3. Assert DB state reverted — both surfaces mutate through one Action.
+        """
+        # Step 1: switch to alt via telnet.
+        _cmd(self.character, "Alt Face").func()
+        self.sheet.refresh_from_db()
+        self.assertEqual(
+            self.sheet.active_persona_id,
+            self.alt.pk,
+            "telnet switch to alt should have been applied",
+        )
+
+        # Step 2: revert to primary via web seam.
+        primary = self.sheet.primary_persona
+        ref = ActionRef(backend=ActionBackend.REGISTRY, registry_key="set_active_persona")
+        result = dispatch_player_action(self.character, ref, {"persona_id": primary.pk})
+
+        # Step 3: assert DB reverted to primary.
+        self.sheet.refresh_from_db()
+        self.assertTrue(result.detail.success, "web dispatch should succeed")
+        self.assertEqual(
+            self.sheet.active_persona_id,
+            primary.pk,
+            "active persona should be primary after web-seam revert",
+        )
+
+    def test_foreign_persona_rejected_via_telnet(self) -> None:
+        """A persona from another sheet is rejected; active persona is unchanged.
+
+        ``CmdPersona.func()`` catches ``CommandError`` and messages the caller,
+        so we assert the raise by calling ``resolve_action_args()`` directly
+        (mirroring how ``test_persona_command.py`` tests the unknown-name path).
+        """
+        other_sheet = CharacterSheetFactory()
+        foreign_name = other_sheet.primary_persona.name
+
+        primary_before = self.sheet.primary_persona
+
+        cmd = _cmd(self.character, foreign_name)
+        cmd._name = foreign_name
+
+        with self.assertRaises(CommandError, msg="foreign persona name should raise CommandError"):
+            cmd.resolve_action_args()
+
+        self.sheet.refresh_from_db()
+        self.assertEqual(
+            active_persona_for_sheet(self.sheet),
+            primary_before,
+            "active persona must be unchanged after rejected switch",
+        )

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -93,7 +93,10 @@ Key service functions for scene round lifecycle:
 
 ### `views.py`
 - **`SceneViewSet`**: Scene CRUD operations and filtering
-- **`PersonaViewSet`**: Persona management
+- **`PersonaViewSet`**: Persona management. `set_active` dispatches `SetActivePersonaAction`
+  (key `"set_active_persona"`, `actions/definitions/personas.py`) via `dispatch_player_action`
+  — the same seam the telnet `CmdPersona` uses. `set_active_persona` (service) remains the
+  sole mutator of `CharacterSheet.active_persona`; the action wraps it.
 - **`SceneSummaryRevisionViewSet`**: Summary revision management
 
 ### `interaction_views.py`

--- a/src/world/scenes/tests/test_active_persona.py
+++ b/src/world/scenes/tests/test_active_persona.py
@@ -108,6 +108,7 @@ class SetActivePersonaEndpointTests(TestCase):
         _, other_sheet = _sheet()
         resp = self._post(puppet=self.character, persona_id=other_sheet.primary_persona.pk)
         self.assertEqual(resp.status_code, 400)
+        self.assertIn("That isn't one of this character's identities.", str(resp.data))
 
     def test_no_played_character_400(self):
         resp = self._post(puppet=None, persona_id=self.alt.pk)

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -50,7 +50,7 @@ from world.scenes.serializers import (
     SetActivePersonaRequestSerializer,
     SetRoundModeRequestSerializer,
 )
-from world.scenes.services import ActivePersonaError, broadcast_scene_message, set_active_persona
+from world.scenes.services import broadcast_scene_message
 from world.societies.renown_serializers import (
     RenownCardSerializer,
     RenownSerializer,
@@ -455,20 +455,25 @@ class PersonaViewSet(
         body.is_valid(raise_exception=True)
         puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
         sheet = getattr(puppet, "sheet_data", None) if puppet is not None else None  # noqa: GETATTR_LITERAL
-        if sheet is None:
+        if puppet is None or sheet is None:
             msg = "You must be playing a character to switch identities."
             raise serializers.ValidationError(msg)
-        persona = Persona.objects.filter(
-            pk=body.validated_data["persona_id"], character_sheet_id=sheet.pk
-        ).first()
-        if persona is None:
-            msg = "That isn't one of this character's identities."
-            raise serializers.ValidationError(msg)
-        try:
-            set_active_persona(sheet, persona)
-        except ActivePersonaError as exc:
-            raise serializers.ValidationError(exc.user_message) from exc
-        return Response(ActivePersonaResultSerializer({"active_persona_id": persona.pk}).data)
+        from actions.constants import ActionBackend  # noqa: PLC0415
+        from actions.player_interface import dispatch_player_action  # noqa: PLC0415
+        from actions.types import ActionRef  # noqa: PLC0415
+
+        ref = ActionRef(backend=ActionBackend.REGISTRY, registry_key="set_active_persona")
+        result = dispatch_player_action(
+            puppet, ref, {"persona_id": body.validated_data["persona_id"]}
+        )
+        detail = result.detail  # ActionResult (REGISTRY dispatch is never deferred)
+        if not detail.success:
+            raise serializers.ValidationError(detail.message)
+        return Response(
+            ActivePersonaResultSerializer(
+                {"active_persona_id": detail.data["active_persona_id"]}
+            ).data
+        )
 
     @extend_schema(responses=RenownSerializer, tags=["personas"])
     @action(detail=True, methods=[HTTPMethod.GET])


### PR DESCRIPTION
Closes #1347

## Summary

Makes "set active persona" (wear a face) a real registry Action so the web ViewSet and a new telnet command both drive it through one shared path; adds an E2E journey.

- New `SetActivePersonaAction` (key `set_active_persona`, REGISTRY, target SELF) wraps the existing `set_active_persona` service (still the sole mutator) and validates the persona belongs to the actor's own sheet (uniform rejection — no existence leak).
- `PersonaViewSet.set_active` now dispatches that action via `dispatch_player_action` instead of calling the service directly — web + telnet converge on one path. API request/response unchanged (zero `gen-api-types` schema diff).
- New telnet `CmdPersona` (`persona`, alias `wear-face`): bare `persona`/`persona list` lists the caller's own faces (marks the active one); `persona <name>` switches.
- E2E telnet journey: list → switch → DB reflects it; web↔telnet parity; foreign-persona rejection. Plus action/command unit tests.
- Docs updated: appearance_and_identity, 3 CLAUDE.md guides, roadmap. No model/FK/signature change → no migration, no MODEL_MAP regen.

Scope boundary: deliberately does NOT change the pose/sdesc read-path (`record_interaction` / `_characters_to_active_personas`). Making poses reflect the presented persona — with the privacy/discovery/freeze machinery — remains #1109's scope, per this issue's "ties into #1109/#1110" note.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1347 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (8 commits) — clean, no conflicts, no migration collision.

<!-- last-addressed-comment: 0 -->