### PR TITLE
Bug: persona deed-spread / save-deed-story bypass action.run (ADR-0001)

### DIFF
--- a/src/actions/definitions/deeds.py
+++ b/src/actions/definitions/deeds.py
@@ -1,0 +1,208 @@
+"""Deed-scene Actions — spread a tale and save a written deed account (#1503).
+
+Both actions are `SCENE_ADAPTIVE` and return `None` from `round_declaration`, so they resolve
+immediately while still participating in anti-spam gating and pose-order tracking.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from actions.base import Action
+from actions.types import ActionResult, TargetType
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from actions.types import ActionContext
+
+
+@dataclass
+class SpreadTaleAction(Action):
+    """Spread a tale about a deed the actor's persona knows.
+
+    kwargs:
+        persona_id: PK of the ``Persona`` performing the spread (must belong to the actor).
+        scene_id: PK of the ``Scene`` where the tale is told.
+        deed_id: PK of the ``LegendEntry`` being spread.
+        effort_level: "low" / "medium" / "high" — defaults to "medium".
+        specialization_id: Optional PK of a Performance specialization.
+        pose_text: Optional in-character pose text (blank if omitted).
+    """
+
+    key: str = "spread_tale"
+    name: str = "Spread a Tale"
+    icon: str = "megaphone"
+    category: str = "social"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(  # noqa: C901, PLR0911
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from django.core.exceptions import ValidationError  # noqa: PLC0415
+        from django.shortcuts import get_object_or_404  # noqa: PLC0415
+
+        from world.locations.activity_services import room_activity_band  # noqa: PLC0415
+        from world.scenes.action_services import create_and_resolve_area_action  # noqa: PLC0415
+        from world.scenes.models import Scene  # noqa: PLC0415
+        from world.societies.models import LegendEntry  # noqa: PLC0415
+        from world.societies.spread_services import (  # noqa: PLC0415
+            SPREAD_TALE_ACTION_KEY,
+            get_or_create_spread_a_tale_template,
+            get_spread_specializations,
+            get_spreadable_deeds,
+            spread_check_modifiers,
+        )
+
+        sheet = actor.sheet_data
+        persona_id = kwargs.get("persona_id")
+        if persona_id is None:
+            return ActionResult(success=False, message="You must choose a persona.")
+
+        from world.scenes.models import Persona  # noqa: PLC0415
+
+        persona = Persona.objects.filter(pk=persona_id, character_sheet=sheet).first()
+        if persona is None:
+            return ActionResult(success=False, message="You do not control that persona.")
+
+        scene_id = kwargs.get("scene_id")
+        if scene_id is None:
+            return ActionResult(success=False, message="You must be in a scene.")
+        scene = get_object_or_404(Scene, pk=scene_id)
+        account = actor.account
+        if account is None:
+            requester_id = kwargs.get("requester_account_id")
+            if requester_id is not None:
+                from evennia.accounts.models import AccountDB  # noqa: PLC0415
+
+                account = AccountDB.objects.filter(pk=requester_id).first()
+        if account is None or not scene.participants.filter(pk=account.pk).exists():
+            return ActionResult(success=False, message="You are not a participant in that scene.")
+
+        deed_id = kwargs.get("deed_id")
+        if deed_id is None:
+            return ActionResult(success=False, message="You must choose a deed to spread.")
+        deed = get_object_or_404(LegendEntry, pk=deed_id)
+        if not get_spreadable_deeds(persona).filter(pk=deed.pk).exists():
+            return ActionResult(
+                success=False,
+                message="This persona is not aware of that deed.",
+            )
+
+        specialization = None
+        specialization_id = kwargs.get("specialization_id")
+        if specialization_id is not None:
+            from world.skills.models import Specialization  # noqa: PLC0415
+
+            valid_ids = set(get_spread_specializations().values_list("pk", flat=True))
+            if specialization_id not in valid_ids:
+                return ActionResult(
+                    success=False,
+                    message="That form cannot be used to spread a tale.",
+                )
+            specialization = Specialization.objects.get(pk=specialization_id)
+
+        extra_modifiers = spread_check_modifiers(sheet.character, specialization)
+        template = get_or_create_spread_a_tale_template()
+
+        try:
+            result = create_and_resolve_area_action(
+                scene=scene,
+                initiator_persona=persona,
+                action_template=template,
+                action_key=SPREAD_TALE_ACTION_KEY,
+                pose_text=kwargs.get("pose_text", ""),
+                effort_level=kwargs.get("effort_level", "medium"),
+                spread_deed_target=deed,
+                extra_modifiers=extra_modifiers,
+            )
+        except ValidationError as exc:
+            return ActionResult(success=False, message=exc.messages[0])
+        except ValueError:
+            return ActionResult(
+                success=False,
+                message="The tale could not be spread right now.",
+            )
+
+        main = result.action_resolution.main_result
+        outcome = main.check_result.outcome_name if main and main.check_result else "Unknown"
+        band = room_activity_band(scene.location).label
+        return ActionResult(
+            success=True,
+            message=f"You spread the tale of {deed.title}.",
+            data={"resolved": True, "outcome": outcome, "band": band},
+        )
+
+    def round_declaration(self, ctx: Any, **kwargs: Any) -> tuple[Any, dict[str, Any]] | None:
+        """Immediate resolution only."""
+        return None
+
+
+@dataclass
+class SaveDeedStoryAction(Action):
+    """Save (or replace) this persona's written account of a deed.
+
+    kwargs:
+        persona_id: PK of the ``Persona`` authoring the story.
+        deed_id: PK of the ``LegendEntry`` being written about.
+        text: The written account.
+    """
+
+    key: str = "save_deed_story"
+    name: str = "Save Deed Story"
+    icon: str = "quill"
+    category: str = "social"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from django.shortcuts import get_object_or_404  # noqa: PLC0415
+
+        from world.scenes.models import Persona  # noqa: PLC0415
+        from world.societies.models import LegendEntry  # noqa: PLC0415
+        from world.societies.spread_services import (  # noqa: PLC0415
+            get_spreadable_deeds,
+            save_deed_story,
+        )
+
+        sheet = actor.sheet_data
+        persona_id = kwargs.get("persona_id")
+        if persona_id is None:
+            return ActionResult(success=False, message="You must choose a persona.")
+
+        persona = Persona.objects.filter(pk=persona_id, character_sheet=sheet).first()
+        if persona is None:
+            return ActionResult(success=False, message="You do not control that persona.")
+
+        deed_id = kwargs.get("deed_id")
+        if deed_id is None:
+            return ActionResult(success=False, message="You must choose a deed.")
+        deed = get_object_or_404(LegendEntry, pk=deed_id)
+        if not get_spreadable_deeds(persona).filter(pk=deed.pk).exists():
+            return ActionResult(
+                success=False,
+                message="This persona is not aware of that deed.",
+            )
+
+        text = kwargs.get("text", "").strip()
+        if not text:
+            return ActionResult(success=False, message="You must write something.")
+
+        story = save_deed_story(author_persona=persona, deed=deed, text=text)
+        return ActionResult(
+            success=True,
+            message="You record your account of the deed.",
+            data={"story_id": story.pk, "author_name": persona.name, "text": story.text},
+        )
+
+    def round_declaration(self, ctx: Any, **kwargs: Any) -> tuple[Any, dict[str, Any]] | None:
+        """Immediate resolution only."""
+        return None

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -23,6 +23,7 @@ from actions.definitions.communication import (
     SayAction,
     WhisperAction,
 )
+from actions.definitions.deeds import SaveDeedStoryAction, SpreadTaleAction
 from actions.definitions.duels import (
     AcceptChallengeAction,
     AcknowledgeRiskAction,
@@ -104,6 +105,8 @@ _ALL_ACTIONS: list[Action] = [
     UnequipAction(),
     RoomEditAction(),
     SetActivePersonaAction(),
+    SpreadTaleAction(),
+    SaveDeedStoryAction(),
     PutInAction(),
     TakeOutAction(),
     ActivatePermitAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -209,6 +209,8 @@ class ActionRegistryTests(TestCase):
             "set_active_persona",
             "resolve_alteration",
             "rest",
+            "spread_tale",
+            "save_deed_story",
         }
         assert set(ACTIONS_BY_KEY.keys()) == expected_keys
 

--- a/src/actions/tests/test_deed_actions.py
+++ b/src/actions/tests/test_deed_actions.py
@@ -1,0 +1,146 @@
+"""Unit tests for deed Actions (#1503)."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from actions.definitions.deeds import SaveDeedStoryAction, SpreadTaleAction
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.scenes.factories import PersonaFactory, SceneFactory, SceneParticipationFactory
+from world.societies.factories import (
+    LegendEntryFactory,
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    SocietyFactory,
+)
+
+
+class DeedActionSetupMixin:
+    """Build a controlled persona + scene + deed graph for deed action tests."""
+
+    @classmethod
+    def _build_awareness_graph(cls, character, account):
+        """Return (persona, scene, deed) where account participates and persona knows the deed."""
+        cls.sheet = CharacterSheetFactory(character=character)
+        persona = cls.sheet.primary_persona
+
+        scene = SceneFactory()
+        SceneParticipationFactory(scene=scene, account=account)
+
+        society = SocietyFactory()
+        org = OrganizationFactory(society=society)
+        OrganizationMembershipFactory(persona=persona, organization=org)
+        deed = LegendEntryFactory(persona=PersonaFactory(), base_value=50)
+        deed.societies_aware.add(society)
+
+        return persona, scene, deed
+
+
+class SpreadTaleActionTests(TestCase, DeedActionSetupMixin):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.account = AccountFactory()
+        cls.character = CharacterFactory()
+        cls.character.account = cls.account
+        cls.persona, cls.scene, cls.deed = cls._build_awareness_graph(cls.character, cls.account)
+        cls.action = SpreadTaleAction()
+
+    def _run(self, **kwargs):
+        """Invoke the action directly, merging defaults."""
+        defaults = {
+            "persona_id": self.persona.pk,
+            "scene_id": self.scene.pk,
+            "deed_id": self.deed.pk,
+            "effort_level": "medium",
+            "specialization_id": None,
+            "pose_text": "A song.",
+        }
+        defaults.update(kwargs)
+        return self.action.run(actor=self.character, **defaults)
+
+    def test_success_returns_outcome_and_band(self):
+        fake_resolution = SimpleNamespace(
+            action_resolution=SimpleNamespace(
+                main_result=SimpleNamespace(
+                    check_result=SimpleNamespace(outcome_name="Good Success")
+                )
+            )
+        )
+        with patch(
+            "world.scenes.action_services.create_and_resolve_area_action",
+            return_value=fake_resolution,
+        ):
+            result = self._run()
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.data["outcome"], "Good Success")
+        self.assertEqual(result.data["band"], "Busy")
+
+    def test_fails_when_persona_not_owned(self):
+        other_persona = PersonaFactory()
+        result = self._run(persona_id=other_persona.pk)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.message, "You do not control that persona.")
+
+    def test_fails_when_not_a_scene_participant(self):
+        self.scene.participants.clear()
+        result = self._run()
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.message, "You are not a participant in that scene.")
+
+    def test_fails_when_deed_not_known(self):
+        unknown = LegendEntryFactory(persona=PersonaFactory(), base_value=10)
+        result = self._run(deed_id=unknown.pk)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.message, "This persona is not aware of that deed.")
+
+    def test_fails_when_specialization_not_usable(self):
+        result = self._run(specialization_id=999999)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.message, "That form cannot be used to spread a tale.")
+
+
+class SaveDeedStoryActionTests(TestCase, DeedActionSetupMixin):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.account = AccountFactory()
+        cls.character = CharacterFactory()
+        cls.character.account = cls.account
+        cls.persona, _scene, cls.deed = cls._build_awareness_graph(cls.character, cls.account)
+        cls.action = SaveDeedStoryAction()
+
+    def _run(self, **kwargs):
+        defaults = {
+            "persona_id": self.persona.pk,
+            "deed_id": self.deed.pk,
+            "text": "I was there.",
+        }
+        defaults.update(kwargs)
+        return self.action.run(actor=self.character, **defaults)
+
+    def test_success_saves_story(self):
+        result = self._run()
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.data["text"], "I was there.")
+        self.assertEqual(result.data["author_name"], self.persona.name)
+        self.assertIn("story_id", result.data)
+
+    def test_fails_when_deed_not_known(self):
+        unknown = LegendEntryFactory(persona=PersonaFactory(), base_value=10)
+        result = self._run(deed_id=unknown.pk)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.message, "This persona is not aware of that deed.")
+
+    def test_fails_when_text_is_empty(self):
+        result = self._run(text="   ")
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.message, "You must write something.")

--- a/src/commands/deeds.py
+++ b/src/commands/deeds.py
@@ -1,0 +1,224 @@
+"""Telnet ``deed`` command — spread a tale or save a deed story (#1503).
+
+A single namespace command dispatches to two SCENE_ADAPTIVE Actions:
+``SpreadTaleAction`` (``deed spread ...``) and ``SaveDeedStoryAction``
+(``deed story ...``). Eligibility, scene participation, and deed awareness
+all live in the Actions, just like the web endpoints.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from actions.constants import ActionBackend
+from commands.command import DispatchCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from actions.types import ActionRef
+
+# Subverb -> registry action key. Kept in a single mapping so the grammar tokens
+# are declared once; individual comparisons still need noqa because they parse the
+# player's bare subverb against the command's grammar.
+_SUBVERBS: dict[str, str] = {
+    "spread": "spread_tale",
+    "story": "save_deed_story",
+}
+
+
+class CmdDeed(DispatchCommand):
+    """Record or spread word of deeds your persona knows.
+
+    Usage:
+        deed spread <deed name or id>
+            [effort=<low|medium|high>]
+            [specialization=<name or id>]
+            [pose=<in-character text>]
+        deed story <deed name or id>=<written account>
+
+    Examples:
+        deed spread The Sinking of the Argent
+        deed spread 47 effort=high pose=Singing a mournful ballad.
+        deed story The Sinking of the Argent=I was there when she went down.
+    """
+
+    key = "deed"
+    locks = "cmd:all()"
+
+    _sub_verb: str = ""
+    _rest: str = ""
+
+    # Tokens that begin an optional keyword argument for ``deed spread``.
+    _SPREAD_KWARG_RE = re.compile(
+        r"\s+(?=effort\s*=|specialization\s*=|spec\s*=|pose\s*=)",
+        flags=re.IGNORECASE,
+    )
+
+    def func(self) -> None:
+        """Parse sub-verb, then hand off to DispatchCommand for dispatch."""
+        raw = (self.args or "").strip()
+        if not raw:
+            msg = self._usage()
+            raise CommandError(msg)
+
+        head, _, tail = raw.partition(" ")
+        self._sub_verb = head.lower()
+        self._rest = tail.strip()
+        if self._sub_verb not in _SUBVERBS:
+            msg = self._usage()
+            raise CommandError(msg)
+
+        super().func()
+
+    def resolve_action_ref(self) -> ActionRef:
+        """Return the SCENE_ADAPTIVE ref for the parsed sub-verb."""
+        from actions.types import ActionRef  # noqa: PLC0415
+
+        return ActionRef(
+            backend=ActionBackend.SCENE_ADAPTIVE,
+            registry_key=_SUBVERBS[self._sub_verb],
+        )
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        """Build kwargs for whichever Action the sub-verb selected."""
+        if self._sub_verb == "spread":  # noqa: STRING_LITERAL
+            return self._resolve_spread_args()
+        return self._resolve_story_args()
+
+    # -- spread ----------------------------------------------------------------
+
+    def _resolve_spread_args(self) -> dict[str, Any]:
+        """Parse ``deed spread <deed> [effort=...] [specialization=...] [pose=...]``."""
+        if not self._rest:
+            msg = "Spread what deed? (deed spread <deed name or id>)"
+            raise CommandError(msg)
+
+        parts = self._SPREAD_KWARG_RE.split(self._rest)
+        deed_value = parts[0].strip()
+        if not deed_value:
+            msg = "Spread what deed? (deed spread <deed name or id>)"
+            raise CommandError(msg)
+
+        effort = "medium"
+        specialization_id: int | None = None
+        pose_text = ""
+
+        for token in parts[1:]:
+            key, sep, value = token.partition("=")
+            if not sep:
+                continue
+            key = key.strip().lower()
+            value = value.strip()
+            if key in ("specialization", "spec"):  # noqa: STRING_LITERAL
+                specialization_id = self._resolve_specialization(value).pk
+            elif key == "effort":  # noqa: STRING_LITERAL
+                effort = self._normalize_effort(value)
+            elif key == "pose":  # noqa: STRING_LITERAL
+                pose_text = value
+
+        persona = self._active_persona()
+        deed = self._resolve_deed(persona, deed_value)
+        scene_id = self._current_scene_id()
+
+        return {
+            "persona_id": persona.pk,
+            "scene_id": scene_id,
+            "deed_id": deed.pk,
+            "effort_level": effort,
+            "specialization_id": specialization_id,
+            "pose_text": pose_text,
+        }
+
+    # -- story -----------------------------------------------------------------
+
+    def _resolve_story_args(self) -> dict[str, Any]:
+        """Parse ``deed story <deed>=<text>``."""
+        if "=" not in self._rest:
+            msg = "Record a story how? (deed story <deed name or id>=<written account>)"
+            raise CommandError(msg)
+        deed_value, _, text = self._rest.partition("=")
+        deed_value = deed_value.strip()
+        text = text.strip()
+        if not deed_value:
+            msg = "Record a story about which deed?"
+            raise CommandError(msg)
+        if not text:
+            msg = "You must write something."
+            raise CommandError(msg)
+
+        persona = self._active_persona()
+        deed = self._resolve_deed(persona, deed_value)
+
+        return {
+            "persona_id": persona.pk,
+            "deed_id": deed.pk,
+            "text": text,
+        }
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _active_persona(self) -> Any:
+        """Return the caller's active/worn persona."""
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        sheet = self.caller.sheet_data
+        persona = active_persona_for_sheet(sheet)
+        if persona is None:
+            msg = "You have no active persona."
+            raise CommandError(msg)
+        return persona
+
+    def _current_scene_id(self) -> int:
+        """Return the active scene for the caller's current location."""
+        from world.scenes.interaction_services import _get_active_scene  # noqa: PLC0415
+
+        scene = _get_active_scene(self.caller.location)
+        if scene is None:
+            msg = "There is no active scene here."
+            raise CommandError(msg)
+        account = self.caller.account
+        if account is None or not scene.participants.filter(pk=account.pk).exists():
+            msg = "You are not a participant in this scene."
+            raise CommandError(msg)
+        return scene.pk
+
+    def _resolve_deed(self, persona: Any, value: str) -> Any:
+        """Resolve a deed the persona can spread, by name or id."""
+        from world.societies.spread_services import get_spreadable_deeds  # noqa: PLC0415
+
+        qs = get_spreadable_deeds(persona)
+        if value.isdigit():
+            deed = qs.filter(pk=int(value)).first()
+        else:
+            deed = qs.filter(title__iexact=value).first()
+        if deed is None:
+            msg = f"You don't know a deed matching '{value}'."
+            raise CommandError(msg)
+        return deed
+
+    def _resolve_specialization(self, value: str) -> Any:
+        """Resolve a Performance specialization usable for spreading tales."""
+        from world.societies.spread_services import get_spread_specializations  # noqa: PLC0415
+
+        qs = get_spread_specializations()
+        if value.isdigit():
+            spec = qs.filter(pk=int(value)).first()
+        else:
+            spec = qs.filter(name__iexact=value).first()
+        if spec is None:
+            msg = f"No usable specialization matching '{value}'."
+            raise CommandError(msg)
+        return spec
+
+    @staticmethod
+    def _normalize_effort(value: str) -> str:
+        """Return a lowercase effort level the action accepts."""
+        clean = value.lower()
+        if clean not in ("low", "medium", "high"):
+            msg = "Effort must be low, medium, or high."
+            raise CommandError(msg)
+        return clean
+
+    def _usage(self) -> str:
+        return "Usage: deed spread <deed> [...] | deed story <deed>=<text>"

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -34,6 +34,7 @@ from commands.consent import (
     CmdPersuade,
     CmdRestoreSense,
 )
+from commands.deeds import CmdDeed
 from commands.door import CmdLock, CmdUnlock
 from commands.duels import CmdDuel
 from commands.endorse import CmdEndorse, CmdPoses
@@ -202,6 +203,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdDuel,
             # Scene lifecycle telnet command (#1445)
             CmdScene,
+            # Deed spread / deed story telnet namespace (#1503)
+            CmdDeed,
             # #1470 — owner-gated room editor (name/description/public-private).
             CmdManageRoom,
             # #1347 — list faces + wear-face active persona switch.

--- a/src/commands/tests/test_deed_commands.py
+++ b/src/commands/tests/test_deed_commands.py
@@ -1,0 +1,123 @@
+"""Unit tests for ``CmdDeed`` — spread / story telnet namespace (#1503)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from actions.constants import ActionBackend
+from actions.types import ActionResult, DispatchResult
+from commands.deeds import CmdDeed
+from commands.exceptions import CommandError
+from world.character_sheets.factories import CharacterSheetFactory
+
+
+def _cmd(caller, args=""):
+    cmd = CmdDeed()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"deed {args}".strip()
+    cmd.cmdname = "deed"
+    return cmd
+
+
+class CmdDeedTests(TestCase):
+    def setUp(self) -> None:
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        self.character.msg = MagicMock()
+        self.persona = self.sheet.primary_persona
+        self.deed = SimpleNamespace(pk=101)
+        self.spec = SimpleNamespace(pk=202)
+
+    def _patch_helpers(self, cmd):
+        """Make resolve helpers return controlled fixtures."""
+        cmd._resolve_deed = MagicMock(return_value=self.deed)
+        cmd._resolve_specialization = MagicMock(return_value=self.spec)
+        cmd._current_scene_id = MagicMock(return_value=303)
+
+    def test_spread_parses_and_dispatches(self):
+        cmd = _cmd(self.character, "spread Test Deed effort=high specialization=Song pose=A song.")
+        self._patch_helpers(cmd)
+        with patch("commands.command.dispatch_player_action") as disp:
+            disp.return_value = DispatchResult(
+                backend=ActionBackend.SCENE_ADAPTIVE,
+                deferred=False,
+                detail=ActionResult(success=True, message="You spread the tale."),
+            )
+            cmd.func()
+
+        ref = disp.call_args.args[1]
+        kwargs = disp.call_args.args[2]
+        self.assertEqual(ref.backend, ActionBackend.SCENE_ADAPTIVE)
+        self.assertEqual(ref.registry_key, "spread_tale")
+        self.assertEqual(kwargs["persona_id"], self.persona.pk)
+        self.assertEqual(kwargs["scene_id"], 303)
+        self.assertEqual(kwargs["deed_id"], 101)
+        self.assertEqual(kwargs["effort_level"], "high")
+        self.assertEqual(kwargs["specialization_id"], 202)
+        self.assertEqual(kwargs["pose_text"], "A song.")
+
+    def test_spread_bare_deed_defaults(self):
+        cmd = _cmd(self.character, "spread 47")
+        self._patch_helpers(cmd)
+        with patch("commands.command.dispatch_player_action") as disp:
+            disp.return_value = DispatchResult(
+                backend=ActionBackend.SCENE_ADAPTIVE,
+                deferred=False,
+                detail=ActionResult(success=True, message="Spread."),
+            )
+            cmd.func()
+
+        kwargs = disp.call_args.args[2]
+        self.assertEqual(kwargs["effort_level"], "medium")
+        self.assertIsNone(kwargs["specialization_id"])
+        self.assertEqual(kwargs["pose_text"], "")
+
+    def test_spread_rejects_bare_command(self):
+        cmd = _cmd(self.character, "spread")
+        cmd.func()
+        self.assertTrue(
+            any("Spread what deed?" in str(c.args[0]) for c in self.character.msg.call_args_list)
+        )
+
+    def test_story_parses_and_dispatches(self):
+        cmd = _cmd(self.character, "story Test Deed=I was there.")
+        cmd._resolve_deed = MagicMock(return_value=self.deed)
+        with patch("commands.command.dispatch_player_action") as disp:
+            disp.return_value = DispatchResult(
+                backend=ActionBackend.SCENE_ADAPTIVE,
+                deferred=False,
+                detail=ActionResult(success=True, message="Saved."),
+            )
+            cmd.func()
+
+        ref = disp.call_args.args[1]
+        kwargs = disp.call_args.args[2]
+        self.assertEqual(ref.registry_key, "save_deed_story")
+        self.assertEqual(kwargs["persona_id"], self.persona.pk)
+        self.assertEqual(kwargs["deed_id"], 101)
+        self.assertEqual(kwargs["text"], "I was there.")
+
+    def test_story_rejects_missing_equals(self):
+        cmd = _cmd(self.character, "story Test Deed")
+        cmd._resolve_deed = MagicMock(return_value=self.deed)
+        cmd.func()
+        self.assertTrue(
+            any("Record a story how?" in str(c.args[0]) for c in self.character.msg.call_args_list)
+        )
+
+    def test_unknown_subverb_rejects(self):
+        cmd = _cmd(self.character, "dance")
+        with self.assertRaises(CommandError):
+            cmd.func()
+
+
+class CmdDeedCmdsetRegistrationTests(TestCase):
+    def test_deed_command_registered(self) -> None:
+        from commands.default_cmdsets import CharacterCmdSet
+
+        cmdset = CharacterCmdSet()
+        cmdset.at_cmdset_creation()
+        keys = {c.key for c in cmdset.commands}
+        self.assertIn("deed", keys)

--- a/src/world/scenes/tests/test_spread_endpoints.py
+++ b/src/world/scenes/tests/test_spread_endpoints.py
@@ -36,6 +36,11 @@ class SpreadEndpointTest(APITestCase):
         cls.deed = LegendEntryFactory(persona=PersonaFactory(), base_value=50)
         cls.deed.societies_aware.add(society)
         ActionPointPool.get_or_create_for_character(character)
+        from world.scenes.models import get_scene_round_defaults_config
+
+        config = get_scene_round_defaults_config()
+        config.anti_spam_seconds = 0
+        config.save(update_fields=["anti_spam_seconds"])
 
     def setUp(self) -> None:
         self.client.force_authenticate(user=self.account)

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -523,19 +523,14 @@ class PersonaViewSet(
     @action(detail=True, methods=[HTTPMethod.POST])
     def spread(self, request: Request, pk: int | None = None) -> Response:  # noqa: PLR0911
         """#745 — Spread a tale: resolve an area 'Spread a Tale' action for this persona."""
-        from django.core.exceptions import ValidationError  # noqa: PLC0415
         from django.shortcuts import get_object_or_404  # noqa: PLC0415
 
-        from world.locations.activity_services import room_activity_band  # noqa: PLC0415
-        from world.scenes.action_services import create_and_resolve_area_action  # noqa: PLC0415
         from world.scenes.models import Scene  # noqa: PLC0415
+        from world.skills.models import Specialization  # noqa: PLC0415
         from world.societies.models import LegendEntry  # noqa: PLC0415
         from world.societies.spread_services import (  # noqa: PLC0415
-            SPREAD_TALE_ACTION_KEY,
-            get_or_create_spread_a_tale_template,
             get_spread_specializations,
             get_spreadable_deeds,
-            spread_check_modifiers,
         )
 
         persona = self.get_object()
@@ -562,46 +557,55 @@ class PersonaViewSet(
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        specialization = None
         specialization_id = data.get("specialization")
         if specialization_id:
-            from world.skills.models import Specialization  # noqa: PLC0415
-
             valid_ids = set(get_spread_specializations().values_list("pk", flat=True))
             if specialization_id not in valid_ids:
                 return Response(
                     {"detail": "That form can't be used to spread a tale."},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
-            specialization = Specialization.objects.get(pk=specialization_id)
-        extra_modifiers = spread_check_modifiers(persona.character_sheet.character, specialization)
+            Specialization.objects.get(pk=specialization_id)
 
-        template = get_or_create_spread_a_tale_template()
+        from actions.constants import ActionBackend  # noqa: PLC0415
+        from actions.errors import ActionDispatchError  # noqa: PLC0415
+        from actions.player_interface import dispatch_player_action  # noqa: PLC0415
+        from actions.types import ActionRef  # noqa: PLC0415
+
+        character = persona.character_sheet.character
+        ref = ActionRef(backend=ActionBackend.SCENE_ADAPTIVE, registry_key="spread_tale")
         try:
-            result = create_and_resolve_area_action(
-                scene=scene,
-                initiator_persona=persona,
-                action_template=template,
-                action_key=SPREAD_TALE_ACTION_KEY,
-                pose_text=data["pose_text"],
-                effort_level=data["effort_level"],
-                spread_deed_target=deed,
-                extra_modifiers=extra_modifiers,
+            result = dispatch_player_action(
+                character,
+                ref,
+                {
+                    "persona_id": persona.pk,
+                    "scene_id": scene.pk,
+                    "deed_id": deed.pk,
+                    "effort_level": data["effort_level"],
+                    "specialization_id": specialization_id,
+                    "pose_text": data["pose_text"],
+                    "requester_account_id": request.user.pk,
+                },
             )
-        except ValidationError as exc:
-            return Response({"detail": exc.messages[0]}, status=status.HTTP_400_BAD_REQUEST)
-        except ValueError:
-            # e.g. the deed was deactivated between eligibility and resolution.
-            return Response(
-                {"detail": "The tale could not be spread right now."},
-                status=status.HTTP_409_CONFLICT,
+        except ActionDispatchError as exc:
+            http_status = (
+                status.HTTP_429_TOO_MANY_REQUESTS
+                if exc.code == ActionDispatchError.ANTI_SPAM_COOLDOWN
+                else status.HTTP_400_BAD_REQUEST
             )
+            return Response({"detail": exc.user_message}, status=http_status)
+        detail = result.detail
+        if detail is None or not detail.success:
+            message = detail.message if detail is not None else "The tale could not be spread."
+            http_status = (
+                status.HTTP_409_CONFLICT
+                if message == "The tale could not be spread right now."
+                else status.HTTP_400_BAD_REQUEST
+            )
+            return Response({"detail": message}, status=http_status)
 
-        main = result.action_resolution.main_result
-        outcome = main.check_result.outcome_name if main and main.check_result else "Unknown"
-        band = room_activity_band(scene.location).label
-        payload = {"resolved": True, "outcome": outcome, "band": band}
-        return Response(SpreadResultSerializer(payload).data)
+        return Response(SpreadResultSerializer(detail.data).data)
 
     def _account_controls_persona(self, request: Request, persona: Persona) -> bool:
         """True when the requesting account currently tenures this persona."""
@@ -661,10 +665,7 @@ class PersonaViewSet(
         from django.shortcuts import get_object_or_404  # noqa: PLC0415
 
         from world.societies.models import LegendEntry  # noqa: PLC0415
-        from world.societies.spread_services import (  # noqa: PLC0415
-            get_spreadable_deeds,
-            save_deed_story,
-        )
+        from world.societies.spread_services import get_spreadable_deeds  # noqa: PLC0415
 
         persona = self.get_object()
         if not self._account_controls_persona(request, persona):
@@ -682,7 +683,39 @@ class PersonaViewSet(
                 {"detail": "This persona is not aware of that deed."},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        story = save_deed_story(author_persona=persona, deed=deed, text=data["text"])
+
+        from actions.constants import ActionBackend  # noqa: PLC0415
+        from actions.errors import ActionDispatchError  # noqa: PLC0415
+        from actions.player_interface import dispatch_player_action  # noqa: PLC0415
+        from actions.types import ActionRef  # noqa: PLC0415
+
+        character = persona.character_sheet.character
+        ref = ActionRef(backend=ActionBackend.SCENE_ADAPTIVE, registry_key="save_deed_story")
+        try:
+            result = dispatch_player_action(
+                character,
+                ref,
+                {
+                    "persona_id": persona.pk,
+                    "deed_id": deed.pk,
+                    "text": data["text"],
+                },
+            )
+        except ActionDispatchError as exc:
+            http_status = (
+                status.HTTP_429_TOO_MANY_REQUESTS
+                if exc.code == ActionDispatchError.ANTI_SPAM_COOLDOWN
+                else status.HTTP_400_BAD_REQUEST
+            )
+            return Response({"detail": exc.user_message}, status=http_status)
+        detail = result.detail
+        if detail is None or not detail.success:
+            message = detail.message if detail is not None else "The story could not be saved."
+            return Response({"detail": message}, status=status.HTTP_400_BAD_REQUEST)
+
+        from world.societies.models import LegendDeedStory  # noqa: PLC0415
+
+        story = LegendDeedStory.objects.select_related("author").get(pk=detail.data["story_id"])
         return Response(DeedStorySerializer(story).data, status=status.HTTP_201_CREATED)
 
     @extend_schema(


### PR DESCRIPTION
Closes #1503

## Summary

Converts PersonaViewSet.spread and PersonaViewSet.deed_story from direct service calls into SCENE_ADAPTIVE Actions (SpreadTaleAction / SaveDeedStoryAction), registers them, and adds the CmdDeed telnet namespace with deed spread and deed story sub-verbs. Updates the action registry test and adds coverage for both Actions and the command.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1503 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main; resolved expected_keys conflict by keeping both main's new resolve_alteration/rest entries and this branch's spread_tale/save_deed_story entries.

<!-- last-addressed-comment: 0 -->