### PR TITLE
needs-design: an AFK participant can stall a STRICT scene round indefinitely (presence-gated completion requires everyone present to declare)

### DIFF
--- a/docs/adr/0047-quorum-resolution-for-strict-rounds-afk-own-peril-skip.md
+++ b/docs/adr/0047-quorum-resolution-for-strict-rounds-afk-own-peril-skip.md
@@ -1,0 +1,15 @@
+# STRICT rounds resolve on a quorum; an AFK participant's own peril is skipped on the END tick
+
+STRICT (and therefore danger) round completion switched from unanimity to a quorum
+(`ceil(advance_quorum_pct / 100 × present_active_count)`, reusing the field POSE_ORDER already
+uses; at 100 it reduces to the prior unanimity), so one conscious-but-AK participant can no longer
+deadlock the round — and a GM lowering `advance_quorum_pct` via `set_scene_round_mode` re-checks
+completion immediately. To keep ADR-0004's true intent (an AFK *character* is not harmed while
+away), `resolve_scene_round` excludes an undeclared present `can_act` participant from the END-tick
+target set, so their *own* acute conditions do not advance from a round they didn't engage in; the
+prior unanimity rule had conflated "don't harm the AFK character" with "the round can't advance past
+them." We rejected an explicit away/idle participant status and an N-round auto-pass — both add
+machinery for a problem the quorum already solves. *Whose* declaration advances *whose* peril
+(involved-party-only) is a separate question, owned by #1479.
+
+> Status: accepted · Source: #1480 · Extends: ADR-0004

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -99,3 +99,4 @@ treat those names as hints to confirm, not gospel.
 - [0044 — Covenant sworn objective is recorded as free text](0044-covenant-sworn-objective-is-free-text.md)
 - [0045 — Multi-target casts validate a target list with per-target consent](0045-multi-target-casts-with-per-target-consent.md)
 - [0046 — Power-tier breakthroughs gate at fixed path thresholds](0046-power-tier-breakthroughs-gate-at-fixed-thresholds.md)
+- [0047 — STRICT rounds resolve on a quorum; an AFK participant's own peril is skipped on the END tick](0047-quorum-resolution-for-strict-rounds-afk-own-peril-skip.md)

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -695,15 +695,15 @@ action consent flow, and a three-mode non-combat round framework.
     - `distinct_actors_this_round(scene_round) -> int` — distinct participants with declarations this round.
     - `record_pose_order_action(scene_round, participant, target_persona=None)` — write an `is_immediate=True` ledger row.
     - `advance_pose_order_round_if_quorum(scene_round) -> SceneRound` — advance `round_number` when quorum met (round stays DECLARING).
-    - `scene_round_is_complete(scene_round) -> bool` — presence-gated: True when all present ACTIVE participants have a deferred declaration.
-    - `resolve_scene_round(scene_round)` — social-only resolver: runs CHALLENGE declarations in initiative order, fires end tick, advances round.
+    - `scene_round_is_complete(scene_round) -> bool` — quorum-gated (#1480): True when ≥ `ceil(advance_quorum_pct / 100 × present_active_count)` present ACTIVE `can_act` participants have a deferred (`is_immediate=False`) declaration; at 100 reduces to unanimity. Absent and present-`not can_act` participants are implicit passes.
+    - `resolve_scene_round(scene_round)` — social-only resolver: runs CHALLENGE declarations in initiative order, fires end tick, advances round. **AFK own-peril skip (#1480):** an undeclared present `can_act` participant is excluded from the END-tick target set so their own acute conditions don't advance (ADR-0004); declared/absent/unconscious participants tick as before.
     - `maybe_resolve_scene_round(scene_round)` — resolves iff `scene_round_is_complete` is True.
   - **Scene administration (`scene_admin_services.py`, #1445):**
     - `actor_can_administer_scene(actor, scene) -> bool` — permission gate; True for GM/Staff characters (`is_story_runner`), staff accounts, or scene co-owners (`is_owner=True`).
     - `resolve_actor_account(actor) -> AccountDB | None` — controlling account for a PC actor; None for GM/Staff/NPC.
     - `add_present_as_co_owners(scene, room)` — mark every present character with a controlling account as a co-owner at scene creation (anti-grab: latecomers are non-owners).
     - `finish_scene_full(scene, by_account=None)` — full scene-finish orchestration: `finish_scene()` → `on_scene_finished()` → deferred fatigue resets → `broadcast_scene_message(END)`. Idempotent.
-    - `set_scene_round_mode(scene_round, *, mode, advance_quorum_pct, max_actions_per_round, per_target_repeat_lock) -> SceneRound` (`round_services.py`) — apply mode/knob changes in-place; raises `RoundModeError` on STRICT-exit with pending declarations (#1466 removed the DANGER-immutable block — danger rounds are ordinary STRICT rounds).
+    - `set_scene_round_mode(scene_round, *, mode, advance_quorum_pct, max_actions_per_round, per_target_repeat_lock) -> SceneRound` (`round_services.py`) — apply mode/knob changes in-place; raises `RoundModeError` on STRICT-exit with pending declarations (#1466 removed the DANGER-immutable block — danger rounds are ordinary STRICT rounds). #1480: after applying, re-checks completion on a DECLARING STRICT round so a quorum change takes effect immediately.
     - `ensure_round_for_acute_condition(character_sheet) -> SceneRound | None` (`round_services.py`) — ensure an active scene round for the room (enrolling everyone present); creates a STRICT `SceneRound(start_reason=DANGER)` when none active, else the peril rides the existing round (#1466; renamed from `auto_start_or_extend_danger_round`).
 - **Read-visibility surface (canonical):**
   - `Scene.objects.viewable_by(account)` — queryset; staff=all, auth non-staff=public OR participant,

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -79,17 +79,24 @@ Key service functions for scene round lifecycle:
 - `resolve_scene_round(scene_round)`: Unconditional resolver — runs declared CHALLENGE actions in
   initiative order, fires the end-round tick (which advances acute conditions — DoTs, bleed-out, plummet),
   then either advances to the next round or **auto-ends** (a `start_reason==DANGER` round COMPLETES once
-  `_danger_persists` is False — no ACTIVE participant still carries an acute danger condition).
+  `_danger_persists` is False — no ACTIVE participant still carries an acute danger condition). **AFK
+  own-peril skip (#1480):** a present `can_act` participant who did NOT declare this round (swept as an
+  implicit pass by quorum completion) is excluded from the END-tick target set, so their OWN acute
+  conditions do not advance from a round they didn't engage in (ADR-0004 — an AFK character is not harmed
+  while away). Declared, absent, and present-`not can_act` (unconscious) participants tick as before.
 - `ensure_round_for_acute_condition(character_sheet) -> SceneRound | None`: ensures an active scene round
   for the character's room (enrolling everyone present). When none is active, creates a STRICT
   `SceneRound(start_reason=DANGER)`; when one already exists (any mode), the peril rides it. Caller
   guarantees the character is not in active combat. (Renamed from `auto_start_or_extend_danger_round`.)
-- `maybe_resolve_scene_round(scene_round)`: Resolves only when presence-gated completion is met
-  (every present ACTIVE participant who *can act* has a deferred declaration row).
-- `scene_round_is_complete(scene_round) -> bool`: True when all present ACTIVE participants who *can act*
-  have a deferred (`is_immediate=False`) declaration for the current round. Absent and present-but-`not
-  can_act` participants (e.g. an unconscious bleeding victim) are implicit passes — they never block, so a
-  conscious bystander's declaration alone can drive resolution (AFK-safety + no deadlock).
+- `maybe_resolve_scene_round(scene_round)`: Resolves only when quorum-gated completion is met.
+- `scene_round_is_complete(scene_round) -> bool`: True when enough present ACTIVE participants who *can
+  act* have a deferred (`is_immediate=False`) declaration for the current round — the threshold is
+  `ceil(advance_quorum_pct / 100 × present_active_count)` (the same field POSE_ORDER uses; at 100 it
+  reduces to unanimity, so a GM/staff can still require everyone). Absent and present-but-`not can_act`
+  participants are implicit passes (never block); an undeclared present `can_act` participant counts
+  toward the denominator but not the declared count, so a quorum below 100 lets the round resolve without
+  them — ending the single-AFK-participant deadlock (#1480) without a wall clock. The AFK participant's
+  own peril is skipped separately at resolution (see `resolve_scene_round`).
 
 ### `views.py`
 - **`SceneViewSet`**: Scene CRUD operations and filtering
@@ -137,7 +144,9 @@ Scene rounds support three action-gating modes (orthogonal to `start_reason`):
 | `POSE_ORDER` | Actions resolve immediately; after `ceil(quorum_pct × active_count)` distinct actors |
 | | have acted, `round_number` advances. Default for social rounds. |
 | `STRICT` | Actions are declared into a ledger while `is_declaration_open`; the full round |
-| | resolves batch when presence-gated completion is met or a GM force-resolves. Danger |
+| | resolves batch when quorum-gated completion is met (`ceil(advance_quorum_pct/100 × present_active)`,
+| | #1480 — not unanimity) or a GM force-resolves. An undeclared present `can_act` participant's own |
+| | peril is skipped on the END tick (ADR-0004). Danger |
 | | rounds (#1466) are STRICT: the peril ticks at resolution; the round auto-ends when it clears. |
 
 `SceneRoundDefaultsConfig` (singleton pk=1, accessed via `get_scene_round_defaults_config()`) lets

--- a/src/world/scenes/round_services.py
+++ b/src/world/scenes/round_services.py
@@ -291,12 +291,19 @@ def ensure_round_for_acute_condition(character_sheet: CharacterSheet) -> SceneRo
 
 
 def scene_round_is_complete(scene_round: SceneRound) -> bool:
-    """Presence-gated completion: True when every ACTIVE participant present in the room
-    who *can act* has a declaration/pass row for the current round. Absent participants
-    are implicit passes (never block); present-but-``not can_act`` participants (e.g. an
-    unconscious bleeding victim) are also implicit passes, so they cannot deadlock the
-    round — a conscious bystander's declaration alone drives resolution. No timer —
-    presence is the idle signal (AFK-safety)."""
+    """Quorum-gated completion: True when enough ACTIVE participants present in the room
+    who *can act* have declared for the current round. The threshold is
+    ``ceil(advance_quorum_pct / 100 × present_active_count)`` — the same field POSE_ORDER
+    uses (``advance_pose_order_round_if_quorum``); at 100 it reduces to unanimity, so a
+    GM/staff can still require everyone. Absent participants and present-but-``not
+    can_act`` participants (e.g. an unconscious bleeding victim) are implicit passes
+    (never block); an undeclared present ``can_act`` participant counts toward the
+    denominator but not the declared count, so a quorum below 100 lets the round resolve
+    without them — ending the AFK-stall deadlock (#1480). No timer — presence is the idle
+    signal (AFK-safety); the AFK participant's own peril is skipped separately at
+    resolution (see ``resolve_scene_round``)."""
+    import math  # noqa: PLC0415
+
     from world.vitals.services import can_act  # noqa: PLC0415
 
     present_ids = {s.character_id for s in _present_character_sheets(scene_round.room)}
@@ -315,7 +322,9 @@ def scene_round_is_complete(scene_round: SceneRound) -> bool:
     ]
     if not present_active:
         return False  # nobody present and able to drive resolution
-    return all(p.pk in declared_ids for p in present_active)
+    needed = math.ceil(scene_round.advance_quorum_pct / 100 * len(present_active))
+    declared_present_active = sum(1 for p in present_active if p.pk in declared_ids)
+    return declared_present_active >= needed
 
 
 @transaction.atomic

--- a/src/world/scenes/round_services.py
+++ b/src/world/scenes/round_services.py
@@ -348,12 +348,33 @@ def resolve_scene_round(scene_round: SceneRound) -> SceneRound:
     rnd.status = RoundStatus.RESOLVING
     rnd.save(update_fields=["status"])
 
+    # Snapshot who declared this round BEFORE _resolve_scene_declarations deletes the
+    # declaration rows. A present ``can_act`` participant who did NOT declare (swept as an
+    # implicit pass by quorum completion) is excluded from the END-tick target set below:
+    # their OWN acute conditions must not advance from a round they didn't engage in
+    # (ADR-0004 — an AFK character is not harmed while away). Declared participants, absent
+    # participants, and present-``not can_act`` participants (e.g. an unconscious victim)
+    # tick as before.
+    from world.vitals.services import can_act  # noqa: PLC0415
+
+    declared_ids = set(
+        rnd.action_declarations.filter(
+            round_number=rnd.round_number, is_immediate=False
+        ).values_list("participant_id", flat=True)
+    )
+    present_ids = {s.character_id for s in _present_character_sheets(rnd.room)}
+
     _resolve_scene_declarations(rnd)
 
     targets = [
         p.character_sheet.character
         for p in rnd.participants.filter(status=SceneRoundParticipantStatus.ACTIVE).select_related(
             "character_sheet__character"
+        )
+        if not (
+            p.character_sheet.character_id in present_ids
+            and can_act(p.character_sheet)
+            and p.pk not in declared_ids
         )
     ]
     tick_round_for_targets(targets, timing="end")

--- a/src/world/scenes/round_services.py
+++ b/src/world/scenes/round_services.py
@@ -86,6 +86,15 @@ def set_scene_round_mode(
     if update_fields:
         scene_round.save(update_fields=update_fields)
 
+    # A knob change can make an in-flight DECLARING STRICT round newly complete (e.g. a GM
+    # lowering advance_quorum_pct below the count of current declarers). Re-check
+    # completion so the change takes effect immediately rather than waiting for the next
+    # declaration (#1480). Safe no-op otherwise: maybe_resolve_scene_round guards on
+    # status==DECLARING and scene_round_is_complete. OPEN/POSE_ORDER rounds are unaffected
+    # (they tick immediately via _tick_scene_round_if_active, not via completion).
+    if scene_round.mode == SceneRoundMode.STRICT and scene_round.status == RoundStatus.DECLARING:
+        maybe_resolve_scene_round(scene_round)
+
     return scene_round
 
 

--- a/src/world/scenes/tests/test_round_mode_services.py
+++ b/src/world/scenes/tests/test_round_mode_services.py
@@ -129,6 +129,48 @@ class SetSceneRoundModeTests(TestCase):
         self.assertEqual(rnd.mode, SceneRoundMode.POSE_ORDER)
         self.assertIs(result, rnd)
 
+    def test_lowering_quorum_resolves_in_flight_strict_round(self):
+        """#1480: a GM lowering advance_quorum_pct re-checks completion immediately, so an
+        in-flight DECLARING STRICT round that was below quorum resolves as soon as the new
+        (lower) quorum is met — no need to wait for the next declaration."""
+        from world.character_sheets.factories import CharacterSheetFactory
+
+        room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+        rnd = SceneRoundFactory(
+            room=room,
+            status=RoundStatus.DECLARING,
+            round_number=1,
+            mode=SceneRoundMode.STRICT,
+            advance_quorum_pct=100,  # ceil(1.0*3)=3 -> incomplete with one declarer
+        )
+        sheets = []
+        for _ in range(3):
+            sheet = CharacterSheetFactory()
+            sheet.character.db_location = room
+            sheet.character.save(update_fields=["db_location"])
+            sheets.append(sheet)
+        participants = [
+            SceneRoundParticipantFactory(scene_round=rnd, character_sheet=s) for s in sheets
+        ]
+        SceneActionDeclaration.objects.create(  # only one declares
+            scene_round=rnd,
+            round_number=rnd.round_number,
+            participant=participants[0],
+            is_immediate=False,
+            is_pass=True,
+        )
+        # Incomplete at quorum 100 (1 of 3 declared).
+        self.assertFalse(rnd.status == RoundStatus.BETWEEN_ROUNDS)
+
+        set_scene_round_mode(rnd, advance_quorum_pct=1)  # ceil(0.01*3)=1 -> quorum met
+
+        rnd.refresh_from_db()
+        # Resolved immediately: round advanced (DECLARING, round_number 2) and the
+        # declaration row was swept.
+        self.assertEqual(rnd.status, RoundStatus.DECLARING)
+        self.assertEqual(rnd.round_number, 2)
+        self.assertEqual(SceneActionDeclaration.objects.filter(scene_round=rnd).count(), 0)
+
 
 class ActiveRoundForRoomTests(TestCase):
     @classmethod

--- a/src/world/scenes/tests/test_round_services.py
+++ b/src/world/scenes/tests/test_round_services.py
@@ -278,6 +278,41 @@ class SceneRoundResolutionTests(TestCase):
         self._declare_pass(p2)
         assert scene_round_is_complete(self.rnd) is False
 
+    def test_afk_own_peril_skipped_on_quorum_resolve(self):
+        # 3 present, 2 declare (quorum 60 met), the undeclared third is AFK. The AFK
+        # participant's OWN acute condition must NOT tick on the END round-resolution
+        # tick (ADR-0004: an AFK character is not harmed while away), while a declarer's
+        # own condition DOES tick. This is the #1480 companion to the quorum change —
+        # without it, quorum resolution would advance an AFK person's own peril.
+        self.rnd.mode = SceneRoundMode.STRICT
+        self.rnd.advance_quorum_pct = 60
+        self.rnd.save(update_fields=["mode", "advance_quorum_pct"])
+        p_decl = self._participant(present=True, initiative_order=0)
+        p_afk = self._participant(present=True, initiative_order=1)  # never declares
+        p_third = self._participant(present=True, initiative_order=2)
+        self._declare_pass(p_decl)
+        self._declare_pass(p_third)
+        dot_template = ConditionTemplateFactory(
+            default_duration_type=DurationType.ROUNDS, default_duration_value=3
+        )
+        decl_dot = ConditionInstanceFactory(
+            target=p_decl.character_sheet.character,
+            condition=dot_template,
+            rounds_remaining=3,
+        )
+        afk_dot = ConditionInstanceFactory(
+            target=p_afk.character_sheet.character,
+            condition=dot_template,
+            rounds_remaining=3,
+        )
+
+        resolve_scene_round(self.rnd)
+
+        decl_dot.refresh_from_db()
+        afk_dot.refresh_from_db()
+        assert decl_dot.rounds_remaining == 2  # declarer's own condition ticked
+        assert afk_dot.rounds_remaining == 3  # AFK (undeclared) own condition skipped
+
 
 class SceneRoundOutcomeBroadcastTests(TestCase):
     """_resolve_scene_declarations broadcasts an OUTCOME narration for each resolved challenge."""

--- a/src/world/scenes/tests/test_round_services.py
+++ b/src/world/scenes/tests/test_round_services.py
@@ -245,6 +245,39 @@ class SceneRoundResolutionTests(TestCase):
         assert self.rnd.round_number == 2
         assert SceneActionDeclaration.objects.filter(scene_round=self.rnd).count() == 0
 
+    def test_complete_on_quorum_not_unanimity(self):
+        # 3 present, 2 declare, advance_quorum_pct=60 -> ceil(0.6*3)=2 met -> complete.
+        # (Under the old unanimity rule this was False — the AFK stall fixed in #1480.)
+        self.rnd.advance_quorum_pct = 60
+        self.rnd.save(update_fields=["advance_quorum_pct"])
+        p1 = self._participant(present=True, initiative_order=0)
+        p2 = self._participant(present=True, initiative_order=1)
+        self._participant(present=True, initiative_order=2)  # undeclared (AFK)
+        self._declare_pass(p1)
+        self._declare_pass(p2)
+        assert scene_round_is_complete(self.rnd) is True
+
+    def test_not_complete_below_quorum(self):
+        # 3 present, 1 declares, quorum 60 -> ceil(0.6*3)=2 not met -> incomplete.
+        self.rnd.advance_quorum_pct = 60
+        self.rnd.save(update_fields=["advance_quorum_pct"])
+        p1 = self._participant(present=True, initiative_order=0)
+        self._participant(present=True, initiative_order=1)
+        self._participant(present=True, initiative_order=2)
+        self._declare_pass(p1)
+        assert scene_round_is_complete(self.rnd) is False
+
+    def test_quorum_100_reproduces_unanimity(self):
+        # quorum 100 -> ceil(1.0*3)=3 -> every present can_act participant must declare.
+        self.rnd.advance_quorum_pct = 100
+        self.rnd.save(update_fields=["advance_quorum_pct"])
+        p1 = self._participant(present=True, initiative_order=0)
+        p2 = self._participant(present=True, initiative_order=1)
+        self._participant(present=True, initiative_order=2)  # undeclared
+        self._declare_pass(p1)
+        self._declare_pass(p2)
+        assert scene_round_is_complete(self.rnd) is False
+
 
 class SceneRoundOutcomeBroadcastTests(TestCase):
     """_resolve_scene_declarations broadcasts an OUTCOME narration for each resolved challenge."""


### PR DESCRIPTION
Closes #1480

## Summary

STRICT scene rounds now resolve on a quorum (ceil(advance_quorum_pct/100 x present_active_count), reusing POSE_ORDER's field) instead of unanimity, so one conscious-but-AFK participant can no longer deadlock the round. An undeclared present can_act participant's own acute conditions are skipped on the END tick (ADR-0004 preserved). A GM lowering advance_quorum_pct via set_scene_round_mode now re-checks completion immediately. No new models/fields/enums/actions — ForceResolveRoundAction and SetRoundModeAction were reused; the anti-reinvention ledger is in the spec on the issue. Closes #1479's sibling (#1479 owns involved-party-only peril driving, layered on the same target set). Spec + ledger on the issue body; ADR-0047 extends ADR-0004.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1480 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased 4 commits onto origin/main (branch was local-only); no conflicts.

<!-- last-addressed-comment: 0 -->