### PR TITLE
feat(#1728): signature deferred surfaces — combat damage/narration, web ViewSet, polish

### DIFF
--- a/docs/adr/0072-signature-motif-bonus-is-additive-not-a-variant.md
+++ b/docs/adr/0072-signature-motif-bonus-is-additive-not-a-variant.md
@@ -85,13 +85,33 @@ technique, not a new form of it.
   fold is a fast-follow).
 - Signature `capability_grants` have no cast-time seam (the technique-authored capability
   grant seam does not exist anywhere yet).
-- Combat cosmetic narration of the bonus (`NARRATIVE_ONLY`-style hook for the combat path
-  is a fast-follow).
+- Combat cosmetic narration of the bonus (a `render_action_outcome_narration`-style hook
+  for the combat path is a fast-follow).
 - Web selection surface (`SignatureViewSet`) — the management UI for players to pick their
   bonus from the web is deferred.
 
 **Supersedes ADR-0056** (which described the resonance-divergence model). The discordant
 resonance idea is closed; if the resonance override ever becomes desirable it must be
 treated as a new, separate design question, not a resumption of ADR-0056.
+
+## Addendum (2026-07-04, #1728)
+
+Three of the four deferred fast-follows above shipped:
+
+- The combat damage seam: `signature_damage_profiles(character, technique)`
+  (`world/magic/services/signature_effects.py`) returns the signed bonus's damage
+  profiles; `CombatTechniqueResolver._apply_damage` (`world/combat/services.py`) folds
+  them in alongside the technique's own.
+- Combat cosmetic narration: `resolve_signature_snippet(character, technique)`
+  (same module, extracted from `world/scenes/cast_services.py`) is now shared by both
+  `render_action_outcome_narration` and `_record_and_broadcast_pc_action`
+  (`world/combat/services.py`), so the signature clause surfaces in combat too.
+- The web selection surface: `SignatureViewSet` (`world/magic/views_signature.py`),
+  routed at `/api/magic/signatures/` (`list`/`set`/`clear`), dispatching the same
+  Actions via the shared `PuppetActorMixin`.
+
+**Still deferred:** the capability-grant cast seam. No technique/signature
+capability-grant cast seam exists anywhere yet, so `SignatureMotifBonusCapabilityGrant`
+rows remain inert (flagged as such in `SignatureMotifBonusAdmin`'s inline help text).
 
 > Status: accepted · Source: #1582 (2026-06-30) · Supersedes: ADR-0056

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -33,10 +33,13 @@ Powers, affinities, auras, resonances, threads-as-currency, rituals, and Mage Sc
     (`services/signature.py`): `available_signature_bonuses`, `set_signature_bonus`,
     `clear_signature_bonus`, `signature_bonus_for`. Cast wiring
     (`services/signature_effects.py`): `signature_intensity_delta` + `apply_signature_bonus_conditions`
-    (uses shared `apply_technique_conditions` seam). Narration: `signature_clause` in
-    `narration.py`. Actions: `SignatureSetAction` / `SignatureClearAction` /
-    `SignatureListAction` (REGISTRY). Telnet: `CmdSignature` (`commands/signature.py`,
-    key `"signature"`). E2E: `test_signature_motif_e2e.py`.
+    (uses shared `apply_technique_conditions` seam) + (#1728) `signature_damage_profiles`
+    (combat `_apply_damage` fold) + `resolve_signature_snippet` (shared non-combat/combat
+    cosmetic narration). Narration: `signature_clause` in `narration.py`. Actions:
+    `SignatureSetAction` / `SignatureClearAction` / `SignatureListAction` (REGISTRY).
+    Telnet: `CmdSignature` (`commands/signature.py`, key `"signature"`). Web (#1728):
+    `SignatureViewSet` (`views_signature.py`, routes under `/api/magic/signatures/`).
+    E2E: `test_signature_motif_e2e.py`.
   - **Specialization engine (ADR-0055 — #1578):** `AbstractSpecializedVariant`
     (shared abstract base — the "one specialization engine"), `TechniqueVariant`
     (concrete — resonance-specialized form of a parent `Technique`, `unlock_thread_level`≥3);

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -324,6 +324,8 @@ and DB `CheckConstraint("thread_signature_bonus_technique_only")`. Migrations: 0
 |----------|---------|
 | `signature_intensity_delta(character, technique) -> int` | Returns `bonus.flat_intensity_delta` or 0; added to `use_technique(power_intensity_bonus=…)` on both cast paths |
 | `apply_signature_bonus_conditions(*, character, technique, success_level, eff_intensity, targets_by_kind, source_character)` | Applies `bonus.cached_condition_applications` through the SHARED `apply_technique_conditions` seam (`applied_condition_rows=` param) — NO parallel apply path |
+| `signature_damage_profiles(character, technique) -> list` | (#1728) Returns `bonus.cached_damage_profiles` or `[]`; `CombatTechniqueResolver._apply_damage` (`world/combat/services.py`) appends these to the technique's own profiles before resolving damage |
+| `resolve_signature_snippet(character, technique) -> str \| None` | (#1728) Resolves the cosmetic clause — prefers `bonus.narrative_snippet`, falls back to the first Motif facet name; shared by the non-combat cast pose and the combat OUTCOME narration |
 
 `apply_technique_conditions` gained an optional `applied_condition_rows` param (default
 `None` = use the technique's own rows; when provided, applies those rows instead). This
@@ -335,7 +337,20 @@ behavior change).
 **Non-combat narration** (`narration.py`): `signature_clause(snippet) -> str` builds a
 cosmetic em-dash clause from the bonus's `narrative_snippet`. Used in
 `render_cast_outcome_narration` (standalone cast pose) via the `signature_snippet=`
-param. Combat-path cosmetic narration is a deferred fast-follow.
+param. (#1728) Combat-path cosmetic narration now shares the same snippet resolution via
+`resolve_signature_snippet` (`services/signature_effects.py`), surfaced in
+`render_action_outcome_narration` + `_record_and_broadcast_pc_action`
+(`world/combat/services.py`).
+
+**Web surface (#1728)** (`views_signature.py`): `SignatureViewSet` dispatches
+`SignatureListAction` / `SignatureSetAction` / `SignatureClearAction` through the shared
+`PuppetActorMixin` (`views_actor.py`, also used by `SanctumViewSet`). Routes (`urls.py`,
+basename `signature`): `GET /api/magic/signatures/`, `POST
+/api/magic/signatures/set/`, `POST /api/magic/signatures/clear/`.
+
+**Admin:** `SignatureMotifBonusAdmin` (`admin.py`) with inlines for the three payload
+child models; each inline's `help_text` flags wiring status (capability grants are
+inert — no cast seam yet).
 
 **Actions** (`actions/definitions/signature.py`, REGISTRY, `category="magic"`):
 - `SignatureSetAction` (key `"signature_set"`) — attach a bonus to a thread.
@@ -352,11 +367,12 @@ Motif → weave TECHNIQUE thread → select bonus → cast → assert cosmetic s
 Interaction, intensity delta applied, condition lands on caster. Also tests rejection
 (`SignatureBonusNotAvailable` / `TechniqueNotOwned`) and bonus portability between threads.
 
-**Deferred fast-follows (NOT in #1582):**
-- `damage_profiles` cast seam (combat `_apply_damage` fold).
-- `capability_grants` cast seam (no general technique-authored capability grant seam yet).
-- Combat cosmetic narration (`NARRATIVE_ONLY`-style hook for combat path).
-- Web selection surface (`SignatureViewSet`).
+**Deferred fast-follow (NOT shipped as of #1728):**
+- `capability_grants` cast seam — no general technique-authored capability grant seam
+  exists anywhere yet, so `SignatureMotifBonusCapabilityGrant` rows remain inert.
+
+**Shipped in #1728** (see `docs/adr/0072-...` addendum): the `damage_profiles` combat
+cast seam, combat cosmetic narration, and the web `SignatureViewSet`.
 
 ### Threads as Currency Consumers (Resonance Pivot Spec A §2.1)
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -8509,6 +8509,78 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/magic/signatures/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description List available bonuses and set/clear the signature bonus on a Thread.
+     *
+     *     ``list`` runs :class:`SignatureListAction`. ``set``/``clear`` resolve the
+     *     ``Thread`` (scoped to the actor's own threads) and, for ``set``, the
+     *     ``SignatureMotifBonus`` catalog row, then dispatch
+     *     :class:`SignatureSetAction` / :class:`SignatureClearAction`.
+     */
+    get: operations['magic_signatures_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/magic/signatures/clear/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description List available bonuses and set/clear the signature bonus on a Thread.
+     *
+     *     ``list`` runs :class:`SignatureListAction`. ``set``/``clear`` resolve the
+     *     ``Thread`` (scoped to the actor's own threads) and, for ``set``, the
+     *     ``SignatureMotifBonus`` catalog row, then dispatch
+     *     :class:`SignatureSetAction` / :class:`SignatureClearAction`.
+     */
+    post: operations['magic_signatures_clear_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/magic/signatures/set/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description List available bonuses and set/clear the signature bonus on a Thread.
+     *
+     *     ``list`` runs :class:`SignatureListAction`. ``set``/``clear`` resolve the
+     *     ``Thread`` (scoped to the actor's own threads) and, for ``set``, the
+     *     ``SignatureMotifBonus`` catalog row, then dispatch
+     *     :class:`SignatureSetAction` / :class:`SignatureClearAction`.
+     */
+    post: operations['magic_signatures_set_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/magic/soul-tether/{relationship_id}/': {
     parameters: {
       query?: never;
@@ -40179,6 +40251,60 @@ export interface operations {
         content: {
           'application/json': components['schemas']['SceneEntryEndorsement'];
         };
+      };
+    };
+  };
+  magic_signatures_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  magic_signatures_clear_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  magic_signatures_set_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/src/schema.json
+++ b/src/schema.json
@@ -13249,6 +13249,57 @@ paths:
               schema:
                 $ref: '#/components/schemas/SceneEntryEndorsement'
           description: ''
+  /api/magic/signatures/:
+    get:
+      operationId: magic_signatures_retrieve
+      description: |-
+        List available bonuses and set/clear the signature bonus on a Thread.
+
+        ``list`` runs :class:`SignatureListAction`. ``set``/``clear`` resolve the
+        ``Thread`` (scoped to the actor's own threads) and, for ``set``, the
+        ``SignatureMotifBonus`` catalog row, then dispatch
+        :class:`SignatureSetAction` / :class:`SignatureClearAction`.
+      tags:
+      - magic
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/magic/signatures/clear/:
+    post:
+      operationId: magic_signatures_clear_create
+      description: |-
+        List available bonuses and set/clear the signature bonus on a Thread.
+
+        ``list`` runs :class:`SignatureListAction`. ``set``/``clear`` resolve the
+        ``Thread`` (scoped to the actor's own threads) and, for ``set``, the
+        ``SignatureMotifBonus`` catalog row, then dispatch
+        :class:`SignatureSetAction` / :class:`SignatureClearAction`.
+      tags:
+      - magic
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/magic/signatures/set/:
+    post:
+      operationId: magic_signatures_set_create
+      description: |-
+        List available bonuses and set/clear the signature bonus on a Thread.
+
+        ``list`` runs :class:`SignatureListAction`. ``set``/``clear`` resolve the
+        ``Thread`` (scoped to the actor's own threads) and, for ``set``, the
+        ``SignatureMotifBonus`` catalog row, then dispatch
+        :class:`SignatureSetAction` / :class:`SignatureClearAction`.
+      tags:
+      - magic
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          description: No response body
   /api/magic/soul-tether/{relationship_id}/:
     get:
       operationId: magic_soul_tether_retrieve

--- a/src/world/combat/interaction_services.py
+++ b/src/world/combat/interaction_services.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from world.combat.constants import ClashResolution, EncounterOutcome
-from world.magic.narration import power_outcome_clause
+from world.magic.narration import power_outcome_clause, signature_clause
 from world.scenes.constants import InteractionMode
 from world.scenes.models import Interaction
 
@@ -177,13 +177,14 @@ def _assemble_hit_line(head: str, tail_clauses: list[str], power_clause: str) ->
     return f"{body} {power_clause}." if power_clause else f"{body}."
 
 
-def render_action_outcome_narration(
+def render_action_outcome_narration(  # noqa: PLR0913 - all params describe one narration; cohesive
     *,
     actor_label: str,
     technique_name: str,
     target_label: str | None,
     outcome: ActionOutcome,
     power_ledger: PowerLedger | None = None,
+    signature_snippet: str | None = None,
 ) -> str:
     """Render a one-line, deterministic outcome narration from resolved data.
 
@@ -198,6 +199,11 @@ def render_action_outcome_narration(
     for clean penetration, or "— the place’s resonance swells the working" for
     an environment amplification. Combo and non-magic paths pass ``None`` and
     get no clause, preserving backward compatibility.
+
+    When ``signature_snippet`` is supplied (the caster's technique is signed with
+    a ``SignatureMotifBonus``, #1728), its cosmetic "— <snippet>" clause is
+    appended alongside the power clause — the combat-narration sibling of
+    ``render_cast_outcome_narration``'s signature handling.
 
     Examples:
         "Kira’s Frost Bolt strikes the Pyromancer for 24 damage."
@@ -218,17 +224,20 @@ def render_action_outcome_narration(
         return f"{actor_label} uses {technique_name}."
 
     power_clause = power_outcome_clause(power_ledger)
+    sig_clause = signature_clause(signature_snippet)
+    suffix_parts = [c for c in (power_clause, sig_clause) if c]
+    suffix = " ".join(suffix_parts)
 
     # Targeted action with no damage and no wounds → miss (or warded bounce).
     if total_damage <= 0 and not wounds:
         base = f"{actor_label}’s {technique_name} misses {target_label}"
-        return f"{base} {power_clause}." if power_clause else f"{base}."
+        return f"{base} {suffix}." if suffix else f"{base}."
 
     head = f"{actor_label}’s {technique_name} strikes {target_label} for {total_damage} damage"
     tail = _build_tail_clauses(
         wounds=wounds, defeated=defeated, dying=dying, knocked_out=knocked_out
     )
-    return _assemble_hit_line(head, tail, power_clause)
+    return _assemble_hit_line(head, tail, suffix)
 
 
 def render_flee_outcome_narration(

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -440,6 +440,11 @@ class CombatTechniqueResolver:
         resistance applies independently).  SINGLE / SELF techniques are unchanged
         — only ``focused_opponent_target`` is used.
 
+        Combines the technique's own profiles with its signed
+        SignatureMotifBonus's profiles, if any (#1728) — both are
+        ``AbstractDamageProfile`` subclasses, so weapon-augment, SL-multiplier,
+        property-bonus, and multi-target all apply uniformly to both.
+
         Per opponent:
         - skip if DEFEATED (checked fresh after each preceding write)
         - for each damage profile: compute budget, apply SL multiplier, call
@@ -449,15 +454,18 @@ class CombatTechniqueResolver:
         combination.
         """
         from world.conditions.services import get_damage_multiplier  # noqa: PLC0415
+        from world.magic.services.signature_effects import (  # noqa: PLC0415
+            signature_damage_profiles,
+        )
 
         targets = self._resolved_opponent_targets()
         if not targets:
             return []
 
         technique = self.action.focused_action
-        profiles = list(
-            technique.damage_profiles.select_related("damage_type").all(),
-        )
+        attacker = self.participant.character_sheet.character
+        profiles = list(technique.damage_profiles.select_related("damage_type").all())
+        profiles += signature_damage_profiles(attacker, technique)
         if not profiles:
             return []
 
@@ -466,7 +474,6 @@ class CombatTechniqueResolver:
         if multiplier <= 0:
             return []
 
-        attacker = self.participant.character_sheet.character
         weapon = effective_weapon_profile(attacker)
         any_weapon_landed = False
 

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -30,8 +30,9 @@ if TYPE_CHECKING:
     from world.conditions.types import AppliedConditionResult, RemovedConditionResult
     from world.covenants.models import CovenantRole
     from world.items.models import ItemInstance
-    from world.magic.models import FuryTier, Technique, TechniqueDamageProfile
+    from world.magic.models import FuryTier, Technique
     from world.magic.models.anima import CharacterAnima
+    from world.magic.models.techniques import AbstractDamageProfile
     from world.magic.types import TechniqueUseResult
     from world.magic.types.power_ledger import PowerLedger
     from world.scenes.models import Interaction, Persona
@@ -396,7 +397,7 @@ class CombatTechniqueResolver:
     def _apply_profiles_to_target(  # noqa: PLR0913
         self,
         target: CombatOpponent,
-        profiles: list[TechniqueDamageProfile],
+        profiles: list[AbstractDamageProfile],
         weapon: WeaponContribution | None,
         *,
         sl: int,
@@ -494,7 +495,7 @@ class CombatTechniqueResolver:
 
     def _profile_damage(  # noqa: PLR0913
         self,
-        profile: TechniqueDamageProfile,
+        profile: AbstractDamageProfile,
         weapon: WeaponContribution | None,
         target: CombatOpponent,
         *,
@@ -5824,7 +5825,7 @@ def effective_weapon_profile(character: Character) -> WeaponContribution | None:
 
 
 def _weapon_augmented_budget(
-    profile: TechniqueDamageProfile,
+    profile: AbstractDamageProfile,
     budget: int,
     weapon: WeaponContribution | None,
     sheet: object | None = None,

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -3836,13 +3836,17 @@ def _record_and_broadcast_pc_action(  # noqa: PLR0913
 
             persist_power_ledger(interaction=interaction, ledger=combat_result.power_ledger)
 
+    from world.magic.services.signature_effects import resolve_signature_snippet  # noqa: PLC0415
+
     target_label = target.name if target is not None else None
+    signature_snippet = resolve_signature_snippet(participant.character_sheet.character, technique)
     narration = render_action_outcome_narration(
         actor_label=str(participant),
         technique_name=technique.name,
         target_label=target_label,
         outcome=outcome,
         power_ledger=combat_result.power_ledger if combat_result is not None else None,
+        signature_snippet=signature_snippet,
     )
     broadcast_action_outcome(encounter=participant.encounter, narration=narration)
 

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -325,15 +325,34 @@ preserved.
   technique itself carried it; a non-behavior-altering signature condition (e.g.
   Entangled) stays consent-free. The non-combat cast routes (`world/scenes/cast_services.py`)
   pass `caster=initiator_persona.character_sheet.character` at all three consent gates.
+- **Combat damage seam (#1728)** (`services/signature_effects.py`):
+  `signature_damage_profiles(character, technique)` returns the signed bonus's
+  `cached_damage_profiles` (or `[]` if unsigned); `CombatTechniqueResolver._apply_damage`
+  (`world/combat/services.py`) appends these to the technique's own profiles before
+  resolving damage — the bonus's authored damage now lands in combat.
 - **Non-combat narration** (`narration.py`): `signature_clause(snippet)` builds the
   em-dash cosmetic line; folded into `render_cast_outcome_narration`.
+- **Combat narration (#1728)**: `resolve_signature_snippet(character, technique)`
+  (`services/signature_effects.py`) resolves the cosmetic clause (preferring
+  `bonus.narrative_snippet`, falling back to the first Motif facet name), shared by the
+  non-combat cast pose and the combat path — `render_action_outcome_narration` +
+  `_record_and_broadcast_pc_action` (`world/combat/services.py`) now surface it.
 - **Actions** (`actions/definitions/signature.py`): `SignatureSetAction` (key
   `"signature_set"`), `SignatureClearAction` (key `"signature_clear"`),
   `SignatureListAction` (key `"signature_list"`).
 - **Telnet:** `CmdSignature` (`commands/signature.py`, key `"signature"`) — namespaced
   subverbs (`set`/`clear`/`list`) to avoid bare-key collisions.
-- **Deferred (fast-follow):** `damage_profiles` combat seam; capability-grant cast seam;
-  combat cosmetic narration; web `SignatureViewSet`.
+- **Web (#1728):** `SignatureViewSet` (`views_signature.py`) dispatches the same
+  Actions via the shared `PuppetActorMixin` (`views_actor.py`, also used by
+  `SanctumViewSet`). Routes (`urls.py`, basename `signature`): `GET
+  /api/magic/signatures/`, `POST /api/magic/signatures/set/`, `POST
+  /api/magic/signatures/clear/`.
+- **Admin:** `SignatureMotifBonusAdmin` with inlines for the three payload child models;
+  each inline's `help_text` flags its wiring status (capability grants are inert — no
+  cast seam yet).
+- **Deferred (fast-follow):** the capability-grant cast seam — no technique/signature
+  capability-grant cast seam exists anywhere yet, so `SignatureMotifBonusCapabilityGrant`
+  rows remain inert.
 
 ### Motif System
 

--- a/src/world/magic/admin.py
+++ b/src/world/magic/admin.py
@@ -40,6 +40,10 @@ from world.magic.models import (
     RitualCheckConfig,
     RitualComponentRequirement,
     SceneEntryEndorsement,
+    SignatureMotifBonus,
+    SignatureMotifBonusAppliedCondition,
+    SignatureMotifBonusCapabilityGrant,
+    SignatureMotifBonusDamageProfile,
     SoulfrayConfig,
     SoulTetherConfig,
     StandingCapBand,
@@ -841,3 +845,63 @@ class TechniqueGrantAdmin(admin.ModelAdmin):
     list_display = ["technique", "item_template", "ritual", "verb", "acquisition_ap_cost"]
     list_filter = ["verb"]
     autocomplete_fields = ["technique", "item_template", "ritual"]
+
+
+class SignatureMotifBonusCapabilityGrantInline(admin.TabularInline):
+    """Capability-grant payload rows for a SignatureMotifBonus.
+
+    WARNING: these rows are currently INERT. There is no technique-capability-grant
+    cast seam (combat or non-combat) that reads a SignatureMotifBonus's capability
+    grants — authoring a row here has no in-game effect yet.
+    """
+
+    model = SignatureMotifBonusCapabilityGrant
+    extra = 0
+    autocomplete_fields = ["capability"]
+    verbose_name = "Capability Grant (INERT — not applied at cast time)"
+    verbose_name_plural = "Capability Grants (INERT — not applied at cast time)"
+
+
+class SignatureMotifBonusDamageProfileInline(admin.TabularInline):
+    """Damage-profile payload rows for a SignatureMotifBonus.
+
+    NOTE: applied in COMBAT casts only. A standalone (non-combat) cast of a
+    technique carrying a signed bonus deals no damage from these rows.
+    """
+
+    model = SignatureMotifBonusDamageProfile
+    extra = 0
+    autocomplete_fields = ["damage_type"]
+    verbose_name = "Damage Profile (combat casts only)"
+    verbose_name_plural = "Damage Profiles (combat casts only)"
+
+
+class SignatureMotifBonusAppliedConditionInline(admin.TabularInline):
+    """Applied-condition payload rows for a SignatureMotifBonus.
+
+    Fully wired on both cast paths (combat + non-combat) — no caveat needed.
+    """
+
+    model = SignatureMotifBonusAppliedCondition
+    extra = 0
+    autocomplete_fields = ["condition"]
+
+
+@admin.register(SignatureMotifBonus)
+class SignatureMotifBonusAdmin(admin.ModelAdmin):
+    """Staff-authored, Motif-gated additive bonus signed onto a TECHNIQUE thread.
+
+    Payload rows below carry differing wiring status — see each inline's help text
+    before authoring: capability grants are inert (no cast seam yet); damage
+    profiles apply in combat casts only; applied conditions are fully wired.
+    """
+
+    list_display = ["name", "required_facet", "required_resonance", "flat_intensity_delta"]
+    list_filter = ["required_facet", "required_resonance"]
+    search_fields = ["name", "narrative_snippet"]
+    autocomplete_fields = ["required_facet", "required_resonance"]
+    inlines = [
+        SignatureMotifBonusCapabilityGrantInline,
+        SignatureMotifBonusDamageProfileInline,
+        SignatureMotifBonusAppliedConditionInline,
+    ]

--- a/src/world/magic/models/signature.py
+++ b/src/world/magic/models/signature.py
@@ -104,7 +104,7 @@ class SignatureMotifBonus(SharedMemoryModel):
 
         To invalidate: ``del instance.cached_damage_profiles``.
         """
-        return list(self.damage_profiles.all())
+        return list(self.damage_profiles.select_related("damage_type").all())
 
     @cached_property
     def cached_condition_applications(self) -> list:
@@ -112,7 +112,7 @@ class SignatureMotifBonus(SharedMemoryModel):
 
         To invalidate: ``del instance.cached_condition_applications``.
         """
-        return list(self.condition_applications.all())
+        return list(self.condition_applications.select_related("condition__category").all())
 
     # ------------------------------------------------------------------
     # Gate predicate

--- a/src/world/magic/models/techniques.py
+++ b/src/world/magic/models/techniques.py
@@ -677,6 +677,22 @@ class AbstractDamageProfile(SharedMemoryModel):
         ),
     )
 
+    def compute_damage_budget(
+        self,
+        *,
+        effective_power: int,
+        success_level: int,
+    ) -> int:
+        """Per-formula damage value before SL multiplier and soak."""
+        return _scale_by_power_and_sl(
+            self.base_damage,
+            self.damage_intensity_multiplier,
+            effective_power,
+            self.damage_per_extra_sl,
+            success_level,
+            self.minimum_success_level,
+        )
+
     class Meta:
         abstract = True
 
@@ -983,19 +999,3 @@ class TechniqueDamageProfile(AbstractDamageProfile):
     def __str__(self) -> str:
         type_str = self.damage_type.name if self.damage_type else "untyped"
         return f"{self.technique.name} → {self.base_damage} {type_str}"
-
-    def compute_damage_budget(
-        self,
-        *,
-        effective_power: int,
-        success_level: int,
-    ) -> int:
-        """Per-formula damage value before SL multiplier and soak."""
-        return _scale_by_power_and_sl(
-            self.base_damage,
-            self.damage_intensity_multiplier,
-            effective_power,
-            self.damage_per_extra_sl,
-            success_level,
-            self.minimum_success_level,
-        )

--- a/src/world/magic/serializers_signature.py
+++ b/src/world/magic/serializers_signature.py
@@ -1,0 +1,20 @@
+"""Serializers for the Signature bonus API surface (#1728 Task 4).
+
+Request-only validators — the ``set``/``clear`` endpoints resolve the
+``Thread``/``SignatureMotifBonus`` objects themselves before dispatching to
+``action.run()``. The ``list`` response is built directly from
+``SignatureListAction``'s ``ActionResult.data`` (no model serializer needed).
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class SignatureSetSerializer(serializers.Serializer):
+    thread_id = serializers.IntegerField()
+    bonus_id = serializers.IntegerField()
+
+
+class SignatureClearSerializer(serializers.Serializer):
+    thread_id = serializers.IntegerField()

--- a/src/world/magic/services/signature_effects.py
+++ b/src/world/magic/services/signature_effects.py
@@ -13,11 +13,14 @@ payload applies on top of the technique's own payload:
   seam the technique's own conditions use — exposed via
   :func:`apply_signature_bonus_conditions`. No parallel apply path.
 
-Both helpers are NO-OPs when the technique is not signed. Capability grants and
-damage profiles authored on a SignatureMotifBonus are NOT applied here: there is
-no cast-time seam for technique-authored capability grants today, and standalone
-casts deal no damage (the combat damage seam is a fast-follow). Cosmetic narration
-of the bonus is Task 6.
+Damage profiles authored on a SignatureMotifBonus ARE applied — not here (there is
+no cast-time damage seam; standalone casts deal no damage), but at the combat
+damage seam via :func:`signature_damage_profiles`, consumed by
+``CombatTechniqueResolver._apply_damage`` (``world/combat/services.py``), which
+appends the signed technique's bonus profiles to the technique's own before
+resolving damage. Capability grants authored on a SignatureMotifBonus remain
+unapplied: there is no cast-time OR combat seam for technique-authored capability
+grants today. Cosmetic narration of the bonus is Task 6.
 """
 
 from __future__ import annotations
@@ -52,6 +55,26 @@ def signature_intensity_delta(character, technique: Technique) -> int:
     """
     bonus = signature_bonus_for(character, technique)
     return bonus.flat_intensity_delta if bonus is not None else 0
+
+
+def signature_damage_profiles(character, technique: Technique) -> list:
+    """Return the signed technique's SignatureMotifBonusDamageProfile rows, or [].
+
+    Cheap read through the cached ``character.threads`` handler (via
+    :func:`signature_bonus_for`). The combat damage seam (``_apply_damage``)
+    appends these to the technique's own profiles so the bonus's authored damage
+    lands alongside it. NO-OP (``[]``) when the technique is not signed.
+
+    Args:
+        character: The casting game Character (not CharacterSheet).
+        technique: The technique being cast.
+
+    Returns:
+        The active ``SignatureMotifBonus.cached_damage_profiles``, or ``[]`` if
+        the technique is not signed.
+    """
+    bonus = signature_bonus_for(character, technique)
+    return bonus.cached_damage_profiles if bonus is not None else []
 
 
 def apply_signature_bonus_conditions(  # noqa: PLR0913 - cohesive condition-application params

--- a/src/world/magic/services/signature_effects.py
+++ b/src/world/magic/services/signature_effects.py
@@ -20,7 +20,12 @@ damage seam via :func:`signature_damage_profiles`, consumed by
 appends the signed technique's bonus profiles to the technique's own before
 resolving damage. Capability grants authored on a SignatureMotifBonus remain
 unapplied: there is no cast-time OR combat seam for technique-authored capability
-grants today. Cosmetic narration of the bonus is Task 6.
+grants today.
+
+Cosmetic narration of the bonus (the "— <snippet>" clause) is resolved by
+:func:`resolve_signature_snippet` — shared by the non-combat cast pose
+(``world/scenes/cast_services.py``) and the combat OUTCOME narration
+(``world/combat/services.py``'s ``_record_and_broadcast_pc_action``).
 """
 
 from __future__ import annotations
@@ -75,6 +80,40 @@ def signature_damage_profiles(character, technique: Technique) -> list:
     """
     bonus = signature_bonus_for(character, technique)
     return bonus.cached_damage_profiles if bonus is not None else []
+
+
+def resolve_signature_snippet(character, technique: Technique) -> str | None:
+    """Resolve the cosmetic narration snippet for a signed technique's bonus.
+
+    Resolves the active bonus via :func:`signature_bonus_for`, then prefers
+    ``bonus.narrative_snippet`` (staff-authored prose). When blank, falls back
+    to the first facet name found in the character's Motif
+    (``MotifResonanceAssociation.facet.name``). Returns ``None`` when the
+    technique is not signed or no fallback facet is available.
+
+    Shared by both cast paths — non-combat (`world/scenes/cast_services.py`) and
+    combat (`world/combat/services.py`'s ``_record_and_broadcast_pc_action``).
+
+    Args:
+        character: The casting game Character (not CharacterSheet).
+        technique: The technique being cast.
+    """
+    bonus = signature_bonus_for(character, technique)
+    if bonus is None:
+        return None
+    if bonus.narrative_snippet:
+        return bonus.narrative_snippet
+    # Fallback: primary Motif facet name (first MotifResonanceAssociation on record).
+    from world.magic.models.motifs import MotifResonanceAssociation  # noqa: PLC0415
+
+    first_assoc = (
+        MotifResonanceAssociation.objects.filter(
+            motif_resonance__motif__character=character.sheet_data
+        )
+        .select_related("facet")
+        .first()
+    )
+    return first_assoc.facet.name if first_assoc is not None else None
 
 
 def apply_signature_bonus_conditions(  # noqa: PLR0913 - cohesive condition-application params

--- a/src/world/magic/tests/integration/test_signature_combat_damage_e2e.py
+++ b/src/world/magic/tests/integration/test_signature_combat_damage_e2e.py
@@ -12,6 +12,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
+from actions.factories import ActionTemplateFactory
+from world.checks.factories import CheckTypeFactory
 from world.combat.constants import ActionCategory
 from world.combat.services import resolve_combat_technique
 from world.combat.tests.test_combat_magic_integration import _setup_pc_attacking_mook
@@ -28,6 +30,8 @@ from world.magic.factories import (
 from world.magic.models import SignatureMotifBonus, Thread
 from world.magic.models.signature import SignatureMotifBonusDamageProfile
 from world.magic.services.signature import set_signature_bonus
+from world.scenes.constants import InteractionMode
+from world.scenes.models import Interaction
 
 
 class SignatureCombatDamageE2ETests(TestCase):
@@ -108,4 +112,70 @@ class SignatureCombatDamageE2ETests(TestCase):
             f"Expected signed damage ({signed_damage}) > unsigned damage "
             f"({unsigned_damage}) — the signature bonus's damage profile must "
             "land alongside the technique's own.",
+        )
+
+
+class SignatureCombatNarrationE2ETests(TestCase):
+    """The combat OUTCOME narration surfaces a signed technique's cosmetic clause.
+
+    #1728, Task 3.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=2, multiplier=Decimal("1.00"), label="Full"
+        )
+
+    def test_signed_technique_appends_signature_clause_to_combat_narration(self) -> None:
+        """A signed cast's combat OUTCOME broadcast ends with "— <snippet>"."""
+        from world.combat.services import _resolve_pc_action
+
+        participant, action, opponent, _anima, technique, _room = _setup_pc_attacking_mook(
+            technique_intensity=5,
+            technique_control=10,
+            technique_anima_cost=2,
+            base_power=20,
+            opponent_health=999,
+        )
+        technique.action_template = ActionTemplateFactory(check_type=CheckTypeFactory())
+        technique.save()
+
+        sheet = participant.character_sheet
+        CharacterTechniqueFactory(character=sheet, technique=technique)
+
+        motif = MotifFactory(character=sheet)
+        resonance = ResonanceFactory()
+        facet = FacetFactory(name="SigCombatNarrationFacet")
+        motif_res = MotifResonanceFactory(motif=motif, resonance=resonance)
+        MotifResonanceAssociationFactory(motif_resonance=motif_res, facet=facet)
+
+        bonus = SignatureMotifBonus.objects.create(
+            name="Combat Narration Bonus",
+            narrative_snippet="webs of shimmering silk unfurl",
+            required_facet=facet,
+        )
+        thread = Thread.objects.create(
+            owner=sheet,
+            resonance=resonance,
+            target_kind=TargetKind.TECHNIQUE,
+            target_technique=technique,
+        )
+        sheet.character.threads.invalidate()
+        set_signature_bonus(thread, bonus)
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            _resolve_pc_action(participant=participant, action=action, offense_check_fn=None)
+
+        opponent.refresh_from_db()
+        narration = Interaction.objects.filter(
+            persona__name="Narrator", mode=InteractionMode.OUTCOME
+        ).latest("timestamp")
+
+        self.assertIn(
+            "— webs of shimmering silk unfurl",
+            narration.content,
+            "Combat OUTCOME narration must surface the signed bonus's cosmetic snippet, "
+            f"got: {narration.content!r}",
         )

--- a/src/world/magic/tests/integration/test_signature_combat_damage_e2e.py
+++ b/src/world/magic/tests/integration/test_signature_combat_damage_e2e.py
@@ -1,0 +1,111 @@
+"""End-to-end test: a signed technique's damage profile lands in combat (#1728, Task 2).
+
+Proves the ``CombatTechniqueResolver._apply_damage`` seam now folds a signed
+technique's ``SignatureMotifBonusDamageProfile`` rows in alongside the technique's
+own ``TechniqueDamageProfile`` rows — differential assertion: the same combat cast
+resolved once with the technique signed and once unsigned must deal strictly more
+opponent damage when signed.
+"""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from world.combat.constants import ActionCategory
+from world.combat.services import resolve_combat_technique
+from world.combat.tests.test_combat_magic_integration import _setup_pc_attacking_mook
+from world.conditions.factories import DamageSuccessLevelMultiplierFactory
+from world.magic.constants import TargetKind
+from world.magic.factories import (
+    CharacterTechniqueFactory,
+    FacetFactory,
+    MotifFactory,
+    MotifResonanceAssociationFactory,
+    MotifResonanceFactory,
+    ResonanceFactory,
+)
+from world.magic.models import SignatureMotifBonus, Thread
+from world.magic.models.signature import SignatureMotifBonusDamageProfile
+from world.magic.services.signature import set_signature_bonus
+
+
+class SignatureCombatDamageE2ETests(TestCase):
+    """Differential: signed technique deals strictly more combat damage (#1728)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=2, multiplier=Decimal("1.00"), label="Full"
+        )
+
+    def _resolve_total_damage(self, *, sign_technique: bool) -> int:
+        """Build a fresh combat-cast fixture and return total opponent damage dealt.
+
+        The technique carries its own TechniqueDamageProfile (base_damage=20, via
+        the EffectType base_power auto-seed). When ``sign_technique`` is True the
+        caster's technique Thread is signed with a SignatureMotifBonus carrying its
+        own SignatureMotifBonusDamageProfile (base_damage=50) — the resolver should
+        combine both profiles against the opponent.
+        """
+        participant, action, opponent, _anima, technique, _room = _setup_pc_attacking_mook(
+            technique_intensity=5,
+            technique_control=10,
+            technique_anima_cost=2,
+            base_power=20,
+            opponent_health=999,
+        )
+        sheet = participant.character_sheet
+        CharacterTechniqueFactory(character=sheet, technique=technique)
+
+        if sign_technique:
+            motif = MotifFactory(character=sheet)
+            resonance = ResonanceFactory()
+            facet = FacetFactory(name="SigCombatDamageFacet")
+            motif_res = MotifResonanceFactory(motif=motif, resonance=resonance)
+            MotifResonanceAssociationFactory(motif_resonance=motif_res, facet=facet)
+
+            bonus = SignatureMotifBonus.objects.create(
+                name="Combat Signature Bonus",
+                required_facet=facet,
+            )
+            SignatureMotifBonusDamageProfile.objects.create(
+                signature_bonus=bonus,
+                base_damage=50,
+                minimum_success_level=1,
+            )
+
+            thread = Thread.objects.create(
+                owner=sheet,
+                resonance=resonance,
+                target_kind=TargetKind.TECHNIQUE,
+                target_technique=technique,
+            )
+            sheet.character.threads.invalidate()
+            set_signature_bonus(thread, bonus)
+
+        with patch("world.combat.services.perform_check") as mock_perform:
+            mock_perform.return_value = MagicMock(success_level=2)
+            result = resolve_combat_technique(
+                participant=participant,
+                action=action,
+                fatigue_category=ActionCategory.PHYSICAL,
+                offense_check_type=MagicMock(),
+                offense_check_fn=None,
+            )
+
+        opponent.refresh_from_db()
+        return sum(r.damage_dealt for r in result.damage_results)
+
+    def test_signed_technique_deals_signature_bonus_damage_in_combat(self) -> None:
+        """A signed technique's SignatureMotifBonusDamageProfile adds to combat damage."""
+        unsigned_damage = self._resolve_total_damage(sign_technique=False)
+        signed_damage = self._resolve_total_damage(sign_technique=True)
+
+        self.assertGreater(
+            signed_damage,
+            unsigned_damage,
+            f"Expected signed damage ({signed_damage}) > unsigned damage "
+            f"({unsigned_damage}) — the signature bonus's damage profile must "
+            "land alongside the technique's own.",
+        )

--- a/src/world/magic/tests/test_signature_admin.py
+++ b/src/world/magic/tests/test_signature_admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+from django.test import TestCase
+
+from world.magic.models.signature import SignatureMotifBonus
+
+
+class SignatureAdminTests(TestCase):
+    def test_signature_motif_bonus_is_registered(self):
+        assert SignatureMotifBonus in admin.site._registry

--- a/src/world/magic/tests/test_signature_damage_profile.py
+++ b/src/world/magic/tests/test_signature_damage_profile.py
@@ -1,0 +1,23 @@
+from decimal import Decimal
+
+from django.test import TestCase
+
+from world.magic.models.signature import SignatureMotifBonus, SignatureMotifBonusDamageProfile
+
+
+class SignatureDamageProfileBudgetTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.bonus = SignatureMotifBonus.objects.create(name="Spider's Bite")
+        cls.profile = SignatureMotifBonusDamageProfile.objects.create(
+            signature_bonus=cls.bonus,
+            base_damage=4,
+            damage_intensity_multiplier=Decimal("0.5"),
+            damage_per_extra_sl=1,
+            minimum_success_level=1,
+        )
+
+    def test_signature_profile_has_compute_damage_budget(self):
+        # Inherited from AbstractDamageProfile after Task 1.
+        budget = self.profile.compute_damage_budget(effective_power=10, success_level=2)
+        assert budget > 0

--- a/src/world/magic/tests/test_signature_viewset.py
+++ b/src/world/magic/tests/test_signature_viewset.py
@@ -1,0 +1,251 @@
+"""Tests for SignatureViewSet — HTTP contract for list/set/clear (#1728 Task 4).
+
+Exercises the endpoints the way the web frontend hits them:
+  • GET  /api/magic/signatures/            → available bonuses + technique threads
+  • POST /api/magic/signatures/set/         → attach a bonus to one of the actor's own threads
+  • POST /api/magic/signatures/clear/       → remove the bonus from one of the actor's own threads
+  • cross-character thread id → 400
+  • no puppet → 400 "No active character."
+
+Uses ``force_authenticate`` + a ``SimpleNamespace`` puppet-bearing user, mirroring
+``world/magic/tests/test_sanctum_viewset.py``. Unlike the sanctum tests, the
+Actions are NOT mocked here — real ``SignatureSetAction``/``SignatureClearAction``/
+``SignatureListAction`` run against real service-layer state, per the Task 4 brief
+(assert via ``signature_bonus_for``/the ``Thread`` row).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.constants import TargetKind
+from world.magic.factories import (
+    CharacterTechniqueFactory,
+    FacetFactory,
+    GiftFactory,
+    MotifFactory,
+    MotifResonanceAssociationFactory,
+    MotifResonanceFactory,
+    ResonanceFactory,
+    TechniqueFactory,
+)
+from world.magic.models import SignatureMotifBonus, Thread
+from world.magic.services.signature import signature_bonus_for
+from world.magic.views_signature import SignatureViewSet
+
+
+def _actor_user(character):
+    """Fake authenticated user whose ``puppet`` is ``character``."""
+    return SimpleNamespace(
+        is_authenticated=True,
+        is_staff=False,
+        pk=character.db_account_id,
+        puppet=character,
+    )
+
+
+def _no_puppet_user():
+    """Fake authenticated user with no puppet — actor cannot be resolved."""
+    return SimpleNamespace(is_authenticated=True, is_staff=False, pk=None, puppet=None)
+
+
+class SignatureViewSetTestBase(TestCase):
+    """Common setup: one character with a qualifying bonus + owned TECHNIQUE thread."""
+
+    def setUp(self) -> None:
+        from evennia.utils.idmapper.models import flush_cache
+
+        flush_cache()
+        self.factory = APIRequestFactory()
+
+        self.character = CharacterFactory()
+        self.sheet = CharacterSheetFactory(character=self.character)
+        self.motif = MotifFactory(character=self.sheet)
+        self.resonance = ResonanceFactory()
+        self.facet = FacetFactory(name="Signature Viewset Facet")
+        self.motif_res = MotifResonanceFactory(motif=self.motif, resonance=self.resonance)
+        MotifResonanceAssociationFactory(motif_resonance=self.motif_res, facet=self.facet)
+
+        self.gift = GiftFactory()
+        self.technique = TechniqueFactory(gift=self.gift, level=1, damage_profile=False)
+        CharacterTechniqueFactory(character=self.sheet, technique=self.technique)
+
+        self.bonus = SignatureMotifBonus.objects.create(
+            name="Viewset Test Bonus",
+            required_facet=self.facet,
+        )
+
+        self.thread = Thread.objects.create(
+            owner=self.sheet,
+            resonance=self.resonance,
+            target_kind=TargetKind.TECHNIQUE,
+            target_technique=self.technique,
+        )
+        self.sheet.character.threads.invalidate()
+
+    def tearDown(self) -> None:
+        self.thread.delete()
+        self.sheet.character.threads.invalidate()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_list(self, puppet):
+        request = self.factory.get("/api/magic/signatures/")
+        force_authenticate(request, user=puppet)
+        view = SignatureViewSet.as_view({"get": "list"})
+        return view(request)
+
+    def _post_set(self, puppet, payload):
+        request = self.factory.post("/api/magic/signatures/set/", payload, format="json")
+        force_authenticate(request, user=puppet)
+        view = SignatureViewSet.as_view({"post": "set_bonus"})
+        return view(request)
+
+    def _post_clear(self, puppet, payload):
+        request = self.factory.post("/api/magic/signatures/clear/", payload, format="json")
+        force_authenticate(request, user=puppet)
+        view = SignatureViewSet.as_view({"post": "clear_bonus"})
+        return view(request)
+
+
+# ===========================================================================
+# list
+# ===========================================================================
+
+
+class SignatureListEndpointTests(SignatureViewSetTestBase):
+    def test_list_success_returns_available_bonuses_and_threads(self) -> None:
+        resp = self._get_list(_actor_user(self.character))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(self.bonus.pk, resp.data["available_bonus_ids"])
+        thread_rows = resp.data["technique_threads"]
+        matching = [row for row in thread_rows if row["thread_id"] == self.thread.pk]
+        self.assertEqual(len(matching), 1)
+        self.assertEqual(matching[0]["technique_name"], self.technique.name)
+        self.assertIsNone(matching[0]["current_bonus"])
+
+    def test_list_no_puppet_returns_400(self) -> None:
+        resp = self._get_list(_no_puppet_user())
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("active character", resp.data["detail"].lower())
+
+
+# ===========================================================================
+# set
+# ===========================================================================
+
+
+class SignatureSetEndpointTests(SignatureViewSetTestBase):
+    def test_set_success_returns_200_and_persists(self) -> None:
+        resp = self._post_set(
+            _actor_user(self.character),
+            {"thread_id": self.thread.pk, "bonus_id": self.bonus.pk},
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["thread_id"], self.thread.pk)
+        self.assertEqual(resp.data["bonus_id"], self.bonus.pk)
+
+        refreshed = Thread.objects.get(pk=self.thread.pk)
+        self.assertEqual(refreshed.signature_bonus_id, self.bonus.pk)
+        self.sheet.character.threads.invalidate()
+        self.assertEqual(signature_bonus_for(self.sheet.character, self.technique), self.bonus)
+
+    def test_set_no_puppet_returns_400(self) -> None:
+        resp = self._post_set(
+            _no_puppet_user(),
+            {"thread_id": self.thread.pk, "bonus_id": self.bonus.pk},
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("active character", resp.data["detail"].lower())
+
+    def test_set_rejects_thread_belonging_to_another_character(self) -> None:
+        """A thread_id that isn't one of the actor's own threads is rejected."""
+        other_character = CharacterFactory()
+        other_sheet = CharacterSheetFactory(character=other_character)
+        other_technique = TechniqueFactory(gift=self.gift, level=1, damage_profile=False)
+        CharacterTechniqueFactory(character=other_sheet, technique=other_technique)
+        other_thread = Thread.objects.create(
+            owner=other_sheet,
+            resonance=self.resonance,
+            target_kind=TargetKind.TECHNIQUE,
+            target_technique=other_technique,
+        )
+        try:
+            resp = self._post_set(
+                _actor_user(self.character),
+                {"thread_id": other_thread.pk, "bonus_id": self.bonus.pk},
+            )
+
+            self.assertEqual(resp.status_code, 400)
+            refreshed = Thread.objects.get(pk=other_thread.pk)
+            self.assertIsNone(refreshed.signature_bonus_id)
+        finally:
+            other_thread.delete()
+
+    def test_set_unknown_bonus_id_returns_400(self) -> None:
+        resp = self._post_set(
+            _actor_user(self.character),
+            {"thread_id": self.thread.pk, "bonus_id": 999_999},
+        )
+
+        self.assertEqual(resp.status_code, 400)
+
+
+# ===========================================================================
+# clear
+# ===========================================================================
+
+
+class SignatureClearEndpointTests(SignatureViewSetTestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.thread.signature_bonus = self.bonus
+        self.thread.save(update_fields=["signature_bonus", "updated_at"])
+        self.sheet.character.threads.invalidate()
+
+    def test_clear_success_returns_200_and_persists(self) -> None:
+        resp = self._post_clear(_actor_user(self.character), {"thread_id": self.thread.pk})
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["thread_id"], self.thread.pk)
+
+        refreshed = Thread.objects.get(pk=self.thread.pk)
+        self.assertIsNone(refreshed.signature_bonus_id)
+
+    def test_clear_no_puppet_returns_400(self) -> None:
+        resp = self._post_clear(_no_puppet_user(), {"thread_id": self.thread.pk})
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("active character", resp.data["detail"].lower())
+
+    def test_clear_rejects_thread_belonging_to_another_character(self) -> None:
+        other_character = CharacterFactory()
+        other_sheet = CharacterSheetFactory(character=other_character)
+        other_technique = TechniqueFactory(gift=self.gift, level=1, damage_profile=False)
+        CharacterTechniqueFactory(character=other_sheet, technique=other_technique)
+        other_thread = Thread.objects.create(
+            owner=other_sheet,
+            resonance=self.resonance,
+            target_kind=TargetKind.TECHNIQUE,
+            target_technique=other_technique,
+            signature_bonus=self.bonus,
+        )
+        try:
+            resp = self._post_clear(_actor_user(self.character), {"thread_id": other_thread.pk})
+
+            self.assertEqual(resp.status_code, 400)
+            refreshed = Thread.objects.get(pk=other_thread.pk)
+            self.assertEqual(refreshed.signature_bonus_id, self.bonus.pk)
+        finally:
+            other_thread.delete()

--- a/src/world/magic/urls.py
+++ b/src/world/magic/urls.py
@@ -131,6 +131,11 @@ from world.magic.views_sanctum import SanctumViewSet  # noqa: E402
 
 router.register("sanctums", SanctumViewSet, basename="sanctum")
 
+# #1728 Task 4 — Signature Motif Bonus (#1582) web surface
+from world.magic.views_signature import SignatureViewSet  # noqa: E402
+
+router.register("signatures", SignatureViewSet, basename="signature")
+
 
 urlpatterns = [
     # Literal paths MUST come before *router.urls so that "rituals/perform/" is

--- a/src/world/magic/views_actor.py
+++ b/src/world/magic/views_actor.py
@@ -1,0 +1,32 @@
+"""Shared actor-resolution mixin for magic-app puppet-gated viewsets.
+
+Extracted from ``SanctumViewSet`` (#1497) so any web viewset that dispatches
+through ``action.run()`` on behalf of the requesting user's active puppet can
+reuse the same resolution logic (#1728).
+"""
+
+from __future__ import annotations
+
+from django.core.exceptions import ObjectDoesNotExist
+
+
+class PuppetActorMixin:
+    """Resolve the caller's active puppet ObjectDB, verifying sheet ownership."""
+
+    def _resolve_actor(self, request):
+        """Return the caller's active puppet ObjectDB if they own its sheet.
+
+        Mirrors ``world.relationships.views.RelationshipUpdateViewSet._resolve_actor``.
+        Returns the ObjectDB character (puppet) or ``None`` when resolution
+        fails — caller should respond with HTTP 400.
+        """
+        actor = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
+        if actor is None:
+            return None
+        try:
+            sheet = actor.sheet_data
+        except (AttributeError, ObjectDoesNotExist):
+            return None
+        if sheet.character.db_account_id != request.user.pk:
+            return None
+        return actor

--- a/src/world/magic/views_sanctum.py
+++ b/src/world/magic/views_sanctum.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from rest_framework import status, viewsets
@@ -39,6 +38,7 @@ from world.magic.serializers_sanctum import (
     SanctumThreadSerializer,
     WeaveActionSerializer,
 )
+from world.magic.views_actor import PuppetActorMixin
 
 if TYPE_CHECKING:
     from world.scenes.models import Persona
@@ -68,7 +68,7 @@ def _active_persona_for_request(request) -> Persona:
     return active_persona_for_sheet(entry.character_sheet)
 
 
-class SanctumViewSet(viewsets.ReadOnlyModelViewSet):
+class SanctumViewSet(PuppetActorMixin, viewsets.ReadOnlyModelViewSet):
     """Read + action endpoints for the player's Sanctum surface.
 
     `list` returns Sanctums the user has standing in (owns or has woven
@@ -129,30 +129,10 @@ class SanctumViewSet(viewsets.ReadOnlyModelViewSet):
         )
 
     # ------------------------------------------------------------------
-    # Actor resolution
-    # ------------------------------------------------------------------
-
-    def _resolve_actor(self, request):
-        """Return the caller's active puppet ObjectDB if they own its sheet.
-
-        Mirrors ``world.relationships.views.RelationshipUpdateViewSet._resolve_actor``.
-        Returns the ObjectDB character (puppet) or ``None`` when resolution
-        fails — caller should respond with HTTP 400.
-        """
-        actor = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        if actor is None:
-            return None
-        try:
-            sheet = actor.sheet_data
-        except (AttributeError, ObjectDoesNotExist):
-            return None
-        if sheet.character.db_account_id != request.user.pk:
-            return None
-        return actor
-
-    # ------------------------------------------------------------------
     # Write endpoints — converge on action.run()
     # ------------------------------------------------------------------
+    # Actor resolution (``_resolve_actor``) is inherited from ``PuppetActorMixin``
+    # (extracted to ``views_actor.py`` in #1728 so ``SignatureViewSet`` can share it).
 
     @action(detail=True, methods=["post"], url_path="homecoming")
     def homecoming(self, request, feature_instance_id=None):

--- a/src/world/magic/views_signature.py
+++ b/src/world/magic/views_signature.py
@@ -1,0 +1,101 @@
+"""Signature-bonus API views (#1728 Task 4).
+
+Web DRF surface over the signature-bonus selection Actions (#1582). Both
+telnet (``CmdSignature``) and the web converge on
+``actions/definitions/signature.py`` via ``action.run()``, mirroring
+``SanctumViewSet`` (#1497).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from actions.definitions.signature import (
+    SignatureClearAction,
+    SignatureListAction,
+    SignatureSetAction,
+)
+from world.magic.models import SignatureMotifBonus, Thread
+from world.magic.serializers_signature import SignatureClearSerializer, SignatureSetSerializer
+from world.magic.views_actor import PuppetActorMixin
+
+#: Error detail returned when the request has no active character to act as.
+NO_ACTIVE_CHARACTER_DETAIL = "No active character."
+#: Error detail when the given thread_id isn't one of the actor's own threads.
+THREAD_NOT_FOUND_DETAIL = "That is not one of your technique threads."
+#: Error detail when the given bonus_id doesn't resolve to a catalog row.
+BONUS_NOT_FOUND_DETAIL = "No such signature bonus."
+
+
+class SignatureViewSet(PuppetActorMixin, viewsets.ViewSet):
+    """List available bonuses and set/clear the signature bonus on a Thread.
+
+    ``list`` runs :class:`SignatureListAction`. ``set``/``clear`` resolve the
+    ``Thread`` (scoped to the actor's own threads) and, for ``set``, the
+    ``SignatureMotifBonus`` catalog row, then dispatch
+    :class:`SignatureSetAction` / :class:`SignatureClearAction`.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    @staticmethod
+    def _resolve_own_thread(actor: Any, thread_id: int) -> Thread | None:
+        """Return the actor's own Thread matching ``thread_id``, or ``None``."""
+        for thread in actor.threads.all():
+            if thread.pk == thread_id:
+                return thread
+        return None
+
+    def list(self, request: Any) -> Response:
+        actor = self._resolve_actor(request)
+        if actor is None:
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
+        result = SignatureListAction().run(actor=actor)
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(result.data)
+
+    @action(detail=False, methods=["post"], url_path="set")
+    def set_bonus(self, request: Any) -> Response:
+        serializer = SignatureSetSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        actor = self._resolve_actor(request)
+        if actor is None:
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
+        thread = self._resolve_own_thread(actor, serializer.validated_data["thread_id"])
+        if thread is None:
+            return Response({"detail": THREAD_NOT_FOUND_DETAIL}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            bonus = SignatureMotifBonus.objects.get(pk=serializer.validated_data["bonus_id"])
+        except SignatureMotifBonus.DoesNotExist:
+            return Response({"detail": BONUS_NOT_FOUND_DETAIL}, status=status.HTTP_400_BAD_REQUEST)
+        result = SignatureSetAction().run(actor=actor, thread=thread, bonus=bonus)
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(result.data)
+
+    @action(detail=False, methods=["post"], url_path="clear")
+    def clear_bonus(self, request: Any) -> Response:
+        serializer = SignatureClearSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        actor = self._resolve_actor(request)
+        if actor is None:
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
+        thread = self._resolve_own_thread(actor, serializer.validated_data["thread_id"])
+        if thread is None:
+            return Response({"detail": THREAD_NOT_FOUND_DETAIL}, status=status.HTTP_400_BAD_REQUEST)
+        result = SignatureClearAction().run(actor=actor, thread=thread)
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(result.data)

--- a/src/world/scenes/cast_services.py
+++ b/src/world/scenes/cast_services.py
@@ -63,7 +63,6 @@ if TYPE_CHECKING:
     from actions.types import PendingActionResolution
     from world.character_sheets.models import CharacterSheet
     from world.magic.models import FuryTier, Technique
-    from world.magic.models.signature import SignatureMotifBonus
     from world.magic.services.fury import FuryResolution
     from world.magic.types.power_ledger import PowerLedger
     from world.magic.types.pull import CastPullDeclaration
@@ -191,35 +190,6 @@ def _resolve_cast(  # noqa: PLR0913 - cohesive cast-resolution params
     return result, power_ledger, fury_res
 
 
-def _resolve_signature_snippet(
-    bonus: SignatureMotifBonus | None, character_sheet: CharacterSheet
-) -> str | None:
-    """Resolve the cosmetic narration snippet for a signed technique's bonus.
-
-    Prefers ``bonus.narrative_snippet`` (staff-authored prose). When blank, falls
-    back to the first facet name found in the character's Motif
-    (``MotifResonanceAssociation.facet.name``).  Returns ``None`` when no bonus is
-    set or no fallback facet is available.
-
-    Args:
-        bonus: The active ``SignatureMotifBonus`` (or ``None`` — early-return).
-        character_sheet: The caster's ``CharacterSheet`` (used for the Motif lookup).
-    """
-    if bonus is None:
-        return None
-    if bonus.narrative_snippet:
-        return bonus.narrative_snippet
-    # Fallback: primary Motif facet name (first MotifResonanceAssociation on record).
-    from world.magic.models.motifs import MotifResonanceAssociation  # noqa: PLC0415
-
-    first_assoc = (
-        MotifResonanceAssociation.objects.filter(motif_resonance__motif__character=character_sheet)
-        .select_related("facet")
-        .first()
-    )
-    return first_assoc.facet.name if first_assoc is not None else None
-
-
 def create_cast_outcome_pose(  # noqa: PLR0913 - all params describe one pose; cohesive
     *,
     scene: Scene,
@@ -247,10 +217,11 @@ def create_cast_outcome_pose(  # noqa: PLR0913 - all params describe one pose; c
 
     # Signature-motif cosmetic (#1582): append the signed bonus's narrative snippet
     # (or primary Motif facet name as fallback) to the cast-outcome narration.
-    from world.magic.services.signature import signature_bonus_for  # noqa: PLC0415
+    from world.magic.services.signature_effects import resolve_signature_snippet  # noqa: PLC0415
 
-    sig_bonus = signature_bonus_for(caster_persona.character_sheet.character, technique)
-    signature_snippet = _resolve_signature_snippet(sig_bonus, caster_persona.character_sheet)
+    signature_snippet = resolve_signature_snippet(
+        caster_persona.character_sheet.character, technique
+    )
 
     narration = render_cast_outcome_narration(
         actor_label=caster_persona.name,


### PR DESCRIPTION
Ships the five deferred signature-motif surfaces from #1582 / ADR-0072, completing combat parity + the web surface for signatures. Spec (approved on the issue) lives in #1728's body.

## What shipped

1. **Signature damage in combat** — `CombatTechniqueResolver._apply_damage` now applies a signed technique's `SignatureMotifBonusDamageProfile` rows (new `signature_damage_profiles` helper, mirroring `signature_intensity_delta`). Reuses the existing per-profile machinery; additive, never replaces technique damage. Prereq: moved `compute_damage_budget` from the concrete `TechniqueDamageProfile` up to `AbstractDamageProfile` (found in spec review — signature profiles would otherwise `AttributeError`).
2. **Combat cosmetic narration** — the signature clause (`— <snippet>`) now surfaces on the combat hit line, via a `resolve_signature_snippet` helper **extracted** from the non-combat path (`cast_services.py`) into `signature_effects.py` and shared by both cast paths + the shared `signature_clause`.
3. **Web `SignatureViewSet`** — `GET /api/magic/signatures/`, `POST .../set/`, `POST .../clear/`, converging on the existing `SignatureSet/Clear/ListAction.run()` seam (same seam telnet uses). Extracted a shared `PuppetActorMixin` now used by both `SanctumViewSet` and `SignatureViewSet`. Actor-scoped — cross-account reads/writes rejected. (React UI stays on the #1328 frontend-parity track; this is the DRF surface only.)
4. **Perf tidy** — `select_related("condition__category")` / `select_related("damage_type")` on the signature cached-properties.
5. **Admin guard** — `SignatureMotifBonusAdmin` + payload inlines with `help_text` telling staff which rows are inert (capability grants) or combat-only (damage), so they don't author dead rows.

## Notes

- **Scope:** all five deferred items in one PR (user-ratified). Anti-reinvention: the only genuinely-new code is the web ViewSet, two small service helpers, and the admin — everything else reuses existing machinery.
- **Still deferred (documented, not filed):** the technique/signature capability-grant cast seam. It exists **nowhere** (combat or non-combat) — a separate `needs-design` question about what a cast-time capability grant *does* mechanically. Recorded in ADR-0072's addendum + `world/magic/CLAUDE.md`; capability-grant rows remain inert, and the admin help_text says so.
- **Docs in tandem:** ADR-0072 addendum (+ its stale `NARRATIVE_ONLY` pointer fixed), `world/magic/CLAUDE.md` deferred list, `docs/systems/{magic,INDEX}.md`. `MODEL_MAP.md` unchanged (no schema/signature change; verified).
- **Review:** subagent-driven — each of the 6 tasks got a spec+quality review; a final whole-branch review (different model) returned **ready to merge** (no Critical/Important) after tracing the combat path end-to-end (unsigned casts byte-identical, no double-application, actor-scoping airtight).
- **Testing:** SQLite fast tier locally per task (viewset/model/admin) + a combat damage/narration E2E; magic combat/E2E tests are `@tag("postgres")`, so **CI's Postgres parity suite is the gate** for those.

Closes #1728

🤖 Generated with [Claude Code](https://claude.com/claude-code)
