### PR TITLE
refactor: resolve 50 sonarcloud:high issues (#1629-#1678)

### DIFF
--- a/frontend/src/rituals/components/RitualSessionDraftDialog.tsx
+++ b/frontend/src/rituals/components/RitualSessionDraftDialog.tsx
@@ -55,6 +55,12 @@ interface PersonaOption {
   name: string;
 }
 
+/** Drop personas already chosen so the search dropdown only offers new picks. */
+function filterUnselected(results: PersonaOption[], selected: PersonaOption[]): PersonaOption[] {
+  const selectedIds = new Set(selected.map((p) => p.id));
+  return results.filter((r) => !selectedIds.has(r.id));
+}
+
 interface InviteePickerProps {
   selected: PersonaOption[];
   onAdd: (persona: PersonaOption) => void;
@@ -77,11 +83,7 @@ function InviteePicker({ selected, onAdd, onRemove, disabled }: InviteePickerPro
     debounceRef.current = setTimeout(() => {
       setSearching(true);
       searchPersonas(query.trim())
-        .then((res) => {
-          // Filter out already-selected personas
-          const selectedIds = new Set(selected.map((p) => p.id));
-          setResults(res.filter((r) => !selectedIds.has(r.id)));
-        })
+        .then((res) => setResults(filterUnselected(res, selected)))
         .catch(() => setResults([]))
         .finally(() => setSearching(false));
     }, 300);

--- a/frontend/src/rituals/pages/RitualSessionDetailPage.tsx
+++ b/frontend/src/rituals/pages/RitualSessionDetailPage.tsx
@@ -88,6 +88,19 @@ const STATE_CLASSES: Record<string, string> = {
   DECLINED: 'bg-red-100 text-red-800',
 };
 
+// ---------------------------------------------------------------------------
+// Mutation error message
+// ---------------------------------------------------------------------------
+
+/** Derive a user-facing error string from a mutation's error state, or null. */
+function mutationErrorMessage(
+  mutation: { isError: boolean; error: unknown },
+  fallback: string
+): string | null {
+  if (!mutation.isError) return null;
+  return mutation.error instanceof Error ? mutation.error.message : fallback;
+}
+
 function StateBadge({ state }: { state: string }) {
   const label = STATE_LABELS[state] ?? state;
   const cls = STATE_CLASSES[state] ?? 'bg-muted text-muted-foreground';
@@ -175,16 +188,8 @@ function RitualSessionDetailInner({ sessionId }: DetailInnerProps) {
     });
   }
 
-  const fireError = fireMutation.isError
-    ? fireMutation.error instanceof Error
-      ? fireMutation.error.message
-      : 'Failed to fire session'
-    : null;
-  const cancelError = cancelMutation.isError
-    ? cancelMutation.error instanceof Error
-      ? cancelMutation.error.message
-      : 'Failed to cancel session'
-    : null;
+  const fireError = mutationErrorMessage(fireMutation, 'Failed to fire session');
+  const cancelError = mutationErrorMessage(cancelMutation, 'Failed to cancel session');
 
   return (
     <div className="space-y-6">

--- a/src/actions/definitions/alterations.py
+++ b/src/actions/definitions/alterations.py
@@ -161,6 +161,51 @@ class ResolveAlterationAction(Action):
             return None, "The Mage Scar could not be resolved. Please contact staff."
         return result, ""
 
+    def _resolve_pending(
+        self,
+        actor: ObjectDB,
+        sheet: CharacterSheet,
+        kwargs: dict[str, Any],
+    ) -> tuple[Any, str]:
+        """Look up the pending alteration and dispatch; return (result, error_message)."""
+        from world.magic.constants import PendingAlterationStatus  # noqa: PLC0415
+        from world.magic.models import PendingAlteration  # noqa: PLC0415
+        from world.scenes.scene_admin_services import resolve_actor_account  # noqa: PLC0415
+
+        pending_id = kwargs.get("pending_id")
+        if not isinstance(pending_id, int):
+            return None, "Which pending alteration do you want to resolve?"
+
+        try:
+            pending = PendingAlteration.objects.select_related("character").get(
+                pk=pending_id,
+                character=sheet,
+                status=PendingAlterationStatus.OPEN,
+            )
+        except PendingAlteration.DoesNotExist:
+            return None, "You have no open pending alteration with that id."
+
+        account = resolve_actor_account(actor)
+        is_staff = bool(account and account.is_staff)
+        library_template_id = kwargs.get("library_template_id")
+        if library_template_id is not None:
+            if not isinstance(library_template_id, int):
+                return None, "A valid library entry is required."
+            return self._resolve_library(
+                pending,
+                library_template_id,
+                account,
+                is_staff,
+                sheet,
+            )
+        return self._resolve_scratch(
+            pending,
+            kwargs,
+            account,
+            is_staff,
+            sheet,
+        )
+
     def execute(
         self,
         actor: ObjectDB,
@@ -169,54 +214,15 @@ class ResolveAlterationAction(Action):
     ) -> ActionResult:
         from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
 
-        from world.magic.constants import PendingAlterationStatus  # noqa: PLC0415
-        from world.magic.models import PendingAlteration  # noqa: PLC0415
-        from world.scenes.scene_admin_services import resolve_actor_account  # noqa: PLC0415
-
-        result = None
-        message = "You can't resolve that Mage Scar right now."
-
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
-            message = "Only characters can resolve Mage Scars."
-        else:
-            pending_id = kwargs.get("pending_id")
-            if not isinstance(pending_id, int):
-                message = "Which pending alteration do you want to resolve?"
-            else:
-                try:
-                    pending = PendingAlteration.objects.select_related("character").get(
-                        pk=pending_id,
-                        character=sheet,
-                        status=PendingAlterationStatus.OPEN,
-                    )
-                except PendingAlteration.DoesNotExist:
-                    message = "You have no open pending alteration with that id."
-                else:
-                    account = resolve_actor_account(actor)
-                    is_staff = bool(account and account.is_staff)
-                    library_template_id = kwargs.get("library_template_id")
-                    if library_template_id is not None:
-                        if not isinstance(library_template_id, int):
-                            message = "A valid library entry is required."
-                        else:
-                            result, message = self._resolve_library(
-                                pending,
-                                library_template_id,
-                                account,
-                                is_staff,
-                                sheet,
-                            )
-                    else:
-                        result, message = self._resolve_scratch(
-                            pending,
-                            kwargs,
-                            account,
-                            is_staff,
-                            sheet,
-                        )
+            return ActionResult(
+                success=False,
+                message="Only characters can resolve Mage Scars.",
+            )
 
+        result, message = self._resolve_pending(actor, sheet, kwargs)
         if result is not None:
             return ActionResult(
                 success=True,

--- a/src/actions/definitions/combat_maneuvers.py
+++ b/src/actions/definitions/combat_maneuvers.py
@@ -28,6 +28,10 @@ if TYPE_CHECKING:
     from world.character_sheets.models import CharacterSheet
     from world.combat.models import CombatEncounter, CombatParticipant, CombatRoundAction
 
+# Repeated ActionResult failure messages, extracted to satisfy S1192.
+NOT_IN_ACTIVE_ROUND_MESSAGE = "You are not in an active combat round."
+NO_ACTION_DECLARED_MESSAGE = "You have not declared an action yet."
+
 
 def _sheet(actor: ObjectDB) -> CharacterSheet | None:
     """Return *actor*'s CharacterSheet, or None if absent."""
@@ -107,7 +111,7 @@ class FleeAction(Action):
 
         participant = _active_combat_participant(actor, {RoundStatus.DECLARING})
         if participant is None:
-            return ActionResult(success=False, message="You are not in an active combat round.")
+            return ActionResult(success=False, message=NOT_IN_ACTIVE_ROUND_MESSAGE)
         try:
             declare_flee(participant)
         except ValueError as err:
@@ -138,7 +142,7 @@ class CoverAction(Action):
 
         participant = _active_combat_participant(actor, {RoundStatus.DECLARING})
         if participant is None:
-            return ActionResult(success=False, message="You are not in an active combat round.")
+            return ActionResult(success=False, message=NOT_IN_ACTIVE_ROUND_MESSAGE)
         if ally_participant_id is None:
             return ActionResult(success=False, message="Cover requires an ally to protect.")
         ally = _resolve_ally(participant, ally_participant_id)
@@ -174,7 +178,7 @@ class InterposeAction(Action):
 
         participant = _active_combat_participant(actor, {RoundStatus.DECLARING})
         if participant is None:
-            return ActionResult(success=False, message="You are not in an active combat round.")
+            return ActionResult(success=False, message=NOT_IN_ACTIVE_ROUND_MESSAGE)
         ally = _resolve_ally(participant, ally_participant_id)
         if ally_participant_id is not None and ally is None:
             return ActionResult(success=False, message="No such ally in this encounter.")
@@ -206,10 +210,10 @@ class ReadyAction(Action):
 
         participant = _active_combat_participant(actor, {RoundStatus.DECLARING})
         if participant is None:
-            return ActionResult(success=False, message="You are not in an active combat round.")
+            return ActionResult(success=False, message=NOT_IN_ACTIVE_ROUND_MESSAGE)
         action = _current_round_action(participant)
         if action is None:
-            return ActionResult(success=False, message="You have not declared an action yet.")
+            return ActionResult(success=False, message=NO_ACTION_DECLARED_MESSAGE)
         toggle_action_ready(action)
         if action.is_ready:
             return ActionResult(success=True, message="You are ready.")
@@ -239,10 +243,10 @@ class UpgradeComboAction(Action):
 
         participant = _active_combat_participant(actor, {RoundStatus.DECLARING})
         if participant is None:
-            return ActionResult(success=False, message="You are not in an active combat round.")
+            return ActionResult(success=False, message=NOT_IN_ACTIVE_ROUND_MESSAGE)
         action = _current_round_action(participant)
         if action is None:
-            return ActionResult(success=False, message="You have not declared an action yet.")
+            return ActionResult(success=False, message=NO_ACTION_DECLARED_MESSAGE)
         combo = ComboDefinition.objects.filter(pk=combo_id).first() if combo_id else None
         if combo is None:
             return ActionResult(success=False, message="No such combo.")
@@ -277,10 +281,10 @@ class RevertComboAction(Action):
 
         participant = _active_combat_participant(actor, {RoundStatus.DECLARING})
         if participant is None:
-            return ActionResult(success=False, message="You are not in an active combat round.")
+            return ActionResult(success=False, message=NOT_IN_ACTIVE_ROUND_MESSAGE)
         action = _current_round_action(participant)
         if action is None:
-            return ActionResult(success=False, message="You have not declared an action yet.")
+            return ActionResult(success=False, message=NO_ACTION_DECLARED_MESSAGE)
         try:
             revert_combo_upgrade(action)
         except ValueError as err:

--- a/src/actions/definitions/deeds.py
+++ b/src/actions/definitions/deeds.py
@@ -37,7 +37,38 @@ class SpreadTaleAction(Action):
     category: str = "social"
     target_type: TargetType = TargetType.SELF
 
-    def execute(  # noqa: C901, PLR0911
+    @staticmethod
+    def _resolve_account(actor: ObjectDB, scene: Any, kwargs: dict[str, Any]) -> Any:
+        """Resolve the requesting account, or None if it isn't a scene participant."""
+        account = actor.account
+        if account is None:
+            requester_id = kwargs.get("requester_account_id")
+            if requester_id is not None:
+                from evennia.accounts.models import AccountDB  # noqa: PLC0415
+
+                account = AccountDB.objects.filter(pk=requester_id).first()
+        if account is None or not scene.participants.filter(pk=account.pk).exists():
+            return None
+        return account
+
+    @staticmethod
+    def _resolve_specialization(kwargs: dict[str, Any]) -> tuple[Any, str]:
+        """Return (specialization, error_message); specialization is None when not chosen."""
+        specialization_id = kwargs.get("specialization_id")
+        if specialization_id is None:
+            return None, ""
+
+        from world.skills.models import Specialization  # noqa: PLC0415
+        from world.societies.spread_services import (  # noqa: PLC0415
+            get_spread_specializations,
+        )
+
+        valid_ids = set(get_spread_specializations().values_list("pk", flat=True))
+        if specialization_id not in valid_ids:
+            return None, "That form cannot be used to spread a tale."
+        return Specialization.objects.get(pk=specialization_id), ""
+
+    def execute(  # noqa: PLR0911
         self,
         actor: ObjectDB,
         context: ActionContext | None = None,
@@ -53,7 +84,6 @@ class SpreadTaleAction(Action):
         from world.societies.spread_services import (  # noqa: PLC0415
             SPREAD_TALE_ACTION_KEY,
             get_or_create_spread_a_tale_template,
-            get_spread_specializations,
             get_spreadable_deeds,
             spread_check_modifiers,
         )
@@ -73,14 +103,8 @@ class SpreadTaleAction(Action):
         if scene_id is None:
             return ActionResult(success=False, message="You must be in a scene.")
         scene = get_object_or_404(Scene, pk=scene_id)
-        account = actor.account
+        account = self._resolve_account(actor, scene, kwargs)
         if account is None:
-            requester_id = kwargs.get("requester_account_id")
-            if requester_id is not None:
-                from evennia.accounts.models import AccountDB  # noqa: PLC0415
-
-                account = AccountDB.objects.filter(pk=requester_id).first()
-        if account is None or not scene.participants.filter(pk=account.pk).exists():
             return ActionResult(success=False, message="You are not a participant in that scene.")
 
         deed_id = kwargs.get("deed_id")
@@ -93,18 +117,9 @@ class SpreadTaleAction(Action):
                 message="This persona is not aware of that deed.",
             )
 
-        specialization = None
-        specialization_id = kwargs.get("specialization_id")
-        if specialization_id is not None:
-            from world.skills.models import Specialization  # noqa: PLC0415
-
-            valid_ids = set(get_spread_specializations().values_list("pk", flat=True))
-            if specialization_id not in valid_ids:
-                return ActionResult(
-                    success=False,
-                    message="That form cannot be used to spread a tale.",
-                )
-            specialization = Specialization.objects.get(pk=specialization_id)
+        specialization, spec_error = self._resolve_specialization(kwargs)
+        if spec_error:
+            return ActionResult(success=False, message=spec_error)
 
         extra_modifiers = spread_check_modifiers(sheet.character, specialization)
         template = get_or_create_spread_a_tale_template()

--- a/src/actions/definitions/events.py
+++ b/src/actions/definitions/events.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 _MSG_NO_CHARACTER = "You must have an active character with a persona to manage events."
 _MSG_WHICH_EVENT = "Which event? Provide an event id."
 _MSG_WHICH_INVITATION = "Which invitation? Provide an invitation id."
+_MSG_HOST_OR_STAFF_ONLY = "Only the event host or staff can do that."
 
 
 @dataclass
@@ -252,7 +253,7 @@ class ScheduleEventAction(_HostLifecycleAction):
         if event is None:
             return ActionResult(success=False, message=_MSG_WHICH_EVENT)
         if account is None or not (_is_host(account, event) or _is_staff(account)):
-            return ActionResult(success=False, message="Only the event host or staff can do that.")
+            return ActionResult(success=False, message=_MSG_HOST_OR_STAFF_ONLY)
         try:
             schedule_event(event)
         except EventError as exc:
@@ -289,7 +290,7 @@ class StartEventAction(_HostLifecycleAction):
         if event is None:
             return ActionResult(success=False, message=_MSG_WHICH_EVENT)
         if account is None or not (_is_host(account, event) or _is_staff(account)):
-            return ActionResult(success=False, message="Only the event host or staff can do that.")
+            return ActionResult(success=False, message=_MSG_HOST_OR_STAFF_ONLY)
         try:
             start_event(event)
         except EventError as exc:
@@ -366,7 +367,7 @@ class CancelEventAction(_HostLifecycleAction):
         if event is None:
             return ActionResult(success=False, message=_MSG_WHICH_EVENT)
         if account is None or not (_is_host(account, event) or _is_staff(account)):
-            return ActionResult(success=False, message="Only the event host or staff can do that.")
+            return ActionResult(success=False, message=_MSG_HOST_OR_STAFF_ONLY)
         try:
             cancel_event(event)
         except EventError as exc:

--- a/src/actions/definitions/journals.py
+++ b/src/actions/definitions/journals.py
@@ -20,6 +20,10 @@ if TYPE_CHECKING:
     from actions.types import ActionContext
 
 
+_MSG_NO_ACTIVE_CHARACTER = "No active character."
+_MSG_ENTRY_NOT_FOUND = "That journal entry was not found."
+
+
 @dataclass
 class _BaseJournalAction(Action):
     """Shared base: sheet resolution + sheet-required prerequisite."""
@@ -53,7 +57,7 @@ class CreateJournalEntryAction(_BaseJournalAction):
 
         sheet = self._sheet(actor)
         if sheet is None:
-            return ActionResult(success=False, message="No active character.")
+            return ActionResult(success=False, message=_MSG_NO_ACTIVE_CHARACTER)
 
         entry = create_journal_entry(
             author=sheet,
@@ -91,7 +95,7 @@ class RespondToJournalAction(_BaseJournalAction):
 
         sheet = self._sheet(actor)
         if sheet is None:
-            return ActionResult(success=False, message="No active character.")
+            return ActionResult(success=False, message=_MSG_NO_ACTIVE_CHARACTER)
 
         parent = kwargs.get("parent")
         parent_id = kwargs.get("parent_id")
@@ -102,7 +106,7 @@ class RespondToJournalAction(_BaseJournalAction):
             try:
                 parent = JournalEntry.objects.get(pk=parent_id)
             except JournalEntry.DoesNotExist:
-                return ActionResult(success=False, message="That journal entry was not found.")
+                return ActionResult(success=False, message=_MSG_ENTRY_NOT_FOUND)
         else:
             return ActionResult(success=False, message="No journal entry selected.")
         if response_type not in ResponseType.values:
@@ -150,18 +154,18 @@ class EditJournalEntryAction(_BaseJournalAction):
 
         sheet = self._sheet(actor)
         if sheet is None:
-            return ActionResult(success=False, message="No active character.")
+            return ActionResult(success=False, message=_MSG_NO_ACTIVE_CHARACTER)
 
         entry = kwargs.get("entry")
         entry_id = kwargs.get("entry_id")
         if isinstance(entry, JournalEntry):
             if entry.author_id != sheet.pk:
-                return ActionResult(success=False, message="That journal entry was not found.")
+                return ActionResult(success=False, message=_MSG_ENTRY_NOT_FOUND)
         elif entry_id is not None:
             try:
                 entry = JournalEntry.objects.get(pk=entry_id, author_id=sheet.pk)
             except JournalEntry.DoesNotExist:
-                return ActionResult(success=False, message="That journal entry was not found.")
+                return ActionResult(success=False, message=_MSG_ENTRY_NOT_FOUND)
         else:
             return ActionResult(success=False, message="No journal entry selected.")
 

--- a/src/actions/definitions/projects.py
+++ b/src/actions/definitions/projects.py
@@ -20,6 +20,10 @@ if TYPE_CHECKING:
     from actions.types import ActionContext, ActionResult
 
 
+_MSG_NO_CHARACTER_SHEET = "You have no character sheet."
+_MSG_NO_SUCH_PROJECT = "No such project."
+
+
 @dataclass
 class DonateToProjectAction(Action):
     """Donate money from your own purse to an ACTIVE project (#1574).
@@ -63,7 +67,7 @@ class DonateToProjectAction(Action):
 
         sheet = actor.sheet_data
         if sheet is None:
-            return _ActionResult(success=False, message="You have no character sheet.")
+            return _ActionResult(success=False, message=_MSG_NO_CHARACTER_SHEET)
         try:
             persona = active_persona_for_sheet(sheet)
         except Persona.DoesNotExist:
@@ -71,7 +75,7 @@ class DonateToProjectAction(Action):
 
         project = Project.objects.filter(pk=project_id).first()
         if project is None:
-            return _ActionResult(success=False, message="No such project.")
+            return _ActionResult(success=False, message=_MSG_NO_SUCH_PROJECT)
 
         try:
             donate_to_project(project, donor_persona=persona, amount=amount)
@@ -129,7 +133,7 @@ class CheckContributeAction(Action):
             return _ActionResult(success=False, message="Contribute to which project, and how?")
         sheet = actor.sheet_data
         if sheet is None:
-            return _ActionResult(success=False, message="You have no character sheet.")
+            return _ActionResult(success=False, message=_MSG_NO_CHARACTER_SHEET)
         try:
             persona = active_persona_for_sheet(sheet)
         except Persona.DoesNotExist:
@@ -137,7 +141,7 @@ class CheckContributeAction(Action):
 
         project = Project.objects.filter(pk=project_id).first()
         if project is None:
-            return _ActionResult(success=False, message="No such project.")
+            return _ActionResult(success=False, message=_MSG_NO_SUCH_PROJECT)
         method = ContributionMethod.objects.filter(
             kind=project.kind, name__iexact=method_name, is_active=True
         ).first()
@@ -195,7 +199,7 @@ class StoryContributeAction(Action):
             return _ActionResult(success=False, message="Tell the story for which project?")
         sheet = actor.sheet_data
         if sheet is None:
-            return _ActionResult(success=False, message="You have no character sheet.")
+            return _ActionResult(success=False, message=_MSG_NO_CHARACTER_SHEET)
         try:
             persona = active_persona_for_sheet(sheet)
         except Persona.DoesNotExist:
@@ -203,7 +207,7 @@ class StoryContributeAction(Action):
 
         project = Project.objects.filter(pk=project_id).first()
         if project is None:
-            return _ActionResult(success=False, message="No such project.")
+            return _ActionResult(success=False, message=_MSG_NO_SUCH_PROJECT)
 
         contribution = set_contribution_story(project, contributor_persona=persona, text=text)
         if contribution is None:

--- a/src/actions/definitions/relationships.py
+++ b/src/actions/definitions/relationships.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
     from actions.types import ActionContext
 
 
+_MSG_INVALID_POINTS = "Invalid points value."
+
+
 @dataclass
 class BaseRelationshipAction(Action):
     """Shared base for relationship-building verbs."""
@@ -165,7 +168,7 @@ class CreateFirstImpressionAction(BaseRelationshipAction):
                 linked_scene=self._active_scene_for(actor, target_sheet),
             )
         except (TypeError, ValueError):
-            return ActionResult(success=False, message="Invalid points value.")
+            return ActionResult(success=False, message=_MSG_INVALID_POINTS)
         except ValidationError as exc:
             return ActionResult(success=False, message=str(exc))
 
@@ -211,7 +214,7 @@ class CreateDevelopmentAction(BaseRelationshipAction):
         try:
             points = int(kwargs.get("points", 0))
         except (TypeError, ValueError):
-            return ActionResult(success=False, message="Invalid points value.")
+            return ActionResult(success=False, message=_MSG_INVALID_POINTS)
 
         try:
             xp_awarded = int(kwargs.get("xp_awarded", 0))
@@ -277,7 +280,7 @@ class CreateCapstoneAction(BaseRelationshipAction):
         try:
             points = int(kwargs.get("points", 0))
         except (TypeError, ValueError):
-            return ActionResult(success=False, message="Invalid points value.")
+            return ActionResult(success=False, message=_MSG_INVALID_POINTS)
 
         try:
             capstone = create_capstone(
@@ -341,7 +344,7 @@ class RedistributePointsAction(BaseRelationshipAction):
         try:
             points = int(kwargs.get("points", 0))
         except (TypeError, ValueError):
-            return ActionResult(success=False, message="Invalid points value.")
+            return ActionResult(success=False, message=_MSG_INVALID_POINTS)
 
         try:
             change = redistribute_points(

--- a/src/actions/definitions/rounds.py
+++ b/src/actions/definitions/rounds.py
@@ -28,6 +28,7 @@ from world.scenes.round_services import (
 # Repeated ActionResult failure messages, extracted to satisfy S1192.
 NOT_IN_A_ROOM_MESSAGE = "You are not in a room."
 NO_CHARACTER_SHEET_MESSAGE = "No character sheet found."
+NO_ACTIVE_ROUND_MESSAGE = "There is no active round here."
 
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
@@ -62,6 +63,77 @@ class StartRoundAction(Action):
     category: str = "scenes"
     target_type: TargetType = TargetType.AREA
 
+    @staticmethod
+    def _create_new_round(  # noqa: PLR0913
+        actor: ObjectDB,
+        room: ObjectDB,
+        *,
+        mode: str | None,
+        advance_quorum_pct: int | None,
+        max_actions_per_round: int | None,
+        per_target_repeat_lock: bool | None,
+    ) -> tuple[SceneRound | None, str | None]:
+        """Create a fresh round; return (round, error_message).
+
+        With no knob overrides, create a round from config defaults. With overrides,
+        require an active scene and scene-admin permission, then apply the overrides.
+        """
+        from world.scenes.models import get_scene_round_defaults_config  # noqa: PLC0415
+
+        cfg = get_scene_round_defaults_config()
+        has_override = any(
+            v is not None
+            for v in (mode, advance_quorum_pct, max_actions_per_round, per_target_repeat_lock)
+        )
+
+        if not has_override:
+            rnd = SceneRound.objects.create(
+                room=room,
+                status=RoundStatus.DECLARING,
+                round_number=1,
+                start_reason=SceneRoundStartReason.OPT_IN,
+                mode=cfg.default_mode,
+                advance_quorum_pct=cfg.advance_quorum_pct,
+                max_actions_per_round=cfg.max_actions_per_round,
+                per_target_repeat_lock=cfg.per_target_repeat_lock,
+            )
+            return rnd, None
+
+        # Gate: overrides require an active scene + admin permission.
+        from world.scenes.models import Scene as _Scene  # noqa: PLC0415
+        from world.scenes.scene_admin_services import (  # noqa: PLC0415
+            actor_can_administer_scene,
+        )
+
+        scene = _Scene.objects.filter(location=room, is_active=True).first()
+        if scene is None or not actor_can_administer_scene(actor, scene):
+            return None, (
+                "Only a scene GM/owner can choose the round mode at start (start a scene first)."
+            )
+
+        rnd = SceneRound.objects.create(
+            room=room,
+            status=RoundStatus.DECLARING,
+            round_number=1,
+            start_reason=SceneRoundStartReason.OPT_IN,
+            mode=mode if mode is not None else cfg.default_mode,
+            advance_quorum_pct=(
+                advance_quorum_pct if advance_quorum_pct is not None else cfg.advance_quorum_pct
+            ),
+            max_actions_per_round=(
+                max_actions_per_round
+                if max_actions_per_round is not None
+                else cfg.max_actions_per_round
+            ),
+            per_target_repeat_lock=(
+                per_target_repeat_lock
+                if per_target_repeat_lock is not None
+                else cfg.per_target_repeat_lock
+            ),
+            scene=scene,
+        )
+        return rnd, None
+
     def execute(  # noqa: PLR0913
         self,
         actor: ObjectDB,
@@ -81,67 +153,18 @@ class StartRoundAction(Action):
         if sheet is None:
             return ActionResult(success=False, message=NO_CHARACTER_SHEET_MESSAGE)
 
-        _has_override = any(
-            v is not None
-            for v in (mode, advance_quorum_pct, max_actions_per_round, per_target_repeat_lock)
-        )
-
         rnd = _active_round_for_room(room)
         if rnd is None:
-            from world.scenes.models import get_scene_round_defaults_config  # noqa: PLC0415
-
-            cfg = get_scene_round_defaults_config()
-
-            if _has_override:
-                # Gate: overrides require an active scene + admin permission.
-                from world.scenes.models import Scene as _Scene  # noqa: PLC0415
-                from world.scenes.scene_admin_services import (  # noqa: PLC0415
-                    actor_can_administer_scene,
-                )
-
-                scene = _Scene.objects.filter(location=room, is_active=True).first()
-                if scene is None or not actor_can_administer_scene(actor, scene):
-                    return ActionResult(
-                        success=False,
-                        message=(
-                            "Only a scene GM/owner can choose the round mode at start"
-                            " (start a scene first)."
-                        ),
-                    )
-                rnd = SceneRound.objects.create(
-                    room=room,
-                    status=RoundStatus.DECLARING,
-                    round_number=1,
-                    start_reason=SceneRoundStartReason.OPT_IN,
-                    mode=mode if mode is not None else cfg.default_mode,
-                    advance_quorum_pct=(
-                        advance_quorum_pct
-                        if advance_quorum_pct is not None
-                        else cfg.advance_quorum_pct
-                    ),
-                    max_actions_per_round=(
-                        max_actions_per_round
-                        if max_actions_per_round is not None
-                        else cfg.max_actions_per_round
-                    ),
-                    per_target_repeat_lock=(
-                        per_target_repeat_lock
-                        if per_target_repeat_lock is not None
-                        else cfg.per_target_repeat_lock
-                    ),
-                    scene=scene,
-                )
-            else:
-                rnd = SceneRound.objects.create(
-                    room=room,
-                    status=RoundStatus.DECLARING,
-                    round_number=1,
-                    start_reason=SceneRoundStartReason.OPT_IN,
-                    mode=cfg.default_mode,
-                    advance_quorum_pct=cfg.advance_quorum_pct,
-                    max_actions_per_round=cfg.max_actions_per_round,
-                    per_target_repeat_lock=cfg.per_target_repeat_lock,
-                )
+            rnd, error = self._create_new_round(
+                actor,
+                room,
+                mode=mode,
+                advance_quorum_pct=advance_quorum_pct,
+                max_actions_per_round=max_actions_per_round,
+                per_target_repeat_lock=per_target_repeat_lock,
+            )
+            if error is not None:
+                return ActionResult(success=False, message=error)
         elif rnd.status == RoundStatus.BETWEEN_ROUNDS:
             rnd = start_scene_round(rnd)
 
@@ -205,7 +228,7 @@ class SetRoundModeAction(Action):
 
         rnd = _active_round_for_room(room)
         if rnd is None:
-            return ActionResult(success=False, message="There is no active round here.")
+            return ActionResult(success=False, message=NO_ACTIVE_ROUND_MESSAGE)
 
         # Opportunistically link the round to the scene if not already linked.
         if rnd.scene_id is None:
@@ -254,7 +277,7 @@ class JoinRoundAction(Action):
 
         rnd = _active_round_for_room(room)
         if rnd is None:
-            return ActionResult(success=False, message="There is no active round here.")
+            return ActionResult(success=False, message=NO_ACTIVE_ROUND_MESSAGE)
 
         SceneRoundParticipant.objects.get_or_create(
             scene_round=rnd,
@@ -319,7 +342,7 @@ class EndRoundAction(Action):
 
         rnd = _active_round_for_room(room)
         if rnd is None:
-            return ActionResult(success=False, message="There is no active round here.")
+            return ActionResult(success=False, message=NO_ACTIVE_ROUND_MESSAGE)
 
         end_scene_round(rnd)
         return ActionResult(success=True, message="The round ends.")
@@ -357,7 +380,7 @@ class PassRoundAction(Action):
 
         rnd = _active_round_for_room(room)
         if rnd is None:
-            return ActionResult(success=False, message="There is no active round here.")
+            return ActionResult(success=False, message=NO_ACTIVE_ROUND_MESSAGE)
 
         participant = SceneRoundParticipant.objects.filter(
             scene_round=rnd,
@@ -408,7 +431,7 @@ class ForceResolveRoundAction(Action):
 
         rnd = _active_round_for_room(room)
         if rnd is None:
-            return ActionResult(success=False, message="There is no active round here.")
+            return ActionResult(success=False, message=NO_ACTIVE_ROUND_MESSAGE)
 
         if rnd.status != RoundStatus.DECLARING:
             return ActionResult(success=False, message="The round is not gathering declarations.")

--- a/src/actions/definitions/sanctum.py
+++ b/src/actions/definitions/sanctum.py
@@ -41,6 +41,10 @@ if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
 
+_MSG_NO_ACTIVE_CHARACTER = "No active character."
+_MSG_OPERATION_FAILED = "Operation failed."
+
+
 # ---------------------------------------------------------------------------
 # Module-level resolution helpers — shared with commands/sanctum.py so the
 # room→RoomProfile→SanctumDetails walk lives in exactly one place.
@@ -137,7 +141,7 @@ class SanctumInstallAction(SanctumActionBase):
     def execute(self, actor: ObjectDB, context: Any = None, **kwargs: Any) -> ActionResult:
         persona = self._persona(actor)
         if persona is None:
-            return self._fail("No active character.")
+            return self._fail(_MSG_NO_ACTIVE_CHARACTER)
         try:
             result = perform_sanctification(
                 kwargs["room_profile"],
@@ -146,7 +150,7 @@ class SanctumInstallAction(SanctumActionBase):
                 owner_mode=kwargs["owner_mode"],
             )
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", "Operation failed."))  # noqa: GETATTR_LITERAL
+            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
         if result.fizzled:
             return ActionResult(
                 success=True,
@@ -181,7 +185,7 @@ class SanctumHomecomingAction(SanctumActionBase):
     def execute(self, actor: ObjectDB, context: Any = None, **kwargs: Any) -> ActionResult:
         persona = self._persona(actor)
         if persona is None:
-            return self._fail("No active character.")
+            return self._fail(_MSG_NO_ACTIVE_CHARACTER)
         try:
             result = perform_homecoming_ritual(
                 kwargs["sanctum"],
@@ -190,7 +194,7 @@ class SanctumHomecomingAction(SanctumActionBase):
                 narrative_text=kwargs.get("narrative_text", ""),
             )
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", "Operation failed."))  # noqa: GETATTR_LITERAL
+            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
         return ActionResult(
             success=True,
             message="The Homecoming ritual is complete.",
@@ -216,7 +220,7 @@ class SanctumPurgingAction(SanctumActionBase):
     def execute(self, actor: ObjectDB, context: Any = None, **kwargs: Any) -> ActionResult:
         persona = self._persona(actor)
         if persona is None:
-            return self._fail("No active character.")
+            return self._fail(_MSG_NO_ACTIVE_CHARACTER)
         try:
             result = perform_purging_ritual(
                 kwargs["sanctum"],
@@ -225,7 +229,7 @@ class SanctumPurgingAction(SanctumActionBase):
                 kwargs["resonance_sacrificed"],
             )
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", "Operation failed."))  # noqa: GETATTR_LITERAL
+            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
         return ActionResult(
             success=True,
             message="The Purging ritual is complete.",
@@ -250,13 +254,13 @@ class SanctumWeaveAction(SanctumActionBase):
     def execute(self, actor: ObjectDB, context: Any = None, **kwargs: Any) -> ActionResult:
         persona = self._persona(actor)
         if persona is None:
-            return self._fail("No active character.")
+            return self._fail(_MSG_NO_ACTIVE_CHARACTER)
         try:
             thread = weave_sanctum_thread(
                 kwargs["sanctum"], persona.character_sheet, kwargs["slot_kind"]
             )
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", "Operation failed."))  # noqa: GETATTR_LITERAL
+            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
         return ActionResult(
             success=True,
             message="You weave a thread into the Sanctum.",
@@ -275,11 +279,11 @@ class SanctumDissolveAction(SanctumActionBase):
     def execute(self, actor: ObjectDB, context: Any = None, **kwargs: Any) -> ActionResult:
         persona = self._persona(actor)
         if persona is None:
-            return self._fail("No active character.")
+            return self._fail(_MSG_NO_ACTIVE_CHARACTER)
         try:
             result = perform_dissolution(kwargs["sanctum"], persona)
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", "Operation failed."))  # noqa: GETATTR_LITERAL
+            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
         return ActionResult(
             success=True,
             message="The Sanctum is dissolved.",
@@ -304,11 +308,11 @@ class SanctumAbsorbAction(SanctumActionBase):
     def execute(self, actor: ObjectDB, context: Any = None, **kwargs: Any) -> ActionResult:
         persona = self._persona(actor)
         if persona is None:
-            return self._fail("No active character.")
+            return self._fail(_MSG_NO_ACTIVE_CHARACTER)
         try:
             result = absorb_sanctum_pool(kwargs["sanctum"], persona)
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", "Operation failed."))  # noqa: GETATTR_LITERAL
+            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
         return ActionResult(
             success=True,
             message="You absorb the Sanctum's resonance pool.",
@@ -332,11 +336,11 @@ class SanctumSeverAction(SanctumActionBase):
     def execute(self, actor: ObjectDB, context: Any = None, **kwargs: Any) -> ActionResult:
         persona = self._persona(actor)
         if persona is None:
-            return self._fail("No active character.")
+            return self._fail(_MSG_NO_ACTIVE_CHARACTER)
         try:
             sever_sanctum_thread(kwargs["thread"])
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", "Operation failed."))  # noqa: GETATTR_LITERAL
+            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
         return ActionResult(
             success=True,
             message="You sever the thread.",

--- a/src/actions/types.py
+++ b/src/actions/types.py
@@ -149,30 +149,31 @@ class ActionRef:
     # Blueprint pk for set_the_stage: identifies which PositionBlueprint to instantiate.
     blueprint_id: int | None = None
 
+    def _validate_combat(self) -> None:
+        """Validate the COMBAT-backend invariants (technique vs clash, passive slots)."""
+        has_technique = self.technique_id is not None
+        has_clash = self.clash_id is not None and self.clash_action_slot is not None
+        if not has_technique and not has_clash:
+            msg = "COMBAT ActionRef requires either technique_id or (clash_id + clash_action_slot)"
+            raise ValueError(msg)
+        if has_technique and has_clash:
+            msg = "COMBAT ActionRef must not set both technique_id and clash_id"
+            raise ValueError(msg)
+        passive_slots = {
+            CombatActionSlot.PASSIVE_PHYSICAL,
+            CombatActionSlot.PASSIVE_SOCIAL,
+            CombatActionSlot.PASSIVE_MENTAL,
+        }
+        if self.action_slot in passive_slots and self.technique_id is None:
+            msg = "Passive COMBAT ActionRef requires technique_id"
+            raise ValueError(msg)
+
     def __post_init__(self) -> None:
         if self.backend == ActionBackend.CHALLENGE and self.challenge_instance_id is None:
             msg = "CHALLENGE ActionRef requires challenge_instance_id"
             raise ValueError(msg)
         if self.backend == ActionBackend.COMBAT:
-            has_technique = self.technique_id is not None
-            has_clash = self.clash_id is not None and self.clash_action_slot is not None
-            if not has_technique and not has_clash:
-                msg = (
-                    "COMBAT ActionRef requires either technique_id "
-                    "or (clash_id + clash_action_slot)"
-                )
-                raise ValueError(msg)
-            if has_technique and has_clash:
-                msg = "COMBAT ActionRef must not set both technique_id and clash_id"
-                raise ValueError(msg)
-            passive_slots = {
-                CombatActionSlot.PASSIVE_PHYSICAL,
-                CombatActionSlot.PASSIVE_SOCIAL,
-                CombatActionSlot.PASSIVE_MENTAL,
-            }
-            if self.action_slot in passive_slots and self.technique_id is None:
-                msg = "Passive COMBAT ActionRef requires technique_id"
-                raise ValueError(msg)
+            self._validate_combat()
         if self.backend == ActionBackend.REGISTRY and self.registry_key is None:
             msg = "REGISTRY ActionRef requires registry_key"
             raise ValueError(msg)

--- a/src/commands/combat.py
+++ b/src/commands/combat.py
@@ -715,9 +715,6 @@ class CmdDeclareTechnique(_CombatCommandMixin, DispatchCommand):
         When ``secondary`` was parsed, ``action_slot`` is forwarded so
         ``CastTechniqueAction.round_declaration`` routes to the passive slot.
         """
-        from world.magic.models.techniques import ConditionTargetKind  # noqa: PLC0415
-        from world.magic.services.targeting import derive_target_relationship  # noqa: PLC0415
-
         self._parse_args()
         kwargs: dict[str, Any] = {"effort_level": self._effort}
 
@@ -737,8 +734,21 @@ class CmdDeclareTechnique(_CombatCommandMixin, DispatchCommand):
         # CombatRoundAction, where resolve_combat_technique consumes them.
         self._inject_fury_kwargs(kwargs)
 
-        if not self._target_name:
-            return kwargs
+        if self._target_name:
+            self._inject_target_kwargs(kwargs)
+
+        return kwargs
+
+    def _inject_target_kwargs(self, kwargs: dict[str, Any]) -> None:
+        """Resolve ``at <target>`` into the right kwarg based on combat context.
+
+        In a DECLARING combat round the technique's authored target relationship
+        decides the kwarg (``ENEMY`` → ``focused_opponent_target_id``;
+        ``ALLY``/``SELF`` → ``focused_ally_target_id``). Outside combat it
+        resolves as ``target_persona_id``.
+        """
+        from world.magic.models.techniques import ConditionTargetKind  # noqa: PLC0415
+        from world.magic.services.targeting import derive_target_relationship  # noqa: PLC0415
 
         # Check whether we're in a DECLARING combat round to decide how to
         # resolve the target name. Cache the participant for later helpers.
@@ -761,8 +771,6 @@ class CmdDeclareTechnique(_CombatCommandMixin, DispatchCommand):
             persona_id = self._resolve_target_persona_id()
             if persona_id is not None:
                 kwargs["target_persona_id"] = persona_id
-
-        return kwargs
 
 
 class CmdClashCommit(_CombatCommandMixin, DispatchCommand):

--- a/src/commands/combat_maneuvers.py
+++ b/src/commands/combat_maneuvers.py
@@ -143,41 +143,66 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
         CombatRoundAction (or None). Fury/Berserk are suppressed when
         ``participant`` is None (outside an encounter).
         """
-        from world.magic.services.soulfray import get_soulfray_warning  # noqa: PLC0415
-
-        lines: list[str] = []
         character = self.caller.puppet if hasattr(self.caller, "puppet") else self.caller
+        lines: list[str] = []
+        lines.extend(self._anima_lines(character))
+        lines.extend(self._soulfray_lines(character))
+        if participant is not None:
+            lines.extend(self._fury_and_berserk_lines(character, action))
+        return lines
+
+    @staticmethod
+    def _anima_lines(character: Any) -> list[str]:
+        """Current/maximum anima, or nothing when there's no anima row yet."""
         try:
             anima = character.anima
-            lines.append(f"Anima: {anima.current}/{anima.maximum}")
         except (AttributeError, ObjectDoesNotExist):
-            pass  # No anima row yet — omit rather than mislead with 0/0.
+            return []  # No anima row yet — omit rather than mislead with 0/0.
+        return [f"Anima: {anima.current}/{anima.maximum}"]
+
+    @staticmethod
+    def _soulfray_lines(character: Any) -> list[str]:
+        """Soulfray stage (with death-risk marker), or nothing when none."""
+        from world.magic.services.soulfray import get_soulfray_warning  # noqa: PLC0415
 
         warning = get_soulfray_warning(character)
-        if warning is not None:
-            risk = " — |rdeath risk|n" if warning.has_death_risk else ""
-            lines.append(f"Soulfray: {warning.stage_name}{risk}")
+        if warning is None:
+            return []
+        risk = " — |rdeath risk|n" if warning.has_death_risk else ""
+        return [f"Soulfray: {warning.stage_name}{risk}"]
 
-        if participant is not None:
-            berserk = self._berserk_instance(character)
-            control = "lost" if berserk is not None else "retained"
-            if action is not None and action.fury_commitment_id:
-                anchor_name = "unknown"
-                if action.fury_anchor_id and action.fury_anchor is not None:
-                    anchor_char = action.fury_anchor.character
-                    if anchor_char is not None:
-                        anchor_name = anchor_char.db_key
-                lines.append(
-                    f"Fury: committed (depth {action.fury_commitment.depth}, "
-                    f"anchored to {anchor_name}) — control {control}"
-                )
-            if berserk is not None:
-                rounds = ""
-                if berserk.rounds_remaining is not None:
-                    unit = "round" if berserk.rounds_remaining == 1 else "rounds"
-                    rounds = f" ({berserk.rounds_remaining} {unit} left)"
-                lines.append(f"Berserk: active{rounds}")
+    def _fury_and_berserk_lines(self, character: Any, action: Any) -> list[str]:
+        """Fury-commitment and Berserk lines for an in-encounter participant."""
+        berserk = self._berserk_instance(character)
+        lines: list[str] = []
+        if action is not None and action.fury_commitment_id:
+            lines.append(self._fury_line(action, berserk))
+        if berserk is not None:
+            lines.append(self._berserk_line(berserk))
         return lines
+
+    @staticmethod
+    def _fury_line(action: Any, berserk: Any) -> str:
+        """One line describing the committed fury and whether control is held."""
+        control = "lost" if berserk is not None else "retained"
+        anchor_name = "unknown"
+        if action.fury_anchor_id and action.fury_anchor is not None:
+            anchor_char = action.fury_anchor.character
+            if anchor_char is not None:
+                anchor_name = anchor_char.db_key
+        return (
+            f"Fury: committed (depth {action.fury_commitment.depth}, "
+            f"anchored to {anchor_name}) — control {control}"
+        )
+
+    @staticmethod
+    def _berserk_line(berserk: Any) -> str:
+        """One line describing the active Berserk condition and rounds left."""
+        rounds = ""
+        if berserk.rounds_remaining is not None:
+            unit = "round" if berserk.rounds_remaining == 1 else "rounds"
+            rounds = f" ({berserk.rounds_remaining} {unit} left)"
+        return f"Berserk: active{rounds}"
 
     def _berserk_instance(self, character: Any) -> Any:
         """The active Berserk ConditionInstance on *character*, or None."""

--- a/src/commands/consent_preferences.py
+++ b/src/commands/consent_preferences.py
@@ -209,7 +209,6 @@ class CmdConsent(DispatchCommand):
 
     def _show_summary(self, category_key: str | None = None) -> None:
         """Render the caller's social-consent summary."""
-        from world.consent.models import SocialConsentCategory  # noqa: PLC0415
         from world.consent.services import get_social_consent_summary  # noqa: PLC0415
 
         tenure = self._active_tenure()
@@ -229,13 +228,20 @@ class CmdConsent(DispatchCommand):
         else:
             lines.append("  No per-category rules set (all categories use the global preference).")
 
-        whitelist = summary["whitelist"]
+        self._append_whitelist_summary(lines, summary["whitelist"], category_key)
+        self.msg("\n".join(lines))
+
+    def _append_whitelist_summary(
+        self, lines: list[str], whitelist: Any, category_key: str | None
+    ) -> None:
+        """Append the whitelist section (optionally scoped to one category) to *lines*."""
+        from world.consent.models import SocialConsentCategory  # noqa: PLC0415
+
         if category_key:
             try:
                 category = SocialConsentCategory.objects.get_by_natural_key(category_key)
             except SocialConsentCategory.DoesNotExist:
                 lines.append(f"  No category named '{category_key}'.")
-                self.msg("\n".join(lines))
                 return
             filtered = [entry for entry in whitelist if entry.category_id == category.pk]
             if filtered:
@@ -250,5 +256,3 @@ class CmdConsent(DispatchCommand):
             )
         else:
             lines.append("  No whitelist entries.")
-
-        self.msg("\n".join(lines))

--- a/src/commands/events.py
+++ b/src/commands/events.py
@@ -72,6 +72,9 @@ _KEY_BY = "by"
 # stay single-token so the "exactly one target" check stays unambiguous.
 _MULTIWORD_KEYS = frozenset({_KEY_NAME, _KEY_DESC, _KEY_ROOM, _KEY_WHEN})
 
+# Parse-error labels (shared so the wording stays identical across call sites).
+_LABEL_EVENT_ID = "event id"
+
 # Invite target-type tokens → InvitationTargetType values.
 _INVITE_TARGET_TOKENS: dict[str, str] = {
     "persona": "persona",
@@ -269,7 +272,7 @@ class CmdEvent(ArxCommand):
         if len(parts) < 2 or "=" not in parts[1]:  # noqa: PLR2004
             msg = "Usage: event invite <id> persona=<name|id> [by=<persona>]  (or org= / society=)"
             raise CommandError(msg)
-        event_id = self._parse_id(parts[0], "event id")
+        event_id = self._parse_id(parts[0], _LABEL_EVENT_ID)
         kwargs = _parse_kwargs(parts[1])
         target_type, target_id = self._resolve_invite_target(kwargs)
         invited_by_id: int | None = None
@@ -330,7 +333,7 @@ class CmdEvent(ArxCommand):
         from world.events.models import Event  # noqa: PLC0415
         from world.events.services import get_visible_events  # noqa: PLC0415
 
-        event_id = self._parse_id(rest, "event id")
+        event_id = self._parse_id(rest, _LABEL_EVENT_ID)
         persona = self._actor_persona_or_none()
         event = get_visible_events(persona).filter(pk=event_id).first()
         if event is None:
@@ -433,7 +436,7 @@ class CmdEvent(ArxCommand):
         if not rest:
             msg = f"Usage: event {subverb} <id>"
             raise CommandError(msg)
-        return self._parse_id(rest, "event id")
+        return self._parse_id(rest, _LABEL_EVENT_ID)
 
     def _parse_id(self, value: str, label: str) -> int:
         value = value.strip().removeprefix("#")

--- a/src/commands/form.py
+++ b/src/commands/form.py
@@ -110,10 +110,27 @@ class CmdForm(DispatchCommand):
 
     def _show_hub(self) -> None:
         """Render the caller's active alternate self + available list."""
-        from world.forms.models import ActiveAlternateSelf, AlternateSelf  # noqa: PLC0415
+        from world.forms.models import AlternateSelf  # noqa: PLC0415
 
         sheet = self.caller.sheet_data
-        lines: list[str] = []
+        lines: list[str] = [self._active_self_line(sheet)]
+
+        alts = list(AlternateSelf.objects.filter(character_id=sheet.pk).order_by("display_name"))
+        if alts:
+            lines.append("Available alternate selves:")
+            lines.extend(f"  {self._alt_label(alt)}" for alt in alts)
+        else:
+            lines.append("You have no alternate selves.")
+
+        if not sheet.in_control:
+            lines.append("You are not in control — revert is blocked.")
+
+        self.msg("\n".join(lines))
+
+    @staticmethod
+    def _active_self_line(sheet: Any) -> str:
+        """One line naming the active alternate self, or the true self."""
+        from world.forms.models import ActiveAlternateSelf  # noqa: PLC0415
 
         active = (
             ActiveAlternateSelf.objects.filter(character=sheet)
@@ -122,29 +139,20 @@ class CmdForm(DispatchCommand):
         )
         if active is not None and active.alternate_self is not None:
             name = active.alternate_self.display_name or "an alternate self"
-            lines.append(f"You are in {name}.")
-        else:
-            lines.append("You are in your true self.")
+            return f"You are in {name}."
+        return "You are in your true self."
 
-        alts = list(AlternateSelf.objects.filter(character_id=sheet.pk).order_by("display_name"))
-        if alts:
-            lines.append("Available alternate selves:")
-            for alt in alts:
-                label = alt.display_name or "unnamed"
-                facets: list[str] = []
-                if alt.persona is not None:
-                    facets.append(f"persona {alt.persona.name}")
-                if alt.form_id is not None:
-                    facets.append("form")
-                if alt.combat_profile_id is not None:
-                    facets.append("combat profile")
-                if facets:
-                    label += f" ({', '.join(facets)})"
-                lines.append(f"  {label}")
-        else:
-            lines.append("You have no alternate selves.")
-
-        if not sheet.in_control:
-            lines.append("You are not in control — revert is blocked.")
-
-        self.msg("\n".join(lines))
+    @staticmethod
+    def _alt_label(alt: Any) -> str:
+        """Display label for one alternate self, annotated with its facets."""
+        label = alt.display_name or "unnamed"
+        facets: list[str] = []
+        if alt.persona is not None:
+            facets.append(f"persona {alt.persona.name}")
+        if alt.form_id is not None:
+            facets.append("form")
+        if alt.combat_profile_id is not None:
+            facets.append("combat profile")
+        if facets:
+            label += f" ({', '.join(facets)})"
+        return label

--- a/src/commands/parsing.py
+++ b/src/commands/parsing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 import re
 from typing import TYPE_CHECKING
 
@@ -68,6 +69,59 @@ def parse_targets_from_text(
     return remaining, targets
 
 
+@dataclass
+class _KvParseState:
+    """Mutable accumulator for ``parse_kv_and_flags`` as it walks the tokens."""
+
+    kwargs: dict[str, str] = field(default_factory=dict)
+    flags: set[str] = field(default_factory=set)
+    key: str = ""
+    value_parts: list[str] = field(default_factory=list)
+
+    def flush_key(self) -> None:
+        """Commit the active key's accumulated value into ``kwargs`` (if any key)."""
+        if self.key:
+            self.kwargs[self.key] = " ".join(self.value_parts).strip()
+
+
+def _consume_bare_token(
+    token: str,
+    state: _KvParseState,
+    multiword_keys: frozenset[str],
+    known_flags: frozenset[str],
+) -> None:
+    """Apply a token with no leading ``key=`` to *state*, mutating it in place.
+
+    A bare known flag ends an active multi-word key (flushing it) and is
+    recorded; otherwise it is appended to a multi-word value, recorded as a flag
+    for a non-multiword key, or rejected.
+    """
+    key = state.key
+    if key and key in multiword_keys:
+        if token in known_flags:
+            state.flush_key()
+            state.flags.add(token)
+            state.key = ""
+            state.value_parts = []
+        else:
+            state.value_parts.append(token)
+        return
+    if key:
+        if token not in known_flags:
+            msg = (
+                f"Unexpected argument '{token}' after '{key}='. "
+                "Multi-word values are only allowed for the multi-word keys."
+            )
+            raise CommandError(msg)
+        state.flags.add(token)
+        return
+    if token in known_flags:
+        state.flags.add(token)
+        return
+    msg = f"Unexpected argument '{token}'."
+    raise CommandError(msg)
+
+
 def parse_kv_and_flags(
     rest: str,
     *,
@@ -82,38 +136,13 @@ def parse_kv_and_flags(
     rather than absorbing the flag into the body. Bare tokens with no ``=`` are
     flags (if known) or an error.
     """
-    tokens = rest.split()
-    kwargs: dict[str, str] = {}
-    flags: set[str] = set()
-    key = ""
-    value_parts: list[str] = []
-    for token in tokens:
+    state = _KvParseState()
+    for token in rest.split():
         if "=" in token and not token.startswith("="):
-            if key:
-                kwargs[key] = " ".join(value_parts).strip()
-            key, _, value = token.partition("=")
-            value_parts = [value] if value else []
-        elif key and key in multiword_keys and token in known_flags:
-            kwargs[key] = " ".join(value_parts).strip()
-            key = ""
-            value_parts = []
-            flags.add(token)
-        elif key and key in multiword_keys:
-            value_parts.append(token)
-        elif key:
-            if token in known_flags:
-                flags.add(token)
-            else:
-                msg = (
-                    f"Unexpected argument '{token}' after '{key}='. "
-                    "Multi-word values are only allowed for the multi-word keys."
-                )
-                raise CommandError(msg)
-        elif token in known_flags:
-            flags.add(token)
+            state.flush_key()
+            state.key, _, value = token.partition("=")
+            state.value_parts = [value] if value else []
         else:
-            msg = f"Unexpected argument '{token}'."
-            raise CommandError(msg)
-    if key:
-        kwargs[key] = " ".join(value_parts).strip()
-    return kwargs, flags
+            _consume_bare_token(token, state, multiword_keys, known_flags)
+    state.flush_key()
+    return state.kwargs, state.flags

--- a/src/commands/progression_rewards.py
+++ b/src/commands/progression_rewards.py
@@ -33,6 +33,10 @@ _KUDOS_CLAIM_ARGC = 3
 _VOTE_TARGET_ARGC = 2
 _RANDOMSCENE_ARGC = 2
 
+# Shared command lock + error wording (kept single-sourced for consistency).
+_LOCK_ALL = "cmd:all()"
+_NO_ACTIVE_CHARACTER_MSG = "You have no active character on the roster."
+
 
 class CmdKudos(ArxCommand):
     """Claim kudos for XP.
@@ -44,7 +48,7 @@ class CmdKudos(ArxCommand):
 
     key = "kudos"
     aliases: ClassVar[list[str]] = []
-    locks = "cmd:all()"
+    locks = _LOCK_ALL
     help_category = "Progression"
     action = None
 
@@ -80,7 +84,7 @@ class CmdKudos(ArxCommand):
 
         account = get_account_for_character(self.caller)
         if account is None:
-            msg = "You have no active character on the roster."
+            msg = _NO_ACTIVE_CHARACTER_MSG
             raise CommandError(msg)
         points = KudosPointsData.objects.filter(account=account).first()
         available = points.current_available if points else 0
@@ -103,7 +107,7 @@ class CmdVote(ArxCommand):
 
     key = "vote"
     aliases: ClassVar[list[str]] = []
-    locks = "cmd:all()"
+    locks = _LOCK_ALL
     help_category = "Progression"
     action = None
 
@@ -153,7 +157,7 @@ class CmdVote(ArxCommand):
 
         account = get_account_for_character(self.caller)
         if account is None:
-            msg = "You have no active character on the roster."
+            msg = _NO_ACTIVE_CHARACTER_MSG
             raise CommandError(msg)
         budget = get_or_create_vote_budget(account)
         votes = get_votes_by_voter(account)
@@ -174,7 +178,7 @@ class CmdRandomScene(ArxCommand):
 
     key = "randomscene"
     aliases: ClassVar[list[str]] = ["rscene"]
-    locks = "cmd:all()"
+    locks = _LOCK_ALL
     help_category = "Progression"
     action = None
 
@@ -209,7 +213,7 @@ class CmdRandomScene(ArxCommand):
 
         account = get_account_for_character(self.caller)
         if account is None:
-            msg = "You have no active character on the roster."
+            msg = _NO_ACTIVE_CHARACTER_MSG
             raise CommandError(msg)
         targets = (
             RandomSceneTarget.objects.filter(account=account, game_week=get_current_game_week())
@@ -239,7 +243,7 @@ class CmdPathIntent(ArxCommand):
 
     key = "pathintent"
     aliases: ClassVar[list[str]] = []
-    locks = "cmd:all()"
+    locks = _LOCK_ALL
     help_category = "Progression"
     action = None
 

--- a/src/commands/relationships.py
+++ b/src/commands/relationships.py
@@ -87,28 +87,17 @@ _KEY_XP = "xp"
 _MULTIWORD_KEYS = frozenset({_KEY_TITLE, _KEY_WRITEUP})
 
 
-def _parse_name_and_kwargs(rest: str) -> tuple[str, dict[str, str]]:
-    """Split ``<name> key=value ...`` into the leading target name + a kwargs dict.
+def _parse_kwargs_tokens(tokens: list[str]) -> dict[str, str]:
+    """Parse ``key=value ...`` tokens into a kwargs dict.
 
-    The target name is positional (may be multi-word until the first ``key=``).
-    A key's value extends to the next ``key=`` token for the free-text keys
-    (``title`` / ``writeup``); other keys take exactly one value token, and a
-    bare token following a completed single-word value is an error.
+    A free-text key (``title`` / ``writeup``) extends to the next ``key=`` token;
+    other keys take exactly one value token, and a bare token following a
+    completed single-word value is an error.
     """
-    tokens = rest.split()
-    name_parts: list[str] = []
-    idx = 0
-    while idx < len(tokens) and "=" not in tokens[idx]:
-        name_parts.append(tokens[idx])
-        idx += 1
-    name = " ".join(name_parts).strip()
-    if idx == len(tokens):
-        return name, {}
-
     kwargs: dict[str, str] = {}
     key = ""
     value_parts: list[str] = []
-    for token in tokens[idx:]:
+    for token in tokens:
         if "=" in token and not token.startswith("="):
             if key:
                 kwargs[key] = " ".join(value_parts).strip()
@@ -127,7 +116,25 @@ def _parse_name_and_kwargs(rest: str) -> tuple[str, dict[str, str]]:
             raise CommandError(msg)
     if key:
         kwargs[key] = " ".join(value_parts).strip()
-    return name, kwargs
+    return kwargs
+
+
+def _parse_name_and_kwargs(rest: str) -> tuple[str, dict[str, str]]:
+    """Split ``<name> key=value ...`` into the leading target name + a kwargs dict.
+
+    The target name is positional (may be multi-word until the first ``key=``).
+    Remaining ``key=value`` tokens are parsed by ``_parse_kwargs_tokens``.
+    """
+    tokens = rest.split()
+    name_parts: list[str] = []
+    idx = 0
+    while idx < len(tokens) and "=" not in tokens[idx]:
+        name_parts.append(tokens[idx])
+        idx += 1
+    name = " ".join(name_parts).strip()
+    if idx == len(tokens):
+        return name, {}
+    return name, _parse_kwargs_tokens(tokens[idx:])
 
 
 def _require_int(value: str | None, name: str) -> int:

--- a/src/commands/sanctum.py
+++ b/src/commands/sanctum.py
@@ -282,11 +282,7 @@ class CmdSanctum(DispatchCommand):
 
     def _show_status_hub(self) -> None:
         """List the caller's standing Sanctums and note any local Sanctum."""
-        from django.db.models import Q  # noqa: PLC0415
-
         from actions.definitions.sanctum import sanctum_in_room  # noqa: PLC0415
-        from world.magic.constants import TargetKind  # noqa: PLC0415
-        from world.magic.models import SanctumDetails, Thread  # noqa: PLC0415
 
         lines = [
             "|wSanctum actions|n: install, homecoming, purging, weave, dissolve, absorb, sever"
@@ -295,43 +291,54 @@ class CmdSanctum(DispatchCommand):
         # getattr avoids AttributeError on objects that don't carry a sheet.
         sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
         if sheet is not None:
-            from world.locations.models import LocationOwnership  # noqa: PLC0415
-            from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
-
-            persona = active_persona_for_sheet(sheet)
-            if persona is not None:
-                woven_ids = Thread.objects.filter(
-                    owner=sheet,
-                    target_kind=TargetKind.SANCTUM,
-                    retired_at__isnull=True,
-                ).values_list("target_sanctum_details_id", flat=True)
-                owned_room_ids = LocationOwnership.objects.filter(
-                    holder_persona=persona,
-                    ended_at__isnull=True,
-                ).values_list("room_profile_id", flat=True)
-                sanctums = (
-                    SanctumDetails.objects.select_related(
-                        "feature_instance__room_profile",
-                        "resonance_type",
-                    )
-                    .filter(
-                        Q(feature_instance_id__in=woven_ids)
-                        | Q(feature_instance__room_profile_id__in=owned_room_ids)
-                    )
-                    .filter(feature_instance__dissolved_at__isnull=True)
-                    .distinct()
-                )
-                if sanctums.exists():
-                    lines.append("Your standing Sanctums:")
-                    for s in sanctums:
-                        rtype = s.resonance_type
-                        res_name = rtype.name if rtype is not None else "Unknown"
-                        lines.append(f"  #{s.pk} — {res_name} Sanctum")
-                else:
-                    lines.append("You have no standing Sanctums.")
+            lines.extend(self._standing_sanctum_lines(sheet))
 
         local_sanctum = sanctum_in_room(self.caller.location)
         if local_sanctum is not None:
             lines.append("A Sanctum stands here.")
 
         self.msg("\n".join(lines))
+
+    def _standing_sanctum_lines(self, sheet: Any) -> list[str]:
+        """Lines listing the standing Sanctums the caller has woven into or owns."""
+        from django.db.models import Q  # noqa: PLC0415
+
+        from world.locations.models import LocationOwnership  # noqa: PLC0415
+        from world.magic.constants import TargetKind  # noqa: PLC0415
+        from world.magic.models import SanctumDetails, Thread  # noqa: PLC0415
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        persona = active_persona_for_sheet(sheet)
+        if persona is None:
+            return []
+
+        woven_ids = Thread.objects.filter(
+            owner=sheet,
+            target_kind=TargetKind.SANCTUM,
+            retired_at__isnull=True,
+        ).values_list("target_sanctum_details_id", flat=True)
+        owned_room_ids = LocationOwnership.objects.filter(
+            holder_persona=persona,
+            ended_at__isnull=True,
+        ).values_list("room_profile_id", flat=True)
+        sanctums = (
+            SanctumDetails.objects.select_related(
+                "feature_instance__room_profile",
+                "resonance_type",
+            )
+            .filter(
+                Q(feature_instance_id__in=woven_ids)
+                | Q(feature_instance__room_profile_id__in=owned_room_ids)
+            )
+            .filter(feature_instance__dissolved_at__isnull=True)
+            .distinct()
+        )
+        if not sanctums.exists():
+            return ["You have no standing Sanctums."]
+
+        lines = ["Your standing Sanctums:"]
+        for s in sanctums:
+            rtype = s.resonance_type
+            res_name = rtype.name if rtype is not None else "Unknown"
+            lines.append(f"  #{s.pk} — {res_name} Sanctum")
+        return lines

--- a/src/commands/weather.py
+++ b/src/commands/weather.py
@@ -8,6 +8,8 @@ on demand. The frontend renders the same `current_conditions` data as a widget.
 
 from __future__ import annotations
 
+from typing import Any
+
 from commands.command import ArxCommand
 
 
@@ -48,22 +50,7 @@ class CmdTime(ArxCommand):
             return
 
         conditions = current_conditions(room)
-        lines: list[str] = []
-        if conditions.ic_time is None:
-            lines.append("|xThe world's clock isn't running yet.|n")
-        else:
-            descriptor = conditions.phase.label if conditions.phase is not None else "an hour"
-            if conditions.season is not None:
-                descriptor = f"{descriptor} in {conditions.season.label}"
-            stamp = conditions.ic_time.strftime("%H:%M, %B %d, %Y")
-            lines.append(f"|wIt is {descriptor} — {stamp}.|n")
-
-        if conditions.weather_type is not None:
-            lines.append(f"|wWeather here:|n {conditions.weather_type.name}")
-            if conditions.emit_text:
-                lines.append(f"  |x{conditions.emit_text}|n")
-        else:
-            lines.append("|xThe weather here is unremarkable.|n")
+        lines: list[str] = [self._time_line(conditions), *self._weather_lines(conditions)]
 
         if account is not None and is_category_muted(
             account=account, category=NarrativeCategory.WEATHER
@@ -71,3 +58,24 @@ class CmdTime(ArxCommand):
             lines.append("|x(weather echoes squelched — `weather unsquelch` to resume)|n")
 
         self.msg("\n".join(lines))
+
+    @staticmethod
+    def _time_line(conditions: Any) -> str:
+        """One line for the IC clock (time/phase/season), or a not-running notice."""
+        if conditions.ic_time is None:
+            return "|xThe world's clock isn't running yet.|n"
+        descriptor = conditions.phase.label if conditions.phase is not None else "an hour"
+        if conditions.season is not None:
+            descriptor = f"{descriptor} in {conditions.season.label}"
+        stamp = conditions.ic_time.strftime("%H:%M, %B %d, %Y")
+        return f"|wIt is {descriptor} — {stamp}.|n"
+
+    @staticmethod
+    def _weather_lines(conditions: Any) -> list[str]:
+        """The room's effective weather and its emit line, or an unremarkable notice."""
+        if conditions.weather_type is None:
+            return ["|xThe weather here is unremarkable.|n"]
+        lines = [f"|wWeather here:|n {conditions.weather_type.name}"]
+        if conditions.emit_text:
+            lines.append(f"  |x{conditions.emit_text}|n")
+        return lines

--- a/src/world/achievements/models.py
+++ b/src/world/achievements/models.py
@@ -17,6 +17,11 @@ from world.achievements.constants import (
     RewardType,
 )
 
+# String model reference for the CharacterSheet FK target. Using a single
+# constant keeps the lazy "app_label.ModelName" reference consistent across the
+# several models in this file that link to a character.
+CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
+
 
 class StatDefinition(SharedMemoryModel):
     """
@@ -57,7 +62,7 @@ class StatTracker(SharedMemoryModel):
     """
 
     character_sheet = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="stat_trackers",
         help_text="The character this stat belongs to",
@@ -268,7 +273,7 @@ class CharacterAchievement(SharedMemoryModel):
     """
 
     character_sheet = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="achievements",
         help_text="The character who earned this achievement",
@@ -430,7 +435,7 @@ class CharacterTitle(SharedMemoryModel):
     """
 
     character_sheet = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="titles",
     )

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -2145,45 +2145,69 @@ def select_npc_actions(
     for opponent in opponents:
         pool_entries = entries_by_pool.get(opponent.threat_pool_id, [])
         cooldown_used = recently_used_by_opponent.get(opponent.pk, set())
-        eligible = _get_eligible_entries(opponent, pool_entries, cooldown_used)
-        if not eligible:
-            continue
-
-        target_pool, targeting_participants = _npc_action_target_pool(
-            opponent, active_participants, encounter
+        actions.extend(
+            _build_opponent_round_actions(
+                opponent,
+                pool_entries,
+                cooldown_used,
+                active_participants,
+                encounter,
+            )
         )
 
-        # Empty-pool guard: create no action row when the combatant has no valid
-        # target — a #1584 ALLY summon with no live enemy, or a #1590
-        # calmed/neutral opponent whose threat-read yielded no PCs.
-        if not target_pool:
-            continue
+    return actions
 
-        if opponent.tier == OpponentTier.SWARM and opponent.swarm_count is not None:
-            n_attacks = swarm_attack_count(
-                opponent.swarm_count,
-                opponent.bodies_per_attack or 1,
-                len(target_pool),
-            )
-        else:
-            n_attacks = 1
 
-        for attack_index in range(n_attacks):
-            weights = [e.weight for e in eligible]
-            chosen = random.choices(eligible, weights=weights, k=1)[0]  # noqa: S311
-            action = CombatOpponentAction.objects.create(
-                opponent=opponent,
-                round_number=encounter.round_number,
-                threat_entry=chosen,
-            )
-            _set_npc_action_targets(
-                action,
-                chosen,
-                target_pool,
-                targeting_participants=targeting_participants,
-                rotation=attack_index,
-            )
-            actions.append(action)
+def _build_opponent_round_actions(
+    opponent: CombatOpponent,
+    pool_entries: list[ThreatPoolEntry],
+    cooldown_used: set[int],
+    active_participants: list[CombatParticipant],
+    encounter: CombatEncounter,
+) -> list[CombatOpponentAction]:
+    """Create one opponent's NPC action rows for the current round.
+
+    Returns the created actions, or an empty list when the opponent skips the
+    round — no eligible (off-cooldown) threat entry, or the empty-pool guard:
+    no valid target (a #1584 ALLY summon with no live enemy, or a #1590
+    calmed/neutral opponent whose threat-read yielded no PCs).
+    """
+    eligible = _get_eligible_entries(opponent, pool_entries, cooldown_used)
+    if not eligible:
+        return []
+
+    target_pool, targeting_participants = _npc_action_target_pool(
+        opponent, active_participants, encounter
+    )
+    if not target_pool:
+        return []
+
+    if opponent.tier == OpponentTier.SWARM and opponent.swarm_count is not None:
+        n_attacks = swarm_attack_count(
+            opponent.swarm_count,
+            opponent.bodies_per_attack or 1,
+            len(target_pool),
+        )
+    else:
+        n_attacks = 1
+
+    actions: list[CombatOpponentAction] = []
+    for attack_index in range(n_attacks):
+        weights = [e.weight for e in eligible]
+        chosen = random.choices(eligible, weights=weights, k=1)[0]  # noqa: S311
+        action = CombatOpponentAction.objects.create(
+            opponent=opponent,
+            round_number=encounter.round_number,
+            threat_entry=chosen,
+        )
+        _set_npc_action_targets(
+            action,
+            chosen,
+            target_pool,
+            targeting_participants=targeting_participants,
+            rotation=attack_index,
+        )
+        actions.append(action)
 
     return actions
 
@@ -2263,6 +2287,74 @@ def swarm_attack_count(swarm_count: int, bodies_per_attack: int, active_pc_count
     return max(1, min(raw, active_pc_count))
 
 
+def _zero_opponent_damage_result(opponent: CombatOpponent) -> OpponentDamageResult:
+    """A no-effect damage result (hit cancelled or reduced to nothing)."""
+    return OpponentDamageResult(
+        damage_dealt=0,
+        health_damaged=False,
+        probed=False,
+        probing_increment=0,
+        defeated=False,
+        kills=0,
+        opponent_id=opponent.pk,
+    )
+
+
+def _apply_swarm_damage(opponent: CombatOpponent, raw_damage: int) -> OpponentDamageResult:
+    """Resolve a landing hit on a SWARM opponent (#875).
+
+    Swarms have no HP, soak, or probing — a landing attack clears bodies.
+    """
+    kills = min(swarm_kills(raw_damage, opponent.body_toughness or 1), opponent.swarm_count)
+    opponent.swarm_count -= kills
+    defeated = opponent.swarm_count <= 0
+    if defeated:
+        opponent.status = OpponentStatus.DEFEATED
+    opponent.save(update_fields=["swarm_count", "status"])
+    return OpponentDamageResult(
+        damage_dealt=kills,
+        health_damaged=False,
+        probed=False,
+        probing_increment=0,
+        defeated=defeated,
+        kills=kills,
+        opponent_id=opponent.pk,
+    )
+
+
+def _emit_opponent_pre_apply(
+    opponent: CombatOpponent,
+    raw_damage: int,
+    damage_type: DamageType | None,
+    source_sheet: CharacterSheet | None,
+) -> tuple[int, bool]:
+    """Emit DAMAGE_PRE_APPLY for an opponent; return ``(amount, dropped)``.
+
+    Mirrors the participant path so reactive defences (force-field/reflect/blink)
+    fire on NPCs and ALLY summons identically (#1584). Returns the possibly
+    mutated damage amount and whether the hit should be dropped — the event
+    cancelled it, or the mutated amount fell to <= 0. Opponents with no
+    objectdb/location skip the event (amount unchanged, never dropped here).
+    """
+    if opponent.objectdb is None or opponent.objectdb.location is None:
+        return raw_damage, False
+    damage_source = classify_source(source_sheet.character if source_sheet is not None else None)
+    pre_payload = DamagePreApplyPayload(
+        target=opponent.objectdb,
+        amount=raw_damage,
+        damage_type=damage_type,
+        source=damage_source,
+    )
+    stack = emit_event(
+        EventName.DAMAGE_PRE_APPLY,
+        pre_payload,
+        location=opponent.objectdb.location,
+    )
+    if stack.was_cancelled():
+        return raw_damage, True
+    return pre_payload.amount, pre_payload.amount <= 0
+
+
 def apply_damage_to_opponent(  # noqa: PLR0913
     opponent: CombatOpponent,
     raw_damage: int,
@@ -2284,65 +2376,18 @@ def apply_damage_to_opponent(  # noqa: PLR0913
     """
     # Swarm: no HP, no soak, no probing -- a landing attack clears bodies.
     if opponent.tier == OpponentTier.SWARM and opponent.swarm_count is not None:
-        kills = min(swarm_kills(raw_damage, opponent.body_toughness or 1), opponent.swarm_count)
-        opponent.swarm_count -= kills
-        defeated = opponent.swarm_count <= 0
-        if defeated:
-            opponent.status = OpponentStatus.DEFEATED
-        opponent.save(update_fields=["swarm_count", "status"])
         del source_sheet
-        return OpponentDamageResult(
-            damage_dealt=kills,
-            health_damaged=False,
-            probed=False,
-            probing_increment=0,
-            defeated=defeated,
-            kills=kills,
-            opponent_id=opponent.pk,
-        )
+        return _apply_swarm_damage(opponent, raw_damage)
 
-    # --- DAMAGE_PRE_APPLY (cancellable, amount mutable) — mirrors the participant
-    # path so reactive defences (force-field/reflect/blink) fire on NPCs and
-    # ALLY summons identically (#1584).
-    # bypass_pre_apply=True skips emit + mutation; the bounced-reflect path uses
-    # this to terminate re-emission (loop guard). ---
+    # DAMAGE_PRE_APPLY (cancellable, amount mutable). bypass_pre_apply=True skips
+    # emit + mutation; the bounced-reflect path uses this to terminate re-emission
+    # (loop guard).
     if not bypass_pre_apply:
-        if opponent.objectdb is not None and opponent.objectdb.location is not None:
-            damage_source = classify_source(
-                source_sheet.character if source_sheet is not None else None
-            )
-            pre_payload = DamagePreApplyPayload(
-                target=opponent.objectdb,
-                amount=raw_damage,
-                damage_type=damage_type,
-                source=damage_source,
-            )
-            stack = emit_event(
-                EventName.DAMAGE_PRE_APPLY,
-                pre_payload,
-                location=opponent.objectdb.location,
-            )
-            if stack.was_cancelled():
-                return OpponentDamageResult(
-                    damage_dealt=0,
-                    health_damaged=False,
-                    probed=False,
-                    probing_increment=0,
-                    defeated=False,
-                    kills=0,
-                    opponent_id=opponent.pk,
-                )
-            raw_damage = pre_payload.amount
-            if raw_damage <= 0:
-                return OpponentDamageResult(
-                    damage_dealt=0,
-                    health_damaged=False,
-                    probed=False,
-                    probing_increment=0,
-                    defeated=False,
-                    kills=0,
-                    opponent_id=opponent.pk,
-                )
+        raw_damage, dropped = _emit_opponent_pre_apply(
+            opponent, raw_damage, damage_type, source_sheet
+        )
+        if dropped:
+            return _zero_opponent_damage_result(opponent)
 
     effective_soak = 0 if bypass_soak else opponent.soak_value
 

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -2466,7 +2466,72 @@ def _scene_participant(scene: "Scene", character_sheet: "CharacterSheet") -> boo
     return SceneParticipation.objects.filter(scene=scene, account_id=account_id).exists()
 
 
-def get_treatment_candidates(  # noqa: C901
+def _treatment_scene_ok(
+    treatment: TreatmentTemplate,
+    scene: "Scene",
+    helper_sheet: "CharacterSheet",
+    target_sheet: "CharacterSheet",
+) -> bool:
+    """Return True when *treatment*'s scene gate is satisfied for both parties."""
+    if not treatment.scene_required:
+        return True
+    return (
+        scene.is_active
+        and _scene_participant(scene, helper_sheet)
+        and _scene_participant(scene, target_sheet)
+    )
+
+
+def _find_bond_thread(
+    candidate_threads: list["Thread"],
+    target_sheet: "CharacterSheet",
+) -> "Thread | None":
+    """Return the first helper thread anchored to *target_sheet*, or None."""
+    for thread in candidate_threads:
+        if _thread_anchors_to_character(thread, target_sheet):
+            return thread
+    return None
+
+
+def _condition_matches_treatment(treatment: TreatmentTemplate, instance: ConditionInstance) -> bool:
+    """Return True when a condition instance is a valid target for *treatment*."""
+    if treatment.target_kind == TreatmentTargetKind.PRIMARY:
+        return instance.condition_id == treatment.target_condition_id
+    if treatment.target_kind == TreatmentTargetKind.AFTERMATH:
+        return instance.condition.parent_condition_id == treatment.target_condition_id
+    return True
+
+
+def _build_treatment_candidates(
+    treatment: TreatmentTemplate,
+    bond_thread: "Thread | None",
+    alteration_qs: Iterable["PendingAlteration"],
+    condition_qs: Iterable[ConditionInstance],
+) -> list[dict[str, Any]]:
+    """Build candidate dicts for a single *treatment* over the target's effects."""
+    if treatment.target_kind == TreatmentTargetKind.PENDING_ALTERATION:
+        return [
+            {
+                "treatment": treatment,
+                "target_effect": alteration,
+                "target_effect_type": TARGET_EFFECT_ALTERATION,
+                "bond_thread": bond_thread,
+            }
+            for alteration in alteration_qs
+        ]
+    return [
+        {
+            "treatment": treatment,
+            "target_effect": instance,
+            "target_effect_type": TARGET_EFFECT_CONDITION,
+            "bond_thread": bond_thread,
+        }
+        for instance in condition_qs
+        if _condition_matches_treatment(treatment, instance)
+    ]
+
+
+def get_treatment_candidates(
     helper_sheet: "CharacterSheet",
     target_sheet: "CharacterSheet",
     scene: "Scene",
@@ -2494,22 +2559,7 @@ def get_treatment_candidates(  # noqa: C901
     ).exists():
         return []
 
-    def _scene_ok(treatment: TreatmentTemplate) -> bool:
-        if not treatment.scene_required:
-            return True
-        return (
-            scene.is_active
-            and _scene_participant(scene, helper_sheet)
-            and _scene_participant(scene, target_sheet)
-        )
-
     candidate_threads = list(Thread.objects.filter(owner=helper_sheet, retired_at__isnull=True))
-
-    def _find_bond_thread() -> "Thread | None":
-        for thread in candidate_threads:
-            if _thread_anchors_to_character(thread, target_sheet):
-                return thread
-        return None
 
     condition_qs = ConditionInstance.objects.filter(
         target=target_character,
@@ -2524,44 +2574,19 @@ def get_treatment_candidates(  # noqa: C901
     candidates: list[dict[str, Any]] = []
 
     for treatment in TreatmentTemplate.objects.all():
-        if not _scene_ok(treatment):
+        if not _treatment_scene_ok(treatment, scene, helper_sheet, target_sheet):
             continue
 
         if treatment.requires_bond:
-            bond_thread = _find_bond_thread()
+            bond_thread = _find_bond_thread(candidate_threads, target_sheet)
             if bond_thread is None:
                 continue
         else:
             bond_thread = None
 
-        if treatment.target_kind == TreatmentTargetKind.PENDING_ALTERATION:
-            candidates.extend(
-                {
-                    "treatment": treatment,
-                    "target_effect": alteration,
-                    "target_effect_type": TARGET_EFFECT_ALTERATION,
-                    "bond_thread": bond_thread,
-                }
-                for alteration in alteration_qs
-            )
-            continue
-
-        for instance in condition_qs:
-            if treatment.target_kind == TreatmentTargetKind.PRIMARY:
-                if instance.condition_id != treatment.target_condition_id:
-                    continue
-            elif treatment.target_kind == TreatmentTargetKind.AFTERMATH:
-                if instance.condition.parent_condition_id != treatment.target_condition_id:
-                    continue
-
-            candidates.append(
-                {
-                    "treatment": treatment,
-                    "target_effect": instance,
-                    "target_effect_type": TARGET_EFFECT_CONDITION,
-                    "bond_thread": bond_thread,
-                }
-            )
+        candidates.extend(
+            _build_treatment_candidates(treatment, bond_thread, alteration_qs, condition_qs)
+        )
 
     return candidates
 

--- a/src/world/conditions/views.py
+++ b/src/world/conditions/views.py
@@ -51,6 +51,8 @@ from world.conditions.services import (
 )
 from world.conditions.types import CapabilitySummary, EffectLookups
 
+_NO_CHARACTER_FOUND_DETAIL = "No character found."
+
 # =============================================================================
 # Lookup Table ViewSets
 # =============================================================================
@@ -271,7 +273,7 @@ class CharacterConditionsViewSet(CharacterContextMixin, viewsets.ViewSet):
         character = self._get_character(request)
         if not character:
             return Response(
-                {"detail": "No character found."},
+                {"detail": _NO_CHARACTER_FOUND_DETAIL},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
@@ -295,7 +297,7 @@ class CharacterConditionsViewSet(CharacterContextMixin, viewsets.ViewSet):
         character = self._get_character(request)
         if not character:
             return Response(
-                {"detail": "No character found."},
+                {"detail": _NO_CHARACTER_FOUND_DETAIL},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
@@ -471,7 +473,7 @@ class TreatmentCandidateViewSet(CharacterContextMixin, viewsets.ViewSet):
         character = self._get_character(request)
         if not character:
             return Response(
-                {"detail": "No character found."},
+                {"detail": _NO_CHARACTER_FOUND_DETAIL},
                 status=status.HTTP_404_NOT_FOUND,
             )
 

--- a/src/world/fatigue/services.py
+++ b/src/world/fatigue/services.py
@@ -478,6 +478,36 @@ def apply_exhaustion_damage(character_sheet: CharacterSheet, amount: int) -> Non
     )
 
 
+def _tick_fatigue_collapse_for_target(
+    target: ObjectDB | None,  # noqa: OBJECTDB_PARAM
+) -> None:
+    """Evaluate non-cast over-capacity fatigue collapse for a single round target.
+
+    Helper for ``tick_fatigue_collapse_for_targets``. No-ops for a ``None`` target,
+    a target without a CharacterSheet, or one without a traits handler (NPCs /
+    non-character objects in the round are not fatigue-tracked).
+    """
+    if target is None:
+        return
+    try:
+        sheet = target.sheet_data
+    except (AttributeError, ObjectDoesNotExist):
+        return
+    if sheet is None:
+        return
+    try:
+        # Probe fatigue capability once; targets without a traits handler
+        # (NPCs / non-character objects in the round) are not fatigue-tracked.
+        capacities = {cat: get_fatigue_capacity(sheet, cat) for cat in FATIGUE_ENDURANCE_STAT}
+    except AttributeError:
+        return
+    for category, capacity in capacities.items():
+        if capacity <= 0:
+            continue
+        if get_fatigue_zone(sheet, category) in _TECHNIQUE_COLLAPSE_ZONES:
+            resolve_fatigue_collapse(sheet, category)
+
+
 def tick_fatigue_collapse_for_targets(
     targets: Iterable[ObjectDB],  # noqa: OBJECTDB_PARAM
 ) -> None:
@@ -494,25 +524,7 @@ def tick_fatigue_collapse_for_targets(
     (vitals.tick_round_for_targets) on round resolution.
     """
     for target in targets:
-        if target is None:
-            continue
-        try:
-            sheet = target.sheet_data
-        except (AttributeError, ObjectDoesNotExist):
-            continue
-        if sheet is None:
-            continue
-        try:
-            # Probe fatigue capability once; targets without a traits handler
-            # (NPCs / non-character objects in the round) are not fatigue-tracked.
-            capacities = {cat: get_fatigue_capacity(sheet, cat) for cat in FATIGUE_ENDURANCE_STAT}
-        except AttributeError:
-            continue
-        for category, capacity in capacities.items():
-            if capacity <= 0:
-                continue
-            if get_fatigue_zone(sheet, category) in _TECHNIQUE_COLLAPSE_ZONES:
-                resolve_fatigue_collapse(sheet, category)
+        _tick_fatigue_collapse_for_target(target)
 
 
 def reset_fatigue(character_sheet: CharacterSheet) -> None:

--- a/src/world/items/views.py
+++ b/src/world/items/views.py
@@ -88,6 +88,11 @@ from world.items.services.usage import use_item
 from world.magic.services.auth import _resolve_actor_sheet
 from world.roster.models import RosterEntry
 
+# Shared validation message for missing required query parameters across the
+# item-first viewsets (these are computed/permission-context params, not
+# queryset filters, so they're validated manually rather than via a FilterSet).
+REQUIRED_QUERY_PARAM_MESSAGE = "This query parameter is required."
+
 
 def _user_plays_pk(user: AccountDB, pk: int) -> bool:
     """True if ``user`` has an active roster tenure on the character_sheet at ``pk``.
@@ -288,9 +293,7 @@ class ItemFacetViewSet(viewsets.ViewSet):
         # noqa: USE_FILTERSET
         instance_pk = _parse_int_param(request.query_params.get("item_instance"))  # noqa: USE_FILTERSET
         if instance_pk is None:
-            raise serializers.ValidationError(
-                {"item_instance": "This query parameter is required."}
-            )
+            raise serializers.ValidationError({"item_instance": REQUIRED_QUERY_PARAM_MESSAGE})
         try:
             item = (
                 ItemInstance.objects.select_related("holder_character_sheet__character")
@@ -398,11 +401,9 @@ class ItemFacetViewSet(viewsets.ViewSet):
         instance_pk = _parse_int_param(request.query_params.get("item_instance"))  # noqa: USE_FILTERSET
         facet_pk = _parse_int_param(request.query_params.get("facet"))  # noqa: USE_FILTERSET
         if instance_pk is None:
-            raise serializers.ValidationError(
-                {"item_instance": "This query parameter is required."}
-            )
+            raise serializers.ValidationError({"item_instance": REQUIRED_QUERY_PARAM_MESSAGE})
         if facet_pk is None:
-            raise serializers.ValidationError({"facet": "This query parameter is required."})
+            raise serializers.ValidationError({"facet": REQUIRED_QUERY_PARAM_MESSAGE})
         try:
             item_instance = ItemInstance.objects.select_related(
                 "holder_character_sheet__character"
@@ -481,7 +482,7 @@ class ItemInstanceViewSet(viewsets.ViewSet):
         # noqa: USE_FILTERSET
         character_pk = _parse_int_param(request.query_params.get("character"))  # noqa: USE_FILTERSET
         if character_pk is None:
-            raise serializers.ValidationError({"character": "This query parameter is required."})
+            raise serializers.ValidationError({"character": REQUIRED_QUERY_PARAM_MESSAGE})
         try:
             character = ObjectDB.objects.get(pk=character_pk)
         except ObjectDB.DoesNotExist as exc:
@@ -626,7 +627,7 @@ class EquippedItemViewSet(viewsets.ViewSet):
         # noqa: USE_FILTERSET
         character_pk = _parse_int_param(request.query_params.get("character"))  # noqa: USE_FILTERSET
         if character_pk is None:
-            raise serializers.ValidationError({"character": "This query parameter is required."})
+            raise serializers.ValidationError({"character": REQUIRED_QUERY_PARAM_MESSAGE})
         try:
             character = ObjectDB.objects.get(pk=character_pk)
         except ObjectDB.DoesNotExist as exc:
@@ -747,9 +748,7 @@ class OutfitViewSet(viewsets.ViewSet):
         # noqa: USE_FILTERSET
         sheet_pk = _parse_int_param(request.query_params.get("character_sheet"))  # noqa: USE_FILTERSET
         if sheet_pk is None:
-            raise serializers.ValidationError(
-                {"character_sheet": "This query parameter is required."}
-            )
+            raise serializers.ValidationError({"character_sheet": REQUIRED_QUERY_PARAM_MESSAGE})
         try:
             sheet = CharacterSheet.objects.get(pk=sheet_pk)
         except CharacterSheet.DoesNotExist as exc:
@@ -899,7 +898,7 @@ class OutfitSlotViewSet(viewsets.ViewSet):
         # noqa: USE_FILTERSET
         outfit_pk = _parse_int_param(request.query_params.get("outfit"))  # noqa: USE_FILTERSET
         if outfit_pk is None:
-            raise serializers.ValidationError({"outfit": "This query parameter is required."})
+            raise serializers.ValidationError({"outfit": REQUIRED_QUERY_PARAM_MESSAGE})
         try:
             outfit = (
                 Outfit.objects.select_related("character_sheet")
@@ -1398,11 +1397,9 @@ class ItemStyleCraftViewSet(viewsets.ViewSet):
         instance_pk = _parse_int_param(request.query_params.get("item_instance"))  # noqa: USE_FILTERSET
         style_pk = _parse_int_param(request.query_params.get("style"))  # noqa: USE_FILTERSET
         if instance_pk is None:
-            raise serializers.ValidationError(
-                {"item_instance": "This query parameter is required."}
-            )
+            raise serializers.ValidationError({"item_instance": REQUIRED_QUERY_PARAM_MESSAGE})
         if style_pk is None:
-            raise serializers.ValidationError({"style": "This query parameter is required."})
+            raise serializers.ValidationError({"style": REQUIRED_QUERY_PARAM_MESSAGE})
         try:
             item_instance = ItemInstance.objects.select_related(
                 "holder_character_sheet__character"

--- a/src/world/magic/effect_palette_content.py
+++ b/src/world/magic/effect_palette_content.py
@@ -65,6 +65,12 @@ from world.magic.seeds_cast import get_standalone_cast_template
 # Identity keys (module-level constants for stable naming)
 # ---------------------------------------------------------------------------
 
+#: Flow-step parameter placeholder substituted with the live event payload at runtime.
+PAYLOAD_PLACEHOLDER: str = "@payload"
+
+#: Shared TechniqueStyle name for the space-bending translocation techniques.
+TRANSLOCATION_STANCE_STYLE_NAME: str = "Translocation Stance"
+
 # --- Task 14a: Summon ---
 
 #: Name of the ThreatPool the summoned ally draws its attacks from.
@@ -218,7 +224,7 @@ def ensure_summon_content() -> None:
         defaults={
             "parent_id": None,
             "parameters": {
-                "payload": "@payload",
+                "payload": PAYLOAD_PLACEHOLDER,
                 "threat_pool_id": pool.pk,
                 "bond_rounds": _SUMMON_BOND_ROUNDS,
                 "max_health": _SUMMON_MAX_HEALTH,
@@ -377,7 +383,7 @@ def _seed_call_service_flow(
     that need static ids (e.g. ``destination_position_id``) alongside the payload.
     """
     flow, _created = FlowDefinition.objects.get_or_create(name=flow_name)
-    params: dict[str, object] = {"payload": "@payload"}
+    params: dict[str, object] = {"payload": PAYLOAD_PLACEHOLDER}
     if extra_params:
         params.update(extra_params)
     root_step, _created = FlowStepDefinition.objects.get_or_create(
@@ -498,7 +504,7 @@ def ensure_force_field_content() -> None:
         variable_name=_INIT_ABSORB_BUFFER_PATH,
         defaults={
             "parent_id": None,
-            "parameters": {"payload": "@payload", "buffer": _FORCE_FIELD_INIT_BUFFER},
+            "parameters": {"payload": PAYLOAD_PLACEHOLDER, "buffer": _FORCE_FIELD_INIT_BUFFER},
         },
     )
     ca_trigger, _created = TriggerDefinition.objects.get_or_create(
@@ -818,7 +824,7 @@ def ensure_teleport_content() -> None:
     _seed_technique(
         TELEPORT_TECHNIQUE_NAME,
         gift_name="Translocation",
-        style_name="Translocation Stance",
+        style_name=TRANSLOCATION_STANCE_STYLE_NAME,
         effect_type_name="Teleport",
         description="Techniques that bend space to move the caster instantly.",
         technique_description=(
@@ -887,7 +893,7 @@ def ensure_obstacle_content() -> None:
     _seed_technique(
         OBSTACLE_TECHNIQUE_NAME,
         gift_name="Translocation",
-        style_name="Translocation Stance",
+        style_name=TRANSLOCATION_STANCE_STYLE_NAME,
         effect_type_name="Obstacle",
         description="Techniques that reshape the battlefield with barriers and blockades.",
         technique_description=(
@@ -926,7 +932,7 @@ def ensure_incorporeal_content() -> None:
     _seed_technique(
         INCORPOREAL_TECHNIQUE_NAME,
         gift_name="Translocation",
-        style_name="Translocation Stance",
+        style_name=TRANSLOCATION_STANCE_STYLE_NAME,
         effect_type_name="Incorporeal Form",
         description="Techniques that phase the caster out of the physical plane.",
         technique_description=(
@@ -965,7 +971,7 @@ def ensure_sink_content() -> None:
     _seed_technique(
         SINK_TECHNIQUE_NAME,
         gift_name="Translocation",
-        style_name="Translocation Stance",
+        style_name=TRANSLOCATION_STANCE_STYLE_NAME,
         effect_type_name="Earth Sink",
         description="Techniques that merge the caster with the earth for a fleeting moment.",
         technique_description=(
@@ -1032,7 +1038,7 @@ def ensure_telekinesis_content() -> None:
     _seed_technique(
         TELEKINESIS_TECHNIQUE_NAME,
         gift_name="Translocation",
-        style_name="Translocation Stance",
+        style_name=TRANSLOCATION_STANCE_STYLE_NAME,
         effect_type_name="Telekinesis",
         description="Techniques that move objects and enemies with invisible force.",
         technique_description=(

--- a/src/world/magic/views_sanctum.py
+++ b/src/world/magic/views_sanctum.py
@@ -43,6 +43,9 @@ from world.magic.serializers_sanctum import (
 if TYPE_CHECKING:
     from world.scenes.models import Persona
 
+#: Error detail returned when the request has no active character to act as.
+NO_ACTIVE_CHARACTER_DETAIL = "No active character."
+
 
 def _active_persona_for_request(request) -> Persona:
     """Resolve the request user's ACTIVE persona — the face they're on (#981).
@@ -158,7 +161,9 @@ class SanctumViewSet(viewsets.ReadOnlyModelViewSet):
         serializer.is_valid(raise_exception=True)
         actor = self._resolve_actor(request)
         if actor is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
         result = SanctumHomecomingAction().run(
             actor=actor,
             sanctum=sanctum,
@@ -176,7 +181,9 @@ class SanctumViewSet(viewsets.ReadOnlyModelViewSet):
         serializer.is_valid(raise_exception=True)
         actor = self._resolve_actor(request)
         if actor is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
         new_resonance = get_object_or_404(
             Resonance, pk=serializer.validated_data["new_resonance_id"]
         )
@@ -197,7 +204,9 @@ class SanctumViewSet(viewsets.ReadOnlyModelViewSet):
         serializer.is_valid(raise_exception=True)
         actor = self._resolve_actor(request)
         if actor is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
         result = SanctumWeaveAction().run(
             actor=actor,
             sanctum=sanctum,
@@ -224,7 +233,9 @@ class SanctumViewSet(viewsets.ReadOnlyModelViewSet):
         serializer.is_valid(raise_exception=True)
         actor = self._resolve_actor(request)
         if actor is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
         room_profile = get_object_or_404(
             RoomProfile, pk=serializer.validated_data["room_profile_id"]
         )
@@ -261,7 +272,9 @@ class SanctumViewSet(viewsets.ReadOnlyModelViewSet):
         sanctum = self.get_object()
         actor = self._resolve_actor(request)
         if actor is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
         result = SanctumDissolveAction().run(actor=actor, sanctum=sanctum)
         if not result.success:
             return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
@@ -272,7 +285,9 @@ class SanctumViewSet(viewsets.ReadOnlyModelViewSet):
         sanctum = self.get_object()
         actor = self._resolve_actor(request)
         if actor is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
         result = SanctumAbsorbAction().run(actor=actor, sanctum=sanctum)
         if not result.success:
             return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
@@ -283,7 +298,9 @@ class SanctumViewSet(viewsets.ReadOnlyModelViewSet):
         sanctum = self.get_object()
         actor = self._resolve_actor(request)
         if actor is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
         thread = get_object_or_404(
             Thread,
             pk=thread_id,

--- a/src/world/progression/factories.py
+++ b/src/world/progression/factories.py
@@ -29,6 +29,10 @@ from world.progression.models import (
 )
 from world.progression.types import DevelopmentSource, ProgressionReason
 
+# Module path imported lazily inside LazyFunctions to fetch the current game week;
+# extracted to a single constant to satisfy S1192.
+_WEEK_SERVICES_MODULE = "world.game_clock.week_services"
+
 
 class ExperiencePointsDataFactory(factory_django.DjangoModelFactory):
     """Factory for ExperiencePointsData."""
@@ -204,7 +208,7 @@ class WeeklySkillUsageFactory(factory_django.DjangoModelFactory):
     trait = factory.SubFactory("world.traits.factories.TraitFactory")
     game_week = factory.LazyFunction(
         lambda: __import__(
-            "world.game_clock.week_services", fromlist=["get_current_game_week"]
+            _WEEK_SERVICES_MODULE, fromlist=["get_current_game_week"]
         ).get_current_game_week()
     )
     points_earned = 0
@@ -242,7 +246,7 @@ class WeeklySocialEngagementFactory(factory_django.DjangoModelFactory):
     account = factory.SubFactory("evennia_extensions.factories.AccountFactory")
     game_week = factory.LazyFunction(
         lambda: __import__(
-            "world.game_clock.week_services", fromlist=["get_current_game_week"]
+            _WEEK_SERVICES_MODULE, fromlist=["get_current_game_week"]
         ).get_current_game_week()
     )
     pending_points = Decimal(0)
@@ -259,7 +263,7 @@ class RandomSceneTargetFactory(factory_django.DjangoModelFactory):
     target_persona = factory.SubFactory("world.scenes.factories.PersonaFactory")
     game_week = factory.LazyFunction(
         lambda: __import__(
-            "world.game_clock.week_services", fromlist=["get_current_game_week"]
+            _WEEK_SERVICES_MODULE, fromlist=["get_current_game_week"]
         ).get_current_game_week()
     )
     slot_number = 1

--- a/src/world/progression/views.py
+++ b/src/world/progression/views.py
@@ -82,6 +82,9 @@ MAX_TRANSACTION_LIMIT = 200
 # Repeated 404 detail message, extracted to satisfy S1192.
 NO_CHARACTER_FOUND_MESSAGE = "No character found."
 
+# Repeated 400 detail message when no active character can act, extracted to satisfy S1192.
+NO_ACTIVE_CHARACTER_MESSAGE = "No active character to act as."
+
 
 class TransactionPagination(LimitOffsetPagination):
     """Pagination for progression transaction lists."""
@@ -202,7 +205,7 @@ class ClaimKudosView(APIView):
         actor = _actor_for_account(account)
         if actor is None:
             return Response(
-                {"detail": "No active character to act as."},
+                {"detail": NO_ACTIVE_CHARACTER_MESSAGE},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         result = ClaimKudosAction().run(
@@ -248,7 +251,7 @@ class VoteViewSet(
         actor = _actor_for_account(voter)
         if actor is None:
             return Response(
-                {"detail": "No active character to act as."},
+                {"detail": NO_ACTIVE_CHARACTER_MESSAGE},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -277,7 +280,7 @@ class VoteViewSet(
         actor = _actor_for_account(voter)
         if actor is None:
             return Response(
-                {"detail": "No active character to act as."},
+                {"detail": NO_ACTIVE_CHARACTER_MESSAGE},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         result = RemoveVoteAction().run(
@@ -333,7 +336,7 @@ class RandomSceneViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         actor = _actor_for_account(account)
         if actor is None:
             return Response(
-                {"detail": "No active character to act as."},
+                {"detail": NO_ACTIVE_CHARACTER_MESSAGE},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         result = ClaimRandomSceneAction().run(actor=actor, target_id=pk)
@@ -365,7 +368,7 @@ class RandomSceneViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         actor = _actor_for_account(account)
         if actor is None:
             return Response(
-                {"detail": "No active character to act as."},
+                {"detail": NO_ACTIVE_CHARACTER_MESSAGE},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/src/world/relationships/models.py
+++ b/src/world/relationships/models.py
@@ -22,6 +22,9 @@ from world.relationships.constants import (
     UpdateVisibility,
 )
 
+# Django related_name template producing a per-concrete-subclass reverse accessor.
+CLASS_SET_RELATED_NAME = "%(class)s_set"
+
 
 class RelationshipCondition(SharedMemoryModel):
     """
@@ -867,21 +870,21 @@ class WriteupFeedbackBase(SharedMemoryModel):
         on_delete=models.CASCADE,
         null=True,
         blank=True,
-        related_name="%(class)s_set",
+        related_name=CLASS_SET_RELATED_NAME,
     )
     development = models.ForeignKey(
         "relationships.RelationshipDevelopment",
         on_delete=models.CASCADE,
         null=True,
         blank=True,
-        related_name="%(class)s_set",
+        related_name=CLASS_SET_RELATED_NAME,
     )
     capstone = models.ForeignKey(
         "relationships.RelationshipCapstone",
         on_delete=models.CASCADE,
         null=True,
         blank=True,
-        related_name="%(class)s_set",
+        related_name=CLASS_SET_RELATED_NAME,
     )
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
 

--- a/src/world/relationships/views.py
+++ b/src/world/relationships/views.py
@@ -39,6 +39,8 @@ from world.relationships.serializers import (
     WriteupKudosWriteSerializer,
 )
 
+NO_ACTIVE_CHARACTER_MESSAGE = "No active character."
+
 
 class RelationshipConditionViewSet(ReadOnlyModelViewSet):
     """List and retrieve relationship conditions."""
@@ -199,13 +201,13 @@ class RelationshipUpdateViewSet(GenericViewSet):
         """Return the caller's active puppet ObjectDB if they own its sheet."""
         actor = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
         if actor is None:
-            return None, "No active character."
+            return None, NO_ACTIVE_CHARACTER_MESSAGE
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
-            return None, "No active character."
+            return None, NO_ACTIVE_CHARACTER_MESSAGE
         if sheet.character.db_account_id != request.user.pk:
-            return None, "No active character."
+            return None, NO_ACTIVE_CHARACTER_MESSAGE
         return actor, ""
 
     def _resolve_track(self, track_id: int, label: str):

--- a/src/world/room_features/factories.py
+++ b/src/world/room_features/factories.py
@@ -17,6 +17,8 @@ from world.room_features.models import (
     Trap,
 )
 
+ROOM_PROFILE_FACTORY = "evennia_extensions.factories.RoomProfileFactory"
+
 
 class RoomFeatureKindFactory(DjangoModelFactory):
     class Meta:
@@ -53,7 +55,7 @@ class RoomFeatureInstanceFactory(DjangoModelFactory):
     class Meta:
         model = RoomFeatureInstance
 
-    room_profile = factory.SubFactory("evennia_extensions.factories.RoomProfileFactory")
+    room_profile = factory.SubFactory(ROOM_PROFILE_FACTORY)
     feature_kind = factory.SubFactory(RoomFeatureKindFactory)
     level = 1
 
@@ -63,7 +65,7 @@ class RoomFeatureProgressionDetailsFactory(DjangoModelFactory):
         model = RoomFeatureProgressionDetails
 
     project = factory.SubFactory("world.projects.factories.ProjectFactory")
-    target_room_profile = factory.SubFactory("evennia_extensions.factories.RoomProfileFactory")
+    target_room_profile = factory.SubFactory(ROOM_PROFILE_FACTORY)
     target_feature_kind = factory.SubFactory(RoomFeatureKindFactory)
     target_level = 1
 
@@ -72,7 +74,7 @@ class TrapFactory(DjangoModelFactory):
     class Meta:
         model = Trap
 
-    room_profile = factory.SubFactory("evennia_extensions.factories.RoomProfileFactory")
+    room_profile = factory.SubFactory(ROOM_PROFILE_FACTORY)
     name = factory.Sequence(lambda n: f"trap-{n}")
     consequence_pool = factory.SubFactory("actions.factories.ConsequencePoolFactory")
     detect_check_type = factory.SubFactory("world.checks.factories.CheckTypeFactory")

--- a/src/world/room_features/models.py
+++ b/src/world/room_features/models.py
@@ -20,6 +20,8 @@ from world.room_features.constants import (
     RoomFeatureServiceStrategy,
 )
 
+ROOM_PROFILE_MODEL = "evennia_extensions.RoomProfile"
+
 
 class RoomFeatureKind(SharedMemoryModel):
     """Catalog row for a kind of installable room feature.
@@ -190,7 +192,7 @@ class RoomFeatureInstance(SharedMemoryModel):
     """
 
     room_profile = models.OneToOneField(
-        "evennia_extensions.RoomProfile",
+        ROOM_PROFILE_MODEL,
         on_delete=models.CASCADE,
         related_name="feature_instance",
         primary_key=True,
@@ -248,7 +250,7 @@ class RoomFeatureProgressionDetails(SharedMemoryModel):
         primary_key=True,
     )
     target_room_profile = models.ForeignKey(
-        "evennia_extensions.RoomProfile",
+        ROOM_PROFILE_MODEL,
         on_delete=models.PROTECT,
         related_name="feature_progression_projects",
         help_text="The room the feature will be installed in or upgraded.",
@@ -296,7 +298,7 @@ class Trap(SharedMemoryModel):
     """
 
     room_profile = models.ForeignKey(
-        "evennia_extensions.RoomProfile",
+        ROOM_PROFILE_MODEL,
         on_delete=models.CASCADE,
         related_name="traps",
         help_text="The room this trap is set in. A room may hold several traps.",

--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -116,12 +116,142 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
         delivery_receivers = list(Persona.objects.filter(pk__in=receiver_ids))
         return delivery_receivers, len(delivery_receivers) == len(set(receiver_ids))
 
+    @staticmethod
+    def _reject_treatment_fields_for_non_treat(
+        action_key: str, serializer: SceneActionRequestCreateSerializer
+    ) -> None:
+        """Reject treatment-only fields submitted for a non-treat_condition action (#1486).
+
+        Treatment fields are only meaningful for treat_condition. Rejecting all four up front lets
+        the create path assume ``treatment_id`` implies treat_condition; previously only
+        ``treatment_id`` was rejected and the other three were silently ignored.
+        """
+        if action_key == TREAT_CONDITION_KEY:
+            return
+        if any(
+            v is not None
+            for v in (
+                serializer.validated_data.get("treatment_id"),
+                serializer.validated_data.get("target_condition_instance_id"),
+                serializer.validated_data.get("target_pending_alteration_id"),
+                serializer.validated_data.get("bond_thread_id"),
+            )
+        ):
+            raise DRFValidationError(
+                {"treatment_fields": "Treatment fields are only valid for treat_condition."}
+            )
+
+    @staticmethod
+    def _resolve_treatment_target_effect(
+        serializer: SceneActionRequestCreateSerializer,
+    ) -> tuple[Any, str]:
+        """Resolve the single treat_condition target effect (condition XOR alteration) (#1486)."""
+        one_effect_error = DRFValidationError(
+            {"target_effect": "Specify exactly one target effect (condition or alteration)."}
+        )
+        condition_instance_id = serializer.validated_data.get("target_condition_instance_id")
+        pending_alteration_id = serializer.validated_data.get("target_pending_alteration_id")
+        if condition_instance_id is not None and pending_alteration_id is not None:
+            raise one_effect_error
+        if condition_instance_id is not None:
+            from world.conditions.models import ConditionInstance  # noqa: PLC0415
+
+            target_effect = get_object_or_404(ConditionInstance, pk=condition_instance_id)
+            return target_effect, TARGET_EFFECT_CONDITION
+        if pending_alteration_id is not None:
+            from world.magic.models import PendingAlteration  # noqa: PLC0415
+
+            target_effect = get_object_or_404(PendingAlteration, pk=pending_alteration_id)
+            return target_effect, TARGET_EFFECT_ALTERATION
+        raise one_effect_error
+
+    def _resolve_treatment(
+        self,
+        serializer: SceneActionRequestCreateSerializer,
+        *,
+        action_key: str,
+        initiator_persona: Persona,
+        target_persona: Persona | None,
+        scene: Scene,
+    ) -> tuple[Any, Any, str | None, dict[str, Any] | None]:
+        """Validate & resolve the treat_condition treatment, target effect, and matched candidate.
+
+        Returns ``(treatment, target_effect, target_effect_type, matched_candidate)``; all ``None``
+        for non-treat actions. Re-runs ``get_treatment_candidates`` and requires the submitted pair
+        to match one candidate by pk, so every scene/engagement/bond gate stays in the service and
+        a client cannot fabricate an arbitrary treatment_id + target pair (#1486).
+        """
+        if action_key != TREAT_CONDITION_KEY:
+            return None, None, None, None
+
+        treatment_id = serializer.validated_data.get("treatment_id")
+        if treatment_id is None:
+            raise DRFValidationError({"treatment_id": "treat_condition requires a treatment_id."})
+        # treat_condition is a heal-another flow: it always targets a single other persona.
+        # Cardinality allows 0 targets for SINGLE actions, so guard explicitly.
+        if target_persona is None:
+            raise DRFValidationError(
+                {"target_persona": "treat_condition requires a target persona."}
+            )
+
+        target_effect, target_effect_type = self._resolve_treatment_target_effect(serializer)
+
+        from world.conditions.models import TreatmentTemplate  # noqa: PLC0415
+        from world.conditions.services import get_treatment_candidates  # noqa: PLC0415
+
+        treatment = get_object_or_404(TreatmentTemplate, pk=treatment_id)
+        candidates = get_treatment_candidates(
+            initiator_persona.character_sheet, target_persona.character_sheet, scene
+        )
+        matched_candidate = next(
+            (
+                c
+                for c in candidates
+                if c["treatment"].pk == treatment.pk
+                and c["target_effect"].pk == target_effect.pk
+                and c["target_effect_type"] == target_effect_type
+            ),
+            None,
+        )
+        if matched_candidate is None:
+            raise DRFValidationError(
+                {"treatment": "That treatment is not available for this target in this scene."}
+            )
+        return treatment, target_effect, target_effect_type, matched_candidate
+
+    @staticmethod
+    def _apply_treatment_fks(
+        action_request: SceneActionRequest,
+        *,
+        treatment: Any,
+        target_effect: Any,
+        target_effect_type: str | None,
+        matched_candidate: dict[str, Any],
+    ) -> None:
+        """Mirror the telnet treat command's FK-setting on a freshly created request (#1486).
+
+        Sets treatment, the matching target effect, and the matched candidate's bond_thread (NOT a
+        client-supplied id — the discovery query already selected the valid anchored thread).
+        """
+        action_request.treatment = treatment
+        if target_effect_type == TARGET_EFFECT_CONDITION:
+            action_request.target_condition_instance = target_effect
+        else:
+            action_request.target_pending_alteration = target_effect
+        action_request.thread_used = matched_candidate["bond_thread"]
+        action_request.save(
+            update_fields=[
+                "treatment",
+                "target_condition_instance",
+                "target_pending_alteration",
+                "thread_used",
+            ]
+        )
+
     @extend_schema(
         request=SceneActionRequestCreateSerializer, responses=SceneActionRequestSerializer
     )
-    def create(  # noqa: C901, PLR0912, PLR0915
-        self, request: Request, *args: Any, **kwargs: Any
-    ) -> Response:
+    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Create a new action request."""
         serializer = SceneActionRequestCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -140,25 +270,7 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
         effort_level: str = serializer.validated_data["effort_level"]
 
         self._validate_cardinality(action_key, target_ids)
-
-        # Treatment fields are only meaningful for treat_condition (#1486).
-        # Reject ALL four up front for any other action_key so the create path
-        # below can assume treatment_id implies treat_condition. A non-treat
-        # action has no business carrying any of them; previously only
-        # treatment_id was rejected and the other three were silently ignored.
-        treatment_id = serializer.validated_data.get("treatment_id")
-        if action_key != TREAT_CONDITION_KEY and any(
-            v is not None
-            for v in (
-                treatment_id,
-                serializer.validated_data.get("target_condition_instance_id"),
-                serializer.validated_data.get("target_pending_alteration_id"),
-                serializer.validated_data.get("bond_thread_id"),
-            )
-        ):
-            raise DRFValidationError(
-                {"treatment_fields": "Treatment fields are only valid for treat_condition."}
-            )
+        self._reject_treatment_fields_for_non_treat(action_key, serializer)
 
         try:
             scene = Scene.objects.get(pk=scene_id, is_active=True)
@@ -200,85 +312,13 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Treat-condition candidate validation (#1486). The telnet treat
-        # command only ever submits candidates from get_treatment_candidates,
-        # so the scene/engagement/bond gates are implicitly satisfied. The web
-        # endpoint MUST NOT accept an arbitrary treatment_id + target pair a
-        # client could fabricate — that would bypass every gate. So we re-run
-        # the candidate query and require the submitted pair to match one
-        # candidate by pk. This delegates all gate logic to the service (no
-        # duplicated gate logic in the view); the view only resolves submitted
-        # ids, matches against the service's output, and sets FKs.
-        treatment = None
-        target_effect = None
-        target_effect_type: str | None = None
-        matched_candidate: dict[str, Any] | None = None
-        if action_key == TREAT_CONDITION_KEY:
-            if treatment_id is None:
-                raise DRFValidationError(
-                    {"treatment_id": "treat_condition requires a treatment_id."}
-                )
-            # treat_condition is a heal-another flow: it always targets a
-            # single other persona. Cardinality allows 0 targets for SINGLE
-            # actions, so guard explicitly rather than AttributeError on None.
-            if target_persona is None:
-                raise DRFValidationError(
-                    {"target_persona": "treat_condition requires a target persona."}
-                )
-            condition_instance_id = serializer.validated_data.get("target_condition_instance_id")
-            pending_alteration_id = serializer.validated_data.get("target_pending_alteration_id")
-            if condition_instance_id is not None and pending_alteration_id is not None:
-                raise DRFValidationError(
-                    {
-                        "target_effect": (
-                            "Specify exactly one target effect (condition or alteration)."
-                        )
-                    }
-                )
-            if condition_instance_id is not None:
-                from world.conditions.models import ConditionInstance  # noqa: PLC0415
-
-                target_effect = get_object_or_404(ConditionInstance, pk=condition_instance_id)
-                target_effect_type = TARGET_EFFECT_CONDITION
-            elif pending_alteration_id is not None:
-                from world.magic.models import PendingAlteration  # noqa: PLC0415
-
-                target_effect = get_object_or_404(PendingAlteration, pk=pending_alteration_id)
-                target_effect_type = TARGET_EFFECT_ALTERATION
-            else:
-                raise DRFValidationError(
-                    {
-                        "target_effect": (
-                            "Specify exactly one target effect (condition or alteration)."
-                        )
-                    }
-                )
-
-            from world.conditions.models import TreatmentTemplate  # noqa: PLC0415
-            from world.conditions.services import get_treatment_candidates  # noqa: PLC0415
-
-            treatment = get_object_or_404(TreatmentTemplate, pk=treatment_id)
-            helper_sheet = initiator_persona.character_sheet
-            target_sheet = target_persona.character_sheet
-            candidates = get_treatment_candidates(helper_sheet, target_sheet, scene)
-            matched_candidate = next(
-                (
-                    c
-                    for c in candidates
-                    if c["treatment"].pk == treatment.pk
-                    and c["target_effect"].pk == target_effect.pk
-                    and c["target_effect_type"] == target_effect_type
-                ),
-                None,
-            )
-            if matched_candidate is None:
-                raise DRFValidationError(
-                    {
-                        "treatment": (
-                            "That treatment is not available for this target in this scene."
-                        )
-                    }
-                )
+        treatment, target_effect, target_effect_type, matched_candidate = self._resolve_treatment(
+            serializer,
+            action_key=action_key,
+            initiator_persona=initiator_persona,
+            target_persona=target_persona,
+            scene=scene,
+        )
 
         try:
             action_request = create_action_request(
@@ -300,24 +340,14 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Mirror the telnet treat command's FK-setting (commands/conditions.py):
-        # set treatment, the matching target effect, and the matched candidate's
-        # bond_thread (NOT a client-supplied id — the discovery query already
-        # selected the valid anchored thread).
+        # Mirror the telnet treat command's FK-setting (commands/conditions.py).
         if action_key == TREAT_CONDITION_KEY and matched_candidate is not None:
-            action_request.treatment = treatment
-            if target_effect_type == TARGET_EFFECT_CONDITION:
-                action_request.target_condition_instance = target_effect
-            else:
-                action_request.target_pending_alteration = target_effect
-            action_request.thread_used = matched_candidate["bond_thread"]
-            action_request.save(
-                update_fields=[
-                    "treatment",
-                    "target_condition_instance",
-                    "target_pending_alteration",
-                    "thread_used",
-                ]
+            self._apply_treatment_fks(
+                action_request,
+                treatment=treatment,
+                target_effect=target_effect,
+                target_effect_type=target_effect_type,
+                matched_candidate=matched_candidate,
             )
 
         return Response(

--- a/src/world/secrets/services.py
+++ b/src/world/secrets/services.py
@@ -228,6 +228,42 @@ class SecretExposureResult:
     notified_persona_victim_ids: tuple[int, ...] = ()
 
 
+def _apply_relational_exposure(
+    secret: Secret, persona: Persona
+) -> tuple[dict[int, int], list[int]]:
+    """Apply the first-exposure **relational** channel (direct victim hits) (#1429).
+
+    Returns ``(organization_victim_deltas, notified_persona_victim_ids)``. Organization victims
+    take an ``OrganizationReputation`` delta independent of philosophy; persona victims are granted
+    the knowledge (prompting a player-driven relationship decision) and recorded. Helper for
+    ``expose_secret`` — only called on the first exposure of a secret.
+    """
+    from world.roster.models import RosterEntry  # noqa: PLC0415 — cross-app, avoid cycle at load
+    from world.societies.renown import (  # noqa: PLC0415 — cross-app, avoid import cycle at load
+        bump_organization_reputation,
+    )
+
+    org_deltas: dict[int, int] = {}
+    notified_persona_ids: list[int] = []
+    default_severity = DEFAULT_VICTIM_SEVERITY_BY_LEVEL.get(secret.level, 0)
+    for victim in secret.victims.select_related("organization", "persona__character_sheet"):
+        if victim.organization_id:
+            severity = victim.severity if victim.severity is not None else default_severity
+            new_value = bump_organization_reputation(persona, victim.organization, -severity)
+            if new_value is not None:
+                org_deltas[victim.organization_id] = new_value
+        elif victim.persona_id:
+            # Going public reaches the victim too: grant a PC victim the knowledge, which
+            # prompts them (via grant_secret_knowledge) to decide a relationship effect.
+            victim_entry = RosterEntry.objects.filter(
+                character_sheet=victim.persona.character_sheet
+            ).first()
+            if victim_entry is not None:
+                grant_secret_knowledge(roster_entry=victim_entry, secret=secret)
+                notified_persona_ids.append(victim.persona_id)
+    return org_deltas, notified_persona_ids
+
+
 def expose_secret(secret: Secret, *, societies: Iterable[Society]) -> SecretExposureResult:
     """Fire the reputation consequences of a secret becoming known to ``societies`` (#1429).
 
@@ -245,10 +281,8 @@ def expose_secret(secret: Secret, *, societies: Iterable[Society]) -> SecretExpo
     Reputation is attributed to the subject's primary persona (only established/primary identities
     accrue reputation, enforced downstream). Idempotent across re-exposure.
     """
-    from world.roster.models import RosterEntry  # noqa: PLC0415 — cross-app, avoid cycle at load
     from world.societies.renown import (  # noqa: PLC0415 — cross-app, avoid import cycle at load
         apply_archetype_society_reputation,
-        bump_organization_reputation,
     )
 
     persona = secret.subject_sheet.primary_persona
@@ -264,22 +298,7 @@ def expose_secret(secret: Secret, *, societies: Iterable[Society]) -> SecretExpo
     org_deltas: dict[int, int] = {}
     notified_persona_ids: list[int] = []
     if first_exposure:
-        default_severity = DEFAULT_VICTIM_SEVERITY_BY_LEVEL.get(secret.level, 0)
-        for victim in secret.victims.select_related("organization", "persona__character_sheet"):
-            if victim.organization_id:
-                severity = victim.severity if victim.severity is not None else default_severity
-                new_value = bump_organization_reputation(persona, victim.organization, -severity)
-                if new_value is not None:
-                    org_deltas[victim.organization_id] = new_value
-            elif victim.persona_id:
-                # Going public reaches the victim too: grant a PC victim the knowledge, which
-                # prompts them (via grant_secret_knowledge) to decide a relationship effect.
-                victim_entry = RosterEntry.objects.filter(
-                    character_sheet=victim.persona.character_sheet
-                ).first()
-                if victim_entry is not None:
-                    grant_secret_knowledge(roster_entry=victim_entry, secret=secret)
-                    notified_persona_ids.append(victim.persona_id)
+        org_deltas, notified_persona_ids = _apply_relational_exposure(secret, persona)
 
     return SecretExposureResult(
         newly_exposed_society_ids=tuple(society.pk for society in newly),

--- a/src/world/stories/services/beats.py
+++ b/src/world/stories/services/beats.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
     from actions.models.consequence_pools import ConsequencePool
     from world.scenes.models import Persona
-    from world.stories.models import Episode
+    from world.stories.models import Episode, Story
 
 
 def evaluate_auto_beats(progress: AnyStoryProgress) -> None:
@@ -222,59 +222,14 @@ def record_aggregate_contribution(
         if beat.outcome != BeatOutcome.SUCCESS:
             new_outcome = _evaluate_aggregate_beat(beat)
             if new_outcome == BeatOutcome.SUCCESS:
-                beat.outcome = new_outcome
-                beat.save(update_fields=["outcome", "updated_at"])
-
-                # BeatCompletion for aggregate threshold crossing is scope-aware:
-                # - CHARACTER: attribute to the character who crossed it.
-                # - GROUP: attribute to the group (gm_table); individual contributions
-                #   are already in the AggregateBeatContribution ledger.
-                # - GLOBAL: no FK required.
-                completion_kwargs: dict = {
-                    "beat": beat,
-                    "outcome": new_outcome,
-                    "era": era,
-                }
-                if scope == StoryScope.CHARACTER:
-                    completion_kwargs["character_sheet"] = character_sheet
-                    completion_kwargs["roster_entry"] = roster_entry
-                elif scope == StoryScope.GROUP:
-                    from world.stories.services.progress import (  # noqa: PLC0415
-                        get_active_progress_for_story,
-                    )
-
-                    group_progress = get_active_progress_for_story(story)
-                    if group_progress is not None:
-                        completion_kwargs["gm_table"] = group_progress.gm_table
-                # GLOBAL: no scope-specific FK
-
-                aggregate_completion = BeatCompletion.objects.create(**completion_kwargs)
-
-                # Fire consequence pool for the aggregate threshold crossing.
-                # Participants are auto-derived from contribution rows.
-                # For GROUP scope, group_progress may be None if no active progress exists
-                # (defined in the elif block above); other scopes always pass None.
-                _agg_pool_progress = (
-                    group_progress  # type: ignore[possibly-undefined]
-                    if scope == StoryScope.GROUP
-                    else None
+                _finalize_aggregate_crossing(
+                    beat=beat,
+                    story=story,
+                    scope=scope,
+                    character_sheet=character_sheet,
+                    roster_entry=roster_entry,
+                    era=era,
                 )
-                _maybe_fire_pool_on_completion(
-                    completion=aggregate_completion,
-                    progress=_agg_pool_progress,
-                    scope=story.scope,
-                    explicit_participants=None,
-                )
-
-                # Narrative notification for the aggregate threshold crossing.
-                # Resolve an active progress to fan out recipients per scope.
-                from world.stories.services.progress import (  # noqa: PLC0415
-                    get_active_progress_for_story,
-                )
-
-                agg_progress = get_active_progress_for_story(story)
-                if agg_progress is not None:
-                    _notify_beat_completion(aggregate_completion, agg_progress)
 
         # Write-path hook: open a SessionRequest if the episode is now ready-to-run
         # and requires a GM session. Walk beat -> episode -> chapter -> story to
@@ -287,6 +242,69 @@ def record_aggregate_contribution(
             maybe_create_session_request(progress)
 
     return contrib
+
+
+def _finalize_aggregate_crossing(  # noqa: PLR0913
+    *,
+    beat: Beat,
+    story: Story,
+    scope: str,
+    character_sheet: CharacterSheet,
+    roster_entry: RosterEntry | None,
+    era: Era | None,
+) -> None:
+    """Flip an aggregate beat to SUCCESS and fire its completion side effects.
+
+    Called by record_aggregate_contribution only after the contribution ledger
+    has crossed the beat's required_points threshold. Must run inside the
+    caller's atomic transaction. Persists the outcome, writes a scope-aware
+    BeatCompletion, fires the consequence pool, and fans out the narrative
+    notification.
+
+    BeatCompletion attribution is scope-aware:
+      - CHARACTER: attribute to the character who crossed it.
+      - GROUP: attribute to the group (gm_table); individual contributions are
+        already in the AggregateBeatContribution ledger.
+      - GLOBAL: no FK required.
+    """
+    from world.stories.services.progress import (  # noqa: PLC0415
+        get_active_progress_for_story,
+    )
+
+    beat.outcome = BeatOutcome.SUCCESS
+    beat.save(update_fields=["outcome", "updated_at"])
+
+    completion_kwargs: dict = {
+        "beat": beat,
+        "outcome": BeatOutcome.SUCCESS,
+        "era": era,
+    }
+    group_progress = None
+    if scope == StoryScope.CHARACTER:
+        completion_kwargs["character_sheet"] = character_sheet
+        completion_kwargs["roster_entry"] = roster_entry
+    elif scope == StoryScope.GROUP:
+        group_progress = get_active_progress_for_story(story)
+        if group_progress is not None:
+            completion_kwargs["gm_table"] = group_progress.gm_table
+    # GLOBAL: no scope-specific FK
+
+    aggregate_completion = BeatCompletion.objects.create(**completion_kwargs)
+
+    # Fire consequence pool for the aggregate threshold crossing. Participants are
+    # auto-derived from contribution rows. For GROUP scope, group_progress may be
+    # None when no active progress exists; other scopes always pass None.
+    _maybe_fire_pool_on_completion(
+        completion=aggregate_completion,
+        progress=group_progress if scope == StoryScope.GROUP else None,
+        scope=scope,
+        explicit_participants=None,
+    )
+
+    # Narrative notification: resolve an active progress to fan out recipients per scope.
+    agg_progress = get_active_progress_for_story(story)
+    if agg_progress is not None:
+        _notify_beat_completion(aggregate_completion, agg_progress)
 
 
 def expire_overdue_beats(now: datetime | None = None) -> int:
@@ -721,40 +739,68 @@ def _resolve_participants_for_pool(
         otherwise (will raise LegendAwardParticipantMissingError if pool needs it).
     GLOBAL scope: always empty (raises LegendAwardScopeError if pool needs it).
     """
+    if scope == StoryScope.CHARACTER:
+        return _character_scope_participants(progress, explicit_participants)
+    if scope == StoryScope.GROUP:
+        return _group_scope_participants(completion, explicit_participants)
+    # GLOBAL: no auto-derived participants.
+    return []
+
+
+def _character_scope_participants(
+    progress: AnyStoryProgress | None,
+    explicit_participants: list[Persona] | None,
+) -> list[Persona]:
+    """Resolve CHARACTER-scope pool participants: primary persona plus optional extras."""
+    if progress is None:
+        return list(explicit_participants) if explicit_participants else []
+    participants: list[Persona] = [progress.character_sheet.primary_persona]
+    if explicit_participants:
+        participants.extend(explicit_participants)
+    return participants
+
+
+def _group_scope_participants(
+    completion: BeatCompletion,
+    explicit_participants: list[Persona] | None,
+) -> list[Persona]:
+    """Resolve GROUP-scope pool participants.
+
+    Uses explicit_participants when provided; otherwise auto-derives from the
+    AggregateBeatContribution ledger for AGGREGATE_THRESHOLD beats; otherwise
+    returns an empty list (the pool guard raises later if it needs participants).
+    """
+    if explicit_participants is not None:
+        return list(explicit_participants)
+    # Auto-derive for AGGREGATE_THRESHOLD: all contributors → primary personas.
+    if completion.beat.predicate_type == BeatPredicateType.AGGREGATE_THRESHOLD:
+        return _derive_aggregate_participants(completion.beat)
+    # GM_MARKED without explicit list → empty (pool guard checks later).
+    return []
+
+
+def _derive_aggregate_participants(beat: Beat) -> list[Persona]:
+    """Map every distinct contributing character sheet to its PRIMARY persona.
+
+    Sheets without a primary persona are skipped. Used for GROUP-scope
+    AGGREGATE_THRESHOLD pools where participants are not explicitly supplied.
+    """
     from world.scenes.constants import PersonaType  # noqa: PLC0415
     from world.scenes.models import Persona  # noqa: PLC0415
 
-    if scope == StoryScope.CHARACTER:
-        if progress is None:
-            return list(explicit_participants) if explicit_participants else []
-        participants: list[Persona] = [progress.character_sheet.primary_persona]
-        if explicit_participants:
-            participants.extend(explicit_participants)
-        return participants
-
-    if scope == StoryScope.GROUP:
-        if explicit_participants is not None:
-            return list(explicit_participants)
-        # Auto-derive for AGGREGATE_THRESHOLD: all contributors → primary personas.
-        if completion.beat.predicate_type == BeatPredicateType.AGGREGATE_THRESHOLD:
-            sheet_ids = list(
-                AggregateBeatContribution.objects.filter(beat=completion.beat)
-                .values_list("character_sheet_id", flat=True)
-                .distinct()
-            )
-            derived: list[Persona] = []
-            for sid in sheet_ids:
-                persona = Persona.objects.filter(
-                    character_sheet_id=sid, persona_type=PersonaType.PRIMARY
-                ).first()
-                if persona is not None:
-                    derived.append(persona)
-            return derived
-        # GM_MARKED without explicit list → empty (pool guard checks later).
-        return []
-
-    # GLOBAL: no auto-derived participants.
-    return []
+    sheet_ids = list(
+        AggregateBeatContribution.objects.filter(beat=beat)
+        .values_list("character_sheet_id", flat=True)
+        .distinct()
+    )
+    derived: list[Persona] = []
+    for sid in sheet_ids:
+        persona = Persona.objects.filter(
+            character_sheet_id=sid, persona_type=PersonaType.PRIMARY
+        ).first()
+        if persona is not None:
+            derived.append(persona)
+    return derived
 
 
 def _maybe_fire_pool_on_completion(

--- a/src/world/vitals/services.py
+++ b/src/world/vitals/services.py
@@ -38,7 +38,12 @@ if TYPE_CHECKING:
     from world.character_sheets.models import CharacterSheet
     from world.checks.models import CheckType as CheckTypeHint, Consequence, ConsequenceEffect
     from world.checks.types import ModifierBreakdown, PendingResolution
-    from world.conditions.models import ConditionInstance, ConditionTemplate, DamageType
+    from world.conditions.models import (
+        ConditionInstance,
+        ConditionStage,
+        ConditionTemplate,
+        DamageType,
+    )
     from world.conditions.types import RoundTickResult
     from world.scenes.models import Interaction
     from world.vitals.models import VitalsConsequenceConfig
@@ -763,6 +768,27 @@ def resolve_abandonment(character_sheet: CharacterSheet | None) -> bool:
     return _resolve_peril_via_pool(character_sheet, instance, pool)
 
 
+def _advance_to_next_stage(instance: ConditionInstance, stage: ConditionStage) -> None:
+    """Advance ``instance`` to the next higher bleed-out stage, if one exists.
+
+    No-op when ``stage`` is already the highest authored ``stage_order`` for the
+    condition (the caller resolves the terminal stage separately).
+    """
+    from world.conditions.models import ConditionStage  # noqa: PLC0415
+
+    next_stage = (
+        ConditionStage.objects.filter(
+            condition=instance.condition,
+            stage_order__gt=stage.stage_order,
+        )
+        .order_by("stage_order")
+        .first()
+    )
+    if next_stage is not None:
+        instance.current_stage = next_stage
+        instance.save(update_fields=["current_stage"])
+
+
 def advance_bleed_out(character_sheet: CharacterSheet | None) -> bool:
     """Advance staged bleed-out conditions toward death.
 
@@ -782,7 +808,6 @@ def advance_bleed_out(character_sheet: CharacterSheet | None) -> bool:
         BLEED_OUT_CONDITION_NAME,
     )
     from world.conditions.models import (  # noqa: PLC0415
-        ConditionStage,
         ConditionTemplate,
     )
     from world.conditions.services import (  # noqa: PLC0415
@@ -830,17 +855,7 @@ def advance_bleed_out(character_sheet: CharacterSheet | None) -> bool:
 
         if int(result.success_level) < 0:
             # Failed resist on a non-terminal stage: advance to the next stage.
-            next_stage = (
-                ConditionStage.objects.filter(
-                    condition=instance.condition,
-                    stage_order__gt=stage.stage_order,
-                )
-                .order_by("stage_order")
-                .first()
-            )
-            if next_stage is not None:
-                instance.current_stage = next_stage
-                instance.save(update_fields=["current_stage"])
+            _advance_to_next_stage(instance, stage)
 
     return False
 


### PR DESCRIPTION
Resolves all 50 open `sonarcloud:high` issues (#1629–#1678) in one bundle.

## What changed
Behavior-preserving code-quality cleanup flagged by SonarCloud, in three buckets:

- **python:S1192** (~26 issues) — extracted each duplicated string literal into a
  single module-level constant and replaced every occurrence. No wording changes.
- **python:S3776** (~21 issues) — reduced cognitive complexity of functions to ≤15
  by extracting well-named private helpers and using early-return guard clauses.
  Public signatures unchanged; all side effects/return values preserved.
- **typescript:S2004 / S3776** (3 issues) — un-nested deeply nested callbacks and
  extracted pure helpers in the rituals frontend.

## Verification
- `ruff check` clean on all changed files.
- `ty check` (project config) passes; no new diagnostics introduced.
- Fast SQLite test tier run for every touched app (actions, commands, world.combat,
  world.conditions, world.magic, world.relationships, world.progression,
  world.room_features, world.achievements, world.vitals, world.scenes,
  world.secrets, world.fatigue, world.items, world.stories).
- Frontend `pnpm typecheck` + `lint` clean.

Closes #1629
Closes #1630
Closes #1631
Closes #1632
Closes #1633
Closes #1634
Closes #1635
Closes #1636
Closes #1637
Closes #1638
Closes #1639
Closes #1640
Closes #1641
Closes #1642
Closes #1643
Closes #1644
Closes #1645
Closes #1646
Closes #1647
Closes #1648
Closes #1649
Closes #1650
Closes #1651
Closes #1652
Closes #1653
Closes #1654
Closes #1655
Closes #1656
Closes #1657
Closes #1658
Closes #1659
Closes #1660
Closes #1661
Closes #1662
Closes #1663
Closes #1664
Closes #1665
Closes #1666
Closes #1667
Closes #1668
Closes #1669
Closes #1670
Closes #1671
Closes #1672
Closes #1673
Closes #1674
Closes #1675
Closes #1676
Closes #1677
Closes #1678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
