### PR TITLE
Wire FORMATION role picker to emit COVENANT_ROLE reference

### DIFF
--- a/frontend/src/rituals/CLAUDE.md
+++ b/frontend/src/rituals/CLAUDE.md
@@ -83,14 +83,18 @@ participant-fields form:
   sent in `participant_kwargs`; instead it becomes an entry in the `references` array
   (`{ kind: emits_reference, ref_<kind>_id: value }`). Currently wired kinds:
   `COVENANT_ROLE → ref_covenant_role_id`, `COVENANT → ref_covenant_id`.
-- **`depends_on` path resolution** — `CovenantRolePickerField` declares
-  `depends_on: "session.target_covenant.covenant_type"`. The dialog resolves this by:
-  1. Reading the `COVENANT`-kind entry from `session.session_references` (primary path).
-  2. Falling back to `session_kwargs.target_covenant` for older sessions.
-  3. Fetching `GET /api/covenants/covenants/{id}/` to get `covenant_type`.
-  4. Injecting the resolved value into `formValues` under the full
-     `"session.target_covenant.covenant_type"` key — so `CovenantRolePickerField`
-     reads it via `formValues[field.depends_on]` with no changes to the field component.
+- **`depends_on` path resolution** — `CovenantRolePickerField` declares a
+  `depends_on` key that the dialog resolves and injects into `formValues` so the
+  picker can read it via `formValues[field.depends_on]`. Two strategies:
+  1. **Session-reference path (induction):**
+     `depends_on: "session.target_covenant.covenant_type"`. The dialog reads the
+     `COVENANT`-kind entry from `session.session_references` (falling back to
+     `session_kwargs.target_covenant` for older sessions), fetches
+     `GET /api/covenants/covenants/{id}/` to get `covenant_type`, and injects it
+     under the full path key.
+  2. **Bare session-kwargs key (formation):** `depends_on: "covenant_type"`. The
+     dialog injects all string/number values from `session.session_kwargs` under
+     their bare keys — so the picker finds `covenant_type` directly, no fetch.
 
 ### `RitualField` descriptors (extended)
 
@@ -109,8 +113,9 @@ The `participant_fields` schema lives in `input_schema.participant_fields` on th
 
 - `frontend/src/rituals/__tests__/RitualSessionPages.test.tsx` — component tests for
   `RitualSessionResponseDialog` covering: role-picker rendering from `participantFieldsSchema`,
-  `emits_reference` → `references` conversion on accept, and `candidate_only` field hiding
-  for the initiator.
+  `emits_reference` → `references` conversion on accept (induction + formation),
+  `candidate_only` field hiding for the initiator (induction only), and bare
+  session-kwargs `depends_on` resolution (formation).
 
 ## Common Gotchas
 

--- a/frontend/src/rituals/__tests__/RitualSessionPages.test.tsx
+++ b/frontend/src/rituals/__tests__/RitualSessionPages.test.tsx
@@ -675,4 +675,108 @@ describe('RitualSessionResponseDialog', () => {
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
     expect(screen.queryByText('Covenant Role')).not.toBeInTheDocument();
   });
+
+  // ---------------------------------------------------------------------------
+  // Formation accept: covenant_role_picker renders for ALL participants (no applies_to gate)
+  // and depends_on: "covenant_type" resolves from session_kwargs (no fetch).
+  // ---------------------------------------------------------------------------
+
+  /**
+   * participant_fields schema for a covenant formation ritual:
+   * - chosen_covenant_role: covenant_role_picker
+   *   emits_reference: "COVENANT_ROLE"
+   *   depends_on: "covenant_type"  (bare session-kwargs key, NOT a session-reference path)
+   *   required: true
+   *   (NO applies_to — all founders need a role, including the initiator)
+   */
+  const formationParticipantFieldsSchema: RitualInputSchema = {
+    fields: [
+      {
+        name: 'chosen_covenant_role',
+        label: 'Covenant Role',
+        type: 'covenant_role_picker',
+        emits_reference: 'COVENANT_ROLE',
+        depends_on: 'covenant_type',
+        required: true,
+      },
+    ],
+  };
+
+  // Formation session: covenant_type lives in session_kwargs (drafted by the initiator).
+  const formationSession: RitualSessionDetail = {
+    ...sampleSessionDetail,
+    id: 2,
+    session_kwargs: {
+      name: 'The Iron Pact',
+      covenant_type: 'durance',
+      sworn_objective: 'Defend the realm',
+    },
+  };
+
+  it('renders role picker for the initiator (no applies_to gate) and resolves covenant_type from session_kwargs', async () => {
+    // Stub apiFetch for roles list only (no covenant detail fetch needed —
+    // depends_on resolves from session_kwargs directly).
+    vi.mocked(apiFetch).mockImplementation((url: string) => {
+      if (url.includes('/api/covenants/roles/')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 12, name: 'Warden', covenant_type: 'durance' }],
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    const acceptMutate = vi.fn();
+    mockUseAcceptRitualSession.mockReturnValue({ ...idleMutation, mutate: acceptMutate });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RitualSessionResponseDialog
+            session={formationSession}
+            // participantId 99 IS the initiator — FORMATION must still show the picker.
+            participantId={99}
+            open={true}
+            onOpenChange={vi.fn()}
+            participantFieldsSchema={formationParticipantFieldsSchema}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Assertion 1: the role picker renders for the initiator (no applies_to gate).
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+
+    // Wait for roles to load (driven by covenant_type from session_kwargs).
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).not.toBeDisabled();
+    });
+
+    // Drive the Radix Select: open and pick 'Warden'.
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(await screen.findByText('Warden'));
+
+    // Click Accept.
+    await waitFor(() => {
+      expect(screen.getByTestId('accept-button')).not.toBeDisabled();
+    });
+    await userEvent.click(screen.getByTestId('accept-button'));
+
+    // Assertion 2: accept mutation was called with the COVENANT_ROLE reference.
+    await waitFor(() => {
+      expect(acceptMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 2,
+          body: expect.objectContaining({
+            references: [{ kind: 'COVENANT_ROLE', ref_covenant_role_id: 12 }],
+          }),
+        }),
+        expect.anything()
+      );
+    });
+  });
 });

--- a/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
+++ b/frontend/src/rituals/components/RitualSessionResponseDialog.tsx
@@ -14,16 +14,21 @@
  * Decline button and a plain Accept button (no form) are shown.
  *
  * --- depends_on path resolution ---
- * CovenantRolePickerField has `depends_on: "session.target_covenant.covenant_type"`.
- * We resolve this path by:
- *   1. Reading the COVENANT-kind entry from session.session_references (the primary path for
- *      induction sessions). Falls back to extracting target_covenant from session_kwargs for
- *      older sessions that stored it there.
- *   2. Fetching GET /api/covenants/covenants/{id}/ to get covenant_type.
- *   3. Injecting the resolved value into formValues under the full depends_on key
- *      "session.target_covenant.covenant_type" before passing to RitualForm.
- * CovenantRolePickerField reads formValues[field.depends_on] — the key is the full path
- * string, so no changes are needed to CovenantRolePickerField itself.
+ * Two strategies, tried together:
+ *
+ *  1. Session-reference path (induction): CovenantRolePickerField declares
+ *     `depends_on: "session.target_covenant.covenant_type"`. We resolve this by:
+ *     a. Reading the COVENANT-kind entry from session.session_references (falls
+ *        back to extracting target_covenant from session_kwargs for older sessions).
+ *     b. Fetching GET /api/covenants/covenants/{id}/ to get covenant_type.
+ *     c. Injecting the resolved value into formValues under the full depends_on key.
+ *
+ *  2. Bare session-kwargs key (formation): CovenantRolePickerField declares
+ *     `depends_on: "covenant_type"`. We inject all string/number session_kwargs
+ *     under their bare keys, so the picker finds the value directly — no fetch.
+ *
+ * CovenantRolePickerField reads formValues[field.depends_on]; the key matches the
+ * depends_on string, so no changes are needed to CovenantRolePickerField itself.
  *
  * --- applies_to gating ---
  * Fields with applies_to === "candidate_only" are hidden from the initiator. The
@@ -128,6 +133,28 @@ function useTargetCovenantType(session: RitualSessionDetail): string | null {
   return data?.covenant_type ?? null;
 }
 
+/**
+ * Extract session_kwargs as a flat record suitable for depends_on resolution.
+ *
+ * FORMATION's chosen_covenant_role field uses depends_on: "covenant_type" — a
+ * bare key into session_kwargs. By injecting all session kwargs under their
+ * bare keys, CovenantRolePickerField finds the value via formValues[field.depends_on].
+ *
+ * Only string and number values are injected; nested objects/arrays are skipped
+ * (no current depends_on key references them).
+ */
+function extractSessionKwargsForDependsOn(sessionKwargs: unknown): Record<string, string | number> {
+  const result: Record<string, string | number> = {};
+  if (typeof sessionKwargs !== 'object' || sessionKwargs === null) return result;
+  const kw = sessionKwargs as Record<string, unknown>;
+  for (const [k, v] of Object.entries(kw)) {
+    if (typeof v === 'string' || typeof v === 'number') {
+      result[k] = v;
+    }
+  }
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Module-level constants
 // ---------------------------------------------------------------------------
@@ -171,20 +198,30 @@ export function RitualSessionResponseDialog({
   const acceptMutation = useAcceptRitualSession();
   const declineMutation = useDeclineRitualSession();
 
-  // Resolve depends_on path "session.target_covenant.covenant_type".
-  // We fetch the target covenant's type and inject it into formValues under the full
-  // depends_on key. CovenantRolePickerField reads formValues[field.depends_on] which
-  // is the full string "session.target_covenant.covenant_type" — so the key must match.
+  // Resolve depends_on paths.
+  //
+  // Two resolution strategies, tried in order:
+  //  1. Session-reference path (induction): "session.target_covenant.covenant_type"
+  //     — fetch the COVENANT referenced at session level and read its covenant_type.
+  //  2. Bare session-kwargs key (formation): "covenant_type"
+  //     — read the value directly from session.session_kwargs.
+  //
+  // CovenantRolePickerField reads formValues[field.depends_on]; we inject the
+  // resolved value under that key so the picker can find it.
   const targetCovenantType = useTargetCovenantType(session);
 
   /**
-   * Build the formValues passed to RitualForm, injecting the resolved covenant_type
-   * under the full depends_on path key so CovenantRolePickerField can read it.
+   * Build the formValues passed to RitualForm, injecting resolved depends_on
+   * values so dependent fields (e.g. CovenantRolePickerField) can read them.
    */
   const formValuesWithResolved: Record<string, string | number | null> = {
     ...participantValues,
-    // Inject resolved path value so CovenantRolePickerField finds it via:
-    //   formValues[field.depends_on]  where depends_on = "session.target_covenant.covenant_type"
+    // Session-kwargs values: inject every session kwarg under its bare key so
+    // fields with depends_on pointing at a session kwarg (e.g. "covenant_type"
+    // in FORMATION) resolve without a separate fetch.
+    ...extractSessionKwargsForDependsOn(session.session_kwargs),
+    // Session-reference path (induction): the resolved covenant_type from the
+    // COVENANT session-reference, injected under the full path key.
     'session.target_covenant.covenant_type': targetCovenantType,
   };
 

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -2491,6 +2491,7 @@ class CovenantFormationRitualFactory(factory.django.DjangoModelFactory):
                     "name": "chosen_covenant_role",
                     "type": "covenant_role_picker",
                     "depends_on": "covenant_type",
+                    "emits_reference": "COVENANT_ROLE",
                     "required": True,
                 },
             ],

--- a/src/world/magic/tests/test_session_views.py
+++ b/src/world/magic/tests/test_session_views.py
@@ -612,6 +612,91 @@ class RitualInductionRoundTripTests(TestCase):
         self.assertEqual(membership.covenant_role_id, candidate_role.pk)
 
 
+class RitualFormationRoundTripTests(TestCase):
+    """Integration: draft → all founders accept with COVENANT_ROLE refs → fire → covenant created.
+
+    Mirrors RitualInductionRoundTripTests but for FORMATION. The key asymmetry:
+    in FORMATION *every* accepting participant (including the initiator) supplies
+    a chosen role — there is no ``applies_to: "candidate_only"`` gate.
+    """
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    def test_draft_accept_fire_creates_covenant_with_founder_roles(self) -> None:
+        from world.covenants.constants import CovenantType
+        from world.covenants.factories import CovenantRoleFactory
+        from world.covenants.models import CharacterCovenantRole, Covenant
+
+        # --- participants (two founders) ---
+        _, initiator_account, initiator_sheet = _make_tenure_with_account()
+        _, invitee_account, invitee_sheet = _make_tenure_with_account()
+
+        # --- roles (both DURANCE to match the session kwargs below) ---
+        initiator_role = CovenantRoleFactory(covenant_type=CovenantType.DURANCE)
+        invitee_role = CovenantRoleFactory(covenant_type=CovenantType.DURANCE)
+
+        ritual = _make_formation_ritual()
+
+        # --- step 1: initiator drafts with session-level kwargs + their own role ref ---
+        # The initiator is auto-ACCEPTED at draft time; their COVENANT_ROLE reference
+        # is supplied via initiator_references (not a separate accept call).
+        self.client.force_authenticate(user=initiator_account)
+        draft = self.client.post(
+            "/api/magic/rituals/sessions/",
+            {
+                "ritual_id": ritual.pk,
+                "invitee_ids": [invitee_sheet.pk],
+                "session_kwargs": {
+                    "name": "The Iron Pact",
+                    "covenant_type": CovenantType.DURANCE.value,
+                    "sworn_objective": "Defend the realm",
+                },
+                "initiator_references": [
+                    {"kind": "COVENANT_ROLE", "ref_covenant_role_id": initiator_role.pk}
+                ],
+                "expires_at": _future_dt(),
+            },
+            format="json",
+        )
+        self.assertEqual(draft.status_code, 201, draft.data)
+        session_id = draft.data["id"]
+
+        # --- step 2: invitee accepts with COVENANT_ROLE ref ---
+        self.client.force_authenticate(user=invitee_account)
+        accept_inv = self.client.post(
+            f"/api/magic/rituals/sessions/{session_id}/accept/",
+            {
+                "participant_kwargs": {},
+                "references": [{"kind": "COVENANT_ROLE", "ref_covenant_role_id": invitee_role.pk}],
+            },
+            format="json",
+        )
+        self.assertEqual(accept_inv.status_code, 200, accept_inv.data)
+
+        # --- step 3: initiator fires ---
+        self.client.force_authenticate(user=initiator_account)
+        fire = self.client.post(
+            f"/api/magic/rituals/sessions/{session_id}/fire/", {}, format="json"
+        )
+        self.assertEqual(fire.status_code, 200, fire.data)
+        self.assertEqual(fire.data["result_kind"], "covenant")
+
+        # --- assert: covenant was created ---
+        covenant = Covenant.objects.get(name="The Iron Pact")
+        self.assertEqual(covenant.covenant_type, CovenantType.DURANCE.value)
+
+        # --- assert: both founders have CCR rows with their chosen roles ---
+        init_membership = CharacterCovenantRole.objects.get(
+            character_sheet=initiator_sheet, covenant=covenant
+        )
+        self.assertEqual(init_membership.covenant_role_id, initiator_role.pk)
+        inv_membership = CharacterCovenantRole.objects.get(
+            character_sheet=invitee_sheet, covenant=covenant
+        )
+        self.assertEqual(inv_membership.covenant_role_id, invitee_role.pk)
+
+
 class RitualSessionDetailParticipantFieldsTests(TestCase):
     """GET /api/magic/rituals/sessions/{id}/ exposes participant_fields."""
 
@@ -632,3 +717,18 @@ class RitualSessionDetailParticipantFieldsTests(TestCase):
         self.assertIn("chosen_covenant_role", names)
         role_field = next(f for f in fields if f["name"] == "chosen_covenant_role")
         self.assertEqual(role_field["emits_reference"], "COVENANT_ROLE")
+
+    def test_detail_exposes_participant_fields_for_formation(self) -> None:
+        from world.magic.factories import RitualSessionFactory
+
+        _, account, sheet = _make_tenure_with_account()
+        ritual = _make_formation_ritual()
+        session = RitualSessionFactory(ritual=ritual, initiator=sheet)
+        self.client.force_authenticate(user=account)
+        response = self.client.get(f"/api/magic/rituals/sessions/{session.pk}/")
+        self.assertEqual(response.status_code, 200)
+        fields = response.data["participant_fields"]
+        role_field = next(f for f in fields if f["name"] == "chosen_covenant_role")
+        self.assertEqual(role_field["emits_reference"], "COVENANT_ROLE")
+        # FORMATION must NOT gate the role field — all founders need a role.
+        self.assertNotIn("applies_to", role_field)


### PR DESCRIPTION
## Summary

Closes #1313

The FORMATION covenant-creation ritual's `chosen_covenant_role` participant field was missing the `emits_reference` descriptor. The frontend dialog only converts fields with `emits_reference` into the `references` array on accept — so the picked role landed in `participant_kwargs` and never became a `COVENANT_ROLE` reference. When `create_covenant_via_session` ran, it found no reference and raised `RequiredReferenceMissingError`.

## Changes

**Backend (`src/world/magic/factories.py`)** — Added `"emits_reference": "COVENANT_ROLE"` to the FORMATION `chosen_covenant_role` field. Deliberately **no** `applies_to: "candidate_only"` gate — all founders (including the initiator) need a role, unlike induction where only the candidate supplies one.

**Frontend (`RitualSessionResponseDialog.tsx`)** — Generalized the `depends_on` resolution. Previously hardcoded for induction's `"session.target_covenant.covenant_type"` path (resolved via a COVENANT session-reference fetch). FORMATION uses `"covenant_type"` — a bare session-kwargs key. Added `extractSessionKwargsForDependsOn()` which injects all string/number session kwargs under their bare keys, so the role picker resolves `covenant_type` directly from `session_kwargs` with no fetch.

## Tests

- **`RitualFormationRoundTripTests`** — full integration: draft (with initiator role ref via `initiator_references`) → invitee accepts with role ref → fire → covenant created + both founders have correct `CharacterCovenantRole` rows.
- **`test_detail_exposes_participant_fields_for_formation`** — asserts `emits_reference` is present and `applies_to` is absent on the FORMATION field.
- **Frontend** — formation test verifying the role picker renders for the initiator (no gate), `covenant_type` resolves from `session_kwargs` (no fetch), and accept emits the `COVENANT_ROLE` reference.

## Test results

- Backend: 3039 tests pass (3037 baseline + 2 new), 0 failures
- Frontend: 19 tests pass (18 baseline + 1 new), typecheck clean, prettier clean