### PR TITLE
Battle round resolution: non-STRIKE per-declaration catalog queries (CapabilityType/ConditionTemplate/ConsequencePool/ConditionStage)

### DIFF
--- a/docs/systems/battles.md
+++ b/docs/systems/battles.md
@@ -407,7 +407,10 @@ BALANCED posture all contribute nothing:
 `ConsequencePool`/`ConditionStage` (the Surrounded entry roll,
 `_maybe_apply_surrounded`) also read through `cached_all()` (#1871), so none of
 the five per-declaration catalog lookups in `resolution.py` — STRIKE or
-non-STRIKE — re-query their table per declaration. `ConditionTemplate` is the one
+non-STRIKE — re-query their table per declaration. The Surrounded *terminal* pool
+lookup (`select_surrounded_terminal_pool`, reached once per terminal-stage
+Surrounded participant per round rather than per declaration) was folded into the
+same `cached_all()` pass in the same change. `ConditionTemplate` is the one
 exception worth calling out explicitly: it isn't missing from this list because
 it's uncached — it uses its own pre-existing `get_by_name()` cache
 (`world/conditions/models.py`) rather than `cached_all()`, and the rescue/

--- a/docs/systems/battles.md
+++ b/docs/systems/battles.md
@@ -402,6 +402,19 @@ BALANCED posture all contribute nothing:
 | Commander bonus | `commander_bonus_for_side_at_place(side, place)` | Max (not sum) `get_modifier_total` walk against the `"battle_command"` `ModifierTarget` (`ensure_battle_command_modifier_target`, seeded by `factories.py`) across every ACTIVE unit's `commander` on that side/place, read from `battle.state_cache` (#1846); 0 if none commanded |
 | Posture | `BATTLE_POSTURE_CHECK_MODIFIER.get(participant.side.posture)` | `constants.py` dict — AGGRESSIVE −5, BALANCED 0, DEFENSIVE +10 |
 
+`cached_all()` coverage extends beyond the two catalogs above: `CapabilityType`
+(mobility/reposition, `_has_unimpaired_mobility`/`_resolve_reposition_success`) and
+`ConsequencePool`/`ConditionStage` (the Surrounded entry roll,
+`_maybe_apply_surrounded`) also read through `cached_all()` (#1871), so none of
+the five per-declaration catalog lookups in `resolution.py` — STRIKE or
+non-STRIKE — re-query their table per declaration. `ConditionTemplate` is the one
+exception worth calling out explicitly: it isn't missing from this list because
+it's uncached — it uses its own pre-existing `get_by_name()` cache
+(`world/conditions/models.py`) rather than `cached_all()`, and the rescue/
+escalation/Surrounded-entry paths (`_resolve_rescue_success`,
+`_advance_surrounded_participants`, `_maybe_apply_surrounded`) all call it that
+way.
+
 The first three sources only apply to STRIKE declarations (they read `declaration.target_unit`,
 which is `None` for SUPPORT/RESCUE); commander and posture apply to every declaration kind.
 Posture also independently scales VP gain (`BATTLE_POSTURE_VP_MULTIPLIER`, applied in

--- a/src/actions/models/consequence_pools.py
+++ b/src/actions/models/consequence_pools.py
@@ -8,13 +8,18 @@ from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from actions.types import WeightedConsequence, _entry_to_weighted
+from core.managers import CachedAllMixin
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
+
+
+class ConsequencePoolManager(CachedAllMixin, NaturalKeyManager):
+    """Manager for ConsequencePool with natural key support, plus cached_all() (#1871)."""
 
 
 class ConsequencePool(NaturalKeyMixin, SharedMemoryModel):
     """Named, reusable collection of consequences with single-depth inheritance."""
 
-    objects = NaturalKeyManager()
+    objects = ConsequencePoolManager()
 
     class NaturalKeyConfig:
         fields = ["name"]

--- a/src/actions/tests/test_consequence_pools.py
+++ b/src/actions/tests/test_consequence_pools.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from actions.factories import ConsequencePoolEntryFactory, ConsequencePoolFactory
+from actions.models.consequence_pools import ConsequencePool
 from actions.services import get_effective_consequences
 from actions.types import WeightedConsequence
 from world.checks.factories import ConsequenceFactory
@@ -286,3 +287,23 @@ class CachedConsequencesTests(TestCase):
         result = child.cached_consequences
         relist_entry = next(wc for wc in result if wc.label == "CP_Relist")
         assert relist_entry.weight == 42
+
+
+class ConsequencePoolCachedAllTests(TestCase):
+    def setUp(self) -> None:
+        ConsequencePool.objects.flush_all_cache()
+        ConsequencePool.flush_instance_cache()
+
+    def test_second_call_hits_identity_map_zero_queries(self) -> None:
+        ConsequencePoolFactory()
+        ConsequencePool.objects.flush_all_cache()
+        ConsequencePool.flush_instance_cache()
+        ConsequencePool.objects.cached_all()  # prime
+        with self.assertNumQueries(0):
+            ConsequencePool.objects.cached_all()
+
+    def test_returns_every_row(self) -> None:
+        first = ConsequencePoolFactory()
+        second = ConsequencePoolFactory()
+        result = ConsequencePool.objects.cached_all()
+        self.assertCountEqual([r.pk for r in result], [first.pk, second.pk])

--- a/src/world/battles/resolution.py
+++ b/src/world/battles/resolution.py
@@ -276,7 +276,7 @@ def select_surrounded_terminal_pool(
     pool_name = (
         POOL_SURROUNDED_TERMINAL_PVP if opposing_pc_present else POOL_SURROUNDED_TERMINAL_ENEMY
     )
-    return ConsequencePool.objects.filter(name=pool_name).first()
+    return next((p for p in ConsequencePool.objects.cached_all() if p.name == pool_name), None)
 
 
 def resolve_surrounded_terminal(

--- a/src/world/battles/resolution.py
+++ b/src/world/battles/resolution.py
@@ -878,8 +878,9 @@ def _resolve_rescue_success(declaration: BattleActionDeclaration) -> None:
     if not targets:
         return
 
-    template = ConditionTemplate.objects.filter(name=SURROUNDED_CONDITION_NAME).first()
-    if template is None:
+    try:
+        template = ConditionTemplate.get_by_name(SURROUNDED_CONDITION_NAME)
+    except ConditionTemplate.DoesNotExist:
         return
 
     for target in targets:
@@ -1019,8 +1020,9 @@ def _advance_surrounded_participants(
     from world.conditions.services import get_active_conditions  # noqa: PLC0415
     from world.vitals.services import advance_surrounded  # noqa: PLC0415
 
-    template = ConditionTemplate.objects.filter(name=SURROUNDED_CONDITION_NAME).first()
-    if template is None:
+    try:
+        template = ConditionTemplate.get_by_name(SURROUNDED_CONDITION_NAME)
+    except ConditionTemplate.DoesNotExist:
         return  # seeding gap — nothing to advance
 
     participants = BattleParticipant.objects.filter(

--- a/src/world/battles/resolution.py
+++ b/src/world/battles/resolution.py
@@ -922,10 +922,23 @@ def _maybe_apply_surrounded(declaration: BattleActionDeclaration) -> bool:
     if not _is_isolated(participant):
         return False
 
-    pool = ConsequencePool.objects.filter(name=POOL_SURROUNDED_ENTRY).first()
-    template = ConditionTemplate.objects.filter(name=SURROUNDED_CONDITION_NAME).first()
+    pool = next(
+        (p for p in ConsequencePool.objects.cached_all() if p.name == POOL_SURROUNDED_ENTRY),
+        None,
+    )
+    try:
+        template = ConditionTemplate.get_by_name(SURROUNDED_CONDITION_NAME)
+    except ConditionTemplate.DoesNotExist:
+        template = None
     entry_stage = (
-        ConditionStage.objects.filter(condition=template, stage_order=1).first()
+        next(
+            (
+                s
+                for s in ConditionStage.objects.cached_all()
+                if s.condition_id == template.pk and s.stage_order == 1
+            ),
+            None,
+        )
         if template is not None
         else None
     )

--- a/src/world/battles/resolution.py
+++ b/src/world/battles/resolution.py
@@ -100,7 +100,14 @@ def _has_unimpaired_mobility(character_sheet: CharacterSheet) -> bool:
     from world.conditions.models import CapabilityType  # noqa: PLC0415
     from world.conditions.services import get_effective_capability_value  # noqa: PLC0415
 
-    movement = CapabilityType.objects.filter(name=FoundationalCapability.MOVEMENT).first()
+    movement = next(
+        (
+            c
+            for c in CapabilityType.objects.cached_all()
+            if c.name == FoundationalCapability.MOVEMENT
+        ),
+        None,
+    )
     if movement is None:
         return False
     return get_effective_capability_value(character_sheet, movement) > 0
@@ -722,7 +729,14 @@ def _resolve_reposition_success(
     if requested_distance == 0:
         return
 
-    speed_capability = CapabilityType.objects.filter(name="speed").first()
+    speed_capability = next(
+        (
+            c
+            for c in CapabilityType.objects.cached_all()
+            if c.name == "speed"  # noqa: STRING_LITERAL
+        ),
+        None,
+    )
     max_distance = Decimal(
         vehicle.unit.effective_capability(speed_capability) if speed_capability else 0
     )

--- a/src/world/battles/tests/test_query_scaling.py
+++ b/src/world/battles/tests/test_query_scaling.py
@@ -11,6 +11,7 @@ marginal cost drop. A regression in any of these would raise the marginal
 above the budget.
 """
 
+from decimal import Decimal
 from unittest.mock import patch
 
 from django.db import connection
@@ -18,18 +19,22 @@ from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 
 from actions.factories import ActionTemplateFactory
-from world.battles.models import BattleActionKind, BattleSideRole
+from world.battles.constants import BattleActionScope, VehicleKind
+from world.battles.factories import BattlePlaceFactory
+from world.battles.models import BattleActionKind, BattleSideRole, BattleUnitCapability
 from world.battles.resolution import resolve_battle_round
 from world.battles.services import (
     add_side,
     add_unit,
     begin_battle_round,
     create_battle,
+    create_battle_vehicle,
     declare_battle_action,
     enlist_participant,
 )
-from world.battles.tests.test_resolution import _success_result
+from world.battles.tests.test_resolution import _failure_result, _success_result
 from world.character_sheets.factories import CharacterSheetFactory
+from world.conditions.factories import CapabilityTypeFactory, ConditionInstanceFactory
 from world.magic.factories import (
     CharacterAnimaFactory,
     CharacterTechniqueFactory,
@@ -37,7 +42,7 @@ from world.magic.factories import (
     TechniqueFactory,
 )
 from world.magic.models.soulfray import SoulfrayConfig
-from world.vitals.factories import CharacterVitalsFactory
+from world.vitals.factories import CharacterVitalsFactory, ensure_surrounded_content
 
 
 class ResolveBattleRoundQueryScalingTests(TestCase):
@@ -126,4 +131,156 @@ class ResolveBattleRoundQueryScalingTests(TestCase):
             f"{per_declaration_budget}. Q(2)={q_small}, Q(5)={q_large}. "
             "A new per-declaration query may have been introduced in the "
             "use_technique path or the battles modifier stack (#1846).",
+        )
+
+    def _build_mixed_round(self, num_reps: int):
+        """Build a round with a fixed REPOSITION + RESCUE declaration, plus
+        `num_reps` repetitions of a (failing/isolated STRIKE, ROUT, RALLY)
+        triple -- covering every non-STRIKE catalog-lookup path #1871 fixes.
+
+        Returns (battle_round, failing_characters) -- the caller mocks
+        perform_check to fail only for `failing_characters`.
+        """
+        surrounded_content = ensure_surrounded_content()
+        battle = create_battle(name=f"Mixed Scaling Battle N={num_reps}")
+        attacker_side = add_side(battle=battle, role=BattleSideRole.ATTACKER)
+        defender_side = add_side(battle=battle, role=BattleSideRole.DEFENDER)
+
+        technique = TechniqueFactory(action_template=ActionTemplateFactory(), damage_profile=False)
+        enemy_unit = add_unit(battle=battle, side=defender_side, name="Target Unit", strength=1000)
+        own_unit = add_unit(battle=battle, side=attacker_side, name="Own Unit", strength=1000)
+
+        vehicle = create_battle_vehicle(
+            battle=battle,
+            side=attacker_side,
+            place_name="Vehicle",
+            vehicle_kind=VehicleKind.SHIP,
+        )
+        speed = CapabilityTypeFactory(name="speed")
+        BattleUnitCapability.objects.create(unit=vehicle.unit, capability=speed, value=5)
+
+        def _new_participant():
+            sheet = CharacterSheetFactory()
+            CharacterVitalsFactory(character_sheet=sheet, health=100, max_health=100)
+            CharacterTechniqueFactory(character=sheet, technique=technique)
+            CharacterAnimaFactory(character=sheet.character, current=50, maximum=50)
+            participant = enlist_participant(
+                battle=battle, character_sheet=sheet, side=attacker_side
+            )
+            return sheet, participant
+
+        commander_sheet, commander = _new_participant()
+        vehicle.unit.commander = commander_sheet
+        vehicle.unit.save(update_fields=["commander"])
+
+        victim_sheet, victim = _new_participant()
+        ConditionInstanceFactory(
+            target=victim_sheet.character,
+            condition=surrounded_content["condition"],
+            current_stage=surrounded_content["stages"][0],
+        )
+        _rescuer_sheet, rescuer = _new_participant()
+
+        battle_round = begin_battle_round(battle=battle)
+
+        declare_battle_action(
+            participant=commander,
+            action_kind=BattleActionKind.REPOSITION,
+            technique=technique,
+            scope=BattleActionScope.PLACE,
+            target_place=vehicle.place,
+            reposition_dx=Decimal(1),
+            reposition_dy=Decimal(0),
+        )
+        declare_battle_action(
+            participant=rescuer,
+            action_kind=BattleActionKind.RESCUE,
+            technique=technique,
+            target_ally=victim,
+        )
+
+        failing_characters = set()
+        for _ in range(num_reps):
+            strike_place = BattlePlaceFactory(battle=battle)
+            strike_sheet = CharacterSheetFactory()
+            CharacterVitalsFactory(character_sheet=strike_sheet, health=100, max_health=100)
+            CharacterTechniqueFactory(character=strike_sheet, technique=technique)
+            CharacterAnimaFactory(character=strike_sheet.character, current=50, maximum=50)
+            striker = enlist_participant(
+                battle=battle,
+                character_sheet=strike_sheet,
+                side=attacker_side,
+                place=strike_place,
+            )
+            declare_battle_action(
+                participant=striker,
+                action_kind=BattleActionKind.STRIKE,
+                technique=technique,
+                target_unit=enemy_unit,
+            )
+            failing_characters.add(strike_sheet.character)
+
+            _, router = _new_participant()
+            declare_battle_action(
+                participant=router,
+                action_kind=BattleActionKind.ROUT,
+                technique=technique,
+                target_unit=enemy_unit,
+            )
+
+            _, rallier = _new_participant()
+            declare_battle_action(
+                participant=rallier,
+                action_kind=BattleActionKind.RALLY,
+                technique=technique,
+                target_unit=own_unit,
+            )
+
+        return battle_round, failing_characters
+
+    def _count_queries_for_mixed_round(self, battle_round, failing_characters) -> int:
+        """Resolve a mixed round and return the number of SQL queries executed.
+
+        `failing_characters` get a failure result (to exercise the isolated-
+        failure -> _maybe_apply_surrounded path); everyone else succeeds.
+        """
+
+        def _side_effect(character, *_args, **_kwargs):
+            return _failure_result() if character in failing_characters else _success_result(3)
+
+        with patch("world.battles.resolution.perform_check") as mock_check:
+            mock_check.side_effect = _side_effect
+            with CaptureQueriesContext(connection) as ctx:
+                resolve_battle_round(battle_round=battle_round)
+        return len(ctx)
+
+    def test_mixed_round_marginal_per_declaration_cost_stays_bounded(self) -> None:
+        """Marginal query cost per added (STRIKE-fail/ROUT/RALLY) triple stays
+        bounded for a round that also includes REPOSITION and RESCUE (#1871).
+
+        Measures Q(1) and Q(4) reps (a fixed REPOSITION+RESCUE pair present in
+        both) and asserts (Q(4) - Q(1)) / (3 declarations/rep * 3 extra reps)
+        stays below a budget -- proving the non-STRIKE catalog lookups this
+        issue fixes (CapabilityType, ConditionTemplate, ConsequencePool,
+        ConditionStage) don't reintroduce per-declaration query growth.
+        """
+        round_small, failing_small = self._build_mixed_round(num_reps=1)
+        round_large, failing_large = self._build_mixed_round(num_reps=4)
+
+        q_small = self._count_queries_for_mixed_round(round_small, failing_small)
+        q_large = self._count_queries_for_mixed_round(round_large, failing_large)
+
+        marginal = (q_large - q_small) / (3 * (4 - 1))
+        # baseline (#1871): Q(1)=193, Q(4)=454, marginal=29.0
+        # Budget set just above this observed marginal -- a regression here means
+        # a new per-declaration query was reintroduced into one of the non-STRIKE
+        # resolution paths (#1871).
+        per_declaration_budget = 35
+        self.assertLess(
+            marginal,
+            per_declaration_budget,
+            f"Marginal per-declaration query cost {marginal:.1f} exceeds budget "
+            f"{per_declaration_budget}. Q(1)={q_small}, Q(4)={q_large}. "
+            "A new per-declaration query may have been introduced in one of "
+            "the non-STRIKE resolution paths (#1871).",
         )

--- a/src/world/conditions/models.py
+++ b/src/world/conditions/models.py
@@ -18,6 +18,7 @@ from django.db.models import Q
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.managers import CachedAllMixin
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.conditions.constants import (
     ConditionInteractionOutcome,
@@ -107,6 +108,10 @@ class ConditionCategory(NaturalKeyMixin, SharedMemoryModel):
         return list(self.conditions.all())
 
 
+class CapabilityTypeManager(CachedAllMixin, NaturalKeyManager):
+    """Manager for CapabilityType with natural key support, plus cached_all() (#1871)."""
+
+
 class CapabilityType(NaturalKeyMixin, SharedMemoryModel):
     """
     Capabilities that can be restricted or enhanced by conditions.
@@ -134,7 +139,7 @@ class CapabilityType(NaturalKeyMixin, SharedMemoryModel):
         help_text="Capability-level prerequisite checked for ALL sources of this Capability.",
     )
 
-    objects = NaturalKeyManager()
+    objects = CapabilityTypeManager()
 
     class NaturalKeyConfig:
         fields = ["name"]
@@ -480,6 +485,10 @@ class ConditionTemplate(NaturalKeyMixin, SharedMemoryModel):
         return ConditionTemplateReactiveHandler(self)
 
 
+class ConditionStageManager(CachedAllMixin, NaturalKeyManager):
+    """Manager for ConditionStage with natural key support, plus cached_all() (#1871)."""
+
+
 class ConditionStage(NaturalKeyMixin, SharedMemoryModel):
     """
     A stage in a progressive condition.
@@ -574,7 +583,7 @@ class ConditionStage(NaturalKeyMixin, SharedMemoryModel):
         blank=True,
     )
 
-    objects = NaturalKeyManager()
+    objects = ConditionStageManager()
 
     class NaturalKeyConfig:
         fields = ["condition", "stage_order"]

--- a/src/world/conditions/tests/test_catalog_managers.py
+++ b/src/world/conditions/tests/test_catalog_managers.py
@@ -1,0 +1,46 @@
+"""Tests for the CachedAllMixin managers added to CapabilityType/ConditionStage (#1871)."""
+
+from django.test import TestCase
+
+from world.conditions.factories import CapabilityTypeFactory, ConditionStageFactory
+from world.conditions.models import CapabilityType, ConditionStage
+
+
+class CapabilityTypeCachedAllTests(TestCase):
+    def setUp(self) -> None:
+        CapabilityType.objects.flush_all_cache()
+        CapabilityType.flush_instance_cache()
+
+    def test_second_call_hits_identity_map_zero_queries(self) -> None:
+        CapabilityTypeFactory(name="movement")
+        CapabilityType.objects.flush_all_cache()
+        CapabilityType.flush_instance_cache()
+        CapabilityType.objects.cached_all()  # prime
+        with self.assertNumQueries(0):
+            CapabilityType.objects.cached_all()
+
+    def test_returns_every_row(self) -> None:
+        first = CapabilityTypeFactory(name="movement")
+        second = CapabilityTypeFactory(name="speed")
+        result = CapabilityType.objects.cached_all()
+        self.assertCountEqual([r.pk for r in result], [first.pk, second.pk])
+
+
+class ConditionStageCachedAllTests(TestCase):
+    def setUp(self) -> None:
+        ConditionStage.objects.flush_all_cache()
+        ConditionStage.flush_instance_cache()
+
+    def test_second_call_hits_identity_map_zero_queries(self) -> None:
+        ConditionStageFactory()
+        ConditionStage.objects.flush_all_cache()
+        ConditionStage.flush_instance_cache()
+        ConditionStage.objects.cached_all()  # prime
+        with self.assertNumQueries(0):
+            ConditionStage.objects.cached_all()
+
+    def test_returns_every_row(self) -> None:
+        first = ConditionStageFactory()
+        second = ConditionStageFactory()
+        result = ConditionStage.objects.cached_all()
+        self.assertCountEqual([r.pk for r in result], [first.pk, second.pk])


### PR DESCRIPTION
Closes #1871

## Summary

Extends #1846's cached_all() catalog-cache pattern to the three remaining non-STRIKE catalog models that still re-queried on every declaration (CapabilityType, ConsequencePool, ConditionStage via three new manager subclasses mirroring ModifierTargetManager/IntensityTierManager), and reuses ConditionTemplate's existing get_by_name() name-PK cache for its three call sites instead of building a redundant second cache (an anti-reinvention correction made during planning, after the spec's original draft proposed a fourth new manager). Rewires all 5 originally-scoped catalog lookups in world/battles/resolution.py (_has_unimpaired_mobility, _resolve_reposition_success, _resolve_rescue_success, _advance_surrounded_participants, _maybe_apply_surrounded), plus one more caught by whole-branch review (select_surrounded_terminal_pool, same ConsequencePool model, folded in per this repo's Fold-In-Dont-File rule). Adds a new mixed-round query-scaling test (STRIKE-fail-isolated + ROUT + RALLY + REPOSITION + RESCUE in one round) proving the marginal per-declaration query cost stays bounded (measured 29.0, budget 35) for non-STRIKE rounds, alongside the existing untouched STRIKE-only test (24.0/30). No behavior change anywhere -- every rewritten lookup preserves its exact degrade-gracefully-when-unseeded fallback. No migrations (manager-only changes, verified via makemigrations --check --dry-run).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1871 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto latest main (branch was local-only, not yet pushed) -- no conflicts, main had moved forward with several unrelated merges.

<!-- last-addressed-comment: 0 -->