### PR TITLE
Combat declaration panel: surface soulfray-accept + fury controls (web)

### DIFF
--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -986,8 +986,11 @@ integration test suite.
   declaration via the existing `accept soulfray` / `decline soulfray` offer flow (declining is
   free re-declare; an unconfirmed risky cast is a clean no-op — AFK-safe, ADR-0004). Telnet
   `cast … fury=<tier> anchor=<name>` parses through to the same dispatch seam the web uses.
-- **Frontend / web UI** — the backend is complete; the declaration panel and round-by-round
-  clash visibility UI is a follow-up (incl. the combat-panel soulfray-accept + fury controls).
+- **Combat declaration web panel** — **DONE** (#1543): the `YourTurn` panel surfaces the
+  Soulfray-risk accept gate and Fury tier + bonded-anchor pickers, merging
+  `confirm_soulfray_risk`, `fury_commitment_id`, and `fury_anchor_id` into the existing
+  dispatch kwargs on the shared `ActionRef` seam from #1454; the write path is unchanged
+  (only read-side descriptor enrichment + frontend wiring).
 
 ### Shared Future Work (combat-adjacent)
 - **Encounter scaling / GM tooling** — difficulty from story context + party composition, encounter builder

--- a/frontend/src/combat/__tests__/YourTurn.test.tsx
+++ b/frontend/src/combat/__tests__/YourTurn.test.tsx
@@ -291,6 +291,23 @@ function makePlayerAction(clashId: number | null, displayName: string): PlayerAc
   };
 }
 
+/** Focused combat-cast PlayerAction fixture with Soulfray + Fury descriptor fields (#1543). */
+function makeCastPlayerAction(
+  techniqueId: number,
+  displayName: string,
+  overrides: Partial<PlayerAction> = {}
+): PlayerAction {
+  const base = makePlayerAction(null, displayName);
+  return {
+    ...base,
+    ref: { ...base.ref, technique_id: techniqueId },
+    soulfray_warning: null,
+    available_fury_tiers: [],
+    eligible_fury_anchors: [],
+    ...overrides,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -1334,5 +1351,189 @@ describe('YourTurn — combat pull dispatch kwargs (issue-1455)', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('selected-pull-summary')).not.toBeInTheDocument();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task 7 (issue-1543) — Soulfray + Fury declaration wiring
+// ---------------------------------------------------------------------------
+
+describe('YourTurn — soulfray and fury declaration wiring (issue-1543)', () => {
+  const warning = {
+    stage_name: 'Perilous Cast',
+    stage_description: 'This cast risks Soulfray.',
+    has_death_risk: true,
+  };
+
+  const furyTiers = [
+    {
+      id: 10,
+      name: 'Spark',
+      depth: 1,
+      control_penalty: 1,
+      intensity_bonus: 1,
+      berserk_severity: 0,
+    },
+    {
+      id: 11,
+      name: 'Blaze',
+      depth: 3,
+      control_penalty: 2,
+      intensity_bonus: 3,
+      berserk_severity: 1,
+    },
+  ];
+
+  const furyAnchors = [
+    { id: 20, name: 'Keth', provocation_cap: 2 },
+    { id: 21, name: 'Lira', provocation_cap: 5 },
+  ];
+
+  it('sends confirm_soulfray_risk when warning is present and accepted', async () => {
+    setupMocks();
+    const cast = makeCastPlayerAction(7, 'Doom Touch', { soulfray_warning: warning });
+
+    mockActionDeclarationCard.mockImplementation(({ actionContext, onContextChange, readOnly }) => {
+      const slot = actionContext.slot as string;
+      return (
+        <div data-testid={`action-card-${slot}`} data-readonly={String(readOnly ?? false)}>
+          <button
+            type="button"
+            data-testid={`card-select-technique-${slot}`}
+            onClick={() =>
+              onContextChange({ slot, effort: 'MEDIUM', strainCommitment: 0, techniqueId: 7 })
+            }
+          >
+            select technique
+          </button>
+        </div>
+      );
+    });
+
+    render(<YourTurn {...defaultProps({ availableActions: [cast] })} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('card-select-technique-focused'));
+    expect(screen.getByTestId('soulfray-accept-gate')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('checkbox', { name: /accept the risk/i }));
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ready-badge')).toBeInTheDocument();
+    });
+
+    const calls = mockMutateAsync.mock.calls as Array<[{ kwargs: Record<string, unknown> }]>;
+    expect(calls[0][0].kwargs).toMatchObject({
+      effort_level: 'medium',
+      confirm_soulfray_risk: true,
+    });
+
+    mockActionDeclarationCard.mockImplementation(defaultCardImpl);
+  });
+
+  it('does not send fury kwargs when no fury is chosen', async () => {
+    setupMocks();
+    const cast = makeCastPlayerAction(8, 'Fury Cast', {
+      soulfray_warning: null,
+      available_fury_tiers: furyTiers,
+      eligible_fury_anchors: furyAnchors,
+    });
+
+    mockActionDeclarationCard.mockImplementation(({ actionContext, onContextChange, readOnly }) => {
+      const slot = actionContext.slot as string;
+      return (
+        <div data-testid={`action-card-${slot}`} data-readonly={String(readOnly ?? false)}>
+          <button
+            type="button"
+            data-testid={`card-select-technique-${slot}`}
+            onClick={() =>
+              onContextChange({ slot, effort: 'MEDIUM', strainCommitment: 0, techniqueId: 8 })
+            }
+          >
+            select technique
+          </button>
+        </div>
+      );
+    });
+
+    render(<YourTurn {...defaultProps({ availableActions: [cast] })} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('card-select-technique-focused'));
+    expect(screen.getByTestId('fury-declaration')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ready-badge')).toBeInTheDocument();
+    });
+
+    const calls = mockMutateAsync.mock.calls as Array<[{ kwargs: Record<string, unknown> }]>;
+    expect(calls[0][0].kwargs).toMatchObject({ effort_level: 'medium' });
+    expect(calls[0][0].kwargs).not.toHaveProperty('fury_commitment_id');
+    expect(calls[0][0].kwargs).not.toHaveProperty('fury_anchor_id');
+
+    mockActionDeclarationCard.mockImplementation(defaultCardImpl);
+  });
+
+  it('sends fury_commitment_id + fury_anchor_id when fury is chosen within cap', async () => {
+    setupMocks();
+    const cast = makeCastPlayerAction(9, 'Fury Cast', {
+      soulfray_warning: null,
+      available_fury_tiers: furyTiers,
+      eligible_fury_anchors: furyAnchors,
+    });
+
+    mockActionDeclarationCard.mockImplementation(({ actionContext, onContextChange, readOnly }) => {
+      const slot = actionContext.slot as string;
+      return (
+        <div data-testid={`action-card-${slot}`} data-readonly={String(readOnly ?? false)}>
+          <button
+            type="button"
+            data-testid={`card-select-technique-${slot}`}
+            onClick={() =>
+              onContextChange({ slot, effort: 'MEDIUM', strainCommitment: 0, techniqueId: 9 })
+            }
+          >
+            select technique
+          </button>
+        </div>
+      );
+    });
+
+    render(<YourTurn {...defaultProps({ availableActions: [cast] })} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('card-select-technique-focused'));
+
+    // Pick tier Spark (depth 1) and anchor Keth (cap 2) — within cap.
+    const tierTrigger = screen.getByTestId('fury-tier-select');
+    await userEvent.click(tierTrigger);
+    const tierOption = await screen.findByText('Spark (depth 1)');
+    await userEvent.click(tierOption);
+
+    const anchorTrigger = screen.getByTestId('fury-anchor-select');
+    await userEvent.click(anchorTrigger);
+    const anchorOption = await screen.findByText('Keth (cap 2)');
+    await userEvent.click(anchorOption);
+
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ready-badge')).toBeInTheDocument();
+    });
+
+    const calls = mockMutateAsync.mock.calls as Array<[{ kwargs: Record<string, unknown> }]>;
+    expect(calls[0][0].kwargs).toMatchObject({
+      effort_level: 'medium',
+      fury_commitment_id: 10,
+      fury_anchor_id: 20,
+    });
+
+    mockActionDeclarationCard.mockImplementation(defaultCardImpl);
   });
 });

--- a/frontend/src/combat/components/FuryDeclaration.test.tsx
+++ b/frontend/src/combat/components/FuryDeclaration.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { FuryDeclaration } from './FuryDeclaration';
 

--- a/frontend/src/combat/components/FuryDeclaration.test.tsx
+++ b/frontend/src/combat/components/FuryDeclaration.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FuryDeclaration } from './FuryDeclaration';
+
+const tiers = [
+  {
+    id: 1,
+    name: 'Simmering',
+    depth: 1,
+    control_penalty: 1,
+    intensity_bonus: 2,
+    berserk_severity: 0,
+  },
+  {
+    id: 2,
+    name: 'Unleashed',
+    depth: 2,
+    control_penalty: 4,
+    intensity_bonus: 5,
+    berserk_severity: 3,
+  },
+];
+const anchors = [
+  { id: 7, name: 'Rival', provocation_cap: 1 },
+  { id: 8, name: 'Mentor', provocation_cap: 3 },
+];
+
+describe('FuryDeclaration', () => {
+  it('renders tier and anchor selects', () => {
+    render(
+      <FuryDeclaration
+        tiers={tiers}
+        anchors={anchors}
+        tierId={null}
+        anchorId={null}
+        onTierChange={() => {}}
+        onAnchorChange={() => {}}
+      />
+    );
+    expect(screen.getByTestId('fury-tier-select')).toBeInTheDocument();
+    expect(screen.getByTestId('fury-anchor-select')).toBeInTheDocument();
+  });
+
+  it('shows an over-cap warning when the chosen tier exceeds the anchor cap', () => {
+    render(
+      <FuryDeclaration
+        tiers={tiers}
+        anchors={anchors}
+        tierId={2} // depth 2
+        anchorId={7} // cap 1
+        onTierChange={() => {}}
+        onAnchorChange={() => {}}
+      />
+    );
+    expect(screen.getByTestId('fury-over-cap-warning')).toBeInTheDocument();
+  });
+
+  it('shows no over-cap warning when within cap', () => {
+    render(
+      <FuryDeclaration
+        tiers={tiers}
+        anchors={anchors}
+        tierId={2} // depth 2
+        anchorId={8} // cap 3
+        onTierChange={() => {}}
+        onAnchorChange={() => {}}
+      />
+    );
+    expect(screen.queryByTestId('fury-over-cap-warning')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/combat/components/FuryDeclaration.tsx
+++ b/frontend/src/combat/components/FuryDeclaration.tsx
@@ -1,0 +1,93 @@
+/**
+ * FuryDeclaration — tier + bonded-anchor pickers for a combat cast (#1543).
+ * Shown by YourTurn only when the focused slot is a cast. Holds no state (state
+ * lives in YourTurn, threaded via callbacks — mirrors selectedPull/strainByClash).
+ * When both are cleared, YourTurn sends no fury kwargs.
+ */
+import type { FuryTierOption, FuryAnchorOption } from '@/scenes/actionTypes';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface FuryDeclarationProps {
+  tiers: FuryTierOption[];
+  anchors: FuryAnchorOption[];
+  tierId: number | null;
+  anchorId: number | null;
+  onTierChange: (id: number | null) => void;
+  onAnchorChange: (id: number | null) => void;
+  disabled?: boolean;
+}
+
+export function FuryDeclaration({
+  tiers,
+  anchors,
+  tierId,
+  anchorId,
+  onTierChange,
+  onAnchorChange,
+  disabled = false,
+}: FuryDeclarationProps) {
+  const selectedTier = tiers.find((t) => t.id === tierId) ?? null;
+  const selectedAnchor = anchors.find((a) => a.id === anchorId) ?? null;
+  const overCap =
+    selectedTier !== null &&
+    selectedAnchor !== null &&
+    selectedTier.depth > selectedAnchor.provocation_cap;
+
+  return (
+    <div
+      className="space-y-2 rounded border border-border bg-card/60 p-2"
+      data-testid="fury-declaration"
+    >
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Fury</p>
+      <div className="space-y-1.5">
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Tier</span>
+        <Select
+          value={tierId !== null ? String(tierId) : ''}
+          onValueChange={(v) => onTierChange(v === '' ? null : Number(v))}
+          disabled={disabled}
+        >
+          <SelectTrigger data-testid="fury-tier-select" className="h-8 text-xs">
+            <SelectValue placeholder="No fury" />
+          </SelectTrigger>
+          <SelectContent>
+            {tiers.map((t) => (
+              <SelectItem key={t.id} value={String(t.id)} className="text-xs">
+                {t.name} (depth {t.depth})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-1.5">
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Anchor</span>
+        <Select
+          value={anchorId !== null ? String(anchorId) : ''}
+          onValueChange={(v) => onAnchorChange(v === '' ? null : Number(v))}
+          disabled={disabled || tierId === null}
+        >
+          <SelectTrigger data-testid="fury-anchor-select" className="h-8 text-xs">
+            <SelectValue placeholder="Bonded anchor" />
+          </SelectTrigger>
+          <SelectContent>
+            {anchors.map((a) => (
+              <SelectItem key={a.id} value={String(a.id)} className="text-xs">
+                {a.name} (cap {a.provocation_cap})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {overCap && (
+        <p className="text-[10px] text-destructive" data-testid="fury-over-cap-warning">
+          Fury tier exceeds your bond with {selectedAnchor?.name}.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/combat/components/SoulfrayAcceptGate.test.tsx
+++ b/frontend/src/combat/components/SoulfrayAcceptGate.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SoulfrayAcceptGate } from './SoulfrayAcceptGate';
+
+const warning = {
+  stage_name: 'Fractured',
+  stage_description: 'Your soul strains.',
+  has_death_risk: false,
+};
+
+describe('SoulfrayAcceptGate', () => {
+  it('renders the warning prose and stage name', () => {
+    render(
+      <SoulfrayAcceptGate
+        warning={warning}
+        techniqueName="Firebolt"
+        animaCost={3}
+        accepted={false}
+        onAcceptChange={() => {}}
+      />
+    );
+    expect(screen.getByText(/Fractured/)).toBeInTheDocument();
+    expect(screen.getByText(/Firebolt/)).toBeInTheDocument();
+  });
+
+  it('disables submit intent until accepted', () => {
+    const onChange = vi.fn();
+    render(
+      <SoulfrayAcceptGate
+        warning={warning}
+        techniqueName="Firebolt"
+        animaCost={3}
+        accepted={false}
+        onAcceptChange={onChange}
+      />
+    );
+    const checkbox = screen.getByRole('checkbox', { name: /accept the risk/i });
+    fireEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('uses red styling when has_death_risk', () => {
+    render(
+      <SoulfrayAcceptGate
+        warning={{ ...warning, has_death_risk: true }}
+        techniqueName="Firebolt"
+        animaCost={3}
+        accepted={false}
+        onAcceptChange={() => {}}
+      />
+    );
+    const gate = screen.getByTestId('soulfray-accept-gate');
+    expect(gate.className).toContain('red');
+  });
+});

--- a/frontend/src/combat/components/SoulfrayAcceptGate.tsx
+++ b/frontend/src/combat/components/SoulfrayAcceptGate.tsx
@@ -1,0 +1,64 @@
+/**
+ * SoulfrayAcceptGate — inline accept gate for a combat cast that carries a
+ * Soulfray warning (#1543). Renders the warning prose (reusing the same
+ * SoulfrayWarningData shape + danger styling as <SoulfrayWarning>) plus an
+ * "Accept the risk" toggle whose state lives in YourTurn until submit.
+ *
+ * Distinct from scenes' <SoulfrayWarning>, which is a momentary
+ * Cancel/Proceed block; combat needs a persistent accept that holds with the
+ * rest of the declaration state.
+ */
+import type { SoulfrayWarningData } from '@/scenes/actionTypes';
+import { cn } from '@/lib/utils';
+
+interface SoulfrayAcceptGateProps {
+  warning: SoulfrayWarningData;
+  techniqueName: string;
+  animaCost: number;
+  accepted: boolean;
+  onAcceptChange: (v: boolean) => void;
+  disabled?: boolean;
+}
+
+export function SoulfrayAcceptGate({
+  warning,
+  techniqueName,
+  animaCost,
+  accepted,
+  onAcceptChange,
+  disabled = false,
+}: SoulfrayAcceptGateProps) {
+  const isDangerous = warning.has_death_risk;
+
+  return (
+    <div
+      data-testid="soulfray-accept-gate"
+      className={cn(
+        'rounded-lg border p-3',
+        isDangerous ? 'border-red-500 bg-red-950/50' : 'border-amber-500 bg-amber-950/50'
+      )}
+    >
+      <h3 className={cn('mb-1 text-sm font-bold', isDangerous ? 'text-red-400' : 'text-amber-400')}>
+        {isDangerous ? 'DANGER: ' : ''}Soulfray Warning — {warning.stage_name}
+      </h3>
+      <p className="mb-1 text-xs text-gray-300">{warning.stage_description}</p>
+      <p className="mb-2 text-xs text-gray-400">
+        Casting <strong>{techniqueName}</strong> will cost <strong>{animaCost} anima</strong> and
+        may worsen your condition.
+      </p>
+      <label className="flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          role="checkbox"
+          aria-label="Accept the risk"
+          checked={accepted}
+          disabled={disabled}
+          onChange={(e) => onAcceptChange(e.target.checked)}
+          data-testid="soulfray-accept-checkbox"
+          className="accent-amber-500"
+        />
+        Accept the risk
+      </label>
+    </div>
+  );
+}

--- a/frontend/src/combat/sections/YourTurn.tsx
+++ b/frontend/src/combat/sections/YourTurn.tsx
@@ -16,8 +16,10 @@ import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { ActionDeclarationCard } from '@/actions/ActionDeclarationCard';
 import type { ActionContext, ActionSlot, EffortLevel, TargetOption } from '@/actions/types';
-import type { PlayerAction } from '@/scenes/actionTypes';
+import type { PlayerAction, SoulfrayWarningData } from '@/scenes/actionTypes';
 import { MovementActions } from '../components/MovementActions';
+import { SoulfrayAcceptGate } from '../components/SoulfrayAcceptGate';
+import { FuryDeclaration } from '../components/FuryDeclaration';
 import { ThreadPullDialog, type PullSelection } from '@/magic/components/threads/ThreadPullDialog';
 import {
   Select,
@@ -144,7 +146,11 @@ function buildFocusedJob(
   focusedContext: ActionContext,
   effortLevel: string,
   dispatchAction: DispatchFn,
-  selectedPull: PullSelection | null
+  selectedPull: PullSelection | null,
+  soulfrayAccepted: boolean,
+  soulfrayWarning: SoulfrayWarningData | null,
+  furyTierId: number | null,
+  furyAnchorId: number | null
 ): DispatchJob | null {
   if (focusedContext.techniqueId === undefined) return null;
 
@@ -164,6 +170,12 @@ function buildFocusedJob(
     pullKwargs.pull_thread_ids = selectedPull.thread_ids;
   }
 
+  const furyKwargs: Record<string, number> = {};
+  if (furyTierId !== null) furyKwargs.fury_commitment_id = furyTierId;
+  if (furyAnchorId !== null) furyKwargs.fury_anchor_id = furyAnchorId;
+  const soulfrayKwarg =
+    soulfrayWarning !== null && soulfrayAccepted ? { confirm_soulfray_risk: true } : {};
+
   return () =>
     dispatchAction({
       ref: {
@@ -171,7 +183,13 @@ function buildFocusedJob(
         technique_id: focusedContext.techniqueId ?? null,
         action_slot: 'focused',
       },
-      kwargs: { effort_level: effortLevel, ...targetKwargs, ...pullKwargs },
+      kwargs: {
+        effort_level: effortLevel,
+        ...targetKwargs,
+        ...pullKwargs,
+        ...soulfrayKwarg,
+        ...furyKwargs,
+      },
     });
 }
 
@@ -399,6 +417,11 @@ export function YourTurn({
   // ThreadPullDialog. Sent in kwargs of the focused/clash dispatch on submit.
   const [selectedPull, setSelectedPull] = useState<PullSelection | null>(null);
 
+  // Soulfray + fury declaration state for combat-cast focused actions (#1543).
+  const [soulfrayAccepted, setSoulfrayAccepted] = useState(false);
+  const [furyTierId, setFuryTierId] = useState<number | null>(null);
+  const [furyAnchorId, setFuryAnchorId] = useState<number | null>(null);
+
   // Cover picker state — selected ally participant PK (string for Select compatibility).
   const [coverAllyId, setCoverAllyId] = useState<string>('');
   const [maneuverError, setManeuverError] = useState<string | null>(null);
@@ -408,6 +431,9 @@ export function YourTurn({
     setSubmitted(false);
     setPullDialogOpen(false);
     setSelectedPull(null);
+    setSoulfrayAccepted(false);
+    setFuryTierId(null);
+    setFuryAnchorId(null);
     setCoverAllyId('');
     setManeuverError(null);
   }, [roundNumber]);
@@ -522,6 +548,20 @@ export function YourTurn({
     return selected?.reach ?? null;
   })();
 
+  // Soulfray + fury descriptor for the currently selected focused cast (#1543).
+  const focusedCastDescriptor = (() => {
+    if (focusedContext.techniqueId === undefined) return null;
+    return availableActions.find((a) => a.ref.technique_id === focusedContext.techniqueId) ?? null;
+  })();
+  const soulfrayWarning = focusedCastDescriptor?.soulfray_warning ?? null;
+  const furyTiers = focusedCastDescriptor?.available_fury_tiers ?? [];
+  const furyAnchors = focusedCastDescriptor?.eligible_fury_anchors ?? [];
+  const furyOverCap =
+    furyTierId !== null &&
+    furyAnchorId !== null &&
+    (furyTiers.find((t) => t.id === furyTierId)?.depth ?? 0) >
+      (furyAnchors.find((a) => a.id === furyAnchorId)?.provocation_cap ?? 0);
+
   // Current declared maneuver (from own round action).
   const declaredManeuver = ownRoundAction?.maneuver ?? null;
 
@@ -548,6 +588,15 @@ export function YourTurn({
 
     setSubmitError(null);
 
+    if (soulfrayWarning !== null && !soulfrayAccepted) {
+      setSubmitError('Accept the Soulfray risk to proceed.');
+      return;
+    }
+    if (furyOverCap) {
+      setSubmitError('Chosen fury tier exceeds your bond with the anchor.');
+      return;
+    }
+
     // The round effort comes from the focused slot and applies to every
     // declaration (focused + passives). The COMBAT dispatch requires
     // effort_level in kwargs on every ref or it rejects (UNKNOWN_ACTION_REF).
@@ -557,7 +606,16 @@ export function YourTurn({
     // (focused first guarantees the server sees focused before passives).
     // selectedPull (if any) rides on focused and clash kwargs — the backend
     // commits a CombatPull when those kwargs are present.
-    const focusedJob = buildFocusedJob(focusedContext, effortLevel, dispatchAction, selectedPull);
+    const focusedJob = buildFocusedJob(
+      focusedContext,
+      effortLevel,
+      dispatchAction,
+      selectedPull,
+      soulfrayAccepted,
+      soulfrayWarning,
+      furyTierId,
+      furyAnchorId
+    );
     const passiveJobs = buildPassiveJobs(
       visiblePassiveSlots,
       passiveContexts,
@@ -653,6 +711,27 @@ export function YourTurn({
           actorPositionId={actorPositionId}
           positionAdjacency={encounter?.position_adjacency ?? []}
         />
+        {soulfrayWarning !== null && (
+          <SoulfrayAcceptGate
+            warning={soulfrayWarning}
+            techniqueName={focusedCastDescriptor?.display_name ?? 'Cast'}
+            animaCost={0}
+            accepted={soulfrayAccepted}
+            onAcceptChange={setSoulfrayAccepted}
+            disabled={isLocked}
+          />
+        )}
+        {furyTiers.length > 0 && (
+          <FuryDeclaration
+            tiers={furyTiers}
+            anchors={furyAnchors}
+            tierId={furyTierId}
+            anchorId={furyAnchorId}
+            onTierChange={setFuryTierId}
+            onAnchorChange={setFuryAnchorId}
+            disabled={isLocked}
+          />
+        )}
       </div>
 
       {/* Clash contribution subsection — shown when clash actions are available */}
@@ -878,7 +957,12 @@ export function YourTurn({
       {/* Submit declarations button */}
       <button
         type="button"
-        disabled={isLocked || dispatchPending}
+        disabled={
+          isLocked ||
+          dispatchPending ||
+          (soulfrayWarning !== null && !soulfrayAccepted) ||
+          furyOverCap
+        }
         onClick={() => {
           handleSubmit().catch(() => {});
         }}

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -13954,6 +13954,12 @@ export interface components {
       status: string;
       event_id: number;
     };
+    /** @description Read-only representation of one eligible bonded fury anchor (#1543). */
+    AnchorOption: {
+      readonly id: number;
+      readonly name: string;
+      readonly provocation_cap: number;
+    };
     /**
      * @description Request serializer for POST /api/magic/applicable-pulls/.
      *
@@ -17129,6 +17135,15 @@ export interface components {
      * @enum {string}
      */
     FormTypeEnum: 'true' | 'alternate' | 'disguise';
+    /** @description Read-only representation of one selectable FuryTier (#1543). */
+    FuryTierOption: {
+      readonly id: number;
+      readonly name: string;
+      readonly depth: number;
+      readonly control_penalty: number;
+      readonly intensity_bonus: number;
+      readonly berserk_severity: number;
+    };
     /** @description For players submitting a GM application. */
     GMApplicationCreate: {
       application_text: string;
@@ -22721,6 +22736,9 @@ export interface components {
         | (components['schemas']['ActionCategoryEnum'] | components['schemas']['NullEnum'])
         | null;
       readonly reach: string | null;
+      readonly soulfray_warning: components['schemas']['SoulfrayWarning'] | null;
+      readonly available_fury_tiers: components['schemas']['FuryTierOption'][];
+      readonly eligible_fury_anchors: components['schemas']['AnchorOption'][];
     };
     /**
      * @description Write serializer - player creates feedback.

--- a/frontend/src/scenes/actionTypes.ts
+++ b/frontend/src/scenes/actionTypes.ts
@@ -75,6 +75,31 @@ export interface AvailableEnhancement {
   soulfray_warning: SoulfrayWarningData | null;
 }
 
+/**
+ * A fury tier the player may commit for a combat-cast technique (#1543).
+ * Mirrors the backend FuryTierOption serializer shape.
+ */
+export interface FuryTierOption {
+  id: number;
+  name: string;
+  depth: number;
+  control_penalty: number;
+  intensity_bonus: number;
+  /** 0 → never berserk; higher values increase berserk severity on overcommit. */
+  berserk_severity: number;
+}
+
+/**
+ * A bond/anchor eligible to cap fury commitment for a combat-cast technique (#1543).
+ * Mirrors the backend AnchorOption serializer shape.
+ */
+export interface FuryAnchorOption {
+  id: number;
+  name: string;
+  /** Pre-computed bond cap used for client-side tier gating. */
+  provocation_cap: number;
+}
+
 export type ActionCategory = 'physical' | 'social' | 'mental';
 
 export interface PlayerAction {
@@ -98,6 +123,15 @@ export interface PlayerAction {
    * null / "any" → no restriction; "same" → must share a position; "adjacent" → same or neighbouring.
    */
   reach?: string | null;
+  /**
+   * Soulfray warning for combat-cast techniques that risk death (#1543).
+   * null / absent → no death-risk warning applies.
+   */
+  soulfray_warning?: SoulfrayWarningData | null;
+  /** Available fury commitment tiers for combat-cast techniques (#1543). */
+  available_fury_tiers?: FuryTierOption[];
+  /** Eligible fury anchors (bonds) that can cap fury commitment (#1543). */
+  eligible_fury_anchors?: FuryAnchorOption[];
 }
 
 export interface PlayerActionsResponse {

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -489,6 +489,10 @@ def _combat_actions(
     from world.magic.services.soulfray import get_soulfray_warning  # noqa: PLC0415
     from world.relationships.models import CharacterRelationship  # noqa: PLC0415
 
+    grants = list(grants)
+    if not grants:
+        return []
+
     fury_tiers = tuple(
         FuryTierOption(
             id=t.pk,
@@ -501,6 +505,18 @@ def _combat_actions(
         for t in FuryTier.objects.order_by("depth")
     )
     soulfray_warning = get_soulfray_warning(character)
+    anchors: list[AnchorOption] = []
+    for rel in CharacterRelationship.objects.filter(
+        source=sheet, is_active=True, is_pending=False
+    ).select_related("target", "target__character"):
+        anchor_sheet = rel.target
+        cap = provocation_cap(character, anchor_sheet)
+        if cap < 1:
+            continue
+        anchor_char = anchor_sheet.character
+        name = anchor_char.key if anchor_char is not None else str(anchor_sheet)
+        anchors.append(AnchorOption(id=anchor_sheet.pk, name=name, provocation_cap=cap))
+    eligible_fury_anchors = tuple(anchors)
 
     result: list[PlayerAction] = []
     for grant in grants:
@@ -513,17 +529,6 @@ def _combat_actions(
             backend=ActionBackend.COMBAT,
             technique_id=technique.pk,
         )
-        anchors: list[AnchorOption] = []
-        for rel in CharacterRelationship.objects.filter(
-            source=sheet, is_active=True, is_pending=False
-        ).select_related("target", "target__character"):
-            anchor_sheet = rel.target
-            cap = provocation_cap(character, anchor_sheet)
-            if cap < 1:
-                continue
-            anchor_char = anchor_sheet.character
-            name = anchor_char.key if anchor_char is not None else str(anchor_sheet)
-            anchors.append(AnchorOption(id=anchor_sheet.pk, name=name, provocation_cap=cap))
         result.append(
             PlayerAction(
                 backend=ActionBackend.COMBAT,
@@ -535,7 +540,7 @@ def _combat_actions(
                 reach=technique.reach,
                 soulfray_warning=soulfray_warning,
                 available_fury_tiers=fury_tiers,
-                eligible_fury_anchors=tuple(anchors),
+                eligible_fury_anchors=eligible_fury_anchors,
             )
         )
 

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -48,7 +48,9 @@ from actions.round_context import RoundContext, get_active_round_context
 from actions.types import (
     ActionRef,
     ActionResult,
+    AnchorOption,
     DispatchResult,
+    FuryTierOption,
     PlayerAction,
     StrainAvailability,
     TargetFilters,
@@ -476,9 +478,29 @@ def _combat_actions(
     # currently perform (dead, or any unmet capability requirement). Combat
     # techniques per character are bounded (a handful), so a clear per-technique
     # loop is acceptable for v1 — no batching needed.
+    # Soulfray + fury declaration context (#1543). One soulfray lookup per
+    # character; fury tiers are a small authored catalog; anchors are the
+    # caster's consented relationships with a non-zero bond.
+    from world.magic.models import FuryTier  # noqa: PLC0415
     from world.magic.services.capability_requirements import (  # noqa: PLC0415
         technique_performable,
     )
+    from world.magic.services.fury import provocation_cap  # noqa: PLC0415
+    from world.magic.services.soulfray import get_soulfray_warning  # noqa: PLC0415
+    from world.relationships.models import CharacterRelationship  # noqa: PLC0415
+
+    fury_tiers = tuple(
+        FuryTierOption(
+            id=t.pk,
+            name=t.name,
+            depth=t.depth,
+            control_penalty=t.control_penalty,
+            intensity_bonus=t.intensity_bonus,
+            berserk_severity=t.berserk_severity,
+        )
+        for t in FuryTier.objects.order_by("depth")
+    )
+    soulfray_warning = get_soulfray_warning(character)
 
     result: list[PlayerAction] = []
     for grant in grants:
@@ -491,6 +513,17 @@ def _combat_actions(
             backend=ActionBackend.COMBAT,
             technique_id=technique.pk,
         )
+        anchors: list[AnchorOption] = []
+        for rel in CharacterRelationship.objects.filter(
+            source=sheet, is_active=True, is_pending=False
+        ).select_related("target", "target__character"):
+            anchor_sheet = rel.target
+            cap = provocation_cap(character, anchor_sheet)
+            if cap < 1:
+                continue
+            anchor_char = anchor_sheet.character
+            name = anchor_char.key if anchor_char is not None else str(anchor_sheet)
+            anchors.append(AnchorOption(id=anchor_sheet.pk, name=name, provocation_cap=cap))
         result.append(
             PlayerAction(
                 backend=ActionBackend.COMBAT,
@@ -500,6 +533,9 @@ def _combat_actions(
                 action_template=template,
                 action_category=technique.action_category,
                 reach=technique.reach,
+                soulfray_warning=soulfray_warning,
+                available_fury_tiers=fury_tiers,
+                eligible_fury_anchors=tuple(anchors),
             )
         )
 

--- a/src/actions/serializers.py
+++ b/src/actions/serializers.py
@@ -77,6 +77,25 @@ class SoulfrayWarningSerializer(serializers.Serializer):
     has_death_risk = serializers.BooleanField(read_only=True)
 
 
+class FuryTierOptionSerializer(serializers.Serializer):
+    """Read-only representation of one selectable FuryTier (#1543)."""
+
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    depth = serializers.IntegerField(read_only=True)
+    control_penalty = serializers.IntegerField(read_only=True)
+    intensity_bonus = serializers.IntegerField(read_only=True)
+    berserk_severity = serializers.IntegerField(read_only=True)
+
+
+class AnchorOptionSerializer(serializers.Serializer):
+    """Read-only representation of one eligible bonded fury anchor (#1543)."""
+
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    provocation_cap = serializers.IntegerField(read_only=True)
+
+
 class AvailableEnhancementSerializer(serializers.Serializer):
     """Read-only serializer for AvailableEnhancement (technique enhancement option)."""
 
@@ -133,6 +152,9 @@ class PlayerActionSerializer(serializers.Serializer):
         choices=ActionCategory.choices, read_only=True, allow_null=True
     )
     reach = serializers.CharField(read_only=True, allow_null=True)
+    soulfray_warning = SoulfrayWarningSerializer(read_only=True, allow_null=True)
+    available_fury_tiers = FuryTierOptionSerializer(many=True, read_only=True)
+    eligible_fury_anchors = AnchorOptionSerializer(many=True, read_only=True)
 
     def get_difficulty(self, obj: PlayerAction) -> str | None:
         """Return the difficulty enum value string, or None."""

--- a/src/actions/tests/test_player_action_descriptor.py
+++ b/src/actions/tests/test_player_action_descriptor.py
@@ -3,6 +3,8 @@ from django.test import TestCase
 from actions.constants import ActionBackend, TargetKind
 from actions.types import (
     ActionRef,
+    AnchorOption,
+    FuryTierOption,
     PlayerAction,
     StrainAvailability,
     TargetFilters,
@@ -53,3 +55,42 @@ class PlayerActionDescriptorTests(TestCase):
         )
         self.assertEqual(action.target_spec.kind, TargetKind.PERSONA)
         self.assertEqual(action.strain.cap, 14)
+
+
+def _base_player_action() -> PlayerAction:
+    return PlayerAction(
+        backend=ActionBackend.COMBAT,
+        display_name="Cast",
+        ref=ActionRef(backend=ActionBackend.COMBAT, technique_id=1),
+    )
+
+
+class TestPlayerActionFurySoulfrayDefaults(TestCase):
+    def test_soulfray_warning_defaults_none(self) -> None:
+        assert _base_player_action().soulfray_warning is None
+
+    def test_available_fury_tiers_defaults_empty(self) -> None:
+        assert _base_player_action().available_fury_tiers == ()
+
+    def test_eligible_fury_anchors_defaults_empty(self) -> None:
+        assert _base_player_action().eligible_fury_anchors == ()
+
+    def test_fury_tier_option_is_frozen(self) -> None:
+        opt = FuryTierOption(
+            id=1,
+            name="Unleashed",
+            depth=2,
+            control_penalty=4,
+            intensity_bonus=5,
+            berserk_severity=3,
+        )
+        assert opt.depth == 2
+        try:
+            opt.depth = 9  # type: ignore[misc]
+        except AttributeError:
+            return
+        self.fail("FuryTierOption must be frozen")
+
+    def test_anchor_option_fields(self) -> None:
+        opt = AnchorOption(id=7, name="Rival", provocation_cap=3)
+        assert opt.provocation_cap == 3

--- a/src/actions/tests/test_player_action_descriptor.py
+++ b/src/actions/tests/test_player_action_descriptor.py
@@ -97,6 +97,33 @@ class TestPlayerActionFurySoulfrayDefaults(TestCase):
         assert opt.provocation_cap == 3
 
 
+class TestPlayerActionSerializerFurySoulfray(TestCase):
+    def test_serializer_round_trips_fury_and_soulfray(self) -> None:
+        from actions.serializers import PlayerActionSerializer
+
+        pa = PlayerAction(
+            backend=ActionBackend.COMBAT,
+            display_name="Cast",
+            ref=ActionRef(backend=ActionBackend.COMBAT, technique_id=1),
+            available_fury_tiers=(
+                FuryTierOption(
+                    id=1,
+                    name="Unleashed",
+                    depth=2,
+                    control_penalty=4,
+                    intensity_bonus=5,
+                    berserk_severity=3,
+                ),
+            ),
+            eligible_fury_anchors=(AnchorOption(id=7, name="Rival", provocation_cap=3),),
+        )
+        data = PlayerActionSerializer(pa).data
+        assert data["available_fury_tiers"][0]["depth"] == 2
+        assert data["available_fury_tiers"][0]["berserk_severity"] == 3
+        assert data["eligible_fury_anchors"][0]["provocation_cap"] == 3
+        assert data["soulfray_warning"] is None
+
+
 class TestCombatActionsDescriptorEnrichment(TestCase):
     """_combat_actions populates soulfray_warning + fury fields (#1543)."""
 

--- a/src/actions/tests/test_player_action_descriptor.py
+++ b/src/actions/tests/test_player_action_descriptor.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from actions.constants import ActionBackend, TargetKind
+from actions.player_interface import _combat_actions
 from actions.types import (
     ActionRef,
     AnchorOption,
@@ -94,3 +95,103 @@ class TestPlayerActionFurySoulfrayDefaults(TestCase):
     def test_anchor_option_fields(self) -> None:
         opt = AnchorOption(id=7, name="Rival", provocation_cap=3)
         assert opt.provocation_cap == 3
+
+
+class TestCombatActionsDescriptorEnrichment(TestCase):
+    """_combat_actions populates soulfray_warning + fury fields (#1543)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from actions.factories import ActionTemplateFactory
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.checks.factories import CheckTypeFactory
+        from world.combat.constants import ParticipantStatus
+        from world.combat.factories import CombatEncounterFactory, CombatParticipantFactory
+        from world.magic.factories import (
+            CharacterTechniqueFactory,
+            FuryConfigFactory,
+            FuryTierFactory,
+            TechniqueFactory,
+        )
+        from world.relationships.constants import TrackSign
+        from world.relationships.factories import (
+            CharacterRelationshipFactory,
+            RelationshipTierFactory,
+            RelationshipTrackFactory,
+            RelationshipTrackProgressFactory,
+        )
+        from world.scenes.constants import RoundStatus
+
+        # Active DECLARING encounter with an ACTIVE participant.
+        cls.encounter = CombatEncounterFactory(
+            status=RoundStatus.DECLARING,
+            round_number=1,
+        )
+        cls.participant = CombatParticipantFactory(
+            encounter=cls.encounter,
+            status=ParticipantStatus.ACTIVE,
+        )
+        cls.sheet = cls.participant.character_sheet
+        cls.character = cls.sheet.character
+
+        # Known technique with an action_template (combat-usable).
+        cls.check_type = CheckTypeFactory()
+        cls.template = ActionTemplateFactory(check_type=cls.check_type)
+        cls.technique = TechniqueFactory(
+            damage_profile=False,
+            action_template=cls.template,
+        )
+        CharacterTechniqueFactory(character=cls.sheet, technique=cls.technique)
+
+        # Fury tiers to surface on the descriptor.
+        FuryConfigFactory()
+        cls.tier_smoulder = FuryTierFactory(
+            name="Smouldering",
+            depth=1,
+        )
+        cls.tier_inferno = FuryTierFactory(
+            name="Inferno",
+            depth=3,
+        )
+
+        # A consented relationship at tier 1 so provocation_cap >= 1.
+        cls.anchor_sheet = CharacterSheetFactory()
+        track = RelationshipTrackFactory(sign=TrackSign.POSITIVE)
+        tier_row = RelationshipTierFactory(
+            track=track,
+            tier_number=1,
+            point_threshold=10,
+        )
+        cls.relationship = CharacterRelationshipFactory(
+            source=cls.sheet,
+            target=cls.anchor_sheet,
+            is_active=True,
+            is_pending=False,
+        )
+        RelationshipTrackProgressFactory(
+            relationship=cls.relationship,
+            track=track,
+            developed_points=tier_row.point_threshold,
+            capacity=tier_row.point_threshold,
+        )
+
+    def test_cast_descriptor_carries_fury_tiers(self) -> None:
+        actions = _combat_actions(self.character)
+        cast = next(a for a in actions if a.ref.technique_id == self.technique.pk)
+        self.assertEqual(len(cast.available_fury_tiers), 2)
+        self.assertTrue(all(t.depth is not None for t in cast.available_fury_tiers))
+        self.assertEqual(
+            [t.id for t in cast.available_fury_tiers],
+            [self.tier_smoulder.pk, self.tier_inferno.pk],
+        )
+
+    def test_cast_descriptor_soulfray_warning_none_without_stage(self) -> None:
+        actions = _combat_actions(self.character)
+        cast = next(a for a in actions if a.ref.technique_id == self.technique.pk)
+        self.assertIsNone(cast.soulfray_warning)
+
+    def test_anchors_listed_only_for_nonzero_bond(self) -> None:
+        actions = _combat_actions(self.character)
+        cast = next(a for a in actions if a.ref.technique_id == self.technique.pk)
+        self.assertTrue(any(a.provocation_cap >= 1 for a in cast.eligible_fury_anchors))
+        self.assertTrue(all(a.provocation_cap >= 1 for a in cast.eligible_fury_anchors))

--- a/src/actions/types.py
+++ b/src/actions/types.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from actions.constants import ActionBackend, ActionCategory, CombatActionSlot, TargetKind
+from world.magic.types.techniques import SoulfrayWarning
 from world.mechanics.constants import DifficultyIndicator
 
 if TYPE_CHECKING:
@@ -253,6 +254,12 @@ class PlayerAction:
     # can pre-filter selectable targets by position before declaring.
     reach: str | None = None
 
+    # Soulfray + fury declaration context for combat cast techniques (#1543).
+    # None/empty for non-cast actions; populated by _combat_actions for casts.
+    soulfray_warning: SoulfrayWarning | None = None
+    available_fury_tiers: tuple[FuryTierOption, ...] = ()
+    eligible_fury_anchors: tuple[AnchorOption, ...] = ()
+
 
 class ActionInterrupted(Exception):
     """Raised when a trigger stops an action's intent event."""
@@ -396,3 +403,33 @@ class StrainAvailability:
 
     cap: int
     default: int = 0
+
+
+@dataclass(frozen=True)
+class FuryTierOption:
+    """One selectable Fury tier for the declaration picker (#1543).
+
+    Mirrors the authored ``FuryTier`` fields the player needs to choose.
+    ``id`` is the FuryTier PK sent as ``fury_commitment_id``.
+    """
+
+    id: int
+    name: str
+    depth: int
+    control_penalty: int
+    intensity_bonus: int
+    berserk_severity: int
+
+
+@dataclass(frozen=True)
+class AnchorOption:
+    """One eligible bonded anchor for the fury declaration picker (#1543).
+
+    ``id`` is the anchor CharacterSheet PK sent as ``fury_anchor_id``.
+    ``provocation_cap`` is the bond-derived ceiling pre-computed server-side
+    so the client can gate tiers without a round-trip.
+    """
+
+    id: int
+    name: str
+    provocation_cap: int

--- a/src/schema.json
+++ b/src/schema.json
@@ -23635,6 +23635,23 @@ components:
       required:
       - event_id
       - status
+    AnchorOption:
+      type: object
+      description: Read-only representation of one eligible bonded fury anchor (#1543).
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        provocation_cap:
+          type: integer
+          readOnly: true
+      required:
+      - id
+      - name
+      - provocation_cap
     ApplicablePullsRequestRequest:
       type: object
       description: |-
@@ -30473,6 +30490,35 @@ components:
         * `true` - True Form
         * `alternate` - Alternate Form
         * `disguise` - Disguise
+    FuryTierOption:
+      type: object
+      description: Read-only representation of one selectable FuryTier (#1543).
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        depth:
+          type: integer
+          readOnly: true
+        control_penalty:
+          type: integer
+          readOnly: true
+        intensity_bonus:
+          type: integer
+          readOnly: true
+        berserk_severity:
+          type: integer
+          readOnly: true
+      required:
+      - berserk_severity
+      - control_penalty
+      - depth
+      - id
+      - intensity_bonus
+      - name
     GMApplicationCreate:
       type: object
       description: For players submitting a GM application.
@@ -40695,19 +40741,37 @@ components:
           type: string
           readOnly: true
           nullable: true
+        soulfray_warning:
+          allOf:
+          - $ref: '#/components/schemas/SoulfrayWarning'
+          readOnly: true
+          nullable: true
+        available_fury_tiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/FuryTierOption'
+          readOnly: true
+        eligible_fury_anchors:
+          type: array
+          items:
+            $ref: '#/components/schemas/AnchorOption'
+          readOnly: true
       required:
       - action_category
       - action_template
+      - available_fury_tiers
       - backend
       - check_type
       - description
       - difficulty
       - display_name
+      - eligible_fury_anchors
       - enhancements
       - prerequisite_met
       - prerequisite_reasons
       - reach
       - ref
+      - soulfray_warning
       - strain
       - target_spec
     PlayerFeedbackCreate:


### PR DESCRIPTION
Closes #1543

## Summary

Surfaces the two player decisions #1454 made real — Soulfray-risk acceptance and Fury tier + bonded-anchor commitment — in the web combat declaration panel (`YourTurn`). Both already worked on telnet and reached the backend through the shared `action.run()` dispatch kwargs seam; the web never offered them.

**Approach: read-only descriptor enrichment + frontend wiring. No write-path change.** The three new fields are flat, read-only, self-scoped surfaces on the combat `PlayerAction` descriptor, mirroring the scene `AvailableEnhancement.soulfray_warning` precedent.

**Backend (read path only):**
- `FuryTierOption` + `AnchorOption` frozen dataclasses and three optional `PlayerAction` fields (`soulfray_warning`, `available_fury_tiers`, `eligible_fury_anchors`) in `actions/types.py`.
- `_combat_actions` (`player_interface.py`) populates them — character-scoped queries hoisted out of the per-technique loop (one query each, SharedMemoryModel-cached). Eligible anchors are the caster's own bonded relationships with a non-zero `provocation_cap`, sourced from `get_relationship_tier` (the same read `provocation_cap` uses, so client eligibility and server validation can't diverge).
- `PlayerActionSerializer` gains three read-only fields; `soulfray_warning` reuses the existing `SoulfrayWarningSerializer` verbatim. Regenerated `schema.json` + `frontend/src/generated/api.d.ts`.

**Frontend:**
- `<SoulfrayAcceptGate>` — inline "accept the risk" toggle (reuses the scene `<SoulfrayWarning>` danger styling) shown only when the focused cast carries a warning.
- `<FuryDeclaration>` — tier + anchor pickers built on shadcn `Select` primitives, shown only for a cast focused slot. Owns no state (mirrors `selectedPull`/`strainByClash`).
- `YourTurn` wires both: state reset on round advance; `confirm_soulfray_risk` (only when warning present AND accepted) and `fury_commitment_id`/`fury_anchor_id` (only when set) merged into the focused-slot dispatch kwargs; submit gated on unaccepted warning and tier-over-cap.

**Server stays authoritative** — the frontend gate is advisory (saves round-trips). `_cap_fury_by_provocation` already rejects over-cap / Berserk / missing-anchor; the reactive `_combat_soulfray_gate` remains the safety net. No new server validation, no models, no migrations.

**Tests:** backend descriptor-enrichment + serializer round-trip (734 actions tests pass); frontend kwargs-assembly + component tests (Vitest). `pnpm build` green.

Closes #1543

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1543 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (436b7a2b, incl. #1559 technique-authoring) — no conflicts; no file overlap with this branch. Post-rebase: 734 actions tests pass, pnpm build green, pre-commit full pass.

<!-- last-addressed-comment: 0 -->