### PR TITLE
fix(character-sheets): stop the appearance section de-anonymizing masked faces (#1325)

### DIFF
--- a/docs/systems/appearance_and_identity.md
+++ b/docs/systems/appearance_and_identity.md
@@ -228,7 +228,7 @@ path copies a descriptor from a sibling persona.
 | Trait **mutability** tag | **ABSENT** | small new flag on `FormTrait` |
 | Natural baseline + change log | **ABSENT** | new |
 | Two-slot active state (`current_real_form` + `active_fake_overlay`) | **BUILT (#1110)** | `forms.CharacterFormState.active_form` (real) + `active_fake_overlay` + `overlay_kind` (`DisguiseKind`); `apply_disguise`/`remove_disguise`; `get_presented_appearance(pierced=)` swaps the overlay in unless pierced (the pierce *contest* stays the senior dev's) |
-| Single render composition (gated by viewer) | **NOT WIRED** | rendering ignores both active pointers; reads TRUE form |
+| Single render composition (gated by viewer) | **PARTLY WIRED (#1325)** | scalar fields ARE viewer-gated: `_build_appearance` exposes exact `height_inches` only to owner/staff (others get the coarse `height_band` label via `get_height_band`) and shows the free-text `description` only when `reveal_identity`; form-trait *overlay* selection still reads the TRUE form (ignores `active_fake_overlay`) — that part remains not wired |
 
 **Consolidation to ratify:** retire the legacy `Characteristic` path for skin/eye/hair
 so `FormTrait` is the single home (kills the telnet-vs-web duplication).

--- a/src/world/character_sheets/serializers.py
+++ b/src/world/character_sheets/serializers.py
@@ -333,11 +333,29 @@ def _resolve_presented_identity(
     )
 
 
-def _build_appearance(sheet: CharacterSheet) -> AppearanceSection:
+def _build_appearance(
+    sheet: CharacterSheet, *, reveal_identity: bool, privileged: bool
+) -> AppearanceSection:
     """Build the appearance section: normalized TRUE-form traits overlaid with the
     active persona's descriptors (descriptor, else normalized) — mirroring the telnet
-    ``item_data`` composition. Query-free: reads prefetched forms + personas.
+    ``item_data`` composition.
+
+    Identity gating (#1325):
+
+    - **Exact ``height_inches`` is owner/staff-only** (``privileged``). Every other
+      observer — including a stranger viewing the real public face — sees ``None`` and
+      reads only the coarse ``height_band`` (you can tell someone is tall by looking, but
+      not their precise inches, and two faces of one character can't be matched on it).
+    - **Free-text ``description`` shows only when ``reveal_identity``.** A mask must not
+      leak prose that names height, scars, or hair ("a tall auburn-haired woman…").
+    - ``form_traits`` already reduce to the generic option name unless the *presented*
+      persona supplies a descriptor (a base mask shows "red", not "flowing crimson"); a
+      richer disguise overlay supplying its own descriptors is the disguise system's job.
+
+    One query (the ``HeightBand`` range lookup); otherwise reads prefetched forms + personas.
     """
+    from world.forms.services import get_height_band  # noqa: PLC0415
+
     character = sheet.character
 
     active = _resolve_active_persona(sheet)
@@ -357,10 +375,14 @@ def _build_appearance(sheet: CharacterSheet) -> AppearanceSection:
     else:
         form_traits = []
 
+    true_height = sheet.true_height_inches
+    band = get_height_band(true_height) if true_height is not None else None
+
     return AppearanceSection(
-        height_inches=sheet.true_height_inches,
+        height_inches=true_height if privileged else None,
+        height_band=band.display_name if band is not None else None,
         build=_id_name_or_null(sheet.build, name_field="display_name"),
-        description=sheet.additional_desc,
+        description=sheet.additional_desc if reveal_identity else "",
         form_traits=form_traits,
     )
 
@@ -925,7 +947,9 @@ class CharacterSheetSerializer(serializers.Serializer):
                 reveal_identity=reveal_identity,
                 bio_profile=bio_profile,
             ),
-            "appearance": _build_appearance(sheet),
+            "appearance": _build_appearance(
+                sheet, reveal_identity=reveal_identity, privileged=privileged
+            ),
             "stats": _build_stats(sheet) if show_stats else {},
             "skills": _build_skills(sheet) if show_skills else [],
             "path": _build_path_detail(sheet),

--- a/src/world/character_sheets/tests/test_profile_identity_privacy.py
+++ b/src/world/character_sheets/tests/test_profile_identity_privacy.py
@@ -93,6 +93,64 @@ class ProfileIdentityPrivacyTests(APITestCase):
         # ...but the secret alt list is NOT — only the presented (primary) face.
         assert len(data["personas"]) == 1
 
+    def _set_body(self, sheet, *, inches=70, desc="a tall auburn-haired woman with a birthmark"):
+        """Give a sheet an exact height + identifying free-text description."""
+        sheet.true_height_inches = inches
+        sheet.additional_desc = desc
+        sheet.save(update_fields=["true_height_inches", "additional_desc"])
+
+    def test_non_owner_of_an_anonymous_face_gets_band_not_exact_height_and_no_description(
+        self,
+    ) -> None:
+        """A masked character leaks neither exact height nor identifying prose (#1325)."""
+        from world.forms.factories import HeightBandFactory
+
+        HeightBandFactory(name="average", display_name="Average", min_inches=66, max_inches=72)
+        sheet = self._character_sheet(AccountFactory(), fake_active=True)
+        self._set_body(sheet)
+        viewer = AccountFactory()
+        self._character_sheet(viewer)
+
+        appearance = self._get(sheet, viewer).data["appearance"]
+        # Exact inches are owner/staff-only; the observer sees only the coarse band.
+        assert appearance["height_inches"] is None
+        assert appearance["height_band"] == "Average"
+        # The free-text description must not leak through the mask.
+        assert appearance["description"] == ""
+
+    def test_owner_sees_exact_height_and_description(self) -> None:
+        """The owner's own sheet shows the precise height + their description (#1325)."""
+        from world.forms.factories import HeightBandFactory
+
+        HeightBandFactory(name="average", display_name="Average", min_inches=66, max_inches=72)
+        owner = AccountFactory()
+        sheet = self._character_sheet(owner, fake_active=True)
+        self._set_body(sheet)
+
+        appearance = self._get(sheet, owner).data["appearance"]
+        assert appearance["height_inches"] == 70
+        assert appearance["height_band"] == "Average"
+        assert appearance["description"] == "a tall auburn-haired woman with a birthmark"
+
+    def test_non_owner_of_a_public_face_gets_band_but_keeps_public_description(self) -> None:
+        """A public (non-masked) face still bands height for observers, but its desc is public.
+
+        You can't measure exact inches by looking — but a public character's description is
+        meant to be read, so only height is coarsened (#1325).
+        """
+        from world.forms.factories import HeightBandFactory
+
+        HeightBandFactory(name="average", display_name="Average", min_inches=66, max_inches=72)
+        sheet = self._character_sheet(AccountFactory(), fake_active=False)
+        self._set_body(sheet, desc="an imposing figure")
+        viewer = AccountFactory()
+        self._character_sheet(viewer)
+
+        appearance = self._get(sheet, viewer).data["appearance"]
+        assert appearance["height_inches"] is None
+        assert appearance["height_band"] == "Average"
+        assert appearance["description"] == "an imposing figure"
+
     def test_a_discoverer_sees_the_revealed_identity(self) -> None:
         owner = AccountFactory()
         sheet = self._character_sheet(owner, fake_active=True)

--- a/src/world/character_sheets/tests/test_viewset.py
+++ b/src/world/character_sheets/tests/test_viewset.py
@@ -462,7 +462,7 @@ class TestAppearanceSection(TestCase):
     def test_appearance_has_all_expected_keys(self) -> None:
         """The appearance section contains every specified field."""
         appearance = self._get_appearance()
-        expected_keys = {"height_inches", "build", "description", "form_traits"}
+        expected_keys = {"height_inches", "height_band", "build", "description", "form_traits"}
         assert set(appearance.keys()) == expected_keys
 
     def test_height_inches(self) -> None:
@@ -1885,11 +1885,13 @@ class TestCharacterSheetQueryCount(TestCase):
         20.    goals
         21.    personas + thumbnails (via Prefetch select_related)
         22.    persona trait_descriptors (nested Prefetch — appearance overlay)
-        23-25. Session management (savepoint, update, release)
-        26.    block gate — one indexed exists() check (#1278, get_object)
+        23.    HeightBand range lookup for the coarse band label (#1325; one constant
+               query — the band is derived from inches, not stored on the sheet)
+        24-26. Session management (savepoint, update, release)
+        27.    block gate — one indexed exists() check (#1278, get_object)
         """
         url = f"/api/character-sheets/{self.character.pk}/"
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(27):
             response = self.client.get(url)
         assert response.status_code == 200
         # Verify all sections are populated
@@ -2067,10 +2069,12 @@ class TestPrefetchCompleteness(TestCase):
         with self.assertNumQueries(0):
             _build_identity(sheet)
 
-    def test_appearance_zero_queries(self) -> None:
+    def test_appearance_one_query(self) -> None:
+        # 1 query: the HeightBand range lookup for the coarse band label (#1325). It is a
+        # single constant query — independent of form/trait count — not an N+1.
         sheet = self._get_sheet()
-        with self.assertNumQueries(0):
-            _build_appearance(sheet)
+        with self.assertNumQueries(1):
+            _build_appearance(sheet, reveal_identity=True, privileged=True)
 
     def test_stats_zero_queries(self) -> None:
         sheet = self._get_sheet()

--- a/src/world/character_sheets/types.py
+++ b/src/world/character_sheets/types.py
@@ -53,9 +53,17 @@ class FormTraitEntry(TypedDict):
 
 
 class AppearanceSection(TypedDict):
-    """The appearance section of the character sheet API response."""
+    """The appearance section of the character sheet API response.
+
+    ``height_inches`` is the exact height, exposed only to the owner / staff (#1325);
+    every other observer sees ``None`` there and reads the coarse ``height_band`` label
+    instead, so two faces of one character can't be correlated by an identical height.
+    ``description`` (the free-text ``additional_desc``) is blank unless the presented
+    identity is revealed — a mask must not leak identifying prose.
+    """
 
     height_inches: int | None
+    height_band: str | None
     build: IdNameRef | None
     description: str
     form_traits: list[FormTraitEntry]


### PR DESCRIPTION
## Summary

Closes a de-anonymization leak in the appearance section of `GET /api/character-sheets/{pk}/` (#1325). `_build_appearance` was the **only** profile section never gated on the per-viewer reveal flags (`identity` / `story` / `personas` all are, since #1109). It returned the real `true_height_inches` and free-text `additional_desc` to **every** viewer, so a passer-by viewing an anonymous mask could:

1. Read identifying prose directly (`additional_desc` can name height, scars, hair — "a tall auburn-haired woman with a birthmark"), and
2. Correlate two faces of one character by their identical exact height — the alt-derivation #1109 exists to prevent.

## Design (per the resolved call on the issue)

- **Exact `height_inches` is owner/staff-only** (`privileged`). Every other observer — including a stranger viewing the real public face — now gets `None` there and a new coarse **`height_band`** label instead. *You can tell someone is tall by looking, not their precise inches; and two faces can't be matched on it.*
- **Free-text `description` shows only when `reveal_identity`.** A mask must not leak prose. A public (non-masked) face keeps its description (it's meant to be read) — only height is coarsened there.
- `form_traits` already reduced correctly — the persona-descriptor overlay falls back to the generic option name, so a base mask shows "red", not "flowing crimson". Spoofing trait *values* via a richer disguise overlay stays the disguise system's job.
- `build` is unchanged (already a generic category).

## Anti-reinvention

No new model or banding cutoffs: a **`HeightBand`** model + **`get_height_band(inches)`** service already exist in `world/forms`, and character creation already let players pick a band and told them *"Other characters will see you as '<band>' rather than your [exact height]."* The sheet serializer simply never honored it. `true_height_inches`' own help_text already said *"staff-visible only."* This PR wires the existing intent through the read path.

## Surface / drift

`AppearanceSection` gains `height_band: str | None`. The endpoint is an untyped `to_representation` dict, so there is **no OpenAPI-schema / api-types drift** (verified: `just gen-api-types` changed only these source/test files). Nothing in the frontend renders the sheet appearance yet, so the leak was in the API response itself — fixed at the source.

## Tests

`test_profile_identity_privacy` gains three cases: masked observer → band + no exact height + blank description; owner → exact height + description; public-face observer → band but description kept. Band lookup is one constant query (builder 0 → 1, endpoint budget 26 → 27; not an N+1). Full `character_sheets` fast tier green (250 tests).

## Out of scope (follow-ups)

- Form-trait *overlay* selection still reads the TRUE form (ignores `active_fake_overlay`) — that's the disguise-overlay wiring (#1110 / the senior dev's slice).
- `HeightBand.hide_build` (hide build at extreme scales) is a display-scaling concern, not this leak.

Closes #1325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
