### PR TITLE
refactor(items): converge web present-outfit onto PresentOutfitAction (#1508)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -5946,13 +5946,10 @@ export interface paths {
     get: operations['items_fashion_presentations_list'];
     put?: never;
     /**
-     * @description Present an outfit + list presentations (#514).
+     * @description Record the requesting account's acting character presenting an outfit at an event.
      *
-     *     POST /api/items/fashion-presentations/ — record the requesting account's
-     *     acting character presenting an outfit at an event.
-     *     GET  /api/items/fashion-presentations/?event=<id> — list presentations
-     *     (filterable by event) so the UI can show who is presenting there to judge.
-     *     GET  /api/items/fashion-presentations/<pk>/ — retrieve one presentation.
+     *     Body: ``event`` (required) + optional ``outfit`` PKs. Returns the created
+     *     presentation (201), or 400 when the event has no host society / other rule failure.
      */
     post: operations['items_fashion_presentations_create'];
     delete?: never;
@@ -17264,11 +17261,12 @@ export interface components {
     /**
      * @description Serializer for FashionPresentation create + read (#514).
      *
-     *     Write: accepts ``event`` (required) + optional ``outfit`` PKs from the
-     *     request body. The ``presenter`` is resolved from the requesting account in
-     *     the view (``FashionPresentationViewSet.perform_create``) and injected via
-     *     ``serializer.save(presenter=sheet)`` — never supplied by the client
-     *     (mirrors the endorsement views' ``endorser_sheet`` handling).
+     *     Write: validates ``event`` (required) + optional ``outfit`` PKs from the request
+     *     body. The orchestration runs through ``PresentOutfitAction`` in
+     *     ``FashionPresentationViewSet.create`` (ADR-0001 — telnet + web share the registered
+     *     Action seam, #1508); this serializer only validates input and serializes the result.
+     *     The ``presenter`` is resolved from the requesting account in the view, never supplied
+     *     by the client.
      *
      *     Read: all fields are present; read-only fields cannot be supplied.
      */
@@ -17290,11 +17288,12 @@ export interface components {
     /**
      * @description Serializer for FashionPresentation create + read (#514).
      *
-     *     Write: accepts ``event`` (required) + optional ``outfit`` PKs from the
-     *     request body. The ``presenter`` is resolved from the requesting account in
-     *     the view (``FashionPresentationViewSet.perform_create``) and injected via
-     *     ``serializer.save(presenter=sheet)`` — never supplied by the client
-     *     (mirrors the endorsement views' ``endorser_sheet`` handling).
+     *     Write: validates ``event`` (required) + optional ``outfit`` PKs from the request
+     *     body. The orchestration runs through ``PresentOutfitAction`` in
+     *     ``FashionPresentationViewSet.create`` (ADR-0001 — telnet + web share the registered
+     *     Action seam, #1508); this serializer only validates input and serializes the result.
+     *     The ``presenter`` is resolved from the requesting account in the view, never supplied
+     *     by the client.
      *
      *     Read: all fields are present; read-only fields cannot be supplied.
      */

--- a/src/actions/definitions/fashion.py
+++ b/src/actions/definitions/fashion.py
@@ -66,14 +66,16 @@ class PresentOutfitAction(Action):
         presenter = actor.sheet_data
 
         try:
-            present_outfit_service(presenter, event, outfit)
+            presentation = present_outfit_service(presenter, event, outfit)
         except FashionPresentationError as exc:
             return ActionResult(success=False, message=exc.user_message)
 
         sdm = context.scene_data if context else SceneDataManager()
         actor_state = sdm.initialize_state_for_object(actor)
         message_location(actor_state, "$You() $conj(present) your look.")
-        return ActionResult(success=True)
+        # Carry the created presentation so the web viewset can serialize the response
+        # without re-querying — telnet ignores it (#1508).
+        return ActionResult(success=True, data={"presentation": presentation})
 
 
 @dataclass

--- a/src/schema.json
+++ b/src/schema.json
@@ -9377,13 +9377,10 @@ paths:
     post:
       operationId: items_fashion_presentations_create
       description: |-
-        Present an outfit + list presentations (#514).
+        Record the requesting account's acting character presenting an outfit at an event.
 
-        POST /api/items/fashion-presentations/ — record the requesting account's
-        acting character presenting an outfit at an event.
-        GET  /api/items/fashion-presentations/?event=<id> — list presentations
-        (filterable by event) so the UI can show who is presenting there to judge.
-        GET  /api/items/fashion-presentations/<pk>/ — retrieve one presentation.
+        Body: ``event`` (required) + optional ``outfit`` PKs. Returns the created
+        presentation (201), or 400 when the event has no host society / other rule failure.
       tags:
       - items
       requestBody:
@@ -30630,11 +30627,12 @@ components:
       description: |-
         Serializer for FashionPresentation create + read (#514).
 
-        Write: accepts ``event`` (required) + optional ``outfit`` PKs from the
-        request body. The ``presenter`` is resolved from the requesting account in
-        the view (``FashionPresentationViewSet.perform_create``) and injected via
-        ``serializer.save(presenter=sheet)`` — never supplied by the client
-        (mirrors the endorsement views' ``endorser_sheet`` handling).
+        Write: validates ``event`` (required) + optional ``outfit`` PKs from the request
+        body. The orchestration runs through ``PresentOutfitAction`` in
+        ``FashionPresentationViewSet.create`` (ADR-0001 — telnet + web share the registered
+        Action seam, #1508); this serializer only validates input and serializes the result.
+        The ``presenter`` is resolved from the requesting account in the view, never supplied
+        by the client.
 
         Read: all fields are present; read-only fields cannot be supplied.
       properties:
@@ -30680,11 +30678,12 @@ components:
       description: |-
         Serializer for FashionPresentation create + read (#514).
 
-        Write: accepts ``event`` (required) + optional ``outfit`` PKs from the
-        request body. The ``presenter`` is resolved from the requesting account in
-        the view (``FashionPresentationViewSet.perform_create``) and injected via
-        ``serializer.save(presenter=sheet)`` — never supplied by the client
-        (mirrors the endorsement views' ``endorser_sheet`` handling).
+        Write: validates ``event`` (required) + optional ``outfit`` PKs from the request
+        body. The orchestration runs through ``PresentOutfitAction`` in
+        ``FashionPresentationViewSet.create`` (ADR-0001 — telnet + web share the registered
+        Action seam, #1508); this serializer only validates input and serializes the result.
+        The ``presenter`` is resolved from the requesting account in the view, never supplied
+        by the client.
 
         Read: all fields are present; read-only fields cannot be supplied.
       properties:

--- a/src/world/items/serializers.py
+++ b/src/world/items/serializers.py
@@ -505,11 +505,12 @@ class OutfitRenameSerializer(serializers.ModelSerializer):
 class FashionPresentationSerializer(serializers.ModelSerializer):
     """Serializer for FashionPresentation create + read (#514).
 
-    Write: accepts ``event`` (required) + optional ``outfit`` PKs from the
-    request body. The ``presenter`` is resolved from the requesting account in
-    the view (``FashionPresentationViewSet.perform_create``) and injected via
-    ``serializer.save(presenter=sheet)`` — never supplied by the client
-    (mirrors the endorsement views' ``endorser_sheet`` handling).
+    Write: validates ``event`` (required) + optional ``outfit`` PKs from the request
+    body. The orchestration runs through ``PresentOutfitAction`` in
+    ``FashionPresentationViewSet.create`` (ADR-0001 — telnet + web share the registered
+    Action seam, #1508); this serializer only validates input and serializes the result.
+    The ``presenter`` is resolved from the requesting account in the view, never supplied
+    by the client.
 
     Read: all fields are present; read-only fields cannot be supplied.
     """
@@ -533,19 +534,6 @@ class FashionPresentationSerializer(serializers.ModelSerializer):
             "acclaim",
             "created_at",
         ]
-
-    def create(self, validated_data: dict) -> FashionPresentation:  # type: ignore[override]
-        """Delegate to ``present_outfit``; surface service errors as 400."""
-        from world.items.exceptions import FashionPresentationError  # noqa: PLC0415
-        from world.items.services.fashion_presentation import present_outfit  # noqa: PLC0415
-
-        presenter = validated_data.pop("presenter")
-        event = validated_data["event"]
-        outfit = validated_data.get("outfit")
-        try:
-            return present_outfit(presenter, event, outfit)
-        except FashionPresentationError as exc:
-            raise serializers.ValidationError({"detail": exc.user_message}) from exc
 
 
 class FashionJudgementSerializer(serializers.Serializer):

--- a/src/world/items/tests/test_fashion_api.py
+++ b/src/world/items/tests/test_fashion_api.py
@@ -70,6 +70,33 @@ class FashionPresentationAPITests(APITestCase):
         self.assertEqual(response.data["base_score"], 3)
         self.assertEqual(response.data["acclaim"], 3)
 
+    def test_present_endpoint_dispatches_present_outfit_action(self) -> None:
+        """The web POST converges on PresentOutfitAction, not a serializer bypass (#1508).
+
+        Spies on the real ``run`` (it still executes, creating + serializing the
+        presentation → 201) and asserts it was the path taken. A regression back to the
+        serializer's direct ``present_outfit`` call would not call ``run`` and fail here.
+        """
+        from unittest.mock import patch
+
+        from actions.definitions.fashion import PresentOutfitAction
+
+        real_run = PresentOutfitAction.run
+        self.client.force_authenticate(user=self.presenter_account)
+        with (
+            force_check_outcome(self.outcome_success),
+            patch.object(
+                PresentOutfitAction, "run", autospec=True, side_effect=real_run
+            ) as mock_run,
+        ):
+            response = self.client.post(
+                "/api/items/fashion-presentations/",
+                data={"event": self.event.pk},
+                format="json",
+            )
+        self.assertEqual(response.status_code, 201, response.content)
+        mock_run.assert_called_once()
+
     def test_present_does_not_accept_presenter_from_client(self) -> None:
         """A client-supplied presenter is ignored; the request sheet is used."""
         self.client.force_authenticate(user=self.presenter_account)

--- a/src/world/items/views.py
+++ b/src/world/items/views.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from http import HTTPMethod
-from typing import cast
+from typing import Any, cast
 
 from django.db.models import Prefetch, QuerySet
 from django_filters.rest_framework import DjangoFilterBackend
@@ -1271,10 +1271,37 @@ class FashionPresentationViewSet(
     filter_backends = [DjangoFilterBackend]
     filterset_class = FashionPresentationFilter
 
-    def perform_create(self, serializer: serializers.BaseSerializer) -> None:
-        """Resolve the presenter sheet from the requesting account and save."""
+    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Record the requesting account's acting character presenting an outfit at an event.
+
+        Body: ``event`` (required) + optional ``outfit`` PKs. Returns the created
+        presentation (201), or 400 when the event has no host society / other rule failure.
+        """
+        # Converged onto the registered PresentOutfitAction so telnet and web share one
+        # seam (ADR-0001, #1508): the serializer validates input + serializes the result,
+        # but the Action — not the serializer — orchestrates the presentation (and emits the
+        # present-outfit events + scene message the web path previously skipped). The
+        # presenter is resolved server-side from the requesting account, never the client.
+        from actions.definitions.fashion import PresentOutfitAction  # noqa: PLC0415
+
+        in_serializer = self.get_serializer(data=request.data)
+        in_serializer.is_valid(raise_exception=True)
+        event = in_serializer.validated_data["event"]
+        outfit = in_serializer.validated_data.get("outfit")
+
         presenter = _resolve_actor_sheet(self.request, body_key="presenter_sheet_id")
-        serializer.save(presenter=presenter)
+        result = PresentOutfitAction().run(
+            actor=presenter.character,
+            event_id=event.pk,
+            outfit_id=outfit.pk if outfit is not None else None,
+        )
+        if not result.success:
+            raise serializers.ValidationError({"detail": result.message})
+
+        presentation = result.data["presentation"]
+        out_serializer = self.get_serializer(presentation)
+        headers = self.get_success_headers(out_serializer.data)
+        return Response(out_serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
 
 class FashionJudgementViewSet(


### PR DESCRIPTION
## Summary

ADR-0001/0016 cleanup from the #1328 player-reachability audit. The web `FashionPresentationViewSet` reached the present-outfit capability through `FashionPresentationSerializer.create()` calling `present_outfit` **directly**, bypassing the **registered** `PresentOutfitAction`. Two web paths for one capability — and the web path skipped the Action's trigger events + scene message that telnet fires.

## What changed

- **`FashionPresentationViewSet.create()`** now dispatches `PresentOutfitAction.run()`. The serializer stays as the **I/O contract** — it validates `event`/`outfit` input and serializes the result — but no longer orchestrates. Its `create()` bypass is removed.
- **`PresentOutfitAction.execute`** now returns the created `FashionPresentation` in `result.data["presentation"]`, so the viewset serializes the response without a re-query (telnet ignores it).
- **Web parity gain:** the web POST now also emits `BEFORE_PRESENT_OUTFIT` / `PRESENT_OUTFIT` and the "…presents your look" scene message, matching telnet.

This is the conclusion from the design discussion: converging loses **nothing** — the serializer's valuable parts (PK validation, response serialization, OpenAPI schema → api-types) all stay; only the anti-pattern (business logic in `serializer.create()`) is retired.

## Schema / drift

The serializer's `fields` are unchanged, so the request/response **shape** is identical. The schema regen touches only the operation/serializer **description** text (the new docstrings) — committed. No frontend component change (nothing rendered the bypass differently).

## Tests

- Adds `test_present_endpoint_dispatches_present_outfit_action` — spies the real `run` (it still executes → 201) and asserts the endpoint took the Action path, so a regression back to the serializer bypass fails.
- Existing `test_fashion_api` POST/400/auth cases pass unchanged against the converged endpoint.

## Testing

`ruff` + `ty` clean (the pre-existing `fashion.py` ty notes on `intent_event`/`initialize_state_for_object` are untouched). `world.items.tests.test_fashion_api` 9/9; full `actions` suite (759) + ceremony/momentum green.

Closes #1508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
