### PR TITLE
chore(items): crafting hardening — symmetric anima shortfall + factory footgun (#1243)

### DIFF
--- a/src/world/items/crafting/cost.py
+++ b/src/world/items/crafting/cost.py
@@ -165,8 +165,19 @@ def consume_cost(
             msg = "Action points were spent elsewhere before crafting completed."
             raise CraftingCostUnaffordable(msg)
 
-    # Deduct Anima
+    # Deduct Anima — symmetric with the AP path above. ``deduct_anima(lethal=False)``
+    # *clamps* to available anima and never draws life force, so a concurrent spend that
+    # dropped the balance below ``anima_to_spend`` (between staging and now) would be
+    # silently absorbed and the consumed-summary would over-report. Assert sufficiency
+    # first and fail-hard like AP does, so the returned ``anima`` is always truthful.
     if anima_to_spend > 0:
+        from world.magic.models import CharacterAnima  # noqa: PLC0415
+
+        anima_row = CharacterAnima.objects.filter(character=crafter_character).first()
+        current_anima = anima_row.current if anima_row is not None else 0
+        if current_anima < anima_to_spend:
+            msg = "Anima was spent elsewhere before crafting completed."
+            raise CraftingCostUnaffordable(msg)
         deduct_anima(crafter_character, anima_to_spend, lethal=False)
 
     # Consume materials (PARTIAL and FULL both consume ALL materials)

--- a/src/world/items/crafting/services.py
+++ b/src/world/items/crafting/services.py
@@ -12,7 +12,7 @@ handler registry on ``CraftingRecipeKind``.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from django.db import transaction
@@ -66,7 +66,8 @@ class CraftingQuoteCost:
     action_points_have: int
     anima: int
     anima_have: int
-    materials: list[dict]
+    # tuple (not list) so the frozen snapshot is genuinely immutable (#1243).
+    materials: tuple[dict, ...]
 
 
 @dataclass(frozen=True)
@@ -85,7 +86,8 @@ class CraftingQuote:
     costs: CraftingQuoteCost
     affordable: bool
     max_quality_tier: QualityTier | None
-    failure_risk: list[CraftingQuoteRisk] = field(default_factory=list)
+    # tuple (not list) so the frozen snapshot is genuinely immutable (#1243).
+    failure_risk: tuple[CraftingQuoteRisk, ...] = ()
 
 
 def build_crafting_quote(
@@ -201,11 +203,11 @@ def build_crafting_quote(
             action_points_have=ap_have,
             anima=anima_cost,
             anima_have=anima_have,
-            materials=material_rows,
+            materials=tuple(material_rows),
         ),
         affordable=affordable,
         max_quality_tier=max_quality_tier,
-        failure_risk=failure_risk,
+        failure_risk=tuple(failure_risk),
     )
 
 

--- a/src/world/items/factories.py
+++ b/src/world/items/factories.py
@@ -401,14 +401,17 @@ def _wire_recipe_caps_and_consequences(
 class CraftingRecipeFactory(factory.django.DjangoModelFactory):
     """Factory for CraftingRecipe.
 
-    Creates a minimal recipe with sensible defaults. Override ``kind`` when you need
-    a specific recipe kind; note the unique constraint means only one recipe per kind
-    can exist at a time.
+    Creates a minimal recipe with sensible defaults. ``kind`` carries a ``unique``
+    constraint (one recipe per kind), so the factory keys ``django_get_or_create`` on
+    ``kind`` — two bare ``CraftingRecipeFactory()`` calls return the *same* FACET_ATTACH
+    recipe instead of raising ``IntegrityError`` on the second. Override ``kind`` to
+    create a recipe of a different kind. (Per the ``django_get_or_create`` gotcha,
+    non-lookup kwargs are ignored when the row for a ``kind`` already exists.)
     """
 
     class Meta:
         model = "items.CraftingRecipe"
-        django_get_or_create = ("name",)
+        django_get_or_create = ("kind",)
 
     name = factory.Sequence(lambda n: f"Crafting Recipe {n}")
     kind = CraftingRecipeKind.FACET_ATTACH

--- a/src/world/items/tests/test_crafting_cost.py
+++ b/src/world/items/tests/test_crafting_cost.py
@@ -409,3 +409,41 @@ class ConsumeCostApShortfallTests(_CraftingCostBase):
                 staged=staged,
                 consumption=CostConsumption.FULL,
             )
+
+
+class ConsumeCostAnimaShortfallTests(_CraftingCostBase):
+    """consume_cost raises when Anima is drained after staging — symmetric with AP (#1243)."""
+
+    def test_anima_drained_between_stage_and_consume_raises(self) -> None:
+        """A concurrent spend below the staged anima aborts instead of silently clamping.
+
+        ``deduct_anima(lethal=False)`` would clamp to available and leave the consumed
+        summary over-reporting; the symmetric guard fails hard like the AP path instead.
+        """
+        staged = StagedCost(action_points=0, anima=8, material_pks=[])
+
+        # Simulate a concurrent spend draining anima below the staged amount.
+        self.anima.current = 3
+        self.anima.save(update_fields=["current"])
+
+        with self.assertRaises(CraftingCostUnaffordable):
+            consume_cost(
+                crafter_character=self.character,
+                staged=staged,
+                consumption=CostConsumption.FULL,
+            )
+        # The raise aborts before deduct_anima — anima is untouched (no partial clamp).
+        self.anima.refresh_from_db()
+        self.assertEqual(self.anima.current, 3)
+
+    def test_anima_row_deleted_after_staging_raises(self) -> None:
+        """A positive anima cost can't be paid when the anima row vanished after staging."""
+        staged = StagedCost(action_points=0, anima=5, material_pks=[])
+        CharacterAnima.objects.filter(character=self.character).delete()
+
+        with self.assertRaises(CraftingCostUnaffordable):
+            consume_cost(
+                crafter_character=self.character,
+                staged=staged,
+                consumption=CostConsumption.FULL,
+            )

--- a/src/world/items/tests/test_crafting_models.py
+++ b/src/world/items/tests/test_crafting_models.py
@@ -36,6 +36,25 @@ class CraftingRecipeModelTests(TestCase):
         self.assertIn(CraftingRecipeKind.FACET_ATTACH, CraftingRecipeKind.values)
         self.assertIn(CraftingRecipeKind.STYLE_ATTACH, CraftingRecipeKind.values)
 
+    def test_two_bare_factory_calls_reuse_the_same_kind_row(self) -> None:
+        """Two bare ``CraftingRecipeFactory()`` calls return the same row, not IntegrityError.
+
+        ``kind`` is unique; the factory keys ``django_get_or_create`` on it so the second
+        bare call reuses the FACET_ATTACH recipe instead of violating the constraint (#1243).
+        """
+        first = CraftingRecipeFactory()
+        second = CraftingRecipeFactory()
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(
+            CraftingRecipe.objects.filter(kind=CraftingRecipeKind.FACET_ATTACH).count(), 1
+        )
+
+    def test_distinct_kinds_create_distinct_rows(self) -> None:
+        """Passing a distinct ``kind`` still creates a separate recipe."""
+        facet = CraftingRecipeFactory(kind=CraftingRecipeKind.FACET_ATTACH)
+        style = CraftingRecipeFactory(kind=CraftingRecipeKind.STYLE_ATTACH)
+        self.assertNotEqual(facet.pk, style.pk)
+
     def test_cost_consumption_choices(self) -> None:
         """CostConsumption has NONE, PARTIAL, FULL choices."""
         self.assertIn(CostConsumption.NONE, CostConsumption.values)
@@ -49,8 +68,12 @@ class CraftingRecipeModelTests(TestCase):
     def test_unique_kind_constraint(self) -> None:
         """Two recipes with the same kind violate the unique constraint."""
         CraftingRecipeFactory(name="Attach Facet", kind=CraftingRecipeKind.FACET_ATTACH)
+        # The factory get_or_creates on ``kind`` (so a second factory call would reuse the
+        # row); assert the DB constraint directly via the model to exercise it (#1243).
         with self.assertRaises(IntegrityError):
-            CraftingRecipeFactory(name="Attach Facet 2", kind=CraftingRecipeKind.FACET_ATTACH)
+            CraftingRecipe.objects.create(
+                name="Attach Facet 2", kind=CraftingRecipeKind.FACET_ATTACH
+            )
 
     def test_ordering(self) -> None:
         """CraftingRecipe default ordering is by name."""

--- a/src/world/items/tests/test_crafting_query_counts.py
+++ b/src/world/items/tests/test_crafting_query_counts.py
@@ -24,8 +24,10 @@ rather than discovered in production profiling.
   5. consequence_rows.select_related — 1 query (all rows in one hit, not per-row)
   6. consume_cost:
      a. ActionPointConfig × 2 + ActionPointPool GET + pool.spend UPDATE — 4 queries
-     b. deduct_anima → anima GET + unique check + UPDATE — 3 queries
-     c. consume_pks → Django cascade collect (batched IN-lists per FK) + DELETE — ~14 q
+     b. anima sufficiency guard (filter.first) — 1 query (#1243; symmetric with the AP
+        path, asserts the staged anima is still affordable before deducting)
+     c. deduct_anima → anima GET + unique check + UPDATE — 3 queries
+     d. consume_pks → Django cascade collect (batched IN-lists per FK) + DELETE — ~14 q
   7. apply_resolution → apply_all_effects — 0 queries for a consequence with no effects
   8. resolve_capped_tier:
      a. CraftingSkillCap.for_skill — 1 query (single ORDER BY + LIMIT, not per-row)
@@ -168,12 +170,13 @@ class CraftAttachFacetQueryCountTests(TestCase):
     def test_craft_attach_facet_query_count(self) -> None:
         """craft_attach_facet must not scale queries with consequence/cap/material row count.
 
-        Pinned at 63 queries (measured on SQLite, #1031 baseline). Breakdown:
+        Pinned at 64 queries (measured on SQLite; #1031 baseline 63 + 1 for the #1243
+        symmetric anima-sufficiency guard in consume_cost). Breakdown:
           - ~14 SAVEPOINT/RELEASE pairs from @transaction.atomic nesting
           - ~12 Django cascade collect queries before material DELETE (batched IN-lists
             per FK-related model; O(related_models) not O(material_count))
           - ~4 ActionPointConfig duplicate reads from get_or_create_for_character × 2
-          - ~33 real reads/writes covering the pipeline described in the module docstring
+          - ~34 real reads/writes covering the pipeline described in the module docstring
 
         consequence_rows: single SELECT (query 21) — NOT one per row.
         material_requirements: single SELECT (query 9) — NOT one per requirement.
@@ -183,7 +186,7 @@ class CraftAttachFacetQueryCountTests(TestCase):
         consequence row (3 rows) would push the count up by ≥3, exceeding this ceiling.
         """
         with force_check_outcome(self.success_outcome):
-            with self.assertNumQueries(63):
+            with self.assertNumQueries(64):
                 result = craft_attach_facet(
                     crafter_account=self.account,
                     crafter_character=self.character,


### PR DESCRIPTION
## Summary

Follow-up hardening surfaced in the #1031 (generic crafting framework) final review. None of these blocked #1031.

### Main items

- **Symmetric anima spend-shortfall in `consume_cost`** (`world/items/crafting/cost.py`). The AP path raises `CraftingCostUnaffordable` when `pool.spend()` fails, but the anima path used `deduct_anima(..., lethal=False)`, which silently *clamps* to available anima and never draws life force. A concurrent spend that dropped the balance between staging and consume would be absorbed, and the returned `consumed["anima"]` would **over-report** what was actually deducted. Now asserts sufficiency first and fails hard like the AP path, so the summary is always truthful.

- **`CraftingRecipeFactory` single-instance-per-kind footgun** (`world/items/factories.py`). `kind` carries a `unique` constraint, but the factory keyed `django_get_or_create` on `name` (a Sequence). Two bare `CraftingRecipeFactory()` calls produced distinct names with the same `kind` → `IntegrityError`. Now keyed on `kind`: bare calls reuse the FACET_ATTACH row. `test_unique_kind_constraint` now asserts the DB constraint **directly via the model** (the factory get_or_creates and would otherwise shield it).

### Optional polish

- `CraftingQuoteCost.materials` / `CraftingQuote.failure_risk` are now `tuple[...]` (were `list`), so the `frozen=True` snapshots are genuinely immutable; built via `tuple(...)`. Serializers use `many=True`, so the JSON shape is unchanged (no api-type regen).

### Deliberately deferred

- The `CraftingCostUnaffordable.SAFE_MESSAGES` item is left as-is: its messages are dynamic f-strings (can't be enumerated into an allowlist) and **nothing currently gates on `SAFE_MESSAGES`** (views surface `user_message` directly). "Align or drop" is a cross-cutting `ItemError`-convention decision, out of scope for this chore.

## Tests

- `ConsumeCostAnimaShortfallTests` — anima drained / row deleted after staging both raise, mirroring the existing AP-shortfall test; anima untouched on the raise (no partial clamp).
- `CraftingRecipeModelTests` — two bare factory calls reuse the same kind row; distinct kinds create distinct rows; the constraint test exercises the model directly.
- Query-count guard updated: the symmetric anima guard adds exactly **one constant read** (pin 63 → 64; still O(1), no per-row scaling).

## Testing

`ruff` + `ty` clean; full crafting suite green on the fast tier (`test_crafting_cost` / `_models` / `_service` / `_quality` / `_api` / `_query_counts` / `_style` / `_handlers` — 96 tests).

Closes #1243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
