### PR TITLE
chore(action-points): drop the orphan regen + dead bank methods (#1509)

### DIFF
--- a/docs/systems/action_points.md
+++ b/docs/systems/action_points.md
@@ -50,40 +50,36 @@ pool = ActionPointPool.get_or_create_for_character(character)
 
 # Check affordability
 pool.can_afford(50)  # True if current >= 50
-pool.can_bank(30)    # True if current >= 30
 
 # Spend AP from current pool
 success = pool.spend(50)  # Returns bool
 
-# Bank AP (move from current to banked, for teaching offers)
-success = pool.bank(30)  # Returns bool
-
 # Unbank AP (return banked to current, capped at effective maximum; excess is lost)
 actually_restored = pool.unbank(30)  # Returns int (actual amount restored)
 
-# Consume banked AP (when an offer is accepted -- removes from banked, not returned to current)
+# Consume banked AP (when a teaching offer is accepted -- removes from banked, not returned to current)
 success = pool.consume_banked(30)  # Returns bool
-
-# Regenerate AP (add to current, capped at effective maximum)
-actually_added = pool.regenerate(50)  # Returns int (actual amount added)
-
-# Cron-triggered regeneration (applies modifier adjustments)
-actually_added = pool.apply_daily_regen()   # Uses config + ap_daily_regen modifier, updates timestamp
-actually_added = pool.apply_weekly_regen()  # Uses config + ap_weekly_regen modifier
 
 # Effective maximum (base maximum + ap_maximum modifier from distinctions)
 effective_max = pool.get_effective_maximum()  # Returns max(1, maximum + modifier)
 ```
+
+**Regeneration is batch-only (#1509).** AP is replenished by the scheduled job
+`world.game_clock.tasks._apply_ap_regen` (daily + weekly), which computes each pool's
+modifier-adjusted regen amount and effective maximum and `bulk_update`s all pools in a
+few queries (skipping protagonism-locked characters). There is **no** per-pool
+`regenerate()` model method — the batch job is the single regen path. (The `bank()` /
+`can_bank()` deposit helpers were removed as dead code; teaching offers reach `banked`
+through the codex teaching flow and recover/consume it via `unbank()` / `consume_banked()`.)
 
 ### Pool Behavior Summary
 
 | Operation | Source | Destination | Cap | Lost on overflow |
 |-----------|--------|-------------|-----|-----------------|
 | `spend(n)` | current | consumed | n/a (fails if insufficient) | No |
-| `bank(n)` | current | banked | n/a (fails if insufficient) | No |
 | `unbank(n)` | banked | current | effective maximum | Yes (excess lost) |
 | `consume_banked(n)` | banked | consumed | n/a (fails if insufficient) | No |
-| `regenerate(n)` | external | current | effective maximum | Yes (capped) |
+| batch regen (cron) | external | current | effective maximum | Yes (capped) |
 
 ---
 
@@ -133,8 +129,8 @@ for pool in ActionPointPool.objects.all():
 ## Integration Points
 
 - **Mechanics**: Reads `ap_daily_regen`, `ap_weekly_regen`, and `ap_maximum` modifiers via `get_modifier_total()`. Distinctions like Indolent or Efficient create these modifiers.
-- **Codex** (future): Teaching activities cost action points via `pool.spend()` or `pool.bank()`.
-- **Cron**: Daily and weekly jobs call `apply_daily_regen()` and `apply_weekly_regen()` on all pools.
+- **Codex**: Teaching offers commit AP into `banked` and consume it via `pool.consume_banked()` on accept; cancellation returns it via `pool.unbank()`.
+- **Cron**: The `game_clock` daily and weekly jobs call `world.game_clock.tasks._apply_ap_regen`, which batch-regenerates all pools (modifier-adjusted, capped at effective max, protagonism-lock-aware).
 
 ---
 

--- a/src/world/action_points/models.py
+++ b/src/world/action_points/models.py
@@ -155,32 +155,6 @@ class ActionPointPool(SharedMemoryModel):
             self.current = pool.current
         return True
 
-    def bank(self, amount: int) -> bool:
-        """
-        Move action points from current to banked (for teaching offers).
-
-        Uses select_for_update to prevent race conditions.
-
-        Args:
-            amount: Number of AP to bank.
-
-        Returns:
-            True if successful, False if insufficient current AP.
-        """
-        if amount < 0:
-            return False
-
-        with transaction.atomic():
-            pool = ActionPointPool.objects.select_for_update().get(pk=self.pk)
-            if pool.current < amount:
-                return False
-            pool.current -= amount
-            pool.banked += amount
-            pool.save(update_fields=["current", "banked"])
-            self.current = pool.current
-            self.banked = pool.banked
-        return True
-
     def unbank(self, amount: int) -> int:
         """
         Return banked AP to current pool, capped at effective maximum.
@@ -251,45 +225,8 @@ class ActionPointPool(SharedMemoryModel):
             self.banked = pool.banked
         return True
 
-    def regenerate(self, amount: int) -> int:
-        """
-        Add action points to current, capped at effective maximum.
-
-        Banked AP is separate and does not affect regeneration.
-        Uses select_for_update to prevent race conditions.
-        Respects modifier-adjusted maximum (e.g., Efficient increases cap).
-
-        Args:
-            amount: Number of AP to add.
-
-        Returns:
-            Amount actually added (may be less if near maximum).
-        """
-        if amount < 0:
-            return 0
-
-        effective_max = self.get_effective_maximum()
-
-        with transaction.atomic():
-            # Lock row for update
-            pool = ActionPointPool.objects.select_for_update().get(pk=self.pk)
-
-            space_available = effective_max - pool.current
-            actually_added = min(amount, max(0, space_available))
-
-            if actually_added > 0:
-                pool.current += actually_added
-                pool.save(update_fields=["current"])
-                self.current = pool.current
-
-        return actually_added
-
     def can_afford(self, amount: int) -> bool:
         """Check if character has enough current AP to spend."""
-        return self.current >= amount
-
-    def can_bank(self, amount: int) -> bool:
-        """Check if character has enough current AP to bank."""
         return self.current >= amount
 
     def _get_ap_modifier(self, modifier_target_name: str) -> int:

--- a/src/world/action_points/tests/test_models.py
+++ b/src/world/action_points/tests/test_models.py
@@ -157,59 +157,6 @@ class ActionPointPoolSpendTests(ActionPointPoolTestCase):
         assert pool.current == 100
 
 
-class ActionPointPoolBankTests(ActionPointPoolTestCase):
-    """Tests for ActionPointPool.bank method."""
-
-    @classmethod
-    def setUpTestData(cls):
-        """Set up test data."""
-        cls.character = CharacterFactory()
-
-    def test_bank_success(self):
-        """bank moves AP from current to banked."""
-        pool = ActionPointPoolFactory(character=self.character, current=100, banked=0)
-
-        result = pool.bank(30)
-
-        assert result is True
-        pool.refresh_from_db()
-        assert pool.current == 70
-        assert pool.banked == 30
-
-    def test_bank_insufficient_fails(self):
-        """bank returns False when insufficient current AP."""
-        pool = ActionPointPoolFactory(character=self.character, current=20, banked=0)
-
-        result = pool.bank(30)
-
-        assert result is False
-        pool.refresh_from_db()
-        assert pool.current == 20
-        assert pool.banked == 0
-
-    def test_bank_adds_to_existing_banked(self):
-        """bank adds to existing banked amount."""
-        pool = ActionPointPoolFactory(character=self.character, current=100, banked=50)
-
-        result = pool.bank(30)
-
-        assert result is True
-        pool.refresh_from_db()
-        assert pool.current == 70
-        assert pool.banked == 80
-
-    def test_bank_negative_fails(self):
-        """bank returns False for negative amounts."""
-        pool = ActionPointPoolFactory(character=self.character, current=100, banked=0)
-
-        result = pool.bank(-10)
-
-        assert result is False
-        pool.refresh_from_db()
-        assert pool.current == 100
-        assert pool.banked == 0
-
-
 class ActionPointPoolUnbankTests(ActionPointPoolTestCase):
     """Tests for ActionPointPool.unbank method."""
 
@@ -338,66 +285,6 @@ class ActionPointPoolConsumeBankedTests(ActionPointPoolTestCase):
         assert pool.banked == 50
 
 
-class ActionPointPoolRegenerateTests(ActionPointPoolTestCase):
-    """Tests for ActionPointPool.regenerate method."""
-
-    @classmethod
-    def setUpTestData(cls):
-        """Set up test data."""
-        cls.character = CharacterFactory()
-
-    def test_regenerate_adds_to_current(self):
-        """regenerate adds AP to current."""
-        pool = ActionPointPoolFactory(character=self.character, current=100, maximum=200)
-
-        added = pool.regenerate(50)
-
-        assert added == 50
-        pool.refresh_from_db()
-        assert pool.current == 150
-
-    def test_regenerate_capped_at_maximum(self):
-        """regenerate caps at maximum."""
-        pool = ActionPointPoolFactory(character=self.character, current=180, maximum=200)
-
-        added = pool.regenerate(50)
-
-        assert added == 20
-        pool.refresh_from_db()
-        assert pool.current == 200
-
-    def test_regenerate_at_maximum_adds_nothing(self):
-        """regenerate adds nothing when already at maximum."""
-        pool = ActionPointPoolFactory(character=self.character, current=200, maximum=200)
-
-        added = pool.regenerate(50)
-
-        assert added == 0
-        pool.refresh_from_db()
-        assert pool.current == 200
-
-    def test_regenerate_negative_returns_zero(self):
-        """regenerate returns 0 for negative amounts."""
-        pool = ActionPointPoolFactory(character=self.character, current=100, maximum=200)
-
-        added = pool.regenerate(-10)
-
-        assert added == 0
-        pool.refresh_from_db()
-        assert pool.current == 100
-
-    def test_regenerate_ignores_banked(self):
-        """regenerate fills current regardless of banked amount."""
-        pool = ActionPointPoolFactory(character=self.character, current=100, maximum=200, banked=50)
-
-        added = pool.regenerate(100)
-
-        assert added == 100
-        pool.refresh_from_db()
-        assert pool.current == 200
-        assert pool.banked == 50  # Unchanged
-
-
 class ActionPointPoolHelperTests(ActionPointPoolTestCase):
     """Tests for ActionPointPool helper methods."""
 
@@ -420,16 +307,6 @@ class ActionPointPoolHelperTests(ActionPointPoolTestCase):
         """can_afford returns True for exact amount."""
         pool = ActionPointPoolFactory(character=self.character, current=50)
         assert pool.can_afford(50) is True
-
-    def test_can_bank_true(self):
-        """can_bank returns True when sufficient AP."""
-        pool = ActionPointPoolFactory(character=self.character, current=100)
-        assert pool.can_bank(50) is True
-
-    def test_can_bank_false(self):
-        """can_bank returns False when insufficient AP."""
-        pool = ActionPointPoolFactory(character=self.character, current=30)
-        assert pool.can_bank(50) is False
 
 
 class ActionPointPoolGetOrCreateTests(ActionPointPoolTestCase):

--- a/src/world/magic/tests/test_teaching_offer_accept_view.py
+++ b/src/world/magic/tests/test_teaching_offer_accept_view.py
@@ -110,8 +110,8 @@ class TeachingOfferAcceptViewTests(APITestCase):
         _give_xp(self.learner_account, 500)
         # Bank AP on teacher's pool so it can be consumed.
         teacher_pool = ActionPointPool.get_or_create_for_character(self.teacher_character)
-        teacher_pool.regenerate(10)
-        teacher_pool.bank(5)
+        teacher_pool.banked = 5
+        teacher_pool.save(update_fields=["banked"])
 
         self.client.force_authenticate(user=self.learner_account)
         response = self.client.post(self._accept_url(self.offer.pk), {}, format="json")
@@ -192,8 +192,8 @@ class TeachingOfferAcceptViewTests(APITestCase):
         _give_xp(self.learner_account, 500)
         # Give teacher enough banked AP
         teacher_pool = ActionPointPool.get_or_create_for_character(self.teacher_character)
-        teacher_pool.regenerate(10)
-        teacher_pool.bank(5)
+        teacher_pool.banked = 5
+        teacher_pool.save(update_fields=["banked"])
         PendingAlterationFactory(character=self.learner_sheet)
 
         self.client.force_authenticate(user=self.learner_account)


### PR DESCRIPTION
## Summary

ADR-0016 parallel-implementation cleanup from the #1328 player-reachability audit.

AP regeneration runs **only** through the scheduled batch job `world.game_clock.tasks._apply_ap_regen` (daily + weekly) — a `bulk_update` over all pools that respects each character's modifier-adjusted regen/max and skips protagonism-locked (stage-5 corruption) characters. The model's per-pool `ActionPointPool.regenerate()` had **zero production callers** (tests only) and merely *duplicated* that regen rule — the exact "two sources of truth for the same number" footgun. The cron is canonical, so `regenerate()` is removed.

Also removed:
- **`bank()`** — the current→banked deposit helper. Zero production callers (full-src sweep).
- **`can_bank()`** — its pre-check companion. Zero production callers; incoherent to keep a "can you deposit?" check for a deposit op that no longer exists.

The **live** banked-AP surface is untouched: `unbank()` (codex teaching-cancel, `world/codex/models.py:409`) and `consume_banked()` (teaching accept). The teaching-test seeding that used `regenerate()` + `bank()` to stage banked AP now sets `pool.banked` directly.

## Why this direction (per the design discussion)

- *Deleting `regenerate()`* removes the divergent duplicate. The only future use is granting AP to a single pool interactively (potion/reward/effect) — and keeping the method now wouldn't help, since it's *already* a divergent copy of the cron's rule. When that need appears, build the single-pool primitive then, sharing one "add capped at effective max" helper with the cron.
- *The opposite* (make the cron call a per-pool `regenerate()`) is explicitly rejected: it trades the few-query batch for N transactions every tick across all pools.

## Docs

`docs/systems/action_points.md` corrected — it documented the removed methods **and two phantom ones** (`apply_daily_regen` / `apply_weekly_regen`) that don't exist anywhere in the code. Now describes the cron as the single regen path.

## Testing

`ruff` + `ty` clean. `world.action_points` + `test_teaching_offer_accept_view` green on the fast tier (50 tests). No migration (methods only).

Closes #1509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
