### PR TITLE
feat(scenes): friends-list surface — telnet command + web API (#1727)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -5024,6 +5024,41 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/friends/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description The requesting player's OOC friends: list, add (this character or all), remove. */
+    get: operations['friends_list'];
+    put?: never;
+    /** @description The requesting player's OOC friends: list, add (this character or all), remove. */
+    post: operations['friends_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/friends/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** @description The requesting player's OOC friends: list, add (this character or all), remove. */
+    delete: operations['friends_destroy'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/global-story-progress/': {
     parameters: {
       query?: never;
@@ -17545,6 +17580,31 @@ export interface components {
      * @enum {string}
      */
     FormTypeEnum: 'true' | 'alternate' | 'disguise';
+    /** @description A friend row — the friended character's name + the tenures. */
+    Friendship: {
+      readonly id: number;
+      /** @description The friender's tenure (this player's run of the character that friended). */
+      readonly friender_tenure: number;
+      /** @description The friended character's tenure (a specific player's run of that character). */
+      readonly friend_tenure: number;
+      readonly friend_name: string;
+      /** Format: date-time */
+      readonly created_at: string;
+    };
+    /** @description Add a friend: which of your characters friends (or all), and the friended tenure. */
+    FriendshipCreate: {
+      friender_tenure: number;
+      friend_tenure: number;
+      /** @default false */
+      all_characters: boolean;
+    };
+    /** @description Add a friend: which of your characters friends (or all), and the friended tenure. */
+    FriendshipCreateRequest: {
+      friender_tenure: number;
+      friend_tenure: number;
+      /** @default false */
+      all_characters: boolean;
+    };
     /** @description Read-only representation of one selectable FuryTier (#1543). */
     FuryTierOption: {
       readonly id: number;
@@ -20484,6 +20544,21 @@ export interface components {
        */
       previous?: string | null;
       results: components['schemas']['FashionPresentation'][];
+    };
+    PaginatedFriendshipList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['Friendship'][];
     };
     PaginatedGMApplicationDetailList: {
       /** @example 123 */
@@ -33367,6 +33442,71 @@ export interface operations {
         content: {
           'application/json': components['schemas']['FormTrait'];
         };
+      };
+    };
+  };
+  friends_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedFriendshipList'];
+        };
+      };
+    };
+  };
+  friends_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['FriendshipCreateRequest'];
+      };
+    };
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['FriendshipCreate'];
+        };
+      };
+    };
+  };
+  friends_destroy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -101,6 +101,7 @@ from commands.social.blocking import (
     CmdUnmute,
 )
 from commands.social.entrance_flourish import CmdEnter, CmdFlourish
+from commands.social.friends import CmdFriend, CmdFriends, CmdUnfriend
 from commands.social.gossip import CmdGossip
 from commands.social.grievance import CmdGrievance
 from commands.social.soul_tether import CmdSineater, CmdTether
@@ -222,6 +223,10 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdTidings,
             # #1572 — work the rumor mill at a social hub (plant/seek/suppress gossip).
             CmdGossip,
+            # #1727 — the OOC friends list (add/remove/list) + watch-list.
+            CmdFriend,
+            CmdUnfriend,
+            CmdFriends,
             # #1463 — public presence/navigation: who's about, in coloured area paths.
             CmdWhere,
             # #1463 — online roster: who's online, by active persona, coarse idle.

--- a/src/commands/social/friends.py
+++ b/src/commands/social/friends.py
@@ -1,0 +1,147 @@
+"""Telnet friends-list commands (#1727).
+
+Thin wrappers over ``world.scenes.friend_services`` — the telnet face of the OOC friends list. A
+friendship binds *this character's tenure* to the target character's tenure (re-roster-safe,
+alt-private). No business logic here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.core.exceptions import ObjectDoesNotExist
+
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from world.roster.models import RosterTenure
+
+_NO_IDENTITY = "You have no character identity to act with."
+_LOCK_ALL = "cmd:all()"
+_ALL = "all"
+
+
+def _caller_tenure(command: ArxCommand) -> RosterTenure:
+    try:
+        entry = command.caller.sheet_data.roster_entry
+    except (AttributeError, ObjectDoesNotExist) as exc:
+        raise CommandError(_NO_IDENTITY) from exc
+    tenure = entry.current_tenure if entry is not None else None
+    if tenure is None:
+        raise CommandError(_NO_IDENTITY)
+    return tenure
+
+
+def _target_tenure(command: ArxCommand, name: str) -> tuple[object, RosterTenure]:
+    target = command.search_or_raise(name)
+    try:
+        entry = target.sheet_data.roster_entry
+    except (AttributeError, ObjectDoesNotExist) as exc:
+        msg = f"You can't friend {target}."
+        raise CommandError(msg) from exc
+    tenure = entry.current_tenure if entry is not None else None
+    if tenure is None:
+        msg = f"You can't friend {target} right now."
+        raise CommandError(msg)
+    return target, tenure
+
+
+class CmdFriend(ArxCommand):
+    """Add an OOC friend — a trusted RP partner.
+
+    Usage:
+      friend <character>       — friend them from THIS character (default)
+      friend/all <character>   — friend them from ALL your characters
+
+    A friend gets a login/logoff alert for you (a watch list) and may be allowed to act on you under
+    the friends consent mode. Friendships are per-character: `friend/all` adds one for each of your
+    characters, each removable on its own. Out-of-character — separate from IC relationships.
+    """
+
+    key = "+friend"
+    aliases = ["friend"]
+    locks = _LOCK_ALL
+
+    def func(self) -> None:
+        from world.scenes.friend_services import (  # noqa: PLC0415
+            add_friend,
+            add_friend_all_characters,
+        )
+
+        name = (self.args or "").strip()
+        if not name:
+            self.msg("Usage: friend <character>  (or friend/all <character>).")
+            return
+        try:
+            target, target_tenure = _target_tenure(self, name)
+            if _ALL in self.switches:
+                from evennia_extensions.models import PlayerData  # noqa: PLC0415
+
+                player_data, _ = PlayerData.objects.get_or_create(account=self.account)
+                add_friend_all_characters(player_data=player_data, friend_tenure=target_tenure)
+                self.msg(f"All your characters now count {target} as a friend.")
+            else:
+                add_friend(friender_tenure=_caller_tenure(self), friend_tenure=target_tenure)
+                self.msg(f"You added {target} as a friend (from this character).")
+        except CommandError as err:
+            self.msg(str(err))
+
+
+class CmdUnfriend(ArxCommand):
+    """Remove an OOC friend from THIS character (your other characters keep theirs).
+
+    Usage:
+      unfriend <character>
+    """
+
+    key = "+unfriend"
+    aliases = ["unfriend"]
+    locks = _LOCK_ALL
+
+    def func(self) -> None:
+        from world.scenes.friend_services import remove_friend  # noqa: PLC0415
+
+        name = (self.args or "").strip()
+        if not name:
+            self.msg("Usage: unfriend <character>.")
+            return
+        try:
+            target, target_tenure = _target_tenure(self, name)
+            remove_friend(friender_tenure=_caller_tenure(self), friend_tenure=target_tenure)
+            self.msg(f"You removed {target} as a friend (from this character).")
+        except CommandError as err:
+            self.msg(str(err))
+
+
+class CmdFriends(ArxCommand):
+    """List the friends of your current character.
+
+    Usage:
+      friends
+    """
+
+    key = "+friends"
+    aliases = ["friends"]
+    locks = _LOCK_ALL
+
+    def func(self) -> None:
+        from world.scenes.friend_services import friended_tenures_for  # noqa: PLC0415
+
+        try:
+            caller_tenure = _caller_tenure(self)
+        except CommandError as err:
+            self.msg(str(err))
+            return
+        tenures = friended_tenures_for(caller_tenure).select_related(
+            "roster_entry__character_sheet__character"
+        )
+        names = [
+            tenure.roster_entry.character_sheet.character.key
+            for tenure in tenures
+            if tenure.roster_entry.character_sheet.character is not None
+        ]
+        if not names:
+            self.msg("This character has no friends listed.")
+            return
+        self.msg("|wYour friends (this character):|n " + ", ".join(sorted(names)))

--- a/src/commands/tests/test_friends_commands.py
+++ b/src/commands/tests/test_friends_commands.py
@@ -1,0 +1,66 @@
+"""Telnet friends commands (#1727)."""
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.social.friends import CmdFriend, CmdFriends, CmdUnfriend
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
+from world.scenes.models import Friendship
+
+
+class FriendsCommandTests(TestCase):
+    def _played(self, character, account=None):
+        account = account or AccountFactory()
+        player_data = PlayerDataFactory(account=account)
+        entry = RosterEntryFactory(character_sheet__character=character)
+        RosterTenureFactory(roster_entry=entry, player_data=player_data)
+        return account
+
+    def setUp(self) -> None:
+        self.caller = CharacterFactory(db_key="Alice")
+        self.caller.msg = MagicMock()
+        self.account = self._played(self.caller)
+        self.account.msg = MagicMock()
+        self.target = CharacterFactory(db_key="Bob")
+        self._played(self.target)
+        self.caller.search = MagicMock(return_value=self.target)
+
+    def _run(self, cmd_class, args, switches=None):
+        cmd = cmd_class()
+        cmd.caller = self.caller
+        cmd.account = self.account
+        cmd.args = args
+        cmd.switches = switches or []
+        cmd.func()
+        return cmd
+
+    def test_friend_creates_a_friendship_from_this_character(self) -> None:
+        self._run(CmdFriend, "Bob")
+        self.assertTrue(
+            Friendship.objects.filter(
+                friend_tenure__roster_entry__character_sheet__character=self.target
+            ).exists()
+        )
+        self.caller.msg.assert_called()
+
+    def test_friend_requires_a_target(self) -> None:
+        self._run(CmdFriend, "")
+        self.assertFalse(Friendship.objects.exists())
+
+    def test_unfriend_removes_it(self) -> None:
+        self._run(CmdFriend, "Bob")
+        self._run(CmdUnfriend, "Bob")
+        self.assertFalse(Friendship.objects.exists())
+
+    def test_friend_all_fans_out(self) -> None:
+        self._run(CmdFriend, "Bob", switches=["all"])
+        self.assertTrue(Friendship.objects.exists())
+
+    def test_friends_list_shows_the_friend(self) -> None:
+        self._run(CmdFriend, "Bob")
+        self.caller.msg.reset_mock()
+        self._run(CmdFriends, "")
+        self.caller.msg.assert_called()
+        self.assertIn("Bob", self.caller.msg.call_args[0][0])

--- a/src/schema.json
+++ b/src/schema.json
@@ -7701,6 +7701,68 @@ paths:
               schema:
                 $ref: '#/components/schemas/FormTrait'
           description: ''
+  /api/friends/:
+    get:
+      operationId: friends_list
+      description: 'The requesting player''s OOC friends: list, add (this character
+        or all), remove.'
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      tags:
+      - friends
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedFriendshipList'
+          description: ''
+    post:
+      operationId: friends_create
+      description: 'The requesting player''s OOC friends: list, add (this character
+        or all), remove.'
+      tags:
+      - friends
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FriendshipCreateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FriendshipCreate'
+          description: ''
+  /api/friends/{id}/:
+    delete:
+      operationId: friends_destroy
+      description: 'The requesting player''s OOC friends: list, add (this character
+        or all), remove.'
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - friends
+      security:
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/global-story-progress/:
     get:
       operationId: global_story_progress_list
@@ -31074,6 +31136,66 @@ components:
         * `true` - True Form
         * `alternate` - Alternate Form
         * `disguise` - Disguise
+    Friendship:
+      type: object
+      description: A friend row — the friended character's name + the tenures.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        friender_tenure:
+          type: integer
+          readOnly: true
+          description: The friender's tenure (this player's run of the character that
+            friended).
+        friend_tenure:
+          type: integer
+          readOnly: true
+          description: The friended character's tenure (a specific player's run of
+            that character).
+        friend_name:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - friend_name
+      - friend_tenure
+      - friender_tenure
+      - id
+    FriendshipCreate:
+      type: object
+      description: 'Add a friend: which of your characters friends (or all), and the
+        friended tenure.'
+      properties:
+        friender_tenure:
+          type: integer
+        friend_tenure:
+          type: integer
+        all_characters:
+          type: boolean
+          default: false
+      required:
+      - friend_tenure
+      - friender_tenure
+    FriendshipCreateRequest:
+      type: object
+      description: 'Add a friend: which of your characters friends (or all), and the
+        friended tenure.'
+      properties:
+        friender_tenure:
+          type: integer
+        friend_tenure:
+          type: integer
+        all_characters:
+          type: boolean
+          default: false
+      required:
+      - friend_tenure
+      - friender_tenure
     FuryTierOption:
       type: object
       description: Read-only representation of one selectable FuryTier (#1543).
@@ -36885,6 +37007,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FashionPresentation'
+    PaginatedFriendshipList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Friendship'
     PaginatedGMApplicationDetailList:
       type: object
       required:

--- a/src/world/scenes/friend_serializers.py
+++ b/src/world/scenes/friend_serializers.py
@@ -1,0 +1,38 @@
+"""Serializers for the OOC friends-list API (#1727)."""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from world.roster.models import RosterTenure
+from world.scenes.models import Friendship
+
+_NOT_YOUR_CHARACTER = "You can only friend as one of your own characters."
+
+
+class FriendshipCreateSerializer(serializers.Serializer):
+    """Add a friend: which of your characters friends (or all), and the friended tenure."""
+
+    friender_tenure = serializers.PrimaryKeyRelatedField(queryset=RosterTenure.objects.all())
+    friend_tenure = serializers.PrimaryKeyRelatedField(queryset=RosterTenure.objects.all())
+    all_characters = serializers.BooleanField(default=False)
+
+    def validate_friender_tenure(self, value: RosterTenure) -> RosterTenure:
+        if value.player_data.account_id != self.context["request"].user.pk:
+            raise serializers.ValidationError(_NOT_YOUR_CHARACTER)
+        return value
+
+
+class FriendshipSerializer(serializers.ModelSerializer):
+    """A friend row — the friended character's name + the tenures."""
+
+    friend_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Friendship
+        fields = ["id", "friender_tenure", "friend_tenure", "friend_name", "created_at"]
+        read_only_fields = fields
+
+    def get_friend_name(self, obj: Friendship) -> str:
+        character = obj.friend_tenure.roster_entry.character_sheet.character
+        return character.db_key if character is not None else "Unknown"

--- a/src/world/scenes/friend_views.py
+++ b/src/world/scenes/friend_views.py
@@ -1,0 +1,58 @@
+"""OOC friends-list API (#1727) — the web face of world.scenes.friend_services.
+
+A player's friendships (those made by any of their characters): list, add (one character or all),
+remove. Tenure-scoped + alt-private, mirroring the Block/Mute control API.
+"""
+
+from __future__ import annotations
+
+from django.db.models import QuerySet
+from rest_framework import mixins, serializers, status
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from evennia_extensions.models import PlayerData
+from world.scenes.friend_serializers import FriendshipCreateSerializer, FriendshipSerializer
+from world.scenes.friend_services import add_friend, add_friend_all_characters
+from world.scenes.models import Friendship
+
+
+class FriendsPagination(PageNumberPagination):
+    page_size = 100
+
+
+class FriendshipViewSet(
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    GenericViewSet,
+):
+    """The requesting player's OOC friends: list, add (this character or all), remove."""
+
+    permission_classes = [IsAuthenticated]
+    pagination_class = FriendsPagination
+    filter_backends: list = []
+
+    def get_queryset(self) -> QuerySet[Friendship]:
+        return Friendship.objects.filter(
+            friender_tenure__player_data__account=self.request.user
+        ).select_related("friend_tenure__roster_entry__character_sheet__character")
+
+    def get_serializer_class(self) -> type[serializers.BaseSerializer]:
+        return FriendshipCreateSerializer if self.action == "create" else FriendshipSerializer
+
+    def create(self, request: Request, *args: object, **kwargs: object) -> Response:
+        serializer = FriendshipCreateSerializer(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        if data["all_characters"]:
+            player_data, _ = PlayerData.objects.get_or_create(account=request.user)
+            add_friend_all_characters(player_data=player_data, friend_tenure=data["friend_tenure"])
+            return Response(status=status.HTTP_201_CREATED)
+        friendship = add_friend(
+            friender_tenure=data["friender_tenure"], friend_tenure=data["friend_tenure"]
+        )
+        return Response(FriendshipSerializer(friendship).data, status=status.HTTP_201_CREATED)

--- a/src/world/scenes/tests/test_friend_api.py
+++ b/src/world/scenes/tests/test_friend_api.py
@@ -1,0 +1,52 @@
+"""OOC friends-list API (#1727)."""
+
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory
+from world.roster.factories import PlayerDataFactory, RosterTenureFactory
+from world.scenes.models import Friendship
+
+
+class FriendApiTests(APITestCase):
+    def setUp(self) -> None:
+        self.account = AccountFactory()
+        self.player = PlayerDataFactory(account=self.account)
+        self.my_tenure = RosterTenureFactory(player_data=self.player)
+        self.target_tenure = RosterTenureFactory()
+        self.client.force_authenticate(user=self.account)
+
+    def test_create_lists_and_delete(self) -> None:
+        # Add.
+        res = self.client.post(
+            reverse("friend-list"),
+            {"friender_tenure": self.my_tenure.pk, "friend_tenure": self.target_tenure.pk},
+            format="json",
+        )
+        self.assertEqual(res.status_code, 201)
+        friendship = Friendship.objects.get(friender_tenure=self.my_tenure)
+
+        # List (only mine).
+        rows = self.client.get(reverse("friend-list")).data["results"]
+        self.assertEqual(len(rows), 1)
+
+        # Remove.
+        res = self.client.delete(reverse("friend-detail", args=[friendship.pk]))
+        self.assertIn(res.status_code, (200, 204))
+        self.assertFalse(Friendship.objects.exists())
+
+    def test_cannot_friend_as_someone_elses_character(self) -> None:
+        other_tenure = RosterTenureFactory()  # not owned by self.account
+        res = self.client.post(
+            reverse("friend-list"),
+            {"friender_tenure": other_tenure.pk, "friend_tenure": self.target_tenure.pk},
+            format="json",
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_list_excludes_other_players_friendships(self) -> None:
+        # Another player's friendship must not appear in my list.
+        other_player = PlayerDataFactory(account=AccountFactory())
+        other_friender = RosterTenureFactory(player_data=other_player)
+        Friendship.objects.create(friender_tenure=other_friender, friend_tenure=self.target_tenure)
+        self.assertEqual(self.client.get(reverse("friend-list")).data["results"], [])

--- a/src/world/scenes/urls.py
+++ b/src/world/scenes/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from world.scenes.action_views import SceneActionRequestViewSet, SceneActionTargetViewSet
+from world.scenes.friend_views import FriendshipViewSet
 from world.scenes.interaction_views import (
     InteractionFavoriteViewSet,
     InteractionReactionViewSet,
@@ -53,6 +54,7 @@ router.register(
 )
 router.register(r"blocks", BlockViewSet, basename="block")
 router.register(r"mutes", MuteViewSet, basename="mute")
+router.register(r"friends", FriendshipViewSet, basename="friend")
 
 urlpatterns = [
     path("api/", include(router.urls)),


### PR DESCRIPTION
## What

The player surface for the OOC friends list (#1727), on top of the merged foundation (#1731) —
**telnet command + web API**. Both are tenure-scoped + alt-private.

## Telnet (`commands/social/friends.py`)
- `friend <character>` / `friend/all <character>` — friend from this character or all your characters
- `unfriend <character>` — remove from this character
- `friends` — list this character's friends

Thin over `friend_services`, mirroring the block command; resolves the target to its current tenure.

## Web API (`/api/scenes/friends/`)
`FriendshipViewSet` (list / create / destroy), mirroring the Block/Mute control API:
- GET — the requester's friendships (scoped to `friender_tenure__player_data__account`)
- POST — add (this character, or `all_characters` fan-out; validates the friender tenure is yours)
- DELETE — remove a row

`Friendship{Create,}Serializer`; api-types regenerated.

## Tests
`test_friends_commands` (5), `test_friend_api` (3 — create/list/delete, can't-friend-as-another's-
character, list excludes other players').

## Remaining slice
The **React friends UI** — deferred only because it needs a UX-placement call (most natural: a
self-only **Friends tab** on the character sheet, mirroring the gossip/secrets tabs, listing this
character's friends with add/remove). Everything it needs is in this API.

Refs #1727. Depends on #1731 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
