### PR TITLE
docs: fold-in-not-file default for review-surfaced gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,25 +194,14 @@ ratification. The `verify-against-code` skill carries the labeling procedure
 (`[BUILT & WIRED]` / `[BUILT, NOT WIRED]` / `[ABSENT]`), the ledger format, and the
 recurring-traps list. **Use it.**
 
-## Fold In, Don't File — REQUIRED for review-surfaced gaps
+## Fold In, Don't File
 
-**Trivial gaps never become an issue — not now, not later, no exceptions.**
-A missing test for code this PR just wrote, a one-line dedup, a small
-admin/serializer wiring nit, minor polish: fix it in the current branch/PR
-now, or drop it if it's not worth even that. These do not get filed as
-follow-ups under any justification — "it's low-risk," "it's out of scope for
-this task," "it was surfaced during review" are not blockers, they're
-description of exactly the stuff that gets fixed or dropped. Size/value, not
-verification status, is what disqualifies them — being real and
-code-verified doesn't make triviality worth tracking.
-
-File a follow-up only for something substantial enough to need its own PR:
-a genuinely separable system, a scope well beyond the current issue, or an
-open design question that needs a human call — and say what the blocker is
-in the issue body. This rule **overrides any "file follow-up now" step in a
-skill** (including `issue-to-merged-pr`'s PR-opening and post-merge-cleanup
-steps) — those steps describe the mechanism for the substantial-work case,
-not a license to file everything review surfaces.
+Trivial review-surfaced gaps (a missing test, a dedup, a wiring nit) get fixed in
+the current branch/PR now or dropped — never filed as a follow-up issue, no
+exceptions. File only for something substantial enough to need its own PR
+(separable system, scope beyond the current issue, a design question needing a
+human call), with the reason stated in the issue body. Overrides any skill step
+that says to file a follow-up — see `issue-to-merged-pr`'s SKILL.md for detail.
 
 ## Database & Code Quality Invariants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,17 +196,23 @@ recurring-traps list. **Use it.**
 
 ## Fold In, Don't File — REQUIRED for review-surfaced gaps
 
-**Default disposition for any gap surfaced during task review, whole-branch
-review, or PR review is to fix it in the current branch/PR now — not to file a
-follow-up issue.** This applies whether the gap is a missing test, a small
-dedup, a scoping/wiring gap, or similar in-scope polish. File a follow-up only
-when there is a real, stated blocker: a genuinely separable system, a scope
-that spans well beyond the current issue, or an open design question that
-needs a human call. When filing is warranted, say what the blocker is in the
-issue body — "surfaced during review" is not itself a blocker. This rule
-**overrides any "file follow-up now" step in a skill** (including
-`issue-to-merged-pr`'s PR-opening and post-merge-cleanup steps) — those steps
-describe the mechanism for the exception case, not the default.
+**Trivial gaps never become an issue — not now, not later, no exceptions.**
+A missing test for code this PR just wrote, a one-line dedup, a small
+admin/serializer wiring nit, minor polish: fix it in the current branch/PR
+now, or drop it if it's not worth even that. These do not get filed as
+follow-ups under any justification — "it's low-risk," "it's out of scope for
+this task," "it was surfaced during review" are not blockers, they're
+description of exactly the stuff that gets fixed or dropped. Size/value, not
+verification status, is what disqualifies them — being real and
+code-verified doesn't make triviality worth tracking.
+
+File a follow-up only for something substantial enough to need its own PR:
+a genuinely separable system, a scope well beyond the current issue, or an
+open design question that needs a human call — and say what the blocker is
+in the issue body. This rule **overrides any "file follow-up now" step in a
+skill** (including `issue-to-merged-pr`'s PR-opening and post-merge-cleanup
+steps) — those steps describe the mechanism for the substantial-work case,
+not a license to file everything review surfaces.
 
 ## Database & Code Quality Invariants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,20 @@ ratification. The `verify-against-code` skill carries the labeling procedure
 (`[BUILT & WIRED]` / `[BUILT, NOT WIRED]` / `[ABSENT]`), the ledger format, and the
 recurring-traps list. **Use it.**
 
+## Fold In, Don't File — REQUIRED for review-surfaced gaps
+
+**Default disposition for any gap surfaced during task review, whole-branch
+review, or PR review is to fix it in the current branch/PR now — not to file a
+follow-up issue.** This applies whether the gap is a missing test, a small
+dedup, a scoping/wiring gap, or similar in-scope polish. File a follow-up only
+when there is a real, stated blocker: a genuinely separable system, a scope
+that spans well beyond the current issue, or an open design question that
+needs a human call. When filing is warranted, say what the blocker is in the
+issue body — "surfaced during review" is not itself a blocker. This rule
+**overrides any "file follow-up now" step in a skill** (including
+`issue-to-merged-pr`'s PR-opening and post-merge-cleanup steps) — those steps
+describe the mechanism for the exception case, not the default.
+
 ## Database & Code Quality Invariants
 
 Database design:

--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -246,8 +246,20 @@ before opening a PR" into a dispatch to a sub-skill (e.g.
 checkpoint — that manufactures a gate the skill doesn't have.
 
 Compose the PR body's substitution values (summary, follow-ups, sync
-summary). For each deferred follow-up identified during implementation,
-call `scripts/file-followup.sh <title> <body-path> <labels...>` NOW (before
+summary).
+
+**Default disposition: fix it now, in this branch, not a follow-up issue**
+(CLAUDE.md "Fold In, Don't File"). This applies to task-review and
+whole-branch-review findings the same as PR-comment findings — a missing
+test for code this PR just wrote, a one-line dedup, an admin/serializer
+wiring gap are **fixed here**, not deferred. Before opening the PR, loop
+back and address these findings directly.
+
+Only file a follow-up when there's a real, stated blocker — a genuinely
+separable system, scope well beyond this issue, or an open design question
+needing a human call — and say what the blocker is in the issue body.
+For each such follow-up, call
+`scripts/file-followup.sh <title> <body-path> <labels...>` NOW (before
 opening the PR) and collect the issue numbers.
 
 **Before filing each follow-up, run the `verify-against-code` pass on its
@@ -397,8 +409,10 @@ Return to CI watch.
 Run `scripts/post-merge-cleanup.sh <branch> <pr-N>`. Read the JSON:
 - For any `linked_issue_actions` entry with `action: "needs-attention"`,
   post a comment on that issue explaining what merged.
-- For review-driven follow-ups identified during the PR-comment phase,
-  file them now with `scripts/file-followup.sh`.
+- For review-driven gaps identified during the PR-comment phase: the merge
+  already happened, so "fix it now" means a fast-follow commit if trivial;
+  file with `scripts/file-followup.sh` only for a genuine, stated blocker
+  (CLAUDE.md "Fold In, Don't File" — the same default as Step 5).
 
 #### Takeaway evaluation (post-merge)
 

--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -248,14 +248,16 @@ checkpoint — that manufactures a gate the skill doesn't have.
 Compose the PR body's substitution values (summary, follow-ups, sync
 summary).
 
-**Default disposition: fix it now, in this branch, not a follow-up issue**
+**Trivial findings never get filed — fix now or drop, no exceptions**
 (CLAUDE.md "Fold In, Don't File"). This applies to task-review and
 whole-branch-review findings the same as PR-comment findings — a missing
 test for code this PR just wrote, a one-line dedup, an admin/serializer
-wiring gap are **fixed here**, not deferred. Before opening the PR, loop
-back and address these findings directly.
+wiring nit: **fixed here, or dropped**, never deferred to an issue. Being
+correctly verified against code does not make something worth tracking —
+only substantial, separable scope does. Before opening the PR, loop back
+and address (or consciously drop) these findings directly.
 
-Only file a follow-up when there's a real, stated blocker — a genuinely
+Only file a follow-up for something that genuinely needs its own PR — a
 separable system, scope well beyond this issue, or an open design question
 needing a human call — and say what the blocker is in the issue body.
 For each such follow-up, call


### PR DESCRIPTION
## Summary

- Codifies the "don't file speculative follow-up issues" rule directly into `CLAUDE.md` (new "Fold In, Don't File" section) and into `issue-to-merged-pr`'s SKILL.md Step 5 / Step 9, instead of leaving it as agent-memory-only guidance.
- Root cause: #1760's whole-branch review surfaced 5 small in-scope gaps (missing tests, a one-line dedup, an admin wiring question) and the skill's literal instruction was "file it now" — which it correctly did, producing #1797. A fresh review subagent has no access to prior-session memory, so a memory-only correction never reached it.
- New default: fix review-surfaced gaps in the current branch/PR; file a follow-up only for a real, stated blocker (separable system, scope beyond the issue, or a genuine design question).

## Test plan

- [x] Docs-only change; `pre-commit run --all-files` passed on commit.
- N/A — no runtime surface to exercise.