### PR TITLE
perf: cut local test-run overhead ~4-6x (gc storm fix + SQLite schema cache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ pip-log.txt
 .tox
 nosetests.xml
 .ruff_cache/
+# SQLite-tier schema-template cache (see server/conf/sqlite_test_runner.py)
+.test_schema_cache/
 
 # Translations
 *.mo

--- a/docs/adr/0084-sqlite-test-schema-template-cache.md
+++ b/docs/adr/0084-sqlite-test-schema-template-cache.md
@@ -1,0 +1,37 @@
+# SQLite fast tier restores a cached schema template instead of rebuilding per run
+
+**Decision:** the SQLite inner-loop test runner (`server.conf.sqlite_test_runner.SqliteTestRunner`)
+caches the fully-built in-memory test database — schema plus the `post_migrate`-seeded rows
+(content types, permissions, sites) — as a file under `src/.test_schema_cache/`, keyed by a
+fingerprint of current model state (every non-proxy model's deconstructed fields, `Meta` options
+and bases, plus the Django/Evennia versions, with set-iteration order and memory-address reprs
+canonicalized; proxy models are excluded because Evennia typeclasses register lazily on first
+import and would make the key depend on which test modules discovery imported). On a fingerprint
+match, `call_command("migrate")` inside `create_test_db` is swapped for a SQLite backup-API
+restore of the template; on a mismatch the schema builds normally and is re-cached.
+Relatedly, `TimedEvenniaTestRunner.setup_databases` (both tiers) disconnects Evennia's
+idmapper `flush_cache` from `post_migrate` for the duration of test-DB creation and flushes once
+at the end — Django emits `post_migrate` once per installed app (90+), and each handler call ran
+a full `gc.collect()` (~0.4s), ~29s of pure GC per invocation.
+
+**Why:** measured on `world.game_clock` (109 tests, ~3s of actual test execution): a fast-tier
+invocation cost 35-60s of wall clock, ~90% of it fixed per-invocation overhead — ~29s the
+`gc.collect` storm, ~20s building an identical 775-table schema every run, the rest
+imports/discovery. With both fixes a warm run is ~10s. Since the overhead is per-invocation, no
+amount of test-selection narrowing could recover it, and agents' edit→test loops were paying it
+dozens of times per session.
+
+**Rejected:** (a) a warm test-daemon (preforked process holding Django + schema) — largest
+possible win but a new moving part to babysit; unnecessary once the invocation floor is ~10s.
+(b) keying the cache on migration-file hashes — the staleness trap ADR-0083 documents; model-state
+fingerprinting has no migration recorder involvement (the fast tier runs `DisableMigrations`) and
+a false mismatch merely rebuilds (~15s), never reuses stale schema. Fingerprint variants with
+byte-identical schemas were observed (schema-irrelevant repr drift), which is why the runner keeps
+several templates and treats misses as cheap. **Trade-offs:** on a cache hit, `post_migrate`
+receivers do not fire during DB creation — their row side-effects are baked into the template and
+the one semantic in-process receiver (Evennia's `flush_cache`) is invoked explicitly by the
+runner; a future receiver with per-process in-memory side effects would need the same treatment.
+`ARX_SCHEMA_CACHE=0` bypasses the cache entirely.
+
+> Status: accepted · Related: ADR-0083 (CI/test schema from model state), ADR-0013 (schema-only
+> migrations pre-production)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -73,6 +73,7 @@ treat those names as hints to confirm, not gospel.
 - [0021 — main uses a GitHub merge queue + single-leaf migration guard](0021-main-uses-a-merge-queue.md)
 - [0022 — Staff config & game-tuning tooling is admin-hosted, not React](0022-staff-tooling-is-admin-hosted.md)
 - [0083 — CI/test databases build schema from model state; migration replay runs nightly only](0083-ci-schema-from-models.md)
+- [0084 — SQLite fast tier restores a cached schema template instead of rebuilding per run](0084-sqlite-test-schema-template-cache.md)
 
 ### Game-design tenets
 - [0023 — PvP is structurally non-lethal](0023-pvp-is-structurally-non-lethal.md)

--- a/justfile
+++ b/justfile
@@ -15,11 +15,21 @@ default:
 
 # --- Testing -----------------------------------------------------------------
 
+# Internal: warn when tests run from the 9p-mounted main checkout — Python
+# imports over 9p add ~25s to every test invocation vs an ext4 worktree
+# under .claude/worktrees/ (the arxii-worktrees named volume).
+_fs-warn:
+    #!/usr/bin/env bash
+    if [ "$(findmnt -no FSTYPE -T . 2>/dev/null)" = "9p" ]; then
+        echo "WARNING: this checkout is on a 9p mount; test runs pay ~25s extra here." >&2
+        echo "         Prefer an ext4 worktree under .claude/worktrees/ (docs/devcontainer-setup.md)." >&2
+    fi
+
 # Run `arx test` with the given args. Thin pass-through; use when you
 # don't need to capture output to a file.
 #   just test flows --keepdb
 #   just test world.combat.tests.test_combat_service --keepdb -v 2
-test *args:
+test *args: _fs-warn
     uv run arx test {{args}}
 
 # Inner-loop SQLite tier — fast in-memory DB, excludes @tag("postgres")
@@ -33,7 +43,7 @@ test *args:
 #   just test-fast world.checks world.flows
 # For apps where the SQLite tier doesn't work (character_sheets, roster,
 # magic, scenes, codex, areas, societies) use `just test-parity` instead.
-test-fast *args:
+test-fast *args: _fs-warn
     #!/usr/bin/env bash
     set -euo pipefail
     N=$(echo "{{args}}" | wc -w)
@@ -46,7 +56,7 @@ test-fast *args:
 # Force --parallel on the SQLite fast tier, even for a single app.
 # Use when a single app has 100+ tests and serial is too slow.
 #   just test-fast-par world.conditions
-test-fast-par *args:
+test-fast-par *args: _fs-warn
     echo "yes" | uv run arx test --sqlite --parallel --exclude-tag postgres {{args}}
 
 # Derive the Postgres parity-tier test DB name (test_<dbname>) and its
@@ -131,7 +141,7 @@ _ensure-testdb rebuild="":
 #   just test-parity world.character_sheets
 #   just test-parity --rebuild world.character_sheets   # after a model change
 #   just test-parity                              # full suite
-test-parity *args:
+test-parity *args: _fs-warn
     #!/usr/bin/env bash
     set -euo pipefail
     REBUILD=""
@@ -159,7 +169,7 @@ test-parity *args:
 #
 #   just test-affected
 #   just test-affected -v 2             # extra args passed to arx test
-test-affected *args:
+test-affected *args: _fs-warn
     #!/usr/bin/env bash
     set -euo pipefail
     BASE=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main)
@@ -204,7 +214,7 @@ test-affected *args:
 # destroy-test-DB prompt.
 #   just regression
 #   just regression --rebuild
-regression *args:
+regression *args: _fs-warn
     #!/usr/bin/env bash
     set -euo pipefail
     REBUILD=""

--- a/src/server/conf/sqlite_test_runner.py
+++ b/src/server/conf/sqlite_test_runner.py
@@ -61,8 +61,11 @@ from server.conf.test_runner import TimedEvenniaTestRunner
 SCHEMA_CACHE_DIR = Path(__file__).resolve().parents[2] / ".test_schema_cache"
 
 # How many fingerprint files to keep before pruning the oldest (branch
-# switching produces a handful of live fingerprints; more than this is churn).
-_SCHEMA_CACHE_KEEP = 3
+# switching produces a handful of live fingerprints; more than this is
+# churn). A fingerprint mismatch is always safe — it just rebuilds and
+# re-caches (~15s) — so occasional spurious misses cost time, not
+# correctness; keeping a few extra templates absorbs them.
+_SCHEMA_CACHE_KEEP = 5
 
 # CPython object reprs embed memory addresses ("<function now at 0x7f...>");
 # strip them so field kwargs containing callables hash stably across runs.

--- a/src/server/conf/sqlite_test_runner.py
+++ b/src/server/conf/sqlite_test_runner.py
@@ -29,8 +29,8 @@ the default ``DiscoverRunner`` and runs the real refresh implementations
 against actual materialized views.
 
 **Schema-template cache:** building the in-memory test schema from model
-state (``migrate --run-syncdb`` over 90+ apps / ~700 models) costs ~20s of
-every invocation despite creating an identical schema each time. This
+state (``migrate --run-syncdb`` over 90+ apps / ~700 models) costs ~15-20s
+of every invocation despite creating an identical schema each time. This
 runner therefore caches the fully-built test DB (schema + the
 ``post_migrate``-seeded rows: content types, permissions, sites) as a
 SQLite file under ``src/.test_schema_cache/``, keyed by a fingerprint of
@@ -51,6 +51,8 @@ from pathlib import Path
 import re
 import sqlite3
 import tempfile
+import time
+import types
 from typing import Any
 
 from django.db import DEFAULT_DB_ALIAS
@@ -88,6 +90,11 @@ def _stable_repr(value: Any) -> str:
         return "{" + ",".join(f"{_stable_repr(k)}:{_stable_repr(v)}" for k, v in items) + "}"
     if isinstance(value, list | tuple):
         return "[" + ",".join(_stable_repr(item) for item in value) + "]"
+    if isinstance(value, types.FunctionType):
+        # Function repr omits the module, so same-named functions (and all
+        # lambdas) from different modules would collapse to one string once
+        # the address is stripped; hash by module-qualified name instead.
+        return f"<function {value.__module__}.{value.__qualname__}>"
     return _MEMORY_ADDRESS_RE.sub("0x", repr(value))
 
 
@@ -96,12 +103,13 @@ def _schema_fingerprint() -> str:
 
     Covers each concrete model's fields (via ``Field.deconstruct()``),
     ``Meta`` options (indexes, constraints, unique_together, ordering, ...)
-    and bases, plus the Django and Evennia versions. Auto-created M2M
-    through-tables are excluded — their schema is fully determined by the
-    owning ``ManyToManyField``, which is hashed. A false mismatch merely
-    rebuilds the template; a false match would need two genuinely different
-    schemas to hash equal, which address-stripping cannot cause (function
-    reprs keep their qualified names).
+    and bases, plus the Django and Evennia versions and the installed-app
+    labels. Auto-created M2M through-tables are excluded — their schema is
+    fully determined by the owning ``ManyToManyField``, which is hashed. A
+    false mismatch merely rebuilds the template; a false match would need
+    two genuinely different schemas to hash equal, which the
+    canonicalizations in ``_stable_repr`` cannot cause (callables hash by
+    module-qualified name).
     """
     import django  # noqa: PLC0415
     from django.apps import apps  # noqa: PLC0415
@@ -111,6 +119,10 @@ def _schema_fingerprint() -> str:
     hasher = hashlib.sha256()
     hasher.update(django.get_version().encode())
     hasher.update(evennia.__version__.encode())
+    # Include the installed-app list itself: a model-less app being added or
+    # removed can still change what migrate would have produced (post_migrate
+    # receivers seeding rows) without altering any model's state.
+    hasher.update(repr(sorted(app.label for app in apps.get_app_configs())).encode())
     # Proxy models (every Evennia typeclass) have no schema of their own and
     # get registered lazily on first import — including them would make the
     # fingerprint depend on which test modules discovery happened to import.
@@ -136,16 +148,32 @@ def _schema_fingerprint() -> str:
 
 
 def _restore_sqlite_from_template(alias: str, template: Path) -> None:
-    """Copy the cached template DB into the (fresh, empty) in-memory test DB."""
+    """Copy the cached template DB into the (fresh, empty) in-memory test DB.
+
+    The source opens in read-only URI mode: a template deleted between the
+    existence check and this call (concurrent prune or corrupt-fallback in
+    another process) must raise — a plain ``sqlite3.connect(path)`` would
+    silently create an empty DB at the path, and a backup from an empty
+    source "succeeds" while leaving the target with zero tables. For the
+    empty-but-present case, the restored DB is verified to contain tables.
+    Both failures raise ``sqlite3.Error`` subclasses, which the caller's
+    fallback turns into a real ``migrate``.
+    """
     from django.db import connections  # noqa: PLC0415
 
     connection = connections[alias]
     connection.ensure_connection()
-    source = sqlite3.connect(str(template))
+    source = sqlite3.connect(f"file:{template}?mode=ro", uri=True)
     try:
         source.backup(connection.connection)
     finally:
         source.close()
+    tables = connection.connection.execute(
+        "SELECT count(*) FROM sqlite_master WHERE type='table'"
+    ).fetchone()[0]
+    if tables == 0:
+        message = f"schema template {template.name} restored zero tables"
+        raise sqlite3.DatabaseError(message)
 
 
 def _dump_sqlite_to_template(alias: str, template: Path) -> None:
@@ -170,7 +198,12 @@ def _dump_sqlite_to_template(alias: str, template: Path) -> None:
 
 
 def _prune_schema_cache() -> None:
-    """Drop all but the newest ``_SCHEMA_CACHE_KEEP`` cached templates."""
+    """Drop all but the newest ``_SCHEMA_CACHE_KEEP`` cached templates.
+
+    Also sweeps ``*.sqlite3.tmp`` files older than an hour — a hard-killed
+    dump (the ``except BaseException`` cleanup never ran) orphans its tmp
+    file, and nothing else would ever remove it.
+    """
     entries = sorted(
         SCHEMA_CACHE_DIR.glob("schema-*.sqlite3"),
         key=lambda path: path.stat().st_mtime,
@@ -178,6 +211,10 @@ def _prune_schema_cache() -> None:
     )
     for stale in entries[_SCHEMA_CACHE_KEEP:]:
         stale.unlink(missing_ok=True)
+    cutoff = time.time() - 3600
+    for orphan in SCHEMA_CACHE_DIR.glob("*.sqlite3.tmp"):
+        if orphan.stat().st_mtime < cutoff:
+            orphan.unlink(missing_ok=True)
 
 
 @contextmanager
@@ -189,25 +226,28 @@ def _migrate_replaced_by_restore(template: Path) -> Iterator[None]:
     attribute is the reliable seam. Every other command (e.g.
     ``createcachetable``) passes through untouched.
 
-    If the template file turns out unreadable, the target in-memory DB is
-    discarded (closing an in-memory SQLite DB destroys it), the template is
-    deleted, and the real ``migrate`` runs — the next run rebuilds the cache.
+    If the template turns out unreadable, concurrently deleted, or empty,
+    the target in-memory DB is discarded (closing an in-memory SQLite DB
+    destroys it), the template is deleted, and the real ``migrate`` runs —
+    the next run rebuilds the cache.
     """
     from django.core import management  # noqa: PLC0415
 
     real_call_command = management.call_command
 
     def call_command_with_cached_schema(name: Any, *args: Any, **kwargs: Any) -> Any:
-        # Django management-command name, not a domain identifier.
-        if name == "migrate":  # noqa: STRING_LITERAL
-            alias = kwargs.get("database", DEFAULT_DB_ALIAS)
+        # Django management-command name, not a domain identifier. Only the
+        # default alias's template is ever dumped, so only its migrate call
+        # is intercepted — a hypothetical second test DB alias falls through
+        # to a real migrate rather than silently receiving default's schema.
+        if name == "migrate" and kwargs.get("database", DEFAULT_DB_ALIAS) == DEFAULT_DB_ALIAS:  # noqa: STRING_LITERAL
             try:
-                _restore_sqlite_from_template(alias, template)
+                _restore_sqlite_from_template(DEFAULT_DB_ALIAS, template)
                 return None
             except sqlite3.Error:
                 from django.db import connections  # noqa: PLC0415
 
-                connections[alias].close()
+                connections[DEFAULT_DB_ALIAS].close()
                 template.unlink(missing_ok=True)
         return real_call_command(name, *args, **kwargs)
 

--- a/src/server/conf/sqlite_test_runner.py
+++ b/src/server/conf/sqlite_test_runner.py
@@ -27,13 +27,184 @@ have no closures; ``_noop`` matches.
 The PG parity tier (``arx test`` without ``--sqlite``, plus CI shards) uses
 the default ``DiscoverRunner`` and runs the real refresh implementations
 against actual materialized views.
+
+**Schema-template cache:** building the in-memory test schema from model
+state (``migrate --run-syncdb`` over 90+ apps / ~700 models) costs ~20s of
+every invocation despite creating an identical schema each time. This
+runner therefore caches the fully-built test DB (schema + the
+``post_migrate``-seeded rows: content types, permissions, sites) as a
+SQLite file under ``src/.test_schema_cache/``, keyed by a fingerprint of
+current model state. On a fingerprint match the file is restored into the
+in-memory test DB via the SQLite backup API instead of running ``migrate``
+— sub-second instead of ~20s. Any model/field/Meta change (or a
+Django/Evennia upgrade) changes the fingerprint and rebuilds the template.
+Set ``ARX_SCHEMA_CACHE=0`` to bypass the cache entirely.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+import hashlib
+import os
+from pathlib import Path
+import re
+import sqlite3
+import tempfile
 from typing import Any
 
+from django.db import DEFAULT_DB_ALIAS
+
 from server.conf.test_runner import TimedEvenniaTestRunner
+
+# src/.test_schema_cache/ — gitignored; one file per model-state fingerprint.
+SCHEMA_CACHE_DIR = Path(__file__).resolve().parents[2] / ".test_schema_cache"
+
+# How many fingerprint files to keep before pruning the oldest (branch
+# switching produces a handful of live fingerprints; more than this is churn).
+_SCHEMA_CACHE_KEEP = 3
+
+# CPython object reprs embed memory addresses ("<function now at 0x7f...>");
+# strip them so field kwargs containing callables hash stably across runs.
+_MEMORY_ADDRESS_RE = re.compile(r"0x[0-9a-fA-F]+")
+
+
+def _stable_repr(value: Any) -> str:
+    """Deterministic repr for fingerprinting model state.
+
+    Two per-process repr instabilities need canonicalizing: memory
+    addresses inside object reprs, and iteration order of sets (Django
+    stores e.g. ``unique_together`` as a set, and set order follows hash
+    randomization). Containers are walked recursively; sets are emitted in
+    sorted-element order.
+    """
+    if isinstance(value, set | frozenset):
+        return "{" + ",".join(sorted(_stable_repr(item) for item in value)) + "}"
+    if isinstance(value, dict):
+        items = sorted(value.items(), key=lambda kv: repr(kv[0]))
+        return "{" + ",".join(f"{_stable_repr(k)}:{_stable_repr(v)}" for k, v in items) + "}"
+    if isinstance(value, list | tuple):
+        return "[" + ",".join(_stable_repr(item) for item in value) + "]"
+    return _MEMORY_ADDRESS_RE.sub("0x", repr(value))
+
+
+def _schema_fingerprint() -> str:
+    """Hash the schema-relevant model state of every installed app.
+
+    Covers each concrete model's fields (via ``Field.deconstruct()``),
+    ``Meta`` options (indexes, constraints, unique_together, ordering, ...)
+    and bases, plus the Django and Evennia versions. Auto-created M2M
+    through-tables are excluded — their schema is fully determined by the
+    owning ``ManyToManyField``, which is hashed. A false mismatch merely
+    rebuilds the template; a false match would need two genuinely different
+    schemas to hash equal, which address-stripping cannot cause (function
+    reprs keep their qualified names).
+    """
+    import django  # noqa: PLC0415
+    from django.apps import apps  # noqa: PLC0415
+    from django.db.migrations.state import ModelState  # noqa: PLC0415
+    import evennia  # noqa: PLC0415
+
+    hasher = hashlib.sha256()
+    hasher.update(django.get_version().encode())
+    hasher.update(evennia.__version__.encode())
+    states = sorted(
+        (ModelState.from_model(model) for model in apps.get_models()),
+        key=lambda state: (state.app_label, state.name),
+    )
+    for state in states:
+        for field_name, field in sorted(state.fields.items()):
+            _, path, args, kwargs = field.deconstruct()
+            raw = (
+                f"{state.app_label}.{state.name}.{field_name}"
+                f"|{path}|{_stable_repr(args)}|{_stable_repr(kwargs)}"
+            )
+            hasher.update(raw.encode())
+        hasher.update(_stable_repr(state.options).encode())
+        hasher.update(_stable_repr(state.bases).encode())
+    return hasher.hexdigest()[:16]
+
+
+def _restore_sqlite_from_template(alias: str, template: Path) -> None:
+    """Copy the cached template DB into the (fresh, empty) in-memory test DB."""
+    from django.db import connections  # noqa: PLC0415
+
+    connection = connections[alias]
+    connection.ensure_connection()
+    source = sqlite3.connect(str(template))
+    try:
+        source.backup(connection.connection)
+    finally:
+        source.close()
+
+
+def _dump_sqlite_to_template(alias: str, template: Path) -> None:
+    """Save the just-built in-memory test DB as the cached template (atomic)."""
+    from django.db import connections  # noqa: PLC0415
+
+    connection = connections[alias]
+    connection.ensure_connection()
+    template.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=template.parent, suffix=".sqlite3.tmp")
+    os.close(fd)
+    try:
+        target = sqlite3.connect(tmp_name)
+        try:
+            connection.connection.backup(target)
+        finally:
+            target.close()
+        Path(tmp_name).replace(template)
+    except BaseException:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
+
+
+def _prune_schema_cache() -> None:
+    """Drop all but the newest ``_SCHEMA_CACHE_KEEP`` cached templates."""
+    entries = sorted(
+        SCHEMA_CACHE_DIR.glob("schema-*.sqlite3"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    for stale in entries[_SCHEMA_CACHE_KEEP:]:
+        stale.unlink(missing_ok=True)
+
+
+@contextmanager
+def _migrate_replaced_by_restore(template: Path) -> Iterator[None]:
+    """Swap ``call_command("migrate", ...)`` for a template restore.
+
+    ``create_test_db`` imports ``call_command`` from
+    ``django.core.management`` at call time, so rebinding the module
+    attribute is the reliable seam. Every other command (e.g.
+    ``createcachetable``) passes through untouched.
+
+    If the template file turns out unreadable, the target in-memory DB is
+    discarded (closing an in-memory SQLite DB destroys it), the template is
+    deleted, and the real ``migrate`` runs — the next run rebuilds the cache.
+    """
+    from django.core import management  # noqa: PLC0415
+
+    real_call_command = management.call_command
+
+    def call_command_with_cached_schema(name: Any, *args: Any, **kwargs: Any) -> Any:
+        if name == "migrate":  # noqa: STRING_LITERAL — Django management-command name
+            alias = kwargs.get("database", DEFAULT_DB_ALIAS)
+            try:
+                _restore_sqlite_from_template(alias, template)
+                return None
+            except sqlite3.Error:
+                from django.db import connections  # noqa: PLC0415
+
+                connections[alias].close()
+                template.unlink(missing_ok=True)
+        return real_call_command(name, *args, **kwargs)
+
+    management.call_command = call_command_with_cached_schema
+    try:
+        yield
+    finally:
+        management.call_command = real_call_command
 
 
 def _noop() -> None:
@@ -54,6 +225,29 @@ class SqliteTestRunner(TimedEvenniaTestRunner):
         """Install the SQLite-tier monkey-patches after Evennia/Django setup."""
         super().setup_test_environment(**kwargs)
         self._install_sqlite_noops()
+
+    def setup_databases(self, **kwargs: Any) -> Any:
+        """Create the test DB from the schema-template cache when possible.
+
+        Cache hit: ``migrate`` (the ~20s schema build) is replaced by a
+        sub-second SQLite backup-API restore of the cached template. Cache
+        miss: the schema builds normally, then the result is saved as the
+        new template. ``ARX_SCHEMA_CACHE=0`` bypasses the cache.
+        """
+        if os.environ.get("ARX_SCHEMA_CACHE") == "0":
+            return super().setup_databases(**kwargs)
+        template = SCHEMA_CACHE_DIR / f"schema-{_schema_fingerprint()}.sqlite3"
+        if template.exists():
+            if self.verbosity >= 1:
+                print(f"Restoring cached test schema ({template.name}).")
+            with _migrate_replaced_by_restore(template):
+                return super().setup_databases(**kwargs)
+        old_config = super().setup_databases(**kwargs)
+        _dump_sqlite_to_template(DEFAULT_DB_ALIAS, template)
+        _prune_schema_cache()
+        if self.verbosity >= 1:
+            print(f"Cached test schema for reuse ({template.name}).")
+        return old_config
 
     @staticmethod
     def _install_sqlite_noops() -> None:

--- a/src/server/conf/sqlite_test_runner.py
+++ b/src/server/conf/sqlite_test_runner.py
@@ -108,8 +108,15 @@ def _schema_fingerprint() -> str:
     hasher = hashlib.sha256()
     hasher.update(django.get_version().encode())
     hasher.update(evennia.__version__.encode())
+    # Proxy models (every Evennia typeclass) have no schema of their own and
+    # get registered lazily on first import — including them would make the
+    # fingerprint depend on which test modules discovery happened to import.
     states = sorted(
-        (ModelState.from_model(model) for model in apps.get_models()),
+        (
+            ModelState.from_model(model)
+            for model in apps.get_models()
+            if not model._meta.proxy  # noqa: SLF001
+        ),
         key=lambda state: (state.app_label, state.name),
     )
     for state in states:
@@ -188,7 +195,8 @@ def _migrate_replaced_by_restore(template: Path) -> Iterator[None]:
     real_call_command = management.call_command
 
     def call_command_with_cached_schema(name: Any, *args: Any, **kwargs: Any) -> Any:
-        if name == "migrate":  # noqa: STRING_LITERAL — Django management-command name
+        # Django management-command name, not a domain identifier.
+        if name == "migrate":  # noqa: STRING_LITERAL
             alias = kwargs.get("database", DEFAULT_DB_ALIAS)
             try:
                 _restore_sqlite_from_template(alias, template)

--- a/src/server/conf/sqlite_test_runner.py
+++ b/src/server/conf/sqlite_test_runner.py
@@ -54,6 +54,7 @@ import tempfile
 import time
 import types
 from typing import Any
+from urllib.parse import quote
 
 from django.db import DEFAULT_DB_ALIAS
 
@@ -107,9 +108,10 @@ def _schema_fingerprint() -> str:
     labels. Auto-created M2M through-tables are excluded — their schema is
     fully determined by the owning ``ManyToManyField``, which is hashed. A
     false mismatch merely rebuilds the template; a false match would need
-    two genuinely different schemas to hash equal, which the
-    canonicalizations in ``_stable_repr`` cannot cause (callables hash by
-    module-qualified name).
+    two genuinely different schemas to hash equal. The known residual
+    collapses in ``_stable_repr`` (``functools.partial``/bound-method/
+    same-scope-lambda kwargs) can't get there: callable field kwargs are
+    Python-side and never influence the emitted DDL.
     """
     import django  # noqa: PLC0415
     from django.apps import apps  # noqa: PLC0415
@@ -163,7 +165,10 @@ def _restore_sqlite_from_template(alias: str, template: Path) -> None:
 
     connection = connections[alias]
     connection.ensure_connection()
-    source = sqlite3.connect(f"file:{template}?mode=ro", uri=True)
+    # Percent-encode the path: SQLite parses the URI form, so a raw '#' in a
+    # worktree path would truncate it (dropping mode=ro) and '%HH' sequences
+    # would be decoded, both silently defeating the read-only guard.
+    source = sqlite3.connect(f"file:{quote(str(template))}?mode=ro", uri=True)
     try:
         source.backup(connection.connection)
     finally:
@@ -204,16 +209,25 @@ def _prune_schema_cache() -> None:
     dump (the ``except BaseException`` cleanup never ran) orphans its tmp
     file, and nothing else would ever remove it.
     """
-    entries = sorted(
-        SCHEMA_CACHE_DIR.glob("schema-*.sqlite3"),
-        key=lambda path: path.stat().st_mtime,
-        reverse=True,
-    )
-    for stale in entries[_SCHEMA_CACHE_KEEP:]:
+
+    def snapshot(pattern: str) -> list[tuple[Path, float]]:
+        # A concurrent run's prune can unlink an entry between glob and
+        # stat; skip those instead of crashing a run whose schema already
+        # built fine.
+        entries = []
+        for path in SCHEMA_CACHE_DIR.glob(pattern):
+            try:
+                entries.append((path, path.stat().st_mtime))
+            except FileNotFoundError:
+                continue
+        return entries
+
+    templates = sorted(snapshot("schema-*.sqlite3"), key=lambda entry: entry[1], reverse=True)
+    for stale, _mtime in templates[_SCHEMA_CACHE_KEEP:]:
         stale.unlink(missing_ok=True)
     cutoff = time.time() - 3600
-    for orphan in SCHEMA_CACHE_DIR.glob("*.sqlite3.tmp"):
-        if orphan.stat().st_mtime < cutoff:
+    for orphan, mtime in snapshot("*.sqlite3.tmp"):
+        if mtime < cutoff:
             orphan.unlink(missing_ok=True)
 
 

--- a/src/server/conf/test_runner.py
+++ b/src/server/conf/test_runner.py
@@ -90,6 +90,28 @@ class TimedEvenniaTestRunner(EvenniaTestSuiteRunner):
         super().__init__(*args, **kwargs)
         self.test_timings = []
 
+    def setup_databases(self, **kwargs):
+        """Create test databases without Evennia's per-app ``gc.collect()`` storm.
+
+        Evennia connects ``idmapper.flush_cache`` (which ends in a full
+        ``gc.collect()``) to ``post_migrate``, and Django emits that signal
+        once per installed app during test-DB creation — 90+ apps here, at
+        ~0.4s per collect, so the signal handler alone adds ~30s to every
+        test invocation. A brand-new test DB has no stale idmapper state to
+        flush per-app, so disconnect the handler for the duration and run a
+        single flush at the end to preserve the post-migrate semantics.
+        """
+        from django.db.models.signals import post_migrate
+        from evennia.utils.idmapper.models import flush_cache
+
+        was_connected = post_migrate.disconnect(flush_cache)
+        try:
+            return super().setup_databases(**kwargs)
+        finally:
+            if was_connected:
+                post_migrate.connect(flush_cache)
+            flush_cache()
+
     def setup_test_environment(self, **kwargs):
         """Set up test environment with timing notification."""
         super().setup_test_environment(**kwargs)

--- a/tools/skills/running-tests/SKILL.md
+++ b/tools/skills/running-tests/SKILL.md
@@ -22,12 +22,20 @@ Write focused unit tests only when logic is genuinely fiddly and wouldn't be obs
 
 Production runs Postgres exclusively. Tests run in TWO tiers:
 
-1. **Fast tier — SQLite in-memory.** `just test-fast <app>` / `arx test --sqlite <app>`. Schema built from current model state with NO migration replay (`MIGRATION_MODULES = DisableMigrations()` in `server.conf.sqlite_test_settings`). Tests decorated with `@tag("postgres")` are auto-skipped. Inner-loop speed: a typical app runs in 1-15s vs 5-30s on PG.
+1. **Fast tier — SQLite in-memory.** `just test-fast <app>` / `arx test --sqlite <app>`. Schema built from current model state with NO migration replay (`MIGRATION_MODULES = DisableMigrations()` in `server.conf.sqlite_test_settings`), and cached: `SqliteTestRunner` saves the built test DB to `src/.test_schema_cache/` keyed by a model-state fingerprint and restores it on later runs, so only the first run after a model change pays the schema build (~15s extra). Tests decorated with `@tag("postgres")` are auto-skipped. Inner-loop speed: ~6-10s of fixed per-invocation overhead (imports, discovery, cached-schema restore) plus the tests themselves. `ARX_SCHEMA_CACHE=0` bypasses the cache if you suspect it.
 2. **Parity tier — Postgres.** `just test-parity <app>` / `arx test` (no flag — PG is the default). Uses the same schema-from-models build CI uses: the test DB is pre-built by `tools/build_schema.py` (via `just build-test-schema`) and reused across runs with `--keepdb`, not rebuilt from migration replay per run. Migration replay only happens in the nightly `nightly-migration-replay.yml` workflow (ADR-0083). Building the test DB once (`just build-test-schema`, or automatically on the first `just test-parity`/`just regression` run) takes seconds, not the 10+ minutes the old migration-replay path cost — parity runs are fast locally afterward. Go through `just test-parity <app>` / `just regression` (or `build-test-schema --rebuild` after a model change), not bare `arx test`/`arx test --keepdb` — only the `just` recipes probe that the pre-built schema (partition, matviews, seeds) is actually complete before reusing it; a bare Django-created test DB is syncdb-only and missing all three. CI's 6-shard matrix (`.github/workflows/ci.yml`) runs every PR on this tier.
 
 ### Local testing rule
 
 **Use the SQLite fast tier (`just test-fast`) for the inner loop.** For PG-only apps (magic, scenes, etc.), or before pushing, run `just test-parity <app>` — the pre-built test DB makes this fast locally now, not the multi-minute rebuild the old migration-replay path required. Always go through the `just` recipes (`test-parity`/`regression`/`build-test-schema`) rather than bare `arx test`/`arx test --keepdb` against Postgres, so the schema-completeness probe runs before reuse.
+
+### Per-invocation overhead dominates — batch, don't narrow
+
+Most of a fast-tier run's wall time is **fixed per-invocation cost** (interpreter + Django/Evennia imports, test discovery, schema restore), not test execution — 109 tests execute in ~3s inside a ~10s invocation. Two consequences:
+
+- **Batch apps into one invocation.** `just test-fast app1 app2 app3` pays the overhead once (and auto-enables `--parallel`); three separate runs pay it three times.
+- **Don't narrow the selection to save time.** Running one module instead of the whole app saves almost nothing — select by what you want to *see*, not for speed.
+- **Run from an ext4 worktree.** The 9p-mounted main checkout adds ~25s of import stat-storm per invocation; the `just` test recipes warn when you're on 9p. Worktrees under `.claude/worktrees/` don't pay it.
 
 ### Working app set for `--sqlite`
 


### PR DESCRIPTION
## Problem

Local test runs were a major agent bottleneck: a fast-tier (`just test-fast`) invocation cost **35-60s of wall clock for ~3-5s of actual test execution** — ~90% fixed per-invocation overhead, paid on every edit→test cycle. Profiling `setup_databases` found:

- **~29s: a `gc.collect()` storm.** Evennia connects idmapper `flush_cache` (which ends in a full `gc.collect()`) to `post_migrate`; Django emits that signal once per installed app during test-DB creation — 76 collects at ~0.4s each. Every local invocation and every CI shard pays this.
- **~15-20s: rebuilding an identical schema.** `migrate --run-syncdb` over ~700 models produces the same 775-table in-memory DB every run.
- **~25s extra when run from the 9p-mounted main checkout** instead of an ext4 worktree.

## Changes

1. **`TimedEvenniaTestRunner.setup_databases`** (both tiers): disconnect `flush_cache` from `post_migrate` for the duration of DB creation, flush once at the end. 76 → 1 `gc.collect` calls; schema build 52s → 23.5s in a controlled A/B. CI shards get this for free.
2. **Schema-template cache** (`SqliteTestRunner`, ADR-0084): the fully-built test DB (schema + `post_migrate` seed rows) is saved to gitignored `src/.test_schema_cache/`, keyed by a model-state fingerprint (deconstructed fields, Meta options, bases, installed-app labels, Django/Evennia versions; proxy models excluded; set-order/address/callable reprs canonicalized). On a hit, `migrate` is replaced by a SQLite backup-API restore. Misses are always safe — rebuild + re-cache. Hardened per adversarial review: read-only URI open + zero-table check (a concurrently-deleted or empty template falls back to a real migrate), percent-encoded paths, alias-scoped interception, race-tolerant pruning, orphaned-tmp sweep. `ARX_SCHEMA_CACHE=0` bypasses.
3. **`just` test recipes warn on 9p** and point at `.claude/worktrees/`.
4. **Docs**: running-tests skill now carries measured timings and the "per-invocation overhead dominates — batch apps into one invocation, don't narrow selections for speed" guidance; ADR-0084 records the decision and rejected alternatives (test daemon, migration-hash cache keys per ADR-0083's analysis).

## Measured (world.game_clock, 109 tests, idle box)

| | before | after (cold) | after (warm) |
|---|---|---|---|
| ext4 worktree | 35-41s | 16.8s | **9.5s** |
| 9p main checkout | ~59s | — | — (now warns) |

## Verification

- ~2,300 tests across `world.game_clock`, `world.conditions`, `flows`, `world.checks`, `world.combat` pass identically with cache on and off (`world.combat`: 1,420 tests A/B'd cached vs `ARX_SCHEMA_CACHE=0`, both OK), including `--parallel` worker cloning off a restored master.
- Fingerprint stability verified across processes, `PYTHONHASHSEED` values, and test-module import order; two observed fingerprint variants had byte-identical schemas (misses are cheap, never wrong).
- Fault injection: truncated template mid-cache → run falls back to real migrate, passes, deletes the poisoned file; missing file and `#`/`%`-containing paths verified to raise/round-trip correctly.
- Three adversarial review rounds (different model); final round clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)