### PR TITLE
feat(seeds): seed the Search check — perception + Investigation (#1705)

### DIFF
--- a/src/world/seeds/clusters.py
+++ b/src/world/seeds/clusters.py
@@ -39,6 +39,12 @@ def _seed_social() -> None:
     seed_social_check_content()
 
 
+def _seed_investigation() -> None:
+    from world.seeds.investigation_checks import seed_investigation_check_content  # noqa: PLC0415
+
+    seed_investigation_check_content()
+
+
 def _seed_consent() -> None:
     from world.seeds.consent import seed_social_consent_categories  # noqa: PLC0415
 
@@ -60,6 +66,9 @@ CLUSTER_SEEDERS: dict[str, Callable[[], None]] = {
     # Persuasion/Performance skills + their specializations (#1688). After "checks" so the
     # resolution spine exists; authoritative, so it corrects the placeholder stat+stat seed.
     "social": _seed_social,
+    # Investigation: the Search check (perception + Investigation) + the Investigation skill.
+    # After "checks" for the resolution spine; authoritative (#1705).
+    "investigation": _seed_investigation,
     "magic": _seed_magic,
     "items": _seed_items,
     "combat": _seed_combat,
@@ -117,6 +126,9 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
         # Social: seeds Persuasion/Performance skills + their specializations + the
         # stat+skill(+spec) social CheckType compositions (#1688).
         "social": [Specialization],
+        # Investigation seeds the Search CheckType + Investigation skill (shared spine/skill
+        # rows counted under "checks"); it still appears as a seeded cluster (#1705).
+        "investigation": [],
         "magic": [Affinity, Resonance],
         "items": [ItemTemplate],
         # Combat seeds check-types used by the resolution spine, not standalone

--- a/src/world/seeds/investigation_checks.py
+++ b/src/world/seeds/investigation_checks.py
@@ -1,0 +1,72 @@
+"""Seed the investigation Search check — perception + Investigation (#1705).
+
+The search action (``actions/definitions/investigation.py``) rolls a ``CheckType`` named
+``"Search"`` (``clues.constants.SEARCH_CHECK_TYPE_NAME``) that was **never seeded** — so a search
+rolled with no
+authored composition and the action degraded to a PLACEHOLDER. Seed the **Investigation** skill
+(+ its backing SKILL trait) and the **Search** ``CheckType`` as **perception (stat) + Investigation
+(skill)**, authoritatively and idempotently. The specialization layer is optional/future. Mirrors
+``world/seeds/social_checks.py``; this is the mystery/investigation core loop's roll.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+_INVESTIGATION_SKILL = ("Investigation", "Searching, examining, and piecing clues together.")
+_SEARCH_STAT = "perception"
+_EXPLORATION_CATEGORY = "Exploration"
+
+
+def ensure_investigation_skill():
+    """Seed the Investigation ``Skill`` (+ its backing SKILL ``Trait``)."""
+    from world.skills.models import Skill  # noqa: PLC0415
+    from world.traits.models import Trait, TraitCategory, TraitType  # noqa: PLC0415
+
+    name, tooltip = _INVESTIGATION_SKILL
+    trait, _ = Trait.objects.get_or_create(
+        name=name,
+        defaults={
+            "trait_type": TraitType.SKILL,
+            "category": TraitCategory.GENERAL,
+            "is_public": True,
+        },
+    )
+    skill, _ = Skill.objects.get_or_create(
+        trait=trait,
+        defaults={"tooltip": tooltip, "display_order": 0, "is_active": True},
+    )
+    return skill
+
+
+def _ensure_perception_stat():
+    """The perception STAT trait (matches the canonical stat seed: STAT / category META)."""
+    from world.traits.models import Trait, TraitCategory, TraitType  # noqa: PLC0415
+
+    trait, _ = Trait.objects.get_or_create(
+        name=_SEARCH_STAT,
+        defaults={
+            "trait_type": TraitType.STAT,
+            "category": TraitCategory.META,
+            "is_public": True,
+        },
+    )
+    return trait
+
+
+def seed_investigation_check_content() -> None:
+    """Cluster entry — seed the Investigation skill + the Search check (perception + skill)."""
+    from world.checks.models import CheckCategory, CheckType, CheckTypeTrait  # noqa: PLC0415
+    from world.clues.constants import SEARCH_CHECK_TYPE_NAME  # noqa: PLC0415
+
+    skill = ensure_investigation_skill()
+    stat_trait = _ensure_perception_stat()
+    category, _ = CheckCategory.objects.get_or_create(name=_EXPLORATION_CATEGORY)
+    check_type, _ = CheckType.objects.get_or_create(
+        name=SEARCH_CHECK_TYPE_NAME, category=category, defaults={"is_active": True}
+    )
+    weight = Decimal("1.0")  # PLACEHOLDER magnitudes
+    # Authoritative: wipe any prior composition, then rewrite perception + Investigation.
+    CheckTypeTrait.objects.filter(check_type=check_type).delete()
+    CheckTypeTrait.objects.create(check_type=check_type, trait=stat_trait, weight=weight)
+    CheckTypeTrait.objects.create(check_type=check_type, trait=skill.trait, weight=weight)

--- a/src/world/seeds/tests/test_clusters.py
+++ b/src/world/seeds/tests/test_clusters.py
@@ -8,7 +8,16 @@ class TestClusterRegistry(TestCase):
     def test_expected_clusters_registered(self) -> None:
         self.assertEqual(
             set(CLUSTER_SEEDERS),
-            {"checks", "social", "magic", "items", "combat", "consent", "character_creation"},
+            {
+                "checks",
+                "social",
+                "investigation",
+                "magic",
+                "items",
+                "combat",
+                "consent",
+                "character_creation",
+            },
         )
 
     def test_character_creation_cluster_registered_after_magic(self) -> None:

--- a/src/world/seeds/tests/test_investigation_checks.py
+++ b/src/world/seeds/tests/test_investigation_checks.py
@@ -1,0 +1,38 @@
+"""Investigation Search-check seed — perception + Investigation (#1705)."""
+
+from django.test import TestCase
+
+from world.checks.models import CheckType, CheckTypeTrait
+from world.clues.constants import SEARCH_CHECK_TYPE_NAME
+from world.seeds.checks import seed_check_resolution_tables
+from world.seeds.investigation_checks import seed_investigation_check_content
+from world.skills.models import Skill
+from world.traits.models import Trait, TraitType
+
+
+class InvestigationCheckSeedTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        seed_check_resolution_tables()
+        seed_investigation_check_content()
+
+    def test_seeds_investigation_skill(self) -> None:
+        skill = Skill.objects.get(trait__name="Investigation")
+        self.assertEqual(skill.trait.trait_type, TraitType.SKILL)
+
+    def test_search_check_is_perception_plus_investigation(self) -> None:
+        search = CheckType.objects.get(name=SEARCH_CHECK_TYPE_NAME)
+        trait_names = set(
+            CheckTypeTrait.objects.filter(check_type=search).values_list("trait__name", flat=True)
+        )
+        self.assertEqual(trait_names, {"perception", "Investigation"})
+        # perception is a stat, Investigation is the skill leg — the tenet's stat + skill shape.
+        self.assertEqual(Trait.objects.get(name="Investigation").trait_type, TraitType.SKILL)
+        self.assertEqual(Trait.objects.get(name="perception").trait_type, TraitType.STAT)
+
+    def test_idempotent(self) -> None:
+        seed_investigation_check_content()
+        seed_investigation_check_content()
+        search = CheckType.objects.get(name=SEARCH_CHECK_TYPE_NAME)
+        # Authoritative re-seed leaves exactly the two composition rows (no duplicates).
+        self.assertEqual(CheckTypeTrait.objects.filter(check_type=search).count(), 2)


### PR DESCRIPTION
## What

Seed the **Search** check — `perception + Investigation` — which the search action has been rolling
**by name but was never seeded** (`clues.constants.SEARCH_CHECK_TYPE_NAME = "Search"`, fetched at
`actions/definitions/investigation.py:62`, degrading to a PLACEHOLDER when absent). Surfaced by the
#1690 cross-domain check audit as the cleanest "intended stat + skill, never built" gap — and it's
the mystery/investigation core loop's roll.

## How

- New `world/seeds/investigation_checks.py` (`seed_investigation_check_content`), registered as a new
  **`"investigation"`** cluster in `world/seeds/clusters.py` (after `checks` for the resolution spine).
- Seeds the **Investigation** `Skill` (+ its `trait_type=SKILL` Trait, category `GENERAL`) and the
  **Search** `CheckType` (category `Exploration`) as **perception (stat) + Investigation (skill)** via
  `CheckTypeTrait`, authoritatively (wipe-then-rewrite) and idempotently — mirroring `social_checks.py`.
- `perception` is get-or-created to match its canonical seed (STAT / category `META`); existing rows win.

## Anti-reinvention

No new model. Reuses the `Skill`/`Trait`/`CheckType`/`CheckTypeTrait` primitives and the cluster-seed
pattern. `Exploration` `CheckCategory` already exists (plummet/interpose seed it). The composition
matches the documented intent at `clues/constants.py:30`.

## Tests

`world/seeds/tests/test_investigation_checks.py` — seeds the skill, asserts Search = perception +
Investigation (stat + skill), and idempotency. Cluster-registry test updated for the new key; full
`world.seeds` suite green (23).

Closes #1705

🤖 Generated with [Claude Code](https://claude.com/claude-code)
