### PR TITLE
fix(justfile): make test-parity serial by default, not --parallel

### DIFF
--- a/justfile
+++ b/justfile
@@ -131,12 +131,14 @@ _ensure-testdb rebuild="":
         just build-test-schema
     fi
 
-# CI-parity tier — runs the same Postgres path CI runs, in parallel, against
-# a pre-built test DB (schema from current model state, no migration
-# replay). Builds the test DB automatically the first time; pass `--rebuild`
-# to force a rebuild after a model change. Always uses --keepdb — the test
-# DB's schema comes from `build-test-schema`, not Django's migration-driven
-# create_test_db.
+# CI-parity tier — runs the same Postgres path CI runs, against a pre-built
+# test DB (schema from current model state, no migration replay). Builds the
+# test DB automatically the first time; pass `--rebuild` to force a rebuild
+# after a model change. Always uses --keepdb — the test DB's schema comes
+# from `build-test-schema`, not Django's migration-driven create_test_db.
+# Serial by default — this tier is expensive enough that going parallel
+# should be a deliberate choice, not automatic; pass --parallel yourself if
+# you actually want it (e.g. reproducing a CI failure).
 # Use before pushing, and for apps that can't run on the SQLite tier.
 #   just test-parity world.character_sheets
 #   just test-parity --rebuild world.character_sheets   # after a model change
@@ -154,7 +156,7 @@ test-parity *args: _fs-warn
         fi
     done
     just _ensure-testdb "$REBUILD"
-    echo "yes" | uv run arx test --keepdb --parallel "${ARGS[@]}"
+    echo "yes" | uv run arx test --keepdb "${ARGS[@]}"
 
 # Change-impact-aware regression: tests only the apps your branch
 # actually touches PLUS apps that import from them (catches the

--- a/tools/skills/running-tests/SKILL.md
+++ b/tools/skills/running-tests/SKILL.md
@@ -61,9 +61,9 @@ just test-fast-par <app>                 # force --parallel on one large app
 just test-affected                       # diff vs origin/main
 just test-affected --keepdb              # extra args passed to arx test
 
-# Parity tier (PG, parallel; what CI runs):
+# Parity tier (PG, serial by default — pass --parallel yourself if you want it):
 just test-parity <app>                   # one app
-just test-parity                         # full suite, ~30+ min
+just test-parity                         # full suite (avoid locally — see below)
 
 # Generic pass-through (PG, no parallel):
 just test <args>
@@ -150,7 +150,7 @@ just test flows --keepdb    # arx test pass-through
 just test-fast world.foo    # SQLite inner loop (serial)
 just test-fast-par world.foo # SQLite inner loop (forced parallel)
 just test-affected          # only apps your branch touches + importers
-just test-parity world.foo  # PG parity tier (parallel)
+just test-parity world.foo  # PG parity tier (serial; pass --parallel yourself if you want it)
 just regression             # full no-keepdb regression run
 just lint                   # ruff check
 just manage migrate flows   # arx manage pass-through


### PR DESCRIPTION
## Summary
- `just test-parity` hardcoded `--parallel` unconditionally, even for the single-app/single-module targeted runs it's meant for (per the running-tests skill's own guidance to use `test-parity world.magic.tests.test_x` for a targeted repro).
- Postgres-tier local runs should be scoped and deliberate; spinning up parallel workers by default works against that, and against the standing "never run tests in parallel locally" rule.
- Removed the hardcoded `--parallel` from the `test-parity` recipe — it now runs serial by default. Pass `--parallel` explicitly as an arg if you actually want it (e.g. reproducing a CI failure).
- Updated the doc comment above the recipe and the two stale "(parallel)" references in `tools/skills/running-tests/SKILL.md` to match.
- `just regression` is untouched — it's meant to match CI's path exactly, including CI's own parallel execution, and wasn't part of this ask.

## Test plan
- [x] `just --show test-parity` confirms `--parallel` is gone from the recipe body
- [x] `just --list` still parses the justfile with no errors
- [x] No app code touched — no Django test tier applies