### PR TITLE
test(#1328): telnet e2e journey tests for untested commands + battle subverbs

### DIFF
--- a/src/integration_tests/pipeline/test_battle_subverbs_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_battle_subverbs_telnet_e2e.py
@@ -1,0 +1,451 @@
+"""Telnet E2E: battle declare subverbs — the coverage gap (#1328 Bucket C).
+
+Companion to ``test_battle_telnet_e2e.py`` (which covers the strike + round
+lifecycle + peril/rescue). This file covers the remaining ``battle declare``
+subverbs that had no e2e test:
+
+  - ``battle declare support <ally> with <technique>``
+  - ``battle declare rescue <ally> with <technique>``
+  - ``battle declare rout <unit> with <technique>``
+  - ``battle declare rally <unit> with <technique>``
+  - ``battle declare repel place <name> with <technique>``
+  - ``battle declare hold place <name> with <technique>``
+  - ``battle declare breach place <name> fortification <kind> with <technique>``
+  - ``battle declare fortify place <name> fortification <kind> with <technique>``
+  - ``battle declare set_environment with <technique>``
+  - ``battle declare set_environment place <name> with <technique>``
+  - ``battle conclude`` (GM force-conclude)
+
+Each test creates a battle, opens a round, declares, and asserts the
+BattleActionDeclaration row was written with the correct action_kind + target.
+``perform_check`` is not patched — these tests verify the *declaration* path
+(command → Action → DB row), not round resolution.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from actions.factories import ActionTemplateFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from integration_tests.pipeline.test_battle_telnet_e2e import (
+    _make_pc,
+    _make_room,
+    _run,
+)
+from world.battles.constants import (
+    BattleActionKind,
+    BattleActionScope,
+    BattleSideRole,
+    BattleUnitStatus,
+    FortificationKind,
+)
+from world.battles.factories import (
+    FortificationFactory,
+)
+from world.battles.models import BattleActionDeclaration, BattleRound
+from world.battles.services import (
+    add_side,
+    add_unit,
+    create_battle,
+    enlist_participant,
+)
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.factories import (
+    CharacterAnimaFactory,
+    CharacterTechniqueFactory,
+    TechniqueFactory,
+)
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.constants import RoundStatus
+from world.vitals.factories import CharacterVitalsFactory
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_gm(room: object, account: object) -> object:
+    """Create a GM character (staff account) in *room*."""
+    char = CharacterFactory(db_key="BattleSubverbGM", location=room)
+    sheet = CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet=sheet)
+    RosterTenureFactory(roster_entry=entry, player_data__account=account, end_date=None)
+    return char
+
+
+def _make_battle_with_round(room: object) -> tuple[object, object, object, object, object]:
+    """Create a battle with two sides, a unit, and an open DECLARING round.
+
+    Returns (gm_char, battle, attacker_side, defender_side, enemy_unit).
+    """
+    gm_account = AccountFactory(username="battle_subverb_gm", is_staff=True)
+    gm_char = _make_gm(room, gm_account)
+
+    battle = create_battle(name="Subverb E2E Battle")
+    battle.scene.location = room
+    battle.scene.save(update_fields=["location"])
+
+    attacker_side = add_side(battle=battle, role=BattleSideRole.ATTACKER)
+    defender_side = add_side(battle=battle, role=BattleSideRole.DEFENDER)
+    enemy_unit = add_unit(
+        battle=battle, side=attacker_side, name="Vanguard", descriptor="soldiers", strength=100
+    )
+
+    # Open a round so declarations can be recorded.
+    _run(gm_char, "round")
+    return gm_char, battle, attacker_side, defender_side, enemy_unit
+
+
+def _make_battle_pc(
+    room: object,
+    db_key: str,
+    side: object,
+    technique: object,
+) -> tuple[object, object, object]:
+    """Create a PC participant in *side* who knows *technique*.
+
+    Returns (character, sheet, participant).
+    """
+    char, sheet = _make_pc(db_key, room)
+    CharacterVitalsFactory(character_sheet=sheet, health=100, max_health=100)
+    CharacterTechniqueFactory(character=sheet, technique=technique)
+    CharacterAnimaFactory(character=char, current=20, maximum=30)
+    participant = enlist_participant(battle=side.battle, character_sheet=sheet, side=side)
+    return char, sheet, participant
+
+
+def _grant_supreme_command_tier(participant: object, side: object) -> None:
+    """Attach a BATTLE covenant with a SUPREME command-tier role to *side* + *participant*.
+
+    REPEL/HOLD (PLACE scope) require SUBORDINATE or SUPREME; SET_ENVIRONMENT at
+    BATTLE scope requires SUPREME. This helper wires the full chain:
+    covenant → side.covenant → CovenantRole(command_tier=SUPREME) →
+    engaged CharacterCovenantRole.
+    """
+    from world.covenants.constants import CovenantType
+    from world.covenants.factories import (
+        CharacterCovenantRoleFactory,
+        CovenantFactory,
+        CovenantRoleFactory,
+    )
+
+    covenant = CovenantFactory(covenant_type=CovenantType.BATTLE)
+    side.covenant = covenant
+    side.save(update_fields=["covenant"])
+
+    role = CovenantRoleFactory(covenant_type=CovenantType.BATTLE)
+    role.command_tier = "supreme"
+    role.save(update_fields=["command_tier"])
+
+    CharacterCovenantRoleFactory(
+        character_sheet=participant.character_sheet,
+        covenant=covenant,
+        covenant_role=role,
+        engaged=True,
+    )
+
+
+def _last_declaration(battle_round: object) -> BattleActionDeclaration:
+    """Return the most-recent BattleActionDeclaration for *battle_round*."""
+    return BattleActionDeclaration.objects.filter(battle_round=battle_round).order_by("-pk").first()
+
+
+# ---------------------------------------------------------------------------
+# Journey — unit-scoped subverbs (rout, rally)
+# ---------------------------------------------------------------------------
+
+
+class BattleUnitScopedSubverbsE2ETest(TestCase):
+    """rout + rally declarations through CmdBattle."""
+
+    def setUp(self) -> None:
+        self.room = _make_room("BattleSubverbRoom")
+        self.technique = TechniqueFactory(
+            action_template=ActionTemplateFactory(), damage_profile=False
+        )
+        self.gm_char, self.battle, self.attacker_side, self.defender_side, self.enemy_unit = (
+            _make_battle_with_round(self.room)
+        )
+        self.battle_round = BattleRound.objects.filter(
+            battle=self.battle, status=RoundStatus.DECLARING
+        ).first()
+
+        # A PC on the defender side who will declare.
+        self.pc_char, self.pc_sheet, self.pc_participant = _make_battle_pc(
+            self.room, "RoutPC", self.defender_side, self.technique
+        )
+        # A routed unit on the defender side (for rally).
+        self.routed_unit = add_unit(
+            battle=self.battle, side=self.defender_side, name="Broken Squad", descriptor="survivors"
+        )
+        self.routed_unit.status = BattleUnitStatus.ROUTED
+        self.routed_unit.save(update_fields=["status"])
+
+    def test_declare_rout_targets_enemy_unit(self) -> None:
+        """battle declare rout <unit> with <technique> → ROUT declaration against the enemy unit."""
+        _run(self.pc_char, f"declare rout Vanguard with {self.technique.name}")
+
+        decl = _last_declaration(self.battle_round)
+        self.assertIsNotNone(decl, "a declaration should be recorded")
+        self.assertEqual(decl.action_kind, BattleActionKind.ROUT)
+        self.assertEqual(decl.target_unit, self.enemy_unit)
+        self.pc_char.msg.assert_called()
+
+    def test_declare_rally_targets_own_routed_unit(self) -> None:
+        """battle declare rally <unit> → RALLY declaration against own routed unit."""
+        _run(self.pc_char, f"declare rally Broken Squad with {self.technique.name}")
+
+        decl = _last_declaration(self.battle_round)
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.action_kind, BattleActionKind.RALLY)
+        self.assertEqual(decl.target_unit, self.routed_unit)
+
+
+# ---------------------------------------------------------------------------
+# Journey — ally-scoped subverbs (support, rescue)
+# ---------------------------------------------------------------------------
+
+
+class BattleAllyScopedSubverbsE2ETest(TestCase):
+    """support + rescue declarations through CmdBattle."""
+
+    def setUp(self) -> None:
+        self.room = _make_room("BattleAllyRoom")
+        self.technique = TechniqueFactory(
+            action_template=ActionTemplateFactory(), damage_profile=False
+        )
+        self.gm_char, self.battle, self.attacker_side, self.defender_side, self.enemy_unit = (
+            _make_battle_with_round(self.room)
+        )
+        self.battle_round = BattleRound.objects.filter(
+            battle=self.battle, status=RoundStatus.DECLARING
+        ).first()
+
+        # Two PCs on the defender side — one declares, the other is the ally target.
+        self.pc1_char, self.pc1_sheet, self.pc1_participant = _make_battle_pc(
+            self.room, "Supporter", self.defender_side, self.technique
+        )
+        self.pc2_char, self.pc2_sheet, self.pc2_participant = _make_battle_pc(
+            self.room, "AllyTarget", self.defender_side, self.technique
+        )
+
+    def test_declare_support_targets_ally(self) -> None:
+        """battle declare support <ally> with <technique> → SUPPORT declaration against the ally."""
+        _run(self.pc1_char, f"declare support AllyTarget with {self.technique.name}")
+
+        decl = _last_declaration(self.battle_round)
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.action_kind, BattleActionKind.SUPPORT)
+        self.assertEqual(decl.target_ally, self.pc2_participant)
+
+    def test_declare_rescue_targets_ally(self) -> None:
+        """battle declare rescue <ally> with <technique> → RESCUE declaration against the ally."""
+        _run(self.pc1_char, f"declare rescue AllyTarget with {self.technique.name}")
+
+        decl = _last_declaration(self.battle_round)
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.action_kind, BattleActionKind.RESCUE)
+        self.assertEqual(decl.target_ally, self.pc2_participant)
+
+
+# ---------------------------------------------------------------------------
+# Journey — place-scoped subverbs (repel, hold)
+# ---------------------------------------------------------------------------
+
+
+class BattlePlaceScopedSubverbsE2ETest(TestCase):
+    """repel + hold declarations through CmdBattle."""
+
+    def setUp(self) -> None:
+        self.room = _make_room("BattlePlaceRoom")
+        self.technique = TechniqueFactory(
+            action_template=ActionTemplateFactory(), damage_profile=False
+        )
+        self.gm_char, self.battle, self.attacker_side, self.defender_side, self.enemy_unit = (
+            _make_battle_with_round(self.room)
+        )
+        self.battle_round = BattleRound.objects.filter(
+            battle=self.battle, status=RoundStatus.DECLARING
+        ).first()
+        from world.battles.services import add_place
+
+        self.place = add_place(battle=self.battle, name="The Pass")
+
+        self.pc_char, self.pc_sheet, self.pc_participant = _make_battle_pc(
+            self.room, "PlacePC", self.defender_side, self.technique
+        )
+        # REPEL/HOLD are PLACE-scope — require a SUBORDINATE or SUPREME command tier.
+        _grant_supreme_command_tier(self.pc_participant, self.defender_side)
+
+    def test_declare_repel_targets_place(self) -> None:
+        """battle declare repel place <name> with <technique> → REPEL declaration (PLACE scope)."""
+        _run(self.pc_char, f"declare repel place The Pass with {self.technique.name}")
+
+        decl = _last_declaration(self.battle_round)
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.action_kind, BattleActionKind.REPEL)
+        self.assertEqual(decl.target_place, self.place)
+        self.assertEqual(decl.scope, BattleActionScope.PLACE)
+
+    def test_declare_hold_targets_place(self) -> None:
+        """battle declare hold place <name> with <technique> → HOLD declaration (PLACE scope)."""
+        _run(self.pc_char, f"declare hold place The Pass with {self.technique.name}")
+
+        decl = _last_declaration(self.battle_round)
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.action_kind, BattleActionKind.HOLD)
+        self.assertEqual(decl.target_place, self.place)
+        self.assertEqual(decl.scope, BattleActionScope.PLACE)
+
+
+# ---------------------------------------------------------------------------
+# Journey — fortification-scoped subverbs (breach, fortify)
+# ---------------------------------------------------------------------------
+
+
+class BattleFortificationSubverbsE2ETest(TestCase):
+    """breach + fortify declarations through CmdBattle."""
+
+    def setUp(self) -> None:
+        self.room = _make_room("BattleFortRoom")
+        self.technique = TechniqueFactory(
+            action_template=ActionTemplateFactory(), damage_profile=False
+        )
+        self.gm_char, self.battle, self.attacker_side, self.defender_side, self.enemy_unit = (
+            _make_battle_with_round(self.room)
+        )
+        self.battle_round = BattleRound.objects.filter(
+            battle=self.battle, status=RoundStatus.DECLARING
+        ).first()
+        from world.battles.services import add_place
+
+        self.place = add_place(battle=self.battle, name="The Gatehouse")
+
+        # A wall fortification — defended by the defender side (so attackers breach it).
+        self.wall = FortificationFactory(
+            place=self.place,
+            defending_side=self.defender_side,
+            kind=FortificationKind.WALL,
+        )
+
+        # PC on the attacker side (breaches the enemy's wall).
+        self.attacker_char, self.attacker_sheet, self.attacker_participant = _make_battle_pc(
+            self.room, "Breacher", self.attacker_side, self.technique
+        )
+        # PC on the defender side (fortifies their own wall).
+        self.defender_char, self.defender_sheet, self.defender_participant = _make_battle_pc(
+            self.room, "Fortifier", self.defender_side, self.technique
+        )
+
+    def test_declare_breach_targets_fortification(self) -> None:
+        """battle declare breach place <name> fortification <kind> → BREACH declaration."""
+        _run(
+            self.attacker_char,
+            f"declare breach place The Gatehouse fortification wall with {self.technique.name}",
+        )
+
+        decl = _last_declaration(self.battle_round)
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.action_kind, BattleActionKind.BREACH)
+        self.assertEqual(decl.target_fortification, self.wall)
+
+    def test_declare_fortify_targets_fortification(self) -> None:
+        """battle declare fortify place <name> fortification <kind> → FORTIFY declaration."""
+        _run(
+            self.defender_char,
+            f"declare fortify place The Gatehouse fortification wall with {self.technique.name}",
+        )
+
+        decl = _last_declaration(self.battle_round)
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.action_kind, BattleActionKind.FORTIFY)
+        self.assertEqual(decl.target_fortification, self.wall)
+
+
+# ---------------------------------------------------------------------------
+# Journey — set_environment (battle-scope + place-scope)
+# ---------------------------------------------------------------------------
+
+
+class BattleSetEnvironmentSubverbE2ETest(TestCase):
+    """set_environment declarations through CmdBattle."""
+
+    def setUp(self) -> None:
+        self.room = _make_room("BattleEnvRoom")
+        # set_environment requires a technique that carries target_weather_type.
+        from world.weather.factories import WeatherTypeFactory
+
+        self.weather_type = WeatherTypeFactory()
+        self.technique = TechniqueFactory(
+            action_template=ActionTemplateFactory(),
+            damage_profile=False,
+            target_weather_type=self.weather_type,
+        )
+        self.gm_char, self.battle, self.attacker_side, self.defender_side, self.enemy_unit = (
+            _make_battle_with_round(self.room)
+        )
+        self.battle_round = BattleRound.objects.filter(
+            battle=self.battle, status=RoundStatus.DECLARING
+        ).first()
+        from world.battles.services import add_place
+
+        self.place = add_place(battle=self.battle, name="The Valley")
+
+        self.pc_char, self.pc_sheet, self.pc_participant = _make_battle_pc(
+            self.room, "WeatherPC", self.defender_side, self.technique
+        )
+        # SET_ENVIRONMENT at BATTLE scope requires SUPREME command tier;
+        # PLACE scope requires SUBORDINATE or SUPREME.
+        _grant_supreme_command_tier(self.pc_participant, self.defender_side)
+
+    def test_declare_set_environment_battle_scope(self) -> None:
+        """battle declare set_environment with <technique> → SET_ENVIRONMENT at BATTLE scope."""
+        _run(self.pc_char, f"declare set_environment with {self.technique.name}")
+
+        decl = _last_declaration(self.battle_round)
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.action_kind, BattleActionKind.SET_ENVIRONMENT)
+        self.assertEqual(decl.scope, BattleActionScope.BATTLE)
+
+    def test_declare_set_environment_place_scope(self) -> None:
+        """battle declare set_environment place <name> → SET_ENVIRONMENT at PLACE scope."""
+        _run(self.pc_char, f"declare set_environment place The Valley with {self.technique.name}")
+
+        decl = _last_declaration(self.battle_round)
+        self.assertIsNotNone(decl)
+        self.assertEqual(decl.action_kind, BattleActionKind.SET_ENVIRONMENT)
+        self.assertEqual(decl.scope, BattleActionScope.PLACE)
+        self.assertEqual(decl.target_place, self.place)
+
+
+# ---------------------------------------------------------------------------
+# Journey — conclude (GM force-conclude)
+# ---------------------------------------------------------------------------
+
+
+class BattleConcludeSubverbE2ETest(TestCase):
+    """battle conclude → force-concludes the battle."""
+
+    def setUp(self) -> None:
+        self.room = _make_room("BattleConcludeRoom")
+        self.technique = TechniqueFactory(
+            action_template=ActionTemplateFactory(), damage_profile=False
+        )
+        self.gm_char, self.battle, self.attacker_side, self.defender_side, self.enemy_unit = (
+            _make_battle_with_round(self.room)
+        )
+
+    def test_conclude_force_concludes_battle(self) -> None:
+        """battle conclude → battle is concluded + scene inactive."""
+        _run(self.gm_char, "conclude")
+
+        self.battle.refresh_from_db()
+        self.assertTrue(
+            self.battle.is_concluded, "battle should be concluded after 'battle conclude'"
+        )
+        self.battle.scene.refresh_from_db()
+        self.assertFalse(self.battle.scene.is_active, "scene should be inactive after conclusion")
+        self.gm_char.msg.assert_called()
+        msg = self.gm_char.msg.call_args[0][0]
+        self.assertIn("conclude", msg.lower())

--- a/src/integration_tests/pipeline/test_comfort_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_comfort_telnet_e2e.py
@@ -1,0 +1,70 @@
+"""Telnet E2E: comfort glance journey (#1514/#1522).
+
+A light e2e test for ``CmdComfort`` — a read-only personal-comfort glance.
+Proves the command wires up, runs without error against a real character in a
+real room, and produces the expected output shape (personal band + room level).
+
+This is not a state-changing journey; it's a smoke test that the read path
+works end-to-end through the telnet command, not just the service layer.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+from evennia.utils import idmapper
+
+from commands.comfort import CmdComfort
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.vitals.factories import CharacterVitalsFactory
+
+
+def _run(caller: object) -> CmdComfort:
+    """Wire CmdComfort to *caller* and call func(). Returns the cmd instance."""
+    cmd = CmdComfort()
+    cmd.caller = caller
+    cmd.args = ""
+    cmd.raw_string = "comfort"
+    cmd.cmdname = "comfort"
+    caller.msg = MagicMock()
+    cmd.func()
+    return cmd
+
+
+class ComfortTelnetE2EJourneyTest(TestCase):
+    """Bare ``comfort`` → personal band + room level output."""
+
+    def setUp(self) -> None:
+        idmapper.models.flush_cache()
+        self.room = ObjectDBFactory(
+            db_key="ComfortE2ERoom", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.character = CharacterFactory(location=self.room)
+        self.sheet = CharacterSheetFactory(character=self.character)
+        # Full health so injury penalty is 0.
+        CharacterVitalsFactory(character_sheet=self.sheet, health=100, max_health=100)
+
+    def test_comfort_shows_personal_band_and_room_level(self) -> None:
+        """``comfort`` → "You feel <band>." + room level line."""
+        _run(self.character)
+
+        self.character.msg.assert_called()
+        msg = self.character.msg.call_args[0][0]
+
+        # Personal band line.
+        self.assertIn("you feel", msg.lower(), "should show personal comfort band")
+
+        # Room level line.
+        self.assertIn("room itself", msg.lower(), "should show the room's own comfort level")
+        self.assertIn("/10", msg, "should show the room level out of 10")
+
+    def test_comfort_without_location_gives_fallback(self) -> None:
+        """``comfort`` with no location → fallback message."""
+        self.character.location = None
+        _run(self.character)
+
+        self.character.msg.assert_called()
+        msg = self.character.msg.call_args[0][0]
+        self.assertIn("aren't anywhere", msg.lower())

--- a/src/integration_tests/pipeline/test_gossip_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_gossip_telnet_e2e.py
@@ -1,0 +1,201 @@
+"""Telnet E2E: gossip rumor mill journey (#1572).
+
+Drives ``CmdGossip`` end-to-end through the three gossip verbs (list / plant /
+suppress) + seek, asserting DB state after each step and telnet feedback via
+``caller.msg``.
+
+Journey layout:
+  1. ``gossip``            — list gossipable secrets + their regional heat.
+  2. ``gossip plant <#>``  — spread a self-secret → raises regional heat.
+  3. ``gossip suppress <#>`` — talk the heat back down.
+  4. ``gossip seek``       — overhear a hot secret someone else planted.
+
+Tagged ``@tag("postgres")`` — region resolution walks the ``AreaClosure``
+materialized view (PG-only), mirroring ``world.secrets.tests.test_gossip``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase, tag
+
+from commands.social.gossip import CmdGossip
+from world.areas.constants import AreaLevel
+from world.areas.factories import AreaFactory
+from world.character_creation.factories import RealmFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.test_helpers import force_check_outcome
+from world.roster.factories import RosterEntryFactory
+from world.secrets.constants import SecretLevel
+from world.secrets.factories import SecretFactory
+from world.seeds.checks import seed_check_resolution_tables
+from world.seeds.social_checks import seed_social_check_content
+from world.skills.factories import CharacterSpecializationValueFactory
+from world.skills.models import Specialization
+from world.societies.factories import SocietyFactory
+from world.traits.factories import CheckOutcomeFactory
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(caller: object, args: str = "") -> CmdGossip:
+    """Wire CmdGossip to *caller* and call func(). Returns the cmd instance."""
+    cmd = CmdGossip()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"gossip {args}".strip()
+    cmd.cmdname = "gossip"
+    caller.msg = MagicMock()
+    cmd.func()
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# Journey
+# ---------------------------------------------------------------------------
+
+
+@tag("postgres")
+class GossipTelnetE2EJourneyTest(TestCase):
+    """list → plant → suppress → seek through telnet CmdGossip."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        seed_check_resolution_tables()
+        seed_social_check_content()
+
+        cls.special = CheckOutcomeFactory(name="gossip_special_e2e", success_level=2)
+        cls.regular = CheckOutcomeFactory(name="gossip_regular_e2e", success_level=1)
+
+        cls.realm = RealmFactory()
+        cls.region = AreaFactory(level=AreaLevel.REGION, realm=cls.realm)
+        cls.society = SocietyFactory(realm=cls.realm)
+
+        from evennia_extensions.factories import RoomProfileFactory
+
+        cls.hub = RoomProfileFactory(area=cls.region, is_social_hub=True)
+
+        # Gossiper — has the Gossip specialization (skill gate).
+        cls.gossiper_sheet = CharacterSheetFactory()
+        cls.gossiper = cls.gossiper_sheet.character
+        cls.gossip_spec = Specialization.objects.get(
+            name="Gossip", parent_skill__trait__name="Persuasion"
+        )
+        CharacterSpecializationValueFactory(
+            character=cls.gossiper, specialization=cls.gossip_spec, value=10
+        )
+
+        # A self-secret (the gossiper may always spread gossip about themselves).
+        cls.secret = SecretFactory(
+            subject_sheet=cls.gossiper_sheet, level=SecretLevel.UNCOMMON_KNOWLEDGE
+        )
+
+        # Seeker — a second character with Gossip who will overhear the planted secret.
+        cls.seeker_sheet = CharacterSheetFactory()
+        cls.seeker = cls.seeker_sheet.character
+        CharacterSpecializationValueFactory(
+            character=cls.seeker, specialization=cls.gossip_spec, value=10
+        )
+        cls.seeker_entry = RosterEntryFactory(character_sheet=cls.seeker_sheet)
+
+    def _room(self) -> object:
+        return self.hub.objectdb
+
+    # ------------------------------------------------------------------
+    # list
+    # ------------------------------------------------------------------
+
+    def test_bare_gossip_lists_spreadable_secrets(self) -> None:
+        """Bare ``gossip`` lists the character's gossipable secrets."""
+        self.gossiper.location = self._room()
+        _run(self.gossiper, "")
+
+        msg = self.gossiper.msg.call_args[0][0]
+        self.assertIn("Gossip you could spread", msg, "hub should list gossipable secrets")
+        self.assertIn(self.secret.content, msg, "self-secret should appear in the list")
+        self.assertIn("heat here", msg.lower(), "should show regional heat")
+
+    # ------------------------------------------------------------------
+    # plant
+    # ------------------------------------------------------------------
+
+    def test_plant_raises_heat(self) -> None:
+        """gossip plant <#> → raises the secret's regional heat."""
+        from world.secrets.models import SecretGossip
+
+        self.gossiper.location = self._room()
+        with force_check_outcome(self.special):
+            _run(self.gossiper, "plant 1")
+
+        row = SecretGossip.objects.get(secret=self.secret, region=self.region)
+        self.assertEqual(row.heat, 2, "special success should add 2 heat")
+
+        self.gossiper.msg.assert_called()
+        msg = self.gossiper.msg.call_args[0][0]
+        self.assertIn("spread", msg.lower())
+        self.assertIn("heat", msg.lower())
+
+    def test_plant_without_skill_is_rejected(self) -> None:
+        """gossip plant by a character without Gossip skill → skill-gate message."""
+        from world.character_sheets.factories import CharacterSheetFactory
+
+        bare_sheet = CharacterSheetFactory()
+        bare_char = bare_sheet.character
+        bare_char.location = self._room()
+        _run(bare_char, "plant 1")
+
+        bare_char.msg.assert_called()
+        msg = bare_char.msg.call_args[0][0]
+        self.assertIn("ear for it", msg.lower())
+
+    # ------------------------------------------------------------------
+    # suppress
+    # ------------------------------------------------------------------
+
+    def test_suppress_lowers_heat(self) -> None:
+        """gossip suppress <#> → lowers the secret's regional heat."""
+        from world.secrets.models import SecretGossip
+
+        # Pre-plant: set heat to 5.
+        SecretGossip.objects.create(secret=self.secret, region=self.region, heat=5)
+
+        self.gossiper.location = self._room()
+        with force_check_outcome(self.special):
+            _run(self.gossiper, "suppress 1")
+
+        row = SecretGossip.objects.get(secret=self.secret, region=self.region)
+        self.assertEqual(row.heat, 3, "special suppress should remove 2 heat (5 → 3)")
+
+        self.gossiper.msg.assert_called()
+        msg = self.gossiper.msg.call_args[0][0]
+        self.assertIn("quieted", msg.lower())
+
+    # ------------------------------------------------------------------
+    # seek
+    # ------------------------------------------------------------------
+
+    def test_seek_surfaces_a_hot_secret(self) -> None:
+        """gossip seek → overhears a hot secret planted in the region."""
+        from world.secrets.factories import SecretFactory
+        from world.secrets.models import SecretGossip, SecretKnowledge
+
+        # A hot secret about a third party that the seeker doesn't know.
+        target = CharacterSheetFactory()
+        hot = SecretFactory(subject_sheet=target, level=SecretLevel.UNCOMMON_KNOWLEDGE)
+        SecretGossip.objects.create(secret=hot, region=self.region, heat=5)
+
+        self.seeker.location = self._room()
+        with force_check_outcome(self.regular):
+            _run(self.seeker, "seek")
+
+        self.seeker.msg.assert_called()
+        msg = self.seeker.msg.call_args[0][0]
+        self.assertIn("overhear", msg.lower())
+        self.assertIn(hot.content, msg, "should surface the secret's content")
+
+        # The seeker now holds the fact (Level-1 only).
+        held = SecretKnowledge.objects.get(roster_entry=self.seeker_entry, secret=hot)
+        self.assertFalse(held.knows_category, "seek grants fact only, not deeper layers")

--- a/src/integration_tests/pipeline/test_organization_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_organization_telnet_e2e.py
@@ -1,0 +1,284 @@
+"""Telnet E2E: organization membership lifecycle journey (#1511).
+
+Drives the full membership lifecycle through ``CmdOrg`` over the shared
+``dispatch_player_action`` seam — the same REGISTRY path the web uses —
+asserting DB state after each step and telnet feedback via ``caller.msg``.
+
+Journey layout:
+  1. ``org invite <person> in <org>`` — officer invites an outsider → PENDING INVITE.
+  2. ``org join <org>``                — outsider accepts → active membership at base rank (tier 5).
+  3. ``org promote <person> in <org>`` — officer promotes → rank tier 5 → 4.
+  4. ``org demote <person> in <org>``  — officer demotes  → rank tier 4 → 5.
+  5. ``org expel <person> in <org>``   — officer expels   → membership exiled (left_at + exiled_at).
+  6. ``org leave <org>``               — a second member leaves voluntarily (left_at, no exiled_at).
+  7. ``org apply <org>``               — a fresh outsider applies → PENDING APPLICATION.
+
+All assertions run on the SQLite fast tier — no ``@tag("postgres")`` needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+from evennia.utils import idmapper
+
+from commands.organizations import CmdOrg
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.societies.factories import (
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+)
+from world.societies.membership_services import (
+    active_membership_for_persona,
+    ensure_default_rank_ladder,
+    promote_member,
+)
+from world.societies.models import OrganizationMembershipOffer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_room(label: str = "OrgE2ERoom") -> object:
+    return ObjectDBFactory(db_key=label, db_typeclass_path="typeclasses.rooms.Room")
+
+
+def _make_pc(db_key: str, room: object) -> tuple[object, object]:
+    """Create a PC character + sheet in *room*. Returns (character, sheet).
+
+    ``CharacterSheetFactory`` auto-creates a PRIMARY persona — the active face
+    the org Actions resolve via ``active_persona_for_sheet``.
+    """
+    char = CharacterFactory(db_key=db_key, location=room)
+    sheet = CharacterSheetFactory(character=char)
+    return char, sheet
+
+
+def _run(caller: object, args: str = "") -> CmdOrg:
+    """Instantiate CmdOrg wired to *caller*; does NOT call func().
+
+    Mirrors the covenant e2e pattern: the caller wires ``cmd.caller.search``
+    if needed, then calls ``cmd.func()``.
+    """
+    cmd = CmdOrg()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"org {args}".strip()
+    cmd.cmdname = "org"
+    caller.msg = MagicMock()
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# Journey
+# ---------------------------------------------------------------------------
+
+
+class OrganizationLifecycleE2EJourneyTest(TestCase):
+    """Full org membership lifecycle through telnet CmdOrg.
+
+    invite → join → promote → demote → expel; plus a parallel leave + apply
+    sub-journey to cover the voluntary-exit and application paths.
+    """
+
+    def setUp(self) -> None:
+        idmapper.models.flush_cache()
+        self.room = _make_room()
+
+        # A generic (non-covenant) organization with a five-tier rank ladder.
+        # OrganizationFactory auto-creates the default ladder via
+        # ensure_default_rank_ladder when the first membership is created.
+        self.org = OrganizationFactory(name="Thieves Guild")
+        # Tier 1 = Leader (can_invite, can_kick, can_manage_ranks); tier 5 = Contact.
+        # The ladder is lazily created on first join — touch it now so ranks exist.
+        ensure_default_rank_ladder(self.org)
+
+        # Officer — a tier-1 member with management perms.
+        self.officer_char, self.officer_sheet = _make_pc("Officer", self.room)
+        self.officer_persona = self.officer_sheet.primary_persona
+        officer_rank = self.org.ranks.get(tier=1)
+        self.officer_membership = OrganizationMembershipFactory(
+            organization=self.org,
+            persona=self.officer_persona,
+            rank=officer_rank,
+        )
+
+        # Member — a tier-5 member who will be promoted/demoted/expelled.
+        self.member_char, self.member_sheet = _make_pc("Member", self.room)
+        self.member_persona = self.member_sheet.primary_persona
+        base_rank = self.org.ranks.get(tier=5)
+        self.member_membership = OrganizationMembershipFactory(
+            organization=self.org,
+            persona=self.member_persona,
+            rank=base_rank,
+        )
+
+        # Outsider — not yet a member; will be invited + join.
+        self.outsider_char, self.outsider_sheet = _make_pc("Outsider", self.room)
+        self.outsider_persona = self.outsider_sheet.primary_persona
+
+    # ------------------------------------------------------------------
+    # invite → join
+    # ------------------------------------------------------------------
+
+    def test_invite_creates_pending_invite(self) -> None:
+        """org invite <person> in <org> → PENDING OrganizationMembershipOffer (INVITE)."""
+        cmd = _run(self.officer_char, f"invite Outsider in {self.org.name}")
+        cmd.caller.search = MagicMock(return_value=self.outsider_char)
+        cmd.func()
+
+        offer = OrganizationMembershipOffer.objects.filter(
+            organization=self.org,
+            to_persona=self.outsider_persona,
+            kind=OrganizationMembershipOffer.Kind.INVITE,
+            status=OrganizationMembershipOffer.Status.PENDING,
+        ).first()
+        self.assertIsNotNone(offer, "invite should create a PENDING INVITE offer")
+        self.assertEqual(offer.from_persona, self.officer_persona)
+        self.officer_char.msg.assert_called()
+        self.assertIn("invite", self.officer_char.msg.call_args[0][0].lower())
+
+    def test_join_accepts_invite_and_creates_membership(self) -> None:
+        """org join <org> → active membership at base rank (tier 5)."""
+        # First, officer invites the outsider.
+        cmd = _run(self.officer_char, f"invite Outsider in {self.org.name}")
+        cmd.caller.search = MagicMock(return_value=self.outsider_char)
+        cmd.func()
+
+        # Outsider accepts via join.
+        cmd = _run(self.outsider_char, f"join {self.org.name}")
+        cmd.func()
+
+        membership = active_membership_for_persona(self.org, self.outsider_persona)
+        self.assertIsNotNone(membership, "join should create an active membership")
+        self.assertEqual(membership.rank.tier, 5, "new member starts at base rank (tier 5)")
+
+        # The offer is now ACCEPTED.
+        offer = OrganizationMembershipOffer.objects.get(
+            organization=self.org,
+            to_persona=self.outsider_persona,
+            kind=OrganizationMembershipOffer.Kind.INVITE,
+        )
+        self.assertEqual(offer.status, OrganizationMembershipOffer.Status.ACCEPTED)
+
+        self.outsider_char.msg.assert_called()
+        self.assertIn("join", self.outsider_char.msg.call_args[0][0].lower())
+
+    # ------------------------------------------------------------------
+    # promote → demote
+    # ------------------------------------------------------------------
+
+    def test_promote_moves_member_up_one_tier(self) -> None:
+        """org promote <person> in <org> → rank tier 5 → 4."""
+        cmd = _run(self.officer_char, f"promote Member in {self.org.name}")
+        cmd.caller.search = MagicMock(return_value=self.member_char)
+        cmd.func()
+
+        self.member_membership.refresh_from_db()
+        self.assertEqual(
+            self.member_membership.rank.tier,
+            4,
+            "promote should move the member up one tier (5 → 4)",
+        )
+        self.officer_char.msg.assert_called()
+        self.assertIn("promote", self.officer_char.msg.call_args[0][0].lower())
+
+    def test_demote_moves_member_down_one_tier(self) -> None:
+        """org demote <person> in <org> → rank tier 4 → 5.
+
+        Starts from tier 4 (pre-promoted) to exercise the demote path.
+        """
+        # Pre-promote to tier 4 so demote has room to move down.
+        promote_member(self.member_membership, self.officer_membership)
+
+        cmd = _run(self.officer_char, f"demote Member in {self.org.name}")
+        cmd.caller.search = MagicMock(return_value=self.member_char)
+        cmd.func()
+
+        self.member_membership.refresh_from_db()
+        self.assertEqual(
+            self.member_membership.rank.tier,
+            5,
+            "demote should move the member down one tier (4 → 5)",
+        )
+        self.officer_char.msg.assert_called()
+        self.assertIn("demote", self.officer_char.msg.call_args[0][0].lower())
+
+    # ------------------------------------------------------------------
+    # expel
+    # ------------------------------------------------------------------
+
+    def test_expel_deactivates_membership_with_exile(self) -> None:
+        """org expel <person> in <org> → membership left_at + exiled_at set."""
+        cmd = _run(self.officer_char, f"expel Member in {self.org.name}")
+        cmd.caller.search = MagicMock(return_value=self.member_char)
+        cmd.func()
+
+        self.member_membership.refresh_from_db()
+        self.assertIsNotNone(self.member_membership.left_at, "expel sets left_at")
+        self.assertIsNotNone(self.member_membership.exiled_at, "expel sets exiled_at")
+
+        # No longer an active member.
+        self.assertIsNone(
+            active_membership_for_persona(self.org, self.member_persona),
+            "expelled member should have no active membership",
+        )
+        self.officer_char.msg.assert_called()
+        self.assertIn("expel", self.officer_char.msg.call_args[0][0].lower())
+
+    # ------------------------------------------------------------------
+    # leave (voluntary)
+    # ------------------------------------------------------------------
+
+    def test_leave_deactivates_membership_without_exile(self) -> None:
+        """org leave <org> → membership left_at set, exiled_at null (voluntary)."""
+        cmd = _run(self.member_char, f"leave {self.org.name}")
+        cmd.func()
+
+        self.member_membership.refresh_from_db()
+        self.assertIsNotNone(self.member_membership.left_at, "leave sets left_at")
+        self.assertIsNone(self.member_membership.exiled_at, "leave does NOT set exiled_at")
+
+        self.assertIsNone(
+            active_membership_for_persona(self.org, self.member_persona),
+            "departed member should have no active membership",
+        )
+        self.member_char.msg.assert_called()
+        self.assertIn("leave", self.member_char.msg.call_args[0][0].lower())
+
+    # ------------------------------------------------------------------
+    # apply
+    # ------------------------------------------------------------------
+
+    def test_apply_creates_pending_application(self) -> None:
+        """org apply <org> → PENDING OrganizationMembershipOffer (APPLICATION)."""
+        cmd = _run(self.outsider_char, f"apply {self.org.name}")
+        cmd.func()
+
+        offer = OrganizationMembershipOffer.objects.filter(
+            organization=self.org,
+            from_persona=self.outsider_persona,
+            kind=OrganizationMembershipOffer.Kind.APPLICATION,
+            status=OrganizationMembershipOffer.Status.PENDING,
+        ).first()
+        self.assertIsNotNone(offer, "apply should create a PENDING APPLICATION offer")
+        self.assertIsNone(offer.to_persona, "applications have no to_persona")
+
+        self.outsider_char.msg.assert_called()
+        self.assertIn("apply", self.outsider_char.msg.call_args[0][0].lower())
+
+    # ------------------------------------------------------------------
+    # hub
+    # ------------------------------------------------------------------
+
+    def test_bare_org_lists_subverbs(self) -> None:
+        """Bare ``org`` (no args) prints the subverb hub."""
+        cmd = _run(self.officer_char, "")
+        cmd.func()
+        self.officer_char.msg.assert_called()
+        hub_msg = self.officer_char.msg.call_args[0][0]
+        for verb in ("invite", "apply", "join", "leave", "promote", "demote", "expel"):
+            self.assertIn(verb, hub_msg, f"hub should list '{verb}'")

--- a/src/integration_tests/pipeline/test_project_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_project_telnet_e2e.py
@@ -1,0 +1,249 @@
+"""Telnet E2E: project contribution journey (#1574).
+
+Drives ``CmdProject`` end-to-end through the three contribution paths
+(donate / check / story) + the status display, asserting DB state after each
+step and telnet feedback via ``caller.msg``.
+
+Journey layout:
+  1. ``+project <id>``           — status display (progress, threshold, coin cost).
+  2. ``project/donate <id>=<n>`` — money path: debits the purse, advances progress 1 per 100c.
+  3. ``project/check <id>=<m>``  — check path: spends AP, rolls (patched), advances on success.
+  4. ``project/story <id>=<t>`` — records narrative on the latest contribution.
+
+All assertions run on the SQLite fast tier — no ``@tag("postgres")`` needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from evennia.utils import idmapper
+
+from commands.projects import CmdProject
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.currency.services import get_or_create_purse
+from world.projects.constants import (
+    CompletionMode,
+    ContributionKind,
+    ProjectKind,
+    ProjectStatus,
+)
+from world.projects.factories import ProjectFactory
+from world.projects.models import Contribution, ContributionMethod
+from world.projects.services import add_contribution
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pc(name: str, room: object) -> tuple[object, object]:
+    """Create a PC character + sheet in *room*. Returns (character, sheet)."""
+    char = CharacterFactory(db_key=name, location=room)
+    sheet = CharacterSheetFactory(character=char)
+    return char, sheet
+
+
+def _run(caller: object, args: str = "", switches: list[str] | None = None) -> CmdProject:
+    """Wire CmdProject to *caller* and call func(). Returns the cmd instance."""
+    cmd = CmdProject()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.switches = switches or []
+    cmd.raw_string = "project " + (" ".join(f"/{s}" for s in (switches or []))) + f" {args}"
+    cmd.cmdname = "project"
+    caller.msg = MagicMock()
+    cmd.func()
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# Journey
+# ---------------------------------------------------------------------------
+
+
+class ProjectContributionE2EJourneyTest(TestCase):
+    """Donate → status → check → story through telnet CmdProject."""
+
+    def setUp(self) -> None:
+        idmapper.models.flush_cache()
+        self.room = ObjectDBFactory(
+            db_key="ProjectE2ERoom", db_typeclass_path="typeclasses.rooms.Room"
+        )
+
+        self.donor_char, self.donor_sheet = _make_pc("Donor", self.room)
+        self.donor_persona = self.donor_sheet.primary_persona
+
+        # Give the donor a purse with 500 coppers.
+        self.purse = get_or_create_purse(self.donor_sheet)
+        self.purse.balance = 500
+        self.purse.save(update_fields=["balance"])
+
+        # An ACTIVE money-threshold project (1 progress per 100 coppers donated).
+        self.project = ProjectFactory(
+            kind=ProjectKind.TEST_KIND,
+            completion_mode=CompletionMode.SINGLE_THRESHOLD,
+            status=ProjectStatus.ACTIVE,
+            threshold_target=5,
+            current_progress=0,
+            description="Build the bridge",
+        )
+
+    # ------------------------------------------------------------------
+    # status display
+    # ------------------------------------------------------------------
+
+    def test_status_shows_progress_and_remaining_coin(self) -> None:
+        """+project <id> → progress, threshold, and remaining-to-fund display."""
+        _run(self.donor_char, str(self.project.pk))
+
+        msg = self.donor_char.msg.call_args[0][0]
+        self.assertIn(f"#{self.project.pk}", msg, "status should show the project id")
+        self.assertIn("Build the bridge", msg, "status should show the description")
+        self.assertIn("0/5", msg, "status should show current progress / target")
+        self.assertIn("5g", msg, "status should show remaining coin to fund (5 gold = 500c)")
+
+    # ------------------------------------------------------------------
+    # donate (money path)
+    # ------------------------------------------------------------------
+
+    def test_donate_debits_purse_and_advances_progress(self) -> None:
+        """project/donate <id>=<amount> → purse debited, progress advanced."""
+        _run(self.donor_char, f"{self.project.pk}=200", switches=["donate"])
+
+        # Purse: 500 - 200 = 300 coppers remaining.
+        self.purse.refresh_from_db()
+        self.assertEqual(self.purse.balance, 300, "donate should debit the purse by 200")
+
+        # Progress: 200 coppers = 2 progress (1 per 100c).
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.current_progress, 2, "200c should advance progress by 2")
+
+        # A MONEY contribution was recorded.
+        contribution = Contribution.objects.filter(
+            project=self.project,
+            contributor_persona=self.donor_persona,
+            kind=ContributionKind.MONEY,
+        ).first()
+        self.assertIsNotNone(contribution, "a MONEY contribution should be recorded")
+        self.assertEqual(contribution.money_amount, 200)
+
+        self.donor_char.msg.assert_called()
+        donate_msg = self.donor_char.msg.call_args[0][0]
+        self.assertIn("donate", donate_msg.lower())
+
+    def test_donate_insufficient_funds_fails_gracefully(self) -> None:
+        """project/donate with more than the purse balance → failure message, no progress."""
+        _run(self.donor_char, f"{self.project.pk}=1000", switches=["donate"])
+
+        self.purse.refresh_from_db()
+        self.assertEqual(self.purse.balance, 500, "failed donate should not debit the purse")
+
+        self.project.refresh_from_db()
+        self.assertEqual(
+            self.project.current_progress, 0, "failed donate should not advance progress"
+        )
+
+        self.donor_char.msg.assert_called()
+        self.assertIn("insufficient", self.donor_char.msg.call_args[0][0].lower())
+
+    # ------------------------------------------------------------------
+    # check (check-based contribution)
+    # ------------------------------------------------------------------
+
+    def test_check_spends_ap_and_advances_on_success(self) -> None:
+        """project/check <id>=<method> → AP spent, check rolled, progress advanced on success."""
+        # Need a ContributionMethod for the project's kind + a CheckType.
+        from world.checks.factories import CheckTypeFactory
+
+        check_type = CheckTypeFactory()
+        ContributionMethod.objects.create(
+            kind=ProjectKind.TEST_KIND,
+            name="Inspect",
+            check_type=check_type,
+            ap_cost=1,
+            progress_on_success=3,
+            is_active=True,
+        )
+
+        # Give the donor AP.
+        from world.action_points.models import ActionPointPool
+
+        pool = ActionPointPool.get_or_create_for_character(self.donor_char)
+        pool.current = 5
+        pool.save(update_fields=["current"])
+
+        # Patch perform_check to return a successful result.
+        # result.outcome must be a *saved* CheckOutcome (it's FK-stored on Contribution).
+        from world.traits.factories import CheckOutcomeFactory
+
+        mock_result = MagicMock()
+        mock_result.outcome = CheckOutcomeFactory(success_level=2, name="Good")
+        mock_result.success_level = 2
+
+        with patch("world.checks.services.perform_check", return_value=mock_result):
+            _run(self.donor_char, f"{self.project.pk}=Inspect", switches=["check"])
+
+        # AP spent.
+        pool.refresh_from_db()
+        self.assertEqual(pool.current, 4, "check should spend 1 AP")
+
+        # Progress advanced by method.progress_on_success (3).
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.current_progress, 3, "successful check should advance by 3")
+
+        # A CHECK contribution was recorded.
+        contribution = Contribution.objects.filter(
+            project=self.project,
+            contributor_persona=self.donor_persona,
+            kind=ContributionKind.CHECK,
+        ).first()
+        self.assertIsNotNone(contribution, "a CHECK contribution should be recorded")
+
+        self.donor_char.msg.assert_called()
+        check_msg = self.donor_char.msg.call_args[0][0]
+        self.assertIn("advances", check_msg.lower())
+
+    # ------------------------------------------------------------------
+    # story (narrative recording)
+    # ------------------------------------------------------------------
+
+    def test_story_records_narrative_on_latest_contribution(self) -> None:
+        """project/story <id>=<text> → narrative recorded on latest contribution."""
+        # First, make a contribution so there's something to attach the story to.
+        add_contribution(
+            project=self.project,
+            contributor_persona=self.donor_persona,
+            kind=ContributionKind.MONEY,
+            money_amount=100,
+        )
+
+        story_text = "I hauled timber all day"
+        _run(self.donor_char, f"{self.project.pk}={story_text}", switches=["story"])
+
+        contribution = (
+            Contribution.objects.filter(
+                project=self.project,
+                contributor_persona=self.donor_persona,
+            )
+            .order_by("-occurred_at")
+            .first()
+        )
+        self.assertIsNotNone(contribution, "should have a contribution to attach the story to")
+        self.assertEqual(
+            contribution.intent_text, story_text, "story should be recorded on the contribution"
+        )
+
+        self.donor_char.msg.assert_called()
+        story_msg = self.donor_char.msg.call_args[0][0]
+        self.assertIn("recorded", story_msg.lower())
+
+    def test_story_without_prior_contribution_fails(self) -> None:
+        """project/story with no prior contribution → failure message."""
+        _run(self.donor_char, f"{self.project.pk}=My tale", switches=["story"])
+
+        self.donor_char.msg.assert_called()
+        msg = self.donor_char.msg.call_args[0][0]
+        self.assertIn("not contributed", msg.lower())

--- a/src/integration_tests/pipeline/test_signature_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_signature_telnet_e2e.py
@@ -1,0 +1,173 @@
+"""Telnet E2E: signature technique motif journey (#1582).
+
+Drives ``CmdSignature`` end-to-end through the three signature verbs
+(list / set / clear) over the shared ``dispatch_player_action`` seam,
+asserting DB state after each step and telnet feedback via ``caller.msg``.
+
+Journey layout:
+  1. ``signature list``                        — shows available bonuses + technique threads.
+  2. ``signature set technique=<name> bonus=<name>`` — attaches a bonus to a thread.
+  3. ``signature clear technique=<name>``     — removes the bonus.
+
+Mirrors ``world/magic/tests/test_signature_viewset.py``'s setup (same Motif +
+Facet + Resonance + Thread chain) but drives the telnet command rather than the
+ViewSet — proving both surfaces converge on the same Actions.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+from evennia.utils import idmapper
+
+from commands.signature import CmdSignature
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.constants import TargetKind
+from world.magic.factories import (
+    CharacterTechniqueFactory,
+    FacetFactory,
+    GiftFactory,
+    MotifFactory,
+    MotifResonanceAssociationFactory,
+    MotifResonanceFactory,
+    ResonanceFactory,
+    TechniqueFactory,
+)
+from world.magic.models import SignatureMotifBonus, Thread
+from world.magic.services.signature import signature_bonus_for
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(caller: object, args: str = "") -> CmdSignature:
+    """Wire CmdSignature to *caller* and call func(). Returns the cmd instance."""
+    cmd = CmdSignature()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"signature {args}".strip()
+    cmd.cmdname = "signature"
+    caller.msg = MagicMock()
+    cmd.func()
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# Journey
+# ---------------------------------------------------------------------------
+
+
+class SignatureTelnetE2EJourneyTest(TestCase):
+    """list → set → clear through telnet CmdSignature."""
+
+    def setUp(self) -> None:
+        idmapper.models.flush_cache()
+
+        self.character = CharacterFactory()
+        self.sheet = CharacterSheetFactory(character=self.character)
+
+        # Motif + Resonance + Facet — the gating chain for a SignatureMotifBonus.
+        self.motif = MotifFactory(character=self.sheet)
+        self.resonance = ResonanceFactory()
+        self.facet = FacetFactory(name="E2E Signature Facet")
+        self.motif_res = MotifResonanceFactory(motif=self.motif, resonance=self.resonance)
+        MotifResonanceAssociationFactory(motif_resonance=self.motif_res, facet=self.facet)
+
+        # A technique the character knows + a TECHNIQUE-anchored thread.
+        self.gift = GiftFactory()
+        self.technique = TechniqueFactory(gift=self.gift, level=1, damage_profile=False)
+        CharacterTechniqueFactory(character=self.sheet, technique=self.technique)
+
+        # A qualifying signature bonus (gated on the motif's facet).
+        self.bonus = SignatureMotifBonus.objects.create(
+            name="E2E Bonus",
+            required_facet=self.facet,
+        )
+
+        self.thread = Thread.objects.create(
+            owner=self.sheet,
+            resonance=self.resonance,
+            target_kind=TargetKind.TECHNIQUE,
+            target_technique=self.technique,
+            name=self.technique.name,
+        )
+        self.character.threads.invalidate()
+
+    def tearDown(self) -> None:
+        self.thread.delete()
+        self.character.threads.invalidate()
+
+    # ------------------------------------------------------------------
+    # list
+    # ------------------------------------------------------------------
+
+    def test_list_shows_available_bonus_and_technique_thread(self) -> None:
+        """signature list → available bonuses + technique threads with current bonus."""
+        _run(self.character, "list")
+
+        self.character.msg.assert_called()
+        msg = self.character.msg.call_args[0][0]
+        self.assertIn("E2E Bonus", msg, "list should show the available bonus")
+        self.assertIn(self.technique.name, msg, "list should show the technique thread")
+        self.assertIn("none", msg.lower(), "thread should show no bonus set yet")
+
+    # ------------------------------------------------------------------
+    # set
+    # ------------------------------------------------------------------
+
+    def test_set_attaches_bonus_to_thread(self) -> None:
+        """signature set technique=<name> bonus=<name> → bonus attached to the thread."""
+        _run(self.character, f"set technique={self.technique.name} bonus=E2E Bonus")
+
+        self.thread.refresh_from_db()
+        self.assertEqual(
+            self.thread.signature_bonus, self.bonus, "bonus should be set on the thread"
+        )
+
+        # The service-level read confirms it too.
+        self.assertEqual(signature_bonus_for(self.character, self.technique), self.bonus)
+
+        self.character.msg.assert_called()
+        msg = self.character.msg.call_args[0][0]
+        self.assertIn("E2E Bonus", msg)
+        self.assertIn("set", msg.lower())
+
+    def test_set_unknown_technique_is_rejected(self) -> None:
+        """signature set with an unknown technique → error message."""
+        _run(self.character, "set technique=Nonexistent bonus=E2E Bonus")
+
+        self.character.msg.assert_called()
+        # CommandError path calls msg(str) then msg(command_error=...); the
+        # user-facing text is the first positional call.
+        msg = self.character.msg.call_args_list[0][0][0]
+        self.assertIn("don't know a technique", msg.lower())
+
+    def test_set_unknown_bonus_is_rejected(self) -> None:
+        """signature set with an unknown bonus → error message."""
+        _run(self.character, f"set technique={self.technique.name} bonus=Nonexistent")
+
+        self.character.msg.assert_called()
+        msg = self.character.msg.call_args_list[0][0][0]
+        self.assertIn("no signature bonus", msg.lower())
+
+    # ------------------------------------------------------------------
+    # clear
+    # ------------------------------------------------------------------
+
+    def test_clear_removes_bonus_from_thread(self) -> None:
+        """signature clear technique=<name> → bonus removed (null)."""
+        # Pre-set the bonus.
+        self.thread.signature_bonus = self.bonus
+        self.thread.save(update_fields=["signature_bonus"])
+
+        _run(self.character, f"clear technique={self.technique.name}")
+
+        self.thread.refresh_from_db()
+        self.assertIsNone(self.thread.signature_bonus, "clear should null the bonus")
+
+        self.character.msg.assert_called()
+        msg = self.character.msg.call_args[0][0]
+        self.assertIn("cleared", msg.lower())


### PR DESCRIPTION
## Summary

A refreshed audit of #1328 (post ~40 PRs since the 2026-06-25 reachability doc) found several telnet commands with **zero** test coverage and 10 of 12 `CmdBattle` declare subverbs untested. This PR adds e2e journey tests for all of them.

## What changed

### Bucket A — commands with zero test coverage (now covered)

| File | Command | Tests | Coverage |
|---|---|---|---|
| `test_organization_telnet_e2e.py` | `org` | 8 | invite/join/promote/demote/expel/leave/apply/hub |
| `test_project_telnet_e2e.py` | `project` | 6 | status/donate/check/story + insufficient-funds + no-contribution error paths |
| `test_gossip_telnet_e2e.py` | `gossip` | 5 | list/plant/suppress/seek + skill-gate rejection (`@tag("postgres")` — region resolution uses the AreaClosure materialized view) |
| `test_signature_telnet_e2e.py` | `signature` | 5 | list/set/clear + unknown-technique/bonus error paths |
| `test_comfort_telnet_e2e.py` | `comfort` | 2 | band display + no-location fallback |

### Bucket C — battle declare subverbs (now covered)

| File | Subverbs | Tests | Coverage |
|---|---|---|---|
| `test_battle_subverbs_telnet_e2e.py` | rout, rally, support, rescue, repel, hold, breach, fortify, set_environment (×2 scopes), conclude | 11 | Declaration row assertions for each kind + target/scope verification. Reuses helpers from `test_battle_telnet_e2e.py`. |

**Total: 37 new tests** across 6 files. All pass on SQLite except gossip (5 tests, correctly `@tag("postgres")`).

## Test plan

- [x] All 32 SQLite-runnable tests pass (`uv run arx test ... --sqlite --exclude-tag postgres`)
- [x] Gossip tests correctly excluded by `--exclude-tag postgres` (will run in CI parity tier)
- [x] Existing battle e2e tests still pass alongside the new subverb tests
- [x] Pre-commit hooks pass (ruff, ty, migrations check)

Closes nothing — this is additive test coverage for #1328. Related: #1866 (tracks the remaining telnet-surface gaps not covered here).