### PR TITLE
docs(workflow): stop instructing pre-push `pre-commit --all-files` (devcontainer crash risk)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,10 @@ iteration (`just test-fast <app>`), Postgres for parity (`just test-parity` /
 **For PR work, prefer `just test-affected`** — it diffs against `origin/main`
 and runs only the apps your branch touches plus import dependents, so you don't
 waste time on unrelated suites. For a single app, use `just test-fast <app>`.
+(Use `test-affected` for *mid-work* iteration on a multi-app change — but at the
+**final pre-push moment** keep to the focused per-app `just test-fast <app>` and
+skip whole-repo passes; running everything at once can crash the devcontainer.
+See "Completing a Unit of Work.")
 
 Run the fast SQLite tier for the apps you changed, then push and **monitor the PR**,
 fixing what CI catches. **CI is the full-regression gate** — run a local
@@ -300,7 +304,11 @@ rule: see the `running-tests` skill.
   *in this PR*. A code change that leaves its docs stale is incomplete.
 - **Update the roadmap** — mark completed phases/items in the relevant
   `docs/roadmap/*.md`; document what was built, not just that it's done.
-- **Run the fast SQLite tier** for the apps you touched (`just test-affected`
-  or `just test-fast <app>`).
+- **Run the fast SQLite tier** for the apps you touched (`just test-fast <app>`).
+  At this final pre-push moment keep it to the focused per-app run — **do NOT run
+  `pre-commit run --all-files`, a broad `just test-affected`, or `just regression`
+  as a precheck; the whole-repo pass can crash this devcontainer** (per-file hooks
+  already ran at commit, and CI is the gate). If you must re-run hooks locally,
+  scope to the diff: `uv run pre-commit run --from-ref origin/main --to-ref HEAD`.
 - **Push and let CI gate regression** — CI runs the Postgres parity suite on every
   PR; monitor the PR and fix failures there.

--- a/docs/dev-commands.md
+++ b/docs/dev-commands.md
@@ -59,7 +59,9 @@ Django-only command that doesn't fully initialize Evennia.
 - `ruff check .` — Run Python linting (import sorting, flake8 rules, and more)
 - `ruff check . --fix` — Auto-fix Python linting issues where possible
 - `ruff format .` — Format Python code (replaces black/isort, line length 100)
-- `pre-commit run --all-files` — Run all pre-commit hooks (uses ruff)
+- `pre-commit run --all-files` — Run all pre-commit hooks (uses ruff). **Heavy —
+  whole-repo; can crash the devcontainer. Not for pre-push prechecks (see caution
+  below); prefer the diff-scoped `--from-ref origin/main --to-ref HEAD` form.**
 
 **Always commit with hooks — never `--no-verify`.** `--no-verify` skips this
 repo's **custom linters** (`getattr-literal`, `string-literal`, `objectdb-param`,
@@ -68,10 +70,17 @@ cover, so a `--no-verify` commit looks clean locally and then fails CI's
 `pre-commit` job — a wasted round trip. It also skips `ty` (the project-wide
 type checker) and `ruff-format` (a separate hook from `ruff check`), so running
 just `ty check` + `ruff check` by hand afterward is not equivalent to the real
-hook set. If a branch was ever built via `--no-verify` commits, run the full
-`uv run pre-commit run --all-files` (matches CI's `pre-commit` job) before
-push and confirm every hook passes — `uv run pre-commit run --from-ref
-origin/main --to-ref HEAD` scopes it to just the branch's changes.
+hook set. If a branch was ever built via `--no-verify` commits, run the
+**diff-scoped** catch-up `uv run pre-commit run --from-ref origin/main --to-ref
+HEAD` before push and confirm every hook passes.
+
+**Avoid `pre-commit run --all-files` as a pre-push precheck.** The whole-repo
+pass (ty/ruff over thousands of files) can crash this devcontainer — a real
+stability limit, not a style preference. The per-file hooks already run at each
+commit and **CI's `pre-commit` job is the authoritative gate**; let it catch any
+untouched-file reflow rather than risking the session. Use the diff-scoped
+`--from-ref origin/main --to-ref HEAD` form above when you genuinely need to
+re-run hooks locally.
 
 ### CI Quality Gates (SonarCloud)
 

--- a/tools/skills/issue-to-merged-pr-polytoken/SKILL.md
+++ b/tools/skills/issue-to-merged-pr-polytoken/SKILL.md
@@ -180,8 +180,11 @@ PR_SUMMARY="..." PR_RAN_OR_SKIPPED="ran" PR_SYNC_SUMMARY="..." \
 
 The PR body references the approved spec via `Closes #<issue>`.
 
-**Before pushing, run `uv run pre-commit run --all-files`** — matches CI's
-`pre-commit` job exactly (committing with hooks only checks changed files).
+**Do NOT run `uv run pre-commit run --all-files` (or whole-repo test suites) as a
+pre-push precheck — it can crash this devcontainer.** The per-file hooks already
+ran at commit; CI's `pre-commit` job is the gate. Only if the branch used
+`--no-verify` commits, scope the catch-up to the diff (never `--all-files`):
+`uv run pre-commit run --from-ref origin/main --to-ref HEAD`.
 
 ### 6. CI watch
 

--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -285,10 +285,16 @@ PR_SUMMARY="..." PR_RAN_OR_SKIPPED="ran" PR_SYNC_SUMMARY="..." \
 The PR body references the approved spec via `Closes #<issue>` — the spec lives
 in the issue body, so there is no spec-file link to pass.
 
-**Before pushing, run `uv run pre-commit run --all-files`** — this matches CI's
-`pre-commit` job exactly. Committing with hooks only checks *changed* files, so
-ruff-format / Prettier / the custom linters can still reflow or flag untouched files
-that CI then rejects. Running the full pass locally avoids a wasted CI round-trip.
+**Do NOT run `uv run pre-commit run --all-files` (or `just test-affected` /
+`just regression` / any whole-repo suite) as a pre-push precheck.** Running the
+full pass locally at this stage can crash this devcontainer — a real
+resource/stability limit, not a style preference. The per-file pre-commit hooks
+already ran at each commit, and **CI's `pre-commit` job is the gate** — let it
+catch any untouched-file reflow rather than risking the session. Keep to the
+focused checks each task already used (`just test-fast <app>` for a touched app,
+`ruff check <changed files>`). Only if a branch was built with `--no-verify`
+commits (so hooks never ran), scope the catch-up to just the branch's diff —
+`uv run pre-commit run --from-ref origin/main --to-ref HEAD` — never `--all-files`.
 
 ### 6. CI watch
 


### PR DESCRIPTION
## Problem

Running `pre-commit run --all-files` (or broad local test suites) as a final
pre-push precheck can nearly crash this devcontainer — the whole-repo ty/ruff
pass over thousands of files is a real resource/stability hit, not just slow.
Yet the `issue-to-merged-pr` skill (and its polytoken variant) and
`docs/dev-commands.md` explicitly instruct agents to run exactly that before
pushing, so every session hits the landmine.

## Change

Docs/skills only — no code. Replace the "before pushing, run
`pre-commit run --all-files`" directive with: **rely on the per-file hooks that
already ran at each commit + CI's `pre-commit` job as the authoritative gate**;
if you must re-run hooks locally, scope to the branch diff
(`uv run pre-commit run --from-ref origin/main --to-ref HEAD`), never
`--all-files`.

- `tools/skills/issue-to-merged-pr/SKILL.md` — Step 5 push precheck.
- `tools/skills/issue-to-merged-pr-polytoken/SKILL.md` — same step.
- `docs/dev-commands.md` — command-list caution + the `--no-verify` catch-up
  paragraph now recommends the diff-scoped form.
- `CLAUDE.md` — "Completing a Unit of Work" + Testing sections: keep the final
  pre-push moment to focused per-app `just test-fast <app>`, skip whole-repo
  passes (`--all-files`, broad `just test-affected`, `just regression`); `CI is
  the gate`. Mid-work `test-affected` iteration is still fine.

## Notes

CI remains the full regression + `pre-commit` gate, so nothing is lost by
dropping the local whole-repo pass. Captured also as a persistent agent-memory
note in the same spirit.
