### PR TITLE
feat: weather-echo squelch on the web (#1522)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -9588,6 +9588,51 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/narrative/category-mutes/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Manage the requesting user's UserCategoryMutes — suppress a whole category's live push.
+     *
+     *     The category-level analogue of the story-mute ViewSet (e.g. squelch the WEATHER echo). Muting
+     *     does NOT gate read access; muted messages still create delivery rows and stay readable in the
+     *     category's tab. Only the live push is skipped.
+     *
+     *     GET    /api/narrative/category-mutes/      — list my category mutes
+     *     POST   /api/narrative/category-mutes/      — mute a category
+     *     DELETE /api/narrative/category-mutes/{id}/ — unmute
+     */
+    get: operations['narrative_category_mutes_list'];
+    put?: never;
+    /** @description Create the mute and return a UserCategoryMuteSerializer response. */
+    post: operations['narrative_category_mutes_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/narrative/category-mutes/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** @description Delete the mute. IsOwnCategoryMuteOrStaff enforces ownership via get_object(). */
+    delete: operations['narrative_category_mutes_destroy'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/narrative/deliveries/{id}/acknowledge/': {
     parameters: {
       query?: never;
@@ -14582,6 +14627,26 @@ export interface components {
         [key: string]: unknown;
       } | null;
     };
+    /**
+     * @description * `story` - Story update
+     *     * `atmosphere` - Atmosphere
+     *     * `visions` - Visions
+     *     * `happenstance` - Happenstance
+     *     * `system` - System
+     *     * `covenant` - Covenant
+     *     * `renown` - Renown
+     *     * `weather` - Weather
+     * @enum {string}
+     */
+    CategoryF17Enum:
+      | 'story'
+      | 'atmosphere'
+      | 'visions'
+      | 'happenstance'
+      | 'system'
+      | 'covenant'
+      | 'renown'
+      | 'weather';
     /** @description Nested serializer for challenge approaches. */
     ChallengeApproach: {
       readonly id: number;
@@ -19202,7 +19267,7 @@ export interface components {
       readonly id: number;
       /** @description IC content shown to recipients. */
       readonly body: string;
-      readonly category: components['schemas']['NarrativeMessageCategoryEnum'];
+      readonly category: components['schemas']['CategoryF17Enum'];
       /** @description Null = automated/system-sourced. */
       readonly sender_account: number | null;
       readonly related_story: number | null;
@@ -19211,26 +19276,6 @@ export interface components {
       /** Format: date-time */
       readonly sent_at: string;
     };
-    /**
-     * @description * `story` - Story update
-     *     * `atmosphere` - Atmosphere
-     *     * `visions` - Visions
-     *     * `happenstance` - Happenstance
-     *     * `system` - System
-     *     * `covenant` - Covenant
-     *     * `renown` - Renown
-     *     * `weather` - Weather
-     * @enum {string}
-     */
-    NarrativeMessageCategoryEnum:
-      | 'story'
-      | 'atmosphere'
-      | 'visions'
-      | 'happenstance'
-      | 'system'
-      | 'covenant'
-      | 'renown'
-      | 'weather';
     NarrativeMessageDelivery: {
       readonly id: number;
       readonly message: components['schemas']['NarrativeMessage'];
@@ -21271,6 +21316,21 @@ export interface components {
        */
       previous?: string | null;
       results: components['schemas']['TransitionRequiredOutcome'][];
+    };
+    PaginatedUserCategoryMuteList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['UserCategoryMute'][];
     };
     PaginatedUserStoryMuteList: {
       /** @example 123 */
@@ -25932,6 +25992,21 @@ export interface components {
       destroyed: boolean;
       soft_deleted: boolean;
       applied_effect_count: number;
+    };
+    /** @description Full UserCategoryMute representation. */
+    UserCategoryMute: {
+      readonly id: number;
+      category: components['schemas']['CategoryF17Enum'];
+      /** Format: date-time */
+      readonly muted_at: string;
+    };
+    /** @description Input serializer for POST /api/narrative/category-mutes/. */
+    UserCategoryMuteCreate: {
+      category: components['schemas']['CategoryF17Enum'];
+    };
+    /** @description Input serializer for POST /api/narrative/category-mutes/. */
+    UserCategoryMuteCreateRequest: {
+      category: components['schemas']['CategoryF17Enum'];
     };
     /** @description Full UserStoryMute representation. */
     UserStoryMute: {
@@ -39412,6 +39487,73 @@ export interface operations {
     };
   };
   mutes_destroy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  narrative_category_mutes_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedUserCategoryMuteList'];
+        };
+      };
+    };
+  };
+  narrative_category_mutes_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UserCategoryMuteCreateRequest'];
+      };
+    };
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['UserCategoryMuteCreate'];
+        };
+      };
+    };
+  };
+  narrative_category_mutes_destroy: {
     parameters: {
       query?: never;
       header?: never;

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -14627,26 +14627,6 @@ export interface components {
         [key: string]: unknown;
       } | null;
     };
-    /**
-     * @description * `story` - Story update
-     *     * `atmosphere` - Atmosphere
-     *     * `visions` - Visions
-     *     * `happenstance` - Happenstance
-     *     * `system` - System
-     *     * `covenant` - Covenant
-     *     * `renown` - Renown
-     *     * `weather` - Weather
-     * @enum {string}
-     */
-    CategoryF17Enum:
-      | 'story'
-      | 'atmosphere'
-      | 'visions'
-      | 'happenstance'
-      | 'system'
-      | 'covenant'
-      | 'renown'
-      | 'weather';
     /** @description Nested serializer for challenge approaches. */
     ChallengeApproach: {
       readonly id: number;
@@ -19262,12 +19242,32 @@ export interface components {
       /** @description Free-text summary of the last interaction; used by both mission and functionary contexts to surface 'why we left off where we did'. */
       last_interaction_summary?: string;
     };
+    /**
+     * @description * `story` - Story update
+     *     * `atmosphere` - Atmosphere
+     *     * `visions` - Visions
+     *     * `happenstance` - Happenstance
+     *     * `system` - System
+     *     * `covenant` - Covenant
+     *     * `renown` - Renown
+     *     * `weather` - Weather
+     * @enum {string}
+     */
+    NarrativeCategoryEnum:
+      | 'story'
+      | 'atmosphere'
+      | 'visions'
+      | 'happenstance'
+      | 'system'
+      | 'covenant'
+      | 'renown'
+      | 'weather';
     /** @description Player-facing message representation. Excludes ooc_note. */
     NarrativeMessage: {
       readonly id: number;
       /** @description IC content shown to recipients. */
       readonly body: string;
-      readonly category: components['schemas']['CategoryF17Enum'];
+      readonly category: components['schemas']['NarrativeCategoryEnum'];
       /** @description Null = automated/system-sourced. */
       readonly sender_account: number | null;
       readonly related_story: number | null;
@@ -25996,17 +25996,17 @@ export interface components {
     /** @description Full UserCategoryMute representation. */
     UserCategoryMute: {
       readonly id: number;
-      category: components['schemas']['CategoryF17Enum'];
+      category: components['schemas']['NarrativeCategoryEnum'];
       /** Format: date-time */
       readonly muted_at: string;
     };
     /** @description Input serializer for POST /api/narrative/category-mutes/. */
     UserCategoryMuteCreate: {
-      category: components['schemas']['CategoryF17Enum'];
+      category: components['schemas']['NarrativeCategoryEnum'];
     };
     /** @description Input serializer for POST /api/narrative/category-mutes/. */
     UserCategoryMuteCreateRequest: {
-      category: components['schemas']['CategoryF17Enum'];
+      category: components['schemas']['NarrativeCategoryEnum'];
     };
     /** @description Full UserStoryMute representation. */
     UserStoryMute: {

--- a/frontend/src/narrative/CLAUDE.md
+++ b/frontend/src/narrative/CLAUDE.md
@@ -26,6 +26,12 @@ Implemented in Phase 4 Wave 1.
 - `muteStory(storyId)` — `POST /api/narrative/story-mutes/` (idempotent)
 - `unmuteStory(storyId)` — `DELETE /api/narrative/story-mutes/{id}/`
 
+**#1522 — category mute (squelch a whole category, e.g. WEATHER):**
+
+- `getCategoryMutes()` — `GET /api/narrative/category-mutes/` (current user's category mutes)
+- `muteCategory({ category })` — `POST /api/narrative/category-mutes/`
+- `unmuteCategory(muteId)` — `DELETE /api/narrative/category-mutes/{id}/`
+
 ### `queries.ts`
 
 React Query hooks:
@@ -47,6 +53,11 @@ React Query hooks:
 - `useStoryMutes()` — current user's mute list
 - `useIsStoryMuted(storyId)` — derived hook returning `boolean`
 - `useMuteStory()` / `useUnmuteStory()` — toggle mutations; invalidate `storyMutes` cache
+
+**#1522 — category mute:**
+
+- `useCategoryMutes()` — current user's category mutes (`throwOnError: true`)
+- `useMuteCategory()` / `useUnmuteCategory()` — toggle mutations; invalidate `categoryMutes` cache
 
 ### `types.ts`
 
@@ -80,6 +91,12 @@ Re-exports from `@/generated/api`:
 | `SendStoryOOCDialog.tsx`  | Lead GM/staff dialog: compose OOC notice → fans out to all story participants              |
 | `MuteStoryToggle.tsx`     | Bell icon button on `StoryDetailPage` — mutes/unmutes real-time narrative push for a story |
 
+**#1522 — category mute:**
+
+| File                      | Purpose                                                                                                                                                                                                                                        |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CategoryMuteToggles.tsx` | Switch per squelchable ambient category (currently WEATHER) on `MuteSettingsPage` — ON = muted (push suppressed, still readable in-tab); the web face of the telnet `weather squelch` toggle. `SQUELCHABLE_CATEGORIES` is the extensible list. |
+
 ### `pages/`
 
 **Phase 4:** The narrative app owned no top-level page. Its UI surfaced through three
@@ -98,8 +115,9 @@ integration points:
 | ---------------------- | -------------------------- | -------------- |
 | `MuteSettingsPage.tsx` | `/narrative/mute-settings` | ProtectedRoute |
 
-`MuteSettingsPage` lists all stories the current user has muted, with per-row
-Unmute button and a "Manage muted stories" link surfaced in `MessagesSection`.
+`MuteSettingsPage` has two sections: **Ambient Categories** (`CategoryMuteToggles` — squelch the
+weather echo, #1522) and **Muted Stories** (per-row Unmute button). A "Manage muted stories" link
+is surfaced in `MessagesSection`.
 
 ## Data Flow
 

--- a/frontend/src/narrative/__tests__/MuteSettingsPage.test.tsx
+++ b/frontend/src/narrative/__tests__/MuteSettingsPage.test.tsx
@@ -15,6 +15,9 @@ import { MuteSettingsPage } from '../pages/MuteSettingsPage';
 vi.mock('../queries', () => ({
   useStoryMutes: vi.fn(),
   useUnmuteStory: vi.fn(),
+  useCategoryMutes: vi.fn(),
+  useMuteCategory: vi.fn(),
+  useUnmuteCategory: vi.fn(),
 }));
 
 import * as queries from '../queries';
@@ -76,6 +79,20 @@ function setupMocks({
   vi.mocked(queries.useUnmuteStory).mockReturnValue(
     makeMutationIdle(unmuteMutate) as unknown as ReturnType<typeof queries.useUnmuteStory>
   );
+
+  // The page also renders the category-mute toggles; stub those hooks (empty = nothing muted).
+  vi.mocked(queries.useCategoryMutes).mockReturnValue({
+    data: { count: 0, next: null, previous: null, results: [] },
+    isLoading: false,
+    isSuccess: true,
+    error: null,
+  } as unknown as ReturnType<typeof queries.useCategoryMutes>);
+  vi.mocked(queries.useMuteCategory).mockReturnValue(
+    makeMutationIdle() as unknown as ReturnType<typeof queries.useMuteCategory>
+  );
+  vi.mocked(queries.useUnmuteCategory).mockReturnValue(
+    makeMutationIdle() as unknown as ReturnType<typeof queries.useUnmuteCategory>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -90,7 +107,73 @@ describe('MuteSettingsPage', () => {
   it('renders page heading', () => {
     setupMocks();
     render(<MuteSettingsPage />, { wrapper: createWrapper() });
+    expect(screen.getByRole('heading', { name: 'Notification Settings' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Muted Stories' })).toBeInTheDocument();
+  });
+
+  it('renders the weather category toggle, unchecked when not muted', () => {
+    setupMocks();
+    render(<MuteSettingsPage />, { wrapper: createWrapper() });
+    const sw = screen.getByTestId('category-mute-switch');
+    expect(sw).toBeInTheDocument();
+    expect(sw).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('mutes the weather category when the toggle is switched on', async () => {
+    const user = userEvent.setup();
+    const muteMutate = vi.fn();
+    setupMocks();
+    vi.mocked(queries.useMuteCategory).mockReturnValue(
+      makeMutationIdle(muteMutate) as unknown as ReturnType<typeof queries.useMuteCategory>
+    );
+
+    render(<MuteSettingsPage />, { wrapper: createWrapper() });
+    await user.click(screen.getByTestId('category-mute-switch'));
+
+    expect(muteMutate).toHaveBeenCalledWith({ category: 'weather' });
+  });
+
+  it('shows the weather toggle as checked when the category is muted', () => {
+    setupMocks();
+    vi.mocked(queries.useCategoryMutes).mockReturnValue({
+      data: {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [{ id: 7, category: 'weather', muted_at: '2026-06-01T00:00:00Z' }],
+      },
+      isLoading: false,
+      isSuccess: true,
+      error: null,
+    } as unknown as ReturnType<typeof queries.useCategoryMutes>);
+
+    render(<MuteSettingsPage />, { wrapper: createWrapper() });
+    expect(screen.getByTestId('category-mute-switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('unmutes the weather category when toggled off', async () => {
+    const user = userEvent.setup();
+    const unmuteMutate = vi.fn();
+    setupMocks();
+    vi.mocked(queries.useCategoryMutes).mockReturnValue({
+      data: {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [{ id: 7, category: 'weather', muted_at: '2026-06-01T00:00:00Z' }],
+      },
+      isLoading: false,
+      isSuccess: true,
+      error: null,
+    } as unknown as ReturnType<typeof queries.useCategoryMutes>);
+    vi.mocked(queries.useUnmuteCategory).mockReturnValue(
+      makeMutationIdle(unmuteMutate) as unknown as ReturnType<typeof queries.useUnmuteCategory>
+    );
+
+    render(<MuteSettingsPage />, { wrapper: createWrapper() });
+    await user.click(screen.getByTestId('category-mute-switch'));
+
+    expect(unmuteMutate).toHaveBeenCalledWith(7);
   });
 
   it('renders empty state when no mutes exist', () => {
@@ -111,6 +194,18 @@ describe('MuteSettingsPage', () => {
 
     vi.mocked(queries.useUnmuteStory).mockReturnValue(
       makeMutationIdle() as unknown as ReturnType<typeof queries.useUnmuteStory>
+    );
+    vi.mocked(queries.useCategoryMutes).mockReturnValue({
+      data: { count: 0, next: null, previous: null, results: [] },
+      isLoading: false,
+      isSuccess: true,
+      error: null,
+    } as unknown as ReturnType<typeof queries.useCategoryMutes>);
+    vi.mocked(queries.useMuteCategory).mockReturnValue(
+      makeMutationIdle() as unknown as ReturnType<typeof queries.useMuteCategory>
+    );
+    vi.mocked(queries.useUnmuteCategory).mockReturnValue(
+      makeMutationIdle() as unknown as ReturnType<typeof queries.useUnmuteCategory>
     );
 
     const { container } = render(<MuteSettingsPage />, { wrapper: createWrapper() });

--- a/frontend/src/narrative/api.ts
+++ b/frontend/src/narrative/api.ts
@@ -15,8 +15,11 @@ import type {
   MyMessagesQueryParams,
   NarrativeMessageDelivery,
   PaginatedDeliveries,
+  PaginatedCategoryMutes,
   PaginatedGemits,
   PaginatedMutes,
+  UserCategoryMute,
+  UserCategoryMuteCreateBody,
   UserStoryMute,
   UserStoryMuteCreateBody,
 } from './types';
@@ -114,6 +117,52 @@ export async function unmuteStory(muteId: number): Promise<void> {
   const res = await apiFetch(`${BASE_URL}/story-mutes/${muteId}/`, { method: 'DELETE' });
   if (!res.ok) {
     throw new Error(`Failed to unmute story (mute id ${muteId})`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// UserCategoryMute endpoints (#1522) — squelch a whole category (e.g. WEATHER)
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/narrative/category-mutes/
+ * Returns the current account's list of muted narrative categories.
+ */
+export async function getCategoryMutes(): Promise<PaginatedCategoryMutes> {
+  const res = await apiFetch(`${BASE_URL}/category-mutes/`);
+  if (!res.ok) {
+    throw new Error('Failed to load category mutes');
+  }
+  return res.json() as Promise<PaginatedCategoryMutes>;
+}
+
+/**
+ * POST /api/narrative/category-mutes/
+ * Body: { category: <NarrativeCategory> }
+ * Returns 201 with the created UserCategoryMute.
+ */
+export async function muteCategory(data: UserCategoryMuteCreateBody): Promise<UserCategoryMute> {
+  const res = await apiFetch(`${BASE_URL}/category-mutes/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const err = new Error('Failed to mute category') as Error & { status?: number };
+    err.status = res.status;
+    throw err;
+  }
+  return res.json() as Promise<UserCategoryMute>;
+}
+
+/**
+ * DELETE /api/narrative/category-mutes/{id}/
+ * Removes the mute. Returns 204 No Content on success.
+ */
+export async function unmuteCategory(muteId: number): Promise<void> {
+  const res = await apiFetch(`${BASE_URL}/category-mutes/${muteId}/`, { method: 'DELETE' });
+  if (!res.ok) {
+    throw new Error(`Failed to unmute category (mute id ${muteId})`);
   }
 }
 

--- a/frontend/src/narrative/components/CategoryMuteToggles.tsx
+++ b/frontend/src/narrative/components/CategoryMuteToggles.tsx
@@ -1,0 +1,106 @@
+/**
+ * CategoryMuteToggles (#1522) — squelch whole narrative categories from the web.
+ *
+ * The web face of the telnet `weather squelch` toggle: a Switch per squelchable category. ON =
+ * muted (the live push is suppressed; messages still land in the category's tab). Mirrors the
+ * `MuteStoryToggle` bell, but keyed to a `NarrativeCategory` rather than a story.
+ *
+ * The squelchable set is deliberately small — only ambient, recurring pushes a player would want
+ * to silence (currently the weather echo). Add a row here as new ambient categories appear.
+ */
+
+import { Switch } from '@/components/ui/switch';
+import { Skeleton } from '@/components/ui/skeleton';
+
+import { useCategoryMutes, useMuteCategory, useUnmuteCategory } from '../queries';
+import type { NarrativeCategory, UserCategoryMute } from '../types';
+
+interface SquelchableCategory {
+  category: NarrativeCategory;
+  label: string;
+  description: string;
+}
+
+/** Ambient, recurring categories a player can silence. PLACEHOLDER copy. */
+const SQUELCHABLE_CATEGORIES: SquelchableCategory[] = [
+  {
+    category: 'weather',
+    label: 'Weather',
+    description: 'Ambient weather echoes as conditions change around you.',
+  },
+];
+
+interface CategoryToggleRowProps {
+  config: SquelchableCategory;
+  mute: UserCategoryMute | undefined;
+}
+
+function CategoryToggleRow({ config, mute }: CategoryToggleRowProps) {
+  const muteCategory = useMuteCategory();
+  const unmuteCategory = useUnmuteCategory();
+
+  const isMuted = mute !== undefined;
+  const isPending = muteCategory.isPending || unmuteCategory.isPending;
+
+  const handleToggle = (nextMuted: boolean) => {
+    if (nextMuted) {
+      muteCategory.mutate({ category: config.category });
+    } else if (mute) {
+      unmuteCategory.mutate(mute.id);
+    }
+  };
+
+  return (
+    <div
+      className="flex items-center justify-between rounded-lg border bg-card p-4"
+      data-testid="category-mute-row"
+    >
+      <div className="space-y-0.5 pr-4">
+        <p className="font-medium">{config.label}</p>
+        <p className="text-xs text-muted-foreground">{config.description}</p>
+      </div>
+      <Switch
+        checked={isMuted}
+        disabled={isPending}
+        onCheckedChange={handleToggle}
+        aria-label={`Mute ${config.label} notifications`}
+        data-testid="category-mute-switch"
+      />
+    </div>
+  );
+}
+
+export function CategoryMuteToggles() {
+  const { data, isLoading } = useCategoryMutes();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {SQUELCHABLE_CATEGORIES.map((c) => (
+          <div key={c.category} className="rounded-lg border bg-card p-4">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-5 w-9" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const mutesByCategory = new Map<string, UserCategoryMute>(
+    (data?.results ?? []).map((m) => [m.category, m])
+  );
+
+  return (
+    <div className="space-y-3">
+      {SQUELCHABLE_CATEGORIES.map((config) => (
+        <CategoryToggleRow
+          key={config.category}
+          config={config}
+          mute={mutesByCategory.get(config.category)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/narrative/pages/MuteSettingsPage.tsx
+++ b/frontend/src/narrative/pages/MuteSettingsPage.tsx
@@ -1,7 +1,9 @@
 /**
- * MuteSettingsPage — list of muted stories with per-row Unmute button.
+ * MuteSettingsPage — notification mute settings: ambient categories (e.g. weather) and
+ * per-story mutes.
  *
- * Lets users review what they have muted and remove mutes selectively.
+ * Lets users squelch whole narrative categories (the weather echo, #1522) and review/remove
+ * their per-story mutes selectively.
  *
  * Wave 11 will register the route at /profile/mute-settings.
  */
@@ -11,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useStoryMutes, useUnmuteStory } from '../queries';
 import type { UserStoryMute } from '../types';
+import { CategoryMuteToggles } from '../components/CategoryMuteToggles';
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -102,13 +105,24 @@ function MuteSettingsInner() {
 export function MuteSettingsPage() {
   return (
     <div className="container mx-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
-      <h1 className="mb-2 text-2xl font-bold">Muted Stories</h1>
+      <h1 className="mb-2 text-2xl font-bold">Notification Settings</h1>
       <p className="mb-6 text-muted-foreground">
-        Muted stories still appear in your dashboard — real-time notifications are suppressed.
+        Muted items still appear in your dashboard — only the real-time push is suppressed.
       </p>
-      <ErrorBoundary>
-        <MuteSettingsInner />
-      </ErrorBoundary>
+
+      <section className="mb-8">
+        <h2 className="mb-3 text-lg font-semibold">Ambient Categories</h2>
+        <ErrorBoundary>
+          <CategoryMuteToggles />
+        </ErrorBoundary>
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold">Muted Stories</h2>
+        <ErrorBoundary>
+          <MuteSettingsInner />
+        </ErrorBoundary>
+      </section>
     </div>
   );
 }

--- a/frontend/src/narrative/queries.ts
+++ b/frontend/src/narrative/queries.ts
@@ -6,10 +6,13 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   acknowledgeDelivery,
   broadcastGemit,
+  getCategoryMutes,
   getGemits,
   getMyMessages,
   getStoryMutes,
+  muteCategory,
   muteStory,
+  unmuteCategory,
   unmuteStory,
 } from './api';
 import { useAppSelector } from '@/store/hooks';
@@ -17,6 +20,7 @@ import type {
   BroadcastGemitBody,
   GemitListParams,
   MyMessagesQueryParams,
+  UserCategoryMuteCreateBody,
   UserStoryMuteCreateBody,
 } from './types';
 
@@ -26,6 +30,7 @@ export const narrativeKeys = {
     [...narrativeKeys.all, 'my-messages', filters] as const,
   gemits: (params?: GemitListParams) => [...narrativeKeys.all, 'gemits', params] as const,
   storyMutes: () => [...narrativeKeys.all, 'story-mutes'] as const,
+  categoryMutes: () => [...narrativeKeys.all, 'category-mutes'] as const,
 };
 
 // Alias for the gemit list root — used by ChatWindow to invalidate on gemit push.
@@ -113,6 +118,38 @@ export function useUnmuteStory() {
     mutationFn: (muteId: number) => unmuteStory(muteId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: narrativeKeys.storyMutes() }).catch(() => {});
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// UserCategoryMute hooks (#1522) — squelch a whole category (e.g. WEATHER echo)
+// ---------------------------------------------------------------------------
+
+export function useCategoryMutes() {
+  return useQuery({
+    queryKey: narrativeKeys.categoryMutes(),
+    queryFn: getCategoryMutes,
+    throwOnError: true,
+  });
+}
+
+export function useMuteCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: UserCategoryMuteCreateBody) => muteCategory(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: narrativeKeys.categoryMutes() }).catch(() => {});
+    },
+  });
+}
+
+export function useUnmuteCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (muteId: number) => unmuteCategory(muteId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: narrativeKeys.categoryMutes() }).catch(() => {});
     },
   });
 }

--- a/frontend/src/narrative/types.ts
+++ b/frontend/src/narrative/types.ts
@@ -9,7 +9,7 @@ import type { components } from '@/generated/api';
 
 export type NarrativeMessage = components['schemas']['NarrativeMessage'];
 export type NarrativeMessageDelivery = components['schemas']['NarrativeMessageDelivery'];
-export type NarrativeCategory = components['schemas']['NarrativeMessageCategoryEnum'];
+export type NarrativeCategory = components['schemas']['NarrativeCategoryEnum'];
 
 export interface MyMessagesQueryParams {
   category?: NarrativeCategory;

--- a/frontend/src/narrative/types.ts
+++ b/frontend/src/narrative/types.ts
@@ -80,3 +80,21 @@ export interface PaginatedMutes {
   previous: string | null;
   results: UserStoryMute[];
 }
+
+// ---------------------------------------------------------------------------
+// UserCategoryMute (#1522) — squelch a whole narrative category's live push
+// (e.g. the WEATHER echo). Generated from UserCategoryMuteSerializer.
+// ---------------------------------------------------------------------------
+
+export type UserCategoryMute = components['schemas']['UserCategoryMute'];
+
+export interface UserCategoryMuteCreateBody {
+  category: NarrativeCategory;
+}
+
+export interface PaginatedCategoryMutes {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: UserCategoryMute[];
+}

--- a/src/schema.json
+++ b/src/schema.json
@@ -15568,6 +15568,81 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/narrative/category-mutes/:
+    get:
+      operationId: narrative_category_mutes_list
+      description: |-
+        Manage the requesting user's UserCategoryMutes — suppress a whole category's live push.
+
+        The category-level analogue of the story-mute ViewSet (e.g. squelch the WEATHER echo). Muting
+        does NOT gate read access; muted messages still create delivery rows and stay readable in the
+        category's tab. Only the live push is skipped.
+
+        GET    /api/narrative/category-mutes/      — list my category mutes
+        POST   /api/narrative/category-mutes/      — mute a category
+        DELETE /api/narrative/category-mutes/{id}/ — unmute
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - narrative
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedUserCategoryMuteList'
+          description: ''
+    post:
+      operationId: narrative_category_mutes_create
+      description: Create the mute and return a UserCategoryMuteSerializer response.
+      tags:
+      - narrative
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCategoryMuteCreateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCategoryMuteCreate'
+          description: ''
+  /api/narrative/category-mutes/{id}/:
+    delete:
+      operationId: narrative_category_mutes_destroy
+      description: Delete the mute. IsOwnCategoryMuteOrStaff enforces ownership via
+        get_object().
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - narrative
+      security:
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/narrative/deliveries/{id}/acknowledge/:
     post:
       operationId: narrative_deliveries_acknowledge_create
@@ -24903,6 +24978,26 @@ components:
       - target_spec
       - target_type
       - tier
+    CategoryF17Enum:
+      enum:
+      - story
+      - atmosphere
+      - visions
+      - happenstance
+      - system
+      - covenant
+      - renown
+      - weather
+      type: string
+      description: |-
+        * `story` - Story update
+        * `atmosphere` - Atmosphere
+        * `visions` - Visions
+        * `happenstance` - Happenstance
+        * `system` - System
+        * `covenant` - Covenant
+        * `renown` - Renown
+        * `weather` - Weather
     ChallengeApproach:
       type: object
       description: Nested serializer for challenge approaches.
@@ -34690,7 +34785,7 @@ components:
           description: IC content shown to recipients.
         category:
           allOf:
-          - $ref: '#/components/schemas/NarrativeMessageCategoryEnum'
+          - $ref: '#/components/schemas/CategoryF17Enum'
           readOnly: true
         sender_account:
           type: integer
@@ -34722,26 +34817,6 @@ components:
       - related_story
       - sender_account
       - sent_at
-    NarrativeMessageCategoryEnum:
-      enum:
-      - story
-      - atmosphere
-      - visions
-      - happenstance
-      - system
-      - covenant
-      - renown
-      - weather
-      type: string
-      description: |-
-        * `story` - Story update
-        * `atmosphere` - Atmosphere
-        * `visions` - Visions
-        * `happenstance` - Happenstance
-        * `system` - System
-        * `covenant` - Covenant
-        * `renown` - Renown
-        * `weather` - Weather
     NarrativeMessageDelivery:
       type: object
       properties:
@@ -38144,6 +38219,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TransitionRequiredOutcome'
+    PaginatedUserCategoryMuteList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserCategoryMute'
     PaginatedUserStoryMuteList:
       type: object
       required:
@@ -47301,6 +47399,39 @@ components:
       - charges_remaining
       - destroyed
       - soft_deleted
+    UserCategoryMute:
+      type: object
+      description: Full UserCategoryMute representation.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        category:
+          $ref: '#/components/schemas/CategoryF17Enum'
+        muted_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - category
+      - id
+      - muted_at
+    UserCategoryMuteCreate:
+      type: object
+      description: Input serializer for POST /api/narrative/category-mutes/.
+      properties:
+        category:
+          $ref: '#/components/schemas/CategoryF17Enum'
+      required:
+      - category
+    UserCategoryMuteCreateRequest:
+      type: object
+      description: Input serializer for POST /api/narrative/category-mutes/.
+      properties:
+        category:
+          $ref: '#/components/schemas/CategoryF17Enum'
+      required:
+      - category
     UserStoryMute:
       type: object
       description: Full UserStoryMute representation.

--- a/src/schema.json
+++ b/src/schema.json
@@ -24978,26 +24978,6 @@ components:
       - target_spec
       - target_type
       - tier
-    CategoryF17Enum:
-      enum:
-      - story
-      - atmosphere
-      - visions
-      - happenstance
-      - system
-      - covenant
-      - renown
-      - weather
-      type: string
-      description: |-
-        * `story` - Story update
-        * `atmosphere` - Atmosphere
-        * `visions` - Visions
-        * `happenstance` - Happenstance
-        * `system` - System
-        * `covenant` - Covenant
-        * `renown` - Renown
-        * `weather` - Weather
     ChallengeApproach:
       type: object
       description: Nested serializer for challenge approaches.
@@ -34772,6 +34752,26 @@ components:
       required:
       - npc_persona
       - persona
+    NarrativeCategoryEnum:
+      enum:
+      - story
+      - atmosphere
+      - visions
+      - happenstance
+      - system
+      - covenant
+      - renown
+      - weather
+      type: string
+      description: |-
+        * `story` - Story update
+        * `atmosphere` - Atmosphere
+        * `visions` - Visions
+        * `happenstance` - Happenstance
+        * `system` - System
+        * `covenant` - Covenant
+        * `renown` - Renown
+        * `weather` - Weather
     NarrativeMessage:
       type: object
       description: Player-facing message representation. Excludes ooc_note.
@@ -34785,7 +34785,7 @@ components:
           description: IC content shown to recipients.
         category:
           allOf:
-          - $ref: '#/components/schemas/CategoryF17Enum'
+          - $ref: '#/components/schemas/NarrativeCategoryEnum'
           readOnly: true
         sender_account:
           type: integer
@@ -47407,7 +47407,7 @@ components:
           type: integer
           readOnly: true
         category:
-          $ref: '#/components/schemas/CategoryF17Enum'
+          $ref: '#/components/schemas/NarrativeCategoryEnum'
         muted_at:
           type: string
           format: date-time
@@ -47421,7 +47421,7 @@ components:
       description: Input serializer for POST /api/narrative/category-mutes/.
       properties:
         category:
-          $ref: '#/components/schemas/CategoryF17Enum'
+          $ref: '#/components/schemas/NarrativeCategoryEnum'
       required:
       - category
     UserCategoryMuteCreateRequest:
@@ -47429,7 +47429,7 @@ components:
       description: Input serializer for POST /api/narrative/category-mutes/.
       properties:
         category:
-          $ref: '#/components/schemas/CategoryF17Enum'
+          $ref: '#/components/schemas/NarrativeCategoryEnum'
       required:
       - category
     UserStoryMute:

--- a/src/server/conf/settings.py
+++ b/src/server/conf/settings.py
@@ -313,6 +313,11 @@ SPECTACULAR_SETTINGS = {
     # appears. Pin ours explicitly.
     "ENUM_NAME_OVERRIDES": {
         "MissionVisibilityEnum": "world.missions.constants.MissionVisibility.choices",
+        # Several serializers expose a `category` field from the same NarrativeCategory
+        # choices (NarrativeMessage, NarrativeMessageDelivery, UserCategoryMute); without
+        # this, spectacular emits a hash-suffixed collision name (CategoryF17Enum) that
+        # churns whenever a new `category` field appears. Pin it (#1522).
+        "NarrativeCategoryEnum": "world.narrative.constants.NarrativeCategory.choices",
     },
 }
 

--- a/src/world/narrative/filters.py
+++ b/src/world/narrative/filters.py
@@ -1,7 +1,12 @@
 import django_filters
 
 from world.narrative.constants import NarrativeCategory
-from world.narrative.models import Gemit, NarrativeMessageDelivery, UserStoryMute
+from world.narrative.models import (
+    Gemit,
+    NarrativeMessageDelivery,
+    UserCategoryMute,
+    UserStoryMute,
+)
 
 
 class NarrativeMessageDeliveryFilter(django_filters.FilterSet):
@@ -42,3 +47,13 @@ class UserStoryMuteFilter(django_filters.FilterSet):
     class Meta:
         model = UserStoryMute
         fields = ["story"]
+
+
+class UserCategoryMuteFilter(django_filters.FilterSet):
+    """Filter UserCategoryMutes by category (account is always scoped to request.user in view)."""
+
+    category = django_filters.ChoiceFilter(choices=NarrativeCategory.choices)
+
+    class Meta:
+        model = UserCategoryMute
+        fields = ["category"]

--- a/src/world/narrative/permissions.py
+++ b/src/world/narrative/permissions.py
@@ -82,3 +82,24 @@ class IsOwnStoryMuteOrStaff(BasePermission):
         if request.user.is_staff:
             return True
         return obj.account_id == request.user.pk
+
+
+class IsOwnCategoryMuteOrStaff(BasePermission):
+    """Owners of a UserCategoryMute (account == request.user) or staff may delete it."""
+
+    message = "You may only manage your own category mutes."
+
+    def has_permission(self, request: "Request", view: "APIView") -> bool:
+        """Authenticated users only."""
+        return bool(request.user and request.user.is_authenticated)
+
+    def has_object_permission(
+        self,
+        request: "Request",
+        view: "APIView",
+        obj: "Model",
+    ) -> bool:
+        """Only the owning account or staff may delete the mute."""
+        if request.user.is_staff:
+            return True
+        return obj.account_id == request.user.pk

--- a/src/world/narrative/serializers.py
+++ b/src/world/narrative/serializers.py
@@ -1,7 +1,13 @@
 from rest_framework import serializers
 
 from world.narrative.constants import GemitReach
-from world.narrative.models import Gemit, NarrativeMessage, NarrativeMessageDelivery, UserStoryMute
+from world.narrative.models import (
+    Gemit,
+    NarrativeMessage,
+    NarrativeMessageDelivery,
+    UserCategoryMute,
+    UserStoryMute,
+)
 
 
 class NarrativeMessageSerializer(serializers.ModelSerializer):
@@ -149,4 +155,35 @@ class UserStoryMuteCreateSerializer(serializers.ModelSerializer):
         if UserStoryMute.objects.filter(account=request.user, story=story).exists():
             msg = "You have already muted this story."
             raise serializers.ValidationError({"story": msg})
+        return attrs
+
+
+# ---------------------------------------------------------------------------
+# UserCategoryMute serializers (#1522 — squelch a whole narrative category, e.g. WEATHER)
+# ---------------------------------------------------------------------------
+
+
+class UserCategoryMuteSerializer(serializers.ModelSerializer):
+    """Full UserCategoryMute representation."""
+
+    class Meta:
+        model = UserCategoryMute
+        fields = ["id", "category", "muted_at"]
+        read_only_fields = ["id", "muted_at"]
+
+
+class UserCategoryMuteCreateSerializer(serializers.ModelSerializer):
+    """Input serializer for POST /api/narrative/category-mutes/."""
+
+    class Meta:
+        model = UserCategoryMute
+        fields = ["category"]
+
+    def validate(self, attrs: dict) -> dict:
+        """Reject if this account already has a mute for this category."""
+        request = self.context["request"]
+        category = attrs["category"]
+        if UserCategoryMute.objects.filter(account=request.user, category=category).exists():
+            msg = "You have already muted this category."
+            raise serializers.ValidationError({"category": msg})
         return attrs

--- a/src/world/narrative/tests/test_category_mute_views.py
+++ b/src/world/narrative/tests/test_category_mute_views.py
@@ -1,0 +1,119 @@
+"""API tests for /api/narrative/category-mutes/ (#1522).
+
+The web face of the category squelch (e.g. silence the WEATHER echo). Mirrors the story-mute
+ViewSet tests: list/create/delete scoped to the requesting account.
+"""
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from core_management.test_utils import suppress_permission_errors
+from evennia_extensions.factories import AccountFactory
+from world.narrative.constants import NarrativeCategory
+from world.narrative.models import UserCategoryMute
+
+MUTES_URL = "/api/narrative/category-mutes/"
+
+
+class UserCategoryMuteListTest(APITestCase):
+    """GET /api/narrative/category-mutes/ — list own mutes."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = AccountFactory()
+        cls.other = AccountFactory()
+
+    def test_lists_own_mutes(self):
+        UserCategoryMute.objects.create(account=self.user, category=NarrativeCategory.WEATHER)
+        UserCategoryMute.objects.create(account=self.other, category=NarrativeCategory.WEATHER)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(MUTES_URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["category"] == NarrativeCategory.WEATHER
+
+    @suppress_permission_errors
+    def test_unauthenticated_rejected(self):
+        response = self.client.get(MUTES_URL)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+
+class UserCategoryMuteCreateTest(APITestCase):
+    """POST /api/narrative/category-mutes/ — mute a category."""
+
+    def setUp(self):
+        self.user = AccountFactory()
+
+    def test_create_mute(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            MUTES_URL, {"category": NarrativeCategory.WEATHER}, format="json"
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert UserCategoryMute.objects.filter(
+            account=self.user, category=NarrativeCategory.WEATHER
+        ).exists()
+
+    def test_mute_response_shape(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            MUTES_URL, {"category": NarrativeCategory.WEATHER}, format="json"
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.data
+        assert "id" in data
+        assert data["category"] == NarrativeCategory.WEATHER
+        assert "muted_at" in data
+
+    def test_missing_category_rejected(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(MUTES_URL, {}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_invalid_category_rejected(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(MUTES_URL, {"category": "not-a-category"}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_duplicate_mute_rejected_by_serializer(self):
+        UserCategoryMute.objects.create(account=self.user, category=NarrativeCategory.WEATHER)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            MUTES_URL, {"category": NarrativeCategory.WEATHER}, format="json"
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class UserCategoryMuteDeleteTest(APITestCase):
+    """DELETE /api/narrative/category-mutes/{id}/ — unmute."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = AccountFactory()
+        cls.other = AccountFactory()
+
+    def setUp(self):
+        self.mute = UserCategoryMute.objects.create(
+            account=self.user, category=NarrativeCategory.WEATHER
+        )
+
+    def _url(self):
+        return f"{MUTES_URL}{self.mute.pk}/"
+
+    def test_owner_can_delete(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(self._url())
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not UserCategoryMute.objects.filter(pk=self.mute.pk).exists()
+
+    @suppress_permission_errors
+    def test_non_owner_rejected(self):
+        self.client.force_authenticate(user=self.other)
+        response = self.client.delete(self._url())
+        assert response.status_code in (
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+        )

--- a/src/world/narrative/urls.py
+++ b/src/world/narrative/urls.py
@@ -5,12 +5,14 @@ from world.narrative.views import (
     GemitViewSet,
     MarkNarrativeMessageAcknowledgedView,
     MyNarrativeMessagesView,
+    UserCategoryMuteViewSet,
     UserStoryMuteViewSet,
 )
 
 router = DefaultRouter()
 router.register(r"gemits", GemitViewSet, basename="gemit")
 router.register(r"story-mutes", UserStoryMuteViewSet, basename="storymute")
+router.register(r"category-mutes", UserCategoryMuteViewSet, basename="categorymute")
 
 urlpatterns = [
     path("my-messages/", MyNarrativeMessagesView.as_view(), name="narrative-my-messages"),

--- a/src/world/narrative/views.py
+++ b/src/world/narrative/views.py
@@ -10,16 +10,29 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from world.narrative.constants import GemitReach
-from world.narrative.filters import GemitFilter, NarrativeMessageDeliveryFilter, UserStoryMuteFilter
-from world.narrative.models import Gemit, NarrativeMessageDelivery, UserStoryMute
+from world.narrative.filters import (
+    GemitFilter,
+    NarrativeMessageDeliveryFilter,
+    UserCategoryMuteFilter,
+    UserStoryMuteFilter,
+)
+from world.narrative.models import (
+    Gemit,
+    NarrativeMessageDelivery,
+    UserCategoryMute,
+    UserStoryMute,
+)
 from world.narrative.permissions import (
     IsDeliveryRecipientOrStaff,
+    IsOwnCategoryMuteOrStaff,
     IsOwnStoryMuteOrStaff,
 )
 from world.narrative.serializers import (
     GemitCreateSerializer,
     GemitSerializer,
     NarrativeMessageDeliverySerializer,
+    UserCategoryMuteCreateSerializer,
+    UserCategoryMuteSerializer,
     UserStoryMuteCreateSerializer,
     UserStoryMuteSerializer,
 )
@@ -191,6 +204,58 @@ class UserStoryMuteViewSet(
 
     def destroy(self, request: "Request", *args: Any, **kwargs: Any) -> Response:
         """Delete the mute. IsOwnStoryMuteOrStaff enforces ownership via get_object()."""
+        mute = self.get_object()
+        mute.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# UserCategoryMute ViewSet (#1522 — squelch a whole narrative category, e.g. WEATHER echoes)
+# ---------------------------------------------------------------------------
+
+
+class UserCategoryMuteViewSet(
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Manage the requesting user's UserCategoryMutes — suppress a whole category's live push.
+
+    The category-level analogue of the story-mute ViewSet (e.g. squelch the WEATHER echo). Muting
+    does NOT gate read access; muted messages still create delivery rows and stay readable in the
+    category's tab. Only the live push is skipped.
+
+    GET    /api/narrative/category-mutes/      — list my category mutes
+    POST   /api/narrative/category-mutes/      — mute a category
+    DELETE /api/narrative/category-mutes/{id}/ — unmute
+    """
+
+    filterset_class = UserCategoryMuteFilter
+    pagination_class = StandardResultsSetPagination
+    filter_backends = [DjangoFilterBackend]
+    permission_classes = [IsAuthenticated, IsOwnCategoryMuteOrStaff]
+
+    def get_queryset(self) -> "QuerySet[UserCategoryMute]":
+        """Scope to the requesting user's mutes."""
+        return UserCategoryMute.objects.filter(account=self.request.user).order_by("-muted_at")
+
+    def get_serializer_class(self) -> "type[BaseSerializer]":
+        if self.action == "create":
+            return UserCategoryMuteCreateSerializer
+        return UserCategoryMuteSerializer
+
+    def create(self, request: "Request", *args: Any, **kwargs: Any) -> Response:
+        """Create the mute and return a UserCategoryMuteSerializer response."""
+        serializer = UserCategoryMuteCreateSerializer(
+            data=request.data, context={"request": request}
+        )
+        serializer.is_valid(raise_exception=True)
+        mute = serializer.save(account=request.user)
+        return Response(UserCategoryMuteSerializer(mute).data, status=status.HTTP_201_CREATED)
+
+    def destroy(self, request: "Request", *args: Any, **kwargs: Any) -> Response:
+        """Delete the mute. IsOwnCategoryMuteOrStaff enforces ownership via get_object()."""
         mute = self.get_object()
         mute.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/world/weather/CLAUDE.md
+++ b/src/world/weather/CLAUDE.md
@@ -86,7 +86,9 @@ Services (`world.weather.services`):
   precisely; offline players skip it — no stale catch-up flood).
 - **Squelch** — `narrative.UserCategoryMute` (mirrors `UserStoryMute`: suppress the live push,
   keep it readable in the tab). `narrative.services.set_category_mute` / `is_category_muted`;
-  `time` command exposes `weather squelch` / `weather unsquelch` on the WEATHER category.
+  `time` command exposes `weather squelch` / `weather unsquelch` on the WEATHER category. The
+  **web face** is `narrative.UserCategoryMuteViewSet` (`/api/narrative/category-mutes/`) →
+  `CategoryMuteToggles` Switch on the frontend `MuteSettingsPage` (#1522).
 - **`current_conditions(room) -> ConditionsSummary`** (`types.py`): IC time + phase + season +
   the room's effective weather + one emit line. Any field is None when its source is absent.
 - **`time` command** (`commands/weather.py`, `CmdTime`, alias `weather`): the telnet face of


### PR DESCRIPTION
## Summary

Adds the **web face of the category squelch** (#1522) — silence a whole narrative category's live push (the **weather echo**) from the browser, matching the telnet `weather squelch` toggle. Builds directly on the already-shipped `narrative.UserCategoryMute` model + `set_category_mute`/`is_category_muted` services.

### Backend (`world.narrative`)
- **`UserCategoryMuteViewSet`** (`/api/narrative/category-mutes/`, list/create/delete) + `UserCategoryMute{,Create}Serializer`, `UserCategoryMuteFilter`, `IsOwnCategoryMuteOrStaff` — the category-level analogue of the existing story-mute ViewSet, scoped to the requesting account. Muting suppresses **only** the live push; messages still create delivery rows and stay readable in the category tab.

### Frontend (`narrative`)
- `getCategoryMutes` / `muteCategory` / `unmuteCategory` + `useCategoryMutes` / `useMuteCategory` / `useUnmuteCategory` hooks.
- **`CategoryMuteToggles`** — a `Switch` per squelchable ambient category (currently **WEATHER**, via the extensible `SQUELCHABLE_CATEGORIES` list), surfaced as an "Ambient Categories" section on `MuteSettingsPage`.

## Testing
- `arx test world.narrative.tests.test_category_mute_views world.narrative.tests.test_category_mute` — **13 tests OK** (view list/create/delete/auth/ownership/dup + the existing service contract).
- Full FE suite green (2277 tests); `MuteSettingsPage.test.tsx` extended with the toggle on/off/checked cases.
- `pnpm typecheck`, `pnpm lint` (0 errors), `pre-commit` full pass.

## Anti-reinvention
Reuses the shipped `UserCategoryMute` model + services and the story-mute ViewSet/serializer/permission/filter shape — this PR only adds the missing HTTP + React surface over them. No new model, migration, or service.

Refs #1522 (one slice; umbrella stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
