### PR TITLE
docs(devcontainer): correct polytoken umans config + record dc-build verification

### DIFF
--- a/.devcontainer/polytoken.md
+++ b/.devcontainer/polytoken.md
@@ -25,42 +25,60 @@ Claude-Code-via-umans setup.
 
 Recommended: run `polytoken config ui` and add a provider. Umans is reached as a
 **custom Anthropic-compatible** provider. Equivalent hand-written config
-(`~/.config/polytoken/config.yaml`) for reference:
+(`~/.config/polytoken/config.yaml`), verified against polytoken 0.3.3's
+`schemas app-config` and a live `polytoken exec` smoke test:
 
 ```yaml
+defaults:
+  full: umans-glm-5.2              # a full-class model must be the default
 providers:
   umans:
-    kind: custom_anthropic_compatible
+    kind:
+      type: custom_anthropic_compatible   # tagged object, not a bare string
     url: https://api.code.umans.ai
     protocol: anthropic_messages
     auth:
-      key: ${UMANS_API_TOKEN}      # do NOT hardcode the sk-... token here
+      type: static_key                     # required discriminator
+      key: ${UMANS_API_TOKEN}              # do NOT hardcode the sk-... token here
       format: anthropic_x_api_key
 models:
   umans-glm-5.2:
     provider: umans
     provider_name: umans-glm-5.2
-    variant: other
-    class: full
-    context_window: 200000          # confirm GLM 5.2's actual window
+    class: full                            # required for custom models
+    context_window: 405504                 # umans-side cap; Z.ai native is 1M
+    max_tokens: 131072                     # umans max_completion_tokens for GLM-5.2
 ```
+
+The `context_window` / `max_tokens` above are umans's own caps for `umans-glm-5.2`
+(below Z.ai's native 1M), read from the authoritative
+`GET https://api.code.umans.ai/v1/models/info` endpoint — query it for the current
+per-model `context_window`, `max_completion_tokens`, and reasoning levels rather
+than guessing.
+
+Validate with `polytoken config validate --user` before relying on it.
+Polytoken also ships a built-in `umans_messages` protocol, so a catalog-based
+provider may be even simpler — `polytoken config ui` is the path of least
+resistance.
 
 **Token handling:** the umans token already lives in `~/.umans/config.json`
 (`api_token`). Reference it via the `${UMANS_API_TOKEN}` env substitution (set
 the var in your local, gitignored env) or paste it through `polytoken config ui`.
 Never commit the token.
 
-## Verify at first `dc-build` (deferred until in-flight work is done)
+## Verified at first `dc-build` (2026-06-29)
 
-A devcontainer rebuild is the only disruptive step, so it waits until current
-sessions are wrapped. On that rebuild:
+All four checks below passed on the first no-cache rebuild after in-flight work
+wrapped:
 
-1. `polytoken --version` resolves (binary installed, on `PATH`).
-2. `polytoken config ui` writes to `~/.config/polytoken/` and that dir is on the
-   `arxii-polytoken-config` volume (`docker volume ls | grep polytoken`).
-3. Start a session, confirm its history lands under `~/.local/share/polytoken`.
-   **If sessions land in `~/.local/state/polytoken` instead, add a third volume
-   there** — XDG data-vs-state split is unconfirmed.
-4. After the firewall reapplies, `polytoken` reaches umans and a fresh
-   `claude` (via umans base URL) still works — both ride the one
-   `api.code.umans.ai` allowlist entry.
+1. ✅ `polytoken --version` → `0.3.3` (binary installed, on `PATH`).
+2. ✅ `~/.config/polytoken/config.yaml` writes to the `arxii-polytoken-config`
+   volume; the dir is `vscode`-owned and shows as a mount in `/proc/mounts`.
+3. ✅ Session history lands under **`~/.local/share/polytoken/sessions/`** (the
+   `arxii-polytoken-data` volume), **not** `~/.local/state/polytoken`. **No third
+   volume is needed** — the XDG data-vs-state question is settled.
+4. ✅ After the firewall reapplies, `api.code.umans.ai` is reachable (a direct
+   Anthropic `/v1/messages` call returned a GLM-5.2 message) and `polytoken exec`
+   ran a full session through umans, while a non-allowlisted host (`google.com`)
+   stayed blocked — confirming default-deny is intact and both harnesses ride the
+   one `api.code.umans.ai` allowlist entry.


### PR DESCRIPTION
## What

Follow-up to #1626. The devcontainer was rebuilt (`just dc-build`, no-cache) now
that in-flight work has wrapped, and the deferred polytoken+umans verification was
run inside the fresh container. This PR corrects the config template and records
the results.

## Why

The `~/.config/polytoken/config.yaml` template committed in #1626 was authored
speculatively and **fails `polytoken config validate`** on the installed 0.3.3
binary. Corrected against `polytoken schemas app-config` and a live `polytoken
exec` session through umans:

- `kind` is a tagged object `{type: custom_anthropic_compatible}`, not a bare string
- `auth` needs the `type: static_key` discriminator
- custom models require a `class`; a full-class model must be the default
- `context_window` was `200000` — the real umans-side cap is **405504** (max
  output **131072**), read from `GET /v1/models/info` (below Z.ai's native 1M)

## Verified at this rebuild

- ✅ `polytoken 0.3.3` on PATH
- ✅ `arxii-polytoken-config` + `arxii-polytoken-data` volumes mount, are
  `vscode`-owned, and persist across the rebuild
- ✅ Session history lands in `~/.local/share/polytoken/sessions/` (the data
  volume) — **not** `~/.local/state`; **no third volume needed**
- ✅ `api.code.umans.ai` reachable through the firewall (direct `/v1/messages`
  call + a full `polytoken exec` session both succeed), while `google.com` stays
  blocked — default-deny intact

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
