### PR TITLE
perf(magic): trim per-cast Audere eligibility queries; fix end_audere no-op docstring

### DIFF
--- a/src/world/magic/audere.py
+++ b/src/world/magic/audere.py
@@ -168,6 +168,54 @@ def soulfray_stage_order_snapshot(character: ObjectDB) -> int:
     return soulfray_instance.current_stage.stage_order
 
 
+def _evaluate_audere_gates(
+    character: ObjectDB, runtime_intensity: int, threshold: AudereThreshold
+) -> int | None:
+    """Run all Audere eligibility gates cheapest-first.
+
+    Returns the resolved Soulfray ``stage_order`` when every gate passes,
+    or ``None`` as soon as any gate fails. Gates are ordered cheapest-first so
+    the common case (cast below the intensity gate) short-circuits before any
+    query beyond the threshold fetch the caller already made.
+
+    Gates:
+    1. Intensity — zero-query arithmetic (runtime_intensity >= minimum tier)
+    2. Soulfray — 1 query (ConditionInstance + current_stage)
+    3. Engagement — 1 exists() query
+    4. Already-in-Audere — 1 exists() query
+    """
+    from world.conditions.models import ConditionInstance
+    from world.mechanics.engagement import CharacterEngagement
+
+    if not _check_intensity_gate(runtime_intensity, threshold.minimum_intensity_tier.threshold):
+        return None
+
+    soulfray_instance = (
+        ConditionInstance.objects.filter(
+            target=character,
+            condition__name=SOULFRAY_CONDITION_NAME,
+        )
+        .select_related("current_stage")
+        .first()
+    )
+    if soulfray_instance is None or soulfray_instance.current_stage is None:
+        return None
+    stage_order = soulfray_instance.current_stage.stage_order
+    if stage_order < threshold.minimum_warp_stage.stage_order:
+        return None
+
+    if not CharacterEngagement.objects.filter(character=character).exists():
+        return None
+
+    if ConditionInstance.objects.filter(
+        target=character,
+        condition__name=AUDERE_CONDITION_NAME,
+    ).exists():
+        return None
+
+    return stage_order
+
+
 def check_audere_eligibility(character: ObjectDB, runtime_intensity: int) -> bool:
     """Check whether a character meets all gates for Audere activation.
 
@@ -178,25 +226,10 @@ def check_audere_eligibility(character: ObjectDB, runtime_intensity: int) -> boo
     4. Character has a CharacterEngagement
     5. Character is NOT already in Audere
     """
-    from world.conditions.models import ConditionInstance
-    from world.mechanics.engagement import CharacterEngagement
-
     threshold = AudereThreshold.objects.first()
     if threshold is None:
         return False
-
-    has_engagement = CharacterEngagement.objects.filter(character=character).exists()
-    already_in_audere = ConditionInstance.objects.filter(
-        target=character,
-        condition__name=AUDERE_CONDITION_NAME,
-    ).exists()
-
-    return (
-        _check_intensity_gate(runtime_intensity, threshold.minimum_intensity_tier.threshold)
-        and _check_soulfray_gate(character, threshold.minimum_warp_stage.stage_order)
-        and has_engagement
-        and not already_in_audere
-    )
+    return _evaluate_audere_gates(character, runtime_intensity, threshold) is not None
 
 
 def corruption_advisory_for_character(character: ObjectDB) -> str:

--- a/src/world/magic/audere.py
+++ b/src/world/magic/audere.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from django.db import models, transaction
 from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
+
+if TYPE_CHECKING:
+    from world.character_sheets.models import CharacterSheet
 
 AUDERE_CONDITION_NAME = "Audere"
 AUDERE_MAJORA_CONDITION_NAME = "Audere Majora"
@@ -347,23 +351,32 @@ def end_audere(character: ObjectDB) -> None:
 
 
 def maybe_create_audere_offer(
-    character: ObjectDB, runtime_intensity: int
+    character: ObjectDB, runtime_intensity: int, *, sheet: CharacterSheet | None = None
 ) -> PendingAudereOffer | None:
     """Persist a poll-able offer when the Audere gate opens for this cast.
 
     Returns None (no row) for NPCs without a CharacterSheet or when any
     eligibility gate fails. Idempotent: repeated qualifying casts update the
     single row per character (update_or_create).
+
+    Accepts an optional ``sheet`` kwarg to avoid re-fetching the CharacterSheet
+    when the caller already has it (e.g. the Step 8c cast hook). When omitted,
+    falls back to fetching it.
     """
     from world.character_sheets.models import CharacterSheet
 
-    sheet = CharacterSheet.objects.filter(character=character).first()
+    if sheet is None:
+        sheet = CharacterSheet.objects.filter(character=character).first()
     if sheet is None:
         return None
-    if not check_audere_eligibility(character, runtime_intensity):
+
+    threshold = AudereThreshold.objects.first()
+    if threshold is None:
         return None
 
-    stage_order = soulfray_stage_order_snapshot(character)
+    stage_order = _evaluate_audere_gates(character, runtime_intensity, threshold)
+    if stage_order is None:
+        return None
 
     offer, _created = PendingAudereOffer.objects.update_or_create(
         character_sheet=sheet,

--- a/src/world/magic/audere.py
+++ b/src/world/magic/audere.py
@@ -313,7 +313,11 @@ def offer_audere(character: ObjectDB, *, accept: bool) -> AudereOfferResult:
 def end_audere(character: ObjectDB) -> None:
     """End Audere for a character, reverting all bonuses.
 
-    Safe to call even if Audere is not active (no-op).
+    The caller must guarantee Audere is active on ``character`` (typically by
+    pre-filtering on an actual ConditionInstance, as ``cleanup_completed_encounter``
+    does). This function does not check for an active Audere condition before
+    reverting the engagement intensity modifier and anima pool — calling it
+    without an active Audere condition would silently corrupt engagement state.
     """
     from world.conditions.models import ConditionTemplate
     from world.conditions.services import remove_condition

--- a/src/world/magic/audere.py
+++ b/src/world/magic/audere.py
@@ -120,17 +120,14 @@ class AudereOfferResult:
 
 
 def _check_intensity_gate(runtime_intensity: int, minimum_tier_threshold: int) -> bool:
-    """Return True if runtime intensity resolves to a tier at or above minimum."""
-    from world.magic.models import IntensityTier
+    """Return True if runtime intensity resolves to a tier at or above minimum.
 
-    resolved_tier = (
-        IntensityTier.objects.filter(threshold__lte=runtime_intensity)
-        .order_by("-threshold")
-        .first()
-    )
-    if resolved_tier is None:
-        return False
-    return resolved_tier.threshold >= minimum_tier_threshold
+    Mathematically equivalent to ``runtime_intensity >= minimum_tier_threshold``:
+    the resolved tier is the max IntensityTier whose threshold <= runtime_intensity,
+    and that tier's threshold >= minimum iff runtime_intensity >= minimum.
+    The IntensityTier ladder query is therefore unnecessary.
+    """
+    return runtime_intensity >= minimum_tier_threshold
 
 
 def _check_soulfray_gate(character: ObjectDB, minimum_stage_order: int) -> bool:

--- a/src/world/magic/services/techniques.py
+++ b/src/world/magic/services/techniques.py
@@ -1089,7 +1089,7 @@ def use_technique(  # noqa: PLR0913  — orchestrator; multiple small responsibi
     # gate. NPCs without sheets and ineligible characters are no-ops inside.
     from world.magic.audere import maybe_create_audere_offer  # noqa: PLC0415
 
-    maybe_create_audere_offer(character, stats.intensity)
+    maybe_create_audere_offer(character, stats.intensity, sheet=sheet)
 
     from world.magic.audere_majora import maybe_create_audere_majora_offer  # noqa: PLC0415
 

--- a/src/world/magic/tests/test_audere.py
+++ b/src/world/magic/tests/test_audere.py
@@ -23,6 +23,7 @@ from world.magic.factories import (
     IntensityTierFactory,
     wire_audere_power_multipliers,
 )
+from world.magic.tests.audere_test_helpers import build_audere_gate_fixture
 from world.mechanics.constants import EngagementType
 from world.mechanics.engagement import CharacterEngagement
 from world.mechanics.factories import (
@@ -310,3 +311,23 @@ class AudereConditionPropertyTests(TestCase):
     def test_audere_majora_has_death_deferred(self):
         prop_names = list(self.majora.properties.values_list("name", flat=True))
         self.assertIn("death_deferred", prop_names)
+
+
+class AudereEligibilityQueryCountTests(TestCase):
+    """Regression test: common-case query budget for check_audere_eligibility (#917)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        gate = build_audere_gate_fixture(tier_suffix="qc")
+        cls.threshold = gate.threshold
+
+    def test_below_gate_uses_one_query(self) -> None:
+        """A cast below the intensity gate short-circuits after the threshold fetch.
+
+        Only 1 query: AudereThreshold.objects.first(). The intensity gate is a
+        zero-query arithmetic check that fails, so no Soulfray/engagement/Audere
+        queries fire.
+        """
+        character = ObjectDB.objects.create(db_key="query_count_char")
+        with self.assertNumQueries(1):
+            check_audere_eligibility(character, runtime_intensity=1)


### PR DESCRIPTION
Closes #917

## Summary

Trims the per-cast Audere eligibility check from ~5 queries to ~1-2 by (1) lazy cheapest-first gate ordering via a new _evaluate_audere_gates helper, (2) replacing the IntensityTier ladder query with a zero-query arithmetic comparison, (3) surfacing the Soulfray stage from a single gate evaluation so maybe_create_audere_offer reuses it instead of re-querying, and (4) passing the already-resolved sheet through at the Step 8c hook. Also corrects end_audere's docstring to state its real contract (docstring-only; sole caller already pre-filters). Adds a query-count regression test locking in the 1-query common case.

## Follow-ups filed

- #1828

## Notes

- Spec: reviewed & approved on #917 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Already up to date with main; no conflicts.

<!-- last-addressed-comment: 0 -->