### PR TITLE
Telnet: duel lifecycle (challenge / accept / decline / withdraw / acknowledge-risk)

### DIFF
--- a/docs/audits/2026-06-25-player-reachability-coverage.md
+++ b/docs/audits/2026-06-25-player-reachability-coverage.md
@@ -74,9 +74,9 @@ re-listing them, so each row maps cleanly to one tracking issue. `tracked` = exi
 
 ### Combat & duels
 - TELNET+WEB: declare technique w/ effort/target/secondary (#1330); clash-commit (#1451); flee / cover
-  / interpose / join / leave / ready / combo up-down / yield (#1453).
-- WEB-ONLY: PvP **duel** lifecycle — challenge / accept / decline / withdraw / acknowledge-risk
-  (registered Actions, web-dispatchable, **no telnet command, untracked**; only `yield` reached telnet).
+  / interpose / join / leave / ready / combo up-down / yield (#1453); PvP **duel** lifecycle —
+  challenge / accept / decline / withdraw / acknowledge-risk (`duel <subverb>`, `CmdDuel`, #1492; was
+  WEB-ONLY — telnet command added, only `yield` had reached telnet before via `combat yield`).
 - **PLANNED-UNBUILT (→ registry):** soulfray-risk accept + fury commit (#1454); knockback + trap-in-combat
   (#1317); reactive interpose / DANGER-arming (#1316); shapeshift + combat profiles (#1111); ranged /
   reach / archery; mounts; verticality / flying.
@@ -232,7 +232,7 @@ shows which ledger capabilities each variety exercises and where its gaps are. N
 - **Scene — general RP:** say/pose/consent/endorse (✔ reachable) · reactions/favorites, mark-private,
   Places, keep-vs-discard summary (web-only / blind spots) · implicit start, provisional keep/discard
   (planned).
-- **Scene — combat:** declare/clash/maneuvers (✔) · duel lifecycle (web-only, untracked) · ranged,
+- **Scene — combat:** declare/clash/maneuvers (✔) · duel lifecycle (✔ telnet+web, #1492) · ranged,
   shapeshift, knockback (planned).
 - **Scene — GM-run table:** scene-round set-mode (✔) · combat-round lifecycle, beat-marking, table
   seating (web-only) · umpire tooling, session resolvers (planned). *The whole GM table-running journey

--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -692,9 +692,11 @@ guard wired into `resolve_round`/`declare_action`; duel-state serializers.
 `use_technique` → `deduct_anima`/soulfray so a non-lethal duel draws no overburn deficit,
 clamps soulfray below any death-risk stage, and never fires a `character_loss` consequence.
 
-**Web-first actions:** `challenge` (social-consent-gated) / `accept` / `decline` /
+**Actions (telnet + web):** `challenge` (social-consent-gated) / `accept` / `decline` /
 `withdraw` / `yield` / `acknowledge_risk`. **Frontend:** `combat/duels/DuelChallengeControls`
-(+ yield / acknowledge controls), reusing the existing combat round UI + dispatch.
+(+ yield / acknowledge controls), reusing the existing combat round UI + dispatch. **Telnet:**
+the `duel <subverb>` namespace (`CmdDuel`, #1492) routes challenge/accept/decline/withdraw/risk
+through the same `dispatch_player_action` REGISTRY seam; `yield` stays on `combat yield` (#1453).
 
 ### Duels — Phase 2 (SHIPPED — 2026-06-20)
 

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -132,6 +132,16 @@ actions, backends, and service functions.
   collisions (mirrors `CmdRitual`'s `ritual <subverb>` routing). Each verb wraps an existing
   combat service via its Action in `actions/definitions/combat_maneuvers.py`; `yield` reuses
   the existing `YieldAction`.
+- **`duels.py`**: `CmdDuel` (`duel`, #1492) — the PC-vs-PC duel-lifecycle namespace. One command
+  routes a leading subverb (`duel challenge <name>` / `accept [id]` / `decline [id]` /
+  `withdraw [id]` / `risk`) to a REGISTRY `ActionRef` and dispatches through `dispatch_player_action` —
+  the same seam the web uses — reaching the already-built duel Actions in
+  `actions/definitions/duels.py` (`challenge`/`accept`/`decline`/`withdraw`/`acknowledge_risk`). Bare
+  `duel` prints a status hub (pending incoming/outgoing challenges + active-duel state). Namespaced —
+  not bare keys — because `accept`/`decline` collide with `CmdAccept`/`CmdDeny`; mirrors `CmdCombat`'s
+  subverb routing. `yield` (concede an active duel) stays on `combat yield` (#1453); the hub points to
+  it. The optional `[id]` selects a specific pending challenge (the #1180 threaded-inbox path); without
+  it the action falls back to the actor's single pending challenge. No business logic in the command.
 - **`endorse.py`**: `CmdPoses` (`poses`) and `CmdEndorse` (`endorse`) — telnet faces of
   `PoseEndorseAction`, `SceneEntryEndorseAction`, `StylePresentationEndorseAction`.
   `poses <char>` lists endorseable poses in the current scene.

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -35,6 +35,7 @@ from commands.consent import (
     CmdRestoreSense,
 )
 from commands.door import CmdLock, CmdUnlock
+from commands.duels import CmdDuel
 from commands.endorse import CmdEndorse, CmdPoses
 from commands.evennia_overrides.builder import CmdDig, CmdLink, CmdOpen, CmdUnlink
 from commands.evennia_overrides.communication import (
@@ -197,6 +198,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdClashCommit,
             # Shared combat verbs: combat <subverb> (#1453, #1452)
             CmdCombat,
+            # PC-vs-PC duel lifecycle: duel <subverb> (#1492)
+            CmdDuel,
             # Scene lifecycle telnet command (#1445)
             CmdScene,
             # #1470 — owner-gated room editor (name/description/public-private).

--- a/src/commands/duels.py
+++ b/src/commands/duels.py
@@ -1,0 +1,157 @@
+"""Duel-lifecycle telnet command — the ``duel <subverb>`` namespace (#1492).
+
+A single command routes the PC-vs-PC duel-lifecycle verbs (challenge, accept,
+decline, withdraw, risk) through the shared ``dispatch_player_action`` seam — the
+same REGISTRY path the web uses, reaching the existing duel Actions in
+``actions/definitions/duels.py``. No new game logic lives here; the command only
+parses telnet text and dispatches.
+
+The verbs live under the ``duel`` namespace rather than as bare top-level keys
+because ``accept`` / ``decline`` collide with ``CmdAccept`` / ``CmdDeny`` (consent
+and offer responses). Mirrors ``CmdRitual`` (subverb routing) and ``CmdCombat``
+(the namespaced status-hub pattern). ``yield`` (concede an active duel) stays on
+``combat yield`` (#1453); the status hub points to it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from actions.constants import ActionBackend
+from commands.command import DispatchCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from actions.types import ActionRef
+
+# subverb -> registry action key. ``risk`` is the short verb for acknowledge-risk.
+_SUBVERBS: dict[str, str] = {
+    "challenge": "challenge",
+    "accept": "accept",
+    "decline": "decline",
+    "withdraw": "withdraw",
+    "risk": "acknowledge_risk",
+}
+
+# subverbs that take a single target-name argument.
+_TARGET_SUBVERBS = frozenset({"challenge"})
+# subverbs that take an optional numeric challenge id.
+_ID_SUBVERBS = frozenset({"accept", "decline", "withdraw"})
+
+
+class CmdDuel(DispatchCommand):
+    """Issue or answer a PC-vs-PC duel challenge.
+
+    Usage:
+        duel                        — show your pending challenges + duel state
+        duel challenge <name>       — challenge a co-located character to a duel
+        duel accept [id]            — accept a pending challenge directed at you
+        duel decline [id]           — decline a pending challenge directed at you
+        duel withdraw [id]          — rescind a pending challenge you issued
+        duel risk                   — acknowledge the lethal risk of your duel
+
+    The optional ``id`` selects a specific pending challenge when you have more
+    than one; without it the command acts on your single pending challenge. To
+    concede an active duel, use ``combat yield``.
+    """
+
+    key = "duel"
+    locks = "cmd:all()"
+
+    _subverb: str = ""
+    _rest: str = ""
+
+    def func(self) -> None:
+        """Route the leading subverb; bare ``duel`` shows the status hub."""
+        raw = (self.args or "").strip()
+        if not raw:
+            self._show_status_hub()
+            return
+        parts = raw.split(maxsplit=1)
+        self._subverb = parts[0].lower()
+        self._rest = parts[1].strip() if len(parts) > 1 else ""
+        if self._subverb not in _SUBVERBS:
+            options = ", ".join(_SUBVERBS)
+            self.msg(f"Unknown duel action '{self._subverb}'. Try: {options}.")
+            return
+        super().func()  # resolve_action_ref + resolve_action_args + dispatch
+
+    def resolve_action_ref(self) -> ActionRef:
+        """Build a REGISTRY ActionRef for the parsed subverb."""
+        from actions.types import ActionRef  # noqa: PLC0415
+
+        return ActionRef(backend=ActionBackend.REGISTRY, registry_key=_SUBVERBS[self._subverb])
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        """Resolve the subverb's arguments into dispatch kwargs."""
+        if self._subverb in _TARGET_SUBVERBS:
+            target = self.search_or_raise(self._require_rest("a target name"))
+            return {"target": target}
+        if self._subverb in _ID_SUBVERBS:
+            challenge_id = self._parse_optional_id()
+            return {} if challenge_id is None else {"challenge_id": challenge_id}
+        return {}  # risk — no arguments
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _require_rest(self, what: str) -> str:
+        if not self._rest:
+            msg = f"Usage: duel {self._subverb} <{what}>."
+            raise CommandError(msg)
+        return self._rest
+
+    def _parse_optional_id(self) -> int | None:
+        """Return the optional numeric challenge id, or None when omitted."""
+        if not self._rest:
+            return None
+        if not self._rest.isdigit():
+            msg = f"Usage: duel {self._subverb} [<challenge id>]."
+            raise CommandError(msg)
+        return int(self._rest)
+
+    def _incoming_challenge(self) -> Any:
+        """Return the caller's single PENDING incoming challenge, or None."""
+        from actions.definitions.duels import _pending_challenge_for_challenged  # noqa: PLC0415
+
+        return _pending_challenge_for_challenged(self.caller)
+
+    def _outgoing_challenge(self) -> Any:
+        """Return the caller's single PENDING outgoing challenge, or None."""
+        from actions.definitions.duels import _pending_challenge_for_challenger  # noqa: PLC0415
+
+        return _pending_challenge_for_challenger(self.caller)
+
+    def _active_duel(self) -> Any:
+        """Return the caller's active DUEL CombatParticipant, or None."""
+        from actions.definitions.duels import _active_duel_participant  # noqa: PLC0415
+
+        return _active_duel_participant(self.caller)
+
+    def _show_status_hub(self) -> None:
+        """Print the caller's pending challenges and current duel state."""
+        lines = [
+            "|wDuel actions|n: challenge <name>, accept [id], decline [id], withdraw [id], risk"
+        ]
+        incoming = self._incoming_challenge()
+        outgoing = self._outgoing_challenge()
+        participant = self._active_duel()
+        if incoming is not None:
+            challenger = incoming.challenger_sheet.character.db_key
+            lines.append(
+                f"Pending challenge from {challenger} (#{incoming.pk}) — "
+                "duel accept / duel decline."
+            )
+        if outgoing is not None:
+            challenged = outgoing.challenged_sheet.character.db_key
+            lines.append(f"You have challenged {challenged} (#{outgoing.pk}) — duel withdraw.")
+        if participant is not None:
+            if participant.encounter.is_lethal:
+                lines.append(
+                    "You are in a lethal duel — duel risk to acknowledge the risk, "
+                    "combat yield to concede."
+                )
+            else:
+                lines.append("You are in a duel — combat yield to concede.")
+        if incoming is None and outgoing is None and participant is None:
+            lines.append("You have no pending duel challenges.")
+        self.msg("\n".join(lines))

--- a/src/commands/tests/test_duel_command.py
+++ b/src/commands/tests/test_duel_command.py
@@ -1,0 +1,138 @@
+"""Unit tests for CmdDuel — the ``duel <subverb>`` namespace (#1492).
+
+Verify subverb → REGISTRY-key routing, challenge target resolution, optional
+challenge-id parsing, the unknown-subverb guard, and the bare-``duel`` status hub.
+Mirrors the mock-caller style of ``test_combat_maneuvers_command.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from actions.constants import ActionBackend
+from actions.types import ActionResult, DispatchResult
+from commands.duels import CmdDuel
+from commands.exceptions import CommandError
+
+_DISPATCH = "commands.command.dispatch_player_action"
+
+
+def _make_cmd(args: str) -> CmdDuel:
+    cmd = CmdDuel()
+    cmd.caller = MagicMock()
+    cmd.args = args
+    cmd.raw_string = f"duel {args}"
+    cmd.cmdname = "duel"
+    return cmd
+
+
+class CmdDuelRoutingTests(TestCase):
+    def test_challenge_builds_registry_ref(self) -> None:
+        cmd = _make_cmd("challenge Bob")
+        cmd._subverb = "challenge"
+        ref = cmd.resolve_action_ref()
+        self.assertEqual(ref.backend, ActionBackend.REGISTRY)
+        self.assertEqual(ref.registry_key, "challenge")
+
+    def test_accept_builds_registry_ref(self) -> None:
+        cmd = _make_cmd("accept")
+        cmd._subverb = "accept"
+        self.assertEqual(cmd.resolve_action_ref().registry_key, "accept")
+
+    def test_decline_builds_registry_ref(self) -> None:
+        cmd = _make_cmd("decline")
+        cmd._subverb = "decline"
+        self.assertEqual(cmd.resolve_action_ref().registry_key, "decline")
+
+    def test_withdraw_builds_registry_ref(self) -> None:
+        cmd = _make_cmd("withdraw")
+        cmd._subverb = "withdraw"
+        self.assertEqual(cmd.resolve_action_ref().registry_key, "withdraw")
+
+    def test_risk_maps_to_acknowledge_risk_key(self) -> None:
+        cmd = _make_cmd("risk")
+        cmd._subverb = "risk"
+        self.assertEqual(cmd.resolve_action_ref().registry_key, "acknowledge_risk")
+
+    def test_unknown_subverb_messages_and_does_not_dispatch(self) -> None:
+        cmd = _make_cmd("frobnicate")
+        with patch(_DISPATCH) as dispatch:
+            cmd.func()
+        dispatch.assert_not_called()
+        cmd.caller.msg.assert_called()
+
+    def test_challenge_dispatches_registry_ref_through_func(self) -> None:
+        cmd = _make_cmd("challenge Bob")
+        cmd.caller.search.return_value = MagicMock()
+        result = DispatchResult(
+            backend=ActionBackend.REGISTRY,
+            deferred=False,
+            detail=ActionResult(success=True, message="You issue a duel challenge to Bob."),
+        )
+        with patch(_DISPATCH, return_value=result) as dispatch:
+            cmd.func()
+        dispatch.assert_called_once()
+        _, ref, _kwargs = dispatch.call_args.args
+        self.assertEqual(ref.registry_key, "challenge")
+
+    def test_bare_duel_shows_status_hub(self) -> None:
+        cmd = _make_cmd("")
+        with (
+            patch.object(cmd, "_incoming_challenge", return_value=None),
+            patch.object(cmd, "_outgoing_challenge", return_value=None),
+            patch.object(cmd, "_active_duel", return_value=None),
+            patch(_DISPATCH) as dispatch,
+        ):
+            cmd.func()
+        dispatch.assert_not_called()
+        cmd.caller.msg.assert_called_once()
+        self.assertIn("Duel actions", cmd.caller.msg.call_args.args[0])
+
+
+class CmdDuelArgResolutionTests(TestCase):
+    def test_challenge_resolves_target_kwarg(self) -> None:
+        cmd = _make_cmd("challenge Bob")
+        cmd._subverb, cmd._rest = "challenge", "Bob"
+        sentinel = MagicMock()
+        cmd.caller.search.return_value = sentinel
+        kwargs = cmd.resolve_action_args()
+        self.assertEqual(kwargs, {"target": sentinel})
+
+    def test_challenge_without_name_raises(self) -> None:
+        cmd = _make_cmd("challenge")
+        cmd._subverb, cmd._rest = "challenge", ""
+        with self.assertRaises(CommandError):
+            cmd.resolve_action_args()
+
+    def test_accept_parses_optional_challenge_id(self) -> None:
+        cmd = _make_cmd("accept 7")
+        cmd._subverb, cmd._rest = "accept", "7"
+        self.assertEqual(cmd.resolve_action_args(), {"challenge_id": 7})
+
+    def test_accept_without_id_passes_no_kwargs(self) -> None:
+        cmd = _make_cmd("accept")
+        cmd._subverb, cmd._rest = "accept", ""
+        self.assertEqual(cmd.resolve_action_args(), {})
+
+    def test_decline_parses_optional_challenge_id(self) -> None:
+        cmd = _make_cmd("decline 4")
+        cmd._subverb, cmd._rest = "decline", "4"
+        self.assertEqual(cmd.resolve_action_args(), {"challenge_id": 4})
+
+    def test_withdraw_parses_optional_challenge_id(self) -> None:
+        cmd = _make_cmd("withdraw 9")
+        cmd._subverb, cmd._rest = "withdraw", "9"
+        self.assertEqual(cmd.resolve_action_args(), {"challenge_id": 9})
+
+    def test_non_numeric_challenge_id_raises(self) -> None:
+        cmd = _make_cmd("accept bogus")
+        cmd._subverb, cmd._rest = "accept", "bogus"
+        with self.assertRaises(CommandError):
+            cmd.resolve_action_args()
+
+    def test_risk_takes_no_args(self) -> None:
+        cmd = _make_cmd("risk")
+        cmd._subverb, cmd._rest = "risk", ""
+        self.assertEqual(cmd.resolve_action_args(), {})

--- a/src/commands/tests/test_duel_command_journey.py
+++ b/src/commands/tests/test_duel_command_journey.py
@@ -1,0 +1,127 @@
+"""Telnet journey tests for CmdDuel — the full duel lifecycle over the seam (#1492).
+
+Drives ``CmdDuel.func()`` end-to-end with real characters through
+``dispatch_player_action`` (the same REGISTRY seam the web uses), asserting the
+DB-state outcome of each verb rather than mocking. Proves the telnet command
+reaches each already-built duel Action:
+
+  - ``duel challenge <name>`` → PENDING DuelChallenge
+  - ``duel accept``           → ACCEPTED + linked CombatEncounter
+  - ``duel decline``          → DECLINED, no encounter
+  - ``duel withdraw``         → WITHDRAWN, no encounter
+  - ``duel risk`` (lethal)    → EncounterRiskAcknowledgement recorded
+
+ObjectDB rows live in setUp (not deepcopy-safe) with ``idmapper.flush_cache()``
+to avoid idmapper contamination between tests — mirroring
+``world/combat/tests/test_duels_integration.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.test import TestCase
+from evennia.utils import idmapper
+
+from commands.duels import CmdDuel
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import DuelChallengeStatus
+from world.combat.duels import create_lethal_duel
+from world.combat.factories import ThreatPoolFactory
+from world.combat.models import CombatEncounter, DuelChallenge, EncounterRiskAcknowledgement
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+
+
+def _make_room(name: str = "Arena") -> Any:
+    return ObjectDBFactory(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+
+
+def _make_pc(name: str, room: Any) -> tuple[Any, Any]:
+    """Return (character ObjectDB, CharacterSheet) with an active RosterTenure.
+
+    The tenure chain is required for the challenge consent gate to resolve.
+    """
+    actor = CharacterFactory(db_key=name, location=room)
+    sheet = CharacterSheetFactory(character=actor)
+    entry = RosterEntryFactory(character_sheet=sheet)
+    RosterTenureFactory(roster_entry=entry)
+    return actor, sheet
+
+
+def _run(caller: Any, args: str) -> CmdDuel:
+    """Construct and execute ``duel <args>`` as *caller* would over telnet."""
+    cmd = CmdDuel()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"duel {args}".strip()
+    cmd.cmdname = "duel"
+    cmd.func()
+    return cmd
+
+
+class CmdDuelJourneyTests(TestCase):
+    def setUp(self) -> None:
+        idmapper.models.flush_cache()
+        self.room = _make_room()
+        self.challenger, self.challenger_sheet = _make_pc("Challenger", self.room)
+        self.target, self.target_sheet = _make_pc("Target", self.room)
+
+    def _challenge(self) -> DuelChallenge:
+        _run(self.challenger, "challenge Target")
+        challenge = DuelChallenge.objects.filter(
+            challenger_sheet=self.challenger_sheet,
+            challenged_sheet=self.target_sheet,
+            status=DuelChallengeStatus.PENDING,
+        ).first()
+        self.assertIsNotNone(challenge, "duel challenge should create a PENDING DuelChallenge")
+        return challenge
+
+    def test_challenge_creates_pending_challenge(self) -> None:
+        self._challenge()
+
+    def test_accept_creates_linked_encounter(self) -> None:
+        challenge = self._challenge()
+
+        _run(self.target, "accept")
+
+        challenge.refresh_from_db()
+        self.assertEqual(challenge.status, DuelChallengeStatus.ACCEPTED)
+        self.assertIsNotNone(challenge.resulting_encounter, "accept should link an encounter")
+        self.assertEqual(CombatEncounter.objects.count(), 1)
+
+    def test_decline_terminates_without_encounter(self) -> None:
+        challenge = self._challenge()
+
+        _run(self.target, "decline")
+
+        challenge.refresh_from_db()
+        self.assertEqual(challenge.status, DuelChallengeStatus.DECLINED)
+        self.assertFalse(CombatEncounter.objects.exists())
+
+    def test_withdraw_terminates_without_encounter(self) -> None:
+        challenge = self._challenge()
+
+        _run(self.challenger, "withdraw")
+
+        challenge.refresh_from_db()
+        self.assertEqual(challenge.status, DuelChallengeStatus.WITHDRAWN)
+        self.assertFalse(CombatEncounter.objects.exists())
+
+    def test_risk_in_lethal_duel_records_acknowledgement(self) -> None:
+        encounter = create_lethal_duel(
+            self.challenger_sheet,
+            {"name": "Ogre", "max_health": 30, "threat_pool": ThreatPoolFactory()},
+            self.room,
+        )
+        self.assertFalse(EncounterRiskAcknowledgement.objects.filter(encounter=encounter).exists())
+
+        _run(self.challenger, "risk")
+
+        self.assertTrue(
+            EncounterRiskAcknowledgement.objects.filter(
+                encounter=encounter,
+                character_sheet=self.challenger_sheet,
+            ).exists(),
+            "duel risk should record the PC's lethal-risk acknowledgement",
+        )


### PR DESCRIPTION
Closes #1492

## Summary

Adds a thin `duel <subverb>` telnet command (`CmdDuel`) over the five already-built, web-dispatchable PC-vs-PC duel-lifecycle Actions — `challenge` / `accept` / `decline` / `withdraw` / `acknowledge_risk` — routing each through `dispatch_player_action` (the same REGISTRY seam the web uses). Before this, only `yield` reached telnet (via `combat yield`). Bare `duel` prints a status hub. Namespaced (not bare keys) because `accept`/`decline` collide with CmdAccept/CmdDeny; mirrors CmdCombat's subverb routing. Zero new models/services/dataclasses — pure coverage-gap wire-up. Covered by mock-caller unit tests + a real-character telnet journey test (challenge→accept→encounter, decline, withdraw, lethal-duel risk-ack).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1492 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto origin/main; no conflicts.

<!-- last-addressed-comment: 0 -->