### PR TITLE
Stakes engine: mission auto-wire (finish on_mission_complete_for_beat)

### DIFF
--- a/docs/systems/MODEL_MAP.md
+++ b/docs/systems/MODEL_MAP.md
@@ -3382,7 +3382,7 @@
 - `emit_terminal_rewards(instance: 'MissionInstance', route: 'MissionOptionRoute', deed: 'MissionDeedRecord') -> 'list[MissionDeedRewardLine]' — Emit one :class:`MissionDeedRewardLine` per (template × recipient).`
 - `enter_node(instance: 'MissionInstance', node: 'MissionNode') -> 'None' — Record entry into ``node`` and advance the run's position.`
 - `journal_for(character: 'ObjectDB') -> 'list[JournalEntry]' — Return one :class:`JournalEntry` per mission this character is in.`
-- `on_mission_complete_for_beat(instance: 'MissionInstance') -> 'MissionBeatTriggerRecord | None' — Record a Mission → Beat terminal trigger (5b.3 stub-record).`
+- `on_mission_complete_for_beat(instance: 'MissionInstance', *, route: 'MissionOptionRoute | None' = None) -> 'MissionBeatTriggerRecord | None' — Record a Mission → Beat terminal trigger and complete the linked Beat.`
 - `resolve_beat_option(instance: 'MissionInstance', character: 'ObjectDB', *, option_id: 'int', approach_id: 'int | None' = None) -> 'ResolvedBeat' — Resolve the chosen option for ``character``; deliver both narratives.`
 - `resolve_group_node(instance: 'MissionInstance', node: 'MissionNode') -> 'list[MissionDeedRecord]' — Resolve a group ``node`` from its collected ``MissionGroupBallot`` rows (#1036).`
 - `resolve_option(instance: 'MissionInstance', node: 'MissionNode', option: 'MissionOption', actor: 'MissionParticipant', *, chosen_approach: 'ChallengeApproach | None' = None, advance: 'bool' = True) -> 'MissionDeedRecord' — Resolve ``actor`` taking ``option`` at ``node``; return its deed.`

--- a/src/world/missions/services/__init__.py
+++ b/src/world/missions/services/__init__.py
@@ -24,12 +24,11 @@ Public surface:
     walks ``applied=False`` :class:`MissionRewardQueue` rows. Both
     LP/Resonance grant helpers are stub-sealed in 5b.2 pending
     payload-enrichment work (DESIGN §13.3).
-  * :func:`on_mission_complete_for_beat` (Phase 5b.3) — Mission→Beat seam
-    called at terminal. 5b.3 lands the cross-app data shape (Beat.required_mission
-    and MissionInstance.source_beat FKs) and a stub-record service that
-    notes the trigger without flipping any Beat; the engine that actually
-    advances/resolves the Beat is deferred (see module docstring for the
-    three deferred product-level questions).
+  * :func:`on_mission_complete_for_beat` (Phase 5b.3 / #1747) — Mission→Beat
+    seam called at terminal. Completes the linked ``Beat`` via
+    ``record_outcome_tier_completion`` (graded tier) or
+    ``record_gm_marked_outcome(SUCCESS)`` (BRANCH terminal). Free-run
+    instances (``source_beat=None``) are a no-op.
 """
 
 from world.missions.services.beat import on_mission_complete_for_beat

--- a/src/world/missions/services/beat.py
+++ b/src/world/missions/services/beat.py
@@ -1,27 +1,35 @@
-"""Mission → Story Beat seam (5b.3 — stub-record only).
+"""Mission → Story Beat seam.
 
-Phase 5b.3 lands the cross-app data shape:
-  * Beat.required_mission FK (authoring-time: a Beat may name a MissionTemplate it requires)
-  * MissionInstance.source_beat FK (runtime: an instance may have been launched as a Beat resolver)
+When a ``MissionInstance`` with ``source_beat`` set reaches a terminal route,
+``on_mission_complete_for_beat`` completes the linked ``Beat`` automatically:
 
-The actual "complete the Beat when a mission terminates" engine is deferred. See:
+  * A graded ``outcome_tier`` (CHECK/JOINT terminal) drives
+    ``record_outcome_tier_completion`` (PR1), which derives
+    ``BeatOutcome.SUCCESS``/``FAILURE`` from ``success_level`` and fires the
+    beat's consequence pool at the matching tier.
+  * A null ``outcome_tier`` (BRANCH terminal, or ``route=None``) drives
+    ``record_gm_marked_outcome`` with ``SUCCESS`` — reaching a terminal branch
+    node means the mission was navigated to completion.
 
-  1. Which BeatOutcome does a mission completion produce? (Always SUCCESS? Per-route?)
-  2. How does Beat.required_mission interact with BeatPredicateType? (Override?
-     Constrained to GM_MARKED? New MISSION_COMPLETED predicate type?)
-  3. How does (instance, beat) resolve to the right StoryProgress/GroupStoryProgress
-     given the beat's StoryScope? (Holder's progress? All participants? GMTable lookup?)
+Free-run instances (``source_beat_id is None``) are a no-op, as before. The
+trigger-record log (``MissionBeatTriggerRecord``) is retained for
+observability.
 
-These belong to a future stories-missions seam design pass. Until then,
-on_mission_complete_for_beat() is a stub-record (appends to a module-level list,
-same shape as integrations/beat_stub.py). Tests assert the trigger is recorded;
-no BeatCompletion is created in 5b.3.
+The three deferred questions from the original 5b.3 stub are now resolved:
 
-See docs/plans/2026-05-18-missions-design.md §13.x for the broader design intent.
+  1. Which ``BeatOutcome``: derived from ``outcome_tier.success_level`` sign
+     (graded) or ``SUCCESS`` (BRANCH), matching PR1's convention.
+  2. ``required_mission``/``predicate_type``: independent columns; the engine
+     dispatches on ``route.outcome_tier`` presence. Mismatches are logged,
+     not raised. No new predicate type.
+  3. ``StoryProgress`` scope: resolved via ``beat.episode.chapter.story`` →
+     ``get_active_progress_for_story``. ``None`` (story not started) is a
+     safe no-op.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from django.utils import timezone
@@ -29,7 +37,9 @@ from django.utils import timezone
 from world.missions.types import MissionBeatTriggerRecord
 
 if TYPE_CHECKING:
-    from world.missions.models import MissionInstance
+    from world.missions.models import MissionInstance, MissionOptionRoute
+
+logger = logging.getLogger(__name__)
 
 
 _MISSION_BEAT_TRIGGERS: list[MissionBeatTriggerRecord] = []
@@ -37,23 +47,22 @@ _MISSION_BEAT_TRIGGERS: list[MissionBeatTriggerRecord] = []
 
 def on_mission_complete_for_beat(
     instance: MissionInstance,
+    *,
+    route: MissionOptionRoute | None = None,
 ) -> MissionBeatTriggerRecord | None:
-    """Record a Mission → Beat terminal trigger (5b.3 stub-record).
+    """Record a Mission → Beat terminal trigger and complete the linked Beat.
 
     Called from ``_finish_terminal`` after the instance is marked COMPLETE.
 
-    * If ``instance.source_beat_id is None`` the instance is a free run
-      (no Beat reporting). Returns ``None`` and records nothing — the call
-      is a cheap no-op (one attribute read + return).
-    * Otherwise: appends one :class:`MissionBeatTriggerRecord` to the
-      module-level log and returns it. NOT idempotent — calling twice
-      records two rows; mirrors the shape of
-      :mod:`world.missions.integrations.beat_stub`.
+    Args:
+        instance: The terminating ``MissionInstance``.
+        route: The terminal ``MissionOptionRoute`` (or ``None`` for a BRANCH
+            terminal that has no route object). Its ``outcome_tier``
+            determines which completion path fires.
 
-    Phase 5b.3 deliberately does NOT create a
-    :class:`world.stories.models.BeatCompletion` and does NOT call any
-    stories service. The seam is data-only in 5b.3; see the module docstring
-    for the three deferred product-level questions.
+    Returns:
+        The recorded ``MissionBeatTriggerRecord``, or ``None`` when the
+        instance is a free run (``source_beat_id is None``).
     """
     if instance.source_beat_id is None:
         return None
@@ -63,7 +72,89 @@ def on_mission_complete_for_beat(
         triggered_at=timezone.now(),
     )
     _MISSION_BEAT_TRIGGERS.append(record)
+    _complete_linked_beat(instance, route)
     return record
+
+
+def _complete_linked_beat(
+    instance: MissionInstance,
+    route: MissionOptionRoute | None,
+) -> None:
+    """Complete the instance's linked Beat via the stories service.
+
+    Resolves ``StoryProgress`` from the beat's story chain, then dispatches:
+
+      * graded ``outcome_tier`` → ``record_outcome_tier_completion``
+      * no tier (``route is None`` or ``route.outcome_tier is None``) →
+        ``record_gm_marked_outcome(SUCCESS)``
+
+    Predicate-type mismatches and missing progress are logged and skipped —
+    a beat-completion failure must never roll back the mission completion
+    (the instance is already COMPLETE when this runs).
+    """
+    from world.stories.constants import BeatOutcome  # noqa: PLC0415
+    from world.stories.models import Beat  # noqa: PLC0415
+    from world.stories.services.beats import (  # noqa: PLC0415
+        record_gm_marked_outcome,
+        record_outcome_tier_completion,
+    )
+    from world.stories.services.progress import (  # noqa: PLC0415
+        get_active_progress_for_story,
+    )
+
+    try:
+        beat = Beat.objects.select_related(
+            "episode__chapter__story",
+        ).get(pk=instance.source_beat_id)
+    except Beat.DoesNotExist:
+        logger.warning(
+            "MissionBeat: source_beat %s not found for instance %s; skipping.",
+            instance.source_beat_id,
+            instance.pk,
+        )
+        return
+
+    if beat.outcome != BeatOutcome.UNSATISFIED:
+        logger.debug(
+            "MissionBeat: beat %s already resolved (%s); skipping.",
+            beat.pk,
+            beat.outcome,
+        )
+        return
+
+    story = beat.episode.chapter.story
+    progress = get_active_progress_for_story(story)
+    if progress is None:
+        logger.debug(
+            "MissionBeat: no active progress for story %s; skipping beat %s.",
+            story.pk,
+            beat.pk,
+        )
+        return
+
+    has_tier = route is not None and route.outcome_tier_id is not None
+
+    try:
+        if has_tier:
+            record_outcome_tier_completion(
+                progress=progress,
+                beat=beat,
+                outcome_tier=route.outcome_tier,
+            )
+        else:
+            record_gm_marked_outcome(
+                progress=progress,
+                beat=beat,
+                outcome=BeatOutcome.SUCCESS,
+            )
+    except ValueError:
+        logger.warning(
+            "MissionBeat: predicate-type mismatch for beat %s "
+            "(type=%s, has_tier=%s); skipping completion.",
+            beat.pk,
+            beat.predicate_type,
+            has_tier,
+        )
 
 
 def get_triggers() -> tuple[MissionBeatTriggerRecord, ...]:

--- a/src/world/missions/services/multiplayer.py
+++ b/src/world/missions/services/multiplayer.py
@@ -401,7 +401,7 @@ def _resolve_joint(
         anchor_deed.save(update_fields=["route_candidate"])
         emit_candidate_rewards(instance, candidate, anchor_deed)
     if next_node is None:
-        _finish_terminal(instance)
+        _finish_terminal(instance, route=route)
         # Phase 5b.0: JOINT terminal emits the route's reward lines ONCE.
         emit_terminal_rewards(instance, route, anchor_deed)
     else:

--- a/src/world/missions/services/resolution.py
+++ b/src/world/missions/services/resolution.py
@@ -466,24 +466,27 @@ def _teardown_spawned_room(instance: MissionInstance) -> None:
     complete_instanced_room(instance.spawned_room.objectdb)
 
 
-def _finish_terminal(instance: MissionInstance) -> None:
+def _finish_terminal(
+    instance: MissionInstance,
+    *,
+    route: MissionOptionRoute | None = None,
+) -> None:
     """Mark the run complete (terminal route reached).
 
-    Phase 5b.3: after the status write, notify the Mission→Beat seam. The
-    call is a cheap no-op when ``instance.source_beat_id is None`` (a free
-    run); when set, it appends one :class:`MissionBeatTriggerRecord` to the
-    seam's stub-record log. The actual Beat-completion engine is deferred —
-    see :mod:`world.missions.services.beat` for the three deferred
-    product-level design questions. JOINT terminals call ``_finish_terminal``
-    exactly once (Phase 4 invariant), so the seam fires exactly once per
-    instance termination.
+    After the status write, notify the Mission→Beat seam. The call is a cheap
+    no-op when ``instance.source_beat_id is None`` (a free run); when set, it
+    completes the linked ``Beat`` via ``on_mission_complete_for_beat``.
+    ``route`` is the terminal :class:`MissionOptionRoute` (or ``None`` for a
+    BRANCH terminal with no route object). JOINT terminals call
+    ``_finish_terminal`` exactly once (Phase 4 invariant), so the seam fires
+    exactly once per instance termination.
     """
     instance.status = MissionStatus.COMPLETE
     instance.completed_at = timezone.now()
     instance.current_node = None
     instance.save()
     _teardown_spawned_room(instance)
-    on_mission_complete_for_beat(instance)
+    on_mission_complete_for_beat(instance, route=route)
 
 
 def resolve_option(  # noqa: PLR0913
@@ -577,7 +580,7 @@ def resolve_option(  # noqa: PLR0913
     is_terminal = False
     if advance:
         if next_node is None:
-            _finish_terminal(instance)
+            _finish_terminal(instance, route=route)
             is_terminal = True
         else:
             instance.current_node = next_node
@@ -640,7 +643,7 @@ def _resolve_branch(
                 next_node = None
 
         if next_node is None:
-            _finish_terminal(instance)
+            _finish_terminal(instance, route=route)
             is_terminal = True
             terminal_route = route  # may be None when branch is terminal via
             # an option with neither branch_target nor a null-tier route.

--- a/src/world/missions/tests/test_services_beat.py
+++ b/src/world/missions/tests/test_services_beat.py
@@ -1,20 +1,32 @@
-"""Tests for the Phase-5b.3 ``on_mission_complete_for_beat`` stub-record service.
+"""Tests for ``on_mission_complete_for_beat`` — the mission→Beat seam.
 
-See :mod:`world.missions.services.beat` for the deferred product-level
-design questions. 5b.3 only verifies the trigger-record shape and the
-free-vs-beat-bound branching; no BeatCompletion is created, no stories
-service is called.
+Phase 5b.3 landed the trigger-record shape; this module now also verifies
+that the linked ``Beat`` is completed when a beat-bound instance terminates.
 """
 
 from django.test import TestCase
 
-from world.missions.factories import MissionInstanceFactory, MissionTemplateFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.missions.factories import (
+    MissionInstanceFactory,
+    MissionOptionRouteFactory,
+    MissionTemplateFactory,
+)
 from world.missions.services import beat as beat_service, on_mission_complete_for_beat
-from world.stories.factories import BeatFactory
+from world.stories.constants import BeatOutcome, BeatPredicateType, StoryScope
+from world.stories.factories import (
+    BeatFactory,
+    ChapterFactory,
+    EpisodeFactory,
+    StoryFactory,
+    StoryProgressFactory,
+)
+from world.stories.models import BeatCompletion
+from world.traits.factories import CheckOutcomeFactory
 
 
 class OnMissionCompleteForBeatTests(TestCase):
-    """Stub-record shape: free → None; beat-bound → record."""
+    """Trigger-record shape: free → None; beat-bound → record."""
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -58,9 +70,8 @@ class OnMissionCompleteForBeatTests(TestCase):
         self.assertEqual(beat_service.get_triggers(), ())
 
     def test_double_call_records_two_triggers_not_idempotent(self) -> None:
-        # Matches beat_stub's append-on-every-call shape — the stub is a
-        # call log, not a state machine. The future engine (which actually
-        # flips the Beat) will own idempotency at that layer.
+        # The trigger log is append-only (observability). The beat-completion
+        # guard prevents a double-completion (see MissionBeatCompletionTests).
         beat = BeatFactory()
         instance = MissionInstanceFactory(template=self.template, source_beat=beat)
 
@@ -70,15 +81,159 @@ class OnMissionCompleteForBeatTests(TestCase):
         self.assertIsNotNone(first)
         self.assertIsNotNone(second)
         self.assertEqual(len(beat_service.get_triggers()), 2)
-        # The two records carry the same (instance, beat) pks — the only
-        # variance is ``triggered_at``.
-        self.assertEqual(first.instance_pk, second.instance_pk)
-        self.assertEqual(first.beat_pk, second.beat_pk)
 
-    def test_get_triggers_returns_immutable_tuple(self) -> None:
-        # Mirrors beat_stub.get_calls()'s tuple-not-list contract.
-        beat = BeatFactory()
+
+class MissionBeatCompletionTests(TestCase):
+    """on_mission_complete_for_beat completes the linked Beat."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.template = MissionTemplateFactory(name="beat-completion-tmpl")
+        cls.sheet = CharacterSheetFactory()
+        cls.story = StoryFactory(scope=StoryScope.CHARACTER, character_sheet=cls.sheet)
+        cls.chapter = ChapterFactory(story=cls.story)
+        cls.episode = EpisodeFactory(chapter=cls.chapter)
+
+    def setUp(self) -> None:
+        beat_service.clear_triggers()
+
+    def _make_progress(self):
+        return StoryProgressFactory(
+            story=self.story, character_sheet=self.sheet, current_episode=self.episode
+        )
+
+    def test_check_terminal_completes_outcome_tier_beat(self) -> None:
+        """A graded-tier route completes an OUTCOME_TIER beat via record_outcome_tier_completion."""
+        tier = CheckOutcomeFactory(name="Victory", success_level=4)
+        beat = BeatFactory(
+            episode=self.episode,
+            predicate_type=BeatPredicateType.OUTCOME_TIER,
+        )
+        self._make_progress()
         instance = MissionInstanceFactory(template=self.template, source_beat=beat)
-        on_mission_complete_for_beat(instance)
-        triggers = beat_service.get_triggers()
-        self.assertIsInstance(triggers, tuple)
+        route = MissionOptionRouteFactory(outcome_tier=tier, target_node=None)
+
+        on_mission_complete_for_beat(instance, route=route)
+
+        beat.refresh_from_db()
+        self.assertEqual(beat.outcome, BeatOutcome.SUCCESS)
+        completion = BeatCompletion.objects.get(beat=beat)
+        self.assertEqual(completion.outcome_tier, tier)
+
+    def test_failure_tier_completes_outcome_tier_beat_as_failure(self) -> None:
+        """A negative success_level tier resolves FAILURE."""
+        tier = CheckOutcomeFactory(name="Defeat", success_level=-3)
+        beat = BeatFactory(
+            episode=self.episode,
+            predicate_type=BeatPredicateType.OUTCOME_TIER,
+        )
+        self._make_progress()
+        instance = MissionInstanceFactory(template=self.template, source_beat=beat)
+        route = MissionOptionRouteFactory(outcome_tier=tier, target_node=None)
+
+        on_mission_complete_for_beat(instance, route=route)
+
+        beat.refresh_from_db()
+        self.assertEqual(beat.outcome, BeatOutcome.FAILURE)
+        completion = BeatCompletion.objects.get(beat=beat)
+        self.assertEqual(completion.outcome_tier, tier)
+
+    def test_branch_terminal_completes_gm_marked_beat_as_success(self) -> None:
+        """A no-tier route (BRANCH) completes a GM_MARKED beat as SUCCESS."""
+        beat = BeatFactory(
+            episode=self.episode,
+            predicate_type=BeatPredicateType.GM_MARKED,
+        )
+        self._make_progress()
+        instance = MissionInstanceFactory(template=self.template, source_beat=beat)
+        route = MissionOptionRouteFactory(outcome_tier=None, target_node=None)
+
+        on_mission_complete_for_beat(instance, route=route)
+
+        beat.refresh_from_db()
+        self.assertEqual(beat.outcome, BeatOutcome.SUCCESS)
+        self.assertTrue(BeatCompletion.objects.filter(beat=beat).exists())
+
+    def test_branch_terminal_with_none_route_completes_gm_marked_beat(self) -> None:
+        """route=None (branch_target-only terminal) still completes as SUCCESS."""
+        beat = BeatFactory(
+            episode=self.episode,
+            predicate_type=BeatPredicateType.GM_MARKED,
+        )
+        self._make_progress()
+        instance = MissionInstanceFactory(template=self.template, source_beat=beat)
+
+        on_mission_complete_for_beat(instance, route=None)
+
+        beat.refresh_from_db()
+        self.assertEqual(beat.outcome, BeatOutcome.SUCCESS)
+
+    def test_skips_when_no_progress(self) -> None:
+        """No StoryProgress → no BeatCompletion, no error."""
+        tier = CheckOutcomeFactory(success_level=3)
+        beat = BeatFactory(
+            episode=self.episode,
+            predicate_type=BeatPredicateType.OUTCOME_TIER,
+        )
+        # No StoryProgress created.
+        instance = MissionInstanceFactory(template=self.template, source_beat=beat)
+        route = MissionOptionRouteFactory(outcome_tier=tier, target_node=None)
+
+        on_mission_complete_for_beat(instance, route=route)
+
+        beat.refresh_from_db()
+        self.assertEqual(beat.outcome, BeatOutcome.UNSATISFIED)
+        self.assertFalse(BeatCompletion.objects.filter(beat=beat).exists())
+
+    def test_skips_when_beat_already_resolved(self) -> None:
+        """An already-resolved beat is not double-completed."""
+        tier = CheckOutcomeFactory(success_level=4)
+        beat = BeatFactory(
+            episode=self.episode,
+            predicate_type=BeatPredicateType.OUTCOME_TIER,
+            outcome=BeatOutcome.SUCCESS,
+        )
+        self._make_progress()
+        instance = MissionInstanceFactory(template=self.template, source_beat=beat)
+        route = MissionOptionRouteFactory(outcome_tier=tier, target_node=None)
+
+        on_mission_complete_for_beat(instance, route=route)
+
+        # No new BeatCompletion created (beat was already SUCCESS).
+        self.assertEqual(BeatCompletion.objects.filter(beat=beat).count(), 0)
+
+    def test_predicate_mismatch_logged_not_raised(self) -> None:
+        """GM_MARKED beat + graded route → ValueError caught, no crash."""
+        tier = CheckOutcomeFactory(success_level=4)
+        beat = BeatFactory(
+            episode=self.episode,
+            predicate_type=BeatPredicateType.GM_MARKED,
+        )
+        self._make_progress()
+        instance = MissionInstanceFactory(template=self.template, source_beat=beat)
+        route = MissionOptionRouteFactory(outcome_tier=tier, target_node=None)
+
+        # Must not raise.
+        on_mission_complete_for_beat(instance, route=route)
+
+        beat.refresh_from_db()
+        self.assertEqual(beat.outcome, BeatOutcome.UNSATISFIED)
+
+    def test_double_call_completes_beat_only_once(self) -> None:
+        """The trigger log records two entries, but the beat completes once."""
+        tier = CheckOutcomeFactory(success_level=4)
+        beat = BeatFactory(
+            episode=self.episode,
+            predicate_type=BeatPredicateType.OUTCOME_TIER,
+        )
+        self._make_progress()
+        instance = MissionInstanceFactory(template=self.template, source_beat=beat)
+        route = MissionOptionRouteFactory(outcome_tier=tier, target_node=None)
+
+        on_mission_complete_for_beat(instance, route=route)
+        on_mission_complete_for_beat(instance, route=route)
+
+        # Two trigger records (append-only log).
+        self.assertEqual(len(beat_service.get_triggers()), 2)
+        # But only one BeatCompletion.
+        self.assertEqual(BeatCompletion.objects.filter(beat=beat).count(), 1)

--- a/src/world/missions/tests/test_services_resolution_beat.py
+++ b/src/world/missions/tests/test_services_resolution_beat.py
@@ -1,12 +1,9 @@
-"""Phase 5b.3 — terminal-path integration tests for the Mission→Beat seam.
+"""Terminal-path integration tests for the Mission→Beat seam.
 
 When ``_finish_terminal`` fires (the single chokepoint for SOLO and JOINT
 terminal completion), ``on_mission_complete_for_beat`` runs. With
-``source_beat`` set we expect exactly one trigger record per termination;
-with ``source_beat=None`` we expect none.
-
-These tests exercise the wiring, not the engine — there is no Beat-flip
-to assert in 5b.3.
+``source_beat`` set we expect exactly one trigger record per termination
+and a ``BeatCompletion``; with ``source_beat=None`` we expect none.
 """
 
 from unittest.mock import patch
@@ -33,8 +30,9 @@ from world.missions.factories import (
 )
 from world.missions.models import MissionGroupBallot, MissionInstance, MissionNode, MissionOption
 from world.missions.services import beat as beat_service, resolve_group_node, resolve_option
-from world.stories.factories import BeatFactory
-from world.stories.models import Beat
+from world.stories.constants import BeatOutcome, BeatPredicateType
+from world.stories.factories import BeatFactory, StoryProgressFactory
+from world.stories.models import Beat, BeatCompletion
 from world.traits.factories import CheckOutcomeFactory
 
 _PERFORM_CHECK = "world.missions.services.resolution.perform_check"
@@ -93,6 +91,12 @@ class SoloTerminalBeatSeamTests(TestCase):
 
     def test_solo_terminal_of_beat_bound_records_one_trigger(self) -> None:
         beat = BeatFactory()
+        # The beat needs an active StoryProgress for its story to complete.
+        story = beat.episode.chapter.story
+        sheet = self.character.sheet_data
+        story.character_sheet = sheet
+        story.save()
+        StoryProgressFactory(story=story, character_sheet=sheet)
         instance, entry, actor, option = self._make_terminal_run(source_beat=beat)
 
         # BRANCH option with no branch_target / null-tier route → terminal.
@@ -102,6 +106,10 @@ class SoloTerminalBeatSeamTests(TestCase):
         self.assertEqual(len(triggers), 1)
         self.assertEqual(triggers[0].instance_pk, instance.pk)
         self.assertEqual(triggers[0].beat_pk, beat.pk)
+        # BRANCH terminal → GM_MARKED beat resolved as SUCCESS.
+        beat.refresh_from_db()
+        self.assertEqual(beat.outcome, BeatOutcome.SUCCESS)
+        self.assertTrue(BeatCompletion.objects.filter(beat=beat).exists())
 
     def test_solo_terminal_of_free_instance_records_no_trigger(self) -> None:
         instance, entry, actor, option = self._make_terminal_run(source_beat=None)
@@ -168,7 +176,13 @@ class JointTerminalBeatSeamTests(TestCase):
         return instance, node, picks
 
     def test_joint_terminal_of_beat_bound_records_one_trigger(self) -> None:
-        beat = BeatFactory()
+        # OUTCOME_TIER beat: the JOINT CHECK terminal has a graded outcome_tier.
+        beat = BeatFactory(predicate_type=BeatPredicateType.OUTCOME_TIER)
+        story = beat.episode.chapter.story
+        sheet = self.char_h.sheet_data
+        story.character_sheet = sheet
+        story.save()
+        StoryProgressFactory(story=story, character_sheet=sheet)
         instance, node, picks = self._setup_joint_run(source_beat=beat)
 
         # Every per-attempt perform_check returns success → JointCombine.ANY
@@ -187,3 +201,8 @@ class JointTerminalBeatSeamTests(TestCase):
         self.assertEqual(len(triggers), 1)
         self.assertEqual(triggers[0].instance_pk, instance.pk)
         self.assertEqual(triggers[0].beat_pk, beat.pk)
+        # Graded tier (success_level=3) → OUTCOME_TIER beat resolved as SUCCESS.
+        beat.refresh_from_db()
+        self.assertEqual(beat.outcome, BeatOutcome.SUCCESS)
+        completion = BeatCompletion.objects.get(beat=beat)
+        self.assertEqual(completion.outcome_tier, self.success)


### PR DESCRIPTION
Closes #1747

## Summary

Finishes the mission→Beat completion seam (`on_mission_complete_for_beat`). When a beat-linked MissionInstance terminates, the linked Beat is automatically completed via `record_outcome_tier_completion` (graded tier from CHECK/JOINT terminals) or `record_gm_marked_outcome(SUCCESS)` (BRANCH terminals with no tier). The terminal `MissionOptionRoute` is threaded through `_finish_terminal` → `on_mission_complete_for_beat`. Predicate mismatches are logged, not raised — mission completion is never rolled back.

Key decisions (approved in spec review):
- BRANCH terminals → SUCCESS (reaching terminal = success by construction)
- Thread route into `_finish_terminal` (smallest change, route in scope at all 3 call sites)
- StoryProgress resolved via `beat.episode.chapter.story` → `get_active_progress_for_story`
- Log-and-skip on predicate mismatches (never raises)

Tests: 12 tests in `test_services_beat.py` (trigger-record shape + beat completion), 3 updated tests in `test_services_resolution_beat.py` (SOLO + JOINT terminal integration). Full missions+stories suite: 1517 tests passing.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1747 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch was up to date with main; no rebase needed.

<!-- last-addressed-comment: 0 -->