### PR TITLE
MaterialLoreEffect content authoring (post-Plan 3)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1576,7 +1576,8 @@ unified NPCServiceOffer PERMIT effect handler. Buildings spawn from completed
   capped at `MAX_FORTIFICATION_LEVEL`), `BuildingMaterial`
   (per-building snapshot of materials used at construction), `MaterialLoreEffect`
   (per-template special properties — godswar stone → resonance_amp etc.; zero
-  rows shipped, content-authored), `BuildingPermitDetails` (persona-scoped permit
+  rows shipped; content-authored via the `MaterialLoreEffectAdmin` Django admin
+  registration, #695), `BuildingPermitDetails` (persona-scoped permit
   holder, building_kind + approved_wards M2M), `BuildingConstructionDetails`
   (Project per-kind payload for BUILDING_CONSTRUCTION),
   `BuildingExtensionDetails` (#670: BUILDING_EXTENSION payload — `added_budget`,
@@ -1697,8 +1698,9 @@ unified NPCServiceOffer PERMIT effect handler. Buildings spawn from completed
   the BuildingPermit ItemTemplate + House BuildingKind + wires House onto
   Builders Guild Clerk PERMIT offers). NOT a committed fixture (per #683).
 - **Out of scope, filed as followups:** BuildingKind catalog expansion (#694),
-  MaterialLoreEffect content authoring (#695), Building → Neighborhood → Domain
-  progression (#696), BUILDING_RENOVATION / BUILDING_UPGRADE project kinds
+  MaterialLoreEffect catalog content — authoring surface shipped in #695;
+  ongoing staff content authoring, not a code task — Building → Neighborhood →
+  Domain progression (#696), BUILDING_RENOVATION / BUILDING_UPGRADE project kinds
   (#673; EXTENSION + INTERIOR_DESIGN shipped with #670).
 - **Cross-app dependencies:** `world.areas` (Area + AreaClosure + ward fields),
   `world.items` (ItemTemplate + ItemInstance + OwnershipEvent + `lore_value`),

--- a/src/world/buildings/admin.py
+++ b/src/world/buildings/admin.py
@@ -8,7 +8,12 @@ from typing import ClassVar
 
 from django.contrib import admin
 
-from world.buildings.models import ArchitecturalStyle, BuildingSizeTier, StyleAffinity
+from world.buildings.models import (
+    ArchitecturalStyle,
+    BuildingSizeTier,
+    MaterialLoreEffect,
+    StyleAffinity,
+)
 
 
 @admin.register(BuildingSizeTier)
@@ -37,3 +42,19 @@ class ArchitecturalStyleAdmin(admin.ModelAdmin):
     list_filter: ClassVar[list[str]] = ["is_default", "is_active"]
     search_fields: ClassVar[list[str]] = ["name"]
     inlines: ClassVar[list[type[admin.TabularInline]]] = [StyleAffinityInline]
+
+
+@admin.register(MaterialLoreEffect)
+class MaterialLoreEffectAdmin(admin.ModelAdmin):
+    """The material-lore catalog — content authored here, not in code (#695)."""
+
+    list_display: ClassVar[list[str]] = [
+        "template",
+        "target_stat",
+        "units_per_tier",
+        "magnitude_per_tier",
+        "max_tiers",
+    ]
+    list_filter: ClassVar[list[str]] = ["target_stat"]
+    search_fields: ClassVar[list[str]] = ["template__name", "target_stat"]
+    autocomplete_fields: ClassVar[list[str]] = ["template"]

--- a/src/world/buildings/tests/test_admin.py
+++ b/src/world/buildings/tests/test_admin.py
@@ -1,0 +1,11 @@
+"""Tests for buildings admin registrations."""
+
+from django.contrib import admin
+from django.test import TestCase
+
+from world.buildings.models import MaterialLoreEffect
+
+
+class MaterialLoreEffectAdminTests(TestCase):
+    def test_material_lore_effect_is_registered(self) -> None:
+        assert MaterialLoreEffect in admin.site._registry


### PR DESCRIPTION
Closes #695

## Summary

Ships the missing Django admin authoring surface for `MaterialLoreEffect` (Plan 3, #668) — the model shipped with zero rows and zero admin registration, so staff had no way to author content at all.

Descoped from the issues original "author the full material-lore catalog" ask: pre-launch content-authoring breadth is low-leverage, and this repo has no code-shippable path for it anyway (no JSON fixtures in VCS, no data migrations pre-production per ADR-0013). The actual gap was the authoring tool itself.

- Adds `MaterialLoreEffectAdmin` (standalone `ModelAdmin` in `world/buildings/admin.py`, following the existing `ArchitecturalStyleAdmin` content-catalog pattern) with `autocomplete_fields=["template"]`, filterable/searchable by `target_stat` and template name.
- No inline on `ItemTemplateAdmin` (items app) — would invert the buildings→items FK/dependency direction (ADR-0010).
- Adds a registration regression test mirroring `world/magic/tests/test_signature_admin.py`.
- Updates the two `docs/systems/INDEX.md` bullets describing `MaterialLoreEffect` to reflect the authoring surface now existing.
- Linked to #1220 (game-tuning admin dashboard epic) as a small worked example of the same "admin-hosted content authoring" pattern at a much smaller scale — not a dependency in either direction.

Actual catalog content (godswar stone, primeval lumber, etc.) is left to staff via the shipped admin UI — not a code deliverable of this PR.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #695 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch created directly from origin/main tip (b823400a); no sync/rebase needed — main has not moved.

<!-- last-addressed-comment: 0 -->