### PR TITLE
feat(skills): port Superpowers brainstorm/plan/worktree spine to Polytoken

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -106,10 +106,21 @@ claude plugin install superpowers@claude-plugins-official 2>/dev/null || true
 # skills committed to tools/skills/ appear on the next container creation.
 # nullglob: if tools/skills/ is empty, the loop body should NOT run with the
 # literal pattern (which would create a dangling "*" symlink).
+#
+# A skill that declares `compatibility: polytoken-only` in its SKILL.md
+# frontmatter is Polytoken-exclusive and is SKIPPED here — it would collide
+# with a same-named superpowers plugin skill (brainstorming, writing-plans,
+# using-git-worktrees) in Claude Code. The plain `compatibility: polytoken`
+# marker is additive: such skills are mirrored into Polytoken (below) AND
+# symlinked into Claude Code as before. The sync-polytoken-skills step mirrors
+# both marker variants into .polytoken/skills/.
 mkdir -p /home/vscode/.claude/skills
 shopt -s nullglob
 for skill in /workspaces/arxii/tools/skills/*/; do
   name=$(basename "$skill")
+  if grep -q "^compatibility:[[:space:]]*polytoken-only$" "$skill/SKILL.md" 2>/dev/null; then
+    continue
+  fi
   ln -sfn "$skill" "/home/vscode/.claude/skills/$name"
 done
 shopt -u nullglob

--- a/justfile
+++ b/justfile
@@ -222,10 +222,11 @@ dc-build:
 dc-shell:
     devcontainer exec --workspace-folder . bash
 
-# Re-copy polytoken-compatible skills (compatibility: polytoken) into
-# .polytoken/skills/ after editing a bridged skill. post-create.sh runs this at
-# container creation; this recipe is for picking up mid-session edits. Claude
-# Code needs no equivalent — it follows the ~/.claude/skills symlinks live.
+# Re-copy polytoken-compatible skills (compatibility: polytoken or
+# polytoken-only) into .polytoken/skills/ after editing a bridged skill.
+# post-create.sh runs this at container creation; this recipe is for picking up
+# mid-session edits. Claude Code needs no equivalent — it follows the
+# ~/.claude/skills symlinks live (and skips polytoken-only skills there).
 sync-polytoken-skills:
     bash tools/skills/sync-polytoken-skills.sh
 

--- a/tools/skills/README.md
+++ b/tools/skills/README.md
@@ -4,10 +4,11 @@ Project-specific skills (the open "Agent Skills" `SKILL.md` format) that support
 the development workflow. `tools/skills/` is the single canonical home.
 
 In the devcontainer, these skills are **installed automatically** —
-`.devcontainer/post-create.sh` symlinks every `tools/skills/<name>/`
-directory into `~/.claude/skills/` on container creation. No manual
-copy needed; changes you make to a skill here are picked up
-immediately because the symlink points back at this directory.
+`.devcontainer/post-create.sh` symlinks each `tools/skills/<name>/` directory
+into `~/.claude/skills/` on container creation, except skills marked
+`compatibility: polytoken-only` (those are Polytoken-exclusive; see below). No
+manual copy needed; changes you make to a skill here are picked up immediately
+because the symlink points back at this directory.
 
 For bare-metal usage, see the options below.
 
@@ -18,7 +19,9 @@ harness, and both read the same `SKILL.md` format. They differ only in **where**
 they discover skills:
 
 - **Claude Code** reads `~/.claude/skills/` and **follows symlinks**, so the
-  symlink loop above exposes *all* skills to it.
+  symlink loop above exposes harness-agnostic skills to it (but skips
+  `polytoken-only` skills to avoid colliding with same-named `superpowers`
+  plugin skills).
 - **polytoken** reads `.polytoken/skills/` (project-level) and **does not follow
   symlinks**, so it needs real files there.
 
@@ -27,6 +30,19 @@ in its frontmatter. `.devcontainer/post-create.sh` runs
 `tools/skills/sync-polytoken-skills.sh`, which copies exactly those skills into
 the generated (gitignored) `.polytoken/skills/`. After editing a bridged skill
 mid-session, re-run `just sync-polytoken-skills`.
+
+There are two marker variants:
+
+- **`compatibility: polytoken`** — additive. The skill is mirrored into
+  `.polytoken/skills/` *and* still symlinked into Claude Code via
+  `~/.claude/skills/`. Use for harness-agnostic skills that don't collide with
+  anything (e.g. `github-operations`, `verify-against-code`).
+- **`compatibility: polytoken-only`** — Polytoken-exclusive. Mirrored into
+  `.polytoken/skills/` but **skipped** by the Claude Code symlink loop. Use for
+  skills that would collide with a same-named `superpowers` plugin skill in
+  Claude Code (e.g. the ported `brainstorming`, `writing-plans`,
+  `using-git-worktrees`, and the `issue-to-merged-pr-polytoken` orchestration
+  skill). This keeps a colleague's Claude Code setup untouched.
 
 Only harness-agnostic skills carry the marker. Skills coupled to Claude Code
 (e.g. `issue-to-merged-pr`, which orchestrates the `superpowers` plugin) stay
@@ -39,13 +55,17 @@ Claude-Code-only — they have no marker and never reach polytoken.
 ```bash
 for skill in tools/skills/*/; do
   name=$(basename "$skill")
+  # Skip Polytoken-exclusive skills — they'd collide with same-named
+  # superpowers plugin skills in Claude Code.
+  grep -q '^compatibility:[[:space:]]*polytoken-only$' "$skill/SKILL.md" 2>/dev/null && continue
   ln -sfn "$(pwd)/${skill%/}" "$HOME/.claude/skills/$name"
 done
 ```
 
 `-sfn` is idempotent — re-run any time. Edits to skill files are picked
 up immediately by Claude Code (the symlink points back at this
-directory).
+directory). To mirror the `polytoken` / `polytoken-only` skills into
+Polytoken on bare metal, run `bash tools/skills/sync-polytoken-skills.sh`.
 
 ### Windows
 

--- a/tools/skills/brainstorming/SKILL.md
+++ b/tools/skills/brainstorming/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: brainstorming
+description: "Use this before any creative work — creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements, and design before implementation. Drafts the spec into the GitHub issue body for team review."
+compatibility: polytoken-only
+---
+
+# Brainstorming Ideas Into Designs
+
+Turn ideas into fully formed designs and specs through collaborative dialogue,
+then post the spec to the **GitHub issue body** for review. This is the design
+gate that prevents the failure mode of building the wrong thing: no code is
+written until a design has been presented and approved.
+
+Start by understanding the current project context, then ask questions one at a
+time to refine the idea. Once you understand what you're building, present the
+design and get user approval, then post it to the issue and **exit** — a member
+must apply `spec:approved` before implementation begins.
+
+<HARD-GATE>
+Do NOT invoke any implementation skill, write any code, scaffold any project, or
+take any implementation action until you have presented a design and the user
+has approved it. This applies to EVERY project regardless of perceived
+simplicity.
+</HARD-GATE>
+
+## Anti-Pattern: "This Is Too Simple To Need A Design"
+
+Every project goes through this process. A todo list, a single-function utility,
+a config change — all of them. "Simple" projects are where unexamined
+assumptions cause the most wasted work. The design can be short (a few sentences
+for truly simple projects), but you MUST present it and get approval.
+
+## Where the spec lives
+
+**The spec lives in the GitHub issue body**, between `<!-- spec:start -->` and
+`<!-- spec:end -->` markers — never as a committed `docs/superpowers/` file.
+This is project convention (ADR-0020, reflected in `docs/spec-template.md`):
+GitHub-as-truth, no on-disk workflow state, review happens where the issue is.
+Preserve the original problem statement above the markers; write the spec
+between them via `gh issue edit <N> --body-file`.
+
+This is a **deliberate alteration** of the upstream Superpowers brainstorming
+skill, which writes specs to `docs/superpowers/specs/`. Do not do that.
+
+## Checklist
+
+You MUST work through these items in order:
+
+1. **Explore project context** — check files, docs, recent commits, `docs/adr/`,
+   `AGENT_GLOSSARY_MAP.md` for canonical terms.
+2. **Ask clarifying questions** — one at a time, understand
+   purpose/constraints/success criteria.
+3. **Propose 2-3 approaches** — with trade-offs and your recommendation.
+4. **Present design** — in sections scaled to their complexity, get user
+   approval after each section.
+5. **Run the `verify-against-code` pass** — for every new surface the design
+   proposes, verify against code (not docs/summaries) and label it
+   `[BUILT & WIRED]` / `[BUILT, NOT WIRED]` / `[ABSENT]` with file:line + caller
+   evidence. This produces the **anti-reinvention ledger**, embedded as a
+   section of the spec. A spec without a code-verified ledger is not finalized.
+   (Skill at `tools/skills/verify-against-code/`.)
+6. **Write the spec into the issue body** — between the `<!-- spec:start -->` /
+   `<!-- spec:end -->` markers, using the section layout in
+   `docs/spec-template.md`. Preserve the original problem statement above the
+   markers.
+7. **Spec self-review** — quick inline check (see below).
+8. **Dispatch the spec reviewer** — using the prompt at
+   `tools/skills/issue-to-merged-pr/spec-document-reviewer-prompt.md`
+   (project-local; extends the canonical reviewer with contract-completeness,
+   implied-condition, and external-constraint checks). If invoked standalone
+   (not via the orchestration skill), run the review inline or via a subagent.
+9. **Hand off for spec review and exit** — flip the issue label and post a
+   review-request comment (see below). Do NOT proceed to implementation.
+
+## The Process
+
+**Understanding the idea:**
+
+- Check the current project state first (files, docs, recent commits, ADRs).
+- Before asking detailed questions, assess scope: if the request describes
+  multiple independent subsystems, flag this immediately. Don't spend questions
+  refining details of a project that needs decomposition.
+- If the project is too large for a single spec, help decompose into
+  sub-projects: what are the independent pieces, how do they relate, what order
+  should they be built? Then brainstorm the first sub-project through the normal
+  design flow. Each sub-project gets its own spec → plan → implementation cycle.
+- For appropriately-scoped projects, ask questions one at a time to refine the
+  idea.
+- Prefer multiple choice questions when possible, but open-ended is fine too.
+- Only one question per message — if a topic needs more exploration, break it
+  into multiple questions.
+- Focus on understanding: purpose, constraints, success criteria.
+
+**Exploring approaches:**
+
+- Propose 2-3 different approaches with trade-offs.
+- Present options conversationally with your recommendation and reasoning.
+- Lead with your recommended option and explain why.
+
+**Presenting the design:**
+
+- Once you believe you understand what you're building, present the design.
+- Scale each section to its complexity: a few sentences if straightforward, up
+  to 200-300 words if nuanced.
+- Ask after each section whether it looks right so far.
+- Cover: architecture, components, data flow, error handling, testing.
+- Use canonical vocabulary from `AGENT_GLOSSARY_MAP.md`; reference relevant
+  ADRs.
+- Be ready to go back and clarify if something doesn't make sense.
+
+**Design for isolation and clarity:**
+
+- Break the system into smaller units that each have one clear purpose,
+  communicate through well-defined interfaces, and can be understood and tested
+  independently.
+- For each unit, you should be able to answer: what does it do, how do you use
+  it, and what does it depend on?
+- Can someone understand a unit does without reading its internals? Can you
+  change the internals without breaking consumers? If not, the boundaries need
+  work.
+
+**Working in existing codebases:**
+
+- Explore the current structure before proposing changes. Follow existing
+  patterns.
+- Where existing code has problems that affect the work, include targeted
+  improvements as part of the design — the way a good developer improves code
+  they are working in.
+- Don't propose unrelated refactoring. Stay focused on what serves the current
+  goal.
+
+## After the Design
+
+**Write the spec to the issue body (not a committed file):**
+
+1. Read the current issue body: `gh issue view <N> --json body --jq .body`.
+2. Compose the new body: the original problem statement (preserved above the
+   markers), then `<!-- spec:start -->`, the spec content using
+   `docs/spec-template.md`'s section layout (including the
+   **anti-reinvention ledger** from the verify-against-code pass), then
+   `<!-- spec:end -->`.
+3. Write it back: `gh issue edit <N> --body-file <tmpfile>` (write the composed
+   body to a temp file first — `gh` reads the new body from a file more
+   reliably than from a shell-quoted argument).
+
+**Spec Self-Review:**
+After writing the spec, look at it with fresh eyes:
+
+1. **Placeholder scan:** Any "TBD", "TODO", incomplete sections, or vague
+   requirements? Fix them.
+2. **Internal consistency:** Do any sections contradict each other? Does the
+   architecture match the feature descriptions?
+3. **Scope check:** Is this focused enough for a single implementation plan, or
+   does it need decomposition?
+4. **Ambiguity check:** Could any requirement be interpreted two different ways?
+   If so, pick one and make it explicit.
+5. **Deferral verification:** Every "deferred" follow-up listed is a proposed
+   future surface — verify its premise against code (the same
+   verify-against-code pass). Drop it if already built/handled; write design-open
+   items as `needs-design` questions, not asserted work.
+
+Fix any issues inline. No need to re-review — just fix and move on.
+
+## Hand off for spec review and exit
+
+This is the exit gate. After the spec is written to the issue and self-reviewed:
+
+1. `gh issue edit <N> --remove-label status:spec-draft --add-label status:spec-review`.
+2. Post a comment that @-mentions the review target (default `@TehomCD`;
+   configurable to a `@Arx-Game/<team>` handle) and links the spec section.
+3. **Exit.** Spec review is async and on a human. Do NOT proceed to plan or
+   implementation, and **do NOT apply `spec:approved`** — only a member does
+   that.
+
+The agent resumes (in a later invocation) once a member has applied
+`spec:approved`; the plan from `writing-plans` is produced then and is
+**ephemeral** (worktree-only, never committed).
+
+## Key Principles
+
+- **One question at a time** — don't overwhelm with multiple questions.
+- **Multiple choice preferred** — easier to answer than open-ended when
+  possible.
+- **YAGNI ruthlessly** — remove unnecessary features from all designs.
+- **Explore alternatives** — always propose 2-3 approaches before settling.
+- **Incremental validation** — present design, get approval before moving on.
+- **GitHub is the truth** — the spec lives on the issue, not on disk. No
+  committed spec file, no on-disk workflow state.

--- a/tools/skills/issue-to-merged-pr-polytoken/SKILL.md
+++ b/tools/skills/issue-to-merged-pr-polytoken/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: issue-to-merged-pr
+description: "Use when working on a GitHub issue from start to merged PR. Picks up an issue (or prompts for one), drafts the spec onto the issue body for team review, implements after a member approves it (spec:approved label), opens a PR, watches CI and fixes failures, and handles post-merge cleanup including filing follow-up issues. Polytoken-native: orchestrates the ported brainstorming + writing-plans + using-git-worktrees skills."
+compatibility: polytoken-only
+---
+
+# shared-assets-from: issue-to-merged-pr
+
+# issue-to-merged-pr (Polytoken)
+
+This skill carries a GitHub issue from pickup through to a merged PR. It is
+**multi-invocation**: the agent works up to a human gate, then exits while review
+is async. There are **two** such gates — **spec review on the issue** (a member
+applies the `spec:approved` label) and **code review on the PR** — plus CI. The
+user re-invokes the skill in a new session; the agent reads the issue + PR state
+and picks up the right phase.
+
+**No persistent on-disk workflow state — GitHub (labels + issue body + PR) holds
+the truth. Specs live in the issue body between `<!-- spec:start -->` and
+`<!-- spec:end -->` markers, never as committed files.**
+
+This is the **Polytoken-native** counterpart of the Claude-Code-only
+`issue-to-merged-pr` skill. It reuses the **same bash scripts** verbatim
+(`tools/skills/issue-to-merged-pr/scripts/*`) but orchestrates the ported
+harness-agnostic skills (`brainstorming`, `writing-plans`, `using-git-worktrees`
+under `tools/skills/`) instead of the `superpowers` Claude Code plugin.
+
+## Phase detection on re-invocation
+
+Detection is two-stage: first the **issue/label state** (pre-PR phases), then —
+only once a PR exists — the **PR state** table further down.
+
+### Pre-PR phases (driven by issue labels — the spec lives on the issue)
+
+```bash
+gh issue view <N> --json state,labels,body
+```
+
+Read the `status:*` and `spec:approved` labels. First match wins:
+
+| labels on the issue | Phase |
+|---|---|
+| `spec:approved` present, no open PR yet | **Implementation** — flip `status:spec-review`→`status:implementing`, then build |
+| `status:spec-review`, no `spec:approved` | **Await-approval** — spec is on the issue; a member must apply `spec:approved`. Exit (review is on the human). |
+| `status:spec-draft` (or no `<!-- spec:start -->` marker in the body) | **Design** — draft the spec into the issue body |
+| no `status:*` label | **Pickup** (fresh) |
+
+**The agent MUST NEVER apply `spec:approved` itself.** Only a human org member
+applies it — GitHub restricts label-writes to Triage+, so outsiders can't, but
+the agent holds the maintainer PAT and so must self-restrain. The agent only
+polls for the label.
+
+Once an open PR exists for the branch, use the PR-state table below instead.
+
+### PR phases (driven by PR state)
+
+When invoked with no arg, or with a PR number / issue number whose branch
+already has an open PR, run:
+
+```bash
+gh pr view <pr-or-branch> --json state,mergedAt,statusCheckRollup,reviewDecision,mergeStateStatus
+```
+
+Then, only if checks are all-success and the PR is open, call
+`scripts/read-pr-comments.sh <pr>` to populate the unread-comments cell. Pick the
+phase from this table (rows top-to-bottom; first match wins):
+
+| `state` | `mergeStateStatus` | `statusCheckRollup` aggregate | unread-comments | Phase |
+|---|---|---|---|---|
+| `MERGED` | — | — | — | **Post-merge cleanup** |
+| `CLOSED` | — | — | — | **Closed-without-merge** (notify user, exit) |
+| `OPEN` | `DIRTY` / `BEHIND` | — | — | **Conflict-during-review** (re-sync, push) |
+| `OPEN` | `BLOCKED` | all success | none | **Blocked-on-review** (post comment noting required reviewers missing, exit) |
+| `OPEN` | — | any failure | — | **CI fix** (read failures, fix, push, return to CI watch) |
+| `OPEN` | — | any pending | — | **CI watch** (resume `watch-ci.sh`) |
+| `OPEN` | — | all success | exist | **PR-comment** (address comments, push, bump marker) |
+| `OPEN` | — | all success | none | **Idle** (post status comment, exit — review is on human) |
+
+If the branch exists but has no open PR, fall back to the **Pre-PR phases**
+table above.
+
+## Lifecycle
+
+### 1. Pickup
+
+- If invoked without an issue number, ask the user. If they describe work that
+  doesn't have an issue yet, file one with `scripts/file-followup.sh` first and
+  use its number.
+- Run `scripts/pickup-issue.sh <N>`. It checks skill availability (superpowers
+  plugin OR ported skills — either passes), fetches the issue, infers type,
+  ensures the lane labels exist, claims the issue (assign + `status:spec-draft`),
+  creates the branch, and emits JSON.
+- **Model selection.** Read the `model` and `complexity` fields from the emitted
+  JSON. `pickup-issue.sh` derives the model from the `complexity:*` label, with
+  tier names overridable via `ISSUE_MODEL_HIGH` / `ISSUE_MODEL_MEDIUM` /
+  `ISSUE_MODEL_LOW` env vars (defaults are Claude Code tiers; set them to
+  umans-* models for Polytoken). If `model` is non-empty and the harness supports
+  a model switch, switch now — before any design, planning, or implementation.
+
+### 2. Design (skipped for trivial issue types)
+
+Skip the design step when:
+- Issue label is `chore`, `docs`, `dep-bump`, or `ci-fix`.
+- Issue body is < 300 characters AND has no markdown section headers.
+- Issue title starts with `fix(<scope>): typo|lint|format|…`.
+
+When skipping, go straight to Implementation (claim `status:implementing`).
+
+Otherwise, claim the draft lane (`status:spec-draft`; pickup sets this) and
+invoke the **ported `brainstorming` skill** (`tools/skills/brainstorming/`). It
+handles the full design dialogue and writes the spec into the issue body. Two
+points it already bakes in (from the port):
+- **Spec destination:** the issue body, between `<!-- spec:start -->` and
+  `<!-- spec:end -->` markers (`gh issue edit <N> --body-file`), using
+  `docs/spec-template.md`'s section layout. No committed spec file.
+- **Mandatory `verify-against-code` pass:** before the spec is finalized, run
+  `tools/skills/verify-against-code/` and embed the anti-reinvention ledger as a
+  section of the spec.
+- **Spec-review dispatch:** when the brainstorming skill reaches spec review,
+  dispatch with the prompt at
+  `tools/skills/issue-to-merged-pr/spec-document-reviewer-prompt.md`.
+
+Then hand off for **spec review** and exit (the brainstorming skill's final
+step):
+1. `gh issue edit <N> --remove-label status:spec-draft --add-label status:spec-review`.
+2. Post a comment that @-mentions the review target (default `@TehomCD`;
+   configurable to a `@Arx-Game/<team>` handle) and links the spec section.
+3. **Exit.** Spec review is async and on a human. Do NOT proceed to plan or
+   implementation, and **do NOT apply `spec:approved`**.
+
+The agent resumes (in a later invocation) once a member has applied
+`spec:approved`; the plan from the ported `writing-plans` skill is produced then
+and is **ephemeral** (worktree-only, never committed).
+
+Record the decision (ran vs. skipped) — it goes in the PR body's Notes section.
+
+### 3. Implementation
+
+Entry condition: the issue carries `spec:approved` (a member approved the spec on
+the issue). On entry, flip the lane:
+`gh issue edit <N> --remove-label status:spec-review --add-label status:implementing`.
+Create the worktree via the ported **`using-git-worktrees`** skill
+(`tools/skills/using-git-worktrees/`), then invoke the ported **`writing-plans`**
+skill (`tools/skills/writing-plans/`) to produce the **ephemeral** plan
+(worktree-only, never committed).
+
+The ported `writing-plans` skill goes straight to implementation (it does not
+prompt subagent-vs-inline). Work through the plan task-by-task in this session,
+committing after each. Follow the plan if one exists; otherwise implement
+directly.
+
+**Keep docs in tandem.** Before opening the PR, update the docs your change
+affects *in the same PR* — system doc + `docs/systems/INDEX.md`,
+`docs/systems/MODEL_MAP.md` (regen after model/signature changes), the relevant
+`docs/architecture/*.md` and its diagrams, and the roadmap. A code change that
+leaves its docs stale is incomplete.
+
+### 4. Sync with main
+
+Sync **once here** to surface conflicts and migration collisions early. You do
+**not** need to re-sync every time main moves afterward — the merge queue
+re-integrates the PR against the latest main at merge time.
+
+Run `scripts/sync-with-main.sh <branch>`. On conflict (exit 4): read the emitted
+JSON, comment on impacted issues via `scripts/comment-on-issue.sh`, resolve the
+conflicts, then continue (`git rebase --continue` / `git merge --continue`).
+
+### 5. Push & open PR
+
+Compose the PR body's substitution values. For each deferred follow-up, call
+`scripts/file-followup.sh <title> <body-path> <labels...>` NOW (before opening
+the PR) and collect the issue numbers. **Before filing each follow-up, run the
+`verify-against-code` pass on its premise** — drop it if already built; file
+design-open items as `needs-design` questions, not asserted work.
+
+```bash
+PR_SUMMARY="..." PR_RAN_OR_SKIPPED="ran" PR_SYNC_SUMMARY="..." \
+  scripts/open-pr.sh <branch> <issue-N> <followup-1> <followup-2> ...
+```
+
+The PR body references the approved spec via `Closes #<issue>`.
+
+**Before pushing, run `uv run pre-commit run --all-files`** — matches CI's
+`pre-commit` job exactly (committing with hooks only checks changed files).
+
+### 6. CI watch
+
+Run `scripts/watch-ci.sh <pr-N>`. Outcomes:
+- `OK` (exit 0): enqueue for the merge queue with `scripts/enqueue-pr.sh <pr-N>`,
+  post a brief status comment, exit the session. **Do NOT re-sync or merge by
+  hand** — the merge queue re-tests and merges once a human approves.
+- `FAIL <check-name>` (exit 5): enter the CI-fix phase.
+- timeout (exit 6): post a diagnostic, exit.
+
+### 7. CI fix
+
+Run `scripts/get-ci-failure.sh <pr-N> <check-name>`. Read the log, fix the issue,
+commit, push, return to CI watch.
+
+**Bail conditions:**
+- **Repeat failure:** same `(check-name, failure-signature)` pair fails 3 times
+  across pushes.
+- **Thrash cap:** 5 total pushes on this PR across all fix attempts.
+
+Cross-session attempt counting reconstructs the count from the PR's own commits +
+prior attempt-trail comments. Each CI-fix attempt posts a PR comment with this
+exact prefix:
+
+> `<!-- ci-fix-attempt --> check: <name>, signature: <signature>, push: <commit-sha-short>`
+
+On either bail, post a diagnostic PR comment summarizing every attempt and exit.
+
+### 8. PR-comment phase (re-invocation after human review)
+
+When phase detection lands on **PR-comment**:
+- Run `scripts/read-pr-comments.sh <pr-N>` — get unread comments as JSON.
+- Address each: edit code, commit.
+- Push.
+- **Takeaway evaluation** (see below — runs before the marker bump).
+- Update the PR body marker via the REST API (not `gh pr edit`, which errors on
+  the deprecated Projects field):
+
+```bash
+NEW_MAX=<max comment id you addressed>
+BODY=$(gh pr view <pr> --json body --jq .body)
+NEW_BODY=$(sed -E "s/<!-- last-addressed-comment: [0-9]+ -->/<!-- last-addressed-comment: $NEW_MAX -->/" <<<"$BODY")
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+printf '%s' "$NEW_BODY" | gh api -X PATCH "repos/$REPO/pulls/<pr>" -F body=@-
+```
+
+#### Takeaway evaluation
+
+After all actionable comments are committed and before bumping the marker,
+evaluate each addressed comment for a non-obvious takeaway worth posting on a
+related issue. Post unilaterally if the criteria are met (see the Claude Code
+sibling skill for the full criteria/format). Run the **Layer 3 secret-scan**
+before posting (cross-references `tools/skills/workflow-friction-audit/`):
+
+```bash
+TAKEAWAY_TMP=$(mktemp)
+# Write the comment body to "$TAKEAWAY_TMP".
+if [ -f tools/skills/workflow-friction-audit/secret-patterns.txt ]; then
+  grep -E -n -f tools/skills/workflow-friction-audit/secret-patterns-defaults.txt -f tools/skills/workflow-friction-audit/secret-patterns.txt "$TAKEAWAY_TMP"
+else
+  grep -E -n -f tools/skills/workflow-friction-audit/secret-patterns-defaults.txt "$TAKEAWAY_TMP"
+fi
+# Exit 0 (secret match): abort the post, surface the line, exit.
+# Exit 1 (clean): proceed to comment-on-issue.sh.
+bash tools/skills/issue-to-merged-pr/scripts/comment-on-issue.sh <target-issue-N> "$TAKEAWAY_TMP"
+```
+
+Return to CI watch.
+
+### 9. Post-merge cleanup
+
+Run `scripts/post-merge-cleanup.sh <branch> <pr-N>`. Read the JSON:
+- For any `linked_issue_actions` entry with `action: "needs-attention"`, post a
+  comment on that issue explaining what merged.
+- For review-driven follow-ups identified during the PR-comment phase, file them
+  now with `scripts/file-followup.sh`.
+
+Apply the same takeaway evaluation, criteria, format, and Layer 3 secret-scan
+as Step 8's.
+
+## When to bail (stop and wait for human)
+
+- CI repeat-failure or thrash cap.
+- Sync conflicts the agent can't auto-resolve confidently.
+- During brainstorm, scope feels fundamentally different from the title — post
+  on the original issue suggesting a split, exit before opening any PR.
+- Any `gh` command fails with auth errors. Surface the error and `gh auth
+  status` output.
+- A takeaway-capture post would contain a secret-pattern match. Abort the post,
+  surface the offending line, exit without commenting.
+
+Each bail writes a structured PR or issue comment with: what was attempted,
+where it stopped, what the human should decide.
+
+## Quick reference
+
+| Need | Script |
+|---|---|
+| Start work on issue N | `scripts/pickup-issue.sh N` |
+| Sync with main mid-work | `scripts/sync-with-main.sh <branch>` |
+| Open the PR | `scripts/open-pr.sh <branch> <issue> [followups...]` |
+| File a follow-up issue | `scripts/file-followup.sh <title> <body-path> [labels...]` |
+| Comment on an issue | `scripts/comment-on-issue.sh <issue> <body-path>` |
+| Watch CI | `scripts/watch-ci.sh <pr>` |
+| Enqueue for the merge queue | `scripts/enqueue-pr.sh <pr>` |
+| Read failing log | `scripts/get-ci-failure.sh <pr> <check-name>` |
+| Read unread PR comments | `scripts/read-pr-comments.sh <pr>` |
+| Clean up after merge | `scripts/post-merge-cleanup.sh <branch> <pr>` |
+
+All state-mutating scripts support `--dry-run`. Scripts are at
+`tools/skills/issue-to-merged-pr/scripts/` (shared with the Claude Code sibling
+skill).

--- a/tools/skills/issue-to-merged-pr/scripts/pickup-issue.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/pickup-issue.sh
@@ -25,12 +25,31 @@ usage() {
 ISSUE="$1"
 [[ "$ISSUE" =~ ^[0-9]+$ ]] || usage
 
-# 1. Superpowers precheck
-if ! claude plugin list 2>/dev/null | grep -q "superpowers@claude-plugins-official"; then
-  echo "ERROR: superpowers plugin not installed." >&2
-  echo "Install with:" >&2
-  echo "  claude plugin marketplace add anthropics/claude-plugins-official" >&2
-  echo "  claude plugin install superpowers@claude-plugins-official" >&2
+# 1. Skill-availability precheck (harness-aware).
+# The brainstorming + writing-plans skills must be reachable. They can come from
+# EITHER source, so pass if either is present:
+#   (a) the `superpowers` Claude Code plugin (Claude Code harness), OR
+#   (b) the harness-agnostic ported skills under tools/skills/ (Polytoken),
+#       which the sync script mirrors into .polytoken/skills/.
+# This keeps the script usable under both harnesses without a flag.
+SKILLS_AVAILABLE=0
+if command -v claude >/dev/null 2>&1 \
+  && claude plugin list 2>/dev/null | grep -q "superpowers@claude-plugins-official"; then
+  SKILLS_AVAILABLE=1
+fi
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [[ "$SKILLS_AVAILABLE" -eq 0 ]] \
+  && [[ -f "$REPO_ROOT/tools/skills/brainstorming/SKILL.md" ]] \
+  && [[ -f "$REPO_ROOT/tools/skills/writing-plans/SKILL.md" ]] \
+  && [[ -f "$REPO_ROOT/tools/skills/using-git-worktrees/SKILL.md" ]]; then
+  SKILLS_AVAILABLE=1
+fi
+if [[ "$SKILLS_AVAILABLE" -eq 0 ]]; then
+  echo "ERROR: neither the superpowers plugin nor the ported skills are available." >&2
+  echo "Install one of:" >&2
+  echo "  [Claude Code] claude plugin marketplace add anthropics/claude-plugins-official" >&2
+  echo "                claude plugin install superpowers@claude-plugins-official" >&2
+  echo "  [Polytoken]   just sync-polytoken-skills   (mirrors tools/skills/ -> .polytoken/skills/)" >&2
   exit 2
 fi
 
@@ -103,10 +122,16 @@ git checkout -b "$BRANCH" origin/main
 # 7. Emit JSON (includes model recommendation from complexity:* label)
 URL=$(jq -r '.url' <<<"$ISSUE_JSON")
 COMPLEXITY=$(jq -r '.labels[] | select(.name | startswith("complexity:")) | .name' <<<"$ISSUE_JSON" | head -1)
+# Model selection is harness-dependent. Claude Code uses claude-* models; this
+# repo's Polytoken config uses umans-* models. The model name for each
+# complexity tier is overridable via env var so neither harness is hardcoded:
+#   ISSUE_MODEL_HIGH / ISSUE_MODEL_MEDIUM / ISSUE_MODEL_LOW
+# Defaults are the Claude Code tiers (backwards-compatible with the prior
+# behavior). Set the env vars (e.g. in .devcontainer/dev.env) to retarget.
 case "$COMPLEXITY" in
-  "complexity:high")   MODEL="claude-opus-4-8" ;;
-  "complexity:medium") MODEL="claude-sonnet-4-6" ;;
-  "complexity:low")    MODEL="claude-sonnet-4-6" ;;
+  "complexity:high")   MODEL="${ISSUE_MODEL_HIGH:-claude-opus-4-8}" ;;
+  "complexity:medium") MODEL="${ISSUE_MODEL_MEDIUM:-claude-sonnet-4-6}" ;;
+  "complexity:low")    MODEL="${ISSUE_MODEL_LOW:-claude-sonnet-4-6}" ;;
   *)                   MODEL="" ;;
 esac
 jq -n \

--- a/tools/skills/sync-polytoken-skills.sh
+++ b/tools/skills/sync-polytoken-skills.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Mirror harness-agnostic skills into .polytoken/skills/ so polytoken discovers
-# them. A skill opts in by declaring `compatibility: polytoken` in its SKILL.md
-# frontmatter (Claude Code ignores the field).
+# them. A skill opts in by declaring `compatibility: polytoken` (additive:
+# also kept in Claude Code) or `compatibility: polytoken-only` (Polytoken-
+# exclusive: skipped by the Claude Code symlink loop to avoid colliding with a
+# same-named superpowers plugin skill). Claude Code ignores both fields.
 #
 # Why a copy and not a symlink: polytoken skips symlinked paths during skill
 # discovery, so the files must be real. Claude Code DOES follow symlinks and gets
@@ -19,13 +21,17 @@ DEST="$REPO_ROOT/.polytoken/skills"
 rm -rf "$DEST"
 mkdir -p "$DEST"
 
-# True iff the file's YAML frontmatter (the first --- ... --- block) declares the
-# opt-in marker. Scoped to the frontmatter so a body mention never false-matches.
+# True iff the file's YAML frontmatter (the first --- ... --- block) declares a
+# polytoken opt-in marker — either `compatibility: polytoken` (additive: also
+# mirrored to Polytoken, but still symlinked into Claude Code) or
+# `compatibility: polytoken-only` (Polytoken-exclusive: NOT symlinked into
+# Claude Code, because it would collide with a same-named superpowers plugin
+# skill). Scoped to the frontmatter so a body mention never false-matches.
 declares_marker() {
   awk '
     NR == 1            { if ($0 != "---") exit 1; next }
     $0 == "---"        { exit found ? 0 : 1 }
-    /^compatibility:[[:space:]]*polytoken[[:space:]]*$/ { found = 1 }
+    /^compatibility:[[:space:]]*polytoken(-only)?[[:space:]]*$/ { found = 1 }
     END                { exit found ? 0 : 1 }
   ' "$1"
 }
@@ -39,6 +45,27 @@ for skill_md in "$SRC"/*/SKILL.md; do
     count=$((count + 1))
     echo "  + $name"
   fi
+done
+shopt -u nullglob
+
+# Some Polytoken skills reuse shared assets (scripts/, templates/, prompts) that
+# live in a *sibling* skill directory rather than their own. The canonical case
+# is issue-to-merged-pr-polytoken, whose SKILL.md references scripts/... that
+# actually live in issue-to-merged-pr/scripts/. Copy those shared assets into
+# the mirrored skill so its relative scripts/ references resolve at runtime.
+# Declared via a `# shared-assets-from: <sibling-dir>` line in the SKILL.md.
+shopt -s nullglob
+for skill_md in "$DEST"/*/SKILL.md; do
+  sibling=$(sed -n 's/^# shared-assets-from:[[:space:]]*//p' "$skill_md" | head -1 | tr -d '[:space:]')
+  [[ -n "$sibling" ]] || continue
+  [[ -d "$SRC/$sibling" ]] || { echo "  ! $sibling (shared-assets-from target missing)" >&2; continue; }
+  name="$(basename "$(dirname "$skill_md")")"
+  for asset in "$SRC/$sibling"/*; do
+    base=$(basename "$asset")
+    [[ "$base" == "SKILL.md" || "$base" == "README.md" || "$base" == "references" ]] && continue
+    cp -R "$asset" "$DEST/$name/$base"
+  done
+  echo "    ↳ shared assets from $sibling"
 done
 shopt -u nullglob
 

--- a/tools/skills/using-git-worktrees/SKILL.md
+++ b/tools/skills/using-git-worktrees/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: using-git-worktrees
+description: "Use when starting feature work that needs isolation from the current workspace, or before executing implementation plans — ensures an isolated workspace exists."
+compatibility: polytoken-only
+---
+
+# Using Git Worktrees
+
+## Overview
+
+Ensure work happens in an isolated workspace. Prefer the platform's native
+worktree tool. Fall back to manual git worktrees only when no native tool is
+available.
+
+**Core principle:** Detect existing isolation first. Then use native tools.
+Then fall back to git. Never fight the harness.
+
+**Announce at start:** "I'm using the using-git-worktrees skill to set up an
+isolated workspace."
+
+## Step 0: Detect Existing Isolation
+
+**Before creating anything, check if you are already in an isolated workspace.**
+
+```bash
+GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+BRANCH=$(git branch --show-current)
+```
+
+**Submodule guard:** `GIT_DIR != GIT_COMMON` is also true inside git submodules.
+Before concluding "already in a worktree," verify you are not in a submodule:
+
+```bash
+# If this returns a path, you're in a submodule, not a worktree — treat as normal repo
+git rev-parse --show-superproject-working-tree 2>/dev/null
+```
+
+**If `GIT_DIR != GIT_COMMON` (and not a submodule):** You are already in a
+linked worktree. Skip to Step 2 (Project Setup). Do NOT create another worktree.
+
+Report with branch state:
+- On a branch: "Already in isolated workspace at `<path>` on branch `<name>`."
+- Detached HEAD: "Already in isolated workspace at `<path>` (detached HEAD,
+  externally managed). Branch creation needed at finish time."
+
+**If `GIT_DIR == GIT_COMMON` (or in a submodule):** You are in a normal repo
+checkout.
+
+Has the user already indicated their worktree preference in your instructions?
+If not, ask for consent before creating a worktree:
+
+> "Would you like me to set up an isolated worktree? It protects your current
+> branch from changes."
+
+Honor any existing declared preference without asking. If the user declines
+consent, work in place and skip to Step 2.
+
+## Step 1: Create Isolated Workspace
+
+**You have two mechanisms. Try them in this order.**
+
+### 1a. Native Worktree Tools (preferred)
+
+The user has asked for an isolated workspace (Step 0 consent). Do you already
+have a way to create a worktree? It might be a tool with a name like
+`EnterWorktree`, `WorktreeCreate`, a `/worktree` command, or a `--worktree`
+flag. If you do, use it and skip to Step 2.
+
+Native tools handle directory placement, branch creation, and cleanup
+automatically. Using `git worktree add` when you have a native tool creates
+phantom state your harness can't see or manage.
+
+Only proceed to Step 1b if you have no native worktree tool available.
+
+### 1b. Git Worktree Fallback
+
+**Only use this if Step 1a does not apply** — you have no native worktree tool
+available. Create a worktree manually using git.
+
+#### Already on the feature branch? Work in place.
+
+`pickup-issue.sh` creates the feature branch and checks it out in the current
+worktree. If you are **already on the feature branch** in the main checkout,
+there is no separate `main` workspace to protect — the current checkout *is*
+the isolated workspace. Skip worktree creation and go straight to Step 2
+(Project Setup). Do NOT run `git worktree add` for a branch that is already
+checked out; git will refuse it ("already checked out").
+
+Only create a new worktree if you are currently on `main` (or detached HEAD)
+and want to move the feature branch into an isolated worktree.
+
+#### Directory Selection
+
+Follow this priority order. Explicit user preference always beats observed
+filesystem state.
+
+1. **Check your instructions for a declared worktree directory preference.** If
+   the user has already specified one, use it without asking.
+
+2. **Check for an existing project-local worktree directory:**
+   ```bash
+   ls -d .worktrees 2>/dev/null     # Preferred (hidden)
+   ls -d worktrees 2>/dev/null       # Alternative
+   ```
+   If found, use it. If both exist, `.worktrees` wins.
+
+3. **If there is no other guidance available**, default to `.worktrees/` at the
+   project root.
+
+#### Safety Verification (project-local directories only)
+
+**MUST verify directory is ignored before creating worktree:**
+
+```bash
+git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/dev/null
+```
+
+**If NOT ignored:** Add to .gitignore, commit the change, then proceed.
+
+**Why critical:** Prevents accidentally committing worktree contents to repository.
+
+#### Create the Worktree
+
+```bash
+# Use the BRANCH detected in Step 0 (or the current branch).
+LOCATION=".worktrees"   # or the existing/preferred directory from above
+path="$LOCATION/$BRANCH"
+
+# If the branch already exists (e.g. created by pickup-issue.sh but you are on
+# main), check it out into the worktree WITHOUT -b:
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git worktree add "$path" "$BRANCH"
+else
+  git worktree add "$path" -b "$BRANCH"
+fi
+cd "$path"
+```
+
+**Sandbox fallback:** If `git worktree add` fails with a permission error
+(sandbox denial), tell the user the sandbox blocked worktree creation and you're
+working in the current directory instead. Then run setup and baseline tests in
+place.
+
+## Step 2: Project Setup
+
+This repo uses `uv` and `mise`. Run the project's setup:
+
+```bash
+# Ensure uv is available and dependencies are installed
+uv sync
+```
+
+The devcontainer's `post-create.sh` handles the baseline install, so in the
+container this is usually a no-op or fast.
+
+## Step 3: Verify Clean Baseline
+
+Run tests to ensure the workspace starts clean:
+
+```bash
+# Fast tier for local iteration (SQLite)
+uv run arx test --keepdb world.magic 2>/dev/null || uv run arx test world.magic
+
+# Or the full suite if a broad baseline is warranted
+uv run arx test
+```
+
+**If tests fail:** Report failures, ask whether to proceed or investigate.
+Don't assume pre-existing failures are unrelated — check whether the worktree
+setup (e.g., missing migration) caused them.
+
+**If tests pass:** Report ready.
+
+### Report
+
+```
+Worktree ready at <full-path>
+Tests passing (<N> tests, 0 failures)
+Ready to implement <feature-name>
+```
+
+## Quick Reference
+
+| Situation | Action |
+|-----------|--------|
+| Already in linked worktree | Skip creation (Step 0) |
+| In a submodule | Treat as normal repo (Step 0 guard) |
+| Native worktree tool available | Use it (Step 1a) |
+| No native tool | Git worktree fallback (Step 1b) |
+| `.worktrees/` exists | Use it (verify ignored) |
+| `worktrees/` exists | Use it (verify ignored) |
+| Both exist | Use `.worktrees/` |
+| Neither exists | Check instruction file, then default `.worktrees/` |
+| Directory not ignored | Add to .gitignore + commit |
+| Permission error on create | Sandbox fallback, work in place |
+| Tests fail during baseline | Report failures + ask |
+
+## Common Mistakes
+
+### Fighting the harness
+
+- **Problem:** Using `git worktree add` when the platform already provides
+  isolation.
+- **Fix:** Step 0 detects existing isolation. Step 1a defers to native tools.
+
+### Skipping detection
+
+- **Problem:** Creating a nested worktree inside an existing one.
+- **Fix:** Always run Step 0 before creating anything.
+
+### Skipping ignore verification
+
+- **Problem:** Worktree contents get tracked, pollute git status.
+- **Fix:** Always use `git check-ignore` before creating project-local worktree.
+
+### Proceeding with failing tests
+
+- **Problem:** Can't distinguish new bugs from pre-existing issues.
+- **Fix:** Report failures, get explicit permission to proceed.
+
+## Red Flags
+
+**Never:**
+- Create a worktree when Step 0 detects existing isolation.
+- Use `git worktree add` when you have a native worktree tool.
+- Skip Step 1a by jumping straight to Step 1b's git commands.
+- Create worktree without verifying it's ignored (project-local).
+- Skip baseline test verification.
+- Proceed with failing tests without asking.
+
+**Always:**
+- Run Step 0 detection first.
+- Prefer native tools over git fallback.
+- Follow directory priority: explicit instructions > existing project-local
+  directory > default.
+- Verify directory is ignored for project-local.
+- Auto-detect and run project setup.
+- Verify clean test baseline.

--- a/tools/skills/writing-plans/SKILL.md
+++ b/tools/skills/writing-plans/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: writing-plans
+description: "Use when you have an approved spec or requirements for a multi-step task, before touching code. Produces an ephemeral implementation plan (worktree-only, never committed)."
+compatibility: polytoken-only
+---
+
+# Writing Plans
+
+## Overview
+
+Write comprehensive implementation plans assuming the engineer has zero context
+for our codebase and questionable taste. Document everything they need to know:
+which files to touch for each task, code, testing, docs they might need to check,
+how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD.
+Frequent commits.
+
+Assume they are a skilled developer, but know almost nothing about our toolset or
+problem domain. Assume they don't know good test design very well.
+
+**Announce at start:** "I'm using the writing-plans skill to create the
+implementation plan."
+
+**Context:** If working in an isolated worktree, it should have been created via
+the `using-git-worktrees` skill at execution time.
+
+## Where the plan lives
+
+**Plans are ephemeral — worktree-only, never committed.** Write the plan to a
+file under the worktree (e.g. `.plan.md` or a path the orchestration skill
+chooses) that is gitignored or simply not committed. Do NOT save plans to
+`docs/superpowers/plans/`. There is no committed plan artifact; the spec (in the
+issue body) is the only durable design record.
+
+This is a **deliberate alteration** of the upstream Superpowers writing-plans
+skill, which commits plans to `docs/superpowers/plans/`. Do not do that.
+
+## Scope Check
+
+If the spec covers multiple independent subsystems, it should have been broken
+into sub-project specs during brainstorming. If it wasn't, suggest breaking this
+into separate plans — one per subsystem. Each plan should produce working,
+testable software on its own.
+
+## File Structure
+
+Before defining tasks, map out which files will be created or modified and what
+each one is responsible for. This is where decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each file
+  should have one clear responsibility.
+- You reason best about code you can hold in context at once, and your edits are
+  more reliable when files are focused. Prefer smaller, focused files over large
+  ones that do too much.
+- Files that change together should live together. Split by responsibility, not
+  by technical layer.
+- In existing codebases, follow established patterns. If the codebase uses large
+  files, don't unilaterally restructure — but if a file you're modifying has grown
+  unwieldy, including a split in the plan is reasonable.
+
+This structure informs the task decomposition. Each task should produce
+self-contained changes that make sense independently.
+
+## Task Right-Sizing
+
+A task is the smallest unit that carries its own test cycle and is worth a
+fresh reviewer's gate. When drawing task boundaries: fold setup, configuration,
+scaffolding, and documentation steps into the task whose deliverable needs them;
+split only where a reviewer could meaningfully reject one task while approving
+its neighbor. Each task ends with an independently testable deliverable.
+
+## Bite-Sized Task Granularity
+
+**Each step is one action (2-5 minutes):**
+- "Write the failing test" — step
+- "Run it to make sure it fails" — step
+- "Implement the minimal code to make the test pass" — step
+- "Run the tests and make sure they pass" — step
+- "Commit" — step
+
+## Plan Document Header
+
+**Every plan MUST start with this header:**
+
+```markdown
+# [Feature Name] Implementation Plan
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+## Global Constraints
+
+[The spec's project-wide requirements — version floors, dependency limits,
+naming and copy rules, platform requirements — one line each, with exact
+values copied verbatim from the spec. Every task's requirements implicitly
+include this section.]
+
+---
+```
+
+## Task Structure
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py:123-145`
+- Test: `tests/exact/path/to/test.py`
+
+**Interfaces:**
+- Consumes: [what this task uses from earlier tasks — exact signatures]
+- Produces: [what later tasks rely on — exact function names, parameter
+  and return types. A task's implementer sees only their own task; this
+  block is how they learn the names and types neighboring tasks use.]
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_specific_behavior():
+    result = function(input)
+    assert result == expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run arx test world.magic.tests.test_thing::test_specific_behavior`
+Expected: FAIL with "function not defined"
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+def function(input):
+    return expected
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run arx test world.magic.tests.test_thing::test_specific_behavior`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+```
+````
+
+## No Placeholders
+
+Every step must contain the actual content an engineer needs. These are **plan
+failures** — never write them:
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without actual test code)
+- "Similar to Task N" (repeat the code — the engineer may be reading tasks out
+  of order)
+- Steps that describe what to do without showing how (code blocks required for
+  code steps)
+- References to types, functions, or methods not defined in any task
+
+## Remember
+- Exact file paths always
+- Complete code in every step — if a step changes code, show the code
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Tests run via `uv run arx test` (never bare `python`/`pytest` — misses deps)
+
+## Self-Review
+
+After writing the complete plan, look at the spec with fresh eyes and check the
+plan against it. This is a checklist you run yourself — not a subagent dispatch.
+
+**1. Spec coverage:** Skim each section/requirement in the spec. Can you point
+to a task that implements it? List any gaps.
+
+**2. Placeholder scan:** Search your plan for red flags — any of the patterns
+from the "No Placeholders" section above. Fix them.
+
+**3. Type consistency:** Do the types, method signatures, and property names
+you used in later tasks match what you defined in earlier tasks? A function
+called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+
+If you find issues, fix them inline. No need to re-review — just fix and move
+on. If you find a spec requirement with no task, add the task.
+
+## Execution Handoff
+
+After writing the plan, **go straight to implementation.** Do NOT prompt the
+user to choose subagent-driven vs. inline execution — inline implementation is
+the default for this project (work through the plan task-by-task in this
+session, committing after each). Subagent-driven execution is only for when
+subagents are explicitly requested.
+
+Follow the plan if one exists; otherwise implement directly. Commit frequently.


### PR DESCRIPTION
## Summary

The brainstorm→spec→plan design gate that `issue-to-merged-pr` relies on was Claude-Code-only (it orchestrates the `superpowers` plugin), so under Polytoken the gate was absent entirely — agents jumped straight to building, producing PRs unrelated to the issue intent (as seen on #1581/#1582).

This ports the three spine skills from [obra/superpowers](https://github.com/obra/superpowers) into `tools/skills/`, altered for this project's conventions rather than copied verbatim, plus a Polytoken-native orchestration skill.

## What ships

**4 new skills** (`tools/skills/`, all marked `compatibility: polytoken-only`):

| Skill | Alteration from obra's version |
|---|---|
| `brainstorming` | Spec writes to the **GitHub issue body** (`<!-- spec:start -->` / `<!-- spec:end -->` markers), never a committed `docs/superpowers/` file. Mandates the `verify-against-code` anti-reinvention ledger. Drops the browser visual companion (headless). |
| `writing-plans` | Plan is **ephemeral** (worktree-only, never committed). Goes straight to implementation — no subagent-vs-inline handoff prompt. Uses `uv run arx test`. |
| `using-git-worktrees` | Detects an already-checked-out feature branch (from `pickup-issue.sh`) and works in place rather than fighting git. Adapted to uv. |
| `issue-to-merged-pr-polytoken` | Polytoken-native orchestration skill — full pickup→merge lifecycle. Reuses the existing `issue-to-merged-pr/scripts/*` verbatim. |

**3 modified files:**

- `pickup-issue.sh` — precheck now passes if **either** the superpowers plugin **or** the ported skills are present (no hard-fail under Polytoken); model tiers are env-overridable (`ISSUE_MODEL_HIGH/MEDIUM/LOW`) so Polytoken's umans-* models aren't hardcoded.
- `sync-polytoken-skills.sh` — matches both `polytoken` and `polytoken-only` markers; copies shared assets (scripts/templates/prompt) into a skill that declares `# shared-assets-from:`.
- `post-create.sh` + `README.md` + `justfile` — the `polytoken-only` marker means Polytoken-exclusive: skipped by the Claude Code symlink loop so these can't collide with same-named superpowers plugin skills or the Claude-Code-only `issue-to-merged-pr` skill.

## Coexistence (colleagues untouched)

`compatibility: polytoken-only` = Polytoken-exclusive. These 4 skills mirror to `.polytoken/skills/` but are **never symlinked into `~/.claude/skills/`**, so they cannot collide with a colleague's `superpowers` plugin (`brainstorming`/`writing-plans`/`using-git-worktrees`) or the Claude-Code-only `issue-to-merged-pr`. Their setup is unchanged. Plain `compatibility: polytoken` stays additive (both harnesses).

## Bug fix included

The seven pre-existing markered skills (`github-operations`, `verify-against-code`, etc.) were not loading in Polytoken — `.polytoken/skills/` was never generated. The sync now populates all eleven.

## How to activate (post-merge)

1. Merge this PR.
2. Run `just sync-polytoken-skills` (or it runs automatically on next container create).
3. Run `/reload` in a Polytoken session (re-reads skills/config without restarting).

## Validation

- shellcheck clean on all touched scripts.
- All 13 script/template/prompt references resolve in the generated mirror.
- No dangling `$BRANCH_NAME` references in the ported worktrees skill.
- Pre-commit hooks passed on commit (ESLint/TypeScript/Prettier skipped — no frontend files).

**Not yet dogfooded.** The first real run on an issue is the actual end-to-end validation.

## Notes

- Brainstorm/plan/worktree ported from obra/superpowers (MIT).
- ed3d-plugins was considered as a source but is a Claude Code plugin marketplace (not Polytoken-optimized); the skills inside are themselves a Superpowers derivative, so going to the original avoided a layer of indirection.