### PR TITLE
refactor(checks): Deceive/Con split, Leadership rename, Household Command containment

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -641,7 +641,8 @@ Social structures, organizations, reputation, and legend tracking.
   `Secret` (blackmail material); public news/leaks set `societies_aware`,
   fire `apply_archetype_society_reputation`, and scale `spread_multiplier`
   by the involved personas' fame (`FAME_SPREAD_FACTORS`). Containment =
-  best-of Deception/Intimidation vs crowd size; Stealth (new skill, seeded)
+  Household Command for own-household witnesses, else best-of Con/Intimidation
+  by stat (ruled 2026-07-03); Stealth (new skill, seeded)
   is the act-time leg, wiring later. Untagged deeds skip the fork.
 - **Integrates with:** realms (Society.realm FK), character_sheets (Persona for identity), magic (Audere Majora crossing deed via `AudereMajoraCrossing.legend_entry`), secrets (contained-scandal minting + exposure, #1464), justice (leaked crimes mint heat via the knowledge seam, #1765), actions (shared `action.run()` / `dispatch_player_action()` seam)
 - **Source:** `src/world/societies/`
@@ -1283,7 +1284,7 @@ an idle org reaches stasis in both directions (loan interest still accrues — o
   per-stream proportional landing), `improve_org_domain` (Domain Investment check → gross
   bump + graft crackdown), `process_income_stream(stream, amount)` (landing path),
   `settle_obligations`, `run_weekly_economy` (Sunday rollover phases)
-- **Checks (#930):** Tax Collection (presence + Organization + Stewardship) and Domain
+- **Checks (#930):** Tax Collection / Household Command (presence + Leadership + Stewardship) and Domain
   Investment (intellect + Scholarship + Economics), seeded by the `governance` cluster
 - **Books surface:** `GET /api/currency/org-books/{org}/` (`OrgBooksViewSet`) — treasury,
   graft, income streams w/ pools + `uncollected_total`, debts, obligations, contributions,

--- a/src/integration_tests/game_content/challenges.py
+++ b/src/integration_tests/game_content/challenges.py
@@ -298,7 +298,7 @@ CHALLENGE_DEFS: list[tuple[str, str, int, str, list[str], list[tuple[str, str, s
         [
             ("Cow", "Cow", "Intimidation"),
             ("Convince", "Convince", "Persuasion"),
-            ("Bluff", "Bluff", "Deception"),
+            ("Bluff", "Bluff", "Deceive"),
             ("Seduce", "Seduce", "Seduction"),
         ],
     ),

--- a/src/world/checks/factories.py
+++ b/src/world/checks/factories.py
@@ -105,7 +105,7 @@ class ConsequenceEffectFactory(DjangoModelFactory):
 _SOCIAL_CHECK_TYPES = [
     ("Intimidation", "Coercing through force of presence, threats, or physical dominance.", 0),
     ("Persuasion", "Convincing through reasoned argument, charm, and social grace.", 1),
-    ("Deception", "Misleading through misdirection, half-truths, or outright lies.", 2),
+    ("Deceive", "Misleading through misdirection, half-truths, or outright lies.", 2),
     ("Seduction", "Beguiling through charm, allure, and romantic suggestion.", 3),
     ("Performance", "Captivating an audience through music, oration, or storytelling.", 4),
     ("Presence", "Commanding attention through sheer force of personality.", 5),
@@ -117,8 +117,8 @@ _SOCIAL_TRAIT_WEIGHTS = [
     ("Intimidation", "strength", "0.50"),
     ("Persuasion", "charm", "1.00"),
     ("Persuasion", "intellect", "0.50"),
-    ("Deception", "wits", "1.00"),
-    ("Deception", "charm", "0.50"),
+    ("Deceive", "wits", "1.00"),
+    ("Deceive", "charm", "0.50"),
     ("Seduction", "charm", "1.00"),
     ("Seduction", "presence", "0.50"),
     ("Performance", "presence", "1.00"),
@@ -131,7 +131,7 @@ _SOCIAL_TRAIT_WEIGHTS = [
 _SOCIAL_ACTION_TEMPLATES = [
     ("Intimidate", "Intimidation", "single", "skull"),
     ("Persuade", "Persuasion", "single", "handshake"),
-    ("Deceive", "Deception", "single", "mask"),
+    ("Deceive", "Deceive", "single", "mask"),
     ("Flirt", "Seduction", "single", "heart"),
     ("Perform", "Performance", "area", "music"),
     ("Entrance", "Presence", "area", "sparkles"),

--- a/src/world/missions/services/report.py
+++ b/src/world/missions/services/report.py
@@ -15,8 +15,8 @@ Styles (Apostate's design):
   reporter who has the Persuasion skill.
 - **Mostly-accurate** — a check to report around the truth (#1765): success dodges the criminal
   consequences (heat + the society sting) a CRIME_WATCH line would mint; failure applies them.
-  Never grants the fame/prestige swing either way. PROVISIONAL: rides the same Persuasion check
-  as Embellished until the specialized-check foundation (#1688) lands.
+  Never grants the fame/prestige swing either way. Rides **Con** (charm + Persuasion +
+  Manipulation — ratified 2026-07-03).
 
 Reporting a masked deed barefaced (the run was accepted under a different persona than the one
 reporting) risks the *association chance* (#1765): a failed check copies the mask's pursuit heat
@@ -170,22 +170,25 @@ def _run_embellish_check(reporter: ObjectDB, functionary: Functionary) -> bool:
 def _run_consequence_dodge_check(reporter: ObjectDB, functionary: Functionary) -> bool:
     """The mostly-accurate check: report around the truth to dodge the criminal fallout (#1765).
 
-    PROVISIONAL check choice (flagged on the issue): rides the same Persuasion check +
-    Manipulation specialization + giver-standing difficulty as Embellished until the
-    specialized-check foundation (#1688) provides a better-fitting gate. Unlike Embellished
-    there is no skill gate — anyone may try to talk around the truth; the dice decide.
+    Ratified (Apostate 2026-07-03): rides **Con** (charm + Persuasion +
+    Manipulation — talking someone into a curated version of events) against
+    the giver-standing difficulty. Unlike Embellished there is no skill gate —
+    anyone may try to talk around the truth; the dice decide. Unseeded worlds
+    fail closed (falls back to the bare Persuasion check when Con is absent).
     """
     from world.checks.models import CheckType  # noqa: PLC0415
     from world.checks.services import perform_check  # noqa: PLC0415
 
-    check_type = CheckType.objects.filter(name__iexact="Persuasion").first()
+    check_type = (
+        CheckType.objects.filter(name__iexact="Con").first()
+        or CheckType.objects.filter(name__iexact="Persuasion").first()
+    )
     if check_type is None:
         return False  # unseeded world: the dodge simply fails, consequences apply.
     result = perform_check(
         reporter,
         check_type,
         target_difficulty=_embellish_difficulty(functionary),
-        specialization=_manipulation_specialization(reporter),
     )
     return result.outcome is not None and result.outcome.success_level >= 0
 
@@ -199,8 +202,10 @@ def _apply_masked_deed_association(
     another (the face taking the renown), a failed check copies the mask's pursuit heat onto
     the reporting persona via :func:`world.justice.services.associate_heat` — the same seam
     the #1334 secrets-outing writer uses later. Success means nobody made the connection.
-    PROVISIONAL check choice, same basis as the dodge check. Unseeded worlds fail harsh
-    (association happens without a roll) — consistent with the dodge failing closed.
+    Ratified (Apostate 2026-07-03): **Deceive** (presence + Persuasion + Manipulation) —
+    fooling people in the moment is the disguise-adjacent frame; the full crafted-disguise
+    quality/identification loop is the appearance epic's later scope. Unseeded worlds fail
+    harsh (association happens without a roll) — consistent with the dodge failing closed.
     """
     from world.checks.models import CheckType  # noqa: PLC0415
     from world.checks.services import perform_check  # noqa: PLC0415
@@ -214,13 +219,15 @@ def _apply_masked_deed_association(
     reporting_persona = active_persona_for_sheet(sheet)
     if reporting_persona is None or reporting_persona.pk == mask.pk:
         return
-    check_type = CheckType.objects.filter(name__iexact="Persuasion").first()
+    check_type = (
+        CheckType.objects.filter(name__iexact="Deceive").first()
+        or CheckType.objects.filter(name__iexact="Persuasion").first()
+    )
     if check_type is not None:
         result = perform_check(
             reporter,
             check_type,
             target_difficulty=_embellish_difficulty(functionary),
-            specialization=_manipulation_specialization(reporter),
         )
         if result.outcome is not None and result.outcome.success_level >= 0:
             return  # slipped away clean — nobody connected the faces.

--- a/src/world/missions/tests/test_report_heat.py
+++ b/src/world/missions/tests/test_report_heat.py
@@ -78,11 +78,13 @@ class ReportHeatTestCase(TestCase):
         return self.sheet.primary_persona
 
     def _seed_persuasion_check(self) -> None:
-        # The dodge/association helpers look the CheckType up before calling
-        # perform_check (which the tests mock) — without it they fail closed.
+        # The dodge/association helpers look the CheckTypes up before calling
+        # perform_check (which the tests mock) — without them they fail closed.
+        # Ratified names (2026-07-03): dodge → Con, association → Deceive.
         from world.checks.factories import CheckTypeFactory
 
-        CheckTypeFactory(name="Persuasion")
+        CheckTypeFactory(name="Con")
+        CheckTypeFactory(name="Deceive")
 
     @patch(_DELIVER)
     def test_accurate_report_mints_heat_and_reputation_sting(self, mock_deliver) -> None:  # noqa: ARG002

--- a/src/world/seeds/governance_checks.py
+++ b/src/world/seeds/governance_checks.py
@@ -1,11 +1,13 @@
 """Governance check content seed (#930) — the domain-running skills and checks.
 
 Two new skills (Apostate, 2026-07-02): **Scholarship → Economics** (book-learning;
-improving domains) and **Organization → Stewardship** (directing anyone in the
+improving domains) and **Leadership → Stewardship** (directing anyone in the
 household/org; boosts a dispatched collector). Two check compositions ride them:
 
-- **Tax Collection** — presence + Organization (+ Stewardship): how well a
+- **Tax Collection** — presence + Leadership (+ Stewardship): how well a
   dispatched collection run goes.
+- **Household Command** — presence + Leadership (+ Stewardship): the general
+  be-obeyed-by-your-household check (in-house scandal containment).
 - **Domain Investment** — intellect + Scholarship (+ Economics): improving an
   org's income streams / cracking down on graft.
 
@@ -26,7 +28,7 @@ _GOVERNANCE_SKILLS: list[tuple[str, str, str]] = [
         "mental",
     ),
     (
-        "Organization",
+        "Leadership",
         "Directing people — households, retainers, crews, and chains of command.",
         "social",
     ),
@@ -35,12 +37,16 @@ _GOVERNANCE_SKILLS: list[tuple[str, str, str]] = [
 # (specialization name, parent skill name)
 _GOVERNANCE_SPECIALIZATIONS: list[tuple[str, str]] = [
     ("Economics", "Scholarship"),
-    ("Stewardship", "Organization"),
+    ("Stewardship", "Leadership"),
 ]
 
 # CheckType name -> (stat trait, parent skill, specialization).
 _GOVERNANCE_CHECK_COMPOSITION: dict[str, tuple[str, str, str]] = {
-    "Tax Collection": ("presence", "Organization", "Stewardship"),
+    "Tax Collection": ("presence", "Leadership", "Stewardship"),
+    # The general control-your-household check (Apostate 2026-07-03): be obeyed
+    # by household servants — in-house scandal containment, and later the
+    # direction bonus atop dispatched functionary agents (#672 seam).
+    "Household Command": ("presence", "Leadership", "Stewardship"),
     "Domain Investment": ("intellect", "Scholarship", "Economics"),
 }
 
@@ -56,6 +62,20 @@ def _ensure_governance_category():
         },
     )
     return category
+
+
+def _rename_legacy_organization() -> None:
+    """One-way data rename: the "Organization" skill trait becomes "Leadership".
+
+    Apostate 2026-07-03 — Arx 1 continuity. In-place (pk stable) so the
+    Stewardship spec + any trait values survive; idempotent on fresh DBs.
+    """
+    from world.traits.models import Trait  # noqa: PLC0415
+
+    legacy = Trait.objects.filter(name="Organization").first()
+    if legacy is not None and not Trait.objects.filter(name="Leadership").exists():
+        legacy.name = "Leadership"
+        legacy.save(update_fields=["name"])
 
 
 def ensure_governance_skills() -> dict[str, object]:
@@ -147,6 +167,7 @@ def ensure_governance_check_compositions(
 
 def seed_governance_check_content() -> None:
     """Cluster entry — seed the governance skills, specializations, and checks (#930)."""
+    _rename_legacy_organization()
     skills = ensure_governance_skills()
     specs = ensure_governance_specializations(skills)
     ensure_governance_check_compositions(skills, specs)

--- a/src/world/seeds/social_actions.py
+++ b/src/world/seeds/social_actions.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 _SOCIAL_ACTION_TEMPLATES = [
     ("Intimidate", "Intimidation", "single", "skull", 0),
     ("Persuade", "Persuasion", "single", "handshake", 0),
-    ("Deceive", "Deception", "single", "mask", 0),
+    ("Deceive", "Deceive", "single", "mask", 0),
     ("Flirt", "Seduction", "single", "heart", 0),
     ("Seduce", "Seduction", "single", "flame", 1),
     ("Perform", "Performance", "area", "music", 0),

--- a/src/world/seeds/social_checks.py
+++ b/src/world/seeds/social_checks.py
@@ -45,7 +45,11 @@ _SOCIAL_SPECIALIZATIONS: list[tuple[str, str]] = [
 _SOCIAL_CHECK_COMPOSITION: dict[str, tuple[str, str, str | None]] = {
     "Intimidation": ("presence", "Persuasion", "Intimidation"),
     "Persuasion": ("charm", "Persuasion", None),
-    "Deception": ("charm", "Persuasion", "Manipulation"),
+    # Apostate 2026-07-03: deception splits by stat — presence = Deceive
+    # (fooling people in the moment, incl. under a disguise), charm = Con
+    # (talking someone into a curated version of events).
+    "Deceive": ("presence", "Persuasion", "Manipulation"),
+    "Con": ("charm", "Persuasion", "Manipulation"),
     "Seduction": ("charm", "Persuasion", "Seduction"),
     "Performance": ("presence", "Performance", None),
     "Gossip": ("charm", "Persuasion", "Gossip"),  # #1572 — the gossip plant/seek/suppress check
@@ -117,6 +121,22 @@ def _ensure_stat_trait(name: str):
     return trait
 
 
+def _rename_legacy_deception() -> None:
+    """One-way data rename: the charm-era "Deception" CheckType becomes "Deceive".
+
+    In-place rename (pk stable) so the Deceive social ActionTemplate's FK
+    survives; the authoritative composition rewrite below then re-stats it to
+    presence, and "Con" arrives as the charm row. Idempotent: no-ops once
+    renamed or on fresh databases.
+    """
+    from world.checks.models import CheckType  # noqa: PLC0415
+
+    legacy = CheckType.objects.filter(name="Deception").first()
+    if legacy is not None and not CheckType.objects.filter(name="Deceive").exists():
+        legacy.name = "Deceive"
+        legacy.save(update_fields=["name"])
+
+
 def ensure_social_check_compositions(
     skills: dict[str, object], specs: dict[str, object]
 ) -> dict[str, object]:
@@ -157,4 +177,5 @@ def seed_social_check_content() -> None:
     """Cluster entry — seed the social skills, specializations, and check compositions (#1688)."""
     skills = ensure_social_skills()
     specs = ensure_social_specializations(skills)
+    _rename_legacy_deception()
     ensure_social_check_compositions(skills, specs)

--- a/src/world/seeds/tests/test_governance_checks.py
+++ b/src/world/seeds/tests/test_governance_checks.py
@@ -18,7 +18,7 @@ class GovernanceCheckSeedTests(TestCase):
     def test_seeds_both_skills_with_their_specs(self) -> None:
         for skill_name, spec_name in (
             ("Scholarship", "Economics"),
-            ("Organization", "Stewardship"),
+            ("Leadership", "Stewardship"),
         ):
             skill = Skill.objects.get(trait__name=skill_name)
             self.assertEqual(skill.trait.trait_type, TraitType.SKILL)
@@ -29,7 +29,7 @@ class GovernanceCheckSeedTests(TestCase):
         trait_names = set(
             CheckTypeTrait.objects.filter(check_type=check).values_list("trait__name", flat=True)
         )
-        self.assertEqual(trait_names, {"presence", "Organization"})
+        self.assertEqual(trait_names, {"presence", "Leadership"})
         spec = CheckTypeSpecialization.objects.get(check_type=check)
         self.assertEqual(spec.specialization.name, "Stewardship")
 

--- a/src/world/societies/scandal.py
+++ b/src/world/societies/scandal.py
@@ -85,14 +85,46 @@ def _containment_difficulty(witness_count: int) -> int:
     return CONTAINMENT_BASE_DIFFICULTY + CONTAINMENT_DIFFICULTY_PER_WITNESS * witness_count
 
 
-def _run_containment_check(character, witness_count: int) -> bool:
+def _witnesses_are_own_household(actor_persona, witnesses) -> bool:
+    """Every witness shares an organization with the actor (and there is at least one).
+
+    The trusted-servants case: containment among your own people is command,
+    not deception (Apostate 2026-07-03).
+    """
+    if not witnesses:
+        return False
+    from world.societies.models import OrganizationMembership  # noqa: PLC0415
+
+    actor_orgs = set(
+        OrganizationMembership.objects.filter(
+            persona=actor_persona, left_at__isnull=True, exiled_at__isnull=True
+        ).values_list("organization_id", flat=True)
+    )
+    if not actor_orgs:
+        return False
+    for witness in witnesses:
+        if witness.pk == actor_persona.pk:
+            continue
+        witness_orgs = set(
+            OrganizationMembership.objects.filter(
+                persona=witness, left_at__isnull=True, exiled_at__isnull=True
+            ).values_list("organization_id", flat=True)
+        )
+        if not (witness_orgs & actor_orgs):
+            return False
+    return True
+
+
+def _run_containment_check(character, witness_count: int, *, household: bool = False) -> bool:
     """The hush-it-up roll: the actor's best social tool against the crowd size.
 
-    Auto-picks between the Deception (charm + Persuasion + Manipulation) and
-    Intimidation (presence + Persuasion + Intimidation) compositions by which
-    stat the character is stronger in — "a range of skills based on character
-    capability" (Apostate); the interactive approach-fanned surface is a later
-    slice. Unseeded worlds fail closed (nothing to roll → the scandal leaks).
+    Own-household witnesses → Household Command (presence + Leadership +
+    Stewardship — you are obeyed, not believed; Apostate 2026-07-03).
+    Otherwise auto-picks between Con (charm + Persuasion + Manipulation) and
+    Intimidation (presence + Persuasion + Intimidation) by the stronger stat —
+    "a range of skills based on character capability"; the interactive
+    approach-fanned surface is a later slice. Unseeded worlds fail closed
+    (nothing to roll → the scandal leaks).
     """
     from world.checks.models import CheckType  # noqa: PLC0415
     from world.checks.services import perform_check  # noqa: PLC0415
@@ -100,11 +132,14 @@ def _run_containment_check(character, witness_count: int) -> bool:
     handler = character.traits  # ObjectDB typeclass extension (checks/services idiom)
     charm = handler.get_trait_value("charm")
     presence = handler.get_trait_value("presence")
-    preferred = "Deception" if charm >= presence else "Intimidation"
+    if household:
+        preferred = "Household Command"
+    else:
+        preferred = "Con" if charm >= presence else "Intimidation"
     check_type = (
         CheckType.objects.filter(name__iexact=preferred).first()
         or CheckType.objects.filter(name__iexact="Intimidation").first()
-        or CheckType.objects.filter(name__iexact="Deception").first()
+        or CheckType.objects.filter(name__iexact="Con").first()
     )
     if check_type is None:
         return False
@@ -195,7 +230,9 @@ def route_deed_reach(
 
     if scandal_dots:
         contained = not is_public or _run_containment_check(
-            actor_persona.character_sheet.character, len(witnesses)
+            actor_persona.character_sheet.character,
+            len(witnesses),
+            household=_witnesses_are_own_household(actor_persona, witnesses),
         )
         if contained:
             worst = min(scandal_dots.values())

--- a/src/world/societies/tests/test_scandal.py
+++ b/src/world/societies/tests/test_scandal.py
@@ -33,7 +33,7 @@ class ScandalForkTestCase(TestCase):
         cls.kingdom = AreaFactory(level=AreaLevel.KINGDOM, realm=cls.realm)
         cls.vile = PhilosophicalArchetypeFactory(name="Vile Conduct", mercy_delta=-2)
         cls.noble = PhilosophicalArchetypeFactory(name="Noble Conduct", mercy_delta=2)
-        CheckTypeFactory(name="Deception")
+        CheckTypeFactory(name="Con")
         CheckTypeFactory(name="Intimidation")
 
     def _scene(self, *, public: bool):
@@ -118,3 +118,46 @@ class ScandalForkTestCase(TestCase):
         entry.refresh_from_db()
         # default multiplier 9 × celebrity factor 3 (PLACEHOLDER map).
         self.assertEqual(entry.spread_multiplier, 27)
+
+
+class HouseholdContainmentTests(ScandalForkTestCase):
+    """Own-household witnesses route containment through Household Command."""
+
+    def test_household_witnesses_use_command_check(self):
+        from unittest.mock import patch
+
+        from world.societies.factories import (
+            OrganizationFactory,
+            OrganizationMembershipFactory,
+        )
+
+        CheckTypeFactory(name="Household Command")
+        persona = self._persona()
+        house = OrganizationFactory(name="House Hushly")
+        OrganizationMembershipFactory(persona=persona, organization=house, rank=1)
+        witness = self._persona()
+        OrganizationMembershipFactory(persona=witness, organization=house, rank=3)
+
+        captured = {}
+        from world.checks import services as check_services
+
+        real_perform = check_services.perform_check
+
+        def spy(character, check_type, **kwargs):
+            captured["check"] = check_type.name
+            return real_perform(character, check_type, **kwargs)
+
+        outcome = CheckOutcomeFactory(name="hh_contain", success_level=1)
+        scene = self._scene(public=True)
+        # Force the witness list: patch scene_witness_personas to our pair.
+        with (
+            patch(
+                "world.societies.knowledge_services.scene_witness_personas",
+                return_value=[witness],
+            ),
+            patch("world.checks.services.perform_check", side_effect=spy),
+            force_check_outcome(outcome),
+        ):
+            entry = self._mint(scene, [self.vile], persona=persona)
+        self.assertEqual(captured.get("check"), "Household Command")
+        self.assertTrue(Secret.objects.filter(legend_deed=entry).exists())


### PR DESCRIPTION
Refs #1806 (section B — all four rulings, dictated by Apostate 2026-07-03 and applied verbatim). The disguise↔identification loop behind ruling 1 is recorded on #1107.

- **Deception splits by stat**: presence = **Deceive** (fooling people in the moment, incl. under a disguise), charm = **Con** (talking someone into a curated version of events). The legacy charm-era Deception CheckType renames to Deceive **in place** (pk stable) so the Deceive social action's binding survives; the authoritative seed re-composes it to presence and adds Con.
- **Mostly-accurate dodge → Con**; **mask-association → Deceive** (its first disguise-loop consumer). PROVISIONAL flags retired; the compositions carry the Manipulation leg, so the explicit specialization pass-through is gone.
- **Skill Organization → Leadership** (Arx 1 continuity) via idempotent in-place trait rename — Stewardship spec and any trait values survive; Stealth confirmed agility.
- **Containment**: witnesses who all share an org with the actor route through the new **Household Command** check (presence + Leadership + Stewardship — you are obeyed, not believed); strangers auto-pick Con vs Intimidation by stat.

Tests: 229 fast-tier (seeds/checks/report-heat) + 17 scandal parity incl. the new household-routing spy test. No migrations — every rename is an in-place data-row rename inside the idempotent seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)