### PR TITLE
feat(projects): telnet project status + money-donation surface (#1574 slice 1)

### DIFF
--- a/src/actions/definitions/projects.py
+++ b/src/actions/definitions/projects.py
@@ -1,0 +1,91 @@
+"""Project-contribution actions (#1574).
+
+The shared seam telnet (``CmdProject``) and any future web surface converge on for
+contributing to a Project. ``DonateToProjectAction`` is the money path; check / story
+contribution actions land alongside it when the per-ProjectKind check-method framework
+ships.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from actions.base import Action
+from actions.types import TargetType
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from actions.types import ActionContext, ActionResult
+
+
+@dataclass
+class DonateToProjectAction(Action):
+    """Donate money from your own purse to an ACTIVE project (#1574).
+
+    Anyone may donate; the spend + the contribution land atomically and advance the
+    project's progress. Used by the telnet ``project/donate`` switch and reused by the
+    ransom flow (a Ransom is a money-threshold Project — #1500).
+    """
+
+    key: str = "project_donate"
+    name: str = "Donate to Project"
+    icon: str = "coins"
+    category: str = "projects"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(  # noqa: PLR0911 — distinct guard returns, each a specific failure message
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        *,
+        project_id: int | None = None,
+        amount: int | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from django.core.exceptions import ValidationError as DjangoValidationError  # noqa: PLC0415
+
+        from actions.types import ActionResult as _ActionResult  # noqa: PLC0415
+        from world.currency.constants import format_coppers  # noqa: PLC0415
+        from world.projects.models import Project  # noqa: PLC0415
+        from world.projects.services import (  # noqa: PLC0415
+            ProjectNotActiveError,
+            donate_to_project,
+        )
+        from world.scenes.models import Persona  # noqa: PLC0415
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        if project_id is None or amount is None:
+            return _ActionResult(success=False, message="Donate how much to which project?")
+        if amount <= 0:
+            return _ActionResult(success=False, message="Donate a positive amount.")
+
+        sheet = actor.sheet_data
+        if sheet is None:
+            return _ActionResult(success=False, message="You have no character sheet.")
+        try:
+            persona = active_persona_for_sheet(sheet)
+        except Persona.DoesNotExist:
+            return _ActionResult(success=False, message="You have no active persona to donate as.")
+
+        project = Project.objects.filter(pk=project_id).first()
+        if project is None:
+            return _ActionResult(success=False, message="No such project.")
+
+        try:
+            donate_to_project(project, donor_persona=persona, amount=amount)
+        except DjangoValidationError as exc:
+            return _ActionResult(success=False, message="; ".join(exc.messages))
+        except ProjectNotActiveError as exc:
+            return _ActionResult(success=False, message=str(exc))
+
+        target = project.threshold_target
+        progress = f"{project.current_progress}/{target}" if target is not None else "—"
+        return _ActionResult(
+            success=True,
+            message=(
+                f"You donate {format_coppers(amount)} to project #{project.pk}. "
+                f"Progress: {progress}."
+            ),
+        )

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -132,6 +132,7 @@ from actions.definitions.progression_rewards import (
     RerollRandomSceneAction,
     SetPathIntentAction,
 )
+from actions.definitions.projects import DonateToProjectAction
 from actions.definitions.relationships import (
     CreateCapstoneAction,
     CreateDevelopmentAction,
@@ -198,6 +199,7 @@ _ALL_ACTIONS: list[Action] = [
     EquipAction(),
     UnequipAction(),
     RoomEditAction(),
+    DonateToProjectAction(),
     SetActivePersonaAction(),
     SetSocialConsentPreferenceAction(),
     SetSocialConsentCategoryRuleAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -155,6 +155,7 @@ class ActionRegistryTests(TestCase):
             "equip",
             "unequip",
             "edit_room",
+            "project_donate",
             "put_in",
             "take_out",
             "apply_outfit",

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -227,6 +227,14 @@ actions, backends, and service functions.
   `manageroom/desc <text>`, `manageroom/public <yes|no>`. Edits the room the caller
   is standing in; ownership is gated by `IsRoomOwnerPrerequisite`, writes live in
   `world.locations.services.set_room_display_data`. No business logic in the command.
+- **`projects.py`**: `CmdProject` (`project`, alias `+project`, #1574) — project status +
+  contribution surface. `+project <id>` shows a project's status (progress/target, remaining
+  coin to fund); `project/donate <id>=<amount>` dispatches `DonateToProjectAction` (key
+  `project_donate`), debiting the caller's `CharacterPurse` and recording a MONEY
+  `Contribution` via `world.projects.services.donate_to_project`. The `project/check` and
+  `project/story` switches (per-`ProjectKind` check-based contributions) land with the
+  check-method framework. The ransom flow reuses `donate` — a Ransom is a money-threshold
+  Project (#1500).
 - **`setstage.py`**: `CmdSetStage` (`setstage`, staff `perm(Admin)`, #1498) — telnet face of
   `SetTheStageAction` (key `set_the_stage`, REGISTRY backend). A staff caller instantiates a
   `PositionBlueprint` into their current room: `setstage` shows this room's positions + default

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -80,6 +80,7 @@ from commands.persona import CmdPersona
 from commands.presence import CmdAfk, CmdHide
 from commands.progression import CmdProgressionUnlock, CmdTraining
 from commands.progression_rewards import CmdKudos, CmdPathIntent, CmdRandomScene, CmdVote
+from commands.projects import CmdProject
 from commands.react import CmdReact
 from commands.relationships import CmdRelationship
 from commands.ritual import CmdRitual
@@ -241,6 +242,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             # #1494/#1495 — GM encounter and story lifecycle telnet namespaces.
             CmdEncounter,
             CmdStory,
+            # #1574 — project status + money donation (project/donate, +project).
+            CmdProject,
             # #1470 — owner-gated room editor (name/description/public-private).
             CmdManageRoom,
             # #1498 — staff set-the-stage: apply a position blueprint to the room.

--- a/src/commands/projects.py
+++ b/src/commands/projects.py
@@ -1,0 +1,83 @@
+"""Telnet surface for project contribution + status (#1574).
+
+``+project <id>`` shows a project's status; ``project/donate <id>=<amount>`` donates money
+from your purse. The check / story switches land alongside these once the per-ProjectKind
+check-method framework ships. Thin over ``DonateToProjectAction`` + the projects read layer;
+no business logic in the command.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from actions.definitions.projects import DonateToProjectAction
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+
+class CmdProject(ArxCommand):
+    """View a project or contribute to it.
+
+    Usage:
+      +project <id>                 — show a project's status
+      project/donate <id>=<amount>  — donate money from your purse
+    """
+
+    key = "project"
+    aliases = ("+project",)
+    locks = "cmd:all()"
+    help_category = "Projects"
+    action = DonateToProjectAction()
+
+    def _execute(self) -> None:
+        switches = {s.lower() for s in (self.switches or [])}
+        if "donate" in switches:  # noqa: STRING_LITERAL — Evennia switch name
+            kwargs = self._parse_donate()
+            result = self.action.run(actor=self.caller, **kwargs)
+            if result.message:
+                self.msg(result.message)
+            return
+        self._show_status()
+
+    def _parse_donate(self) -> dict[str, Any]:
+        raw = (self.args or "").strip()
+        if "=" not in raw:
+            msg = "Usage: project/donate <id>=<amount>"
+            raise CommandError(msg)
+        id_part, amount_part = (part.strip() for part in raw.split("=", 1))
+        if not id_part.isdigit() or not amount_part.isdigit():
+            msg = "Both the project id and the amount must be numbers."
+            raise CommandError(msg)
+        return {"project_id": int(id_part), "amount": int(amount_part)}
+
+    def _show_status(self) -> None:
+        from world.currency.constants import format_coppers  # noqa: PLC0415
+        from world.projects.constants import CompletionMode  # noqa: PLC0415
+        from world.projects.models import Project  # noqa: PLC0415
+
+        arg = (self.args or "").strip()
+        if not arg.isdigit():
+            msg = "Which project? Usage: +project <id>"
+            raise CommandError(msg)
+        project = Project.objects.filter(pk=int(arg)).first()
+        if project is None:
+            msg = "No such project."
+            raise CommandError(msg)
+
+        target = project.threshold_target
+        progress = (
+            f"{project.current_progress}/{target}"
+            if target is not None
+            else str(project.current_progress)
+        )
+        lines = [
+            f"|wProject #{project.pk}|n — {project.get_kind_display()} [{project.status}]",
+        ]
+        if project.description:
+            lines.append(project.description)
+        lines.append(f"Progress: {progress}")
+        if target is not None and project.completion_mode == CompletionMode.SINGLE_THRESHOLD:
+            # Money projects fund at 1 progress per 100 coppers; show the coin cost left.
+            remaining = max(0, target - project.current_progress)
+            lines.append(f"Remaining to fund: {format_coppers(remaining * 100)}")
+        self.msg("\n".join(lines))

--- a/src/world/projects/services.py
+++ b/src/world/projects/services.py
@@ -102,6 +102,37 @@ def add_contribution(  # noqa: PLR0913
     return contribution
 
 
+def donate_to_project(project: Project, *, donor_persona: Persona, amount: int) -> Contribution:
+    """Debit ``amount`` coppers from the donor's purse and record a MONEY contribution.
+
+    Atomic: the spend and the contribution land together, or neither. ``transfer``
+    validates funds — a non-positive ``amount`` or an empty purse raises Django's
+    ``ValidationError``; an inactive project raises ``ProjectNotActiveError``. The money
+    is sunk (the project consumes it); the contribution advances ``current_progress`` at
+    one progress per 100 coppers (see ``add_contribution``).
+    """
+    from world.currency.services import get_or_create_purse, transfer  # noqa: PLC0415
+
+    # Fail fast before debiting: never take the donor's money for a contribution that
+    # would then be rejected (add_contribution also guards this).
+    if project.status != ProjectStatus.ACTIVE:
+        msg = (
+            f"Project #{project.pk} status is {project.status}, not ACTIVE — "
+            "cannot accept contributions."
+        )
+        raise ProjectNotActiveError(msg)
+
+    with transaction.atomic():
+        purse = get_or_create_purse(donor_persona.character_sheet)
+        transfer(amount=amount, reason="project_donation", from_purse=purse)
+        return add_contribution(
+            project=project,
+            contributor_persona=donor_persona,
+            kind=ContributionKind.MONEY,
+            money_amount=amount,
+        )
+
+
 def _increment_contribution_stat(persona: Persona) -> None:
     """Increment the projects.total_contributed StatTracker for this persona.
 

--- a/src/world/projects/tests/test_donate.py
+++ b/src/world/projects/tests/test_donate.py
@@ -1,0 +1,81 @@
+"""Tests for donate_to_project — money contribution from a character's purse (#1574)."""
+
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from world.currency.models import CharacterPurse
+from world.projects.constants import ContributionKind, ProjectStatus
+from world.projects.factories import ProjectFactory
+from world.projects.models import Contribution
+from world.projects.services import ProjectNotActiveError, donate_to_project
+from world.scenes.factories import PersonaFactory
+
+
+class DonateToProjectTests(TestCase):
+    def setUp(self) -> None:
+        self.project = ProjectFactory(status=ProjectStatus.ACTIVE, threshold_target=100)
+        self.donor = PersonaFactory()
+        self.purse = CharacterPurse.objects.create(
+            character_sheet=self.donor.character_sheet, balance=10_000
+        )
+
+    def test_debits_purse_records_contribution_and_advances_progress(self) -> None:
+        donate_to_project(self.project, donor_persona=self.donor, amount=5_000)
+
+        self.purse.refresh_from_db()
+        self.assertEqual(self.purse.balance, 5_000)  # 10_000 - 5_000
+
+        contribution = Contribution.objects.get(project=self.project)
+        self.assertEqual(contribution.kind, ContributionKind.MONEY)
+        self.assertEqual(contribution.money_amount, 5_000)
+        self.assertEqual(contribution.contributor_persona, self.donor)
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.current_progress, 50)  # 5_000 // 100
+
+    def test_insufficient_funds_raises_and_rolls_back(self) -> None:
+        with self.assertRaises(ValidationError):
+            donate_to_project(self.project, donor_persona=self.donor, amount=999_999)
+        # Atomic: neither the spend nor the contribution landed.
+        self.purse.refresh_from_db()
+        self.assertEqual(self.purse.balance, 10_000)
+        self.assertFalse(Contribution.objects.filter(project=self.project).exists())
+
+    def test_donating_to_an_inactive_project_raises_and_rolls_back(self) -> None:
+        planning = ProjectFactory(status=ProjectStatus.PLANNING, threshold_target=100)
+        with self.assertRaises(ProjectNotActiveError):
+            donate_to_project(planning, donor_persona=self.donor, amount=100)
+        # The status pre-check fires before any debit.
+        self.purse.refresh_from_db()
+        self.assertEqual(self.purse.balance, 10_000)
+
+
+class DonateToProjectActionTests(TestCase):
+    def setUp(self) -> None:
+        self.project = ProjectFactory(status=ProjectStatus.ACTIVE, threshold_target=100)
+        self.persona = PersonaFactory()
+        self.sheet = self.persona.character_sheet
+        # Present as this persona so active_persona_for_sheet resolves it.
+        self.sheet.active_persona = self.persona
+        self.sheet.save(update_fields=["active_persona"])
+        CharacterPurse.objects.create(character_sheet=self.sheet, balance=10_000)
+        self.actor = self.sheet.character
+
+    def test_action_donates_and_advances_progress(self) -> None:
+        from actions.definitions.projects import DonateToProjectAction
+
+        result = DonateToProjectAction().execute(
+            self.actor, project_id=self.project.pk, amount=5_000
+        )
+        self.assertTrue(result.success, result.message)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.current_progress, 50)
+
+    def test_action_unknown_project_fails_gracefully(self) -> None:
+        from actions.definitions.projects import DonateToProjectAction
+
+        result = DonateToProjectAction().execute(self.actor, project_id=999_999, amount=100)
+        self.assertFalse(result.success)
+        self.assertIn("No such project", result.message)


### PR DESCRIPTION
## Summary

The first slice of the **project-contribution surface** (#1574) — the foundation the captivity ransom flow (#1500) rides. The projects framework was backend-only (models + services, no player surface, `add_contribution` had no caller); this adds the seam for the **money** path.

## What's here

- **`donate_to_project(project, *, donor_persona, amount)`** — debits the donor's `CharacterPurse` and records a `MONEY` `Contribution` atomically (1 progress per 100 coppers, via `add_contribution`). Fails fast before any debit if the project isn't ACTIVE; `transfer` rejects an empty purse. Money is sunk (the project consumes it).
- **`DonateToProjectAction`** (key `project_donate`) — resolves the actor's active persona + the project, calls the service, maps errors to a failure result. The shared seam a web surface can reuse later (ADR-0001).
- **`CmdProject`** (`project`, alias `+project`):
  - `+project <id>` — status (progress / target, coin remaining to fund).
  - `project/donate <id>=<amount>` — dispatches the donate action.

## Scope / what's next

This is slice 1. The `project/check` + `project/story` switches (per-`ProjectKind` check-based contributions, the "authorable check method" core) land in the **next slice, which closes #1574**. The ransom-as-project flow (#1500) then reuses `donate`.

## Tests

`donate_to_project`: debit + record + progress advance; insufficient funds and inactive project both reject **without debiting**. `DonateToProjectAction`: happy path + unknown project. `ruff` + `ty` clean; action registered + command/cmdset import verified.

Refs #1574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
