### PR TITLE
feat(polytoken): cross-model review subagents (Kimi reviews GLM-5.2)

### DIFF
--- a/.devcontainer/polytoken.md
+++ b/.devcontainer/polytoken.md
@@ -31,6 +31,7 @@ Recommended: run `polytoken config ui` and add a provider. Umans is reached as a
 ```yaml
 defaults:
   full: umans-glm-5.2              # a full-class model must be the default
+  mini: umans-flash               # fast/cheap model for compaction + permission classifier
 providers:
   umans:
     kind:
@@ -47,14 +48,35 @@ models:
     provider_name: umans-glm-5.2
     class: full                            # required for custom models
     context_window: 405504                 # umans-side cap; Z.ai native is 1M
-    max_tokens: 131072                     # umans max_completion_tokens for GLM-5.2
+    max_tokens: 131071                     # recommended_max_tokens (must be < the 131072 cap)
+  umans-flash:                             # mini default — silences mini-fallback warnings
+    provider: umans
+    provider_name: umans-flash
+    class: mini
+    context_window: 262144
+    max_tokens: 32768                      # recommended_max_tokens for flash
+  umans-kimi-k2.7:                         # used by the cross-model review subagents below
+    provider: umans
+    provider_name: umans-kimi-k2.7
+    class: full
+    context_window: 262144
+    max_tokens: 32768                      # recommended_max_tokens for kimi
 ```
 
-The `context_window` / `max_tokens` above are umans's own caps for `umans-glm-5.2`
-(below Z.ai's native 1M), read from the authoritative
+The `context_window` / `max_tokens` above are umans's own caps per model (GLM-5.2's
+context is below Z.ai's native 1M), read from the authoritative
 `GET https://api.code.umans.ai/v1/models/info` endpoint — query it for the current
 per-model `context_window`, `max_completion_tokens`, and reasoning levels rather
-than guessing.
+than guessing. **`max_tokens` must be strictly *less than* the model's
+`max_completion_tokens`** — umans rejects a request where they're equal
+(`max_tokens (131072) is at or above the model's max output tokens`), which is why
+each value uses the published `recommended_max_tokens` (one under the cap for
+GLM-5.2; 32768 for flash/kimi).
+
+**Models live in the global (user) config only** — polytoken forbids `models` and
+`defaults` in the project config layer (`ProjectLayerModelsAndDefaultsForbidden`),
+so this block can't be committed to the repo. It lives on the `arxii-polytoken-config`
+volume (persists across rebuilds) and is reproduced here as the recovery recipe.
 
 Validate with `polytoken config validate --user` before relying on it.
 Polytoken also ships a built-in `umans_messages` protocol, so a catalog-based
@@ -65,6 +87,32 @@ resistance.
 (`api_token`). Reference it via the `${UMANS_API_TOKEN}` env substitution (set
 the var in your local, gitignored env) or paste it through `polytoken config ui`.
 Never commit the token.
+
+## Cross-model review subagents (Kimi reviews GLM)
+
+Polytoken has no built-in "adversarial reviewer model" knob — model roles are only
+`full` / `mini` / `nano`. Cross-model review is done with **subagents that pin their
+own model** via `polytoken.model`. The default full model (`umans-glm-5.2`) does the
+work; a reviewer subagent runs on a *different* model (`umans-kimi-k2.7`) so the
+critique isn't the author grading itself.
+
+Two project-level subagents ship in the repo at **`.polytoken/subagents/`** (this
+directory is in version control and bind-mounted into the container, so it is durable
+across rebuilds and shared with every contributor — unlike the global model config
+above):
+
+- **`plan-reviewer.md`** — shadows polytoken's built-in plan reviewer (same name →
+  project layer wins) but pinned to Kimi. The `plan` facet auto-runs it at the
+  plan→execution handoff, so planning gets a cross-model critique for free.
+- **`code-reviewer.md`** — an adversarial code/diff reviewer (no shipped equivalent).
+  Nothing auto-runs it; invoke it via the `subagent` tool / a session prompt
+  ("use the code-reviewer subagent on the current diff"). Read-only; emits
+  severity-classified findings.
+
+Both declare `fallback_models: [default_model:full]`, so on any machine where the
+global config lacks `umans-kimi-k2.7` they degrade gracefully to the default full
+model instead of erroring. Confirm discovery with
+`polytoken --working-dir /workspaces/arxii doctor` (look for the subagent count).
 
 ## Verified at first `dc-build` (2026-06-29)
 

--- a/.devcontainer/polytoken.md
+++ b/.devcontainer/polytoken.md
@@ -37,7 +37,7 @@ providers:
     kind:
       type: custom_anthropic_compatible   # tagged object, not a bare string
     url: https://api.code.umans.ai
-    protocol: anthropic_messages
+    protocol: umans_messages                 # NOT anthropic_messages — see note below
     auth:
       type: static_key                     # required discriminator
       key: ${UMANS_API_TOKEN}              # do NOT hardcode the sk-... token here
@@ -79,9 +79,14 @@ so this block can't be committed to the repo. It lives on the `arxii-polytoken-c
 volume (persists across rebuilds) and is reproduced here as the recovery recipe.
 
 Validate with `polytoken config validate --user` before relying on it.
-Polytoken also ships a built-in `umans_messages` protocol, so a catalog-based
-provider may be even simpler — `polytoken config ui` is the path of least
-resistance.
+
+**Use `protocol: umans_messages`, not `anthropic_messages`.** umans's endpoint
+*does* answer generic Anthropic Messages calls (a raw `curl` to `/v1/messages`
+works), but polytoken's agentic tool-use flow needs its dedicated umans dialect.
+With `anthropic_messages`, tool calls get mangled and every model reflexively
+fires `web_search` on each prompt — even "what is 2+2" comes back as web results
+instead of an answer. Switching the provider to `umans_messages` fixes it for all
+models at once (the protocol is set once on the provider, not per model).
 
 **Token handling:** the umans token already lives in `~/.umans/config.json`
 (`api_token`). Reference it via the `${UMANS_API_TOKEN}` env substitution (set

--- a/.polytoken/subagents/code-reviewer.md
+++ b/.polytoken/subagents/code-reviewer.md
@@ -1,0 +1,78 @@
+---
+name: code-reviewer
+description: Adversarially review a code change (the working-tree diff, or a range the caller names) for correctness bugs, security issues, missing tests, contract violations, and quality problems. Read-only; returns severity-classified findings.
+polytoken:
+  # Cross-model review: the worker runs on the default full model (umans-glm-5.2);
+  # this reviewer runs on a DIFFERENT model (Kimi K2.7) so the critique is adversarial
+  # rather than the author grading its own work. Falls back to the default full model
+  # for anyone whose global config doesn't define umans-kimi-k2.7.
+  model: umans-kimi-k2.7
+  fallback_models: [default_model:full]
+  tools: [file_read, grep, glob, shell, web_search, web_fetch, tag!ALL_MCP]
+  undeferred_tools: [file_read, grep, glob, shell]
+  allow_subagent_spawn: false
+  skills_allow: []
+  skills_deny: []
+  exit_tool_schema:
+    type: object
+    additionalProperties: false
+    required: [summary, findings]
+    properties:
+      summary:
+        type: string
+      findings:
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          required: [severity, title, detail]
+          properties:
+            severity:
+              type: string
+              enum: [critical, high, medium, low]
+            title:
+              type: string
+            detail:
+              type: string
+            location:
+              type: string
+            suggested_fix:
+              type: string
+      limitations:
+        type: array
+        items:
+          type: string
+---
+You are the `code-reviewer` subagent. Adversarially review a code change. Your job is to find real defects, not to reassure — assume the change is wrong until the code convinces you otherwise.
+
+Prompt:
+{{ prompt }}
+
+## Establish the diff
+
+If the prompt names a specific commit range, file set, or branch, review exactly that. Otherwise inspect the current change with read-only git commands:
+
+- `git diff` and `git diff --staged` for uncommitted work.
+- `git merge-base HEAD origin/main` then `git diff <base>...HEAD` to review a branch against `main`.
+- `git show <rev>` / `git log --oneline <range>` to understand intent.
+
+Then open the surrounding files with read-only tools — a diff hunk in isolation hides most real bugs. Read the callers and callees of changed functions, the tests that should cover the change, and any contract/interface the change touches.
+
+## What to hunt for
+
+1. **Correctness** — logic errors, off-by-one, wrong/missing error handling, broken edge cases, null/None and boundary handling, concurrency or ordering hazards, resource leaks, incorrect assumptions about inputs.
+2. **Security** — injection, missing authz/authn checks, unsafe deserialization, secret exposure, SSRF/path traversal, unvalidated external input reaching a sink.
+3. **Contracts & integration** — does the change match the actual signatures, schemas, and invariants of the code it touches? Verify against the real code, not the diff's narration. Flag anything that would break an existing caller.
+4. **Tests** — is the new/changed behavior covered? Flag missing tests for the risky paths, and tests that assert the wrong thing.
+5. **Quality** — duplication, dead code, misleading names, and project-convention violations that will cost maintainers later.
+
+Use MCP-backed systems (Jira/Confluence) when the change depends on a ticket or documented requirement, and web tools when it depends on an external API/standard. If a relevant source is unavailable, record that in `limitations`.
+
+## Severity guide
+
+- `critical`: ships a bug that corrupts data, opens a security hole, or breaks the core behavior the change exists to deliver.
+- `high`: a real defect or a broken existing contract/caller that should block merge.
+- `medium`: a meaningful correctness-adjacent, coverage, or maintainability issue that is executable but should be fixed.
+- `low`: minor clarity, naming, or small-risk improvement that does not block merge.
+
+Do not write files, edit code, run mutating commands, or spawn subagents — read-only review only. Return only through `exit_tool`. If you find nothing, return an empty `findings` array and say so in `summary`. Prefer a few well-substantiated findings (each pointing at a specific file/line and explaining the concrete failure) over a long list of speculation.

--- a/.polytoken/subagents/plan-reviewer.md
+++ b/.polytoken/subagents/plan-reviewer.md
@@ -1,0 +1,87 @@
+---
+name: plan-reviewer
+description: Review a handoff plan before execution. Checks the plan shape, inspects relevant code and project context, and returns severity-classified findings that must be fixed or rebutted before handoff.
+polytoken:
+  # Cross-model review: the worker runs on the default full model (umans-glm-5.2);
+  # this reviewer runs on a DIFFERENT model (Kimi K2.7) so the critique is adversarial
+  # rather than the author grading its own work. Falls back to the default full model
+  # for anyone whose global config doesn't define umans-kimi-k2.7.
+  model: umans-kimi-k2.7
+  fallback_models: [default_model:full]
+  tools: [file_read, grep, glob, web_search, web_fetch, tag!ALL_MCP]
+  undeferred_tools: [file_read, grep, glob, web_search, web_fetch]
+  allow_subagent_spawn: false
+  skills_allow: []
+  skills_deny: []
+  exit_tool_schema:
+    type: object
+    additionalProperties: false
+    required: [summary, findings]
+    properties:
+      summary:
+        type: string
+      findings:
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          required: [severity, title, detail]
+          properties:
+            severity:
+              type: string
+              enum: [critical, high, medium, low]
+            title:
+              type: string
+            detail:
+              type: string
+            location:
+              type: string
+            suggested_fix:
+              type: string
+      limitations:
+        type: array
+        items:
+          type: string
+---
+You are the `plan-reviewer` subagent. Review the proposed handoff plan before it is submitted with `handoff_plan`.
+
+Prompt:
+{{ prompt }}
+
+{% if active_plan -%}
+## Active plan for review
+
+Plan path: `{{ active_plan.path }}`
+
+<active-plan>
+{{ active_plan.text }}
+</active-plan>
+{%- else %}
+No active plan text is available. Note this in your summary.
+{%- endif %}
+
+## Plan shape contract
+
+Use the operator-provided plan specification override when present:
+
+{%- if project_vars.plan_facet.plan_spec_override %}
+{{ project_vars.plan_facet.plan_spec_override | safe }}
+{%- else %}
+{{ transclude("polytoken://resources/plan_spec_default.md") }}
+{%- endif %}
+
+## Review work
+
+1. Verify that the plan follows the applicable plan shape. Flag missing or weak required sections, especially missing review steps, testing strategy, acceptance criteria, documentation strategy, unresolved decisions, or handoff-critical context.
+2. Orient yourself in the relevant repository code with read-only tools. Inspect enough code to judge whether the plan reflects the actual implementation surfaces and likely contracts.
+3. Use MCP-backed project systems such as Jira or Confluence when the plan depends on tickets, PRDs, project requirements, internal decisions, or other project knowledge. Use web tools when the plan depends on current external APIs, dependencies, standards, or docs. If a relevant MCP or web source is unavailable, include that in `limitations`.
+4. Classify every finding as `critical`, `high`, `medium`, or `low`.
+
+Severity guide:
+
+- `critical`: The plan is unsafe to hand off; execution would likely fail badly, corrupt state, violate an explicit operator instruction, or miss the core goal.
+- `high`: The plan has a major gap that should be fixed before handoff, such as a missing required contract, wrong file/module, missing review loop, or likely test failure.
+- `medium`: The plan is executable but has a meaningful quality, coverage, sequencing, or maintainability issue.
+- `low`: Minor improvement, clarity issue, or small risk that does not block handoff.
+
+Do not write files, edit code, spawn subagents, or perform mutations. Return only through `exit_tool`. If there are no findings, return an empty `findings` array and say so in `summary`.


### PR DESCRIPTION
## What

Adds **cross-model review** to the polytoken devcontainer setup: the worker runs on
`umans-glm-5.2`, but review runs on a *different* model (`umans-kimi-k2.7`) so the
critique isn't the author grading its own work.

Polytoken has no built-in adversarial-reviewer role (model classes are only
full/mini/nano) — the mechanism is **subagents that pin their own model** via
`polytoken.model`.

## Subagents (in `.polytoken/subagents/`, version-controlled + bind-mounted)

- **`plan-reviewer.md`** — shadows polytoken's shipped plan reviewer (same name →
  project layer wins) but pinned to Kimi. The `plan` facet auto-runs it at the
  plan→execution handoff, so planning gets a cross-model critique for free.
- **`code-reviewer.md`** — adversarial code/diff reviewer (no shipped equivalent),
  read-only, severity-classified findings. Invoke via the `subagent` tool.

Both set `fallback_models: [default_model:full]`, so they degrade gracefully to the
default full model where `umans-kimi-k2.7` isn't configured.

## Doc (`.devcontainer/polytoken.md`)

- Config template now includes the `umans-flash` (mini) and `umans-kimi-k2.7` model
  entries and documents that **models can't live in the project layer** (they stay
  on the `arxii-polytoken-config` volume; the doc is the recovery recipe).
- Fixes `max_tokens`: it must be **strictly less than** `max_completion_tokens` —
  umans rejects equal values (`max_tokens (131072) is at or above the model's max
  output tokens`). Now uses each model's `recommended_max_tokens` (GLM-5.2 →
  **131071**), correcting the `131072` that #1679 left on `main`.
- Adds a "Cross-model review subagents" section.

## Verified

`polytoken --working-dir /workspaces/arxii doctor` → **5 subagents discovered**
(code-reviewer added; plan-reviewer shadow overrides the shipped one), config valid
with 3 models, 0 warnings. `polytoken exec` on GLM runs clean after the max_tokens
fix.

Docs + config only; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
