### PR TITLE
perf(magic): trim Audere Majora eligibility queries (mirror #917)

### DIFF
--- a/src/world/magic/audere.py
+++ b/src/world/magic/audere.py
@@ -134,44 +134,6 @@ def _check_intensity_gate(runtime_intensity: int, minimum_tier_threshold: int) -
     return runtime_intensity >= minimum_tier_threshold
 
 
-def _check_soulfray_gate(character: ObjectDB, minimum_stage_order: int) -> bool:
-    """Return True if character has Soulfray at the required stage or higher."""
-    from world.conditions.models import ConditionInstance
-
-    soulfray_instance = (
-        ConditionInstance.objects.filter(
-            target=character,
-            condition__name=SOULFRAY_CONDITION_NAME,
-        )
-        .select_related("current_stage")
-        .first()
-    )
-    if soulfray_instance is None or soulfray_instance.current_stage is None:
-        return False
-    return soulfray_instance.current_stage.stage_order >= minimum_stage_order
-
-
-def soulfray_stage_order_snapshot(character: ObjectDB) -> int:
-    """Return the character's current Soulfray stage_order, or 0 if absent.
-
-    Shared by ``maybe_create_audere_offer`` and ``maybe_create_audere_majora_offer``
-    to snapshot the Soulfray stage at offer-creation time.
-    """
-    from world.conditions.models import ConditionInstance
-
-    soulfray_instance = (
-        ConditionInstance.objects.filter(
-            target=character,
-            condition__name=SOULFRAY_CONDITION_NAME,
-        )
-        .select_related("current_stage")
-        .first()
-    )
-    if soulfray_instance is None or soulfray_instance.current_stage is None:
-        return 0
-    return soulfray_instance.current_stage.stage_order
-
-
 def _evaluate_audere_gates(
     character: ObjectDB, runtime_intensity: int, threshold: AudereThreshold
 ) -> int | None:

--- a/src/world/magic/audere_majora.py
+++ b/src/world/magic/audere_majora.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from django.db import models, transaction
 from evennia.objects.models import ObjectDB
@@ -12,14 +13,16 @@ from world.classes.models import PathStage
 from world.magic.audere import (
     AUDERE_CONDITION_NAME,
     AUDERE_MAJORA_CONDITION_NAME,
+    SOULFRAY_CONDITION_NAME,
     AbstractPendingOffer,
     _check_intensity_gate,
-    _check_soulfray_gate,
-    soulfray_stage_order_snapshot,
 )
 from world.magic.models.renown_config import RenownAwardConfig
 from world.progression.models.advancement import AbstractClassLevelAdvancement
 from world.progression.selectors import current_path_for_character
+
+if TYPE_CHECKING:
+    from world.character_sheets.models import CharacterSheet
 
 
 class AudereMajoraThreshold(RenownAwardConfig):
@@ -191,54 +194,80 @@ def eligible_paths_for_threshold(character: ObjectDB, threshold: AudereMajoraThr
     return list(path.child_paths.filter(stage=threshold.target_stage, is_active=True))
 
 
-def check_audere_majora_eligibility(  # noqa: PLR0911
-    character: ObjectDB, runtime_intensity: int
-) -> AudereMajoraThreshold | None:
-    """Check all gates for the Audere Majora offer.
+def _evaluate_majora_gates(  # noqa: PLR0911
+    character: ObjectDB, runtime_intensity: int, sheet: CharacterSheet
+) -> tuple[AudereMajoraThreshold | None, int]:
+    """Run all Audere Majora eligibility gates, returning the threshold + stage.
+
+    Returns ``(threshold, stage_order)`` when every gate passes, or
+    ``(None, 0)`` as soon as any gate fails. The Soulfray query is inlined
+    (mirroring ``_evaluate_audere_gates``) so the ``stage_order`` is captured
+    for the caller to reuse instead of re-querying via
+    ``soulfray_stage_order_snapshot``.
 
     Gates in order:
-    1. Character has a CharacterSheet.
-    2. A threshold exists at boundary_level == sheet.current_level.
-    3. Character has NOT already crossed this threshold.
-    4. Runtime intensity resolves to a tier at or above threshold.minimum_intensity_tier.
-    5. Character has Soulfray at or above threshold.minimum_warp_stage.
-    6. Character has an active CharacterEngagement.
-    7. If threshold.requires_active_audere, character has the Audere condition.
-    8. At least one eligible child path exists.
-
-    Returns the threshold on success, None if any gate fails.
+    1. A threshold exists at boundary_level == sheet.current_level.
+    2. Character has NOT already crossed this threshold.
+    3. Runtime intensity resolves to a tier at or above threshold.minimum_intensity_tier.
+    4. Character has Soulfray at or above threshold.minimum_warp_stage.
+    5. Character has an active CharacterEngagement.
+    6. If threshold.requires_active_audere, character has the Audere condition.
+    7. At least one eligible child path exists.
     """
-    from world.character_sheets.models import CharacterSheet  # noqa: PLC0415
+    from world.conditions.models import ConditionInstance  # noqa: PLC0415
     from world.mechanics.engagement import CharacterEngagement  # noqa: PLC0415
-
-    sheet = CharacterSheet.objects.filter(character=character).first()
-    if sheet is None:
-        return None
 
     threshold = AudereMajoraThreshold.objects.filter(boundary_level=sheet.current_level).first()
     if threshold is None:
-        return None
+        return None, 0
 
     if _has_crossed(sheet, threshold):
-        return None
+        return None, 0
 
     if not _check_intensity_gate(runtime_intensity, threshold.minimum_intensity_tier.threshold):
-        return None
+        return None, 0
 
-    if not _check_soulfray_gate(character, threshold.minimum_warp_stage.stage_order):
-        return None
+    soulfray_instance = (
+        ConditionInstance.objects.filter(
+            target=character,
+            condition__name=SOULFRAY_CONDITION_NAME,
+        )
+        .select_related("current_stage")
+        .first()
+    )
+    if soulfray_instance is None or soulfray_instance.current_stage is None:
+        return None, 0
+    stage_order = soulfray_instance.current_stage.stage_order
+    if stage_order < threshold.minimum_warp_stage.stage_order:
+        return None, 0
 
     if not CharacterEngagement.objects.filter(character=character).exists():
-        return None
+        return None, 0
 
     if threshold.requires_active_audere and not _has_active_condition(
         character, AUDERE_CONDITION_NAME
     ):
-        return None
+        return None, 0
 
     if not eligible_paths_for_threshold(character, threshold):
-        return None
+        return None, 0
 
+    return threshold, stage_order
+
+
+def check_audere_majora_eligibility(
+    character: ObjectDB, runtime_intensity: int
+) -> AudereMajoraThreshold | None:
+    """Check all gates for the Audere Majora offer.
+
+    Returns the threshold on success, None if any gate fails.
+    """
+    from world.character_sheets.models import CharacterSheet  # noqa: PLC0415
+
+    sheet = CharacterSheet.objects.filter(character=character).first()
+    if sheet is None:
+        return None
+    threshold, _stage_order = _evaluate_majora_gates(character, runtime_intensity, sheet)
     return threshold
 
 
@@ -281,7 +310,7 @@ def _broadcast_manifestation(character: ObjectDB, text: str) -> None:
 
 
 def maybe_create_audere_majora_offer(
-    character: ObjectDB, runtime_intensity: int
+    character: ObjectDB, runtime_intensity: int, *, sheet: CharacterSheet | None = None
 ) -> PendingAudereMajoraOffer | None:
     """Persist a poll-able Audere Majora offer when the crossing gate opens for this cast.
 
@@ -289,21 +318,21 @@ def maybe_create_audere_majora_offer(
     Idempotent: repeated qualifying casts update the single row (update_or_create).
     Broadcast fires only on first creation; re-fires after decline broadcast again;
     refreshes from a still-open gate stay silent.
+
+    Accepts an optional ``sheet`` kwarg to avoid re-fetching the CharacterSheet
+    when the caller already has it (e.g. the Step 8c cast hook). When omitted,
+    falls back to fetching it.
     """
     from world.character_sheets.models import CharacterSheet  # noqa: PLC0415
 
-    threshold = check_audere_majora_eligibility(character, runtime_intensity)
-    if threshold is None:
-        return None
-
-    # Sheet/Soulfray re-fetches duplicate eligibility's reads, mirroring
-    # maybe_create_audere_offer's shape. This path runs only at boundary
-    # levels with every gate open; the identity map serves the sheet.
-    sheet = CharacterSheet.objects.filter(character=character).first()
+    if sheet is None:
+        sheet = CharacterSheet.objects.filter(character=character).first()
     if sheet is None:
         return None
 
-    stage_order = soulfray_stage_order_snapshot(character)
+    threshold, stage_order = _evaluate_majora_gates(character, runtime_intensity, sheet)
+    if threshold is None:
+        return None
 
     offer, created = PendingAudereMajoraOffer.objects.update_or_create(
         character_sheet=sheet,

--- a/src/world/magic/services/techniques.py
+++ b/src/world/magic/services/techniques.py
@@ -1093,7 +1093,7 @@ def use_technique(  # noqa: PLR0913  — orchestrator; multiple small responsibi
 
     from world.magic.audere_majora import maybe_create_audere_majora_offer  # noqa: PLC0415
 
-    maybe_create_audere_majora_offer(character, stats.intensity)
+    maybe_create_audere_majora_offer(character, stats.intensity, sheet=sheet)
 
     # Step 9: Per-cast corruption accrual (Magic Scope #7)
     _accrue_cast_corruption(sheet=sheet, technique_result=technique_result)

--- a/src/world/magic/tests/test_audere_majora_offer.py
+++ b/src/world/magic/tests/test_audere_majora_offer.py
@@ -215,3 +215,17 @@ class CastHookImportSmokeTest(TestCase):
     def test_techniques_module_imports_cleanly(self) -> None:
         mod = importlib.import_module("world.magic.services.techniques")
         assert mod is not None
+
+
+class AudereMajoraEligibilityQueryCountTests(TestCase):
+    """Regression test: common-case query budget for check_audere_majora_eligibility (#1828)."""
+
+    def test_npc_without_sheet_uses_one_query(self) -> None:
+        """An NPC without a CharacterSheet short-circuits after the sheet fetch.
+
+        Only 1 query: CharacterSheet.objects.filter(...).first(). No threshold,
+        Soulfray, engagement, or path queries fire.
+        """
+        npc = ObjectDB.objects.create(db_key="majora_query_count_npc")
+        with self.assertNumQueries(1):
+            check_audere_majora_eligibility(npc, runtime_intensity=20)


### PR DESCRIPTION
Closes #1828

## Summary

Mirrors the #917 optimization to the audere_majora.py path. A new _evaluate_majora_gates helper runs all gates in one pass, returning (threshold, stage_order) so maybe_create_audere_majora_offer reuses the sheet (passed from Step 8c) and the Soulfray stage instead of re-querying — eliminating two redundant queries per cast. Also removes the now-dead _check_soulfray_gate and soulfray_stage_order_snapshot helpers from audere.py (after #1829, audere_majora.py was their sole caller; this PR replaces that call too). Adds a query-count regression test for the NPC no-sheet common case.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1828 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Already up to date with main; no conflicts.

<!-- last-addressed-comment: 0 -->