### PR TITLE
Player-facing command/action for BUILDING_RENOVATION (slice of #673, follow-up to #1858)

### DIFF
--- a/src/actions/definitions/locations.py
+++ b/src/actions/definitions/locations.py
@@ -745,3 +745,84 @@ class RemoveFixtureAction(_RoomBuilderAction):
         name = decoration.kind.name
         remove_decoration(decoration)
         return ActionResult(success=True, message=f"{name} removed.")
+
+
+def _kind_flags(kind: Any) -> str:
+    """Bracketed comma-joined short-names of a ``BuildingKind``'s active flags.
+
+    Display-only — the glossary says the flags carry no mechanical weight, so a
+    model method would imply otherwise.
+    """
+    _NAMES = (
+        ("is_residential", "residential"),
+        ("is_commercial", "commercial"),
+        ("is_fortified", "fortified"),
+        ("is_occult", "occult"),
+        ("is_maritime", "maritime"),
+        ("is_agrarian", "agrarian"),
+        ("is_aerial", "aerial"),
+        ("is_subterranean", "subterranean"),
+        ("is_secret", "secret"),
+    )
+    active = [label for field, label in _NAMES if getattr(kind, field)]
+    return f" [{', '.join(active)}]" if active else ""
+
+
+@dataclass
+class StartBuildingRenovationAction(_RoomBuilderAction):
+    """Commission a funded renovation re-pointing the building to a new kind.
+
+    Kwargs: ``target_kind`` (str — name or pk), optional ``room_id`` (web canvas).
+    Bare invocation lists all ``BuildingKind`` rows excluding the building's
+    current kind.
+    """
+
+    key: str = "start_building_renovation"
+    name: str = "Renovate Building"
+    icon: str = "hammer"
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.buildings.models import BuildingKind  # noqa: PLC0415
+        from world.buildings.renovation_services import (  # noqa: PLC0415
+            start_building_renovation,
+        )
+        from world.buildings.room_services import (  # noqa: PLC0415
+            RoomBuildError,
+            building_for_room,
+        )
+
+        room = _resolve_room(actor, kwargs)
+        if room is None:
+            return ActionResult(success=False, message=_no_room_message(kwargs))
+        building = building_for_room(room)
+        if building is None:
+            return ActionResult(success=False, message="This room isn't part of a building.")
+        target = (kwargs.get("target_kind") or "").strip()
+        if not target:
+            lines = [
+                f"{kind.name}{_kind_flags(kind)}"
+                for kind in BuildingKind.objects.exclude(pk=building.kind_id)
+            ]
+            return ActionResult(success=False, message="Renovate to: " + ", ".join(lines))
+        kind = (
+            BuildingKind.objects.get(pk=target)
+            if target.isdigit()
+            else BuildingKind.objects.filter(name__iexact=target).first()
+        )
+        if kind is None:
+            return ActionResult(success=False, message=f"No building kind named '{target}'.")
+        try:
+            project = start_building_renovation(
+                persona=_persona_for(actor), building=building, target_kind=kind
+            )
+        except RoomBuildError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        return ActionResult(
+            success=True,
+            message=f"'{kind.name}' renovation commissioned (project #{project.pk}).",
+        )

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -124,6 +124,7 @@ from actions.definitions.locations import (
     RoomEditAction,
     SetBuildingStyleAction,
     SetPrimaryHomeAction,
+    StartBuildingRenovationAction,
     StartExtensionAction,
     UnlinkRoomsAction,
 )
@@ -263,6 +264,7 @@ _ALL_ACTIONS: list[Action] = [
     SetPrimaryHomeAction(),
     CommissionDecorationAction(),
     StartExtensionAction(),
+    StartBuildingRenovationAction(),
     DonateToProjectAction(),
     CheckContributeAction(),
     StoryContributeAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -170,6 +170,7 @@ class ActionRegistryTests(TestCase):
             "set_primary_home",
             "commission_decoration",
             "start_building_extension",
+            "start_building_renovation",
             "project_donate",
             "project_check",
             "project_story",

--- a/src/actions/tests/test_renovation_action.py
+++ b/src/actions/tests/test_renovation_action.py
@@ -1,0 +1,118 @@
+"""Action-level tests for ``StartBuildingRenovationAction``.
+
+Owner-gated commissioning tests are ``@tag("postgres")`` because the service's
+``is_owner`` gate walks the ``AreaClosure`` materialized view. The list-on-empty
+and wrong-name paths return before the service call and run on SQLite too.
+"""
+
+from django.test import TestCase, tag
+from evennia.objects.models import ObjectDB
+
+from actions.registry import get_action
+from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.models import RoomProfile
+from world.areas.constants import AreaLevel
+from world.areas.factories import AreaFactory
+from world.buildings.factories import BuildingFactory, BuildingKindFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.locations.constants import HolderType, LocationParentType
+from world.locations.models import LocationOwnership
+from world.projects.constants import ProjectKind
+
+
+def _room_in(area, *, name="A Room"):
+    room = ObjectDB.objects.create(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+    RoomProfile.objects.update_or_create(objectdb=room, defaults={"area": area})
+    return room
+
+
+def _owned_building(persona, *, budget=100):
+    area = AreaFactory(level=AreaLevel.BUILDING)
+    building = BuildingFactory(area=area, space_budget=budget)
+    LocationOwnership.objects.create(
+        parent_type=LocationParentType.AREA,
+        area=area,
+        holder_type=HolderType.PERSONA,
+        holder_persona=persona,
+    )
+    return building
+
+
+def _make_owner_in_building():
+    actor = CharacterFactory()
+    CharacterSheetFactory(character=actor)
+    persona = actor.sheet_data.primary_persona
+    building = _owned_building(persona)
+    entry = _room_in(building.area, name="Entry Hall")
+    building.entry_room = entry.room_profile
+    building.save(update_fields=["entry_room"])
+    actor.db_location = entry
+    actor.save(update_fields=["db_location"])
+    return actor, building
+
+
+@tag("postgres")
+class RenovationCommissionTests(TestCase):
+    """Commission / no-op / non-building paths reach the service's is_owner gate."""
+
+    def setUp(self) -> None:
+        self.actor, self.building = _make_owner_in_building()
+        self.target_kind = BuildingKindFactory(name="Occult Manor", is_occult=True)
+
+    def test_commission_creates_project(self) -> None:
+        action = get_action("start_building_renovation")
+        result = action.run(self.actor, target_kind="Occult Manor")
+        assert result.success
+        assert "Occult Manor" in result.message
+        assert "project #" in result.message
+        from world.projects.models import Project
+
+        project = Project.objects.filter(kind=ProjectKind.BUILDING_RENOVATION).first()
+        assert project is not None
+        assert project.building_renovation_details.target_kind == self.target_kind
+
+    def test_noop_renovation_refused(self) -> None:
+        action = get_action("start_building_renovation")
+        result = action.run(self.actor, target_kind=self.building.kind.name)
+        assert not result.success
+        assert "already" in result.message.lower()
+
+    def test_non_building_room_errors(self) -> None:
+        bare_room = ObjectDB.objects.create(
+            db_key="Void", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        RoomProfile.objects.update_or_create(objectdb=bare_room, defaults={"area": AreaFactory()})
+        self.actor.db_location = bare_room
+        self.actor.save(update_fields=["db_location"])
+        action = get_action("start_building_renovation")
+        result = action.run(self.actor, target_kind="Occult Manor")
+        assert not result.success
+        assert "building" in result.message.lower()
+
+
+@tag("postgres")
+class RenovationListingTests(TestCase):
+    """Listing + wrong-name paths — ``is_owner`` runs in the prerequisite gate."""
+
+    def setUp(self) -> None:
+        self.actor, self.building = _make_owner_in_building()
+        self.current_kind = self.building.kind
+        self.other_kind = BuildingKindFactory(name="Occult Manor", is_occult=True)
+
+    def test_bare_invocation_lists_kinds_excluding_current(self) -> None:
+        action = get_action("start_building_renovation")
+        result = action.run(self.actor, target_kind="")
+        assert not result.success
+        assert "Occult Manor" in result.message
+        assert self.current_kind.name not in result.message
+
+    def test_wrong_kind_name_errors(self) -> None:
+        action = get_action("start_building_renovation")
+        result = action.run(self.actor, target_kind="Nonexistent Kind")
+        assert not result.success
+        assert "Nonexistent Kind" in result.message
+
+    def test_kind_flags_shown_in_listing(self) -> None:
+        action = get_action("start_building_renovation")
+        result = action.run(self.actor, target_kind="")
+        assert "occult" in result.message.lower()

--- a/src/actions/tests/test_renovation_action.py
+++ b/src/actions/tests/test_renovation_action.py
@@ -78,10 +78,20 @@ class RenovationCommissionTests(TestCase):
         assert "already" in result.message.lower()
 
     def test_non_building_room_errors(self) -> None:
+        # The actor owns a *non-building* room — the owner prerequisite passes,
+        # but the room isn't part of any building, so the action reports that.
+        area = AreaFactory()
         bare_room = ObjectDB.objects.create(
             db_key="Void", db_typeclass_path="typeclasses.rooms.Room"
         )
-        RoomProfile.objects.update_or_create(objectdb=bare_room, defaults={"area": AreaFactory()})
+        RoomProfile.objects.update_or_create(objectdb=bare_room, defaults={"area": area})
+        persona = self.actor.sheet_data.primary_persona
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.AREA,
+            area=area,
+            holder_type=HolderType.PERSONA,
+            holder_persona=persona,
+        )
         self.actor.db_location = bare_room
         self.actor.save(update_fields=["db_location"])
         action = get_action("start_building_renovation")

--- a/src/commands/locations.py
+++ b/src/commands/locations.py
@@ -18,6 +18,7 @@ rhythm, no monster one-liner):
   room/home                       room/tenant <character>
   room/evict <character>          room/extend <units>
   room/decorate <template> [here]         room/style <style name>
+  room/renovate <kind name|id>
 """
 
 from __future__ import annotations
@@ -36,7 +37,8 @@ _USAGE = (
     "  room/renameexit <exit>=<new name>\n"
     "  room/home  ·  room/tenant <character>  ·  room/evict <character>\n"
     "  room/extend <units>  ·  room/decorate <template> [here]\n"
-    "  room/style <style name>  ·  room/fixture <kind>  ·  room/removefixture <kind>"
+    "  room/style <style name>  ·  room/fixture <kind>  ·  room/removefixture <kind>\n"
+    "  room/renovate <kind name|id>"
 )
 
 _AFFIRMATIVE = frozenset({"yes", "y", "true", "on", "1", "public"})
@@ -103,6 +105,7 @@ class CmdRoom(ArxCommand):
             "extend": lambda a: self._run("start_building_extension", added_budget=a),
             "decorate": self._decorate,
             "style": lambda a: self._run("set_building_style", style=a),
+            "renovate": lambda a: self._run("start_building_renovation", target_kind=a),
             "fixture": lambda a: self._run("place_room_fixture", kind=a),
             "removefixture": lambda a: self._run("remove_room_fixture", kind=a),
         }

--- a/src/commands/tests/test_manageroom_command.py
+++ b/src/commands/tests/test_manageroom_command.py
@@ -100,6 +100,14 @@ class RoomCommandParseTests(TestCase):
         key, kwargs = self._dispatch(["extend"], "50")
         assert (key, kwargs) == ("start_building_extension", {"added_budget": "50"})
 
+    def test_renovate_switch_routes(self) -> None:
+        key, kwargs = self._dispatch(["renovate"], "Occult Manor")
+        assert (key, kwargs) == ("start_building_renovation", {"target_kind": "Occult Manor"})
+
+    def test_renovate_bare_routes_empty(self) -> None:
+        key, kwargs = self._dispatch(["renovate"], "")
+        assert (key, kwargs) == ("start_building_renovation", {"target_kind": ""})
+
     def test_no_switch_raises_usage(self) -> None:
         with self.assertRaises(CommandError):
             self._dispatch([], "anything")


### PR DESCRIPTION
Closes #1860

## Summary

Player-facing room/renovate verb for BUILDING_RENOVATION. Adds StartBuildingRenovationAction (REGISTRY, wraps start_building_renovation service from #1858) + room/renovate telnet switch. Bare invocation lists available BuildingKind rows (with active flag short-names) excluding the building's current kind; naming one commissions a funded renovation project. Owner-gated via IsRoomOwnerPrerequisite.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1860 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: clean rebase, no conflicts

<!-- last-addressed-comment: 0 -->