### PR TITLE
Migrate Audere Majora test fixtures to CharacterFactory (exercise full vitals pipeline)

### DIFF
--- a/src/world/magic/tests/test_audere_majora_crossing.py
+++ b/src/world/magic/tests/test_audere_majora_crossing.py
@@ -3,8 +3,8 @@
 import contextlib
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import CharacterFactory
 from world.classes.factories import PathFactory
 from world.classes.models import CharacterClassLevel, PathStage
 from world.conditions.factories import ConditionInstanceFactory
@@ -435,7 +435,7 @@ class EndAuderaMajoraTests(TestCase):
 
     def setUp(self) -> None:
         _audere, self.majora_template = wire_audere_power_multipliers()
-        self.character = ObjectDB.objects.create(db_key="end_majora_char")
+        self.character = CharacterFactory(db_key="end_majora_char")
 
     def test_removes_condition(self) -> None:
         ConditionInstanceFactory(

--- a/src/world/progression/services/advancement.py
+++ b/src/world/progression/services/advancement.py
@@ -60,13 +60,14 @@ def apply_class_level_advance(sheet: CharacterSheet, *, level_after: int) -> Non
         cl.level = level_after
         cl.save(update_fields=["level"])
     sheet.invalidate_class_level_cache()
-    # Recompute max_health so level-derived base scales immediately. Guard with hasattr
-    # because bare ObjectDB fixtures (used by some tests / non-PC NPCs) don't carry
-    # the threads or combat_pulls handlers that recompute_max_health_with_threads needs.
-    if hasattr(sheet.character, "threads"):
-        from world.magic.services.threads import recompute_max_health_with_threads
+    # Recompute max_health so level-derived base scales immediately. Every character
+    # with a CharacterSheet is a real typeclassed Character (via create_character_with_sheet
+    # / CharacterFactory), so the threads + combat_pulls handlers always exist. The
+    # former hasattr guard was a workaround for bare-ObjectDB test fixtures, which have
+    # since been migrated to CharacterFactory (#1367).
+    from world.magic.services.threads import recompute_max_health_with_threads
 
-        recompute_max_health_with_threads(sheet)
+    recompute_max_health_with_threads(sheet)
 
 
 def cross_into_path(sheet: CharacterSheet, path: Path) -> PathMagicGrantResult:


### PR DESCRIPTION
Closes #1367

## Summary

Removes the `hasattr(sheet.character, 'threads')` guard around `recompute_max_health_with_threads` in `apply_class_level_advance`, making the call unconditional. The Audere Majora test fixtures were already migrated to `CharacterFactory` by #1692, so the guard's skip-path was no longer needed. Also migrates `EndAuderaMajoraTests` from bare `ObjectDB` to `CharacterFactory` for consistency.

The `test_npc_without_sheet_returns_none` bare `ObjectDB` is intentionally left as-is — it verifies the no-sheet early-exit gate and is not a crossing fixture.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1367 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: Rebased onto latest main; no conflicts.

<!-- last-addressed-comment: 0 -->