### PR TITLE
feat(checks): wire collect_check_modifiers into social-action resolution (#1696)

### DIFF
--- a/src/world/checks/CLAUDE.md
+++ b/src/world/checks/CLAUDE.md
@@ -51,6 +51,12 @@ penetration, flee, environmental, clash, **and defense** via `resolve_npc_attack
 through this seam with `scene=encounter.scene`, so fashion/covenant/conditions
 apply uniformly to attack and defense (#750/#512).
 
+**Social/scene actions** funnel their plain (non-technique) check through the same
+seam in `world.scenes.action_services._resolve_action_against_persona`
+(`scene=request.scene`), so conditions / rollmod / scene / equipment / CHARACTER /
+fashion — and, once scoped, **allure** — reach social checks too (#1696). The
+technique branch collects its own modifiers downstream and is left untouched.
+
 ## Integration Points
 
 - **Traits app**: Uses PointConversionRange, CheckRank, ResultChart, CheckOutcome

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -528,6 +528,7 @@ def _resolve_action_against_persona(
         ValueError: If the request has no action_template set.
     """
     from actions.constants import ActionCategory  # noqa: PLC0415
+    from world.checks.services import collect_check_modifiers  # noqa: PLC0415
     from world.fatigue.constants import EFFORT_CHECK_MODIFIER  # noqa: PLC0415
     from world.fatigue.services import apply_fatigue  # noqa: PLC0415
 
@@ -569,12 +570,28 @@ def _resolve_action_against_persona(
         # technique-cast-only mechanic (spec: intensity rides power_intensity_bonus
         # inside use_technique). The serializer rejects fury_commitment_id on
         # plain actions, so fury_commitment is always None here.
+        #
+        # Social/scene actions are always plain, and this is the ONE place they
+        # enter the modifier seam: combat/challenge/vitals already funnel their
+        # checks through collect_check_modifiers, but the social path did not, so
+        # no condition / rollmod / scene / equipment / CHARACTER / fashion (and,
+        # once scoped, allure — #1696) modifier reached a social check. Fold the
+        # initiator's breakdown into extra_modifiers here, scene-scoped so the
+        # perception-relative fashion bonus resolves (#512). The technique branch
+        # collects its own modifiers downstream, so it is left untouched.
+        # ActionTemplate.check_type is NOT NULL, so the action always has a check to
+        # gather modifiers for.
+        breakdown = collect_check_modifiers(
+            action_request.initiator_persona.character_sheet,
+            action_template.check_type,
+            scene=action_request.scene,
+        )
         action_resolution = start_action_resolution(
             character=character,
             template=action_template,
             target_difficulty=difficulty,
             context=context,
-            extra_modifiers=check_modifiers,
+            extra_modifiers=check_modifiers + breakdown.total,
         )
         result = EnhancedSceneActionResult(
             action_resolution=action_resolution,

--- a/src/world/scenes/tests/test_action_services.py
+++ b/src/world/scenes/tests/test_action_services.py
@@ -1,6 +1,7 @@
 """Tests for scene action services: create_action_request and respond_to_action_request."""
 
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
@@ -1655,3 +1656,63 @@ class TestNPCAndAreaFallbackDifficulty(TestCase):
             DIFFICULTY_VALUES[DifficultyChoice.HARD],
             "Area action must resolve at the authored HARD difficulty (60), not NORMAL",
         )
+
+
+class SocialModifierSeamTests(TestCase):
+    """The social/scene action path funnels its check through ``collect_check_modifiers`` (#1696).
+
+    Combat / challenge / vitals already honor the modifier seam; the social path did not, so no
+    condition / rollmod / scene / equipment / CHARACTER / fashion (and, once scoped, allure)
+    modifier reached a social check. These tests pin the wiring: the initiator's breakdown total
+    is folded into ``extra_modifiers`` for plain (non-technique) actions, scene-scoped.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.scene = SceneFactory()
+        cls.initiator = PersonaFactory()
+        cls.action_template = ActionTemplateFactory()
+
+    def setUp(self) -> None:
+        self.accrue_patcher = patch("world.scenes.action_services.accrue")
+        self.accrue_patcher.start()
+        self.addCleanup(self.accrue_patcher.stop)
+
+    def _make_request(self) -> "SceneActionTarget":
+        from world.scenes.action_models import SceneActionRequest
+
+        request = SceneActionRequestFactory(
+            scene=self.scene,
+            initiator_persona=self.initiator,
+            action_key="intimidate",
+            status=ActionRequestStatus.PENDING,
+        )
+        SceneActionRequest.objects.filter(pk=request.pk).update(
+            action_template=self.action_template
+        )
+        request.action_template = self.action_template
+        return SceneActionTargetFactory(action_request=request)
+
+    @patch("world.checks.services.collect_check_modifiers")
+    @patch("world.scenes.action_services.start_action_resolution")
+    def test_breakdown_total_folded_into_extra_modifiers(
+        self, mock_resolve: MagicMock, mock_collect: MagicMock
+    ) -> None:
+        from world.fatigue.constants import EFFORT_CHECK_MODIFIER
+
+        mock_resolve.return_value = _make_pending_resolution(success=True)
+        mock_collect.return_value = SimpleNamespace(total=7)
+
+        row = self._make_request()
+        request = row.action_request
+        respond_to_action_target(action_target=row, decision=ConsentDecision.ACCEPT)
+
+        # collect_check_modifiers is asked for the initiator's sheet + the action's check type,
+        # scene-scoped so the perception-relative fashion bonus can resolve.
+        mock_collect.assert_called_once_with(
+            request.initiator_persona.character_sheet,
+            request.action_template.check_type,
+            scene=request.scene,
+        )
+        expected = EFFORT_CHECK_MODIFIER.get(request.effort_level, 0) + 7
+        self.assertEqual(mock_resolve.call_args.kwargs["extra_modifiers"], expected)


### PR DESCRIPTION
## What

The **foundation slice** of the Allure / social-influence epic (#1696): make social/scene
action checks honor the shared modifier seam. Today combat, challenge, and vitals all funnel
their checks through `collect_check_modifiers`, but `_resolve_action_against_persona` passed
**effort-only** `extra_modifiers` — so **no** condition / rollmod / scene / equipment /
CHARACTER / fashion (and, once scoped, **allure**) modifier reached any social check. That's a
latent bug well beyond Allure, and a prerequisite for the Attracted / Vulnerable conditions (#1697).

## How

- In the **plain (non-technique) branch** of `world.scenes.action_services._resolve_action_against_persona`,
  call `collect_check_modifiers(initiator_sheet, action_template.check_type, scene=request.scene)` and
  fold its `breakdown.total` into `extra_modifiers` alongside the existing effort modifier.
- **Scene-scoped** so the perception-relative fashion bonus resolves (#512).
- The **technique branch is untouched** — techniques (magic/combat-in-scene) collect their own
  modifiers downstream, so folding here would double-count. Social actions are always plain.

## Anti-reinvention

No new surface. `collect_check_modifiers` is **`[BUILT & WIRED]`** (`world/checks/services.py:508`,
called from `world/combat/services.py`, `world/mechanics/challenge_resolution.py:180`); this just
adds the social caller, mirroring the challenge pattern. `ActionTemplate.check_type` is NOT NULL,
so the check is always present (no dead guard).

## Tests

`world.scenes.tests.test_action_services.SocialModifierSeamTests` — pins that the initiator's
breakdown total is folded into `extra_modifiers`, scene-scoped, on top of the effort modifier.
Full `test_action_services` + integration + resolver + area + technique suites stay green
(the real `collect_check_modifiers` now runs in every plain-branch resolution test; breakdown is
0 for bare factory sheets, so behavior is unchanged where no modifier exists).

Refs #1696

🤖 Generated with [Claude Code](https://claude.com/claude-code)
