### PR TITLE
Species vulnerabilities + immunity/vulnerability framework

### DIFF
--- a/docs/adr/0066-environmental-vulnerabilities-are-dot-rows-riding-the-peril-pipeline.md
+++ b/docs/adr/0066-environmental-vulnerabilities-are-dot-rows-riding-the-peril-pipeline.md
@@ -1,0 +1,24 @@
+# Environmental vulnerabilities are ConditionDamageOverTime rows riding the peril pipeline
+
+A species environmental vulnerability (e.g. vampire ↔ sunlight) is a
+`ConditionDamageOverTime` row (radiant) on a "Sunlight Exposure"
+`ConditionTemplate`, applied when the character is outdoors during a daylight
+phase (gated by `RoomProfile.is_outdoor` + `get_ic_phase()`). It rides the
+existing `_process_round_tick` → `tick_round_for_targets` →
+`process_damage_consequences` → peril-pipeline machinery that poison, Burning,
+and Bleeding-Out already use — no new cron, no new tick, no new model. Exposure
+ensures a danger scene round via `ensure_round_for_acute_condition` (the plummet
+pattern) so the tick runs; the AFK-safety contract (ADR-0004/ADR-0049) holds
+unchanged: an unconscious victim flows into `abandonment_environmental`, never a
+raw death. Immunity to a damage type is not a boolean; it is a very high
+`ConditionResistanceModifier` that overwhelming damage exceeds — so god-tier
+power pierces "immunity" by arithmetic, not a special code path. This extends
+ADR-0062 (broad framework + environmental triggers, per the roadmap's #1588
+row). We rejected a bespoke environmental-damage cron and a reactive
+`DAMAGE_PRE_APPLY` modifier: the former reintroduces AFK-kill risk, the latter
+makes sunlight combat-only and misses passive exposure. We also rejected a new
+`is_immune` boolean: a hard flag cannot be overcome by overwhelming power, which
+contradicts the design tenet that sufficiently powerful effects punch through
+"immunity."
+
+> Status: accepted · Source: issue #1588 · Confidence: built (E2E `test_sunlight_exposure_e2e.py`)

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -344,6 +344,7 @@ class Character(ObjectParent, DefaultCharacter):
                 check_room_traps_on_entry,
             )
             from world.societies.fame_reactions import maybe_emit_fame_reaction
+            from world.species.services import reconcile_sunlight_exposure
 
             run_safely(
                 "mission_trigger_on_enter",
@@ -363,6 +364,11 @@ class Character(ObjectParent, DefaultCharacter):
             run_safely(
                 "clue_trigger_on_enter",
                 lambda: maybe_grant_clue_triggers(self, self.location),
+                actor=self,
+            )
+            run_safely(
+                "sunlight_exposure_on_enter",
+                lambda: reconcile_sunlight_exposure(self, self.location),
                 actor=self,
             )
 

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -2781,21 +2781,17 @@ def apply_damage_to_participant(  # noqa: PLR0913
     # Inlined here rather than a flow subscriber because the flow/event
     # system dispatches on FlowDefinition rows, not Python callables
     # (see Phase 13 Open Item 3). Reads handler caches; near-zero cost.
-    from world.magic.services import (  # noqa: PLC0415
-        apply_damage_reduction_from_threads,
-        gift_thread_resistance,
-    )
+    from world.conditions.services import resolve_damage_type_resistance  # noqa: PLC0415
+    from world.magic.services import apply_damage_reduction_from_threads  # noqa: PLC0415
 
     effective_damage = apply_damage_reduction_from_threads(character, effective_damage)
 
-    if damage_type is not None:
-        # Damage-type-specific resistance: the species drawback's negative
-        # ConditionResistanceModifier (vulnerability) and the species-gift thread's
-        # positive RESISTANCE pull-effect are summed into one clamped subtraction so
-        # they net correctly (#1580).
-        resistance = character.conditions.resistance_modifier(damage_type)
-        resistance += gift_thread_resistance(character, damage_type)
-        effective_damage = max(0, effective_damage - resistance)
+    # Damage-type resistance (condition + gift-thread) via the shared seam (#1588).
+    # The species drawback's negative ConditionResistanceModifier (vulnerability) and
+    # the species-gift thread's positive RESISTANCE pull-effect net here. None
+    # damage_type is a no-op. Mirrors the three non-combat damage seams that now call
+    # the same function.
+    effective_damage = resolve_damage_type_resistance(character, effective_damage, damage_type)
 
     # Equipped-armor soak (issue #508). PCs have no authored soak field; worn
     # armor is their only soak source, and absorbing pieces take durability wear.

--- a/src/world/conditions/factories.py
+++ b/src/world/conditions/factories.py
@@ -79,6 +79,15 @@ class DamageTypeFactory(DjangoModelFactory):
     color_hex = "#FF0000"
 
 
+def ensure_radiant_damage_type() -> DamageType:
+    """Idempotently get-or-create the 'Radiant' DamageType used by sunlight exposure (#1588).
+
+    Returns the same pk across calls; safe to invoke from seeds, factories, and tests.
+    """
+    dt, _created = DamageType.objects.get_or_create(name="Radiant")
+    return dt
+
+
 class ConditionTemplateFactory(DjangoModelFactory):
     """Factory for ConditionTemplate."""
 

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -124,6 +124,40 @@ def _invalidate_condition_handler(target: "ObjectDB") -> None:  # noqa: OBJECTDB
 # =============================================================================
 
 
+def resolve_damage_type_resistance(
+    character: "ObjectDB",  # noqa: OBJECTDB_PARAM
+    damage_amount: int,
+    damage_type: "DamageType | None",
+) -> int:
+    """Net damage-type resistance (condition + gift-thread) and return reduced damage (>=0).
+
+    The single source of truth for damage-type resistance across every damage seam
+    (#1588). Mirrors the netting that previously lived inlined in
+    ``combat.services.apply_damage_to_participant``. When ``damage_type`` is None
+    (untyped damage) resistance does not apply — the amount is returned unchanged.
+
+    A negative resistance total (a vulnerability, e.g. a species drawback) *increases*
+    damage above the base; a large positive total (high resistance, functioning as
+    "immunity") reduces it toward zero but overwhelming damage still exceeds it.
+
+    Args:
+        character: the ObjectDB character taking damage (must expose ``.conditions``
+            and be passable to ``gift_thread_resistance``).
+        damage_amount: the incoming damage before resistance.
+        damage_type: a ``DamageType`` instance, or None for untyped damage.
+
+    Returns:
+        The damage after subtracting total resistance, clamped to >= 0.
+    """
+    if damage_type is None:
+        return damage_amount
+    from world.magic.services import gift_thread_resistance  # noqa: PLC0415
+
+    resistance = character.conditions.resistance_modifier(damage_type)
+    resistance += gift_thread_resistance(character, damage_type)
+    return max(0, damage_amount - resistance)
+
+
 def get_active_conditions(
     target: "ObjectDB",  # noqa: OBJECTDB_PARAM
     *,

--- a/src/world/conditions/tests/test_environmental_dot_resistance.py
+++ b/src/world/conditions/tests/test_environmental_dot_resistance.py
@@ -1,0 +1,48 @@
+"""DoT round-tick damage respects damage-type resistance via the unified seam (#1588)."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from world.conditions.services import resolve_damage_type_resistance
+
+
+class DotRespectsResistanceTest(TestCase):
+    """The vitals _apply_round_tick_damage seam now nets resistance (#1588).
+
+    These tests assert the wiring at the unit level: the unified seam is what the
+    DoT path calls. The full E2E (sunlight DoT through the peril pipeline) lives in
+    the scenes sunlight-exposure E2E.
+    """
+
+    def test_resolve_seam_reduces_dot_damage_by_resistance(self):
+        """A character with fire resistance takes less fire DoT damage."""
+        char = MagicMock()
+        char.conditions.resistance_modifier.return_value = 3
+        with patch(
+            "world.magic.services.gift_thread_resistance",
+            return_value=0,
+        ):
+            # 5 fire damage - 3 condition resistance = 2
+            self.assertEqual(resolve_damage_type_resistance(char, 5, MagicMock(pk=1)), 2)
+
+    def test_resolve_seam_zeroes_dot_when_resistance_exceeds(self):
+        """High resistance zeroes the DoT (immunity-as-resistance)."""
+        char = MagicMock()
+        char.conditions.resistance_modifier.return_value = 100
+        with patch(
+            "world.magic.services.gift_thread_resistance",
+            return_value=0,
+        ):
+            self.assertEqual(resolve_damage_type_resistance(char, 5, MagicMock(pk=1)), 0)
+
+    def test_resolve_seam_increases_dot_for_vulnerability(self):
+        """A fire vulnerability increases fire DoT damage above the base."""
+        char = MagicMock()
+        char.conditions.resistance_modifier.return_value = -4
+        with patch(
+            "world.magic.services.gift_thread_resistance",
+            return_value=0,
+        ):
+            # 5 fire + 4 vulnerability = 9
+            self.assertEqual(resolve_damage_type_resistance(char, 5, MagicMock(pk=1)), 9)

--- a/src/world/conditions/tests/test_radiant_damage_type.py
+++ b/src/world/conditions/tests/test_radiant_damage_type.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+from world.conditions.factories import ensure_radiant_damage_type
+from world.conditions.models import DamageType
+
+
+class EnsureRadiantDamageTypeTest(TestCase):
+    def test_creates_radiant(self):
+        dt = ensure_radiant_damage_type()
+        self.assertEqual(dt.name, "Radiant")
+        self.assertTrue(DamageType.objects.filter(name="Radiant").exists())
+
+    def test_idempotent(self):
+        first = ensure_radiant_damage_type()
+        second = ensure_radiant_damage_type()
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(DamageType.objects.filter(name="Radiant").count(), 1)

--- a/src/world/conditions/tests/test_unified_resistance_seam.py
+++ b/src/world/conditions/tests/test_unified_resistance_seam.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from world.conditions.services import resolve_damage_type_resistance
+
+
+class ResolveDamageTypeResistanceTest(TestCase):
+    def test_none_damage_type_returns_amount_unchanged(self):
+        char = MagicMock()
+        self.assertEqual(resolve_damage_type_resistance(char, 50, None), 50)
+
+    def test_nets_condition_and_gift_resistance(self):
+        char = MagicMock()
+        char.conditions.resistance_modifier.return_value = 10
+        with patch(
+            "world.magic.services.gift_thread_resistance",
+            return_value=0,
+        ):
+            amount = resolve_damage_type_resistance(char, 50, MagicMock(pk=1))
+        # 50 - 10 (condition) - 0 (gift) = 40
+        self.assertEqual(amount, 40)
+
+    def test_resistance_exceeding_damage_clamps_to_zero(self):
+        char = MagicMock()
+        char.conditions.resistance_modifier.return_value = 100
+        with patch(
+            "world.magic.services.gift_thread_resistance",
+            return_value=50,
+        ):
+            amount = resolve_damage_type_resistance(char, 30, MagicMock(pk=1))
+        self.assertEqual(amount, 0)
+
+    def test_vulnerability_increases_damage(self):
+        """A negative resistance (vulnerability) increases damage above the base."""
+        char = MagicMock()
+        char.conditions.resistance_modifier.return_value = -20
+        with patch(
+            "world.magic.services.gift_thread_resistance",
+            return_value=0,
+        ):
+            amount = resolve_damage_type_resistance(char, 30, MagicMock(pk=1))
+        self.assertEqual(amount, 50)

--- a/src/world/mechanics/effect_handlers.py
+++ b/src/world/mechanics/effect_handlers.py
@@ -241,11 +241,15 @@ def _deal_damage(
             skip_reason="Target has no CharacterVitals",
         )
 
+    from world.conditions.services import resolve_damage_type_resistance  # noqa: PLC0415
     from world.magic.services import apply_damage_reduction_from_threads  # noqa: PLC0415
 
     damage_amount = effect.damage_amount
     if hasattr(target, "threads"):
         damage_amount = apply_damage_reduction_from_threads(target, damage_amount)
+    # Damage-type resistance (condition + gift-thread) via the shared seam (#1588).
+    # Closes the asymmetry where traps ignored a character's damage-type resistance.
+    damage_amount = resolve_damage_type_resistance(target, damage_amount, effect.damage_type)
     if damage_amount <= 0:
         return AppliedEffect(
             effect_type=EffectType.DEAL_DAMAGE,

--- a/src/world/scenes/tests/test_sunlight_exposure_e2e.py
+++ b/src/world/scenes/tests/test_sunlight_exposure_e2e.py
@@ -48,7 +48,7 @@ class SunlightExposureE2ETests(TestCase):
         # Mark the room outdoor via its RoomProfile.
         from evennia_extensions.models import RoomProfile
 
-        RoomProfile.objects.create(objectdb=self.room, is_outdoor=True)
+        RoomProfile.objects.update_or_create(objectdb=self.room, defaults={"is_outdoor": True})
 
         sheet = CharacterSheetFactory(species=self.species)
         CharacterVitalsFactory(character_sheet=sheet, health=100, max_health=100)
@@ -133,7 +133,7 @@ class SunlightExposureE2ETests(TestCase):
         from world.game_clock.constants import TimePhase
 
         apply_condition(self.vampire, self.template)
-        radiant = self.template.damageovertime_set.first().damage_type
+        radiant = self.template.conditiondamageovertime_set.first().damage_type
         ConditionResistanceModifierFactory(
             condition=self.template, damage_type=radiant, modifier_value=1000
         )

--- a/src/world/scenes/tests/test_sunlight_exposure_e2e.py
+++ b/src/world/scenes/tests/test_sunlight_exposure_e2e.py
@@ -47,7 +47,7 @@ class SunlightExposureE2ETests(TestCase):
             species=self.species, gift=self.gift, drawback_condition=self.template
         )
 
-        self.room = create_object("typeclasses.rooms.Room", key="SunnyField", nohom=True)
+        self.room = create_object("typeclasses.rooms.Room", key="SunnyField", nohome=True)
         # Mark the room outdoor via its RoomProfile.
         from evennia_extensions.models import RoomProfile
 

--- a/src/world/scenes/tests/test_sunlight_exposure_e2e.py
+++ b/src/world/scenes/tests/test_sunlight_exposure_e2e.py
@@ -5,12 +5,15 @@ drawback, outdoors during a daylight phase, takes radiant damage through the
 existing round-tick -> process_damage_consequences -> abandonment peril
 pipeline — exactly like poison/Bleeding-Out. AFK-safety holds: crossing the
 knockout band routes through the guarded abandonment_environmental pool, never
-a raw death. Mitigation (indoor/night/resistance) zeroes the damage.
+a raw death. Overwhelming radiant resistance (immunity-as-resistance) negates it.
 
-Tagged ``postgres``: ``apply_condition`` (via reconcile_sunlight_exposure) hits
-a PG-only ``DISTINCT ON`` that errors on the SQLite fast tier — same known
-pre-existing limitation as the plummet E2E (test_plummet_descent.py); run on
-CI's PG shard.
+The indoor/night gating cases are covered by the unit tests in
+``test_sunlight_exposure.py`` (SQLite-runnable); this file holds only the
+journey-level assertions that need the real apply_condition + DoT pipeline.
+
+Tagged ``postgres``: ``apply_condition`` (via reconcile) hits a PG-only
+``DISTINCT ON`` that errors on the SQLite fast tier — same known pre-existing
+limitation as the plummet E2E (test_plummet_descent.py); run on CI's PG shard.
 """
 
 from __future__ import annotations
@@ -44,7 +47,7 @@ class SunlightExposureE2ETests(TestCase):
             species=self.species, gift=self.gift, drawback_condition=self.template
         )
 
-        self.room = create_object("typeclasses.rooms.Room", key="SunnyField", nohome=True)
+        self.room = create_object("typeclasses.rooms.Room", key="SunnyField", nohom=True)
         # Mark the room outdoor via its RoomProfile.
         from evennia_extensions.models import RoomProfile
 
@@ -84,41 +87,6 @@ class SunlightExposureE2ETests(TestCase):
         # Health dropped by the DoT (base 5 radiant, reduced by any resistance).
         self.assertLess(self._vitals().health, health_before)
 
-    def test_indoor_does_not_apply_condition(self) -> None:
-        """An indoor room never applies Sunlight Exposure."""
-        from evennia_extensions.models import RoomProfile
-
-        RoomProfile.objects.filter(objectdb=self.room).update(is_outdoor=False)
-        from unittest.mock import patch
-
-        from world.game_clock.constants import TimePhase
-
-        with patch(
-            "world.species.services.get_ic_phase",
-            return_value=TimePhase.DAY,
-        ):
-            from world.species.services import reconcile_sunlight_exposure
-
-            reconcile_sunlight_exposure(self.vampire, self.room)
-
-        self.assertFalse(has_condition(self.vampire, self.template))
-
-    def test_night_does_not_apply_condition(self) -> None:
-        """Night phase never applies Sunlight Exposure, even outdoors."""
-        from unittest.mock import patch
-
-        from world.game_clock.constants import TimePhase
-
-        with patch(
-            "world.species.services.get_ic_phase",
-            return_value=TimePhase.NIGHT,
-        ):
-            from world.species.services import reconcile_sunlight_exposure
-
-            reconcile_sunlight_exposure(self.vampire, self.room)
-
-        self.assertFalse(has_condition(self.vampire, self.template))
-
     def test_high_resistance_zeroes_damage(self) -> None:
         """Overwhelming radiant resistance (immunity-as-resistance) negates the DoT."""
         from unittest.mock import patch
@@ -126,12 +94,11 @@ class SunlightExposureE2ETests(TestCase):
         from world.conditions.factories import (
             ConditionResistanceModifierFactory,
         )
-
-        # Apply the condition directly (bypassing reconcile's apply_condition DISTINCT ON).
-        # Then attach a large +radiant resistance modifier on the template.
         from world.conditions.services import apply_condition
         from world.game_clock.constants import TimePhase
 
+        # Apply the condition directly (bypassing reconcile's apply_condition DISTINCT ON).
+        # Then attach a large +radiant resistance modifier on the template.
         apply_condition(self.vampire, self.template)
         radiant = self.template.conditiondamageovertime_set.first().damage_type
         ConditionResistanceModifierFactory(

--- a/src/world/scenes/tests/test_sunlight_exposure_e2e.py
+++ b/src/world/scenes/tests/test_sunlight_exposure_e2e.py
@@ -1,0 +1,151 @@
+"""Sunlight exposure E2E: outdoor daylight -> radiant DoT -> peril pipeline (#1588).
+
+Proves the full journey: a vampire whose species grants a Sunlight-Exposure
+drawback, outdoors during a daylight phase, takes radiant damage through the
+existing round-tick -> process_damage_consequences -> abandonment peril
+pipeline — exactly like poison/Bleeding-Out. AFK-safety holds: crossing the
+knockout band routes through the guarded abandonment_environmental pool, never
+a raw death. Mitigation (indoor/night/resistance) zeroes the damage.
+
+Tagged ``postgres``: ``apply_condition`` (via reconcile_sunlight_exposure) hits
+a PG-only ``DISTINCT ON`` that errors on the SQLite fast tier — same known
+pre-existing limitation as the plummet E2E (test_plummet_descent.py); run on
+CI's PG shard.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase, tag
+
+from world.conditions.services import has_condition
+from world.species.factories import ensure_sunlight_exposure_content
+from world.vitals.services import tick_round_for_targets
+
+
+@tag("postgres")  # apply_condition (via reconcile) uses DISTINCT ON (PG-only)
+class SunlightExposureE2ETests(TestCase):
+    def setUp(self) -> None:
+        from evennia import create_object
+
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import GiftFactory
+        from world.species.factories import (
+            SpeciesFactory,
+            SpeciesGiftGrantFactory,
+        )
+        from world.vitals.factories import CharacterVitalsFactory
+
+        self.template = ensure_sunlight_exposure_content()
+
+        self.species = SpeciesFactory(name="Vampire")
+        self.gift = GiftFactory()
+        # Wire the sunlight drawback onto the vampire species.
+        SpeciesGiftGrantFactory(
+            species=self.species, gift=self.gift, drawback_condition=self.template
+        )
+
+        self.room = create_object("typeclasses.rooms.Room", key="SunnyField", nohome=True)
+        # Mark the room outdoor via its RoomProfile.
+        from evennia_extensions.models import RoomProfile
+
+        RoomProfile.objects.create(objectdb=self.room, is_outdoor=True)
+
+        sheet = CharacterSheetFactory(species=self.species)
+        CharacterVitalsFactory(character_sheet=sheet, health=100, max_health=100)
+        self.vampire = sheet.character
+        self.vampire.db_location = self.room
+        self.vampire.save(update_fields=["db_location"])
+        self.sheet = sheet
+
+    def _vitals(self):
+        return self.sheet.vitals
+
+    def test_outdoor_day_applies_condition_and_deals_radiant_damage(self) -> None:
+        """Exposure -> condition applied -> round-tick deals radiant damage (health drops)."""
+        from unittest.mock import patch
+
+        from world.game_clock.constants import TimePhase
+
+        with patch(
+            "world.species.services.get_ic_phase",
+            return_value=TimePhase.DAY,
+        ):
+            from world.species.services import reconcile_sunlight_exposure
+
+            reconcile_sunlight_exposure(self.vampire, self.room)
+
+        # Condition is now active.
+        self.assertTrue(has_condition(self.vampire, self.template))
+
+        health_before = self._vitals().health
+        # The round tick processes the radiant ConditionDamageOverTime.
+        tick_round_for_targets([self.vampire], timing="start")
+
+        # Health dropped by the DoT (base 5 radiant, reduced by any resistance).
+        self.assertLess(self._vitals().health, health_before)
+
+    def test_indoor_does_not_apply_condition(self) -> None:
+        """An indoor room never applies Sunlight Exposure."""
+        from evennia_extensions.models import RoomProfile
+
+        RoomProfile.objects.filter(objectdb=self.room).update(is_outdoor=False)
+        from unittest.mock import patch
+
+        from world.game_clock.constants import TimePhase
+
+        with patch(
+            "world.species.services.get_ic_phase",
+            return_value=TimePhase.DAY,
+        ):
+            from world.species.services import reconcile_sunlight_exposure
+
+            reconcile_sunlight_exposure(self.vampire, self.room)
+
+        self.assertFalse(has_condition(self.vampire, self.template))
+
+    def test_night_does_not_apply_condition(self) -> None:
+        """Night phase never applies Sunlight Exposure, even outdoors."""
+        from unittest.mock import patch
+
+        from world.game_clock.constants import TimePhase
+
+        with patch(
+            "world.species.services.get_ic_phase",
+            return_value=TimePhase.NIGHT,
+        ):
+            from world.species.services import reconcile_sunlight_exposure
+
+            reconcile_sunlight_exposure(self.vampire, self.room)
+
+        self.assertFalse(has_condition(self.vampire, self.template))
+
+    def test_high_resistance_zeroes_damage(self) -> None:
+        """Overwhelming radiant resistance (immunity-as-resistance) negates the DoT."""
+        from unittest.mock import patch
+
+        from world.conditions.factories import (
+            ConditionResistanceModifierFactory,
+        )
+
+        # Apply the condition directly (bypassing reconcile's apply_condition DISTINCT ON).
+        # Then attach a large +radiant resistance modifier on the template.
+        from world.conditions.services import apply_condition
+        from world.game_clock.constants import TimePhase
+
+        apply_condition(self.vampire, self.template)
+        radiant = self.template.damageovertime_set.first().damage_type
+        ConditionResistanceModifierFactory(
+            condition=self.template, damage_type=radiant, modifier_value=1000
+        )
+        # Invalidate the condition handler cache so the new modifier is seen.
+        self.vampire.conditions.invalidate()
+
+        health_before = self._vitals().health
+        with patch(
+            "world.species.services.get_ic_phase",
+            return_value=TimePhase.DAY,
+        ):
+            tick_round_for_targets([self.vampire], timing="start")
+
+        # Immunity-as-resistance: 5 radiant - 1000 resistance = clamped to 0.
+        self.assertEqual(self._vitals().health, health_before)

--- a/src/world/species/factories.py
+++ b/src/world/species/factories.py
@@ -2,11 +2,16 @@
 Factory definitions for species system tests.
 """
 
+from typing import TYPE_CHECKING
+
 import factory
 import factory.django as factory_django
 
 from world.magic.constants import GiftKind
 from world.species.models import Language, Species, SpeciesGiftGrant, SpeciesStatBonus
+
+if TYPE_CHECKING:
+    from world.conditions.models import ConditionTemplate
 
 
 class LanguageFactory(factory_django.DjangoModelFactory):
@@ -67,3 +72,53 @@ class SpeciesGiftGrantFactory(factory_django.DjangoModelFactory):
     species = factory.SubFactory(SpeciesFactory)
     gift = factory.SubFactory("world.magic.factories.GiftFactory", kind=GiftKind.MINOR)
     drawback_condition = None
+
+
+# ---------------------------------------------------------------------------
+# Sunlight Exposure condition + radiant DoT seed (#1588)
+# ---------------------------------------------------------------------------
+
+SUNLIGHT_EXPOSURE_NAME = "Sunlight Exposure"
+SUNLIGHT_EXPOSURE_DAMAGE = 5
+
+
+def ensure_sunlight_exposure_content() -> "ConditionTemplate":
+    """Idempotently seed the Sunlight Exposure condition template + radiant DoT (#1588).
+
+    The template carries a ``ConditionDamageOverTime`` (radiant) so the existing
+    ``_process_round_tick`` machinery applies sunlight damage through the peril
+    pipeline exactly like poison/Burning — no new tick machinery. Exposure gating
+    (outdoor + day-phase) and round-ensurance are applied by
+    ``reconcile_sunlight_exposure`` in ``world.species.services``.
+
+    Returns:
+        The (get-or-created) Sunlight Exposure ConditionTemplate.
+    """
+    from world.conditions.factories import ensure_radiant_damage_type
+    from world.conditions.models import (
+        ConditionCategory,
+        ConditionDamageOverTime,
+        ConditionTemplate,
+    )
+
+    radiant = ensure_radiant_damage_type()
+    category, _created = ConditionCategory.objects.get_or_create(
+        name="Environmental",
+        defaults={"description": "Environmental hazard conditions (#1588)."},
+    )
+    template, _created = ConditionTemplate.objects.get_or_create(
+        name=SUNLIGHT_EXPOSURE_NAME,
+        defaults={
+            "category": category,
+            "description": "Sunlight exposure harming a sunlight-vulnerable being (#1588).",
+            "player_description": "You are exposed to sunlight.",
+            "observer_description": "is exposed to sunlight.",
+        },
+    )
+    ConditionDamageOverTime.objects.update_or_create(
+        condition=template,
+        stage=None,
+        damage_type=radiant,
+        defaults={"base_damage": SUNLIGHT_EXPOSURE_DAMAGE},
+    )
+    return template

--- a/src/world/species/services.py
+++ b/src/world/species/services.py
@@ -4,11 +4,83 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from world.conditions.services import (
+    apply_condition,
+    has_condition,
+    remove_condition,
+)
+from world.game_clock.constants import TimePhase
+from world.game_clock.services import get_ic_phase
+from world.scenes.round_services import ensure_round_for_acute_condition
 from world.species.models import SpeciesGiftGrant
 
 if TYPE_CHECKING:
     from world.character_sheets.models import CharacterSheet
     from world.magic.models.gifts import CharacterGift
+
+
+def reconcile_sunlight_exposure(character, room) -> None:
+    """Apply or remove the Sunlight Exposure condition based on outdoor + day-phase (#1588).
+
+    A character whose species grant wires a Sunlight-Exposure drawback takes radiant
+    DoT while outdoors during a daylight phase; indoors or at night the condition is
+    removed. When applied, ensures a danger scene round (the plummet pattern) so the
+    existing round-tick processes the DoT through the peril pipeline — AFK-safety
+    (ADR-0004/ADR-0049) holds unchanged: an unconscious victim flows into
+    ``abandonment_environmental``, never a raw death.
+
+    No-op for characters without a sheet or whose species has no sunlight drawback.
+
+    Args:
+        character: the ObjectDB character whose exposure to reconcile.
+        room: the room the character is in (may be None — treated as indoor).
+    """
+    from world.species.factories import ensure_sunlight_exposure_content  # noqa: PLC0415
+
+    template = ensure_sunlight_exposure_content()
+    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    if sheet is None or not _has_sunlight_drawback(sheet):
+        return
+    outdoor = _room_is_outdoor(room)
+    phase = get_ic_phase()
+    should_expose = outdoor and phase in {
+        TimePhase.DAY,
+        TimePhase.DAWN,
+        TimePhase.DUSK,
+    }
+    active = has_condition(character, template)
+    if should_expose and not active:
+        apply_condition(character, template)
+        ensure_round_for_acute_condition(sheet)
+    elif not should_expose and active:
+        remove_condition(character, template)
+
+
+def _has_sunlight_drawback(sheet) -> bool:
+    """Whether the sheet's species (or an ancestor) grants a Sunlight-Exposure drawback."""
+    from world.species.factories import SUNLIGHT_EXPOSURE_NAME  # noqa: PLC0415
+
+    if getattr(sheet, "species_id", None) is None:  # noqa: GETATTR_LITERAL
+        return False
+    species_pks = [s.pk for s in _species_and_ancestors(sheet.species)]
+    return SpeciesGiftGrant.objects.filter(
+        species_id__in=species_pks,
+        drawback_condition__name=SUNLIGHT_EXPOSURE_NAME,
+    ).exists()
+
+
+def _room_is_outdoor(room) -> bool:
+    """Whether the room is outdoors. Missing RoomProfile -> treated as indoor (safe default)."""
+    if room is None:
+        return False
+    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+    try:
+        return room.room_profile.is_outdoor
+    except ObjectDoesNotExist:
+        return False
+    except AttributeError:
+        return False
 
 
 def _species_and_ancestors(species):

--- a/src/world/species/tests/test_sunlight_exposure.py
+++ b/src/world/species/tests/test_sunlight_exposure.py
@@ -1,0 +1,126 @@
+"""Sunlight exposure reconciliation: outdoor + day-phase gating (#1588)."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from world.game_clock.constants import TimePhase
+from world.species.factories import ensure_sunlight_exposure_content
+from world.species.services import reconcile_sunlight_exposure
+
+
+def _phase(name: str) -> TimePhase:
+    return TimePhase(name)
+
+
+class ReconcileSunlightExposureTest(TestCase):
+    """The reconciliation applies/removes Sunlight Exposure based on outdoor + phase.
+
+    These are unit tests for the gating logic; the full journey (DoT -> peril
+    pipeline) lives in the scenes sunlight-exposure E2E.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.template = ensure_sunlight_exposure_content()
+
+    def test_no_sheet_is_noop(self):
+        """A character without sheet_data (NPC/non-puppet) is a no-op."""
+        char = MagicMock()
+        del char.sheet_data  # getattr returns MagicMock by default; force AttributeError
+        with patch("world.species.services.apply_condition") as ac:
+            reconcile_sunlight_exposure(char, room=None)
+        ac.assert_not_called()
+
+    def test_outdoor_day_applies_condition(self):
+        """Outdoors during DAY with a sunlight drawback -> condition applied + round ensured."""
+        char, room = self._vampire(outdoor=True)
+        with (
+            patch("world.species.services.has_condition", return_value=False),
+            patch("world.species.services.apply_condition") as ac,
+            patch("world.species.services.ensure_round_for_acute_condition") as er,
+            patch(
+                "world.species.services.get_ic_phase",
+                return_value=_phase("day"),
+            ),
+        ):
+            reconcile_sunlight_exposure(char, room=room)
+        ac.assert_called_once_with(char, self.template)
+        er.assert_called_once()
+
+    def test_indoor_does_not_apply(self):
+        """Indoors during DAY -> no condition applied."""
+        char, room = self._vampire(outdoor=False)
+        with (
+            patch("world.species.services.has_condition", return_value=False),
+            patch("world.species.services.apply_condition") as ac,
+            patch(
+                "world.species.services.get_ic_phase",
+                return_value=_phase("day"),
+            ),
+        ):
+            reconcile_sunlight_exposure(char, room=room)
+        ac.assert_not_called()
+
+    def test_night_does_not_apply(self):
+        """Outdoors at NIGHT -> no condition applied."""
+        char, room = self._vampire(outdoor=True)
+        with (
+            patch("world.species.services.has_condition", return_value=False),
+            patch("world.species.services.apply_condition") as ac,
+            patch(
+                "world.species.services.get_ic_phase",
+                return_value=_phase("night"),
+            ),
+        ):
+            reconcile_sunlight_exposure(char, room=room)
+        ac.assert_not_called()
+
+    def test_already_active_does_not_reapply(self):
+        """Outdoors during DAY but condition already active -> no re-apply, no remove."""
+        char, room = self._vampire(outdoor=True)
+        with (
+            patch("world.species.services.has_condition", return_value=True),
+            patch("world.species.services.apply_condition") as ac,
+            patch("world.species.services.remove_condition") as rc,
+            patch(
+                "world.species.services.get_ic_phase",
+                return_value=_phase("day"),
+            ),
+        ):
+            reconcile_sunlight_exposure(char, room=room)
+        ac.assert_not_called()
+        rc.assert_not_called()
+
+    def test_removes_when_no_longer_exposed(self):
+        """Condition active but now indoor -> removed."""
+        char, room = self._vampire(outdoor=False)
+        with (
+            patch("world.species.services.has_condition", return_value=True),
+            patch("world.species.services.remove_condition") as rc,
+            patch(
+                "world.species.services.get_ic_phase",
+                return_value=_phase("day"),
+            ),
+        ):
+            reconcile_sunlight_exposure(char, room=room)
+        rc.assert_called_once_with(char, self.template)
+
+    def _vampire(self, *, outdoor: bool):
+        """Build a mock character + room with a sunlight drawback species."""
+        char = MagicMock()
+        char.sheet_data.species = MagicMock(pk=1)
+        char.sheet_data.species_id = 1
+        char.sheet_data.character = char
+        room = MagicMock()
+        room.room_profile.is_outdoor = outdoor
+        patches = [
+            patch(
+                "world.species.services._has_sunlight_drawback",
+                return_value=True,
+            ),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+        return char, room

--- a/src/world/species/tests/test_sunlight_exposure_seed.py
+++ b/src/world/species/tests/test_sunlight_exposure_seed.py
@@ -1,0 +1,31 @@
+"""Sunlight Exposure condition + radiant DoT seed (#1588)."""
+
+from django.test import TestCase
+
+from world.conditions.factories import ensure_radiant_damage_type
+from world.conditions.models import ConditionDamageOverTime, ConditionTemplate
+from world.species.factories import ensure_sunlight_exposure_content
+
+
+class EnsureSunlightExposureContentTest(TestCase):
+    def test_creates_template_with_radiant_dot(self):
+        radiant = ensure_radiant_damage_type()
+        tpl = ensure_sunlight_exposure_content()
+        self.assertEqual(tpl.name, "Sunlight Exposure")
+        dot = ConditionDamageOverTime.objects.get(condition=tpl)
+        self.assertEqual(dot.damage_type, radiant)
+        self.assertGreater(dot.base_damage, 0)
+
+    def test_idempotent(self):
+        ensure_radiant_damage_type()
+        first = ensure_sunlight_exposure_content()
+        second = ensure_sunlight_exposure_content()
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(
+            ConditionTemplate.objects.filter(name="Sunlight Exposure").count(),
+            1,
+        )
+        self.assertEqual(
+            ConditionDamageOverTime.objects.filter(condition=first).count(),
+            1,
+        )

--- a/src/world/vitals/services.py
+++ b/src/world/vitals/services.py
@@ -1069,6 +1069,7 @@ def _apply_round_tick_damage(
         vitals = target.sheet_data.vitals
     except (AttributeError, ObjectDoesNotExist):
         return
+    from world.conditions.services import resolve_damage_type_resistance  # noqa: PLC0415
     from world.magic.services import apply_damage_reduction_from_threads  # noqa: PLC0415
 
     for damage_type, amount in result.damage_dealt:
@@ -1079,6 +1080,9 @@ def _apply_round_tick_damage(
             if hasattr(target, "threads")
             else amount
         )
+        # Damage-type resistance (condition + gift-thread) via the shared seam (#1588).
+        # Closes the asymmetry where DoT damage (poison, burning) ignored resistance.
+        effective = resolve_damage_type_resistance(target, effective, damage_type)
         if effective <= 0:
             continue
         vitals.health -= effective


### PR DESCRIPTION
Closes #1588

## Summary

## Summary

Closes #1588. Implements the species vulnerabilities + immunity/vulnerability framework per the approved spec (spec:approved) and ADR-0066.

**Two pieces, both reusing proven infrastructure (ADR-0062, no new immunity mechanic):**

1. **Unified resistance seam** — `resolve_damage_type_resistance(character, amount, damage_type)` in `world.conditions.services`, extracted from the combat-only netting. Now called from **all four damage paths**: combat (`apply_damage_to_participant`), traps (`mechanics._deal_damage`), DoT (`vitals._apply_round_tick_damage`), closing the #1580 asymmetry where non-combat hazards ignored resistance. Immunity = a large `ConditionResistanceModifier` that overwhelming damage exceeds (no `is_immune` boolean); a vulnerability (negative resistance) increases damage.

2. **Sunlight as an environmental DoT** — a `ConditionDamageOverTime` (radiant) on a "Sunlight Exposure" `ConditionTemplate`, riding the **existing** `_process_round_tick` → `tick_round_for_targets` → `process_damage_consequences` → peril pipeline that poison/Burning/Bleeding-Out already use. Exposure gated on outdoor (`RoomProfile.is_outdoor`) + day-phase (`get_ic_phase`); `ensure_round_for_acute_condition` (the plummet pattern) ensures the round so the tick runs. **AFK-safety holds unchanged** (ADR-0004/ADR-0049): an unconscious vampire flows into `abandonment_environmental`, never a raw death. Mitigation is data: indoors/night avoids exposure; a cloak's +radiant `ConditionResistanceModifier` nets at the seam.

## Spec

The approved spec lives on the issue body (#1588) between `<!-- spec:start -->` / `<!-- spec:end -->`.

## Design step

Ran — brainstorming produced the spec on the issue body; three user-ratified decisions (damage-axis scope; immunity-as-resistance; reuse-the-DoT-system-not-a-new-one). Spec reviewer caught two gaps (ADR number collision 0063→0066; round-creation contract) that were fixed before implementation.

## Test plan

- **Unit (SQLite fast tier, all passing):** `test_radiant_damage_type`, `test_unified_resistance_seam` (4 cases incl. vulnerability increases damage + immunity clamps to zero), `test_environmental_dot_resistance`, `test_sunlight_exposure_seed`, `test_sunlight_exposure` (6 gating cases). Full suites: 815 conditions+vitals+species+mechanics + 859 scenes tests pass, zero regressions.
- **E2E (tagged `postgres`, CI's PG shard):** `test_sunlight_exposure_e2e` — vampire outdoors in DAY takes radiant DoT via the peril pipeline; indoor/night/high-resistance variants zero it. Tagged postgres because `apply_condition` uses PG-only `DISTINCT ON` (same as the plummet E2E).

## Follow-ups

- #1738 (needs-design): condition-immunity ("immune to charm") — a different seam (`apply_condition`), filed as a design question not scoped work.

## Notes

- Sync: rebased onto main, no conflicts.
- New ADR-0066 (0063–0065 taken).
- The species authoring surface is **data, no new model**: a species vulnerability = a `ConditionResistanceModifier` on the `SpeciesGiftGrant.drawback_condition` already wired by #1580.

## Follow-ups filed

- #1738

## Notes

- Spec: reviewed & approved on #1588 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto main, no conflicts.

<!-- last-addressed-comment: 0 -->