### PR TITLE
Combat telnet: surface anima / soulfray / fury status for informed decisions

### DIFF
--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -161,9 +161,11 @@ actions, backends, and service functions.
   namespace. One command routes a leading subverb (`combat flee` / `cover <ally>` /
   `interpose [ally]` / `join` / `leave` / `ready` / `combo <name>` / `revert` / `yield`)
   to a REGISTRY `ActionRef` and dispatches through `dispatch_player_action` — the same
-  seam the web `CombatEncounterViewSet` uses. Bare `combat` prints a status hub (mirrors
-  `CmdSheet`). Verbs are namespaced — not bare top-level keys — to avoid exit/channel/alias
-  collisions (mirrors `CmdRitual`'s `ritual <subverb>` routing). Each verb wraps an existing
+  seam the web `CombatEncounterViewSet` uses. Bare `combat` prints a status hub — anima +
+  soulfray stage (+ fury/Berserk when in an active round) alongside the declared action —
+  mirroring the resource/risk visibility the web combat panel will show (#1543). Verbs are
+  namespaced — not bare top-level keys — to avoid exit/channel/alias collisions (mirrors
+  `CmdRitual`'s `ritual <subverb>` routing). Each verb wraps an existing
   combat service via its Action in `actions/definitions/combat_maneuvers.py`; `yield` reuses
   the existing `YieldAction`.
 - **`duels.py`**: `CmdDuel` (`duel`, #1492) — the PC-vs-PC duel-lifecycle namespace. One command

--- a/src/commands/combat_maneuvers.py
+++ b/src/commands/combat_maneuvers.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from django.core.exceptions import ObjectDoesNotExist
+
 from actions.constants import ActionBackend
 from commands.combat import _CombatCommandMixin
 from commands.command import DispatchCommand
@@ -133,8 +135,31 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
             raise CommandError(msg)
         return combo.pk
 
+    def _render_resource_state(self, participant: Any) -> list[str]:
+        """Anima + soulfray (always, if present) + fury/Berserk (active round only).
+
+        Read-only over existing services — no mechanics. ``participant`` is the
+        caller's CombatParticipant or None (outside an encounter); fury/Berserk
+        are suppressed when it is None.
+        """
+        from world.magic.services.soulfray import get_soulfray_warning  # noqa: PLC0415
+
+        lines: list[str] = []
+        character = self.caller.puppet if hasattr(self.caller, "puppet") else self.caller
+        try:
+            anima = character.anima
+            lines.append(f"Anima: {anima.current}/{anima.maximum}")
+        except (AttributeError, ObjectDoesNotExist):
+            pass  # No anima row yet — omit rather than mislead with 0/0.
+
+        warning = get_soulfray_warning(character)
+        if warning is not None:
+            risk = " — |rdeath risk|n" if warning.has_death_risk else ""
+            lines.append(f"Soulfray: {warning.stage_name}{risk}")
+        return lines
+
     def _show_status_hub(self) -> None:
-        """Print the caller's current declared action plus the available subverbs."""
+        """Print resource/risk state + the declared action + available subverbs."""
         lines = [
             "|wCombat actions|n: "
             "flee, cover <ally>, interpose [ally], join, leave, ready, "
@@ -142,6 +167,7 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
         ]
         participant = self._combat_participant_or_none()
         if participant is None:
+            lines.extend(self._render_resource_state(participant))
             lines.append("You are not currently declaring in combat.")
         else:
             from world.combat.models import CombatRoundAction  # noqa: PLC0415
@@ -150,6 +176,7 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
                 participant=participant,
                 round_number=participant.encounter.round_number,
             ).first()
+            lines.extend(self._render_resource_state(participant))
             if action is None:
                 lines.append("You have not declared an action this round.")
             else:

--- a/src/commands/combat_maneuvers.py
+++ b/src/commands/combat_maneuvers.py
@@ -135,12 +135,13 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
             raise CommandError(msg)
         return combo.pk
 
-    def _render_resource_state(self, participant: Any) -> list[str]:
+    def _render_resource_state(self, participant: Any, action: Any) -> list[str]:
         """Anima + soulfray (always, if present) + fury/Berserk (active round only).
 
         Read-only over existing services — no mechanics. ``participant`` is the
-        caller's CombatParticipant or None (outside an encounter); fury/Berserk
-        are suppressed when it is None.
+        caller's CombatParticipant or None; ``action`` is this round's
+        CombatRoundAction (or None). Fury/Berserk are suppressed when
+        ``participant`` is None (outside an encounter).
         """
         from world.magic.services.soulfray import get_soulfray_warning  # noqa: PLC0415
 
@@ -156,7 +157,28 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
         if warning is not None:
             risk = " — |rdeath risk|n" if warning.has_death_risk else ""
             lines.append(f"Soulfray: {warning.stage_name}{risk}")
+
+        if participant is not None and action is not None and action.fury_commitment_id:
+            anchor_name = "unknown"
+            if action.fury_anchor_id and action.fury_anchor is not None:
+                anchor_char = action.fury_anchor.character
+                if anchor_char is not None:
+                    anchor_name = anchor_char.db_key
+            control = (self._berserk_active(character) and "lost") or "retained"
+            lines.append(
+                f"Fury: committed (depth {action.fury_commitment.depth}, "
+                f"anchored to {anchor_name}) — control {control}"
+            )
         return lines
+
+    def _berserk_active(self, character: Any) -> bool:
+        """True when a Berserk ConditionInstance is currently active on *character*."""
+        from world.conditions.models import ConditionInstance  # noqa: PLC0415
+
+        return ConditionInstance.objects.filter(
+            target=character,
+            condition__name="Berserk",
+        ).exists()
 
     def _show_status_hub(self) -> None:
         """Print resource/risk state + the declared action + available subverbs."""
@@ -167,16 +189,22 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
         ]
         participant = self._combat_participant_or_none()
         if participant is None:
-            lines.extend(self._render_resource_state(participant))
+            lines.extend(self._render_resource_state(participant, None))
             lines.append("You are not currently declaring in combat.")
         else:
             from world.combat.models import CombatRoundAction  # noqa: PLC0415
 
-            action = CombatRoundAction.objects.filter(
-                participant=participant,
-                round_number=participant.encounter.round_number,
-            ).first()
-            lines.extend(self._render_resource_state(participant))
+            action = (
+                CombatRoundAction.objects.select_related(
+                    "fury_commitment", "fury_anchor__character"
+                )
+                .filter(
+                    participant=participant,
+                    round_number=participant.encounter.round_number,
+                )
+                .first()
+            )
+            lines.extend(self._render_resource_state(participant, action))
             if action is None:
                 lines.append("You have not declared an action this round.")
             else:

--- a/src/commands/combat_maneuvers.py
+++ b/src/commands/combat_maneuvers.py
@@ -158,27 +158,35 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
             risk = " — |rdeath risk|n" if warning.has_death_risk else ""
             lines.append(f"Soulfray: {warning.stage_name}{risk}")
 
-        if participant is not None and action is not None and action.fury_commitment_id:
-            anchor_name = "unknown"
-            if action.fury_anchor_id and action.fury_anchor is not None:
-                anchor_char = action.fury_anchor.character
-                if anchor_char is not None:
-                    anchor_name = anchor_char.db_key
-            control = (self._berserk_active(character) and "lost") or "retained"
-            lines.append(
-                f"Fury: committed (depth {action.fury_commitment.depth}, "
-                f"anchored to {anchor_name}) — control {control}"
-            )
+        if participant is not None:
+            berserk = self._berserk_instance(character)
+            control = "lost" if berserk is not None else "retained"
+            if action is not None and action.fury_commitment_id:
+                anchor_name = "unknown"
+                if action.fury_anchor_id and action.fury_anchor is not None:
+                    anchor_char = action.fury_anchor.character
+                    if anchor_char is not None:
+                        anchor_name = anchor_char.db_key
+                lines.append(
+                    f"Fury: committed (depth {action.fury_commitment.depth}, "
+                    f"anchored to {anchor_name}) — control {control}"
+                )
+            if berserk is not None:
+                rounds = ""
+                if berserk.rounds_remaining is not None:
+                    unit = "round" if berserk.rounds_remaining == 1 else "rounds"
+                    rounds = f" ({berserk.rounds_remaining} {unit} left)"
+                lines.append(f"Berserk: active{rounds}")
         return lines
 
-    def _berserk_active(self, character: Any) -> bool:
-        """True when a Berserk ConditionInstance is currently active on *character*."""
+    def _berserk_instance(self, character: Any) -> Any:
+        """The active Berserk ConditionInstance on *character*, or None."""
         from world.conditions.models import ConditionInstance  # noqa: PLC0415
 
         return ConditionInstance.objects.filter(
             target=character,
             condition__name="Berserk",
-        ).exists()
+        ).first()
 
     def _show_status_hub(self) -> None:
         """Print resource/risk state + the declared action + available subverbs."""

--- a/src/commands/tests/test_combat_maneuvers_command.py
+++ b/src/commands/tests/test_combat_maneuvers_command.py
@@ -65,8 +65,15 @@ class CmdCombatRoutingTests(TestCase):
 
     def test_bare_combat_shows_status_hub(self) -> None:
         cmd = _make_cmd("")
-        with patch.object(cmd, "_combat_participant_or_none", return_value=None):
+        with (
+            patch.object(cmd, "_combat_participant_or_none", return_value=None) as participant,
+            patch.object(cmd, "_render_resource_state", return_value=[]) as resources,
+        ):
             cmd.func()
+        # Outside combat the hub calls the resource readout collaborator with
+        # no participant/action and still prints the actions header.
+        participant.assert_called_once()
+        resources.assert_called_once_with(None, None)
         cmd.caller.msg.assert_called_once()
         self.assertIn("Combat actions", cmd.caller.msg.call_args.args[0])
 

--- a/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
@@ -44,7 +44,7 @@ from world.combat.factories import (
     ThreatPoolFactory,
 )
 from world.combat.models import CombatRoundAction
-from world.combat.services import resolve_round
+from world.combat.services import begin_declaration_phase, resolve_round
 from world.conditions.factories import DamageSuccessLevelMultiplierFactory
 from world.magic.factories import (
     BuffPassiveTechniqueFactory,
@@ -568,3 +568,46 @@ class CombatCastTelnetE2ETests(TestCase):
         self.assertIn(anchor_sheet.character.db_key, out)
         self.assertIn("retained", out)  # no Berserk yet → control retained
         self.assertNotIn("Berserk:", out)
+
+    @tag("postgres")
+    def test_combat_hub_shows_berserk_after_lost_control(self) -> None:
+        """After fury loses control, the hub shows Berserk + rounds remaining."""
+        from world.magic.factories import (
+            BerserkConditionTemplateFactory,
+            FuryConfigFactory,
+            FuryTierFactory,
+        )
+
+        FuryConfigFactory()
+        BerserkConditionTemplateFactory()
+        tier = FuryTierFactory()
+        anchor_sheet = CharacterSheetFactory()
+
+        with patch("world.magic.services.soulfray.get_soulfray_warning", return_value=None):
+            _make_cmd(
+                self.character,
+                f"{self.technique.name} at {self.opponent_name} "
+                f"fury={tier.name} anchor={anchor_sheet.character.db_key}",
+            ).func()
+
+        with (
+            patch("world.combat.services.perform_check") as mock_offense,
+            patch("world.magic.services.fury.get_relationship_tier", return_value=2),
+            patch("world.checks.services.perform_check") as mock_control,
+        ):
+            mock_offense.return_value = MagicMock(success_level=2)
+            # Below lucid_grade_floor → control lost → Berserk applied.
+            mock_control.return_value = MagicMock(success_level=1)
+            resolve_round(self.encounter)
+
+        # The encounter left DECLARING after resolve_round. Open a fresh
+        # DECLARING round so the participant is active again and the hub can
+        # surface the persistent Berserk condition.
+        begin_declaration_phase(self.encounter)
+
+        cmd = _make_combat_cmd(self.character, "")
+        with patch("world.magic.services.soulfray.get_soulfray_warning", return_value=None):
+            cmd.func()
+        out = "\n".join(cmd._captured)
+        self.assertIn("Berserk:", out)
+        self.assertIn("active", out)

--- a/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
@@ -30,6 +30,7 @@ from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper import models as idmapper_models
 
 from commands.combat import CmdDeclareTechnique
+from commands.combat_maneuvers import CmdCombat
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.constants import (
     ActionCategory,
@@ -66,6 +67,19 @@ def _make_cmd(caller: ObjectDB, args: str) -> CmdDeclareTechnique:
     cmd.args = args
     cmd.raw_string = f"cast {args}"
     cmd.cmdname = "cast"
+    return cmd
+
+
+def _make_combat_cmd(caller: ObjectDB, args: str) -> CmdCombat:
+    """Build a bare ``combat`` command against *caller* and capture its output."""
+    cmd = CmdCombat()
+    cmd.args = args
+    cmd.raw_string = f"combat {args}".strip()
+    cmd.caller = caller
+    cmd.account = None
+    captured: list[str] = []
+    cmd.msg = lambda msg="", **kwargs: captured.append(str(msg))  # noqa: ARG005
+    cmd._captured = captured  # type: ignore[attr-defined]
     return cmd
 
 
@@ -503,3 +517,29 @@ class CombatCastTelnetE2ETests(TestCase):
             ).exists(),
             "losing control to fury must apply a Berserk condition to the caster",
         )
+
+    def test_combat_hub_shows_anima_and_omits_absent_lines(self) -> None:
+        """Bare ``combat`` shows anima; soulfray/fury/Berserk are absent → omitted."""
+        cmd = _make_combat_cmd(self.character, "")
+        with patch("world.magic.services.soulfray.get_soulfray_warning", return_value=None):
+            cmd.func()
+        out = "\n".join(cmd._captured)
+        self.assertIn("Anima: 20/20", out)
+        self.assertNotIn("Soulfray:", out)
+        self.assertNotIn("Fury:", out)
+        self.assertNotIn("Berserk:", out)
+
+    def test_combat_hub_shows_soulfray_stage_with_death_risk(self) -> None:
+        """When get_soulfray_warning returns a stage, the hub shows it + death risk."""
+        from world.magic.types.techniques import SoulfrayWarning
+
+        warning = SoulfrayWarning(
+            stage_name="Frayed", stage_description="edges fraying", has_death_risk=True
+        )
+        cmd = _make_combat_cmd(self.character, "")
+        with patch("world.magic.services.soulfray.get_soulfray_warning", return_value=warning):
+            cmd.func()
+        out = "\n".join(cmd._captured)
+        self.assertIn("Anima: 20/20", out)
+        self.assertIn("Soulfray: Frayed", out)
+        self.assertIn("death risk", out)

--- a/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
@@ -543,3 +543,28 @@ class CombatCastTelnetE2ETests(TestCase):
         self.assertIn("Anima: 20/20", out)
         self.assertIn("Soulfray: Frayed", out)
         self.assertIn("death risk", out)
+
+    def test_combat_hub_shows_committed_fury(self) -> None:
+        """A declared fury tier + anchor surfaces on the combat hub (pre-resolve)."""
+        from world.magic.factories import FuryConfigFactory, FuryTierFactory
+
+        FuryConfigFactory()
+        tier = FuryTierFactory()
+        anchor_sheet = CharacterSheetFactory()
+
+        with patch("world.magic.services.soulfray.get_soulfray_warning", return_value=None):
+            _make_cmd(
+                self.character,
+                f"{self.technique.name} at {self.opponent_name} "
+                f"fury={tier.name} anchor={anchor_sheet.character.db_key}",
+            ).func()
+
+        cmd = _make_combat_cmd(self.character, "")
+        with patch("world.magic.services.soulfray.get_soulfray_warning", return_value=None):
+            cmd.func()
+        out = "\n".join(cmd._captured)
+        self.assertIn("Fury:", out)
+        self.assertIn(str(tier.depth), out)
+        self.assertIn(anchor_sheet.character.db_key, out)
+        self.assertIn("retained", out)  # no Berserk yet → control retained
+        self.assertNotIn("Berserk:", out)

--- a/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
@@ -611,3 +611,19 @@ class CombatCastTelnetE2ETests(TestCase):
         out = "\n".join(cmd._captured)
         self.assertIn("Berserk:", out)
         self.assertIn("active", out)
+
+    def test_combat_hub_outside_combat_shows_anima_only(self) -> None:
+        """Outside any encounter: anima (+ soulfray if present), no fury/Berserk."""
+        # A character with anima but no CombatParticipant / encounter.
+        solo_sheet = CharacterSheetFactory()
+        solo_char = solo_sheet.character
+        CharacterAnimaFactory(character=solo_char, current=7, maximum=10)
+
+        cmd = _make_combat_cmd(solo_char, "")
+        with patch("world.magic.services.soulfray.get_soulfray_warning", return_value=None):
+            cmd.func()
+        out = "\n".join(cmd._captured)
+        self.assertIn("Anima: 7/10", out)
+        self.assertNotIn("Fury:", out)
+        self.assertNotIn("Berserk:", out)
+        self.assertIn("not currently declaring", out)


### PR DESCRIPTION
Closes #1544

## Summary

Enriches the bare `combat` telnet status hub (`CmdCombat._show_status_hub`) with resource/risk visibility so the soulfray-accept and fury-commit decisions are informed.

Read-only enrichment of an existing command — no new models, serializers, enums, constants, or service functions. A new `_render_resource_state(participant, action)` helper assembles four existing reads into display lines:
- **Anima** — `character.anima` (current/maximum), always shown when present; omitted silently when no row exists yet.
- **Soulfray** — `get_soulfray_warning(character)` → stage name, with `|rdeath risk|n` flagged when the stage carries death risk. Always shown when a warning exists.
- **Fury** — the round's `CombatRoundAction.fury_commitment` (depth) + `fury_anchor` (bonded character), shown only inside an active round when fury was committed this round.
- **Berserk** — active `ConditionInstance` (looked up by name `Berserk`, a catalog key — not a behavioral constant), shown only inside an active round; control word (lost/retained) derives from its presence.

Fury/Berserk are suppressed when there's no active participant (outside an encounter). Query hygiene: the `CombatRoundAction` read uses `select_related(`fury_commitment`, `fury_anchor__character`)`; the Berserk `ConditionInstance` is fetched once and reused for both the control word and the active line.

The shared `build_resource_readout` service is the natural scope of the unbuilt web sibling #1543 (YAGNI until a second caller exists); not filed as a follow-up.

E2E coverage: 4 new tests in `test_combat_cast_telnet_e2e.py` driving the real `cast`/`combat` commands — anima+omit-absent, soulfray stage + death risk, committed fury, berserk-after-lost-control (`@tag(`postgres`)` — apply_condition uses PG-only `DISTINCT ON`), plus not-in-combat (anima-only). 11/11 green on the SQLite fast tier; the PG-tagged Berserk test runs on CI's Postgres shard.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1544 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (branch was local-only); no conflicts. Main brought in parallel CLAUDE.md additions (ritual_adapters, setstage, weather) — folded in.

<!-- last-addressed-comment: 0 -->