### PR TITLE
Witness-handling capability surface — approach-fanned concealment/containment (#1824)

### DIFF
--- a/docs/roadmap/planned-systems.md
+++ b/docs/roadmap/planned-systems.md
@@ -240,8 +240,12 @@ Build to the ADR; these are not open questions. See
   fame-scaled spread). **Civic-hub reader BUILT (#1450, closes the epic):** Notice Board / Town
   Crier RoomFeatureKinds gate a local tidings slice (`hub_feed_for_room`: room → area →
   `societies_for_area`) surfaced as arrival echo, `tidings local`, and a web room-panel block;
-  crier install places a Functionary. Still open (separate issues): act-time Stealth
-  witness-reduction wiring; interactive approach-fanned containment; venue vitality (PC-owned
+  crier install places a Functionary. **Witness handling BUILT (#1824):** the declared
+  capability list (`WITNESS_APPROACHES` + `witness_approaches_for`) replaces the containment
+  auto-pick when an approach is declared (bribery attempt tags its own CrimeKind); act-time
+  Stealth witness-reduction is wired end-to-end via the mission approach fan (a Stealth
+  `ChallengeApproach` → `concealed` deed). Still open: an async prompted-choice containment
+  UX at fork time (service param is live; needs its own design); venue vitality (PC-owned
   RP hubs) is its own future umbrella.
 - **Roster release / end-tenure**; **events RSVP-accept** (invitee response); **projects activation
   service** — small but real gaps where one half of a loop is unbuilt. `intent`.

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -686,10 +686,18 @@ Social structures, organizations, reputation, and legend tracking.
   successfully-contained scandalous acts mint an act-anchored contained
   `Secret` (blackmail material); public news/leaks set `societies_aware`,
   fire `apply_archetype_society_reputation`, and scale `spread_multiplier`
-  by the involved personas' fame (`FAME_SPREAD_FACTORS`). Containment =
-  Household Command for own-household witnesses, else best-of Con/Intimidation
-  by stat (ruled 2026-07-03); Stealth (new skill, seeded)
-  is the act-time leg, wiring later. Untagged deeds skip the fork.
+  by the involved personas' fame (`FAME_SPREAD_FACTORS`). Containment (#1824):
+  a declared `WitnessApproach` (`WITNESS_APPROACHES` registry — intimidation /
+  seduction / manipulation→Con-or-Deceive / bribery / household;
+  `witness_approaches_for(character, household=)` is the one eligibility
+  predicate; a declared bribery attempt tags the deed with the `bribery`
+  CrimeKind), else the legacy auto-pick (Household Command for own-household
+  witnesses, Con/Intimidation by stat). Act-time Stealth is wired:
+  `concealed=True` on the deed services rolls `reduce_witnesses_by_stealth`
+  (weakest link on group events; full success sheds all outsiders AND
+  auto-contains via `fully_concealed`); a Stealth mission `ChallengeApproach`
+  declares it (`ResolutionContext.chosen_approach` → `_legend_award`).
+  Untagged deeds skip the fork.
 - **`Organization`/`Society` as `NpcRegard` target (#1717):** either can now be the *target* (not
   holder) of a notable NPC's external opinion — see the Regard bullet in the NPC Services
   section above.

--- a/src/world/checks/tests/test_legend_award_handler.py
+++ b/src/world/checks/tests/test_legend_award_handler.py
@@ -76,6 +76,29 @@ class LegendAwardHandlerCreateEventTests(TestCase):
 
         assert "1 participant" in result.description
 
+    def test_stealth_approach_threads_concealed_into_the_deed(self) -> None:
+        """#1824 — a Stealth mission approach is the 'do it sneakily' declaration."""
+        from unittest.mock import patch
+
+        from world.checks.factories import CheckTypeFactory
+        from world.mechanics.factories import ChallengeApproachFactory
+
+        stealth_approach = ChallengeApproachFactory(check_type=CheckTypeFactory(name="Stealth"))
+        loud_approach = ChallengeApproachFactory(check_type=CheckTypeFactory(name="Oratory"))
+        consequence = ConsequenceFactory()
+        effect = _make_legend_effect(consequence, self.source_type, template="Done quietly.")
+
+        for approach, expected in ((stealth_approach, True), (loud_approach, False), (None, False)):
+            context = ResolutionContext(
+                character=self.character,
+                participants=[self.persona_a],
+                chosen_approach=approach,
+            )
+            with patch("world.societies.services.create_legend_event") as spy:
+                spy.return_value = (MagicMock(), [])
+                apply_effect(effect, context)
+            self.assertEqual(spy.call_args.kwargs.get("concealed"), expected)
+
     def test_routes_via_apply_all_effects(self) -> None:
         """apply_all_effects routes LEGEND_AWARD through the handler."""
         consequence = ConsequenceFactory()

--- a/src/world/checks/types.py
+++ b/src/world/checks/types.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
     from actions.types import ActionContext
     from world.checks.models import CheckType, Consequence
-    from world.mechanics.models import ChallengeInstance
+    from world.mechanics.models import ChallengeApproach, ChallengeInstance
     from world.missions.models import MissionInstance
     from world.scenes.models import Persona, Scene
     from world.stories.models import Beat, Story
@@ -76,6 +76,10 @@ class ResolutionContext:
     # applied against a known tier rather than a freshly-rolled check (beat auto-wire,
     # mission routes). None when the caller rolls its own check via select_consequence().
     outcome_tier: CheckOutcome | None = None
+    # The mission-challenge approach the player declared (#1824) — how they chose
+    # to do the thing. Effects read it for act-shape: a Stealth approach makes a
+    # LEGEND_AWARD deed concealed (the "do it sneakily" declaration surface).
+    chosen_approach: ChallengeApproach | None = None
 
     @property
     def location(self) -> ObjectDB:

--- a/src/world/mechanics/effect_handlers.py
+++ b/src/world/mechanics/effect_handlers.py
@@ -370,6 +370,10 @@ def _tier_multiplier(success_level: int) -> float:
     return 1.0 + max(0, success_level) / 5
 
 
+# #1824 — the CheckType whose declared mission approach marks a deed as sneaky.
+_STEALTH_CHECK_NAME = "stealth"
+
+
 def _legend_award(
     effect: "ConsequenceEffect",
     context: "ResolutionContext",
@@ -424,6 +428,12 @@ def _legend_award(
     # LegendEvent.title has max_length=200 (AbstractLegendRecord).
     title = description[:200]
 
+    # #1824 — choosing a Stealth approach for the challenge IS the "do it
+    # sneakily" declaration: the resulting deed rolls act-time concealment.
+    concealed = (
+        context.chosen_approach is not None
+        and context.chosen_approach.check_type.name.lower() == _STEALTH_CHECK_NAME
+    )
     event, entries = create_legend_event(
         title,
         effect.legend_source_type,
@@ -432,6 +442,7 @@ def _legend_award(
         description=description,
         scene=context.scene,
         story=context.story,
+        concealed=concealed,
     )
     return AppliedEffect(
         effect_type=EffectType.LEGEND_AWARD,

--- a/src/world/missions/services/resolution.py
+++ b/src/world/missions/services/resolution.py
@@ -586,7 +586,9 @@ def resolve_option(  # noqa: PLR0913
     consequence = _select_route_consequence(route, result, candidate)
     # Carry the run so mission-aware effects (e.g. a rescue route's
     # RESCUE_CAPTIVE) can reach run state like ``rescue_target``.
-    context = ResolutionContext(character=character, mission_instance=instance)
+    context = ResolutionContext(
+        character=character, mission_instance=instance, chosen_approach=chosen_approach
+    )
     apply_resolution(PendingResolution(result, consequence), context)
 
     is_terminal = False

--- a/src/world/seeds/social_checks.py
+++ b/src/world/seeds/social_checks.py
@@ -53,6 +53,10 @@ _SOCIAL_CHECK_COMPOSITION: dict[str, tuple[str, str, str | None]] = {
     "Seduction": ("charm", "Persuasion", "Seduction"),
     "Performance": ("presence", "Performance", None),
     "Gossip": ("charm", "Persuasion", "Gossip"),  # #1572 — the gossip plant/seek/suppress check
+    # #1824 — the witness-handling bribery approach (pay them off; the attempt
+    # itself is a CrimeKind). Bare Persuasion: no existing spec fits a plain
+    # transaction — FLAGGED as a possible spec-list hole for the skills audit.
+    "Bribery": ("charm", "Persuasion", None),
 }
 
 

--- a/src/world/societies/AGENT_GLOSSARY.md
+++ b/src/world/societies/AGENT_GLOSSARY.md
@@ -57,8 +57,12 @@ A per-society judgment, never a taxonomy: an act whose archetype dot-product aga
 _Avoid_: scandal type, scandal category, outrage score
 
 **Containment**:
-The after-the-act half of concealment (#1464): a check of the actor's best social tool against the crowd size that routes a public scandalous act to a contained Secret instead of society awareness. Distinct from act-time concealment (Stealth/magic reducing who witnesses at all).
+The after-the-act half of concealment (#1464): a check against the crowd size that routes a public scandalous act to a contained Secret instead of society awareness. Rolled with a declared Witness Approach when one was chosen (#1824), else the actor's best social tool. Distinct from act-time concealment (Stealth/magic reducing who witnesses at all).
 _Avoid_: cover-up roll (informal), suppression (that's gossip heat)
+
+**Witness Approach**:
+One entry of the #1824 capability list — a named tool for dealing with witnesses (intimidation, seduction, manipulation, bribery, household command), each resolving to a seeded CheckType; bribery's attempt also tags the deed with the `bribery` CrimeKind. `witness_approaches_for` is the single eligibility predicate (visibility = selectability).
+_Avoid_: containment option, hush method.
 
 **Reach (act)**:
 Where knowledge of an act lands at birth — contained (a Secret) or the realm walk's societies — always derived from room privacy + containment + the fame of those involved, never authored per act (ADR-0082). Continental/world are escalation (gemit, common knowledge, legend), never minted.

--- a/src/world/societies/constants.py
+++ b/src/world/societies/constants.py
@@ -227,6 +227,12 @@ SCANDAL_THRESHOLD = -10
 CONTAINMENT_BASE_DIFFICULTY = 0
 CONTAINMENT_DIFFICULTY_PER_WITNESS = 2
 
+# Act-time concealment (#1824): a declared-sneaky deed rolls Stealth against
+# the crowd before witnesses are minted. success_level at/past FULL removes
+# every witness but the actor; at/past PARTIAL drops half. PLACEHOLDER tuning.
+CONCEALMENT_FULL_LEVEL = 3
+CONCEALMENT_PARTIAL_LEVEL = 1
+
 # Contained-scandal Secret level scales with how badly the act reads
 # (|worst dot| at or past each floor, descending). (level, |dot| floor).
 SCANDAL_SECRET_LEVEL_FLOORS: tuple[tuple[int, int], ...] = (

--- a/src/world/societies/scandal.py
+++ b/src/world/societies/scandal.py
@@ -16,9 +16,12 @@ At scene-deed birth the fork runs (``route_deed_reach``):
   ``PersonaDeedKnowledge``; society awareness never fires.
 - **Public room, not scandalous** → news: the realm walk's societies become
   aware, reputation fires, spread scales with fame.
-- **Public room, scandalous** → a containment check (best of the actor's
-  social tools; difficulty grows with the crowd). Success = contained Secret;
-  failure = the scandal leaks (aware + reputation + fame-scaled spread).
+- **Public room, scandalous** → a containment check (a declared witness-
+  handling approach when one was chosen — the #1824 capability list — else
+  the actor's best social tool; difficulty grows with the crowd). Success =
+  contained Secret; failure = the scandal leaks (aware + reputation +
+  fame-scaled spread). An act-time Stealth declaration (#1824) sheds
+  witnesses before the fork; a full concealment success auto-contains.
 
 Mechanics stay tribal: thresholds/difficulties live in constants, never in
 player-facing docs.
@@ -30,6 +33,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from world.societies.constants import (
+    CONCEALMENT_FULL_LEVEL,
+    CONCEALMENT_PARTIAL_LEVEL,
     CONTAINMENT_BASE_DIFFICULTY,
     CONTAINMENT_DIFFICULTY_PER_WITNESS,
     FAME_SPREAD_FACTORS,
@@ -39,6 +44,9 @@ from world.societies.constants import (
 from world.societies.renown import _archetype_dot_product
 
 if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from world.checks.models import CheckType
     from world.scenes.models import Persona, Scene
     from world.societies.models import LegendEntry, PhilosophicalArchetype, Society
 
@@ -115,32 +123,161 @@ def _witnesses_are_own_household(actor_persona, witnesses) -> bool:
     return True
 
 
-def _run_containment_check(character, witness_count: int, *, household: bool = False) -> bool:
-    """The hush-it-up roll: the actor's best social tool against the crowd size.
+@dataclass(frozen=True)
+class WitnessApproach:
+    """One entry of the witness-handling capability list (#1824, ratified 2026-07-03).
 
-    Own-household witnesses → Household Command (presence + Leadership +
-    Stewardship — you are obeyed, not believed; Apostate 2026-07-03).
-    Otherwise auto-picks between Con (charm + Persuasion + Manipulation) and
-    Intimidation (presence + Persuasion + Intimidation) by the stronger stat —
-    "a range of skills based on character capability"; the interactive
-    approach-fanned surface is a later slice. Unseeded worlds fail closed
+    ``check_type_name`` of None means the approach resolves between Con and
+    Deceive by the actor's stronger social stat (the #1811 charm/presence
+    split). ``mints_crime_slug`` marks approaches whose *attempt* is itself a
+    crime (bribery — the compounding risk): the deed gets that CrimeKind tag
+    at declaration, latent while contained, soaking heat if it ever leaks.
+    """
+
+    key: str
+    label: str
+    check_type_name: str | None
+    household_only: bool = False
+    mints_crime_slug: str | None = None
+
+
+# Ordered as ratified on #1824. Extensible: a new tool is a new entry (and a
+# seeded CheckType), never a new code path.
+WITNESS_APPROACHES: tuple[WitnessApproach, ...] = (
+    WitnessApproach(key="intimidation", label="Intimidation", check_type_name="Intimidation"),
+    WitnessApproach(key="seduction", label="Seduction", check_type_name="Seduction"),
+    WitnessApproach(key="manipulation", label="Manipulation", check_type_name=None),
+    WitnessApproach(
+        key="bribery", label="Bribery", check_type_name="Bribery", mints_crime_slug="bribery"
+    ),
+    WitnessApproach(
+        key="household",
+        label="Household Command",
+        check_type_name="Household Command",
+        household_only=True,
+    ),
+)
+
+
+def _resolve_approach_check_type(approach: WitnessApproach, character) -> CheckType | None:
+    """The approach's CheckType row, or None when the world hasn't seeded it."""
+    from world.checks.models import CheckType  # noqa: PLC0415
+
+    name = approach.check_type_name
+    if name is None:
+        # Manipulation ("they didn't see what they saw") is deception — the
+        # #1811 split: Con rides charm, Deceive rides presence.
+        handler = character.traits
+        charm = handler.get_trait_value("charm")
+        presence = handler.get_trait_value("presence")
+        name = "Con" if charm >= presence else "Deceive"
+    return CheckType.objects.filter(name__iexact=name).first()
+
+
+def witness_approaches_for(character, *, household: bool = False) -> list[WitnessApproach]:
+    """The capability list: which witness-handling tools this character can bring.
+
+    One predicate drives visibility AND selectability: an approach is offered
+    when its CheckType is seeded (and, for Household Command, when every
+    witness is the actor's own household). Social stats are universal, so
+    capability shapes the odds, not the menu.
+    """
+    return [
+        approach
+        for approach in WITNESS_APPROACHES
+        if (household or not approach.household_only)
+        and _resolve_approach_check_type(approach, character) is not None
+    ]
+
+
+def _approach_for_key(key: str | None) -> WitnessApproach | None:
+    if key is None:
+        return None
+    for approach in WITNESS_APPROACHES:
+        if approach.key == key:
+            return approach
+    return None
+
+
+def reduce_witnesses_by_stealth(
+    characters: list[ObjectDB], actor_personas: list[Persona], witnesses: list[Persona]
+) -> tuple[list[Persona], bool]:
+    """Act-time concealment (#1824): roll Stealth against the crowd, shed watchers.
+
+    Group jobs are weakest-link: every acting character rolls and the worst
+    result governs. Returns ``(witnesses, fully_concealed)``: a full success
+    leaves only the actors in the witness set AND flags the act unwitnessed
+    (the reach fork auto-contains — even a public room holds no one who saw);
+    a partial sheds half the outsiders; a failure changes nothing. Unseeded
+    worlds (no Stealth CheckType) change nothing.
+    """
+    from world.checks.models import CheckType  # noqa: PLC0415
+    from world.checks.services import perform_check  # noqa: PLC0415
+
+    if not characters:
+        return witnesses, False
+    check_type = CheckType.objects.filter(name__iexact="Stealth").first()
+    if check_type is None:
+        return witnesses, False
+    actor_pks = {actor.pk for actor in actor_personas}
+    outsider_count = sum(1 for w in witnesses if w.pk not in actor_pks)
+    worst: int | None = None
+    for character in characters:
+        result = perform_check(
+            character,
+            check_type,
+            target_difficulty=_containment_difficulty(outsider_count),
+        )
+        level = result.outcome.success_level if result.outcome is not None else 0
+        worst = level if worst is None else min(worst, level)
+    if worst is None or worst < CONCEALMENT_PARTIAL_LEVEL:
+        return witnesses, False
+    if worst >= CONCEALMENT_FULL_LEVEL:
+        return [w for w in witnesses if w.pk in actor_pks], True
+    # Partial: half the outsiders never noticed. Deterministic (pk order) so
+    # tests and re-runs agree; which half is flavor, not fairness.
+    outsiders = sorted((w for w in witnesses if w.pk not in actor_pks), key=lambda w: w.pk)
+    kept_outsiders = outsiders[: len(outsiders) // 2]
+    kept_pks = actor_pks | {w.pk for w in kept_outsiders}
+    return [w for w in witnesses if w.pk in kept_pks], False
+
+
+def _run_containment_check(
+    character,
+    witness_count: int,
+    *,
+    household: bool = False,
+    approach_key: str | None = None,
+) -> bool:
+    """The hush-it-up roll: a declared tool, or the actor's best one.
+
+    A declared ``approach_key`` (from ``WITNESS_APPROACHES``) resolves to its
+    CheckType — the #1824 capability surface. With no declaration (or an
+    unknown/unseeded key) the legacy auto-pick stands: own-household witnesses
+    → Household Command (you are obeyed, not believed; Apostate 2026-07-03),
+    else Con vs Intimidation by the stronger stat. Unseeded worlds fail closed
     (nothing to roll → the scandal leaks).
     """
     from world.checks.models import CheckType  # noqa: PLC0415
     from world.checks.services import perform_check  # noqa: PLC0415
 
-    handler = character.traits  # ObjectDB typeclass extension (checks/services idiom)
-    charm = handler.get_trait_value("charm")
-    presence = handler.get_trait_value("presence")
-    if household:
-        preferred = "Household Command"
-    else:
-        preferred = "Con" if charm >= presence else "Intimidation"
-    check_type = (
-        CheckType.objects.filter(name__iexact=preferred).first()
-        or CheckType.objects.filter(name__iexact="Intimidation").first()
-        or CheckType.objects.filter(name__iexact="Con").first()
-    )
+    check_type = None
+    declared = _approach_for_key(approach_key)
+    if declared is not None and (household or not declared.household_only):
+        check_type = _resolve_approach_check_type(declared, character)
+    if check_type is None:
+        handler = character.traits  # ObjectDB typeclass extension (checks/services idiom)
+        charm = handler.get_trait_value("charm")
+        presence = handler.get_trait_value("presence")
+        if household:
+            preferred = "Household Command"
+        else:
+            preferred = "Con" if charm >= presence else "Intimidation"
+        check_type = (
+            CheckType.objects.filter(name__iexact=preferred).first()
+            or CheckType.objects.filter(name__iexact="Intimidation").first()
+            or CheckType.objects.filter(name__iexact="Con").first()
+        )
     if check_type is None:
         return False
     result = perform_check(
@@ -200,17 +337,38 @@ def _mint_contained_secret(
     return secret.pk
 
 
-def route_deed_reach(
+def _tag_approach_crime(entry: LegendEntry, approach: WitnessApproach) -> None:
+    """Bribery's compounding risk: the attempt itself is a crime (#1824).
+
+    Tagged at declaration, before the roll — a contained scandal keeps the tag
+    latent (heat only accrues as knowledge spreads), a leak compounds. Missing
+    seed rows are a silent no-op (unseeded worlds have no law to break).
+    """
+    from world.justice.models import CrimeKind  # noqa: PLC0415
+    from world.justice.services import tag_deed_crimes  # noqa: PLC0415
+
+    kind = CrimeKind.objects.filter(slug=approach.mints_crime_slug).first()
+    if kind is not None:
+        tag_deed_crimes(entry, [kind])
+
+
+def route_deed_reach(  # noqa: PLR0913
     *,
     entry: LegendEntry,
     scene: Scene | None,
     actor_persona: Persona,
     witnesses: list[Persona],
+    containment_approach: str | None = None,
+    fully_concealed: bool = False,
 ) -> DeedReachResult:
     """The #1464 birth fork. Called after witness knowledge is granted.
 
     No scene, no room, or an untagged deed → legacy no-op (nothing minted,
-    nothing aware — exactly the pre-#1464 behavior).
+    nothing aware — exactly the pre-#1464 behavior). ``containment_approach``
+    (#1824) is a declared ``WitnessApproach.key``; None keeps the auto-pick.
+    ``fully_concealed`` (#1824) is the act-time Stealth full success: nobody
+    saw, so a scandal auto-contains without a hush-up roll. (An empty witness
+    list alone does NOT auto-contain — a public room holds an ambient crowd.)
     """
     from evennia_extensions.models import room_is_publicly_listed  # noqa: PLC0415
     from world.areas.services import societies_for_scene  # noqa: PLC0415
@@ -229,10 +387,17 @@ def route_deed_reach(
     is_public = room_is_publicly_listed(scene.location)
 
     if scandal_dots:
-        contained = not is_public or _run_containment_check(
+        declared = _approach_for_key(containment_approach)
+        needs_hush = is_public and not fully_concealed
+        if declared is not None and declared.mints_crime_slug and needs_hush:
+            # Only a *used* tool mints the crime — a private or fully
+            # concealed act never reached the bribing stage.
+            _tag_approach_crime(entry, declared)
+        contained = not needs_hush or _run_containment_check(
             actor_persona.character_sheet.character,
             len(witnesses),
             household=_witnesses_are_own_household(actor_persona, witnesses),
+            approach_key=containment_approach,
         )
         if contained:
             worst = min(scandal_dots.values())

--- a/src/world/societies/services.py
+++ b/src/world/societies/services.py
@@ -38,6 +38,22 @@ if TYPE_CHECKING:
     from world.covenants.models import CovenantRole
 
 
+def _shed_witnesses_if_concealed(
+    concealed: bool, personas: list[Persona], witnesses: list[Persona]
+) -> tuple[list[Persona], bool]:
+    """#1824 — a declared-sneaky act rolls Stealth before anyone "saw" it.
+
+    Group acts are weakest-link: every actor rolls and the worst result
+    governs how many outsiders noticed. Undeclared acts pass through.
+    """
+    if not concealed:
+        return witnesses, False
+    from world.societies.scandal import reduce_witnesses_by_stealth  # noqa: PLC0415
+
+    characters = [p.character_sheet.character for p in personas if p.character_sheet]
+    return reduce_witnesses_by_stealth(characters, personas, witnesses)
+
+
 @transaction.atomic
 def create_solo_deed(  # noqa: PLR0913
     persona: Persona,
@@ -50,6 +66,8 @@ def create_solo_deed(  # noqa: PLR0913
     story: Story | None = None,
     crime_kinds: list | None = None,
     archetypes: list | None = None,
+    concealed: bool = False,
+    containment_approach: str | None = None,
 ) -> LegendEntry:
     """Create a legend deed not tied to a shared event.
 
@@ -67,6 +85,10 @@ def create_solo_deed(  # noqa: PLR0913
         archetypes: Optional ``PhilosophicalArchetype`` rows framing the act
             (#1464) — deed sources SHOULD tag; untagged deeds can never read as
             scandal (missed tags = missed scandals) and skip the reach fork.
+        concealed: #1824 — the act was declared sneaky: a Stealth roll sheds
+            witnesses before knowledge is minted.
+        containment_approach: #1824 — a declared ``WitnessApproach.key`` for
+            the hush-up roll; None keeps the auto-pick.
 
     Returns:
         The created LegendEntry.
@@ -97,6 +119,7 @@ def create_solo_deed(  # noqa: PLR0913
         )
 
         witnesses = scene_witness_personas(scene)
+        witnesses, fully_concealed = _shed_witnesses_if_concealed(concealed, [persona], witnesses)
         grant_deed_knowledge(
             deed=entry,
             personas=witnesses,
@@ -106,7 +129,14 @@ def create_solo_deed(  # noqa: PLR0913
         # #1464 — the reach fork: contained Secret vs society awareness.
         from world.societies.scandal import route_deed_reach  # noqa: PLC0415
 
-        route_deed_reach(entry=entry, scene=scene, actor_persona=persona, witnesses=witnesses)
+        route_deed_reach(
+            entry=entry,
+            scene=scene,
+            actor_persona=persona,
+            witnesses=witnesses,
+            containment_approach=containment_approach,
+            fully_concealed=fully_concealed,
+        )
     new_credits = credit_engaged_covenants(entry=entry)
     refresh_legend_views()
     from world.covenants.services import recompute_covenant_level  # noqa: PLC0415
@@ -129,6 +159,8 @@ def create_legend_event(  # noqa: PLR0913
     created_by: AccountDB | None = None,
     crime_kinds: list | None = None,
     archetypes: list | None = None,
+    concealed: bool = False,
+    containment_approach: str | None = None,
 ) -> tuple[LegendEvent, list[LegendEntry]]:
     """Create a shared event and individual deeds for each participant.
 
@@ -147,6 +179,11 @@ def create_legend_event(  # noqa: PLR0913
         archetypes: Optional ``PhilosophicalArchetype`` rows framing the shared
             act (#1464) — every participant's entry carries them; the reach
             fork routes each entry (each participant hushes their own part).
+        concealed: #1824 — the act was declared sneaky: every actor rolls
+            Stealth (weakest link governs) to shed witnesses before knowledge
+            is minted.
+        containment_approach: #1824 — a declared ``WitnessApproach.key`` for
+            each entry's hush-up roll; None keeps the auto-pick.
 
     Returns:
         Tuple of (LegendEvent, list of LegendEntry instances).
@@ -198,6 +235,9 @@ def create_legend_event(  # noqa: PLR0913
         from world.societies.scandal import route_deed_reach  # noqa: PLC0415
 
         witnesses = scene_witness_personas(scene)
+        witnesses, fully_concealed = _shed_witnesses_if_concealed(
+            concealed, list(personas), witnesses
+        )
         for e in entries:
             grant_deed_knowledge(
                 deed=e,
@@ -206,7 +246,14 @@ def create_legend_event(  # noqa: PLR0913
                 room=scene.location,
             )
             # #1464 — each participant routes (and hushes) their own part.
-            route_deed_reach(entry=e, scene=scene, actor_persona=e.persona, witnesses=witnesses)
+            route_deed_reach(
+                entry=e,
+                scene=scene,
+                actor_persona=e.persona,
+                witnesses=witnesses,
+                containment_approach=containment_approach,
+                fully_concealed=fully_concealed,
+            )
     all_credits: list[CovenantLegendCredit] = []
     for e in entries:
         all_credits.extend(credit_engaged_covenants(entry=e))

--- a/src/world/societies/tests/test_scandal.py
+++ b/src/world/societies/tests/test_scandal.py
@@ -161,3 +161,204 @@ class HouseholdContainmentTests(ScandalForkTestCase):
             entry = self._mint(scene, [self.vile], persona=persona)
         self.assertEqual(captured.get("check"), "Household Command")
         self.assertTrue(Secret.objects.filter(legend_deed=entry).exists())
+
+
+class WitnessApproachTests(ScandalForkTestCase):
+    """#1824 — the declared capability list replaces the auto-pick."""
+
+    def _mint_with_approach(self, approach_key, *, persona=None, success_level=1):
+        from unittest.mock import patch
+
+        from world.societies.factories import LegendSourceTypeFactory
+
+        persona = persona or self._persona()
+        captured = {}
+        from world.checks import services as check_services
+
+        real_perform = check_services.perform_check
+
+        def spy(character, check_type, **kwargs):
+            captured["check"] = check_type.name
+            return real_perform(character, check_type, **kwargs)
+
+        outcome = CheckOutcomeFactory(name=f"wa_{approach_key}", success_level=success_level)
+        with (
+            patch("world.checks.services.perform_check", side_effect=spy),
+            force_check_outcome(outcome),
+        ):
+            entry = create_solo_deed(
+                persona,
+                "PLACEHOLDER: the deed in question",
+                LegendSourceTypeFactory(),
+                10,
+                scene=self._scene(public=True),
+                archetypes=[self.vile],
+                containment_approach=approach_key,
+            )
+        return entry, captured
+
+    def test_declared_intimidation_uses_intimidation(self):
+        _, captured = self._mint_with_approach("intimidation")
+        self.assertEqual(captured.get("check"), "Intimidation")
+
+    def test_declared_seduction_uses_seduction(self):
+        CheckTypeFactory(name="Seduction")
+        _, captured = self._mint_with_approach("seduction")
+        self.assertEqual(captured.get("check"), "Seduction")
+
+    def test_declared_manipulation_resolves_con_or_deceive(self):
+        # charm == presence (equal traits) → the charm branch → Con.
+        CheckTypeFactory(name="Deceive")
+        _, captured = self._mint_with_approach("manipulation")
+        self.assertEqual(captured.get("check"), "Con")
+
+    def test_declared_bribery_tags_the_deed_even_when_contained(self):
+        from world.justice.models import CrimeKind, DeedCrimeTag
+
+        CheckTypeFactory(name="Bribery")
+        CrimeKind.objects.create(slug="bribery", name="Bribery")
+        entry, captured = self._mint_with_approach("bribery", success_level=1)
+        self.assertEqual(captured.get("check"), "Bribery")
+        self.assertTrue(Secret.objects.filter(legend_deed=entry).exists())
+        self.assertTrue(
+            DeedCrimeTag.objects.filter(deed=entry, crime_kind__slug="bribery").exists()
+        )
+
+    def test_unknown_approach_falls_back_to_auto_pick(self):
+        # Equal charm/presence → the legacy Con branch, exactly as undeclared.
+        _, captured = self._mint_with_approach("interpretive-dance")
+        self.assertEqual(captured.get("check"), "Con")
+
+    def test_capability_list_gates_household_and_unseeded_tools(self):
+        from world.societies.scandal import witness_approaches_for
+
+        CheckTypeFactory(name="Seduction")
+        CheckTypeFactory(name="Household Command")
+        character = self._persona().character_sheet.character
+        keys = [a.key for a in witness_approaches_for(character, household=False)]
+        # Bribery unseeded here → dropped; household tool needs household=True.
+        self.assertIn("intimidation", keys)
+        self.assertIn("seduction", keys)
+        self.assertIn("manipulation", keys)
+        self.assertNotIn("bribery", keys)
+        self.assertNotIn("household", keys)
+        household_keys = [a.key for a in witness_approaches_for(character, household=True)]
+        self.assertIn("household", household_keys)
+
+
+class ActTimeConcealmentTests(ScandalForkTestCase):
+    """#1824 — the declared-sneaky Stealth roll sheds witnesses before minting."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        CheckTypeFactory(name="Stealth")
+
+    def _mint_concealed(self, *, success_level, witnesses, persona):
+        from unittest.mock import patch
+
+        from world.societies.factories import LegendSourceTypeFactory
+
+        outcome = CheckOutcomeFactory(name=f"sneak_{success_level}", success_level=success_level)
+        with (
+            patch(
+                "world.societies.knowledge_services.scene_witness_personas",
+                return_value=witnesses,
+            ),
+            force_check_outcome(outcome),
+        ):
+            return create_solo_deed(
+                persona,
+                "PLACEHOLDER: the deed in question",
+                LegendSourceTypeFactory(),
+                10,
+                scene=self._scene(public=True),
+                archetypes=[self.vile],
+                concealed=True,
+            )
+
+    def test_full_success_leaves_no_outside_knowledge_and_auto_contains(self):
+        from world.societies.models import PersonaDeedKnowledge
+
+        persona = self._persona()
+        bystander = self._persona()
+        # Forced outcome governs BOTH the stealth roll and any containment roll,
+        # so a full success (3) proves auto-containment only via knowledge count.
+        entry = self._mint_concealed(
+            success_level=3, witnesses=[persona, bystander], persona=persona
+        )
+        knowers = set(
+            PersonaDeedKnowledge.objects.filter(deed=entry).values_list("persona_id", flat=True)
+        )
+        self.assertNotIn(bystander.pk, knowers)
+        self.assertTrue(Secret.objects.filter(legend_deed=entry).exists())
+        self.assertEqual(entry.societies_aware.count(), 0)
+
+    def test_failure_changes_nothing(self):
+        from world.societies.models import PersonaDeedKnowledge
+
+        persona = self._persona()
+        bystander = self._persona()
+        # success_level=0 fails the stealth roll AND the containment roll → leak.
+        entry = self._mint_concealed(
+            success_level=0, witnesses=[persona, bystander], persona=persona
+        )
+        knowers = set(
+            PersonaDeedKnowledge.objects.filter(deed=entry).values_list("persona_id", flat=True)
+        )
+        self.assertIn(bystander.pk, knowers)
+        self.assertFalse(Secret.objects.filter(legend_deed=entry).exists())
+        self.assertGreater(entry.societies_aware.count(), 0)
+
+    def test_partial_success_sheds_half_the_outsiders(self):
+        from world.societies.scandal import reduce_witnesses_by_stealth
+
+        persona = self._persona()
+        outsiders = [self._persona() for _ in range(4)]
+        outcome = CheckOutcomeFactory(name="sneak_partial", success_level=1)
+        with force_check_outcome(outcome):
+            kept, fully = reduce_witnesses_by_stealth(
+                [persona.character_sheet.character], [persona], [persona, *outsiders]
+            )
+        self.assertFalse(fully)
+        kept_outsiders = [w for w in kept if w.pk != persona.pk]
+        self.assertEqual(len(kept_outsiders), 2)
+
+    def test_group_concealment_is_weakest_link(self):
+        from unittest.mock import patch
+
+        from world.societies.scandal import reduce_witnesses_by_stealth
+
+        actor_a = self._persona()
+        actor_b = self._persona()
+        bystander = self._persona()
+        good = CheckOutcomeFactory(name="sneak_good", success_level=3)
+        bad = CheckOutcomeFactory(name="sneak_bad", success_level=0)
+        from world.checks import services as check_services
+
+        real_perform = check_services.perform_check
+        outcomes = iter([good, bad])
+
+        def alternating(character, check_type, **kwargs):
+            result = real_perform(character, check_type, **kwargs)
+            forced = next(outcomes)
+            return type(result)(
+                check_type=result.check_type,
+                outcome=forced,
+                chart=result.chart,
+                roller_rank=result.roller_rank,
+                target_rank=result.target_rank,
+                rank_difference=result.rank_difference,
+                trait_points=result.trait_points,
+                aspect_bonus=result.aspect_bonus,
+                total_points=result.total_points,
+            )
+
+        with patch("world.checks.services.perform_check", side_effect=alternating):
+            kept, fully = reduce_witnesses_by_stealth(
+                [actor_a.character_sheet.character, actor_b.character_sheet.character],
+                [actor_a, actor_b],
+                [actor_a, actor_b, bystander],
+            )
+        self.assertFalse(fully)
+        self.assertIn(bystander, kept)


### PR DESCRIPTION
Closes #1824

## Summary

Implements the #1824 witness-handling capability surface (ratified in the #1806 quick-fire round, follow-on to #1464's containment MVP):

- **`WITNESS_APPROACHES` registry + `witness_approaches_for`** (`world/societies/scandal.py`) — the declared capability list (intimidation / seduction / manipulation→Con-or-Deceive by stronger stat / bribery / household command). One eligibility predicate drives visibility and selectability; an approach is offered when its CheckType is seeded (household command additionally requires all witnesses share the actor's household). Extensible: a new tool is a new entry + seeded CheckType, never a new code path.
- **Declared containment** — `route_deed_reach`/`_run_containment_check` accept a declared `WitnessApproach.key`; unknown/unseeded keys fall back to the legacy auto-pick (#1811 rules preserved).
- **Bribery mints its own crime** — a *used* bribery declaration tags the deed with the `bribery` CrimeKind before the roll (latent while contained, compounding on a leak). Private or fully-concealed acts never reach the bribing stage and don't tag.
- **Act-time Stealth wired end-to-end** — a Stealth mission `ChallengeApproach` is the "do it sneakily" declaration: `ResolutionContext.chosen_approach` → `_legend_award` threads `concealed=True` into the deed services; `reduce_witnesses_by_stealth` rolls weakest-link across group actors (full success sheds all outsiders AND auto-contains via `fully_concealed`; partial sheds half deterministically).
- **Seeds**: `Bribery` check (bare Persuasion — flagged as a possible spec-list hole per the skills audit convention). Tuning constants are PLACEHOLDER.
- Docs: societies INDEX section, glossary (Witness Approach term), roadmap. Deliberately open (recorded in roadmap, not filed): an async prompted-choice containment UX at fork time — the service param is live; the surface needs its own design.

Note: the fast SQLite tier shows 22 pre-existing failures in legend materialized-view tests (`no such table: societies_covenantlegendsummary`) that reproduce identically on pristine main — unrelated to this diff. All 57 scandal/legend-award tests plus the full missions/mechanics suites (1023) pass.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1824 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto origin/main (2273d0b4) before push; no conflicts.

<!-- last-addressed-comment: 0 -->