### PR TITLE
feat(secrets): gossip web surface — REST API + React panel (#1572)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -12145,6 +12145,52 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/secrets/gossip/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description The Level-1 secrets the viewing character could spread + their heat in this region (#1572).
+     *
+     *     The web face of bare ``gossip`` (the telnet list). IC-scoped: ``viewer`` is a RosterEntry pk
+     *     validated by ``for_account``; no/unowned viewer → an empty list. Heat is read for the
+     *     character's current room's region (0 when the character is roomless).
+     */
+    get: operations['secrets_gossip_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/secrets/gossip/action/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description Plant / seek / suppress gossip at a social hub (#1572) — the web face of ``CmdGossip``.
+     *
+     *     Converges on the same ``world.secrets.gossip`` services the telnet command calls. ``viewer`` is
+     *     validated by ``for_account``; the services enforce the Gossip-skill + social-hub gates and raise
+     *     ``GossipError`` (surfaced as its ``user_message``, never ``str(exc)``).
+     */
+    post: operations['secrets_gossip_action_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/secrets/grievance/': {
     parameters: {
       query?: never;
@@ -14175,13 +14221,6 @@ export interface components {
      * @enum {string}
      */
     ActionCategoryEnum: 'physical' | 'social' | 'mental';
-    /**
-     * @description * `submit` - Submit
-     *     * `edit` - Edit
-     *     * `agree` - Agree
-     * @enum {string}
-     */
-    ActionEnum: 'submit' | 'edit' | 'agree';
     /**
      * @description Serializer for ActionRef frozen dataclass — the round-trippable dispatch reference.
      *
@@ -17900,6 +17939,37 @@ export interface components {
       readonly display_order: number;
       /** @description Check if this domain is optional (doesn't require point allocation). */
       readonly is_optional: boolean;
+    };
+    /**
+     * @description * `plant` - Plant
+     *     * `seek` - Seek
+     *     * `suppress` - Suppress
+     * @enum {string}
+     */
+    GossipActionActionEnum: 'plant' | 'seek' | 'suppress';
+    /**
+     * @description Input for a gossip action: the verb, the active character's RosterEntry pk, and — for
+     *     plant/suppress — the target secret (#1572).
+     */
+    GossipActionRequest: {
+      action: components['schemas']['GossipActionActionEnum'];
+      /** @description The active (viewing) character's RosterEntry pk. */
+      viewer: number;
+      /** @description Required for plant/suppress. */
+      secret?: number;
+    };
+    /** @description Outcome of a plant/seek/suppress gossip action (#1572). */
+    GossipResult: {
+      readonly success: boolean;
+      readonly heat: number;
+      readonly went_public: boolean;
+      readonly content: string | null;
+    };
+    /** @description A Level-1 secret the viewer holds + could spread, with its heat in this region (#1572). */
+    GossipSecret: {
+      readonly id: number;
+      readonly content: string;
+      readonly heat: number;
     };
     /** @description A preset grievance swing offered to a wronged character (#1429). */
     GrievanceOption: {
@@ -24526,10 +24596,17 @@ export interface components {
        *     * `edit` - Edit
        *     * `agree` - Agree
        */
-      action: components['schemas']['ActionEnum'];
+      action: components['schemas']['SceneSummaryRevisionActionEnum'];
       /** Format: date-time */
       readonly timestamp: string;
     };
+    /**
+     * @description * `submit` - Submit
+     *     * `edit` - Edit
+     *     * `agree` - Agree
+     * @enum {string}
+     */
+    SceneSummaryRevisionActionEnum: 'submit' | 'edit' | 'agree';
     SceneSummaryRevisionRequest: {
       /** @description The ephemeral scene this revision belongs to */
       scene: number;
@@ -24544,7 +24621,7 @@ export interface components {
        *     * `edit` - Edit
        *     * `agree` - Agree
        */
-      action: components['schemas']['ActionEnum'];
+      action: components['schemas']['SceneSummaryRevisionActionEnum'];
     };
     /**
      * @description * `unassigned` - Unassigned
@@ -44244,6 +44321,51 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['SceneDetail'];
+        };
+      };
+    };
+  };
+  secrets_gossip_list: {
+    parameters: {
+      query?: {
+        /** @description Viewer's RosterEntry pk. */
+        viewer?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['GossipSecret'][];
+        };
+      };
+    };
+  };
+  secrets_gossip_action_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['GossipActionRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['GossipResult'];
         };
       };
     };

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -14,6 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { RenownPanel } from '@/renown/components/RenownPanel';
 import { RenownCardPanel } from '@/renown/components/RenownCardPanel';
 import { VitalsPanel } from '@/vitals/components/VitalsPanel';
+import { GossipPanel } from '@/secrets/components/GossipPanel';
 import { SecretsTab } from '@/secrets/components/SecretsTab';
 import { CluesTab } from '@/clues/components/CluesTab';
 import { TitlesPanel } from '@/achievements/components/TitlesPanel';
@@ -56,6 +57,7 @@ export function CharacterSheetPage() {
           <TabsTrigger value="titles">Titles</TabsTrigger>
           <TabsTrigger value="secrets">Secrets</TabsTrigger>
           {isMyCharacter && <TabsTrigger value="clues">Clues</TabsTrigger>}
+          {isMyCharacter && <TabsTrigger value="gossip">Gossip</TabsTrigger>}
         </TabsList>
 
         <TabsContent value="sheet" className="space-y-4">
@@ -124,6 +126,15 @@ export function CharacterSheetPage() {
                 CharacterSheet pk the clues API filters by. Radix unmounts inactive tab content,
                 so the query only fires when this tab is opened. */}
             <CluesTab characterSheetId={entry.character.id} />
+          </TabsContent>
+        )}
+
+        {isMyCharacter && (
+          <TabsContent value="gossip" className="space-y-4">
+            {/* Gossip is the active character's own spreadable Level-1 secrets, location-bound to a
+                social hub (#1572) — so it's a self-only tab keyed on the active RosterEntry, not the
+                viewed subject. Radix unmounts inactive tabs, so the query only fires when opened. */}
+            <GossipPanel viewerId={viewerEntryId} />
           </TabsContent>
         )}
       </Tabs>

--- a/frontend/src/secrets/__tests__/GossipPanel.test.tsx
+++ b/frontend/src/secrets/__tests__/GossipPanel.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * GossipPanel (#1572) — lists the active character's spreadable Level-1 secrets with their regional
+ * heat, and offers seek / spread / quiet. Mocks the query + mutation hooks so the panel renders
+ * synchronously.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GossipPanel } from '../components/GossipPanel';
+import type { GossipSecret } from '../types';
+
+const mutate = vi.fn();
+
+vi.mock('@/secrets/queries', () => ({
+  useGossipQuery: vi.fn(),
+  useGossipActionMutation: vi.fn(() => ({
+    mutate,
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+    data: undefined,
+    error: null,
+  })),
+}));
+
+import { useGossipQuery } from '@/secrets/queries';
+
+const mockQuery = vi.mocked(useGossipQuery);
+
+function mockRows(rows: GossipSecret[]): void {
+  mockQuery.mockReturnValue({
+    data: rows,
+    isLoading: false,
+    isError: false,
+  } as ReturnType<typeof useGossipQuery>);
+}
+
+describe('GossipPanel', () => {
+  it('prompts to pick a character when none is active', () => {
+    mockRows([]);
+    render(<GossipPanel viewerId={null} />);
+    expect(screen.getByText(/select a character/i)).toBeInTheDocument();
+  });
+
+  it('lists spreadable gossip with its heat', () => {
+    mockRows([{ id: 7, content: 'A juicy rumor.', heat: 3 }]);
+    render(<GossipPanel viewerId={42} />);
+    expect(screen.getByText('A juicy rumor.')).toBeInTheDocument();
+    expect(screen.getByText(/heat here: 3/i)).toBeInTheDocument();
+  });
+
+  it('dispatches a plant when Spread is clicked', () => {
+    mockRows([{ id: 7, content: 'A juicy rumor.', heat: 3 }]);
+    render(<GossipPanel viewerId={42} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Spread' }));
+    expect(mutate).toHaveBeenCalledWith({ action: 'plant', viewer: 42, secret: 7 });
+  });
+
+  it('dispatches a seek when Listen is clicked', () => {
+    mockRows([]);
+    render(<GossipPanel viewerId={42} />);
+    fireEvent.click(screen.getByRole('button', { name: /listen for gossip/i }));
+    expect(mutate).toHaveBeenCalledWith({ action: 'seek', viewer: 42 });
+  });
+});

--- a/frontend/src/secrets/api.ts
+++ b/frontend/src/secrets/api.ts
@@ -1,7 +1,12 @@
 /** Character Secrets REST calls (#1334, #1429). */
 import { apiFetch } from '@/evennia_replacements/api';
 
-import type { GrievanceOption, PaginatedKnownSecretList } from './types';
+import type {
+  GossipResult,
+  GossipSecret,
+  GrievanceOption,
+  PaginatedKnownSecretList,
+} from './types';
 
 /** Secrets the active viewing character (`viewerId`, a RosterEntry pk) knows about `subjectId`. */
 export async function listKnownSecrets(
@@ -48,4 +53,36 @@ export async function submitGrievance(payload: SubmitGrievancePayload): Promise<
     const detail = await res.json().catch(() => null);
     throw new Error(detail?.detail ?? 'Failed to register grievance');
   }
+}
+
+/** The Level-1 secrets the active character could spread, with heat in their current region (#1572). */
+export async function listGossip(viewerId: number): Promise<GossipSecret[]> {
+  const res = await apiFetch(`/api/secrets/gossip/?viewer=${viewerId}`);
+  if (!res.ok) {
+    throw new Error('Failed to load gossip');
+  }
+  return res.json() as Promise<GossipSecret[]>;
+}
+
+export interface GossipActionPayload {
+  action: 'plant' | 'seek' | 'suppress';
+  viewer: number;
+  secret?: number;
+}
+
+/** Plant / seek / suppress gossip at a social hub (#1572) — the web face of the `gossip` command. */
+export async function gossipAction(payload: GossipActionPayload): Promise<GossipResult> {
+  const res = await apiFetch('/api/secrets/gossip/action/', {
+    method: 'POST',
+    body: JSON.stringify({
+      action: payload.action,
+      viewer: payload.viewer,
+      secret: payload.secret ?? null,
+    }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null);
+    throw new Error(detail?.detail ?? 'Gossip failed');
+  }
+  return res.json() as Promise<GossipResult>;
 }

--- a/frontend/src/secrets/components/GossipPanel.tsx
+++ b/frontend/src/secrets/components/GossipPanel.tsx
@@ -1,0 +1,80 @@
+import { useGossipActionMutation, useGossipQuery } from '../queries';
+
+/** The gossip panel (#1572): work the rumor mill at a social hub — the web face of the telnet
+ * `gossip` command. Lists the Level-1 secrets the active character could spread (with their heat in
+ * the current region), and offers seek / spread / quiet. Gossip is per active character and
+ * location-bound (you must be at a social hub); the services enforce the Gossip-skill + hub gates
+ * and surface a message when they aren't met. `viewerId` is the active RosterEntry pk, or null. */
+export function GossipPanel({ viewerId }: { viewerId: number | null }) {
+  const { data, isLoading, isError } = useGossipQuery(viewerId);
+  const action = useGossipActionMutation();
+
+  if (viewerId === null) {
+    return <p className="text-muted-foreground">Select a character to work the rumor mill.</p>;
+  }
+  if (isLoading) return <p className="text-muted-foreground">Loading…</p>;
+  if (isError) return <p className="text-destructive">Failed to load gossip.</p>;
+
+  const secrets = data ?? [];
+  const overheard = action.isSuccess ? action.data : undefined;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">Rumors you could spread at this hub.</p>
+        <button
+          type="button"
+          disabled={action.isPending}
+          className="rounded border px-2 py-1 text-sm hover:bg-accent disabled:opacity-50"
+          onClick={() => action.mutate({ action: 'seek', viewer: viewerId })}
+        >
+          Listen for gossip
+        </button>
+      </div>
+
+      {action.isError && (
+        <p className="text-sm text-destructive">{(action.error as Error).message}</p>
+      )}
+      {overheard?.content && (
+        <p className="rounded-md border border-dashed p-2 text-sm italic">
+          You overhear a rumor: {overheard.content}
+        </p>
+      )}
+
+      {secrets.length === 0 ? (
+        <p className="text-muted-foreground">You hold no idle gossip worth spreading.</p>
+      ) : (
+        secrets.map((secret) => (
+          <div key={secret.id} className="space-y-1 rounded-md border p-3">
+            <p>{secret.content}</p>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">Heat here: {secret.heat}</span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  disabled={action.isPending}
+                  className="rounded border px-2 py-1 text-sm hover:bg-accent disabled:opacity-50"
+                  onClick={() =>
+                    action.mutate({ action: 'plant', viewer: viewerId, secret: secret.id })
+                  }
+                >
+                  Spread
+                </button>
+                <button
+                  type="button"
+                  disabled={action.isPending}
+                  className="rounded border px-2 py-1 text-sm hover:bg-accent disabled:opacity-50"
+                  onClick={() =>
+                    action.mutate({ action: 'suppress', viewer: viewerId, secret: secret.id })
+                  }
+                >
+                  Quiet
+                </button>
+              </div>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/frontend/src/secrets/queries.ts
+++ b/frontend/src/secrets/queries.ts
@@ -1,8 +1,14 @@
 /** React Query hooks for the secret tab (#1334) + the grievance flow (#1429). */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { listGrievanceOptions, listKnownSecrets, submitGrievance } from './api';
-import type { SubmitGrievancePayload } from './api';
+import {
+  gossipAction,
+  listGossip,
+  listGrievanceOptions,
+  listKnownSecrets,
+  submitGrievance,
+} from './api';
+import type { GossipActionPayload, SubmitGrievancePayload } from './api';
 
 export const secretKeys = {
   known: (subjectId: number, viewerId: number) =>
@@ -35,6 +41,31 @@ export function useSubmitGrievanceMutation() {
     mutationFn: (payload: SubmitGrievancePayload) => submitGrievance(payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['secrets', 'known'] });
+    },
+  });
+}
+
+export const gossipKeys = {
+  list: (viewerId: number) => ['secrets', 'gossip', viewerId] as const,
+};
+
+/** The active character's spreadable gossip + regional heat. Disabled until there's an active
+ * character — gossip is per character (and location-bound), never account-wide (#1572). */
+export function useGossipQuery(viewerId: number | null) {
+  return useQuery({
+    queryKey: gossipKeys.list(viewerId ?? 0),
+    queryFn: () => listGossip(viewerId as number),
+    enabled: viewerId != null,
+  });
+}
+
+/** Plant / seek / suppress gossip; refetches the list on success (#1572). */
+export function useGossipActionMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: GossipActionPayload) => gossipAction(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['secrets', 'gossip'] });
     },
   });
 }

--- a/frontend/src/secrets/types.ts
+++ b/frontend/src/secrets/types.ts
@@ -6,3 +6,8 @@ export type PaginatedKnownSecretList = components['schemas']['PaginatedKnownSecr
 
 /** A preset grievance response a wronged character may choose (#1429). */
 export type GrievanceOption = components['schemas']['GrievanceOption'];
+
+/** Gossip (#1572): a Level-1 secret you could spread + its heat in this region. */
+export type GossipSecret = components['schemas']['GossipSecret'];
+/** Outcome of a plant/seek/suppress gossip action (#1572). */
+export type GossipResult = components['schemas']['GossipResult'];

--- a/src/schema.json
+++ b/src/schema.json
@@ -20420,6 +20420,60 @@ paths:
               schema:
                 $ref: '#/components/schemas/SceneDetail'
           description: ''
+  /api/secrets/gossip/:
+    get:
+      operationId: secrets_gossip_list
+      description: |-
+        The Level-1 secrets the viewing character could spread + their heat in this region (#1572).
+
+        The web face of bare ``gossip`` (the telnet list). IC-scoped: ``viewer`` is a RosterEntry pk
+        validated by ``for_account``; no/unowned viewer → an empty list. Heat is read for the
+        character's current room's region (0 when the character is roomless).
+      parameters:
+      - in: query
+        name: viewer
+        schema:
+          type: integer
+        description: Viewer's RosterEntry pk.
+      tags:
+      - secrets
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GossipSecret'
+          description: ''
+  /api/secrets/gossip/action/:
+    post:
+      operationId: secrets_gossip_action_create
+      description: |-
+        Plant / seek / suppress gossip at a social hub (#1572) — the web face of ``CmdGossip``.
+
+        Converges on the same ``world.secrets.gossip`` services the telnet command calls. ``viewer`` is
+        validated by ``for_account``; the services enforce the Gossip-skill + social-hub gates and raise
+        ``GossipError`` (surfaced as its ``user_message``, never ``str(exc)``).
+      tags:
+      - secrets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GossipActionRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GossipResult'
+          description: ''
   /api/secrets/grievance/:
     post:
       operationId: secrets_grievance_create
@@ -23854,16 +23908,6 @@ components:
         * `physical` - Physical
         * `social` - Social
         * `mental` - Mental
-    ActionEnum:
-      enum:
-      - submit
-      - edit
-      - agree
-      type: string
-      description: |-
-        * `submit` - Submit
-        * `edit` - Edit
-        * `agree` - Agree
     ActionRef:
       type: object
       description: |-
@@ -31856,6 +31900,73 @@ components:
       - id
       - is_optional
       - name
+    GossipActionActionEnum:
+      enum:
+      - plant
+      - seek
+      - suppress
+      type: string
+      description: |-
+        * `plant` - Plant
+        * `seek` - Seek
+        * `suppress` - Suppress
+    GossipActionRequest:
+      type: object
+      description: |-
+        Input for a gossip action: the verb, the active character's RosterEntry pk, and — for
+        plant/suppress — the target secret (#1572).
+      properties:
+        action:
+          $ref: '#/components/schemas/GossipActionActionEnum'
+        viewer:
+          type: integer
+          description: The active (viewing) character's RosterEntry pk.
+        secret:
+          type: integer
+          description: Required for plant/suppress.
+      required:
+      - action
+      - viewer
+    GossipResult:
+      type: object
+      description: Outcome of a plant/seek/suppress gossip action (#1572).
+      properties:
+        success:
+          type: boolean
+          readOnly: true
+        heat:
+          type: integer
+          readOnly: true
+        went_public:
+          type: boolean
+          readOnly: true
+        content:
+          type: string
+          readOnly: true
+          nullable: true
+      required:
+      - content
+      - heat
+      - success
+      - went_public
+    GossipSecret:
+      type: object
+      description: A Level-1 secret the viewer holds + could spread, with its heat
+        in this region (#1572).
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        content:
+          type: string
+          readOnly: true
+        heat:
+          type: integer
+          readOnly: true
+      required:
+      - content
+      - heat
+      - id
     GrievanceOption:
       type: object
       description: A preset grievance swing offered to a wronged character (#1429).
@@ -44332,7 +44443,7 @@ components:
           description: The summary text for this revision
         action:
           allOf:
-          - $ref: '#/components/schemas/ActionEnum'
+          - $ref: '#/components/schemas/SceneSummaryRevisionActionEnum'
           description: |-
             Whether this is a submission, edit, or agreement
 
@@ -44351,6 +44462,16 @@ components:
       - persona_name
       - scene
       - timestamp
+    SceneSummaryRevisionActionEnum:
+      enum:
+      - submit
+      - edit
+      - agree
+      type: string
+      description: |-
+        * `submit` - Submit
+        * `edit` - Edit
+        * `agree` - Agree
     SceneSummaryRevisionRequest:
       type: object
       properties:
@@ -44366,7 +44487,7 @@ components:
           description: The summary text for this revision
         action:
           allOf:
-          - $ref: '#/components/schemas/ActionEnum'
+          - $ref: '#/components/schemas/SceneSummaryRevisionActionEnum'
           description: |-
             Whether this is a submission, edit, or agreement
 

--- a/src/world/secrets/constants.py
+++ b/src/world/secrets/constants.py
@@ -59,3 +59,11 @@ GOSSIP_PLANT_REGULAR = 1  # heat added by a regular-success plant
 GOSSIP_PLANT_SPECIAL = 2  # heat added by a special-success plant (spec counts double)
 GOSSIP_SUPPRESS_REGULAR = 1  # heat removed by a regular-success suppress
 GOSSIP_SUPPRESS_SPECIAL = 2  # heat removed by a special-success suppress
+
+
+class GossipAction(models.TextChoices):
+    """The web gossip verbs (the #1572 web face of the telnet ``gossip`` subcommands)."""
+
+    PLANT = "plant", "Plant"
+    SEEK = "seek", "Seek"
+    SUPPRESS = "suppress", "Suppress"

--- a/src/world/secrets/serializers.py
+++ b/src/world/secrets/serializers.py
@@ -8,6 +8,8 @@ unplaced, renders as **"Unknown"** (a first-class state, not a blank).
 
 from rest_framework import serializers
 
+from world.secrets.constants import GossipAction
+
 # Runtime import (not TYPE_CHECKING): drf-spectacular calls get_type_hints() on the method
 # fields, which evaluates the ``obj: SecretKnowledge`` annotations — they must resolve at runtime.
 from world.secrets.models import SecretKnowledge
@@ -97,4 +99,37 @@ class SecretGrievanceSerializer(serializers.Serializer):
         if has_option == has_custom:
             msg = "Provide either an option or both custom_points and custom_track."
             raise serializers.ValidationError(msg)
+        return attrs
+
+
+class GossipSecretSerializer(serializers.Serializer):
+    """A Level-1 secret the viewer holds + could spread, with its heat in this region (#1572)."""
+
+    id = serializers.IntegerField(read_only=True)
+    content = serializers.CharField(read_only=True)
+    heat = serializers.IntegerField(read_only=True)
+
+
+class GossipResultSerializer(serializers.Serializer):
+    """Outcome of a plant/seek/suppress gossip action (#1572)."""
+
+    success = serializers.BooleanField(read_only=True)
+    heat = serializers.IntegerField(read_only=True)
+    went_public = serializers.BooleanField(read_only=True)
+    # For a successful seek: the overheard rumor's text (null otherwise).
+    content = serializers.CharField(read_only=True, allow_null=True)
+
+
+class GossipActionSerializer(serializers.Serializer):
+    """Input for a gossip action: the verb, the active character's RosterEntry pk, and — for
+    plant/suppress — the target secret (#1572)."""
+
+    action = serializers.ChoiceField(choices=GossipAction.choices)
+    viewer = serializers.IntegerField(help_text="The active (viewing) character's RosterEntry pk.")
+    secret = serializers.IntegerField(required=False, help_text="Required for plant/suppress.")
+
+    def validate(self, attrs: dict) -> dict:
+        needs_secret = attrs["action"] in (GossipAction.PLANT, GossipAction.SUPPRESS)
+        if needs_secret and attrs.get("secret") is None:
+            raise serializers.ValidationError({"secret": "Required for plant and suppress."})
         return attrs

--- a/src/world/secrets/tests/test_gossip_api.py
+++ b/src/world/secrets/tests/test_gossip_api.py
@@ -1,0 +1,95 @@
+"""Gossip web API (#1572) — the GossipListView / GossipActionView plumbing.
+
+The gossip *mechanic* is exercised (on Postgres) in test_gossip.py; here the services are mocked so
+these stay on SQLite and focus on the view layer: for_account scoping, serialization, dispatch, and
+GossipError → user_message responses.
+"""
+
+from unittest.mock import patch
+
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory, RoomProfileFactory
+from evennia_extensions.models import PlayerData
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.secrets.constants import SecretLevel
+from world.secrets.factories import SecretFactory
+from world.secrets.gossip import GossipError, GossipResult
+
+LIST_URL = "/api/secrets/gossip/"
+ACTION_URL = "/api/secrets/gossip/action/"
+
+
+class GossipApiTests(APITestCase):
+    def setUp(self) -> None:
+        self.account = AccountFactory()
+        player_data, _ = PlayerData.objects.get_or_create(account=self.account)
+        self.entry = RosterEntryFactory()
+        RosterTenureFactory(player_data=player_data, roster_entry=self.entry)
+        self.character = self.entry.character_sheet.character
+        # Give the character a room so the action endpoints don't 400 as roomless.
+        self.character.db_location = RoomProfileFactory(is_social_hub=True).objectdb
+        self.character.save()
+        self.secret = SecretFactory(level=SecretLevel.UNCOMMON_KNOWLEDGE, content="A scandal.")
+        self.client.force_authenticate(user=self.account)
+
+    @patch("world.secrets.gossip.region_heat_for", return_value=5)
+    @patch("world.secrets.gossip.spreadable_secrets")
+    def test_list_returns_spreadable_with_heat(self, mock_spread, _mock_heat) -> None:  # noqa: PT019
+        mock_spread.return_value = [self.secret]
+        rows = self.client.get(LIST_URL, {"viewer": self.entry.pk}).data
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["id"], self.secret.pk)
+        self.assertEqual(rows[0]["content"], "A scandal.")
+        self.assertEqual(rows[0]["heat"], 5)
+
+    def test_list_unowned_viewer_is_empty(self) -> None:
+        other = RosterEntryFactory()  # not owned by self.account
+        self.assertEqual(self.client.get(LIST_URL, {"viewer": other.pk}).data, [])
+
+    @patch("world.secrets.gossip.seek_gossip")
+    def test_seek_dispatches_and_returns_result(self, mock_seek) -> None:
+        mock_seek.return_value = GossipResult(
+            success=True, heat=0, surfaced_secret_id=self.secret.pk
+        )
+        res = self.client.post(
+            ACTION_URL, {"action": "seek", "viewer": self.entry.pk}, format="json"
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(res.data["success"])
+        # A successful seek surfaces the overheard rumor's text.
+        self.assertEqual(res.data["content"], "A scandal.")
+
+    @patch("world.secrets.gossip.plant_gossip")
+    def test_plant_dispatches(self, mock_plant) -> None:
+        mock_plant.return_value = GossipResult(success=True, heat=2)
+        res = self.client.post(
+            ACTION_URL,
+            {"action": "plant", "viewer": self.entry.pk, "secret": self.secret.pk},
+            format="json",
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["heat"], 2)
+        mock_plant.assert_called_once()
+
+    @patch("world.secrets.gossip.plant_gossip")
+    def test_gossip_error_surfaces_user_message(self, mock_plant) -> None:
+        mock_plant.side_effect = GossipError("x", user_message="You don't have the ear for it.")
+        res = self.client.post(
+            ACTION_URL,
+            {"action": "plant", "viewer": self.entry.pk, "secret": self.secret.pk},
+            format="json",
+        )
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.data["detail"], "You don't have the ear for it.")
+
+    def test_plant_requires_a_secret(self) -> None:
+        res = self.client.post(
+            ACTION_URL, {"action": "plant", "viewer": self.entry.pk}, format="json"
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_unowned_viewer_on_action_is_forbidden(self) -> None:
+        other = RosterEntryFactory()
+        res = self.client.post(ACTION_URL, {"action": "seek", "viewer": other.pk}, format="json")
+        self.assertEqual(res.status_code, 403)

--- a/src/world/secrets/urls.py
+++ b/src/world/secrets/urls.py
@@ -4,6 +4,8 @@ from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from world.secrets.views import (
+    GossipActionView,
+    GossipListView,
     GrievanceOptionListView,
     KnownSecretViewSet,
     SecretGrievanceView,
@@ -16,5 +18,8 @@ urlpatterns = [
     # #1429 — the secret-victim grievance flow (mirrors the telnet +grievance command).
     path("grievance-options/", GrievanceOptionListView.as_view(), name="grievance-options"),
     path("grievance/", SecretGrievanceView.as_view(), name="secret-grievance"),
+    # #1572 — the gossip web surface (mirrors the telnet `gossip` command).
+    path("gossip/", GossipListView.as_view(), name="gossip-list"),
+    path("gossip/action/", GossipActionView.as_view(), name="gossip-action"),
     *router.urls,
 ]

--- a/src/world/secrets/views.py
+++ b/src/world/secrets/views.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from django.core.exceptions import ValidationError
 from django.db.models import BooleanField, Exists, ExpressionWrapper, OuterRef
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
@@ -24,9 +25,13 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from world.relationships.models import GrievanceOption, RelationshipTrack
 from world.roster.models import RosterEntry
+from world.secrets.constants import GossipAction
 from world.secrets.filters import KnownSecretFilter
 from world.secrets.models import Secret, SecretKnowledge
 from world.secrets.serializers import (
+    GossipActionSerializer,
+    GossipResultSerializer,
+    GossipSecretSerializer,
     GrievanceOptionSerializer,
     KnownSecretSerializer,
     SecretGrievanceSerializer,
@@ -145,3 +150,107 @@ class SecretGrievanceView(APIView):
         except ValidationError as exc:
             return Response({"detail": exc.messages}, status=status.HTTP_400_BAD_REQUEST)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class GossipListView(APIView):
+    """The Level-1 secrets the viewing character could spread + their heat in this region (#1572).
+
+    The web face of bare ``gossip`` (the telnet list). IC-scoped: ``viewer`` is a RosterEntry pk
+    validated by ``for_account``; no/unowned viewer → an empty list. Heat is read for the
+    character's current room's region (0 when the character is roomless).
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        parameters=[OpenApiParameter("viewer", int, description="Viewer's RosterEntry pk.")],
+        responses=GossipSecretSerializer(many=True),
+    )
+    def get(self, request: Request) -> Response:
+        from world.secrets.gossip import region_heat_for, spreadable_secrets  # noqa: PLC0415
+
+        raw = request.query_params.get("viewer")  # noqa: use_filterset — auth scope, not a filter
+        if not raw or not raw.isdigit():
+            return Response([])
+        viewer = RosterEntry.objects.for_account(request.user).filter(pk=int(raw)).first()
+        if viewer is None:
+            return Response([])
+        character = viewer.character_sheet.character
+        room = character.location
+        rows = [
+            {
+                "id": secret.pk,
+                "content": secret.content,
+                "heat": region_heat_for(secret, room=room) if room is not None else 0,
+            }
+            for secret in spreadable_secrets(character)
+        ]
+        return Response(GossipSecretSerializer(rows, many=True).data)
+
+
+class GossipActionView(APIView):
+    """Plant / seek / suppress gossip at a social hub (#1572) — the web face of ``CmdGossip``.
+
+    Converges on the same ``world.secrets.gossip`` services the telnet command calls. ``viewer`` is
+    validated by ``for_account``; the services enforce the Gossip-skill + social-hub gates and raise
+    ``GossipError`` (surfaced as its ``user_message``, never ``str(exc)``).
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(request=GossipActionSerializer, responses=GossipResultSerializer)
+    def post(self, request: Request) -> Response:
+        from world.secrets.gossip import (  # noqa: PLC0415
+            GossipError,
+            plant_gossip,
+            seek_gossip,
+            suppress_gossip,
+        )
+
+        data = GossipActionSerializer(data=request.data)
+        data.is_valid(raise_exception=True)
+        payload = data.validated_data
+
+        viewer = RosterEntry.objects.for_account(request.user).filter(pk=payload["viewer"]).first()
+        if viewer is None:
+            return Response(
+                {"detail": "No such active character."}, status=status.HTTP_403_FORBIDDEN
+            )
+        character = viewer.character_sheet.character
+        room = character.location
+        if room is None:
+            return Response(
+                {"detail": "Your character isn't anywhere to gossip."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        action = payload["action"]
+        try:
+            if action == GossipAction.SEEK:
+                result = seek_gossip(character, room=room)
+            else:
+                secret = Secret.objects.filter(pk=payload["secret"]).first()
+                if secret is None:
+                    return Response({"detail": "No such secret."}, status=status.HTTP_404_NOT_FOUND)
+                spread = plant_gossip if action == GossipAction.PLANT else suppress_gossip
+                result = spread(character, secret, room=room)
+        except GossipError as exc:
+            return Response({"detail": exc.user_message}, status=status.HTTP_403_FORBIDDEN)
+
+        content = None
+        if result.surfaced_secret_id is not None and action == GossipAction.SEEK and result.success:
+            content = (
+                Secret.objects.filter(pk=result.surfaced_secret_id)
+                .values_list("content", flat=True)
+                .first()
+            )
+        return Response(
+            GossipResultSerializer(
+                {
+                    "success": result.success,
+                    "heat": result.heat,
+                    "went_public": result.went_public,
+                    "content": content,
+                }
+            ).data
+        )


### PR DESCRIPTION
## What

The **web surface** for gossip — the React + REST parallel to the merged telnet `gossip` command —
completing #1572's last slice. Extends the existing secrets API + `frontend/src/secrets` module
(no new app/scaffolding).

## Backend (`world/secrets`)
- **`GET /api/secrets/gossip/?viewer=<RosterEntry pk>`** (`GossipListView`) — the viewer's
  spreadable Level-1 secrets + their heat in the character's current region.
- **`POST /api/secrets/gossip/action/`** (`GossipActionView`) — `plant` / `seek` / `suppress`,
  dispatching the same `world.secrets.gossip` services the telnet command uses. `GossipError` →
  its `user_message` (never `str(exc)`, per the CodeQL rule); `for_account` scopes `viewer` to the
  requester's own characters (IC, never account-wide).
- `GossipAction` `TextChoices` + `Gossip{Secret,Result,Action}` serializers; registered on the
  existing secrets router; `api-types` regenerated.

## Frontend (`src/secrets` + roster)
- `listGossip` / `gossipAction` api fns, `useGossipQuery` / `useGossipActionMutation` hooks
  (refetch the list on success), `GossipSecret` / `GossipResult` types.
- **`GossipPanel.tsx`** — the rumor list + seek / spread / quiet buttons, mirroring `SecretsTab` +
  `GrievancePrompt`.
- A self-only **Gossip tab** on `CharacterSheetPage` (gated `isMyCharacter`, like Clues), keyed on
  the active `RosterEntry` — gossip is the active character's own, location-bound to a social hub.

## Anti-reinvention
Extends the existing secrets API/module (the Explore confirmed `world/secrets/{views,serializers,urls}`
and `frontend/src/secrets/` already exist). Reuses the `for_account` viewer-scoping idiom, the
`exc.user_message` error pattern, the `apiFetch` + TanStack-Query data layer, and the Radix tab mount.

## Tests / gates
`test_gossip_api` (7 — list scoping, dispatch, `GossipError` surfacing, validation) +
`GossipPanel.test.tsx` (4). `pnpm typecheck` / `lint` / `build` all green; secrets backend suite (25) green.

Closes #1572

🤖 Generated with [Claude Code](https://claude.com/claude-code)
