### PR TITLE
docs: correct false "Audere Majora unreachable" ledger claim (#1586)

### DIFF
--- a/docs/roadmap/player-capability-ledger.md
+++ b/docs/roadmap/player-capability-ledger.md
@@ -94,7 +94,7 @@ in-fiction trigger is plausible.
 | **Learn / train / buy** an existing technique | ❌ → DESIGNED | **ADR-0056** (signature thread for one technique) + **ADR-0053** (unlock gate) | MVP |
 | **Leveling grants magical power** (unlocks gifts/techniques) | ❌ → DESIGNED | **ADR-0053** (XP-unlock) + **ADR-0051** (thread strength); `Gift` docstring "powers unlock as you level" is not implemented | **now (foundational)** |
 | Trainer / teaching system | ❌ ABSENT | (`MentorBond` is a combat bond, not teaching) | soon |
-| Path-crossing (Audere Majora) — change path in play | 🟨 WIRED-UNPROVEN | resolution built, **offer never created in live code → unreachable** | fix+prove |
+| Path-crossing (Audere Majora) — change path in play | ✅ PROVEN | offer created by cast hook `maybe_create_audere_majora_offer` (`world/magic/services/techniques.py` Step 8c); journey driven E2E in `test_audere_telnet_e2e.py` | done |
 | Ritual of the Durance level-up | 🟨 WIRED-UNPROVEN | works via generic machinery but **unseeded** | fix |
 | Codex teaching / learning | 🟧 BUILT-NOT-WIRED | `CodexTeachingOffer.accept` has no player surface | soon |
 
@@ -136,7 +136,13 @@ A large build program; this ledger makes it **sequenceable and honest**. Five fl
 
 ### Fix (integrity / foundational holes)
 - `CharacterGiftViewSet` unguarded `ModelViewSet` (mints gift bindings, bypasses `action.run`).
-- Audere Majora offer never created in live code (climax unreachable).
+- Audere Majora: verify the private DB seed of `AudereMajoraThreshold` rows
+  (boundary levels 5/10/15/20) exists in the live DB. The offer-creation cast
+  hook (`techniques.py:950`) is wired and E2E-tested, but the gate returns
+  `None` at gate 2 unless those threshold rows are present. Ceremony text
+  (`vision_text`/`manifestation_text`) is intentionally DB-authored only, never
+  committed (see `world/magic/CLAUDE.md`, Audere & Audere Majora). No code
+  change; an ops/seed-verification check.
 - Ritual of the Durance unseeded.
 
 ### Cut (sludge — close, per "no rare permutations")


### PR DESCRIPTION
## What

Corrects a false claim in `docs/roadmap/player-capability-ledger.md` (introduced
in the #1576 realignment): that the Audere Majora crossing is WIRED-UNPROVEN
with "offer never created in live code → unreachable."

## Why it's wrong (verified against code)

The Audere Majora offer **is** created on every cast, on the line right after the
regular Audere offer:

```python
# src/world/magic/services/techniques.py — Step 8c of use_technique
from world.magic.audere_majora import maybe_create_audere_majora_offer  # noqa: PLC0415
maybe_create_audere_majora_offer(character, stats.intensity)
```

- `maybe_create_audere_majora_offer` (`world/magic/audere_majora.py:283-320`)
  persists the offer via `PendingAudereMajoraOffer.objects.update_or_create(...)`
  and broadcasts the manifestation EMIT on first creation.
- No flag or guard — runs unconditionally on the live cast spine, beside the
  regular Audere call (`maybe_create_audere_offer` at the same step), which the
  ledger already rates ✅ PROVEN.
- Landed in `64ea3874` ("Audere Majora — Path-progression threshold-crossing
  power-tier gate (#955)").
- The crossing journey is driven end-to-end in
  `integration_tests/pipeline/test_audere_telnet_e2e.py`
  (`CmdAccept path=<name> declaration=<text>` → registry → handler → service →
  `PendingAudereMajoraOffer` consumed + `AudereMajoraCrossing` recorded).
- `world/magic/CLAUDE.md` already documents this as a wired cast hook.

## Changes

One file, two spots:

1. **GROW-pillar row** (line 97): `🟨 WIRED-UNPROVEN … unreachable` →
   `✅ PROVEN` — offer created by the cast hook; journey E2E-tested.
2. **Fix bullet** (line 139): replaced the false "offer never created" item with
   the accurate residual check — **verify the private `AudereMajoraThreshold`
   seed (levels 5/10/15/20) exists in the live DB**. The gate returns `None` at
   gate 2 unless those rows exist; ceremony text is intentionally DB-authored
   only, never committed. This is an ops/seed-verification note, not a code task.

No code change. No tests touched (docs-only; pre-commit shard-coverage hook passed).

Refs #1586