### PR TITLE
refactor: honest PendingActionResolution annotations on social actions (#1245)

### DIFF
--- a/src/actions/definitions/social.py
+++ b/src/actions/definitions/social.py
@@ -23,7 +23,7 @@ from actions.types import TargetFilters, TargetType
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
-    from actions.types import ActionContext, ActionResult
+    from actions.types import ActionContext, ActionResult, PendingActionResolution
     from flows.scene_data_manager import SceneDataManager
 
 
@@ -50,7 +50,7 @@ class _SocialTemplateAction(Action):
         actor: ObjectDB,
         context: ActionContext | None = None,
         **kwargs: Any,
-    ) -> ActionResult:
+    ) -> PendingActionResolution:
         from actions.models import ActionTemplate  # noqa: PLC0415
         from actions.services import start_action_resolution  # noqa: PLC0415
         from world.checks.types import ResolutionContext  # noqa: PLC0415
@@ -129,7 +129,7 @@ class EntranceAction(_SocialTemplateAction):
         actor: ObjectDB,
         context: ActionContext | None = None,
         **kwargs: Any,
-    ) -> ActionResult:
+    ) -> PendingActionResolution:
         from actions.models import ActionTemplate  # noqa: PLC0415
         from actions.services import start_action_resolution  # noqa: PLC0415
         from world.checks.types import ResolutionContext  # noqa: PLC0415
@@ -148,8 +148,13 @@ class EntranceAction(_SocialTemplateAction):
             context=resolution_ctx,
         )
 
-        # On a SUCCESSFUL entrance, open the entry-flourish offer (actor self-grant).
-        if template.grants_entry_flourish and self._succeeded(result):
+        # On a SUCCESSFUL entrance, open the entry-flourish offer (actor self-grant). Read success
+        # the one canonical way now that the return type is honestly ``PendingActionResolution``
+        # (#1245) — ``main_result`` is Optional (a paused resolution hasn't run the main step), so
+        # a None main means "not resolved successfully" and no offer opens.
+        main = result.main_result
+        succeeded = main is not None and main.check_result.success_level > 0
+        if template.grants_entry_flourish and succeeded:
             from world.magic.entry_flourish import (  # noqa: PLC0415
                 maybe_create_entry_flourish_offer,
             )
@@ -162,20 +167,6 @@ class EntranceAction(_SocialTemplateAction):
                 result.message = f"{result.message}\n{prompt}" if result.message else prompt
 
         return result
-
-    @staticmethod
-    def _succeeded(result: object) -> bool:
-        """Return True if the resolution result indicates success.
-
-        Handles both ``ActionResult`` (has ``.success``) and ``PendingActionResolution``
-        (reads ``main_result.check_result.success_level``).
-        """
-        if hasattr(result, "success"):
-            return bool(result.success)
-        main = getattr(result, "main_result", None)  # noqa: GETATTR_LITERAL
-        if main is None:
-            return False
-        return main.check_result.success_level > 0
 
 
 @dataclass

--- a/src/actions/tests/test_entry_flourish_dispatch.py
+++ b/src/actions/tests/test_entry_flourish_dispatch.py
@@ -52,10 +52,42 @@ class EntranceActionDispatchTest(TestCase):
             new_callable=lambda: property(lambda _self: fake_location),
         )
 
+    def _resolution(self, *, success_level: int):
+        """Build the PRODUCTION ``PendingActionResolution`` ``execute()`` actually returns (#1245).
+
+        EntranceAction reads ``result.main_result.check_result.success_level`` — so the test
+        must exercise that real path, not a stand-in ``ActionResult(success=...)`` (the prior
+        stub bypassed the load-bearing branch). Pass ``success_level=0`` for a failed check.
+        """
+        from actions.types import PendingActionResolution, StepResult
+        from world.checks.types import CheckResult
+
+        outcome = MagicMock()
+        outcome.success_level = success_level
+        check_result = CheckResult(
+            check_type=MagicMock(),
+            outcome=outcome,
+            chart=None,
+            roller_rank=None,
+            target_rank=None,
+            rank_difference=0,
+            trait_points=0,
+            aspect_bonus=0,
+            total_points=0,
+        )
+        step = StepResult(step_label="main", check_result=check_result, consequence_id=None)
+        return PendingActionResolution(
+            template_id=0,
+            character_id=0,
+            target_difficulty=0,
+            resolution_context_data={},
+            current_phase="complete",
+            main_result=step,
+        )
+
     def test_success_creates_offer_for_actor_and_scene(self):
         """On a successful Entrance with grants_entry_flourish=True, the offer is created."""
         from actions.definitions.social import EntranceAction
-        from actions.types import ActionResult
         from world.scenes.factories import SceneFactory
 
         actor = self._make_actor()
@@ -65,7 +97,7 @@ class EntranceActionDispatchTest(TestCase):
         scene = SceneFactory()
         fake_location = MagicMock()
         fake_location.active_scene = scene
-        success_result = ActionResult(success=True)
+        success_result = self._resolution(success_level=1)
 
         with (
             patch(
@@ -84,7 +116,6 @@ class EntranceActionDispatchTest(TestCase):
     def test_failure_does_not_create_offer(self):
         """On a failed Entrance, no offer is created even if grants_entry_flourish=True."""
         from actions.definitions.social import EntranceAction
-        from actions.types import ActionResult
         from world.scenes.factories import SceneFactory
 
         actor = self._make_actor()
@@ -94,7 +125,7 @@ class EntranceActionDispatchTest(TestCase):
         scene = SceneFactory()
         fake_location = MagicMock()
         fake_location.active_scene = scene
-        failure_result = ActionResult(success=False)
+        failure_result = self._resolution(success_level=0)
 
         with (
             patch(
@@ -113,7 +144,6 @@ class EntranceActionDispatchTest(TestCase):
     def test_success_without_grants_entry_flourish_does_not_create_offer(self):
         """Successful Entrance on a template without grants_entry_flourish creates no offer."""
         from actions.definitions.social import EntranceAction
-        from actions.types import ActionResult
         from world.scenes.factories import SceneFactory
 
         actor = self._make_actor()
@@ -123,13 +153,48 @@ class EntranceActionDispatchTest(TestCase):
         scene = SceneFactory()
         fake_location = MagicMock()
         fake_location.active_scene = scene
-        success_result = ActionResult(success=True)
+        success_result = self._resolution(success_level=1)
 
         with (
             patch(
                 "actions.services.start_action_resolution",
                 return_value=success_result,
             ),
+            self._location_patch(actor, fake_location),
+            patch(
+                "world.magic.entry_flourish.maybe_create_entry_flourish_offer",
+            ) as mock_offer,
+        ):
+            EntranceAction().execute(actor, context)
+
+        mock_offer.assert_not_called()
+
+    def test_paused_resolution_no_main_creates_no_offer(self):
+        """A paused resolution (``main_result is None``) hasn't succeeded → no offer (#1245).
+
+        With honest annotations the None-guard is the only success-undetermined path; the prior
+        ``ActionResult`` stub couldn't express it.
+        """
+        from actions.definitions.social import EntranceAction
+        from actions.types import PendingActionResolution
+
+        actor = self._make_actor()
+        context = MagicMock()
+        self._make_entrance_template(grants_entry_flourish=True)
+
+        fake_location = MagicMock()
+        fake_location.active_scene = None
+        paused = PendingActionResolution(
+            template_id=0,
+            character_id=0,
+            target_difficulty=0,
+            resolution_context_data={},
+            current_phase="awaiting_confirmation",
+            main_result=None,
+        )
+
+        with (
+            patch("actions.services.start_action_resolution", return_value=paused),
             self._location_patch(actor, fake_location),
             patch(
                 "world.magic.entry_flourish.maybe_create_entry_flourish_offer",


### PR DESCRIPTION
## Summary

Makes the social action layer's return annotations honest (#1245) — pre-existing tech debt that #1140 surfaced (not introduced by it).

`actions.services.start_action_resolution` returns a **`PendingActionResolution`**, but the social `execute()` methods annotated `-> ActionResult` — a different type. That lie forced `EntranceAction._succeeded` to **duck-type both shapes** (`hasattr(result, "success")` for `ActionResult` OR `result.main_result.check_result.success_level` for `PendingActionResolution`) to read whether the entrance check passed.

### Changes (`actions/definitions/social.py`)
- Corrected the two execute methods that actually return a resolution — `_SocialTemplateAction.execute` (the base, inherited by intimidate/persuade/deceive/flirt/perform/restore-sense) and `EntranceAction.execute` — to `-> PendingActionResolution`.
- Left `ResolveFlourishOfferAction.execute` at `-> ActionResult` (it genuinely constructs and returns an `ActionResult`).
- **Removed `EntranceAction._succeeded`**; read success the single canonical way — `result.main_result.check_result.success_level > 0` (matching `cast_services.py` / `services.py`). Kept the legitimate `main_result is None` guard (a *paused* resolution hasn't run the main step — that's an Optional field, not duck-typing).

### Tests
- Updated the three `EntranceActionDispatchTest` cases to stub the **production `PendingActionResolution`** (real `StepResult` + `CheckResult`) instead of a stand-in `ActionResult(success=...)` — so the load-bearing `main_result.check_result.success_level` branch is now actually exercised (it previously was only by inspection).
- Added `test_paused_resolution_no_main_creates_no_offer` for the `main_result is None` path the old `ActionResult` stub couldn't express.

## Testing
`ruff` + `ty` clean (the annotation is now truthful). `actions.tests.test_entry_flourish_dispatch` + `actions.tests.test_social_dispatch` exercise the path; CI runs the full backend regression (the local test DB wouldn't build — the recurring `CREATE DATABASE` hang).

Closes #1245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
