### PR TITLE
ADR log + ubiquitous-language glossary + design/cleanup skills (#1482 initial deliverable)

### DIFF
--- a/AGENT_GLOSSARY_MAP.md
+++ b/AGENT_GLOSSARY_MAP.md
@@ -1,0 +1,289 @@
+# Arx II agent glossary map
+
+Ubiquitous-language reference for agents and developers. This file holds the
+**cross-cutting (root) terms** that span apps; each app keeps its own
+`AGENT_GLOSSARY.md` next to its code for domain-local vocabulary. Definitions
+describe what a term **IS**, not what it does; when synonyms exist one canonical
+term is chosen and the rest are listed under `_Avoid_`.
+
+## Per-app glossaries
+
+- [magic](src/world/magic/AGENT_GLOSSARY.md)
+- [covenants](src/world/covenants/AGENT_GLOSSARY.md)
+- [scenes](src/world/scenes/AGENT_GLOSSARY.md)
+- [combat](src/world/combat/AGENT_GLOSSARY.md)
+- [conditions](src/world/conditions/AGENT_GLOSSARY.md)
+- [checks](src/world/checks/AGENT_GLOSSARY.md)
+- [mechanics](src/world/mechanics/AGENT_GLOSSARY.md)
+- [progression](src/world/progression/AGENT_GLOSSARY.md)
+- [classes](src/world/classes/AGENT_GLOSSARY.md)
+- [societies](src/world/societies/AGENT_GLOSSARY.md)
+- [relationships](src/world/relationships/AGENT_GLOSSARY.md)
+- [secrets](src/world/secrets/AGENT_GLOSSARY.md)
+- [clues](src/world/clues/AGENT_GLOSSARY.md)
+- [codex](src/world/codex/AGENT_GLOSSARY.md)
+- [stories](src/world/stories/AGENT_GLOSSARY.md)
+- [gm](src/world/gm/AGENT_GLOSSARY.md)
+- [missions](src/world/missions/AGENT_GLOSSARY.md)
+- [tarot](src/world/tarot/AGENT_GLOSSARY.md)
+- [currency](src/world/currency/AGENT_GLOSSARY.md)
+- [achievements](src/world/achievements/AGENT_GLOSSARY.md)
+- [goals](src/world/goals/AGENT_GLOSSARY.md)
+- [items](src/world/items/AGENT_GLOSSARY.md)
+- [traits](src/world/traits/AGENT_GLOSSARY.md)
+- [areas/positioning](src/world/areas/positioning/AGENT_GLOSSARY.md)
+
+## Relationships (how the root concepts connect)
+
+Both the web frontend and telnet converge on **`action.run()`** — the **Seam**. An
+**Action** owns its prerequisites and execution and calls **Service Functions** for
+state changes; **Commands** are the thin telnet layer. **Flows** are a separate
+reactive layer where **Triggers** run flows in response to **Events**. A **Check**
+resolves an attempt through the rank/chart/outcome pipeline into a graded
+**CheckOutcome** that draws from a **Consequence Pool**; **Modifiers** adjust it. A
+**Round** (action-driven) sequences declarations inside a **Scene**; **combat** is
+one specialization. **Personas** are the IC identities that own reputation and
+appear in scenes; **Threads** are the magic currency that anchors to traits,
+techniques, sanctums, relationships and other targets. Progression runs along a
+**Path** of **Levels**, narrated as **the Durance**, measured by **Legend** and
+awarded live through **Renown**.
+
+## Architecture seam
+
+**Action**:
+A self-contained unit of game behavior (`src/actions/`, base class `actions.base.Action`)
+that owns its own prerequisites (permission checks) and execution; anything a player
+can do is a real Action. _Avoid_: command, handler.
+
+**Seam**:
+The single `action.run()` doorway that both the web dispatcher and telnet commands
+converge on, so one Action serves both interfaces. _Avoid_: entrypoint, gateway.
+
+**Service Function**:
+A function in `src/flows/service_functions/` that performs an actual state change;
+Actions and Flows call service functions rather than mutating state inline. _Avoid_: helper, util, manager method.
+
+**Command**:
+The thin telnet-compatibility wrapper (`src/commands/`) that parses text and calls
+`action.run()`; it carries no business logic. _Avoid_: action.
+
+**ActionRef / dispatch_player_action**:
+The reference and dispatch path by which the web frontend names an Action (by registry
+key) and routes intent through the seam. _Avoid_: command string.
+
+**SCENE_ADAPTIVE**:
+The `ActionBackend` for actions that work both inside a combat/scene round and outside
+one (e.g. a standalone technique cast); the round rules decide immediate, deferred, or
+blocked execution. _Avoid_: combat-only, always-immediate.
+
+**Flow**:
+A database-defined workflow (`FlowDefinition` + steps) in the reactive layer that
+executes game logic in response to events. _Avoid_: script, pipeline.
+
+**Trigger**:
+A `TriggerDefinition`/`Trigger` that listens for a named **Event** and runs a Flow in
+response. _Avoid_: signal, hook, listener.
+
+**Event**:
+A named occurrence (`EventName` choice) emitted during play that Triggers can react to;
+the codebase uses explicit service-function calls, not Django signals. _Avoid_: signal.
+
+**Object State (BaseState)**:
+A mutable wrapper (`flows.object_states.BaseState` and subclasses like `CharacterState`,
+`RoomState`) placed around an Evennia object during flow execution to expose dynamic
+permissions and scene state. _Avoid_: proxy, adapter.
+
+**Behavior**:
+A reusable package of game logic attached to an object that supplies actions/handlers
+it can participate in. _Avoid_: mixin, component.
+
+**Enhancement / Effect**:
+An `ActionEnhancement` links a source (item, condition, technique) to a base Action and
+contributes typed **Effects** (handlers in `actions/effects/`) that modify how the action
+resolves. _Avoid_: buff, modifier (Effect is the action-layer term; Modifier is the
+mechanics-layer term).
+
+## Identity
+
+**Persona**:
+An in-character identity a player presents (`PRIMARY` / `ESTABLISHED` / `TEMPORARY`);
+reputation and IC-meaningful state hang off the Persona, never the account. _Avoid_: character, alt, mask.
+
+**CharacterSheet**:
+The source-of-truth anchor for a character's mechanical data (traits, vitals, sheet
+state) that personas and forms compose over. _Avoid_: profile, stats blob.
+
+**Guise**:
+A projected fake overlay (a mask/disguise/illusion) shown over the real form; it reverts
+to the current real form when pierced. _Avoid_: disguise, alias.
+
+**Roster**:
+A category group of characters (Active, Inactive, Available, etc.) used for character
+lifecycle and applications. _Avoid_: cast list.
+
+**RosterEntry**:
+The bridge record linking one character (ObjectDB) to its Roster. _Avoid_: membership.
+
+**RosterTenure**:
+A player↔character relationship over a span of time, carrying anonymity (player number)
+and approval data; `end_date` null means current. _Avoid_: ownership record.
+
+## Resolution
+
+**Check**:
+A resolved attempt run through the rank/chart/outcome pipeline; it exposes a graded
+outcome and never leaks raw roll numbers. _Avoid_: roll, dice check.
+
+**CheckType / CheckRank / ResultChart / CheckOutcome**:
+A **CheckType** is the database-defined kind of check (weighted traits + aspects); a
+**CheckRank** is a banded tier of capability; a **ResultChart** maps the rank difference
+and points to a graded **CheckOutcome**. _Avoid_: difficulty class, DC, pass/fail.
+
+**Consequence Pool / graded outcome**:
+The authored pool of consequences a graded outcome draws from; difficulty comes from
+authored model/config fields routed through the pool, never hardcoded constants or binary
+pass/fail. _Avoid_: loot table, success/failure flag.
+
+**Capability**:
+A gating ability that determines whether a character may attempt or benefit from
+something, granted by techniques, conditions, or progression. _Avoid_: permission, perk.
+
+**Challenge / ChallengeInstance**:
+A **Challenge** is the authored obstacle definition resolved through checks; a
+**ChallengeInstance** is one live instantiation against participants. _Avoid_: encounter (combat-specific), test.
+
+**Modifier / ModifierTarget**:
+A **Modifier** adjusts a resolved value; its **ModifierTarget** names which derived value
+or check the adjustment applies to. _Avoid_: bonus, buff.
+
+**Round / RoundContext**:
+A **Round** is one action-driven cycle of declarations; the **RoundContext** is the seam
+object carrying its mode and state. Rounds advance on actions, never on wall-clock time
+(dangerous progression must never advance while AFK). _Avoid_: turn timer, tick.
+
+**Round mode (OPEN / POSE_ORDER / STRICT)**:
+The resolution mode of a Round — **OPEN** (free declaration), **POSE_ORDER** (informal
+turn order), or **STRICT** (enforced order); a danger round is `STRICT` specialized with
+`DANGER`. _Avoid_: forced mode, combat mode.
+
+**Focused vs Secondary action**:
+Within a round a character takes one **focused** action plus up to two **secondary**
+actions; focused-vs-secondary is the per-round choice, not a trait of the technique.
+_Avoid_: passive (for "secondary"), main/off (for the pairing).
+
+## Four character primitives
+
+**Distinction**:
+An authored, individualizing trait-tag that marks what makes a character particular
+(and can anchor threads/checks). _Avoid_: feat, tag.
+
+**Condition**:
+A time-bound state applied to a character (template → instance → stage) that can alter
+checks, capabilities, or behavior. _Avoid_: status effect, buff/debuff.
+
+**Resonance**:
+A magical affinity-tied charge a character earns and spends (a `balance` with
+`lifetime_earned`); resonance gains feed dramatic and progression mechanics. _Avoid_: mana, essence.
+
+**Secret**:
+A piece of concealed canon scoped per knower; the `secrets` app stays dependency-free and
+other systems FK into it. _Avoid_: rumor, mystery.
+
+## Magic spine
+
+**Thread**:
+The magic currency/anchor (`world.magic.Thread`) that ties a character to a typed target
+(trait, technique, facet, relationship track, capstone, covenant role, or sanctum) and is
+levelled and pulled. _Avoid_: bond, string, link.
+
+**Anima**:
+A character's animating magical reserve (`CharacterAnima`) drawn on to perform rituals and
+weave threads. _Avoid_: mana, energy.
+
+**Intensity vs Power**:
+**Intensity** is the authored tier/magnitude band of a technique's effect; **Power** is the
+realized force a particular casting brings to bear. Keep them distinct — they are not synonyms. _Avoid_: using "power" for "intensity".
+
+## Progression & legend
+
+**Durance**:
+"The Durance" is a character's whole life-journey through the world; it is the narrative
+frame over the Class/Level backend, not a single event. _Avoid_: "a Durance" (singular event), career.
+
+**Ritual of the Durance**:
+The dramatic ceremony that advances a character a Level — one rite within the Durance.
+_Avoid_: "a Durance", level-up.
+
+**Audere Majora**:
+A dramatic advancement event (a threshold-crossing) that can mint a legend deed; treated
+purely as a neutral progression/resolved-pool surface. _Avoid_: restating its ceremonial wording or any in-world purpose.
+
+**Path / PathStage / Level**:
+A **Path** is the progression track a character follows; a **PathStage** is a named band
+along it; a **Level** is the discrete advancement step within the backend. _Avoid_: class tree, tier.
+
+**Legend / Legend Points**:
+**Legend** is the metric of how storied a character is; **Legend Points** are awarded only
+for storied/dangerous deeds, never as a combat/XP grind. _Avoid_: XP (for Legend), score.
+
+**Renown**:
+The live award mechanism (`RenownAwardConfig`, `fire_renown_award`) that fires legend/
+resonance awards for qualifying deeds; Renown is the mechanism, Legend is the metric.
+_Avoid_: blanket-avoiding "renown"; fame, reputation.
+
+**XP / Kudos / Development Points**:
+Out-of-character advancement currencies for creating content and developing a character;
+XP is never a combat reward (combat merits Legend, not XP). _Avoid_: using XP for in-combat awards.
+
+## Public-event vectors
+
+**Scene**:
+A unit of recorded roleplay among personas; scenes are provisional/ephemeral by default
+with explicit keep-vs-discard agency, and interaction (targeting another PC) is what makes
+one. _Avoid_: log, session.
+
+**Gemit**:
+A staff/GM real-time **push** broadcast, hand-authored verbatim and persisted for
+reach-scoped retroactive viewing — the push vector of the public-reaction center. _Avoid_: broadcast, news, gossip.
+
+**Tidings**:
+The **pull**/browse feed of the public-reaction center, scoped to the societies a persona
+hears through. _Avoid_: news feed, inbox.
+
+## Process & design tenets
+
+**Journey**:
+An unbounded coverage goal for a domain (combat/social/magic), tracked as a GitHub
+Milestone and sliced into plain-language gap issues. _Avoid_: epic, issue (a Journey is neither).
+
+**Gap**:
+A concrete, observed shortfall in a journey, filed as a single actionable issue. _Avoid_: bug, feature request (when it is a journey slice).
+
+**Consent-gates-behavior**:
+The rule that consent for an effect on another PC depends on whether it alters that PC's
+*behavior* (compulsion/charm/fear), not on benign-vs-hostile; pure capability/stat changes
+are consent-free. _Avoid_: consent-gates-harm.
+
+**PvP non-lethality**:
+The structural rule that PC-vs-PC combat never kills or injures — it resolves to yield or
+knockout; lethality is exclusive to PC-vs-significant-NPC. _Avoid_: suppressed death branch.
+
+**AFK-safe**:
+The invariant that tempo is action-driven and dangerous progression never advances while a
+character is away. _Avoid_: real-time, timed.
+
+**Drama-maximizing**:
+The standing design preference for the high-drama/ceremony path over the minimal switch
+(e.g. a War Covenant "rises" via a banner-call ritual). _Avoid_: minimal/MVP framing as the goal.
+
+**Individualization**:
+The principle that mechanics should make characters more particular; homogenizing
+"everyone gets the same grant" designs are rejected. _Avoid_: standardization, parity-by-default.
+
+**Visibility = eligibility**:
+The rule that what a viewer can see defines what they are eligible to act on; UI displays
+are per-persona, never per-account. _Avoid_: global visibility.
+
+**Provisional scene**:
+A scene that is ephemeral by default and only persists on an explicit keep decision;
+observation alone never auto-persists RP. _Avoid_: auto-saved scene, draft.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ and verify issue number↔title before any mutation. Temporary — removal track
 
 - **Never work directly on main.** Branch first: `git checkout -b feature-name`.
   After a squash-merge: `git checkout main && git pull && git branch -D feature-name`.
-- **`main` uses a merge queue (#991).** Once a PR is green, **enqueue it**
+- **`main` uses a merge queue (#991; see ADR-0021).** Once a PR is green, **enqueue it**
   (`gh pr merge --auto --squash`, or `enqueue-pr.sh` in the `issue-to-merged-pr`
   skill) and stop — do not re-sync with main or merge by hand. The queue
   re-tests the PR on top of the latest main and merges in order; a human
@@ -50,7 +50,7 @@ and verify issue number↔title before any mutation. Temporary — removal track
 ### Spec review happens on the issue, gated by labels
 
 New feature specs live in the **GitHub issue body** (between `<!-- spec:start -->`
-and `<!-- spec:end -->`), not as committed files. (Pre-convention specs still live
+and `<!-- spec:end -->`), not as committed files (see ADR-0020). (Pre-convention specs still live
 in `docs/superpowers/`; being triaged — see #660.) The `issue-to-merged-pr` flow
 drafts the spec, flags the team, then **stops** until a human org member approves.
 **Labels are the source of truth:**
@@ -108,6 +108,21 @@ file `src/.env`; Django commands run from `src/`.
 - **Django development** (models, views, APIs, tests) — `django_notes.md`.
 - **Evennia migration quirks** — `docs/evennia-quirks.md`. Use `arx manage
   makemigrations` (custom command that prevents phantom Evennia-library migrations).
+- **Decision log** — `docs/adr/README.md` before changing architecture, a
+  pipeline/contract, models, or a design tenet; an ADR records *why* a decision was
+  made and the alternative that was rejected. Don't re-litigate a recorded decision.
+- **Glossary** — `AGENT_GLOSSARY_MAP.md` (+ the app's `AGENT_GLOSSARY.md` next to its
+  code) before designing or naming anything; use the canonical terms, not the
+  `_Avoid_` synonyms.
+
+### Decisions & Vocabulary
+
+ADRs (`docs/adr/`) hold the *why* behind hard, surprising, traded-off decisions and
+the rejected alternatives; the glossary (`AGENT_GLOSSARY_MAP.md` → per-app
+`AGENT_GLOSSARY.md`) holds the canonical ubiquitous language. The
+`domain-glossary-and-adr` skill keeps both current; `design-vocabulary` and
+`architecture-cleanup` enable periodic deepening. (Note: "module" stays a code
+unit — it is NOT redefined to mean "component".)
 
 ## Docs Are Directives — Keep Them in Tandem
 
@@ -126,6 +141,11 @@ service-function signatures, update the docs that describe them as part of the w
 - **Architecture doc** — update the relevant `docs/architecture/*.md` (including its
   diagrams) when you change a pipeline, contract, or flow it documents.
 - **Roadmap** — mark the relevant `docs/roadmap/*.md` and record *what was built*.
+- **Decision log** — when you make a hard-to-reverse, surprising, real-trade-off
+  decision, record it as a one-paragraph ADR in `docs/adr/` in the same PR; when you
+  reverse one, mark the old ADR superseded.
+- **Glossary** — when you add, rename, or remove a domain term, update the app's
+  `AGENT_GLOSSARY.md` (+ the root `AGENT_GLOSSARY_MAP.md`) in the same PR.
 - **Fix-on-sight** — if you touch code a doc describes and find the doc already wrong,
   correct it at the source in the same PR (use the `verify-against-code` skill's
   `[BUILT & WIRED]` / `[BUILT, NOT WIRED]` / `[ABSENT]` labeling).
@@ -152,9 +172,9 @@ recurring-traps list. **Use it.**
 
 Database design:
 
-- **No JSON fields.** Each setting/configuration is a proper column with validation
-  and indexing. Use foreign keys, real data types, DB constraints — all data
-  queryable with standard Django ORM.
+- **No JSON fields** (see ADR-0007). Each setting/configuration is a proper column
+  with validation and indexing. Use foreign keys, real data types, DB constraints —
+  all data queryable with standard Django ORM.
 - **Avoid direct FKs to ObjectDB.** Evennia's ObjectDB is a generic base for all
   game objects; an FK to it is almost always too broad. Use a specific model
   (Persona, RosterEntry, CharacterSheet, RoomProfile). Ask: "could this be a vase of
@@ -164,7 +184,7 @@ Database design:
   when ObjectDB is genuinely right. Lint scope expands one app at a time (the
   `files:` regex in `.pre-commit-config.yaml`); new code in in-scope modules must
   pass clean.
-- **FK direction — depend specific→general.** When a link joins two systems, decide
+- **FK direction — depend specific→general** (see ADR-0010). When a link joins two systems, decide
   which side the FK belongs on *deliberately*: it lives on the more specific/dependent
   system and points at the reusable primitive, **never** on the primitive. Don't anchor
   it on whichever app you happen to be editing — a general model (e.g. `Secret`) must not
@@ -174,12 +194,12 @@ Database design:
 Code quality (always-on; full list in `django_notes.md`):
 
 - **No relative imports** — absolute only (`from world.roster.models import Roster`).
-- **No Django signals** — explicit, testable service-function calls instead.
+- **No Django signals** — explicit, testable service-function calls instead (see ADR-0009).
 - **No data migrations pre-production** — schema migrations only; no `RunPython`
-  backfills (no meaningful rows yet).
+  backfills (no meaningful rows yet) (see ADR-0013).
 - **Preserve the dev database** — never drop/flush/destroy it except in dire need.
 - **PostgreSQL only (production)** — use PG features directly (CTEs, materialized
-  views, `DISTINCT ON`, JSONB); no DB-agnostic workarounds.
+  views, `DISTINCT ON`, JSONB); no DB-agnostic workarounds (see ADR-0012).
 - **100-char line limit.** Use `.env` for configurable settings.
 
 The full standards (type annotations + `ty`, model-instance preference, avoid dict
@@ -199,7 +219,7 @@ no-backwards-compat, `# noqa` policy + custom-linter tokens) live in `django_not
   non-lookup kwargs when the row pre-exists) + the `_create` fix: see `django_notes.md`.
 - **New apps: avoid multiple migrations during development** — see
   `docs/evennia-quirks.md`.
-- **SharedMemoryModel** — all concrete models use it (import from
+- **SharedMemoryModel** (see ADR-0008) — all concrete models use it (import from
   `evennia.utils.idmapper.models`, **never** `evennia.utils.models`). It's the
   identity-map cache: trust it; don't reinvent `resolve_*`/`batch_fetch_*` helpers
   or cache-flushing. See the `sharedmemory-model` skill.

--- a/docs/adr/0001-action-centric-dispatch-through-the-player-action-seam.md
+++ b/docs/adr/0001-action-centric-dispatch-through-the-player-action-seam.md
@@ -1,0 +1,9 @@
+# Action-centric dispatch through the player-action seam
+
+Both the web client (WebSocket/REST) and telnet converge on `dispatch_player_action()`, which routes
+each intent by backend (REGISTRY → `action.run()`, CHALLENGE, COMBAT, SCENE_ADAPTIVE) so every player
+capability is a real `actions.base.Action`; we rejected per-channel command logic and a single flat
+`action.run()`. The common shorthand "everything goes through `action.run()`" is imprecise — the
+shared seam is the dispatcher, and `action.run()` is one backend it routes to.
+
+> Status: accepted · Source: #1336, src/actions/base.py, player_interface.py

--- a/docs/adr/0002-one-round-framework-three-modes.md
+++ b/docs/adr/0002-one-round-framework-three-modes.md
@@ -1,0 +1,9 @@
+# One round framework, three modes, as the shared RoundContext seam
+
+A single `SceneRound`/`RoundContext` provides tempo in three modes — OPEN (immediate), POSE_ORDER
+(quorum), and STRICT (deferred-initiative) — and combat is just a STRICT specialization while a
+danger round is STRICT with `start_reason=DANGER`; we rejected a combat-only round system bolted
+beside a separate social path. One seam means social Rounds (the common case) and combat share tempo,
+turn order, and per-round effects instead of diverging.
+
+> Status: accepted · Source: #1351, #520, ROADMAP

--- a/docs/adr/0003-combat-action-economy-one-focused-two-secondary.md
+++ b/docs/adr/0003-combat-action-economy-one-focused-two-secondary.md
@@ -1,0 +1,9 @@
+# Combat action economy: one focused + up to two secondary actions
+
+Each Round a PC takes one focused action plus up to two secondary actions (one per non-chosen
+category), so the per-round choice is which category to spend focus on rather than a flat budget of
+interchangeable actions; we rejected a single flat action count. Focused-vs-secondary is the
+per-round decision while category is a fixed trait of the technique — and player surfaces say
+"secondary," never "passive."
+
+> Status: accepted · Source: #874, memory

--- a/docs/adr/0004-tempo-is-action-driven-never-wall-clock.md
+++ b/docs/adr/0004-tempo-is-action-driven-never-wall-clock.md
@@ -1,0 +1,8 @@
+# Tempo is action-driven, never wall-clock (AFK-safe)
+
+Dangerous progression advances only when a player acts, driven off the RoundContext seam, never off
+`game_clock`, so nothing harmful happens to a character while their player is AFK; we rejected
+real-time tick progression. Any long-term scheduler tier is capped non-lethal precisely because it
+can advance unattended.
+
+> Status: accepted · Source: #520, design-tenets.md

--- a/docs/adr/0005-reactive-behavior-is-a-separate-flows-engine.md
+++ b/docs/adr/0005-reactive-behavior-is-a-separate-flows-engine.md
@@ -1,0 +1,8 @@
+# Reactive behavior is a separate flows/triggers/events engine
+
+"Something happens when X" — curses, hazards, item reactions, condition decay — is authored as
+Events → Triggers → Flows in `src/flows/`, a reactive layer distinct from the action layer that
+player intents drive; we rejected inlining reactive effects into Actions. Keeping reaction
+data-driven lets designers author it without editing action code.
+
+> Status: accepted · Source: src/flows/, ROADMAP

--- a/docs/adr/0006-scenes-are-provisional-never-auto-persist-rp.md
+++ b/docs/adr/0006-scenes-are-provisional-never-auto-persist-rp.md
@@ -1,0 +1,8 @@
+# Scenes are provisional by default; never auto-persist RP
+
+Auto-started Scenes are ephemeral and discardable, with explicit keep-vs-discard agency before
+anything is retained, and interaction (targeting another PC) is what makes a Scene — observation does
+not; we rejected auto-persisting observed RP. Silently recording RP a player thought was private is a
+privacy hazard, so the default is discard, not keep.
+
+> Status: accepted · Source: #1309/#1362, memory

--- a/docs/adr/0007-no-json-fields-typed-queryable-columns.md
+++ b/docs/adr/0007-no-json-fields-typed-queryable-columns.md
@@ -1,0 +1,8 @@
+# No JSON fields; every setting is a typed, queryable column
+
+Each setting or configuration gets a real column with FKs, validation, and DB constraints so all data
+is queryable with the ORM and indexable; we rejected JSON-blob flexibility because it forfeits
+queryability and validation. The one ratified exception is the `eligibility_rule` predicate JSONField,
+where the value is an opaque rule expression rather than queried state.
+
+> Status: accepted · Source: CLAUDE.md, npc_services/models.py

--- a/docs/adr/0008-all-concrete-models-use-sharedmemorymodel.md
+++ b/docs/adr/0008-all-concrete-models-use-sharedmemorymodel.md
@@ -1,0 +1,8 @@
+# All concrete models use SharedMemoryModel
+
+Every concrete model inherits `SharedMemoryModel` (imported from `evennia.utils.idmapper.models`, never
+`evennia.utils.models`) and we trust its identity-map cache rather than hand-rolling `resolve_*` /
+`batch_fetch_*` helpers or manual cache-flushing; we rejected plain `models.Model` plus bespoke
+caching. Reinventing the cache fights the idmapper instead of using it.
+
+> Status: accepted · Source: sharedmemory-model skill

--- a/docs/adr/0009-no-django-signals-explicit-service-functions.md
+++ b/docs/adr/0009-no-django-signals-explicit-service-functions.md
@@ -1,0 +1,7 @@
+# No Django signals; explicit service-function calls
+
+State changes route through named service functions rather than `post_save`/`pre_delete` signal
+handlers, so the control flow is explicit and testable at the call site; we rejected the idiomatic
+Django signal pattern. Signals hide causation and make ordering and test setup fragile.
+
+> Status: accepted · Source: CLAUDE.md

--- a/docs/adr/0010-fk-direction-specific-to-general.md
+++ b/docs/adr/0010-fk-direction-specific-to-general.md
@@ -1,0 +1,9 @@
+# FK direction is specific→general; avoid FKs to ObjectDB
+
+A link between two systems puts the FK on the more specific/dependent side pointing at the reusable
+primitive, never the reverse, so primitives (e.g. `Secret`) stay dependency-free instead of importing
+every consumer; a direct FK to generic `ObjectDB` is lint-blocked by `tools/lint_objectdb_param.py`. We
+rejected anchoring the FK on whichever app we happened to be editing, and FKs to ObjectDB ("could this
+be a vase of flowers?") in favor of specific models like Persona or CharacterSheet.
+
+> Status: accepted · Source: CLAUDE.md

--- a/docs/adr/0011-ic-state-keys-on-charactersheet-not-account.md
+++ b/docs/adr/0011-ic-state-keys-on-charactersheet-not-account.md
@@ -1,0 +1,8 @@
+# IC-meaningful state keys on CharacterSheet/Persona, never AccountDB
+
+IC ownership and standing — items, permits, reputation — key on the body (`CharacterSheet`) with
+Persona as a display overlay, while OOC rewards key on the Account; we rejected Account-scoped IC FKs
+and Persona-scoped inventories. Account-scoped IC state collapses alt-privacy by linking a player's
+characters, and Persona-scoped state fragments what one body actually owns.
+
+> Status: accepted · Source: design-tenets.md, #684

--- a/docs/adr/0012-postgresql-only-in-production.md
+++ b/docs/adr/0012-postgresql-only-in-production.md
@@ -1,0 +1,8 @@
+# PostgreSQL-only in production; use PG features directly
+
+Production targets PostgreSQL and we use its features directly — CTEs, partitioning, `DISTINCT ON`,
+BRIN, materialized views, JSONB — with no DB-agnostic abstraction layer; we rejected portability. The
+cost is real and shows up as occasional SQLite fast-tier divergences, which we accept in exchange for
+PG power, with the Postgres parity tier as the gate.
+
+> Status: accepted · Source: CLAUDE.md

--- a/docs/adr/0013-schema-only-migrations-pre-production.md
+++ b/docs/adr/0013-schema-only-migrations-pre-production.md
@@ -1,0 +1,7 @@
+# Schema-only migrations pre-production
+
+Before launch we write schema migrations only — no `RunPython` data migrations or backfills — because
+the dev database is disposable and holds no meaningful rows to preserve; we rejected defensive
+backfills. There is nothing to migrate yet, so backfill code would be untested ballast.
+
+> Status: accepted · Source: CLAUDE.md

--- a/docs/adr/0014-no-persisted-derived-data-derive-on-read.md
+++ b/docs/adr/0014-no-persisted-derived-data-derive-on-read.md
@@ -1,0 +1,8 @@
+# No persisted derived data; derive-on-read
+
+Derived or synthesized values are computed on read — in-memory `cached_property` is fine — and never
+stored as DB rows or columns, so the source data stays the single truth; we rejected denormalized
+"synthesized" rows. For example, a covenant member's effective speed and sub-role are derived per
+character per thread-level on read, not cached on a participant row.
+
+> Status: accepted · Source: memory, covenants.md

--- a/docs/adr/0015-no-polymorphic-genericfk-models.md
+++ b/docs/adr/0015-no-polymorphic-genericfk-models.md
@@ -1,0 +1,7 @@
+# No polymorphic / GenericFK / ContentType models
+
+Relationships are modeled concretely with real FKs; we categorically reject GenericForeignKey /
+ContentType polymorphism. Generic FKs forfeit type safety, referential integrity, and clear queries —
+a concrete model per relationship is always preferred even at the cost of more tables.
+
+> Status: accepted · Source: memory

--- a/docs/adr/0016-one-shared-base-per-concept.md
+++ b/docs/adr/0016-one-shared-base-per-concept.md
@@ -1,0 +1,8 @@
+# One shared base per concept; no parallel implementations
+
+Two parallel implementations of a single concept are tech debt, so siblings converge on a shared base
+class or a downstream convergence model and share fields via Django abstract base classes; we rejected
+per-sibling duplication. When a second implementation of the same idea appears, find the shared base
+rather than letting both drift.
+
+> Status: accepted · Source: memory

--- a/docs/adr/0017-new-subsystems-are-submodules.md
+++ b/docs/adr/0017-new-subsystems-are-submodules.md
@@ -1,0 +1,7 @@
+# New subsystems are submodules of existing apps
+
+A new subsystem defaults to a submodule of an existing app (e.g. `areas/positioning/`) rather than a
+new Django app; we rejected spinning up a fresh app per subsystem. Many small apps make a convoluted,
+collision-prone migration graph, so we only create a new app when the boundary genuinely warrants it.
+
+> Status: accepted · Source: memory

--- a/docs/adr/0018-range-partition-the-interaction-table.md
+++ b/docs/adr/0018-range-partition-the-interaction-table.md
@@ -1,0 +1,8 @@
+# Range-partition the Interaction table
+
+`scenes_interaction` is `PARTITION BY RANGE` (monthly, composite PK `(id, timestamp)`, BRIN indexes),
+a deliberate one-way, PG-only commitment to scene-log scale; we rejected an unpartitioned table. The
+price is structural — child tables that reference Interaction need `db_constraint=False`, and
+post-partition columns must be added via late `AddField` — and we accept it for the write/scan volume.
+
+> Status: accepted · Source: partition SQL, #572

--- a/docs/adr/0019-unified-resolution-one-roll-path.md
+++ b/docs/adr/0019-unified-resolution-one-roll-path.md
@@ -1,0 +1,8 @@
+# Unified resolution: one roll path, data-sourced difficulty, graded outcomes
+
+Every IC outcome routes through `perform_check` (by CheckType), with difficulty read from authored
+model/config fields and results resolved through weighted Consequence Pools into graded outcomes; we
+rejected ad-hoc `random.*`, hardcoded difficulty constants, binary pass/fail, and GM fiat. One roll
+path keeps difficulty authored and outcomes graded everywhere instead of reinvented per feature.
+
+> Status: accepted · Source: design-tenets.md, #548

--- a/docs/adr/0020-feature-specs-live-in-the-issue-body.md
+++ b/docs/adr/0020-feature-specs-live-in-the-issue-body.md
@@ -1,0 +1,8 @@
+# Feature specs live in the GitHub issue body, gated by labels
+
+A feature spec lives between `spec:start`/`spec:end` markers in the GitHub issue body, and the
+member-only `spec:approved` label is the authorization boundary on our public repo; spec files are not
+committed. We rejected committed spec files and comment-based gating — comments can't gate because
+anyone can comment, whereas only Triage+ org members can apply labels.
+
+> Status: accepted · Source: CLAUDE.md

--- a/docs/adr/0021-main-uses-a-merge-queue.md
+++ b/docs/adr/0021-main-uses-a-merge-queue.md
@@ -1,0 +1,8 @@
+# main uses a GitHub merge queue + single-leaf migration guard
+
+`main` lands work through GitHub's native merge queue (squash), which re-tests each PR on top of the
+latest main before merging, and `django-linear-migrations`' `max_migration.txt` surfaces cross-PR
+migration collisions as an ordinary git conflict; we rejected manual re-sync cascades. The queue plus
+the single-leaf guard keeps parallel PRs from silently colliding on migration order.
+
+> Status: accepted · Source: #991

--- a/docs/adr/0022-staff-tooling-is-admin-hosted.md
+++ b/docs/adr/0022-staff-tooling-is-admin-hosted.md
@@ -1,0 +1,8 @@
+# Staff config & game-tuning tooling is admin-hosted, not React
+
+Superuser/staff configuration and game-tuning UI is built on django-unfold + HTMX, reusing the
+existing admin RBAC, rather than in the React client; we rejected building it into the player
+frontend. Staff tooling can lean on admin permissions and server-rendered forms, so it doesn't earn
+the cost of bespoke React surfaces.
+
+> Status: accepted · Source: #1220, memory

--- a/docs/adr/0023-pvp-is-structurally-non-lethal.md
+++ b/docs/adr/0023-pvp-is-structurally-non-lethal.md
@@ -1,0 +1,8 @@
+# PvP is structurally non-lethal
+
+PC-vs-PC conflict never kills or injures — it resolves by yield or knockout in the non-lethal
+comic-book convention — and lethality is reserved for PC-vs-significant-NPC stakes; we rejected a
+shared lethal combat path with PvP death merely suppressed. Non-lethality is expressed structurally,
+so there is no death branch to accidentally re-enable for PvP.
+
+> Status: accepted · Source: ROADMAP, combat.md

--- a/docs/adr/0024-consent-gates-behavior-altering-effects.md
+++ b/docs/adr/0024-consent-gates-behavior-altering-effects.md
@@ -1,0 +1,8 @@
+# Consent gates behavior-altering effects, not benefit
+
+Consent for an effect on another PC is required only when it alters that PC's behavior — compulsion,
+charm, fear — and not for benign capability or stat changes, with the Golden Rule handling abuse; we
+rejected gating on benign-vs-hostile. What needs consent is loss of behavioral agency, not whether the
+effect helps or harms.
+
+> Status: accepted · Source: memory, design-tenets.md

--- a/docs/adr/0025-never-parse-pose-text-for-mechanics.md
+++ b/docs/adr/0025-never-parse-pose-text-for-mechanics.md
@@ -1,0 +1,7 @@
+# Never parse pose text for mechanics
+
+Mechanical inputs come only from explicit toggles — mood, stance, buttons — and free-text prose is
+never read for effects; we rejected keyword-parsing of poses. Parsing prose is brittle and punishes
+expressive writing, so intent must be stated through structured controls, not inferred from words.
+
+> Status: accepted · Source: design-tenets.md

--- a/docs/adr/0026-the-watched-player-is-always-ooc-aware.md
+++ b/docs/adr/0026-the-watched-player-is-always-ooc-aware.md
@@ -1,0 +1,8 @@
+# The watched player is always OOC-aware
+
+Concealment can hide who or what is present, but never *that* someone is present, and there is no
+`staff_only_can_see` hidden-observer backdoor; we rejected invisible observation. A player is always
+OOC-aware they may be perceived — a structural privacy floor that no concealment or staff path may
+breach.
+
+> Status: accepted · Source: design-tenets.md

--- a/docs/adr/0027-visibility-equals-eligibility.md
+++ b/docs/adr/0027-visibility-equals-eligibility.md
@@ -1,0 +1,8 @@
+# Visibility = eligibility: one predicate, no locked options
+
+A single `eligibility_rule` predicate decides both whether an option appears and whether it can be
+selected, so there is no separate visibility layer and no greyed-out "locked, here's how to unlock"
+UI; we rejected splitting visibility from selectability. If you can't pick it, you don't see it — one
+rule, no teasing locked rows.
+
+> Status: accepted · Source: design-tenets.md, npc_services

--- a/docs/adr/0028-web-first-not-wired-into-react-is-not-implemented.md
+++ b/docs/adr/0028-web-first-not-wired-into-react-is-not-implemented.md
@@ -1,0 +1,7 @@
+# Web-first: not wired into React = not implemented
+
+The React client is the completion bar: a feature is unfinished until it has a web surface, and telnet
+follows rather than leads; we rejected treating a green backend as done. A working service function
+with no React wiring is not a shipped feature — design for modern web UX first.
+
+> Status: accepted · Source: design-tenets.md, ROADMAP

--- a/docs/adr/0029-named-public-faces-are-always-shown-by-name.md
+++ b/docs/adr/0029-named-public-faces-are-always-shown-by-name.md
@@ -1,0 +1,8 @@
+# Named/public faces are always shown by name
+
+A Persona's public name renders to everyone, and an sdesc is triggered by *concealment*, never by
+*unfamiliarity*; we rejected the classic MUD pattern of scrambling a stranger's name into a
+description. Hiding known names behind "you don't recognize them" is an accessibility wall, so
+unfamiliarity alone never suppresses a public name.
+
+> Status: accepted · Source: design-tenets.md

--- a/docs/adr/0030-gms-author-story-trees-outcomes-resolve-by-roll.md
+++ b/docs/adr/0030-gms-author-story-trees-outcomes-resolve-by-roll.md
@@ -1,0 +1,8 @@
+# GMs author story trees; outcomes resolve by player roll, not fiat
+
+GMs author the rolls, outcomes, and story branches and umpire modifiers, but results resolve from the
+player's roll rather than GM fiat, so authoring tools rank above live intervention tools; we rejected
+GM-decides-the-outcome-on-the-spot. Pre-authored, roll-resolved outcomes keep player agency intact and
+GM effort scalable.
+
+> Status: accepted · Source: design-tenets.md

--- a/docs/adr/0031-exact-numbers-in-the-ledger-labels-in-the-fiction.md
+++ b/docs/adr/0031-exact-numbers-in-the-ledger-labels-in-the-fiction.md
@@ -1,0 +1,8 @@
+# Exact numbers in the ledger, descriptive labels in the fiction
+
+Decision surfaces (the ledger) show precise figures, while IC prose and NPC mouths render the same
+quantity qualitatively as a descriptive label; we rejected both "hide all numbers" and "show raw
+numbers in the fiction." Players deciding need exactness; the fiction needs flavor — the same value,
+two registers.
+
+> Status: accepted · Source: design-tenets.md

--- a/docs/adr/0032-constrained-bystander-reactions.md
+++ b/docs/adr/0032-constrained-bystander-reactions.md
@@ -1,0 +1,7 @@
+# Constrained bystander reactions
+
+Witnesses choose from predefined reaction menus that resolve *after* the actor's action completes,
+never as free-form mid-action interference; we rejected open-ended bystander interjection. Bounded,
+post-resolution reactions keep an actor's turn coherent while still letting onlookers respond.
+
+> Status: accepted · Source: design-tenets.md

--- a/docs/adr/0033-privacy-is-mvp-gating.md
+++ b/docs/adr/0033-privacy-is-mvp-gating.md
@@ -1,0 +1,8 @@
+# Privacy / RP-leak prevention is MVP-gating
+
+Privacy and RP-leak prevention are MVP-gating and never deferrable, because private RP exposed widely
+is a catastrophic, unrecoverable failure; we rejected treating privacy as a post-launch polish item.
+Any feature that could leak private RP must ship its privacy guarantees in the same increment, not
+later.
+
+> Status: accepted · Source: #1041, memory

--- a/docs/adr/0034-mechanics-individualize-characters.md
+++ b/docs/adr/0034-mechanics-individualize-characters.md
@@ -1,0 +1,8 @@
+# Mechanics individualize characters
+
+Mechanics should differentiate characters from one another, so we reject homogenizing
+"everyone-gets-the-same-power" grants in favor of capabilities that make a given character distinct.
+Sameness erases the individuality that drives RP, so a uniform grant is the wrong default even when
+it's the simplest.
+
+> Status: accepted · Source: #516, memory

--- a/docs/adr/0035-default-to-the-high-drama-ceremony-path.md
+++ b/docs/adr/0035-default-to-the-high-drama-ceremony-path.md
@@ -1,0 +1,8 @@
+# Default to the high-drama / ceremony path
+
+When a capability could be a quiet state change or a dramatic ceremony, we design toward the
+high-ceremony path — e.g. a War Covenant rises via a banner-call ritual, not a silent `active=true`;
+we rejected the minimal-switch default. The ceremony is the point: it creates the narrative beat the
+mechanic exists to produce.
+
+> Status: accepted · Source: memory

--- a/docs/adr/0036-combat-merits-legend-never-xp.md
+++ b/docs/adr/0036-combat-merits-legend-never-xp.md
@@ -1,0 +1,8 @@
+# Combat merits Legend, never XP
+
+Combat awards Legend Points only when an encounter is storied or genuinely dangerous, while XP is
+earned by creating content for others — so combat is never an XP source and there is no combat→XP
+grind; we rejected framing combat as a route to advancement currency. Tying advancement to fighting
+incentivizes grinding, which we structurally avoid.
+
+> Status: accepted · Source: memory

--- a/docs/adr/0037-encounter-difficulty-scales-on-party-size-and-level.md
+++ b/docs/adr/0037-encounter-difficulty-scales-on-party-size-and-level.md
@@ -1,0 +1,8 @@
+# Encounter difficulty scales on party size + average level only
+
+Encounter difficulty scales on party size and average level and nothing else — never threads,
+relationships, covenants, facets, or fashion; we rejected scaling on a PC's social richness. A
+thread-rich PC is simply stronger and should *feel* stronger, not be matched by tougher enemies that
+erase the payoff of those investments.
+
+> Status: accepted · Source: #566, combat.md

--- a/docs/adr/0038-asymmetrical-pve-npcs-have-no-sheets.md
+++ b/docs/adr/0038-asymmetrical-pve-npcs-have-no-sheets.md
@@ -1,0 +1,8 @@
+# Asymmetrical PvE; NPCs have no character sheets
+
+PCs have full character sheets while opposition is modeled as threat-patterns and soak, and encounters
+are intentionally un-soloable, designed around teamwork; we rejected symmetrical TTRPG-style balance
+where NPCs are statted like PCs. Asymmetry lets encounters demand cooperation instead of rewarding a
+single optimized build.
+
+> Status: accepted · Source: combat.md · Confidence: derived-from-roadmap, verify against code

--- a/docs/adr/0039-bulk-resolution-uses-honest-terminal-states.md
+++ b/docs/adr/0039-bulk-resolution-uses-honest-terminal-states.md
@@ -1,0 +1,9 @@
+# Bulk resolution uses honest terminal states
+
+Bulk close/resolve/archive operations must never block on absent players, never falsely mark
+unresolved items "done," and never orphan them — they move loose ends to an honest terminal state
+(e.g. story FORECLOSED) and track wrap-up as follow-up; we rejected a single optimistic "done" that
+papers over reality. An honest terminal state keeps the records truthful when not everything could
+actually be completed.
+
+> Status: accepted · Source: #1185/#759, memory

--- a/docs/adr/0040-incapacitation-and-dying-decoupled-from-vitals.md
+++ b/docs/adr/0040-incapacitation-and-dying-decoupled-from-vitals.md
@@ -1,0 +1,8 @@
+# Incapacitation & dying decoupled from a single vitals enum
+
+Mortality (`CharacterVitals.life_state`: alive/dead) is split from capability and consciousness, which
+are modeled as conditions (Unconscious, Bleeding Out) rather than as rungs of one
+`ALIVE→DYING→DEAD` ladder; we rejected the single-enum ladder. A linear enum made states like "dying
+but still conscious" unrepresentable, so the axes are kept independent.
+
+> Status: accepted · Source: #595 · Confidence: derived-from-roadmap, verify against code

--- a/docs/adr/0041-resonance-is-earned-from-being-perceived.md
+++ b/docs/adr/0041-resonance-is-earned-from-being-perceived.md
@@ -1,0 +1,8 @@
+# Resonance is earned from being perceived, not from casting
+
+Resonance accrues from being witnessed — endorsements, presentations, presence — rather than
+mechanically from the act of casting; we rejected the intuitive cast→fuel loop. Pegging the economy to
+being perceived forces social engagement, so a mage who never appears to others gains nothing simply
+by casting in private.
+
+> Status: accepted · Source: magic.md · Confidence: derived-from-roadmap, verify against code

--- a/docs/adr/0042-covenants-are-group-only.md
+++ b/docs/adr/0042-covenants-are-group-only.md
@@ -1,0 +1,8 @@
+# Covenants are group-only (min 2 members)
+
+A covenant is inherently a group structure: `create_covenant()` rejects fewer than two distinct
+founders (`InsufficientFoundersError`), and active membership falling below the minimum auto-dissolves
+the covenant; we rejected solo oaths. A covenant of one is a contradiction, so the floor is enforced
+at both formation and attrition.
+
+> Status: accepted · Source: covenants.md · Confidence: derived-from-roadmap, verify against code

--- a/docs/adr/0043-covenant-role-and-rank-are-orthogonal.md
+++ b/docs/adr/0043-covenant-role-and-rank-are-orthogonal.md
@@ -1,0 +1,9 @@
+# CovenantRole and CovenantRank are orthogonal axes
+
+Combat-power `CovenantRole` (Sword/Shield/Crown, carrying `speed_rank`) is a separate axis from
+administrative `CovenantRank` (whose `can_invite`/`can_kick`/`can_manage_ranks` flags gate authority);
+the two are never merged and there is no `is_leadership` flag on Role. We rejected collapsing power and
+authority into one ladder so a powerful Sword can be administratively junior and a quiet Shield can run
+the covenant.
+
+> Status: accepted · Source: #1027, covenants.md · Confidence: derived-from-roadmap, verify against code

--- a/docs/adr/0044-covenant-sworn-objective-is-free-text.md
+++ b/docs/adr/0044-covenant-sworn-objective-is-free-text.md
@@ -1,0 +1,9 @@
+# Covenant sworn objective is recorded as free text
+
+A covenant's `sworn_objective` is currently a free-text `TextField` that fires no completion or
+dissolution events, so an objective being "met" never auto-ends the covenant; we chose this over a
+structured goal model wired to completion events, which would push covenants toward being
+"completed" rather than enduring. A structured `SwornObjective` FK is a roadmapped future slice, so
+treat the free-text form as the present decision, not a permanent one.
+
+> Status: accepted · Source: covenants.md · Confidence: derived-from-roadmap, verify against code

--- a/docs/adr/0045-multi-target-casts-with-per-target-consent.md
+++ b/docs/adr/0045-multi-target-casts-with-per-target-consent.md
@@ -1,0 +1,10 @@
+# Multi-target casts validate a target list with per-target consent
+
+A cast carries a list of target Personas through a validation seam (`validate_cast_target`), where
+cardinality is enforced from the technique's authored `target_type` (SELF/SINGLE/multi) and each
+target is evaluated independently so an AFK or non-consenting target blocks no one else; we rejected a
+single-target-only model and an all-or-nothing consent gate. (Source #572 governs the Interaction
+storage scale, not this seam — confirm the cast-target persistence shape against code before relying
+on a specific field layout.)
+
+> Status: accepted · Source: #572, magic/services/targeting.py · Confidence: derived-from-roadmap, verify against code

--- a/docs/adr/0046-power-tier-breakthroughs-gate-at-fixed-thresholds.md
+++ b/docs/adr/0046-power-tier-breakthroughs-gate-at-fixed-thresholds.md
@@ -1,0 +1,8 @@
+# Power-tier breakthroughs gate at fixed path thresholds
+
+Crossing a power tier happens only at fixed steps along a character's path, through a dramatic,
+resolved advancement event, while the intermediate levels between thresholds are mundane; we rejected
+smooth per-level progression. Gating the big jumps at set thresholds concentrates advancement into
+narrative climaxes instead of a steady drip.
+
+> Status: accepted · Source: character-progression.md · Confidence: derived-from-roadmap, verify against code

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,101 @@
+# Architecture Decision Records
+
+This log records the *why* behind the hard, surprising, traded-off decisions that shape Arx II —
+and the alternatives we rejected. An ADR captures a moment of reasoning so a future agent or human
+doesn't relitigate a settled question or "fix" something that was deliberate.
+
+`docs/roadmap/design-tenets.md` and the invariants in `CLAUDE.md` are the **forward-looking directives** —
+they tell you what to do. The ADRs are the **record of why** that directive exists and what was
+weighed against it. The two must stay in tandem: when a decision changes, update both the directive
+and add (or supersede) the ADR in the same PR.
+
+## When to offer an ADR
+
+Offer an ADR only when a decision clears all three bars:
+
+1. **Hard to reverse** — undoing it later means a migration, a data rewrite, or churning many call
+   sites, not flipping a flag.
+2. **Surprising** — a competent newcomer would reasonably expect the opposite, so the choice needs a
+   recorded rationale to survive.
+3. **A real trade-off** — we gave up something concrete (portability, flexibility, idiomatic
+   convention) to get something concrete; both sides are worth naming.
+
+If a decision is none of these, it's just code — don't write an ADR for it.
+
+## Format
+
+Each ADR is one tight file: a decision-shaped H1 title, one short paragraph (1–3 sentences) giving
+the context, what we decided, and why — including the rejected alternative — and a one-line footer.
+
+```md
+# {Short decision-shaped title}
+
+{1–3 sentences: the context, what we decided, and why — including the rejected alternative.}
+
+> Status: accepted · Source: {roadmap §X / issue #N / CLAUDE.md / memory}
+```
+
+No Status/Options/Consequences sections — keep it to the paragraph unless extra structure genuinely
+earns its place. Use repo vocabulary (Persona, Scene, Round, seam, Action); don't redefine terms.
+ADRs derived from the roadmap that name specific models/fields carry a "verify against code" note —
+treat those names as hints to confirm, not gospel.
+
+## Index
+
+### Architecture & seams
+- [0001 — Action-centric dispatch through the player-action seam](0001-action-centric-dispatch-through-the-player-action-seam.md)
+- [0002 — One round framework, three modes, as the shared RoundContext seam](0002-one-round-framework-three-modes.md)
+- [0003 — Combat action economy: one focused + up to two secondary actions](0003-combat-action-economy-one-focused-two-secondary.md)
+- [0004 — Tempo is action-driven, never wall-clock (AFK-safe)](0004-tempo-is-action-driven-never-wall-clock.md)
+- [0005 — Reactive behavior is a separate flows/triggers/events engine](0005-reactive-behavior-is-a-separate-flows-engine.md)
+- [0006 — Scenes are provisional by default; never auto-persist RP](0006-scenes-are-provisional-never-auto-persist-rp.md)
+
+### Database & modeling
+- [0007 — No JSON fields; every setting is a typed, queryable column](0007-no-json-fields-typed-queryable-columns.md)
+- [0008 — All concrete models use SharedMemoryModel](0008-all-concrete-models-use-sharedmemorymodel.md)
+- [0009 — No Django signals; explicit service-function calls](0009-no-django-signals-explicit-service-functions.md)
+- [0010 — FK direction is specific→general; avoid FKs to ObjectDB](0010-fk-direction-specific-to-general.md)
+- [0011 — IC-meaningful state keys on CharacterSheet/Persona, never AccountDB](0011-ic-state-keys-on-charactersheet-not-account.md)
+- [0012 — PostgreSQL-only in production; use PG features directly](0012-postgresql-only-in-production.md)
+- [0013 — Schema-only migrations pre-production](0013-schema-only-migrations-pre-production.md)
+- [0014 — No persisted derived data; derive-on-read](0014-no-persisted-derived-data-derive-on-read.md)
+- [0015 — No polymorphic / GenericFK / ContentType models](0015-no-polymorphic-genericfk-models.md)
+- [0016 — One shared base per concept; no parallel implementations](0016-one-shared-base-per-concept.md)
+- [0017 — New subsystems are submodules of existing apps](0017-new-subsystems-are-submodules.md)
+- [0018 — Range-partition the Interaction table](0018-range-partition-the-interaction-table.md)
+
+### Resolution
+- [0019 — Unified resolution: one roll path, data-sourced difficulty, graded outcomes](0019-unified-resolution-one-roll-path.md)
+
+### Process & workflow
+- [0020 — Feature specs live in the GitHub issue body, gated by labels](0020-feature-specs-live-in-the-issue-body.md)
+- [0021 — main uses a GitHub merge queue + single-leaf migration guard](0021-main-uses-a-merge-queue.md)
+- [0022 — Staff config & game-tuning tooling is admin-hosted, not React](0022-staff-tooling-is-admin-hosted.md)
+
+### Game-design tenets
+- [0023 — PvP is structurally non-lethal](0023-pvp-is-structurally-non-lethal.md)
+- [0024 — Consent gates behavior-altering effects, not benefit](0024-consent-gates-behavior-altering-effects.md)
+- [0025 — Never parse pose text for mechanics](0025-never-parse-pose-text-for-mechanics.md)
+- [0026 — The watched player is always OOC-aware](0026-the-watched-player-is-always-ooc-aware.md)
+- [0027 — Visibility = eligibility: one predicate, no locked options](0027-visibility-equals-eligibility.md)
+- [0028 — Web-first: not wired into React = not implemented](0028-web-first-not-wired-into-react-is-not-implemented.md)
+- [0029 — Named/public faces are always shown by name](0029-named-public-faces-are-always-shown-by-name.md)
+- [0030 — GMs author story trees; outcomes resolve by player roll, not fiat](0030-gms-author-story-trees-outcomes-resolve-by-roll.md)
+- [0031 — Exact numbers in the ledger, descriptive labels in the fiction](0031-exact-numbers-in-the-ledger-labels-in-the-fiction.md)
+- [0032 — Constrained bystander reactions](0032-constrained-bystander-reactions.md)
+- [0033 — Privacy / RP-leak prevention is MVP-gating](0033-privacy-is-mvp-gating.md)
+- [0034 — Mechanics individualize characters](0034-mechanics-individualize-characters.md)
+- [0035 — Default to the high-drama / ceremony path](0035-default-to-the-high-drama-ceremony-path.md)
+- [0036 — Combat merits Legend, never XP](0036-combat-merits-legend-never-xp.md)
+- [0037 — Encounter difficulty scales on party size + average level only](0037-encounter-difficulty-scales-on-party-size-and-level.md)
+- [0038 — Asymmetrical PvE; NPCs have no character sheets](0038-asymmetrical-pve-npcs-have-no-sheets.md)
+- [0039 — Bulk resolution uses honest terminal states](0039-bulk-resolution-uses-honest-terminal-states.md)
+
+### Domain architecture
+- [0040 — Incapacitation & dying decoupled from a single vitals enum](0040-incapacitation-and-dying-decoupled-from-vitals.md)
+- [0041 — Resonance is earned from being perceived, not from casting](0041-resonance-is-earned-from-being-perceived.md)
+- [0042 — Covenants are group-only (min 2 members)](0042-covenants-are-group-only.md)
+- [0043 — CovenantRole and CovenantRank are orthogonal axes](0043-covenant-role-and-rank-are-orthogonal.md)
+- [0044 — Covenant sworn objective is recorded as free text](0044-covenant-sworn-objective-is-free-text.md)
+- [0045 — Multi-target casts validate a target list with per-target consent](0045-multi-target-casts-with-per-target-consent.md)
+- [0046 — Power-tier breakthroughs gate at fixed path thresholds](0046-power-tier-breakthroughs-gate-at-fixed-thresholds.md)

--- a/docs/spec-template.md
+++ b/docs/spec-template.md
@@ -1,0 +1,88 @@
+# Spec template
+
+> **This file is a reference TEMPLATE, not a spec instance.** Real feature specs
+> live in the **GitHub issue body** (between `<!-- spec:start -->` and
+> `<!-- spec:end -->`), per ADR-0020 — never as a committed file. Copy the sections
+> below into the issue body and fill them in; don't commit a filled-out copy here.
+
+Fill in every section. Delete a section only after deciding it genuinely doesn't
+apply — don't default to skipping. Use canonical vocabulary from
+`AGENT_GLOSSARY_MAP.md` (+ the app's `AGENT_GLOSSARY.md`); check `docs/adr/` for any
+decision that already constrains this work.
+
+---
+
+## <Title> (#<issue-number>)
+
+**Status:** spec-draft / spec-review / approved · **Branch:** `<branch>` · **Date:** <YYYY-MM-DD>
+
+### Goal
+
+One or two paragraphs: the problem, who has it, and what "done" looks like in
+player- or staff-facing terms. State the outcome, not the implementation.
+
+### User Stories
+
+A numbered list, extensive — one line each:
+
+1. As a `<actor>`, I want `<feature>`, so that `<benefit>`.
+2. As a `<actor>`, I want `<feature>`, so that `<benefit>`.
+3. …
+
+Cover the primary actor and the secondary ones (other players, GM/staff, observers).
+
+### Decisions (user-ratified)
+
+Numbered, stakeholder-approved constraints this spec is built on. Each is a settled
+choice the design must respect — link the ADR if one exists, or flag a decision that
+should become one.
+
+1. <constraint>
+2. <constraint>
+
+### Test seams
+
+Where the feature is exercised. Prefer existing seams; use the **highest** seam
+possible; the ideal is **one** (this repo's `action.run()` / dispatch seam, where
+telnet and web converge). List the seam(s) and the user journey each covers.
+
+### Verified leak analysis
+
+Privacy / RP-leak prevention is MVP-gating (ADR-0033). Table every surface that
+could expose IC or private content and confirm it's contained:
+
+| Surface | What could leak | Contained by |
+|---|---|---|
+| <surface> | <data> | <mechanism / "n/a"> |
+
+### Anti-reinvention ledger
+
+Run the `verify-against-code` pass. For every new surface the design proposes, label
+it against the code (not docs/summaries) with file:line + caller evidence:
+
+| Proposed surface | Verdict | Evidence (file:line + caller) |
+|---|---|---|
+| `<surface>` | BUILT & WIRED / BUILT, NOT WIRED / ABSENT | `<file:line>`; <caller or "no caller"> |
+
+Prefer reuse-with-extension over build-new; drop any stub whose user goal is already
+wired elsewhere.
+
+### Design
+
+The spec body: models, service functions, actions, flows, API/UI surfaces, and how
+they fit the existing architecture. Reference the canonical terms and the relevant
+ADRs. Note any new ADR this work should add.
+
+### Testing
+
+The test plan and tier: SQLite fast tier (`just test-fast <app>`) for local
+iteration, Postgres parity (CI) for the gate. Prefer big journey/E2E tests over
+fine-grained unit tests; add focused unit tests only for fiddly parse/error paths the
+E2E doesn't reach.
+
+### Scope / follow-ups
+
+- **In scope:** <what this PR delivers>
+- **Deferred:** <out-of-scope items> — verify each deferral's premise against code
+  before filing it as an issue (a deferral is a proposed future surface); file
+  design-open items as `needs-design` questions, not asserted work.

--- a/src/world/achievements/AGENT_GLOSSARY.md
+++ b/src/world/achievements/AGENT_GLOSSARY.md
@@ -1,0 +1,21 @@
+# Achievements glossary
+
+**Achievement**:
+A staff-defined milestone a character can earn across any game system, hidden by default and awarded automatically when all its stat-threshold requirements are met. Achievements can chain via a prerequisite and carry a notification level (personal, room, or gamewide).
+_Avoid_: badge, trophy, accomplishment
+
+**Discovery**:
+The single record marking the first time a hidden Achievement is earned by anyone, supporting simultaneous co-discoverers; once it exists, the Achievement becomes visible to all players.
+_Avoid_: first-find, unlock event
+
+**Stat**:
+In this app, a named numeric counter (a tracked metric like "quests_completed" or "relationships.total_established") that game systems increment and that achievement requirements check against. This is distinct from a traits Stat (a core character statistic such as Strength) — an achievements Stat is a measured tally, not an ability score.
+_Avoid_: counter, metric (as the canonical term)
+
+**StatDefinition**:
+The lookup row defining a trackable Stat — its unique dot-separated key, display name, and description — so the same normalized stat identity is shared between a StatTracker and an AchievementRequirement instead of raw strings.
+_Avoid_: stat key, stat type
+
+**StatTracker**:
+The per-character row holding the current integer value of one StatDefinition for one character (unique per character + stat), incremented atomically by other systems and read by the achievements engine.
+_Avoid_: stat counter, stat value row

--- a/src/world/areas/positioning/AGENT_GLOSSARY.md
+++ b/src/world/areas/positioning/AGENT_GLOSSARY.md
@@ -1,0 +1,17 @@
+# Positioning glossary
+
+**Position kind**:
+The classification of a position node within a room's spatial graph: PRIMARY (the default open region), FEATURE (an authored sub-region like a balcony, altar, or pit), ELEVATED (a raised rim such as a catwalk), AERIAL (a flight-only twin layer auto-created above ground positions), CHASM (a below-ground drop reached by falling), and the reserved BARRIER_SIDE (dynamic carving).
+_Avoid_: position type, terrain type, zone kind
+
+**Blueprint**:
+A reusable, room-independent template of position nodes and edges that a GM authors once and instantiates onto any room to generate a live position graph, used for staging non-combat scenes.
+_Avoid_: layout, template map, stage preset
+
+**Aerial layer**:
+The flight-only twin graph materialized above a room's ground positions — each ground node gains an "Above <name>" twin connected by a vertical edge, with horizontal aerial edges mirroring ground adjacency but all freely passable so airborne objects fly over walls and gates. It exists only while airborne objects occupy the room and is torn down when the last one lands.
+_Avoid_: flight layer, sky layer, air zone
+
+**Plummet**:
+The escalating fall that begins when an entity enters a CHASM position and the FELL event fires: it ensures a danger SceneRound, applies the staged "Plummeting" condition to the faller, and instantiates a "Catch the Faller" challenge, descending each round until caught or resolved.
+_Avoid_: fall, drop, falling

--- a/src/world/checks/AGENT_GLOSSARY.md
+++ b/src/world/checks/AGENT_GLOSSARY.md
@@ -1,0 +1,29 @@
+# Checks glossary
+
+**CheckType**:
+A named, database-defined check (Stealth, Diplomacy, Composure, Penetration) composed of weighted trait contributions and weighted aspect relevances, grouped under a `CheckCategory`. It is the staff-authored "kind of test" that `perform_check` resolves.
+_Avoid_: skill check, roll type, test
+
+**CheckRank**:
+A lookup table mapping a point total to a discrete rank level via exponential thresholds. Both the roller's points and the target difficulty are converted to ranks, and the rank difference selects which result chart applies.
+_Avoid_: tier, grade, rank band
+
+**ResultChart**:
+A 0–100 outcome table selected by the rank difference between roller and target. After the effective roll is taken it maps the roll to a `CheckOutcome`.
+_Avoid_: difficulty table, roll table, success table
+
+**CheckOutcome**:
+The named result of a check (Success, Catastrophic Failure) with a numeric `success_level` from -10 to +10. It is the resolved verdict a chart yields for a roll — consumers branch on success_level, not on raw roll numbers (which are never exposed).
+_Avoid_: result, degree of success, outcome tier
+
+**Aspect**:
+A broad character archetype (Warfare, Subterfuge, Diplomacy, Scholarship) that grants bonuses to matching checks. Players see aspect names as flavor; the weights linking a CheckType to an aspect are staff-only mechanical values, scaled by the character's most recent path and level.
+_Avoid_: archetype tag, talent, domain
+
+**Composure**:
+A seeded social CheckType — resisting social pressure through force of will (willpower-weighted) — resolved when a defender actively resists a social action. Distinct from the Composure Stat (the Social-category trait it draws on).
+_Avoid_: willpower check, resolve, resistance (for the named CheckType)
+
+**rollmod**:
+A flat per-character roll modifier summed from the character sheet's and the controlling account's `rollmod` values, added to the d100 before clamping to 1–100. A staff/debug lever, returning zero when the relations are absent.
+_Avoid_: luck, roll bonus, fudge

--- a/src/world/classes/AGENT_GLOSSARY.md
+++ b/src/world/classes/AGENT_GLOSSARY.md
@@ -1,0 +1,21 @@
+# Classes glossary
+
+**Path**:
+The narrative-facing class system — a named position in a character's evolution hierarchy (e.g. "Path of Steel" evolving into "Vanguard"), tracing the journey toward greatness through acts, legend, and achievements. Each Path has a `PathStage` and a minimum level.
+_Avoid_: class (reserve "class" for `CharacterClass`), career, profession.
+
+**CharacterClass**:
+The mechanical class definition — trait requirements, level tracking, and the anchor for XP-cost charts and per-stage health rates. The backend Class/Level system that underlies a character's Path.
+_Avoid_: Path (the two are distinct systems), job.
+
+**PathStage**:
+The evolution-stage band of a Path — PROSPECT, POTENTIAL, PUISSANT, TRUE, GRAND, TRANSCENDENT — derived from level by fixed breakpoints (levels 1/3/6/11/16/21).
+_Avoid_: tier (tier is a separate Class/Level concept), rank, phase.
+
+**Level**:
+A character's numeric standing (1–30) in a specific `CharacterClass`, stored on a `CharacterClassLevel` row; the primary class level drives health and advancement.
+_Avoid_: rank, grade.
+
+**ClassStageHealthRate**:
+The authored per-(`CharacterClass`, `PathStage`) rate of health gained per character level while inside that stage band.
+_Avoid_: HP curve, health table.

--- a/src/world/clues/AGENT_GLOSSARY.md
+++ b/src/world/clues/AGENT_GLOSSARY.md
@@ -1,0 +1,25 @@
+# Investigation & discovery glossary
+
+**Clue**:
+A pointer to exactly one discoverable target — a codex entry, a mission, a captive to rescue, or a character secret — selected by `target_kind` and its matching per-kind FK. It is a real fact that always points at something: a clue cannot be saved without a target, so there are no red herrings and no empty clues.
+_Avoid_: hint, lead, red herring.
+
+**RoomClue**:
+A placement that hides a `Clue` in a room with an authored `detect_difficulty`, found via a Search check. The active-acquisition counterpart to a `ClueTrigger`, mirroring `room_features.Trap`.
+_Avoid_: hidden clue, room placement.
+
+**ClueTrigger**:
+A placement that grants a `Clue` passively on room entry to any eligible character who does not already hold it — no roll, the world reveals it because of who you are or where you are. The item-anchored variant `ItemClueTrigger` fires the same way on acquiring an item of a given kind.
+_Avoid_: passive clue, auto-grant.
+
+**Search**:
+The active acquisition path: the `SearchAction` charges AP plus mental fatigue and rolls the seeded Search CheckType (Perception + Investigation) against each hidden `RoomClue`'s `detect_difficulty`, acquiring the ones spotted.
+_Avoid_: look, detect, perception roll.
+
+**Research Project**:
+A `ProjectKind.RESEARCH` project (on the shared `world/projects` framework, with `ResearchProjectDetails` naming the clue) by which contributors spend AP on Research rolls to win a clue's target collaboratively. The RESEARCH `resolution_mode`; progress is floored at zero so a failed help never detracts, and completion grants the target to every contributor.
+_Avoid_: investigation, study.
+
+**Rescue**:
+The RESCUE clue target: a `Clue` pointing at a `Captivity`, planted at a capture site, that hands the finder the captive's rescue mission on acquisition. Capture plants discovery and freeing the captive clears the rescue clues.
+_Avoid_: free, recover.

--- a/src/world/codex/AGENT_GLOSSARY.md
+++ b/src/world/codex/AGENT_GLOSSARY.md
@@ -1,0 +1,9 @@
+# Codex glossary
+
+**Codex / CodexEntry**:
+The canon-lore store: a `CodexEntry` is an individual piece of reviewed world knowledge (subject, summary, lore and mechanics content, learning costs) nested under a `CodexSubject` and `CodexCategory`. The authorship/canon boundary against a Secret — Codex is canon-true-about-the-world authored under lore authority, where a Secret is a hidden, earned fact about a concrete entity with a keeper and consequences.
+_Avoid_: lore entry, wiki article, article.
+
+**CharacterCodexKnowledge**:
+A roster-scoped record of what one character knows or is learning about a `CodexEntry`, carrying a status (UNCOVERED while learning, KNOWN once fully learned), accumulated `learning_progress`, and who taught it. Knowledge belongs to the character itself, so a new player inheriting the character inherits what it knows.
+_Avoid_: known lore, learned entry, codex progress.

--- a/src/world/combat/AGENT_GLOSSARY.md
+++ b/src/world/combat/AGENT_GLOSSARY.md
@@ -1,0 +1,61 @@
+# Combat glossary
+
+**CombatEncounter**:
+The top-level container for one fight — an `AbstractRound` subclass carrying its required scene, room, encounter type, risk level, stakes, and typed outcome. It owns the participants, opponents, clashes, and per-round action ledger.
+_Avoid_: battle, fight (as a model name), combat session
+
+**CombatParticipant**:
+A PC's enrolment in a `CombatEncounter` (one per character per encounter), tracking status (active/fled/removed), covenant role, and the character's per-round strain budget.
+_Avoid_: combatant, fighter, player (for the PC's encounter row)
+
+**CombatOpponent**:
+An NPC entity in a `CombatEncounter`, defined by its `OpponentTier`, health/soak/probing stats, threat pool, and (for bosses) phases. The NPC analogue of a `CombatParticipant`.
+_Avoid_: enemy, monster, mob, NPC participant
+
+**Maneuver**:
+A special non-technique declaration a PC can make for a round (`CombatManeuver`: FLEE, COVER, YIELD, INTERPOSE) — a verb that is neither a technique cast nor a clash commit. Each is a real Action on the shared dispatch seam.
+_Avoid_: special move, stance, command
+
+**Yield**:
+The maneuver by which a PC concedes — in a duel the yielding PC loses immediately. PvP is structurally non-lethal (yield / knockout), so yielding ends the contest without injury or death.
+_Avoid_: surrender, forfeit, submit, defeat
+
+**Interpose**:
+The maneuver by which a PC stands ready to step in front of an attack aimed at an ally and intercept it (a clean block). It costs fatigue only on the round it actually fires; an armed-but-never-triggered interpose costs nothing.
+_Avoid_: block, guard, intercept, bodyguard
+
+**Clash**:
+The reserved combat primitive for a multi-round contest in which two sides pour magical energy into overpowering each other (the "beam-struggle" trope) — the clash of wills. Modelled by `Clash` with a flavor discriminator (CLASH / LOCK / WARD / BREAK). The word "clash" is reserved for this feature and must not name any other concept.
+_Avoid_: contest, struggle, beam struggle; backfire / rejection / dissonance for unrelated opposing-resonance effects
+
+**Strain**:
+Anima a PC commits beyond a technique's effective cost floor, converted by a diminishing-returns curve (`StrainConfig`) into a power/intensity bonus passed to the cast. Strain scales the technique's power and progress delta — never the check roll.
+_Avoid_: push, overcharge, effort (effort modifies the roll; strain scales power)
+
+**CombatPull**:
+A per-(participant, round) commit envelope capturing the resonance, tier, and threads a participant spends on a thread pull during combat. Resolved effects are snapshotted so mid-round authoring edits cannot retroactively change a committed pull.
+_Avoid_: thread pull (the in-combat record specifically), draw
+
+**ThreatPool**:
+A named collection of the possible actions an NPC can take in a round (`ThreatPoolEntry` rows); a boss phase or opponent draws its behaviour from its assigned pool.
+_Avoid_: action list, move set, aggro pool
+
+**BossPhase**:
+One stage of a boss fight (`BossPhase`) with its own threat pool, soak, probing threshold, and health trigger; a boss progresses through its phases as its health crosses each trigger.
+_Avoid_: stage, form, tier (tier is the opponent's power class)
+
+**OpponentTier**:
+The power class of an NPC opponent (`OpponentTier`: SWARM, MOOK, ELITE, BOSS, HERO_KILLER), seeding its baseline stat budget. SWARM uses count/body-toughness mechanics; HERO_KILLER is the unbeatable presence.
+_Avoid_: rank, level, difficulty (for the NPC's class)
+
+**Party Profile**:
+An immutable level-only snapshot of the active party (`PartyProfile`: party_size + avg_level) feeding the encounter-scaling formula. Difficulty scales on party size and average level only — never on threads, relationships, or other narrative richness.
+_Avoid_: party stats, party power, party rating
+
+**Focused action**:
+The single primary action a PC commits in a round — the one that matches a combo slot and carries the round's main intent. A round is one focused action plus up to two secondary actions.
+_Avoid_: main action, primary (use "focused" specifically)
+
+**Secondary action**:
+A supporting action a PC takes alongside the focused action (physical and/or social), up to two per round. The non-focused action type.
+_Avoid_: passive

--- a/src/world/conditions/AGENT_GLOSSARY.md
+++ b/src/world/conditions/AGENT_GLOSSARY.md
@@ -1,0 +1,33 @@
+# Conditions glossary
+
+**ConditionTemplate**:
+The authored definition of a condition (e.g. Burning, Frozen) — its category, duration and stacking rules, progression flag, removal rules, and combat settings. The reusable blueprint from which active instances are created.
+_Avoid_: status definition, effect type, buff/debuff (for the template)
+
+**ConditionInstance**:
+A single active condition on a target (character, object, or room), carrying runtime state: current stage, stacks, severity, remaining duration, source, and suppression. The materialized application of a `ConditionTemplate`.
+_Avoid_: active status, applied effect, buff (for the runtime row)
+
+**ConditionStage**:
+One step in a progressive condition (`ConditionStage`), ordered within its template, with its own rounds-to-next, resist check/difficulty, and severity multiplier. A condition advances stage-by-stage as rounds elapse.
+_Avoid_: phase, level, step
+
+**alters_behavior**:
+A boolean flag on `ConditionCategory` marking conditions that change how a character BEHAVES (compulsion, charm, fear) rather than only their capabilities or stats. It is the consent gate: a behavior-altering effect on another PC requires that PC's consent; pure capability/stat effects do not.
+_Avoid_: is_mental, is_control, hostile (the flag is about behavior-change, not harm)
+
+**DoT**:
+Periodic damage dealt by a condition (`ConditionDamageOverTime`: damage type, base damage, scaling, tick timing). Acute DoT ticks per combat/scene round; long-term (chronic) DoT is flagged `is_long_term`, skipped by the per-round tick, and advanced instead by the daily chronic-effect batch with a non-lethal clamp.
+_Avoid_: damage tick, bleed, poison (for the general mechanism)
+
+**Capability effect channel**:
+The condition effect that adds to or subtracts from a target's capability value (`ConditionCapabilityEffect`: additive integer, floored at zero). It governs what a character CAN do — movement, flight, casting — distinct from check or resistance modifiers.
+_Avoid_: ability modifier, stat effect
+
+**Check effect channel**:
+The condition effect that modifies check rolls (`ConditionCheckModifier`: per-check-type modifier value, optionally scaling with severity), folded into a check's extra modifiers by the modifier seam.
+_Avoid_: roll bonus, skill modifier
+
+**Resistance effect channel**:
+The condition effect that modifies damage resistance (`ConditionResistanceModifier`: per-damage-type modifier, null = all types). Resistance is math, not binary immunity — intensity minus resistance gives the net value.
+_Avoid_: armor, immunity, soak

--- a/src/world/covenants/AGENT_GLOSSARY.md
+++ b/src/world/covenants/AGENT_GLOSSARY.md
@@ -1,0 +1,25 @@
+# Covenants glossary
+
+**Covenant**:
+A magically-empowered group oath — a blood-bound pact that binds its members under shared roles and goals. It is a per-kind extension of an `Organization` (a `Covenant` always has a backing org and shares its pk), scoped by a `CovenantType`.
+_Avoid_: guild, faction, party.
+
+**Covenant of the Durance**:
+The `CovenantType.DURANCE` covenant — the default, life-journey kind of oath, distinct from a battle covenant. "Covenant of the Durance" is the display label of that type.
+_Avoid_: a Durance, durance covenant.
+
+**War Covenant / Covenant of Battle**:
+The `CovenantType.BATTLE` covenant — an oath sworn to a martial cause. A STANDING one can stand down into dormancy and *rise again* through a "call the banners" rise ritual; a CAMPAIGN one dissolves when its defining story concludes.
+_Avoid_: setting active=true / "activating" a covenant (a dormant covenant rises via ritual, it is not flipped on).
+
+**Covenant Role**:
+The combat-power axis of membership: a role's archetype (Sword / Shield / Crown), speed_rank, role bonuses, and COVENANT_ROLE Thread-pull eligibility. Orthogonal to authority.
+_Avoid_: rank, position, office.
+
+**Covenant Rank**:
+The administrative-authority axis of membership: a per-covenant tier on the rank ladder (lower tier number = higher authority) whose capability flags gate invite / kick / manage. Orthogonal to Role.
+_Avoid_: role, level.
+
+**Mentor's Vow / Mentor Bond**:
+A consensual bond pairing a higher-level mentor with a lower-level sidekick so a level-mismatched party scales fairly; the `MentorBond` record is active while `dissolved_at` is null.
+_Avoid_: master/apprentice (a future flavor display-label only, with no model surface), patron, sponsor.

--- a/src/world/currency/AGENT_GLOSSARY.md
+++ b/src/world/currency/AGENT_GLOSSARY.md
@@ -1,0 +1,21 @@
+# Currency glossary
+
+**Copper**:
+The single integer base unit of all money — every balance, calculation, and API value is stored and computed in coppers, with mixed-form display ("3g 4s 7c") generated on the way out. One silver is 10 coppers; one gold is 100 coppers.
+_Avoid_: gold, money, coin (as the unit of account)
+
+**Denomination**:
+One of the named minted instrument coins above gold (Gold Knight, Baroness, Countess, Duchess, Queen, Empress), each worth ten times the last. A denomination is a physical instrument for theater, transport, and theft — not an account unit.
+_Avoid_: coin type, bill
+
+**CharacterPurse**:
+The ledger holding one character's personal money as a copper balance, anchored to the body (CharacterSheet) rather than a persona.
+_Avoid_: wallet, personal account
+
+**OrganizationTreasury**:
+The ledger holding one organization's money as a copper balance, with rank-gated spend authority controlling which members may draw from it.
+_Avoid_: org bank, org wallet
+
+**Graft**:
+A never-zero percentage leak skimmed off the top of every organizational income flow, driven by NPC servant dissatisfaction and floored above zero by doctrine. It can be bought down by treating servants but never eliminated, and is deliberately distinct from magic's Corruption.
+_Avoid_: tax, corruption, skim

--- a/src/world/gm/AGENT_GLOSSARY.md
+++ b/src/world/gm/AGENT_GLOSSARY.md
@@ -1,0 +1,21 @@
+# GM glossary
+
+**GM / Storyteller**:
+A player approved to run stories for others, identified by a `GMProfile` and a trust/permission `GMLevel`. The canonical term throughout the codebase is "GM"; a Lead GM is the GM assigned to and authoring a given story.
+_Avoid_: Storyteller, Dungeon Master, DM, game master.
+
+**GMProfile**:
+A player's GM identity — one per account, carrying their `GMLevel`, approval date, and approver. Created when a `GMApplication` is approved; GM-level permission checks query this model.
+_Avoid_: GM account, GM record.
+
+**GMTable**:
+A GM's working group: a named set of players (via their personas) engaging with a set of stories, with an ACTIVE/ARCHIVED lifecycle. The unit that owns GROUP-scope story progress and anchors Lead-GM permission checks.
+_Avoid_: party, group, campaign.
+
+**GMTableMembership**:
+A player's presence at a `GMTable`, pinned to a specific `Persona` (never a temporary mask) rather than to a CharacterSheet. Supports soft-leave via `left_at` so membership history outlives a persona, with one active membership per (table, persona); it is not a privacy mechanism, since the underlying character stays walkable.
+_Avoid_: seat, table member, participant.
+
+**Assistant GM (AGM)**:
+A GM (`GMProfile`) who has claimed a single `agm_eligible` beat session to run, seeing only that beat's internal description plus the Lead GM's framing — not the rest of the story. The claim lifecycle lives in the stories app as `AssistantGMClaim` (REQUESTED → APPROVED/REJECTED/CANCELLED → COMPLETED); AGM is a per-beat role, not a separate identity from GMProfile.
+_Avoid_: co-GM, helper GM, sub-GM.

--- a/src/world/goals/AGENT_GLOSSARY.md
+++ b/src/world/goals/AGENT_GLOSSARY.md
@@ -1,0 +1,9 @@
+# Goals glossary
+
+**Goal**:
+A character's declared point allocation in a goal domain (with optional notes and a status), where the invested points add as a situational bonus on checks that align with the goal. Characters distribute a fixed pool (30 points) across their goals.
+_Avoid_: objective, ambition, aspiration
+
+**Goal Domain**:
+A broad category of pursuit into which a character invests goal points, stored as a `ModifierTarget` row with `category='goal'` rather than as a hardcoded enum. The design set is Standing, Wealth, Knowledge, Mastery, Bonds, and Needs; some domains (e.g. Drives) are optional and require no point allocation.
+_Avoid_: goal category, goal type

--- a/src/world/items/AGENT_GLOSSARY.md
+++ b/src/world/items/AGENT_GLOSSARY.md
@@ -1,0 +1,29 @@
+# Items glossary
+
+**Facet**:
+A node of hierarchical imagery or symbolism (Creatures > Mammals > Wolf; Materials > Textiles > Silk) that players assign to resonances to define personal magical meaning. An item carries facets (via ItemFacet rows) so that a wearer's matching Threads on those facets boost their magic — the symbolic axis.
+_Avoid_: tag, theme, symbol
+
+**Style**:
+A staff-curated aesthetic vocabulary word (Seductive, Menacing, Regal) that an item can carry. Distinct from a Facet: a Style is an aesthetic adjective each character binds to a resonance of their choosing for a coherence bonus, where a Facet is fixed symbolic imagery — the same Style can mean different magic for different characters.
+_Avoid_: aesthetic, look, vibe
+
+**QualityTier**:
+A discrete, color-coded quality level (Common=white, Fine=green, Masterwork=purple) spanning an internal numeric range and carrying a stat multiplier, reused across systems to give consistent visual language for quality and difficulty.
+_Avoid_: grade, rarity, quality level
+
+**GearArchetype**:
+A coarse equipment categorization (Light/Medium/Heavy Armor, Robe, one- or two-handed Melee, Ranged, Thrown, Shield, Jewelry, Clothing) used to gate covenant-role compatibility and combat-stat eligibility.
+_Avoid_: gear type, equipment class, item category
+
+**CraftingRecipe**:
+The top-level record that drives one crafting workflow, unique per recipe kind, bundling the check configuration, resource costs, success thresholds, and default consumption policy for crafting attempts.
+_Avoid_: blueprint, formula, pattern
+
+**CraftingSkillCap**:
+A row mapping a minimum skill value to the highest QualityTier a crafter at that skill band can produce for a recipe; the crafter's craftable ceiling is the cap of the highest band whose threshold they meet.
+_Avoid_: skill gate, quality limit
+
+**lore-critical**:
+The property of an ItemInstance that must never be auto-purged by soft-delete cleanup because it carries material lore value, attached facets, or transfer provenance (it changed hands). A strict subset of "differs from template" — cosmetic-only data like a custom name or quality tier is not lore-critical.
+_Avoid_: significant, important, protected

--- a/src/world/magic/AGENT_GLOSSARY.md
+++ b/src/world/magic/AGENT_GLOSSARY.md
@@ -1,0 +1,100 @@
+# Magic glossary
+
+**Affinity**:
+One of the three magical sources — Celestial, Primal, or Abyssal — modeled as a first-class domain entity with an optional link to the modifier system. Every Resonance belongs to one Affinity.
+
+**Aura**:
+A character's soul-state expressed as percentages across the three Affinities (celestial / primal / abyssal), constrained to sum to 100. Its presence is the derived gate for whether a character can work magic at all.
+
+**Anima**:
+A character's pool of magical energy (current / maximum). It governs the *safety* of casting, not access — magic can always be attempted, and a shortfall is paid from life force rather than blocking the cast.
+_Avoid_: mana, magic points.
+
+**Gift**:
+A thematic collection of Techniques (e.g. Pyromancy, Shadow Majesty), associated with a set of Resonances. A character acquires a Gift to gain access to its Techniques.
+
+**Technique**:
+A specific, player-created magical ability that lives within a Gift, carrying base intensity, control, and anima cost plus a style and effect type. It is the primary unit of magical action.
+_Avoid_: power, spell, ability.
+
+**Cantrip**:
+A staff-curated starter Technique template selected during character creation; at CG finalization it produces a real Technique in the character's Gift. Its mechanical fields are hidden from the player.
+_Avoid_: starter spell, baby technique (informal only).
+
+**Intensity**:
+The magnitude a caster *channels* — it drives cost and risk (anima cost, control mishap, Soulfray, Audere gating, resonance attribution). It is a base/static value on the Technique and is never reduced by a ward.
+
+**Power**:
+The effective magnitude the working carries into the world — it drives landed effect (damage budgets, condition severity, capability grants, clash progress). Power is always derived and recomputed each cast, never stored; it is seeded by intensity and then diverges.
+
+**Control**:
+A Technique's base safety/precision stat. High control reduces anima cost and eliminates mishap risk; it is the efficiency lever opposite intensity.
+
+**Control Mishap**:
+An additional consequence drawn when runtime intensity exceeds control (the `control_deficit`), routed through the consequence pool whose deficit band matches via `MishapPoolTier`. It never replaces the intended effect and never carries character-loss consequences.
+_Avoid_: fumble, miscast.
+
+**Soulfray**:
+The magical strain a character accrues by casting while anima is depleted below the configured threshold ratio; severity scales with depletion and is tested against a resilience check. Tuned by the `SoulfrayConfig` singleton.
+
+**Overburn**:
+The condition where a cast's effective anima cost exceeds the available pool and the deficit is drawn from the caster's life force. Non-lethal encounters clamp cost to available anima instead.
+
+**Penetration**:
+The contest run when a Technique's Power meets a target's ward: a check against the ward's strength whose success level selects a factor from the authored ladder, applied as the `PENETRATION` stage of power derivation. Unwarded casts record no penetration entry.
+
+**Ward**:
+A target's defensive barrier (a positive `barrier_strength`) that Power must penetrate to land its effect. A ward reduces Power only; it must never reduce intensity.
+_Avoid_: shield, barrier (as the canonical term).
+
+**Backfire**:
+The adverse consequence resolved when a cast is worked in an environment whose Affinity is OPPOSED to the caster's, drawing from the pairing's authored consequence pool. The opposed half of the resonance-environment interaction.
+
+**Resonance Environment**:
+The directed pairing between a caster's Affinity and the place's Affinity that conditions a cast — an ALIGNED pairing amplifies (and may grant a boon), an OPPOSED pairing backfires or defiles. Modeled as nine `AffinityInteraction` rows plus a tuning singleton.
+
+**PowerLedger**:
+The transient, never-persisted record of how a cast's Power was derived — an ordered list of entries each carrying a stage, source label, operation, amount, and running total. It is recomputed on every cast and surfaced for transparency.
+
+**PowerStage**:
+The enum naming each phase of power derivation in the ledger (base, flat modifier, multiplier, term, environment, reactive, combat pull, penetration, clamp). Each ledger entry is tagged with one stage.
+
+**Thread**:
+A per-character attachment owned by a CharacterSheet, anchored to exactly one anchor (Trait / Technique / Facet / relationship track / relationship capstone / covenant role / Mantle / Sanctum) and channeling a single Resonance. It accrues `developed_points` into a `level` and is the unit of long-term magical investment.
+
+**Imbue**:
+Spending Resonance currency to advance an existing Thread's developed points and level. Player-facing it is the Rite of Imbuing, a CEREMONY-kind Ritual completed by the `imbue` finisher.
+
+**Weave**:
+Creating a new Thread on an anchor the character is unlocked to weave on. Player-facing it is the Rite of Weaving, a CEREMONY-kind Ritual completed by the `weave` finisher.
+
+**Ritual**:
+An authored magical procedure dispatched in one of four ways: SERVICE (invokes a service-function path), FLOW (invokes a flow definition), CEREMONY (creates a pending effect a finisher command later consumes), or SCENE_ACTION (fires a check via a `RitualCheckConfig` sidecar). Performance converges on the single `perform_ritual` Action.
+
+**Sanctum**:
+A leveled room that serves as a Thread anchor via `target_sanctum_details`, capped at the sanctum feature's level × 10. A Sanctum-anchored Thread is pull-applicable (an in-sanctum boost) while the character is in the Sanctum's room.
+
+**Mantle**:
+A specific, storied, attunable ItemInstance in the world (a particular sword, amulet, banner) with authored progression levels. A character attunes by weaving a MANTLE-kind Thread anchored on the Mantle, gated on having cleared at least its first level; the Thread's level cannot exceed the character's max-cleared mantle level.
+
+**Mage Scar**:
+The player-facing name for a magical alteration imprinted on a character by magical exposure — a queued, tiered cosmetic-to-profound change carrying social, weakness, and resonance effects. Backend class and table names retain the `MagicalAlteration` naming.
+_Avoid_: Magical Scar, Magical Alteration (as the player-facing name).
+
+**Soul Tether**:
+A bond mechanic between two PCs whose tuning lives in the `SoulTetherConfig` singleton, providing a rescue-and-resolution mechanism with a dramatic advancement/modifier surface (sineating, rescue rituals, stage-advance bonuses). The Sinner and Sineater are its two roles.
+
+**Sineater**:
+One of the two roles in a Soul Tether bond — the participant who performs Sineating actions on the bond. The complementary role is the Sinner.
+
+**Dramatic Moment**:
+A staff-tagged scene moment of an authored category that simultaneously grants a character Resonance and fires a renown award. Tags are immutable provenance records, capped per character per scene.
+
+**Entry Flourish**:
+A self-grant of Resonance triggered on a successful Entrance social action, where the entrant declares one of their claimed Resonances to broadcast. Idempotent per scene; it is the actor-side complement to the peer-side scene-entry endorsement.
+
+**Endorsement**:
+A peer's recognition of another character's pose (`PoseEndorsement`) that settles at the weekly tick to grant Resonance from a shared pot. A legitimate, live Resonance-award mechanism alongside scene-entry and style-presentation endorsements.
+
+**Renown**:
+The reputation/legend award fired alongside certain magical events (Dramatic Moments, Audere Majora crossings) via `fire_renown_award`. A live award mechanism; when an event's configured risk is NONE, no deed is minted.

--- a/src/world/mechanics/AGENT_GLOSSARY.md
+++ b/src/world/mechanics/AGENT_GLOSSARY.md
@@ -1,0 +1,33 @@
+# Mechanics glossary
+
+**ModifierCategory**:
+A broad grouping for modifier targets (stat, magic, affinity, resonance, goal). A cached lookup table that organizes the unified target registry for display and filtering.
+_Avoid_: modifier group, modifier kind
+
+**ModifierTarget**:
+A single entry in the unified registry of everything that can be modified — one row per stat, capability, check type, damage resistance, resonance, or goal domain. Replaces the former separate Affinity/Resonance/GoalDomain models; optional FKs link it to the concrete trait, capability, check type, or damage type it represents.
+_Avoid_: modifiable, affinity/resonance (as separate models), attribute
+
+**ModifierSource**:
+The provenance record for a character's modifier — where it came from (e.g. a distinction effect template plus the character-distinction instance). It answers WHICH target a modifier grants and its base value, and drives cascade cleanup when the source is removed.
+_Avoid_: origin, provider, grantor
+
+**CharacterModifier**:
+A materialized modifier value on a character (`value`, `source`, optional `expires_at`) for fast lookup. All modifiers for a given target stack (values sum); zero-value rows are hidden from display. Its target is derived from the source, stored directly for efficient queries.
+_Avoid_: stat bonus, buff value, character stat row
+
+**ConsequenceEffect**:
+A structured mechanical effect applied when a consequence is selected (typed `effect_type` with validated fields, ordered execution). All mechanical outcomes must be such structured primitives — GMs pick pre-authored consequences and never freehand effects; `mechanical_description` is display flavor only.
+_Avoid_: outcome, result effect, freeform effect
+
+**Property**:
+A neutral descriptive tag on a target or environment describing what something IS, not what can be done to it (flammable, locked, magical, frozen). Grouped under a `PropertyCategory`.
+_Avoid_: trait, flag, tag (generic), attribute
+
+**ObjectProperty**:
+A runtime attachment of a `Property` to a specific game object — the instance binding that gives an individual object its descriptive tags.
+_Avoid_: object flag, object tag, attribute row
+
+**Approach**:
+A way to resolve a challenge (`ChallengeApproach`), connecting what a character can do (an `Application`) with how it is rolled (a `CheckType`) for a specific challenge template, optionally gated by a required effect property.
+_Avoid_: method, tactic, option, resolution path

--- a/src/world/missions/AGENT_GLOSSARY.md
+++ b/src/world/missions/AGENT_GLOSSARY.md
@@ -1,0 +1,13 @@
+# Missions glossary
+
+**Mission**:
+An authored branching graph of decision nodes a character undertakes, drawn from a `MissionTemplate` and run as a `MissionInstance` (the live run, whose state is just its current node plus durable snapshots and recorded deeds — no state blob). The umbrella term for the system; "Mission" names the concept, with template-vs-instance distinguishing the static graph from a play-through.
+_Avoid_: quest, job, task.
+
+**MissionTemplate**:
+An authored mission: the static node graph (entered at its single entry node) plus its availability metadata — level band, risk tier, draw weight, arc scope, and visibility. The reusable definition that `MissionInstance` runs.
+_Avoid_: mission definition, quest template.
+
+**Mission Deed**:
+A `MissionDeedRecord` — one recorded consequential act taken within a mission run, attributed to the acting participant's character (moral and narrative consequence follows the actor). Its structured payouts are stored as child `MissionDeedRewardLine` rows rather than a dict.
+_Avoid_: deed log, mission action, consequence record.

--- a/src/world/progression/AGENT_GLOSSARY.md
+++ b/src/world/progression/AGENT_GLOSSARY.md
@@ -1,0 +1,19 @@
+# Progression glossary
+
+> Durance, XP, Kudos, and Development Points are cross-cutting terms — see the root `AGENT_GLOSSARY_MAP.md`.
+
+**Unlock**:
+An authored advancement target a character can spend XP to acquire — e.g. `ClassLevelUnlock` (a class level) or `TraitRatingUnlock` (a major trait threshold) — whose availability is governed by Requirements.
+_Avoid_: perk, purchase, upgrade.
+
+**Requirement**:
+An authored gate attached to an Unlock, evaluated per character through `is_met_by_character(character) -> (bool, str)`. Concrete kinds include Trait, Level, ClassLevel, MultiClass, Tier, Achievement, Relationship, and Legend requirements.
+_Avoid_: prerequisite, condition (reserve "condition" for the conditions system).
+
+**ClassLevelAdvancement**:
+The receipt for a single within-tier class-level advance performed through the Ritual of the Durance; it records level_before/after, officiant, ritual, and scene, and survives character death. Its tier-crossing sibling is `AudereMajoraCrossing`, both sharing `AbstractClassLevelAdvancement`.
+_Avoid_: level-up event, training record.
+
+**PathIntent**:
+A character's mutable declared intention for their next Path — one row per sheet, overwritten on re-declaration — which the Audere Majora offer pre-selects when it is among the eligible paths.
+_Avoid_: path receipt, path choice (it is an aspiration, not a committed record).

--- a/src/world/relationships/AGENT_GLOSSARY.md
+++ b/src/world/relationships/AGENT_GLOSSARY.md
@@ -1,0 +1,29 @@
+# Relationships glossary
+
+**RelationshipTrack**:
+A named axis along which one character's relationship toward another develops (Trust, Respect, Rivalry, Fear), each carrying a positive or negative sign.
+_Avoid_: dimension, stat, axis (when unqualified).
+
+**RelationshipTier**:
+A milestone threshold within a track (e.g. Wary → Acquaintance → Confidant), reached once developed points cross the tier's `point_threshold`.
+_Avoid_: level, rank, stage.
+
+**Absolute Value**:
+The unsigned total magnitude of all of a relationship's track points (developed plus temporary), always positive; the permanent-only variant is the Developed Absolute Value.
+_Avoid_: intensity, total score, magnitude.
+
+**Affection**:
+The signed sum of a relationship's track points — positive-sign tracks add, negative-sign tracks subtract — expressing its net warmth or hostility.
+_Avoid_: sentiment, like/dislike, net score.
+
+**Capacity**:
+The per-track ceiling on developed (permanent) points; it is raised by Updates and Capstones.
+_Avoid_: cap, max points, limit.
+
+**Development vs Update**:
+A Development adds permanent (developed) points up to capacity (capped at 7 per week, driven by a social roll, awards XP); an Update adds decaying temporary points (linear over 10 days) plus permanent capacity, and is unlimited.
+_Avoid_: conflating the two; "edit", "change" (Change is its own model that redistributes existing points).
+
+**RelationshipCapstone**:
+A monumental, never-gated moment that adds both permanent points and capacity at once; the anchor that future magical-tether power is built around.
+_Avoid_: milestone, climax, peak event.

--- a/src/world/scenes/AGENT_GLOSSARY.md
+++ b/src/world/scenes/AGENT_GLOSSARY.md
@@ -1,0 +1,34 @@
+# Scenes glossary
+
+**Scene**:
+Root term — the primary roleplay-session entity (participants, personas, recorded interactions, privacy mode). Defined in the wider character/identity domain; not redefined here.
+
+**Persona**:
+Root term — the identity a participant wears within a scene (PRIMARY/ESTABLISHED/TEMPORARY), anchored by FK to the source-of-truth CharacterSheet. Not redefined here.
+
+**Gemit**:
+Root term — a staff/GM broadcast pushed to a public-reaction surface. Not redefined here.
+
+**SceneRound**:
+A non-combat round/turn structure anchored to a room, carrying a gating mode (OPEN, POSE_ORDER, STRICT) plus per-round knobs (quorum, action cap, repeat-target lock). At most one active round exists per room. Combat is one specialization of this round seam; rounds advance on declared action, never on wall-clock time.
+_Avoid_: turn, tick, combat round (for the general case)
+
+**Pose**:
+A single IC contribution recorded within a scene — the atomic unit of RP (pose, say, whisper, emit), modelled by `Interaction`. It carries its own privacy tier and target personas for thread derivation.
+_Avoid_: message, post, line, Interaction (at player surfaces)
+
+**Effort Level**:
+The initiator's declared exertion on a social action (`EffortLevel`: very low / low / medium / high / extreme), forwarded at dispatch. It is a check-roll modifier and charges the initiator social fatigue — orthogonal to a technique's power levers.
+_Avoid_: intensity, difficulty (effort is the initiator's input, not the target's)
+
+**Difficulty Choice**:
+The defender's authored plausibility band (`DifficultyChoice`: trivial / easy / normal / hard / daunting) selected at consent time — the defender, never the initiator, sets how hard the action is to land. Frontend labels map to bands ("It works" → easy, "Hard but possible" → hard, "No way" → daunting).
+_Avoid_: difficulty rating, target number (for the player-facing choice)
+
+**Highlight reel**:
+A read-only curated digest of a scene: one fully-sealed featured moment (highest-reacted GM-tagged pose, else most-reacted pose) plus a ranked index of remaining reacted poses, capped at ten. Filtered through interaction read-visibility so it can never surface a pose the viewer cannot see.
+_Avoid_: feed, recap, summary, spotlight
+
+**Co-owner**:
+A character marked `is_owner=True` on their `SceneParticipation` because they were present in the room at scene creation, granting scene-administration rights (finish, change round mode). Latecomers who join mid-scene are non-owner participants and never inherit admin rights by entering.
+_Avoid_: host, GM (GMs administer via story-runner status, not co-ownership), moderator

--- a/src/world/secrets/AGENT_GLOSSARY.md
+++ b/src/world/secrets/AGENT_GLOSSARY.md
@@ -1,0 +1,17 @@
+# Secrets glossary
+
+**Secret**:
+A hidden fact or relationship about one character (its `subject_sheet`, who is both the subject and sole owner), with a level, an optional category, and consequences. The missing fourth privacy primitive alongside Distinction (permanent trait), Condition (live state), and Resonance — a fact that must be earned and shared rather than a trait or state.
+_Avoid_: private distinction, hidden flag, shared secret (a multi-party situation is two distinct single-owner Secrets).
+
+**Secret Level (1–4)**:
+An ordinal (`SecretLevel`: Uncommon Knowledge, Whispers, Carefully Kept, Dangerous) giving a secret its narrative weight and default share-scope. The 1–4 value is structural and load-bearing — only Level-1 player-flavor may be free-authored, and the value defaults a victim's reputation hit — while the display names are placeholder.
+_Avoid_: tier, severity, depth.
+
+**Secret Provenance**:
+Where a secret came from (`SecretProvenance`: GM-authored, action-anchored, or player-flavor), read as a canonicity spectrum from canon down to unverified flavor. It drives the anchor-scales-with-level rule and OOC attribution; it is attribution, not a trust-warning.
+_Avoid_: source, origin, trust level.
+
+**SecretKnowledge**:
+A roster-scoped record that one character holds a given secret, so knowledge follows the character across players. Holding the row is the fact layer; `knows_category` and `knows_consequences` are partial-knowledge layers that unlock independently and monotonically, so a secret's Unknown layers can persist per-knower even after the fact is out.
+_Avoid_: known secret, CharacterSecret, secret grant.

--- a/src/world/societies/AGENT_GLOSSARY.md
+++ b/src/world/societies/AGENT_GLOSSARY.md
@@ -1,0 +1,33 @@
+# Societies glossary
+
+**Society**:
+A socio-political stratum within a Realm, defined by six Principle Axes; characters relate to it through their Personas (memberships, reputation, legend awareness).
+_Avoid_: faction, org, culture.
+
+**Organization**:
+A specific group within a Society — a noble family, guild, gang, business, or standalone covenant — carrying rank titles and optional principle overrides. It belongs to (or stands apart from) exactly one Society.
+_Avoid_: faction, guild (guild is one OrganizationType, not the general term).
+
+**OrganizationType**:
+A template categorizing organizations and supplying their default five-rank title set (e.g. noble_family, guild, secret_society, covenant).
+_Avoid_: org category, kind.
+
+**Reputation / ReputationTier**:
+A persona's hidden numeric standing (−1000 to +1000) with a Society or Organization. The raw value is never shown; players see only the named `ReputationTier` (Reviled … Unknown … Revered).
+_Avoid_: standing, favor, rep score.
+
+**Principle Axes**:
+The six −5..+5 value axes — mercy, method, status, change, allegiance, power — that define a Society's (or Organization's) moral character; archetype vectors dot-product against them to produce reputation deltas.
+_Avoid_: alignment, morals, stats.
+
+**LegendEntry / Deed**:
+A single notable accomplishment ("deed") earned by a persona, carrying a base legend value that further telling can extend up to a spread cap. Legend itself is the permanent, accumulating metric of remarkable accomplishment.
+_Avoid_: feat, achievement (Achievement is a separate system), accomplishment record.
+
+**LegendSpread**:
+A single instance of a deed being retold or embellished, adding value (clamped to the deed's remaining spread capacity) and widening which societies are aware of it.
+_Avoid_: rumor, telling event, gossip record.
+
+**Renown**:
+The live award *mechanism* — `fire_renown_award` reading an authored `RenownAwardConfig` (Magnitude / Risk / Reach / Archetypes) — that fires a deed's downstream consequences: fame buffer, permanent prestige, the legend `base_value`, and per-society reputation deltas. Distinct from Legend, which is the metric Renown feeds.
+_Avoid_: fame (fame is one output of Renown), reputation, the Legend total.

--- a/src/world/stories/AGENT_GLOSSARY.md
+++ b/src/world/stories/AGENT_GLOSSARY.md
@@ -1,0 +1,33 @@
+# Stories glossary
+
+**Story / Chapter / Episode / Beat / Transition**:
+The narrative hierarchy: a **Story** is a top-level campaign container with a scope and maturity; a **Chapter** is a major arc within it; an **Episode** is a node in the episode DAG; a **Beat** is a boolean predicate attached to an episode (the gateable unit of progress); and a **Transition** is a first-class directed edge between episodes, fired automatically or by GM choice. Episodes are nodes and Transitions are edges — a Story progresses by satisfying Beats to make Transitions eligible.
+_Avoid_: campaign (Story), arc (Chapter), session/scene (Episode), objective/flag (Beat), branch/link (Transition).
+
+**Era**:
+A temporal metaplot tag (player-facing "Season N") that stories and events are stamped against, with exactly one ACTIVE era enforced at a time. It is a temporal label, not a parent in the Story/Chapter/Episode hierarchy.
+_Avoid_: season, age, epoch.
+
+**Story Maturity**:
+The authoring-completeness of a single Story / Chapter / Episode node — `StoryMaturity`: PITCH, OUTLINE, or PLOT. Per-node and orthogonal to runtime progress status, with no cross-node ordering constraint; it is how finished the authoring is, not where play has reached.
+_Avoid_: draft state, completeness, stage.
+
+**Progress Status**:
+The finer-grained state of a progress pointer (`ProgressStatus`: ACTIVE, WAITING_FOR_GM, RESTING, COMPLETED, FORECLOSED). `is_active` stays True for ACTIVE / WAITING_FOR_GM / RESTING; COMPLETED and FORECLOSED clear it.
+_Avoid_: progress state, pointer status.
+
+**FORECLOSED**:
+The honest terminal `ProgressStatus` for a progress run still in flight when its story is concluded — distinct from COMPLETED (which means the run genuinely reached an ending). It exists so an unfinished thread is never falsely reported done, nor left orphaned in a live state.
+_Avoid_: cancelled, abandoned, completed.
+
+**Resting Conclusion**:
+The player-facing `Episode.resting_conclusion` text shown when a progress pointer RESTS at that episode — a deliberately non-final pause-point ending. Required before an episode can be promoted to PLOT maturity.
+_Avoid_: ending, pause text.
+
+**Story Note**:
+An append-only, never-player-visible OOC authorial note attached to a Story — general notes and future-idea seeds for the next author. Distinct from per-node pitch/`description` text; not promotable and not editable through the API.
+_Avoid_: GM note, comment, pitch.
+
+**Story Scope**:
+Which kind of subject a Story progresses for — `StoryScope`: UNASSIGNED (the default, not yet placed), CHARACTER (personal), GROUP, or GLOBAL. It selects the progress-pointer type, and an UNASSIGNED story rejects progress creation until it is assigned a scope.
+_Avoid_: level, reach, audience.

--- a/src/world/tarot/AGENT_GLOSSARY.md
+++ b/src/world/tarot/AGENT_GLOSSARY.md
@@ -1,0 +1,17 @@
+# Tarot glossary
+
+**Tarot**:
+The 78-card deck drawn during character creation to derive a surname for familyless characters, where the card and its upright-or-reversed orientation determine the resulting name.
+_Avoid_: card draw, naming deck
+
+**Major Arcana**:
+The 22 suitless cards of the deck (rank 0-21), each carrying a Latin name that becomes the character's surname when drawn upright (or the same name prefixed with "N'" when reversed).
+_Avoid_: trump card
+
+**Minor Arcana**:
+The 56 suited cards of the deck (rank 1-14 across Swords, Cups, Wands, and Coins), whose surname is the singular suit name upright (e.g. "Sword") or "Down"-prefixed when reversed (e.g. "Downsword").
+_Avoid_: pip card, numbered card
+
+**Misbegotten**:
+A heritage of character born from the Tree of Souls with no parents; being familyless, the Misbegotten derive their surname by drawing a Tarot card rather than inheriting one.
+_Avoid_: orphan, parentless

--- a/src/world/traits/AGENT_GLOSSARY.md
+++ b/src/world/traits/AGENT_GLOSSARY.md
@@ -1,0 +1,17 @@
+# Traits glossary
+
+**Trait**:
+The base definition template for any measurable character quality, typed as STAT, SKILL, MODIFIER, or OTHER and grouped by category. Every Stat and Skill is backed by a Trait record, giving them a unified check-resolution pipeline.
+_Avoid_: attribute, stat (for the generic case)
+
+**Stat**:
+One of the 12 core character statistics used in character creation and gameplay, organized into four categories — Physical (Strength, Agility, Stamina), Social (Charm, Presence, Composure), Mental (Intellect, Wits, Stability), and Meta (Luck, Perception, Willpower). A Stat is a Trait of type STAT.
+_Avoid_: ability score, primary attribute
+
+**Skill**:
+A broad learnable competency (Melee Combat, Persuasion) backed one-to-one by a SKILL-type Trait, carrying development and rust progression on the character. Skills are the parent category beneath which Specializations live.
+_Avoid_: proficiency, talent
+
+**Specialization**:
+A specific application beneath a parent Skill (Swords under Melee Combat, Seduction under Persuasion) that stacks with the parent when applicable and, unlike a Skill, is immune to rust. It unlocks once the parent Skill reaches the configured threshold.
+_Avoid_: sub-skill, focus

--- a/tools/skills/README.md
+++ b/tools/skills/README.md
@@ -71,6 +71,28 @@ on it. Enforces un-bundling `AskUserQuestion`/result-claims from their tool
 calls and verifying issue number↔title before mutations. **Delete this skill
 when the harness is fixed** — removal manifest + test in GH #647.
 
+### design-vocabulary
+
+Shared vocabulary for judging interface design — depth, interface, seam,
+leverage, locality, the deletion test, "one adapter = a hypothetical seam,
+two = a real one." Concepts only: it does **not** rename "module" or ban
+"component/service/API". Anchored on the repo's action-dispatch seam; leads with
+the plain principle in user-facing prose.
+
+### architecture-cleanup
+
+Audits a subsystem for shallow modules and leaky seams via Explore subagents and
+the deletion test, then produces a **markdown** report (no HTML/Mermaid — this is
+a headless repo) of candidate refactors ranked Strong / Worth-exploring /
+Speculative. Flags conflicts with recorded ADRs.
+
+### domain-glossary-and-adr
+
+Keeps the `AGENT_GLOSSARY.md` files and `docs/adr/` log current and used: read
+glossary terms before designing, update them in the same PR, and offer an ADR only
+on the three-part bar (hard to reverse, surprising, a real trade-off). Enforces the
+spoiler wall — neutral phrasing in the repo, rationale in private memory.
+
 ## Updating skills
 
 In the devcontainer or Linux/macOS bare-metal: just edit the files

--- a/tools/skills/architecture-cleanup/SKILL.md
+++ b/tools/skills/architecture-cleanup/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: architecture-cleanup
+description: Use when asked to find architectural friction / deepening opportunities in the codebase, or to periodically audit a subsystem for shallow modules and leaky seams. Produces a markdown report of candidate refactors.
+---
+
+# Architecture Cleanup
+
+Audit a subsystem for architectural friction — shallow modules, leaky seams,
+broken locality — and produce a **ranked markdown report of candidate refactors**.
+This skill finds and proposes; it does not refactor unprompted. Pair it with the
+`design-vocabulary` skill (its terms are used throughout) and `superpowers:brainstorming`
+once a candidate is chosen.
+
+**Markdown only.** This is a headless, telnet-first repo. The report is plain
+markdown — no HTML, no Tailwind, no Mermaid, no browser-open ritual. Describe
+before/after in prose, with small ASCII sketches where a diagram genuinely helps.
+Write it to the OS temp dir (e.g. `$TMPDIR/arch-cleanup-<subsystem>.md`) or print it
+inline; do not add files to the repo.
+
+## Process
+
+1. **Read the recorded decisions first.** Open `AGENT_GLOSSARY_MAP.md` (and the
+   touched app's `AGENT_GLOSSARY.md`) plus any `docs/adr/` entries covering the area.
+   You are auditing against the vocabulary and the decisions already on record — not
+   from a blank slate.
+
+2. **Dispatch Explore subagents to walk the subsystem and note friction.** Read-only,
+   fan-out. Have them flag, with `file:line`:
+   - **Understanding requires bouncing** across many small modules to follow one
+     concept (broken locality).
+   - **Shallow modules** — interface nearly as large as the implementation;
+     pass-through wrappers; helpers that re-expose every internal.
+   - **Pure functions extracted only for testability** with no locality benefit (the
+     logic's only home is one caller, but it lives apart "to test it").
+   - **Leaky seams** — callers that must know the *how* behind a doorway (reaching past
+     `dispatch_player_action()` into a backend's internals, depending on ordering the
+     interface doesn't promise).
+   - **Untested through the current interface** — behaviour reachable only by poking
+     internals, a sign the public interface is the wrong shape.
+
+3. **Apply the deletion test** to each candidate (see `design-vocabulary`): would
+   deleting/inlining it make complexity *vanish* (it's a pass-through — propose
+   removal) or *reappear duplicated across N callers* (it earns its keep — leave it)?
+
+4. **Present candidates as a ranked markdown list.** One block per candidate:
+
+   ```
+   ### <short title>   [Strong | Worth-exploring | Speculative]
+   - **Files:** path:line, path:line
+   - **Problem:** the friction, in design-vocabulary terms (shallow / leaky seam / broken locality)
+   - **Solution:** the proposed reshape (deepen the module / move the seam / inline the pass-through)
+   - **Benefit:** stated as locality + leverage gained (fewer files to change, smaller interface to learn)
+   - **Recommendation:** why this strength; what would raise/lower it
+   ```
+
+   Rank by confidence: **Strong** (clear win, low risk), **Worth-exploring** (real
+   friction, needs a design pass), **Speculative** (a smell, may not pay off).
+
+5. **On a chosen candidate, switch to design mode.** Run `superpowers:brainstorming`
+   and reason with the `design-vocabulary` terms before proposing a concrete change.
+   Don't jump from "smell found" to "code edited."
+
+6. **If a candidate contradicts an ADR, flag it explicitly.** Name the ADR, state the
+   conflict, and surface it only when the friction is large enough to warrant
+   *reopening* the decision — not as a quiet override. A recorded decision is reopened
+   in the open, never silently refactored around.
+
+## Guardrails
+
+- Respects the `design-vocabulary` rule: **no renaming "module" to mean "component."**
+  Use the concepts (depth, seam, leverage, locality); keep the repo's nouns.
+- Report is a proposal for a human to ratify — recommend, don't auto-apply.
+- "Shallow" and "for testability only" are *candidates*, not verdicts: stubs and
+  extracted helpers can be intentional placeholders mid-development (see CLAUDE.md
+  dead-code caution). When in doubt, rank lower and ask.

--- a/tools/skills/design-vocabulary/SKILL.md
+++ b/tools/skills/design-vocabulary/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: design-vocabulary
+description: Use when designing or restructuring a subsystem's interface, deciding where a seam goes, judging whether a class/module earns its keep, or making code more testable — the shared deep-module design vocabulary.
+---
+
+# Design Vocabulary
+
+A shared language for talking about interface design in this repo. These are
+**concepts, not renames.** "Module" still means a Python module or Django app
+submodule; "component", "service", "API", and "boundary" all keep their ordinary
+meanings — use them freely. This skill adds vocabulary for *judging* a design; it
+does not relabel the nouns we already have.
+
+Every example anchors on the repo's canonical seam: the player-action doorway in
+`src/actions/player_interface.py` (`dispatch_player_action()`), with `action.run()`
+as one backend it routes to (ADR 0001).
+
+## The concepts
+
+- **Depth** — a lot of behaviour behind a small interface. `dispatch_player_action(actor, intent)`
+  is two arguments; behind it sit registry lookup, permission checks, combat/scene
+  routing, and effect resolution. A deep doorway: callers say *what they want*, not
+  *how it happens*. The opposite — a shallow module — is one whose interface is almost
+  as big as its implementation (a pass-through wrapper, a one-line helper exposing
+  every internal).
+
+- **Interface** — *everything a caller must know to use it correctly*: not just the
+  signature, but invariants, ordering, error modes, and side effects. The action seam's
+  interface includes "prereqs run before execution," "it raises on a failed permission
+  check," "it emits events the flows engine reacts to." A signature you can call but
+  not predict has a hidden interface — that hidden part is real complexity, just
+  undocumented.
+
+- **Seam** — a place you can change behaviour *without editing there*. The dispatcher
+  is the canonical seam: add a backend, swap a routing rule, or stub the whole call in
+  a test, and callers (web and telnet alike) are untouched. A seam is valuable exactly
+  when something varies across it.
+
+- **Leverage** — capability delivered per unit of interface a caller must learn. The
+  action seam is high-leverage: one small doorway buys every player capability across
+  both channels. A helper that exposes ten methods to do what one call could is
+  low-leverage.
+
+- **Locality** — change, bugs, and the knowledge needed to reason about something all
+  concentrate in one place. Good locality means a change to how combat resolves lives
+  inside the combat backend, not smeared across callers. When you find yourself editing
+  five files to make one conceptual change, locality is broken.
+
+- **The deletion test** — imagine deleting the module and inlining it at its callers.
+  Does complexity *vanish* (it was a pass-through; delete it) or *reappear, duplicated,
+  across N callers* (it was concentrating real work; it earns its keep)? Apply this
+  before defending — or proposing — any wrapper, helper, or "for testability" extraction.
+
+- **One adapter = a hypothetical seam; two = a real one.** Don't introduce a seam until
+  something actually varies across it. A backend interface with a single implementation
+  is speculation; the dispatcher earned its seam the moment web *and* telnet both needed
+  it. Until the second case is real, the abstraction is cost without leverage —
+  YAGNI with a precise test.
+
+## Audience rule
+
+"Seam", "depth", "leverage", "locality" are sanctioned here and in design docs, ADRs,
+and skills. In **user-facing prose, lead with the plain principle, not the jargon** —
+say "the one shared doorway both web and telnet go through," not "the dispatch seam."
+(This reconciles the avoid-impl-jargon discipline: the vocabulary sharpens *our*
+thinking; it is not how we explain a feature to a player or a non-engineer.)
+
+## Where the decisions already live
+
+- **`docs/adr/`** records hard-to-reverse design decisions. Before re-arguing where a
+  seam goes or why a module is shaped as it is, check whether an ADR already settled it
+  (e.g. ADR 0001 on the action seam) — don't re-litigate a recorded decision; if you
+  think it's wrong, reopen it explicitly.
+- **`AGENT_GLOSSARY_MAP.md`** (and per-app `AGENT_GLOSSARY.md`) hold the domain
+  vocabulary. Name modules and interfaces after glossary concepts so the code reads in
+  the ubiquitous language — see the `domain-glossary-and-adr` skill.

--- a/tools/skills/domain-glossary-and-adr/SKILL.md
+++ b/tools/skills/domain-glossary-and-adr/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: domain-glossary-and-adr
+description: Use when introducing or sharpening a domain term, when a design conversation lands a hard-to-reverse decision, or when working in an app whose AGENT_GLOSSARY.md or docs/adr/ needs updating — keeps the glossary and ADR log current and used.
+---
+
+# Domain Glossary & ADR
+
+Two living records of *how this game is built and named*: the **glossaries**
+(`AGENT_GLOSSARY_MAP.md` + per-app `src/<app>/AGENT_GLOSSARY.md`) hold the ubiquitous
+language; **`docs/adr/`** holds the hard-to-reverse decisions and their "why." This
+skill keeps both current and used. Pair with `design-vocabulary` for the seam/depth
+terms — the ADR log is where the architectural *why* lives, alongside commit messages
+and private agent-memory.
+
+## Use the glossary before you design
+
+- Before designing in an app, **read its `src/<app>/AGENT_GLOSSARY.md` and the root
+  `AGENT_GLOSSARY_MAP.md`** (cross-cutting terms). Use those *exact* terms in code,
+  specs, and ADRs — name models and interfaces after glossary concepts so code reads
+  in the ubiquitous language.
+- **Challenge a term that conflicts with the glossary.** If a design wants to call a
+  thing something the glossary already names differently, that's a flag — converge on
+  the canonical term or change the glossary deliberately, never silently fork.
+- **Sharpen fuzzy or overloaded terms** to the one canonical word. The map lists
+  rejected synonyms under `_Avoid_`; add to it when you retire a near-synonym.
+
+## Keep it current (the tandem rule)
+
+- When you **add or rename a domain concept, update the relevant `AGENT_GLOSSARY.md`
+  in the same PR** (per CLAUDE.md "Docs Are Directives"). If the app has no glossary
+  yet, create it lazily and link it from `AGENT_GLOSSARY_MAP.md`'s per-app list.
+- A glossary is a **glossary only**: each entry says what a term **IS**, not what it
+  does. No implementation details, no specs, no procedures — those live in code, system
+  docs, and ADRs.
+
+## Offer an ADR sparingly — the three-part bar
+
+Propose an ADR **only when all three hold**:
+
+1. **Hard to reverse** — undoing it later means a migration, a data reshape, or
+   rewriting many callers.
+2. **Surprising without context** — a newcomer would reasonably do it differently.
+3. **The result of a real trade-off** — you chose this over a named alternative for
+   stated reasons.
+
+If any leg is missing, it isn't an ADR — it's a code comment, a glossary entry, or
+nothing. Most decisions are not ADRs.
+
+When it qualifies, write to `docs/adr/` in the existing one-paragraph format (see
+`docs/adr/README.md` and entries like `0001`): a short title, the decision and the
+rejected alternative in prose, then a `> Status: … · Source: …` line cross-referencing
+the issue/roadmap. **Number = highest existing ADR + 1** (read the directory; don't
+compute from memory).
+
+## Spoiler wall
+
+Glossaries and ADRs are **public repo artifacts.** Some domain terms are
+spoiler-sensitive: the glossary marks them by giving a neutral definition plus an
+`_Avoid_: restating its in-world purpose` note. For such a term, never put the secret
+*purpose* it protects — or any in-world ceremonial wording — into a glossary, an ADR, or
+a commit message. Name the term and its neutral mechanical surface only; the protected
+rationale lives **only in private agent-memory**. When unsure whether a rationale is a
+spoiler, leave it out of the repo and keep it in memory.

--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -140,7 +140,9 @@ invoke `superpowers:brainstorming`. **Override two superpowers substeps:**
 - **Spec destination:** write the spec into the **issue body**, between
   `<!-- spec:start -->` and `<!-- spec:end -->` markers, preserving the original
   problem statement above them (`gh issue edit <N> --body-file`). Don't create a
-  new committed `docs/superpowers/` spec file for this work.
+  new committed `docs/superpowers/` spec file for this work. Use the section layout
+  in `docs/spec-template.md`, and before drafting consult `docs/adr/` for decisions
+  that already constrain the work and `AGENT_GLOSSARY_MAP.md` for canonical terms.
 - **Spec-review dispatch:** when the brainstorming flow reaches "dispatch
   spec-document-reviewer," dispatch with the prompt at
   `tools/skills/issue-to-merged-pr/spec-document-reviewer-prompt.md` instead of

--- a/tools/skills/verify-against-code/SKILL.md
+++ b/tools/skills/verify-against-code/SKILL.md
@@ -21,6 +21,8 @@ This is the code-verified half of the Anti-Reinvention Pass (CLAUDE.md). It exis
 
 ## The check (per proposed surface)
 
+Before proposing any new surface, also check `docs/adr/` for a recorded decision that already constrains it, and name it with the canonical vocabulary from `AGENT_GLOSSARY_MAP.md` (not an `_Avoid_` synonym).
+
 1. **Read the actual definition** (grep + open the file). Don't infer from a name or a doc.
 2. **Find a live caller.** Grep for real usages outside tests/migrations.
 3. **Label it** — exactly one:


### PR DESCRIPTION
Adopts the **durable artifact + vocabulary layer** from the mattpocock/skills research (#1482), keeping superpowers as the process spine. Three pillars + process wiring.

## What's in here

### 1. Decision log — `docs/adr/` (47 files)
46 one-paragraph ADRs capturing the *why* and the rejected alternative behind hard-to-reverse, surprising, traded-off decisions — mined from the roadmap, `design-tenets.md`, closed epics/issues, and prior agent-memory. `README.md` carries the format + the three-part bar (hard-to-reverse + surprising + real-trade-off).
- HIGH-confidence engineering/DB/process ADRs were code-verified (dispatch seam, partition SQL, SharedMemoryModel, eligibility_rule, merge queue).
- MED-confidence domain ADRs (covenants/magic/progression) were grepped against `models.py`; **0044** and **0045** were softened where the code/roadmap diverged from the source framing (a wrong ADR is worse than none).

### 2. Glossary — `AGENT_GLOSSARY_MAP.md` + 24 per-app `src/<app>/AGENT_GLOSSARY.md`
Canonical ubiquitous language (term → tight definition + `_Avoid_` synonyms), harvested from `docs/systems` + code. Lives next to the code it describes. Caught along the way: **"secondary" not "passive"**, **Legend** (metric) vs **Renown** (live award mechanism), and **12 primary stats** (code beat the stale INDEX's "9").

### 3. Skills — `tools/skills/`
- **design-vocabulary** — deep-module concepts (depth/seam/leverage/locality, the deletion test) anchored on the real `dispatch_player_action()` seam. **Does NOT redefine "module" to mean "component"** (per maintainer's hard no); keeps our vocabulary.
- **architecture-cleanup** — a **markdown-only** deepening pass (no HTML/Tailwind/Mermaid ritual — wrong fit for a headless/telnet-first repo).
- **domain-glossary-and-adr** — keeps the glossary + ADRs current and used; offers ADRs only on the three-part bar; holds the spoiler wall.

### Process wiring
- `CLAUDE.md`: "Where to Look" + "Docs Are Directives" now consult/update the ADR log and glossary in-tandem; new **Decisions & Vocabulary** section; terse `(see ADR-NNNN)` pointers on existing invariants.
- `docs/spec-template.md`: formalizes the spec template — grafts `to-prd`'s **User Stories** list + **test-seam sketch** onto our existing leak-analysis + anti-reinvention-ledger sections (specs still live in issue bodies per ADR-0020).
- Light cross-refs added to `verify-against-code` and `issue-to-merged-pr`.

## Notes
- **Spoiler wall held:** no death-aversion framing, Audere Majora wording, or in-world ceremonial rationale in any repo artifact (scanned). Spoiler-sensitive term names are defined neutrally only.
- **Not** a replacement for superpowers — Matt's process skills (tdd/grilling/handoff) are redundant with ours and were deliberately not adopted, nor were his `triage` labels or the `CONTEXT.md` name.
- All pre-commit hooks pass (no Python touched).

## Follow-up (local, not in this PR)
Agent-memory lives outside the repo, so slimming the ~22 converted memories to one-line ADR pointers is a separate local step (mapping recorded in the plan). The two spoiler memories stay private and untouched.

Part of #1482 (initial deliverable). 🤖 Generated with [Claude Code](https://claude.com/claude-code)