### PR TITLE
feat(skills): bridge harness-agnostic skills to polytoken

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -113,3 +113,9 @@ for skill in /workspaces/arxii/tools/skills/*/; do
   ln -sfn "$skill" "/home/vscode/.claude/skills/$name"
 done
 shopt -u nullglob
+
+# Mirror polytoken-compatible skills into .polytoken/skills/ as real copies so
+# the polytoken harness discovers them too (it does not follow symlinks like
+# Claude Code does). Selects skills whose SKILL.md declares
+# `compatibility: polytoken`. Idempotent; re-run via `just sync-polytoken-skills`.
+bash /workspaces/arxii/tools/skills/sync-polytoken-skills.sh

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 docs/superpowers/*
 !docs/superpowers/specs/
 
+# polytoken: .polytoken/subagents/ is committed authored content, but
+# .polytoken/skills/ is a generated mirror of tools/skills/ (see
+# tools/skills/sync-polytoken-skills.sh) and permissions.local.yaml is local state.
+.polytoken/skills/
+.polytoken/permissions.local.yaml
+
 # Packages
 *.egg
 *.egg-info

--- a/justfile
+++ b/justfile
@@ -222,6 +222,13 @@ dc-build:
 dc-shell:
     devcontainer exec --workspace-folder . bash
 
+# Re-copy polytoken-compatible skills (compatibility: polytoken) into
+# .polytoken/skills/ after editing a bridged skill. post-create.sh runs this at
+# container creation; this recipe is for picking up mid-session edits. Claude
+# Code needs no equivalent — it follows the ~/.claude/skills symlinks live.
+sync-polytoken-skills:
+    bash tools/skills/sync-polytoken-skills.sh
+
 # --- Demo content -------------------------------------------------------------
 
 # Spawn a playable combat scenario via the PlayableCombatScenarioFactory.

--- a/tools/skills/README.md
+++ b/tools/skills/README.md
@@ -1,6 +1,7 @@
-# Claude Code Skills
+# Agent Skills
 
-Project-specific skills for Claude Code that support development workflow.
+Project-specific skills (the open "Agent Skills" `SKILL.md` format) that support
+the development workflow. `tools/skills/` is the single canonical home.
 
 In the devcontainer, these skills are **installed automatically** —
 `.devcontainer/post-create.sh` symlinks every `tools/skills/<name>/`
@@ -9,6 +10,27 @@ copy needed; changes you make to a skill here are picked up
 immediately because the symlink points back at this directory.
 
 For bare-metal usage, see the options below.
+
+## Two harnesses: Claude Code and polytoken
+
+The devcontainer runs both Claude Code and the [polytoken](../../.devcontainer/polytoken.md)
+harness, and both read the same `SKILL.md` format. They differ only in **where**
+they discover skills:
+
+- **Claude Code** reads `~/.claude/skills/` and **follows symlinks**, so the
+  symlink loop above exposes *all* skills to it.
+- **polytoken** reads `.polytoken/skills/` (project-level) and **does not follow
+  symlinks**, so it needs real files there.
+
+A skill opts into the polytoken mirror by declaring **`compatibility: polytoken`**
+in its frontmatter. `.devcontainer/post-create.sh` runs
+`tools/skills/sync-polytoken-skills.sh`, which copies exactly those skills into
+the generated (gitignored) `.polytoken/skills/`. After editing a bridged skill
+mid-session, re-run `just sync-polytoken-skills`.
+
+Only harness-agnostic skills carry the marker. Skills coupled to Claude Code
+(e.g. `issue-to-merged-pr`, which orchestrates the `superpowers` plugin) stay
+Claude-Code-only — they have no marker and never reach polytoken.
 
 ## Bare-metal install
 

--- a/tools/skills/codebase-indexing/SKILL.md
+++ b/tools/skills/codebase-indexing/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: codebase-indexing
+compatibility: polytoken
 description: Use when models have changed significantly, after migrations, or when cross-app relationship data in docs/systems/MODEL_MAP.md seems stale. Also use when you can't find how systems connect and need to regenerate the model map.
 ---
 

--- a/tools/skills/design-vocabulary/SKILL.md
+++ b/tools/skills/design-vocabulary/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: design-vocabulary
+compatibility: polytoken
 description: Use when designing or restructuring a subsystem's interface, deciding where a seam goes, judging whether a class/module earns its keep, or making code more testable — the shared deep-module design vocabulary.
 ---
 

--- a/tools/skills/domain-glossary-and-adr/SKILL.md
+++ b/tools/skills/domain-glossary-and-adr/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: domain-glossary-and-adr
+compatibility: polytoken
 description: Use when introducing or sharpening a domain term, when a design conversation lands a hard-to-reverse decision, or when working in an app whose AGENT_GLOSSARY.md or docs/adr/ needs updating — keeps the glossary and ADR log current and used.
 ---
 

--- a/tools/skills/github-operations/SKILL.md
+++ b/tools/skills/github-operations/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: github-operations
+compatibility: polytoken
 description: Use before any GitHub operation via the gh CLI — creating/editing/closing/commenting on issues or PRs, assigning, labelling, or referencing an issue/PR number. Especially right after gh issue create / gh pr create when you need the new number, or when about to mutate an issue you "know" the number of.
 ---
 

--- a/tools/skills/running-tests/SKILL.md
+++ b/tools/skills/running-tests/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: running-tests
+compatibility: polytoken
 description: Use when running or writing tests in this repo — choosing the SQLite fast tier vs Postgres parity tier, the just test recipes, @tag("postgres") decisions, --keepdb pitfalls, or diagnosing SQLite-vs-PG test failures.
 ---
 

--- a/tools/skills/sharedmemory-model/SKILL.md
+++ b/tools/skills/sharedmemory-model/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sharedmemory-model
+compatibility: polytoken
 description: Use when adding or working with Django models in this repo, resolving an apparent N+1, optimizing queries, caching, or walking foreign-key relationships — and before writing any resolve_/batch_fetch_ helper or flushing the identity map.
 ---
 

--- a/tools/skills/sync-polytoken-skills.sh
+++ b/tools/skills/sync-polytoken-skills.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Mirror harness-agnostic skills into .polytoken/skills/ so polytoken discovers
+# them. A skill opts in by declaring `compatibility: polytoken` in its SKILL.md
+# frontmatter (Claude Code ignores the field).
+#
+# Why a copy and not a symlink: polytoken skips symlinked paths during skill
+# discovery, so the files must be real. Claude Code DOES follow symlinks and gets
+# the same skills via ~/.claude/skills (see .devcontainer/post-create.sh), so
+# tools/skills/ stays the single canonical home. .polytoken/skills/ is generated
+# (gitignored). Re-run after editing a bridged skill: `just sync-polytoken-skills`.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC="$REPO_ROOT/tools/skills"
+DEST="$REPO_ROOT/.polytoken/skills"
+
+# Rebuild from scratch so a skill that drops the marker (or is deleted) does not
+# linger in the mirror.
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
+# True iff the file's YAML frontmatter (the first --- ... --- block) declares the
+# opt-in marker. Scoped to the frontmatter so a body mention never false-matches.
+declares_marker() {
+  awk '
+    NR == 1            { if ($0 != "---") exit 1; next }
+    $0 == "---"        { exit found ? 0 : 1 }
+    /^compatibility:[[:space:]]*polytoken[[:space:]]*$/ { found = 1 }
+    END                { exit found ? 0 : 1 }
+  ' "$1"
+}
+
+count=0
+shopt -s nullglob
+for skill_md in "$SRC"/*/SKILL.md; do
+  if declares_marker "$skill_md"; then
+    name="$(basename "$(dirname "$skill_md")")"
+    cp -R "$SRC/$name" "$DEST/$name"
+    count=$((count + 1))
+    echo "  + $name"
+  fi
+done
+shopt -u nullglob
+
+echo "sync-polytoken-skills: copied $count skill(s) to .polytoken/skills/"

--- a/tools/skills/verify-against-code/SKILL.md
+++ b/tools/skills/verify-against-code/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: verify-against-code
+compatibility: polytoken
 description: Use when a feature design, spec, or implementation plan is about to propose a new code surface (model, dataclass, enum, serializer, component, hook, helper, field, endpoint) OR wire up an existing stub (a "not wired" button/endpoint/flow), or when relying on a systems/architecture/roadmap doc's claim about what exists or doesn't, OR when filing a follow-up/audit issue or writing a "deferred follow-up" into a spec (a deferral is a proposed future surface — verify its premise before it becomes a filed issue) — before committing the spec, filing the issue, or writing code.
 ---
 


### PR DESCRIPTION
## What

Makes our harness-agnostic "knowledge" skills discoverable in the **polytoken**
harness, alongside Claude Code. Both harnesses read the same Agent Skills
`SKILL.md` format; they differ only in discovery:

- **Claude Code** reads `~/.claude/skills/` and **follows symlinks** (today's setup).
- **polytoken** reads project-level `.polytoken/skills/` and **does not follow
  symlinks** — it needs real files.

## How

- A skill opts into the polytoken mirror with **`compatibility: polytoken`** in its
  frontmatter (Claude Code ignores the field). Added to the 7 agnostic skills:
  `running-tests`, `sharedmemory-model`, `verify-against-code`, `codebase-indexing`,
  `design-vocabulary`, `github-operations`, `domain-glossary-and-adr`.
- `tools/skills/sync-polytoken-skills.sh` copies the marked skills into
  `.polytoken/skills/` (real files, since symlinks don't work for polytoken).
  `tools/skills/` stays the single canonical home; `.polytoken/skills/` is a
  generated, gitignored mirror.
- Wired into `.devcontainer/post-create.sh` (runs at container creation) and a
  `just sync-polytoken-skills` recipe (for mid-session skill edits).

## Deferred

The Claude-Code-coupled workflow skills carry no marker and stay Claude-Code-only:
`issue-to-merged-pr`, `architecture-cleanup`, `workflow-friction-audit`,
`grounding-before-action`. Migrating `issue-to-merged-pr` off its `superpowers`
dependency (so it can run in polytoken too) is a separate, larger effort.

## Verified

`polytoken --working-dir /workspaces/arxii doctor` reports **10 skills** (3 shipped
+ 7 ours), exactly the marked subset — `issue-to-merged-pr` et al. do not leak in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
