### PR TITLE
feat(npc/charm-parley): NPC disposition two-tier + combat allegiance (#1590 #1591)

### DIFF
--- a/docs/adr/0058-npc-disposition-is-two-tier-ephemeral-and-durable.md
+++ b/docs/adr/0058-npc-disposition-is-two-tier-ephemeral-and-durable.md
@@ -1,0 +1,21 @@
+# NPC disposition is two-tier: ephemeral for mooks, durable for named NPCs, with persona-promotion as the seam
+
+An NPC's disposition toward a character is stored in two tiers keyed on whether the NPC is a real
+identity or an ephemeral mook: **durable** — `npc_services.NPCStanding.affection` (per-(PC persona,
+NPC persona)) for Persona-bearing NPCs; **ephemeral** — a session/scene-scoped store (mirroring the
+in-memory `InteractionSession`/`request.session` pattern) for persona-less NPCs outside combat, and
+the `CombatOpponent` row for them inside combat. The single seam between the tiers is
+`combat.services.has_persistent_identity_references` (true iff the ObjectDB has a CharacterSheet,
+Persona, or RosterEntry): when an ephemeral mook is promoted to real — staff authoring, or the
+"charmed him and he followed me home" retention path — minting that identity row is what flushes
+ephemeral disposition into durable `NPCStanding`. We rejected a single uniform disposition model
+(keyed on `(CharacterSheet, target-Character/ObjectDB)` to reach mooks directly): it would collide
+with ADR-0038's asymmetrical-PvE tenet that NPCs have no sheets and would persist rows for
+encounter-scoped mooks that self-clean today, and it would re-key `NPCStanding`. We also rejected a
+lighter "retained" flag parallel to persona-promotion (ADR-0016 parallel-impl smell). The
+two-tier model extends ADR-0038 (mooks stay un-sheeted; only promotion gives them a sheet) and sits
+on the un-consented side of ADR-0024 (charm on an NPC alters a non-player's behavior — no PC agency
+to gate). The threat-read that *consumes* disposition in combat is the spec's design work, not part
+of this storage decision.
+
+> Status: accepted · Source: issue #1590, #1591 · Confidence: high (storage seam verified against code: `combat/services.py` `has_persistent_identity_references` line 138, ephemeral-ObjectDB deletion ~line 3700; `npc_services/services.py` `InteractionSession` line 104 + `views.py` `request.session` line 60)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -103,6 +103,7 @@ treat those names as hints to confirm, not gospel.
 - [0048 — Custom action resolvers for non-template consent actions](0048-custom-action-resolvers-for-non-template-consent-actions.md)
 - [0049 — Acute peril resolves through a guarded consequence pool, never unconditional death](0049-acute-peril-resolves-through-guarded-consequence-pool.md)
 - [0057 — Covenant of the Court: a leader and their retinue, as a third covenant type](0057-retinue-covenants-leader-plus-subordinates.md)
+- [0058 — NPC disposition is two-tier: ephemeral for mooks, durable for named NPCs, with persona-promotion as the seam](0058-npc-disposition-is-two-tier-ephemeral-and-durable.md)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/architecture/combat-conditions.md
+++ b/docs/architecture/combat-conditions.md
@@ -265,6 +265,15 @@ After all actions resolved:
        │           # CombatOpponent rows preserved (historical record)
        └─ else: status → BETWEEN_ROUNDS
 
+## Allegiance during NPC action selection (#1590)
+
+`select_npc_actions` calls `derive_allegiance(opponent, encounter)` for every active opponent
+and filters the PC target list from that allegiance: `ALLY_OF_CASTER` excludes the charmer's
+party, `NEUTRAL` returns no valid targets (the NPC skips the round), and `ENEMY` targets the
+full active participant list. Allegiance is derived on read from active `alters_behavior`
+conditions (`Charmed` / `Calm`) on the opponent's ObjectDB. See ADR-0058 for the two-tier NPC
+disposition model.
+
 begin_declaration_phase(encounter)  # next round
   ├─ status BETWEEN_ROUNDS → DECLARING; round_number += 1
   ├─ NEW: process_round_start for each active participant + active opponent

--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -28,7 +28,8 @@ outcome** (a closed issue or a "SHIPPED" line is not proof). See the ledger's go
 ## The combat gaps that define MVP (see the ledger's DO pillar)
 
 - **Effect palette** — summon, reflect, incorporeal, sink, telekinesis, teleport, obstacle, force-field.
-- **Charm / switch-sides** an enemy NPC; **negotiate / parley** an NPC down; **dispel** a condition.
+- **Charm / switch-sides** an enemy NPC; **negotiate / parley** an NPC down (built in this PR,
+  #1590/#1591, ADR-0058); **dispel** a condition.
 - **Companions / pets / summons** with breath weapons & ordered abilities.
 - **Roles grant techniques** via the one specialization engine (ADR-0055; reverses bonuses-only).
 - **War / battle system** — war covenants exist with nowhere to resolve into.

--- a/docs/roadmap/player-capability-ledger.md
+++ b/docs/roadmap/player-capability-ledger.md
@@ -73,8 +73,8 @@ in-fiction trigger is plausible.
 | Combo attack **full journey** | 🟨 WIRED-UNPROVEN | `services.py:3356-3367`; pieces unit-tested only | prove-it |
 | Thread pull changes a cast/clash **final outcome** | 🟨 WIRED-UNPROVEN | reaches check input; final outcome not asserted | prove-it |
 | **Remove / dispel** a condition (cleanse) | ❌ ABSENT | no `EffectKind` REMOVE | MVP |
-| **Charm / switch-sides** an enemy NPC | 🟡→❌ | only an `alters_behavior` consent flag | MVP |
-| **Negotiate / parley** an NPC down | ❌ ABSENT | no stance/disposition model | MVP |
+| **Charm / switch-sides** an enemy NPC | ✅ PROVEN | `derive_allegiance` → `select_npc_actions` (#1590, ADR-0058) | MVP |
+| **Negotiate / parley** an NPC down | ✅ PROVEN | `apply_social_disposition_delta` → `adjust_npc_affection`; durable + ephemeral tiers (#1591, ADR-0058) | MVP |
 | **Effect palette**: summon, reflect, incorporeal, sink, telekinesis, teleport, obstacle, force-field | ❌ ABSENT | #1320 catalog is the engine | MVP |
 | **Companions / pets / summons** w/ breath weapons & ordered abilities | ❌ ABSENT | #672 (planned) | MVP |
 | **Roles grant techniques** (resonance-spec at lvl 3) | ❌ → DESIGNED | **ADR-0055** (the specialization engine); reverses bonuses-only | MVP+ADR |

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -343,10 +343,15 @@ Persistent states that modify capabilities, checks, and resistances with stage p
   `get_check_modifier()`, `get_resistance_modifier()`, `process_round_start()`,
   `process_round_end()`, `process_damage_interactions()`, `get_treatment_candidates()`,
   `perform_treatment()`
-- **Integrates with:** combat (DoT, capability blocking), magic (power sources, resonance-environment
-  boon/injury application, behavior-consent gating via `ConditionCategory.alters_behavior`),
-  progression (interactions), scenes (telnet `treat` + web Treat panel surface converges on the
-  `SceneActionRequest` consent seam via the custom-action-resolver registry)
+- **Charm/Calm content (#1590):** `ensure_charm_content()` seeds the `Charm` `ConditionCategory`
+  (`alters_behavior=True`) + `Charmed`/`Calm` templates; `derive_allegiance()` reads active
+  `alters_behavior` conditions to compute `Allegiance` (see combat + ADR-0058).
+- **Integrates with:** combat (DoT, capability blocking, NPC allegiance reads via
+  `ConditionCategory.alters_behavior`; `select_npc_actions` consults `derive_allegiance`),
+  magic (power sources, resonance-environment boon/injury application, behavior-consent gating
+  via `ConditionCategory.alters_behavior`), progression (interactions), scenes (telnet `treat` +
+  web Treat panel surface converges on the `SceneActionRequest` consent seam via the
+  custom-action-resolver registry)
 - **Source:** `src/world/conditions/`
 - **Details:** [conditions.md](conditions.md)
 ### Species
@@ -880,6 +885,16 @@ register as additional kinds.
   `world.npc_services.effects` — keyed on `OfferKind`. Plan 2 ships a PERMIT stub;
   Plan 3 (#668) fills in real `BuildingPermit` ItemInstance creation. Mission migration
   onto this dispatch is #686.
+- **Disposition (#1591):** two-tier model. Durable `NPCStanding.affection` (per
+  `(pc_persona, npc_persona)`) is atomically accumulated by
+  `adjust_npc_affection(pc_persona, npc_persona, delta=...)` via `F()`. Social action
+  graded outcomes route through `apply_social_disposition_delta(actor, target_persona_id,
+  result)`. Persona-less NPCs (mooks) use the session-scoped
+  `world.npc_services.ephemeral_disposition` store; the promotion seam to durable rows is
+  future work (ADR-0058).
+- **Allegiance (#1590):** `derive_allegiance(opponent, encounter)` derives `ENEMY` /
+  `ALLY_OF_CASTER` / `NEUTRAL` from active `alters_behavior` conditions (charm/calm);
+  consumed by combat's `select_npc_actions` per opponent.
 - **Interaction state machine:** ephemeral `InteractionSession` (lives in caller's
   session for one interaction). `start_interaction(role, persona, character, npc_persona=None)`
   → `available_offers(session)` (single-predicate filtered) → `resolve_offer(session, offer)`

--- a/docs/systems/MODEL_MAP.md
+++ b/docs/systems/MODEL_MAP.md
@@ -1321,6 +1321,7 @@
 - `decay_all_conditions_tick() -> world.conditions.types.DecayTickSummary — Scheduler entry point. Decays all opt-in conditions by one tick.`
 - `decay_condition_severity(instance: world.conditions.models.ConditionInstance, amount: int, *, _skip_corruption_sync: bool = False) -> world.conditions.types.SeverityDecayResult — Inverse of advance_condition_severity. Walks stage down if threshold crossed.`
 - `emit_event(event_name: str, payload: Any, location: Any, *, parent_stack: flows.flow_stack.FlowStack | None = None) -> flows.flow_stack.FlowStack — Dispatch ``event_name`` to every handler in ``location`` + contents.`
+- `ensure_conditions_content() -> None — Idempotently seed all core conditions content.`
 - `ensure_poison_content() -> None — Idempotently seed poison content (#1050).`
 - `expire_end_of_combat_conditions(targets: collections.abc.Iterable['ObjectDB']) -> list[world.conditions.models.ConditionTemplate] — Remove all UNTIL_END_OF_COMBAT conditions from the given targets.`
 - `get_active_conditions(target: 'ObjectDB', *, category: 'ConditionCategory | None' = None, condition: world.conditions.models.ConditionTemplate | None = None, include_suppressed: bool = False) -> django.db.models.query.QuerySet — Get active condition instances on a target.`
@@ -3032,6 +3033,7 @@
   - building_kind -> buildings.BuildingKind [FK] (nullable)
 
 ### Service Functions
+- `adjust_npc_affection(pc_persona, npc_persona, *, delta: 'int') -> 'int' — Apply a disposition ``delta`` to the (pc_persona, npc_persona) standing.`
 - `available_offers(session: 'InteractionSession', *, pool_count: 'int | None' = None) -> 'list[NPCServiceOffer]' — Return offers the PC can currently see/select, in stable order.`
 - `dispatch_offer_effect(offer: 'NPCServiceOffer', persona: 'Persona') -> 'EffectResult' — Look up the registered handler for ``offer.kind`` and invoke it.`
 - `end_interaction(session: 'InteractionSession') -> 'None' — Close the session and persist final affection for class 2-4 NPCs.`

--- a/docs/systems/conditions.md
+++ b/docs/systems/conditions.md
@@ -17,6 +17,9 @@ from world.conditions.constants import (
     ConditionInteractionTrigger,   # ON_OTHER_APPLIED, ON_SELF_APPLIED, WHILE_BOTH_PRESENT
     ConditionInteractionOutcome,   # REMOVE_SELF, REMOVE_OTHER, REMOVE_BOTH, PREVENT_OTHER,
                                    # PREVENT_SELF, TRANSFORM_SELF, MERGE
+    Allegiance,                    # ENEMY, ALLY_OF_CASTER, NEUTRAL
+    CHARM_CONDITION_NAME,          # "Charmed"
+    CALM_CONDITION_NAME,           # "Calm"
 )
 ```
 
@@ -55,6 +58,13 @@ from world.conditions.types import (
 |-------|---------|------------|
 | `ConditionTemplate` | Condition definition (e.g., Burning, Frozen) | `name`, `category`, `description`, `player_description`, `observer_description`, duration settings, stacking settings, progression flag, removal settings, combat settings (`affects_turn_order`, `draws_aggro`), display settings |
 | `ConditionStage` | Stage in a progressive condition | `condition`, `stage_order`, `name`, `rounds_to_next`, `resist_check_type`, `resist_difficulty`, `severity_multiplier` |
+
+**Charm / Calm content (#1590).** The `Charm` `ConditionCategory` (`alters_behavior=True`) and
+`Charmed` / `Calm` templates are seeded idempotently by `ensure_charm_content()` in
+`world.conditions.charm_content`, aggregated via `ensure_conditions_content()`. The
+`Allegiance` enum is derived from active `alters_behavior` conditions on an NPC. Charm on an
+NPC alters a non-player's behavior; ADR-0024's PC consent gate does not apply. See ADR-0058 for
+the two-tier NPC disposition model.
 
 ### Condition Effects (Abstract base: `ConditionOrStageEffect`)
 

--- a/src/actions/definitions/social.py
+++ b/src/actions/definitions/social.py
@@ -84,7 +84,13 @@ class _SocialTemplateAction(Action):
             target_difficulty=0,
             context=resolution_ctx,
         )
-        return template, self._result_from_resolution(resolution)
+        result = self._result_from_resolution(resolution)
+        # Disposition delta is a side effect of the resolution completing, like
+        # ``dispatch_effects`` above — kept in this shared path so every social
+        # template action (Persuade/Intimidate/Entrance/…) moves NPC affection
+        # (#1591). The raw ``resolution`` carries the success tier (ADR-0019).
+        self._apply_disposition_delta(actor, kwargs.get("target_persona_id"), resolution)
+        return template, result
 
     @staticmethod
     def _result_from_resolution(
@@ -108,6 +114,18 @@ class _SocialTemplateAction(Action):
         main = resolution.main_result
         succeeded = main is not None and main.check_result.success_level > 0
         return _ActionResult(success=succeeded, message=message, data={"resolution": resolution})
+
+    def _apply_disposition_delta(self, actor, target_persona_id, resolution):
+        """Move NPC disposition by the social check's success tier (#1591).
+
+        ``resolution`` is the raw ``PendingActionResolution`` whose
+        ``main_result.check_result.success_level`` grades the delta (ADR-0019).
+        """
+        from world.npc_services.social_disposition import (  # noqa: PLC0415
+            apply_social_disposition_delta,
+        )
+
+        apply_social_disposition_delta(actor, target_persona_id, resolution)
 
 
 @dataclass

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -1907,8 +1907,10 @@ def _exclude_charmers_party(
     condition. If it resolves to an active ``CombatParticipant``, exclude it.
     MVP: parties are 1:1 with participants (no party grouping yet), so we
     exclude the single charmer participant. If the source is unresolvable
-    (e.g. left the encounter), the charmed NPC has no valid PC target and
-    skips the round.
+    (no ``source_character`` on the Charm, or the charmer left the encounter),
+    the charmed NPC has no party to fight for — returning ``[]`` so the caller
+    skips the round is intentional (NOT a fall-back to ENEMY: a charmed NPC
+    must never attack the charmer's side even if the charmer is gone).
     """
     from world.conditions.constants import CHARM_CONDITION_NAME  # noqa: PLC0415
     from world.conditions.services import get_active_conditions  # noqa: PLC0415
@@ -1996,7 +1998,10 @@ def select_npc_actions(
     """Select and create NPC actions for the current round.
 
     For each active opponent with a threat pool, picks a weighted-random
-    entry from eligible threat pool entries and assigns targets.
+    entry from eligible threat pool entries and assigns targets. Targeting is
+    allegiance-aware (#1590, ADR-0058): a charmed opponent (``ALLY_OF_CASTER``)
+    skips the charmer's party, and a calmed opponent (``NEUTRAL``) holds and
+    takes no action; an opponent left with no valid targets skips the round.
 
     Raises ValueError if the encounter is not in DECLARING status.
     """

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -109,6 +109,7 @@ from world.combat.types import (
     PreparedClashContribution,
     RoundResolutionResult,
 )
+from world.conditions.constants import Allegiance
 from world.fatigue.constants import EFFORT_CHECK_MODIFIER, EffortLevel
 from world.fatigue.services import apply_fatigue, get_fatigue_penalty
 from world.magic.constants import EffectKind
@@ -1897,6 +1898,54 @@ def _select_targets(
     return list(rotated[:count])
 
 
+def _exclude_charmers_party(
+    opponent: CombatOpponent, participants: list[CombatParticipant]
+) -> list[CombatParticipant]:
+    """Return ``participants`` minus the charm source's party (#1590).
+
+    The charmer is the ``source_character`` on the opponent's active Charm
+    condition. If it resolves to an active ``CombatParticipant``, exclude it.
+    MVP: parties are 1:1 with participants (no party grouping yet), so we
+    exclude the single charmer participant. If the source is unresolvable
+    (e.g. left the encounter), the charmed NPC has no valid PC target and
+    skips the round.
+    """
+    from world.conditions.constants import CHARM_CONDITION_NAME  # noqa: PLC0415
+    from world.conditions.services import get_active_conditions  # noqa: PLC0415
+
+    if opponent.objectdb_id is None:
+        return participants
+    charmer_pk = None
+    for inst in get_active_conditions(opponent.objectdb):
+        if inst.condition.name == CHARM_CONDITION_NAME and inst.source_character_id is not None:
+            charmer_pk = inst.source_character_id
+            break
+    if charmer_pk is None:
+        return []
+    return [p for p in participants if p.character_sheet.character_id != charmer_pk]
+
+
+def _get_opponent_targets(
+    opponent: CombatOpponent,
+    active_participants: list[CombatParticipant],
+    encounter: CombatEncounter,
+) -> list[CombatParticipant]:
+    """Return the PCs an NPC is allowed to target after consulting allegiance.
+
+    Calm (``NEUTRAL``) returns an empty list so the NPC skips the round.
+    Charm (``ALLY_OF_CASTER``) excludes the charmer's party. Everything else
+    returns the full active participant list (#1590).
+    """
+    from world.npc_services.allegiance import derive_allegiance  # noqa: PLC0415
+
+    allegiance = derive_allegiance(opponent, encounter)
+    if allegiance == Allegiance.NEUTRAL:
+        return []
+    if allegiance == Allegiance.ALLY_OF_CASTER:
+        return _exclude_charmers_party(opponent, list(active_participants))
+    return list(active_participants)
+
+
 def _batch_fetch_cooldown_data(
     opponents: list[CombatOpponent],
     entries_by_pool: dict[int, list[ThreatPoolEntry]],
@@ -2008,11 +2057,16 @@ def select_npc_actions(
         if not eligible:
             continue
 
+        # Threat-read (#1590): consult allegiance to filter valid targets.
+        opponent_targets = _get_opponent_targets(opponent, active_participants, encounter)
+        if not opponent_targets:
+            continue
+
         if opponent.tier == OpponentTier.SWARM and opponent.swarm_count is not None:
             n_attacks = swarm_attack_count(
                 opponent.swarm_count,
                 opponent.bodies_per_attack or 1,
-                len(active_participants),
+                len(opponent_targets),
             )
         else:
             n_attacks = 1
@@ -2020,7 +2074,7 @@ def select_npc_actions(
         for attack_index in range(n_attacks):
             weights = [e.weight for e in eligible]
             chosen = random.choices(eligible, weights=weights, k=1)[0]  # noqa: S311
-            targets = _select_targets(chosen, active_participants, rotation=attack_index)
+            targets = _select_targets(chosen, opponent_targets, rotation=attack_index)
             action = CombatOpponentAction.objects.create(
                 opponent=opponent,
                 round_number=encounter.round_number,

--- a/src/world/combat/tests/test_npc_allegiance_targeting.py
+++ b/src/world/combat/tests/test_npc_allegiance_targeting.py
@@ -1,0 +1,83 @@
+"""E2E tests for NPC allegiance-aware targeting (#1590)."""
+
+from django.test import TestCase
+
+from world.combat.constants import TargetingMode, TargetSelection
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+    ThreatPoolEntryFactory,
+    ThreatPoolFactory,
+)
+from world.combat.services import select_npc_actions
+from world.conditions.charm_content import ensure_charm_content
+from world.conditions.constants import CALM_CONDITION_NAME, CHARM_CONDITION_NAME
+from world.conditions.models import ConditionTemplate
+from world.conditions.services import bulk_apply_conditions
+from world.conditions.types import BulkConditionApplication
+from world.scenes.constants import RoundStatus
+from world.vitals.models import CharacterVitals
+
+
+class NpcAllegianceTargetingTest(TestCase):
+    """NPC target selection respects derived allegiance (charm/calm)."""
+
+    def setUp(self):
+        super().setUp()
+        ensure_charm_content()
+        self.encounter = CombatEncounterFactory(round_number=1, status=RoundStatus.DECLARING)
+        self.pool = ThreatPoolFactory()
+        ThreatPoolEntryFactory(
+            pool=self.pool,
+            targeting_mode=TargetingMode.SINGLE,
+            target_selection=TargetSelection.RANDOM,
+        )
+        self.pc_a = self._make_active_participant()
+        self.pc_b = self._make_active_participant()
+        self.enemy_opponent = CombatOpponentFactory(encounter=self.encounter, threat_pool=self.pool)
+
+    def _make_active_participant(self):
+        participant = CombatParticipantFactory(encounter=self.encounter)
+        CharacterVitals.objects.create(
+            character_sheet=participant.character_sheet,
+            health=100,
+            max_health=100,
+        )
+        return participant
+
+    def _apply_charm(self, opponent, source_participant):
+        template = ConditionTemplate.objects.get(name=CHARM_CONDITION_NAME)
+        bulk_apply_conditions(
+            [BulkConditionApplication(target=opponent.objectdb, template=template)],
+            source_character=source_participant.character_sheet.character,
+        )
+
+    def _apply_calm(self, opponent):
+        template = ConditionTemplate.objects.get(name=CALM_CONDITION_NAME)
+        bulk_apply_conditions(
+            [BulkConditionApplication(target=opponent.objectdb, template=template)],
+        )
+
+    def _targeted_character_ids(self, actions):
+        return {t.character_sheet_id for a in actions for t in a.targets.all()}
+
+    def test_uncharmed_npc_targets_normally(self):
+        actions = select_npc_actions(self.encounter)
+        self.assertTrue(any(a.opponent_id == self.enemy_opponent.pk for a in actions))
+
+    def test_charmed_npc_does_not_target_charmers_party(self):
+        self._apply_charm(self.enemy_opponent, self.pc_a)
+        actions = select_npc_actions(self.encounter)
+        targeted = self._targeted_character_ids(actions)
+        self.assertNotIn(self.pc_a.character_sheet_id, targeted)
+        # The charmed NPC still acts; it just cannot target the charmer.
+        self.assertTrue(any(a.opponent_id == self.enemy_opponent.pk for a in actions))
+
+    def test_calmed_npc_takes_no_action(self):
+        self._apply_calm(self.enemy_opponent)
+        actions = select_npc_actions(self.encounter)
+        self.assertEqual(
+            [a for a in actions if a.opponent_id == self.enemy_opponent.pk],
+            [],
+        )

--- a/src/world/conditions/charm_content.py
+++ b/src/world/conditions/charm_content.py
@@ -1,0 +1,49 @@
+"""Idempotent seed for Charm/Calm condition content (#1590).
+
+Mirrors ``ensure_poison_content``: ``get_or_create`` the Charm category
+(``alters_behavior=True`` — the flag combat consults for allegiance) and the
+Charmed/Calm templates. Called at the same startup-seed point as poison.
+"""
+
+from __future__ import annotations
+
+from world.conditions.constants import (
+    CALM_CONDITION_NAME,
+    CHARM_CONDITION_NAME,
+    DurationType,
+)
+from world.conditions.models import ConditionCategory, ConditionTemplate
+
+
+def ensure_charm_content() -> None:
+    """Idempotently seed the Charm category + Charmed/Calm templates (#1590)."""
+    category, _ = ConditionCategory.objects.get_or_create(
+        name="Charm",
+        defaults={
+            "description": "Compulsion/charm effects that alter an NPC's behavior.",
+            "is_negative": True,
+            "alters_behavior": True,
+        },
+    )
+    ConditionTemplate.objects.get_or_create(
+        name=CHARM_CONDITION_NAME,
+        defaults={
+            "category": category,
+            "description": "Charmed into fighting for the caster.",
+            "default_duration_type": DurationType.ROUNDS,
+            "default_duration_value": 3,
+            "is_stackable": False,
+            "can_be_dispelled": True,
+        },
+    )
+    ConditionTemplate.objects.get_or_create(
+        name=CALM_CONDITION_NAME,
+        defaults={
+            "category": category,
+            "description": "Calmed into holding — will not attack.",
+            "default_duration_type": DurationType.ROUNDS,
+            "default_duration_value": 3,
+            "is_stackable": False,
+            "can_be_dispelled": True,
+        },
+    )

--- a/src/world/conditions/constants.py
+++ b/src/world/conditions/constants.py
@@ -90,6 +90,23 @@ POISONED_CONDITION_NAME: str = "Poisoned"
 SLOW_POISON_CONDITION_NAME: str = "Slow Poison"
 POISON_CATEGORY_NAME: str = "Poison"
 
+# Charm/Calm content identity keys (#1590). Seeded idempotently by
+# ensure_charm_content() in world.conditions.charm_content.
+CHARM_CONDITION_NAME: str = "Charmed"
+CALM_CONDITION_NAME: str = "Calm"
+
+
+class Allegiance(models.TextChoices):
+    """Behavioral allegiance states used by charm/control effects.
+
+    Declared in the conditions constants module so combat and social code can
+    share one source of truth.
+    """
+
+    ENEMY = "enemy", "Enemy"
+    ALLY_OF_CASTER = "ally", "Fights for the charmer"
+    NEUTRAL = "neutral", "Will not attack"
+
 
 class FoundationalCapability:
     """String constants for capabilities every character has innately.

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -2933,3 +2933,15 @@ def ensure_poison_content() -> None:
             "is_long_term": True,
         },
     )
+
+
+def ensure_conditions_content() -> None:
+    """Idempotently seed all core conditions content.
+
+    Aggregates the existing poison seed with the charm/calm seed so callers have
+    a single entry point for the condition content required by multiple systems.
+    """
+    from world.conditions.charm_content import ensure_charm_content  # noqa: PLC0415
+
+    ensure_poison_content()
+    ensure_charm_content()

--- a/src/world/conditions/tests/test_charm_content.py
+++ b/src/world/conditions/tests/test_charm_content.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+
+from world.conditions.charm_content import ensure_charm_content
+from world.conditions.constants import CALM_CONDITION_NAME, CHARM_CONDITION_NAME
+from world.conditions.models import ConditionCategory, ConditionTemplate
+
+
+class EnsureCharmContentTest(TestCase):
+    def test_creates_charm_category_with_alters_behavior(self):
+        ensure_charm_content()
+        cat = ConditionCategory.objects.get(name="Charm")
+        self.assertTrue(cat.alters_behavior)
+
+    def test_creates_charmed_and_calm_templates(self):
+        ensure_charm_content()
+        self.assertTrue(ConditionTemplate.objects.filter(name=CHARM_CONDITION_NAME).exists())
+        self.assertTrue(ConditionTemplate.objects.filter(name=CALM_CONDITION_NAME).exists())
+
+    def test_is_idempotent(self):
+        ensure_charm_content()
+        ensure_charm_content()
+        self.assertEqual(ConditionTemplate.objects.filter(name=CHARM_CONDITION_NAME).count(), 1)

--- a/src/world/npc_services/allegiance.py
+++ b/src/world/npc_services/allegiance.py
@@ -8,6 +8,8 @@ target-selection consults this so a charmed NPC skips the caster's party.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from world.conditions.constants import (
     CALM_CONDITION_NAME,
     CHARM_CONDITION_NAME,
@@ -15,8 +17,14 @@ from world.conditions.constants import (
 )
 from world.conditions.services import get_active_conditions
 
+if TYPE_CHECKING:
+    from world.combat.models import CombatEncounter, CombatOpponent
 
-def derive_allegiance(opponent, encounter) -> Allegiance:  # noqa: ARG001 (encounter for future party lookup)
+
+def derive_allegiance(
+    opponent: CombatOpponent,
+    encounter: CombatEncounter,  # noqa: ARG001 — reserved for future party lookup
+) -> Allegiance:
     """Return the opponent's current allegiance (derived, not stored)."""
     if opponent.objectdb_id is None:
         return Allegiance.ENEMY

--- a/src/world/npc_services/allegiance.py
+++ b/src/world/npc_services/allegiance.py
@@ -1,0 +1,32 @@
+"""Derived-on-read NPC allegiance (#1590, ADR-0058, ADR-0014).
+
+Allegiance is NOT a stored column — it is derived from the opponent's active
+``alters_behavior`` conditions (charm/calm) at read time. A charmed NPC fights
+for the charmer's side; a calmed NPC holds (will not attack). The combat
+target-selection consults this so a charmed NPC skips the caster's party.
+"""
+
+from __future__ import annotations
+
+from world.conditions.constants import (
+    CALM_CONDITION_NAME,
+    CHARM_CONDITION_NAME,
+    Allegiance,
+)
+from world.conditions.services import get_active_conditions
+
+
+def derive_allegiance(opponent, encounter) -> Allegiance:  # noqa: ARG001 (encounter for future party lookup)
+    """Return the opponent's current allegiance (derived, not stored)."""
+    if opponent.objectdb_id is None:
+        return Allegiance.ENEMY
+    active = list(get_active_conditions(opponent.objectdb))
+    names = {inst.condition.name for inst in active}
+    if CHARM_CONDITION_NAME in names:
+        # Charm wins over calm (stronger compulsion). Source-character
+        # validation (charmer is a live PC participant) is the caller's job;
+        # here we trust the condition's presence.
+        return Allegiance.ALLY_OF_CASTER
+    if CALM_CONDITION_NAME in names:
+        return Allegiance.NEUTRAL
+    return Allegiance.ENEMY

--- a/src/world/npc_services/ephemeral_disposition.py
+++ b/src/world/npc_services/ephemeral_disposition.py
@@ -1,0 +1,61 @@
+"""Ephemeral disposition store for persona-less NPCs outside combat (#1591).
+
+A persona-less NPC (mook, beast, random guard) has no Persona, so it has no
+``NPCStanding`` row. Its disposition toward an acting PC lives in a
+session/scene-scoped store — mirroring the ``InteractionSession``/``request.
+session`` pattern (ADR-0058). It self-cleans: when the mook is deleted at
+encounter end (combat) or the session clears (social), the disposition is gone.
+
+The store is a dict-like mapping (Django ``request.session`` in production; a
+plain ``dict`` in tests). Keys are ``"ephemeral_disposition:<pc_sheet_pk>:<npc_pk>"``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typeclasses.characters import Character
+    from world.character_sheets.models import CharacterSheet
+
+_PREFIX = "ephemeral_disposition"
+
+
+def _key(pc_sheet: CharacterSheet, npc_character: Character) -> str:
+    return f"{_PREFIX}:{pc_sheet.pk}:{npc_character.pk}"
+
+
+def get_disposition(
+    store: MutableMapping, pc_sheet: CharacterSheet, npc_character: Character
+) -> int:
+    """Return the ephemeral disposition (default 0)."""
+    return int(store.get(_key(pc_sheet, npc_character), 0))
+
+
+def adjust_disposition(
+    store: MutableMapping,
+    pc_sheet: CharacterSheet,
+    npc_character: Character,
+    *,
+    delta: int,
+) -> int:
+    """Apply ``delta`` to the ephemeral disposition; return the new value."""
+    key = _key(pc_sheet, npc_character)
+    new_value = int(store.get(key, 0)) + delta
+    store[key] = new_value
+    return new_value
+
+
+def clear_for_pair(
+    store: MutableMapping, pc_sheet: CharacterSheet, npc_character: Character
+) -> None:
+    """Remove the single (pc_sheet, npc) entry (used by promotion flush, Task 7)."""
+    store.pop(_key(pc_sheet, npc_character), None)
+
+
+def clear_scene_disposition(store: MutableMapping, pc_sheet: CharacterSheet) -> None:
+    """Remove all ephemeral disposition entries for one PC (scene end)."""
+    prefix = f"{_PREFIX}:{pc_sheet.pk}:"
+    for key in [k for k in store if isinstance(k, str) and k.startswith(prefix)]:
+        del store[key]

--- a/src/world/npc_services/services.py
+++ b/src/world/npc_services/services.py
@@ -623,6 +623,31 @@ def resolve_offer(
 
 
 @transaction.atomic
+def adjust_npc_affection(pc_persona, npc_persona, *, delta: int) -> int:
+    """Apply a disposition ``delta`` to the (pc_persona, npc_persona) standing.
+
+    Reuses the same ``update_or_create`` flush as ``end_interaction`` (no fork —
+    ADR-0016). Creates the row at affection=0 if absent, then applies the delta.
+    Returns the new affection value. No-op-safe for delta=0.
+    """
+    if delta == 0:
+        standing, _ = NPCStanding.objects.get_or_create(
+            persona=pc_persona,
+            npc_persona=npc_persona,
+            defaults={"affection": 0},
+        )
+        return standing.affection
+    standing, _ = NPCStanding.objects.get_or_create(
+        persona=pc_persona,
+        npc_persona=npc_persona,
+        defaults={"affection": 0},
+    )
+    standing.affection += delta
+    standing.save(update_fields=["affection"])
+    return standing.affection
+
+
+@transaction.atomic
 def end_interaction(session: InteractionSession) -> None:
     """Close the session and persist final affection for class 2-4 NPCs.
 

--- a/src/world/npc_services/services.py
+++ b/src/world/npc_services/services.py
@@ -24,6 +24,7 @@ import random
 from typing import TYPE_CHECKING
 
 from django.db import transaction
+from django.db.models import F
 from django.utils import timezone
 
 from world.checks.services import perform_check
@@ -626,24 +627,24 @@ def resolve_offer(
 def adjust_npc_affection(pc_persona, npc_persona, *, delta: int) -> int:
     """Apply a disposition ``delta`` to the (pc_persona, npc_persona) standing.
 
-    Reuses the same ``update_or_create`` flush as ``end_interaction`` (no fork —
-    ADR-0016). Creates the row at affection=0 if absent, then applies the delta.
-    Returns the new affection value. No-op-safe for delta=0.
+    Atomic accumulate: the increment runs as a single ``UPDATE ... SET
+    affection = affection + delta`` via ``F()`` so concurrent calls cannot
+    lose updates (ADR-0016: reuses the NPCStanding affection column, no fork).
+    Creates the row at affection=0 if absent. Returns the new affection value.
+    No-op-safe for delta=0 (still returns current affection).
     """
-    if delta == 0:
-        standing, _ = NPCStanding.objects.get_or_create(
-            persona=pc_persona,
-            npc_persona=npc_persona,
-            defaults={"affection": 0},
-        )
-        return standing.affection
     standing, _ = NPCStanding.objects.get_or_create(
         persona=pc_persona,
         npc_persona=npc_persona,
         defaults={"affection": 0},
     )
-    standing.affection += delta
-    standing.save(update_fields=["affection"])
+    if delta != 0:
+        NPCStanding.objects.filter(pk=standing.pk).update(affection=F("affection") + delta)
+        # ``F()``-based UPDATE bypasses Evennia's SharedMemoryModel instance,
+        # so the cached copy must be purged and reloaded for callers that
+        # already hold the same idmapped object.
+        standing.flush_from_cache(force=True)
+        standing.refresh_from_db()
     return standing.affection
 
 

--- a/src/world/npc_services/social_disposition.py
+++ b/src/world/npc_services/social_disposition.py
@@ -1,0 +1,58 @@
+"""Route a social-action graded outcome to the right disposition tier (#1591)."""
+
+from __future__ import annotations
+
+# Per success-tier disposition deltas (ADR-0019: tier-sourced, not hardcoded
+# check difficulty). success_level is a SmallIntegerField on a -10..+10 scale
+# (world/traits/models.py:484; checks/AGENT_GLOSSARY.md:16); >0 = success,
+# <=0 = no positive movement. Thresholds: >=5 critical, >=3 strong, >=1 marginal.
+_TIER_DELTA = {5: 5, 3: 3, 1: 1}
+
+
+def apply_social_disposition_delta(actor, target_persona_id, result) -> None:
+    """Apply a tiered disposition delta after a social action resolves.
+
+    Persona-bearing NPCs (``target_persona_id`` resolves to a ``Persona``)
+    move durable ``NPCStanding.affection``. The persona-less mook path is
+    deferred — ``execute()`` has no session-scoped ephemeral store in scope,
+    so Task 7's promotion seam will wire that path.
+    """
+    from world.npc_services.services import adjust_npc_affection  # noqa: PLC0415
+    from world.scenes.services import (  # noqa: PLC0415
+        MissingPrimaryPersonaError,
+        persona_for_character,
+    )
+
+    success_level = _success_level(result)
+    delta = _delta_for_tier(success_level)
+    if delta == 0 or target_persona_id is None:
+        return
+
+    from world.scenes.models import Persona  # noqa: PLC0415
+
+    target_persona = Persona.objects.filter(pk=target_persona_id).first()
+    if target_persona is None:
+        return
+
+    # Persona-bearing NPC → durable NPCStanding.
+    try:
+        pc_persona = persona_for_character(actor)
+    except MissingPrimaryPersonaError:
+        # A half-set-up actor should not crash the action.
+        return
+
+    adjust_npc_affection(pc_persona, target_persona, delta=delta)
+
+
+def _success_level(result) -> int:
+    main = getattr(result, "main_result", None)  # noqa: GETATTR_LITERAL
+    if main is not None and getattr(main, "check_result", None) is not None:  # noqa: GETATTR_LITERAL
+        return main.check_result.success_level or 0
+    return 0
+
+
+def _delta_for_tier(success_level: int) -> int:
+    for threshold, delta in sorted(_TIER_DELTA.items(), reverse=True):
+        if success_level >= threshold:
+            return delta
+    return 0

--- a/src/world/npc_services/social_disposition.py
+++ b/src/world/npc_services/social_disposition.py
@@ -28,10 +28,11 @@ def apply_social_disposition_delta(actor, target_persona_id, result) -> None:
     if delta == 0 or target_persona_id is None:
         return
 
+    from world.scenes.action_services import _persona_is_npc  # noqa: PLC0415
     from world.scenes.models import Persona  # noqa: PLC0415
 
     target_persona = Persona.objects.filter(pk=target_persona_id).first()
-    if target_persona is None:
+    if target_persona is None or not _persona_is_npc(target_persona):
         return
 
     # Persona-bearing NPC → durable NPCStanding.

--- a/src/world/npc_services/tests/test_affection_service.py
+++ b/src/world/npc_services/tests/test_affection_service.py
@@ -32,3 +32,15 @@ class AdjustNpcAffectionTest(TestCase):
         NPCStanding.objects.create(persona=self.pc, npc_persona=self.npc, affection=2)
         new = adjust_npc_affection(self.pc, self.npc, delta=-10)
         self.assertEqual(new, -8)
+
+    def test_delta_zero_returns_current_and_no_row_change(self):
+        NPCStanding.objects.create(persona=self.pc, npc_persona=self.npc, affection=7)
+        result = adjust_npc_affection(self.pc, self.npc, delta=0)
+        self.assertEqual(result, 7)
+        standing = NPCStanding.objects.get(persona=self.pc, npc_persona=self.npc)
+        self.assertEqual(standing.affection, 7)
+
+    def test_delta_zero_creates_row_at_zero(self):
+        result = adjust_npc_affection(self.pc, self.npc, delta=0)
+        self.assertEqual(result, 0)
+        self.assertTrue(NPCStanding.objects.filter(persona=self.pc, npc_persona=self.npc).exists())

--- a/src/world/npc_services/tests/test_affection_service.py
+++ b/src/world/npc_services/tests/test_affection_service.py
@@ -1,0 +1,34 @@
+"""Tests for the reusable NPC affection adjustment helper."""
+
+from django.test import TestCase
+
+from world.npc_services.models import NPCStanding
+from world.npc_services.services import adjust_npc_affection
+from world.scenes.factories import PersonaFactory
+
+
+class AdjustNpcAffectionTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.pc = PersonaFactory()
+        cls.npc = PersonaFactory()
+
+    def test_applies_delta_to_existing_standing(self):
+        standing = NPCStanding.objects.create(persona=self.pc, npc_persona=self.npc, affection=10)
+        new = adjust_npc_affection(self.pc, self.npc, delta=5)
+        standing.refresh_from_db()
+        self.assertEqual(new, 15)
+        self.assertEqual(standing.affection, 15)
+
+    def test_creates_row_when_absent(self):
+        self.assertFalse(NPCStanding.objects.filter(persona=self.pc, npc_persona=self.npc).exists())
+        new = adjust_npc_affection(self.pc, self.npc, delta=3)
+        self.assertEqual(new, 3)
+        self.assertEqual(
+            NPCStanding.objects.get(persona=self.pc, npc_persona=self.npc).affection, 3
+        )
+
+    def test_negative_delta_disliked(self):
+        NPCStanding.objects.create(persona=self.pc, npc_persona=self.npc, affection=2)
+        new = adjust_npc_affection(self.pc, self.npc, delta=-10)
+        self.assertEqual(new, -8)

--- a/src/world/npc_services/tests/test_allegiance.py
+++ b/src/world/npc_services/tests/test_allegiance.py
@@ -1,0 +1,63 @@
+"""Tests for derived-on-read NPC allegiance (#1590, ADR-0058, ADR-0014)."""
+
+from django.test import TestCase
+
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+)
+from world.conditions.charm_content import ensure_charm_content
+from world.conditions.constants import (
+    CALM_CONDITION_NAME,
+    CHARM_CONDITION_NAME,
+    Allegiance,
+)
+from world.conditions.models import ConditionTemplate
+from world.conditions.services import bulk_apply_conditions
+from world.conditions.types import BulkConditionApplication
+from world.npc_services.allegiance import derive_allegiance
+
+
+class DeriveAllegianceTest(TestCase):
+    def setUp(self):
+        ensure_charm_content()
+        self.encounter = CombatEncounterFactory()
+        self.enemy_opponent = CombatOpponentFactory(encounter=self.encounter)
+        self.pc_participant = CombatParticipantFactory(encounter=self.encounter)
+
+    def _apply_charm(self, opponent, source):
+        template = ConditionTemplate.objects.get(name=CHARM_CONDITION_NAME)
+        bulk_apply_conditions(
+            [BulkConditionApplication(target=opponent.objectdb, template=template)],
+            source_character=source.character_sheet.character,
+        )
+
+    def _apply_calm(self, opponent):
+        template = ConditionTemplate.objects.get(name=CALM_CONDITION_NAME)
+        bulk_apply_conditions(
+            [BulkConditionApplication(target=opponent.objectdb, template=template)],
+        )
+
+    def test_enemy_by_default(self):
+        self.assertEqual(derive_allegiance(self.enemy_opponent, self.encounter), Allegiance.ENEMY)
+
+    def test_charmed_ally_of_caster(self):
+        self._apply_charm(self.enemy_opponent, source=self.pc_participant)
+        self.assertEqual(
+            derive_allegiance(self.enemy_opponent, self.encounter),
+            Allegiance.ALLY_OF_CASTER,
+        )
+
+    def test_calmed_neutral(self):
+        self._apply_calm(self.enemy_opponent)
+        self.assertEqual(derive_allegiance(self.enemy_opponent, self.encounter), Allegiance.NEUTRAL)
+
+    def test_calm_overrides_when_no_charm(self):
+        # If both somehow present, charm wins (it is the stronger compulsion).
+        self._apply_calm(self.enemy_opponent)
+        self._apply_charm(self.enemy_opponent, source=self.pc_participant)
+        self.assertEqual(
+            derive_allegiance(self.enemy_opponent, self.encounter),
+            Allegiance.ALLY_OF_CASTER,
+        )

--- a/src/world/npc_services/tests/test_allegiance.py
+++ b/src/world/npc_services/tests/test_allegiance.py
@@ -39,6 +39,11 @@ class DeriveAllegianceTest(TestCase):
             [BulkConditionApplication(target=opponent.objectdb, template=template)],
         )
 
+    def test_no_objectdb_is_enemy(self):
+        # An opponent with no in-world ObjectDB cannot be charmed -> ENEMY.
+        opponent = CombatOpponentFactory(encounter=self.encounter, objectdb_id=None)
+        self.assertEqual(derive_allegiance(opponent, self.encounter), Allegiance.ENEMY)
+
     def test_enemy_by_default(self):
         self.assertEqual(derive_allegiance(self.enemy_opponent, self.encounter), Allegiance.ENEMY)
 

--- a/src/world/npc_services/tests/test_ephemeral_disposition.py
+++ b/src/world/npc_services/tests/test_ephemeral_disposition.py
@@ -1,0 +1,53 @@
+"""Tests for the ephemeral disposition store for persona-less NPCs."""
+
+from django.test import TestCase
+
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.npc_services.ephemeral_disposition import (
+    adjust_disposition,
+    clear_for_pair,
+    clear_scene_disposition,
+    get_disposition,
+)
+
+
+class EphemeralDispositionTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.pc_sheet = CharacterSheetFactory()
+        cls.other_pc = CharacterSheetFactory()
+        cls.npc_character = CharacterFactory()
+        cls.other_npc_character = CharacterFactory()
+
+    def test_default_zero(self):
+        store = {}
+        self.assertEqual(get_disposition(store, self.pc_sheet, self.npc_character), 0)
+
+    def test_adjust_accumulates(self):
+        store = {}
+        adjust_disposition(store, self.pc_sheet, self.npc_character, delta=5)
+        adjust_disposition(store, self.pc_sheet, self.npc_character, delta=3)
+        self.assertEqual(get_disposition(store, self.pc_sheet, self.npc_character), 8)
+
+    def test_isolated_per_pc_and_npc(self):
+        store = {}
+        adjust_disposition(store, self.pc_sheet, self.npc_character, delta=5)
+        # Different PC, same NPC:
+        self.assertEqual(get_disposition(store, self.other_pc, self.npc_character), 0)
+
+    def test_clear_scene_removes_only_that_pc(self):
+        store = {}
+        adjust_disposition(store, self.pc_sheet, self.npc_character, delta=5)
+        adjust_disposition(store, self.other_pc, self.npc_character, delta=9)
+        clear_scene_disposition(store, self.pc_sheet)
+        self.assertEqual(get_disposition(store, self.pc_sheet, self.npc_character), 0)
+        self.assertEqual(get_disposition(store, self.other_pc, self.npc_character), 9)
+
+    def test_clear_for_pair_removes_only_one_npc(self):
+        store = {}
+        adjust_disposition(store, self.pc_sheet, self.npc_character, delta=5)
+        adjust_disposition(store, self.pc_sheet, self.other_npc_character, delta=7)
+        clear_for_pair(store, self.pc_sheet, self.npc_character)
+        self.assertEqual(get_disposition(store, self.pc_sheet, self.npc_character), 0)
+        self.assertEqual(get_disposition(store, self.pc_sheet, self.other_npc_character), 7)

--- a/src/world/npc_services/tests/test_social_affection_delta.py
+++ b/src/world/npc_services/tests/test_social_affection_delta.py
@@ -72,8 +72,9 @@ class SocialAffectionDeltaTest(TestCase):
                 target_persona_id=self.npc_persona.pk,
             )
 
-        self.assertIsNotNone(result.main_result)
-        self.assertGreater(result.main_result.check_result.success_level, 0)
+        resolution = result.data["resolution"]
+        self.assertIsNotNone(resolution.main_result)
+        self.assertGreater(resolution.main_result.check_result.success_level, 0)
         standing = NPCStanding.objects.get(
             persona=self.pc_sheet.primary_persona,
             npc_persona=self.npc_persona,
@@ -90,8 +91,9 @@ class SocialAffectionDeltaTest(TestCase):
                 target_persona_id=self.npc_persona.pk,
             )
 
-        self.assertIsNotNone(result.main_result)
-        self.assertLessEqual(result.main_result.check_result.success_level, 0)
+        resolution = result.data["resolution"]
+        self.assertIsNotNone(resolution.main_result)
+        self.assertLessEqual(resolution.main_result.check_result.success_level, 0)
         self.assertFalse(
             NPCStanding.objects.filter(
                 persona=self.pc_sheet.primary_persona,
@@ -106,8 +108,9 @@ class SocialAffectionDeltaTest(TestCase):
         with force_check_outcome(success):
             result = PersuadeAction().run(self.pc_character)
 
-        self.assertIsNotNone(result.main_result)
-        self.assertGreater(result.main_result.check_result.success_level, 0)
+        resolution = result.data["resolution"]
+        self.assertIsNotNone(resolution.main_result)
+        self.assertGreater(resolution.main_result.check_result.success_level, 0)
         self.assertFalse(NPCStanding.objects.exists())
 
     def test_success_level_fallback_for_unexpected_result_shape(self) -> None:
@@ -143,8 +146,9 @@ class SocialAffectionDeltaTest(TestCase):
                 target_persona_id=pc_target_persona.pk,
             )
 
-        self.assertIsNotNone(result.main_result)
-        self.assertGreater(result.main_result.check_result.success_level, 0)
+        resolution = result.data["resolution"]
+        self.assertIsNotNone(resolution.main_result)
+        self.assertGreater(resolution.main_result.check_result.success_level, 0)
         self.assertFalse(
             NPCStanding.objects.filter(
                 persona=self.pc_sheet.primary_persona,

--- a/src/world/npc_services/tests/test_social_affection_delta.py
+++ b/src/world/npc_services/tests/test_social_affection_delta.py
@@ -15,6 +15,7 @@ from actions.definitions.social import PersuadeAction
 from actions.factories import ActionTemplateFactory
 from actions.models.action_templates import ActionTemplate
 from actions.types import ActionResult
+from evennia_extensions.factories import AccountFactory, CharacterFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckCategoryFactory, CheckTypeFactory
 from world.checks.test_helpers import force_check_outcome
@@ -119,3 +120,34 @@ class SocialAffectionDeltaTest(TestCase):
         bare = ActionResult(success=True)
         self.assertEqual(_success_level(bare), 0)
         self.assertEqual(_delta_for_tier(_success_level(bare)), 0)
+
+    def test_pc_target_is_noop(self) -> None:
+        """A successful social action aimed at a PC must not write an NPCStanding row."""
+        from world.scenes.action_services import _persona_is_npc
+
+        pc_target_character = CharacterFactory()
+        pc_target_character.db_account = AccountFactory()
+        pc_target_character.save()
+        pc_target_sheet = CharacterSheetFactory(character=pc_target_character)
+        pc_target_persona = PersonaFactory(
+            character_sheet=pc_target_sheet, persona_type=PersonaType.ESTABLISHED
+        )
+
+        self.assertFalse(_persona_is_npc(pc_target_persona))
+
+        success = CheckOutcomeFactory(name="Social Success PC Target", success_level=5)
+
+        with force_check_outcome(success):
+            result = PersuadeAction().run(
+                self.pc_character,
+                target_persona_id=pc_target_persona.pk,
+            )
+
+        self.assertIsNotNone(result.main_result)
+        self.assertGreater(result.main_result.check_result.success_level, 0)
+        self.assertFalse(
+            NPCStanding.objects.filter(
+                persona=self.pc_sheet.primary_persona,
+                npc_persona=pc_target_persona,
+            ).exists()
+        )

--- a/src/world/npc_services/tests/test_social_affection_delta.py
+++ b/src/world/npc_services/tests/test_social_affection_delta.py
@@ -1,0 +1,121 @@
+"""Test that social-action graded outcomes move NPC disposition (#1591).
+
+Drives the persuade action through ``action.run()`` and asserts that the
+durable ``NPCStanding.affection`` value moves by the success tier. The check
+outcome is forced via the test-rig seam so the tests are deterministic without
+mocking the action lifecycle itself.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from actions.constants import Pipeline
+from actions.definitions.social import PersuadeAction
+from actions.factories import ActionTemplateFactory
+from actions.models.action_templates import ActionTemplate
+from actions.types import ActionResult
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import CheckCategoryFactory, CheckTypeFactory
+from world.checks.test_helpers import force_check_outcome
+from world.npc_services.models import NPCStanding
+from world.scenes.constants import PersonaType
+from world.scenes.factories import PersonaFactory
+from world.traits.factories import CheckOutcomeFactory
+
+
+class SocialAffectionDeltaTest(TestCase):
+    """Social action outcomes apply a tiered disposition delta to persona-bearing NPCs."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.pc_sheet = CharacterSheetFactory()
+        cls.pc_character = cls.pc_sheet.character
+        cls.npc_persona = PersonaFactory(persona_type=PersonaType.ESTABLISHED)
+
+        check_cat = CheckCategoryFactory(name="Social")
+        cls.check_type = CheckTypeFactory(name="Persuasion", category=check_cat)
+
+        # Ensure the "Persuade" ActionTemplate exists with a deterministic SINGLE
+        # pipeline. Using the factory with django_get_or_create would silently drop
+        # non-lookup kwargs if the row already existed, so we upsert explicitly.
+        template = ActionTemplate.objects.filter(name="Persuade").first()
+        if template is None:
+            template = ActionTemplateFactory(
+                name="Persuade",
+                check_type=cls.check_type,
+                pipeline=Pipeline.SINGLE,
+                consequence_pool=None,
+                category="social",
+            )
+        else:
+            template.check_type = cls.check_type
+            template.consequence_pool = None
+            template.pipeline = Pipeline.SINGLE
+            template.save(update_fields=["check_type", "consequence_pool", "pipeline"])
+        cls.template = template
+
+    def test_persuade_success_moves_durable_affection(self) -> None:
+        """A successful social check raises NPCStanding.affection by the tier delta."""
+        success = CheckOutcomeFactory(name="Social Success", success_level=5)
+        self.assertFalse(
+            NPCStanding.objects.filter(
+                persona=self.pc_sheet.primary_persona,
+                npc_persona=self.npc_persona,
+            ).exists()
+        )
+
+        with force_check_outcome(success):
+            result = PersuadeAction().run(
+                self.pc_character,
+                target_persona_id=self.npc_persona.pk,
+            )
+
+        self.assertIsNotNone(result.main_result)
+        self.assertGreater(result.main_result.check_result.success_level, 0)
+        standing = NPCStanding.objects.get(
+            persona=self.pc_sheet.primary_persona,
+            npc_persona=self.npc_persona,
+        )
+        self.assertEqual(standing.affection, 5)
+
+    def test_failure_does_not_move_disposition(self) -> None:
+        """A failed social check leaves affection unchanged and creates no row."""
+        failure = CheckOutcomeFactory(name="Social Failure", success_level=-1)
+
+        with force_check_outcome(failure):
+            result = PersuadeAction().run(
+                self.pc_character,
+                target_persona_id=self.npc_persona.pk,
+            )
+
+        self.assertIsNotNone(result.main_result)
+        self.assertLessEqual(result.main_result.check_result.success_level, 0)
+        self.assertFalse(
+            NPCStanding.objects.filter(
+                persona=self.pc_sheet.primary_persona,
+                npc_persona=self.npc_persona,
+            ).exists()
+        )
+
+    def test_persona_less_target_is_noop(self) -> None:
+        """A target with no persona is a no-op: no ephemeral store update in Task 6."""
+        success = CheckOutcomeFactory(name="Social Success Personaless", success_level=3)
+
+        with force_check_outcome(success):
+            result = PersuadeAction().run(self.pc_character)
+
+        self.assertIsNotNone(result.main_result)
+        self.assertGreater(result.main_result.check_result.success_level, 0)
+        self.assertFalse(NPCStanding.objects.exists())
+
+    def test_success_level_fallback_for_unexpected_result_shape(self) -> None:
+        """The helper returns 0 (no movement) when the result lacks a check_result."""
+        from world.npc_services.social_disposition import (
+            _delta_for_tier,
+            _success_level,
+        )
+
+        bare = ActionResult(success=True)
+        self.assertEqual(_success_level(bare), 0)
+        self.assertEqual(_delta_for_tier(_success_level(bare)), 0)


### PR DESCRIPTION
Closes #1590
Closes #1591

## Summary

Implements both NPC-disposition siblings on **ADR-0058** (two-tier NPC
disposition: durable `NPCStanding.affection` for Persona-bearing NPCs; ephemeral
session/scene-scoped store for persona-less mooks; `has_persistent_identity_references`
is the future promotion seam).

**#1590 — charm / switch-sides (combat allegiance):**
- Seed `Charm` + `Calm` condition templates with `alters_behavior=True` (the
  Charm/Calm/Allegiance condition category).
- `derive_allegiance(opponent, encounter)` — derived-on-read (ADR-0014); charm-before-calm
  precedence; `objectdb_id is None` → ENEMY.
- `select_npc_actions` is allegiance-aware: a charmed NPC (ALLY_OF_CASTER) skips the
  charmer's party; a calmed NPC (NEUTRAL) holds; an unresolvable charmer yields no
  targets (never falls back to ENEMY — a charmed NPC must never attack the charmer's
  side even if the charmer left the encounter).

**#1591 — parley (social actions move disposition):**
- `apply_social_disposition_delta(actor, target_persona_id, resolution)` routes the
  social check's success tier to the disposition delta (ADR-0019 graded outcomes:
  `_TIER_DELTA = {5:5, 3:3, 1:1}` on the -10..+10 `success_level`).
- Wired into the shared `_resolve_template` path so every social template action
  (Persuade/Intimidate/Deceive/Flirt/Perform/Entrance/RestoreSense) moves NPC affection;
  PC targets and persona-less mooks no-op (NPC guard via canonical `_persona_is_npc`).
- `adjust_npc_affection` is atomic (`F('affection') + delta` + `flush_from_cache`/
  `refresh_from_db` per SharedMemoryModel ADR-0008).

**Task 7 (charm-retention promotion flush) skipped per user decision:** verified no
persona-minting path for an ephemeral mook exists today (`has_persistent_identity_references`
is validation-only); the "charmed and followed me home" retention seam is a future
feature, documented in ADR-0058.

Docs in tandem: `conditions.md`, `INDEX.md`, `combat-conditions.md`,
`player-capability-ledger.md`, `combat.md` roadmap, `MODEL_MAP.md` regen,
ADR-0058 + README index. Kimi adversarial review (different model, repeat-until-clean)
round 1+2 — nothing agreed-needs-fixing in this PR.

## Follow-ups filed

(none)

Deferred (not filed — Minor coverage gap adjacent to the skipped Task 7): a
charm-condition-decay-across-rounds test (allegiance reverts to ENEMY when Charm
expires). Core derived-on-read correctness is tested; the decay interaction is
untested. The promotion seam is documented as future in ADR-0058.

## Notes

- Spec: reviewed & approved on #1590 and #1591 (in the issue bodies).
- Brainstorm/plan: ran (subagent-driven-development — 6 implementer tasks + per-task
  reviews + final whole-branch kimi adversarial review).
- Sync-with-main: rebased onto origin/main (8 commits advanced, incl. #1603 "social
  actions return an honest ActionResult"). Resolved one conflict in
  `src/actions/definitions/social.py` — moved the disposition-delta call into the
  shared `_resolve_template` path (covers all social template actions uniformly) and
  adapted test assertions to unwrap `result.data["resolution"]` (#1603 nests the
  `PendingActionResolution` there, not on the `ActionResult` wrapper). 837 tests green
  on the fast SQLite tier (`world.npc_services` + `actions`); `pre-commit run --all-files` clean.

<!-- last-addressed-comment: 0 -->
