### PR TITLE
Sheet centers bundle 1: Reputation/Distinctions/Magic/Locations tabs + covenant identity header (#1446)

### DIFF
--- a/docs/roadmap/design-tenets.md
+++ b/docs/roadmap/design-tenets.md
@@ -335,6 +335,15 @@ This composes with **closed-issue ≠ proven**: a capability counts as covered o
 end-to-end test demonstrates the outcome — "we think it works" is not safe to hand a GM. The
 live coverage map is [`player-capability-ledger.md`](player-capability-ledger.md).
 
+### The sheet describes; the scene does
+
+Sheet centers (web tabs, telnet `sheet/<section>`) are declarative — they
+describe what a character has and is. DOING things (casting, weaving, rituals)
+is invoked in-scene via context-menu actions dispatching `action.run()`, never
+sheet navigation. Corollary: "more findable places is a feature" — a
+main-sheet identity link complements a dedicated section, never replaces it.
+(Apostate, #1446.)
+
 ### Checks are stat + skill (+ specialization), rarely stat + stat
 
 A check's composition defaults to a **stat + the relevant skill**, plus a **specialization

--- a/docs/roadmap/items-equipment.md
+++ b/docs/roadmap/items-equipment.md
@@ -509,7 +509,7 @@ What shipped:
   dominate the final acclaim. Consent boundary: only characters who present are
   judgeable; no self/alt/duplicate judging.
 - **`Persona.prestige_from_fashion`** — a 5th prestige axis (same event-sourced
-  recompute pattern as the other four), surfaced on the Renown tab.
+  recompute pattern as the other four), surfaced on the Reputation tab (né Renown, #1446).
 - **`FacetVogueMomentum` + trendsetter ceremony** — acclaimed presentations accrue
   per-`(society, facet)` vogue momentum (cron-decayed); a seasonal cron crowns the
   top presenter (`Trendsetter`) and rewrites the society's living `FashionStyle`

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -696,7 +696,7 @@ Social structures, organizations, reputation, and legend tracking.
 - **Key Services:** `ensure_default_rank_ladder`, `join_organization`, `leave_organization`, `invite_to_organization`, `apply_to_organization`, `accept_invitation`, `decline_invitation`, `accept_application`, `decline_application`, `promote_member`, `demote_member`, `expel_member`
 - **Action Keys:** `org_invite`, `org_apply`, `org_join`, `org_leave`, `org_promote`, `org_demote`, `org_expel`
 - **Telnet:** `org <subverb>` command; `accept org` / `decline org` offer responses
-- **DRF:** `OrganizationViewSet`, `OrganizationMembershipViewSet`, `OrganizationRankViewSet`, `OrganizationMembershipOfferViewSet` at `/api/societies/organizations/`, `/api/societies/memberships/`, `/api/societies/ranks/`, and `/api/societies/offers/`
+- **DRF:** `OrganizationViewSet` (`?name=` iexact filter), `OrganizationMembershipViewSet`, `OrganizationRankViewSet`, `OrganizationMembershipOfferViewSet`, `OrganizationReputationViewSet` at `/api/societies/organizations/`, `/api/societies/memberships/`, `/api/societies/ranks/`, `/api/societies/offers/`, and `/api/societies/reputations/` (self-scoped org standing, #1446)
 - **Principle Axes:** mercy, method, status, change, allegiance, power (-5 to +5)
 - **Legend deed from crossing:** `LegendEntry.audere_majora_crossing` — reverse OneToOne to `AudereMajoraCrossing` (magic app); set when `cross_threshold` mints a deed via `fire_renown_award` + `_mint_crossing_deed`.
 - **Scandal reach fork (#1464, ADR-0082):** `world/societies/scandal.py` —
@@ -848,7 +848,8 @@ heat; identity-association copies it (`associate_heat` — the #1334 outing seam
   MOSTLY_ACCURATE dodge + masked-report association chance)
 - **Surfaces (self-only):** room-desc tier line + `heat` on the room-state payload;
   safe-now relief line on movement; `sheet/crime` + web Crime tab over
-  `GET /api/justice/heat/` (tiers only, never raw values)
+  `GET /api/justice/heat/` (tiers only, never raw values; `PersonaHeatSerializer`
+  also carries `society` id for the web Reputation tab's client-side join, #1446)
 - **Source:** `src/world/justice/`
 - **Details:** [justice.md](justice.md)
 

--- a/docs/systems/justice.md
+++ b/docs/systems/justice.md
@@ -81,6 +81,8 @@ deeds accept `crime_kinds=` on `create_solo_deed` / `create_legend_event`.
 - `sheet/crime` telnet section + web **Crime** tab (own sheet only) over
   `GET /api/justice/heat/?viewer=<roster-entry>` (`PersonaHeatViewSet` — owner
   validated via `for_account`, scoped via `active_persona_for_sheet`, tiers only).
+  `PersonaHeatSerializer` also exposes `society` (id) so the web Reputation tab
+  can join heat against its own org/society standing rows client-side (#1446).
 
 ## Constants
 

--- a/docs/systems/societies.md
+++ b/docs/systems/societies.md
@@ -195,10 +195,11 @@ Read-only endpoints under `/api/societies/`:
 
 | Endpoint | Viewset | Purpose |
 |----------|---------|---------|
-| `/organizations/` | `OrganizationViewSet` | Organizations the requester belongs to (staff see all) |
+| `/organizations/` | `OrganizationViewSet` | Organizations the requester belongs to (staff see all); `?name=` filters iexact (family-org resolve) |
 | `/memberships/` | `OrganizationMembershipViewSet` | Current memberships, excluding covenants |
 | `/ranks/` | `OrganizationRankViewSet` | Rank ladders for visible organizations |
 | `/offers/` | `OrganizationMembershipOfferViewSet` | Offers owned/received/org-visible to the requester |
+| `/reputations/` | `OrganizationReputationViewSet` | The requester's active persona's org reputations (standing) — `{id, persona, organization, organization_name, tier}`, tier only, self-scoped (#1446) |
 
 All covenant-backed organizations are excluded from the membership/rank/offer endpoints.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -164,6 +164,16 @@ const CovenantDetailPage = lazy(() =>
 );
 
 // ---------------------------------------------------------------------------
+// Lazy-loaded org stub page (#1446, seeds #1884)
+// ---------------------------------------------------------------------------
+
+const OrgPage = lazy(() =>
+  import('@/orgs/pages/OrgPage').then((m) => ({
+    default: m.OrgPage,
+  }))
+);
+
+// ---------------------------------------------------------------------------
 // Lazy-loaded org books pages (#930)
 // ---------------------------------------------------------------------------
 
@@ -774,6 +784,20 @@ function App() {
             <Suspense fallback={<PageLoadingFallback />}>
               <ProtectedRoute>
                 <CovenantDetailPage />
+              </ProtectedRoute>
+            </Suspense>
+          }
+        />
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Org stub page — click-through destination (#1446, seeds #1884)     */}
+        {/* ------------------------------------------------------------------ */}
+        <Route
+          path="/orgs/:id"
+          element={
+            <Suspense fallback={<PageLoadingFallback />}>
+              <ProtectedRoute>
+                <OrgPage />
               </ProtectedRoute>
             </Suspense>
           }

--- a/frontend/src/character_sheets/api.ts
+++ b/frontend/src/character_sheets/api.ts
@@ -1,0 +1,106 @@
+/**
+ * Character sheet API client (#1446) — the rich per-character payload.
+ *
+ * Reads `/api/character-sheets/{id}/` (sheet id == character id). The view's
+ * `CharacterSheetSerializer` (src/world/character_sheets/serializers.py) overrides
+ * `to_representation` directly instead of declaring fields, so drf-spectacular can't infer a
+ * response schema for it — `schema.json` / `generated/api.d.ts` record this operation as
+ * "No response body" (no `components['schemas']['CharacterSheet']` exists). `CharacterSheetPayload`
+ * is therefore hand-written to mirror the serializer's `to_representation` dict and the section
+ * TypedDicts in `src/world/character_sheets/types.py`, not sourced from the generated schema.
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+
+/** Mirrors `world.character_sheets.types.TechniqueEntry`. */
+export interface CharacterSheetTechnique {
+  name: string;
+  level: number;
+  style: string;
+  description: string;
+}
+
+/** Mirrors `world.character_sheets.types.GiftEntry`. */
+export interface CharacterSheetGift {
+  name: string;
+  description: string;
+  resonances: string[];
+  techniques: CharacterSheetTechnique[];
+}
+
+/** Mirrors `world.character_sheets.types.MotifResonanceEntry`. */
+export interface CharacterSheetMotifResonance {
+  name: string;
+  facets: string[];
+}
+
+/** Mirrors `world.character_sheets.types.MotifSection`. */
+export interface CharacterSheetMotif {
+  description: string;
+  resonances: CharacterSheetMotifResonance[];
+}
+
+/** Mirrors `world.character_sheets.types.AnimaRitualSection`. */
+export interface CharacterSheetAnimaRitual {
+  stat: string;
+  skill: string;
+  resonance: string;
+  description: string;
+}
+
+/** Mirrors `world.character_sheets.types.AuraData`. */
+export interface CharacterSheetAura {
+  celestial: number;
+  primal: number;
+  abyssal: number;
+  glimpse_story: string;
+}
+
+/** Mirrors `world.character_sheets.types.MagicSection`. */
+export interface CharacterSheetMagic {
+  gifts: CharacterSheetGift[];
+  motif: CharacterSheetMotif | null;
+  anima_ritual: CharacterSheetAnimaRitual | null;
+  aura: CharacterSheetAura | null;
+}
+
+/** Mirrors `world.character_sheets.types.DistinctionEntry`. */
+export interface CharacterSheetDistinction {
+  id: number;
+  name: string;
+  rank: number;
+  notes: string;
+  is_secret: boolean;
+}
+
+/**
+ * The full `/api/character-sheets/{id}/` payload.
+ *
+ * `identity`, `appearance`, `stats`, `skills`, `path`, `story`, `goals`, `personas`, `theming`,
+ * `profile_picture`, and `current_residence` are left loosely typed here — this task only needs
+ * `distinctions` and `magic` typed precisely (Tasks 9 & 10); refine the rest as their consuming
+ * sections land.
+ */
+export interface CharacterSheetPayload {
+  id: number;
+  can_edit: boolean;
+  identity: Record<string, unknown>;
+  appearance: Record<string, unknown>;
+  stats: Record<string, unknown>;
+  skills: unknown[];
+  path: Record<string, unknown> | null;
+  distinctions: CharacterSheetDistinction[];
+  magic: CharacterSheetMagic | null;
+  story: Record<string, unknown>;
+  goals: unknown[];
+  personas: unknown[];
+  theming: Record<string, unknown>;
+  profile_picture: unknown;
+  current_residence: unknown;
+}
+
+export async function fetchCharacterSheet(sheetId: number): Promise<CharacterSheetPayload> {
+  const res = await apiFetch(`/api/character-sheets/${sheetId}/`);
+  if (!res.ok) throw new Error('Failed to load character sheet');
+  return (await res.json()) as CharacterSheetPayload;
+}

--- a/frontend/src/character_sheets/queries.ts
+++ b/frontend/src/character_sheets/queries.ts
@@ -1,0 +1,16 @@
+/**
+ * Character sheet React Query hooks (#1446).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchCharacterSheet } from './api';
+
+/** The rich character-sheet payload for a single character (sheet id == character id). */
+export function useCharacterSheetQuery(sheetId: number) {
+  return useQuery({
+    queryKey: ['character-sheets', sheetId],
+    queryFn: () => fetchCharacterSheet(sheetId),
+    enabled: !!sheetId,
+  });
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -20,8 +20,6 @@ const links = [
   { to: '/events', label: 'Events' },
   { to: '/codex', label: 'Codex' },
   { to: '/tidings', label: 'Tidings' },
-  { to: '/news', label: 'News' },
-  { to: '/community', label: 'Community' },
   { to: '/threads', label: 'Threads' },
   { to: '/magic/progression', label: 'Progression' },
 ];

--- a/frontend/src/components/character/CharacterPortrait.tsx
+++ b/frontend/src/components/character/CharacterPortrait.tsx
@@ -1,11 +1,14 @@
+import type { ReactNode } from 'react';
 import type { CharacterData, RosterEntryData } from '@/roster/types';
 
 interface CharacterPortraitProps {
   name: CharacterData['name'];
   profilePicture?: RosterEntryData['profile_picture'];
+  /** Optional subtitle content rendered under the name (e.g. covenant/family lines, #1446). */
+  children?: ReactNode;
 }
 
-export function CharacterPortrait({ name, profilePicture }: CharacterPortraitProps) {
+export function CharacterPortrait({ name, profilePicture, children }: CharacterPortraitProps) {
   const url = profilePicture?.media.cloudinary_url;
   return (
     <div className="flex flex-col items-start gap-4 sm:flex-row">
@@ -14,7 +17,10 @@ export function CharacterPortrait({ name, profilePicture }: CharacterPortraitPro
       ) : (
         <div className="h-48 w-48 rounded bg-gray-200" />
       )}
-      <h2 className="text-2xl font-bold">{name}</h2>
+      <div>
+        <h2 className="text-2xl font-bold">{name}</h2>
+        {children}
+      </div>
     </div>
   );
 }

--- a/frontend/src/distinctions/components/DistinctionsTab.test.tsx
+++ b/frontend/src/distinctions/components/DistinctionsTab.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * DistinctionsTab tests (#1446) — sheet-level distinctions list, secret badging, empty state.
+ *
+ * The server already filters secret rows for non-privileged viewers (`_build_distinctions`,
+ * src/world/character_sheets/serializers.py:501) — this component only renders whatever
+ * `useCharacterSheetQuery` returns, adding a `Secret` badge on rows where `is_secret` is true.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { DistinctionsTab } from './DistinctionsTab';
+import type { CharacterSheetPayload, CharacterSheetDistinction } from '@/character_sheets/api';
+
+vi.mock('@/character_sheets/queries', () => ({
+  useCharacterSheetQuery: vi.fn(),
+}));
+
+import * as queries from '@/character_sheets/queries';
+
+function mockPayload(distinctions: CharacterSheetDistinction[] | undefined, isLoading = false) {
+  vi.mocked(queries.useCharacterSheetQuery).mockReturnValue({
+    data: distinctions === undefined ? undefined : ({ distinctions } as CharacterSheetPayload),
+    isLoading,
+  } as unknown as ReturnType<typeof queries.useCharacterSheetQuery>);
+}
+
+function makeDistinction(
+  overrides: Partial<CharacterSheetDistinction> = {}
+): CharacterSheetDistinction {
+  return {
+    id: 1,
+    name: 'Iron Will',
+    rank: 2,
+    notes: 'Forged in the siege of Whitehold.',
+    is_secret: false,
+    ...overrides,
+  };
+}
+
+describe('DistinctionsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the empty state when there are no distinctions', () => {
+    mockPayload([]);
+    render(<DistinctionsTab characterId={1} />);
+    expect(screen.getByTestId('distinctions-empty-state')).toBeInTheDocument();
+  });
+
+  it('renders a row per distinction with rank, and badges only the secret one', () => {
+    mockPayload([
+      makeDistinction(),
+      makeDistinction({ id: 2, name: 'Hidden Oath', rank: 1, is_secret: true }),
+    ]);
+    render(<DistinctionsTab characterId={1} />);
+
+    const rows = screen.getAllByTestId('distinction-row');
+    expect(rows).toHaveLength(2);
+
+    expect(screen.getByText('Iron Will')).toBeInTheDocument();
+    expect(screen.getByText('Rank 2')).toBeInTheDocument();
+    expect(screen.getByText('Hidden Oath')).toBeInTheDocument();
+    expect(screen.getByText('Rank 1')).toBeInTheDocument();
+
+    expect(screen.getAllByText('Secret')).toHaveLength(1);
+  });
+
+  it('shows a spinner while loading', () => {
+    mockPayload(undefined, true);
+    const { container } = render(<DistinctionsTab characterId={1} />);
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/distinctions/components/DistinctionsTab.tsx
+++ b/frontend/src/distinctions/components/DistinctionsTab.tsx
@@ -1,0 +1,62 @@
+/**
+ * DistinctionsTab (#1446) — the character sheet's Distinctions section.
+ *
+ * Ungated: every viewer sees this tab, because the server already filters secret rows for
+ * non-privileged viewers (`_build_distinctions`, src/world/character_sheets/serializers.py:501).
+ * This component only renders whatever `useCharacterSheetQuery` returns — it does NOT
+ * re-implement privacy client-side — and adds a `Secret` badge on rows where `is_secret` is true.
+ */
+
+import { Loader2 } from 'lucide-react';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { useCharacterSheetQuery } from '@/character_sheets/queries';
+
+interface Props {
+  /** CharacterSheet pk (shared with the character ObjectDB pk). */
+  characterId: number;
+}
+
+export function DistinctionsTab({ characterId }: Props) {
+  const { data: payload, isLoading } = useCharacterSheetQuery(characterId);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const distinctions = payload?.distinctions ?? [];
+
+  if (distinctions.length === 0) {
+    return (
+      <p className="py-8 text-center text-muted-foreground" data-testid="distinctions-empty-state">
+        No distinctions yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2" data-testid="distinctions-list">
+      {distinctions.map((distinction) => (
+        <Card key={distinction.id} data-testid="distinction-row">
+          <CardContent className="space-y-1 py-4">
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-medium">{distinction.name}</span>
+              <div className="flex items-center gap-2">
+                <Badge variant="outline">{`Rank ${distinction.rank}`}</Badge>
+                {distinction.is_secret && <Badge variant="secondary">Secret</Badge>}
+              </div>
+            </div>
+            {distinction.notes && (
+              <p className="text-sm text-muted-foreground">{distinction.notes}</p>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -13721,7 +13721,7 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * @description List/retrieve the requester's active persona's organization reputations (standing).
+     * @description List/retrieve org reputations (standing) for personas the requester currently plays.
      *
      *     Self-only: rows are scoped to personas the requester currently plays.
      */
@@ -13742,7 +13742,7 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * @description List/retrieve the requester's active persona's organization reputations (standing).
+     * @description List/retrieve org reputations (standing) for personas the requester currently plays.
      *
      *     Self-only: rows are scoped to personas the requester currently plays.
      */

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -13713,6 +13713,48 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/societies/reputations/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description List/retrieve the requester's active persona's organization reputations (standing).
+     *
+     *     Self-only: rows are scoped to personas the requester currently plays.
+     */
+    get: operations['societies_reputations_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/societies/reputations/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description List/retrieve the requester's active persona's organization reputations (standing).
+     *
+     *     Self-only: rows are scoped to personas the requester currently plays.
+     */
+    get: operations['societies_reputations_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/staff-inbox/': {
     parameters: {
       query?: never;
@@ -16444,6 +16486,14 @@ export interface components {
       readonly background: string;
       relationships?: string[];
       galleries?: components['schemas']['CharacterGallery'][];
+      /**
+       * @description Core-identity covenant: the active DURANCE-type covenant role, if any (#1446).
+       *
+       *     One indexed query per character; bounded by roster pagination in list context.
+       */
+      readonly covenant: {
+        [key: string]: unknown;
+      } | null;
     };
     /** @description Serializer for character achievement records. */
     CharacterAchievement: {
@@ -21563,6 +21613,14 @@ export interface components {
       /** @description Members at this rank can promote/demote others */
       can_manage_ranks?: boolean;
     };
+    /** @description A persona's standing with an organization — named tier only, never the raw value. */
+    OrganizationReputation: {
+      readonly id: number;
+      /** @description The organization this reputation is with */
+      organization: number;
+      readonly organization_name: string;
+      readonly tier: string;
+    };
     OrganizationSearch: {
       id: number;
       name: string;
@@ -22707,6 +22765,21 @@ export interface components {
        */
       previous?: string | null;
       results: components['schemas']['OrganizationRank'][];
+    };
+    PaginatedOrganizationReputationList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['OrganizationReputation'][];
     };
     PaginatedOrganizationSearchList: {
       /** @example 123 */
@@ -25331,6 +25404,7 @@ export interface components {
     PersonaHeat: {
       readonly id: number;
       readonly area_name: string;
+      society: number;
       readonly society_name: string;
       readonly tier: string;
       readonly tier_label: string;
@@ -40304,8 +40378,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this Consequence Pool. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };
@@ -49397,6 +49470,51 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['OrganizationRank'];
+        };
+      };
+    };
+  };
+  societies_reputations_list: {
+    parameters: {
+      query?: {
+        organization?: number;
+        /** @description A page number within the paginated result set. */
+        page?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedOrganizationReputationList'];
+        };
+      };
+    };
+  };
+  societies_reputations_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this Organization Reputation. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['OrganizationReputation'];
         };
       };
     };

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -21616,6 +21616,8 @@ export interface components {
     /** @description A persona's standing with an organization — named tier only, never the raw value. */
     OrganizationReputation: {
       readonly id: number;
+      /** @description The persona (character identity) this reputation belongs to */
+      persona: number;
       /** @description The organization this reputation is with */
       organization: number;
       readonly organization_name: string;

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -49360,6 +49360,7 @@ export interface operations {
   societies_organizations_list: {
     parameters: {
       query?: {
+        name?: string;
         org_type?: string;
         /** @description A page number within the paginated result set. */
         page?: number;

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -40380,7 +40380,8 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        id: string;
+        /** @description A unique integer value identifying this Consequence Pool. */
+        id: number;
       };
       cookie?: never;
     };

--- a/frontend/src/locations/api.ts
+++ b/frontend/src/locations/api.ts
@@ -1,0 +1,24 @@
+/**
+ * Locations API client (#1446) — "My Ships" reads for the Locations sheet tab.
+ *
+ * `GET /api/ships/ships/` is already scoped server-side (`src/world/ships/views.py`) to the
+ * requesting account's active persona's owned + covenant-owned ships — no client-side
+ * persona filtering needed here.
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+import type { components } from '@/generated/api';
+
+export type MyShip = components['schemas']['ShipDetails'];
+
+interface PaginatedShips {
+  results: MyShip[];
+}
+
+/** Fetch the requesting account's active persona's ships (owned + covenant-owned). */
+export async function fetchMyShips(): Promise<MyShip[]> {
+  const res = await apiFetch('/api/ships/ships/');
+  if (!res.ok) throw new Error('Failed to load ships');
+  const data = (await res.json()) as PaginatedShips | MyShip[];
+  return Array.isArray(data) ? data : data.results;
+}

--- a/frontend/src/locations/components/LocationsTab.test.tsx
+++ b/frontend/src/locations/components/LocationsTab.test.tsx
@@ -1,0 +1,132 @@
+import { screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { LocationsTab } from './LocationsTab';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { RenownPayload } from '@/renown/types';
+import type { MyShip } from '../api';
+
+vi.mock('@/renown/queries', () => ({
+  usePersonaRenownQuery: vi.fn(),
+}));
+vi.mock('../queries', () => ({
+  useMyShipsQuery: vi.fn(),
+}));
+
+import { usePersonaRenownQuery } from '@/renown/queries';
+import { useMyShipsQuery } from '../queries';
+
+const mockRenownQuery = vi.mocked(usePersonaRenownQuery);
+const mockShipsQuery = vi.mocked(useMyShipsQuery);
+
+function makeRenown(overrides: Partial<RenownPayload> = {}): RenownPayload {
+  return {
+    persona_id: 1,
+    persona_name: 'Alice',
+    prestige: { dwellings: 0, items: 0, orgs: 0, deeds: 0, fashion: 0, total: 0 },
+    fame: {
+      points: 0,
+      tier: 'unknown',
+      tier_label: 'Unknown',
+      tier_multiplier: 1,
+      next_tier: null,
+      next_tier_threshold: null,
+    },
+    reputation: [],
+    recent_deeds: [],
+    owned_dwellings: [],
+    tenanted_rooms: [],
+    ...overrides,
+  } as RenownPayload;
+}
+
+function setRenown(payload: RenownPayload | undefined, isLoading = false) {
+  mockRenownQuery.mockReturnValue({
+    data: payload,
+    isLoading,
+  } as unknown as UseQueryResult<RenownPayload, Error>);
+}
+
+function setShips(ships: MyShip[] | undefined, isLoading = false) {
+  mockShipsQuery.mockReturnValue({
+    data: ships,
+    isLoading,
+  } as unknown as UseQueryResult<MyShip[], Error>);
+}
+
+describe('LocationsTab', () => {
+  it('renders dwelling, room, and ship names under their section headings', () => {
+    setRenown(
+      makeRenown({
+        owned_dwellings: [
+          {
+            id: 1,
+            name: 'The Rookery',
+            polish_by_category: [],
+            upkeep_warning: false,
+            decayed_features_count: 0,
+            dormant: false,
+            dormant_since: null,
+          },
+        ],
+        tenanted_rooms: [{ id: 2, name: 'Garret Room', polish_by_category: [] }],
+      })
+    );
+    setShips([
+      {
+        id: 3,
+        ship_type: {
+          id: 1,
+          name: 'The Gull',
+          description: '',
+          base_hull: 10,
+          base_handling: 10,
+          base_armament: 10,
+          base_crew_capacity: 4,
+          base_cargo_capacity: 4,
+        },
+        effective_handling: 10,
+        effective_armament: 10,
+        effective_hull: 10,
+        handling_level: 0,
+        armament_level: 0,
+        crew_capacity: 4,
+        cargo_capacity: 4,
+        needs_repair: false,
+        owner_persona_id: 1,
+        owner_persona_name: 'Alice',
+        owner_covenant_id: null,
+        owner_covenant_name: null,
+      },
+    ]);
+
+    renderWithProviders(<LocationsTab personaId={1} />);
+
+    expect(screen.getByText('Owned Dwellings')).toBeInTheDocument();
+    expect(screen.getByText('The Rookery')).toBeInTheDocument();
+    expect(screen.getByText('Tenanted Rooms')).toBeInTheDocument();
+    expect(screen.getByText('Garret Room')).toBeInTheDocument();
+    expect(screen.getByText('Ships')).toBeInTheDocument();
+    expect(screen.getByText('The Gull')).toBeInTheDocument();
+  });
+
+  it('renders the Domains placeholder line', () => {
+    setRenown(makeRenown());
+    setShips([]);
+
+    renderWithProviders(<LocationsTab personaId={1} />);
+
+    expect(screen.getByTestId('domains-placeholder')).toHaveTextContent(
+      'Domains your organizations hold will appear here (#1884).'
+    );
+  });
+
+  it('shows a muted message when there is no active persona to view', () => {
+    setRenown(undefined);
+    setShips(undefined);
+
+    renderWithProviders(<LocationsTab personaId={null} />);
+
+    expect(screen.getByText(/No active character to view locations for/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/locations/components/LocationsTab.test.tsx
+++ b/frontend/src/locations/components/LocationsTab.test.tsx
@@ -100,7 +100,7 @@ describe('LocationsTab', () => {
       },
     ]);
 
-    renderWithProviders(<LocationsTab personaId={1} />);
+    renderWithProviders(<LocationsTab personaId={1} isActiveCharacter />);
 
     expect(screen.getByText('Owned Dwellings')).toBeInTheDocument();
     expect(screen.getByText('The Rookery')).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('LocationsTab', () => {
     setRenown(makeRenown());
     setShips([]);
 
-    renderWithProviders(<LocationsTab personaId={1} />);
+    renderWithProviders(<LocationsTab personaId={1} isActiveCharacter />);
 
     expect(screen.getByTestId('domains-placeholder')).toHaveTextContent(
       'Domains your organizations hold will appear here (#1884).'
@@ -125,8 +125,50 @@ describe('LocationsTab', () => {
     setRenown(undefined);
     setShips(undefined);
 
-    renderWithProviders(<LocationsTab personaId={null} />);
+    renderWithProviders(<LocationsTab personaId={null} isActiveCharacter />);
 
     expect(screen.getByText(/No active character to view locations for/i)).toBeInTheDocument();
+  });
+
+  it('shows a muted notice instead of ships when viewing a non-active character', () => {
+    setRenown(
+      makeRenown({
+        owned_dwellings: [],
+        tenanted_rooms: [],
+      })
+    );
+    setShips([
+      {
+        id: 3,
+        ship_type: {
+          id: 1,
+          name: 'The Gull',
+          description: '',
+          base_hull: 10,
+          base_handling: 10,
+          base_armament: 10,
+          base_crew_capacity: 4,
+          base_cargo_capacity: 4,
+        },
+        effective_handling: 10,
+        effective_armament: 10,
+        effective_hull: 10,
+        handling_level: 0,
+        armament_level: 0,
+        crew_capacity: 4,
+        cargo_capacity: 4,
+        needs_repair: false,
+        owner_persona_id: 1,
+        owner_persona_name: 'Alice',
+        owner_covenant_id: null,
+        owner_covenant_name: null,
+      },
+    ]);
+
+    renderWithProviders(<LocationsTab personaId={1} isActiveCharacter={false} />);
+
+    expect(screen.getByText('Ships are visible while playing this character.')).toBeInTheDocument();
+    expect(screen.queryByText('The Gull')).not.toBeInTheDocument();
+    expect(screen.queryByText('Ships')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/locations/components/LocationsTab.tsx
+++ b/frontend/src/locations/components/LocationsTab.tsx
@@ -6,6 +6,11 @@
  * `owned_dwellings` / `tenanted_rooms`), Ships is a new self-scoped read via
  * `useMyShipsQuery`, and Domains is a muted placeholder until #1884/#930 ship an org-owned
  * domain read API.
+ *
+ * Ships is gated on `isActiveCharacter`: `GET /api/ships/ships/` is server-scoped to the
+ * account's ACTIVE persona, not the persona being viewed, so rendering it for a non-active
+ * character sheet would show the wrong character's ships. When inactive, the query is
+ * disabled (never fetched) and a muted notice renders instead (final review, #1446).
  */
 
 import { Loader2 } from 'lucide-react';
@@ -19,11 +24,12 @@ import { ShipsCard } from './ShipsCard';
 interface Props {
   /** The viewed character's primary persona pk; null when unresolvable. */
   personaId: number | null;
+  /** Whether the viewed character is the viewing account's currently-active character. */
+  isActiveCharacter: boolean;
 }
 
-export function LocationsTab({ personaId }: Props) {
+export function LocationsTab({ personaId, isActiveCharacter }: Props) {
   const { data: renown, isLoading: renownLoading } = usePersonaRenownQuery(personaId);
-  const { data: ships, isLoading: shipsLoading } = useMyShipsQuery();
 
   if (personaId === null) {
     return (
@@ -33,7 +39,7 @@ export function LocationsTab({ personaId }: Props) {
     );
   }
 
-  if (renownLoading || shipsLoading || !renown) {
+  if (renownLoading || !renown) {
     return (
       <div className="flex justify-center py-8">
         <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -45,10 +51,34 @@ export function LocationsTab({ personaId }: Props) {
     <div className="space-y-4">
       <OwnedDwellingsCard dwellings={renown.owned_dwellings} />
       <TenantedRoomsCard rooms={renown.tenanted_rooms} />
-      <ShipsCard ships={ships ?? []} />
+      {isActiveCharacter ? (
+        <ShipsSection />
+      ) : (
+        <p className="text-sm text-muted-foreground" data-testid="ships-foreign-notice">
+          Ships are visible while playing this character.
+        </p>
+      )}
       <p className="text-sm text-muted-foreground" data-testid="domains-placeholder">
         Domains your organizations hold will appear here (#1884).
       </p>
     </div>
   );
+}
+
+/**
+ * Split out so the ships query is only mounted (and therefore only fetched) when the
+ * character being viewed is the account's active character — see module docstring.
+ */
+function ShipsSection() {
+  const { data: ships, isLoading } = useMyShipsQuery();
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return <ShipsCard ships={ships ?? []} />;
 }

--- a/frontend/src/locations/components/LocationsTab.tsx
+++ b/frontend/src/locations/components/LocationsTab.tsx
@@ -1,0 +1,54 @@
+/**
+ * LocationsTab (#1446) — the character sheet's consolidated Locations section.
+ *
+ * Own-only: Dwellings and Tenancies reuse the existing `OwnedDwellingsCard` /
+ * `TenantedRoomsCard` from the Renown app (fed by the same `usePersonaRenownQuery` payload —
+ * `owned_dwellings` / `tenanted_rooms`), Ships is a new self-scoped read via
+ * `useMyShipsQuery`, and Domains is a muted placeholder until #1884/#930 ship an org-owned
+ * domain read API.
+ */
+
+import { Loader2 } from 'lucide-react';
+
+import { usePersonaRenownQuery } from '@/renown/queries';
+import { OwnedDwellingsCard } from '@/renown/components/OwnedDwellingsCard';
+import { TenantedRoomsCard } from '@/renown/components/TenantedRoomsCard';
+import { useMyShipsQuery } from '../queries';
+import { ShipsCard } from './ShipsCard';
+
+interface Props {
+  /** The viewed character's primary persona pk; null when unresolvable. */
+  personaId: number | null;
+}
+
+export function LocationsTab({ personaId }: Props) {
+  const { data: renown, isLoading: renownLoading } = usePersonaRenownQuery(personaId);
+  const { data: ships, isLoading: shipsLoading } = useMyShipsQuery();
+
+  if (personaId === null) {
+    return (
+      <p className="py-8 text-center text-muted-foreground">
+        No active character to view locations for.
+      </p>
+    );
+  }
+
+  if (renownLoading || shipsLoading || !renown) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <OwnedDwellingsCard dwellings={renown.owned_dwellings} />
+      <TenantedRoomsCard rooms={renown.tenanted_rooms} />
+      <ShipsCard ships={ships ?? []} />
+      <p className="text-sm text-muted-foreground" data-testid="domains-placeholder">
+        Domains your organizations hold will appear here (#1884).
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/locations/components/ShipsCard.tsx
+++ b/frontend/src/locations/components/ShipsCard.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { AlertTriangle } from 'lucide-react';
+import type { MyShip } from '../api';
+
+interface Props {
+  ships: MyShip[];
+}
+
+/**
+ * Ships — the persona's owned + covenant-owned vessels (#1446, #1832). Read-only summary:
+ * type name, hull/handling/armament, and a repair-needed flag. Commission/upgrade/repair
+ * stay on the existing ship action surface — no web write dispatch exists yet, so this
+ * card is view-only.
+ */
+export function ShipsCard({ ships }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Ships</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {ships.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No ships owned or crewed.</p>
+        ) : (
+          <ul className="space-y-4 text-sm">
+            {ships.map((ship) => (
+              <li key={ship.id} className="border-b pb-3 last:border-b-0">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="font-semibold">{ship.ship_type.name}</span>
+                  {ship.needs_repair && (
+                    <Badge variant="destructive" className="gap-1">
+                      <AlertTriangle className="h-3 w-3" />
+                      Needs repair
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-muted-foreground">
+                  Hull {ship.effective_hull} · Handling {ship.effective_handling} · Armament{' '}
+                  {ship.effective_armament}
+                </p>
+                {(ship.owner_covenant_name ?? ship.owner_persona_name) && (
+                  <p className="text-xs text-muted-foreground">
+                    Held by {ship.owner_covenant_name ?? ship.owner_persona_name}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/locations/queries.ts
+++ b/frontend/src/locations/queries.ts
@@ -6,10 +6,17 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchMyShips } from './api';
 
-/** The requesting account's active persona's ships (owned + covenant-owned). */
-export function useMyShipsQuery() {
+/**
+ * The requesting account's active persona's ships (owned + covenant-owned).
+ *
+ * `GET /api/ships/ships/` is server-scoped to the account's ACTIVE persona, so callers
+ * viewing a non-active character's sheet must pass `enabled: false` — otherwise this
+ * would silently fetch and render the wrong character's ships (#1446 final review).
+ */
+export function useMyShipsQuery(options: { enabled?: boolean } = {}) {
   return useQuery({
     queryKey: ['ships', 'mine'],
     queryFn: fetchMyShips,
+    enabled: options.enabled ?? true,
   });
 }

--- a/frontend/src/locations/queries.ts
+++ b/frontend/src/locations/queries.ts
@@ -1,0 +1,15 @@
+/**
+ * Locations React Query hooks (#1446).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchMyShips } from './api';
+
+/** The requesting account's active persona's ships (owned + covenant-owned). */
+export function useMyShipsQuery() {
+  return useQuery({
+    queryKey: ['ships', 'mine'],
+    queryFn: fetchMyShips,
+  });
+}

--- a/frontend/src/magic/components/SpellbookTab.test.tsx
+++ b/frontend/src/magic/components/SpellbookTab.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * SpellbookTab tests (#1446) — magic spellbook/status view: gifts, techniques, motif, aura,
+ * and own-view workbench link-outs.
+ *
+ * The server already gates `payload.magic` to null for foreign viewers without visibility
+ * AND for magic-less characters (`_build_magic`, src/world/character_sheets/serializers.py) —
+ * this component only renders whatever `useCharacterSheetQuery` returns.
+ */
+
+import { screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { SpellbookTab } from './SpellbookTab';
+import type { CharacterSheetPayload, CharacterSheetMagic } from '@/character_sheets/api';
+
+vi.mock('@/character_sheets/queries', () => ({
+  useCharacterSheetQuery: vi.fn(),
+}));
+
+import * as queries from '@/character_sheets/queries';
+
+function mockPayload(magic: CharacterSheetMagic | null | undefined, isLoading = false) {
+  vi.mocked(queries.useCharacterSheetQuery).mockReturnValue({
+    data: magic === undefined ? undefined : ({ magic } as CharacterSheetPayload),
+    isLoading,
+  } as unknown as ReturnType<typeof queries.useCharacterSheetQuery>);
+}
+
+function makeMagic(overrides: Partial<CharacterSheetMagic> = {}): CharacterSheetMagic {
+  return {
+    gifts: [
+      {
+        name: 'Pyromancy',
+        description: 'Command over flame.',
+        resonances: ['Ember'],
+        techniques: [
+          {
+            name: 'Flare',
+            level: 3,
+            style: 'Manifestation',
+            description: 'A burst of fire.',
+          },
+        ],
+      },
+    ],
+    motif: {
+      description: 'Smoke and cinders.',
+      resonances: [{ name: 'Ember', facets: ['Fire', 'Ash'] }],
+    },
+    anima_ritual: null,
+    aura: {
+      celestial: 10,
+      primal: 70,
+      abyssal: 20,
+      glimpse_story: 'A candle guttered and did not go out.',
+    },
+    ...overrides,
+  };
+}
+
+describe('SpellbookTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a spinner while loading', () => {
+    mockPayload(undefined, true);
+    const { container } = renderWithProviders(
+      <SpellbookTab characterId={1} isMyCharacter={false} />
+    );
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('shows the muted empty line when magic is null', () => {
+    mockPayload(null);
+    renderWithProviders(<SpellbookTab characterId={1} isMyCharacter={false} />);
+    expect(screen.getByText('Nothing is known of their magic.')).toBeInTheDocument();
+  });
+
+  it('renders the gift, its technique, the motif, and the aura', () => {
+    mockPayload(makeMagic());
+    renderWithProviders(<SpellbookTab characterId={1} isMyCharacter={false} />);
+
+    expect(screen.getByText('Pyromancy')).toBeInTheDocument();
+    expect(screen.getByText('Flare')).toBeInTheDocument();
+    expect(screen.getByText('Smoke and cinders.')).toBeInTheDocument();
+    expect(screen.getByText('A candle guttered and did not go out.')).toBeInTheDocument();
+    // Aura is qualitative — no raw decimal percentages anywhere in the DOM.
+    expect(screen.queryByText(/70/)).not.toBeInTheDocument();
+  });
+
+  it('does not render workbench links for a foreign viewer', () => {
+    mockPayload(makeMagic());
+    renderWithProviders(<SpellbookTab characterId={1} isMyCharacter={false} />);
+    expect(screen.queryByRole('link', { name: /progression/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /threads/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /sanctums/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /rituals/i })).not.toBeInTheDocument();
+  });
+
+  it('renders workbench links for the own view', () => {
+    mockPayload(makeMagic());
+    renderWithProviders(<SpellbookTab characterId={1} isMyCharacter={true} />);
+
+    expect(screen.getByRole('link', { name: /progression/i })).toHaveAttribute(
+      'href',
+      '/magic/progression'
+    );
+    expect(screen.getByRole('link', { name: /threads/i })).toHaveAttribute('href', '/threads');
+    expect(screen.getByRole('link', { name: /sanctums/i })).toHaveAttribute('href', '/sanctums');
+    expect(screen.getByRole('link', { name: /rituals/i })).toHaveAttribute('href', '/rituals');
+  });
+});

--- a/frontend/src/magic/components/SpellbookTab.tsx
+++ b/frontend/src/magic/components/SpellbookTab.tsx
@@ -1,0 +1,166 @@
+/**
+ * SpellbookTab (#1446) — the character sheet's Magic section.
+ *
+ * DESIGN RULING: "The sheet describes; the scene does." This is a spellbook/status view
+ * ONLY — gifts, techniques, motif, and aura rendered as read-only prose/data. NO cast
+ * buttons, invocation UI, or any way to *do* magic from here — casting stays scene-contextual.
+ *
+ * Ungated: every viewer sees this tab, because the server already gates `payload.magic` to
+ * null for foreign viewers without visibility AND for magic-less characters (`_build_magic`,
+ * src/world/character_sheets/serializers.py) — this component only renders whatever
+ * `useCharacterSheetQuery` returns; it does NOT re-implement visibility client-side.
+ *
+ * Aura is rendered qualitatively per the magic app's key rule ("player-facing data is
+ * narrative, not numerical") — the glimpse_story plus a dominant-affinity label, never the
+ * raw celestial/primal/abyssal percentages.
+ */
+
+import { Link } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { useCharacterSheetQuery } from '@/character_sheets/queries';
+import type { CharacterSheetAura } from '@/character_sheets/api';
+
+interface Props {
+  /** CharacterSheet pk (shared with the character ObjectDB pk). */
+  characterId: number;
+  /** True when the viewer owns this character — gates the workbench link-outs. */
+  isMyCharacter: boolean;
+}
+
+/** The affinity with the highest share, as a qualitative label — never the raw percentage. */
+function dominantAffinityLabel(aura: CharacterSheetAura): string {
+  const shares: Array<[string, number]> = [
+    ['Celestial', aura.celestial],
+    ['Primal', aura.primal],
+    ['Abyssal', aura.abyssal],
+  ];
+  return shares.reduce((dominant, share) => (share[1] > dominant[1] ? share : dominant))[0];
+}
+
+export function SpellbookTab({ characterId, isMyCharacter }: Props) {
+  const { data: payload, isLoading } = useCharacterSheetQuery(characterId);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const magic = payload?.magic ?? null;
+
+  return (
+    <div className="space-y-4">
+      {magic === null && (
+        <p className="py-8 text-center text-muted-foreground" data-testid="spellbook-empty-state">
+          Nothing is known of their magic.
+        </p>
+      )}
+
+      {magic && magic.gifts.length > 0 && (
+        <div className="space-y-2" data-testid="spellbook-gifts">
+          <h3 className="text-lg font-semibold">Gifts</h3>
+          {magic.gifts.map((gift) => (
+            <Card key={gift.name} data-testid="spellbook-gift">
+              <CardHeader>
+                <CardTitle className="flex flex-wrap items-center justify-between gap-2 text-base">
+                  <span>{gift.name}</span>
+                  <div className="flex flex-wrap gap-1">
+                    {gift.resonances.map((resonance) => (
+                      <Badge key={resonance} variant="outline">
+                        {resonance}
+                      </Badge>
+                    ))}
+                  </div>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {gift.description && (
+                  <p className="text-sm text-muted-foreground">{gift.description}</p>
+                )}
+                {gift.techniques.map((technique) => (
+                  <div
+                    key={technique.name}
+                    className="rounded-md border p-3"
+                    data-testid="spellbook-technique"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="font-medium">{technique.name}</span>
+                      <div className="flex items-center gap-2">
+                        <Badge variant="secondary">{technique.style}</Badge>
+                        <Badge variant="outline">{`Level ${technique.level}`}</Badge>
+                      </div>
+                    </div>
+                    {technique.description && (
+                      <p className="text-sm text-muted-foreground">{technique.description}</p>
+                    )}
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {magic?.motif && (
+        <Card data-testid="spellbook-motif">
+          <CardHeader>
+            <CardTitle className="text-base">Motif</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {magic.motif.description && (
+              <p className="text-sm text-muted-foreground">{magic.motif.description}</p>
+            )}
+            {magic.motif.resonances.map((resonance) => (
+              <div key={resonance.name} className="flex flex-wrap items-center gap-1">
+                <Badge variant="outline">{resonance.name}</Badge>
+                {resonance.facets.map((facet) => (
+                  <Badge key={facet} variant="secondary">
+                    {facet}
+                  </Badge>
+                ))}
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {magic?.aura && (
+        <Card data-testid="spellbook-aura">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <span>Aura</span>
+              <Badge variant="outline">{dominantAffinityLabel(magic.aura)}</Badge>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {magic.aura.glimpse_story && (
+              <p className="text-sm text-muted-foreground">{magic.aura.glimpse_story}</p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {isMyCharacter && (
+        <div className="flex flex-wrap gap-4 border-t pt-4 text-sm text-muted-foreground">
+          <Link to="/magic/progression" className="hover:underline">
+            Progression
+          </Link>
+          <Link to="/threads" className="hover:underline">
+            Threads
+          </Link>
+          <Link to="/sanctums" className="hover:underline">
+            Sanctums
+          </Link>
+          <Link to="/rituals" className="hover:underline">
+            Rituals
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/magic/components/SpellbookTab.tsx
+++ b/frontend/src/magic/components/SpellbookTab.tsx
@@ -37,7 +37,10 @@ function dominantAffinityLabel(aura: CharacterSheetAura): string {
     ['Primal', aura.primal],
     ['Abyssal', aura.abyssal],
   ];
-  return shares.reduce((dominant, share) => (share[1] > dominant[1] ? share : dominant))[0];
+  return shares.reduce(
+    (dominant, share) => (share[1] > dominant[1] ? share : dominant),
+    shares[0]
+  )[0];
 }
 
 export function SpellbookTab({ characterId, isMyCharacter }: Props) {

--- a/frontend/src/orgs/api.ts
+++ b/frontend/src/orgs/api.ts
@@ -1,0 +1,28 @@
+/**
+ * Organizations API client (#1446) — family/covenant click-throughs on the character sheet.
+ *
+ * Reads `/api/societies/organizations/` filtered by name (iexact match server-side). Used to
+ * resolve a character's family name to a same-named organization for a link target. Visibility
+ * is members-only on the backend, so an empty result is normal — callers should render plain
+ * text in that case, not an error.
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+import type { components } from '@/generated/api';
+
+export type Organization = components['schemas']['Organization'];
+
+interface PaginatedOrganizations {
+  results: Organization[];
+}
+
+/**
+ * Resolve an organization by exact (iexact) name.
+ * GET /api/societies/organizations/?name={name}
+ */
+export async function fetchOrganizationByName(name: string): Promise<Organization | null> {
+  const res = await apiFetch(`/api/societies/organizations/?name=${encodeURIComponent(name)}`);
+  if (!res.ok) throw new Error('Failed to load organization');
+  const data = (await res.json()) as PaginatedOrganizations;
+  return data.results[0] ?? null;
+}

--- a/frontend/src/orgs/api.ts
+++ b/frontend/src/orgs/api.ts
@@ -26,3 +26,17 @@ export async function fetchOrganizationByName(name: string): Promise<Organizatio
   const data = (await res.json()) as PaginatedOrganizations;
   return data.results[0] ?? null;
 }
+
+/**
+ * Fetch a single organization by id, for the org detail stub page (#1446).
+ * GET /api/societies/organizations/{id}/
+ *
+ * Members-only: the backend excludes non-member requesters, so a 404 here is
+ * expected and normal — callers should treat query errors as "render the
+ * not-yet-public placeholder," not a hard failure.
+ */
+export async function fetchOrganizationById(id: number): Promise<Organization> {
+  const res = await apiFetch(`/api/societies/organizations/${id}/`);
+  if (!res.ok) throw new Error('Failed to load organization');
+  return (await res.json()) as Organization;
+}

--- a/frontend/src/orgs/pages/OrgPage.test.tsx
+++ b/frontend/src/orgs/pages/OrgPage.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * OrgPage tests (#1446)
+ *
+ * Covers:
+ *   1. Member case — query resolves an organization, name renders.
+ *   2. Non-member / error case — query errors (members-only 404), the
+ *      not-yet-public placeholder renders instead of crashing.
+ *
+ * Renders OrgPageInner directly (avoids router param plumbing), mirroring
+ * the CovenantDetailPage test convention.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { OrgPageInner } from './OrgPage';
+import type { Organization } from '@/orgs/api';
+
+vi.mock('@/orgs/queries', () => ({
+  useOrganizationQuery: vi.fn(),
+}));
+
+import { useOrganizationQuery } from '@/orgs/queries';
+
+const mockedUseOrganizationQuery = vi.mocked(useOrganizationQuery);
+
+const ORG: Organization = {
+  id: 7,
+  name: 'The Gilded Compass',
+  society_name: 'Merchant Society',
+  org_type_name: 'Guild',
+  ranks: [],
+};
+
+describe('OrgPageInner', () => {
+  it('renders the organization name for a member', () => {
+    mockedUseOrganizationQuery.mockReturnValue({
+      data: ORG,
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useOrganizationQuery>);
+
+    render(<OrgPageInner orgId={7} />);
+
+    expect(screen.getByText('The Gilded Compass')).toBeInTheDocument();
+  });
+
+  it('renders the not-yet-public placeholder on query error (non-member / 404)', () => {
+    mockedUseOrganizationQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof useOrganizationQuery>);
+
+    render(<OrgPageInner orgId={7} />);
+
+    expect(screen.getByText(/not yet public/i)).toBeInTheDocument();
+  });
+
+  it('renders the not-yet-public placeholder on an empty (falsy) result', () => {
+    mockedUseOrganizationQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useOrganizationQuery>);
+
+    render(<OrgPageInner orgId={7} />);
+
+    expect(screen.getByText(/not yet public/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/orgs/pages/OrgPage.tsx
+++ b/frontend/src/orgs/pages/OrgPage.tsx
@@ -1,0 +1,110 @@
+/**
+ * OrgPage — stub organization detail page (#1446).
+ *
+ * This is a click-through destination for organization links elsewhere in the
+ * app (e.g. a character's family name on the sheet). It is explicitly NOT the
+ * full org/house page — that design lives in #1884. For now it shows the org
+ * name and the light metadata the members-only serializer exposes; anyone who
+ * isn't an active member (or an org that doesn't exist) sees a placeholder.
+ *
+ * Route: /orgs/:id
+ */
+
+import { useParams } from 'react-router-dom';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useOrganizationQuery } from '@/orgs/queries';
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function OrgSkeleton() {
+  return (
+    <div className="animate-pulse space-y-2">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-4 w-40" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Not-yet-public placeholder — covers both non-member (query error) and
+// missing/empty organization results.
+// ---------------------------------------------------------------------------
+
+function NotYetPublicCard() {
+  return (
+    <Card>
+      <CardContent className="py-8 text-center text-muted-foreground">
+        This organization&apos;s page is not yet public — full house and organization pages are
+        coming (#1884).
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inner page
+// ---------------------------------------------------------------------------
+
+export function OrgPageInner({ orgId }: { orgId: number }) {
+  const { data: org, isLoading, isError } = useOrganizationQuery(orgId);
+
+  if (isLoading) return <OrgSkeleton />;
+
+  if (isError || !org) {
+    return <NotYetPublicCard />;
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-3">
+          <CardTitle className="text-xl">{org.name}</CardTitle>
+          <Badge variant="outline">{org.org_type_name}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-sm text-muted-foreground">{org.society_name}</p>
+        {org.description && <p className="text-sm">{org.description}</p>}
+        {org.ranks.length > 0 && (
+          <div className="flex flex-wrap gap-2 pt-2">
+            {org.ranks.map((rank) => (
+              <Badge key={rank.id} variant="secondary" className="text-xs">
+                {rank.name}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page export
+// ---------------------------------------------------------------------------
+
+export function OrgPage() {
+  const { id = '' } = useParams<{ id: string }>();
+  const orgId = parseInt(id, 10);
+
+  if (isNaN(orgId) || orgId <= 0) {
+    return (
+      <div className="container mx-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+        <NotYetPublicCard />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+      <ErrorBoundary>
+        <OrgPageInner orgId={orgId} />
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/frontend/src/orgs/queries.ts
+++ b/frontend/src/orgs/queries.ts
@@ -4,7 +4,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchOrganizationByName } from './api';
+import { fetchOrganizationByName, fetchOrganizationById } from './api';
 
 /**
  * Resolve a same-named organization for a character's family (link target).
@@ -15,5 +15,18 @@ export function useOrganizationByName(name: string) {
     queryKey: ['orgs', 'byName', name],
     queryFn: () => fetchOrganizationByName(name),
     enabled: name.length > 0,
+  });
+}
+
+/**
+ * Fetch a single organization by id, for the org detail stub page (#1446).
+ * A members-only 404 surfaces as `isError` — the page renders the not-yet-public
+ * placeholder rather than treating it as a hard failure.
+ */
+export function useOrganizationQuery(orgId: number) {
+  return useQuery({
+    queryKey: ['orgs', 'detail', orgId],
+    queryFn: () => fetchOrganizationById(orgId),
+    enabled: orgId > 0,
   });
 }

--- a/frontend/src/orgs/queries.ts
+++ b/frontend/src/orgs/queries.ts
@@ -1,0 +1,19 @@
+/**
+ * Organizations React Query hooks (#1446).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchOrganizationByName } from './api';
+
+/**
+ * Resolve a same-named organization for a character's family (link target).
+ * Disabled when `name` is empty — the character sheet renders plain text in that case.
+ */
+export function useOrganizationByName(name: string) {
+  return useQuery({
+    queryKey: ['orgs', 'byName', name],
+    queryFn: () => fetchOrganizationByName(name),
+    enabled: name.length > 0,
+  });
+}

--- a/frontend/src/renown/components/RenownPanel.tsx
+++ b/frontend/src/renown/components/RenownPanel.tsx
@@ -13,6 +13,13 @@ import type { RenownPayload } from '../types';
 interface Props {
   /** CharacterSheet pk (shared with the character ObjectDB pk). */
   characterSheetId: number;
+  /**
+   * Society ids the viewer's active persona is currently wanted by (#1765 heat rows).
+   * Own-view only — omit (or leave undefined) when the caller has no wanted-flag data
+   * (e.g. foreign views never pass this). Threaded down to the reputation list so the
+   * consolidated Reputation tab (#1446) doesn't need its own duplicate list.
+   */
+  wantedSocietyIds?: Set<number>;
 }
 
 /**
@@ -25,15 +32,21 @@ interface Props {
  *   - The selected persona's renown payload, rendered as four cards:
  *     Fame, Prestige, Reputation, Recent Deeds.
  */
-export function RenownPanel({ characterSheetId }: Props) {
+export function RenownPanel({ characterSheetId, wantedSocietyIds }: Props) {
   return (
     <PersonaSelectionShell characterSheetId={characterSheetId}>
-      {(personaId) => <PanelBody personaId={personaId} />}
+      {(personaId) => <PanelBody personaId={personaId} wantedSocietyIds={wantedSocietyIds} />}
     </PersonaSelectionShell>
   );
 }
 
-function PanelBody({ personaId }: { personaId: number }) {
+function PanelBody({
+  personaId,
+  wantedSocietyIds,
+}: {
+  personaId: number;
+  wantedSocietyIds?: Set<number>;
+}) {
   const { data: renown, isLoading } = usePersonaRenownQuery(personaId);
   if (isLoading || !renown) {
     return (
@@ -47,17 +60,25 @@ function PanelBody({ personaId }: { personaId: number }) {
       <div className="flex justify-end">
         <SpreadTaleDialog personaId={personaId} />
       </div>
-      <CardLayout renown={renown} personaId={personaId} />
+      <CardLayout renown={renown} personaId={personaId} wantedSocietyIds={wantedSocietyIds} />
     </div>
   );
 }
 
-function CardLayout({ renown, personaId }: { renown: RenownPayload; personaId: number }) {
+function CardLayout({
+  renown,
+  personaId,
+  wantedSocietyIds,
+}: {
+  renown: RenownPayload;
+  personaId: number;
+  wantedSocietyIds?: Set<number>;
+}) {
   return (
     <div className="grid gap-4 md:grid-cols-2">
       <FameCard fame={renown.fame} />
       <PrestigeBreakdownCard prestige={renown.prestige} />
-      <ReputationListCard reputation={renown.reputation} />
+      <ReputationListCard reputation={renown.reputation} wantedSocietyIds={wantedSocietyIds} />
       <DeedsLogCard deeds={renown.recent_deeds} personaId={personaId} />
       <OwnedDwellingsCard dwellings={renown.owned_dwellings} />
       <TenantedRoomsCard rooms={renown.tenanted_rooms} />

--- a/frontend/src/renown/components/ReputationListCard.tsx
+++ b/frontend/src/renown/components/ReputationListCard.tsx
@@ -4,9 +4,16 @@ import type { SocietyReputationEntry } from '../types';
 
 interface Props {
   reputation: SocietyReputationEntry[];
+  /**
+   * Society ids the viewer's active persona is currently wanted by (#1765 heat rows).
+   * Own-view only — omit (or leave undefined) on foreign-view renders.
+   */
+  wantedSocietyIds?: Set<number>;
 }
 
-const TIER_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+// Exported for reuse by the consolidated Reputation tab's Standing card (#1446),
+// which renders the same named-tier badges for organization reputations.
+export const TIER_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
   reviled: 'destructive',
   despised: 'destructive',
   disliked: 'destructive',
@@ -18,7 +25,7 @@ const TIER_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'ou
   revered: 'default',
 };
 
-function formatTier(tier: string): string {
+export function formatTier(tier: string): string {
   return tier.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
@@ -26,7 +33,7 @@ function formatTier(tier: string): string {
  * Per-society reputation list. Named tier labels only — the raw numeric
  * value is intentionally never exposed to the client (#676 spec).
  */
-export function ReputationListCard({ reputation }: Props) {
+export function ReputationListCard({ reputation, wantedSocietyIds }: Props) {
   return (
     <Card>
       <CardHeader>
@@ -42,9 +49,14 @@ export function ReputationListCard({ reputation }: Props) {
             {reputation.map((entry) => (
               <li key={entry.society_id} className="flex items-center justify-between">
                 <span className="font-medium">{entry.society_name}</span>
-                <Badge variant={TIER_VARIANT[entry.tier] ?? 'outline'}>
-                  {formatTier(entry.tier)}
-                </Badge>
+                <div className="flex items-center gap-2">
+                  {wantedSocietyIds?.has(entry.society_id) && (
+                    <Badge variant="destructive">Wanted</Badge>
+                  )}
+                  <Badge variant={TIER_VARIANT[entry.tier] ?? 'outline'}>
+                    {formatTier(entry.tier)}
+                  </Badge>
+                </div>
               </li>
             ))}
           </ul>

--- a/frontend/src/reputation/api.ts
+++ b/frontend/src/reputation/api.ts
@@ -1,0 +1,46 @@
+/**
+ * Reputation tab API client (#1446 — consolidated Reputation tab).
+ *
+ * Reads three self-scoped endpoints:
+ *   - GET /api/societies/reputations/    — the requester's org standing (tiers only).
+ *   - GET /api/societies/memberships/    — the requester's org memberships (rank titles).
+ *   - GET /api/covenants/character-roles/?character_sheet= — covenant role assignments for
+ *     a specific character sheet the requester currently plays.
+ *
+ * All three are self-only on the backend (scoped to personas/sheets the requester currently
+ * plays), so there is no cross-viewer leakage risk here — this module is only ever called
+ * from the Reputation tab's own-view branch.
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+import type { CharacterCovenantRole } from '@/covenants/api';
+import type { components } from '@/generated/api';
+
+export type OrganizationReputation = components['schemas']['OrganizationReputation'];
+export type OrganizationMembership = components['schemas']['OrganizationMembership'];
+
+/** GET /api/societies/reputations/ — the requester's own org standing. */
+export async function fetchOrganizationReputations(): Promise<OrganizationReputation[]> {
+  const res = await apiFetch('/api/societies/reputations/');
+  if (!res.ok) throw new Error('Failed to load organization reputations.');
+  const data = (await res.json()) as { results: OrganizationReputation[] };
+  return data.results;
+}
+
+/** GET /api/societies/memberships/ — the requester's own org memberships. */
+export async function fetchOrganizationMemberships(): Promise<OrganizationMembership[]> {
+  const res = await apiFetch('/api/societies/memberships/');
+  if (!res.ok) throw new Error('Failed to load organization memberships.');
+  const data = (await res.json()) as { results: OrganizationMembership[] };
+  return data.results;
+}
+
+/** GET /api/covenants/character-roles/?character_sheet={characterSheetId} */
+export async function fetchCovenantRolesForSheet(
+  characterSheetId: number
+): Promise<CharacterCovenantRole[]> {
+  const res = await apiFetch(`/api/covenants/character-roles/?character_sheet=${characterSheetId}`);
+  if (!res.ok) throw new Error('Failed to load covenant roles.');
+  const data = (await res.json()) as { results: CharacterCovenantRole[] };
+  return data.results;
+}

--- a/frontend/src/reputation/components/ReputationTab.test.tsx
+++ b/frontend/src/reputation/components/ReputationTab.test.tsx
@@ -135,7 +135,13 @@ describe('ReputationTab', () => {
   it('renders Renown, Standing, and Covenants sections for the own view', () => {
     setRenown(makeRenown());
     renderWithProviders(
-      <ReputationTab entryCharacterId={1} viewerPersonaId={1} isMyCharacter viewerEntryId={1} />
+      <ReputationTab
+        entryCharacterId={1}
+        viewerPersonaId={1}
+        isMyCharacter
+        viewedEntryId={1}
+        viewedPersonaId={1}
+      />
     );
     expect(screen.getByText('Renown')).toBeInTheDocument();
     expect(screen.getByText('Standing')).toBeInTheDocument();
@@ -160,7 +166,13 @@ describe('ReputationTab', () => {
       },
     ]);
     renderWithProviders(
-      <ReputationTab entryCharacterId={1} viewerPersonaId={1} isMyCharacter viewerEntryId={1} />
+      <ReputationTab
+        entryCharacterId={1}
+        viewerPersonaId={1}
+        isMyCharacter
+        viewedEntryId={1}
+        viewedPersonaId={1}
+      />
     );
     expect(screen.getByText('Wanted')).toBeInTheDocument();
   });
@@ -172,11 +184,88 @@ describe('ReputationTab', () => {
         entryCharacterId={1}
         viewerPersonaId={5}
         isMyCharacter={false}
-        viewerEntryId={null}
+        viewedEntryId={null}
+        viewedPersonaId={null}
       />
     );
     expect(screen.queryByText('Standing')).not.toBeInTheDocument();
     expect(screen.queryByText('Covenants')).not.toBeInTheDocument();
     expect(screen.queryByText('Wanted')).not.toBeInTheDocument();
+  });
+
+  it('does not render the account-wide society-reputation list twice (only via RenownPanel)', () => {
+    setRenown(
+      makeRenown({
+        reputation: [{ society_id: 3, society_name: 'The Honest', tier: 'disliked' }],
+      })
+    );
+    renderWithProviders(
+      <ReputationTab
+        entryCharacterId={1}
+        viewerPersonaId={1}
+        isMyCharacter
+        viewedEntryId={1}
+        viewedPersonaId={1}
+      />
+    );
+    // "The Honest" comes from RenownPanel's own reputation card; it must appear exactly
+    // once — the Standing card no longer renders a second, duplicate reputation list.
+    expect(screen.getAllByText('The Honest')).toHaveLength(1);
+  });
+
+  it('filters organization memberships/reputation rows to the viewed persona only', () => {
+    setRenown(makeRenown());
+    setMemberships([
+      {
+        id: 1,
+        organization: 10,
+        organization_name: 'Match Org',
+        persona: 1,
+        persona_name: 'Alice',
+        rank: { id: 1, name: 'Member', tier: 5 },
+        title: 'Member',
+        joined_date: '2026-01-01T00:00:00Z',
+        is_active: true,
+      } as OrganizationMembership,
+      {
+        id: 2,
+        organization: 20,
+        organization_name: 'Other Character Org',
+        persona: 99,
+        persona_name: 'Someone Else',
+        rank: { id: 2, name: 'Member', tier: 5 },
+        title: 'Member',
+        joined_date: '2026-01-01T00:00:00Z',
+        is_active: true,
+      } as OrganizationMembership,
+    ]);
+    setReputations([
+      {
+        id: 1,
+        persona: 1,
+        organization: 10,
+        organization_name: 'Match Org',
+        tier: 'liked',
+      } as OrganizationReputation,
+      {
+        id: 2,
+        persona: 99,
+        organization: 20,
+        organization_name: 'Other Character Org',
+        tier: 'liked',
+      } as OrganizationReputation,
+    ]);
+    renderWithProviders(
+      <ReputationTab
+        entryCharacterId={1}
+        viewerPersonaId={1}
+        isMyCharacter
+        viewedEntryId={1}
+        viewedPersonaId={1}
+      />
+    );
+    // Match Org appears twice: once under Memberships, once under Reputation.
+    expect(screen.getAllByText('Match Org')).toHaveLength(2);
+    expect(screen.queryByText('Other Character Org')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/reputation/components/ReputationTab.test.tsx
+++ b/frontend/src/reputation/components/ReputationTab.test.tsx
@@ -1,0 +1,182 @@
+import { screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { ReputationTab } from './ReputationTab';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { RenownPayload, RenownCardPayload, RenownEligiblePersona } from '@/renown/types';
+import type { PersonaHeatRow } from '@/justice/api';
+import type { OrganizationReputation, OrganizationMembership } from '../api';
+import type { CharacterCovenantRole } from '@/covenants/api';
+
+vi.mock('@/renown/queries', () => ({
+  useRenownEligiblePersonasQuery: vi.fn(),
+  usePersonaRenownQuery: vi.fn(),
+  usePersonaRenownCardQuery: vi.fn(),
+}));
+vi.mock('@/justice/queries', () => ({
+  usePersonaHeat: vi.fn(),
+}));
+vi.mock('../queries', () => ({
+  useOrganizationMembershipsQuery: vi.fn(),
+  useOrganizationReputationsQuery: vi.fn(),
+  useCovenantRolesQuery: vi.fn(),
+}));
+
+import {
+  useRenownEligiblePersonasQuery,
+  usePersonaRenownQuery,
+  usePersonaRenownCardQuery,
+} from '@/renown/queries';
+import { usePersonaHeat } from '@/justice/queries';
+import {
+  useOrganizationMembershipsQuery,
+  useOrganizationReputationsQuery,
+  useCovenantRolesQuery,
+} from '../queries';
+
+const mockPersonasQuery = vi.mocked(useRenownEligiblePersonasQuery);
+const mockRenownQuery = vi.mocked(usePersonaRenownQuery);
+const mockRenownCardQuery = vi.mocked(usePersonaRenownCardQuery);
+const mockHeatQuery = vi.mocked(usePersonaHeat);
+const mockMembershipsQuery = vi.mocked(useOrganizationMembershipsQuery);
+const mockReputationsQuery = vi.mocked(useOrganizationReputationsQuery);
+const mockCovenantRolesQuery = vi.mocked(useCovenantRolesQuery);
+
+function makeRenown(overrides: Partial<RenownPayload> = {}): RenownPayload {
+  return {
+    persona_id: 1,
+    persona_name: 'Alice',
+    prestige: { dwellings: 0, items: 0, orgs: 0, deeds: 0, fashion: 0, total: 0 },
+    fame: {
+      points: 0,
+      tier: 'unknown',
+      tier_label: 'Unknown',
+      tier_multiplier: 1,
+      next_tier: null,
+      next_tier_threshold: null,
+    },
+    reputation: [],
+    recent_deeds: [],
+    owned_dwellings: [],
+    tenanted_rooms: [],
+    ...overrides,
+  } as RenownPayload;
+}
+
+function makeCard(overrides: Partial<RenownCardPayload> = {}): RenownCardPayload {
+  return {
+    persona_id: 1,
+    persona_name: 'Alice',
+    fame: { tier: 'unknown', tier_label: 'Unknown' },
+    visible_deeds: [],
+    visible_reputation: [],
+    ...overrides,
+  };
+}
+
+function setPersonas(personas: RenownEligiblePersona[]) {
+  mockPersonasQuery.mockReturnValue({
+    data: personas,
+    isLoading: false,
+  } as unknown as UseQueryResult<RenownEligiblePersona[], Error>);
+}
+
+function setRenown(payload: RenownPayload | undefined) {
+  mockRenownQuery.mockReturnValue({
+    data: payload,
+    isLoading: false,
+  } as unknown as UseQueryResult<RenownPayload, Error>);
+}
+
+function setCard(payload: RenownCardPayload | undefined) {
+  mockRenownCardQuery.mockReturnValue({
+    data: payload,
+    isLoading: false,
+  } as unknown as UseQueryResult<RenownCardPayload, Error>);
+}
+
+function setHeat(rows: PersonaHeatRow[]) {
+  mockHeatQuery.mockReturnValue({
+    data: rows,
+    isLoading: false,
+  } as unknown as UseQueryResult<PersonaHeatRow[], Error>);
+}
+
+function setMemberships(rows: OrganizationMembership[]) {
+  mockMembershipsQuery.mockReturnValue({
+    data: rows,
+    isLoading: false,
+  } as unknown as UseQueryResult<OrganizationMembership[], Error>);
+}
+
+function setReputations(rows: OrganizationReputation[]) {
+  mockReputationsQuery.mockReturnValue({
+    data: rows,
+    isLoading: false,
+  } as unknown as UseQueryResult<OrganizationReputation[], Error>);
+}
+
+function setCovenantRoles(rows: CharacterCovenantRole[]) {
+  mockCovenantRolesQuery.mockReturnValue({
+    data: rows,
+    isLoading: false,
+  } as unknown as UseQueryResult<CharacterCovenantRole[], Error>);
+}
+
+describe('ReputationTab', () => {
+  beforeEach(() => {
+    setPersonas([{ id: 1, name: 'Alice', persona_type: 'primary' }]);
+    setMemberships([]);
+    setReputations([]);
+    setCovenantRoles([]);
+    setHeat([]);
+  });
+
+  it('renders Renown, Standing, and Covenants sections for the own view', () => {
+    setRenown(makeRenown());
+    renderWithProviders(
+      <ReputationTab entryCharacterId={1} viewerPersonaId={1} isMyCharacter viewerEntryId={1} />
+    );
+    expect(screen.getByText('Renown')).toBeInTheDocument();
+    expect(screen.getByText('Standing')).toBeInTheDocument();
+    expect(screen.getByText('Covenants')).toBeInTheDocument();
+  });
+
+  it('shows a Wanted badge on a society row whose id appears in the heat data', () => {
+    setRenown(
+      makeRenown({
+        reputation: [{ society_id: 3, society_name: 'The Honest', tier: 'disliked' }],
+      })
+    );
+    setHeat([
+      {
+        id: 1,
+        area_name: 'The Ward',
+        society: 3,
+        society_name: 'The Honest',
+        tier: 'heat_is_on',
+        tier_label: 'Heat Is On',
+        alleged_deeds: [],
+      },
+    ]);
+    renderWithProviders(
+      <ReputationTab entryCharacterId={1} viewerPersonaId={1} isMyCharacter viewerEntryId={1} />
+    );
+    expect(screen.getByText('Wanted')).toBeInTheDocument();
+  });
+
+  it('renders only RenownCardPanel for a foreign view — no Standing/Covenants/Wanted', () => {
+    setCard(makeCard());
+    renderWithProviders(
+      <ReputationTab
+        entryCharacterId={1}
+        viewerPersonaId={5}
+        isMyCharacter={false}
+        viewerEntryId={null}
+      />
+    );
+    expect(screen.queryByText('Standing')).not.toBeInTheDocument();
+    expect(screen.queryByText('Covenants')).not.toBeInTheDocument();
+    expect(screen.queryByText('Wanted')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/reputation/components/ReputationTab.tsx
+++ b/frontend/src/reputation/components/ReputationTab.tsx
@@ -2,19 +2,21 @@
  * Consolidated Reputation tab (#1446) — replaces the old standalone Renown tab.
  *
  * Own-view sections:
- *   - Renown: the existing `RenownPanel`, unchanged — fame/prestige/deeds/dwellings plus its
- *     own (unflagged) society-reputation card.
- *   - Standing: society reputation again, this time with "Wanted" flags for any society
- *     currently pursuing the viewer's active persona (#1765 heat), plus organization
- *     memberships (rank titles) and organization reputation (tier badges).
+ *   - Renown: the existing `RenownPanel`, fed the viewed character's wanted-flag data
+ *     (#1765 heat) — fame/prestige/deeds/dwellings plus its own society-reputation card,
+ *     with a destructive "Wanted" badge on any society currently pursuing this character.
+ *   - Standing: organization memberships (rank titles) and organization reputation (tier
+ *     badges) for the character being viewed.
  *   - Covenants: the character's active covenant role assignments.
  *
  * Foreign-view: unchanged `RenownCardPanel` — no Standing/Covenants/Wanted surfaced for
  * someone else's sheet.
  *
- * The society-reputation list is necessarily rendered twice (once inside `RenownPanel`,
- * once here with wanted flags) — `RenownPanel` is intentionally left untouched by this task,
- * so the wanted-aware view lives in the new Standing card instead of being threaded through it.
+ * Scoping note: `/api/societies/reputations/` and `/api/societies/memberships/` are
+ * account-wide (span every character/persona the account plays), not sheet-scoped —
+ * unlike the covenant-roles endpoint, which already filters by `character_sheet`. So the
+ * membership/reputation rows are filtered client-side to `viewedPersonaId` to avoid
+ * leaking a different one of the viewer's own characters' standings onto this sheet.
  */
 
 import { Link } from 'react-router-dom';
@@ -24,12 +26,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { RenownPanel } from '@/renown/components/RenownPanel';
 import { RenownCardPanel } from '@/renown/components/RenownCardPanel';
-import {
-  ReputationListCard,
-  TIER_VARIANT,
-  formatTier,
-} from '@/renown/components/ReputationListCard';
-import { usePersonaRenownQuery } from '@/renown/queries';
+import { TIER_VARIANT, formatTier } from '@/renown/components/ReputationListCard';
 import { usePersonaHeat } from '@/justice/queries';
 import type { PersonaHeatRow } from '@/justice/api';
 import type { CharacterCovenantRole } from '@/covenants/api';
@@ -47,15 +44,25 @@ interface Props {
   viewerPersonaId?: number | null;
   /** True when the viewer owns this character (own-view vs. foreign-view). */
   isMyCharacter: boolean;
-  /** The viewer's active RosterEntry pk; used to key the own-only wanted-flag lookup. */
-  viewerEntryId?: number | null;
+  /**
+   * RosterEntry pk of the character being viewed. Own-view only — used to key the
+   * wanted-flag heat lookup to THIS character, not whichever character the account
+   * currently has active (matches the `viewer=` param CrimeTab passes).
+   */
+  viewedEntryId?: number | null;
+  /**
+   * Persona id of the character being viewed. Own-view only — used to filter the
+   * account-wide org membership/reputation rows down to this character's persona.
+   */
+  viewedPersonaId?: number | null;
 }
 
 export function ReputationTab({
   entryCharacterId,
   viewerPersonaId,
   isMyCharacter,
-  viewerEntryId,
+  viewedEntryId,
+  viewedPersonaId,
 }: Props) {
   if (!isMyCharacter) {
     return (
@@ -69,35 +76,40 @@ export function ReputationTab({
   return (
     <OwnReputationView
       entryCharacterId={entryCharacterId}
-      viewerPersonaId={viewerPersonaId ?? null}
-      viewerEntryId={viewerEntryId ?? null}
+      viewedEntryId={viewedEntryId ?? null}
+      viewedPersonaId={viewedPersonaId ?? null}
     />
   );
 }
 
 function OwnReputationView({
   entryCharacterId,
-  viewerPersonaId,
-  viewerEntryId,
+  viewedEntryId,
+  viewedPersonaId,
 }: {
   entryCharacterId: number;
-  viewerPersonaId: number | null;
-  viewerEntryId: number | null;
+  viewedEntryId: number | null;
+  viewedPersonaId: number | null;
 }) {
+  const { data: heatRows } = usePersonaHeat(viewedEntryId);
+  const wantedSocietyIds = new Set<number>(
+    (heatRows ?? []).map((row: PersonaHeatRow) => row.society)
+  );
+
   return (
     <div className="space-y-6">
       <section aria-labelledby="reputation-tab-renown">
         <h2 id="reputation-tab-renown" className="mb-3 text-lg font-semibold">
           Renown
         </h2>
-        <RenownPanel characterSheetId={entryCharacterId} />
+        <RenownPanel characterSheetId={entryCharacterId} wantedSocietyIds={wantedSocietyIds} />
       </section>
 
       <section aria-labelledby="reputation-tab-standing">
         <h2 id="reputation-tab-standing" className="mb-3 text-lg font-semibold">
           Standing
         </h2>
-        <StandingSection viewerPersonaId={viewerPersonaId} viewerEntryId={viewerEntryId} />
+        <OrganizationStandingCard viewedPersonaId={viewedPersonaId} />
       </section>
 
       <section aria-labelledby="reputation-tab-covenants">
@@ -111,41 +123,20 @@ function OwnReputationView({
 }
 
 // ---------------------------------------------------------------------------
-// Standing — society reputation (wanted-flag aware) + org memberships/reputation.
+// Standing — org memberships/reputation, scoped to the viewed character's persona.
 // ---------------------------------------------------------------------------
 
-function StandingSection({
-  viewerPersonaId,
-  viewerEntryId,
-}: {
-  viewerPersonaId: number | null;
-  viewerEntryId: number | null;
-}) {
-  const { data: renown } = usePersonaRenownQuery(viewerPersonaId);
-  const { data: heatRows } = usePersonaHeat(viewerEntryId);
-  const wantedSocietyIds = new Set<number>(
-    (heatRows ?? []).map((row: PersonaHeatRow) => row.society)
-  );
-
-  return (
-    <div className="grid gap-4 md:grid-cols-2">
-      <ReputationListCard
-        reputation={renown?.reputation ?? []}
-        wantedSocietyIds={wantedSocietyIds}
-      />
-      <OrganizationStandingCard />
-    </div>
-  );
-}
-
-function OrganizationStandingCard() {
+function OrganizationStandingCard({ viewedPersonaId }: { viewedPersonaId: number | null }) {
   const { data: memberships, isLoading: membershipsLoading } =
     useOrganizationMembershipsQuery(true);
   const { data: reputations, isLoading: reputationsLoading } =
     useOrganizationReputationsQuery(true);
 
   const isLoading = membershipsLoading || reputationsLoading;
-  const activeMemberships = (memberships ?? []).filter((m) => m.is_active);
+  const activeMemberships = (memberships ?? []).filter(
+    (m) => m.is_active && m.persona === viewedPersonaId
+  );
+  const scopedReputations = (reputations ?? []).filter((r) => r.persona === viewedPersonaId);
 
   return (
     <Card>
@@ -181,13 +172,13 @@ function OrganizationStandingCard() {
             </div>
             <div>
               <h3 className="mb-2 text-sm font-medium text-muted-foreground">Reputation</h3>
-              {(reputations ?? []).length === 0 ? (
+              {scopedReputations.length === 0 ? (
                 <p className="text-sm text-muted-foreground">
                   No organizations have a recorded opinion yet.
                 </p>
               ) : (
                 <ul className="space-y-2 text-sm">
-                  {(reputations ?? []).map((rep) => (
+                  {scopedReputations.map((rep) => (
                     <li key={rep.id} className="flex items-center justify-between">
                       <Link
                         to={`/orgs/${rep.organization}`}

--- a/frontend/src/reputation/components/ReputationTab.tsx
+++ b/frontend/src/reputation/components/ReputationTab.tsx
@@ -1,0 +1,248 @@
+/**
+ * Consolidated Reputation tab (#1446) — replaces the old standalone Renown tab.
+ *
+ * Own-view sections:
+ *   - Renown: the existing `RenownPanel`, unchanged — fame/prestige/deeds/dwellings plus its
+ *     own (unflagged) society-reputation card.
+ *   - Standing: society reputation again, this time with "Wanted" flags for any society
+ *     currently pursuing the viewer's active persona (#1765 heat), plus organization
+ *     memberships (rank titles) and organization reputation (tier badges).
+ *   - Covenants: the character's active covenant role assignments.
+ *
+ * Foreign-view: unchanged `RenownCardPanel` — no Standing/Covenants/Wanted surfaced for
+ * someone else's sheet.
+ *
+ * The society-reputation list is necessarily rendered twice (once inside `RenownPanel`,
+ * once here with wanted flags) — `RenownPanel` is intentionally left untouched by this task,
+ * so the wanted-aware view lives in the new Standing card instead of being threaded through it.
+ */
+
+import { Link } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { RenownPanel } from '@/renown/components/RenownPanel';
+import { RenownCardPanel } from '@/renown/components/RenownCardPanel';
+import {
+  ReputationListCard,
+  TIER_VARIANT,
+  formatTier,
+} from '@/renown/components/ReputationListCard';
+import { usePersonaRenownQuery } from '@/renown/queries';
+import { usePersonaHeat } from '@/justice/queries';
+import type { PersonaHeatRow } from '@/justice/api';
+import type { CharacterCovenantRole } from '@/covenants/api';
+
+import {
+  useOrganizationMembershipsQuery,
+  useOrganizationReputationsQuery,
+  useCovenantRolesQuery,
+} from '../queries';
+
+interface Props {
+  /** CharacterSheet pk of the character this sheet is showing. */
+  entryCharacterId: number;
+  /** The viewer's own currently-presented persona; null/undefined when unknown. */
+  viewerPersonaId?: number | null;
+  /** True when the viewer owns this character (own-view vs. foreign-view). */
+  isMyCharacter: boolean;
+  /** The viewer's active RosterEntry pk; used to key the own-only wanted-flag lookup. */
+  viewerEntryId?: number | null;
+}
+
+export function ReputationTab({
+  entryCharacterId,
+  viewerPersonaId,
+  isMyCharacter,
+  viewerEntryId,
+}: Props) {
+  if (!isMyCharacter) {
+    return (
+      <RenownCardPanel
+        characterSheetId={entryCharacterId}
+        viewerPersonaId={viewerPersonaId ?? null}
+      />
+    );
+  }
+
+  return (
+    <OwnReputationView
+      entryCharacterId={entryCharacterId}
+      viewerPersonaId={viewerPersonaId ?? null}
+      viewerEntryId={viewerEntryId ?? null}
+    />
+  );
+}
+
+function OwnReputationView({
+  entryCharacterId,
+  viewerPersonaId,
+  viewerEntryId,
+}: {
+  entryCharacterId: number;
+  viewerPersonaId: number | null;
+  viewerEntryId: number | null;
+}) {
+  return (
+    <div className="space-y-6">
+      <section aria-labelledby="reputation-tab-renown">
+        <h2 id="reputation-tab-renown" className="mb-3 text-lg font-semibold">
+          Renown
+        </h2>
+        <RenownPanel characterSheetId={entryCharacterId} />
+      </section>
+
+      <section aria-labelledby="reputation-tab-standing">
+        <h2 id="reputation-tab-standing" className="mb-3 text-lg font-semibold">
+          Standing
+        </h2>
+        <StandingSection viewerPersonaId={viewerPersonaId} viewerEntryId={viewerEntryId} />
+      </section>
+
+      <section aria-labelledby="reputation-tab-covenants">
+        <h2 id="reputation-tab-covenants" className="mb-3 text-lg font-semibold">
+          Covenants
+        </h2>
+        <CovenantsCard characterSheetId={entryCharacterId} />
+      </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Standing — society reputation (wanted-flag aware) + org memberships/reputation.
+// ---------------------------------------------------------------------------
+
+function StandingSection({
+  viewerPersonaId,
+  viewerEntryId,
+}: {
+  viewerPersonaId: number | null;
+  viewerEntryId: number | null;
+}) {
+  const { data: renown } = usePersonaRenownQuery(viewerPersonaId);
+  const { data: heatRows } = usePersonaHeat(viewerEntryId);
+  const wantedSocietyIds = new Set<number>(
+    (heatRows ?? []).map((row: PersonaHeatRow) => row.society)
+  );
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <ReputationListCard
+        reputation={renown?.reputation ?? []}
+        wantedSocietyIds={wantedSocietyIds}
+      />
+      <OrganizationStandingCard />
+    </div>
+  );
+}
+
+function OrganizationStandingCard() {
+  const { data: memberships, isLoading: membershipsLoading } =
+    useOrganizationMembershipsQuery(true);
+  const { data: reputations, isLoading: reputationsLoading } =
+    useOrganizationReputationsQuery(true);
+
+  const isLoading = membershipsLoading || reputationsLoading;
+  const activeMemberships = (memberships ?? []).filter((m) => m.is_active);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Organizations</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <div className="flex justify-center py-4">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <>
+            <div>
+              <h3 className="mb-2 text-sm font-medium text-muted-foreground">Memberships</h3>
+              {activeMemberships.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No active organization memberships.</p>
+              ) : (
+                <ul className="space-y-2 text-sm">
+                  {activeMemberships.map((membership) => (
+                    <li key={membership.id} className="flex items-center justify-between">
+                      <Link
+                        to={`/orgs/${membership.organization}`}
+                        className="font-medium hover:underline"
+                      >
+                        {membership.organization_name}
+                      </Link>
+                      <Badge variant="outline">{membership.title}</Badge>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <div>
+              <h3 className="mb-2 text-sm font-medium text-muted-foreground">Reputation</h3>
+              {(reputations ?? []).length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No organizations have a recorded opinion yet.
+                </p>
+              ) : (
+                <ul className="space-y-2 text-sm">
+                  {(reputations ?? []).map((rep) => (
+                    <li key={rep.id} className="flex items-center justify-between">
+                      <Link
+                        to={`/orgs/${rep.organization}`}
+                        className="font-medium hover:underline"
+                      >
+                        {rep.organization_name}
+                      </Link>
+                      <Badge variant={TIER_VARIANT[rep.tier] ?? 'outline'}>
+                        {formatTier(rep.tier)}
+                      </Badge>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Covenants — active covenant role assignments for this character sheet.
+// ---------------------------------------------------------------------------
+
+function CovenantsCard({ characterSheetId }: { characterSheetId: number }) {
+  const { data: roles, isLoading } = useCovenantRolesQuery(characterSheetId);
+  const activeRoles = (roles ?? []).filter((r: CharacterCovenantRole) => r.is_active);
+
+  return (
+    <Card>
+      <CardContent className="py-4">
+        {isLoading ? (
+          <div className="flex justify-center py-4">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : activeRoles.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No active covenant roles.</p>
+        ) : (
+          <ul className="space-y-2 text-sm">
+            {activeRoles.map((role) => (
+              <li key={role.id} className="flex items-center justify-between">
+                <Link to={`/covenants/${role.covenant}`} className="font-medium hover:underline">
+                  {role.covenant_role.name}
+                </Link>
+                <div className="flex items-center gap-2">
+                  {role.engaged && <Badge variant="default">Engaged</Badge>}
+                  <Badge variant="outline">{role.rank.name}</Badge>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/reputation/queries.ts
+++ b/frontend/src/reputation/queries.ts
@@ -1,0 +1,38 @@
+/**
+ * React Query hooks for the consolidated Reputation tab (#1446).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  fetchOrganizationReputations,
+  fetchOrganizationMemberships,
+  fetchCovenantRolesForSheet,
+} from './api';
+
+/** The viewer's own org standing (Standing card). Own-view only — pass `enabled=false` otherwise. */
+export function useOrganizationReputationsQuery(enabled: boolean) {
+  return useQuery({
+    queryKey: ['reputation', 'organization-reputations'],
+    queryFn: fetchOrganizationReputations,
+    enabled,
+  });
+}
+
+/** The viewer's own org memberships (Standing card). Own-view only. */
+export function useOrganizationMembershipsQuery(enabled: boolean) {
+  return useQuery({
+    queryKey: ['reputation', 'organization-memberships'],
+    queryFn: fetchOrganizationMemberships,
+    enabled,
+  });
+}
+
+/** Active covenant role assignments for a character sheet (Covenants card). Own-view only. */
+export function useCovenantRolesQuery(characterSheetId: number | null) {
+  return useQuery({
+    queryKey: ['reputation', 'covenant-roles', characterSheetId],
+    queryFn: () => fetchCovenantRolesForSheet(characterSheetId as number),
+    enabled: characterSheetId !== null,
+  });
+}

--- a/frontend/src/roster/pages/CharacterSheetPage.test.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.test.tsx
@@ -10,13 +10,18 @@ vi.mock('../queries', () => ({
   useRosterEntryQuery: vi.fn(),
   useMyRosterEntriesQuery: vi.fn(),
 }));
+vi.mock('@/orgs/queries', () => ({
+  useOrganizationByName: vi.fn(),
+}));
 vi.mock('@/vitals/components/VitalsPanel', () => ({
   VitalsPanel: vi.fn(() => <div data-testid="vitals-panel-mock" />),
 }));
 import { useRosterEntryQuery, useMyRosterEntriesQuery } from '../queries';
+import { useOrganizationByName } from '@/orgs/queries';
 
 const mockUseRosterEntryQuery = vi.mocked(useRosterEntryQuery);
 const mockUseMyRosterEntriesQuery = vi.mocked(useMyRosterEntriesQuery);
+const mockUseOrganizationByName = vi.mocked(useOrganizationByName);
 
 describe('CharacterSheetPage', () => {
   beforeEach(() => {
@@ -27,6 +32,13 @@ describe('CharacterSheetPage', () => {
       isSuccess: true,
       error: null,
     } as unknown as ReturnType<typeof useMyRosterEntriesQuery>);
+    // Default: no same-named org resolved — family renders as plain text.
+    mockUseOrganizationByName.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isSuccess: true,
+      error: null,
+    } as unknown as ReturnType<typeof useOrganizationByName>);
   });
 
   it('shows loading state', () => {
@@ -98,5 +110,80 @@ describe('CharacterSheetPage', () => {
       { initialEntries: ['/1'] }
     );
     expect(screen.getByTestId('vitals-panel-mock')).toBeInTheDocument();
+  });
+
+  it('renders a covenant link and role under the name when covenant is set', () => {
+    const entry: RosterEntryData = {
+      id: 1,
+      character: {
+        id: 42,
+        name: 'Test Character',
+        galleries: [],
+        covenant: { id: 7, name: 'Covenant of the Dawn', role: 'Vanguard' },
+      },
+      profile_picture: null,
+      tenures: [],
+      can_apply: false,
+      fullname: 'Test Character',
+      quote: '',
+      description: '',
+      creation_provenance: 'player',
+      creation_provenance_display: 'Player-created',
+      created_for_table_name: null,
+    };
+    mockUseRosterEntryQuery.mockReturnValue({
+      data: entry,
+      isLoading: false,
+      isError: false,
+      error: null,
+      isPending: false,
+      isSuccess: true,
+    } as unknown as UseQueryResult<RosterEntryData, Error>);
+    renderWithProviders(
+      <Routes>
+        <Route path="/:id" element={<CharacterSheetPage />} />
+      </Routes>,
+      { initialEntries: ['/1'] }
+    );
+    const link = screen.getByRole('link', { name: /Covenant of the Dawn/i });
+    expect(link).toHaveAttribute('href', '/covenants/7');
+    expect(screen.getByText(/Vanguard/i)).toBeInTheDocument();
+  });
+
+  it('omits the covenant line when covenant is null', () => {
+    const entry: RosterEntryData = {
+      id: 1,
+      character: {
+        id: 42,
+        name: 'Test Character',
+        galleries: [],
+        covenant: null,
+      },
+      profile_picture: null,
+      tenures: [],
+      can_apply: false,
+      fullname: 'Test Character',
+      quote: '',
+      description: '',
+      creation_provenance: 'player',
+      creation_provenance_display: 'Player-created',
+      created_for_table_name: null,
+    };
+    mockUseRosterEntryQuery.mockReturnValue({
+      data: entry,
+      isLoading: false,
+      isError: false,
+      error: null,
+      isPending: false,
+      isSuccess: true,
+    } as unknown as UseQueryResult<RosterEntryData, Error>);
+    renderWithProviders(
+      <Routes>
+        <Route path="/:id" element={<CharacterSheetPage />} />
+      </Routes>,
+      { initialEntries: ['/1'] }
+    );
+    expect(screen.queryByRole('link', { name: /Covenant of the Dawn/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Vanguard/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -21,6 +21,7 @@ import { SecretsTab } from '@/secrets/components/SecretsTab';
 import { CluesTab } from '@/clues/components/CluesTab';
 import { CrimeTab } from '@/justice/components/CrimeTab';
 import { TitlesPanel } from '@/achievements/components/TitlesPanel';
+import { DistinctionsTab } from '@/distinctions/components/DistinctionsTab';
 
 export function CharacterSheetPage() {
   const { id } = useParams();
@@ -99,6 +100,7 @@ export function CharacterSheetPage() {
           <TabsTrigger value="relationships">Relationships</TabsTrigger>
           <TabsTrigger value="reputation">Reputation</TabsTrigger>
           <TabsTrigger value="titles">Titles</TabsTrigger>
+          <TabsTrigger value="distinctions">Distinctions</TabsTrigger>
           <TabsTrigger value="secrets">Secrets</TabsTrigger>
           {isMyCharacter && <TabsTrigger value="clues">Clues</TabsTrigger>}
           {isMyCharacter && <TabsTrigger value="gossip">Gossip</TabsTrigger>}
@@ -159,6 +161,14 @@ export function CharacterSheetPage() {
           {/* Titles are cosmetic and public — render for any viewer. character.id is the
               CharacterSheet pk the titles API filters by. */}
           <TitlesPanel characterSheetId={entry.character.id} />
+        </TabsContent>
+
+        <TabsContent value="distinctions" className="space-y-4">
+          {/* Ungated (#1446): the server already filters secret rows for non-privileged
+              viewers, so every viewer sees this tab and the tab only renders what it's given.
+              character.id is the CharacterSheet pk (shared with the ObjectDB pk). Radix
+              unmounts inactive tab content, so the query only fires when this tab is opened. */}
+          <DistinctionsTab characterId={entry.character.id} />
         </TabsContent>
 
         <TabsContent value="secrets" className="space-y-4">

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -23,6 +23,7 @@ import { CrimeTab } from '@/justice/components/CrimeTab';
 import { TitlesPanel } from '@/achievements/components/TitlesPanel';
 import { DistinctionsTab } from '@/distinctions/components/DistinctionsTab';
 import { SpellbookTab } from '@/magic/components/SpellbookTab';
+import { LocationsTab } from '@/locations/components/LocationsTab';
 
 export function CharacterSheetPage() {
   const { id } = useParams();
@@ -108,6 +109,7 @@ export function CharacterSheetPage() {
           {isMyCharacter && <TabsTrigger value="gossip">Gossip</TabsTrigger>}
           {isMyCharacter && <TabsTrigger value="crime">Crime</TabsTrigger>}
           {isMyCharacter && <TabsTrigger value="friends">Friends</TabsTrigger>}
+          {isMyCharacter && <TabsTrigger value="locations">Locations</TabsTrigger>}
         </TabsList>
 
         <TabsContent value="sheet" className="space-y-4">
@@ -222,6 +224,17 @@ export function CharacterSheetPage() {
             {/* Your OOC friends list (#1727) — account-wide trusted partners, separate from IC
                 relationships. Add friends from other characters' sheets; this lists + removes. */}
             <FriendsTab />
+          </TabsContent>
+        )}
+
+        {isMyCharacter && (
+          <TabsContent value="locations" className="space-y-4">
+            {/* Consolidated Locations tab (#1446): dwellings, tenancies, and ships. Own-only —
+                dwellings/tenancies are keyed on the viewed character's persona (never the
+                account's first-listed character, to avoid alt-leak), ships are self-scoped
+                server-side to the requester's active persona. Radix unmounts inactive tabs,
+                so these queries only fire when opened. */}
+            <LocationsTab personaId={viewedPersonaId} />
           </TabsContent>
         )}
       </Tabs>

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -47,6 +47,10 @@ export function CharacterSheetPage() {
   // resolve the active character's roster entry. Null when no character is active → no secrets.
   const activeCharacterName = useAppSelector((state) => state.game.active);
   const viewerEntryId = myEntries?.find((e) => e.name === activeCharacterName)?.id ?? null;
+  // For the Locations tab's Ships section: GET /api/ships/ships/ is server-scoped to the
+  // account's ACTIVE persona, not the character being viewed, so only render it when the
+  // viewed character IS the active character (an account can own several characters).
+  const isActiveCharacter = viewerEntryId === entryId;
   // Resolve a same-named org for the family click-through (#1446); membership-gated visibility
   // means an empty/absent result is normal — fall back to plain text in that case.
   const { data: familyOrg } = useOrganizationByName(entry?.character.family ?? '');
@@ -231,10 +235,11 @@ export function CharacterSheetPage() {
           <TabsContent value="locations" className="space-y-4">
             {/* Consolidated Locations tab (#1446): dwellings, tenancies, and ships. Own-only —
                 dwellings/tenancies are keyed on the viewed character's persona (never the
-                account's first-listed character, to avoid alt-leak), ships are self-scoped
-                server-side to the requester's active persona. Radix unmounts inactive tabs,
-                so these queries only fire when opened. */}
-            <LocationsTab personaId={viewedPersonaId} />
+                account's first-listed character, to avoid alt-leak); ships are self-scoped
+                server-side to the requester's ACTIVE persona, so isActiveCharacter gates
+                that section off when viewing a non-active character owned by this account.
+                Radix unmounts inactive tabs, so these queries only fire when opened. */}
+            <LocationsTab personaId={viewedPersonaId} isActiveCharacter={isActiveCharacter} />
           </TabsContent>
         )}
       </Tabs>

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -11,8 +11,7 @@ import {
 } from '@/components/character';
 import { MessagesSection } from '@/narrative/components/MessagesSection';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { RenownPanel } from '@/renown/components/RenownPanel';
-import { RenownCardPanel } from '@/renown/components/RenownCardPanel';
+import { ReputationTab } from '@/reputation/components/ReputationTab';
 import { VitalsPanel } from '@/vitals/components/VitalsPanel';
 import { FriendButton } from '@/friends/components/FriendButton';
 import { FriendsTab } from '@/friends/components/FriendsTab';
@@ -30,7 +29,7 @@ export function CharacterSheetPage() {
 
   // Show messages section only when the viewing user owns this character.
   const isMyCharacter = myEntries?.some((e) => e.id === entryId) ?? false;
-  // For the Renown tab on foreign sheets: resolve the viewer's primary
+  // For the Reputation tab on foreign sheets: resolve the viewer's primary
   // persona from their first owned character. Null when the viewer has
   // no characters → the backend returns the anonymous subset.
   const viewerPersonaId = myEntries?.[0]?.primary_persona_id ?? null;
@@ -64,7 +63,7 @@ export function CharacterSheetPage() {
         <TabsList>
           <TabsTrigger value="sheet">Sheet</TabsTrigger>
           <TabsTrigger value="relationships">Relationships</TabsTrigger>
-          <TabsTrigger value="renown">Renown</TabsTrigger>
+          <TabsTrigger value="reputation">Reputation</TabsTrigger>
           <TabsTrigger value="titles">Titles</TabsTrigger>
           <TabsTrigger value="secrets">Secrets</TabsTrigger>
           {isMyCharacter && <TabsTrigger value="clues">Clues</TabsTrigger>}
@@ -109,15 +108,16 @@ export function CharacterSheetPage() {
           />
         </TabsContent>
 
-        <TabsContent value="renown" className="space-y-4">
-          {isMyCharacter ? (
-            <RenownPanel characterSheetId={entry.character.id} />
-          ) : (
-            <RenownCardPanel
-              characterSheetId={entry.character.id}
-              viewerPersonaId={viewerPersonaId}
-            />
-          )}
+        <TabsContent value="reputation" className="space-y-4">
+          {/* Consolidated Reputation tab (#1446): renown, standing (society + org), covenants,
+              and wanted flags for the own view; the existing RenownCardPanel for foreign views.
+              Radix unmounts inactive tab content, so these queries only fire when opened. */}
+          <ReputationTab
+            entryCharacterId={entry.character.id}
+            viewerPersonaId={viewerPersonaId}
+            isMyCharacter={isMyCharacter}
+            viewerEntryId={viewerEntryId}
+          />
         </TabsContent>
 
         <TabsContent value="titles" className="space-y-4">

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -22,6 +22,7 @@ import { CluesTab } from '@/clues/components/CluesTab';
 import { CrimeTab } from '@/justice/components/CrimeTab';
 import { TitlesPanel } from '@/achievements/components/TitlesPanel';
 import { DistinctionsTab } from '@/distinctions/components/DistinctionsTab';
+import { SpellbookTab } from '@/magic/components/SpellbookTab';
 
 export function CharacterSheetPage() {
   const { id } = useParams();
@@ -101,6 +102,7 @@ export function CharacterSheetPage() {
           <TabsTrigger value="reputation">Reputation</TabsTrigger>
           <TabsTrigger value="titles">Titles</TabsTrigger>
           <TabsTrigger value="distinctions">Distinctions</TabsTrigger>
+          <TabsTrigger value="magic">Magic</TabsTrigger>
           <TabsTrigger value="secrets">Secrets</TabsTrigger>
           {isMyCharacter && <TabsTrigger value="clues">Clues</TabsTrigger>}
           {isMyCharacter && <TabsTrigger value="gossip">Gossip</TabsTrigger>}
@@ -169,6 +171,16 @@ export function CharacterSheetPage() {
               character.id is the CharacterSheet pk (shared with the ObjectDB pk). Radix
               unmounts inactive tab content, so the query only fires when this tab is opened. */}
           <DistinctionsTab characterId={entry.character.id} />
+        </TabsContent>
+
+        <TabsContent value="magic" className="space-y-4">
+          {/* Ungated (#1446): the server already gates payload.magic to null for foreign
+              viewers without visibility and for magic-less characters, so every viewer sees
+              this tab and the tab only renders what it's given (a muted line when null).
+              Spellbook/status view only — "the sheet describes; the scene does." character.id
+              is the CharacterSheet pk. Radix unmounts inactive tab content, so the query only
+              fires when this tab is opened. */}
+          <SpellbookTab characterId={entry.character.id} isMyCharacter={isMyCharacter} />
         </TabsContent>
 
         <TabsContent value="secrets" className="space-y-4">

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -33,6 +33,12 @@ export function CharacterSheetPage() {
   // persona from their first owned character. Null when the viewer has
   // no characters → the backend returns the anonymous subset.
   const viewerPersonaId = myEntries?.[0]?.primary_persona_id ?? null;
+  // For the Reputation tab's own-view: resolve the persona/entry of the character being
+  // VIEWED (not the account's first-listed character) — an account can own several
+  // characters, and scoping to myEntries[0] would leak another character's standing
+  // (heat, org memberships/reputation) onto this sheet.
+  const viewedMyEntry = myEntries?.find((e) => e.id === entryId);
+  const viewedPersonaId = viewedMyEntry?.primary_persona_id ?? null;
   // For the Secrets tab: IC knowledge scopes to the ACTIVE character (never the account), so
   // resolve the active character's roster entry. Null when no character is active → no secrets.
   const activeCharacterName = useAppSelector((state) => state.game.active);
@@ -116,7 +122,8 @@ export function CharacterSheetPage() {
             entryCharacterId={entry.character.id}
             viewerPersonaId={viewerPersonaId}
             isMyCharacter={isMyCharacter}
-            viewerEntryId={viewerEntryId}
+            viewedEntryId={entryId}
+            viewedPersonaId={viewedPersonaId}
           />
         </TabsContent>
 

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -1,6 +1,7 @@
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { useAppSelector } from '@/store/hooks';
 import { useRosterEntryQuery, useMyRosterEntriesQuery } from '../queries';
+import { useOrganizationByName } from '@/orgs/queries';
 import {
   CharacterPortrait,
   BackgroundSection,
@@ -43,9 +44,15 @@ export function CharacterSheetPage() {
   // resolve the active character's roster entry. Null when no character is active → no secrets.
   const activeCharacterName = useAppSelector((state) => state.game.active);
   const viewerEntryId = myEntries?.find((e) => e.name === activeCharacterName)?.id ?? null;
+  // Resolve a same-named org for the family click-through (#1446); membership-gated visibility
+  // means an empty/absent result is normal — fall back to plain text in that case.
+  const { data: familyOrg } = useOrganizationByName(entry?.character.family ?? '');
 
   if (isLoading) return <p className="p-4">Loading...</p>;
   if (!entry) return <p className="p-4">Character not found.</p>;
+
+  const covenant = entry.character.covenant;
+  const family = entry.character.family;
 
   return (
     <div className="container mx-auto space-y-4 p-4">
@@ -53,7 +60,28 @@ export function CharacterSheetPage() {
         <CharacterPortrait
           name={entry.fullname || entry.character.name}
           profilePicture={entry.profile_picture}
-        />
+        >
+          {covenant && (
+            <p className="text-sm text-muted-foreground">
+              <Link to={`/covenants/${covenant.id}`} className="hover:underline">
+                {covenant.name}
+              </Link>
+              {' — '}
+              {covenant.role}
+            </p>
+          )}
+          {family && (
+            <p className="text-sm text-muted-foreground">
+              {familyOrg ? (
+                <Link to={`/orgs/${familyOrg.id}`} className="hover:underline">
+                  {family}
+                </Link>
+              ) : (
+                family
+              )}
+            </p>
+          )}
+        </CharacterPortrait>
         {entry.quote && <blockquote className="italic">"{entry.quote}"</blockquote>}
         {/* Friend this character — an OOC trusted-partner designation (#1727), only on others' sheets. */}
         {!isMyCharacter && (

--- a/frontend/src/roster/types.ts
+++ b/frontend/src/roster/types.ts
@@ -53,6 +53,8 @@ export interface CharacterData {
   background?: string;
   relationships?: string[];
   galleries: CharacterGallery[];
+  /** Core-identity covenant: the active DURANCE-type covenant role, if any (#1446). */
+  covenant?: { id: number; name: string; role: string } | null;
 }
 
 export type CreationProvenance = 'staff' | 'gm_table' | 'player';

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -509,9 +509,16 @@ actions, backends, and service functions.
   *society* reputation); `covenant` (`sheet/covenant` — your covenant membership(s), role, rank,
   and which you're *engaged* in, from `CharacterCovenantRole`; read-only); `title`
   (`sheet/titles`, #1522 — the earned, displayable titles your active character holds, from
-  `achievements.CharacterTitle`; cosmetic, mirrors the web Titles tab). Each is thin over its
-  app's data. Add a section: a renderer + a registry entry (+ `SECTION_NAMES`). *Web tabs for
-  standing/covenant are a follow-up — the "which contextual center owns this" call is open (#1446).*
+  `achievements.CharacterTitle`; cosmetic, mirrors the web Titles tab); `distinction`
+  (`sheet/distinction`, #1446 — your distinctions, secret-badged, over the shared
+  `_build_distinctions` builder, mirroring the web Distinctions tab); `magic` (`sheet/magic`,
+  #1446 — gifts/techniques/motif/aura over the shared `_build_magic` builder, mirroring the web
+  Magic tab; describe-only — casting/weaving/rituals stay in-scene, per "the sheet describes; the
+  scene does" in `design-tenets.md`). Each is thin over its app's data. Add a section: a renderer
+  + a registry entry (+ `SECTION_NAMES`). Standing and covenant now also have web homes: standing
+  lives in the consolidated **Reputation** tab (society + org standing + covenant associations);
+  covenant core identity surfaces in the sheet header, with full detail in the Reputation tab's
+  covenant subsection (#1446).
 
 ### Social Commands (`social/`)
 - **`blocking.py`**: `CmdBlock`/`CmdUnblock`/`CmdShareBlock`/`CmdMute`/`CmdUnmute`/`CmdBlockList`

--- a/src/commands/account/sheet_sections.py
+++ b/src/commands/account/sheet_sections.py
@@ -334,6 +334,69 @@ def _render_crime_section(command: Command) -> list[str]:
     return lines
 
 
+def _render_distinction_section(command: Command) -> list[str]:
+    """The distinctions section (#1446): the active character's distinctions.
+
+    Mirrors the web Distinctions tab — both faces read ``_build_distinctions``. Self-only
+    (privileged view): the owner sees gated entries with a ``(secret)`` marker; the web serves
+    foreign viewers the filtered public list through the sheet serializer instead.
+    """
+    from world.character_sheets.serializers import (  # noqa: PLC0415
+        _build_distinctions,
+        get_character_sheet_queryset,
+    )
+
+    viewer = _viewer_sheet(command)
+    sheet = get_character_sheet_queryset().get(pk=viewer.pk)
+    entries = _build_distinctions(sheet, privileged=True)
+    if not entries:
+        return ["You have no distinctions."]
+    lines = ["|wYour distinctions:|n"]
+    for entry in entries:
+        secret = " |m(secret)|n" if entry["is_secret"] else ""
+        notes = f" — {entry['notes']}" if entry["notes"] else ""
+        lines.append(f"  {entry['name']} (rank {entry['rank']}){secret}{notes}")
+    return lines
+
+
+def _render_magic_section(command: Command) -> list[str]:
+    """The magic section (#1446): the active character's spellbook/status view.
+
+    Mirrors the web Magic tab — both faces read ``_build_magic``. The sheet describes; the
+    scene does: this lists gifts, techniques, motif, and aura — casting/weaving stays with
+    the in-scene commands (``cast``, ``weave``, ``ritual``).
+    """
+    from world.character_sheets.serializers import (  # noqa: PLC0415
+        _build_magic,
+        get_character_sheet_queryset,
+    )
+
+    viewer = _viewer_sheet(command)
+    sheet = get_character_sheet_queryset().get(pk=viewer.pk)
+    magic = _build_magic(sheet)
+    if magic is None:
+        return ["Nothing is known of your magic."]
+    lines = ["|wYour spellbook:|n"]
+    for gift in magic["gifts"]:
+        lines.append(f"  |w{gift['name']}|n")
+        lines.extend(
+            f"    {technique['name']} (level {technique['level']})"
+            for technique in gift["techniques"]
+        )
+        if gift["resonances"]:
+            lines.append(f"    resonances: {', '.join(gift['resonances'])}")
+    motif = magic["motif"]
+    if motif:
+        resonances = ", ".join(entry["name"] for entry in motif["resonances"])
+        lines.append(f"  Motif: {motif['description'] or resonances}")
+        if motif["description"] and resonances:
+            lines.append(f"    resonances: {resonances}")
+    aura = magic["aura"]
+    if aura and aura["glimpse_story"]:
+        lines.append(f"  Aura: {aura['glimpse_story']}")
+    return lines
+
+
 # Switch name → renderer. Add a section by writing a renderer and registering it here (and in
 # SECTION_NAMES for the overview footer). Aliases (secret/secrets) map to the same renderer.
 SHEET_SECTIONS: dict[str, Callable[..., list[str]]] = {
@@ -349,6 +412,9 @@ SHEET_SECTIONS: dict[str, Callable[..., list[str]]] = {
     "titles": _render_titles_section,
     "crime": _render_crime_section,
     "crimes": _render_crime_section,
+    "distinction": _render_distinction_section,
+    "distinctions": _render_distinction_section,
+    "magic": _render_magic_section,
 }
 
 # Canonical section names shown in the bare-``sheet`` footer (deduped; one per real section).
@@ -360,4 +426,6 @@ SECTION_NAMES: tuple[str, ...] = (
     "covenant",
     "title",
     "crime",
+    "distinction",
+    "magic",
 )

--- a/src/schema.json
+++ b/src/schema.json
@@ -22685,6 +22685,10 @@ paths:
         Staff see all non-covenant organizations.
       parameters:
       - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
         name: org_type
         schema:
           type: string

--- a/src/schema.json
+++ b/src/schema.json
@@ -12306,8 +12306,7 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this Consequence Pool.
+          type: string
         required: true
       tags:
       - magic
@@ -22820,6 +22819,60 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationRank'
           description: ''
+  /api/societies/reputations/:
+    get:
+      operationId: societies_reputations_list
+      description: |-
+        List/retrieve the requester's active persona's organization reputations (standing).
+
+        Self-only: rows are scoped to personas the requester currently plays.
+      parameters:
+      - in: query
+        name: organization
+        schema:
+          type: integer
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      tags:
+      - societies
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedOrganizationReputationList'
+          description: ''
+  /api/societies/reputations/{id}/:
+    get:
+      operationId: societies_reputations_retrieve
+      description: |-
+        List/retrieve the requester's active persona's organization reputations (standing).
+
+        Self-only: rows are scoped to personas the requester currently plays.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Organization Reputation.
+        required: true
+      tags:
+      - societies
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationReputation'
+          description: ''
   /api/staff-inbox/:
     get:
       operationId: staff_inbox_retrieve
@@ -28348,11 +28401,21 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CharacterGallery'
+        covenant:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: |-
+            Core-identity covenant: the active DURANCE-type covenant role, if any (#1446).
+
+            One indexed query per character; bounded by roster pagination in list context.
+          readOnly: true
       required:
       - age
       - background
       - char_class
       - concept
+      - covenant
       - family
       - gender
       - id
@@ -39086,6 +39149,28 @@ components:
       - id
       - name
       - tier
+    OrganizationReputation:
+      type: object
+      description: A persona's standing with an organization — named tier only, never
+        the raw value.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        organization:
+          type: integer
+          description: The organization this reputation is with
+        organization_name:
+          type: string
+          readOnly: true
+        tier:
+          type: string
+          readOnly: true
+      required:
+      - id
+      - organization
+      - organization_name
+      - tier
     OrganizationSearch:
       type: object
       properties:
@@ -40943,6 +41028,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OrganizationRank'
+    PaginatedOrganizationReputationList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrganizationReputation'
     PaginatedOrganizationSearchList:
       type: object
       required:
@@ -45270,6 +45378,8 @@ components:
         area_name:
           type: string
           readOnly: true
+        society:
+          type: integer
         society_name:
           type: string
           readOnly: true
@@ -45288,6 +45398,7 @@ components:
       - alleged_deeds
       - area_name
       - id
+      - society
       - society_name
       - tier
       - tier_label

--- a/src/schema.json
+++ b/src/schema.json
@@ -12306,7 +12306,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this Consequence Pool.
         required: true
       tags:
       - magic

--- a/src/schema.json
+++ b/src/schema.json
@@ -39157,6 +39157,9 @@ components:
         id:
           type: integer
           readOnly: true
+        persona:
+          type: integer
+          description: The persona (character identity) this reputation belongs to
         organization:
           type: integer
           description: The organization this reputation is with
@@ -39170,6 +39173,7 @@ components:
       - id
       - organization
       - organization_name
+      - persona
       - tier
     OrganizationSearch:
       type: object

--- a/src/schema.json
+++ b/src/schema.json
@@ -22827,7 +22827,7 @@ paths:
     get:
       operationId: societies_reputations_list
       description: |-
-        List/retrieve the requester's active persona's organization reputations (standing).
+        List/retrieve org reputations (standing) for personas the requester currently plays.
 
         Self-only: rows are scoped to personas the requester currently plays.
       parameters:
@@ -22856,7 +22856,7 @@ paths:
     get:
       operationId: societies_reputations_retrieve
       description: |-
-        List/retrieve the requester's active persona's organization reputations (standing).
+        List/retrieve org reputations (standing) for personas the requester currently plays.
 
         Self-only: rows are scoped to personas the requester currently plays.
       parameters:

--- a/src/world/character_sheets/tests/test_sheet_distinction_magic_sections.py
+++ b/src/world/character_sheets/tests/test_sheet_distinction_magic_sections.py
@@ -1,0 +1,79 @@
+"""Tests for the telnet ``sheet/distinction`` and ``sheet/magic`` sections (#1446).
+
+Telnet parity for the web Distinctions and Magic (spellbook) tabs — both faces read the
+same ``_build_distinctions`` / ``_build_magic`` builders, so they can't drift.
+"""
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.account.sheet_sections import SHEET_SECTIONS
+from world.character_sheets.factories import CharacterFactory, CharacterSheetFactory
+from world.distinctions.factories import CharacterDistinctionFactory, DistinctionFactory
+from world.magic.factories import CharacterGiftFactory, GiftFactory
+from world.secrets.factories import SecretFactory
+
+
+def _command_for(character) -> MagicMock:
+    command = MagicMock()
+    command.caller.puppet = character
+    command.args = ""
+    return command
+
+
+class SheetDistinctionSectionTests(TestCase):
+    def setUp(self) -> None:
+        self.character = CharacterFactory()
+        self.sheet = CharacterSheetFactory(character=self.character)
+
+    def test_registered_with_aliases(self) -> None:
+        self.assertIn("distinction", SHEET_SECTIONS)
+        self.assertIn("distinctions", SHEET_SECTIONS)
+        self.assertIn("magic", SHEET_SECTIONS)
+
+    def test_lists_distinctions_with_rank_and_secret_marker(self) -> None:
+        public = CharacterDistinctionFactory(
+            character=self.character,
+            distinction=DistinctionFactory(name="Silver Tongue"),
+            rank=2,
+        )
+        hidden = CharacterDistinctionFactory(
+            character=self.character,
+            distinction=DistinctionFactory(name="Blood Debt"),
+            rank=1,
+            secret=SecretFactory(),
+        )
+
+        lines = SHEET_SECTIONS["distinction"](_command_for(self.character))
+        text = "\n".join(lines)
+
+        self.assertIn(public.distinction.name, text)
+        self.assertIn("rank 2", text)
+        self.assertIn(hidden.distinction.name, text)  # owner sees gated entries
+        self.assertIn("(secret)", text)
+
+    def test_empty_state(self) -> None:
+        lines = SHEET_SECTIONS["distinction"](_command_for(self.character))
+        self.assertEqual(lines, ["You have no distinctions."])
+
+
+class SheetMagicSectionTests(TestCase):
+    def setUp(self) -> None:
+        self.character = CharacterFactory()
+        self.sheet = CharacterSheetFactory(character=self.character)
+
+    def test_lists_gifts(self) -> None:
+        gift_row = CharacterGiftFactory(
+            character=self.sheet,
+            gift=GiftFactory(name="Emberweaving"),
+        )
+
+        lines = SHEET_SECTIONS["magic"](_command_for(self.character))
+        text = "\n".join(lines)
+
+        self.assertIn(gift_row.gift.name, text)
+
+    def test_empty_state(self) -> None:
+        lines = SHEET_SECTIONS["magic"](_command_for(self.character))
+        self.assertEqual(lines, ["Nothing is known of your magic."])

--- a/src/world/character_sheets/tests/test_viewset.py
+++ b/src/world/character_sheets/tests/test_viewset.py
@@ -69,6 +69,7 @@ from world.roster.factories import (
     TenureMediaFactory,
 )
 from world.scenes.factories import PersonaFactory
+from world.secrets.factories import SecretFactory
 from world.skills.factories import (
     CharacterSkillValueFactory,
     CharacterSpecializationValueFactory,
@@ -942,6 +943,72 @@ class TestDistinctionsEmpty(TestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert response.data["distinctions"] == []
+
+
+class TestDistinctionsPrivacy(TestCase):
+    """Server-side privacy for secret distinctions (final review, #1446).
+
+    A foreign (non-owner, non-staff) viewer's GET must not surface a secret distinction —
+    the public one is visible, the secret one is dropped entirely. The owner's own GET sees
+    both, with ``is_secret`` flagging the gated row.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """Create a character with one public and one secret distinction."""
+        cls.player = PlayerDataFactory()
+        cls.character = CharacterFactory(db_key="SecretDistChar")
+        CharacterSheetFactory(character=cls.character)
+        cls.roster_entry = RosterEntryFactory(character_sheet__character=cls.character)
+        RosterTenureFactory(
+            player_data=cls.player,
+            roster_entry=cls.roster_entry,
+            player_number=1,
+        )
+
+        cls.public_distinction = DistinctionFactory(name="PublicHonor")
+        cls.secret_distinction = DistinctionFactory(name="HiddenShame")
+
+        cls.public_cd = CharacterDistinctionFactory(
+            character=cls.character,
+            distinction=cls.public_distinction,
+            rank=1,
+        )
+        cls.secret_cd = CharacterDistinctionFactory(
+            character=cls.character,
+            distinction=cls.secret_distinction,
+            rank=1,
+            secret=SecretFactory(subject_sheet=cls.roster_entry.character_sheet),
+        )
+
+        # Foreign viewer: authenticated account with no tenure on this character.
+        cls.foreign_player = PlayerDataFactory()
+
+    def _get_distinctions(self, account) -> list:
+        """Fetch the distinctions section from the API as the given account."""
+        client = APIClient()
+        client.force_authenticate(user=account)
+        url = f"/api/character-sheets/{self.character.pk}/"
+        response = client.get(url)
+        assert response.status_code == 200
+        return response.data["distinctions"]
+
+    def test_foreign_viewer_does_not_see_secret_distinction(self) -> None:
+        """A foreign account's GET must contain the public name but never the secret one."""
+        distinctions = self._get_distinctions(self.foreign_player.account)
+        names = {d["name"] for d in distinctions}
+
+        assert "PublicHonor" in names
+        assert "HiddenShame" not in names
+
+    def test_owner_sees_both_distinctions_with_is_secret_flag(self) -> None:
+        """The owner's own GET contains both, with is_secret true on the gated row."""
+        distinctions = self._get_distinctions(self.player.account)
+        by_name = {d["name"]: d for d in distinctions}
+
+        assert set(by_name) == {"PublicHonor", "HiddenShame"}
+        assert by_name["PublicHonor"]["is_secret"] is False
+        assert by_name["HiddenShame"]["is_secret"] is True
 
 
 class TestMagicSectionFull(TestCase):

--- a/src/world/justice/serializers.py
+++ b/src/world/justice/serializers.py
@@ -21,7 +21,15 @@ class PersonaHeatSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PersonaHeat
-        fields = ("id", "area_name", "society_name", "tier", "tier_label", "alleged_deeds")
+        fields = (
+            "id",
+            "area_name",
+            "society",
+            "society_name",
+            "tier",
+            "tier_label",
+            "alleged_deeds",
+        )
 
     def get_tier(self, obj: PersonaHeat) -> str:
         return tier_for_value(obj.value).value

--- a/src/world/justice/tests/test_surfaces.py
+++ b/src/world/justice/tests/test_surfaces.py
@@ -117,6 +117,7 @@ class HeatApiTests(APITestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["tier"], HeatTier.DANGEROUS.value)
         self.assertEqual(rows[0]["area_name"], self.city.name)
+        self.assertEqual(rows[0]["society"], self.crown.pk)  # id for reputation join (#1446)
         self.assertNotIn("value", rows[0])  # tiers only — never the raw number
 
     def test_unowned_viewer_is_empty(self) -> None:

--- a/src/world/roster/serializers/characters.py
+++ b/src/world/roster/serializers/characters.py
@@ -6,6 +6,9 @@ from django.core.exceptions import ObjectDoesNotExist
 from evennia.objects.models import ObjectDB
 from rest_framework import serializers
 
+from world.covenants.constants import CovenantType
+from world.covenants.models import CharacterCovenantRole
+
 
 class CharacterGallerySerializer(serializers.Serializer):
     """Serialize a single gallery entry for a character."""
@@ -59,6 +62,7 @@ class CharacterSerializer(serializers.ModelSerializer):
     )
     relationships = serializers.ListField(child=serializers.CharField(), default=list)
     galleries = CharacterGallerySerializer(many=True, default=list)
+    covenant = serializers.SerializerMethodField()
 
     class Meta:
         model = ObjectDB
@@ -77,6 +81,7 @@ class CharacterSerializer(serializers.ModelSerializer):
             "background",
             "relationships",
             "galleries",
+            "covenant",
         )
         read_only_fields = fields
 
@@ -110,6 +115,28 @@ class CharacterSerializer(serializers.ModelSerializer):
             race_data["species"] = species_data
 
         return race_data
+
+    def get_covenant(self, obj) -> dict | None:
+        """Core-identity covenant: the active DURANCE-type covenant role, if any (#1446).
+
+        One indexed query per character; bounded by roster pagination in list context.
+        """
+        role = (
+            CharacterCovenantRole.objects.filter(
+                character_sheet_id=obj.pk,
+                left_at__isnull=True,
+                covenant__covenant_type=CovenantType.DURANCE,
+            )
+            .select_related("covenant", "covenant_role")
+            .first()
+        )
+        if role is None:
+            return None
+        return {
+            "id": role.covenant.pk,
+            "name": role.covenant.name,
+            "role": role.covenant_role.name,
+        }
 
     def get_char_class(self, _obj):
         # Placeholder until class system is implemented

--- a/src/world/roster/serializers/characters.py
+++ b/src/world/roster/serializers/characters.py
@@ -128,6 +128,7 @@ class CharacterSerializer(serializers.ModelSerializer):
                 covenant__covenant_type=CovenantType.DURANCE,
             )
             .select_related("covenant", "covenant_role")
+            .order_by("-engaged", "joined_at")
             .first()
         )
         if role is None:

--- a/src/world/roster/tests/test_serializers.py
+++ b/src/world/roster/tests/test_serializers.py
@@ -19,6 +19,51 @@ from world.roster.models import ApplicationStatus, RosterApplication
 from world.roster.serializers import MyRosterEntrySerializer, RosterEntrySerializer
 
 
+class CharacterSerializerCovenantTestCase(TestCase):
+    """The covenant identity summary on CharacterSerializer (#1446)."""
+
+    def setUp(self):
+        self.character = CharacterFactory()
+
+    def test_covenant_null_when_no_active_role(self):
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.roster.serializers import CharacterSerializer
+
+        CharacterSheetFactory(character=self.character)
+
+        data = CharacterSerializer(instance=self.character).data
+
+        assert data["covenant"] is None
+
+    def test_covenant_summary_from_active_durance_role(self):
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.covenants.factories import CharacterCovenantRoleFactory
+        from world.roster.serializers import CharacterSerializer
+
+        sheet = CharacterSheetFactory(character=self.character)
+        role = CharacterCovenantRoleFactory(character_sheet=sheet)
+
+        data = CharacterSerializer(instance=self.character).data
+
+        assert data["covenant"] == {
+            "id": role.covenant.pk,
+            "name": role.covenant.name,
+            "role": role.covenant_role.name,
+        }
+
+    def test_covenant_ignores_departed_roles(self):
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.covenants.factories import CharacterCovenantRoleFactory
+        from world.roster.serializers import CharacterSerializer
+
+        sheet = CharacterSheetFactory(character=self.character)
+        CharacterCovenantRoleFactory(character_sheet=sheet, left_at=timezone.now())
+
+        data = CharacterSerializer(instance=self.character).data
+
+        assert data["covenant"] is None
+
+
 class CharacterSerializerTestCase(TestCase):
     """Test the CharacterSerializer, including species field."""
 

--- a/src/world/roster/tests/test_serializers.py
+++ b/src/world/roster/tests/test_serializers.py
@@ -63,6 +63,47 @@ class CharacterSerializerCovenantTestCase(TestCase):
 
         assert data["covenant"] is None
 
+    def test_covenant_prefers_engaged_row_over_other_active_durance_role(self):
+        """Two active DURANCE roles: the engaged one wins, regardless of join order (#1446)."""
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.covenants.factories import CharacterCovenantRoleFactory
+        from world.roster.serializers import CharacterSerializer
+
+        sheet = CharacterSheetFactory(character=self.character)
+        # Joined first, but not engaged — should lose to the engaged row below.
+        CharacterCovenantRoleFactory(character_sheet=sheet, engaged=False)
+        engaged_role = CharacterCovenantRoleFactory(character_sheet=sheet, engaged=True)
+
+        data = CharacterSerializer(instance=self.character).data
+
+        assert data["covenant"] == {
+            "id": engaged_role.covenant.pk,
+            "name": engaged_role.covenant.name,
+            "role": engaged_role.covenant_role.name,
+        }
+
+    def test_covenant_null_when_only_active_role_is_non_durance(self):
+        """A non-DURANCE (e.g. BATTLE) active role must not surface as the identity covenant."""
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.covenants.constants import CovenantType
+        from world.covenants.factories import (
+            CharacterCovenantRoleFactory,
+            CovenantFactory,
+            CovenantRoleFactory,
+        )
+        from world.roster.serializers import CharacterSerializer
+
+        sheet = CharacterSheetFactory(character=self.character)
+        battle_covenant = CovenantFactory(covenant_type=CovenantType.BATTLE)
+        battle_role = CovenantRoleFactory(covenant_type=CovenantType.BATTLE)
+        CharacterCovenantRoleFactory(
+            character_sheet=sheet, covenant=battle_covenant, covenant_role=battle_role
+        )
+
+        data = CharacterSerializer(instance=self.character).data
+
+        assert data["covenant"] is None
+
 
 class CharacterSerializerTestCase(TestCase):
     """Test the CharacterSerializer, including species field."""

--- a/src/world/societies/filters.py
+++ b/src/world/societies/filters.py
@@ -15,10 +15,11 @@ from world.societies.models import (
 class OrganizationFilter(django_filters.FilterSet):
     society = django_filters.CharFilter(field_name="society__name", lookup_expr="iexact")
     org_type = django_filters.CharFilter(field_name="org_type__name", lookup_expr="iexact")
+    name = django_filters.CharFilter(field_name="name", lookup_expr="iexact")
 
     class Meta:
         model = Organization
-        fields = ["society", "org_type"]
+        fields = ["society", "org_type", "name"]
 
 
 class OrganizationMembershipFilter(django_filters.FilterSet):

--- a/src/world/societies/serializers.py
+++ b/src/world/societies/serializers.py
@@ -80,6 +80,7 @@ class OrganizationReputationSerializer(serializers.ModelSerializer):
         model = OrganizationReputation
         fields = [
             "id",
+            "persona",
             "organization",
             "organization_name",
             "tier",

--- a/src/world/societies/serializers.py
+++ b/src/world/societies/serializers.py
@@ -9,6 +9,7 @@ from world.societies.models import (
     OrganizationMembership,
     OrganizationMembershipOffer,
     OrganizationRank,
+    OrganizationReputation,
 )
 
 
@@ -67,6 +68,25 @@ class OrganizationMembershipSerializer(serializers.ModelSerializer):
 
     def get_is_active(self, obj: OrganizationMembership) -> bool:
         return obj.left_at is None and obj.exiled_at is None
+
+
+class OrganizationReputationSerializer(serializers.ModelSerializer):
+    """A persona's standing with an organization — named tier only, never the raw value."""
+
+    organization_name = serializers.CharField(source="organization.name", read_only=True)
+    tier = serializers.SerializerMethodField()
+
+    class Meta:
+        model = OrganizationReputation
+        fields = [
+            "id",
+            "organization",
+            "organization_name",
+            "tier",
+        ]
+
+    def get_tier(self, obj: OrganizationReputation) -> str:
+        return obj.get_tier().value
 
 
 class OrganizationMembershipOfferSerializer(serializers.ModelSerializer):

--- a/src/world/societies/tests/test_organization_api.py
+++ b/src/world/societies/tests/test_organization_api.py
@@ -86,6 +86,20 @@ class OrganizationApiTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_filter_by_name(self) -> None:
+        """Name filter resolves a family/house org for sheet click-throughs (#1446)."""
+        other_org = OrganizationFactory(name="Some Other Org")
+        OrganizationMembershipFactory(organization=other_org, persona=self.persona)
+
+        response = self.client.get(
+            reverse("societies:organization-list"),
+            {"name": "regular org"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rows = response.data["results"]
+        self.assertEqual([org["id"] for org in rows], [self.organization.id])
+
 
 class OrganizationMembershipApiTests(TestCase):
     """Tests for the /api/societies/memberships/ endpoint."""

--- a/src/world/societies/tests/test_reputation_api.py
+++ b/src/world/societies/tests/test_reputation_api.py
@@ -1,0 +1,83 @@
+"""DRF tests for the societies organization-reputation API (#1446)."""
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from evennia_extensions.models import PlayerData
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import (
+    RosterEntryFactory,
+    RosterFactory,
+    RosterTenureFactory,
+)
+from world.societies.factories import (
+    OrganizationFactory,
+    OrganizationReputationFactory,
+)
+
+
+def _active_primary_persona(*, account):
+    """Create a character sheet + active tenure and return its primary persona."""
+    character = CharacterFactory()
+    sheet = CharacterSheetFactory(character=character)
+    roster = RosterFactory()
+    RosterEntryFactory(character_sheet=sheet, roster=roster)
+    player_data = PlayerData.objects.create(account=account)
+    RosterTenureFactory(player_data=player_data, roster_entry=sheet.roster_entry)
+    return sheet.primary_persona
+
+
+class OrganizationReputationApiTests(TestCase):
+    """Tests for the /api/societies/reputations/ endpoint."""
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.account = AccountFactory()
+        self.client.force_authenticate(user=self.account)
+        self.persona = _active_primary_persona(account=self.account)
+        self.organization = OrganizationFactory(name="Standing Org")
+        self.reputation = OrganizationReputationFactory(
+            persona=self.persona,
+            organization=self.organization,
+            value=350,
+        )
+
+    def test_lists_own_reputations_only(self) -> None:
+        """Users see their own persona's org reputations with named tiers, nothing else."""
+        other_account = AccountFactory()
+        other_persona = _active_primary_persona(account=other_account)
+        OrganizationReputationFactory(persona=other_persona, value=-400)
+
+        response = self.client.get(reverse("societies:organization-reputation-list"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rows = response.data["results"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["organization"], self.organization.id)
+        self.assertEqual(rows[0]["organization_name"], self.organization.name)
+        self.assertEqual(rows[0]["tier"], "liked")
+        self.assertNotIn("value", rows[0])
+
+    def test_filter_by_organization(self) -> None:
+        other_org = OrganizationFactory(name="Other Org")
+        OrganizationReputationFactory(persona=self.persona, organization=other_org, value=100)
+
+        response = self.client.get(
+            reverse("societies:organization-reputation-list"),
+            {"organization": self.organization.id},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rows = response.data["results"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["organization"], self.organization.id)
+
+    def test_unauthenticated_requests_are_rejected(self) -> None:
+        self.client.force_authenticate(user=None)
+
+        response = self.client.get(reverse("societies:organization-reputation-list"))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/src/world/societies/tests/test_reputation_api.py
+++ b/src/world/societies/tests/test_reputation_api.py
@@ -58,6 +58,7 @@ class OrganizationReputationApiTests(TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["organization"], self.organization.id)
         self.assertEqual(rows[0]["organization_name"], self.organization.name)
+        self.assertEqual(rows[0]["persona"], self.persona.pk)  # client filters by viewed persona
         self.assertEqual(rows[0]["tier"], "liked")
         self.assertNotIn("value", rows[0])
 

--- a/src/world/societies/urls.py
+++ b/src/world/societies/urls.py
@@ -8,6 +8,7 @@ from world.societies.views import (
     OrganizationMembershipOfferViewSet,
     OrganizationMembershipViewSet,
     OrganizationRankViewSet,
+    OrganizationReputationViewSet,
     OrganizationViewSet,
 )
 
@@ -18,6 +19,11 @@ router.register(r"rankings", RankingDisplayViewSet, basename="ranking-display")
 router.register(r"organizations", OrganizationViewSet, basename="organization")
 router.register(r"memberships", OrganizationMembershipViewSet, basename="organization-membership")
 router.register(r"ranks", OrganizationRankViewSet, basename="organization-rank")
+router.register(
+    r"reputations",
+    OrganizationReputationViewSet,
+    basename="organization-reputation",
+)
 router.register(
     r"offers",
     OrganizationMembershipOfferViewSet,

--- a/src/world/societies/views.py
+++ b/src/world/societies/views.py
@@ -18,12 +18,14 @@ from world.societies.models import (
     OrganizationMembership,
     OrganizationMembershipOffer,
     OrganizationRank,
+    OrganizationReputation,
 )
 from world.societies.permissions import IsOwnMembership, active_persona_q
 from world.societies.serializers import (
     OrganizationMembershipOfferSerializer,
     OrganizationMembershipSerializer,
     OrganizationRankSerializer,
+    OrganizationReputationSerializer,
     OrganizationSerializer,
 )
 
@@ -80,6 +82,26 @@ class OrganizationMembershipViewSet(viewsets.ReadOnlyModelViewSet):
         qs = super().get_queryset().filter(organization__covenant__isnull=True)
         if self.request.user.is_staff:
             return qs
+        return qs.filter(active_persona_q(self.request.user, path="persona"))
+
+
+class OrganizationReputationViewSet(viewsets.ReadOnlyModelViewSet):
+    """List/retrieve the requester's active persona's organization reputations (standing).
+
+    Self-only: rows are scoped to personas the requester currently plays.
+    """
+
+    queryset = OrganizationReputation.objects.select_related("organization").order_by(
+        "organization__name"
+    )
+    serializer_class = OrganizationReputationSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = SocietiesPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ("organization",)
+
+    def get_queryset(self):
+        qs = super().get_queryset()
         return qs.filter(active_persona_q(self.request.user, path="persona"))
 
 

--- a/src/world/societies/views.py
+++ b/src/world/societies/views.py
@@ -86,7 +86,7 @@ class OrganizationMembershipViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class OrganizationReputationViewSet(viewsets.ReadOnlyModelViewSet):
-    """List/retrieve the requester's active persona's organization reputations (standing).
+    """List/retrieve org reputations (standing) for personas the requester currently plays.
 
     Self-only: rows are scoped to personas the requester currently plays.
     """


### PR DESCRIPTION
Part of #1446 (the contextual-centers living map — stays open). Implements the 2026-07-05 rulings recorded there: build plan bundle 1.

## What shipped

**Backend (serializers/viewsets only — NO migrations):**
- `GET /api/societies/reputations/` — self-scoped org reputations (standing) with named tiers; `persona` on rows so clients scope to the viewed character (account-wide `active_persona_q` would otherwise alt-leak)
- `?name=` iexact filter on organizations (family-org resolve for the sheet header link)
- `society` id on heat rows (wanted-flag join, own-view only)
- Nullable `covenant` {id, name, role} on the roster character serializer — the active, engaged-preferred DURANCE covenant role (ruling: covenant is core identity)

**Web sheet (CharacterSheetPage):**
- **Reputation** tab (replaces Renown): RenownPanel + org standing with Wanted badges + covenant associations incl. guest covenants; heat fetched only for own view, standing rows filtered to the viewed persona (fails closed)
- **Distinctions** tab — ungated, server filters secret rows; Secret badge for the owner
- **Magic** spellbook tab — describe-only per the new tenet (*the sheet describes; the scene does*); gifts/techniques/motif/aura + own-view workbench links; no invocation UI
- **Locations** tab (own-only) — dwellings/tenancies (reused renown cards, viewed-persona-scoped) + ships (active-character-gated to match the endpoint's scoping) + domains placeholder (#1884)
- Covenant identity header under the name (links `/covenants/{id}`) + family-name link to the new stub `/orgs/:id` page (placeholder pending #1884, fails closed to plain text)
- Dead `/news` + `/community` nav links removed

**Telnet parity:** `sheet/distinction` + `sheet/magic` over the same `_build_distinctions`/`_build_magic` builders as the web — the faces can't drift.

**Docs in tandem:** design-tenets (new tenet), systems/societies + justice + INDEX, commands CLAUDE.md (stale #1446 follow-up note resolved).

## Review notes (final whole-branch review ran; fixes folded in)
- `/api/character-sheets/{id}/` is schema-invisible to drf-spectacular (`to_representation`-only serializer) — frontend payload type is hand-written against the backend TypedDicts and verified field-by-field; a follow-up `@extend_schema` would let codegen own it
- Roster LIST covenant lookup is +1 indexed query/row (bounded by pagination, both FKs select_related) — deliberate; the banned alternative is a to_attr prefetch onto a SharedMemoryModel parent
- Design question for later: CrimeTab keys heat on the *active* character while the Reputation tab's Wanted badges key on the *viewed* character — aligning them changes #1765's documented semantics, so left as-is
- Wanted badges reflect the active persona's heat even when RenownPanel's persona selector shows an established alt (heat rows carry no persona id); Standing lists primary-persona rows only — both own-eyes-only incompleteness, not leaks

Server-side privacy tests added: foreign viewer never receives secret distinction rows; reputation/heat endpoints assert self-only scoping and that raw values never serialize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)