### PR TITLE
fix: roster apply persistence + EmitAction registry (#1501, #1502)

### DIFF
--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -15,6 +15,7 @@ from actions.definitions.combat_maneuvers import (
     UpgradeComboAction,
 )
 from actions.definitions.communication import (
+    EmitAction,
     MutterAction,
     PemitAction,
     PoseAction,
@@ -90,6 +91,7 @@ _ALL_ACTIONS: list[Action] = [
     SearchAction(),
     SayAction(),
     PoseAction(),
+    EmitAction(),
     WhisperAction(),
     MutterAction(),
     PemitAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -145,6 +145,7 @@ class ActionRegistryTests(TestCase):
             "search",
             "say",
             "pose",
+            "emit",
             "whisper",
             "pemit",
             "mutter",

--- a/src/world/roster/tests/test_viewset.py
+++ b/src/world/roster/tests/test_viewset.py
@@ -4,6 +4,7 @@ Tests for roster API viewsets.
 
 from unittest.mock import patch
 
+from allauth.account.models import EmailAddress
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APIClient
@@ -19,7 +20,7 @@ from world.roster.factories import (
     TenureGalleryFactory,
     TenureMediaFactory,
 )
-from world.roster.models import TenureGallery, TenureMedia
+from world.roster.models import RosterApplication, TenureGallery, TenureMedia
 
 
 class TestRosterViewSet(TestCase):
@@ -327,3 +328,51 @@ class TestRosterEntrySetProfilePicture(TestCase):
         assert response.status_code == 204
         self.entry.refresh_from_db()
         assert self.entry.profile_picture == self.media_link
+
+
+class TestRosterEntryApply(TestCase):
+    """Tests applying to play a roster entry character."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.player = PlayerDataFactory()
+        EmailAddress.objects.create(
+            user=self.player.account,
+            email=self.player.account.email,
+            primary=True,
+            verified=True,
+        )
+        self.client.force_authenticate(user=self.player.account)
+        self.entry = RosterEntryFactory()
+
+    def test_apply_creates_roster_application(self):
+        """POSTing apply persists a RosterApplication for the entry's character."""
+        url = f"/api/roster/entries/{self.entry.id}/apply/"
+        message = "I really want to play this character for many compelling reasons."
+
+        response = self.client.post(url, {"message": message}, format="json")
+
+        assert response.status_code == 204
+        application = RosterApplication.objects.get(
+            player_data=self.player,
+            character=self.entry.character_sheet.character,
+        )
+        assert application.application_text == message
+        assert application.status == "pending"
+
+    def test_apply_rejects_duplicate_pending_application(self):
+        """A second application for the same character returns a validation error."""
+        url = f"/api/roster/entries/{self.entry.id}/apply/"
+        message = "I really want to play this character for many compelling reasons."
+        self.client.post(url, {"message": message}, format="json")
+
+        response = self.client.post(url, {"message": message}, format="json")
+
+        assert response.status_code == 400
+        assert (
+            RosterApplication.objects.filter(
+                player_data=self.player,
+                character=self.entry.character_sheet.character,
+            ).count()
+            == 1
+        )

--- a/src/world/roster/views/entry_views.py
+++ b/src/world/roster/views/entry_views.py
@@ -19,6 +19,7 @@ from world.roster.models import RosterEntry, RosterTenure, TenureMedia
 from world.roster.permissions import IsPlayerOrStaff
 from world.roster.serializers import (
     MyRosterEntrySerializer,
+    RosterApplicationCreateSerializer,
     RosterApplicationSerializer,
     RosterEntrySerializer,
 )
@@ -144,7 +145,18 @@ class RosterEntryViewSet(viewsets.ReadOnlyModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        self.get_object()
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
+        roster_entry = self.get_object()
+        message_serializer = self.get_serializer(data=request.data)
+        message_serializer.is_valid(raise_exception=True)
+
+        create_data = {
+            "character_id": roster_entry.character_sheet.character.id,
+            "application_text": message_serializer.validated_data["message"],
+        }
+        create_serializer = RosterApplicationCreateSerializer(
+            data=create_data,
+            context=self.get_serializer_context(),
+        )
+        create_serializer.is_valid(raise_exception=True)
+        create_serializer.save()
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Two pure-bug fixes from the #1328 player-reachability audit.

- Fix roster `apply` endpoint to actually create the `RosterApplication` row using the existing `RosterApplicationCreateSerializer` (previously validated a message-only serializer and returned 204 without saving).
- Register `EmitAction` in `actions/registry.py` `_ALL_ACTIONS` so the web dispatcher can dispatch it, matching the existing telnet `CmdEmit` wiring.

Closes #1501
Closes #1502