### PR TITLE
Add mandatory start-work.sh entrypoint to the issue-to-merged-pr skill

### DIFF
--- a/tools/skills/issue-to-merged-pr-polytoken/SKILL.md
+++ b/tools/skills/issue-to-merged-pr-polytoken/SKILL.md
@@ -105,6 +105,11 @@ table above.
   pushd "$(jq -r '.worktree_path' <<<"$START_JSON")"
   ```
 
+  Do NOT run `git worktree add` or invoke `using-git-worktrees` Step 1a/1b again
+  — `start-work.sh` already created the git worktree. The `using-git-worktrees`
+  skill's Step 0 will detect you're already isolated and skip creation; that's
+  the expected path on re-entry.
+
 - **Model selection.** Read the `model` and `complexity` fields from the emitted
   JSON. `pickup-issue.sh` derives the model from the `complexity:*` label, with
   tier names overridable via `ISSUE_MODEL_HIGH` / `ISSUE_MODEL_MEDIUM` /

--- a/tools/skills/issue-to-merged-pr-polytoken/SKILL.md
+++ b/tools/skills/issue-to-merged-pr-polytoken/SKILL.md
@@ -86,10 +86,25 @@ table above.
 - If invoked without an issue number, ask the user. If they describe work that
   doesn't have an issue yet, file one with `scripts/file-followup.sh` first and
   use its number.
-- Run `scripts/pickup-issue.sh <N>`. It checks skill availability (superpowers
-  plugin OR ported skills — either passes), fetches the issue, infers type,
-  ensures the lane labels exist, claims the issue (assign + `status:spec-draft`),
-  creates the branch, and emits JSON.
+- **STEP 0 (mandatory, before anything else):** Run `scripts/start-work.sh <N>`.
+  This assigns the issue to you, applies `status:spec-draft`, creates the
+  feature branch, and creates the worktree at `.claude/worktrees/<branch>`.
+  **Do not read the issue body, inspect code, or begin design before this
+  succeeds.** If it exits 3 (assigned to another user), the issue is claimed —
+  stop and pick another. It delegates to `pickup-issue.sh` (claim + branch), then
+  creates the worktree in one call, and emits JSON including `worktree_path`.
+  `start-work.sh` is the **single mandatory first call** — it replaces the prior
+  `pickup-issue.sh` + separate worktree-creation sequence. Skipping it is the #1
+  cause of duplicate work (two sessions on the same issue because neither
+  assigned it).
+- After it succeeds, `pushd` into the emitted `worktree_path` so all subsequent
+  file operations land in the worktree, not the main checkout:
+
+  ```bash
+  START_JSON=$(scripts/start-work.sh <N>)
+  pushd "$(jq -r '.worktree_path' <<<"$START_JSON")"
+  ```
+
 - **Model selection.** Read the `model` and `complexity` fields from the emitted
   JSON. `pickup-issue.sh` derives the model from the `complexity:*` label, with
   tier names overridable via `ISSUE_MODEL_HIGH` / `ISSUE_MODEL_MEDIUM` /
@@ -140,9 +155,11 @@ Entry condition: the issue carries `spec:approved` (a member approved the spec o
 the issue). On entry, flip the lane:
 `gh issue edit <N> --remove-label status:spec-review --add-label status:implementing`.
 Create the worktree via the ported **`using-git-worktrees`** skill
-(`tools/skills/using-git-worktrees/`), then invoke the ported **`writing-plans`**
-skill (`tools/skills/writing-plans/`) to produce the **ephemeral** plan
-(worktree-only, never committed).
+(`tools/skills/using-git-worktrees/`) — but if you ran `start-work.sh` during
+Pickup, the worktree already exists; the `using-git-worktrees` skill's Step 0
+will detect you're already isolated and skip creation. Then invoke the ported
+**`writing-plans`** skill (`tools/skills/writing-plans/`) to produce the
+**ephemeral** plan (worktree-only, never committed).
 
 The ported `writing-plans` skill goes straight to implementation (it does not
 prompt subagent-vs-inline). Work through the plan task-by-task in this session,
@@ -274,6 +291,8 @@ as Step 8's.
 
 - CI repeat-failure or thrash cap.
 - Sync conflicts the agent can't auto-resolve confidently.
+- `start-work.sh` exits 3 (issue assigned to another user). Do NOT proceed; the
+  issue is claimed — pick another.
 - During brainstorm, scope feels fundamentally different from the title — post
   on the original issue suggesting a split, exit before opening any PR.
 - Any `gh` command fails with auth errors. Surface the error and `gh auth
@@ -288,7 +307,7 @@ where it stopped, what the human should decide.
 
 | Need | Script |
 |---|---|
-| Start work on issue N | `scripts/pickup-issue.sh N` |
+| Start work on issue N | `scripts/start-work.sh N` |
 | Sync with main mid-work | `scripts/sync-with-main.sh <branch>` |
 | Open the PR | `scripts/open-pr.sh <branch> <issue> [followups...]` |
 | File a follow-up issue | `scripts/file-followup.sh <title> <body-path> [labels...]` |

--- a/tools/skills/issue-to-merged-pr/SKILL.md
+++ b/tools/skills/issue-to-merged-pr/SKILL.md
@@ -110,9 +110,28 @@ Await-approval, and Implementation.
 - If invoked without an issue number, ask the user. If they describe work
   that doesn't have an issue yet, file one with `scripts/file-followup.sh`
   first and use its number.
-- Run `scripts/pickup-issue.sh <N>`. It checks the superpowers plugin,
-  fetches the issue, infers type, ensures the lane labels exist, claims the
-  issue (assign + `status:spec-draft`), creates the branch, and emits JSON.
+- **STEP 0 (mandatory, before anything else):** Run `scripts/start-work.sh <N>`.
+  This assigns the issue to you, applies `status:spec-draft`, creates the
+  feature branch, and creates the worktree at `.claude/worktrees/<branch>`.
+  **Do not read the issue body, inspect code, or begin design before this
+  succeeds.** If it exits 3 (assigned to another user), the issue is claimed —
+  stop and pick another. It delegates to `pickup-issue.sh` (claim + branch),
+  then creates the worktree in one call, and emits JSON including `worktree_path`.
+  `start-work.sh` is the **single mandatory first call** — it replaces the prior
+  `pickup-issue.sh` + separate worktree-creation sequence. Skipping it is the #1
+  cause of duplicate work (two sessions on the same issue because neither
+  assigned it).
+- After `start-work.sh` succeeds, `cd` into the emitted `worktree_path`. **Do NOT
+  use `EnterWorktree` or create another worktree** — `start-work.sh` already ran
+  `git worktree add`. Using a native worktree tool on top of it recreates the
+  two-branch/phantom-state trap (`references/arxii-worktree-traps.md` §2). The
+  native-tool path in `using-git-worktrees` Step 1a is only for when you enter
+  that skill without having run `start-work.sh`.
+
+  ```bash
+  START_JSON=$(scripts/start-work.sh <N>)
+  cd "$(jq -r '.worktree_path' <<<"$START_JSON")"
+  ```
 - **Model selection.** Read the `model` and `complexity` fields from the
   emitted JSON. If `model` is non-empty, switch now — before any design,
   planning, or implementation work:
@@ -185,9 +204,11 @@ section.
 Entry condition: the issue carries `spec:approved` (a member approved the spec
 on the issue). On entry, flip the lane:
 `gh issue edit <N> --remove-label status:spec-review --add-label status:implementing`.
-Create the worktree (`superpowers:using-git-worktrees`), then invoke
-`superpowers:writing-plans` to produce the **ephemeral** plan (worktree-only,
-never committed).
+Create the worktree (`superpowers:using-git-worktrees`) — but if you ran
+`start-work.sh` during Pickup, the worktree already exists; the
+`using-git-worktrees` skill's Step 0 will detect you're already isolated and
+skip creation. Then invoke `superpowers:writing-plans` to produce the
+**ephemeral** plan (worktree-only, never committed).
 
 When `superpowers:writing-plans` reaches its execution-handoff (the
 "Subagent-Driven vs. Inline? Which approach?" prompt), **do NOT prompt — go
@@ -445,6 +466,8 @@ Load it when you hit one of these, not before.
 
 - CI repeat-failure or thrash cap (see above).
 - Sync conflicts the agent can't auto-resolve confidently.
+- `start-work.sh` exits 3 (issue assigned to another user). Do NOT proceed; the
+  issue is claimed — pick another.
 - During brainstorm, scope feels fundamentally different from the title —
   post on the original issue suggesting a split, exit before opening any PR.
 - Any `gh` command fails with auth errors. Surface the error and the
@@ -460,7 +483,7 @@ where it stopped, what the human should decide.
 
 | Need | Script |
 |---|---|
-| Start work on issue N | `scripts/pickup-issue.sh N` |
+| Start work on issue N | `scripts/start-work.sh N` |
 | Sync with main mid-work | `scripts/sync-with-main.sh <branch>` |
 | Open the PR | `scripts/open-pr.sh <branch> <issue> [followups...]` |
 | File a follow-up issue | `scripts/file-followup.sh <title> <body-path> [labels...]` |

--- a/tools/skills/issue-to-merged-pr/scripts/open-pr.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/open-pr.sh
@@ -79,6 +79,20 @@ if [[ -z "${PR_TITLE:-}" ]]; then
   PR_TITLE="$ISSUE_TITLE"
 fi
 
+# Guard: refuse to open a PR for an issue assigned to another session.
+# Placed BEFORE the dry-run block so --dry-run exercises it too.
+CURRENT_USER=$(gh api user --jq '.login')
+ASSIGNEES=$(gh issue view "$ISSUE" --json assignees --jq '.assignees[].login' 2>/dev/null || true)
+if [[ -n "$ASSIGNEES" ]] && ! grep -qx "$CURRENT_USER" <<<"$ASSIGNEES"; then
+  echo "ERROR: issue #$ISSUE is assigned to someone else ($ASSIGNEES), not you ($CURRENT_USER)." >&2
+  echo "Refusing to open a PR against another session's work. Run start-work.sh on your own issue." >&2
+  exit 3
+fi
+# If unassigned, warn but proceed (the user's priority is "always open a PR").
+if [[ -z "$ASSIGNEES" ]]; then
+  echo "WARN: issue #$ISSUE is unassigned. Consider running start-work.sh to claim it." >&2
+fi
+
 if [[ $DRY_RUN -eq 1 ]]; then
   echo "[dry-run] would open PR:"
   echo "  branch: $BRANCH"

--- a/tools/skills/issue-to-merged-pr/scripts/pickup-issue.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/pickup-issue.sh
@@ -72,7 +72,7 @@ fi
 # 3. Infer type from labels
 LABELS=$(jq -r '.labels[].name' <<<"$ISSUE_JSON")
 TYPE=""
-for candidate in feature fix chore refactor test tests docs perf performance; do
+for candidate in feature fix chore refactor test tests docs perf performance tech-debt; do
   if grep -qx "$candidate" <<<"$LABELS"; then
     TYPE="$candidate"
     break
@@ -85,11 +85,13 @@ fi
 if [[ "$TYPE" == "tests" ]]; then
   TYPE="test"
 fi
+if [[ "$TYPE" == "tech-debt" ]]; then
+  TYPE="chore"
+fi
 if [[ -z "$TYPE" ]]; then
-  echo "ERROR: issue #$ISSUE has no recognized type label" >&2
-  echo "(expected one of: feature, fix, chore, refactor, test, docs, perf/performance)." >&2
+  echo "WARN: issue #$ISSUE has no recognized type label; defaulting branch prefix to 'feature'." >&2
   echo "Labels found: $LABELS" >&2
-  exit 1
+  TYPE="feature"
 fi
 
 # 4. Ensure lane labels exist (idempotent) and claim the issue.
@@ -120,7 +122,10 @@ BRANCH="${TYPE}-${ISSUE}-${SLUG}"
 # a worktree on the .claude/worktrees named volume by the using-git-worktrees
 # skill, not worked on in place on the slow 9p bind mount.
 git fetch origin main --quiet
-git branch "$BRANCH" origin/main
+# Idempotent: reuse the branch if a prior start-work.sh run already created it
+# (re-invocation), instead of failing. Safe — the branch is still based on
+# origin/main only when first created.
+git show-ref --verify --quiet "refs/heads/$BRANCH" || git branch "$BRANCH" origin/main
 
 # 7. Emit JSON (includes model recommendation from complexity:* label)
 URL=$(jq -r '.url' <<<"$ISSUE_JSON")

--- a/tools/skills/issue-to-merged-pr/scripts/start-work.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/start-work.sh
@@ -31,8 +31,13 @@ BRANCH=$(jq -r '.branch' <<<"$PICKUP_JSON")
 #     and the add-assignee). Refuse if the issue is now NOT assigned to us.
 CURRENT_USER=$(gh api user --jq '.login')
 ASSIGNEES=$(gh issue view "$ISSUE" --json assignees --jq '.assignees[].login')
+if [[ -z "$ASSIGNEES" ]]; then
+  echo "ERROR: issue #$ISSUE is unassigned — the claim did not take." >&2
+  echo "(pickup's gh issue edit --add-assignee may have no-op'd, e.g. lacking triage permission). Re-run start-work.sh." >&2
+  exit 3
+fi
 if ! grep -qx "$CURRENT_USER" <<<"$ASSIGNEES"; then
-  echo "ERROR: issue #$ISSUE is not assigned to you ($CURRENT_USER)." >&2
+  echo "ERROR: issue #$ISSUE is assigned to someone else ($ASSIGNEES), not you ($CURRENT_USER)." >&2
   echo "Claim was lost (likely a concurrent session). Re-run start-work.sh." >&2
   exit 3
 fi

--- a/tools/skills/issue-to-merged-pr/scripts/start-work.sh
+++ b/tools/skills/issue-to-merged-pr/scripts/start-work.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# start-work.sh <issue-number>
+#
+# Mandatory first call of the issue-to-merged-pr skill. Assigns the issue
+# (via pickup-issue.sh) and creates an isolated worktree in one call, so the
+# agent cannot begin work without claiming the issue.
+#
+# Emits JSON on stdout (pickup-issue.sh's output plus worktree_path).
+#
+# Exits:
+#   0  success
+#   1  usage / generic error
+#   3  issue assigned to a different user (the duplicate-work guard)
+set -euo pipefail
+
+usage() { echo "Usage: $0 <issue-number>" >&2; exit 1; }
+[[ $# -eq 1 ]] || usage
+ISSUE="$1"
+[[ "$ISSUE" =~ ^[0-9]+$ ]] || usage
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# 1. Claim: delegate to pickup-issue.sh (assigns + status:spec-draft + branch).
+#    pickup-issue.sh exits 3 if the issue is assigned to a different user,
+#    which is the duplicate-work guard.
+PICKUP_JSON=$(bash "$SCRIPT_DIR/pickup-issue.sh" "$ISSUE")
+BRANCH=$(jq -r '.branch' <<<"$PICKUP_JSON")
+
+# 1b. Re-verify assignment after claiming (closes the gap where pickup's
+#     pre-check passed but a concurrent session assigned between the check
+#     and the add-assignee). Refuse if the issue is now NOT assigned to us.
+CURRENT_USER=$(gh api user --jq '.login')
+ASSIGNEES=$(gh issue view "$ISSUE" --json assignees --jq '.assignees[].login')
+if ! grep -qx "$CURRENT_USER" <<<"$ASSIGNEES"; then
+  echo "ERROR: issue #$ISSUE is not assigned to you ($CURRENT_USER)." >&2
+  echo "Claim was lost (likely a concurrent session). Re-run start-work.sh." >&2
+  exit 3
+fi
+
+# 2. Create the worktree at .claude/worktrees/<branch>.
+#    Reuses the using-git-worktrees Step 1b pattern. The branch already exists
+#    (pickup created it unchecked-out), so check it out WITHOUT -b.
+LOCATION=".claude/worktrees"
+mkdir -p "$LOCATION"
+# Verify ignored (worktree skill mandates this). .claude is in .gitignore:87.
+git check-ignore -q "$LOCATION" || {
+  echo "ERROR: $LOCATION is not gitignored — refusing to create a worktree there." >&2
+  echo "Add it to .gitignore first." >&2
+  exit 1
+}
+WORKTREE_PATH="$LOCATION/$BRANCH"
+if [ -d "$WORKTREE_PATH" ]; then
+  echo "NOTE: worktree already exists at $WORKTREE_PATH (idempotent)." >&2
+else
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+fi
+
+# 3. Emit JSON: pickup fields + worktree_path.
+jq -c --arg wt "$WORKTREE_PATH" '. + {worktree_path: $wt}' <<<"$PICKUP_JSON"

--- a/tools/skills/using-git-worktrees/SKILL.md
+++ b/tools/skills/using-git-worktrees/SKILL.md
@@ -77,6 +77,12 @@ Only proceed to Step 1b if you have no native worktree tool available.
 **Only use this if Step 1a does not apply** — you have no native worktree tool
 available. Create a worktree manually using git.
 
+> **If `start-work.sh` (issue-to-merged-pr skill) already created the worktree,**
+> Step 0 will detect you're already isolated and skip to Step 2 — that's the
+> expected path. `start-work.sh` reuses this Step 1b pattern (it runs
+> `git worktree add "$path" "$BRANCH"` after `pickup-issue.sh` creates the
+> branch unchecked-out); you won't reach 1b when entering via `start-work.sh`.
+
 #### Branch already checked out? Move it into a worktree.
 
 `pickup-issue.sh` creates the feature branch with `git branch` (it does **not**


### PR DESCRIPTION
Closes #1914

## Summary

Adds a mandatory `start-work.sh` entrypoint to the issue-to-merged-pr skill so an agent cannot begin work without claiming the issue first.

Triggered by a duplicate-work collision on #1882: a prior session implemented the scope but never assigned the issue or applied status labels, so a second session began investigating the same issue.

- NEW `start-work.sh` — delegates to `pickup-issue.sh` (claim + branch), re-verifies assignment, creates the worktree, emits JSON with `worktree_path`.
- `pickup-issue.sh` (additive): idempotent branch creation; `tech-debt`→`chore` mapping; `feature` fallback when no recognized type label (so #1882-class issues are never refused).
- `open-pr.sh`: assignee guard before the dry-run block (exit 3 if assigned to another; warn-and-proceed if unassigned — preserves "always open a PR").
- Both SKILL.md files: STEP-0 gate prose, Quick Reference, Implementation-phase worktree wording, bail condition. Claude Code source forbids `EnterWorktree`.
- `using-git-worktrees/SKILL.md`: cross-reference.

All 9 acceptance criteria verified live against scratch issues (#1915). shellcheck clean.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1914 (in the issue body)
- Brainstorm/plan: skipped (chore-class skill-tooling change; issue body is the spec)
- Sync-with-main: (no rebase performed; branched from latest main)

<!-- last-addressed-comment: 0 -->