### PR TITLE
refactor: promote _get_active_scene to public get_active_scene (#1370)

### DIFF
--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -192,7 +192,7 @@ actions, backends, and service functions.
   `poses <char>` lists endorseable poses in the current scene.
   `endorse pose/entry/style <char> resonance=<name> [confirm]` dispatches to the
   appropriate action. Both derive the active scene from the caller's room via
-  `_get_active_scene` (#1340).
+  `get_active_scene` (#1340).
 - **`fashion.py`**: `CmdJudgePresentation` (`judge`) — telnet face of
   `JudgePresentationAction`; parses `judge <presentation_id>` (#1340).
 - **`missions.py`**: `CmdMission` (`mission`, #1349) — the mission play namespace. Thin over the
@@ -213,7 +213,7 @@ actions, backends, and service functions.
   (the subverb IS the kind: `react kudos <char> #1`, `react entrance <char> #1 <resonance>`) →
   `ReactToWindowAction`; bare `react` lists open reactable events in the current scene. Pose
   targeting reuses `get_endorseable_poses_in_scene` (`<char> #N`, the same scheme as `endorse`);
-  the active scene derives from the caller's room via `_get_active_scene`. The entrance resonance
+  the active scene derives from the caller's room via `get_active_scene`. The entrance resonance
   name is resolved to `str(pk)` here (mirrors `CmdEndorse._resolve_resonance`) — the Action stays a
   thin slug-taking wrapper. Shared by telnet + the web viewsets; no business logic in the command.
 - **`gemit.py`**: `CmdGemit` (`gemit`, staff-only `perm(Admin)`, #1450) — the *push* face of the

--- a/src/commands/combat.py
+++ b/src/commands/combat.py
@@ -640,10 +640,10 @@ class CmdDeclareTechnique(_CombatCommandMixin, DispatchCommand):
         if not self._target_name:
             return None
 
-        from world.scenes.interaction_services import _get_active_scene  # noqa: PLC0415
+        from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
 
         name = self._target_name.lower()
-        scene = _get_active_scene(self.caller.location)
+        scene = get_active_scene(self.caller.location)
         if scene is None:
             msg = "There is no active scene here."
             raise CommandError(msg)

--- a/src/commands/conditions.py
+++ b/src/commands/conditions.py
@@ -9,7 +9,7 @@ from commands.exceptions import CommandError
 from world.conditions.constants import TARGET_EFFECT_CONDITION
 from world.conditions.services import get_treatment_candidates
 from world.scenes.action_services import create_action_request
-from world.scenes.interaction_services import _get_active_scene
+from world.scenes.interaction_services import get_active_scene
 from world.scenes.services import active_persona_for_sheet
 
 if TYPE_CHECKING:
@@ -43,7 +43,7 @@ class CmdTreatCondition(ArxCommand):
         if not args:
             raise CommandError(_NO_ARGS_MSG)
 
-        scene = _get_active_scene(caller.location)
+        scene = get_active_scene(caller.location)
         if scene is None:
             raise CommandError(_NO_SCENE_MSG)
 

--- a/src/commands/consent.py
+++ b/src/commands/consent.py
@@ -30,7 +30,7 @@ from commands.offer_registry import find_handler, format_pending_listing, get_al
 from world.scenes.action_constants import ActionRequestStatus, ConsentDecision
 from world.scenes.action_models import SceneActionRequest
 from world.scenes.action_services import create_action_request, respond_to_action_request
-from world.scenes.interaction_services import _get_active_scene
+from world.scenes.interaction_services import get_active_scene
 from world.scenes.services import active_persona_for_sheet
 
 if TYPE_CHECKING:
@@ -82,7 +82,7 @@ class ConsentRequestCommand(ArxCommand):
         derives them. Raises ``CommandError`` on either miss so the command
         surfaces a clean message.
         """
-        scene = _get_active_scene(getattr(self.caller, "location", None))  # noqa: GETATTR_LITERAL
+        scene = get_active_scene(getattr(self.caller, "location", None))  # noqa: GETATTR_LITERAL
         if scene is None:
             msg = "You are not in an active scene."
             raise CommandError(msg)

--- a/src/commands/deeds.py
+++ b/src/commands/deeds.py
@@ -171,9 +171,9 @@ class CmdDeed(DispatchCommand):
 
     def _current_scene_id(self) -> int:
         """Return the active scene for the caller's current location."""
-        from world.scenes.interaction_services import _get_active_scene  # noqa: PLC0415
+        from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
 
-        scene = _get_active_scene(self.caller.location)
+        scene = get_active_scene(self.caller.location)
         if scene is None:
             msg = "There is no active scene here."
             raise CommandError(msg)

--- a/src/commands/endorse.py
+++ b/src/commands/endorse.py
@@ -6,7 +6,7 @@ CmdEndorse: ``endorse pose <char> [#N] resonance=<name> [confirm]``
             ``endorse style <char> resonance=<name>``
 
 Both commands derive the active scene from the caller's room
-(``_get_active_scene``), exactly like CmdIntimidate / CmdAccept.
+(``get_active_scene``), exactly like CmdIntimidate / CmdAccept.
 All eligibility and creation logic lives in the actions + service functions.
 """
 
@@ -41,7 +41,7 @@ class CmdPoses(ArxCommand):
 
     def _list_poses(self) -> None:
         from world.magic.services.gain import get_endorseable_poses_in_scene  # noqa: PLC0415
-        from world.scenes.interaction_services import _get_active_scene  # noqa: PLC0415
+        from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
 
         char_name = (self.args or "").strip()
         if not char_name:
@@ -62,7 +62,7 @@ class CmdPoses(ArxCommand):
             msg = "You have no character sheet."
             raise CommandError(msg)
 
-        scene = _get_active_scene(getattr(self.caller, "location", None))  # noqa: GETATTR_LITERAL
+        scene = get_active_scene(getattr(self.caller, "location", None))  # noqa: GETATTR_LITERAL
         if scene is None:
             msg = "There is no active scene here."
             raise CommandError(msg)
@@ -176,9 +176,9 @@ class CmdEndorse(ArxCommand):
         return sheet
 
     def _active_scene(self) -> Any:
-        from world.scenes.interaction_services import _get_active_scene  # noqa: PLC0415
+        from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
 
-        scene = _get_active_scene(getattr(self.caller, "location", None))  # noqa: GETATTR_LITERAL
+        scene = get_active_scene(getattr(self.caller, "location", None))  # noqa: GETATTR_LITERAL
         if scene is None:
             msg = "There is no active scene here."
             raise CommandError(msg)

--- a/src/commands/react.py
+++ b/src/commands/react.py
@@ -10,7 +10,7 @@ One ``react`` command routes a leading subverb:
 
 ``<char> #N`` resolves via the existing ``get_endorseable_poses_in_scene``
 (stable per-author, visibility-filtered numbering) -- the same scheme ``endorse``
-uses. The active scene is derived from the caller's room (``_get_active_scene``).
+uses. The active scene is derived from the caller's room (``get_active_scene``).
 No business logic in the command: parse, resolve the pose, run the Action.
 """
 
@@ -84,9 +84,9 @@ class CmdReact(ArxCommand):
         return sheet
 
     def _active_scene(self) -> Any:
-        from world.scenes.interaction_services import _get_active_scene  # noqa: PLC0415
+        from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
 
-        scene = _get_active_scene(getattr(self.caller, "location", None))  # noqa: GETATTR_LITERAL
+        scene = get_active_scene(getattr(self.caller, "location", None))  # noqa: GETATTR_LITERAL
         if scene is None:
             msg = "There is no active scene here."
             raise CommandError(msg)

--- a/src/commands/social/soul_tether.py
+++ b/src/commands/social/soul_tether.py
@@ -30,7 +30,7 @@ from world.magic.services.soul_tether import (
 )
 from world.magic.types.soul_tether import SoulTetherRole as _SoulTetherRoleEnum
 from world.relationships.models import CharacterRelationship
-from world.scenes.interaction_services import _get_active_scene
+from world.scenes.interaction_services import get_active_scene
 
 _RESONANCE_KWARG = "resonance"
 _SINS_KWARG = "sins"
@@ -302,7 +302,7 @@ class CmdTether(ArxCommand):
         sineater_sheet = _get_sheet(sineater_char)
         caller_sheet = _get_sheet(self.caller)
 
-        scene = _get_active_scene(
+        scene = get_active_scene(
             getattr(self.caller, "location", None)  # noqa: GETATTR_LITERAL
         )
         if scene is None:
@@ -481,7 +481,7 @@ class CmdSineater(ArxCommand):
         sinner_sheet = _get_sheet(sinner_char)
         caller_sheet = _get_sheet(self.caller)
 
-        scene = _get_active_scene(
+        scene = get_active_scene(
             getattr(self.caller, "location", None)  # noqa: GETATTR_LITERAL
         )
         if scene is None:

--- a/src/commands/tests/test_soul_tether_e2e.py
+++ b/src/commands/tests/test_soul_tether_e2e.py
@@ -331,7 +331,7 @@ class SoulTetherJourneyTests(TestCase):
                 f" writeup=Test bond."
             ),
         )
-        # Remove character from room so _get_active_scene returns None.
+        # Remove character from room so get_active_scene returns None.
         self.sinner_char.location = None
         self.sinner_char.save()
         if hasattr(self.room, "_active_scene_cache"):

--- a/src/integration_tests/pipeline/test_consent_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_consent_telnet_e2e.py
@@ -96,7 +96,7 @@ class ConsentTelnetE2ETests(TestCase):
         self.addCleanup(self.accrue_patcher.stop)
 
         # Room both characters share; the scene is located here so the telnet
-        # command's _get_active_scene(location) finds it.
+        # command's get_active_scene(location) finds it.
         self.room = ObjectDB.objects.create(
             db_key="TestRoom",
             db_typeclass_path="typeclasses.rooms.Room",

--- a/src/integration_tests/pipeline/test_endorsement_journey_e2e.py
+++ b/src/integration_tests/pipeline/test_endorsement_journey_e2e.py
@@ -188,7 +188,7 @@ class EndorsementJourneyE2ETests(TestCase):
     def test_poses_no_active_scene_shows_error(self) -> None:
         """``poses`` outside an active scene sends a CommandError message."""
         # Move both characters to a room with no active scene so search succeeds
-        # but _get_active_scene returns None.
+        # but get_active_scene returns None.
         empty_room = ObjectDB.objects.create(
             db_key="EmptyRoom",
             db_typeclass_path="typeclasses.rooms.Room",

--- a/src/world/conditions/views.py
+++ b/src/world/conditions/views.py
@@ -482,9 +482,9 @@ class TreatmentCandidateViewSet(CharacterContextMixin, viewsets.ViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        from world.scenes.interaction_services import _get_active_scene  # noqa: PLC0415
+        from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
 
-        scene = _get_active_scene(character.location)
+        scene = get_active_scene(character.location)
         if scene is None:
             return Response(
                 {"detail": "You are not in an active scene."},

--- a/src/world/covenants/handlers.py
+++ b/src/world/covenants/handlers.py
@@ -194,7 +194,7 @@ def can_engage_membership(membership: CharacterCovenantRole) -> bool:
     the Slice B spec — no .filter() on related managers.
     """
     from world.covenants.constants import CovenantType  # noqa: PLC0415
-    from world.scenes.interaction_services import _get_active_scene  # noqa: PLC0415
+    from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
 
     covenant = membership.covenant
     if covenant.covenant_type == CovenantType.BATTLE:
@@ -204,7 +204,7 @@ def can_engage_membership(membership: CharacterCovenantRole) -> bool:
     location = char.location
     if location is None:
         return False
-    if _get_active_scene(location) is None:
+    if get_active_scene(location) is None:
         return False
     self_sheet = membership.character_sheet
     target_covenant = membership.covenant

--- a/src/world/covenants/tests/test_engagement_prerequisite.py
+++ b/src/world/covenants/tests/test_engagement_prerequisite.py
@@ -94,7 +94,7 @@ class EngagementPrerequisiteBranchesTests(TestCase):
         if hasattr(room, "_active_scene_cache"):
             del room._active_scene_cache
 
-        # No Scene created at this room → _get_active_scene returns None
+        # No Scene created at this room → get_active_scene returns None
         self.assertFalse(can_engage_membership(self.mem_a_durance))
 
         # Cleanup location so other tests start fresh

--- a/src/world/scenes/interaction_services.py
+++ b/src/world/scenes/interaction_services.py
@@ -35,12 +35,14 @@ DELETION_WINDOW_DAYS = 30
 _ephemeral_counter = itertools.count()
 
 
-def _get_active_scene(location: ObjectDB | None) -> Scene | None:
-    """Get the active scene for a location, with in-memory caching.
+def get_active_scene(location: ObjectDB | None) -> Scene | None:
+    """The location → active-scene resolver, with in-memory caching (#1370).
 
-    Caches the result on the location object (which persists in memory via
-    SharedMemoryModel's identity map). Invalidated by
-    invalidate_active_scene_cache() when a scene starts or ends.
+    The single public entry point for deriving the scene at a room — shared by the say/pose
+    recorders and the telnet scene-derivation commands (consent / endorse / react / etc.), so
+    they never hand-roll a parallel ``Scene.objects.filter(...)`` query. Caches the result on
+    the location object (which persists in memory via SharedMemoryModel's identity map);
+    invalidated by ``invalidate_active_scene_cache()`` when a scene starts or ends.
     """
     if location is None:
         return None
@@ -652,7 +654,7 @@ def record_interaction(  # noqa: PLR0913 - all fields needed for interaction cre
         return None
 
     if scene is None:
-        scene = _get_active_scene(character.location)
+        scene = get_active_scene(character.location)
 
     # Ephemeral scenes: push in real-time but never persist
     if scene is not None and scene.privacy_mode == ScenePrivacyMode.EPHEMERAL:
@@ -715,7 +717,7 @@ def record_whisper_interaction(
     except ObjectDoesNotExist:
         return None
 
-    scene = _get_active_scene(character.location)
+    scene = get_active_scene(character.location)
 
     # Ephemeral scenes: push in real-time but never persist
     if scene is not None and scene.privacy_mode == ScenePrivacyMode.EPHEMERAL:

--- a/src/world/scenes/tests/test_interaction_services.py
+++ b/src/world/scenes/tests/test_interaction_services.py
@@ -22,10 +22,10 @@ from world.scenes.factories import (
 )
 from world.scenes.interaction_services import (
     _get_account_for_character,
-    _get_active_scene,
     can_view_interaction,
     create_interaction,
     delete_interaction,
+    get_active_scene,
     mark_very_private,
     push_interaction,
     reassign_persona_interactions,
@@ -852,7 +852,7 @@ class TestGetActiveScene(TestCase):
             db_typeclass_path="typeclasses.rooms.Room",
         )
         scene = SceneFactory(location=room, is_active=True)
-        result = _get_active_scene(room)
+        result = get_active_scene(room)
         assert result is not None
         assert result.pk == scene.pk
 
@@ -862,11 +862,11 @@ class TestGetActiveScene(TestCase):
             db_typeclass_path="typeclasses.rooms.Room",
         )
         SceneFactory(location=room, is_active=False)
-        result = _get_active_scene(room)
+        result = get_active_scene(room)
         assert result is None
 
     def test_returns_none_for_none_location(self) -> None:
-        assert _get_active_scene(None) is None
+        assert get_active_scene(None) is None
 
 
 class TestRecordInteractionActiveSceneFromDB(TestCase):


### PR DESCRIPTION
## Summary

Promotes `world.scenes.interaction_services._get_active_scene` to a public `get_active_scene` (#1370) — a small, self-contained refactor, **no behavior change**.

The location → active-scene resolver was a module-private symbol imported across ~10 modules (the say/pose recorders, plus the telnet consent / endorse / react / conditions / deeds / soul-tether commands and a couple of backend views/handlers). Cross-module import of an underscore symbol is a coupling smell; making it public gives the convergence an explicit, supported entry point (and a clean hook for the #1328 telnet-journey commands).

### Changes
- Renamed the definition to `get_active_scene` and repointed **every** caller (imports + call sites) across 15 files — no thin alias left behind, so the underscore import disappears entirely.
- Left the unrelated `flows/.../room_state.py` `self._get_active_scene` **method** untouched (different symbol).
- Updated the docstring (now documents it as the single public resolver) and the two `commands/CLAUDE.md` references.

## Testing
- `world.scenes.tests.test_interaction_services` + `world.covenants.tests.test_engagement_prerequisite` (both exercise the resolver) — green.
- `ruff` clean on the swept files. Pure rename, so no other behavior to verify; CI runs the full backend regression.

## Note on scope
Two of the repointed files (`commands/combat.py`, `commands/social/soul_tether.py`) are in TehomCD's domain, but these are **import-name renames only** — no logic touched, and the resolver itself is a scenes-domain primitive.

Closes #1370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
