### PR TITLE
feat(friends): React friends UI + web API (#1727)

### DIFF
--- a/frontend/src/friends/__tests__/FriendsTab.test.tsx
+++ b/frontend/src/friends/__tests__/FriendsTab.test.tsx
@@ -1,0 +1,57 @@
+/** FriendsTab (#1727) — lists the player's OOC friends and removes them. Mocks the hooks. */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FriendsTab } from '../components/FriendsTab';
+import type { Friendship } from '../types';
+
+const removeMutate = vi.fn();
+
+vi.mock('@/friends/queries', () => ({
+  useFriendsQuery: vi.fn(),
+  useRemoveFriendMutation: vi.fn(() => ({ mutate: removeMutate, isPending: false })),
+}));
+
+import { useFriendsQuery } from '@/friends/queries';
+
+const mockQuery = vi.mocked(useFriendsQuery);
+
+function mockFriends(results: Friendship[]): void {
+  mockQuery.mockReturnValue({
+    data: { count: results.length, next: null, previous: null, results },
+    isLoading: false,
+    isError: false,
+  } as ReturnType<typeof useFriendsQuery>);
+}
+
+function friend(overrides: Partial<Friendship>): Friendship {
+  return {
+    id: 1,
+    friender_tenure: 10,
+    friend_tenure: 20,
+    friend_name: 'Bob',
+    created_at: '2026-07-01T00:00:00Z',
+    ...overrides,
+  } as Friendship;
+}
+
+describe('FriendsTab', () => {
+  it('lists friends by name', () => {
+    mockFriends([friend({ friend_name: 'Bob' })]);
+    render(<FriendsTab />);
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('empty state prompts to friend from another sheet', () => {
+    mockFriends([]);
+    render(<FriendsTab />);
+    expect(screen.getByText(/no friends listed/i)).toBeInTheDocument();
+  });
+
+  it('removes a friend on click', () => {
+    mockFriends([friend({ id: 7, friend_name: 'Bob' })]);
+    render(<FriendsTab />);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    expect(removeMutate).toHaveBeenCalledWith(7);
+  });
+});

--- a/frontend/src/friends/api.ts
+++ b/frontend/src/friends/api.ts
@@ -1,0 +1,46 @@
+/** OOC friends-list REST calls (#1727). */
+import { apiFetch } from '@/evennia_replacements/api';
+
+import type { PaginatedFriendshipList } from './types';
+
+/** The requesting player's friendships (across all their characters). */
+export async function listFriends(): Promise<PaginatedFriendshipList> {
+  const res = await apiFetch('/api/scenes/friends/');
+  if (!res.ok) {
+    throw new Error('Failed to load friends');
+  }
+  return res.json() as Promise<PaginatedFriendshipList>;
+}
+
+export interface AddFriendPayload {
+  /** Your friending character (a RosterEntry pk). */
+  viewer: number;
+  /** The character to friend (a RosterEntry pk). */
+  friend: number;
+  /** Friend them from ALL your characters (fan-out) rather than just `viewer`. */
+  allCharacters?: boolean;
+}
+
+/** Add a friend — from one character or all of yours (#1727). */
+export async function addFriend(payload: AddFriendPayload): Promise<void> {
+  const res = await apiFetch('/api/scenes/friends/', {
+    method: 'POST',
+    body: JSON.stringify({
+      viewer: payload.viewer,
+      friend: payload.friend,
+      all_characters: payload.allCharacters ?? false,
+    }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null);
+    throw new Error(detail?.detail ?? 'Failed to add friend');
+  }
+}
+
+/** Remove one friendship row (per-character). */
+export async function removeFriend(id: number): Promise<void> {
+  const res = await apiFetch(`/api/scenes/friends/${id}/`, { method: 'DELETE' });
+  if (!res.ok) {
+    throw new Error('Failed to remove friend');
+  }
+}

--- a/frontend/src/friends/components/FriendButton.tsx
+++ b/frontend/src/friends/components/FriendButton.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+import { useAddFriendMutation } from '../queries';
+
+/** "Friend this character" — shown on another character's sheet (#1727). Adds an OOC friendship
+ * from your active character (default) or all your characters. `viewerEntryId` is your active
+ * RosterEntry; `targetEntryId` is the viewed character's RosterEntry. */
+export function FriendButton({
+  viewerEntryId,
+  targetEntryId,
+  targetName,
+}: {
+  viewerEntryId: number | null;
+  targetEntryId: number;
+  targetName: string;
+}) {
+  const add = useAddFriendMutation();
+  const [allCharacters, setAllCharacters] = useState(false);
+
+  if (viewerEntryId === null) return null;
+
+  if (add.isSuccess) {
+    return (
+      <span className="text-sm italic text-muted-foreground">Added {targetName} as a friend.</span>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        disabled={add.isPending}
+        className="rounded border px-3 py-1 text-sm hover:bg-accent disabled:opacity-50"
+        onClick={() => add.mutate({ viewer: viewerEntryId, friend: targetEntryId, allCharacters })}
+      >
+        + Friend {targetName}
+      </button>
+      <label className="flex items-center gap-1 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={allCharacters}
+          onChange={(event) => setAllCharacters(event.target.checked)}
+        />
+        from all my characters
+      </label>
+      {add.isError && (
+        <span className="text-sm text-destructive">{(add.error as Error).message}</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/friends/components/FriendsTab.tsx
+++ b/frontend/src/friends/components/FriendsTab.tsx
@@ -1,0 +1,42 @@
+import { useFriendsQuery, useRemoveFriendMutation } from '../queries';
+
+/** Your OOC friends list (#1727) — trusted RP partners across all your characters, with a login/
+ * logoff watch alert. Separate from in-character relationships. Lists your friends with a remove
+ * button; add a friend from another character's sheet. */
+export function FriendsTab() {
+  const { data, isLoading, isError } = useFriendsQuery();
+  const remove = useRemoveFriendMutation();
+
+  if (isLoading) return <p className="text-muted-foreground">Loading…</p>;
+  if (isError) return <p className="text-destructive">Failed to load friends.</p>;
+
+  const friends = data?.results ?? [];
+  if (friends.length === 0) {
+    return (
+      <p className="text-muted-foreground">
+        You have no friends listed yet. Visit another character's sheet to friend them.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-muted-foreground">
+        Your trusted RP partners (out-of-character). You get a login/logoff alert for each.
+      </p>
+      {friends.map((friend) => (
+        <div key={friend.id} className="flex items-center justify-between rounded-md border p-3">
+          <span>{friend.friend_name}</span>
+          <button
+            type="button"
+            disabled={remove.isPending}
+            className="rounded border px-2 py-1 text-sm hover:bg-accent disabled:opacity-50"
+            onClick={() => remove.mutate(friend.id)}
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/friends/queries.ts
+++ b/frontend/src/friends/queries.ts
@@ -1,0 +1,27 @@
+/** React Query hooks for the OOC friends list (#1727). */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { addFriend, listFriends, removeFriend } from './api';
+import type { AddFriendPayload } from './api';
+
+export const friendKeys = { list: ['friends'] as const };
+
+export function useFriendsQuery() {
+  return useQuery({ queryKey: friendKeys.list, queryFn: listFriends });
+}
+
+export function useAddFriendMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: AddFriendPayload) => addFriend(payload),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: friendKeys.list }),
+  });
+}
+
+export function useRemoveFriendMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => removeFriend(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: friendKeys.list }),
+  });
+}

--- a/frontend/src/friends/types.ts
+++ b/frontend/src/friends/types.ts
@@ -1,0 +1,5 @@
+/** OOC friends-list API types (#1727), from the generated OpenAPI schema. */
+import type { components } from '@/generated/api';
+
+export type Friendship = components['schemas']['Friendship'];
+export type PaginatedFriendshipList = components['schemas']['PaginatedFriendshipList'];

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -17580,7 +17580,7 @@ export interface components {
      * @enum {string}
      */
     FormTypeEnum: 'true' | 'alternate' | 'disguise';
-    /** @description A friend row — the friended character's name + the tenures. */
+    /** @description A friend row — the friended character's name + which of your characters friended. */
     Friendship: {
       readonly id: number;
       /** @description The friender's tenure (this player's run of the character that friended). */
@@ -17591,17 +17591,25 @@ export interface components {
       /** Format: date-time */
       readonly created_at: string;
     };
-    /** @description Add a friend: which of your characters friends (or all), and the friended tenure. */
+    /**
+     * @description Add a friend by character (web-friendly): the friending character + the target character.
+     *
+     *     ``viewer`` / ``friend`` are ``RosterEntry`` pks; the view resolves each to its current tenure.
+     */
     FriendshipCreate: {
-      friender_tenure: number;
-      friend_tenure: number;
+      viewer: number;
+      friend: number;
       /** @default false */
       all_characters: boolean;
     };
-    /** @description Add a friend: which of your characters friends (or all), and the friended tenure. */
+    /**
+     * @description Add a friend by character (web-friendly): the friending character + the target character.
+     *
+     *     ``viewer`` / ``friend`` are ``RosterEntry`` pks; the view resolves each to its current tenure.
+     */
     FriendshipCreateRequest: {
-      friender_tenure: number;
-      friend_tenure: number;
+      viewer: number;
+      friend: number;
       /** @default false */
       all_characters: boolean;
     };

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -14,6 +14,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { RenownPanel } from '@/renown/components/RenownPanel';
 import { RenownCardPanel } from '@/renown/components/RenownCardPanel';
 import { VitalsPanel } from '@/vitals/components/VitalsPanel';
+import { FriendButton } from '@/friends/components/FriendButton';
+import { FriendsTab } from '@/friends/components/FriendsTab';
 import { GossipPanel } from '@/secrets/components/GossipPanel';
 import { SecretsTab } from '@/secrets/components/SecretsTab';
 import { CluesTab } from '@/clues/components/CluesTab';
@@ -47,6 +49,14 @@ export function CharacterSheetPage() {
           profilePicture={entry.profile_picture}
         />
         {entry.quote && <blockquote className="italic">"{entry.quote}"</blockquote>}
+        {/* Friend this character — an OOC trusted-partner designation (#1727), only on others' sheets. */}
+        {!isMyCharacter && (
+          <FriendButton
+            viewerEntryId={viewerEntryId}
+            targetEntryId={entryId}
+            targetName={entry.character.name}
+          />
+        )}
       </div>
 
       <Tabs defaultValue="sheet" className="space-y-4">
@@ -58,6 +68,7 @@ export function CharacterSheetPage() {
           <TabsTrigger value="secrets">Secrets</TabsTrigger>
           {isMyCharacter && <TabsTrigger value="clues">Clues</TabsTrigger>}
           {isMyCharacter && <TabsTrigger value="gossip">Gossip</TabsTrigger>}
+          {isMyCharacter && <TabsTrigger value="friends">Friends</TabsTrigger>}
         </TabsList>
 
         <TabsContent value="sheet" className="space-y-4">
@@ -135,6 +146,14 @@ export function CharacterSheetPage() {
                 social hub (#1572) — so it's a self-only tab keyed on the active RosterEntry, not the
                 viewed subject. Radix unmounts inactive tabs, so the query only fires when opened. */}
             <GossipPanel viewerId={viewerEntryId} />
+          </TabsContent>
+        )}
+
+        {isMyCharacter && (
+          <TabsContent value="friends" className="space-y-4">
+            {/* Your OOC friends list (#1727) — account-wide trusted partners, separate from IC
+                relationships. Add friends from other characters' sheets; this lists + removes. */}
+            <FriendsTab />
           </TabsContent>
         )}
       </Tabs>

--- a/src/schema.json
+++ b/src/schema.json
@@ -31138,7 +31138,8 @@ components:
         * `disguise` - Disguise
     Friendship:
       type: object
-      description: A friend row — the friended character's name + the tenures.
+      description: A friend row — the friended character's name + which of your characters
+        friended.
       properties:
         id:
           type: integer
@@ -31168,34 +31169,38 @@ components:
       - id
     FriendshipCreate:
       type: object
-      description: 'Add a friend: which of your characters friends (or all), and the
-        friended tenure.'
+      description: |-
+        Add a friend by character (web-friendly): the friending character + the target character.
+
+        ``viewer`` / ``friend`` are ``RosterEntry`` pks; the view resolves each to its current tenure.
       properties:
-        friender_tenure:
+        viewer:
           type: integer
-        friend_tenure:
+        friend:
           type: integer
         all_characters:
           type: boolean
           default: false
       required:
-      - friend_tenure
-      - friender_tenure
+      - friend
+      - viewer
     FriendshipCreateRequest:
       type: object
-      description: 'Add a friend: which of your characters friends (or all), and the
-        friended tenure.'
+      description: |-
+        Add a friend by character (web-friendly): the friending character + the target character.
+
+        ``viewer`` / ``friend`` are ``RosterEntry`` pks; the view resolves each to its current tenure.
       properties:
-        friender_tenure:
+        viewer:
           type: integer
-        friend_tenure:
+        friend:
           type: integer
         all_characters:
           type: boolean
           default: false
       required:
-      - friend_tenure
-      - friender_tenure
+      - friend
+      - viewer
     FuryTierOption:
       type: object
       description: Read-only representation of one selectable FuryTier (#1543).

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -139,6 +139,15 @@ Key service functions for scene round lifecycle:
     descriptor-never-auto-attach privacy invariant (#1109) holds structurally.
 - **`SceneSummaryRevisionViewSet`**: Summary revision management
 
+### `friend_views.py` (#1727)
+- **`FriendshipViewSet`**: the web face of the OOC friends list (`friend_services.py`) —
+  list/add/remove. `list` returns the player's friendships (made by any of their characters).
+  `create` takes **`viewer`/`friend` as `RosterEntry` pks** (web clients speak character ids, not
+  tenure ids) plus `all_characters`; the view resolves each to its `current_tenure` server-side and
+  calls `add_friend` / `add_friend_all_characters`. Tenure-scoped + alt-private, mirroring the
+  Block/Mute control API. Telnet parity is `CmdFriend`/`CmdUnfriend`/`CmdFriends`. React surface:
+  `frontend/src/friends/` (`FriendsTab` self-only tab + `FriendButton` on other sheets).
+
 ### `interaction_views.py`
 - **`InteractionViewSet`**: Interaction read + delete + mark_private
 - **`InteractionFavoriteViewSet`**: Toggle favorites — routes through

--- a/src/world/scenes/friend_serializers.py
+++ b/src/world/scenes/friend_serializers.py
@@ -4,27 +4,31 @@ from __future__ import annotations
 
 from rest_framework import serializers
 
-from world.roster.models import RosterTenure
+from world.roster.models import RosterEntry
 from world.scenes.models import Friendship
 
 _NOT_YOUR_CHARACTER = "You can only friend as one of your own characters."
 
 
 class FriendshipCreateSerializer(serializers.Serializer):
-    """Add a friend: which of your characters friends (or all), and the friended tenure."""
+    """Add a friend by character (web-friendly): the friending character + the target character.
 
-    friender_tenure = serializers.PrimaryKeyRelatedField(queryset=RosterTenure.objects.all())
-    friend_tenure = serializers.PrimaryKeyRelatedField(queryset=RosterTenure.objects.all())
+    ``viewer`` / ``friend`` are ``RosterEntry`` pks; the view resolves each to its current tenure.
+    """
+
+    viewer = serializers.PrimaryKeyRelatedField(queryset=RosterEntry.objects.all())
+    friend = serializers.PrimaryKeyRelatedField(queryset=RosterEntry.objects.all())
     all_characters = serializers.BooleanField(default=False)
 
-    def validate_friender_tenure(self, value: RosterTenure) -> RosterTenure:
-        if value.player_data.account_id != self.context["request"].user.pk:
+    def validate_viewer(self, value: RosterEntry) -> RosterEntry:
+        owned = RosterEntry.objects.for_account(self.context["request"].user).filter(pk=value.pk)
+        if not owned.exists():
             raise serializers.ValidationError(_NOT_YOUR_CHARACTER)
         return value
 
 
 class FriendshipSerializer(serializers.ModelSerializer):
-    """A friend row — the friended character's name + the tenures."""
+    """A friend row — the friended character's name + which of your characters friended."""
 
     friend_name = serializers.SerializerMethodField()
 

--- a/src/world/scenes/friend_views.py
+++ b/src/world/scenes/friend_views.py
@@ -19,6 +19,8 @@ from world.scenes.friend_serializers import FriendshipCreateSerializer, Friendsh
 from world.scenes.friend_services import add_friend, add_friend_all_characters
 from world.scenes.models import Friendship
 
+_NO_ACTIVE_TENURE = "That character has no active tenure to friend."
+
 
 class FriendsPagination(PageNumberPagination):
     page_size = 100
@@ -48,11 +50,14 @@ class FriendshipViewSet(
         serializer = FriendshipCreateSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
+        # Resolve each character (RosterEntry) to its current tenure — friendships are tenure-based.
+        friend_tenure = data["friend"].current_tenure
+        viewer_tenure = data["viewer"].current_tenure
+        if friend_tenure is None or viewer_tenure is None:
+            raise serializers.ValidationError(_NO_ACTIVE_TENURE)
         if data["all_characters"]:
             player_data, _ = PlayerData.objects.get_or_create(account=request.user)
-            add_friend_all_characters(player_data=player_data, friend_tenure=data["friend_tenure"])
+            add_friend_all_characters(player_data=player_data, friend_tenure=friend_tenure)
             return Response(status=status.HTTP_201_CREATED)
-        friendship = add_friend(
-            friender_tenure=data["friender_tenure"], friend_tenure=data["friend_tenure"]
-        )
+        friendship = add_friend(friender_tenure=viewer_tenure, friend_tenure=friend_tenure)
         return Response(FriendshipSerializer(friendship).data, status=status.HTTP_201_CREATED)

--- a/src/world/scenes/tests/test_friend_api.py
+++ b/src/world/scenes/tests/test_friend_api.py
@@ -20,7 +20,10 @@ class FriendApiTests(APITestCase):
         # Add.
         res = self.client.post(
             reverse("friend-list"),
-            {"friender_tenure": self.my_tenure.pk, "friend_tenure": self.target_tenure.pk},
+            {
+                "viewer": self.my_tenure.roster_entry.pk,
+                "friend": self.target_tenure.roster_entry.pk,
+            },
             format="json",
         )
         self.assertEqual(res.status_code, 201)
@@ -39,7 +42,7 @@ class FriendApiTests(APITestCase):
         other_tenure = RosterTenureFactory()  # not owned by self.account
         res = self.client.post(
             reverse("friend-list"),
-            {"friender_tenure": other_tenure.pk, "friend_tenure": self.target_tenure.pk},
+            {"viewer": other_tenure.roster_entry.pk, "friend": self.target_tenure.roster_entry.pk},
             format="json",
         )
         self.assertEqual(res.status_code, 400)


### PR DESCRIPTION
## Summary

Adds the **React surface** for the OOC friends list (#1727) — the primary web-first way players manage trusted RP partners — plus the web-API rework it needs. The telnet commands + `friend_services` + models already merged; this is the browser experience.

- **Friends tab** (self-only) on the character sheet: lists your friends by name with a Remove button; empty-state guidance.
- **`+ Friend` button** on *other* characters' sheets, with a **"from all my characters"** checkbox that fans the friendship out across every active tenure (alt-private — each removable on its own).
- **Web API speaks `RosterEntry` pks.** Web clients address characters by id, not tenure id, so `FriendshipViewSet.create` now takes `viewer`/`friend` as RosterEntry pks + `all_characters`, resolving each to its `current_tenure` server-side before calling `add_friend` / `add_friend_all_characters`. Tenure-scoped + alt-private, mirroring the Block/Mute control API.
- New `frontend/src/friends/` module (types/api/queries + `FriendsTab`/`FriendButton`), Vitest coverage, mounted in `CharacterSheetPage`.

## Notes

Friends is an **OOC** designation (trusted play partners), entirely separate from the IC relationship tracker / affection — no IC mechanic touched here.

## Testing

- `arx test world.scenes.tests.test_friend_api world.scenes.tests.test_friend_services commands.tests.test_friends_commands` — 16 passing.
- `pnpm build` green; friends Vitest 3/3; `pre-commit run` all hooks pass.
- Docs: friend web API documented in the scenes app guide.

Closes #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)