### PR TITLE
Telnet journey: ritual cancel subcommand (initiator cancel pending session)

### DIFF
--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -69,8 +69,9 @@ actions, backends, and service functions.
   - `ritual join <id> [role=sinner|sineater]` — accept your invitation
   - `ritual decline <id>` — decline your invitation
   - `ritual fire <id>` — fire the session (initiator only)
+  - `ritual cancel <id>` — cancel a pending session (initiator only)
 
-  Session subcommands call `draft_session` / `accept_session` / `decline_session` / `fire_session` directly.
+  Session subcommands call `draft_session` / `accept_session` / `decline_session` / `fire_session` / `cancel_session` directly.
 - **`weave.py`**: `CmdWeaveThread` (`weave`) — telnet face of `WeaveThreadAction`;
   parses `weave resonance=<name> trait=<name or id> [name=<...>]` (TRAIT anchor only — the
   reference grammar; other anchor kinds are extended by the thread-weaving journey

--- a/src/commands/ritual.py
+++ b/src/commands/ritual.py
@@ -16,6 +16,7 @@ Multi-participant session path:
     ``ritual join <id> [role=sinner|sineater]``      — accept your invitation
     ``ritual decline <id>``                          — decline your invitation
     ``ritual fire <id>``                             — fire the session (initiator only)
+    ``ritual cancel <id>``                           — cancel a pending session (initiator only)
 
 The web path uses ``RitualSessionViewSet`` for sessions and ``RitualPerformView``
 for single-actor rituals — both converge on the same service functions.
@@ -33,7 +34,7 @@ from commands.exceptions import CommandError
 
 _THREAD_KWARG = "thread"
 _THREAD_ID_KEY = "thread_id"
-_SESSION_SUBCMDS = frozenset({"sessions", "draft", "join", "decline", "fire"})
+_SESSION_SUBCMDS = frozenset({"sessions", "draft", "join", "decline", "fire", "cancel"})
 # Kwargs carried into session/participant dicts for rituals that need setup
 # info (e.g. the soul-tether BILATERAL). Keys match what the ritual's
 # service_function_path reads off RitualSession.session_kwargs /
@@ -93,6 +94,7 @@ class CmdRitual(ArxCommand):
         ``ritual join <id> [role=sinner|sineater]``       — accept your invitation
         ``ritual decline <id>``                           — decline your invitation
         ``ritual fire <id>``                              — fire the session (initiator only)
+        ``ritual cancel <id>``                           — cancel a pending session (initiator only)
     """
 
     key = "ritual"
@@ -115,6 +117,8 @@ class CmdRitual(ArxCommand):
                     self._handle_decline(rest)
                 elif first == "fire":  # noqa: STRING_LITERAL
                     self._handle_fire(rest)
+                elif first == "cancel":  # noqa: STRING_LITERAL
+                    self._handle_cancel(rest)
             except CommandError as err:
                 self.caller.msg(str(err))
         else:
@@ -357,6 +361,20 @@ class CmdRitual(ArxCommand):
             msg = f"Session #{session_id} cannot fire yet — not all participants have responded."
             raise CommandError(msg) from None
         self.caller.msg(f"Ritual session #{session_id} has been fired. The ritual is complete.")
+
+    def _handle_cancel(self, rest: str) -> None:
+        """Cancel a pending session (initiator only): ``cancel <id>``."""
+        from world.magic.models.sessions import RitualSession  # noqa: PLC0415
+        from world.magic.services.sessions import cancel_session  # noqa: PLC0415
+
+        session_id = self._parse_session_id(rest, "Usage: ritual cancel <session_id>")
+        sheet = self.caller.sheet_data
+        session = RitualSession.objects.filter(pk=session_id, initiator=sheet).first()
+        if session is None:
+            msg = f"Session #{session_id} not found or you are not its initiator."
+            raise CommandError(msg)
+        cancel_session(session=session)
+        self.caller.msg(f"Ritual session #{session_id} has been cancelled.")
 
     # ------------------------------------------------------------------
     # Single-actor helpers (unchanged)

--- a/src/integration_tests/pipeline/test_ritual_session_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_ritual_session_telnet_e2e.py
@@ -167,6 +167,49 @@ class RitualSessionTelnetE2ETests(TestCase):
         output = self.participant.msg.call_args[0][0]
         self.assertIn("not found or you are not its initiator", output.lower())
 
+    # ------------------------------------------------------------------
+    # cancel
+    # ------------------------------------------------------------------
+
+    def test_cancel_happy_path(self) -> None:
+        """draft → cancel → session deleted + initiator confirmation."""
+        session_pk = self._draft()
+
+        cmd = _run(CmdRitual, self.initiator, f"cancel {session_pk}")
+        cmd.func()
+        self.assertFalse(RitualSession.objects.filter(pk=session_pk).exists())
+        output = self.initiator.msg.call_args[0][0]
+        self.assertIn("cancelled", output.lower())
+        self.assertIn(str(session_pk), output)
+
+    def test_cancel_by_non_initiator_sends_error(self) -> None:
+        """A non-initiator cancelling → error; session survives."""
+        session_pk = self._draft()
+
+        cmd = _run(CmdRitual, self.participant, f"cancel {session_pk}")
+        cmd.func()
+        output = self.participant.msg.call_args[0][0]
+        self.assertIn("not found or you are not its initiator", output.lower())
+        self.assertTrue(RitualSession.objects.filter(pk=session_pk).exists())
+
+    def test_cancel_nonexistent_session_sends_error(self) -> None:
+        """Cancelling a non-existent id → error message, no crash."""
+        cmd = _run(CmdRitual, self.initiator, "cancel 99999")
+        cmd.func()
+        output = self.initiator.msg.call_args[0][0]
+        self.assertIn("not found or you are not its initiator", output.lower())
+
+    def test_cancel_after_participant_joined(self) -> None:
+        """Cancel is unconditional for the initiator — works after a join."""
+        session_pk = self._draft()
+
+        cmd = _run(CmdRitual, self.participant, f"join {session_pk}")
+        cmd.func()
+
+        cmd = _run(CmdRitual, self.initiator, f"cancel {session_pk}")
+        cmd.func()
+        self.assertFalse(RitualSession.objects.filter(pk=session_pk).exists())
+
     def test_draft_unknown_ritual_sends_error(self) -> None:
         """Drafting a non-existent ritual → error."""
         cmd = _run(CmdRitual, self.initiator, "draft Rite of Nonexistent invite=Participant")


### PR DESCRIPTION
Closes #1439

## Summary

Adds the `ritual cancel <id>` telnet subcommand to `CmdRitual`, closing the gap where draft/join/decline/fire/sessions were reachable via telnet but cancel forced the web UI. The new `_handle_cancel` mirrors `_handle_fire`: parses the id via the shared `_parse_session_id`, gates on `initiator=sheet` (the same ORM check the web `IsRitualSessionInitiator` permission enforces), and calls the existing `cancel_session` service — the same service `RitualSessionViewSet.perform_destroy` calls. No new model/migration/API/Action; pure telnet convergence surface. 4 E2E tests added to the existing `test_ritual_session_telnet_e2e.py` (happy path, non-initiator refused, non-existent id, cancel-after-join). Service-direct (not the dispatcher) because the whole session lifecycle is a documented service-direct convention on both surfaces.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1439 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (c584b3d0, #1542 soul-tether). Resolved `ritual.py`/`CLAUDE.md` conflicts: kept main's soul-tether role/resonance/writeup kwargs to `draft`/`join` + helpers (`_resolve_soul_tether_role`, `_parse_trailing_kwarg`, new module constants) and merged in the `cancel` subcmd/route/handler/docstring — the two changes are orthogonal. All 13 E2E tests + ruff/ty/pre-commit clean post-rebase.

<!-- last-addressed-comment: 0 -->