### PR TITLE
Auto-close an empty scene on logout/disconnect (follow-up to #1309)

### DIFF
--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -473,6 +473,16 @@ from world.scenes.scene_admin_services import finish_scene_full
 finish_scene_full(scene, by_account=None) -> None
 ```
 
+```python
+from world.scenes.round_services import maybe_finish_empty_scene
+
+# Auto-close (#1361): finishes room's active scene via finish_scene_full if no
+# PC other than `leaving` remains in room.contents. No-ops if no active scene.
+# Called from Room.at_object_leave (movement) and Character.at_post_unpuppet
+# (disconnect, after Evennia's own base-class relocation has already run).
+maybe_finish_empty_scene(room, *, leaving=None) -> None
+```
+
 ### Lifecycle Actions
 
 **`StartSceneAction`** (`key="start_scene"`, `src/actions/definitions/scenes.py`)

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -478,6 +478,9 @@ from world.scenes.round_services import maybe_finish_empty_scene
 
 # Auto-close (#1361): finishes room's active scene via finish_scene_full if no
 # PC other than `leaving` remains in room.contents. No-ops if no active scene.
+# Skips a scene with a live CombatEncounter/Battle attached (that scene's
+# lifecycle belongs to the encounter/battle outcome, not room emptiness — and
+# such scenes lack the account/participant data finish_scene_full needs).
 # Called from Room.at_object_leave (movement) and Character.at_post_unpuppet
 # (disconnect, after Evennia's own base-class relocation has already run).
 maybe_finish_empty_scene(room, *, leaving=None) -> None

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -480,6 +480,7 @@ class Character(ObjectParent, DefaultCharacter):
             session: Session that was puppeting this character, if any.
             **kwargs: Arbitrary, optional arguments passed by Evennia.
         """
+        origin = self.location
         super().at_post_unpuppet(account=account, session=session, **kwargs)
         target = [session] if session else self.sessions.all()
         for sess in target:
@@ -493,3 +494,12 @@ class Character(ObjectParent, DefaultCharacter):
         from world.scenes.friend_services import notify_friends_of_status
 
         notify_friends_of_status(self, online=False)
+
+        # #1361: the base at_post_unpuppet call above already relocated this
+        # character off-grid if that was its last session — finish the room's
+        # scene if it's now empty. Guard mirrors Evennia's own last-session-out
+        # check rather than re-implementing it.
+        if origin is not None and self.location is None:
+            from world.scenes.round_services import maybe_finish_empty_scene
+
+            maybe_finish_empty_scene(origin, leaving=self)

--- a/src/typeclasses/rooms.py
+++ b/src/typeclasses/rooms.py
@@ -209,3 +209,8 @@ class Room(ObjectParent, DefaultRoom):
         from world.areas.positioning.plummet import resolve_unattended_plummets
 
         resolve_unattended_plummets(self, departing=obj)
+        # #1361: a departure may leave this room's active scene empty — finish it
+        # immediately rather than leaving it open indefinitely.
+        from world.scenes.round_services import maybe_finish_empty_scene
+
+        maybe_finish_empty_scene(self, leaving=obj)

--- a/src/typeclasses/tests/test_unpuppet_scene_close.py
+++ b/src/typeclasses/tests/test_unpuppet_scene_close.py
@@ -1,0 +1,133 @@
+"""Tests for Character.at_post_unpuppet's scene auto-close wiring (#1361)."""
+
+from unittest import mock
+
+from django.test import TestCase
+
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.scenes.factories import SceneFactory
+
+
+def _find_unpuppet_owner(character):
+    """Return the MRO class that directly defines at_post_unpuppet.
+
+    Character inherits (ObjectParent, DefaultCharacter); ObjectParent is a
+    plain mixin (see typeclasses/mixins.py) that does not define
+    at_post_unpuppet, so the simple `__mro__[1]` used by the analogous
+    `_patch_super_puppet` in typeclasses/tests/test_account_puppet_broadcast.py
+    (which works there because Account has single inheritance straight to
+    DefaultAccount) lands on the wrong class here. Walk the MRO to find the
+    actual owner (DefaultCharacter) instead.
+    """
+    for klass in type(character).__mro__[1:]:
+        if "at_post_unpuppet" in klass.__dict__:
+            return klass
+    msg = "at_post_unpuppet not found in MRO"
+    raise AttributeError(msg)
+
+
+def _patch_super_unpuppet(character, fake):
+    """Replace the parent class's at_post_unpuppet with `fake`; return the original.
+
+    Character.at_post_unpuppet calls `super().at_post_unpuppet(...)`, which is
+    Evennia's base DefaultCharacter implementation — it relocates the character
+    to a null location only when this is the last connected session
+    (`self.sessions.count() == 0`). Rather than fighting real Evennia session
+    plumbing to simulate "still connected," stub the parent method directly on
+    the MRO, mirroring the existing `_patch_super_puppet` pattern in
+    typeclasses/tests/test_account_puppet_broadcast.py.
+    """
+    parent = _find_unpuppet_owner(character)
+    original = parent.at_post_unpuppet
+    parent.at_post_unpuppet = fake
+    return original
+
+
+def _restore_super_unpuppet(character, original):
+    parent = _find_unpuppet_owner(character)
+    parent.at_post_unpuppet = original
+
+
+class UnpuppetFinishesEmptySceneTests(TestCase):
+    _PATCH_BASE = "world.scenes.scene_admin_services"
+
+    def setUp(self):
+        self.room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+        self.scene = SceneFactory(location=self.room, is_active=True)
+        self.character = CharacterFactory(db_key="Solo", location=self.room)
+        CharacterSheetFactory(character=self.character)
+
+    def test_disconnect_that_relocates_finishes_the_scene(self):
+        """super().at_post_unpuppet relocating the character (last session out)
+        must trigger maybe_finish_empty_scene for the room it just vacated."""
+
+        def fake_relocate(char_self, account=None, session=None, **kwargs):
+            char_self.location = None  # mimics the real base behavior
+
+        original = _patch_super_unpuppet(self.character, fake_relocate)
+        try:
+            with (
+                mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+                mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+                mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+            ):
+                self.character.at_post_unpuppet()
+        finally:
+            _restore_super_unpuppet(self.character, original)
+
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is True
+
+    def test_disconnect_that_does_not_relocate_does_not_close_scene(self):
+        """A still-connected session (base class no-ops) must not trigger the
+        scene-close check at all."""
+
+        def fake_noop(char_self, account=None, session=None, **kwargs):
+            pass  # mimics "still has another session" — location unchanged
+
+        original = _patch_super_unpuppet(self.character, fake_noop)
+        try:
+            with mock.patch(
+                "world.scenes.round_services.maybe_finish_empty_scene"
+            ) as mock_maybe_finish:
+                self.character.at_post_unpuppet()
+        finally:
+            _restore_super_unpuppet(self.character, original)
+
+        mock_maybe_finish.assert_not_called()
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is False
+
+    def test_real_evennia_relocation_finishes_the_scene_end_to_end(self):
+        """No mocking of super() at all — a freshly-created CharacterFactory has
+        zero attached sessions, so Evennia's real DefaultCharacter.at_post_unpuppet
+        takes its `not self.sessions.count()` branch and relocates for real."""
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            self.character.at_post_unpuppet()
+
+        assert self.character.location is None
+        assert self.character.db.prelogout_location.pk == self.room.pk
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is True
+
+    def test_real_relocation_with_another_pc_present_keeps_scene_active(self):
+        """Disconnect, not alone: real relocation still happens (this PC leaves
+        the room), but another PC remains — the scene must stay active."""
+        other_pc = CharacterFactory(db_key="Staying", location=self.room)
+        CharacterSheetFactory(character=other_pc)
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            self.character.at_post_unpuppet()
+
+        assert self.character.location is None  # this character still relocated
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is False  # but the scene stays open

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -175,6 +175,13 @@ Key service functions for scene round lifecycle:
   A single cheap room-bound query short-circuits ordinary rooms. Rescue (the bleed-out cleared via
   `remove_condition`/`perform_treatment`) before either trigger leaves no acute-peril instance, so
   `resolve_abandonment` no-ops — rescue beats the check.
+- `maybe_finish_empty_scene(room, *, leaving=None)` (#1361): the scene-lifecycle
+  sibling of `resolve_solo_abandoned_victims` — finishes the room's active
+  `Scene` (via `finish_scene_full`) once no PC other than `leaving` remains in
+  `room.contents`. Wired into `Room.at_object_leave` (movement) and
+  `Character.at_post_unpuppet` (disconnect, after Evennia's own base-class
+  relocation — see typeclasses/characters.py — has already removed the
+  character from the room).
 - `ensure_round_for_acute_condition(character_sheet) -> SceneRound | None`: ensures an active scene round
   for the character's room (enrolling everyone present). When none is active, creates a STRICT
   `SceneRound(start_reason=DANGER)`; when one already exists (any mode), the peril rides it. Caller

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -181,7 +181,12 @@ Key service functions for scene round lifecycle:
   `room.contents`. Wired into `Room.at_object_leave` (movement) and
   `Character.at_post_unpuppet` (disconnect, after Evennia's own base-class
   relocation — see typeclasses/characters.py — has already removed the
-  character from the room).
+  character from the room). **Skips** any scene with a live (`completed_at`/
+  `concluded_at` is null) `CombatEncounter` or `Battle` attached — that
+  scene's lifecycle belongs to the encounter/battle outcome, not room
+  emptiness, and such scenes lack the account/participant data
+  `finish_scene_full`'s broadcast step needs (a real CI-caught crash, not a
+  theoretical concern). Follow-up: #1899 (combat/mission disconnect policy).
 - `ensure_round_for_acute_condition(character_sheet) -> SceneRound | None`: ensures an active scene round
   for the character's room (enrolling everyone present). When none is active, creates a STRICT
   `SceneRound(start_reason=DANGER)`; when one already exists (any mode), the peril rides it. Caller

--- a/src/world/scenes/round_services.py
+++ b/src/world/scenes/round_services.py
@@ -576,6 +576,41 @@ def resolve_solo_abandoned_victims(
         resolve_abandonment(sheet)
 
 
+def maybe_finish_empty_scene(
+    room: ObjectDB,  # noqa: OBJECTDB_PARAM
+    *,
+    leaving: ObjectDB | None = None,  # noqa: OBJECTDB_PARAM
+) -> None:
+    """Finish ``room``'s active scene if no PC other than ``leaving`` remains there.
+
+    Mirrors ``resolve_solo_abandoned_victims``'s early-return and
+    exclude-the-departing-id pattern (#1361). Called from ``Room.at_object_leave``
+    (movement — fires before the mover actually leaves ``room.contents``, hence
+    ``leaving``) and from ``Character.at_post_unpuppet`` (disconnect — called
+    after Evennia's own base-class relocation has already removed the character
+    from ``room.contents``, so ``leaving`` has no practical effect there but is
+    passed for signature symmetry).
+    """
+    from world.scenes.models import Scene  # noqa: PLC0415
+    from world.scenes.scene_admin_services import finish_scene_full  # noqa: PLC0415
+
+    scene = Scene.objects.filter(location=room, is_active=True).first()
+    if scene is None:
+        return
+
+    exclude_id = leaving.pk if leaving is not None else None
+    for obj in room.contents:
+        if obj.pk == exclude_id:
+            continue
+        try:
+            obj.sheet_data  # noqa: B018 — attribute access guards NPC/prop skip
+        except (AttributeError, ObjectDoesNotExist):
+            continue
+        return  # a PC remains — scene stays active
+
+    finish_scene_full(scene)
+
+
 @transaction.atomic
 def resolve_scene_round(scene_round: SceneRound) -> SceneRound:
     """Unconditionally resolve a DECLARING round: execute declared CHALLENGE actions in

--- a/src/world/scenes/round_services.py
+++ b/src/world/scenes/round_services.py
@@ -591,11 +591,27 @@ def maybe_finish_empty_scene(
     from ``room.contents``, so ``leaving`` has no practical effect there but is
     passed for signature symmetry).
     """
+    from world.battles.models import Battle  # noqa: PLC0415
     from world.scenes.models import Scene  # noqa: PLC0415
     from world.scenes.scene_admin_services import finish_scene_full  # noqa: PLC0415
 
     scene = Scene.objects.filter(location=room, is_active=True).first()
     if scene is None:
+        return
+
+    # #1361: a scene backing a live CombatEncounter/Battle has its own
+    # lifecycle, resolved via combat/battle outcome rather than room emptiness
+    # — auto-closing it here would be premature. These auxiliary scenes also
+    # lack the account/participant setup a real RP scene has, so
+    # finish_scene_full's broadcast step crashes on them (discovered via CI:
+    # world.stories.tests.test_flee_services.FleeStoryCriticalNPCTests, whose
+    # CombatEncounter fixture regressed against this function). The
+    # combat/mission-disconnect-policy follow-up (#1899) decides what should
+    # happen to a live encounter/battle on disconnect; this just leaves them
+    # untouched for now.
+    if scene.combat_encounters.filter(completed_at__isnull=True).exists():
+        return
+    if Battle.objects.filter(scene=scene, concluded_at__isnull=True).exists():
         return
 
     exclude_id = leaving.pk if leaving is not None else None

--- a/src/world/scenes/tests/test_round_services.py
+++ b/src/world/scenes/tests/test_round_services.py
@@ -976,3 +976,50 @@ class MaybeFinishEmptySceneTests(TestCase):
         other_scene.refresh_from_db()
         assert self.scene.is_finished is True  # this room's scene closes
         assert other_scene.is_finished is False  # unrelated room's scene untouched
+
+
+class RoomAtObjectLeaveFinishesEmptySceneTests(TestCase):
+    """Room.at_object_leave wiring: last PC walking out finishes the scene (#1361)."""
+
+    _PATCH_BASE = "world.scenes.scene_admin_services"
+
+    def setUp(self):
+        from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+        from world.scenes.factories import SceneFactory
+
+        self.room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+        self.scene = SceneFactory(location=self.room, is_active=True)
+        self.CharacterFactory = CharacterFactory
+
+    def _pc_in_room(self, db_key):
+        char = self.CharacterFactory(db_key=db_key, location=self.room)
+        CharacterSheetFactory(character=char)
+        return char
+
+    def test_last_pc_walking_out_finishes_scene(self):
+        pc = self._pc_in_room("Solo")
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            # Mirrors test_solo_last_rescuer_leaves_immediately's direct-hook-call style.
+            self.room.at_object_leave(pc, None)
+
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is True
+
+    def test_pc_walking_out_with_another_pc_remaining_keeps_scene_active(self):
+        leaving_pc = self._pc_in_room("Leaving")
+        self._pc_in_room("Staying")
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            self.room.at_object_leave(leaving_pc, None)
+
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is False

--- a/src/world/scenes/tests/test_round_services.py
+++ b/src/world/scenes/tests/test_round_services.py
@@ -977,6 +977,73 @@ class MaybeFinishEmptySceneTests(TestCase):
         assert self.scene.is_finished is True  # this room's scene closes
         assert other_scene.is_finished is False  # unrelated room's scene untouched
 
+    def test_scene_with_live_combat_encounter_is_not_finished(self):
+        """Regression (#1361): a bare CombatEncounter-backed Scene has no real
+        participant/account data, so finish_scene_full's broadcast step crashes
+        on it (AttributeError: 'NoneType' object has no attribute 'msg') — and
+        even setting that aside, the encounter owns this scene's lifecycle, not
+        room emptiness. Reproduces world.stories.tests.test_flee_services's
+        CombatEncounterFactory(room=...) fixture shape."""
+        from world.combat.factories import CombatEncounterFactory
+        from world.scenes.round_services import maybe_finish_empty_scene
+
+        CombatEncounterFactory(scene=self.scene, room=self.room)
+        pc = self._pc_in_room("Solo")
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            maybe_finish_empty_scene(self.room, leaving=pc)  # must not raise
+
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is False
+
+    def test_scene_with_completed_combat_encounter_still_finishes(self):
+        """The exclusion only applies to a LIVE encounter — once it's completed,
+        an otherwise-empty scene closes normally."""
+        from django.utils import timezone
+
+        from world.combat.factories import CombatEncounterFactory
+        from world.scenes.round_services import maybe_finish_empty_scene
+
+        encounter = CombatEncounterFactory(scene=self.scene, room=self.room)
+        encounter.completed_at = timezone.now()
+        encounter.save(update_fields=["completed_at"])
+        pc = self._pc_in_room("Solo")
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            maybe_finish_empty_scene(self.room, leaving=pc)
+
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is True
+
+    def test_scene_with_live_battle_is_not_finished(self):
+        """Regression (#1361): same crash-prevention/lifecycle-ownership logic
+        as the CombatEncounter case, for the Battle model."""
+        from world.battles.factories import BattleFactory
+        from world.scenes.round_services import maybe_finish_empty_scene
+
+        battle = BattleFactory()  # auto-creates its own backing Scene
+        battle.scene.location = self.room
+        battle.scene.save(update_fields=["location"])
+        pc = self._pc_in_room("Solo")
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            maybe_finish_empty_scene(self.room, leaving=pc)  # must not raise
+
+        battle.scene.refresh_from_db()
+        assert battle.scene.is_finished is False
+
 
 class RoomAtObjectLeaveFinishesEmptySceneTests(TestCase):
     """Room.at_object_leave wiring: last PC walking out finishes the scene (#1361)."""

--- a/src/world/scenes/tests/test_round_services.py
+++ b/src/world/scenes/tests/test_round_services.py
@@ -863,3 +863,116 @@ class SceneRoundOutcomeBroadcastTests(TestCase):
         )
         resolve_scene_round(self.rnd)
         assert Interaction.objects.filter(mode=InteractionMode.OUTCOME).count() == 0
+
+
+class MaybeFinishEmptySceneTests(TestCase):
+    """maybe_finish_empty_scene: the shared core behind both auto-close triggers."""
+
+    _PATCH_BASE = "world.scenes.scene_admin_services"
+
+    def setUp(self):
+        from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+        from world.scenes.factories import SceneFactory
+
+        self.room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+        self.scene = SceneFactory(location=self.room, is_active=True)
+        self.CharacterFactory = CharacterFactory
+
+    def _pc_in_room(self, db_key):
+        char = self.CharacterFactory(db_key=db_key, location=self.room)
+        CharacterSheetFactory(character=char)
+        return char
+
+    def test_no_active_scene_is_a_noop(self):
+        from evennia_extensions.factories import ObjectDBFactory
+        from world.scenes.round_services import maybe_finish_empty_scene
+
+        empty_room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+        # No Scene exists for empty_room — must not raise.
+        maybe_finish_empty_scene(empty_room)
+
+    def test_last_pc_leaving_finishes_the_scene(self):
+        from world.scenes.round_services import maybe_finish_empty_scene
+
+        pc = self._pc_in_room("Solo")
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            maybe_finish_empty_scene(self.room, leaving=pc)
+
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is True
+        assert self.scene.is_active is False
+
+    def test_other_pc_still_present_keeps_scene_active(self):
+        from world.scenes.round_services import maybe_finish_empty_scene
+
+        leaving_pc = self._pc_in_room("Leaving")
+        self._pc_in_room("Staying")
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            maybe_finish_empty_scene(self.room, leaving=leaving_pc)
+
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is False
+
+    def test_npc_without_sheet_does_not_count_as_present(self):
+        from world.scenes.round_services import maybe_finish_empty_scene
+
+        pc = self._pc_in_room("Solo")
+        self.CharacterFactory(db_key="BarePropNPC", location=self.room)  # no CharacterSheet
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            maybe_finish_empty_scene(self.room, leaving=pc)
+
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is True
+
+    def test_no_leaving_kwarg_still_finds_empty_room(self):
+        """Disconnect call site passes leaving for symmetry, but the character is
+        already absent from room.contents by the time it's called — confirm the
+        function works correctly with no PCs present at all, leaving=None."""
+        from world.scenes.round_services import maybe_finish_empty_scene
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            maybe_finish_empty_scene(self.room)
+
+        self.scene.refresh_from_db()
+        assert self.scene.is_finished is True
+
+    def test_scene_at_different_room_is_unaffected(self):
+        """The location=room filter must isolate correctly across rooms."""
+        from evennia_extensions.factories import ObjectDBFactory
+        from world.scenes.factories import SceneFactory
+        from world.scenes.round_services import maybe_finish_empty_scene
+
+        other_room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+        other_scene = SceneFactory(location=other_room, is_active=True)
+        pc = self._pc_in_room("Solo")
+
+        with (
+            mock.patch(f"{self._PATCH_BASE}.on_scene_finished"),
+            mock.patch(f"{self._PATCH_BASE}.process_deferred_fatigue_resets"),
+            mock.patch(f"{self._PATCH_BASE}.broadcast_scene_message"),
+        ):
+            maybe_finish_empty_scene(self.room, leaving=pc)
+
+        self.scene.refresh_from_db()
+        other_scene.refresh_from_db()
+        assert self.scene.is_finished is True  # this room's scene closes
+        assert other_scene.is_finished is False  # unrelated room's scene untouched


### PR DESCRIPTION
Closes #1361

## Summary

Adds `maybe_finish_empty_scene(room, *, leaving=None)` to `world/scenes/round_services.py` and wires it into both the existing movement-departure hook (`Room.at_object_leave`) and the existing disconnect hook (`Character.at_post_unpuppet`). A scene finishes (via the existing `finish_scene_full`) once no PC remains in its room.

The original issue assumed the auto-close core already existed and just needed a disconnect wiring; verification against code found it didn't exist at all, so this builds it from scratch and wires both triggers, per the approved spec on the issue.

A related 'disconnected character looks like a ghost' concern surfaced during design turned out to already be solved by Evennia's base Character class (immediate relocation on disconnect, already active via the existing `super()` call) — so this PR does not add any relocation/grace-period/combat-gate logic, only the scene-close check. Full reasoning is in the issue's spec.

## Follow-ups filed

- #1899

## Notes

- Spec: reviewed & approved on #1361 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto origin/main, no conflicts.

<!-- last-addressed-comment: 0 -->