### PR TITLE
feat: web visibility toggle for quiet/hidden mode (#1484)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -11773,6 +11773,24 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/roster/visibility-settings/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Return the active character's current ``appear_offline`` value. */
+    get: operations['roster_visibility_settings_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** @description Set the active character's ``appear_offline`` (quiet/hidden mode). */
+    patch: operations['roster_visibility_settings_partial_update'];
+    trace?: never;
+  };
   '/api/scenes/': {
     parameters: {
       query?: never;
@@ -22475,6 +22493,16 @@ export interface components {
     PatchedUpdateBulletinReplyInputRequest: {
       body?: string;
     };
+    /**
+     * @description The active character's own visibility prefs (#1484). Starts with ``appear_offline``.
+     *
+     *     Read-and-write of quiet/hidden mode for the requesting player's active character. The
+     *     fine-grained advanced controls (``show_online_status`` / ``allow_pages`` / ``allow_tells``)
+     *     can join this surface later; the model already carries them.
+     */
+    PatchedVisibilitySettingsRequest: {
+      appear_offline?: boolean;
+    };
     /** @description Serializer for Path in CG context. */
     Path: {
       readonly id: number;
@@ -26077,6 +26105,16 @@ export interface components {
      * @enum {string}
      */
     VisibilityFdaEnum: 'private' | 'shared' | 'gossip' | 'public';
+    /**
+     * @description The active character's own visibility prefs (#1484). Starts with ``appear_offline``.
+     *
+     *     Read-and-write of quiet/hidden mode for the requesting player's active character. The
+     *     fine-grained advanced controls (``show_online_status`` / ``allow_pages`` / ``allow_tells``)
+     *     can join this surface later; the model already carries them.
+     */
+    VisibilitySettings: {
+      appear_offline: boolean;
+    };
     /** @description All three fatigue pools plus global flags. */
     VitalsFatigue: {
       physical: components['schemas']['FatiguePoolStatus'];
@@ -43361,6 +43399,48 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['RosterTenureLookup'];
+        };
+      };
+    };
+  };
+  roster_visibility_settings_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['VisibilitySettings'];
+        };
+      };
+    };
+  };
+  roster_visibility_settings_partial_update: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['PatchedVisibilitySettingsRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['VisibilitySettings'];
         };
       };
     };

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,6 +3,46 @@ import { useRealmTheme } from '@/components/realm-theme-provider';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { useSetAppearOffline, useVisibilitySettings } from '@/roster/visibility';
+
+function VisibilityPreferences() {
+  const { data, isLoading, isError } = useVisibilitySettings();
+  const setAppearOffline = useSetAppearOffline();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Visibility</CardTitle>
+        <CardDescription>Control how your active character appears to others.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isError ? (
+          <p className="text-sm text-muted-foreground" data-testid="visibility-no-character">
+            Play a character to manage its visibility.
+          </p>
+        ) : (
+          <div className="flex items-center justify-between">
+            <div className="pr-4">
+              <Label htmlFor="appear-offline">Quiet (hidden) mode</Label>
+              <p className="text-sm text-muted-foreground">
+                When on, you don&apos;t appear in <code>where</code>/<code>who</code> and can&apos;t
+                be paged except by your allowlist. Mail, missions, channels, and same-room presence
+                are unaffected.
+              </p>
+            </div>
+            <Switch
+              id="appear-offline"
+              checked={data?.appear_offline ?? false}
+              disabled={isLoading || setAppearOffline.isPending}
+              onCheckedChange={(next) => setAppearOffline.mutate(next)}
+              aria-label="Quiet (hidden) mode"
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
 
 function ThemePreferences() {
   const { plainMode, setPlainMode } = useRealmTheme();
@@ -30,6 +70,7 @@ function ThemePreferences() {
 export function SettingsPage() {
   return (
     <div className="mt-4 space-y-6">
+      <VisibilityPreferences />
       <ThemePreferences />
       <ConnectedAccounts />
     </div>

--- a/frontend/src/pages/__tests__/SettingsPage.visibility.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.visibility.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * SettingsPage — Visibility (quiet/hidden mode) toggle tests (#1484).
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { SettingsPage } from '../SettingsPage';
+
+vi.mock('@/roster/visibility', () => ({
+  useVisibilitySettings: vi.fn(),
+  useSetAppearOffline: vi.fn(),
+}));
+
+// Theme provider + connected-accounts pull from contexts/network we don't exercise here.
+vi.mock('@/components/realm-theme-provider', () => ({
+  useRealmTheme: () => ({ plainMode: false, setPlainMode: vi.fn() }),
+}));
+vi.mock('@/components/ConnectedAccounts', () => ({ ConnectedAccounts: () => null }));
+
+import * as visibility from '@/roster/visibility';
+
+function mockSettings(data: { appear_offline: boolean } | undefined, { isError = false } = {}) {
+  vi.mocked(visibility.useVisibilitySettings).mockReturnValue({
+    data,
+    isLoading: false,
+    isError,
+  } as unknown as ReturnType<typeof visibility.useVisibilitySettings>);
+}
+
+function mockMutation(mutate = vi.fn()) {
+  vi.mocked(visibility.useSetAppearOffline).mockReturnValue({
+    mutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof visibility.useSetAppearOffline>);
+  return mutate;
+}
+
+describe('SettingsPage visibility toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the toggle unchecked when not hidden', () => {
+    mockSettings({ appear_offline: false });
+    mockMutation();
+    render(<SettingsPage />);
+    expect(screen.getByLabelText('Quiet (hidden) mode')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('renders the toggle checked when hidden', () => {
+    mockSettings({ appear_offline: true });
+    mockMutation();
+    render(<SettingsPage />);
+    expect(screen.getByLabelText('Quiet (hidden) mode')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('calls the mutation when toggled on', async () => {
+    const user = userEvent.setup();
+    mockSettings({ appear_offline: false });
+    const mutate = mockMutation();
+    render(<SettingsPage />);
+    await user.click(screen.getByLabelText('Quiet (hidden) mode'));
+    expect(mutate).toHaveBeenCalledWith(true);
+  });
+
+  it('shows a hint when no character is being played', () => {
+    mockSettings(undefined, { isError: true });
+    mockMutation();
+    render(<SettingsPage />);
+    expect(screen.getByTestId('visibility-no-character')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/roster/visibility.ts
+++ b/frontend/src/roster/visibility.ts
@@ -1,0 +1,48 @@
+/**
+ * Visibility settings (#1484) — the web control for quiet/hidden mode (`appear_offline`).
+ *
+ * Scoped to the player's active character; reads/writes `/api/roster/visibility-settings/` (the
+ * web equivalent of the telnet `hide`/`unhide` commands). React Query hooks + plain fetchers.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { apiFetch } from '@/evennia_replacements/api';
+import type { components } from '@/generated/api';
+
+export type VisibilitySettings = components['schemas']['VisibilitySettings'];
+
+const URL = '/api/roster/visibility-settings/';
+
+export async function fetchVisibilitySettings(): Promise<VisibilitySettings> {
+  const res = await apiFetch(URL);
+  if (!res.ok) throw new Error('Failed to load visibility settings');
+  return res.json() as Promise<VisibilitySettings>;
+}
+
+export async function setAppearOffline(appearOffline: boolean): Promise<VisibilitySettings> {
+  const res = await apiFetch(URL, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ appear_offline: appearOffline }),
+  });
+  if (!res.ok) throw new Error('Failed to update visibility settings');
+  return res.json() as Promise<VisibilitySettings>;
+}
+
+const visibilityKey = ['roster', 'visibility-settings'] as const;
+
+/** The active character's visibility prefs. Quiet (404/no-character) is surfaced as an error. */
+export function useVisibilitySettings() {
+  return useQuery({ queryKey: visibilityKey, queryFn: fetchVisibilitySettings });
+}
+
+export function useSetAppearOffline() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (appearOffline: boolean) => setAppearOffline(appearOffline),
+    onSuccess: (data) => {
+      queryClient.setQueryData(visibilityKey, data);
+    },
+  });
+}

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -265,6 +265,9 @@ actions, backends, and service functions.
   toggles persistent quiet mode (`TenureDisplaySettings.appear_offline` via
   `world.roster.services.display.set_appear_offline`): off where/who + unpageable except the
   caller's `PlayerAllowList`. Viewer-scoping lives in the presence services + `CmdPage`'s gate.
+  The **web equivalent** is `GET`/`PATCH /api/roster/visibility-settings/`
+  (`roster.views.settings_views.VisibilitySettingsView`, #1484) — same `set_appear_offline` write,
+  scoped to the player's active character; the toggle lives on the frontend `SettingsPage`.
 - **`fatigue.py`**: `CmdRest` (`rest`, #1491) — telnet face of `RestAction`. Spend AP to become
   Well-Rested; thin REGISTRY command that delegates directly to `actions.definitions.fatigue.RestAction`.
 - **`sanctum.py`**: `CmdSanctum` (`sanctum`, #1497) — the sanctum-management namespace. One

--- a/src/schema.json
+++ b/src/schema.json
@@ -19830,6 +19830,40 @@ paths:
               schema:
                 $ref: '#/components/schemas/RosterTenureLookup'
           description: ''
+  /api/roster/visibility-settings/:
+    get:
+      operationId: roster_visibility_settings_retrieve
+      description: Return the active character's current ``appear_offline`` value.
+      tags:
+      - roster
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VisibilitySettings'
+          description: ''
+    patch:
+      operationId: roster_visibility_settings_partial_update
+      description: Set the active character's ``appear_offline`` (quiet/hidden mode).
+      tags:
+      - roster
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedVisibilitySettingsRequest'
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VisibilitySettings'
+          description: ''
   /api/scenes/:
     get:
       operationId: scenes_list
@@ -40130,6 +40164,17 @@ components:
         body:
           type: string
           minLength: 1
+    PatchedVisibilitySettingsRequest:
+      type: object
+      description: |-
+        The active character's own visibility prefs (#1484). Starts with ``appear_offline``.
+
+        Read-and-write of quiet/hidden mode for the requesting player's active character. The
+        fine-grained advanced controls (``show_online_status`` / ``allow_pages`` / ``allow_tells``)
+        can join this surface later; the model already carries them.
+      properties:
+        appear_offline:
+          type: boolean
     Path:
       type: object
       description: Serializer for Path in CG context.
@@ -47556,6 +47601,19 @@ components:
         * `shared` - Shared
         * `gossip` - Gossip
         * `public` - Public
+    VisibilitySettings:
+      type: object
+      description: |-
+        The active character's own visibility prefs (#1484). Starts with ``appear_offline``.
+
+        Read-and-write of quiet/hidden mode for the requesting player's active character. The
+        fine-grained advanced controls (``show_online_status`` / ``allow_pages`` / ``allow_tells``)
+        can join this surface later; the model already carries them.
+      properties:
+        appear_offline:
+          type: boolean
+      required:
+      - appear_offline
     VitalsFatigue:
       type: object
       description: All three fatigue pools plus global flags.

--- a/src/world/roster/serializers/settings.py
+++ b/src/world/roster/serializers/settings.py
@@ -1,0 +1,19 @@
+"""Per-character display/visibility settings serializers (#1484, #1463).
+
+The web control surface over ``TenureDisplaySettings.appear_offline`` (quiet/hidden mode). The
+write goes through ``roster.services.display.set_appear_offline`` — this serializer only shapes
+the request/response.
+"""
+
+from rest_framework import serializers
+
+
+class VisibilitySettingsSerializer(serializers.Serializer):
+    """The active character's own visibility prefs (#1484). Starts with ``appear_offline``.
+
+    Read-and-write of quiet/hidden mode for the requesting player's active character. The
+    fine-grained advanced controls (``show_online_status`` / ``allow_pages`` / ``allow_tells``)
+    can join this surface later; the model already carries them.
+    """
+
+    appear_offline = serializers.BooleanField()

--- a/src/world/roster/tests/test_visibility_settings_view.py
+++ b/src/world/roster/tests/test_visibility_settings_view.py
@@ -1,0 +1,69 @@
+"""API tests for GET/PATCH /api/roster/visibility-settings/ (#1484, #1463 follow-up).
+
+The web control for quiet/hidden mode (``appear_offline``). Scoped to the requesting player's
+active character; the write reuses ``set_appear_offline``.
+"""
+
+from types import SimpleNamespace
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import (
+    PlayerDataFactory,
+    RosterEntryFactory,
+    RosterTenureFactory,
+    TenureDisplaySettingsFactory,
+)
+from world.roster.models import TenureDisplaySettings
+from world.roster.views.settings_views import VisibilitySettingsView
+
+URL = "/api/roster/visibility-settings/"
+
+
+class VisibilitySettingsViewTests(TestCase):
+    def setUp(self):
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        self.entry = RosterEntryFactory(character_sheet=self.sheet)
+        self.tenure = RosterTenureFactory(roster_entry=self.entry, player_data=PlayerDataFactory())
+        self.factory = APIRequestFactory()
+
+    def _request(self, method, *, puppet, data=None):
+        request = getattr(self.factory, method)(URL, data or {}, format="json")
+        user = SimpleNamespace(is_authenticated=True, is_staff=False, puppet=puppet)
+        force_authenticate(request, user=user)
+        return VisibilitySettingsView.as_view()(request)
+
+    def test_get_defaults_to_visible_when_no_settings_row(self):
+        resp = self._request("get", puppet=self.character)
+        assert resp.status_code == 200
+        assert resp.data["appear_offline"] is False
+
+    def test_get_reflects_stored_value(self):
+        TenureDisplaySettingsFactory(tenure=self.tenure, appear_offline=True)
+        resp = self._request("get", puppet=self.character)
+        assert resp.status_code == 200
+        assert resp.data["appear_offline"] is True
+
+    def test_patch_enables_hidden_mode(self):
+        resp = self._request("patch", puppet=self.character, data={"appear_offline": True})
+        assert resp.status_code == 200
+        assert resp.data["appear_offline"] is True
+        assert TenureDisplaySettings.objects.get(tenure=self.tenure).appear_offline is True
+
+    def test_patch_disables_hidden_mode(self):
+        TenureDisplaySettingsFactory(tenure=self.tenure, appear_offline=True)
+        resp = self._request("patch", puppet=self.character, data={"appear_offline": False})
+        assert resp.status_code == 200
+        assert resp.data["appear_offline"] is False
+        assert TenureDisplaySettings.objects.get(tenure=self.tenure).appear_offline is False
+
+    def test_patch_requires_the_field(self):
+        resp = self._request("patch", puppet=self.character, data={})
+        assert resp.status_code == 400
+
+    def test_no_played_character_is_400(self):
+        resp = self._request("get", puppet=None)
+        assert resp.status_code == 400

--- a/src/world/roster/urls.py
+++ b/src/world/roster/urls.py
@@ -2,6 +2,7 @@
 URL patterns for the roster system API.
 """
 
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from world.roster.views import (
@@ -14,6 +15,7 @@ from world.roster.views import (
     RosterViewSet,
     TenureGalleryViewSet,
 )
+from world.roster.views.settings_views import VisibilitySettingsView
 
 app_name = "roster"
 
@@ -27,4 +29,11 @@ router.register("mail", PlayerMailViewSet, basename="mail")
 router.register("tenures", RosterTenureViewSet, basename="tenures")
 router.register("galleries", TenureGalleryViewSet, basename="galleries")
 
-urlpatterns = router.urls
+urlpatterns = [
+    path(
+        "visibility-settings/",
+        VisibilitySettingsView.as_view(),
+        name="visibility-settings",
+    ),
+    *router.urls,
+]

--- a/src/world/roster/views/settings_views.py
+++ b/src/world/roster/views/settings_views.py
@@ -1,0 +1,74 @@
+"""Per-character visibility-settings API (#1484, #1463 follow-up).
+
+The web control for quiet/hidden mode (``appear_offline``). Telnet has ``hide``/``unhide``; this is
+the web equivalent — the frontend is the primary interface, so a switch was missing. Scoped to the
+requesting player's **active character**: reads/writes that character's own
+``TenureDisplaySettings`` via the existing ``set_appear_offline`` write path (never duplicated).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers, status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from world.roster.serializers.settings import VisibilitySettingsSerializer
+from world.roster.services.display import set_appear_offline
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
+
+    from world.roster.models import RosterTenure
+
+
+class VisibilitySettingsView(APIView):
+    """GET / PATCH the active character's own visibility prefs (#1484).
+
+    ``GET  /api/roster/visibility-settings/``  → current ``appear_offline``.
+    ``PATCH /api/roster/visibility-settings/`` → set it (reuses ``set_appear_offline``).
+
+    Scoped to the requesting player's currently-played character (its current tenure); a request
+    with no played character is rejected uniformly. A player can only ever read/write their own
+    character's settings — there is no cross-character access.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def _current_tenure(self, request: Request) -> RosterTenure:
+        """The played character's current tenure, or raise a uniform validation error."""
+        puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
+        sheet = getattr(puppet, "sheet_data", None) if puppet is not None else None  # noqa: GETATTR_LITERAL
+        entry = getattr(sheet, "roster_entry", None) if sheet is not None else None  # noqa: GETATTR_LITERAL
+        tenure = entry.current_tenure if entry is not None else None
+        if tenure is None:
+            msg = "You must be playing a character to change its visibility."
+            raise serializers.ValidationError(msg)
+        return tenure
+
+    @extend_schema(responses=VisibilitySettingsSerializer, tags=["roster"])
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Return the active character's current ``appear_offline`` value."""
+        tenure = self._current_tenure(request)
+        settings_obj = getattr(tenure, "display_settings", None)  # noqa: GETATTR_LITERAL
+        appear_offline = bool(settings_obj.appear_offline) if settings_obj is not None else False
+        return Response(VisibilitySettingsSerializer({"appear_offline": appear_offline}).data)
+
+    @extend_schema(
+        request=VisibilitySettingsSerializer,
+        responses=VisibilitySettingsSerializer,
+        tags=["roster"],
+    )
+    def patch(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Set the active character's ``appear_offline`` (quiet/hidden mode)."""
+        body = VisibilitySettingsSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        tenure = self._current_tenure(request)
+        value = set_appear_offline(tenure=tenure, value=body.validated_data["appear_offline"])
+        return Response(
+            VisibilitySettingsSerializer({"appear_offline": value}).data,
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
## Summary

The web control for **quiet/hidden mode** (`appear_offline`) — closes the #1463 follow-up #1484. The backend shipped in #1477 (model + `hide`/`unhide` telnet commands + where/who/page gating), but the frontend — the primary interface — had no switch. This adds one, reusing the existing write path (no duplication).

### Backend (`world.roster`)
- **`VisibilitySettingsView`** (`GET` / `PATCH /api/roster/visibility-settings/`, `VisibilitySettingsSerializer`) — reads/writes the requesting player's **active character's** `appear_offline`. Scoped via the played puppet → its `current_tenure`; a request with no played character is a uniform 400, and there's no cross-character access. The write reuses `roster.services.display.set_appear_offline`; GET defaults to visible when no settings row exists.

### Frontend
- `roster/visibility.ts` — `useVisibilitySettings` / `useSetAppearOffline` hooks over the endpoint.
- A **Visibility** card on `SettingsPage` with a `Switch`, explaining exactly what hiding does (off `where`/`who`, unpageable except your allowlist; mail/missions/channels and same-room presence unaffected). Shows a "play a character" hint when none is active.

## Testing
- `world.roster.tests.test_visibility_settings_view` — **6 tests OK** (GET default/stored, PATCH on/off, missing-field 400, no-played-character 400).
- `SettingsPage.visibility.test.tsx` — toggle unchecked/checked, fires the mutation, no-character hint; full FE suite green (2281).
- Regenerated `api.d.ts` + `schema.json`; updated the commands guide.

## Anti-reinvention
The issue's premise was already code-verified (`set_appear_offline` write + `character_appears_offline` read exist; no `TenureDisplaySettings` API existed). This adds only the missing HTTP surface + web toggle over them — no new model, migration, or service.

Closes #1484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
