### PR TITLE
fix(projects): remove init-time StatDefinition seeding

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -837,8 +837,8 @@ ROOM_FEATURE_PROGRESSION).
   (`BuildingConstructionDetails`, `RoomFeatureProgressionDetails`)
 - **Constants:** `ProjectKind`, `ProjectStatus`, `CompletionMode`, `ContributionKind`,
   `ContributionPrivacy`
-- **Stat definitions:** Project achievement stats are seeded in `AppConfig.ready()` via
-  `register_stat_definitions()`
+- **Stat definitions:** Project achievement stats are created lazily on first
+  contribution (same pattern as combat achievement counters)
 - **Cross-app dependencies:** `world.scenes.Persona`, `societies.Organization`
 - **Source:** `src/world/projects/`
 

--- a/docs/systems/MODEL_MAP.md
+++ b/docs/systems/MODEL_MAP.md
@@ -3183,7 +3183,6 @@
 - `clear_kind_handlers() -> 'None' — Test-only: clear the handler registry.`
 - `get_kind_handler(kind: 'str') -> 'KindHandler' — Return the registered handler for `kind`, or raise LookupError.`
 - `register_kind_handler(kind: 'str', handler: 'KindHandler') -> 'None' — Register a per-kind resolution handler. Re-registration overwrites.`
-- `register_stat_definitions() -> 'None' — Create the StatDefinition rows for project-related achievement stats.`
 - `resolve_project(project: 'Project', *, outcome_tier: 'CheckOutcome') -> 'None' — Finalize a RESOLVING project: dispatch to per-kind handler, set outcome.`
 - `scan_active_projects() -> 'int' — Cron tick: scan ACTIVE projects, transition completion-ready ones to RESOLVING.`
 

--- a/src/world/projects/apps.py
+++ b/src/world/projects/apps.py
@@ -10,13 +10,4 @@ class ProjectsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self) -> None:
-        # Seed StatDefinition rows for project achievement stats.
-        import contextlib  # noqa: PLC0415
-
-        from django.db import OperationalError, ProgrammingError  # noqa: PLC0415
-
-        from world.projects.services import register_stat_definitions  # noqa: PLC0415
-
-        with contextlib.suppress(OperationalError, ProgrammingError):
-            # DB not migrated yet (e.g., during makemigrations); skip silently.
-            register_stat_definitions()
+        """App ready - no DB queries at import time."""

--- a/src/world/projects/services.py
+++ b/src/world/projects/services.py
@@ -105,15 +105,19 @@ def add_contribution(  # noqa: PLR0913
 def _increment_contribution_stat(persona: Persona) -> None:
     """Increment the projects.total_contributed StatTracker for this persona.
 
-    Silent no-op if the StatDefinition isn't seeded (defensive — apps.ready()
-    seeds it, but isolated tests may skip ready()).
+    Lazily creates the StatDefinition row if it does not exist yet, matching the
+    pattern used by combat achievement counters. No import-time / app-ready DB
+    queries are performed here.
     """
     from world.achievements.models import StatDefinition  # noqa: PLC0415
 
-    try:
-        stat_def = StatDefinition.objects.get(key="projects.total_contributed")
-    except StatDefinition.DoesNotExist:
-        return
+    stat_def, _ = StatDefinition.objects.get_or_create(
+        key="projects.total_contributed",
+        defaults={
+            "name": "Total Project Contributions",
+            "description": "Total contributions made across all projects.",
+        },
+    )
     # The stats handler API varies — best to call via the persona's character_sheet.
     # Defensive guard: if the API doesn't exist as assumed, skip silently.
     import contextlib  # noqa: PLC0415
@@ -218,33 +222,3 @@ def scan_active_projects() -> int:
         transitioned += 1
 
     return transitioned
-
-
-# ---------------------------------------------------------------------------
-# StatDefinition seeding (called at app-ready)
-# ---------------------------------------------------------------------------
-
-
-def register_stat_definitions() -> None:
-    """Create the StatDefinition rows for project-related achievement stats.
-
-    Idempotent (get_or_create). Called at app-ready time in apps.py.
-    """
-    from world.achievements.models import StatDefinition  # noqa: PLC0415
-
-    StatDefinition.objects.get_or_create(
-        key="projects.total_contributed",
-        defaults={
-            "name": "Total Project Contributions",
-            "description": "Total contributions made across all projects.",
-        },
-    )
-    StatDefinition.objects.get_or_create(
-        key="projects.completed_critical",
-        defaults={
-            "name": "Critical Project Completions",
-            "description": (
-                "Number of projects the character contributed to that completed at CRITICAL tier."
-            ),
-        },
-    )


### PR DESCRIPTION
Moves StatDefinition creation for `projects.total_contributed` from `ProjectsConfig.ready()` to the first contribution, matching the combat achievement counter pattern. This eliminates Django's warning about DB access during app initialization.

Changes:
- Remove `register_stat_definitions()` call from `apps.py` ready()
- Remove `register_stat_definitions()` function from `services.py`
- Lazily create `projects.total_contributed` in `_increment_contribution_stat()`
- Drop unused `projects.completed_critical` seed
- Update `docs/systems/INDEX.md` and regenerate `MODEL_MAP.md`

Validation:
- `uv run ruff check src/world/projects/apps.py src/world/projects/services.py`
- `just test-fast world.projects`
- `PYTHONWARNINGS=error::RuntimeWarning:django.db.backends.utils just test-fast world.action_points` — no DB-init warning