### PR TITLE
fix: refresh block reason on re-block (#1326 Finding A)

### DIFF
--- a/src/world/scenes/block_services.py
+++ b/src/world/scenes/block_services.py
@@ -267,17 +267,27 @@ def create_block(
         msg = "You cannot block your own character."
         raise ValidationError(msg)
 
-    block, _ = Block.objects.get_or_create(
+    block, created = Block.objects.get_or_create(
         owner=blocker_player,
         blocked_player=blocked_player,
         blocker_persona=blocker_persona,
         blocked_persona=blocked_persona,
         defaults={"reason": reason, "account_level": False, "pending_removal_at": None},
     )
+    # ``defaults`` only apply on INSERT (the django_get_or_create gotcha). On a re-block (the row
+    # already exists — the real path being a re-block within the unblock grace window) refresh the
+    # staff-facing ``reason`` to the latest one rather than silently keeping the stale one (#1326).
+    # (``account_level`` staleness on re-block is a deliberate player-intent question — left as-is.)
+    update_fields: list[str] = []
+    if not created and block.reason != reason:
+        block.reason = reason
+        update_fields.append("reason")
     # Re-blocking a pair mid-grace cancels the pending removal (it's active again).
     if block.pending_removal_at is not None:
         block.pending_removal_at = None
-        block.save(update_fields=["pending_removal_at"])
+        update_fields.append("pending_removal_at")
+    if update_fields:
+        block.save(update_fields=update_fields)
     return block
 
 

--- a/src/world/scenes/tests/test_block_toggle_services.py
+++ b/src/world/scenes/tests/test_block_toggle_services.py
@@ -47,6 +47,18 @@ class BlockToggleServiceTests(TestCase):
         self._create(reason="again")
         assert Block.objects.filter(owner__account=self.blocker_acct).count() == 1
 
+    def test_re_block_refreshes_the_reason(self) -> None:
+        """Re-blocking the same pair updates the staff-facing reason (#1326 Finding A).
+
+        ``get_or_create`` defaults apply only on insert, so the second call's reason was
+        previously dropped. It must now win.
+        """
+        self._create(reason="They were cruel.")
+        block = self._create(reason="And again, worse.")
+        block.refresh_from_db()
+        assert block.reason == "And again, worse."
+        assert Block.objects.filter(owner__account=self.blocker_acct).count() == 1
+
     def test_cannot_block_your_own_character(self) -> None:
         with self.assertRaises(ValidationError):
             create_block(


### PR DESCRIPTION
## Summary

Fixes **Finding A** of #1326 — a staff-facing fidelity bug in the #1278 block code. **Scoped to Finding A only**; the two design-gated items in the issue (account_level staleness on re-block; Finding B contact-flag dedup) are left for your call.

### The bug
`create_block` used `Block.objects.get_or_create(..., defaults={"reason": reason, ...})`. `defaults` apply **only on INSERT** (the standard `django_get_or_create` gotcha). On a re-block — the real path being a re-block within the 1h unblock grace window, when the row still exists — the **new `reason` was silently discarded**, so staff kept the stale reason from the first block.

### The fix
Capture `created`; when the row already exists and the reason changed, refresh `reason` in place — folded into the existing `pending_removal_at` clear as a single `save(update_fields=[...])`.

Deliberately **not** touched: `account_level` staleness on re-block (reset to persona-scoped vs preserve account-wide intent is a player-intent question for you), and Finding B (contact-flag dedup fidelity — needs an `attempt_count`/persona-widening design).

## Testing
- Extended `test_create_block_is_idempotent_per_pair` with `test_re_block_refreshes_the_reason` (re-block with a new reason → the new reason wins; still one row).
- `ruff` clean. The local test DB wouldn't build (the recurring `CREATE DATABASE` hang this environment has), so backend validation is via CI — the change is a 4-line, behavior-narrow fix with a direct test.

## Anti-reinvention
No new surface — corrects an existing `get_or_create` call to honor the latest `reason`.

Closes #1326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
