### PR TITLE
fix(security): scope action target-pk resolution to perceivable objects (#1226)

### DIFF
--- a/src/server/conf/inputfuncs.py
+++ b/src/server/conf/inputfuncs.py
@@ -93,7 +93,7 @@ def _build_action_ref(kwargs: dict) -> object:
     return "No action specified."
 
 
-def _resolve_registry_kwargs(ref: object, raw_kwargs: dict) -> "dict | str":
+def _resolve_registry_kwargs(ref: object, raw_kwargs: dict, actor: object) -> "dict | str":
     """Resolve ObjectDB ``*_id`` kwargs for a REGISTRY ref.
 
     For REGISTRY refs the ``Action`` object is interrogated for its
@@ -101,8 +101,15 @@ def _resolve_registry_kwargs(ref: object, raw_kwargs: dict) -> "dict | str":
     resolved to ``ObjectDB`` instances.  Non-REGISTRY refs pass kwargs through
     unchanged (no contract).
 
+    Resolution is **scoped to objects the actor can perceive** — the same
+    same-location proxy the actions' prerequisites enforce (``_is_visible_to``,
+    #1024). A pk the actor can't perceive returns the *same* "Object not found"
+    error as a non-existent pk, so a client cannot probe arbitrary object
+    existence by pk (#1226). Every registry objectdb-target is a co-located or
+    held object, so this rejects nothing a prerequisite would have let through.
+
     Returns the resolved kwargs dict on success, or an error string on failure
-    (action not found or ObjectDB lookup failed).
+    (action not found, or a target pk that doesn't exist / isn't perceivable).
 
     ``ref`` is typed as ``object`` because all ``actions.*`` imports are deferred
     in this Evennia conf module; the concrete type is ``ActionRef``.
@@ -110,6 +117,7 @@ def _resolve_registry_kwargs(ref: object, raw_kwargs: dict) -> "dict | str":
     from evennia.objects.models import ObjectDB  # noqa: PLC0415
 
     from actions.constants import ActionBackend  # noqa: PLC0415
+    from actions.prerequisites import _is_visible_to  # noqa: PLC0415
     from actions.registry import get_action  # noqa: PLC0415
     from actions.types import ActionRef  # noqa: PLC0415
 
@@ -126,10 +134,11 @@ def _resolve_registry_kwargs(ref: object, raw_kwargs: dict) -> "dict | str":
     resolved: dict = {}
     for key, value in raw_kwargs.items():
         if key.endswith("_id") and isinstance(value, int) and key[:-3] in objectdb_targets:
-            try:
-                resolved[key[:-3]] = ObjectDB.objects.get(pk=value)
-            except ObjectDB.DoesNotExist:
+            obj = ObjectDB.objects.filter(pk=value).first()
+            # Out-of-scope and non-existent collapse to one error — no existence probe.
+            if obj is None or not _is_visible_to(actor, obj):
                 return f"Object not found: {key}={value}."
+            resolved[key[:-3]] = obj
         else:
             resolved[key] = value
     return resolved
@@ -202,7 +211,7 @@ def execute_action(session, *args, **kwargs):  # noqa: ARG001
     ref = ref_or_err
 
     raw_kwargs: dict = kwargs.get("kwargs") or {}
-    resolved_or_err = _resolve_registry_kwargs(ref, raw_kwargs)
+    resolved_or_err = _resolve_registry_kwargs(ref, raw_kwargs, actor)
     if isinstance(resolved_or_err, str):
         _send(False, resolved_or_err)
         return

--- a/src/web/tests/test_execute_action_inputfunc.py
+++ b/src/web/tests/test_execute_action_inputfunc.py
@@ -125,8 +125,10 @@ class ExecuteActionInputfuncTests(TestCase):
         Verified by checking what kwargs are passed to ``dispatch_player_action``.
         """
         actor = _StubActor()
+        actor.location = MagicMock(name="room")
         session = _make_session(puppet=actor)
         target_obj = MagicMock(name="resolved_target")
+        target_obj.location = actor.location  # co-located → perceivable (#1226)
         stub_action = MagicMock()
         stub_action.objectdb_target_kwargs = frozenset({"target"})
         dispatch_result = DispatchResult(
@@ -137,15 +139,16 @@ class ExecuteActionInputfuncTests(TestCase):
 
         with (
             patch("actions.registry.get_action", return_value=stub_action),
-            patch("evennia.objects.models.ObjectDB.objects.get", return_value=target_obj) as get,
+            patch("evennia.objects.models.ObjectDB.objects.filter") as mock_filter,
             patch(
                 "actions.player_interface.dispatch_player_action",
                 return_value=dispatch_result,
             ) as mock_dispatch,
         ):
+            mock_filter.return_value.first.return_value = target_obj
             execute_action(session, action="give", kwargs={"target_id": 42})
 
-        get.assert_called_once_with(pk=42)
+        mock_filter.assert_called_once_with(pk=42)
         # dispatch_player_action receives the resolved object (not the raw int).
         _, _, passed_kwargs = mock_dispatch.call_args.args
         self.assertIn("target", passed_kwargs)
@@ -153,28 +156,50 @@ class ExecuteActionInputfuncTests(TestCase):
         self.assertNotIn("target_id", passed_kwargs)
 
     def test_object_id_not_found_sends_error(self) -> None:
-        """An unresolvable object id sends an error and does not run the action."""
-        from evennia.objects.models import ObjectDB
-
+        """An unresolvable object id sends an error and does not dispatch."""
         actor = _StubActor()
+        actor.location = MagicMock(name="room")
         session = _make_session(puppet=actor)
         stub_action = MagicMock()
         stub_action.objectdb_target_kwargs = frozenset({"target"})
 
         with (
             patch("actions.registry.get_action", return_value=stub_action),
-            patch(
-                "evennia.objects.models.ObjectDB.objects.get",
-                side_effect=ObjectDB.DoesNotExist,
-            ),
+            patch("evennia.objects.models.ObjectDB.objects.filter") as mock_filter,
+            patch("actions.player_interface.dispatch_player_action") as mock_dispatch,
         ):
+            mock_filter.return_value.first.return_value = None
             execute_action(session, action="give", kwargs={"target_id": 9999999})
 
-        stub_action.run.assert_not_called()
+        mock_dispatch.assert_not_called()
         payload = _result_payload(session)
         self.assertEqual(payload["kwargs"]["success"], False)
         self.assertIn("Object not found", payload["kwargs"]["message"])
         self.assertIn("target_id", payload["kwargs"]["message"])
+
+    def test_out_of_scope_object_id_is_uniform_not_found(self) -> None:
+        """An existing but out-of-scope object returns the SAME 'not found' error as a
+        non-existent pk, and never dispatches — closing the existence probe (#1226)."""
+        actor = _StubActor()
+        actor.location = MagicMock(name="room")
+        session = _make_session(puppet=actor)
+        out_of_scope = MagicMock(name="distant_object")
+        out_of_scope.location = MagicMock(name="another_room")  # not co-located, not held
+        stub_action = MagicMock()
+        stub_action.objectdb_target_kwargs = frozenset({"target"})
+
+        with (
+            patch("actions.registry.get_action", return_value=stub_action),
+            patch("evennia.objects.models.ObjectDB.objects.filter") as mock_filter,
+            patch("actions.player_interface.dispatch_player_action") as mock_dispatch,
+        ):
+            mock_filter.return_value.first.return_value = out_of_scope
+            execute_action(session, action="give", kwargs={"target_id": 7})
+
+        mock_dispatch.assert_not_called()
+        payload = _result_payload(session)
+        self.assertEqual(payload["kwargs"]["success"], False)
+        self.assertIn("Object not found", payload["kwargs"]["message"])
 
     def test_action_interrupted_sends_error(self) -> None:
         """ActionInterrupted from action.run is forwarded as a failure response.
@@ -221,7 +246,7 @@ class ExecuteActionInputfuncTests(TestCase):
 
         with (
             patch("actions.registry.get_action", return_value=stub_action),
-            patch("evennia.objects.models.ObjectDB.objects.get") as get,
+            patch("evennia.objects.models.ObjectDB.objects.filter") as db_filter,
             patch(
                 "actions.player_interface.dispatch_player_action",
                 return_value=dispatch_result,
@@ -229,7 +254,7 @@ class ExecuteActionInputfuncTests(TestCase):
         ):
             execute_action(session, action="custom", kwargs={"identifier_id": "some-slug"})
 
-        get.assert_not_called()
+        db_filter.assert_not_called()
         # Non-int id kwargs pass through unresolved to dispatch_player_action.
         _, _, passed_kwargs = mock_dispatch.call_args.args
         self.assertEqual(passed_kwargs.get("identifier_id"), "some-slug")
@@ -255,7 +280,7 @@ class ExecuteActionInputfuncTests(TestCase):
 
         with (
             patch("actions.registry.get_action", return_value=stub_action),
-            patch("evennia.objects.models.ObjectDB.objects.get") as get,
+            patch("evennia.objects.models.ObjectDB.objects.filter") as db_filter,
             patch(
                 "actions.player_interface.dispatch_player_action",
                 return_value=dispatch_result,
@@ -264,7 +289,7 @@ class ExecuteActionInputfuncTests(TestCase):
             execute_action(session, action="apply_outfit", kwargs={"outfit_id": 42})
 
         # Resolver did NOT touch the int — outfit_id arrives raw at dispatch.
-        get.assert_not_called()
+        db_filter.assert_not_called()
         _, _, passed_kwargs = mock_dispatch.call_args.args
         self.assertEqual(passed_kwargs.get("outfit_id"), 42)
         self.assertNotIn("outfit", passed_kwargs)
@@ -513,6 +538,7 @@ class UnifiedDispatchPathTests(TestCase):
         actor = MagicMock()
         session = _make_session(puppet=actor)
         target_obj = MagicMock(name="resolved_target")
+        target_obj.location = actor.location  # co-located → perceivable (#1226)
         dispatch_result = self._stub_dispatch_result()
 
         stub_action = MagicMock()
@@ -520,16 +546,17 @@ class UnifiedDispatchPathTests(TestCase):
 
         with (
             patch("actions.registry.get_action", return_value=stub_action),
-            patch("evennia.objects.models.ObjectDB.objects.get", return_value=target_obj) as db_get,
+            patch("evennia.objects.models.ObjectDB.objects.filter") as db_filter,
             patch(
                 "actions.player_interface.dispatch_player_action",
                 return_value=dispatch_result,
             ) as mock_dispatch,
         ):
+            db_filter.return_value.first.return_value = target_obj
             execute_action(session, action="give", kwargs={"target_id": 42})
 
         # ObjectDB lookup must have fired
-        db_get.assert_called_once_with(pk=42)
+        db_filter.assert_called_once_with(pk=42)
         # dispatch_player_action receives the resolved object (not the raw int).
         # dispatch_player_action(actor, ref, kwargs) — kwargs is the 3rd positional.
         passed_kwargs = mock_dispatch.call_args.args[2]


### PR DESCRIPTION
## #1226 — close the action target-pk existence probe

`_resolve_registry_kwargs` (the websocket `execute_action` dispatch path) resolved `*_id`
target kwargs via a raw `ObjectDB.objects.get(pk=value)` with **no scoping**. So a client
could distinguish *"object N exists"* (it resolves, then a prerequisite rejects it) from
*"object N not found"* — probing arbitrary object existence by pk. #1024 closed the on-use
*exploit*; this closes the information leak.

### Fix
Resolve via `.filter(pk=...).first()` and reject any object the actor can't perceive, using
the **same `_is_visible_to` same-location proxy the prerequisites already enforce** (#1024).
An out-of-scope pk now returns the *same* `Object not found` error as a non-existent one, and
never dispatches — existence can't be probed.

Every registry objectdb-target is co-located or held (whisper / get / drop / give / traverse /
use / put_in / take_out / equip), so this rejects **nothing** a prerequisite would have let
through. REST is read-only, so this websocket path is the only mutation surface (verified — the
function has no other caller). When #1225 replaces `_is_visible_to` with a real perception
system, this scope updates in one place.

### Tests
A co-located target still resolves + dispatches; a non-existent *and* an out-of-scope pk both
return the uniform `Object not found` and never dispatch (the probe-closing assertion); non-int
and undeclared `_id` kwargs still pass through with no DB lookup. inputfunc (15) + fatigue
pipeline (19) suites green.

Closes #1226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
