### PR TITLE
Telnet journey: form a soul tether (propose → accept via ritual session)

### DIFF
--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -64,8 +64,9 @@ actions, backends, and service functions.
   - `ritual <name> [k=v ...]` — single-actor ritual performance (SERVICE rituals execute
     immediately; CEREMONY rituals create a `PendingRitualEffect` for finisher commands)
   - `ritual sessions` — list pending sessions
-  - `ritual draft <name> invite=<char>[,<char>]` — draft a session
-  - `ritual join <id>` — accept your invitation
+  - `ritual draft <name> invite=<char>[,<char>] [role=sinner|sineater resonance=<name> [writeup=...]]`
+    — draft a session (setup-info rituals, e.g. soul-tether BILATERAL)
+  - `ritual join <id> [role=sinner|sineater]` — accept your invitation
   - `ritual decline <id>` — decline your invitation
   - `ritual fire <id>` — fire the session (initiator only)
 

--- a/src/commands/ritual.py
+++ b/src/commands/ritual.py
@@ -197,7 +197,7 @@ class CmdRitual(ArxCommand):
             index += 1
 
         usage = (
-            "Usage: ritual draft <ritual_name> invite=<character>[,<character>\n"
+            "Usage: ritual draft <ritual_name> invite=<character>[,<character>]\n"
             "       [role=sinner|sineater resonance=<name> [writeup=<narrative>]]"
         )
         name = " ".join(name_parts).strip()

--- a/src/commands/ritual.py
+++ b/src/commands/ritual.py
@@ -10,7 +10,7 @@ Single-actor path (SERVICE/CEREMONY kind):
 
 Multi-participant session path:
     ``ritual sessions``                              — list pending sessions
-    ``ritual draft <name> invite=<char>[,<char>]`` — draft a session
+    ``ritual draft <name> invite=<char>[,<char>]``  — draft a session
         (add ``role=sinner|sineater resonance=<name> [writeup=...]`` for rituals
         that carry setup info, e.g. the soul-tether BILATERAL)
     ``ritual join <id> [role=sinner|sineater]``      — accept your invitation
@@ -196,7 +196,10 @@ class CmdRitual(ArxCommand):
                 name_parts.append(token)
             index += 1
 
-        usage = "Usage: ritual draft <ritual_name> invite=<character>[,<character>]"
+        usage = (
+            "Usage: ritual draft <ritual_name> invite=<character>[,<character>\n"
+            "       [role=sinner|sineater resonance=<name> [writeup=<narrative>]]"
+        )
         name = " ".join(name_parts).strip()
         if not name:
             raise CommandError(usage)

--- a/src/commands/ritual.py
+++ b/src/commands/ritual.py
@@ -63,6 +63,20 @@ def _resolve_soul_tether_role(token: str) -> str:
     raise CommandError(msg)
 
 
+def _parse_trailing_kwarg(rest: str, key: str) -> str | None:
+    """Return the value of a ``key=value`` token in *rest*, or None if absent.
+
+    Scans whitespace-delimited tokens for one starting with ``key=`` and
+    returns its value. Used by session subcommands that take a single optional
+    kwarg (e.g. ``join <id> role=sinner``) alongside a positional session id.
+    """
+    prefix = f"{key}="
+    for token in rest.split():
+        if token.startswith(prefix):
+            return token[len(prefix) :]
+    return None
+
+
 class CmdRitual(ArxCommand):
     """Perform a magical ritual or manage a multi-participant ritual session.
 
@@ -259,12 +273,19 @@ class CmdRitual(ArxCommand):
         )
 
     def _handle_join(self, rest: str) -> None:
-        """Accept a session invitation: ``join <id>``."""
+        """Accept a session invitation: ``join <id> [role=sinner|sineater]``."""
         from world.magic.exceptions import SessionNotInPendingError  # noqa: PLC0415
         from world.magic.models.sessions import RitualSessionParticipant  # noqa: PLC0415
         from world.magic.services.sessions import accept_session  # noqa: PLC0415
 
-        session_id = self._parse_session_id(rest, "Usage: ritual join <session_id>")
+        session_id = self._parse_session_id(
+            rest, "Usage: ritual join <session_id> [role=sinner|sineater]"
+        )
+        participant_kwargs: dict[str, Any] = {}
+        role_token = _parse_trailing_kwarg(rest, _ROLE_KWARG)
+        if role_token is not None:
+            participant_kwargs[_PARTICIPANT_ROLE_KEY] = _resolve_soul_tether_role(role_token)
+
         sheet = self.caller.sheet_data
         participant = RitualSessionParticipant.objects.filter(
             session_id=session_id,
@@ -274,7 +295,11 @@ class CmdRitual(ArxCommand):
             msg = f"You are not an invited participant of session #{session_id}."
             raise CommandError(msg)
         try:
-            accept_session(participant=participant, participant_kwargs={}, references=[])
+            accept_session(
+                participant=participant,
+                participant_kwargs=participant_kwargs,
+                references=[],
+            )
         except SessionNotInPendingError:
             msg = f"You have already responded to session #{session_id}."
             raise CommandError(msg) from None

--- a/src/commands/ritual.py
+++ b/src/commands/ritual.py
@@ -10,8 +10,10 @@ Single-actor path (SERVICE/CEREMONY kind):
 
 Multi-participant session path:
     ``ritual sessions``                              — list pending sessions
-    ``ritual draft <name> invite=<char>[,<char>]``   — draft a session
-    ``ritual join <id>``                             — accept your invitation
+    ``ritual draft <name> invite=<char>[,<char>]`` — draft a session
+        (add ``role=sinner|sineater resonance=<name> [writeup=...]`` for rituals
+        that carry setup info, e.g. the soul-tether BILATERAL)
+    ``ritual join <id> [role=sinner|sineater]``      — accept your invitation
     ``ritual decline <id>``                          — decline your invitation
     ``ritual fire <id>``                             — fire the session (initiator only)
 
@@ -32,6 +34,33 @@ from commands.exceptions import CommandError
 _THREAD_KWARG = "thread"
 _THREAD_ID_KEY = "thread_id"
 _SESSION_SUBCMDS = frozenset({"sessions", "draft", "join", "decline", "fire"})
+# Kwargs carried into session/participant dicts for rituals that need setup
+# info (e.g. the soul-tether BILATERAL). Keys match what the ritual's
+# service_function_path reads off RitualSession.session_kwargs /
+# RitualSessionParticipant.participant_kwargs.
+_ROLE_KWARG = "role"
+_RESONANCE_KWARG = "resonance"
+_WRITEUP_KWARG = "writeup"
+_SESSION_RESONANCE_ID_KEY = "resonance_id"
+_SESSION_WRITEUP_KEY = "writeup"
+_PARTICIPANT_ROLE_KEY = "soul_tether_role"
+
+
+def _resolve_soul_tether_role(token: str) -> str:
+    """Map a telnet ``role=`` token to a SoulTetherRole value.
+
+    Returns the canonical uppercase enum value (``"SINNER"`` / ``"SINEATER"``)
+    that the fire handler ``accept_soul_tether_via_session`` compares against.
+    Raises ``CommandError`` for unknown roles.
+    """
+    from world.magic.types.soul_tether import SoulTetherRole  # noqa: PLC0415
+
+    normalized = token.strip().upper()
+    for role in SoulTetherRole:
+        if normalized == role.value:
+            return role.value
+    msg = f"Unknown role '{token}'. Use role=sinner or role=sineater."
+    raise CommandError(msg)
 
 
 class CmdRitual(ArxCommand):
@@ -45,9 +74,11 @@ class CmdRitual(ArxCommand):
     **Multi-participant session lifecycle:**
         ``ritual sessions``                              — list pending sessions
         ``ritual draft <name> invite=<char>[,<char>]``   — draft a session
-        ``ritual join <id>``                             — accept your invitation
-        ``ritual decline <id>``                          — decline your invitation
-        ``ritual fire <id>``                             — fire the session (initiator only)
+            (add ``role=sinner|sineater resonance=<name> [writeup=...]`` for
+            rituals that carry setup info, e.g. the soul-tether BILATERAL)
+        ``ritual join <id> [role=sinner|sineater]``       — accept your invitation
+        ``ritual decline <id>``                           — decline your invitation
+        ``ritual fire <id>``                              — fire the session (initiator only)
     """
 
     key = "ritual"
@@ -107,7 +138,9 @@ class CmdRitual(ArxCommand):
             )
         self.caller.msg("\n".join(lines))
 
-    def _handle_draft(self, rest: str) -> None:
+    def _handle_draft(  # noqa: C901, PLR0912, PLR0915
+        self, rest: str
+    ) -> None:
         """Draft a multi-participant session: ``draft <name> invite=<char>[,<char>]``."""
         from datetime import timedelta  # noqa: PLC0415
 
@@ -122,18 +155,32 @@ class CmdRitual(ArxCommand):
             RitualSessionError,
         )
         from world.magic.models import Ritual  # noqa: PLC0415
+        from world.magic.models.affinity import Resonance  # noqa: PLC0415
         from world.magic.services.sessions import draft_session  # noqa: PLC0415
 
-        # Parse: ``Ritual Name invite=char1[,char2]``
+        # Parse: ``Ritual Name invite=char1[,char2] role=sinner|sineater
+        #         resonance=<name> [writeup=<narrative>]``
         tokens = rest.split()
         name_parts: list[str] = []
         invite_names: list[str] = []
-        for token in tokens:
+        role_token = ""
+        resonance_token = ""
+        writeup = ""
+        index = 0
+        while index < len(tokens):
+            token = tokens[index]
             if token.startswith("invite="):
-                value = token[7:]
-                invite_names = [n.strip() for n in value.split(",") if n.strip()]
+                invite_names = [n.strip() for n in token[7:].split(",") if n.strip()]
+            elif token.startswith(f"{_ROLE_KWARG}="):
+                role_token = token[len(_ROLE_KWARG) + 1 :]
+            elif token.startswith(f"{_RESONANCE_KWARG}="):
+                resonance_token = token[len(_RESONANCE_KWARG) + 1 :]
+            elif token.startswith(f"{_WRITEUP_KWARG}="):
+                writeup = " ".join([token[len(_WRITEUP_KWARG) + 1 :], *tokens[index + 1 :]]).strip()
+                break
             else:
                 name_parts.append(token)
+            index += 1
 
         usage = "Usage: ritual draft <ritual_name> invite=<character>[,<character>]"
         name = " ".join(name_parts).strip()
@@ -171,15 +218,33 @@ class CmdRitual(ArxCommand):
             invitees.append(invitee_sheet)
 
         initiator_sheet = self.caller.sheet_data
+
+        # Build session-level + initiator-participant kwargs from the parsed tokens.
+        session_kwargs: dict[str, Any] = {}
+        initiator_participant_kwargs: dict[str, Any] = {}
+        if role_token:
+            initiator_participant_kwargs[_PARTICIPANT_ROLE_KEY] = _resolve_soul_tether_role(
+                role_token
+            )
+        if resonance_token:
+            resonance_name = resonance_token.strip()
+            resonance = Resonance.objects.filter(name__iexact=resonance_name).first()
+            if resonance is None:
+                msg = f"No resonance named '{resonance_name}'."
+                raise CommandError(msg)
+            session_kwargs[_SESSION_RESONANCE_ID_KEY] = resonance.pk
+        if writeup:
+            session_kwargs[_SESSION_WRITEUP_KEY] = writeup
+
         try:
             session = draft_session(
                 ritual=ritual,
                 initiator=initiator_sheet,
                 proposed_terms="",
-                session_kwargs={},
+                session_kwargs=session_kwargs,
                 invitee_sheets=invitees,
                 session_references=[],
-                initiator_participant_kwargs={},
+                initiator_participant_kwargs=initiator_participant_kwargs,
                 initiator_references=[],
                 expires_at=timezone.now() + timedelta(hours=24),
             )

--- a/src/commands/tests/test_ritual_session_kwargs.py
+++ b/src/commands/tests/test_ritual_session_kwargs.py
@@ -1,0 +1,111 @@
+"""Unit tests: CmdRitual draft/join kwarg parsing for soul-tether sessions (#1449).
+
+Covers the fiddly parse/error paths the journey E2E samples but doesn't
+exhaust. Cheap branch coverage; the E2E (test_soul_tether_telnet_journey_e2e)
+proves the happy path end-to-end.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.ritual import CmdRitual
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.factories import (
+    AcceptSoulTetherRitualFactory,
+    AffinityFactory,
+    ResonanceFactory,
+    wire_soul_tether_content,
+)
+from world.magic.models.sessions import RitualSession
+
+
+def _run(cmd_cls: type, caller: object, args: str = "") -> object:
+    cmd = cmd_cls()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"{cmd_cls.key} {args}".strip()
+    caller.msg = MagicMock()
+    return cmd
+
+
+class RitualDraftKwargsParseTests(TestCase):
+    def setUp(self) -> None:
+        wire_soul_tether_content()
+        self.ritual = AcceptSoulTetherRitualFactory()
+        self.abyssal = AffinityFactory(name="Abyssal")
+        self.resonance = ResonanceFactory(affinity=self.abyssal)
+        self.initiator = CharacterFactory(db_key="DraftInit")
+        self.initiator_sheet = CharacterSheetFactory(character=self.initiator)
+        self.partner = CharacterFactory(db_key="DraftPartner")
+        self.partner_sheet = CharacterSheetFactory(character=self.partner)
+
+    def _draft(self, args: str) -> str:
+        cmd = _run(CmdRitual, self.initiator, f"draft {args}")
+        cmd.caller.search = MagicMock(return_value=self.partner)
+        cmd.func()
+        return self.initiator.msg.call_args[0][0] if self.initiator.msg.called else ""
+
+    def test_unknown_role_sends_error(self) -> None:
+        out = self._draft(
+            f"accept_soul_tether invite=DraftPartner role=wizard resonance={self.resonance.name}"
+        )
+        self.assertIn("Unknown role", out)
+
+    def test_unknown_resonance_name_sends_error(self) -> None:
+        out = self._draft(
+            "accept_soul_tether invite=DraftPartner role=sinner resonance=NopeNoSuchResonance"
+        )
+        self.assertIn("No resonance named", out)
+
+    def test_role_without_resonance_still_drafts(self) -> None:
+        # role without resonance: role is stored, resonance_id absent from session_kwargs.
+        # (The fire handler raises RequiredReferenceMissingError at fire time — that's the
+        # service's job, not the command's. The command should still draft successfully.)
+        out = self._draft("accept_soul_tether invite=DraftPartner role=sinner")
+        self.assertIn("drafted", out.lower())
+        session = RitualSession.objects.get(ritual=self.ritual)
+        self.assertEqual(
+            session.participants.get(character_sheet=self.initiator_sheet).participant_kwargs[
+                "soul_tether_role"
+            ],
+            "SINNER",
+        )
+        self.assertNotIn("resonance_id", session.session_kwargs)
+
+
+class RitualJoinKwargsParseTests(TestCase):
+    def setUp(self) -> None:
+        wire_soul_tether_content()
+        self.ritual = AcceptSoulTetherRitualFactory()
+        self.abyssal = AffinityFactory(name="Abyssal")
+        self.resonance = ResonanceFactory(affinity=self.abyssal)
+        self.initiator = CharacterFactory(db_key="JoinInit")
+        self.initiator_sheet = CharacterSheetFactory(character=self.initiator)
+        self.partner = CharacterFactory(db_key="JoinPartner")
+        self.partner_sheet = CharacterSheetFactory(character=self.partner)
+        # Draft a session the partner is invited to.
+        cmd = _run(
+            CmdRitual,
+            self.initiator,
+            f"draft accept_soul_tether invite=JoinPartner role=sinner "
+            f"resonance={self.resonance.name} writeup=test",
+        )
+        cmd.caller.search = MagicMock(return_value=self.partner)
+        cmd.func()
+        self.session = RitualSession.objects.get(ritual=self.ritual)
+
+    def test_join_with_unknown_role_sends_error(self) -> None:
+        cmd = _run(CmdRitual, self.partner, f"join {self.session.pk} role=wizard")
+        cmd.func()
+        out = self.partner.msg.call_args[0][0]
+        self.assertIn("Unknown role", out)
+
+    def test_join_without_role_still_accepts(self) -> None:
+        cmd = _run(CmdRitual, self.partner, f"join {self.session.pk}")
+        cmd.func()
+        out = self.partner.msg.call_args[0][0]
+        self.assertIn("joined", out.lower())

--- a/src/commands/tests/test_ritual_session_kwargs.py
+++ b/src/commands/tests/test_ritual_session_kwargs.py
@@ -17,6 +17,7 @@ from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.factories import (
     AcceptSoulTetherRitualFactory,
     AffinityFactory,
+    RenewTheOathRitualFactory,
     ResonanceFactory,
     wire_soul_tether_content,
 )
@@ -75,6 +76,43 @@ class RitualDraftKwargsParseTests(TestCase):
             "SINNER",
         )
         self.assertNotIn("resonance_id", session.session_kwargs)
+
+    def test_draft_without_role_still_drafts(self) -> None:
+        # Missing role= token: initiator gets empty participant kwargs, but resonance=
+        # is still parsed into session-level kwargs.
+        out = self._draft(f"accept_soul_tether invite=DraftPartner resonance={self.resonance.name}")
+        self.assertIn("drafted", out.lower())
+        session = RitualSession.objects.get(ritual=self.ritual)
+        initiator_participant = session.participants.get(character_sheet=self.initiator_sheet)
+        self.assertNotIn("soul_tether_role", initiator_participant.participant_kwargs)
+        self.assertEqual(session.session_kwargs.get("resonance_id"), self.resonance.pk)
+
+
+class NonSoulTetherKwargsTests(TestCase):
+    def setUp(self) -> None:
+        self.ritual = RenewTheOathRitualFactory()
+        self.abyssal = AffinityFactory(name="Abyssal")
+        self.resonance = ResonanceFactory(affinity=self.abyssal)
+        self.initiator = CharacterFactory(db_key="RenewInit")
+        self.initiator_sheet = CharacterSheetFactory(character=self.initiator)
+        self.partner = CharacterFactory(db_key="RenewPartner")
+        self.partner_sheet = CharacterSheetFactory(character=self.partner)
+
+    def test_non_soul_tether_ritual_ignores_kwargs(self) -> None:
+        # Non-soul-tether rituals should not reject drafts just because the caller
+        # passes role=/resonance= tokens; the command passes them through generically.
+        cmd = _run(
+            CmdRitual,
+            self.initiator,
+            f"draft {self.ritual.name} invite=RenewPartner role=sinner "
+            f"resonance={self.resonance.name}",
+        )
+        cmd.caller.search = MagicMock(return_value=self.partner)
+        cmd.func()
+        out = self.initiator.msg.call_args[0][0] if self.initiator.msg.called else ""
+        self.assertIn("drafted", out.lower())
+        session = RitualSession.objects.get(ritual=self.ritual)
+        self.assertIsNotNone(session)
 
 
 class RitualJoinKwargsParseTests(TestCase):

--- a/src/integration_tests/pipeline/test_soul_tether_telnet_journey_e2e.py
+++ b/src/integration_tests/pipeline/test_soul_tether_telnet_journey_e2e.py
@@ -1,0 +1,169 @@
+"""Telnet E2E: form a Soul Tether via the ritual session lifecycle (#1449).
+
+Drives the full draft → join → fire journey through CmdRitual against
+full-fidelity eligible-pair fixtures (mirroring test_soul_tether_flow.py's
+_make_eligible_pair) and asserts the real bond forms in the DB — proving
+the bonding loop runs end-to-end via telnet, converging on the same
+draft_session / accept_session / fire_session service seam the web uses.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.ritual import CmdRitual
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.conditions.models import ConditionInstance
+from world.magic.constants import SoulTetherRole, TargetKind
+from world.magic.factories import (
+    AffinityFactory,
+    CharacterAuraFactory,
+    CharacterResonanceFactory,
+    CharacterThreadWeavingUnlockFactory,
+    ResonanceFactory,
+    ThreadWeavingUnlockFactory,
+    wire_soul_tether_content,
+)
+from world.magic.models import Thread
+from world.relationships.factories import (
+    CharacterRelationshipFactory,
+    RelationshipTrackFactory,
+)
+from world.relationships.models import CharacterRelationship
+
+_ABYSSAL = "Abyssal"
+_PRIMAL = "Primal"
+
+
+def _run(cmd_cls: type, caller: object, args: str = "") -> object:
+    """Helper: build and run a command instance (mirrors ritual-session E2E)."""
+    cmd = cmd_cls()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"{cmd_cls.key} {args}".strip()
+    caller.msg = MagicMock()
+    return cmd
+
+
+def _set_aura(sheet: object, *, celestial: str, primal: str, abyssal: str) -> None:
+    char = sheet.character
+    defaults = {
+        "celestial": Decimal(celestial),
+        "primal": Decimal(primal),
+        "abyssal": Decimal(abyssal),
+    }
+    try:
+        aura = char.aura
+        for key, value in defaults.items():
+            setattr(aura, key, value)
+        aura.save()
+    except AttributeError:
+        CharacterAuraFactory(character=char, **defaults)
+
+
+def _grant_track_unlock(sheet: object, track: object) -> object:
+    unlock = ThreadWeavingUnlockFactory(
+        target_kind=TargetKind.RELATIONSHIP_TRACK,
+        unlock_track=track,
+        unlock_trait=None,
+    )
+    return CharacterThreadWeavingUnlockFactory(character=sheet, unlock=unlock)
+
+
+def _make_active_relationship(source: object, target: object) -> object:
+    CharacterRelationshipFactory(source=source, target=target, is_pending=False)
+    return CharacterRelationshipFactory(source=target, target=source, is_pending=False)
+
+
+class SoulTetherTelnetJourneyTests(TestCase):
+    """draft → join → fire through CmdRitual forms a real Soul Tether."""
+
+    def setUp(self) -> None:
+        # setUp (not setUpTestData) avoids the DbHolder deepcopy flake in CI shards.
+        wire_soul_tether_content()
+        self.track = RelationshipTrackFactory()
+        self.abyssal_affinity = AffinityFactory(name=_ABYSSAL)
+        self.resonance = ResonanceFactory(affinity=self.abyssal_affinity)
+
+        # Sinner: Abyssal-primary with a RELATIONSHIP_TRACK ThreadWeavingUnlock.
+        self.sinner_char = CharacterFactory(db_key="JourneySinner")
+        self.sinner_sheet = CharacterSheetFactory(character=self.sinner_char)
+        _set_aura(self.sinner_sheet, celestial="10.00", primal="10.00", abyssal="80.00")
+        _grant_track_unlock(self.sinner_sheet, self.track)
+        # Sinner must have claimed the resonance (accept_soul_tether resonance gate).
+        CharacterResonanceFactory(character_sheet=self.sinner_sheet, resonance=self.resonance)
+
+        # Sineater: Primal-primary.
+        self.sineater_char = CharacterFactory(db_key="JourneySineater")
+        self.sineater_sheet = CharacterSheetFactory(character=self.sineater_char)
+        _set_aura(self.sineater_sheet, celestial="10.00", primal="80.00", abyssal="10.00")
+
+        _make_active_relationship(self.sinner_sheet, self.sineater_sheet)
+
+    def test_formation_journey(self) -> None:
+        """draft (Sinner, role=sinner) → join (Sineater, role=sineater) → fire forms bond."""
+        # 1. Sinner drafts the soul-tether session.
+        cmd = _run(
+            CmdRitual,
+            self.sinner_char,
+            f"draft accept_soul_tether invite=JourneySineater "
+            f"role=sinner resonance={self.resonance.name} writeup=A bond sworn in shadow",
+        )
+        cmd.caller.search = MagicMock(return_value=self.sineater_char)
+        cmd.func()
+        from world.magic.models.sessions import RitualSession
+
+        session = RitualSession.objects.get(ritual__name="accept_soul_tether")
+        self.assertEqual(session.initiator, self.sinner_sheet)
+        self.assertEqual(session.session_kwargs["resonance_id"], self.resonance.pk)
+        self.assertEqual(session.session_kwargs["writeup"], "A bond sworn in shadow")
+        initiator_part = session.participants.get(character_sheet=self.sinner_sheet)
+        self.assertEqual(
+            initiator_part.participant_kwargs["soul_tether_role"], SoulTetherRole.SINNER
+        )
+
+        # 2. Sineater joins, declaring their role.
+        cmd = _run(CmdRitual, self.sineater_char, f"join {session.pk} role=sineater")
+        cmd.func()
+        invitee_part = session.participants.get(character_sheet=self.sineater_sheet)
+        self.assertEqual(
+            invitee_part.participant_kwargs["soul_tether_role"], SoulTetherRole.SINEATER
+        )
+
+        # 3. Sinner fires — the real bond forms.
+        cmd = _run(CmdRitual, self.sinner_char, f"fire {session.pk}")
+        cmd.func()
+
+        rel_out = CharacterRelationship.objects.get(
+            source=self.sinner_sheet, target=self.sineater_sheet
+        )
+        rel_in = CharacterRelationship.objects.get(
+            source=self.sineater_sheet, target=self.sinner_sheet
+        )
+        self.assertTrue(rel_out.is_soul_tether)
+        self.assertTrue(rel_in.is_soul_tether)
+        self.assertEqual(rel_out.soul_tether_role, SoulTetherRole.SINNER)
+        self.assertEqual(rel_in.soul_tether_role, SoulTetherRole.SINEATER)
+
+        # Sinner's RELATIONSHIP_CAPSTONE Thread exists.
+        self.assertTrue(
+            Thread.objects.filter(
+                owner=self.sinner_sheet,
+                target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+                retired_at__isnull=True,
+            ).exists()
+        )
+
+        # SoulTetherActive condition installed on the Sinner.
+        self.assertTrue(
+            ConditionInstance.objects.filter(
+                target=self.sinner_char, condition__name="Soul Tether Active"
+            ).exists()
+        )
+
+        # Session is consumed on successful fire.
+        self.assertFalse(RitualSession.objects.filter(pk=session.pk).exists())

--- a/src/integration_tests/pipeline/test_soul_tether_telnet_journey_e2e.py
+++ b/src/integration_tests/pipeline/test_soul_tether_telnet_journey_e2e.py
@@ -149,12 +149,23 @@ class SoulTetherTelnetJourneyTests(TestCase):
         self.assertEqual(rel_out.soul_tether_role, SoulTetherRole.SINNER)
         self.assertEqual(rel_in.soul_tether_role, SoulTetherRole.SINEATER)
 
-        # Sinner's RELATIONSHIP_CAPSTONE Thread exists.
+        # Sinner's RELATIONSHIP_CAPSTONE Thread exists, anchored to this bond + resonance.
+        capstone = rel_out.capstones.filter(is_ritual_capstone=True).first()
+        self.assertIsNotNone(capstone)
         self.assertTrue(
             Thread.objects.filter(
                 owner=self.sinner_sheet,
                 target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+                target_capstone=capstone,
+                resonance=self.resonance,
                 retired_at__isnull=True,
+            ).exists()
+        )
+
+        # The bond's ritual capstone record formed.
+        self.assertTrue(
+            rel_out.capstones.filter(
+                is_ritual_capstone=True, ritual__name="accept_soul_tether"
             ).exists()
         )
 


### PR DESCRIPTION
Closes #1449

## Summary

Closes the gap from #1345: `CmdRitual`'s session handlers passed empty `session_kwargs`/`participant_kwargs`, so the soul-tether BILATERAL could not be formed via telnet (the fire handler `accept_soul_tether_via_session` raised `RequiredReferenceMissingError`).

Extends the `ritual` telnet command to carry the four pieces the soul-tether needs, distributed across draft (initiator acts) and join (invitee acts):

- `ritual draft <name> invite=<char>[,<char>] role=sinner|sineater resonance=<name> [writeup=<narrative>]` — parses the initiator's role into `participant_kwargs["soul_tether_role"]`, looks up the resonance by name into `session_kwargs["resonance_id"]`, and greedily consumes `writeup=` into `session_kwargs["writeup"]`.
- `ritual join <id> [role=sinner|sineater]` — parses the invitee's role into `participant_kwargs["soul_tether_role"]`.

These flow into the existing session service seam (`draft_session`/`accept_session` in `world/magic/services/sessions.py`) — the same seam the web `RitualSessionViewSet` uses. No new model, service, serializer, or Action; the session lifecycle converges at the service seam by design, not on `action.run()`.

Tests: a full-fidelity Journey E2E (propose -> telnet-accept -> fire forms a real bond, asserting `is_soul_tether`, role-correct `CharacterRelationship` directions, the Sinner's RELATIONSHIP_CAPSTONE Thread, the `Soul Tether Active` ConditionInstance, and the `is_ritual_capstone` RelationshipCapstone) plus parse/error-path unit tests for both subcommands.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1449 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (1 commit pulled in: #1540 Condition treatment / heal-another has no player surface). No conflicts. Strategy: rebase (branch was local-only).

<!-- last-addressed-comment: 0 -->