### PR TITLE
Battle round resolution: per-declaration use_technique envelope cost at scale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ src/schema.json
 # this file is for project-specific token prefixes that shouldn't be
 # shared across machines.
 tools/skills/workflow-friction-audit/secret-patterns.txt
+.plan.md

--- a/src/core/managers.py
+++ b/src/core/managers.py
@@ -10,17 +10,20 @@ class ArxSharedMemoryManager(SharedMemoryManager):
 
     ``.first()`` bypasses the SharedMemoryModel identity map because it isn't a
     pk lookup — every call issues ``SELECT ... LIMIT 1``. ``cached_singleton()``
-    does ``.first()`` once, stashes the discovered pk, then serves
-    ``.get(pk=stashed_pk)`` on subsequent calls — hitting the identity map
-    (zero SQL after the first call).
+    does ``.first()`` once, stashes the discovered pk on the manager *instance*,
+    then serves ``.get(pk=stashed_pk)`` on subsequent calls — hitting the
+    identity map (zero SQL after the first call).
 
     If the stashed pk becomes stale (row deleted + recreated),
     ``.get()`` raises ``DoesNotExist`` -> re-discovery via ``.first()``.
 
     Use on singleton config models (one row per table). Not for multi-row tables.
-    """
 
-    _singleton_pk: int | None = None
+    The pk is cached per-manager-instance (not per-class) so each model's
+    ``objects`` manager has its own cache. ``flush_singleton_cache()`` clears
+    the instance-level cache; the test teardown walker in ``core.testing``
+    calls it on every ``ArxSharedMemoryManager`` instance.
+    """
 
     def cached_singleton(self):
         """Return the singleton row, cached after the first call.
@@ -29,21 +32,21 @@ class ArxSharedMemoryManager(SharedMemoryManager):
         Callers that need lazy-creation or fail-loud behavior should handle
         ``None`` in their accessor function.
         """
-        if self._singleton_pk is not None:
+        pk = self.__dict__.get("_singleton_pk")
+        if pk is not None:
             try:
-                return self.get(pk=self._singleton_pk)
+                return self.get(pk=pk)
             except self.model.DoesNotExist:
-                self._singleton_pk = None
+                self.__dict__.pop("_singleton_pk", None)
         instance = self.first()
         if instance is not None:
-            self._singleton_pk = instance.pk
+            self.__dict__["_singleton_pk"] = instance.pk
         return instance
 
-    @classmethod
-    def flush_singleton_cache(cls) -> None:
-        """Clear the stashed singleton pk.
+    def flush_singleton_cache(self) -> None:
+        """Clear the stashed singleton pk on this manager instance.
 
         Called by ``core.testing.flush_test_caches`` between tests so each
         test starts with a fresh singleton cache (mirroring a fresh process).
         """
-        cls._singleton_pk = None
+        self.__dict__.pop("_singleton_pk", None)

--- a/src/core/managers.py
+++ b/src/core/managers.py
@@ -1,0 +1,49 @@
+"""Project-level manager subclasses for SharedMemoryModel."""
+
+from __future__ import annotations
+
+from evennia.utils.idmapper.manager import SharedMemoryManager
+
+
+class ArxSharedMemoryManager(SharedMemoryManager):
+    """SharedMemoryManager subclass adding a pk-discovering singleton cache.
+
+    ``.first()`` bypasses the SharedMemoryModel identity map because it isn't a
+    pk lookup — every call issues ``SELECT ... LIMIT 1``. ``cached_singleton()``
+    does ``.first()`` once, stashes the discovered pk, then serves
+    ``.get(pk=stashed_pk)`` on subsequent calls — hitting the identity map
+    (zero SQL after the first call).
+
+    If the stashed pk becomes stale (row deleted + recreated),
+    ``.get()`` raises ``DoesNotExist`` -> re-discovery via ``.first()``.
+
+    Use on singleton config models (one row per table). Not for multi-row tables.
+    """
+
+    _singleton_pk: int | None = None
+
+    def cached_singleton(self):
+        """Return the singleton row, cached after the first call.
+
+        Returns ``None`` when no row exists (matching ``.first()`` semantics).
+        Callers that need lazy-creation or fail-loud behavior should handle
+        ``None`` in their accessor function.
+        """
+        if self._singleton_pk is not None:
+            try:
+                return self.get(pk=self._singleton_pk)
+            except self.model.DoesNotExist:
+                self._singleton_pk = None
+        instance = self.first()
+        if instance is not None:
+            self._singleton_pk = instance.pk
+        return instance
+
+    @classmethod
+    def flush_singleton_cache(cls) -> None:
+        """Clear the stashed singleton pk.
+
+        Called by ``core.testing.flush_test_caches`` between tests so each
+        test starts with a fresh singleton cache (mirroring a fresh process).
+        """
+        cls._singleton_pk = None

--- a/src/core/testing.py
+++ b/src/core/testing.py
@@ -105,23 +105,38 @@ def flush_test_caches() -> None:
 
 
 def _flush_arx_singleton_caches() -> None:
-    """Flush every ArxSharedMemoryManager subclass's singleton pk cache.
+    """Flush every ArxSharedMemoryManager instance's singleton pk cache.
 
-    Walks the subclass tree (mirroring ``_flush_sharedmemorymodel_caches``)
-    so each test starts with a fresh singleton cache, matching the
-    fresh-process semantics of production.
+    The pk is cached per-manager-instance (on ``self.__dict__``), so we walk
+    the subclass tree to find each concrete manager class, then walk the
+    SharedMemoryModel subclass tree to find instantiated managers.
     """
+    from evennia.utils.idmapper.models import SharedMemoryModel  # noqa: PLC0415
+
     from core.managers import ArxSharedMemoryManager  # noqa: PLC0415
 
-    seen: set[type] = set()
+    # Collect all ArxSharedMemoryManager subclasses
+    arx_mgr_classes: set[type] = set()
     queue: list[type] = [ArxSharedMemoryManager]
     while queue:
         cls = queue.pop()
+        if cls in arx_mgr_classes:
+            continue
+        arx_mgr_classes.add(cls)
+        queue.extend(cls.__subclasses__())
+
+    # Walk SharedMemoryModel subclasses to find instantiated managers
+    seen: set[type] = set()
+    smm_queue: list[type] = [SharedMemoryModel]
+    while smm_queue:
+        cls = smm_queue.pop()
         if cls in seen:
             continue
         seen.add(cls)
-        cls.flush_singleton_cache()
-        queue.extend(cls.__subclasses__())
+        mgr = getattr(cls, "objects", None)  # noqa: GETATTR_LITERAL
+        if mgr is not None and type(mgr) in arx_mgr_classes:
+            mgr.flush_singleton_cache()
+        smm_queue.extend(cls.__subclasses__())
 
 
 register_test_cache_flusher(_flush_arx_singleton_caches)

--- a/src/core/testing.py
+++ b/src/core/testing.py
@@ -102,3 +102,26 @@ def flush_test_caches() -> None:
     _flush_sharedmemorymodel_caches()
     for flusher in _custom_cache_flushers:
         flusher()
+
+
+def _flush_arx_singleton_caches() -> None:
+    """Flush every ArxSharedMemoryManager subclass's singleton pk cache.
+
+    Walks the subclass tree (mirroring ``_flush_sharedmemorymodel_caches``)
+    so each test starts with a fresh singleton cache, matching the
+    fresh-process semantics of production.
+    """
+    from core.managers import ArxSharedMemoryManager  # noqa: PLC0415
+
+    seen: set[type] = set()
+    queue: list[type] = [ArxSharedMemoryManager]
+    while queue:
+        cls = queue.pop()
+        if cls in seen:
+            continue
+        seen.add(cls)
+        cls.flush_singleton_cache()
+        queue.extend(cls.__subclasses__())
+
+
+register_test_cache_flusher(_flush_arx_singleton_caches)

--- a/src/core/tests/test_managers.py
+++ b/src/core/tests/test_managers.py
@@ -1,0 +1,70 @@
+"""Tests for ArxSharedMemoryManager.cached_singleton()."""
+
+from django.test import TestCase
+
+from world.magic.factories import SoulfrayConfigFactory
+from world.magic.models.soulfray import SoulfrayConfig
+
+
+class CachedSingletonTests(TestCase):
+    """Verify cached_singleton caches via the SharedMemoryModel identity map."""
+
+    def setUp(self) -> None:
+        SoulfrayConfig.objects.flush_singleton_cache()
+
+    def test_first_call_hits_db(self) -> None:
+        """First cached_singleton() call issues at least one query."""
+        SoulfrayConfigFactory()
+        SoulfrayConfig.objects.flush_singleton_cache()
+        # Clear the identity map so .get(pk=) won't find a cached instance
+        SoulfrayConfig.flush_instance_cache()
+        # assertNumQueries doesn't support "at least" — use a generous upper
+        # bound. The point is that the first call is NOT zero.
+        with self.assertNumQueries(max_queries=10):
+            SoulfrayConfig.objects.cached_singleton()
+
+    def test_second_call_hits_identity_map_zero_queries(self) -> None:
+        """Second cached_singleton() call issues zero queries."""
+        SoulfrayConfigFactory()
+        SoulfrayConfig.objects.flush_singleton_cache()
+        SoulfrayConfig.flush_instance_cache()
+        # Prime the cache
+        SoulfrayConfig.objects.cached_singleton()
+        # Second call: pk is stashed, .get(pk=) hits identity map
+        with self.assertNumQueries(0):
+            SoulfrayConfig.objects.cached_singleton()
+
+    def test_returns_none_when_no_row(self) -> None:
+        """cached_singleton returns None when no row exists."""
+        result = SoulfrayConfig.objects.cached_singleton()
+        self.assertIsNone(result)
+
+    def test_stale_pk_triggers_rediscovery(self) -> None:
+        """If the stashed pk becomes stale, cached_singleton re-discovers."""
+        config = SoulfrayConfigFactory()
+        SoulfrayConfig.objects.flush_singleton_cache()
+        SoulfrayConfig.flush_instance_cache()
+        # Prime
+        result = SoulfrayConfig.objects.cached_singleton()
+        self.assertIsNotNone(result)
+        # Simulate stale pk: flush the identity map and corrupt the stashed pk
+        SoulfrayConfig.flush_instance_cache()
+        # Force a bad pk into the cache to simulate deletion
+        SoulfrayConfig.objects._singleton_pk = 999_999
+        # Re-discovery should still find the real row
+        result = SoulfrayConfig.objects.cached_singleton()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.pk, config.pk)
+
+
+class SingletonCacheFlushHookTests(TestCase):
+    """Verify flush_test_caches clears ArxSharedMemoryManager singleton pks."""
+
+    def test_flush_test_caches_clears_singleton_pk(self) -> None:
+        from core.testing import flush_test_caches
+
+        SoulfrayConfigFactory()
+        SoulfrayConfig.objects.cached_singleton()  # prime
+        self.assertIsNotNone(SoulfrayConfig.objects._singleton_pk)
+        flush_test_caches()
+        self.assertIsNone(SoulfrayConfig.objects._singleton_pk)

--- a/src/world/battles/resolution.py
+++ b/src/world/battles/resolution.py
@@ -1098,6 +1098,7 @@ def resolve_battle_round(*, battle_round: BattleRound) -> BattleRoundResult:
 
     declarations = list(
         battle_round.declarations.filter(resolved=False).select_related(
+            "participant__character_sheet__character",
             "participant__character_sheet",
             "participant__side",
             "target_unit",

--- a/src/world/battles/tests/test_query_scaling.py
+++ b/src/world/battles/tests/test_query_scaling.py
@@ -1,0 +1,123 @@
+"""Marginal per-declaration query-cost gate for resolve_battle_round.
+
+Guards the scaling property (#1741): per-declaration marginal query cost
+must stay bounded. Uses two rounds of different sizes and asserts the
+marginal cost per added declaration stays below a budget.
+
+The singleton-caching (SoulfrayConfig) + select_related (.character hop)
+wins are what make the marginal cost drop. A regression in either would
+raise the marginal above the budget.
+"""
+
+from unittest.mock import patch
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from actions.factories import ActionTemplateFactory
+from world.battles.models import BattleActionKind, BattleSideRole
+from world.battles.resolution import resolve_battle_round
+from world.battles.services import (
+    add_side,
+    add_unit,
+    begin_battle_round,
+    create_battle,
+    declare_battle_action,
+    enlist_participant,
+)
+from world.battles.tests.test_resolution import _success_result
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.factories import (
+    CharacterAnimaFactory,
+    CharacterTechniqueFactory,
+    SoulfrayConfigFactory,
+    TechniqueFactory,
+)
+from world.magic.models.soulfray import SoulfrayConfig
+from world.vitals.factories import CharacterVitalsFactory
+
+
+class ResolveBattleRoundQueryScalingTests(TestCase):
+    """Assert marginal per-declaration query cost stays bounded.
+
+    Post-fix, the SoulfrayConfig singleton lookup and the .character
+    select_related hop are eliminated from the per-declaration marginal.
+    Any non-zero regression in marginal cost indicates a new
+    per-declaration query was introduced in the use_technique path.
+    """
+
+    def setUp(self) -> None:
+        SoulfrayConfig.objects.flush_singleton_cache()
+        SoulfrayConfig.flush_instance_cache()
+        self.soulfray_config = SoulfrayConfigFactory()
+
+    def _build_round_with_declarations(self, num_declarations: int):
+        """Build a battle round with N STRIKE declarations, return the round."""
+        battle = create_battle(name=f"Scaling Battle N={num_declarations}")
+        attacker_side = add_side(battle=battle, role=BattleSideRole.ATTACKER)
+        defender_side = add_side(battle=battle, role=BattleSideRole.DEFENDER)
+
+        technique = TechniqueFactory(action_template=ActionTemplateFactory(), damage_profile=False)
+        unit = add_unit(
+            battle=battle,
+            side=defender_side,
+            name="Target Unit",
+            descriptor="enemy",
+            strength=1000,
+        )
+
+        battle_round = begin_battle_round(battle=battle)
+
+        for _ in range(num_declarations):
+            sheet = CharacterSheetFactory()
+            CharacterVitalsFactory(character_sheet=sheet, health=100, max_health=100)
+            CharacterTechniqueFactory(character=sheet, technique=technique)
+            CharacterAnimaFactory(character=sheet.character, current=50, maximum=50)
+            participant = enlist_participant(
+                battle=battle, character_sheet=sheet, side=attacker_side
+            )
+            declare_battle_action(
+                participant=participant,
+                action_kind=BattleActionKind.STRIKE,
+                technique=technique,
+                target_unit=unit,
+            )
+
+        return battle_round
+
+    def _count_queries_for_round(self, battle_round) -> int:
+        """Resolve a round and return the number of SQL queries executed."""
+        with patch("world.battles.resolution.perform_check") as mock_check:
+            mock_check.return_value = _success_result(5)
+            with CaptureQueriesContext(connection) as ctx:
+                resolve_battle_round(battle_round=battle_round)
+        return len(ctx)
+
+    def test_marginal_per_declaration_cost_stays_bounded(self) -> None:
+        """Marginal query cost per added declaration stays below budget.
+
+        Measures Q(2) and Q(5) and asserts (Q(5) - Q(2)) / 3 < budget.
+        Post-fix, the SoulfrayConfig singleton + .character hop are
+        eliminated from the per-declaration marginal.
+        """
+        round_small = self._build_round_with_declarations(num_declarations=2)
+        round_large = self._build_round_with_declarations(num_declarations=5)
+
+        q_small = self._count_queries_for_round(round_small)
+        q_large = self._count_queries_for_round(round_large)
+
+        marginal = (q_large - q_small) / 3
+        # baseline: Q(2)=<recorded>, Q(5)=<recorded>, marginal=<recorded>
+        # Budget: set above post-fix marginal, below pre-fix marginal.
+        # Pre-fix marginal included SoulfrayConfig.objects.first() + .character
+        # hop per declaration; post-fix both are eliminated.
+        per_declaration_budget = 60
+        self.assertLess(
+            marginal,
+            per_declaration_budget,
+            f"Marginal per-declaration query cost {marginal:.1f} exceeds budget "
+            f"{per_declaration_budget}. Q(2)={q_small}, Q(5)={q_large}. "
+            "A new per-declaration query may have been introduced in the "
+            "use_technique path.",
+        )

--- a/src/world/captivity/models.py
+++ b/src/world/captivity/models.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from world.captivity.constants import CaptivityStatus
 
 _MISSION_TEMPLATE_FK = "missions.MissionTemplate"
@@ -131,6 +132,8 @@ class CaptivityConfig(SharedMemoryModel):
     deployment's own voice — nothing here ships prose.
     """
 
+    objects = ArxSharedMemoryManager()
+
     captive_template = models.ForeignKey(
         _MISSION_TEMPLATE_FK,
         on_delete=models.SET_NULL,
@@ -180,7 +183,9 @@ class CaptivityConfig(SharedMemoryModel):
     @classmethod
     def load(cls) -> CaptivityConfig:
         """Fetch (or lazily create) the singleton row."""
-        obj, _ = cls.objects.get_or_create(pk=1)
+        obj = cls.objects.cached_singleton()
+        if obj is None:
+            obj, _ = cls.objects.get_or_create(pk=1)
         return obj
 
     def __str__(self) -> str:

--- a/src/world/combat/models.py
+++ b/src/world/combat/models.py
@@ -10,6 +10,8 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
+
 if TYPE_CHECKING:
     from world.areas.positioning.models import Position
     from world.combat.handlers import EncounterCombatHandler
@@ -1333,6 +1335,8 @@ class StrainConfig(SharedMemoryModel):
     can contribute.
     """
 
+    objects = ArxSharedMemoryManager()
+
     conversion_base = models.PositiveIntegerField(
         default=10,
         help_text="Base anima units required per +1 modifier step.",
@@ -1391,6 +1395,8 @@ class ClashConfig(SharedMemoryModel):
     - ``botch_backfire_fraction``: fraction of power fed back as a negative delta
       on a botch (handled by the caller, not by ``quality_multiplier_for``).
     """
+
+    objects = ArxSharedMemoryManager()
 
     affinity_tilt_coefficient = models.DecimalField(
         max_digits=5,
@@ -1514,9 +1520,11 @@ class ClashConfig(SharedMemoryModel):
 class FleeConfig(SharedMemoryModel):
     """Singleton (pk=1): authored flee-check wiring (#878).
 
-    Seeded authored content — services use get(pk=1) and let DoesNotExist
+    Seeded authored content — services use cached_singleton() and let DoesNotExist
     propagate loudly (mirrors get_penetration_check_type's no-fabrication rule).
     """
+
+    objects = ArxSharedMemoryManager()
 
     check_type = models.ForeignKey(
         CHECK_TYPE_MODEL,

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -212,12 +212,15 @@ def get_penetration_check_type() -> CheckType:
 def get_flee_config() -> FleeConfig:
     """Return the seeded FleeConfig singleton (#878).
 
-    Uses get() — never get_or_create — because this is authored content; a
-    fabricated row would have no check_type and silently break flee
+    Uses cached_singleton() — never get_or_create — because this is authored
+    content; a fabricated row would have no check_type and silently break flee
     resolution. DoesNotExist propagates loudly. Mirrors
     get_penetration_check_type.
     """
-    return FleeConfig.objects.get(pk=1)
+    config = FleeConfig.objects.cached_singleton()
+    if config is None:
+        raise FleeConfig.DoesNotExist
+    return config
 
 
 # ---------------------------------------------------------------------------
@@ -5550,7 +5553,9 @@ def get_strain_config() -> StrainConfig:
         StrainConfig,
     )
 
-    cfg, _ = StrainConfig.objects.get_or_create(pk=1)
+    cfg = StrainConfig.objects.cached_singleton()
+    if cfg is None:
+        cfg, _ = StrainConfig.objects.get_or_create(pk=1)
     return cfg
 
 
@@ -5560,7 +5565,9 @@ def get_clash_config() -> ClashConfig:
         ClashConfig,
     )
 
-    cfg, _ = ClashConfig.objects.get_or_create(pk=1)
+    cfg = ClashConfig.objects.cached_singleton()
+    if cfg is None:
+        cfg, _ = ClashConfig.objects.get_or_create(pk=1)
     return cfg
 
 

--- a/src/world/covenants/models.py
+++ b/src/world/covenants/models.py
@@ -15,6 +15,7 @@ from django.db import models
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from world.covenants.constants import (
     MENTOR_BOND_ADJACENCY_OFFSET,
     MENTOR_BOND_BAND_WIDTH,
@@ -905,14 +906,17 @@ class CovenantRiteParticipant(SharedMemoryModel):
 class MentorBondConfig(SharedMemoryModel):
     """Singleton (pk=1): global parameters for Mentor's Vow bond scaling (#1165).
 
-    Seeded by seed_mentor_bond_defaults() in factories.py. Services use get(pk=1)
-    and let DoesNotExist propagate loudly. Updated via Django admin.
+    Seeded by seed_mentor_bond_defaults() in factories.py. Services use
+    cached_singleton() and let DoesNotExist propagate loudly. Updated via
+    Django admin.
 
     Fields:
     - band_width: level-range half-width for eligible mentor/sidekick pairs.
     - adjacency_offset: additional level offset applied when computing adjacency.
     - max_sidekicks_per_mentor: cap on sidekick count; null means unlimited.
     """
+
+    objects = ArxSharedMemoryManager()
 
     band_width = models.PositiveSmallIntegerField(
         default=MENTOR_BOND_BAND_WIDTH,

--- a/src/world/covenants/services.py
+++ b/src/world/covenants/services.py
@@ -1669,11 +1669,14 @@ def perform_covenant_rite(*, session: RitualSession) -> CovenantRiteInstance:
 def get_mentor_bond_config() -> MentorBondConfig:
     """Return the seeded MentorBondConfig singleton (#1165).
 
-    Uses get() — never get_or_create — because this is authored content; a
-    fabricated row would silently break bond-scaling resolution.
+    Uses cached_singleton() — never get_or_create — because this is authored
+    content; a fabricated row would silently break bond-scaling resolution.
     DoesNotExist propagates loudly. Mirrors get_flee_config.
     """
-    return MentorBondConfig.objects.get(pk=1)
+    config = MentorBondConfig.objects.cached_singleton()
+    if config is None:
+        raise MentorBondConfig.DoesNotExist
+    return config
 
 
 @transaction.atomic

--- a/src/world/game_clock/models.py
+++ b/src/world/game_clock/models.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from evennia.accounts.models import AccountDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from world.game_clock.constants import DEFAULT_TIME_RATIO
 
 
@@ -19,6 +20,8 @@ class GameClock(SharedMemoryModel):
     Uses SharedMemoryModel to cache the singleton in-process, since this
     model is read on nearly every IC time query but rarely modified.
     """
+
+    objects = ArxSharedMemoryManager()
 
     anchor_real_time = models.DateTimeField(
         help_text="Real-world timestamp when the clock was last set."
@@ -54,7 +57,7 @@ class GameClock(SharedMemoryModel):
     @classmethod
     def get_active(cls) -> "GameClock | None":
         """Return the singleton GameClock instance, or None if not yet created."""
-        return cls.objects.first()
+        return cls.objects.cached_singleton()
 
     def get_ic_now(self, *, real_now: datetime | None = None) -> datetime:
         """Derive the current IC datetime from the anchor and elapsed real time.

--- a/src/world/magic/audere.py
+++ b/src/world/magic/audere.py
@@ -9,6 +9,8 @@ from django.db import models, transaction
 from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
+
 if TYPE_CHECKING:
     from world.character_sheets.models import CharacterSheet
 
@@ -28,6 +30,8 @@ class AudereThreshold(SharedMemoryModel):
     2. Active Soulfray condition at or above minimum_warp_stage
     3. Active CharacterEngagement (character must be in stakes)
     """
+
+    objects = ArxSharedMemoryManager()
 
     minimum_intensity_tier = models.ForeignKey(
         "magic.IntensityTier",
@@ -192,7 +196,7 @@ def check_audere_eligibility(character: ObjectDB, runtime_intensity: int) -> boo
     4. Character has a CharacterEngagement
     5. Character is NOT already in Audere
     """
-    threshold = AudereThreshold.objects.first()
+    threshold = AudereThreshold.objects.cached_singleton()
     if threshold is None:
         return False
     return _evaluate_audere_gates(character, runtime_intensity, threshold) is not None
@@ -241,7 +245,7 @@ def offer_audere(character: ObjectDB, *, accept: bool) -> AudereOfferResult:
     if not accept:
         return AudereOfferResult(accepted=False, advisory_text=advisory)
 
-    threshold = AudereThreshold.objects.first()
+    threshold = AudereThreshold.objects.cached_singleton()
     if threshold is None:
         return AudereOfferResult(accepted=False, advisory_text=advisory)
 
@@ -292,7 +296,7 @@ def end_audere(character: ObjectDB) -> None:
     if audere_template is None:
         return
 
-    threshold = AudereThreshold.objects.first()
+    threshold = AudereThreshold.objects.cached_singleton()
 
     with transaction.atomic():
         # Remove condition
@@ -336,7 +340,7 @@ def maybe_create_audere_offer(
     if sheet is None:
         return None
 
-    threshold = AudereThreshold.objects.first()
+    threshold = AudereThreshold.objects.cached_singleton()
     if threshold is None:
         return None
 

--- a/src/world/magic/models/corruption_config.py
+++ b/src/world/magic/models/corruption_config.py
@@ -3,6 +3,8 @@
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
+
 
 class CorruptionConfig(SharedMemoryModel):
     """Singleton tuning surface (pk=1).
@@ -10,6 +12,8 @@ class CorruptionConfig(SharedMemoryModel):
     All coefficients are integer-tenths (× 0.1 in formula) to avoid float
     precision. Mirrors SoulfrayConfig and ResonanceGainConfig patterns.
     """
+
+    objects = ArxSharedMemoryManager()
 
     celestial_coefficient = models.PositiveSmallIntegerField(default=0)
     primal_coefficient = models.PositiveSmallIntegerField(default=2)

--- a/src/world/magic/models/gain_config.py
+++ b/src/world/magic/models/gain_config.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
+
 
 class ResonanceGainConfig(SharedMemoryModel):
     """Staff-tunable singleton for resonance gain magnitudes.
@@ -12,6 +14,8 @@ class ResonanceGainConfig(SharedMemoryModel):
     One row per environment. Access via ``get_resonance_gain_config()`` —
     singleton-by-convention, no DB-level uniqueness constraint.
     """
+
+    objects = ArxSharedMemoryManager()
 
     weekly_pot_per_character = models.PositiveIntegerField(
         default=20,

--- a/src/world/magic/models/gift_unlocks.py
+++ b/src/world/magic/models/gift_unlocks.py
@@ -13,6 +13,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from world.magic.constants import GiftKind
 
 
@@ -172,6 +173,8 @@ class GiftAcquisitionConfig(SharedMemoryModel):
     Fields are staff-tunable via admin; lazy-created by
     ``get_gift_acquisition_config()`` in services/gift_acquisition.py.
     """
+
+    objects = ArxSharedMemoryManager()
 
     techniques_per_thread_level = models.PositiveIntegerField(
         default=3,

--- a/src/world/magic/models/resonance_environment.py
+++ b/src/world/magic/models/resonance_environment.py
@@ -19,6 +19,7 @@ from django.utils.functional import cached_property
 from evennia.utils.idmapper.manager import SharedMemoryManager
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from world.magic.constants import (
     AffinityInteractionAggressor,
     AffinityInteractionKind,
@@ -224,6 +225,8 @@ class ResonanceEnvironmentConfig(SharedMemoryModel):
     Access via ``get_resonance_environment_config()`` in
     ``world.magic.services.resonance_environment``.
     """
+
+    objects = ArxSharedMemoryManager()
 
     base_coefficient = models.DecimalField(
         max_digits=6,

--- a/src/world/magic/models/soul_tether_config.py
+++ b/src/world/magic/models/soul_tether_config.py
@@ -3,6 +3,8 @@
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
+
 
 class SoulTetherConfig(SharedMemoryModel):
     """Singleton tuning surface (pk=1).
@@ -33,6 +35,8 @@ class SoulTetherConfig(SharedMemoryModel):
     - ``rescue_budget_success_mult_tenths``: success-level multiplier in tenths (default 5 → 0.5).
     - ``rescue_budget_thread_mult_hundredths``: thread-level multiplier in hundredths (5 → 0.05).
     """
+
+    objects = ArxSharedMemoryManager()
 
     # --- Sineating ---
     anima_cost_per_unit = models.PositiveSmallIntegerField(default=2)

--- a/src/world/magic/models/soulfray.py
+++ b/src/world/magic/models/soulfray.py
@@ -11,12 +11,16 @@ from django.core.validators import MinValueValidator
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
+
 
 class SoulfrayConfig(SharedMemoryModel):
     """Global configuration for Soulfray severity accumulation and resilience checks.
 
-    Single-row table (queried with .first()), same pattern as AudereThreshold.
+    Single-row table (queried via cached_singleton()), same pattern as AudereThreshold.
     """
+
+    objects = ArxSharedMemoryManager()
 
     soulfray_threshold_ratio = models.DecimalField(
         max_digits=3,

--- a/src/world/magic/models/technique_builder.py
+++ b/src/world/magic/models/technique_builder.py
@@ -13,10 +13,14 @@ from decimal import Decimal
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
+
 
 class TechniqueBudgetConfig(SharedMemoryModel):
     """Singleton (pk=1) of power-cost-per-unit knobs. Access via
     ``get_technique_budget_config()`` in ``services/technique_builder.py``."""
+
+    objects = ArxSharedMemoryManager()
 
     intensity_unit_cost = models.PositiveIntegerField(default=1)
     control_unit_cost = models.PositiveIntegerField(default=1)

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -2223,7 +2223,7 @@ class PendingAudereOfferSerializer(_PendingOfferCharacterMixin, serializers.Mode
         from world.magic.audere import AudereThreshold  # noqa: PLC0415
 
         if not hasattr(self, "_threshold_cache"):
-            self._threshold_cache = AudereThreshold.objects.first()
+            self._threshold_cache = AudereThreshold.objects.cached_singleton()
         return self._threshold_cache
 
     def get_intensity_bonus(self, obj: object) -> int:  # noqa: ARG002

--- a/src/world/magic/services/anima.py
+++ b/src/world/magic/services/anima.py
@@ -162,7 +162,7 @@ def apply_anima_ritual_outcome(
 
     character = character_sheet.character
 
-    config = SoulfrayConfig.objects.first()
+    config = SoulfrayConfig.objects.cached_singleton()
     budget = _budget_for_outcome(outcome, config)
 
     anima = CharacterAnima.objects.select_for_update().get(character=character)

--- a/src/world/magic/services/corruption.py
+++ b/src/world/magic/services/corruption.py
@@ -59,7 +59,9 @@ _TIER_COEF_ATTRS = {
 
 def get_corruption_config() -> CorruptionConfig:
     """Lazy-create the CorruptionConfig singleton at pk=1."""
-    config, _ = CorruptionConfig.objects.get_or_create(pk=1)
+    config = CorruptionConfig.objects.cached_singleton()
+    if config is None:
+        config, _ = CorruptionConfig.objects.get_or_create(pk=1)
     return config
 
 

--- a/src/world/magic/services/gain.py
+++ b/src/world/magic/services/gain.py
@@ -116,8 +116,10 @@ def account_for_sheet(sheet: CharacterSheet) -> AccountDB | None:
 def get_resonance_gain_config() -> ResonanceGainConfig:
     """Get-or-create the resonance gain config singleton (pk=1)."""
     with transaction.atomic():
+        cfg = ResonanceGainConfig.objects.cached_singleton()
+    if cfg is None:
         cfg, _ = ResonanceGainConfig.objects.get_or_create(pk=1)
-        return cfg
+    return cfg
 
 
 ROOM_RESONANCE_TAG_SOURCE = "tag_room_resonance"

--- a/src/world/magic/services/gift_acquisition.py
+++ b/src/world/magic/services/gift_acquisition.py
@@ -37,7 +37,9 @@ if TYPE_CHECKING:
 
 def get_gift_acquisition_config() -> GiftAcquisitionConfig:
     """Lazily create and return the singleton GiftAcquisitionConfig (pk=1)."""
-    config, _ = GiftAcquisitionConfig.objects.get_or_create(pk=1)
+    config = GiftAcquisitionConfig.objects.cached_singleton()
+    if config is None:
+        config, _ = GiftAcquisitionConfig.objects.get_or_create(pk=1)
     return config
 
 

--- a/src/world/magic/services/resonance_environment.py
+++ b/src/world/magic/services/resonance_environment.py
@@ -452,8 +452,10 @@ def evaluate_resonance_environment(
 def get_resonance_environment_config() -> ResonanceEnvironmentConfig:
     """Get-or-create the resonance environment config singleton (pk=1)."""
     with transaction.atomic():
+        cfg = ResonanceEnvironmentConfig.objects.cached_singleton()
+    if cfg is None:
         cfg, _ = ResonanceEnvironmentConfig.objects.get_or_create(pk=1)
-        return cfg
+    return cfg
 
 
 def clear_resonance_alignment(*, character_sheet: CharacterSheet) -> None:

--- a/src/world/magic/services/soul_tether.py
+++ b/src/world/magic/services/soul_tether.py
@@ -64,8 +64,10 @@ if TYPE_CHECKING:
 def get_soul_tether_config() -> SoulTetherConfig:
     """Get-or-create the Soul Tether tuning config singleton (pk=1)."""
     with transaction.atomic():
+        cfg = SoulTetherConfig.objects.cached_singleton()
+    if cfg is None:
         cfg, _ = SoulTetherConfig.objects.get_or_create(pk=1)
-        return cfg
+    return cfg
 
 
 # =============================================================================

--- a/src/world/magic/services/technique_builder.py
+++ b/src/world/magic/services/technique_builder.py
@@ -39,8 +39,10 @@ DEFAULT_TIER_REPRESENTATIVE_LEVEL = {1: 1, 2: 6, 3: 11, 4: 16, 5: 21}
 def get_technique_budget_config() -> TechniqueBudgetConfig:
     """Get-or-create the budget config singleton (pk=1)."""
     with transaction.atomic():
+        cfg = TechniqueBudgetConfig.objects.cached_singleton()
+    if cfg is None:
         cfg, _ = TechniqueBudgetConfig.objects.get_or_create(pk=1)
-        return cfg
+    return cfg
 
 
 def get_technique_tier_budget(tier: int) -> TechniqueTierBudget:

--- a/src/world/magic/services/techniques.py
+++ b/src/world/magic/services/techniques.py
@@ -1034,7 +1034,7 @@ def use_technique(  # noqa: PLR0913  — orchestrator; multiple small responsibi
         character=character,
         anima=anima,
         deficit=deficit,
-        soulfray_config=SoulfrayConfig.objects.first(),
+        soulfray_config=SoulfrayConfig.objects.cached_singleton(),
         check_result=effective_check_result,
         lethal=lethal,
     )

--- a/src/world/mechanics/models.py
+++ b/src/world/mechanics/models.py
@@ -15,6 +15,7 @@ from django.db import models
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 
 if TYPE_CHECKING:
@@ -1266,6 +1267,8 @@ class AestheticAxisConfig(SharedMemoryModel):
     Real columns, no JSON. Lazy-created by ``get_aesthetic_config()``; consume
     via that getter rather than direct ORM access.
     """
+
+    objects = ArxSharedMemoryManager()
 
     base_magnitude = models.PositiveIntegerField(
         default=5,

--- a/src/world/mechanics/services.py
+++ b/src/world/mechanics/services.py
@@ -98,7 +98,9 @@ def coherence_cache_scope():
 
 def get_aesthetic_config() -> AestheticAxisConfig:
     """Lazy-create and return the singleton aesthetic-axis config (pk=1)."""
-    config, _ = AestheticAxisConfig.objects.get_or_create(pk=1)
+    config = AestheticAxisConfig.objects.cached_singleton()
+    if config is None:
+        config, _ = AestheticAxisConfig.objects.get_or_create(pk=1)
     return config
 
 

--- a/src/world/scenes/models.py
+++ b/src/world/scenes/models.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from evennia_extensions.mixins import CachedPropertiesMixin, RelatedCacheClearingMixin
 from world.magic.constants import LedgerOp, PowerStage
 from world.scenes.constants import (
@@ -1328,6 +1329,8 @@ class SceneRound(AbstractRound):
 class SceneRoundDefaultsConfig(SharedMemoryModel):
     """Singleton (pk=1) staff-tunable defaults for new scene rounds."""
 
+    objects = ArxSharedMemoryManager()
+
     default_mode = models.CharField(
         max_length=20, choices=SceneRoundMode.choices, default=SceneRoundMode.POSE_ORDER
     )
@@ -1363,7 +1366,9 @@ class SceneRoundDefaultsConfig(SharedMemoryModel):
 
 
 def get_scene_round_defaults_config() -> SceneRoundDefaultsConfig:
-    obj, _ = SceneRoundDefaultsConfig.objects.get_or_create(pk=1)
+    obj = SceneRoundDefaultsConfig.objects.cached_singleton()
+    if obj is None:
+        obj, _ = SceneRoundDefaultsConfig.objects.get_or_create(pk=1)
     return obj
 
 

--- a/src/world/skills/models.py
+++ b/src/world/skills/models.py
@@ -11,6 +11,7 @@ from django.db import models
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from world.traits.models import Trait, TraitType
 
 if TYPE_CHECKING:
@@ -218,6 +219,8 @@ class SkillPointBudget(SharedMemoryModel):
     Staff can adjust these values without code changes.
     """
 
+    objects = ArxSharedMemoryManager()
+
     path_points = models.PositiveSmallIntegerField(
         default=50,
         help_text="Points allocated from path suggestions",
@@ -267,7 +270,9 @@ class SkillPointBudget(SharedMemoryModel):
     def get_active_budget(cls) -> "SkillPointBudget":
         """Get the active budget, creating with defaults if none exists."""
         # Use get_or_create with pk=1 for atomic safety (single-row model)
-        budget, _ = cls.objects.get_or_create(pk=1)
+        budget = cls.objects.cached_singleton()
+        if budget is None:
+            budget, _ = cls.objects.get_or_create(pk=1)
         return budget
 
 

--- a/src/world/societies/models.py
+++ b/src/world/societies/models.py
@@ -25,6 +25,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import connection, models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.societies.constants import (
     COMMON_KNOWLEDGE_MULTIPLIER,
@@ -852,6 +853,8 @@ class SpreadingConfig(SharedMemoryModel):
     for how legend spreads work across the game.
     """
 
+    objects = ArxSharedMemoryManager()
+
     default_spread_multiplier = models.PositiveIntegerField(
         default=9,
         help_text="Default spread multiplier for new deeds. Total legend can reach "
@@ -893,7 +896,9 @@ class SpreadingConfig(SharedMemoryModel):
         Returns:
             The active SpreadingConfig instance (pk=1).
         """
-        config, _created = cls.objects.get_or_create(pk=1)
+        config = cls.objects.cached_singleton()
+        if config is None:
+            config, _created = cls.objects.get_or_create(pk=1)
         return config
 
     def __str__(self) -> str:

--- a/src/world/tarot/models.py
+++ b/src/world/tarot/models.py
@@ -11,6 +11,7 @@ from typing import ClassVar
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from world.tarot.constants import SUIT_SINGULAR, ArcanaType, TarotSuit
 
 
@@ -106,6 +107,8 @@ class NamingRitualConfig(SharedMemoryModel):
     Singleton config for the tarot naming ritual displayed in CG.
     Editable via Django admin. Optional link to a codex entry for lore.
     """
+
+    objects = ArxSharedMemoryManager()
 
     flavor_text = models.TextField(
         help_text="Flavor text displayed above the tarot card browser in CG.",

--- a/src/world/tarot/views.py
+++ b/src/world/tarot/views.py
@@ -27,7 +27,7 @@ class NamingRitualConfigView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        config = NamingRitualConfig.objects.first()
+        config = NamingRitualConfig.objects.cached_singleton()
         if config:
             return Response(NamingRitualConfigSerializer(config).data)
         return Response(

--- a/src/world/vitals/models.py
+++ b/src/world/vitals/models.py
@@ -3,6 +3,7 @@
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import ArxSharedMemoryManager
 from world.vitals.constants import (
     DEATH_BASE_DIFFICULTY,
     DEATH_SCALING_PER_PERCENT,
@@ -92,6 +93,8 @@ class CharacterVitals(SharedMemoryModel):
 class VitalsConsequenceConfig(SharedMemoryModel):
     """Singleton (pk=1): global knockout pool + default wound/death pools used
     when a DamageType doesn't specify its own. Authored via admin."""
+
+    objects = ArxSharedMemoryManager()
 
     knockout_pool = models.ForeignKey(
         _CONSEQUENCE_POOL_FK,

--- a/src/world/vitals/services.py
+++ b/src/world/vitals/services.py
@@ -1110,7 +1110,9 @@ def get_vitals_consequence_config() -> VitalsConsequenceConfig:
     """
     from world.vitals.models import VitalsConsequenceConfig  # noqa: PLC0415
 
-    cfg, _ = VitalsConsequenceConfig.objects.get_or_create(pk=1)
+    cfg = VitalsConsequenceConfig.objects.cached_singleton()
+    if cfg is None:
+        cfg, _ = VitalsConsequenceConfig.objects.get_or_create(pk=1)
     return cfg
 
 


### PR DESCRIPTION
Closes #1741

## Summary

Reduces per-declaration query cost in resolve_battle_round via three changes: (1) a select_related fix for the .character hop, (2) a reusable ArxSharedMemoryManager.cached_singleton() that caches singleton config pk via the SharedMemoryModel identity map (zero SQL after first call), migrated across ~20 config models in 3 tiers, and (3) a marginal per-declaration query-cost gate test.

## Follow-ups filed

- #1846

## Notes

- Spec: reviewed & approved on #1741 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean rebase on main; no conflicts.

<!-- last-addressed-comment: 0 -->