### PR TITLE
feat: primary residence — set + auto-default home (#1514)

### DIFF
--- a/src/commands/evennia_overrides/movement.py
+++ b/src/commands/evennia_overrides/movement.py
@@ -92,8 +92,13 @@ class CmdHome(ArxCommand):
     locks = "cmd:all()"
     action = HomeAction()
 
+    SET_SWITCH: ClassVar[str] = "set"
+
     def _execute(self) -> None:
-        if "set" in self.switches:  # noqa: STRING_LITERAL — Evennia switch token
+        # ``switches`` is populated by the cmdhandler at parse time; a directly-constructed
+        # command (unit tests) may not have it, so default to empty.
+        switches = getattr(self, "switches", None) or ()  # noqa: GETATTR_LITERAL
+        if self.SET_SWITCH in switches:
             self._set_home()
             return
         super()._execute()

--- a/src/commands/evennia_overrides/movement.py
+++ b/src/commands/evennia_overrides/movement.py
@@ -77,9 +77,44 @@ class CmdGive(ArxCommand):
 
 
 class CmdHome(ArxCommand):
-    """Return to your home location."""
+    """Return to your home — or set it.
+
+    Usage:
+      home        - recall to your home location
+      home/set    - make the room you're standing in your home (you must own or rent it)
+
+    Your home is where ``home`` recalls you to; a residence defaults to the first room you
+    rent or acquire until you change it here (#1514).
+    """
 
     key = "home"
     aliases: ClassVar[list[str]] = ["recall"]
     locks = "cmd:all()"
     action = HomeAction()
+
+    def _execute(self) -> None:
+        if "set" in self.switches:  # noqa: STRING_LITERAL — Evennia switch token
+            self._set_home()
+            return
+        super()._execute()
+
+    def _set_home(self) -> None:
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        from commands.exceptions import CommandError  # noqa: PLC0415
+        from world.locations.services import is_owner, is_tenant, set_residence  # noqa: PLC0415
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        room = self.caller.location
+        if room is None:
+            msg = "You aren't anywhere you could call home."
+            raise CommandError(msg)
+        try:
+            persona = active_persona_for_sheet(self.caller.sheet_data)
+        except (AttributeError, ObjectDoesNotExist):
+            persona = None
+        if persona is None or not (is_owner(persona, room) or is_tenant(persona, room)):
+            msg = "You can only set your home to a room you own or rent."
+            raise CommandError(msg)
+        set_residence(character=self.caller, room=room)
+        self.msg(f"Home set to {room.key}.")

--- a/src/commands/tests/test_dispatchers.py
+++ b/src/commands/tests/test_dispatchers.py
@@ -474,6 +474,24 @@ class CmdHomeTests(TestCase):
             cmd.func()
             mock_run.assert_called_once_with(actor=caller)
 
+    def test_home_set_requires_standing(self):
+        # home/set on a room you have no owner/tenant standing in is refused (#1514).
+        room = ObjectDBFactory(
+            db_key="HomeRoom",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        caller = ObjectDBFactory(
+            db_key="Homeless",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        caller.msg = MagicMock()
+        cmd = _make_cmd(CmdHome, caller)
+        cmd.switches = [CmdHome.SET_SWITCH]
+        cmd.func()
+        sent = " ".join(str(c.args[0]) for c in caller.msg.call_args_list if c.args)
+        assert "own or rent" in sent
+
 
 class CmdUndressTests(TestCase):
     def test_undress_resolves_with_no_args(self) -> None:

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -856,7 +856,7 @@ def transfer_ownership(  # noqa: PLR0913
             existing.ended_at = when
             existing.save()
 
-        return LocationOwnership.objects.create(
+        ownership = LocationOwnership.objects.create(
             parent_type=parent_type,
             area=area,
             room_profile=room_profile,
@@ -866,6 +866,10 @@ def transfer_ownership(  # noqa: PLR0913
             acquired_at=when,
             notes=notes,
         )
+        # Acquire a room with no home yet → it becomes your home until you change it (#1514).
+        # Area-level ownership and org owners are skipped (no single character / not a room).
+        maybe_default_residence(to_persona, room_profile)
+        return ownership
 
 
 def grant_tenancy(  # noqa: PLR0913
@@ -888,7 +892,7 @@ def grant_tenancy(  # noqa: PLR0913
 
     parent_type = LocationParentType.AREA if area is not None else LocationParentType.ROOM
     tenant_type = HolderType.PERSONA if tenant_persona is not None else HolderType.ORGANIZATION
-    return LocationTenancy.objects.create(
+    tenancy = LocationTenancy.objects.create(
         parent_type=parent_type,
         area=area,
         room_profile=room_profile,
@@ -898,6 +902,59 @@ def grant_tenancy(  # noqa: PLR0913
         ends_at=ends_at,
         notes=notes,
     )
+    # Rent a room with no home yet → it becomes your home until you change it (#1514).
+    maybe_default_residence(tenant_persona, room_profile)
+    return tenancy
+
+
+def _character_for_persona(persona: Persona | None) -> DefaultObject | None:
+    """The character (ObjectDB) behind a persona, or None."""
+    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+    if persona is None:
+        return None
+    try:
+        return persona.character_sheet.character
+    except (AttributeError, ObjectDoesNotExist):
+        return None
+
+
+def set_residence(*, character: DefaultObject, room: DefaultObject) -> None:
+    """Set a character's primary residence (#1514).
+
+    Reuses Evennia's ``home`` — the location ``CmdHome`` recalls to and the fall-back if the
+    current room is destroyed — which is the intended dual meaning for a residence. Permission
+    gating (the character has owner/tenant standing in ``room``) is the caller's concern.
+    """
+    character.home = room
+
+
+def _has_chosen_residence(character: DefaultObject) -> bool:
+    """Whether the character has a *real* residence vs none / the system default fall-back home.
+
+    Evennia gives every object a default ``home`` (``settings.DEFAULT_HOME``), so "no residence
+    yet" is not simply ``home is None`` — it's that *or* the global default.
+    """
+    from django.conf import settings  # noqa: PLC0415
+
+    home = character.home
+    if home is None:
+        return False
+    default = settings.DEFAULT_HOME
+    return default is None or f"#{home.id}" != default
+
+
+def maybe_default_residence(persona: Persona | None, room_profile: RoomProfile | None) -> None:
+    """Default a persona's character home to this room when it has none yet (#1514).
+
+    Called when a persona accepts a room (tenancy/ownership). Per-character (Evennia ``home``),
+    triggered by a persona grant; never overwrites a residence the player has already chosen.
+    """
+    if persona is None or room_profile is None:
+        return
+    character = _character_for_persona(persona)
+    if character is not None and not _has_chosen_residence(character):
+        set_residence(character=character, room=room_profile.objectdb)
 
 
 def end_tenancy(

--- a/src/world/locations/tests/test_residence.py
+++ b/src/world/locations/tests/test_residence.py
@@ -1,0 +1,57 @@
+"""Primary residence (#1514): set_residence + auto-default on first rent/acquire.
+
+Residence reuses Evennia's ``home`` (what ``CmdHome`` recalls to). Renting or acquiring a room
+defaults it as home when the character hasn't chosen one; an existing choice is never clobbered.
+"""
+
+from django.test import TestCase
+
+from evennia_extensions.factories import RoomProfileFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.locations.services import (
+    grant_tenancy,
+    set_residence,
+    transfer_ownership,
+)
+
+
+class ResidenceTests(TestCase):
+    def _character_and_persona(self):
+        sheet = CharacterSheetFactory()
+        return sheet.character, sheet.primary_persona
+
+    def test_set_residence_sets_home(self) -> None:
+        character, _ = self._character_and_persona()
+        room = RoomProfileFactory().objectdb
+        set_residence(character=character, room=room)
+        assert character.home == room
+
+    def test_renting_a_room_defaults_it_as_home(self) -> None:
+        character, persona = self._character_and_persona()
+        room_profile = RoomProfileFactory()
+        grant_tenancy(room_profile=room_profile, tenant_persona=persona)
+        assert character.home == room_profile.objectdb
+
+    def test_acquiring_a_room_defaults_it_as_home(self) -> None:
+        character, persona = self._character_and_persona()
+        room_profile = RoomProfileFactory()
+        transfer_ownership(room_profile=room_profile, to_persona=persona)
+        assert character.home == room_profile.objectdb
+
+    def test_auto_default_never_overwrites_a_chosen_residence(self) -> None:
+        character, persona = self._character_and_persona()
+        chosen = RoomProfileFactory().objectdb
+        set_residence(character=character, room=chosen)  # the player picked this one
+
+        grant_tenancy(room_profile=RoomProfileFactory(), tenant_persona=persona)
+        assert character.home == chosen  # a later rental doesn't move their home
+
+    def test_org_and_area_grants_do_not_set_a_personal_home(self) -> None:
+        # Area-level tenancy (no room) has no single room to home to → no-op, no error.
+        character, persona = self._character_and_persona()
+        from world.areas.constants import AreaLevel
+        from world.areas.factories import AreaFactory
+
+        before = character.home
+        grant_tenancy(area=AreaFactory(level=AreaLevel.WARD), tenant_persona=persona)
+        assert character.home == before


### PR DESCRIPTION
**Primary residence for #1514** — resolves the "what is a character's *home*?" question that gated the comfort→AP-regen effect. Independent of the other #1514 PRs (off main, no comfort code).

## What
- **Reuses Evennia's `home`** (what `CmdHome` already recalls to) as the primary residence — no new model — which is also the fall-back-if-room-destroyed location (the intended dual meaning).
- **`set_residence(*, character, room)`** sets it; caller gates owner/tenant standing.
- **Auto-default** — renting (`grant_tenancy`) or acquiring (`transfer_ownership`) a room makes it your home *if you haven't chosen one*, robust against Evennia's default fall-back home, never clobbering a chosen residence. Area-level and org grants are no-ops.
- **`home/set` switch** on `CmdHome` — sets the room you're standing in (gated to rooms you own/rent), `home` still recalls. Stays in the intuitive home-namespace and **avoids the Arx-1 `home` / `+home` / `@sethome` collision** by using a switch rather than three commands. In-home management (locks/access) stays with the separate room-roles/security work, not overloaded here.

## Anti-reinvention
No new model/migration — reuses Evennia `home` + the existing `CmdHome`/`HomeAction` recall and the existing `is_owner`/`is_tenant` standing helpers.

## How it completes #1514
The comfort→AP-regen consumer reads `comfort_level(character.home)`. That wiring is its **own careful slice** — the regen cron is a bulk task with a `CharacterModifier`/`ModifierTarget` totals system, so comfort should feed *that* path (comfort → an AP-regen modifier), not a per-character cascade query bolted into the bulk loop. This PR delivers the home resolution it needs.

## Tests / gates
5 residence tests (set, auto-default on rent + acquire, never-overwrite-a-choice, area/org no-op); full `world.locations` + `CmdHome` dispatcher tests green (249). Ruff/ty clean; no migration.

Refs #1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)
