### PR TITLE
feat(consent): surface #1698 modes + blacklist + deny-and-block on the web (#1751)

### DIFF
--- a/docs/systems/consent.md
+++ b/docs/systems/consent.md
@@ -204,19 +204,23 @@ the resulting state.
 ## Frontend
 
 The `frontend/src/consent/` module provides a **Privacy** tab at `/profile/privacy`
-with three sections:
+(`CategoryConsentRow` + `WhitelistManager`/`BlacklistManager`):
 
 1. **Global switch** — master `allow_social_actions` toggle.
-2. **Per-category rules** — one row per `SocialConsentCategory` with a mode selector
-   (EVERYONE / ALLOWLIST); collapses when the global switch is off.
-3. **Whitelist** — add/remove allowed tenures per category; visible only when at
-   least one category is in ALLOWLIST mode.
+2. **Per-category rules** — one row per `SocialConsentCategory` with a mode selector spanning
+   all four `ConsentMode`s (Everyone / Everyone except blacklist / Friends + whitelist /
+   Allowlist only); collapses when the global switch is off.
+3. **Whitelist** — add/remove allowed tenures per category; shown under `ALLOWLIST` **and**
+   `FRIENDS_WHITELIST` (friends auto-pass, the whitelist is the extra-allow list).
+4. **Blacklist** (#1698) — `BlacklistManager` (mirrors `WhitelistManager`, keyed on
+   `blocked_tenure`); shown under `ALL_BUT_BLACKLIST`.
 
-> **[BUILT, NOT WIRED — web follow-up]** The #1698 modes (`ALL_BUT_BLACKLIST`,
-> `FRIENDS_WHITELIST`) and the blacklist manager are fully built on the backend, web API,
-> and telnet, but the React Privacy tab's mode selector still offers only EVERYONE/ALLOWLIST
-> and has no blacklist section or graded deny-and-blacklist button. Surfacing them on the
-> web-first UI is a tracked follow-up.
+Query layer: `consent/api.ts` + `consent/queries.ts` carry the `fetch/add/removeBlacklist`
+trio and `useBlacklist` / `useAddBlacklist` / `useRemoveBlacklist` (mirroring the whitelist
+hooks). The **deny-and-blacklist** affordance lives on the scene consent prompt
+(`scenes/components/ConsentPrompt.tsx` — a "Deny & block" button that sends
+`blacklist_actor: true` through `respondToRequest`); the accept-side difficulty-grade picker
+(`PLAUSIBILITY_BANDS`) predates #1698.
 
 ---
 

--- a/frontend/src/consent/__tests__/PrivacyPage.test.tsx
+++ b/frontend/src/consent/__tests__/PrivacyPage.test.tsx
@@ -46,6 +46,9 @@ vi.mock('../queries', () => ({
   useWhitelist: vi.fn(),
   useAddWhitelist: vi.fn(),
   useRemoveWhitelist: vi.fn(),
+  useBlacklist: vi.fn(),
+  useAddBlacklist: vi.fn(),
+  useRemoveBlacklist: vi.fn(),
 }));
 
 // Mock MyTenureSelect so we can control character selection
@@ -182,12 +185,39 @@ function setupDefaultMocks() {
     isPending: false,
   } as unknown as ReturnType<typeof queries.useRemoveWhitelist>);
 
+  const addBlacklistMutate = vi.fn();
+  const removeBlacklistMutate = vi.fn();
+
+  vi.mocked(queries.useBlacklist).mockReturnValue({
+    data: { count: 0, results: [] },
+    isLoading: false,
+  } as unknown as ReturnType<typeof queries.useBlacklist>);
+
+  vi.mocked(queries.useAddBlacklist).mockReturnValue({
+    mutate: addBlacklistMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof queries.useAddBlacklist>);
+
+  vi.mocked(queries.useRemoveBlacklist).mockReturnValue({
+    mutate: removeBlacklistMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof queries.useRemoveBlacklist>);
+
   vi.mocked(mailQueries.useTenureSearch).mockReturnValue({
     data: { count: 0, results: [] },
     isLoading: false,
   } as unknown as ReturnType<typeof mailQueries.useTenureSearch>);
 
-  return { upsertMutate, deleteMutate, addMutate, removeMutate, updateMutate, createMutateAsync };
+  return {
+    upsertMutate,
+    deleteMutate,
+    addMutate,
+    removeMutate,
+    updateMutate,
+    createMutateAsync,
+    addBlacklistMutate,
+    removeBlacklistMutate,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -249,6 +279,59 @@ describe('PrivacyPage', () => {
       category: mockCategories[0].id,
       mode: 'allowlist',
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // #1698 — new modes upsert with their value
+  // -------------------------------------------------------------------------
+
+  it('calls upsertCategoryRule when switching to all_but_blacklist mode', async () => {
+    const { upsertMutate } = setupDefaultMocks();
+    renderWithProviders(<PrivacyPage />);
+
+    fireEvent.change(screen.getByLabelText('Character'), { target: { value: '1' } });
+    await waitFor(() => screen.getByText('Romantic'));
+
+    const selects = screen.getAllByTestId('mock-select');
+    fireEvent.change(selects[0], { target: { value: 'all_but_blacklist' } });
+
+    expect(upsertMutate).toHaveBeenCalledWith({
+      preference: mockPreferenceWithId.id,
+      category: mockCategories[0].id,
+      mode: 'all_but_blacklist',
+    });
+  });
+
+  it('calls useAddBlacklist when barring a character under all_but_blacklist mode', async () => {
+    const { addBlacklistMutate } = setupDefaultMocks();
+
+    // Pre-set the Romantic category rule to "all_but_blacklist" so BlacklistManager is visible.
+    vi.mocked(queries.useCategoryRules).mockReturnValue({
+      data: {
+        count: 1,
+        results: [{ id: 99, preference: 5, category: 10, mode: 'all_but_blacklist' }],
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof queries.useCategoryRules>);
+
+    vi.mocked(mailQueries.useTenureSearch).mockReturnValue({
+      data: { count: 1, results: [{ id: 7, display_name: 'Zara' }] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof mailQueries.useTenureSearch>);
+
+    renderWithProviders(<PrivacyPage />);
+
+    fireEvent.change(screen.getByLabelText('Character'), { target: { value: '1' } });
+
+    await waitFor(() => screen.getByPlaceholderText('Search character to bar...'));
+
+    const zaraButton = await screen.findByRole('button', { name: 'Zara' });
+    await userEvent.click(zaraButton);
+
+    expect(addBlacklistMutate).toHaveBeenCalledWith(
+      { owner_tenure: 1, blocked_tenure: 7, category: 10 },
+      expect.any(Object)
+    );
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/consent/__tests__/queries.test.ts
+++ b/frontend/src/consent/__tests__/queries.test.ts
@@ -16,6 +16,9 @@ import {
   fetchWhitelist,
   addWhitelist,
   removeWhitelist,
+  fetchBlacklist,
+  addBlacklist,
+  removeBlacklist,
 } from '../api';
 
 function mockOkResponse(data: unknown) {
@@ -252,6 +255,73 @@ describe('consent/api', () => {
       vi.mocked(apiFetch).mockResolvedValue(mockErrorResponse());
 
       await expect(removeWhitelist(1)).rejects.toThrow('Failed to remove whitelist entry');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Blacklist (#1698)
+  // -------------------------------------------------------------------------
+
+  describe('fetchBlacklist', () => {
+    it('calls /api/consent/blacklist/ with owner_tenure and category filters', async () => {
+      const data = { count: 0, results: [] };
+      vi.mocked(apiFetch).mockResolvedValue(mockOkResponse(data));
+
+      const result = await fetchBlacklist(42, 3);
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/consent/blacklist/?owner_tenure=42&category=3');
+      expect(result).toEqual(data);
+    });
+
+    it('throws on error response', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockErrorResponse());
+
+      await expect(fetchBlacklist(42, 3)).rejects.toThrow('Failed to load consent blacklist');
+    });
+  });
+
+  describe('addBlacklist', () => {
+    it('sends POST to /api/consent/blacklist/', async () => {
+      const data = {
+        id: 1,
+        owner_tenure: 42,
+        blocked_tenure: 7,
+        category: 3,
+        added_at: '2026-01-01T00:00:00Z',
+      };
+      vi.mocked(apiFetch).mockResolvedValue(mockOkResponse(data));
+
+      const result = await addBlacklist({ owner_tenure: 42, blocked_tenure: 7, category: 3 });
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/consent/blacklist/', {
+        method: 'POST',
+        body: JSON.stringify({ owner_tenure: 42, blocked_tenure: 7, category: 3 }),
+      });
+      expect(result).toEqual(data);
+    });
+
+    it('throws on error response', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockErrorResponse());
+
+      await expect(
+        addBlacklist({ owner_tenure: 42, blocked_tenure: 7, category: 3 })
+      ).rejects.toThrow('Failed to add blacklist entry');
+    });
+  });
+
+  describe('removeBlacklist', () => {
+    it('sends DELETE to /api/consent/blacklist/{id}/', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockEmptyOk());
+
+      await removeBlacklist(1);
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/consent/blacklist/1/', { method: 'DELETE' });
+    });
+
+    it('throws on error response', async () => {
+      vi.mocked(apiFetch).mockResolvedValue(mockErrorResponse());
+
+      await expect(removeBlacklist(1)).rejects.toThrow('Failed to remove blacklist entry');
     });
   });
 });

--- a/frontend/src/consent/api.ts
+++ b/frontend/src/consent/api.ts
@@ -7,11 +7,14 @@ import type {
   SocialConsentCategoryRuleRequest,
   SocialConsentWhitelist,
   SocialConsentWhitelistRequest,
+  SocialConsentBlacklist,
+  SocialConsentBlacklistRequest,
 } from './types';
 
 type PaginatedCategories = components['schemas']['PaginatedSocialConsentCategoryList'];
 type PaginatedCategoryRules = components['schemas']['PaginatedSocialConsentCategoryRuleList'];
 type PaginatedWhitelist = components['schemas']['PaginatedSocialConsentWhitelistList'];
+type PaginatedBlacklist = components['schemas']['PaginatedSocialConsentBlacklistList'];
 
 // ---------------------------------------------------------------------------
 // Categories (read-only)
@@ -132,5 +135,44 @@ export async function removeWhitelist(id: number): Promise<void> {
   const res = await apiFetch(`/api/consent/whitelist/${id}/`, { method: 'DELETE' });
   if (!res.ok) {
     throw new Error('Failed to remove whitelist entry');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Blacklist (#1698 — antagonism blacklist, consulted under ALL_BUT_BLACKLIST)
+// ---------------------------------------------------------------------------
+
+export async function fetchBlacklist(
+  tenureId: number,
+  categoryId: number
+): Promise<PaginatedBlacklist> {
+  const params = new URLSearchParams({
+    owner_tenure: String(tenureId),
+    category: String(categoryId),
+  });
+  const res = await apiFetch(`/api/consent/blacklist/?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error('Failed to load consent blacklist');
+  }
+  return res.json();
+}
+
+export async function addBlacklist(
+  body: SocialConsentBlacklistRequest
+): Promise<SocialConsentBlacklist> {
+  const res = await apiFetch('/api/consent/blacklist/', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to add blacklist entry');
+  }
+  return res.json();
+}
+
+export async function removeBlacklist(id: number): Promise<void> {
+  const res = await apiFetch(`/api/consent/blacklist/${id}/`, { method: 'DELETE' });
+  if (!res.ok) {
+    throw new Error('Failed to remove blacklist entry');
   }
 }

--- a/frontend/src/consent/components/BlacklistManager.tsx
+++ b/frontend/src/consent/components/BlacklistManager.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { useBlacklist, useAddBlacklist, useRemoveBlacklist } from '../queries';
+import { useTenureSearch } from '@/mail/queries';
+
+interface Props {
+  tenureId: number;
+  categoryId: number;
+}
+
+/** Antagonism blacklist (#1698) — people barred from this category under "Everyone except my
+ * blacklist" mode. The blocked party is never told. Mirrors WhitelistManager. */
+function BlacklistManagerInner({ tenureId, categoryId }: Props) {
+  const [search, setSearch] = useState('');
+  const { data: blacklist, isLoading: blacklistLoading } = useBlacklist(tenureId, categoryId);
+  const { data: searchResults } = useTenureSearch(search);
+  const addBlacklist = useAddBlacklist();
+  const removeBlacklist = useRemoveBlacklist();
+
+  if (blacklistLoading) {
+    return (
+      <div className="mt-2 space-y-2 pl-4">
+        <Skeleton className="h-6 w-32" />
+        <Skeleton className="h-6 w-24" />
+      </div>
+    );
+  }
+
+  const entries = blacklist?.results ?? [];
+
+  return (
+    <div className="mt-2 space-y-2 pl-4">
+      {entries.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {entries.map((entry) => (
+            <span
+              key={entry.id}
+              className="flex items-center gap-1 rounded-full bg-secondary px-3 py-1 text-sm"
+            >
+              {entry.blocked_tenure_name ?? entry.blocked_tenure}
+              <button
+                type="button"
+                aria-label={`Remove ${entry.blocked_tenure_name ?? `tenure ${entry.blocked_tenure}`} from blacklist`}
+                className="ml-1 text-muted-foreground hover:text-foreground"
+                onClick={() =>
+                  removeBlacklist.mutate({
+                    id: entry.id,
+                    ownerTenureId: tenureId,
+                    categoryId,
+                  })
+                }
+              >
+                &times;
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No characters on the blacklist yet.</p>
+      )}
+
+      <div className="space-y-1">
+        <Input
+          placeholder="Search character to bar..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="max-w-xs"
+        />
+        {searchResults && searchResults.results.length > 0 && (
+          <ul className="max-w-xs rounded border">
+            {searchResults.results.map((opt) => (
+              <li key={opt.id}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="w-full justify-start"
+                  disabled={
+                    addBlacklist.isPending || entries.some((e) => e.blocked_tenure === opt.id)
+                  }
+                  onClick={() => {
+                    addBlacklist.mutate(
+                      { owner_tenure: tenureId, blocked_tenure: opt.id, category: categoryId },
+                      { onSuccess: () => setSearch('') }
+                    );
+                  }}
+                >
+                  {opt.display_name}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function BlacklistManager(props: Props) {
+  return (
+    <ErrorBoundary>
+      <BlacklistManagerInner {...props} />
+    </ErrorBoundary>
+  );
+}

--- a/frontend/src/consent/components/CategoryConsentRow.tsx
+++ b/frontend/src/consent/components/CategoryConsentRow.tsx
@@ -6,8 +6,13 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { WhitelistManager } from './WhitelistManager';
+import { BlacklistManager } from './BlacklistManager';
 import { useUpsertCategoryRule, useDeleteCategoryRule } from '../queries';
-import type { SocialConsentCategory, SocialConsentCategoryRule } from '../types';
+import type {
+  SocialConsentCategory,
+  SocialConsentCategoryRule,
+  SocialConsentCategoryRuleModeEnum,
+} from '../types';
 
 interface Props {
   tenureId: number;
@@ -28,8 +33,13 @@ export function CategoryConsentRow({ tenureId, preferenceId, category, rule }: P
         deleteRule.mutate({ id: rule.id, preferenceId });
       }
       // If there's no rule yet "everyone" is the implicit default — nothing to do.
-    } else if (value === 'allowlist') {
-      upsertRule.mutate({ preference: preferenceId, category: category.id, mode: 'allowlist' });
+    } else {
+      // allowlist / all_but_blacklist / friends_whitelist all upsert the mode (#1698).
+      upsertRule.mutate({
+        preference: preferenceId,
+        category: category.id,
+        mode: value as SocialConsentCategoryRuleModeEnum,
+      });
     }
   }
 
@@ -47,17 +57,24 @@ export function CategoryConsentRow({ tenureId, preferenceId, category, rule }: P
           onValueChange={handleModeChange}
           disabled={upsertRule.isPending || deleteRule.isPending}
         >
-          <SelectTrigger className="w-40">
+          <SelectTrigger className="w-56">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="everyone">Everyone</SelectItem>
+            <SelectItem value="all_but_blacklist">Everyone except blacklist</SelectItem>
+            <SelectItem value="friends_whitelist">Friends + whitelist</SelectItem>
             <SelectItem value="allowlist">Allowlist only</SelectItem>
           </SelectContent>
         </Select>
       </div>
-      {currentMode === 'allowlist' && (
+      {/* Allowlist and friends-whitelist both consult the whitelist (friends auto-pass);
+          all-but-blacklist consults the blacklist. */}
+      {(currentMode === 'allowlist' || currentMode === 'friends_whitelist') && (
         <WhitelistManager tenureId={tenureId} categoryId={category.id} />
+      )}
+      {currentMode === 'all_but_blacklist' && (
+        <BlacklistManager tenureId={tenureId} categoryId={category.id} />
       )}
     </div>
   );

--- a/frontend/src/consent/queries.ts
+++ b/frontend/src/consent/queries.ts
@@ -10,14 +10,19 @@ import {
   fetchWhitelist,
   addWhitelist,
   removeWhitelist,
+  fetchBlacklist,
+  addBlacklist,
+  removeBlacklist,
 } from './api';
 import type {
   SocialConsentPreferenceRequest,
   SocialConsentCategoryRuleRequest,
   SocialConsentWhitelistRequest,
+  SocialConsentBlacklistRequest,
   PaginatedSocialConsentCategoryList,
   PaginatedSocialConsentCategoryRuleList,
   PaginatedSocialConsentWhitelistList,
+  PaginatedSocialConsentBlacklistList,
 } from './types';
 
 // ---------------------------------------------------------------------------
@@ -30,6 +35,8 @@ export const consentKeys = {
   categoryRules: (preferenceId: number) => ['consent', 'category-rules', preferenceId] as const,
   whitelist: (tenureId: number, categoryId: number) =>
     ['consent', 'whitelist', tenureId, categoryId] as const,
+  blacklist: (tenureId: number, categoryId: number) =>
+    ['consent', 'blacklist', tenureId, categoryId] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -157,6 +164,51 @@ export function useRemoveWhitelist() {
     onSuccess: ({ ownerTenureId, categoryId }) => {
       queryClient.invalidateQueries({
         queryKey: consentKeys.whitelist(ownerTenureId, categoryId),
+      });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Blacklist (#1698)
+// ---------------------------------------------------------------------------
+
+export function useBlacklist(tenureId: number | undefined, categoryId: number | undefined) {
+  return useQuery<PaginatedSocialConsentBlacklistList>({
+    queryKey: consentKeys.blacklist(tenureId!, categoryId!),
+    queryFn: () => fetchBlacklist(tenureId!, categoryId!),
+    enabled: !!tenureId && !!categoryId,
+    throwOnError: true,
+  });
+}
+
+export function useAddBlacklist() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: SocialConsentBlacklistRequest) => addBlacklist(body),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: consentKeys.blacklist(data.owner_tenure, data.category),
+      });
+    },
+  });
+}
+
+export function useRemoveBlacklist() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      ownerTenureId,
+      categoryId,
+    }: {
+      id: number;
+      ownerTenureId: number;
+      categoryId: number;
+    }) => removeBlacklist(id).then(() => ({ ownerTenureId, categoryId })),
+    onSuccess: ({ ownerTenureId, categoryId }) => {
+      queryClient.invalidateQueries({
+        queryKey: consentKeys.blacklist(ownerTenureId, categoryId),
       });
     },
   });

--- a/frontend/src/consent/types.ts
+++ b/frontend/src/consent/types.ts
@@ -11,9 +11,13 @@ export type SocialConsentCategoryRuleModeEnum =
   components['schemas']['SocialConsentCategoryRuleModeEnum'];
 export type SocialConsentWhitelist = components['schemas']['SocialConsentWhitelist'];
 export type SocialConsentWhitelistRequest = components['schemas']['SocialConsentWhitelistRequest'];
+export type SocialConsentBlacklist = components['schemas']['SocialConsentBlacklist'];
+export type SocialConsentBlacklistRequest = components['schemas']['SocialConsentBlacklistRequest'];
 export type PaginatedSocialConsentCategoryList =
   components['schemas']['PaginatedSocialConsentCategoryList'];
 export type PaginatedSocialConsentCategoryRuleList =
   components['schemas']['PaginatedSocialConsentCategoryRuleList'];
 export type PaginatedSocialConsentWhitelistList =
   components['schemas']['PaginatedSocialConsentWhitelistList'];
+export type PaginatedSocialConsentBlacklistList =
+  components['schemas']['PaginatedSocialConsentBlacklistList'];

--- a/frontend/src/scenes/actionQueries.ts
+++ b/frontend/src/scenes/actionQueries.ts
@@ -147,6 +147,11 @@ export async function respondToRequest(
      * persona id so the backend can record per-target acceptance.
      */
     target_persona_id?: number;
+    /**
+     * On deny, also add the initiator to this defender's antagonism blacklist for
+     * the action's category (#1698). No-op on accept / when the action has no category.
+     */
+    blacklist_actor?: boolean;
   }
 ): Promise<ActionRequestResponse> {
   // Backend ConsentResponseSerializer expects: { decision: "accept" | "deny" }
@@ -161,6 +166,9 @@ export async function respondToRequest(
   }
   if (body.resist_effort !== undefined) {
     requestBody.resist_effort = body.resist_effort;
+  }
+  if (body.blacklist_actor) {
+    requestBody.blacklist_actor = true;
   }
   const res = await apiFetch(`/api/action-requests/${requestId}/respond/`, {
     method: 'POST',

--- a/frontend/src/scenes/components/ConsentPrompt.test.tsx
+++ b/frontend/src/scenes/components/ConsentPrompt.test.tsx
@@ -152,6 +152,24 @@ describe('ConsentPrompt', () => {
     });
   });
 
+  it('clicking "Deny & block" calls respondToRequest with blacklist_actor: true (#1698)', async () => {
+    vi.mocked(fetchPendingRequests).mockResolvedValue({ results: [MOCK_REQUEST] });
+    vi.mocked(respondToRequest).mockResolvedValue({ status: 'resolved' });
+    const user = userEvent.setup();
+
+    render(<ConsentPrompt sceneId="42" />, { wrapper: createWrapper() });
+
+    const denyBlock = await screen.findByRole('button', { name: /deny & block/i });
+    await user.click(denyBlock);
+
+    await waitFor(() => {
+      expect(respondToRequest).toHaveBeenCalledWith('42', 7, {
+        accept: false,
+        blacklist_actor: true,
+      });
+    });
+  });
+
   it('clicking Accept (neutral) calls respondToRequest with difficulty: normal', async () => {
     vi.mocked(fetchPendingRequests).mockResolvedValue({ results: [MOCK_REQUEST] });
     vi.mocked(respondToRequest).mockResolvedValue({ status: 'resolved' });

--- a/frontend/src/scenes/components/ConsentPrompt.tsx
+++ b/frontend/src/scenes/components/ConsentPrompt.tsx
@@ -44,6 +44,7 @@ interface ConsentCardProps {
   resistEffort: string;
   onResistChange: (v: string) => void;
   onDeny: () => void;
+  onDenyBlock: () => void;
   onAccept: (difficulty: string) => void;
   isPending: boolean;
 }
@@ -57,6 +58,7 @@ function ConsentCard({
   resistEffort,
   onResistChange,
   onDeny,
+  onDenyBlock,
   onAccept,
   isPending,
 }: ConsentCardProps) {
@@ -100,6 +102,16 @@ function ConsentCard({
         <Button size="sm" variant="outline" onClick={onDeny} disabled={isPending}>
           <X className="mr-1 h-3.5 w-3.5" />
           Deny
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onDenyBlock}
+          disabled={isPending}
+          title="Deny and bar this person from this kind of action toward you"
+        >
+          <ShieldAlert className="mr-1 h-3.5 w-3.5" />
+          Deny &amp; block
         </Button>
         <Button
           size="sm"
@@ -149,12 +161,15 @@ export function ConsentPrompt({ sceneId }: Props) {
       accept,
       difficulty,
       resist_effort,
+      blacklist_actor,
     }: {
       requestId: number;
       accept: boolean;
       difficulty?: string;
       resist_effort?: string;
-    }) => respondToRequest(sceneId, requestId, { accept, difficulty, resist_effort }),
+      blacklist_actor?: boolean;
+    }) =>
+      respondToRequest(sceneId, requestId, { accept, difficulty, resist_effort, blacklist_actor }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
       queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
@@ -174,17 +189,20 @@ export function ConsentPrompt({ sceneId }: Props) {
       accept,
       difficulty,
       resist_effort,
+      blacklist_actor,
     }: {
       requestId: number;
       targetPersonaId: number;
       accept: boolean;
       difficulty?: string;
       resist_effort?: string;
+      blacklist_actor?: boolean;
     }) =>
       respondToRequest(sceneId, requestId, {
         accept,
         difficulty,
         resist_effort,
+        blacklist_actor,
         target_persona_id: targetPersonaId,
       }),
     onSuccess: () => {
@@ -215,6 +233,9 @@ export function ConsentPrompt({ sceneId }: Props) {
             resistEffort={selectedResist}
             onResistChange={(val) => setResistEffort((prev) => ({ ...prev, [cardKey]: val }))}
             onDeny={() => respond.mutate({ requestId: req.id, accept: false })}
+            onDenyBlock={() =>
+              respond.mutate({ requestId: req.id, accept: false, blacklist_actor: true })
+            }
             onAccept={(difficulty) =>
               respond.mutate({
                 requestId: req.id,
@@ -246,6 +267,14 @@ export function ConsentPrompt({ sceneId }: Props) {
                 requestId: t.action_request_id,
                 targetPersonaId: t.target_persona_id,
                 accept: false,
+              })
+            }
+            onDenyBlock={() =>
+              respondTarget.mutate({
+                requestId: t.action_request_id,
+                targetPersonaId: t.target_persona_id,
+                accept: false,
+                blacklist_actor: true,
               })
             }
             onAccept={(difficulty) =>


### PR DESCRIPTION
## Summary

Finishes #1698 on the web-first surface — the backend, web API, and telnet shipped in #1698, but the React Privacy tab still only offered EVERYONE/ALLOWLIST. This wires the rest:

- **Mode selector** now spans all four `ConsentMode`s (Everyone / Everyone except blacklist / Friends + whitelist / Allowlist only). `handleModeChange` upserts any non-everyone mode; the `WhitelistManager` shows under `allowlist` **and** `friends_whitelist` (friends auto-pass, the whitelist is the extra-allow list).
- **`BlacklistManager`** — new component mirroring `WhitelistManager` (keyed on `blocked_tenure`/`blocked_tenure_name`), shown under `all_but_blacklist`.
- **Blacklist query layer** — `fetch/add/removeBlacklist` in `api.ts`, `useBlacklist`/`useAddBlacklist`/`useRemoveBlacklist` + `consentKeys.blacklist` in `queries.ts`, and the type re-exports.
- **Deny-and-block** — a "Deny & block" button on the scene `ConsentPrompt` sends `blacklist_actor: true` through `respondToRequest` (both the primary-request and per-target paths). The accept-side difficulty-grade picker (`PLAUSIBILITY_BANDS`) already existed pre-#1698, so no change there.

Pure hand-wiring — the generated types (blacklist schema, both new mode enum values, `blacklist_actor` on the respond body) all landed with #1698.

## Testing

- Vitest: `consent/__tests__/queries.test.ts` (blacklist fetch/add/remove), `consent/__tests__/PrivacyPage.test.tsx` (all_but_blacklist mode-select + blacklist add), `scenes/components/ConsentPrompt.test.tsx` (deny-and-block) — 60 passing across the three files.
- `pnpm build` green (tsc -b + vite + collectstatic); eslint + prettier clean.
- Doc updated: `docs/systems/consent.md` frontend section (removed the [BUILT, NOT WIRED] note).

Closes #1751

🤖 Generated with [Claude Code](https://claude.com/claude-code)