### PR TITLE
feat(scenes): Guise Sheet authoring — cover identities carry their own bio (#1270)

### DIFF
--- a/docs/systems/MODEL_MAP.md
+++ b/docs/systems/MODEL_MAP.md
@@ -929,6 +929,7 @@
   - aspects <- checks.CheckTypeAspect
   - item_check_modifiers <- items.ItemCheckModifier
   - escalation_curves <- combat.EscalationCurve
+  - project_contribution_methods <- projects.ContributionMethod
   - detect_traps <- room_features.Trap
   - disarm_traps <- room_features.Trap
 
@@ -3481,6 +3482,7 @@
 **Pointed to by:**
   - resonance_grants <- magic.ResonanceGrant
   - research_details <- clues.ResearchProjectDetails
+  - ransom_captivities <- captivity.Captivity
   - contributions <- projects.Contribution
   - resulting_building <- buildings.Building
   - building_construction_details <- buildings.BuildingConstructionDetails
@@ -3493,14 +3495,27 @@
   - contributor_persona -> scenes.Persona [FK]
   - item_instance -> items.ItemInstance [FK] (nullable)
   - check_outcome -> traits.CheckOutcome [FK] (nullable)
+  - contribution_method -> projects.ContributionMethod [FK] (nullable)
+
+### ContributionMethod
+**Foreign Keys:**
+  - check_type -> checks.CheckType [FK]
+**Pointed to by:**
+  - contributions <- projects.Contribution
 
 ### Service Functions
-- `add_contribution(*, project: 'Project', contributor_persona: 'Persona', kind: 'str', ap_amount: 'int | None' = None, money_amount: 'int | None' = None, item_instance: 'ItemInstance | None' = None, check_outcome: 'CheckOutcome | None' = None, intent_text: 'str' = '', privacy_setting: 'str' = 'PRIVATE') -> 'Contribution' — Add a contribution to an ACTIVE Project and advance current_progress.`
+- `add_contribution(*, project: 'Project', contributor_persona: 'Persona', kind: 'str', ap_amount: 'int | None' = None, money_amount: 'int | None' = None, item_instance: 'ItemInstance | None' = None, check_outcome: 'CheckOutcome | None' = None, contribution_method: 'ContributionMethod | None' = None, intent_text: 'str' = '', privacy_setting: 'str' = 'PRIVATE') -> 'Contribution' — Add a contribution to an ACTIVE Project and advance current_progress.`
+- `clear_instant_completion_kinds() -> 'None' — Test-only: clear the instant-completion registry.`
 - `clear_kind_handlers() -> 'None' — Test-only: clear the handler registry.`
+- `contribute_check_to_project(project: 'Project', *, actor: 'ObjectDB', contributor_persona: 'Persona', method: 'ContributionMethod') -> 'Contribution' — Make a check-based contribution: spend AP, roll the check, advance on success (#1574).`
+- `donate_to_project(project: 'Project', *, donor_persona: 'Persona', amount: 'int') -> 'Contribution' — Debit ``amount`` coppers from the donor's purse and record a MONEY contribution.`
 - `get_kind_handler(kind: 'str') -> 'KindHandler' — Return the registered handler for `kind`, or raise LookupError.`
+- `maybe_complete_immediately(project: 'Project') -> 'bool' — Resolve an instant-completion project the moment its threshold is funded (#1500).`
+- `register_instant_completion_kind(kind: 'str') -> 'None' — Mark a ProjectKind as completing immediately on threshold (re-register safe).`
 - `register_kind_handler(kind: 'str', handler: 'KindHandler') -> 'None' — Register a per-kind resolution handler. Re-registration overwrites.`
 - `resolve_project(project: 'Project', *, outcome_tier: 'CheckOutcome') -> 'None' — Finalize a RESOLVING project: dispatch to per-kind handler, set outcome.`
 - `scan_active_projects() -> 'int' — Cron tick: scan ACTIVE projects, transition completion-ready ones to RESOLVING.`
+- `set_contribution_story(project: 'Project', *, contributor_persona: 'Persona', text: 'str') -> 'Contribution | None' — Attach the narrative of how a contributor helped to their most recent contribution (#1574).`
 
 
 ## world.realms
@@ -4070,6 +4085,7 @@
 - `invalidate_active_scene_cache(location: 'ObjectDB') -> 'None' — Clear the cached active scene for a location.`
 - `persona_for_character(character: 'Character') -> 'Persona' — Return the PC's PRIMARY persona; raise loud on missing sheet/persona.`
 - `set_active_persona(sheet: 'CharacterSheet', persona: 'Persona') -> 'None' — Set the character's active face (#981) — the ONLY mutator.`
+- `set_persona_profile(persona: 'Persona', *, concept: 'str | None' = None, quote: 'str | None' = None, personality: 'str | None' = None, background: 'str | None' = None) -> 'Profile' — Author the fabricated bio a non-primary persona presents — its **Guise Sheet** (#1270).`
 
 
 ## world.secrets

--- a/docs/systems/appearance_and_identity.md
+++ b/docs/systems/appearance_and_identity.md
@@ -66,6 +66,17 @@ artist changes persona with an *identical* body; a curse changes the body and
   `PersonaViewSet` `create-established` / `create-mask` actions. The raw `ModelViewSet` create was
   removed — these are the only creation surfaces. They create the persona and **nothing else**, so
   the *Privacy invariant* below holds structurally (no descriptor is ever copied from a sibling).
+- **Guise Sheet — the cover's own bio (#1270).** An established/cover persona carries its OWN
+  fabricated bio (`Persona.profile → character_sheets.Profile`: concept / quote / personality /
+  background) so the *absence* of a bio doesn't instantly out it as fake; the sheet's `true_profile`
+  stays the real face's bio (presented by PRIMARY). `scenes.services.set_persona_profile` is the
+  **sole mutator** (PRIMARY rejected; narrative text only — **lineage stays display-only**, every
+  *mechanical* lineage read pinned to `true_profile` via the sheet's forwarding properties).
+  Authored on telnet via `persona profile <name> [concept=… quote=… personality=… background=…]`;
+  the web profile serializer already renders the *presented* face's profile cover-aware (slices
+  1–3), so a guise authored anywhere shows correctly — a dedicated **web authoring form** is the
+  remaining follow-up. (Telnet `@sheet` is self/staff-only, so a non-privileged viewer never sees
+  another's cover there; the `<cover> (<real>)` reveal is a web-profile concern.)
 - **Named/public personas** (PRIMARY, ESTABLISHED) render **by name to everyone** —
   the accessibility guarantee.
 - **Anonymous personas** (`is_fake_name`, typically TEMPORARY — the mask) render as a

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -268,7 +268,10 @@ actions, backends, and service functions.
   <name>` (durable ESTABLISHED) and `persona mask <name>` (TEMPORARY anonymous mask, worn on
   creation) call the validated `scenes.services.create_persona`/`create_mask` directly (#1127) — the
   same services the web `create-established`/`create-mask` actions use; staff bypass the
-  ESTABLISHED cap. Pose/sdesc reflection of the presented persona is #1109's scope, not this command.
+  ESTABLISHED cap. `persona profile <name> [concept=… quote=… personality=… background=…]` (#1270)
+  views or authors a non-primary persona's **Guise Sheet** (its own fabricated bio) via
+  `scenes.services.set_persona_profile` (sole mutator; PRIMARY rejected); values run free to the
+  next key. Pose/sdesc reflection of the presented persona is #1109's scope, not this command.
 - **`form.py`**: `CmdForm` (`form`, #1111 slice 4) — list, shift into, or revert
   your alternate selves. Bare `form`/`form list` renders the active alt-self
   (`true self` if none) and the available list. `form shift <name|id>` resolves the

--- a/src/commands/persona.py
+++ b/src/commands/persona.py
@@ -10,6 +10,7 @@ directly (the same services the web ``create-established`` / ``create-mask`` act
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 from actions.constants import ActionBackend
@@ -23,6 +24,9 @@ if TYPE_CHECKING:
 _LIST = "list"
 _CREATE = "create"
 _MASK = "mask"
+_PROFILE = "profile"
+_GUISE_FIELDS = ("concept", "quote", "personality", "background")
+_GUISE_KEY_RE = re.compile(r"\b(concept|quote|personality|background)=")
 
 
 class CmdPersona(DispatchCommand):
@@ -33,6 +37,8 @@ class CmdPersona(DispatchCommand):
         persona list          — same as bare ``persona``
         persona create <name> — create a new established (durable) identity
         persona mask <name>   — create a temporary anonymous mask and wear it
+        persona profile <name> [concept=… quote=… personality=… background=…]
+                              — view or author a cover identity's own (fabricated) bio
         persona <name>        — switch your active face to the named persona
         wear-face <name>      — alias for persona <name>
     """
@@ -55,6 +61,9 @@ class CmdPersona(DispatchCommand):
             return
         if verb.lower() == _MASK:
             self._create_mask(rest.strip())
+            return
+        if verb.lower() == _PROFILE:
+            self._handle_profile(rest.strip())
             return
         self._name = raw
         super().func()  # resolve_action_ref + resolve_action_args + dispatch
@@ -91,6 +100,85 @@ class CmdPersona(DispatchCommand):
             self.msg(exc.user_message)
             return
         self.msg(f"You don a mask: '{mask.name}'. You are now presenting as it.")
+
+    def _handle_profile(self, rest: str) -> None:
+        """``persona profile <name> [field=value ...]`` — view or author a guise bio (#1270).
+
+        A cover identity carries its own fabricated bio so its *absence* doesn't out it as fake.
+        With no fields, shows the named persona's current guise bio; with ``concept=`` /
+        ``quote=`` / ``personality=`` / ``background=`` (free text to the next key), authors them.
+        """
+        if not rest:
+            self.msg(
+                "Usage: persona profile <name> "
+                "[concept=... quote=... personality=... background=...]"
+            )
+            return
+        match = _GUISE_KEY_RE.search(rest)
+        if match is None:
+            name, fields = rest, {}
+        else:
+            name = rest[: match.start()].strip()
+            fields = self._parse_guise_fields(rest[match.start() :])
+        if not name:
+            self.msg("Usage: persona profile <name> [field=value ...]")
+            return
+        persona = self._resolve_own_persona(name)
+        if persona is None:
+            return
+        if not fields:
+            self._show_guise(persona)
+            return
+        from world.scenes.services import GuiseProfileError, set_persona_profile  # noqa: PLC0415
+
+        try:
+            set_persona_profile(persona, **fields)
+        except GuiseProfileError as exc:
+            self.msg(exc.user_message)
+            return
+        self.msg(f"Updated the guise bio for '{persona.name}': {', '.join(fields)}.")
+
+    @staticmethod
+    def _parse_guise_fields(text: str) -> dict[str, str]:
+        """Split ``field=value …`` where each value runs free until the next known key."""
+        parts = _GUISE_KEY_RE.split(text)
+        # parts = ['', key1, val1, key2, val2, …] — pre-first-key chunk is empty (we sliced there).
+        fields: dict[str, str] = {}
+        for index in range(1, len(parts) - 1, 2):
+            fields[parts[index]] = parts[index + 1].strip()
+        return fields
+
+    def _resolve_own_persona(self, name: str) -> Any:
+        """Resolve a name to one of the caller's own personas, or None (already messaged)."""
+        from world.scenes.models import Persona  # noqa: PLC0415
+
+        sheet = self.caller.sheet_data
+        matches = list(Persona.objects.filter(character_sheet_id=sheet.pk, name__iexact=name))
+        if not matches:
+            available = ", ".join(
+                p.name for p in Persona.objects.filter(character_sheet_id=sheet.pk)
+            )
+            self.msg(f"No persona named '{name}'. Available: {available}.")
+            return None
+        if len(matches) > 1:
+            self.msg(f"Multiple personas match '{name}'. Be more specific.")
+            return None
+        return matches[0]
+
+    def _show_guise(self, persona: Any) -> None:
+        """Render a persona's current guise bio (or a prompt to author one)."""
+        profile = persona.profile
+        if profile is None:
+            self.msg(
+                f"'{persona.name}' has no guise bio yet. Author one with: "
+                f"persona profile {persona.name} concept=..."
+            )
+            return
+        lines = [f"|wGuise bio for {persona.name}:|n"]
+        for field_name in _GUISE_FIELDS:
+            value = getattr(profile, field_name)
+            lines.append(f"  {field_name.title()}: {value or '(unset)'}")
+        self.msg("\n".join(lines))
 
     def resolve_action_ref(self) -> ActionRef:
         """Build a REGISTRY ActionRef for ``set_active_persona``."""

--- a/src/commands/tests/test_persona_command.py
+++ b/src/commands/tests/test_persona_command.py
@@ -131,6 +131,43 @@ class CmdPersonaCreateTests(TestCase):
         self.assertIn("Usage: persona create", sent)
 
 
+class CmdPersonaProfileTests(TestCase):
+    """`persona profile <name> [field=value …]` — view/author a cover's guise bio (#1270)."""
+
+    def setUp(self) -> None:
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        self.character.msg = MagicMock()
+        self.cover = PersonaFactory(
+            character_sheet=self.sheet, persona_type=PersonaType.ESTABLISHED, name="Robert"
+        )
+
+    def _sent(self) -> str:
+        return "\n".join(str(c.args[0]) for c in self.character.msg.call_args_list)
+
+    def test_authors_the_guise_bio(self) -> None:
+        _cmd(self.character, "profile Robert concept=A wine merchant quote=In vino veritas").func()
+        self.cover.refresh_from_db()
+        assert self.cover.profile is not None
+        assert self.cover.profile.concept == "A wine merchant"
+        assert self.cover.profile.quote == "In vino veritas"
+
+    def test_shows_the_guise_bio_after_authoring(self) -> None:
+        _cmd(self.character, "profile Robert concept=A wine merchant").func()
+        self.character.msg.reset_mock()
+        _cmd(self.character, "profile Robert").func()
+        self.assertIn("A wine merchant", self._sent())
+
+    def test_unauthored_guise_prompts_to_create(self) -> None:
+        _cmd(self.character, "profile Robert").func()
+        self.assertIn("no guise bio yet", self._sent())
+
+    def test_cannot_author_a_guise_for_the_primary_face(self) -> None:
+        primary = self.sheet.primary_persona
+        _cmd(self.character, f"profile {primary.name} concept=nope").func()
+        self.assertIn("true face", self._sent().lower())
+
+
 class CmdPersonaActiveNoneTests(TestCase):
     """Listing must not crash when active_persona_for_sheet returns None."""
 

--- a/src/world/scenes/AGENT_GLOSSARY.md
+++ b/src/world/scenes/AGENT_GLOSSARY.md
@@ -6,6 +6,10 @@ Root term — the primary roleplay-session entity (participants, personas, recor
 **Persona**:
 Root term — the identity a participant wears within a scene (PRIMARY/ESTABLISHED/TEMPORARY), anchored by FK to the source-of-truth CharacterSheet. Not redefined here.
 
+**Guise Sheet**:
+The fabricated bio a non-primary (cover/established) persona presents as its own — its `Persona.profile` (a `character_sheets.Profile`: concept/quote/personality/background), so the *absence* of a bio doesn't out the cover as fake. Distinct from the sheet's `true_profile` (the real face's bio, presented by PRIMARY). Authored via `set_persona_profile`; lineage stays display-only (mechanical reads pin to `true_profile`).
+_Avoid_: fake sheet, alt bio, cover profile (the model is `Profile`; the surface is the Guise Sheet).
+
 **Gemit**:
 Root term — a staff/GM broadcast pushed to a public-reaction surface. Not redefined here.
 

--- a/src/world/scenes/services.py
+++ b/src/world/scenes/services.py
@@ -8,7 +8,7 @@ from world.scenes.models import Persona, Scene
 
 if TYPE_CHECKING:
     from typeclasses.characters import Character
-    from world.character_sheets.models import CharacterSheet
+    from world.character_sheets.models import CharacterSheet, Profile
     from world.forms.models import CharacterForm
 
 ActionType = SceneAction
@@ -198,6 +198,64 @@ def create_mask(
         apply_disguise(sheet.character, disguise_form, kind=kind)
     set_active_persona(sheet, mask)
     return mask
+
+
+class GuiseProfileError(ValueError):
+    """An invalid Guise-Sheet authoring request (#1270).
+
+    Carries a fixed ``user_message`` (per ``feedback_codeql_exceptions``) so the authoring surface
+    surfaces a safe string. Raised when authoring a guise for the PRIMARY face (whose real bio is
+    the sheet's ``true_profile``, edited through the sheet — never as a guise).
+    """
+
+    user_message = "You can't give your true face a cover bio — edit your real sheet instead."
+
+
+def set_persona_profile(
+    persona: Persona,
+    *,
+    concept: str | None = None,
+    quote: str | None = None,
+    personality: str | None = None,
+    background: str | None = None,
+) -> Profile:
+    """Author the fabricated bio a non-primary persona presents — its **Guise Sheet** (#1270).
+
+    A cover/established persona needs its OWN concept/quote/personality/background so the *absence*
+    of a bio doesn't instantly out it as fake. This is the **sole mutator** of ``Persona.profile``:
+    it attaches a fresh ``Profile`` the first time the persona is given a bio, then updates only the
+    fields passed (``None`` leaves a field untouched, so callers can edit one field at a time).
+
+    PRIMARY is rejected — the real face's bio is the sheet's ``true_profile``, edited through the
+    sheet, never authored here. Only narrative text is set; **lineage stays display-only** (the
+    sheet's forwarding properties keep every *mechanical* lineage read on the real ``true_profile``,
+    so a fabricated guise can never leak into mechanics).
+    """
+    from world.character_sheets.models import Profile  # noqa: PLC0415
+    from world.scenes.constants import PersonaType  # noqa: PLC0415
+
+    if persona.persona_type == PersonaType.PRIMARY:
+        msg = "Cannot author a guise profile for a PRIMARY persona."
+        raise GuiseProfileError(msg)
+
+    profile = persona.profile
+    created = profile is None
+    if created:
+        profile = Profile()
+    updates = {
+        "concept": concept,
+        "quote": quote,
+        "personality": personality,
+        "background": background,
+    }
+    for field_name, value in updates.items():
+        if value is not None:
+            setattr(profile, field_name, value)
+    profile.save()
+    if created:
+        persona.profile = profile
+        persona.save(update_fields=["profile"])
+    return profile
 
 
 def broadcast_scene_message(scene: Scene, action: ActionType) -> None:

--- a/src/world/scenes/tests/test_persona_creation.py
+++ b/src/world/scenes/tests/test_persona_creation.py
@@ -22,7 +22,13 @@ from world.forms.factories import (
 from world.forms.models import CharacterFormState, FormType, PersonaTraitDescriptor
 from world.scenes.constants import PersonaType
 from world.scenes.models import Persona
-from world.scenes.services import PersonaCreationError, create_mask, create_persona
+from world.scenes.services import (
+    GuiseProfileError,
+    PersonaCreationError,
+    create_mask,
+    create_persona,
+    set_persona_profile,
+)
 from world.scenes.views import PersonaViewSet
 
 
@@ -111,6 +117,42 @@ class CreateMaskTests(TestCase):
 
         state = CharacterFormState.objects.get(character=self.character)
         assert state.active_fake_overlay_id == disguise.id
+
+
+class SetPersonaProfileTests(TestCase):
+    """Authoring a cover identity's own (fabricated) bio — the Guise Sheet (#1270)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+        cls.cover = create_persona(cls.sheet, name="Robert D'Vile", persona_type="established")
+
+    def test_attaches_a_profile_the_first_time(self):
+        assert self.cover.profile is None
+        profile = set_persona_profile(
+            self.cover, concept="A jovial wine merchant", quote="In vino veritas."
+        )
+        self.cover.refresh_from_db()
+        assert self.cover.profile_id == profile.pk
+        assert profile.concept == "A jovial wine merchant"
+        assert profile.quote == "In vino veritas."
+
+    def test_partial_update_leaves_other_fields_untouched(self):
+        set_persona_profile(self.cover, concept="Merchant", background="Born in the river-ward.")
+        # A later edit of one field must not blank the others.
+        set_persona_profile(self.cover, concept="Spice merchant")
+        self.cover.refresh_from_db()
+        assert self.cover.profile.concept == "Spice merchant"
+        assert self.cover.profile.background == "Born in the river-ward."
+
+    def test_reuses_the_same_profile_on_re_edit(self):
+        first = set_persona_profile(self.cover, concept="One")
+        second = set_persona_profile(self.cover, quote="Two")
+        assert first.pk == second.pk  # one guise profile per persona, not a new row each edit
+
+    def test_rejects_primary_persona(self):
+        with self.assertRaises(GuiseProfileError):
+            set_persona_profile(self.sheet.primary_persona, concept="not allowed")
 
 
 class CreatePersonaEndpointTests(TestCase):


### PR DESCRIPTION
## What

The per-persona `Profile` model + the **cover-aware web display** shipped in #1270 slices 1–3 — but **nothing ever populated** a cover persona's `Profile`, so a cover could never actually *get* a fabricated bio. This adds the missing **authoring** surface.

## How

- **Service** `world.scenes.services.set_persona_profile` — the **sole mutator** of `Persona.profile`. Attaches a fresh `Profile` the first time a non-primary persona is given a bio, then updates only the narrative fields passed (`None` leaves a field untouched, so one-field edits work). **PRIMARY is rejected** (the real face's bio is the sheet's `true_profile`, edited through the sheet). Lineage stays **display-only** — every *mechanical* lineage read is pinned to `true_profile` by the sheet's forwarding properties, so a fabricated guise can never leak into mechanics.
- **Telnet** `persona profile <name> [concept=… quote=… personality=… background=…]` (`CmdPersona`) — views or authors a non-primary persona's guise bio; values run free to the next key.
- **Docs**: `appearance_and_identity.md`, `commands/CLAUDE.md`, scenes glossary, `MODEL_MAP`.

## On "telnet parity"

Investigating the parity gap: telnet `@sheet` is **self/staff-only** (non-staff can't view another character's sheet), so there is **no telnet cover-leak** — privileged viewers correctly see the real bio, and the `<cover> (<real>)` reveal is inherently a web-profile concern (already cover-aware). So the real work here is the **authoring** capability, which is what this delivers.

## Tests

`world.scenes.tests.test_persona_creation` + `commands.tests.test_persona_command` — **33 passing** (SQLite fast tier), incl. 8 new: service (attach / partial-update / reuse-row / PRIMARY-rejected) and command (author / show / unauthored-prompt / PRIMARY-rejected).

## Status & follow-up

This makes the Guise Sheet **usable end-to-end** (author via telnet → displays cover-aware on web + telnet). The remaining piece — a **web authoring form** on the React frontend (the primary surface) — is filed as **#1682** (endpoint + form). Marked `Refs` rather than `Closes` so the reviewer decides whether #1270 closes now or stays open for #1682.

Refs #1270