### PR TITLE
chore(devcontainer): install polytoken harness + allowlist umans

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,6 +47,11 @@ ENV PATH="/home/vscode/.local/bin:${PATH}"
 # cannot write its credentials.
 RUN mkdir -p /home/vscode/.claude
 
+# Same rationale for polytoken's config + data dirs (the arxii-polytoken-config
+# and arxii-polytoken-data volumes in compose). Provider credentials live in
+# ~/.config/polytoken; session history under ~/.local/share/polytoken (XDG).
+RUN mkdir -p /home/vscode/.config/polytoken /home/vscode/.local/share/polytoken
+
 # Install mise, then bake the project toolchain at build time. Network is
 # unrestricted during build, so the runtime firewall never needs mise's
 # download hosts. Only mise.toml is copied so the layer caches well.
@@ -79,3 +84,12 @@ USER vscode
 # node so the binary lands at .../node/24.4.1/bin/claude — already on
 # PATH for any shell that activates mise (via ~/.bashrc).
 RUN ~/.local/bin/mise exec -C /tmp/mise -- npm install -g @anthropic-ai/claude-code
+
+# Install polytoken — a separate coding-agent harness (daemon + CLI/TUI) run
+# alongside Claude Code. Same build-time rationale as Claude Code above: latest
+# at build, no churn on container recreate, explicit upgrades via `just dc-build`.
+# The installer fetches a static linux/amd64 binary into ~/.local/bin (already
+# on PATH) with no sudo. Build-time network is open, so the runtime firewall
+# never needs get/dl.polytoken.dev — only the model-provider host
+# (api.code.umans.ai) is allowlisted in init-firewall.sh.
+RUN curl -fsS https://get.polytoken.dev | bash

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -26,6 +26,12 @@ services:
       - arxii-worktrees:/workspaces/arxii/.claude/worktrees
       # Persist Claude Code auth/config so login survives container rebuilds.
       - arxii-claude-home:/home/vscode/.claude
+      # Persist polytoken's config (incl. model-provider credentials) and
+      # session history across rebuilds, mirroring arxii-claude-home above.
+      # Config dir confirmed at ~/.config/polytoken; sessions under
+      # ~/.local/share/polytoken (XDG). Verify the session dir at first dc-build.
+      - arxii-polytoken-config:/home/vscode/.config/polytoken
+      - arxii-polytoken-data:/home/vscode/.local/share/polytoken
       # Shadow the host's src/.env (which points DATABASE_URL at a bare-metal
       # localhost Postgres) with a container-specific file. sync-env.sh
       # generates dev.env from src/.env with DATABASE_URL rewritten before
@@ -102,3 +108,5 @@ volumes:
   arxii-fe-node-modules:
   arxii-worktrees:
   arxii-claude-home:
+  arxii-polytoken-config:
+  arxii-polytoken-data:

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -124,6 +124,11 @@ resolve_and_add "statsig.com"
 resolve_and_add "pypi.org"
 # SonarCloud — public-project API for fetching code-quality findings on PRs.
 resolve_and_add "sonarcloud.io"
+# Umans Code — Anthropic-compatible model endpoint (https://api.code.umans.ai).
+# Backs two harnesses: Claude Code via its ANTHROPIC_BASE_URL override, and
+# polytoken's custom Anthropic-compatible provider. Two stable AWS EIPs
+# (eu-west-3); dig-resolved like the other small/stable hosts above.
+resolve_and_add "api.code.umans.ai"
 
 # ---- b) GitHub meta API (git + api + web + packages CIDRs) ----
 echo "Fetching GitHub IP ranges via meta API..."

--- a/.devcontainer/polytoken.md
+++ b/.devcontainer/polytoken.md
@@ -1,0 +1,66 @@
+# Polytoken in the devcontainer
+
+[Polytoken](https://docs.polytoken.dev/) is a second coding-agent harness (a
+daemon + CLI/TUI) installed alongside Claude Code. It is a separate binary with
+its own config and session store, so it stays fully distinct from the
+Claude-Code-via-umans setup.
+
+## What this change adds
+
+- **Dockerfile** — installs the polytoken binary at image-build time
+  (`curl -fsS https://get.polytoken.dev | bash` → `~/.local/bin/polytoken`,
+  already on `PATH`, no sudo). Pre-creates `~/.config/polytoken` and
+  `~/.local/share/polytoken` so the named volumes inherit `vscode` ownership.
+- **docker-compose.yml** — two named volumes persist polytoken across rebuilds:
+  - `arxii-polytoken-config` → `~/.config/polytoken` (config **and** provider
+    credentials — the part that hurts to lose on a rebuild)
+  - `arxii-polytoken-data` → `~/.local/share/polytoken` (session history)
+- **init-firewall.sh** — allowlists `api.code.umans.ai` (umans's
+  Anthropic-compatible endpoint). This same entry also restores durable
+  Claude-Code-via-umans access, which the runtime firewall otherwise blocks.
+  The installer hosts (`get`/`dl.polytoken.dev`) are **not** allowlisted because
+  install happens at build time, when egress is unrestricted.
+
+## Configuring the umans provider
+
+Recommended: run `polytoken config ui` and add a provider. Umans is reached as a
+**custom Anthropic-compatible** provider. Equivalent hand-written config
+(`~/.config/polytoken/config.yaml`) for reference:
+
+```yaml
+providers:
+  umans:
+    kind: custom_anthropic_compatible
+    url: https://api.code.umans.ai
+    protocol: anthropic_messages
+    auth:
+      key: ${UMANS_API_TOKEN}      # do NOT hardcode the sk-... token here
+      format: anthropic_x_api_key
+models:
+  umans-glm-5.2:
+    provider: umans
+    provider_name: umans-glm-5.2
+    variant: other
+    class: full
+    context_window: 200000          # confirm GLM 5.2's actual window
+```
+
+**Token handling:** the umans token already lives in `~/.umans/config.json`
+(`api_token`). Reference it via the `${UMANS_API_TOKEN}` env substitution (set
+the var in your local, gitignored env) or paste it through `polytoken config ui`.
+Never commit the token.
+
+## Verify at first `dc-build` (deferred until in-flight work is done)
+
+A devcontainer rebuild is the only disruptive step, so it waits until current
+sessions are wrapped. On that rebuild:
+
+1. `polytoken --version` resolves (binary installed, on `PATH`).
+2. `polytoken config ui` writes to `~/.config/polytoken/` and that dir is on the
+   `arxii-polytoken-config` volume (`docker volume ls | grep polytoken`).
+3. Start a session, confirm its history lands under `~/.local/share/polytoken`.
+   **If sessions land in `~/.local/state/polytoken` instead, add a third volume
+   there** — XDG data-vs-state split is unconfirmed.
+4. After the firewall reapplies, `polytoken` reaches umans and a fresh
+   `claude` (via umans base URL) still works — both ride the one
+   `api.code.umans.ai` allowlist entry.


### PR DESCRIPTION
## What

Adds **polytoken** (a second coding-agent harness — daemon + CLI/TUI) to the
devcontainer alongside Claude Code, and allowlists umans's Anthropic-compatible
endpoint in the egress firewall.

| File | Change |
|---|---|
| `Dockerfile` | Build-time install of the polytoken binary into `~/.local/bin` (no sudo); pre-create `~/.config/polytoken` + `~/.local/share/polytoken` for volume ownership |
| `docker-compose.yml` | `arxii-polytoken-config` / `arxii-polytoken-data` named volumes — persist provider credentials + session history across rebuilds, mirroring `arxii-claude-home` |
| `init-firewall.sh` | Allowlist `api.code.umans.ai` (two stable AWS EIPs, dig path) |
| `polytoken.md` | Setup notes, umans provider config template, verify-at-`dc-build` checklist |

## Why

- A second harness to run alongside Claude Code, kept fully distinct (own binary,
  config, sessions).
- The `api.code.umans.ai` allowlist entry does double duty: it backs polytoken's
  custom Anthropic-compatible provider **and** restores durable
  Claude-Code-via-umans, which `postStartCommand`'s firewall reapply otherwise
  blocks.

## Validation status

Validated **without** a rebuild (via throwaway-container probes off the current
image): install works (polytoken 0.3.3 → `~/.local/bin`), config dir is
`~/.config/polytoken`, umans resolves to stable AWS IPs (suits the dig path),
`shellcheck` clean, pre-commit passes.

**Deferred to a `dc-build`** (the only disruptive step): firewall reapply,
session-dir persistence, and a polytoken↔umans smoke test — see the checklist in
`.devcontainer/polytoken.md`. CI does not build the devcontainer, so these can
only be confirmed by a local `dc-build`; if anything needs adjusting (e.g.
sessions land in `~/.local/state/polytoken`), it's a small follow-up.

Install hosts `get`/`dl.polytoken.dev` need no firewall entry — install is
build-time, when egress is unrestricted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
