### PR TITLE
Telnet: set-the-stage (staff scene positioning)

### DIFF
--- a/docs/audits/2026-06-25-player-reachability-coverage.md
+++ b/docs/audits/2026-06-25-player-reachability-coverage.md
@@ -89,8 +89,9 @@ re-listing them, so each row maps cleanly to one tracking issue. `tracked` = exi
   transitions, scheduling, assistant-GM claims, story→table offers, Era advance/archive; **GM tables**
   (world/gm) — create/archive/transfer table, seat members, roster invites, GM applications; **mission
   authoring** (templates / assign / nodes / options / rewards).
-- NO-SURFACE: `finalize_gm_character` (GM character/NPC authoring, unwired); `set_the_stage` GM
-  positioning is WEB-ONLY; trap **arming/placement** absent (only disarm exists).
+- NO-SURFACE: `finalize_gm_character` (GM character/NPC authoring, unwired); trap
+  **arming/placement** absent (only disarm exists). `set_the_stage` GM positioning is now
+  TELNET+WEB (telnet `setstage`, #1498 — was WEB-ONLY).
 - **PLANNED-UNBUILT (→ registry):** umpire check-modifier tooling; GM trust→risk leveling; live
   Situation/Encounter session resolvers; cross-table GM availability marketplace.
 
@@ -179,8 +180,9 @@ re-listing them, so each row maps cleanly to one tracking issue. `tracked` = exi
 ### Space, movement & building
 - TELNET+WEB: traverse exit; home; get/drop/give; look/inventory; edit owned room (CmdManageRoom +
   RoomEditAction, #1472 — room-editor HAS telnet parity).
-- WEB-ONLY: move_to_position (Places sub-locations, no telnet); set_the_stage (GM); disarm_trap
-  (#1051); activate_permit (raise a building).
+- WEB-ONLY: move_to_position (Places sub-locations, no telnet); disarm_trap
+  (#1051); activate_permit (raise a building). `set_the_stage` (GM) is now TELNET+WEB
+  (telnet `setstage`, #1498).
 - TELNET-ONLY: Dig/Open/Link/Unlink (Evennia builder cmds — room/exit *creation* has no web/Action).
 - **NO-SURFACE:** property **transfer_ownership / grant_tenancy / end_tenancy** (the ownership half of
   property mgmt the room-editor doesn't fill); area/blueprint authoring (reparent_area, create_position,

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -202,6 +202,13 @@ actions, backends, and service functions.
   `manageroom/desc <text>`, `manageroom/public <yes|no>`. Edits the room the caller
   is standing in; ownership is gated by `IsRoomOwnerPrerequisite`, writes live in
   `world.locations.services.set_room_display_data`. No business logic in the command.
+- **`setstage.py`**: `CmdSetStage` (`setstage`, staff `perm(Admin)`, #1498) — telnet face of
+  `SetTheStageAction` (key `set_the_stage`, REGISTRY backend). A staff caller instantiates a
+  `PositionBlueprint` into their current room: `setstage` shows this room's positions + default
+  blueprint, `setstage list` lists all blueprints by pk, `setstage <name|id>` instantiates one,
+  `setstage <name|id> replace` replaces the room's existing position grid. Thin `ArxCommand` over
+  `action.run()` (same seam as the web quick-action `_set_the_stage_actions`); staff-gated by
+  `StaffOnlyPrerequisite`. No business logic in the command.
 - **`persona.py`**: `CmdPersona` (`persona`, alias `wear-face`, #1347) — list own
   personas or switch the active one. Bare `persona`/`persona list` renders all the
   caller's personas (marking the active one `◄ active`). `persona <name>`/`wear-face

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -80,6 +80,7 @@ from commands.react import CmdReact
 from commands.relationships import CmdRelationship
 from commands.ritual import CmdRitual
 from commands.scene import CmdScene
+from commands.setstage import CmdSetStage
 from commands.social.blocking import (
     CmdBlock,
     CmdBlockList,
@@ -230,6 +231,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdStory,
             # #1470 — owner-gated room editor (name/description/public-private).
             CmdManageRoom,
+            # #1498 — staff set-the-stage: apply a position blueprint to the room.
+            CmdSetStage,
             # #1514 — in-room comfort/weather readout (the mechanical surface).
             CmdComfort,
             # #1347 — list faces + wear-face active persona switch.

--- a/src/commands/setstage.py
+++ b/src/commands/setstage.py
@@ -28,6 +28,10 @@ class CmdSetStage(ArxCommand):
       setstage list                  -- list all position blueprints
       setstage <name|id>             -- instantiate <name|id> into this room
       setstage <name|id> replace     -- replace existing positions
+
+    The words "list" and "replace" are reserved: a blueprint literally named
+    "list" must be invoked by id, and "replace" cannot be used as a blueprint
+    name invoked by name.
     """
 
     key = "setstage"
@@ -74,24 +78,25 @@ class CmdSetStage(ArxCommand):
             self.msg("You are nowhere to stage.")
             return
 
-        positions = Position.objects.filter(room=room).order_by("name")
-        if positions:
-            lines = ["Positions here:"]
-            lines += [f"  {p.name}" for p in positions]
-        else:
-            lines = ["No positions are set in this room yet."]
-        self.msg("\n".join(lines))
-
-        if show_all:
-            blueprints = PositionBlueprint.objects.all().order_by("name")
-            if blueprints:
-                lines = ["Position blueprints:"]
-                lines += [f"  {bp.pk}: {bp.name}" for bp in blueprints]
+        if not show_all:
+            positions = Position.objects.filter(room=room).order_by("name")
+            if positions:
+                lines = ["Positions here:"]
+                lines += [f"  {p.name}" for p in positions]
             else:
-                lines = ["No position blueprints are defined."]
+                lines = ["No positions are set in this room yet."]
             self.msg("\n".join(lines))
+
+            profile = getattr(room, "room_profile", None)  # noqa: GETATTR_LITERAL
+            default = profile.default_blueprint if profile is not None else None
+            if default is not None:
+                self.msg(f"Default blueprint here: {default.name} (pk {default.pk})")
             return
 
-        default = room.room_profile.default_blueprint if room.room_profile else None
-        if default is not None:
-            self.msg(f"Default blueprint here: {default.name} (pk {default.pk})")
+        blueprints = PositionBlueprint.objects.all().order_by("name")
+        if blueprints:
+            lines = ["Position blueprints:"]
+            lines += [f"  {bp.pk}: {bp.name}" for bp in blueprints]
+        else:
+            lines = ["No position blueprints are defined."]
+        self.msg("\n".join(lines))

--- a/src/commands/setstage.py
+++ b/src/commands/setstage.py
@@ -12,9 +12,10 @@ from typing import Any
 from actions.definitions.positioning import SetTheStageAction
 from commands.command import ArxCommand
 from commands.exceptions import CommandError
-from world.areas.positioning.models import PositionBlueprint
+from world.areas.positioning.models import Position, PositionBlueprint
 
 _REPLACE_TOKEN = "replace"  # noqa: S105
+_LIST_SUBVERB = "list"
 
 
 class CmdSetStage(ArxCommand):
@@ -24,6 +25,7 @@ class CmdSetStage(ArxCommand):
 
     Usage:
       setstage                       -- show this room's positions
+      setstage list                  -- list all position blueprints
       setstage <name|id>             -- instantiate <name|id> into this room
       setstage <name|id> replace     -- replace existing positions
     """
@@ -56,3 +58,40 @@ class CmdSetStage(ArxCommand):
             not_found_msg="No such blueprint. (setstage list to see them.)",
         )
         return {"blueprint_id": blueprint.pk, "replace": replace}
+
+    def func(self) -> None:
+        """Route bare/list to read-only hubs; otherwise run the action."""
+        raw = (self.args or "").strip().lower()
+        if not raw or raw == _LIST_SUBVERB:
+            self._render_hub(show_all=(raw == _LIST_SUBVERB))
+            return
+        super().func()
+
+    def _render_hub(self, *, show_all: bool) -> None:
+        """Show the caller's current room positions, and optionally all blueprints."""
+        room = self.caller.location
+        if room is None:
+            self.msg("You are nowhere to stage.")
+            return
+
+        positions = Position.objects.filter(room=room).order_by("name")
+        if positions:
+            lines = ["Positions here:"]
+            lines += [f"  {p.name}" for p in positions]
+        else:
+            lines = ["No positions are set in this room yet."]
+        self.msg("\n".join(lines))
+
+        if show_all:
+            blueprints = PositionBlueprint.objects.all().order_by("name")
+            if blueprints:
+                lines = ["Position blueprints:"]
+                lines += [f"  {bp.pk}: {bp.name}" for bp in blueprints]
+            else:
+                lines = ["No position blueprints are defined."]
+            self.msg("\n".join(lines))
+            return
+
+        default = room.room_profile.default_blueprint if room.room_profile else None
+        if default is not None:
+            self.msg(f"Default blueprint here: {default.name} (pk {default.pk})")

--- a/src/commands/setstage.py
+++ b/src/commands/setstage.py
@@ -1,0 +1,58 @@
+"""Telnet face of SetTheStageAction (#1498).
+
+Thin command: a staff caller instantiates a ``PositionBlueprint`` into their
+current room. Delegates to ``SetTheStageAction`` via ``action.run()`` -- the
+same seam the web quick-action (``_set_the_stage_actions``) reaches.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from actions.definitions.positioning import SetTheStageAction
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+from world.areas.positioning.models import PositionBlueprint
+
+_REPLACE_TOKEN = "replace"  # noqa: S105
+
+
+class CmdSetStage(ArxCommand):
+    """Set the stage in your current room -- apply a position blueprint.
+
+    Staff-only. You must be standing in the room to stage.
+
+    Usage:
+      setstage                       -- show this room's positions
+      setstage <name|id>             -- instantiate <name|id> into this room
+      setstage <name|id> replace     -- replace existing positions
+    """
+
+    key = "setstage"
+    aliases: list[str] = []
+    locks = "cmd:perm(Admin)"
+    help_category = "Building"
+    action = SetTheStageAction()
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        """Parse ``<name|id> [replace]`` into SetTheStageAction kwargs."""
+        raw = (self.args or "").strip()
+        if not raw:
+            msg = "Set the stage with which blueprint? (setstage list to see them.)"
+            raise CommandError(msg)
+
+        parts = raw.split()
+        replace = parts[-1].lower() == _REPLACE_TOKEN
+        if replace:
+            parts = parts[:-1]
+
+        if not parts:
+            msg = "Set the stage with which blueprint? (setstage list to see them.)"
+            raise CommandError(msg)
+
+        blueprint = self.resolve_by_name_or_id(
+            PositionBlueprint,
+            " ".join(parts),
+            not_found_msg="No such blueprint. (setstage list to see them.)",
+        )
+        return {"blueprint_id": blueprint.pk, "replace": replace}

--- a/src/commands/tests/test_setstage_command.py
+++ b/src/commands/tests/test_setstage_command.py
@@ -1,0 +1,43 @@
+"""setstage command (#1498) — parse telnet text into SetTheStageAction kwargs."""
+
+from django.test import TestCase
+
+from commands.exceptions import CommandError
+from commands.setstage import CmdSetStage
+from world.areas.positioning.factories import PositionBlueprintFactory
+
+
+class SetStageParseTests(TestCase):
+    def _parse(self, args: str) -> dict:
+        cmd = CmdSetStage()
+        cmd.args = args
+        return cmd.resolve_action_args()
+
+    def test_name_resolves_to_blueprint_id(self) -> None:
+        bp = PositionBlueprintFactory(name="The Dueling Green")
+        assert self._parse("The Dueling Green") == {
+            "blueprint_id": bp.pk,
+            "replace": False,
+        }
+
+    def test_id_resolves_to_blueprint_id(self) -> None:
+        bp = PositionBlueprintFactory(name="Tavern Booths")
+        assert self._parse(str(bp.pk)) == {
+            "blueprint_id": bp.pk,
+            "replace": False,
+        }
+
+    def test_trailing_replace_sets_replace_true(self) -> None:
+        bp = PositionBlueprintFactory(name="Court Dais")
+        assert self._parse("Court Dais replace") == {
+            "blueprint_id": bp.pk,
+            "replace": True,
+        }
+
+    def test_missing_args_raises(self) -> None:
+        with self.assertRaises(CommandError):
+            self._parse("")
+
+    def test_unknown_name_raises(self) -> None:
+        with self.assertRaises(CommandError):
+            self._parse("No Such Blueprint")

--- a/src/commands/tests/test_setstage_command.py
+++ b/src/commands/tests/test_setstage_command.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from commands.exceptions import CommandError
 from commands.setstage import CmdSetStage
-from evennia_extensions.factories import AccountFactory
+from evennia_extensions.factories import AccountFactory, RoomProfileFactory
 from world.areas.positioning.factories import PositionBlueprintFactory
 from world.areas.positioning.models import Position
 
@@ -45,16 +45,24 @@ class SetStageParseTests(TestCase):
             self._parse("No Such Blueprint")
 
 
-def _make_staff_character(key: str, room) -> object:
-    """Return an Evennia character connected to a staff account."""
+def _make_character(key: str, room, *, is_staff: bool) -> object:
+    """Return an Evennia character connected to an account."""
     from evennia import create_object
 
     char = create_object("typeclasses.characters.Character", key=key, location=room, nohome=True)
-    account = AccountFactory(username=f"account_{key}", is_staff=True)
-    account.save()
+    account = AccountFactory(username=f"account_{key}", is_staff=is_staff)
     char.db_account = account
-    char.save()
     return char
+
+
+def _make_staff_character(key: str, room) -> object:
+    """Return an Evennia character connected to a staff account."""
+    return _make_character(key, room, is_staff=True)
+
+
+def _make_nonstaff_character(key: str, room) -> object:
+    """Return an Evennia character connected to a non-staff account."""
+    return _make_character(key, room, is_staff=False)
 
 
 def _make_room(key: str = "The Solar") -> object:
@@ -77,7 +85,17 @@ class SetStageHubTests(TestCase):
         room = _make_room()
         caller = _make_staff_character("stagehand", room)
         msgs = self._run("", caller)
-        assert any("No positions" in m or "positions" in m.lower() for m in msgs)
+        self.assertIn("No positions are set in this room yet.", msgs)
+
+    def test_bare_setstage_with_default_blueprint(self) -> None:
+        room = _make_room()
+        blueprint = PositionBlueprintFactory(name="Hall Layout")
+        profile = RoomProfileFactory(objectdb=room)
+        profile.default_blueprint = blueprint
+        profile.save()
+        caller = _make_staff_character("stagehand", room)
+        msgs = self._run("", caller)
+        assert any("Default blueprint here:" in m for m in msgs)
 
     def test_list_lists_blueprints(self) -> None:
         PositionBlueprintFactory(name="Alpha")
@@ -89,6 +107,15 @@ class SetStageHubTests(TestCase):
 
 
 class SetStageRunTests(TestCase):
+    def _run(self, args: str, caller) -> list[str]:
+        cmd = CmdSetStage()
+        cmd.args = args
+        cmd.caller = caller
+        messages: list[str] = []
+        caller.msg = lambda *a, **_k: messages.append(a[0] if a else "")
+        cmd.func()
+        return messages
+
     def test_setstage_name_instantiates_positions(self) -> None:
         room = _make_room()
         caller = _make_staff_character("stager", room)
@@ -98,11 +125,39 @@ class SetStageRunTests(TestCase):
 
         add_blueprint_position(bp, "Center", description="The centre")
 
-        cmd = CmdSetStage()
-        cmd.args = "Lone Dais"
-        cmd.caller = caller
-        messages: list[str] = []
-        caller.msg = lambda *a, **_k: messages.append(a[0] if a else "")
-        cmd.func()
+        self._run("Lone Dais", caller)
 
         assert Position.objects.filter(room=room).count() == 1
+
+    def test_nonstaff_caller_is_blocked_by_staff_only_prerequisite(self) -> None:
+        room = _make_room()
+        caller = _make_nonstaff_character("poser", room)
+        bp = PositionBlueprintFactory(name="Lone Dais")
+        from world.areas.positioning.services import add_blueprint_position
+
+        add_blueprint_position(bp, "Center", description="The centre")
+
+        msgs = self._run("Lone Dais", caller)
+
+        assert any("Staff only." in m for m in msgs)
+        assert Position.objects.filter(room=room).count() == 0
+
+    def test_setstage_replace_replaces_existing_position_grid(self) -> None:
+        room = _make_room()
+        caller = _make_staff_character("replacer", room)
+        from world.areas.positioning.services import add_blueprint_position
+
+        bp_a = PositionBlueprintFactory(name="Lone Dais")
+        add_blueprint_position(bp_a, "Center", description="The centre")
+        bp_b = PositionBlueprintFactory(name="Tight Alley")
+        add_blueprint_position(bp_b, "Alley", description="A narrow passage")
+
+        self._run("Lone Dais", caller)
+        assert Position.objects.filter(room=room).count() == 1
+        assert Position.objects.filter(room=room, name="Center").exists()
+
+        self._run("Tight Alley replace", caller)
+        positions = Position.objects.filter(room=room)
+        assert positions.count() == 1
+        assert positions.first().name == "Alley"
+        assert not Position.objects.filter(room=room, name="Center").exists()

--- a/src/commands/tests/test_setstage_command.py
+++ b/src/commands/tests/test_setstage_command.py
@@ -4,7 +4,9 @@ from django.test import TestCase
 
 from commands.exceptions import CommandError
 from commands.setstage import CmdSetStage
+from evennia_extensions.factories import AccountFactory
 from world.areas.positioning.factories import PositionBlueprintFactory
+from world.areas.positioning.models import Position
 
 
 class SetStageParseTests(TestCase):
@@ -41,3 +43,66 @@ class SetStageParseTests(TestCase):
     def test_unknown_name_raises(self) -> None:
         with self.assertRaises(CommandError):
             self._parse("No Such Blueprint")
+
+
+def _make_staff_character(key: str, room) -> object:
+    """Return an Evennia character connected to a staff account."""
+    from evennia import create_object
+
+    char = create_object("typeclasses.characters.Character", key=key, location=room, nohome=True)
+    account = AccountFactory(username=f"account_{key}", is_staff=True)
+    account.save()
+    char.db_account = account
+    char.save()
+    return char
+
+
+def _make_room(key: str = "The Solar") -> object:
+    from evennia import create_object
+
+    return create_object("typeclasses.rooms.Room", key=key, nohome=True)
+
+
+class SetStageHubTests(TestCase):
+    def _run(self, args: str, caller) -> list[str]:
+        cmd = CmdSetStage()
+        cmd.args = args
+        cmd.caller = caller
+        messages: list[str] = []
+        caller.msg = lambda *a, **_k: messages.append(a[0] if a else "")
+        cmd.func()
+        return messages
+
+    def test_bare_setstage_shows_hub(self) -> None:
+        room = _make_room()
+        caller = _make_staff_character("stagehand", room)
+        msgs = self._run("", caller)
+        assert any("No positions" in m or "positions" in m.lower() for m in msgs)
+
+    def test_list_lists_blueprints(self) -> None:
+        PositionBlueprintFactory(name="Alpha")
+        PositionBlueprintFactory(name="Beta")
+        caller = _make_staff_character("listonly", _make_room())
+        msgs = self._run("list", caller)
+        assert any("Alpha" in m for m in msgs)
+        assert any("Beta" in m for m in msgs)
+
+
+class SetStageRunTests(TestCase):
+    def test_setstage_name_instantiates_positions(self) -> None:
+        room = _make_room()
+        caller = _make_staff_character("stager", room)
+        # A blueprint with one position template -> one live Position in the room.
+        bp = PositionBlueprintFactory(name="Lone Dais")
+        from world.areas.positioning.services import add_blueprint_position
+
+        add_blueprint_position(bp, "Center", description="The centre")
+
+        cmd = CmdSetStage()
+        cmd.args = "Lone Dais"
+        cmd.caller = caller
+        messages: list[str] = []
+        caller.msg = lambda *a, **_k: messages.append(a[0] if a else "")
+        cmd.func()
+
+        assert Position.objects.filter(room=room).count() == 1


### PR DESCRIPTION
Closes #1498

## Summary

Adds a `setstage` telnet command wrapping the existing staff-only `SetTheStageAction` (key `set_the_stage`), closing coverage-gap #1498 — the action was WEB-ONLY. Web + telnet now converge on `action.run()` (ADR-0001).

**Design decision (resolved the fork the issue posed):** telnet command, NOT admin-hosted. `set_the_stage` is a live in-scene GM verb (stand in the room, instantiate a PositionBlueprint into the current location) — same shape as CmdManageRoom/RoomEditAction and the staff broadcast verbs. ADR-0022 scopes config/tuning to admin, not live verbs; a web-only live verb is a plain ADR-0001 convergence gap.

**Command:** `setstage` (status hub), `setstage list` (blueprint catalog), `setstage <name|id>` (instantiate), `setstage <name|id> replace` (replace grid). Thin `ArxCommand` over `action.run()`; `perm(Admin)` front-gate + the action's `StaffOnlyPrerequisite` as the authoritative gate (layered, per the CmdPemit precedent). No new model/service/Action/migration.

**Naming:** standalone `setstage` (no `gm` namespace today — every staff verb is its own top-level key). A shared GM-setup namespace is recorded as `needs-design` in the spec to revisit once a second GM-setup verb lands.

**Tests:** 11 tests — parse (name/id/replace/missing/unknown), non-staff block, hub, list, default-blueprint, and a replace run-path integration test. Controller-verified green on SQLite; ruff clean.

Docs in tandem: `commands/CLAUDE.md` bullet + audit ledger row `set_the_stage` WEB-ONLY → TELNET+WEB.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1498 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (local-only branch); 6 commits, no conflicts.

<!-- last-addressed-comment: 0 -->