### PR TITLE
Wire renovation + style room-builder verbs into React

### DIFF
--- a/frontend/src/buildings/api.ts
+++ b/frontend/src/buildings/api.ts
@@ -3,10 +3,12 @@ import { apiFetch } from '@/evennia_replacements/api';
 import type {
   BuildingManagerPayload,
   ForRoomResult,
-  RoomComfortBreakdown,
+  PaginatedArchitecturalStyleList,
+  PaginatedBuildingKindList,
   PaginatedDecorationTemplateList,
   PaginatedRoomSizeTierList,
   RoomBuilderActionKey,
+  RoomComfortBreakdown,
 } from './types';
 
 async function getJson<T>(url: string, fallbackError: string): Promise<T> {
@@ -64,6 +66,23 @@ export function fetchDecorationTemplates(
   return getJson(
     `/api/buildings/decoration-templates/${params}`,
     'Failed to load the decoration catalog.'
+  );
+}
+
+export function fetchBuildingKinds(search?: string): Promise<PaginatedBuildingKindList> {
+  const params = search ? `?search=${encodeURIComponent(search)}` : '';
+  return getJson(`/api/buildings/building-kinds/${params}`, 'Failed to load building kinds.');
+}
+
+export function fetchArchitecturalStyles(
+  characterId: number,
+  search?: string
+): Promise<PaginatedArchitecturalStyleList> {
+  const params = new URLSearchParams({ character_id: String(characterId) });
+  if (search) params.set('search', search);
+  return getJson(
+    `/api/buildings/architectural-styles/?${params.toString()}`,
+    'Failed to load architectural styles.'
   );
 }
 

--- a/frontend/src/buildings/components/BuildingBuilderDialog.tsx
+++ b/frontend/src/buildings/components/BuildingBuilderDialog.tsx
@@ -11,7 +11,9 @@ import { BuilderCanvas } from './BuilderCanvas';
 import { DecorationDialog } from './DecorationDialog';
 import { DigDialog } from './DigDialog';
 import { ExtensionDialog } from './ExtensionDialog';
+import { RenovationDialog } from './RenovationDialog';
 import { RoomDetailPanel } from './RoomDetailPanel';
+import { StyleDialog } from './StyleDialog';
 
 interface BuildingBuilderDialogProps {
   buildingId: number;
@@ -46,6 +48,8 @@ export function BuildingBuilderDialog({
   const [decorateRoom, setDecorateRoom] = useState(false);
   const [decorateOpen, setDecorateOpen] = useState(false);
   const [extendOpen, setExtendOpen] = useState(false);
+  const [renovateOpen, setRenovateOpen] = useState(false);
+  const [styleOpen, setStyleOpen] = useState(false);
   const action = useRoomBuilderAction(characterId, buildingId);
 
   const payload = manager.data;
@@ -103,6 +107,22 @@ export function BuildingBuilderDialog({
               disabled={entryRoomId == null}
             >
               Extend Building
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setRenovateOpen(true)}
+              disabled={entryRoomId == null}
+            >
+              Renovate
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setStyleOpen(true)}
+              disabled={entryRoomId == null}
+            >
+              Style
             </Button>
             {payload && <BudgetMeter building={payload.building} />}
           </div>
@@ -185,6 +205,22 @@ export function BuildingBuilderDialog({
               currentBudget={payload.building.space_budget}
               open={extendOpen}
               onOpenChange={setExtendOpen}
+              runAction={runAction}
+            />
+            <RenovationDialog
+              anchorRoomId={entryRoomId}
+              currentKind={payload.building.kind}
+              renovationCost={payload.building.renovation_cost ?? null}
+              open={renovateOpen}
+              onOpenChange={setRenovateOpen}
+              runAction={runAction}
+            />
+            <StyleDialog
+              anchorRoomId={entryRoomId}
+              characterId={characterId}
+              currentStyle={payload.building.style ?? null}
+              open={styleOpen}
+              onOpenChange={setStyleOpen}
               runAction={runAction}
             />
           </>

--- a/frontend/src/buildings/components/RenovationDialog.test.tsx
+++ b/frontend/src/buildings/components/RenovationDialog.test.tsx
@@ -1,0 +1,96 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import type { BuildingKind } from '../types';
+import { RenovationDialog } from './RenovationDialog';
+
+vi.mock('../queries', () => ({
+  useBuildingKindsQuery: vi.fn(),
+}));
+
+const { useBuildingKindsQuery } = await import('../queries');
+
+const kinds: BuildingKind[] = [
+  {
+    id: 1,
+    name: 'House',
+    description: 'A residential dwelling.',
+    is_residential: true,
+    is_commercial: false,
+    is_fortified: false,
+    is_occult: false,
+    is_maritime: false,
+    is_agrarian: false,
+    is_aerial: false,
+    is_subterranean: false,
+    is_secret: false,
+  },
+  {
+    id: 2,
+    name: 'Fortress',
+    description: 'A fortified hold.',
+    is_residential: false,
+    is_commercial: false,
+    is_fortified: true,
+    is_occult: false,
+    is_maritime: false,
+    is_agrarian: false,
+    is_aerial: false,
+    is_subterranean: true,
+    is_secret: false,
+  },
+];
+
+function renderDialog(overrides: Partial<Parameters<typeof RenovationDialog>[0]> = {}) {
+  const runAction = vi.fn();
+  const onOpenChange = vi.fn();
+  vi.mocked(useBuildingKindsQuery).mockReturnValue({
+    data: { results: kinds, count: kinds.length },
+    isLoading: false,
+  } as never);
+  renderWithProviders(
+    <RenovationDialog
+      anchorRoomId={7}
+      currentKind="House"
+      renovationCost={15000}
+      open
+      onOpenChange={onOpenChange}
+      runAction={runAction}
+      {...overrides}
+    />
+  );
+  return { runAction, onOpenChange };
+}
+
+describe('RenovationDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the cost from the manager payload', () => {
+    renderDialog();
+    expect(screen.getByText(/Cost:.*15000.*coppers/)).toBeInTheDocument();
+  });
+
+  it('excludes the current kind from the list', () => {
+    renderDialog();
+    // The dialog's Renovate button for "House" should NOT be present (current kind).
+    // Only "Fortress" remains.
+    expect(screen.getByText('Fortress')).toBeInTheDocument();
+    expect(screen.queryByText('House')).not.toBeInTheDocument();
+  });
+
+  it('dispatches start_building_renovation with the anchor room_id and target_kind', async () => {
+    const { runAction, onOpenChange } = renderDialog();
+
+    await userEvent.click(screen.getByText('Renovate'));
+
+    expect(runAction).toHaveBeenCalledWith('start_building_renovation', {
+      room_id: 7,
+      target_kind: 'Fortress',
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/src/buildings/components/RenovationDialog.tsx
+++ b/frontend/src/buildings/components/RenovationDialog.tsx
@@ -1,0 +1,91 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+
+import { useBuildingKindsQuery } from '../queries';
+import type { BuildingKind, RoomBuilderActionKey } from '../types';
+
+interface RenovationDialogProps {
+  /** The entry room of the building (dispatch anchor). */
+  anchorRoomId: number;
+  /** The building's current kind name — excluded from the renovation list. */
+  currentKind: string;
+  /** The server-provided renovation cost in coppers (from the manager payload). */
+  renovationCost: number | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  runAction: (key: RoomBuilderActionKey, kwargs: Record<string, unknown>) => void;
+}
+
+const KIND_FLAGS: { field: keyof BuildingKind; label: string }[] = [
+  { field: 'is_residential', label: 'Residential' },
+  { field: 'is_commercial', label: 'Commercial' },
+  { field: 'is_fortified', label: 'Fortified' },
+  { field: 'is_occult', label: 'Occult' },
+  { field: 'is_maritime', label: 'Maritime' },
+  { field: 'is_agrarian', label: 'Agrarian' },
+  { field: 'is_aerial', label: 'Aerial' },
+  { field: 'is_subterranean', label: 'Subterranean' },
+  { field: 'is_secret', label: 'Secret' },
+];
+
+/**
+ * Pick a new BuildingKind to renovate the building into. Mirrors
+ * DecorationDialog (catalog picker → runAction). The current kind is excluded
+ * client-side (the manager payload carries it).
+ */
+export function RenovationDialog({
+  anchorRoomId,
+  currentKind,
+  renovationCost,
+  open,
+  onOpenChange,
+  runAction,
+}: RenovationDialogProps) {
+  const kinds = useBuildingKindsQuery('', open);
+  const available = (kinds.data?.results ?? []).filter((kind) => kind.name !== currentKind);
+
+  const renovate = (kindName: string) => {
+    runAction('start_building_renovation', { room_id: anchorRoomId, target_kind: kindName });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Renovate the building</DialogTitle>
+        </DialogHeader>
+        {renovationCost != null && (
+          <p className="text-sm text-muted-foreground">Cost: {renovationCost} coppers</p>
+        )}
+        <div className="flex max-h-96 flex-col gap-2 overflow-y-auto">
+          {kinds.isLoading && <p className="text-sm text-muted-foreground">Loading catalog…</p>}
+          {available.map((kind) => (
+            <div key={kind.id} className="rounded-md border p-2">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-semibold">{kind.name}</span>
+                <Button size="sm" onClick={() => renovate(kind.name)}>
+                  Renovate
+                </Button>
+              </div>
+              {kind.description && (
+                <p className="mt-1 text-xs text-muted-foreground">{kind.description}</p>
+              )}
+              <div className="mt-1 flex flex-wrap gap-1">
+                {KIND_FLAGS.filter((flag) => kind[flag.field]).map((flag) => (
+                  <Badge key={flag.field} variant="outline">
+                    {flag.label}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          ))}
+          {kinds.data && available.length === 0 && (
+            <p className="text-sm text-muted-foreground">No other kinds available.</p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/buildings/components/StyleDialog.test.tsx
+++ b/frontend/src/buildings/components/StyleDialog.test.tsx
@@ -1,0 +1,90 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import type { ArchitecturalStyle } from '../types';
+import { StyleDialog } from './StyleDialog';
+
+vi.mock('../queries', () => ({
+  useArchitecturalStylesQuery: vi.fn(),
+}));
+
+const { useArchitecturalStylesQuery } = await import('../queries');
+
+const styles: ArchitecturalStyle[] = [
+  {
+    id: 1,
+    name: 'Vernacular Timberframe',
+    description: 'A common style.',
+    is_default: true,
+    prestige_bonus: 0,
+    cost_multiplier: '1',
+  },
+  {
+    id: 2,
+    name: 'Antique Imperial',
+    description: 'A throwback style.',
+    is_default: false,
+    prestige_bonus: 50,
+    cost_multiplier: '1.500',
+  },
+];
+
+function renderDialog(overrides: Partial<Parameters<typeof StyleDialog>[0]> = {}) {
+  const runAction = vi.fn();
+  const onOpenChange = vi.fn();
+  vi.mocked(useArchitecturalStylesQuery).mockReturnValue({
+    data: { results: styles, count: styles.length },
+    isLoading: false,
+  } as never);
+  renderWithProviders(
+    <StyleDialog
+      anchorRoomId={7}
+      characterId={42}
+      currentStyle={null}
+      open
+      onOpenChange={onOpenChange}
+      runAction={runAction}
+      {...overrides}
+    />
+  );
+  return { runAction, onOpenChange };
+}
+
+describe('StyleDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists learned styles with flavor badges', () => {
+    renderDialog();
+    expect(screen.getByText('Vernacular Timberframe')).toBeInTheDocument();
+    expect(screen.getByText('Antique Imperial')).toBeInTheDocument();
+    expect(screen.getByText('Throwback')).toBeInTheDocument();
+    expect(screen.getByText('+50 prestige')).toBeInTheDocument();
+  });
+
+  it('dispatches set_building_style with the anchor room_id and style name', async () => {
+    const { runAction, onOpenChange } = renderDialog();
+
+    // Click "Apply" on the throwback style (the second one).
+    const applyButtons = screen.getAllByText('Apply');
+    await userEvent.click(applyButtons[1]);
+
+    expect(runAction).toHaveBeenCalledWith('set_building_style', {
+      room_id: 7,
+      style: 'Antique Imperial',
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('disables the Apply button for the current style', () => {
+    renderDialog({ currentStyle: 'Vernacular Timberframe' });
+    const applyButtons = screen.getAllByText('Apply');
+    // The first style is the current one — its button should be disabled.
+    expect(applyButtons[0]).toBeDisabled();
+    // The second style is still applyable.
+    expect(applyButtons[1]).toBeEnabled();
+  });
+});

--- a/frontend/src/buildings/components/StyleDialog.tsx
+++ b/frontend/src/buildings/components/StyleDialog.tsx
@@ -1,0 +1,91 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+
+import { useArchitecturalStylesQuery } from '../queries';
+import type { RoomBuilderActionKey } from '../types';
+
+interface StyleDialogProps {
+  /** The entry room of the building (dispatch anchor). */
+  anchorRoomId: number;
+  /** The active puppet's ObjectDB pk (viewer context for the per-viewer read). */
+  characterId: number;
+  /** The building's current style name, or null if unset. */
+  currentStyle: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  runAction: (key: RoomBuilderActionKey, kwargs: Record<string, unknown>) => void;
+}
+
+/**
+ * Pick an architectural style to dress the building in. Mirrors RenovationDialog
+ * (catalog picker → runAction). The endpoint already filters to styles the
+ * viewer can build (default styles always; throwback styles only when codex-known).
+ */
+export function StyleDialog({
+  anchorRoomId,
+  characterId,
+  currentStyle,
+  open,
+  onOpenChange,
+  runAction,
+}: StyleDialogProps) {
+  const styles = useArchitecturalStylesQuery(characterId, '', open);
+
+  const apply = (styleName: string) => {
+    runAction('set_building_style', { room_id: anchorRoomId, style: styleName });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Set building style</DialogTitle>
+        </DialogHeader>
+        <div className="flex max-h-96 flex-col gap-2 overflow-y-auto">
+          {styles.isLoading && <p className="text-sm text-muted-foreground">Loading styles…</p>}
+          {(styles.data?.results ?? []).map((style) => (
+            <div key={style.id} className="rounded-md border p-2">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-semibold">
+                  {style.name}
+                  {style.name === currentStyle && (
+                    <span className="ml-2 text-xs text-muted-foreground">(current)</span>
+                  )}
+                </span>
+                <Button
+                  size="sm"
+                  variant={style.name === currentStyle ? 'secondary' : 'default'}
+                  onClick={() => apply(style.name)}
+                  disabled={style.name === currentStyle}
+                >
+                  Apply
+                </Button>
+              </div>
+              {style.description && (
+                <p className="mt-1 text-xs text-muted-foreground">{style.description}</p>
+              )}
+              <div className="mt-1 flex flex-wrap gap-1">
+                {style.is_default ? (
+                  <Badge variant="outline">Common</Badge>
+                ) : (
+                  <Badge variant="secondary">Throwback</Badge>
+                )}
+                {style.prestige_bonus ? (
+                  <Badge variant="outline">+{style.prestige_bonus} prestige</Badge>
+                ) : null}
+                {style.cost_multiplier && style.cost_multiplier !== '1' && (
+                  <Badge variant="outline">×{style.cost_multiplier} cost</Badge>
+                )}
+              </div>
+            </div>
+          ))}
+          {styles.data && styles.data.results.length === 0 && (
+            <p className="text-sm text-muted-foreground">No styles available.</p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/buildings/queries.ts
+++ b/frontend/src/buildings/queries.ts
@@ -3,7 +3,9 @@ import { toast } from 'sonner';
 
 import {
   dispatchRoomBuilder,
+  fetchArchitecturalStyles,
   fetchBuildingForRoom,
+  fetchBuildingKinds,
   fetchBuildingManager,
   fetchDecorationTemplates,
   fetchRoomComfort,
@@ -21,6 +23,9 @@ export const buildingKeys = {
   roomComfort: (roomId: number) => [...buildingKeys.all, 'room-comfort', roomId] as const,
   sizeTiers: () => [...buildingKeys.all, 'room-size-tiers'] as const,
   templates: (search: string) => [...buildingKeys.all, 'decoration-templates', search] as const,
+  buildingKinds: (search: string) => [...buildingKeys.all, 'building-kinds', search] as const,
+  architecturalStyles: (characterId: number, search: string) =>
+    [...buildingKeys.all, 'architectural-styles', characterId, search] as const,
   personaSearch: (term: string) => [...buildingKeys.all, 'persona-search', term] as const,
 };
 
@@ -74,6 +79,28 @@ export function useDecorationTemplatesQuery(search = '', enabled = true) {
     queryKey: buildingKeys.templates(search),
     queryFn: () => fetchDecorationTemplates(search || undefined),
     enabled,
+    staleTime: FIVE_MINUTES,
+  });
+}
+
+export function useBuildingKindsQuery(search = '', enabled = true) {
+  return useQuery({
+    queryKey: buildingKeys.buildingKinds(search),
+    queryFn: () => fetchBuildingKinds(search || undefined),
+    enabled,
+    staleTime: FIVE_MINUTES,
+  });
+}
+
+export function useArchitecturalStylesQuery(
+  characterId: number | null | undefined,
+  search = '',
+  enabled = true
+) {
+  return useQuery({
+    queryKey: buildingKeys.architecturalStyles(characterId ?? 0, search),
+    queryFn: () => fetchArchitecturalStyles(characterId!, search || undefined),
+    enabled: enabled && characterId != null,
     staleTime: FIVE_MINUTES,
   });
 }

--- a/frontend/src/buildings/types.ts
+++ b/frontend/src/buildings/types.ts
@@ -8,12 +8,17 @@ export type ManagerTenancy = ManagerRoom['tenancies'][number];
 export type ForRoomResult = components['schemas']['ForRoomResult'];
 export type RoomSizeTier = components['schemas']['RoomSizeTier'];
 export type DecorationTemplate = components['schemas']['DecorationTemplate'];
+export type BuildingKind = components['schemas']['BuildingKind'];
+export type ArchitecturalStyle = components['schemas']['ArchitecturalStyle'];
 export type RoomComfortBreakdown = components['schemas']['RoomComfortBreakdown'];
 export type ExposureAxis = components['schemas']['RoomComfortBreakdown']['axes'][number];
 export type FixtureKind = components['schemas']['RoomComfortBreakdown']['fixture_kinds'][number];
 export type PaginatedRoomSizeTierList = components['schemas']['PaginatedRoomSizeTierList'];
 export type PaginatedDecorationTemplateList =
   components['schemas']['PaginatedDecorationTemplateList'];
+export type PaginatedBuildingKindList = components['schemas']['PaginatedBuildingKindList'];
+export type PaginatedArchitecturalStyleList =
+  components['schemas']['PaginatedArchitecturalStyleList'];
 
 /** Registry keys of the Room Builder actions this surface dispatches. */
 export type RoomBuilderActionKey =
@@ -30,6 +35,7 @@ export type RoomBuilderActionKey =
   | 'set_primary_home'
   | 'commission_decoration'
   | 'start_building_extension'
+  | 'start_building_renovation'
   | 'set_building_style'
   | 'place_room_fixture'
   | 'remove_room_fixture';

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -1103,6 +1103,100 @@ export interface paths {
     patch: operations['boundaries_treasured_subjects_partial_update'];
     trace?: never;
   };
+  '/api/buildings/architectural-styles/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description The ArchitecturalStyle catalog for the builder picker, per-viewer filtered (#1882).
+     *
+     *     ``set_building_style`` is knowledge-gated (``can_build_style``): default
+     *     styles are open, throwback styles require codex knowledge. This endpoint
+     *     returns only styles the requesting persona can build, so unlearned throwback
+     *     styles never reach the picker.
+     */
+    get: operations['buildings_architectural_styles_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/buildings/architectural-styles/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description The ArchitecturalStyle catalog for the builder picker, per-viewer filtered (#1882).
+     *
+     *     ``set_building_style`` is knowledge-gated (``can_build_style``): default
+     *     styles are open, throwback styles require codex knowledge. This endpoint
+     *     returns only styles the requesting persona can build, so unlearned throwback
+     *     styles never reach the picker.
+     */
+    get: operations['buildings_architectural_styles_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/buildings/building-kinds/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description The admin-authored BuildingKind catalog for the renovation picker (#1882).
+     *
+     *     Public read — BuildingKind is an open author-authored catalog (no owner
+     *     gating needed for listing). The frontend excludes the building's current
+     *     kind client-side (it knows the kind from the manager payload).
+     */
+    get: operations['buildings_building_kinds_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/buildings/building-kinds/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description The admin-authored BuildingKind catalog for the renovation picker (#1882).
+     *
+     *     Public read — BuildingKind is an open author-authored catalog (no owner
+     *     gating needed for listing). The frontend excludes the building's current
+     *     kind client-side (it knows the kind from the manager payload).
+     */
+    get: operations['buildings_building_kinds_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/buildings/decoration-templates/': {
     parameters: {
       query?: never;
@@ -15832,6 +15926,27 @@ export interface components {
      * @enum {string}
      */
     ArcanaTypeEnum: 'major' | 'minor';
+    /**
+     * @description An authorable architectural style for the builder picker (#1882).
+     *
+     *     The player-facing lore lives in the linked ``CodexSubject`` — knowing that
+     *     subject is what gates throwback styles (``can_build_style``). The description
+     *     is surfaced inline here so the picker needn't hit the Codex app.
+     */
+    ArchitecturalStyle: {
+      readonly id: number;
+      name: string;
+      description: string | null;
+      /** @description Default-available (living-realm tier). Non-default styles are the discoverable throwback tier (#1469): buildable only once the persona's character KNOWS an entry under codex_subject (research-unlocked). */
+      is_default?: boolean;
+      /** @description Base dwelling-prestige addend for a building wearing this style (#1469 throwback tier). PLACEHOLDER magnitudes pending the tuning pass. */
+      prestige_bonus?: number;
+      /**
+       * Format: decimal
+       * @description Construction/renovation cost knob for this style (#1469). Data only for now — charging awaits the economy pass (Phase E cost deduction is unwired).
+       */
+      cost_multiplier?: string;
+    };
     AreaList: {
       readonly id: number;
       readonly name: string;
@@ -16345,6 +16460,28 @@ export interface components {
       display_name: string;
       /** @description Whether available in character creation */
       is_cg_selectable?: boolean;
+    };
+    /**
+     * @description An authorable building category for the renovation picker (#1882).
+     *
+     *     Open catalog — rows authored by staff. Each row carries non-exclusive
+     *     descriptive flags the picker badges (a fortified witch-king manor is
+     *     ``residential + fortified + occult + aerial``).
+     */
+    BuildingKind: {
+      readonly id: number;
+      name: string;
+      /** @description Admin-editable flavor describing what this kind is. */
+      description?: string;
+      is_residential?: boolean;
+      is_commercial?: boolean;
+      is_fortified?: boolean;
+      is_occult?: boolean;
+      is_maritime?: boolean;
+      is_agrarian?: boolean;
+      is_aerial?: boolean;
+      is_subterranean?: boolean;
+      is_secret?: boolean;
     };
     /** @description The full owner-facing manager payload. */
     BuildingManager: {
@@ -20459,6 +20596,7 @@ export interface components {
       name: string;
       kind: string;
       style: string | null;
+      renovation_cost: number | null;
       space_budget: number;
       space_used: number;
       space_remaining: number;
@@ -21956,6 +22094,21 @@ export interface components {
       previous?: string | null;
       results: components['schemas']['AlternateSelf'][];
     };
+    PaginatedArchitecturalStyleList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['ArchitecturalStyle'][];
+    };
     PaginatedAreaListList: {
       /** @example 123 */
       count: number;
@@ -22045,6 +22198,21 @@ export interface components {
        */
       previous?: string | null;
       results: components['schemas']['BugReportDetail'][];
+    };
+    PaginatedBuildingKindList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['BuildingKind'][];
     };
     PaginatedChallengeInstanceList: {
       /** @example 123 */
@@ -31508,6 +31676,102 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['TreasuredSubject'];
+        };
+      };
+    };
+  };
+  buildings_architectural_styles_list: {
+    parameters: {
+      query: {
+        /** @description ObjectDB id of the viewing character (must be your own). */
+        character_id: number;
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description A search term. */
+        search?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedArchitecturalStyleList'];
+        };
+      };
+    };
+  };
+  buildings_architectural_styles_retrieve: {
+    parameters: {
+      query: {
+        /** @description ObjectDB id of the viewing character (must be your own). */
+        character_id: number;
+      };
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ArchitecturalStyle'];
+        };
+      };
+    };
+  };
+  buildings_building_kinds_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description A search term. */
+        search?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedBuildingKindList'];
+        };
+      };
+    };
+  };
+  buildings_building_kinds_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this building kind. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['BuildingKind'];
         };
       };
     };

--- a/src/schema.json
+++ b/src/schema.json
@@ -1775,6 +1775,139 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/buildings/architectural-styles/:
+    get:
+      operationId: buildings_architectural_styles_list
+      description: |-
+        The ArchitecturalStyle catalog for the builder picker, per-viewer filtered (#1882).
+
+        ``set_building_style`` is knowledge-gated (``can_build_style``): default
+        styles are open, throwback styles require codex knowledge. This endpoint
+        returns only styles the requesting persona can build, so unlearned throwback
+        styles never reach the picker.
+      parameters:
+      - in: query
+        name: character_id
+        schema:
+          type: integer
+        description: ObjectDB id of the viewing character (must be your own).
+        required: true
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - buildings
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedArchitecturalStyleList'
+          description: ''
+  /api/buildings/architectural-styles/{id}/:
+    get:
+      operationId: buildings_architectural_styles_retrieve
+      description: |-
+        The ArchitecturalStyle catalog for the builder picker, per-viewer filtered (#1882).
+
+        ``set_building_style`` is knowledge-gated (``can_build_style``): default
+        styles are open, throwback styles require codex knowledge. This endpoint
+        returns only styles the requesting persona can build, so unlearned throwback
+        styles never reach the picker.
+      parameters:
+      - in: query
+        name: character_id
+        schema:
+          type: integer
+        description: ObjectDB id of the viewing character (must be your own).
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - buildings
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArchitecturalStyle'
+          description: ''
+  /api/buildings/building-kinds/:
+    get:
+      operationId: buildings_building_kinds_list
+      description: |-
+        The admin-authored BuildingKind catalog for the renovation picker (#1882).
+
+        Public read — BuildingKind is an open author-authored catalog (no owner
+        gating needed for listing). The frontend excludes the building's current
+        kind client-side (it knows the kind from the manager payload).
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - buildings
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBuildingKindList'
+          description: ''
+  /api/buildings/building-kinds/{id}/:
+    get:
+      operationId: buildings_building_kinds_retrieve
+      description: |-
+        The admin-authored BuildingKind catalog for the renovation picker (#1882).
+
+        Public read — BuildingKind is an open author-authored catalog (no owner
+        gating needed for listing). The frontend excludes the building's current
+        kind client-side (it knows the kind from the manager payload).
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this building kind.
+        required: true
+      tags:
+      - buildings
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BuildingKind'
+          description: ''
   /api/buildings/decoration-templates/:
     get:
       operationId: buildings_decoration_templates_list
@@ -26891,6 +27024,46 @@ components:
       description: |-
         * `major` - Major Arcana
         * `minor` - Minor Arcana
+    ArchitecturalStyle:
+      type: object
+      description: |-
+        An authorable architectural style for the builder picker (#1882).
+
+        The player-facing lore lives in the linked ``CodexSubject`` — knowing that
+        subject is what gates throwback styles (``can_build_style``). The description
+        is surfaced inline here so the picker needn't hit the Codex app.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+          nullable: true
+        is_default:
+          type: boolean
+          description: 'Default-available (living-realm tier). Non-default styles
+            are the discoverable throwback tier (#1469): buildable only once the persona''s
+            character KNOWS an entry under codex_subject (research-unlocked).'
+        prestige_bonus:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: Base dwelling-prestige addend for a building wearing this style
+            (#1469 throwback tier). PLACEHOLDER magnitudes pending the tuning pass.
+        cost_multiplier:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,2}(?:\.\d{0,3})?$
+          description: Construction/renovation cost knob for this style (#1469). Data
+            only for now — charging awaits the economy pass (Phase E cost deduction
+            is unwired).
+      required:
+      - description
+      - id
+      - name
     AreaList:
       type: object
       properties:
@@ -27913,6 +28086,45 @@ components:
           description: Whether available in character creation
       required:
       - display_name
+      - name
+    BuildingKind:
+      type: object
+      description: |-
+        An authorable building category for the renovation picker (#1882).
+
+        Open catalog — rows authored by staff. Each row carries non-exclusive
+        descriptive flags the picker badges (a fortified witch-king manor is
+        ``residential + fortified + occult + aerial``).
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+          description: Admin-editable flavor describing what this kind is.
+        is_residential:
+          type: boolean
+        is_commercial:
+          type: boolean
+        is_fortified:
+          type: boolean
+        is_occult:
+          type: boolean
+        is_maritime:
+          type: boolean
+        is_agrarian:
+          type: boolean
+        is_aerial:
+          type: boolean
+        is_subterranean:
+          type: boolean
+        is_secret:
+          type: boolean
+      required:
+      - id
       - name
     BuildingManager:
       type: object
@@ -36833,6 +37045,9 @@ components:
         style:
           type: string
           nullable: true
+        renovation_cost:
+          type: integer
+          nullable: true
         space_budget:
           type: integer
         space_used:
@@ -36852,6 +37067,7 @@ components:
       - id
       - kind
       - name
+      - renovation_cost
       - space_budget
       - space_remaining
       - space_used
@@ -39767,6 +39983,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AlternateSelf'
+    PaginatedArchitecturalStyleList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArchitecturalStyle'
     PaginatedAreaListList:
       type: object
       required:
@@ -39905,6 +40144,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BugReportDetail'
+    PaginatedBuildingKindList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BuildingKind'
     PaginatedChallengeInstanceList:
       type: object
       required:

--- a/src/world/buildings/serializers.py
+++ b/src/world/buildings/serializers.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from rest_framework import serializers
 
 from evennia_extensions.models import RoomSizeTier
-from world.buildings.models import ProjectTemplate
+from world.buildings.models import ArchitecturalStyle, BuildingKind, ProjectTemplate
 
 
 class CharacterContextRequestSerializer(serializers.Serializer):
@@ -62,6 +62,7 @@ class ManagerBuildingSerializer(serializers.Serializer):
     name = serializers.CharField()
     kind = serializers.CharField()
     style = serializers.CharField(allow_null=True)
+    renovation_cost = serializers.IntegerField(allow_null=True)
     space_budget = serializers.IntegerField()
     space_used = serializers.IntegerField()
     space_remaining = serializers.IntegerField()
@@ -118,6 +119,47 @@ class DecorationTemplateSerializer(serializers.ModelSerializer):
             "increments",
             "tier_prerequisites",
         ]
+
+
+class BuildingKindSerializer(serializers.ModelSerializer):
+    """An authorable building category for the renovation picker (#1882).
+
+    Open catalog — rows authored by staff. Each row carries non-exclusive
+    descriptive flags the picker badges (a fortified witch-king manor is
+    ``residential + fortified + occult + aerial``).
+    """
+
+    class Meta:
+        model = BuildingKind
+        fields = [
+            "id",
+            "name",
+            "description",
+            "is_residential",
+            "is_commercial",
+            "is_fortified",
+            "is_occult",
+            "is_maritime",
+            "is_agrarian",
+            "is_aerial",
+            "is_subterranean",
+            "is_secret",
+        ]
+
+
+class ArchitecturalStyleSerializer(serializers.ModelSerializer):
+    """An authorable architectural style for the builder picker (#1882).
+
+    The player-facing lore lives in the linked ``CodexSubject`` — knowing that
+    subject is what gates throwback styles (``can_build_style``). The description
+    is surfaced inline here so the picker needn't hit the Codex app.
+    """
+
+    description = serializers.CharField(source="codex_subject.description", allow_null=True)
+
+    class Meta:
+        model = ArchitecturalStyle
+        fields = ["id", "name", "description", "is_default", "prestige_bonus", "cost_multiplier"]
 
 
 class ExposureAxisSerializer(serializers.Serializer):

--- a/src/world/buildings/tests/test_architectural_styles_viewset.py
+++ b/src/world/buildings/tests/test_architectural_styles_viewset.py
@@ -1,0 +1,110 @@
+"""ArchitecturalStyle catalog read endpoint (#1882).
+
+Per-viewer filtered: default styles are open; throwback styles appear only
+when the requesting persona's character KNOWS a codex entry under the style's
+codex_subject. Mirrors the test_style_discovery.py persona/codex fixture
+pattern, but tests the API endpoint rather than can_build_style directly.
+"""
+
+from django.test import tag
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.buildings.models import ArchitecturalStyle
+from world.buildings.seeds import ensure_architectural_styles
+from world.character_sheets.factories import CharacterSheetFactory
+from world.codex.constants import CodexKnowledgeStatus
+from world.codex.models import CharacterCodexKnowledge
+from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
+
+DEFAULT_STYLE = "Vernacular Timberframe PLACEHOLDER"
+THROWBACK = "Antique Imperial PLACEHOLDER"
+
+
+@tag("sqlite_safe")
+class ArchitecturalStyleViewSetTests(APITestCase):
+    def setUp(self) -> None:
+        ensure_architectural_styles()
+        self.default_style = ArchitecturalStyle.objects.get(name=DEFAULT_STYLE)
+        self.throwback = ArchitecturalStyle.objects.get(name=THROWBACK)
+
+        self.account = AccountFactory()
+        self.actor = CharacterFactory()
+        sheet = CharacterSheetFactory(character=self.actor)
+        self.roster_entry = RosterEntryFactory(character_sheet=sheet)
+        RosterTenureFactory(
+            roster_entry=self.roster_entry, player_data=PlayerDataFactory(account=self.account)
+        )
+        self.sheet = sheet
+
+    def _get(self, url="/api/buildings/architectural-styles/", **params):
+        self.client.force_authenticate(user=self.account)
+        return self.client.get(url, params)
+
+    def test_requires_authentication(self) -> None:
+        response = self.client.get(
+            "/api/buildings/architectural-styles/", {"character_id": self.sheet.pk}
+        )
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
+
+    def test_missing_character_id_is_400(self) -> None:
+        self.client.force_authenticate(user=self.account)
+        response = self.client.get("/api/buildings/architectural-styles/")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unowned_character_returns_empty(self) -> None:
+        # A character_id not owned by this account: _viewer_persona returns None,
+        # the queryset returns .none() — an empty result list, not a 404.
+        other_sheet = CharacterSheetFactory()
+        response = self._get(character_id=other_sheet.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["results"], [])
+
+    def test_default_styles_visible_to_all(self) -> None:
+        response = self._get(character_id=self.sheet.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = {row["name"] for row in response.json()["results"]}
+        self.assertIn(DEFAULT_STYLE, names)
+
+    def test_throwback_hidden_until_learned(self) -> None:
+        response = self._get(character_id=self.sheet.pk)
+        names = {row["name"] for row in response.json()["results"]}
+        self.assertNotIn(THROWBACK, names)
+
+    def test_throwback_visible_after_learning(self) -> None:
+        entry = self.throwback.codex_subject.entries.first()
+        CharacterCodexKnowledge.objects.create(
+            roster_entry=self.roster_entry,
+            entry=entry,
+            status=CodexKnowledgeStatus.KNOWN,
+        )
+
+        response = self._get(character_id=self.sheet.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = {row["name"] for row in response.json()["results"]}
+        self.assertIn(THROWBACK, names)
+
+        throwback_row = next(row for row in response.json()["results"] if row["name"] == THROWBACK)
+        self.assertFalse(throwback_row["is_default"])
+        self.assertGreater(throwback_row["prestige_bonus"], 0)
+        self.assertEqual(throwback_row["cost_multiplier"], "1.500")
+        # The description is sourced from the linked codex_subject.
+        self.assertIsNotNone(throwback_row["description"])
+
+    def test_inactive_style_never_appears(self) -> None:
+        entry = self.throwback.codex_subject.entries.first()
+        CharacterCodexKnowledge.objects.create(
+            roster_entry=self.roster_entry,
+            entry=entry,
+            status=CodexKnowledgeStatus.KNOWN,
+        )
+        self.throwback.is_active = False
+        self.throwback.save(update_fields=["is_active"])
+
+        response = self._get(character_id=self.sheet.pk)
+        names = {row["name"] for row in response.json()["results"]}
+        self.assertNotIn(THROWBACK, names)

--- a/src/world/buildings/tests/test_building_kinds_viewset.py
+++ b/src/world/buildings/tests/test_building_kinds_viewset.py
@@ -1,0 +1,86 @@
+"""BuildingKind catalog read endpoint (#1882).
+
+Public read — BuildingKind is an open admin-authored catalog. The endpoint
+returns all rows with id, name, description, and the nine descriptive flags.
+"""
+
+from django.test import tag
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory
+from world.buildings.models import BuildingKind
+
+
+@tag("sqlite_safe")
+class BuildingKindViewSetTests(APITestCase):
+    def setUp(self) -> None:
+        self.account = AccountFactory()
+        self.house = BuildingKind.objects.create(
+            name="House",
+            description="A residential dwelling.",
+            is_residential=True,
+        )
+        self.tavern = BuildingKind.objects.create(
+            name="Tavern",
+            description="A commercial gathering place.",
+            is_commercial=True,
+            is_maritime=True,
+        )
+        self.fortress = BuildingKind.objects.create(
+            name="Fortress",
+            description="A fortified hold.",
+            is_fortified=True,
+            is_subterranean=True,
+        )
+
+    def _get(self, url="/api/buildings/building-kinds/", **params):
+        self.client.force_authenticate(user=self.account)
+        return self.client.get(url, params)
+
+    def test_requires_authentication(self) -> None:
+        response = self.client.get("/api/buildings/building-kinds/")
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
+
+    def test_lists_all_kinds_with_flags(self) -> None:
+        response = self._get()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        names = {row["name"] for row in results}
+        self.assertEqual(names, {"House", "Tavern", "Fortress"})
+
+        house = next(row for row in results if row["name"] == "House")
+        self.assertEqual(house["description"], "A residential dwelling.")
+        self.assertTrue(house["is_residential"])
+        self.assertFalse(house["is_commercial"])
+        self.assertFalse(house["is_fortified"])
+        self.assertFalse(house["is_occult"])
+        self.assertFalse(house["is_maritime"])
+        self.assertFalse(house["is_agrarian"])
+        self.assertFalse(house["is_aerial"])
+        self.assertFalse(house["is_subterranean"])
+        self.assertFalse(house["is_secret"])
+
+        tavern = next(row for row in results if row["name"] == "Tavern")
+        self.assertTrue(tavern["is_commercial"])
+        self.assertTrue(tavern["is_maritime"])
+
+        fortress = next(row for row in results if row["name"] == "Fortress")
+        self.assertTrue(fortress["is_fortified"])
+        self.assertTrue(fortress["is_subterranean"])
+
+    def test_results_are_paginated(self) -> None:
+        response = self._get()
+        data = response.json()
+        self.assertIn("results", data)
+        self.assertIn("count", data)
+        self.assertEqual(data["count"], 3)
+
+    def test_search_filters_by_name(self) -> None:
+        response = self._get(search="Tavern")
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["name"], "Tavern")

--- a/src/world/buildings/urls.py
+++ b/src/world/buildings/urls.py
@@ -4,6 +4,8 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from world.buildings.views import (
+    ArchitecturalStyleViewSet,
+    BuildingKindViewSet,
     BuildingManagerViewSet,
     DecorationTemplateViewSet,
     RoomSizeTierViewSet,
@@ -15,5 +17,7 @@ router = DefaultRouter()
 router.register(r"manager", BuildingManagerViewSet, basename="building-manager")
 router.register(r"room-size-tiers", RoomSizeTierViewSet, basename="room-size-tier")
 router.register(r"decoration-templates", DecorationTemplateViewSet, basename="decoration-template")
+router.register(r"building-kinds", BuildingKindViewSet, basename="building-kind")
+router.register(r"architectural-styles", ArchitecturalStyleViewSet, basename="architectural-style")
 
 urlpatterns = [path("", include(router.urls))]

--- a/src/world/buildings/views.py
+++ b/src/world/buildings/views.py
@@ -29,14 +29,19 @@ from rest_framework.response import Response
 
 from evennia_extensions.models import ObjectDisplayData, RoomProfile, RoomSizeTier
 from world.buildings.models import (
+    ArchitecturalStyle,
     Building,
+    BuildingKind,
     DecorationKind,
     ProjectTemplate,
     ProjectTemplatePolishIncrement,
     RoomDecoration,
 )
+from world.buildings.room_constants import RENOVATION_THRESHOLD
 from world.buildings.room_services import building_exits, building_for_room, space_used
 from world.buildings.serializers import (
+    ArchitecturalStyleSerializer,
+    BuildingKindSerializer,
     BuildingManagerSerializer,
     CharacterContextRequestSerializer,
     DecorationTemplateSerializer,
@@ -147,6 +152,7 @@ class BuildingManagerViewSet(viewsets.ViewSet):
                 "style": (
                     building.architectural_style.name if building.architectural_style_id else None
                 ),
+                "renovation_cost": RENOVATION_THRESHOLD * 100,
                 "space_budget": building.space_budget,
                 "space_used": used,
                 "space_remaining": max(0, building.space_budget - used),
@@ -330,3 +336,67 @@ class DecorationTemplateViewSet(viewsets.ReadOnlyModelViewSet):
             )
             .order_by("name")
         )
+
+
+@extend_schema(tags=["buildings"])
+class BuildingKindViewSet(viewsets.ReadOnlyModelViewSet):
+    """The admin-authored BuildingKind catalog for the renovation picker (#1882).
+
+    Public read — BuildingKind is an open author-authored catalog (no owner
+    gating needed for listing). The frontend excludes the building's current
+    kind client-side (it knows the kind from the manager payload).
+    """
+
+    queryset = BuildingKind.objects.order_by("name")
+    serializer_class = BuildingKindSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = BuildingsCatalogPagination
+    filter_backends = [SearchFilter]
+    search_fields = ["name", "description"]
+
+
+@extend_schema(tags=["buildings"], parameters=[_CHARACTER_ID_PARAM])
+class ArchitecturalStyleViewSet(viewsets.ReadOnlyModelViewSet):
+    """The ArchitecturalStyle catalog for the builder picker, per-viewer filtered (#1882).
+
+    ``set_building_style`` is knowledge-gated (``can_build_style``): default
+    styles are open, throwback styles require codex knowledge. This endpoint
+    returns only styles the requesting persona can build, so unlearned throwback
+    styles never reach the picker.
+    """
+
+    serializer_class = ArchitecturalStyleSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = BuildingsCatalogPagination
+    filter_backends = [SearchFilter]
+    search_fields = ["name"]
+
+    def get_queryset(self):
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
+        from world.codex.models import CharacterCodexKnowledge  # noqa: PLC0415
+
+        persona = _viewer_persona(self.request)
+        if persona is None:
+            return ArchitecturalStyle.objects.none()
+        # Replicate can_build_style at the queryset level so SearchFilter +
+        # pagination compose correctly. Default styles are open; throwback
+        # styles require a KNOWN codex entry under their codex_subject.
+        # can_build_style also returns False for inactive styles and for
+        # non-default styles with no codex_subject — both are excluded here
+        # (is_active filter + codex_subject_id__in handles the latter).
+        try:
+            roster_entry = persona.character_sheet.roster_entry
+        except (AttributeError, ObjectDoesNotExist):
+            roster_entry = None
+        if roster_entry is not None:
+            known_subject_ids = CharacterCodexKnowledge.objects.filter(
+                roster_entry=roster_entry,
+                status=CodexKnowledgeStatus.KNOWN,
+            ).values_list("entry__subject_id", flat=True)
+            return ArchitecturalStyle.objects.filter(is_active=True).filter(
+                Q(is_default=True) | Q(codex_subject_id__in=known_subject_ids)
+            )
+        # No roster entry — only default styles are buildable.
+        return ArchitecturalStyle.objects.filter(is_active=True, is_default=True)


### PR DESCRIPTION
## Summary

Closes #1882. Wires the two remaining room-builder verbs that had backend actions but no React UI: `start_building_renovation` (#1860) and `set_building_style`.

**Premise correction:** the issue claimed the entire room-builder web surface was unbuilt, but 3 of 4 sibling verbs were already wired (`commission_decoration` → DecorationDialog, `start_building_extension` → ExtensionDialog, `place_room_fixture`/`remove_room_fixture` → ComfortSection). A generic dispatch endpoint already serves every builder verb. This PR closes the gap for the last two.

### Backend reads (no action changes, no migrations)

- **`BuildingKindViewSet`** (public read) — lists all `BuildingKind` rows with the nine descriptive flags for the renovation picker.
- **`ArchitecturalStyleViewSet`** (per-viewer filtered) — lists only styles the requesting persona `can_build_style` (default styles open; throwback styles require codex knowledge). Replicates `can_build_style` at the queryset level so SearchFilter + pagination compose correctly.
- **`renovation_cost`** field on `ManagerBuildingSerializer`, computed server-side from `RENOVATION_THRESHOLD * 100` — no client-side constant, no drift risk.

### Frontend

- **`RenovationDialog.tsx`** — catalog picker that excludes the current kind, shows flag badges + cost, dispatches `start_building_renovation`.
- **`StyleDialog.tsx`** — catalog picker showing learned styles with flavor badges (prestige/cost), dispatches `set_building_style`.
- New fetch fns, query hooks, types, and `BuildingBuilderDialog` wiring (two new buttons: "Renovate", "Style").

### Non-goals

- No new mutation endpoints — both verbs ride the existing generic dispatch endpoint.
- No backend action changes, no new actions, no migrations.
- `set_building_style`'s `cost_multiplier` is flavor-only (economy pass unwired); the dialog displays it without charging.
- Telnet surface (`CmdRoom`) already complete — untouched.

## Test plan

- [x] `test_building_kinds_viewset.py` — list returns all kinds with flags; pagination; search (4 tests)
- [x] `test_architectural_styles_viewset.py` — default styles visible to all; throwback hidden until learned; inactive never appears (7 tests)
- [x] `RenovationDialog.test.tsx` — renders cost, excludes current kind, dispatches with correct kwargs (3 tests)
- [x] `StyleDialog.test.tsx` — lists styles with badges, dispatches with correct kwargs, disables current style (3 tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm vitest run src/buildings/` — 19 tests pass (incl. pre-existing DigDialog)
- [x] Action registry `expected_keys` unchanged (both keys already present)
- [x] `uv run pre-commit run --all-files` — all hooks pass on changed files

Closes #1882