### PR TITLE
feat: per-character comfort web surface (#1522)

### DIFF
--- a/frontend/src/comfort/api.ts
+++ b/frontend/src/comfort/api.ts
@@ -1,0 +1,22 @@
+/**
+ * Comfort API client (#1522).
+ *
+ * Plain async fetchers — React Query hooks live in queries.ts. Mirrors the weather/conditions
+ * read pattern, but comfort is personal: a thin GET that returns how uncomfortable the active
+ * character is in their current room, and why.
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+import type { components } from '@/generated/api';
+
+export type CharacterComfort = components['schemas']['CharacterComfort'];
+
+/**
+ * Fetch the per-character comfort readout.
+ * GET /api/locations/comfort/?character_id={characterId}
+ */
+export async function fetchCharacterComfort(characterId: number): Promise<CharacterComfort> {
+  const res = await apiFetch(`/api/locations/comfort/?character_id=${characterId}`);
+  if (!res.ok) throw new Error('Failed to load comfort');
+  return res.json() as Promise<CharacterComfort>;
+}

--- a/frontend/src/comfort/components/ComfortWidget.tsx
+++ b/frontend/src/comfort/components/ComfortWidget.tsx
@@ -1,0 +1,49 @@
+/**
+ * Personal comfort readout (#1522).
+ *
+ * The web face of the `comfort` command: a compact glance at how uncomfortable the active
+ * character is where they stand, and why. Reads the active character id (passed by the top bar)
+ * and queries `/api/locations/comfort/`. Stays silent while the character is comfortable — it
+ * only surfaces when something is biting, so the bar isn't cluttered in a cozy room.
+ */
+
+import { useCharacterComfort } from '../queries';
+
+/** Tailwind text colors per band index (0 = comfortable … 4 = extreme). PLACEHOLDER palette. */
+const BAND_COLORS = [
+  'text-muted-foreground',
+  'text-amber-500',
+  'text-orange-500',
+  'text-orange-600',
+  'text-red-600',
+] as const;
+
+function titleCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+interface ComfortWidgetProps {
+  characterId: number | null;
+}
+
+export function ComfortWidget({ characterId }: ComfortWidgetProps) {
+  const { data } = useCharacterComfort(characterId);
+
+  // No data yet, or the character is comfortable → don't clutter the bar.
+  if (!data || data.band_index <= 0) return null;
+
+  const color = BAND_COLORS[data.band_index] ?? BAND_COLORS[BAND_COLORS.length - 1];
+  const reasons = data.reasons.map(titleCase).join(', ');
+  const tooltip = reasons ? `${data.band} — ${reasons}` : data.band;
+
+  return (
+    <div
+      className={`flex items-center gap-1 text-xs ${color}`}
+      title={tooltip}
+      aria-label="Personal comfort"
+    >
+      <span aria-hidden>🌡</span>
+      <span>{data.band}</span>
+    </div>
+  );
+}

--- a/frontend/src/comfort/queries.ts
+++ b/frontend/src/comfort/queries.ts
@@ -1,0 +1,21 @@
+/**
+ * Comfort React Query hooks (#1522).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchCharacterComfort } from './api';
+
+/**
+ * The active character's personal comfort readout. Disabled until a character is known.
+ * Re-polls each minute so a fresh weather roll (or a change of clothes) stays current.
+ */
+export function useCharacterComfort(characterId: number | null) {
+  return useQuery({
+    queryKey: ['comfort', 'summary', characterId],
+    queryFn: () => fetchCharacterComfort(characterId as number),
+    enabled: characterId != null,
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  });
+}

--- a/frontend/src/game/components/GameTopBar.tsx
+++ b/frontend/src/game/components/GameTopBar.tsx
@@ -4,6 +4,7 @@ import { useGameSocket } from '@/hooks/useGameSocket';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import type { MyRosterEntry } from '@/roster/types';
 import { WeatherWidget } from '@/weather/components/WeatherWidget';
+import { ComfortWidget } from '@/comfort/components/ComfortWidget';
 
 import { PersonaSwitcher } from './PersonaSwitcher';
 
@@ -111,6 +112,7 @@ export function GameTopBar({ characters }: GameTopBarProps) {
         ))}
 
       <div className="ml-auto flex items-center gap-3">
+        <ComfortWidget characterId={activeCharacter?.character_id ?? null} />
         <WeatherWidget />
         <div className="flex items-center gap-2">
           <div className={`h-2 w-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`} />

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -6377,6 +6377,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/locations/comfort/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description GET /summary/?character_id=<id> — how uncomfortable that character is, and why. */
+    get: operations['locations_comfort_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/magic/applicable-pulls/': {
     parameters: {
       query?: never;
@@ -14844,6 +14861,23 @@ export interface components {
       description?: string;
       /** @description Minimum level required to have this class (0-10) */
       minimum_level?: number;
+    };
+    /**
+     * @description Read-only per-character comfort readout (mirrors ``CharacterComfortSummary``).
+     *
+     *     ``felt`` is the per-axis residual exposure (room felt minus the character's mitigation,
+     *     floored), keyed by the lowercased exposure-axis name (``cold``/``heat``/``wet``/…) and
+     *     carrying only the nonzero axes.
+     */
+    CharacterComfort: {
+      band: string;
+      band_index: number;
+      discomfort: number;
+      reasons: string[];
+      injury: number;
+      readonly felt: {
+        [key: string]: number;
+      };
     };
     /**
      * @description Read-only serializer for a character's covenant role assignment.
@@ -34893,6 +34927,28 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+    };
+  };
+  locations_comfort_retrieve: {
+    parameters: {
+      query: {
+        /** @description ObjectDB id of the character to read comfort for (must be your own). */
+        character_id: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CharacterComfort'];
+        };
       };
     };
   };

--- a/src/schema.json
+++ b/src/schema.json
@@ -10079,6 +10079,30 @@ paths:
       responses:
         '200':
           description: No response body
+  /api/locations/comfort/:
+    get:
+      operationId: locations_comfort_retrieve
+      description: GET /summary/?character_id=<id> — how uncomfortable that character
+        is, and why.
+      parameters:
+      - in: query
+        name: character_id
+        schema:
+          type: integer
+        description: ObjectDB id of the character to read comfort for (must be your
+          own).
+        required: true
+      tags:
+      - comfort
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterComfort'
+          description: ''
   /api/magic/applicable-pulls/:
     post:
       operationId: magic_applicable_pulls_create
@@ -25530,6 +25554,39 @@ components:
       required:
       - id
       - name
+    CharacterComfort:
+      type: object
+      description: |-
+        Read-only per-character comfort readout (mirrors ``CharacterComfortSummary``).
+
+        ``felt`` is the per-axis residual exposure (room felt minus the character's mitigation,
+        floored), keyed by the lowercased exposure-axis name (``cold``/``heat``/``wet``/…) and
+        carrying only the nonzero axes.
+      properties:
+        band:
+          type: string
+        band_index:
+          type: integer
+        discomfort:
+          type: integer
+        reasons:
+          type: array
+          items:
+            type: string
+        injury:
+          type: integer
+        felt:
+          type: object
+          additionalProperties:
+            type: integer
+          readOnly: true
+      required:
+      - band
+      - band_index
+      - discomfort
+      - felt
+      - injury
+      - reasons
     CharacterCovenantRole:
       type: object
       description: |-

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path("api/journals/", include("world.journals.urls", namespace="journals")),
     path("api/clock/", include("world.game_clock.urls")),
     path("api/weather/", include("world.weather.urls")),
+    path("api/locations/", include("world.locations.urls")),
     path("api/currency/", include("world.currency.urls")),
     path("api/events/", include("world.events.urls")),
     path("api/combat/", include("world.combat.urls")),

--- a/src/world/locations/CLAUDE.md
+++ b/src/world/locations/CLAUDE.md
@@ -61,6 +61,16 @@ targets (`COMFORT_MITIGATION_TARGET_NAMES`, e.g. `cold_mitigation`), read via `g
 lazily — one-way dependency.) Magnitudes/bands/targets are PLACEHOLDER (seed the targets for
 spells/conditions to write to).
 
+**API + React widget (#1522).** `GET /api/locations/comfort/?character_id=<id>`
+(`world.locations.views.ComfortViewSet`, `CharacterComfortSerializer`) → the `CharacterComfort`
+schema (`band`, `band_index`, `discomfort`, `reasons`, `injury`, `felt` map). Comfort is
+**personal**, so the endpoint only serves a character the requesting account plays
+(`RosterEntry.objects.for_account` tenure gate; unowned/unknown → 404). The frontend
+`ComfortWidget` (`frontend/src/comfort/`) takes the active character id from the `GameTopBar`,
+queries it via React Query, and renders a compact band glance (reasons in the tooltip) **only when
+something is biting** — it stays silent while the character is comfortable, so a cozy room isn't
+cluttered. Mirrors the weather widget's read pattern (`world/weather/CLAUDE.md`).
+
 See `docs/plans/2026-05-09-location-stats-design.md` for the original
 cascade design and `docs/plans/2026-05-14-room-cascade-resonance-unification.md`
 for the resonance axis addition.

--- a/src/world/locations/serializers.py
+++ b/src/world/locations/serializers.py
@@ -1,0 +1,39 @@
+"""Serializers for the locations REST API (#1522).
+
+Currently just the per-character comfort read — "how uncomfortable am I, and why" — the web
+face of the ``comfort`` command, mirroring ``character_comfort.character_comfort_summary``.
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from world.locations.character_comfort import CharacterComfortSummary
+
+
+class ComfortRequestSerializer(serializers.Serializer):
+    """Query-param validation for the comfort read — a required character id.
+
+    ``character_id`` is the character's ObjectDB pk (== CharacterSheet pk by construction).
+    """
+
+    character_id = serializers.IntegerField()
+
+
+class CharacterComfortSerializer(serializers.Serializer):
+    """Read-only per-character comfort readout (mirrors ``CharacterComfortSummary``).
+
+    ``felt`` is the per-axis residual exposure (room felt minus the character's mitigation,
+    floored), keyed by the lowercased exposure-axis name (``cold``/``heat``/``wet``/…) and
+    carrying only the nonzero axes.
+    """
+
+    band = serializers.CharField()
+    band_index = serializers.IntegerField()
+    discomfort = serializers.IntegerField()
+    reasons = serializers.ListField(child=serializers.CharField())
+    injury = serializers.IntegerField()
+    felt = serializers.SerializerMethodField()
+
+    def get_felt(self, obj: CharacterComfortSummary) -> dict[str, int]:
+        return {axis.value: value for axis, value in obj.felt.items()}

--- a/src/world/locations/tests/test_comfort_views.py
+++ b/src/world/locations/tests/test_comfort_views.py
@@ -1,0 +1,80 @@
+"""API tests for GET /api/locations/comfort/ (#1522).
+
+The per-character comfort read is personal: it requires auth and only serves a character the
+requesting account actually plays.
+"""
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory, RoomProfileFactory
+from world.areas.constants import AreaLevel
+from world.areas.factories import AreaFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.locations.constants import LocationParentType, StatKey
+from world.locations.models import LocationValueModifier
+from world.roster.factories import (
+    PlayerDataFactory,
+    RosterEntryFactory,
+    RosterTenureFactory,
+)
+
+COMFORT_URL = "/api/locations/comfort/"
+
+
+class ComfortSummaryApiTest(APITestCase):
+    def setUp(self) -> None:
+        self.user = AccountFactory()
+        self.ward = AreaFactory(level=AreaLevel.WARD)
+        self.room = RoomProfileFactory(area=self.ward).objectdb
+
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        self.character.location = self.room
+        # Wire the account to the character via an active roster tenure so for_account finds it.
+        entry = RosterEntryFactory(character_sheet=self.sheet)
+        RosterTenureFactory(
+            roster_entry=entry,
+            player_data=PlayerDataFactory(account=self.user),
+        )
+
+    def _make_cold(self, cold: int) -> None:
+        LocationValueModifier.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=self.ward,
+            stat_key=StatKey.COLD,
+            value=cold,
+        )
+
+    def test_requires_authentication(self) -> None:
+        response = self.client.get(COMFORT_URL, {"character_id": self.sheet.pk})
+        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+    def test_missing_character_id_is_400(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        assert self.client.get(COMFORT_URL).status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_unowned_character_is_404(self) -> None:
+        other_sheet = CharacterSheetFactory()
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(COMFORT_URL, {"character_id": other_sheet.pk})
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_reports_comfort_band_and_reasons(self) -> None:
+        self._make_cold(50)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(COMFORT_URL, {"character_id": self.sheet.pk})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["discomfort"] == 50
+        assert response.data["band"] == "Moderately uncomfortable"
+        assert response.data["reasons"] == ["cold"]
+        assert response.data["felt"] == {"cold": 50}
+
+    def test_comfortable_character_reports_empty_reasons(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(COMFORT_URL, {"character_id": self.sheet.pk})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["discomfort"] == 0
+        assert response.data["band"] == "Comfortable"
+        assert response.data["reasons"] == []
+        assert response.data["felt"] == {}

--- a/src/world/locations/urls.py
+++ b/src/world/locations/urls.py
@@ -1,0 +1,13 @@
+"""URL configuration for the locations API (#1522)."""
+
+from django.urls import path
+
+from world.locations.views import ComfortViewSet
+
+app_name = "locations"
+
+comfort_summary = ComfortViewSet.as_view({"get": "summary"})
+
+urlpatterns = [
+    path("comfort/", comfort_summary, name="comfort-summary"),
+]

--- a/src/world/locations/views.py
+++ b/src/world/locations/views.py
@@ -1,0 +1,62 @@
+"""API views for the locations system (#1522).
+
+The per-character comfort read: the web face of the ``comfort`` command. Comfort is *personal*
+(it depends on what you're wearing, your wards, and your injuries), so the endpoint only serves
+the requesting account's own characters.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from evennia.accounts.models import AccountDB
+from rest_framework import status, viewsets
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from world.character_sheets.models import CharacterSheet
+from world.locations.character_comfort import character_comfort_summary
+from world.locations.serializers import CharacterComfortSerializer, ComfortRequestSerializer
+from world.roster.models import RosterEntry
+
+
+@extend_schema(tags=["comfort"])
+class ComfortViewSet(viewsets.ViewSet):
+    """Read-only per-character comfort. Personal data — only the requesting account's characters."""
+
+    serializer_class = CharacterComfortSerializer
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="character_id",
+                type=int,
+                required=True,
+                description="ObjectDB id of the character to read comfort for (must be your own).",
+            )
+        ],
+        responses=CharacterComfortSerializer,
+    )
+    def summary(self, request: Request) -> Response:
+        """GET /summary/?character_id=<id> — how uncomfortable that character is, and why."""
+        request_params = ComfortRequestSerializer(data=request.query_params)
+        request_params.is_valid(raise_exception=True)
+        character_id = request_params.validated_data["character_id"]
+
+        user = cast(AccountDB, request.user)
+        # Comfort is personal: only serve a character the requesting account actually plays.
+        # character_id == character_sheet_id by construction (CharacterSheet.character is a
+        # primary-key OneToOne to ObjectDB), so the tenure check doubles as the ownership gate.
+        owned = RosterEntry.objects.for_account(user).filter(character_sheet_id=character_id)
+        if not owned.exists():
+            return Response({"detail": "Character not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        sheet = CharacterSheet.objects.filter(pk=character_id).first()
+        if sheet is None:
+            return Response({"detail": "Character not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        summary = character_comfort_summary(sheet.character)
+        return Response(CharacterComfortSerializer(summary).data)


### PR DESCRIPTION
## Summary

Adds the **web face of the per-character comfort readout** (#1522) — "how uncomfortable am *I* where I stand, and why" — the browser counterpart to the `comfort` command.

- **`GET /api/locations/comfort/?character_id=<id>`** (`ComfortViewSet`, `CharacterComfortSerializer`) → the `CharacterComfort` schema (`band`, `band_index`, `discomfort`, `reasons`, `injury`, per-axis `felt` map), wrapping `character_comfort.character_comfort_summary`.
- **Personal data:** comfort depends on what you're wearing, your wards, and your injuries, so the endpoint only serves a character the requesting account actually plays (`RosterEntry.objects.for_account` tenure gate; unowned/unknown → 404).
- **React `ComfortWidget`** (`frontend/src/comfort/`) takes the active character id from `GameTopBar`, queries via React Query (1-min poll), and renders a compact band glance with the biting reasons in the tooltip — **only when something is biting**, staying silent while comfortable so a cozy room isn't cluttered. Mirrors the weather widget's read pattern.
- Regenerated `api.d.ts` + `schema.json`; updated `world/locations/CLAUDE.md` (API + widget section).

## Testing

- `arx test world.locations.tests.test_comfort_views` — 5 tests, **OK** (auth required, 400 on missing id, 404 on unowned character, band/reasons/felt on a cold room, empty when comfortable).
- Frontend `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm build` — all green.
- `pre-commit` full pass on changed files.

Closes #1522 is **not** implied — this is one slice; the umbrella stays open for the remaining follow-ups (echo squelch on web, re-seed upsert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
