### PR TITLE
Make init-firewall.sh safe to re-run inside a live container

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -29,6 +29,19 @@ iptables -t mangle -F
 iptables -t mangle -X
 ipset destroy allowed-domains 2>/dev/null || true
 
+# Re-run safety: `iptables -F` clears rules but NOT the default policy. On a
+# fresh container start the policy is ACCEPT, so the pre-lockdown fetches in
+# step 3 (curl to GitHub/Fastly/Cloudflare) work. But when this script is
+# re-run inside an already-firewalled container (e.g. by hand to refresh a
+# stale allowlist), a prior run left OUTPUT/INPUT at DROP — and that DROP
+# silently blocks step 3's own curls, so the script dies at the first fetch
+# AFTER flushing, leaving the container locked out with no allowlist rule
+# installed. Reset both chains to ACCEPT here so setup always starts open;
+# step 4 flips them back to DROP once the allowlist is built. Fail-open during
+# setup only.
+iptables -P INPUT ACCEPT
+iptables -P OUTPUT ACCEPT
+
 # ---------------------------------------------------------------------------
 # 2. Baseline ACCEPT rules (must come before default-deny policies).
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`init-firewall.sh` assumes it starts from a default-**ACCEPT** iptables policy. That
holds on a fresh container start (postStartCommand), but **not** when the script is
re-run inside an already-firewalled container — e.g. by hand to refresh a stale
allowlist.

`iptables -F` clears the *rules* but leaves the *default policy* untouched. So on a
re-run, the leftover `OUTPUT DROP` from the previous run silently blocks the
script's own pre-lockdown `curl`s to `api.github.com`/`api.fastly.com`/`cloudflare.com`
(step 3). The first fetch returns empty → `exit 1` → the script dies **after**
flushing but **before** installing the allowlist ACCEPT rule (step 4). The container
is left locked out of everything except DNS/SSH/loopback/docker-bridge.

Observed in the wild: a manual re-run left `OUTPUT policy DROP`, the `allowed-domains`
ipset populated but with `References: 0` (no rule pointed at it), and all HTTPS egress
dead.

## Fix

Reset `INPUT`/`OUTPUT` policy to `ACCEPT` immediately after the flush, so setup always
starts from an open state regardless of prior policy. Step 4 still flips both back to
`DROP` once the allowlist is built, so the end state is unchanged. Fail-open during
setup only — consistent with the existing "gather ranges before lockdown" design.

## Verification

- Reproduced the lockout state (`OUTPUT policy DROP`, no allowlist rule) and confirmed
  the **unpatched** script fails the same way when re-run from it.
- With the patch, re-running from a `DROP` state completes cleanly: allowlist rebuilt
  (124 entries, `References: 1`), both self-checks pass (google blocked, github
  reachable), and `api.code.umans.ai` / `api.anthropic.com` reachable again.

No behavior change on fresh container start (policy is already ACCEPT there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
