### PR TITLE
fix: social actions return an honest ActionResult (#1245)

### DIFF
--- a/src/actions/definitions/social.py
+++ b/src/actions/definitions/social.py
@@ -23,6 +23,7 @@ from actions.types import TargetFilters, TargetType
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
+    from actions.models import ActionTemplate
     from actions.types import ActionContext, ActionResult, PendingActionResolution
     from flows.scene_data_manager import SceneDataManager
 
@@ -51,13 +52,27 @@ class _SocialTemplateAction(Action):
         context: ActionContext | None = None,
         **kwargs: Any,
     ) -> ActionResult:
+        _template, result = self._resolve_template(actor, context, **kwargs)
+        return result
+
+    def _resolve_template(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None,
+        **kwargs: Any,
+    ) -> tuple[ActionTemplate, ActionResult]:
+        """Resolve this action's ActionTemplate and wrap the outcome into an ``ActionResult``.
+
+        Shared by the base ``execute()`` and ``EntranceAction.execute()`` (which needs the
+        ``ActionTemplate`` afterward to decide the entry-flourish offer). Dispatches inherent
+        target effects first (no-op for plain social actions; RestoreSense removes Berserk).
+        On this path a single dispatch only runs through ``execute()``, never the consent
+        path too.
+        """
         from actions.models import ActionTemplate  # noqa: PLC0415
         from actions.services import start_action_resolution  # noqa: PLC0415
         from world.checks.types import ResolutionContext  # noqa: PLC0415
 
-        # Dispatch any inherent target effects first (no-op for plain social
-        # actions; RestoreSense removes Berserk here). On this path a single
-        # dispatch only runs through execute(), never the consent path too.
         scene_data = context.scene_data if context is not None else None
         self.dispatch_effects(actor, kwargs.get("target"), scene_data)
 
@@ -69,7 +84,7 @@ class _SocialTemplateAction(Action):
             target_difficulty=0,
             context=resolution_ctx,
         )
-        return self._result_from_resolution(resolution)
+        return template, self._result_from_resolution(resolution)
 
     @staticmethod
     def _result_from_resolution(
@@ -154,24 +169,7 @@ class EntranceAction(_SocialTemplateAction):
         context: ActionContext | None = None,
         **kwargs: Any,
     ) -> ActionResult:
-        from actions.models import ActionTemplate  # noqa: PLC0415
-        from actions.services import start_action_resolution  # noqa: PLC0415
-        from world.checks.types import ResolutionContext  # noqa: PLC0415
-
-        # Dispatch any inherent target effects first (no-op for Entrance today),
-        # mirroring the base social execute() so the pattern stays consistent.
-        scene_data = context.scene_data if context is not None else None
-        self.dispatch_effects(actor, kwargs.get("target"), scene_data)
-
-        template = ActionTemplate.objects.get(name=self.template_name)
-        resolution_ctx = ResolutionContext(character=actor, action_context=context)
-        resolution = start_action_resolution(
-            character=actor,
-            template=template,
-            target_difficulty=0,
-            context=resolution_ctx,
-        )
-        result = self._result_from_resolution(resolution)
+        template, result = self._resolve_template(actor, context, **kwargs)
 
         # On a SUCCESSFUL entrance, open the entry-flourish offer (actor self-grant)
         # and prompt the actor toward declaring it. The prompt rides the result

--- a/src/actions/definitions/social.py
+++ b/src/actions/definitions/social.py
@@ -23,7 +23,7 @@ from actions.types import TargetFilters, TargetType
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
-    from actions.types import ActionContext, ActionResult
+    from actions.types import ActionContext, ActionResult, PendingActionResolution
     from flows.scene_data_manager import SceneDataManager
 
 
@@ -63,12 +63,36 @@ class _SocialTemplateAction(Action):
 
         template = ActionTemplate.objects.get(name=self.template_name)
         resolution_ctx = ResolutionContext(character=actor, action_context=context)
-        return start_action_resolution(
+        resolution = start_action_resolution(
             character=actor,
             template=template,
             target_difficulty=0,
             context=resolution_ctx,
         )
+        return self._result_from_resolution(resolution)
+
+    @staticmethod
+    def _result_from_resolution(
+        resolution: PendingActionResolution, message: str | None = None
+    ) -> ActionResult:
+        """Wrap a ``PendingActionResolution`` into the ``ActionResult`` its consumers expect.
+
+        ``execute()``'s only live consumers are REGISTRY ones — the telnet command
+        (reads ``.message``) and the web dispatcher (stuffs the result into
+        ``DispatchResult.detail``, typed ``ActionResult``). The rich pending-resolution
+        object is consumed elsewhere by direct callers of ``start_action_resolution``
+        (scene consent, cast), never through here — so returning an ``ActionResult`` is
+        both honest and what these consumers actually read (#1245). Success is the one
+        canonical expression every resolution consumer uses
+        (``main_result.check_result.success_level``); ``main_result is None`` is a
+        *paused* resolution whose main step hasn't rolled, so it cannot have succeeded.
+        The full resolution rides ``data`` so nothing is lost.
+        """
+        from actions.types import ActionResult as _ActionResult  # noqa: PLC0415
+
+        main = resolution.main_result
+        succeeded = main is not None and main.check_result.success_level > 0
+        return _ActionResult(success=succeeded, message=message, data={"resolution": resolution})
 
 
 @dataclass
@@ -141,15 +165,19 @@ class EntranceAction(_SocialTemplateAction):
 
         template = ActionTemplate.objects.get(name=self.template_name)
         resolution_ctx = ResolutionContext(character=actor, action_context=context)
-        result = start_action_resolution(
+        resolution = start_action_resolution(
             character=actor,
             template=template,
             target_difficulty=0,
             context=resolution_ctx,
         )
+        result = self._result_from_resolution(resolution)
 
-        # On a SUCCESSFUL entrance, open the entry-flourish offer (actor self-grant).
-        if template.grants_entry_flourish and self._succeeded(result):
+        # On a SUCCESSFUL entrance, open the entry-flourish offer (actor self-grant)
+        # and prompt the actor toward declaring it. The prompt rides the result
+        # ``message`` like every other action — the command surfaces it via
+        # ``self.msg(result.message)`` and the web dispatcher via ``detail.message`` (#1245).
+        if template.grants_entry_flourish and result.success:
             from world.magic.entry_flourish import (  # noqa: PLC0415
                 maybe_create_entry_flourish_offer,
             )
@@ -162,20 +190,6 @@ class EntranceAction(_SocialTemplateAction):
                 result.message = f"{result.message}\n{prompt}" if result.message else prompt
 
         return result
-
-    @staticmethod
-    def _succeeded(result: object) -> bool:
-        """Return True if the resolution result indicates success.
-
-        Handles both ``ActionResult`` (has ``.success``) and ``PendingActionResolution``
-        (reads ``main_result.check_result.success_level``).
-        """
-        if hasattr(result, "success"):
-            return bool(result.success)
-        main = getattr(result, "main_result", None)  # noqa: GETATTR_LITERAL
-        if main is None:
-            return False
-        return main.check_result.success_level > 0
 
 
 @dataclass

--- a/src/actions/tests/resolution_helpers.py
+++ b/src/actions/tests/resolution_helpers.py
@@ -1,0 +1,54 @@
+"""Shared builders for stubbing ``start_action_resolution`` in action/command tests.
+
+``start_action_resolution`` returns a ``PendingActionResolution``; these helpers build
+that real production type (with a real ``StepResult`` + ``CheckResult``) so tests exercise
+the load-bearing ``main_result.check_result.success_level`` read instead of a stand-in
+``ActionResult`` that only happens to expose ``.success`` (#1245).
+
+Kept separate from the scene-specific ``world.scenes.tests.cast_test_helpers`` — that one
+returns the cast-only ``EnhancedSceneActionResult`` wrapper, hardcodes success, and lives
+in the scenes layer; these return the raw resolution and take a success level.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from actions.types import PendingActionResolution, StepResult
+from world.checks.types import CheckResult
+
+
+def make_resolution(success_level: int) -> PendingActionResolution:
+    """A completed ``PendingActionResolution`` whose main step rolled ``success_level``."""
+    check_result = CheckResult(
+        check_type=MagicMock(),
+        outcome=MagicMock(success_level=success_level),
+        chart=None,
+        roller_rank=None,
+        target_rank=None,
+        rank_difference=0,
+        trait_points=0,
+        aspect_bonus=0,
+        total_points=0,
+    )
+    step = StepResult(step_label="main", check_result=check_result, consequence_id=None)
+    return PendingActionResolution(
+        template_id=0,
+        character_id=0,
+        target_difficulty=0,
+        resolution_context_data={},
+        current_phase="main",
+        main_result=step,
+    )
+
+
+def make_paused_resolution() -> PendingActionResolution:
+    """A paused ``PendingActionResolution`` whose main step has not rolled yet."""
+    return PendingActionResolution(
+        template_id=0,
+        character_id=0,
+        target_difficulty=0,
+        resolution_context_data={},
+        current_phase="gate",
+        main_result=None,
+    )

--- a/src/actions/tests/test_entry_flourish_dispatch.py
+++ b/src/actions/tests/test_entry_flourish_dispatch.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
+from actions.tests.resolution_helpers import make_paused_resolution, make_resolution
+
 
 class ActionTemplateEntryFlourishFieldTest(TestCase):
     def test_entrance_template_grants_entry_flourish(self):
@@ -34,50 +36,6 @@ class EntranceActionDispatchTest(TestCase):
         from evennia_extensions.factories import ObjectDBFactory
 
         return ObjectDBFactory(db_key="DispatchTestActor")
-
-    def _resolution(self, success_level: int):
-        """Build a real ``PendingActionResolution`` whose main step rolled ``success_level``.
-
-        This is what ``start_action_resolution`` actually returns — the load-bearing
-        ``main_result.check_result.success_level`` branch is exercised for real, instead
-        of a stand-in ``ActionResult`` that only happened to expose ``.success`` (#1245).
-        """
-        from actions.types import PendingActionResolution, StepResult
-        from world.checks.types import CheckResult
-
-        check_result = CheckResult(
-            check_type=MagicMock(),
-            outcome=MagicMock(success_level=success_level),
-            chart=None,
-            roller_rank=None,
-            target_rank=None,
-            rank_difference=0,
-            trait_points=0,
-            aspect_bonus=0,
-            total_points=0,
-        )
-        step = StepResult(step_label="main", check_result=check_result, consequence_id=None)
-        return PendingActionResolution(
-            template_id=0,
-            character_id=0,
-            target_difficulty=0,
-            resolution_context_data={},
-            current_phase="main",
-            main_result=step,
-        )
-
-    def _paused_resolution(self):
-        """Build a ``PendingActionResolution`` whose main step has not rolled yet."""
-        from actions.types import PendingActionResolution
-
-        return PendingActionResolution(
-            template_id=0,
-            character_id=0,
-            target_difficulty=0,
-            resolution_context_data={},
-            current_phase="gate",
-            main_result=None,
-        )
 
     def _make_entrance_template(self, grants_entry_flourish: bool):
         """Create and return an ActionTemplate for Entrance."""
@@ -118,7 +76,7 @@ class EntranceActionDispatchTest(TestCase):
         with (
             patch(
                 "actions.services.start_action_resolution",
-                return_value=self._resolution(success_level=1),
+                return_value=make_resolution(1),
             ),
             self._location_patch(actor, fake_location),
             patch(
@@ -149,7 +107,7 @@ class EntranceActionDispatchTest(TestCase):
         with (
             patch(
                 "actions.services.start_action_resolution",
-                return_value=self._resolution(success_level=0),
+                return_value=make_resolution(0),
             ),
             self._location_patch(actor, fake_location),
             patch(
@@ -180,7 +138,7 @@ class EntranceActionDispatchTest(TestCase):
         with (
             patch(
                 "actions.services.start_action_resolution",
-                return_value=self._paused_resolution(),
+                return_value=make_paused_resolution(),
             ),
             self._location_patch(actor, fake_location),
             patch(
@@ -207,7 +165,7 @@ class EntranceActionDispatchTest(TestCase):
         with (
             patch(
                 "actions.services.start_action_resolution",
-                return_value=self._resolution(success_level=1),
+                return_value=make_resolution(1),
             ),
             self._location_patch(actor, fake_location),
             patch(

--- a/src/actions/tests/test_entry_flourish_dispatch.py
+++ b/src/actions/tests/test_entry_flourish_dispatch.py
@@ -35,6 +35,50 @@ class EntranceActionDispatchTest(TestCase):
 
         return ObjectDBFactory(db_key="DispatchTestActor")
 
+    def _resolution(self, success_level: int):
+        """Build a real ``PendingActionResolution`` whose main step rolled ``success_level``.
+
+        This is what ``start_action_resolution`` actually returns — the load-bearing
+        ``main_result.check_result.success_level`` branch is exercised for real, instead
+        of a stand-in ``ActionResult`` that only happened to expose ``.success`` (#1245).
+        """
+        from actions.types import PendingActionResolution, StepResult
+        from world.checks.types import CheckResult
+
+        check_result = CheckResult(
+            check_type=MagicMock(),
+            outcome=MagicMock(success_level=success_level),
+            chart=None,
+            roller_rank=None,
+            target_rank=None,
+            rank_difference=0,
+            trait_points=0,
+            aspect_bonus=0,
+            total_points=0,
+        )
+        step = StepResult(step_label="main", check_result=check_result, consequence_id=None)
+        return PendingActionResolution(
+            template_id=0,
+            character_id=0,
+            target_difficulty=0,
+            resolution_context_data={},
+            current_phase="main",
+            main_result=step,
+        )
+
+    def _paused_resolution(self):
+        """Build a ``PendingActionResolution`` whose main step has not rolled yet."""
+        from actions.types import PendingActionResolution
+
+        return PendingActionResolution(
+            template_id=0,
+            character_id=0,
+            target_difficulty=0,
+            resolution_context_data={},
+            current_phase="gate",
+            main_result=None,
+        )
+
     def _make_entrance_template(self, grants_entry_flourish: bool):
         """Create and return an ActionTemplate for Entrance."""
         from actions.factories import ActionTemplateFactory
@@ -52,8 +96,13 @@ class EntranceActionDispatchTest(TestCase):
             new_callable=lambda: property(lambda _self: fake_location),
         )
 
-    def test_success_creates_offer_for_actor_and_scene(self):
-        """On a successful Entrance with grants_entry_flourish=True, the offer is created."""
+    def test_success_creates_offer_and_prompts_via_result_message(self):
+        """On a successful Entrance with grants_entry_flourish=True, the offer is created.
+
+        ``execute()`` returns a real ``ActionResult`` whose ``message`` carries the
+        flourish prompt — the command/web both surface it through the normal result
+        channel (#1245).
+        """
         from actions.definitions.social import EntranceAction
         from actions.types import ActionResult
         from world.scenes.factories import SceneFactory
@@ -65,12 +114,42 @@ class EntranceActionDispatchTest(TestCase):
         scene = SceneFactory()
         fake_location = MagicMock()
         fake_location.active_scene = scene
-        success_result = ActionResult(success=True)
 
         with (
             patch(
                 "actions.services.start_action_resolution",
-                return_value=success_result,
+                return_value=self._resolution(success_level=1),
+            ),
+            self._location_patch(actor, fake_location),
+            patch(
+                "world.magic.entry_flourish.maybe_create_entry_flourish_offer",
+            ) as mock_offer,
+        ):
+            result = EntranceAction().execute(actor, context)
+
+        mock_offer.assert_called_once_with(actor, scene)
+        # A genuine ActionResult (honest annotation) carrying the flourish prompt.
+        self.assertIsInstance(result, ActionResult)
+        self.assertTrue(result.success)
+        self.assertIn("flourish", (result.message or "").lower())
+
+    def test_failure_does_not_create_offer(self):
+        """On a failed Entrance, no offer is created even if grants_entry_flourish=True."""
+        from actions.definitions.social import EntranceAction
+        from world.scenes.factories import SceneFactory
+
+        actor = self._make_actor()
+        context = MagicMock()
+        self._make_entrance_template(grants_entry_flourish=True)
+
+        scene = SceneFactory()
+        fake_location = MagicMock()
+        fake_location.active_scene = scene
+
+        with (
+            patch(
+                "actions.services.start_action_resolution",
+                return_value=self._resolution(success_level=0),
             ),
             self._location_patch(actor, fake_location),
             patch(
@@ -79,12 +158,15 @@ class EntranceActionDispatchTest(TestCase):
         ):
             EntranceAction().execute(actor, context)
 
-        mock_offer.assert_called_once_with(actor, scene)
+        mock_offer.assert_not_called()
 
-    def test_failure_does_not_create_offer(self):
-        """On a failed Entrance, no offer is created even if grants_entry_flourish=True."""
+    def test_paused_resolution_no_main_creates_no_offer(self):
+        """A paused resolution (main step not yet rolled) creates no offer.
+
+        ``main_result is None`` is not a success — this is the branch the old
+        ``ActionResult(success=...)`` stub couldn't express (#1245).
+        """
         from actions.definitions.social import EntranceAction
-        from actions.types import ActionResult
         from world.scenes.factories import SceneFactory
 
         actor = self._make_actor()
@@ -94,12 +176,11 @@ class EntranceActionDispatchTest(TestCase):
         scene = SceneFactory()
         fake_location = MagicMock()
         fake_location.active_scene = scene
-        failure_result = ActionResult(success=False)
 
         with (
             patch(
                 "actions.services.start_action_resolution",
-                return_value=failure_result,
+                return_value=self._paused_resolution(),
             ),
             self._location_patch(actor, fake_location),
             patch(
@@ -113,7 +194,6 @@ class EntranceActionDispatchTest(TestCase):
     def test_success_without_grants_entry_flourish_does_not_create_offer(self):
         """Successful Entrance on a template without grants_entry_flourish creates no offer."""
         from actions.definitions.social import EntranceAction
-        from actions.types import ActionResult
         from world.scenes.factories import SceneFactory
 
         actor = self._make_actor()
@@ -123,12 +203,11 @@ class EntranceActionDispatchTest(TestCase):
         scene = SceneFactory()
         fake_location = MagicMock()
         fake_location.active_scene = scene
-        success_result = ActionResult(success=True)
 
         with (
             patch(
                 "actions.services.start_action_resolution",
-                return_value=success_result,
+                return_value=self._resolution(success_level=1),
             ),
             self._location_patch(actor, fake_location),
             patch(

--- a/src/commands/tests/test_entrance_flourish_e2e.py
+++ b/src/commands/tests/test_entrance_flourish_e2e.py
@@ -17,10 +17,9 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase, tag
 
 from actions.factories import ActionTemplateFactory
-from actions.types import PendingActionResolution, StepResult
+from actions.tests.resolution_helpers import make_resolution
 from commands.social.entrance_flourish import CmdEnter, CmdFlourish
 from world.character_sheets.factories import CharacterSheetFactory
-from world.checks.types import CheckResult
 from world.magic.entry_flourish import PendingEntryFlourishOffer
 from world.magic.factories import CharacterResonanceFactory, ResonanceFactory
 from world.magic.models import CharacterResonance
@@ -28,35 +27,6 @@ from world.magic.models import CharacterResonance
 # Patch the function at the module it lives in; EntranceAction imports it
 # locally via ``from actions.services import start_action_resolution``.
 _ENTRANCE_RESOLUTION_PATH = "actions.services.start_action_resolution"
-
-
-def _successful_resolution() -> PendingActionResolution:
-    """Build the real ``PendingActionResolution`` ``start_action_resolution`` returns.
-
-    A successful main step (``success_level=1``) is what drives ``EntranceAction`` to
-    mint the offer + nudge the actor. Stubbing the production type (not a stand-in
-    ``ActionResult``) keeps the e2e honest about the actual return shape (#1245).
-    """
-    check_result = CheckResult(
-        check_type=MagicMock(),
-        outcome=MagicMock(success_level=1),
-        chart=None,
-        roller_rank=None,
-        target_rank=None,
-        rank_difference=0,
-        trait_points=0,
-        aspect_bonus=0,
-        total_points=0,
-    )
-    step = StepResult(step_label="main", check_result=check_result, consequence_id=None)
-    return PendingActionResolution(
-        template_id=0,
-        character_id=0,
-        target_difficulty=0,
-        resolution_context_data={},
-        current_phase="main",
-        main_result=step,
-    )
 
 
 @tag("postgres")
@@ -105,7 +75,7 @@ class EntranceFlourishJourneyTest(TestCase):
         """After a successful entrance, an offer is minted and the player is told to flourish."""
         with patch(
             _ENTRANCE_RESOLUTION_PATH,
-            return_value=_successful_resolution(),
+            return_value=make_resolution(1),
         ):
             self._run_enter()
 

--- a/src/commands/tests/test_entrance_flourish_e2e.py
+++ b/src/commands/tests/test_entrance_flourish_e2e.py
@@ -1,9 +1,10 @@
 """E2E journey: enter → flourish prompt → flourish <resonance> → grant (#1339).
 
 Drives the full telnet loop end-to-end. The only mock is
-``start_action_resolution`` — we stub it to return a success ActionResult so
-the test doesn't need a full ActionTemplate + check-chain seed. Everything
-else (offer creation, notification, flourish resolution, grant write) is real.
+``start_action_resolution`` — we stub it to return a successful
+``PendingActionResolution`` (its real return type) so the test doesn't need a
+full ActionTemplate + check-chain seed. Everything else (offer creation,
+notification, flourish resolution, grant write) is real.
 
 Tagged ``postgres`` because ``grant_resonance`` / ``create_entry_flourish``
 write ``ResonanceGrant`` rows and the magic test tier is PG-only.
@@ -16,9 +17,10 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase, tag
 
 from actions.factories import ActionTemplateFactory
-from actions.types import ActionResult
+from actions.types import PendingActionResolution, StepResult
 from commands.social.entrance_flourish import CmdEnter, CmdFlourish
 from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.types import CheckResult
 from world.magic.entry_flourish import PendingEntryFlourishOffer
 from world.magic.factories import CharacterResonanceFactory, ResonanceFactory
 from world.magic.models import CharacterResonance
@@ -26,6 +28,35 @@ from world.magic.models import CharacterResonance
 # Patch the function at the module it lives in; EntranceAction imports it
 # locally via ``from actions.services import start_action_resolution``.
 _ENTRANCE_RESOLUTION_PATH = "actions.services.start_action_resolution"
+
+
+def _successful_resolution() -> PendingActionResolution:
+    """Build the real ``PendingActionResolution`` ``start_action_resolution`` returns.
+
+    A successful main step (``success_level=1``) is what drives ``EntranceAction`` to
+    mint the offer + nudge the actor. Stubbing the production type (not a stand-in
+    ``ActionResult``) keeps the e2e honest about the actual return shape (#1245).
+    """
+    check_result = CheckResult(
+        check_type=MagicMock(),
+        outcome=MagicMock(success_level=1),
+        chart=None,
+        roller_rank=None,
+        target_rank=None,
+        rank_difference=0,
+        trait_points=0,
+        aspect_bonus=0,
+        total_points=0,
+    )
+    step = StepResult(step_label="main", check_result=check_result, consequence_id=None)
+    return PendingActionResolution(
+        template_id=0,
+        character_id=0,
+        target_difficulty=0,
+        resolution_context_data={},
+        current_phase="main",
+        main_result=step,
+    )
 
 
 @tag("postgres")
@@ -65,14 +96,16 @@ class EntranceFlourishJourneyTest(TestCase):
 
     def _received_messages(self) -> list[str]:
         """Return all text strings passed to character.msg()."""
-        # ArxCommand.func() calls self.msg(result.message) — positional first arg
+        # Both the entrance flourish prompt and the flourish confirmation ride
+        # ``result.message`` — ArxCommand.func() surfaces them via self.msg(result.message),
+        # which lands on character.msg. Collect every positional-first-arg call here.
         return [str(call.args[0]) for call in self.character.msg.call_args_list if call.args]
 
     def test_enter_creates_offer_and_notifies_player(self) -> None:
         """After a successful entrance, an offer is minted and the player is told to flourish."""
         with patch(
             _ENTRANCE_RESOLUTION_PATH,
-            return_value=ActionResult(success=True, message="You sweep into the room."),
+            return_value=_successful_resolution(),
         ):
             self._run_enter()
 


### PR DESCRIPTION
## Summary

Makes the social action layer's return annotations honest (#1245). The social/template `execute()` methods annotated `-> ActionResult` but actually returned a **`PendingActionResolution`** — a different, unrelated dataclass.

That lie had two real consequences:
1. It forced `EntranceAction._succeeded` to **duck-type both shapes** (`hasattr(result, "success")` OR `result.main_result.check_result.success_level`).
2. The entry-flourish path wrote `result.message` on a `PendingActionResolution`, **which has no `message` field**. It only ever passed because every dispatch test stubbed an `ActionResult`; a real `enter` over telnet would `AttributeError` at `command.py`'s `if result.message:`.

## Why wrap into `ActionResult` (and not the other options)

`execute()`'s only **live** consumers are REGISTRY ones — the telnet command (reads `.message`) and the web dispatcher (stuffs the result into `DispatchResult.detail`, typed `ActionResult`). The rich `PendingActionResolution` (with its `awaiting_confirmation` / `gate_results` pause semantics) is consumed elsewhere by **direct** callers of `start_action_resolution` (scene consent, cast) — never through `execute()`.

- Annotating `execute -> PendingActionResolution` introduces `invalid-method-override` ty errors (the base `Action.execute` declares `-> ActionResult`), and widening the base to a union is a ~15-consumer blast radius (`covenant`/`events`/`hire`/`alterations`/`player_interface` all read `.success`/`.message`).
- Returning a real `ActionResult` is both **honest** and **what these consumers actually read** — and it fixes the latent web mismatch where a `PendingActionResolution` was being assigned to a field typed `ActionResult`.

## Changes (`actions/definitions/social.py`)

- Add `_SocialTemplateAction._result_from_resolution` — wraps the resolution into an `ActionResult`, deriving `success` from the one canonical expression every resolution consumer uses (`main_result.check_result.success_level`; `main_result is None` is a *paused* resolution, so not a success). The full resolution rides `data["resolution"]` so nothing is lost.
- `EntranceAction.execute` puts the flourish prompt on `result.message` like every other action (command surfaces it via `self.msg(result.message)`, web via `detail.message`). Removes the `_succeeded` duck-typing.
- `command.py` needs **no change** — `run()` genuinely returns `ActionResult` again, matching the contract already documented in `docs/systems/INDEX.md`.

## Tests

- Dispatch unit tests stub the **production `PendingActionResolution`** (real `StepResult` + `CheckResult`) so the load-bearing `main_result.check_result.success_level` branch is exercised for real, plus a new `test_paused_resolution_no_main_creates_no_offer` for the `main_result is None` path the old `ActionResult` stub couldn't express.
- The e2e stubs the real return type too; the flourish prompt now arrives through the normal `result.message` channel.

## Testing

`ruff` + `ty` clean (the file's ty diagnostics actually drop 6→4 — the two override errors a naive annotation would add are avoided, and the old `.message`-on-a-resolution problem is gone). SQLite dispatch tier 7/7; PG parity tier (`test_entrance_flourish_e2e` + `test_entrance_flourish_commands` + `test_social_dispatch`) 13/13.

Closes #1245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
