### PR TITLE
Status & inventory rail panels + purse/AP read endpoints (#1446)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -50,7 +50,10 @@ Powers, affinities, auras, resonances, threads-as-currency, rituals, and Mage Sc
     latent provisioning at CG + `gift_resonances_for` (the four cast sites).
   - **Anima / rituals:** `CharacterAnima`, `CharacterAnimaRitual`,
     `AnimaRitualPerformance`, `SoulfrayConfig`, `MishapPoolTier`,
-    `TechniqueOutcomeModifier`
+    `TechniqueOutcomeModifier`. `ANIMA_BANDS` + `anima_band_for(current, maximum)`
+    (`constants.py`, PLACEHOLDER labels pending Apostate rewrite) derive the
+    qualitative band word; `CharacterAnimaSerializer.band` surfaces it for the
+    web Status tab + `sheet/status` telnet section (#1446)
   - **Mage Scars (renamed from Magical Scars — display-only, §7.2):**
     `MagicalAlterationTemplate`, `PendingAlteration`, `MagicalAlterationEvent`
   - **Spec A Thread + Currency (NEW):** `Thread` (discriminator + typed FKs:
@@ -767,10 +770,14 @@ Time/effort resource economy with regeneration via cron. The most complete gate 
   - `ActionPointPool.get_or_create_for_character(character)` — safe accessor
   - `pool.can_afford(amount) -> bool` — check before spending
   - `pool.spend(amount) -> bool` — atomic via `select_for_update`
-  - `pool.bank(amount) -> bool`, `pool.unbank(amount) -> int`
+  - `pool.unbank(amount) -> int`, `pool.consume_banked(amount) -> bool` (no `bank()` — removed
+    as dead code; `banked` only accrues via the codex teaching flow)
   - `pool.get_effective_maximum() -> int` — base + distinction modifiers
   - `pool.apply_daily_regen()`, `pool.apply_weekly_regen()`
 - **Pattern:** Fully integrated with mechanics modifier system via `get_modifier_total(sheet, modifier_target)` for regen rates and pool max. Uses `select_for_update` for race-condition safety.
+- **Surfaces:** `GET /api/action-points/{character_id}/` (`ActionPointPoolView`) — self-scoped
+  read `{current, effective_maximum, banked}` for the web Status tab + `sheet/status` telnet
+  section; `current` is the authoritative weekly-remaining figure (#1446)
 - **Integrates with:** codex (teaching costs AP), mechanics (AP modifiers from distinctions), cron (daily/weekly regeneration)
 - **Source:** `src/world/action_points/`
 - **Details:** [action_points.md](action_points.md)
@@ -1490,6 +1497,10 @@ an idle org reaches stasis in both directions (loan interest still accrues — o
   graft, income streams w/ pools + `uncollected_total`, debts, obligations, contributions,
   ledger; per-line summon affordances drive the npc_services interaction dialog
   (`frontend/src/org_books/`)
+- **Purse surface:** `GET /api/currency/purse/{character_id}/` (`CharacterPurseView`) —
+  self-scoped `{balance}` coppers (vitals-view gating: staff or active tenure, else 404);
+  lazy-creates the purse at zero. Feeds the web Status tab (`formatCoppers`) and
+  `sheet/status` telnet section (#1446)
 - **Source:** `src/world/currency/`
 
 ### Predicates (shared rule engine)

--- a/docs/systems/action_points.md
+++ b/docs/systems/action_points.md
@@ -134,6 +134,17 @@ for pool in ActionPointPool.objects.all():
 
 ---
 
+## API
+
+- `GET /api/action-points/{character_id}/` (`ActionPointPoolView`) — self-scoped read-only
+  pool: `{current, effective_maximum, banked}`. Visibility: staff, or an account with an
+  active tenure on the character (else 404, the vitals-view rule). Lazy-creates the pool
+  with config defaults. `current` is the authoritative "AP remaining this week" figure —
+  the weekly cron tops it up additively. Feeds the web Status tab and the `sheet/status`
+  telnet section (#1446).
+
+---
+
 ## Admin
 
 Both models registered with organized fieldsets:

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -82,6 +82,14 @@ part of the Resonance Pivot — relationship flavor is now carried by
 | `CharacterAnima` | Magical energy pool | `current`, `maximum`, `last_recovery` | OneToOne via `character.anima` |
 | `CharacterAnimaRitual` | Personalized recovery rituals | `stat`, `skill`, `resonance`, `personal_description`, `is_primary` | FK via `character.anima_rituals` |
 
+**Anima band vocabulary (#1446).** `ANIMA_BANDS` (`constants.py`) is a descending
+`(min_ratio, label)` tuple (PLACEHOLDER labels pending Apostate rewrite — brimming /
+vibrant / steady / dimmed / guttering / spent), mirroring `vitals.constants
+.WOUND_DESCRIPTIONS`. `anima_band_for(current, maximum) -> str` resolves the qualitative
+word (player-facing anima is narrative, never a raw number); `CharacterAnimaSerializer.band`
+(a `SerializerMethodField`) surfaces it on `/character-anima/`, and the same helper backs
+the web Status tab and the `sheet/status` telnet section.
+
 **CharacterResonance reshape note.** Prior to Spec A, `CharacterResonance`
 carried `scope`, `strength`, `is_active`, and FK'd `ObjectDB`. Those fields
 were dropped (no readers beyond Mage Scars, which now uses
@@ -1313,7 +1321,7 @@ the legacy ThreadType lookup no longer exists.
 | `/character-auras/` | GET/POST | Character aura data |
 | `/character-resonances/` | GET | Character resonances (balance + lifetime_earned per Spec A §2.2; create/delete via service functions, not REST mutations) |
 | `/character-gifts/` | GET/POST/DELETE | Character's acquired gifts |
-| `/character-anima/` | GET/POST/PATCH | Character anima pool |
+| `/character-anima/` | GET/POST/PATCH | Character anima pool (`band` — qualitative `anima_band_for` word, #1446) |
 | `/character-anima-rituals/` | GET/POST/PATCH/DELETE | Character's rituals |
 | `/character-facets/` | GET/POST/PATCH/DELETE | Character facet assignments |
 | `/techniques/` | GET/POST/PATCH | Character techniques |

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -9,6 +9,7 @@ import { PresencePanel } from './components/PresencePanel';
 import { EventsSidebarPanel } from '@/events/components/EventsSidebarPanel';
 import { StoryTray } from '@/missions/components/StoryTray';
 import { StatusPanel } from '@/status/components/StatusPanel';
+import { InventorySidebarPanel } from '@/inventory/components/InventorySidebarPanel';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useFocusStack, type FocusEntry } from '@/inventory/hooks/useFocusStack';
 import { Toaster } from '@/components/ui/sonner';
@@ -96,6 +97,11 @@ export function GamePage() {
             presencePanel={<PresencePanel />}
             statusPanel={
               activeCharacterId ? <StatusPanel characterId={activeCharacterId} /> : undefined
+            }
+            inventoryPanel={
+              activeCharacterId ? (
+                <InventorySidebarPanel characterId={activeCharacterId} />
+              ) : undefined
             }
           />
         }

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { GameLayout } from './components/GameLayout';
 import { GameTopBar } from './components/GameTopBar';
 import { GameWindow } from './components/GameWindow';
@@ -7,6 +8,7 @@ import { SidebarTabPanel } from './components/SidebarTabPanel';
 import { PresencePanel } from './components/PresencePanel';
 import { EventsSidebarPanel } from '@/events/components/EventsSidebarPanel';
 import { StoryTray } from '@/missions/components/StoryTray';
+import { StatusPanel } from '@/status/components/StatusPanel';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useFocusStack, type FocusEntry } from '@/inventory/hooks/useFocusStack';
 import { Toaster } from '@/components/ui/sonner';
@@ -26,6 +28,15 @@ export function GamePage() {
   const { sessions, active } = useAppSelector((state) => state.game);
 
   const focus = useFocusStack(DEFAULT_ROOM_ENTRY);
+
+  // Resolve the active character name to its underlying ObjectDB pk (copied
+  // from WardrobePage's snippet — CharacterSheet is OneToOne with ObjectDB
+  // via primary_key=True, so the same id doubles as the character sheet pk).
+  const activeEntry = useMemo(
+    () => characters.find((entry) => entry.name === active) ?? null,
+    [characters, active]
+  );
+  const activeCharacterId = activeEntry?.character_id ?? null;
 
   if (!account) {
     return (
@@ -83,6 +94,9 @@ export function GamePage() {
             storiesPanel={<StoryTray roomKey={roomData?.name ?? 'nowhere'} />}
             eventsPanel={<EventsSidebarPanel />}
             presencePanel={<PresencePanel />}
+            statusPanel={
+              activeCharacterId ? <StatusPanel characterId={activeCharacterId} /> : undefined
+            }
           />
         }
       />

--- a/frontend/src/game/components/SidebarTabPanel.tsx
+++ b/frontend/src/game/components/SidebarTabPanel.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useCallback, useState } from 'react';
-import { Activity, BookOpen, Calendar, MapPin, Scroll, Users } from 'lucide-react';
+import { Activity, Backpack, BookOpen, Calendar, MapPin, Scroll, Users } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 interface SidebarTabPanelProps {
@@ -12,6 +12,8 @@ interface SidebarTabPanelProps {
   presencePanel?: ReactNode;
   /** #1446 qualitative status tab — health/fatigue/anima as words, coin + AP as numbers. */
   statusPanel?: ReactNode;
+  /** #1446 read-only carried-items tab — the sheet describes; the scene does. */
+  inventoryPanel?: ReactNode;
   /**
    * Label for the room tab. Defaults to ``"Room"`` but the parent can
    * pass the currently-focused subject (a character or item name) so the
@@ -29,6 +31,7 @@ export function SidebarTabPanel({
   codexPanel,
   presencePanel,
   statusPanel,
+  inventoryPanel,
   roomTabLabel,
 }: SidebarTabPanelProps) {
   const [activeTab, setActiveTab] = useState('room');
@@ -48,7 +51,7 @@ export function SidebarTabPanel({
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} className="flex h-full flex-col">
-      <TabsList className="mx-2 mt-2 grid w-auto grid-cols-6">
+      <TabsList className="mx-2 mt-2 grid w-auto grid-cols-7">
         <TabsTrigger value="room" className="gap-1 text-xs" title={label}>
           <MapPin className="h-3 w-3 shrink-0" />
           <span className="inline-block max-w-[8rem] truncate">{label}</span>
@@ -72,6 +75,10 @@ export function SidebarTabPanel({
         <TabsTrigger value="status" className="gap-1 text-xs">
           <Activity className="h-3 w-3" />
           Status
+        </TabsTrigger>
+        <TabsTrigger value="inventory" className="gap-1 text-xs">
+          <Backpack className="h-3 w-3" />
+          Items
         </TabsTrigger>
       </TabsList>
       <TabsContent value="room" className="mt-0 flex-1 overflow-y-auto">
@@ -102,6 +109,11 @@ export function SidebarTabPanel({
       <TabsContent value="status" className="mt-0 flex-1 overflow-y-auto p-3">
         {activatedTabs.has('status')
           ? (statusPanel ?? <p className="text-sm text-muted-foreground">No status to show.</p>)
+          : null}
+      </TabsContent>
+      <TabsContent value="inventory" className="mt-0 flex-1 overflow-y-auto p-3">
+        {activatedTabs.has('inventory')
+          ? (inventoryPanel ?? <p className="text-sm text-muted-foreground">Nothing carried.</p>)
           : null}
       </TabsContent>
     </Tabs>

--- a/frontend/src/game/components/SidebarTabPanel.tsx
+++ b/frontend/src/game/components/SidebarTabPanel.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useCallback, useState } from 'react';
-import { BookOpen, Calendar, MapPin, Scroll, Users } from 'lucide-react';
+import { Activity, BookOpen, Calendar, MapPin, Scroll, Users } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 interface SidebarTabPanelProps {
@@ -10,6 +10,8 @@ interface SidebarTabPanelProps {
   codexPanel?: ReactNode;
   /** #1463 presence tab — who's online + where (coloured area paths). */
   presencePanel?: ReactNode;
+  /** #1446 qualitative status tab — health/fatigue/anima as words, coin + AP as numbers. */
+  statusPanel?: ReactNode;
   /**
    * Label for the room tab. Defaults to ``"Room"`` but the parent can
    * pass the currently-focused subject (a character or item name) so the
@@ -26,6 +28,7 @@ export function SidebarTabPanel({
   storiesPanel,
   codexPanel,
   presencePanel,
+  statusPanel,
   roomTabLabel,
 }: SidebarTabPanelProps) {
   const [activeTab, setActiveTab] = useState('room');
@@ -45,7 +48,7 @@ export function SidebarTabPanel({
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} className="flex h-full flex-col">
-      <TabsList className="mx-2 mt-2 grid w-auto grid-cols-5">
+      <TabsList className="mx-2 mt-2 grid w-auto grid-cols-6">
         <TabsTrigger value="room" className="gap-1 text-xs" title={label}>
           <MapPin className="h-3 w-3 shrink-0" />
           <span className="inline-block max-w-[8rem] truncate">{label}</span>
@@ -65,6 +68,10 @@ export function SidebarTabPanel({
         <TabsTrigger value="codex" className="gap-1 text-xs">
           <BookOpen className="h-3 w-3" />
           Codex
+        </TabsTrigger>
+        <TabsTrigger value="status" className="gap-1 text-xs">
+          <Activity className="h-3 w-3" />
+          Status
         </TabsTrigger>
       </TabsList>
       <TabsContent value="room" className="mt-0 flex-1 overflow-y-auto">
@@ -90,6 +97,11 @@ export function SidebarTabPanel({
       <TabsContent value="codex" className="mt-0 flex-1 overflow-y-auto p-3">
         {activatedTabs.has('codex')
           ? (codexPanel ?? <p className="text-sm text-muted-foreground">Codex coming soon.</p>)
+          : null}
+      </TabsContent>
+      <TabsContent value="status" className="mt-0 flex-1 overflow-y-auto p-3">
+        {activatedTabs.has('status')
+          ? (statusPanel ?? <p className="text-sm text-muted-foreground">No status to show.</p>)
           : null}
       </TabsContent>
     </Tabs>

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -40780,7 +40780,8 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        id: string;
+        /** @description A unique integer value identifying this Consequence Pool. */
+        id: number;
       };
       cookie?: never;
     };

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -134,6 +134,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/action-points/{character_id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only AP pool for the status surfaces (#1446).
+     *
+     *     Visibility: staff, or an account with an active tenure on the character.
+     *     Everyone else receives 404 (the vitals-view rule). Pools lazy-create with
+     *     config defaults so a fresh character still reads cleanly. ``current`` is
+     *     the authoritative "AP remaining" — the weekly cron tops it up additively.
+     */
+    get: operations['action_points_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/action-requests/': {
     parameters: {
       query?: never;
@@ -4495,6 +4519,29 @@ export interface paths {
      *     mirrors RankingDisplayViewSet).
      */
     get: operations['currency_org_books_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/currency/purse/{character_id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only personal purse for the status surfaces (#1446).
+     *
+     *     Visibility: staff, or an account with an active tenure on the character.
+     *     Everyone else receives 404 (the vitals-view rule). Purse rows lazy-create
+     *     at zero so a coinless character still reads cleanly.
+     */
+    get: operations['currency_purse_retrieve'];
     put?: never;
     post?: never;
     delete?: never;
@@ -15686,6 +15733,12 @@ export interface components {
      * @enum {string}
      */
     ActionCategoryEnum: 'physical' | 'social' | 'mental';
+    /** @description The viewer's own AP pool — ``current`` is the spendable "remaining this week". */
+    ActionPointPool: {
+      current: number;
+      effective_maximum: number;
+      banked: number;
+    };
     /**
      * @description Serializer for ActionRef frozen dataclass — the round-trippable dispatch reference.
      *
@@ -16630,6 +16683,8 @@ export interface components {
       current?: number;
       /** @description Maximum anima capacity. */
       maximum?: number;
+      /** @description Qualitative anima word for status surfaces (#1446). */
+      readonly band: string;
       /**
        * Format: date-time
        * @description When anima was last recovered through ritual.
@@ -16929,6 +16984,14 @@ export interface components {
       expires_at?: string | null;
       /** Format: date-time */
       readonly created_at: string;
+    };
+    /** @description The viewer's own coin purse — a single coppers balance (the client formats g/s/c). */
+    CharacterPurse: {
+      /**
+       * Format: int64
+       * @description Coppers on hand.
+       */
+      balance?: number;
     };
     /** @description Full serializer for CharacterRelationship detail view. */
     CharacterRelationship: {
@@ -30179,6 +30242,27 @@ export interface operations {
       };
     };
   };
+  action_points_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        character_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ActionPointPool'];
+        };
+      };
+    };
+  };
   action_requests_list: {
     parameters: {
       query?: {
@@ -35871,6 +35955,27 @@ export interface operations {
       };
     };
   };
+  currency_purse_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        character_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CharacterPurse'];
+        };
+      };
+    };
+  };
   distinctions_categories_list: {
     parameters: {
       query?: never;
@@ -40675,8 +40780,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        /** @description A unique integer value identifying this Consequence Pool. */
-        id: number;
+        id: string;
       };
       cookie?: never;
     };

--- a/frontend/src/inventory/components/InventorySidebarPanel.tsx
+++ b/frontend/src/inventory/components/InventorySidebarPanel.tsx
@@ -1,0 +1,81 @@
+/**
+ * InventorySidebarPanel — compact carried-items list on the game rail's
+ * Inventory tab (#1446).
+ *
+ * Read-only: "the sheet describes; the scene does" — equip/use actions
+ * belong to scene objects and the Wardrobe page, not this panel. It only
+ * lists what's carried, marks what's currently worn, and links out to
+ * /wardrobe for full management.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { Badge } from '@/components/ui/badge';
+import { useActionResult } from '@/hooks/actionResultBus';
+import type { ActionResultPayload } from '@/hooks/types';
+import { ItemCard } from './ItemCard';
+import { inventoryKeys, useEquippedItems, useInventory } from '../hooks/useInventory';
+
+interface InventorySidebarPanelProps {
+  characterId: number;
+}
+
+export function InventorySidebarPanel({ characterId }: InventorySidebarPanelProps) {
+  const { data: inventory = [] } = useInventory(characterId);
+  const { data: equipped = [] } = useEquippedItems(characterId);
+  const queryClient = useQueryClient();
+
+  // Equip/unequip and other item-affecting actions travel through the
+  // websocket dispatcher (see WardrobePage). Invalidate the same query keys
+  // on a successful result so this panel stays in sync with scene actions.
+  const handleActionResult = useCallback(
+    (payload: ActionResultPayload) => {
+      if (!payload.success) return;
+      queryClient
+        .invalidateQueries({ queryKey: inventoryKeys.inventory(characterId) })
+        .catch(() => {});
+      queryClient
+        .invalidateQueries({ queryKey: inventoryKeys.equipped(characterId) })
+        .catch(() => {});
+    },
+    [characterId, queryClient]
+  );
+  useActionResult(handleActionResult);
+
+  const equippedItemIds = useMemo(
+    () => new Set(equipped.map((row) => row.item_instance)),
+    [equipped]
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold">Inventory</h2>
+        <Link to="/wardrobe" className="text-xs text-primary hover:underline">
+          Manage in wardrobe
+        </Link>
+      </div>
+      {inventory.length === 0 ? (
+        <p className="text-sm italic text-muted-foreground">You aren&apos;t carrying anything.</p>
+      ) : (
+        <ul className="space-y-2">
+          {inventory.map((item) => (
+            <li key={item.id} className="relative">
+              <ItemCard item={item} />
+              {equippedItemIds.has(item.id) && (
+                <Badge
+                  variant="outline"
+                  className="absolute right-2 top-2 text-[10px]"
+                  data-testid={`worn-badge-${item.id}`}
+                >
+                  Worn
+                </Badge>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/inventory/components/__tests__/InventorySidebarPanel.test.tsx
+++ b/frontend/src/inventory/components/__tests__/InventorySidebarPanel.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * InventorySidebarPanel tests (#1446).
+ *
+ * Read-only carried-items list on the game rail's Inventory tab: renders
+ * both carried item names, marks the equipped one, and links out to
+ * /wardrobe for management.
+ */
+
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { InventorySidebarPanel } from '../InventorySidebarPanel';
+import type { ItemInstance, EquippedItem } from '../../types';
+
+vi.mock('../../hooks/useInventory', () => ({
+  useInventory: vi.fn(),
+  useEquippedItems: vi.fn(),
+  inventoryKeys: {
+    inventory: (characterId: number) => ['inventory', characterId] as const,
+    equipped: (characterId: number) => ['equipped', characterId] as const,
+  },
+}));
+
+import { useInventory, useEquippedItems } from '../../hooks/useInventory';
+
+const mockInventory = vi.mocked(useInventory);
+const mockEquipped = vi.mocked(useEquippedItems);
+
+function makeItem(overrides: Partial<ItemInstance> = {}): ItemInstance {
+  return {
+    id: 1,
+    template: {
+      id: 10,
+      name: 'Linen Tunic',
+      weight: '1.20',
+      size: 2,
+      value: 25,
+      is_container: false,
+      is_stackable: false,
+      is_consumable: false,
+      is_craftable: true,
+      image_url: '',
+    },
+    quality_tier: {
+      id: 3,
+      name: 'Fine',
+      color_hex: '#4ade80',
+      numeric_min: 50,
+      numeric_max: 75,
+      stat_multiplier: '1.10',
+      sort_order: 3,
+    },
+    display_name: 'Linen Tunic',
+    display_description: 'A simple linen tunic, well-tailored.',
+    display_image_url: null,
+    contained_in: 1,
+    quantity: 1,
+    charges: 0,
+    is_open: false,
+    is_usable: false,
+    ...overrides,
+  };
+}
+
+function setQueries({
+  inventory,
+  equipped = [],
+}: {
+  inventory: ItemInstance[];
+  equipped?: EquippedItem[];
+}) {
+  mockInventory.mockReturnValue({
+    data: inventory,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useInventory>);
+  mockEquipped.mockReturnValue({
+    data: equipped,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useEquippedItems>);
+}
+
+describe('InventorySidebarPanel', () => {
+  beforeEach(() => {
+    mockInventory.mockReset();
+    mockEquipped.mockReset();
+  });
+
+  it('renders both carried item names, marks the equipped one, and links to /wardrobe', () => {
+    const tunic = makeItem({ id: 1, display_name: 'Linen Tunic' });
+    const dagger = makeItem({ id: 2, display_name: 'Rusty Dagger' });
+    setQueries({
+      inventory: [tunic, dagger],
+      equipped: [
+        {
+          id: 1,
+          item_instance: 1,
+          body_region: 'torso',
+          equipment_layer: 'outer',
+        } as EquippedItem,
+      ],
+    });
+
+    renderWithProviders(<InventorySidebarPanel characterId={7} />);
+
+    expect(screen.getByText('Linen Tunic')).toBeInTheDocument();
+    expect(screen.getByText('Rusty Dagger')).toBeInTheDocument();
+    expect(screen.getByTestId('worn-badge-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('worn-badge-2')).not.toBeInTheDocument();
+
+    const link = screen.getByRole('link', { name: /wardrobe/i });
+    expect(link).toHaveAttribute('href', '/wardrobe');
+  });
+
+  it('shows a muted empty state when nothing is carried', () => {
+    setQueries({ inventory: [] });
+    renderWithProviders(<InventorySidebarPanel characterId={7} />);
+    expect(screen.getByText(/aren.t carrying anything/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/magic/api.ts
+++ b/frontend/src/magic/api.ts
@@ -989,6 +989,8 @@ export interface CharacterAnimaRecord {
   character: number;
   current: number;
   maximum: number;
+  /** Qualitative anima word for status surfaces (#1446), e.g. "steady". */
+  band: string;
   last_recovery: string | null;
 }
 

--- a/frontend/src/status/api.ts
+++ b/frontend/src/status/api.ts
@@ -1,0 +1,37 @@
+/**
+ * Status API client (#1446) — the qualitative status panel's own currency reads.
+ *
+ * Both endpoints follow the vitals-view visibility rule: staff, or an account with
+ * an active tenure on the character, else 404. `fetchCharacterPurse` and
+ * `fetchActionPoints` mirror `fetchCharacterVitals`'s null-on-404 behavior (see
+ * `frontend/src/vitals/vitalsQueries.ts`) so the panel can simply render nothing
+ * for a character the viewer doesn't own.
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+import type { components } from '@/generated/api';
+
+export type CharacterPurse = components['schemas']['CharacterPurse'];
+export type ActionPointPool = components['schemas']['ActionPointPool'];
+
+/**
+ * Fetch the viewer's coin purse for a character (ObjectDB pk).
+ * Returns null on 401/403/404 — viewers without permission simply see no purse line.
+ */
+export async function fetchCharacterPurse(characterId: number): Promise<CharacterPurse | null> {
+  const res = await apiFetch(`/api/currency/purse/${characterId}/`);
+  if (res.status === 401 || res.status === 403 || res.status === 404) return null;
+  if (!res.ok) throw new Error(`Failed to load purse for character ${characterId}`);
+  return res.json();
+}
+
+/**
+ * Fetch the viewer's AP pool for a character (ObjectDB pk).
+ * Returns null on 401/403/404 — viewers without permission simply see no AP line.
+ */
+export async function fetchActionPoints(characterId: number): Promise<ActionPointPool | null> {
+  const res = await apiFetch(`/api/action-points/${characterId}/`);
+  if (res.status === 401 || res.status === 403 || res.status === 404) return null;
+  if (!res.ok) throw new Error(`Failed to load action points for character ${characterId}`);
+  return res.json();
+}

--- a/frontend/src/status/components/StatusPanel.test.tsx
+++ b/frontend/src/status/components/StatusPanel.test.tsx
@@ -1,0 +1,158 @@
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { StatusPanel } from './StatusPanel';
+import type { CharacterVitalsData } from '@/vitals/vitalsQueries';
+
+vi.mock('@/vitals/vitalsQueries', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/vitals/vitalsQueries')>()),
+  useCharacterVitalsQuery: vi.fn(),
+}));
+vi.mock('@/magic/queries', () => ({
+  useCharacterAnima: vi.fn(),
+  useCharacterResonances: vi.fn(),
+}));
+vi.mock('../queries', () => ({
+  useCharacterPurse: vi.fn(),
+  useActionPoints: vi.fn(),
+}));
+
+import { useCharacterVitalsQuery } from '@/vitals/vitalsQueries';
+import { useCharacterAnima, useCharacterResonances } from '@/magic/queries';
+import { useActionPoints, useCharacterPurse } from '../queries';
+
+const mockVitals = vi.mocked(useCharacterVitalsQuery);
+const mockAnima = vi.mocked(useCharacterAnima);
+const mockResonances = vi.mocked(useCharacterResonances);
+const mockPurse = vi.mocked(useCharacterPurse);
+const mockActionPoints = vi.mocked(useActionPoints);
+
+const VITALS: CharacterVitalsData = {
+  health: 40,
+  max_health: 100,
+  health_percentage: 0.4,
+  wound_description: 'Badly wounded',
+  status: 'alive',
+  fatigue: {
+    physical: { current: 2, capacity: 10, percentage: 20, zone: 'strained' },
+    social: { current: 0, capacity: 8, percentage: 0, zone: 'fresh' },
+    mental: { current: 0, capacity: 8, percentage: 0, zone: 'tired' },
+    well_rested: false,
+    rested_today: false,
+  },
+};
+
+function setQueries({
+  vitals = VITALS,
+  isLoading = false,
+  anima = { id: 1, character: 7, current: 30, maximum: 50, last_recovery: null, band: 'steady' },
+  resonances = [],
+  purse = { balance: 347 },
+  actionPoints = { current: 3, effective_maximum: 5, banked: 0 },
+}: {
+  vitals?: CharacterVitalsData | null;
+  isLoading?: boolean;
+  anima?: unknown;
+  resonances?: unknown[];
+  purse?: unknown;
+  actionPoints?: unknown;
+} = {}) {
+  mockVitals.mockReturnValue({
+    data: vitals,
+    isLoading,
+  } as unknown as ReturnType<typeof useCharacterVitalsQuery>);
+  mockAnima.mockReturnValue({
+    data: anima,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useCharacterAnima>);
+  mockResonances.mockReturnValue({
+    data: resonances,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useCharacterResonances>);
+  mockPurse.mockReturnValue({
+    data: purse,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useCharacterPurse>);
+  mockActionPoints.mockReturnValue({
+    data: actionPoints,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useActionPoints>);
+}
+
+describe('StatusPanel', () => {
+  beforeEach(() => {
+    mockVitals.mockReset();
+    mockAnima.mockReset();
+    mockResonances.mockReset();
+    mockPurse.mockReset();
+    mockActionPoints.mockReset();
+  });
+
+  it('renders wound description as words, never a numeric health fraction', () => {
+    setQueries();
+    renderWithProviders(<StatusPanel characterId={7} />);
+    expect(screen.getByText('Badly wounded')).toBeInTheDocument();
+    expect(screen.queryByText(/\d+\s*\/\s*\d+/)).not.toBeInTheDocument();
+  });
+
+  it('renders fatigue zone words per pool', () => {
+    setQueries();
+    renderWithProviders(<StatusPanel characterId={7} />);
+    expect(screen.getByText(/Physical:\s*strained/i)).toBeInTheDocument();
+    expect(screen.getByText(/Social:\s*fresh/i)).toBeInTheDocument();
+    expect(screen.getByText(/Mental:\s*tired/i)).toBeInTheDocument();
+  });
+
+  it('renders the anima band word', () => {
+    setQueries();
+    renderWithProviders(<StatusPanel characterId={7} />);
+    expect(screen.getByText('steady')).toBeInTheDocument();
+  });
+
+  it('renders resonance names, muted, and an empty-state line when none', () => {
+    setQueries({ resonances: [] });
+    renderWithProviders(<StatusPanel characterId={7} />);
+    expect(screen.getByText('No resonances yet.')).toBeInTheDocument();
+  });
+
+  it('renders resonance names when present', () => {
+    setQueries({
+      resonances: [
+        { id: 1, character_sheet: 7, resonance: 1, resonance_name: 'Grief', claimed_at: '' },
+      ],
+    });
+    renderWithProviders(<StatusPanel characterId={7} />);
+    expect(screen.getByText('Grief')).toBeInTheDocument();
+  });
+
+  it('renders the coin line via formatCoppers', () => {
+    setQueries({ purse: { balance: 347 } });
+    renderWithProviders(<StatusPanel characterId={7} />);
+    expect(screen.getByText('3g 4s 7c')).toBeInTheDocument();
+  });
+
+  it('renders the AP line as "N of M this week"', () => {
+    setQueries({ actionPoints: { current: 3, effective_maximum: 5, banked: 0 } });
+    renderWithProviders(<StatusPanel characterId={7} />);
+    expect(screen.getByText(/3 of 5 this week/)).toBeInTheDocument();
+  });
+
+  it('shows banked AP when nonzero', () => {
+    setQueries({ actionPoints: { current: 3, effective_maximum: 5, banked: 2 } });
+    renderWithProviders(<StatusPanel characterId={7} />);
+    expect(screen.getByText(/\(\+2 banked\)/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when the viewer lacks permission (null vitals)', () => {
+    setQueries({ vitals: null });
+    const { container } = renderWithProviders(<StatusPanel characterId={7} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a loading skeleton while the vitals query is in flight', () => {
+    setQueries({ vitals: null, isLoading: true });
+    renderWithProviders(<StatusPanel characterId={7} />);
+    expect(screen.getByTestId('status-panel-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('status-panel')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/status/components/StatusPanel.tsx
+++ b/frontend/src/status/components/StatusPanel.tsx
@@ -83,7 +83,9 @@ export function StatusPanel({ characterId }: { characterId: number }) {
       </CardHeader>
       <CardContent className="space-y-4">
         <section aria-label="Condition" className="space-y-1">
-          <p className="text-sm text-muted-foreground">{vitals.wound_description || 'Unhurt.'}</p>
+          <p className="text-sm text-muted-foreground">
+            {vitals.wound_description || 'A healthy appearance.'}
+          </p>
         </section>
 
         <section aria-label="Fatigue" className="space-y-2">

--- a/frontend/src/status/components/StatusPanel.tsx
+++ b/frontend/src/status/components/StatusPanel.tsx
@@ -66,10 +66,7 @@ export function StatusPanel({ characterId }: { characterId: number }) {
 
   if (!vitals) return null;
 
-  // `band` is generated on CharacterAnima (#1446) but the hand-rolled
-  // CharacterAnimaRecord interface in magic/api.ts predates it — extend
-  // locally rather than editing a file outside this task's scope.
-  const animaBand = (anima as { band?: string } | undefined)?.band;
+  const animaBand = anima?.band;
 
   return (
     <Card data-testid="status-panel">

--- a/frontend/src/status/components/StatusPanel.tsx
+++ b/frontend/src/status/components/StatusPanel.tsx
@@ -1,0 +1,152 @@
+/**
+ * StatusPanel — qualitative status card stack on the game rail's Status tab (#1446).
+ *
+ * DESIGN RULING: "The sheet describes; the scene does" — this panel is read-only
+ * status; no spend/use buttons. Health, stamina (fatigue), and anima render as
+ * WORDS only (wound description, fatigue zone names, anima band) — never the
+ * numeric StatBar used on the character sheet. Coins and Action Points are
+ * currencies, so numbers are fine for those two lines.
+ *
+ * Mirrors VitalsPanel's null-on-403/404 behavior: when the vitals query yields
+ * null (viewer doesn't own this character), the whole panel renders nothing.
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+import { formatCoppers } from '@/lib/currency';
+import { useCharacterAnima, useCharacterResonances } from '@/magic/queries';
+import { useCharacterVitalsQuery } from '@/vitals/vitalsQueries';
+import type { CharacterStatus } from '@/vitals/vitalsQueries';
+import { useActionPoints, useCharacterPurse } from '../queries';
+
+const STATUS_BADGE_CLASSES: Record<CharacterStatus, string> = {
+  alive: 'bg-green-100 text-green-800 border-green-300',
+  dying: 'bg-red-100 text-red-800 border-red-300',
+  incapacitated: 'bg-amber-100 text-amber-800 border-amber-300',
+  dead: 'bg-slate-200 text-slate-700 border-slate-400',
+};
+
+const ZONE_BADGE_CLASSES: Record<string, string> = {
+  fresh: 'bg-green-100 text-green-800 border-green-300',
+  strained: 'bg-yellow-100 text-yellow-800 border-yellow-300',
+  tired: 'bg-orange-100 text-orange-800 border-orange-300',
+  overexerted: 'bg-red-100 text-red-800 border-red-300',
+  exhausted: 'bg-red-200 text-red-900 border-red-400',
+};
+
+const FATIGUE_POOL_LABELS = {
+  physical: 'Physical',
+  social: 'Social',
+  mental: 'Mental',
+} as const;
+
+export function StatusPanel({ characterId }: { characterId: number }) {
+  const { data: vitals, isLoading } = useCharacterVitalsQuery(characterId);
+  const { data: anima } = useCharacterAnima(characterId);
+  const { data: resonances = [] } = useCharacterResonances(characterId);
+  const { data: purse } = useCharacterPurse(characterId);
+  const { data: actionPoints } = useActionPoints(characterId);
+
+  if (isLoading) {
+    return (
+      <Card data-testid="status-panel-loading">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Status</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!vitals) return null;
+
+  // `band` is generated on CharacterAnima (#1446) but the hand-rolled
+  // CharacterAnimaRecord interface in magic/api.ts predates it — extend
+  // locally rather than editing a file outside this task's scope.
+  const animaBand = (anima as { band?: string } | undefined)?.band;
+
+  return (
+    <Card data-testid="status-panel">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">Status</CardTitle>
+          <Badge
+            variant="outline"
+            className={cn('capitalize', STATUS_BADGE_CLASSES[vitals.status])}
+          >
+            {vitals.status}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <section aria-label="Condition" className="space-y-1">
+          <p className="text-sm text-muted-foreground">{vitals.wound_description || 'Unhurt.'}</p>
+        </section>
+
+        <section aria-label="Fatigue" className="space-y-2">
+          <p className="text-sm font-medium">Fatigue</p>
+          <div className="flex flex-wrap gap-2">
+            {(['physical', 'social', 'mental'] as const).map((pool) => (
+              <Badge
+                key={pool}
+                variant="outline"
+                className={cn('text-xs capitalize', ZONE_BADGE_CLASSES[vitals.fatigue[pool].zone])}
+              >
+                {FATIGUE_POOL_LABELS[pool]}: {vitals.fatigue[pool].zone}
+              </Badge>
+            ))}
+          </div>
+        </section>
+
+        {animaBand && (
+          <section aria-label="Anima" className="space-y-1">
+            <p className="text-sm font-medium">Anima</p>
+            <Badge variant="outline" className="text-xs capitalize">
+              {animaBand}
+            </Badge>
+          </section>
+        )}
+
+        <section aria-label="Resonances" className="space-y-1">
+          <p className="text-sm font-medium">Resonances</p>
+          {resonances.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No resonances yet.</p>
+          ) : (
+            <ul className="space-y-0.5 text-sm text-muted-foreground">
+              {resonances.map((resonance) => (
+                <li key={resonance.id}>{resonance.resonance_name}</li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section aria-label="Purse" className="space-y-1">
+          <p className="text-sm font-medium">Coin</p>
+          <p className="text-sm text-muted-foreground">
+            {purse ? formatCoppers(purse.balance ?? 0) : 'Unknown.'}
+          </p>
+        </section>
+
+        <section aria-label="Action Points" className="space-y-1">
+          <p className="text-sm font-medium">Action Points</p>
+          <p className="text-sm text-muted-foreground">
+            {actionPoints ? (
+              <>
+                {actionPoints.current} of {actionPoints.effective_maximum} this week
+                {actionPoints.banked > 0 && ` (+${actionPoints.banked} banked)`}
+              </>
+            ) : (
+              'Unknown.'
+            )}
+          </p>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/status/queries.ts
+++ b/frontend/src/status/queries.ts
@@ -1,0 +1,28 @@
+/**
+ * Status React Query hooks (#1446).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchActionPoints, fetchCharacterPurse } from './api';
+import type { ActionPointPool, CharacterPurse } from './api';
+
+/** The viewer's coin purse for a character. Disabled when characterId <= 0. */
+export function useCharacterPurse(characterId: number) {
+  return useQuery<CharacterPurse | null>({
+    queryKey: ['status', 'purse', characterId],
+    queryFn: () => fetchCharacterPurse(characterId),
+    enabled: characterId > 0,
+    staleTime: 10_000,
+  });
+}
+
+/** The viewer's AP pool for a character. Disabled when characterId <= 0. */
+export function useActionPoints(characterId: number) {
+  return useQuery<ActionPointPool | null>({
+    queryKey: ['status', 'action-points', characterId],
+    queryFn: () => fetchActionPoints(characterId),
+    enabled: characterId > 0,
+    staleTime: 10_000,
+  });
+}

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -526,11 +526,17 @@ actions, backends, and service functions.
   `_build_distinctions` builder, mirroring the web Distinctions tab); `magic` (`sheet/magic`,
   #1446 — gifts/techniques/motif/aura over the shared `_build_magic` builder, mirroring the web
   Magic tab; describe-only — casting/weaving/rituals stay in-scene, per "the sheet describes; the
-  scene does" in `design-tenets.md`). Each is thin over its app's data. Add a section: a renderer
+  scene does" in `design-tenets.md`); `status` (`sheet/status`, #1446 — condition, fatigue, and
+  anima as qualitative words (wound band, fatigue zones, `anima_band_for`), plus coin
+  (`format_coppers`) and weekly AP (current/effective-maximum/banked); self-only, read-only,
+  mirroring the web Status tab). Each is thin over its app's data. Add a section: a renderer
   + a registry entry (+ `SECTION_NAMES`). Standing and covenant now also have web homes: standing
   lives in the consolidated **Reputation** tab (society + org standing + covenant associations);
   covenant core identity surfaces in the sheet header, with full detail in the Reputation tab's
-  covenant subsection (#1446).
+  covenant subsection (#1446). Status and Inventory now also have web homes: the game-rail
+  **Status** and **Inventory** tabs (`frontend/src/status/`,
+  `frontend/src/inventory/components/InventorySidebarPanel.tsx` — the latter reuses
+  `useInventory`/`useEquippedItems`/`ItemCard` with Worn badges + a `/wardrobe` link).
 
 ### Social Commands (`social/`)
 - **`blocking.py`**: `CmdBlock`/`CmdUnblock`/`CmdShareBlock`/`CmdMute`/`CmdUnmute`/`CmdBlockList`

--- a/src/commands/account/sheet_sections.py
+++ b/src/commands/account/sheet_sections.py
@@ -397,6 +397,51 @@ def _render_magic_section(command: Command) -> list[str]:
     return lines
 
 
+def _render_status_section(command: Command) -> list[str]:
+    """The status section (#1446): condition, purse, and AP for the active character.
+
+    Mirrors the web Status panel — health/stamina/anima render as WORDS (wound bands,
+    fatigue zones, anima band) over the same vocabularies; coin and AP are currencies
+    and show numbers. Self-only, read-only.
+    """
+    from world.action_points.models import ActionPointPool  # noqa: PLC0415
+    from world.currency.constants import format_coppers  # noqa: PLC0415
+    from world.currency.services import get_or_create_purse  # noqa: PLC0415
+    from world.fatigue.services import get_full_status  # noqa: PLC0415
+    from world.magic.constants import anima_band_for  # noqa: PLC0415
+    from world.vitals.services import derive_character_status  # noqa: PLC0415
+
+    viewer = _viewer_sheet(command)
+    character = viewer.character
+
+    lines = [f"|wStatus — {character.key}:|n"]
+
+    vitals = getattr(viewer, "vitals", None)  # noqa: GETATTR_LITERAL
+    wound = vitals.wound_description if vitals else "a healthy appearance"
+    lines.append(f"  Condition: {derive_character_status(viewer)} — {wound}")
+
+    fatigue_pool = getattr(viewer, "fatigue", None)  # noqa: GETATTR_LITERAL
+    fatigue = get_full_status(viewer, pool=fatigue_pool)
+    zones = ", ".join(
+        f"{category}: {data['zone']}"
+        for category, data in fatigue.items()
+        if isinstance(data, dict)
+    )
+    lines.append(f"  Fatigue: {zones}")
+
+    anima = getattr(character, "anima", None)  # noqa: GETATTR_LITERAL
+    if anima is not None:
+        lines.append(f"  Anima: {anima_band_for(anima.current, anima.maximum)}")
+
+    purse = get_or_create_purse(viewer)
+    lines.append(f"  Coin: {format_coppers(purse.balance)}")
+
+    pool = ActionPointPool.get_or_create_for_character(character)
+    banked = f" (+{pool.banked} banked)" if pool.banked else ""
+    lines.append(f"  AP: {pool.current} of {pool.get_effective_maximum()} this week{banked}")
+    return lines
+
+
 # Switch name → renderer. Add a section by writing a renderer and registering it here (and in
 # SECTION_NAMES for the overview footer). Aliases (secret/secrets) map to the same renderer.
 SHEET_SECTIONS: dict[str, Callable[..., list[str]]] = {
@@ -415,6 +460,7 @@ SHEET_SECTIONS: dict[str, Callable[..., list[str]]] = {
     "distinction": _render_distinction_section,
     "distinctions": _render_distinction_section,
     "magic": _render_magic_section,
+    "status": _render_status_section,
 }
 
 # Canonical section names shown in the bare-``sheet`` footer (deduped; one per real section).
@@ -428,4 +474,5 @@ SECTION_NAMES: tuple[str, ...] = (
     "crime",
     "distinction",
     "magic",
+    "status",
 )

--- a/src/schema.json
+++ b/src/schema.json
@@ -12458,7 +12458,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this Consequence Pool.
         required: true
       tags:
       - magic

--- a/src/schema.json
+++ b/src/schema.json
@@ -159,6 +159,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/CharacterTitle'
           description: ''
+  /api/action-points/{character_id}/:
+    get:
+      operationId: action_points_retrieve
+      description: |-
+        Read-only AP pool for the status surfaces (#1446).
+
+        Visibility: staff, or an account with an active tenure on the character.
+        Everyone else receives 404 (the vitals-view rule). Pools lazy-create with
+        config defaults so a fresh character still reads cleanly. ``current`` is
+        the authoritative "AP remaining" — the weekly cron tops it up additively.
+      parameters:
+      - in: path
+        name: character_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - action-points
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionPointPool'
+          description: ''
   /api/action-requests/:
     get:
       operationId: action_requests_list
@@ -6749,6 +6776,32 @@ paths:
           description: Not a member of the organization.
         '404':
           description: No such organization.
+  /api/currency/purse/{character_id}/:
+    get:
+      operationId: currency_purse_retrieve
+      description: |-
+        Read-only personal purse for the status surfaces (#1446).
+
+        Visibility: staff, or an account with an active tenure on the character.
+        Everyone else receives 404 (the vitals-view rule). Purse rows lazy-create
+        at zero so a coinless character still reads cleanly.
+      parameters:
+      - in: path
+        name: character_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - currency
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterPurse'
+          description: ''
   /api/distinctions/categories/:
     get:
       operationId: distinctions_categories_list
@@ -12405,8 +12458,7 @@ paths:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this Consequence Pool.
+          type: string
         required: true
       tags:
       - magic
@@ -26597,6 +26649,21 @@ components:
         * `physical` - Physical
         * `social` - Social
         * `mental` - Mental
+    ActionPointPool:
+      type: object
+      description: The viewer's own AP pool — ``current`` is the spendable "remaining
+        this week".
+      properties:
+        current:
+          type: integer
+        effective_maximum:
+          type: integer
+        banked:
+          type: integer
+      required:
+      - banked
+      - current
+      - effective_maximum
     ActionRef:
       type: object
       description: |-
@@ -28640,6 +28707,10 @@ components:
           maximum: 2147483647
           minimum: 0
           description: Maximum anima capacity.
+        band:
+          type: string
+          description: Qualitative anima word for status surfaces (#1446).
+          readOnly: true
         last_recovery:
           type: string
           format: date-time
@@ -28647,6 +28718,7 @@ components:
           nullable: true
           description: When anima was last recovered through ritual.
       required:
+      - band
       - character
       - id
       - last_recovery
@@ -29292,6 +29364,17 @@ components:
       - modifier_target_name
       - source
       - value
+    CharacterPurse:
+      type: object
+      description: The viewer's own coin purse — a single coppers balance (the client
+        formats g/s/c).
+      properties:
+        balance:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          description: Coppers on hand.
     CharacterRelationship:
       type: object
       description: Full serializer for CharacterRelationship detail view.

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path("api/clues/", include("world.clues.urls")),
     path("api/fatigue/", include("world.fatigue.urls")),
     path("api/vitals/", include("world.vitals.urls")),
+    path("api/action-points/", include("world.action_points.urls")),
     path("api/areas/", include("world.areas.urls")),
     path("api/player-submissions/", include("world.player_submissions.urls")),
     path("api/staff-inbox/", include("world.staff_inbox.urls")),

--- a/src/world/action_points/serializers.py
+++ b/src/world/action_points/serializers.py
@@ -1,0 +1,13 @@
+"""DRF serializers for the action-points read API (#1446)."""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class ActionPointPoolSerializer(serializers.Serializer):
+    """The viewer's own AP pool — ``current`` is the spendable "remaining this week"."""
+
+    current = serializers.IntegerField()
+    effective_maximum = serializers.IntegerField()
+    banked = serializers.IntegerField()

--- a/src/world/action_points/tests/test_api.py
+++ b/src/world/action_points/tests/test_api.py
@@ -1,0 +1,69 @@
+"""Tests for the self-scoped action-points read endpoint (#1446 bundle 2)."""
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from evennia_extensions.models import PlayerData
+from world.action_points.factories import ActionPointPoolFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import (
+    RosterEntryFactory,
+    RosterFactory,
+    RosterTenureFactory,
+)
+
+AP_URL = "/api/action-points/{pk}/"
+
+
+def _played_character(*, account):
+    """Create a character (with sheet + active tenure held by ``account``)."""
+    character = CharacterFactory()
+    sheet = CharacterSheetFactory(character=character)
+    RosterEntryFactory(character_sheet=sheet, roster=RosterFactory())
+    player_data, _ = PlayerData.objects.get_or_create(account=account)
+    RosterTenureFactory(player_data=player_data, roster_entry=sheet.roster_entry)
+    return character
+
+
+class ActionPointsApiTests(TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.account = AccountFactory()
+        self.client.force_authenticate(user=self.account)
+        self.character = _played_character(account=self.account)
+
+    def test_owner_reads_pool(self) -> None:
+        pool = ActionPointPoolFactory(character=self.character, current=140, banked=25)
+
+        response = self.client.get(AP_URL.format(pk=self.character.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["current"], 140)
+        self.assertEqual(response.data["banked"], 25)
+        self.assertEqual(response.data["effective_maximum"], pool.get_effective_maximum())
+
+    def test_poolless_character_reads_defaults(self) -> None:
+        response = self.client.get(AP_URL.format(pk=self.character.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(response.data["current"], 0)
+        self.assertGreaterEqual(response.data["effective_maximum"], 1)
+
+    def test_stranger_is_404(self) -> None:
+        stranger_character = _played_character(account=AccountFactory())
+
+        response = self.client.get(AP_URL.format(pk=stranger_character.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_anonymous_is_denied(self) -> None:
+        self.client.force_authenticate(user=None)
+
+        response = self.client.get(AP_URL.format(pk=self.character.pk))
+
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )

--- a/src/world/action_points/tests/test_api.py
+++ b/src/world/action_points/tests/test_api.py
@@ -58,6 +58,19 @@ class ActionPointsApiTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_staff_get_on_non_character_pk_is_404_and_creates_no_pool(self) -> None:
+        from evennia_extensions.factories import ObjectDBFactory
+        from world.action_points.models import ActionPointPool
+
+        staff = AccountFactory(is_staff=True)
+        self.client.force_authenticate(user=staff)
+        vase = ObjectDBFactory(db_key="a vase of flowers")
+
+        response = self.client.get(AP_URL.format(pk=vase.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertFalse(ActionPointPool.objects.filter(character=vase).exists())
+
     def test_anonymous_is_denied(self) -> None:
         self.client.force_authenticate(user=None)
 

--- a/src/world/action_points/urls.py
+++ b/src/world/action_points/urls.py
@@ -1,0 +1,10 @@
+"""Action-points URL configuration (#1446)."""
+
+from django.urls import path
+
+from world.action_points.views import ActionPointPoolView
+
+app_name = "action_points"
+urlpatterns = [
+    path("<int:character_id>/", ActionPointPoolView.as_view(), name="character-action-points"),
+]

--- a/src/world/action_points/views.py
+++ b/src/world/action_points/views.py
@@ -1,0 +1,52 @@
+"""Action-points read API (#1446)."""
+
+from __future__ import annotations
+
+from drf_spectacular.utils import extend_schema
+from evennia.objects.models import ObjectDB
+from rest_framework.exceptions import NotFound
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from world.action_points.models import ActionPointPool
+from world.action_points.serializers import ActionPointPoolSerializer
+from world.roster.models import RosterEntry
+
+
+class ActionPointPoolView(APIView):
+    """Read-only AP pool for the status surfaces (#1446).
+
+    Visibility: staff, or an account with an active tenure on the character.
+    Everyone else receives 404 (the vitals-view rule). Pools lazy-create with
+    config defaults so a fresh character still reads cleanly. ``current`` is
+    the authoritative "AP remaining" — the weekly cron tops it up additively.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def _can_view(self, request: Request, character_id: int) -> bool:
+        if request.user.is_staff:
+            return True
+        return (
+            RosterEntry.objects.for_account(request.user)
+            .filter(character_sheet_id=character_id)
+            .exists()
+        )
+
+    @extend_schema(responses=ActionPointPoolSerializer)
+    def get(self, request: Request, character_id: int) -> Response:
+        if not self._can_view(request, character_id):
+            raise NotFound
+        try:
+            character = ObjectDB.objects.get(pk=character_id)  # noqa: OBJECTDB_PARAM
+        except ObjectDB.DoesNotExist:
+            raise NotFound from None
+        pool = ActionPointPool.get_or_create_for_character(character)
+        payload = {
+            "current": pool.current,
+            "effective_maximum": pool.get_effective_maximum(),
+            "banked": pool.banked,
+        }
+        return Response(ActionPointPoolSerializer(payload).data)

--- a/src/world/action_points/views.py
+++ b/src/world/action_points/views.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from drf_spectacular.utils import extend_schema
-from evennia.objects.models import ObjectDB
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -12,6 +11,7 @@ from rest_framework.views import APIView
 
 from world.action_points.models import ActionPointPool
 from world.action_points.serializers import ActionPointPoolSerializer
+from world.character_sheets.models import CharacterSheet
 from world.roster.models import RosterEntry
 
 
@@ -40,10 +40,12 @@ class ActionPointPoolView(APIView):
         if not self._can_view(request, character_id):
             raise NotFound
         try:
-            character = ObjectDB.objects.get(pk=character_id)  # noqa: OBJECTDB_PARAM
-        except ObjectDB.DoesNotExist:
+            sheet = CharacterSheet.objects.get(pk=character_id)
+        except CharacterSheet.DoesNotExist:
+            # Guards the staff path: a bare ObjectDB pk (a vase, a room) must never
+            # lazy-create a junk ActionPointPool row.
             raise NotFound from None
-        pool = ActionPointPool.get_or_create_for_character(character)
+        pool = ActionPointPool.get_or_create_for_character(sheet.character)
         payload = {
             "current": pool.current,
             "effective_maximum": pool.get_effective_maximum(),

--- a/src/world/character_sheets/tests/test_sheet_status_section.py
+++ b/src/world/character_sheets/tests/test_sheet_status_section.py
@@ -1,0 +1,58 @@
+"""Tests for the telnet ``sheet/status`` section (#1446 bundle 2).
+
+Telnet parity for the web Status panel — health/stamina/anima render as words
+(never raw numbers), plus coin and AP-remaining lines over the same services.
+"""
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.account.sheet_sections import SHEET_SECTIONS
+from world.character_sheets.factories import CharacterFactory, CharacterSheetFactory
+from world.currency.services import get_or_create_purse
+from world.vitals.factories import CharacterVitalsFactory
+
+
+def _command_for(character) -> MagicMock:
+    command = MagicMock()
+    command.caller.puppet = character
+    command.args = ""
+    return command
+
+
+class SheetStatusSectionTests(TestCase):
+    def setUp(self) -> None:
+        self.character = CharacterFactory()
+        self.sheet = CharacterSheetFactory(character=self.character)
+
+    def test_registered(self) -> None:
+        self.assertIn("status", SHEET_SECTIONS)
+
+    def test_wounded_character_renders_words_not_numbers(self) -> None:
+        CharacterVitalsFactory(character_sheet=self.sheet, health=50, max_health=100)
+
+        lines = SHEET_SECTIONS["status"](_command_for(self.character))
+        text = "\n".join(lines)
+
+        self.assertIn("wounded", text)  # WOUND_DESCRIPTIONS band word
+        self.assertNotIn("50", text.replace("50c", ""))  # no raw health numbers
+        self.assertNotIn("100", text)
+
+    def test_renders_coin_and_ap_lines(self) -> None:
+        purse = get_or_create_purse(self.sheet)
+        purse.balance = 1234
+        purse.save(update_fields=["balance"])
+
+        lines = SHEET_SECTIONS["status"](_command_for(self.character))
+        text = "\n".join(lines)
+
+        self.assertIn("12g 3s 4c", text)
+        self.assertIn("AP", text)
+
+    def test_default_character_renders_sane_defaults(self) -> None:
+        lines = SHEET_SECTIONS["status"](_command_for(self.character))
+        text = "\n".join(lines)
+
+        self.assertTrue(len(lines) >= 3)
+        self.assertIn("0c", text)  # empty purse

--- a/src/world/currency/serializers.py
+++ b/src/world/currency/serializers.py
@@ -1,0 +1,15 @@
+"""DRF serializers for the currency player API (#1446)."""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from world.currency.models import CharacterPurse
+
+
+class CharacterPurseSerializer(serializers.ModelSerializer):
+    """The viewer's own coin purse — a single coppers balance (the client formats g/s/c)."""
+
+    class Meta:
+        model = CharacterPurse
+        fields = ["balance"]

--- a/src/world/currency/tests/test_purse_api.py
+++ b/src/world/currency/tests/test_purse_api.py
@@ -1,0 +1,68 @@
+"""Tests for the self-scoped personal purse read endpoint (#1446 bundle 2)."""
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from evennia_extensions.models import PlayerData
+from world.character_sheets.factories import CharacterSheetFactory
+from world.currency.services import get_or_create_purse
+from world.roster.factories import (
+    RosterEntryFactory,
+    RosterFactory,
+    RosterTenureFactory,
+)
+
+PURSE_URL = "/api/currency/purse/{pk}/"
+
+
+def _played_sheet(*, account):
+    """Create a character sheet with an active tenure held by ``account``."""
+    character = CharacterFactory()
+    sheet = CharacterSheetFactory(character=character)
+    RosterEntryFactory(character_sheet=sheet, roster=RosterFactory())
+    player_data, _ = PlayerData.objects.get_or_create(account=account)
+    RosterTenureFactory(player_data=player_data, roster_entry=sheet.roster_entry)
+    return sheet
+
+
+class PurseApiTests(TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.account = AccountFactory()
+        self.client.force_authenticate(user=self.account)
+        self.sheet = _played_sheet(account=self.account)
+
+    def test_owner_reads_balance(self) -> None:
+        purse = get_or_create_purse(self.sheet)
+        purse.balance = 1347
+        purse.save(update_fields=["balance"])
+
+        response = self.client.get(PURSE_URL.format(pk=self.sheet.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["balance"], 1347)
+
+    def test_purseless_character_reads_zero(self) -> None:
+        response = self.client.get(PURSE_URL.format(pk=self.sheet.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["balance"], 0)
+
+    def test_stranger_is_404(self) -> None:
+        stranger_sheet = _played_sheet(account=AccountFactory())
+
+        response = self.client.get(PURSE_URL.format(pk=stranger_sheet.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_anonymous_is_denied(self) -> None:
+        self.client.force_authenticate(user=None)
+
+        response = self.client.get(PURSE_URL.format(pk=self.sheet.pk))
+
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )

--- a/src/world/currency/urls.py
+++ b/src/world/currency/urls.py
@@ -1,9 +1,9 @@
-"""URLs for the currency player API (#930 prep — org books)."""
+"""URLs for the currency player API (#930 prep — org books; #1446 personal purse)."""
 
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from world.currency.views import OrgBooksViewSet
+from world.currency.views import CharacterPurseView, OrgBooksViewSet
 
 app_name = "currency"
 
@@ -11,5 +11,6 @@ router = DefaultRouter()
 router.register(r"org-books", OrgBooksViewSet, basename="org-books")
 
 urlpatterns = [
+    path("purse/<int:character_id>/", CharacterPurseView.as_view(), name="character-purse"),
     path("", include(router.urls)),
 ]

--- a/src/world/currency/views.py
+++ b/src/world/currency/views.py
@@ -16,7 +16,9 @@ from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
+from world.character_sheets.models import CharacterSheet
 from world.currency.models import (
     ContributionRecord,
     CurrencyTransfer,
@@ -24,7 +26,13 @@ from world.currency.models import (
     OrgIncomeStream,
     OrgObligation,
 )
-from world.currency.services import get_or_create_economics, get_or_create_treasury
+from world.currency.serializers import CharacterPurseSerializer
+from world.currency.services import (
+    get_or_create_economics,
+    get_or_create_purse,
+    get_or_create_treasury,
+)
+from world.roster.models import RosterEntry
 
 _MSG_NO_ORG = "No such organization."
 _MSG_NOT_MEMBER = "You are not a member of that organization."
@@ -309,3 +317,34 @@ def _books_payload(organization) -> dict:
         ],
         "ledger": ledger,
     }
+
+
+class CharacterPurseView(APIView):
+    """Read-only personal purse for the status surfaces (#1446).
+
+    Visibility: staff, or an account with an active tenure on the character.
+    Everyone else receives 404 (the vitals-view rule). Purse rows lazy-create
+    at zero so a coinless character still reads cleanly.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def _can_view(self, request: Request, character_id: int) -> bool:
+        if request.user.is_staff:
+            return True
+        return (
+            RosterEntry.objects.for_account(request.user)
+            .filter(character_sheet_id=character_id)
+            .exists()
+        )
+
+    @extend_schema(responses=CharacterPurseSerializer)
+    def get(self, request: Request, character_id: int) -> Response:
+        if not self._can_view(request, character_id):
+            raise NotFound
+        try:
+            sheet = CharacterSheet.objects.get(pk=character_id)
+        except CharacterSheet.DoesNotExist:
+            raise NotFound from None
+        purse = get_or_create_purse(sheet)
+        return Response(CharacterPurseSerializer(purse).data)

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -66,6 +66,10 @@ The magic system for Arx II. Power flows from identity and connection.
   `flavor_text`. Unified per Spec A §2.2 — the old `scope`/`strength`/`is_active`
   shape was dropped; row existence replaces `is_active`.
 - `CharacterAnima` - Magical resource (anima) tracking
+- `ANIMA_BANDS` / `anima_band_for(current, maximum)` (`constants.py`, #1446) - Qualitative
+  anima vocabulary (PLACEHOLDER labels pending Apostate rewrite) mirroring
+  `vitals.constants.WOUND_DESCRIPTIONS`; `CharacterAnimaSerializer.band` surfaces it, shared
+  by the web Status tab and the `sheet/status` telnet section
 
 ### Gifts & Techniques
 - `Gift` - Thematic collections of magical techniques (M2M to Resonance — the **supported set**: a weave constraint, not the cast-time value; the cast reads the character's GIFT-thread resonance via `gift_resonances_for`, ADR-0052). Carries a `kind` column (`GiftKind`: `MAJOR` = the one CG-chosen gift, `MINOR` = shared/acquirable — species abilities and in-play powers are delivered as Minor Gifts; ADR-0050, #1577)

--- a/src/world/magic/constants.py
+++ b/src/world/magic/constants.py
@@ -403,3 +403,28 @@ class TechniqueReach(models.TextChoices):
 class FuryCheckTrait(models.TextChoices):
     COMPOSURE = "composure", "Composure"
     WILLPOWER = "willpower", "Willpower"
+
+
+# PLACEHOLDER anima band labels (#1446 bundle 2) — Apostate rewrite pending.
+# Qualitative anima vocabulary for status surfaces (player-facing anima is narrative,
+# not numerical). Mirrors vitals.constants.WOUND_DESCRIPTIONS: (min_ratio, label),
+# descending, first match wins.
+ANIMA_BANDS: tuple[tuple[float, str], ...] = (
+    (0.95, "brimming"),
+    (0.75, "vibrant"),
+    (0.5, "steady"),
+    (0.3, "dimmed"),
+    (0.1, "guttering"),
+    (0.0, "spent"),
+)
+
+
+def anima_band_for(current: int, maximum: int) -> str:
+    """The qualitative band for an anima pool — the word status surfaces show."""
+    if maximum <= 0:
+        return ANIMA_BANDS[-1][1]
+    ratio = current / maximum
+    for threshold, label in ANIMA_BANDS:
+        if ratio >= threshold:
+            return label
+    return ANIMA_BANDS[-1][1]

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from world.magic.audere import AudereThreshold
 from world.conditions.models import CapabilityType, ConditionTemplate, DamageType
 from world.items.models import ItemInstance
-from world.magic.constants import ALTERATION_TIER_CAPS, TargetKind
+from world.magic.constants import ALTERATION_TIER_CAPS, TargetKind, anima_band_for
 from world.magic.models import (
     Cantrip,
     CharacterAnima,
@@ -454,6 +454,8 @@ class CharacterGiftSerializer(serializers.ModelSerializer):
 class CharacterAnimaSerializer(serializers.ModelSerializer):
     """Serializer for CharacterAnima records."""
 
+    band = serializers.SerializerMethodField()
+
     class Meta:
         model = CharacterAnima
         fields = [
@@ -461,9 +463,14 @@ class CharacterAnimaSerializer(serializers.ModelSerializer):
             "character",
             "current",
             "maximum",
+            "band",
             "last_recovery",
         ]
         read_only_fields = ["id", "last_recovery"]
+
+    def get_band(self, obj: CharacterAnima) -> str:
+        """Qualitative anima word for status surfaces (#1446)."""
+        return anima_band_for(obj.current, obj.maximum)
 
 
 # =============================================================================

--- a/src/world/magic/tests/test_anima_band.py
+++ b/src/world/magic/tests/test_anima_band.py
@@ -1,0 +1,37 @@
+"""Tests for the qualitative anima band vocabulary (#1446 bundle 2).
+
+Player-facing anima is narrative, not numerical (the magic app's key rule) — the band
+is the word the status surfaces show instead of current/maximum.
+"""
+
+from django.test import TestCase
+
+from world.magic.constants import ANIMA_BANDS, anima_band_for
+from world.magic.factories import CharacterAnimaFactory
+from world.magic.serializers import CharacterAnimaSerializer
+
+
+class AnimaBandForTests(TestCase):
+    def test_full_pool_is_top_band(self) -> None:
+        self.assertEqual(anima_band_for(100, 100), ANIMA_BANDS[0][1])
+
+    def test_half_pool_is_middle_band(self) -> None:
+        self.assertEqual(anima_band_for(50, 100), "steady")
+
+    def test_empty_pool_is_lowest_band(self) -> None:
+        self.assertEqual(anima_band_for(0, 100), ANIMA_BANDS[-1][1])
+
+    def test_zero_maximum_does_not_divide(self) -> None:
+        self.assertEqual(anima_band_for(0, 0), ANIMA_BANDS[-1][1])
+
+    def test_bands_descend_monotonically(self) -> None:
+        thresholds = [threshold for threshold, _ in ANIMA_BANDS]
+        self.assertEqual(thresholds, sorted(thresholds, reverse=True))
+        self.assertEqual(ANIMA_BANDS[-1][0], 0.0)
+
+
+class AnimaSerializerBandTests(TestCase):
+    def test_band_serialized(self) -> None:
+        anima = CharacterAnimaFactory(current=95, maximum=100)
+        data = CharacterAnimaSerializer(instance=anima).data
+        self.assertEqual(data["band"], ANIMA_BANDS[0][1])


### PR DESCRIPTION
Part of #1446 (the contextual-centers living map — stays open). Bundle 2 of the build plan: the personal economy/status centers ruled 2026-07-05.

## What shipped

**Backend (NO migrations — serializers/views/constants only):**
- `GET /api/currency/purse/{character_id}/` — self-scoped personal purse (coppers balance; vitals-view gating, lazy-creates at zero)
- `GET /api/action-points/{character_id}/` — self-scoped AP pool ({current, effective_maximum, banked}); `current` is the authoritative weekly-remaining figure (the weekly cron tops it up additively). New `world.action_points` API surface mounted at `api/action-points/`
- **Anima band vocabulary** — `ANIMA_BANDS` + `anima_band_for` mirroring the `WOUND_DESCRIPTIONS` threshold ladder; `band` on the anima serializer. **Labels are PLACEHOLDER pending Apostate's rewrite** (brimming/vibrant/steady/dimmed/guttering/spent)

**Game rail (SidebarTabPanel, now 7 tabs, both lazy-mounted):**
- **Status** tab — qualitative words only for health/stamina/anima (wound band, fatigue zones, anima band; tests assert no raw numbers render), plus coin (`formatCoppers`) and "N of M this week" AP. Read-only per the *sheet describes; the scene does* tenet
- **Inventory** tab — thin wrapper over the existing inventory module (useInventory/useEquippedItems/ItemCard), Worn badges, `/wardrobe` link-out, WS invalidation mirroring WardrobePage

**Telnet parity:** `sheet/status` — same vocabularies (shared `anima_band_for`/`wound_description`/fatigue zones), words for vitals, numbers for coin/AP.

**Docs in tandem:** INDEX + action_points + magic system docs, commands CLAUDE.md, magic CLAUDE.md.

## Review notes (final whole-branch review ran; fixes folded in)
- The AP view resolves through `CharacterSheet` so a staff GET on a non-character pk (a vase) can never lazy-create a junk pool row — regression-tested
- The consequence-pool path param was hand-aligned to CI's integer form again: local spectacular degrades it to string when the technique-cast seed row is absent (environment-dependent generator output; pre-existing, tracked in the drift-gate memory)
- Known minors accepted: inventory panel invalidates on every action result (cheap; scoping to item-affecting kinds is a tightening opportunity); purse/AP 404s undocumented in extend_schema (matches the vitals precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)