### PR TITLE
Player-safe surfacing of pending treasured-subject sign-offs (auto-wire the prompt onto Beat pages)

### DIFF
--- a/docs/systems/boundaries.md
+++ b/docs/systems/boundaries.md
@@ -315,7 +315,7 @@ direction split above):**
 |----------|---------------|-------|
 | `/api/treasured-signoffs/` | `TreasuredSignoffViewSet` (`ModelViewSet`, no `destroy`) | See [Sign-off lifecycle](#sign-off-lifecycle) above. |
 | `/api/beats/{id}/stake-availability/` | `BeatStakeAvailabilityView` (`APIView`) | See [GM availability](#gm-stake-availability-counts-only) above. |
-| `/api/stories/my-pending-signoffs/?beats=<id>&beats=<id>` | `PlayerPendingTreasuredSignoffsView` (`APIView`) | Player-safe batched read — see [Player-safe pending-signoff discovery](#frontend-frontendsrcboundaries) above. |
+| `/api/stories/my-pending-signoffs/?beats=<id>&beats=<id>` | `PlayerPendingTreasuredSignoffsView` (`APIView`) | Player-safe batched read — see [Player-safe pending-signoff discovery](#frontend-frontendsrcboundaries) below. |
 
 ---
 

--- a/docs/systems/boundaries.md
+++ b/docs/systems/boundaries.md
@@ -315,6 +315,7 @@ direction split above):**
 |----------|---------------|-------|
 | `/api/treasured-signoffs/` | `TreasuredSignoffViewSet` (`ModelViewSet`, no `destroy`) | See [Sign-off lifecycle](#sign-off-lifecycle) above. |
 | `/api/beats/{id}/stake-availability/` | `BeatStakeAvailabilityView` (`APIView`) | See [GM availability](#gm-stake-availability-counts-only) above. |
+| `/api/stories/my-pending-signoffs/?beats=<id>&beats=<id>` | `PlayerPendingTreasuredSignoffsView` (`APIView`) | Player-safe batched read — see [Player-safe pending-signoff discovery](#frontend-frontendsrcboundaries) above. |
 
 ---
 
@@ -332,13 +333,24 @@ Mirrors the `frontend/src/consent/` module layout (`types.ts`/`api.ts`/`queries.
   the read-only aggregate for a chosen viewer tenure.
 - **`components/TreasuredSignoffPrompt.tsx`** — renders nothing when the tenure has
   no treasured subjects; otherwise offers "Sign off" / "Signed off" + "Withdraw" per
-  subject. **Known gap:** there is no player-facing endpoint that says "your
-  treasured subject is staked in beat X" (`BeatStakeAvailabilityView` is
-  GM/story-owner-only and counts-only, by design). The prompt is therefore only
-  auto-wireable from data the player already owns (their own `TreasuredSubject` +
-  `TreasuredSignoff` rows for a beat they already know the number of) — it lives on
-  `BoundariesPage` with a manual Beat # field rather than auto-surfacing from a
-  Beat/Story page. A future player-safe beat-list endpoint would let this move.
+  subject. Accepts an optional `pendingSubjectIds` prop (#1853): when supplied, the
+  panel narrows to only those subject ids instead of showing every treasured
+  subject the tenure owns. `BoundariesPage` still passes nothing (its manual Beat #
+  field keeps the original "browse and preemptively sign off anything" behavior);
+  `BeatRow` (`frontend/src/stories/components/BeatRow.tsx`) passes the ids a
+  player-safe backend query flags as actually staked-without-signoff on that beat,
+  so the prompt auto-surfaces only where it's actually relevant.
+- **Player-safe pending-signoff discovery (#1853):**
+  `world.stories.services.boundaries.player_pending_treasured_signoffs(player_data,
+  beats) -> list[PendingTreasuredSignoffs]` is the query seam — for a batch of
+  beats, which of the *requesting player's own* treasured subjects are staked
+  without an active sign-off. Exposed to web via
+  `GET /api/stories/my-pending-signoffs/?beats=<id>&beats=<id>`
+  (`PlayerPendingTreasuredSignoffsView`) and to telnet via `story beats
+  <episode-id>` (flags them inline) and `story signoff <beat-id> <subject>
+  [withdraw]` (grants/withdraws) — see `src/commands/CLAUDE.md`'s `story.py` entry.
+  Both surfaces call the identical query function; this is the single shared seam,
+  not two parallel implementations.
 - Both form dialogs wire the `visible_to_tenures` ("Specific characters") sharing
   picker via the existing `TenureMultiSearch` component; the "Consent groups"
   visibility mode has no picker UI anywhere in the frontend yet (no prior art to

--- a/frontend/src/boundaries/__tests__/TreasuredSignoffPrompt.test.tsx
+++ b/frontend/src/boundaries/__tests__/TreasuredSignoffPrompt.test.tsx
@@ -35,6 +35,13 @@ const SUBJECT_UNSIGNED = {
 
 const SUBJECT_SIGNED = { ...SUBJECT_UNSIGNED, id: 11, subject_label: 'The old windmill' };
 
+const SUBJECT_SIGNET_RING = { ...SUBJECT_UNSIGNED, id: 1, subject_label: 'Signet Ring' };
+const SUBJECT_COUSIN_ROWAN = {
+  ...SUBJECT_UNSIGNED,
+  id: 2,
+  subject_label: 'Bond with Cousin Rowan',
+};
+
 const ACTIVE_SIGNOFF_FOR_11 = {
   id: 99,
   beat: 5,
@@ -167,5 +174,69 @@ describe('TreasuredSignoffPrompt', () => {
     await userEvent.click(button);
 
     expect(withdrawMutate).toHaveBeenCalledWith({ id: 99, beat: 5 });
+  });
+
+  it('narrows to only pendingSubjectIds when provided', async () => {
+    mockMutations();
+    vi.mocked(queries.useTreasuredSubjects).mockReturnValue({
+      data: { count: 2, results: [SUBJECT_SIGNET_RING, SUBJECT_COUSIN_ROWAN] },
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    vi.mocked(queries.useTreasuredSignoffs).mockReturnValue({
+      data: { count: 0, results: [] },
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithProviders(
+      <TreasuredSignoffPrompt beatId={42} tenureId={7} pendingSubjectIds={[1]} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Signet Ring')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Bond with Cousin Rowan')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when pendingSubjectIds is an empty array', () => {
+    mockMutations();
+    vi.mocked(queries.useTreasuredSubjects).mockReturnValue({
+      data: { count: 1, results: [SUBJECT_SIGNET_RING] },
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    vi.mocked(queries.useTreasuredSignoffs).mockReturnValue({
+      data: { count: 0, results: [] },
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { container } = renderWithProviders(
+      <TreasuredSignoffPrompt beatId={42} tenureId={7} pendingSubjectIds={[]} />
+    );
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows every subject when pendingSubjectIds is omitted (existing behavior)', async () => {
+    mockMutations();
+    vi.mocked(queries.useTreasuredSubjects).mockReturnValue({
+      data: { count: 2, results: [SUBJECT_SIGNET_RING, SUBJECT_COUSIN_ROWAN] },
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    vi.mocked(queries.useTreasuredSignoffs).mockReturnValue({
+      data: { count: 0, results: [] },
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    renderWithProviders(<TreasuredSignoffPrompt beatId={42} tenureId={7} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Signet Ring')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Bond with Cousin Rowan')).toBeInTheDocument();
   });
 });

--- a/frontend/src/boundaries/api.ts
+++ b/frontend/src/boundaries/api.ts
@@ -6,6 +6,7 @@ import type {
   PaginatedTreasuredSubjectList,
   PatchedPlayerBoundaryRequest,
   PatchedTreasuredSubjectRequest,
+  PendingTreasuredSignoffsEntry,
   PlayerBoundary,
   PlayerBoundaryRequest,
   SceneLinesAndVeils,
@@ -173,6 +174,24 @@ export async function fetchSceneLinesAndVeils(
   );
   if (!res.ok) {
     throw new Error('Failed to load scene lines & veils');
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Player-safe pending treasured-subject sign-offs (#1853, read-only)
+// ---------------------------------------------------------------------------
+
+export async function fetchMyPendingTreasuredSignoffs(
+  beatIds: number[]
+): Promise<PendingTreasuredSignoffsEntry[]> {
+  const params = new URLSearchParams();
+  for (const id of beatIds) {
+    params.append('beats', String(id));
+  }
+  const res = await apiFetch(`/api/stories/my-pending-signoffs/?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error('Failed to load pending sign-offs');
   }
   return res.json();
 }

--- a/frontend/src/boundaries/components/TreasuredSignoffPrompt.tsx
+++ b/frontend/src/boundaries/components/TreasuredSignoffPrompt.tsx
@@ -7,6 +7,12 @@
  * are explicit opt-in (never assumed); an existing grant can be withdrawn,
  * which re-opens the gate (mirrors `world.stories.services.boundaries`'
  * grant/withdraw semantics).
+ *
+ * `pendingSubjectIds` (#1853): when provided, narrows the panel to only
+ * those subject ids (the ones a player-safe backend query flagged as
+ * actually staked-without-signoff on this beat) — used when auto-wired onto
+ * a Beat row. When omitted, keeps the original "browse and preemptively
+ * sign off any treasured subject" behavior (the standalone BoundariesPage).
  */
 
 import { ShieldCheck } from 'lucide-react';
@@ -23,16 +29,21 @@ import {
 interface Props {
   beatId: number;
   tenureId: number;
+  pendingSubjectIds?: number[];
 }
 
-export function TreasuredSignoffPrompt({ beatId, tenureId }: Props) {
+export function TreasuredSignoffPrompt({ beatId, tenureId, pendingSubjectIds }: Props) {
   const { data: subjectsData } = useTreasuredSubjects(tenureId);
   const { data: signoffsData } = useTreasuredSignoffs({ beat: beatId });
 
   const grant = useGrantTreasuredSignoff();
   const withdraw = useWithdrawTreasuredSignoff();
 
-  const subjects = subjectsData?.results ?? [];
+  const allSubjects = subjectsData?.results ?? [];
+  const subjects =
+    pendingSubjectIds === undefined
+      ? allSubjects
+      : allSubjects.filter((s) => pendingSubjectIds.includes(s.id));
   if (subjects.length === 0) {
     return null;
   }

--- a/frontend/src/boundaries/queries.ts
+++ b/frontend/src/boundaries/queries.ts
@@ -13,6 +13,7 @@ import {
   grantTreasuredSignoff,
   withdrawTreasuredSignoff,
   fetchSceneLinesAndVeils,
+  fetchMyPendingTreasuredSignoffs,
 } from './api';
 import type {
   PatchedPlayerBoundaryRequest,
@@ -39,6 +40,8 @@ export const boundariesKeys = {
     ] as const,
   sceneLinesAndVeils: (sceneId: string | number, tenureId: number) =>
     ['boundaries', 'scene-lines-and-veils', sceneId, tenureId] as const,
+  myPendingTreasuredSignoffs: (beatIds: number[]) =>
+    ['boundaries', 'my-pending-treasured-signoffs', [...beatIds].sort((a, b) => a - b)] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -194,6 +197,19 @@ export function useSceneLinesAndVeils(
     queryKey: boundariesKeys.sceneLinesAndVeils(sceneId!, tenureId!),
     queryFn: () => fetchSceneLinesAndVeils(sceneId!, tenureId!),
     enabled: !!sceneId && !!tenureId,
+    throwOnError: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Player-safe pending treasured-subject sign-offs (#1853, read-only)
+// ---------------------------------------------------------------------------
+
+export function useMyPendingTreasuredSignoffs(beatIds: number[]) {
+  return useQuery({
+    queryKey: boundariesKeys.myPendingTreasuredSignoffs(beatIds),
+    queryFn: () => fetchMyPendingTreasuredSignoffs(beatIds),
+    enabled: beatIds.length > 0,
     throwOnError: true,
   });
 }

--- a/frontend/src/boundaries/types.ts
+++ b/frontend/src/boundaries/types.ts
@@ -26,6 +26,8 @@ export type PaginatedTreasuredSignoffList = components['schemas']['PaginatedTrea
 
 export type VisibilityModeEnum = components['schemas']['VisibilityModeEnum'];
 
+export type PendingTreasuredSignoffsEntry = components['schemas']['PendingTreasuredSignoffs'];
+
 // ---------------------------------------------------------------------------
 // Hand-authored types (#1771)
 //

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -14871,6 +14871,32 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/stories/my-pending-signoffs/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description GET /api/stories/my-pending-signoffs/?beats=1&beats=2 (#1853).
+     *
+     *     Player-safe (never GM-facing): for the requesting player's own account,
+     *     which of the given beats have one of THEIR OWN treasured subjects staked
+     *     without an active sign-off. Batched across beats — the caller passes the
+     *     beat ids it already has on screen (mirrors BeatStakeAvailabilityView's
+     *     multi-value query-param style, but scoped to the caller instead of a
+     *     GM-supplied party).
+     */
+    get: operations['stories_my_pending_signoffs_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/stories/staff-workload/': {
     parameters: {
       query?: never;
@@ -25893,6 +25919,17 @@ export interface components {
        * @description Prompt expires after this time. Stale rows are deleted on next access.
        */
       readonly expires_at: string;
+    };
+    /**
+     * @description Player-safe wire shape for one world.stories.types.PendingTreasuredSignoffs entry (#1853).
+     *
+     *     Exposes only the requesting player's own beat_id + treasured_subject_ids —
+     *     the view-level query already guarantees no other player's data can appear
+     *     here (ADR-0033); this serializer adds no fields beyond that.
+     */
+    PendingTreasuredSignoffs: {
+      readonly beat_id: number;
+      readonly treasured_subject_ids: number[];
     };
     PermitOfferDetails: {
       readonly id: number;
@@ -51643,6 +51680,25 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+    };
+  };
+  stories_my_pending_signoffs_list: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PendingTreasuredSignoffs'][];
+        };
       };
     };
   };

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -28789,6 +28789,15 @@ export interface components {
       readonly trust_requirements: string;
       /** @description The character this sheet belongs to */
       readonly character_sheet: number;
+      /**
+       * @description The current tenure of this CHARACTER-scope story's character, if any.
+       *
+       *     Null for GROUP/GLOBAL-scope stories (no character_sheet) and for a
+       *     CHARACTER-scope story whose character has no current tenure. Lets the
+       *     frontend scope the #1853 pending-treasured-signoff auto-surfacing to
+       *     the viewer's own tenure without a second round-trip.
+       */
+      readonly tenure_id: number | null;
       readonly primary_table: number;
       readonly chapters_count: number;
       /** Format: date-time */

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -28790,12 +28790,14 @@ export interface components {
       /** @description The character this sheet belongs to */
       readonly character_sheet: number;
       /**
-       * @description The current tenure of this CHARACTER-scope story's character, if any.
+       * @description The current tenure of this CHARACTER-scope story's character (whoever is
+       *     currently playing them) — coincides with the viewer's own tenure only for
+       *     that player; other viewers get an inert value since
+       *     `TreasuredSignoffPrompt`'s own player-scoped queries return nothing for a
+       *     `tenure_id` that isn't theirs.
        *
        *     Null for GROUP/GLOBAL-scope stories (no character_sheet) and for a
-       *     CHARACTER-scope story whose character has no current tenure. Lets the
-       *     frontend scope the #1853 pending-treasured-signoff auto-surfacing to
-       *     the viewer's own tenure without a second round-trip.
+       *     CHARACTER-scope story whose character has no current tenure.
        */
       readonly tenure_id: number | null;
       readonly primary_table: number;

--- a/frontend/src/stories/__tests__/BeatList.test.tsx
+++ b/frontend/src/stories/__tests__/BeatList.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * BeatList Tests (#1853)
+ *
+ * Covers the query→map→prop wiring between useMyPendingTreasuredSignoffs and
+ * BeatRow's pendingSignoffSubjectIds prop:
+ *  - a beat with a matching pending-signoff entry gets that entry's subject
+ *    ids forwarded to its BeatRow
+ *  - a beat with no matching entry gets undefined (no false-positive prompt)
+ *  - when tenureId is not provided, useMyPendingTreasuredSignoffs is called
+ *    with an empty array (the query is skipped)
+ */
+
+import { screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { BeatList } from '../components/BeatList';
+import type { Beat } from '../types';
+
+vi.mock('../queries', () => ({
+  useBeatList: vi.fn(),
+  useAggregateBeatContributions: vi.fn(),
+}));
+
+vi.mock('@/boundaries/queries', () => ({
+  useMyPendingTreasuredSignoffs: vi.fn(),
+}));
+
+vi.mock('../components/BeatRow', () => ({
+  BeatRow: ({
+    beat,
+    pendingSignoffSubjectIds,
+  }: {
+    beat: Beat;
+    pendingSignoffSubjectIds?: number[];
+  }) => (
+    <li
+      data-testid={`beat-row-${beat.id}`}
+      data-pending-subject-ids={JSON.stringify(pendingSignoffSubjectIds)}
+    />
+  ),
+}));
+
+import * as storiesQueries from '../queries';
+import * as boundariesQueries from '@/boundaries/queries';
+
+function makeBeat(overrides: Partial<Beat> = {}): Beat {
+  return {
+    id: 1,
+    episode: 10,
+    episode_title: 'Test Episode',
+    chapter_title: 'Test Chapter',
+    story_id: 5,
+    story_title: 'Test Story',
+    predicate_type: 'gm_marked',
+    outcome: 'unsatisfied',
+    visibility: 'hinted',
+    internal_description: 'The villain confronts the hero',
+    player_hint: 'Confront the villain',
+    player_resolution_text: undefined,
+    order: 1,
+    required_level: undefined,
+    required_achievement: undefined,
+    required_condition_template: undefined,
+    required_codex_entry: undefined,
+    referenced_story: undefined,
+    referenced_milestone_type: undefined,
+    referenced_chapter: undefined,
+    referenced_episode: undefined,
+    required_points: undefined,
+    agm_eligible: false,
+    deadline: undefined,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-04-19T00:00:00Z',
+    can_mark: false,
+    ...overrides,
+  };
+}
+
+function mockBeatList(beats: Beat[]) {
+  vi.mocked(storiesQueries.useBeatList).mockReturnValue({
+    data: { count: beats.length, next: null, previous: null, results: beats },
+    isLoading: false,
+    isSuccess: true,
+    error: null,
+  } as unknown as ReturnType<typeof storiesQueries.useBeatList>);
+
+  vi.mocked(storiesQueries.useAggregateBeatContributions).mockReturnValue({
+    data: { count: 0, next: null, previous: null, results: [] },
+    isLoading: false,
+    isSuccess: true,
+    error: null,
+  } as unknown as ReturnType<typeof storiesQueries.useAggregateBeatContributions>);
+}
+
+describe('BeatList — pending sign-off query-to-prop wiring (#1853)', () => {
+  it('forwards a matching entry treasured_subject_ids to the corresponding BeatRow', () => {
+    const beatWithPending = makeBeat({ id: 1 });
+    const beatWithoutPending = makeBeat({ id: 2 });
+    mockBeatList([beatWithPending, beatWithoutPending]);
+
+    vi.mocked(boundariesQueries.useMyPendingTreasuredSignoffs).mockReturnValue({
+      data: [{ beat_id: 1, treasured_subject_ids: [100, 200] }],
+      isLoading: false,
+      isSuccess: true,
+      error: null,
+    } as unknown as ReturnType<typeof boundariesQueries.useMyPendingTreasuredSignoffs>);
+
+    renderWithProviders(<BeatList episodeId={10} tenureId={7} />);
+
+    expect(screen.getByTestId('beat-row-1')).toHaveAttribute(
+      'data-pending-subject-ids',
+      JSON.stringify([100, 200])
+    );
+  });
+
+  it('leaves pendingSignoffSubjectIds undefined for a beat with no matching entry', () => {
+    const beatWithPending = makeBeat({ id: 1 });
+    const beatWithoutPending = makeBeat({ id: 2 });
+    mockBeatList([beatWithPending, beatWithoutPending]);
+
+    vi.mocked(boundariesQueries.useMyPendingTreasuredSignoffs).mockReturnValue({
+      data: [{ beat_id: 1, treasured_subject_ids: [100, 200] }],
+      isLoading: false,
+      isSuccess: true,
+      error: null,
+    } as unknown as ReturnType<typeof boundariesQueries.useMyPendingTreasuredSignoffs>);
+
+    renderWithProviders(<BeatList episodeId={10} tenureId={7} />);
+
+    // JSON.stringify(undefined) is itself undefined, so the mock BeatRow
+    // never applies the attribute at all when there's no matching entry.
+    expect(screen.getByTestId('beat-row-2')).not.toHaveAttribute('data-pending-subject-ids');
+  });
+
+  it('calls useMyPendingTreasuredSignoffs with an empty array when tenureId is not provided', () => {
+    mockBeatList([makeBeat({ id: 1 }), makeBeat({ id: 2 })]);
+
+    vi.mocked(boundariesQueries.useMyPendingTreasuredSignoffs).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isSuccess: false,
+      error: null,
+    } as unknown as ReturnType<typeof boundariesQueries.useMyPendingTreasuredSignoffs>);
+
+    renderWithProviders(<BeatList episodeId={10} />);
+
+    expect(boundariesQueries.useMyPendingTreasuredSignoffs).toHaveBeenCalledWith([]);
+  });
+});

--- a/frontend/src/stories/__tests__/BeatRow.test.tsx
+++ b/frontend/src/stories/__tests__/BeatRow.test.tsx
@@ -31,6 +31,27 @@ vi.mock('../components/ContributeBeatDialog', () => ({
   ),
 }));
 
+vi.mock('@/boundaries/components/TreasuredSignoffPrompt', () => ({
+  TreasuredSignoffPrompt: ({
+    beatId,
+    tenureId,
+    pendingSubjectIds,
+  }: {
+    beatId: number;
+    tenureId: number;
+    pendingSubjectIds?: number[];
+  }) => (
+    <div
+      data-testid="treasured-signoff-prompt"
+      data-beat-id={beatId}
+      data-tenure-id={tenureId}
+      data-pending-subject-ids={JSON.stringify(pendingSubjectIds)}
+    >
+      Sign-off prompt
+    </div>
+  ),
+}));
+
 // ---------------------------------------------------------------------------
 // Wrapper
 // ---------------------------------------------------------------------------
@@ -141,5 +162,41 @@ describe('BeatRow — deadline display', () => {
     const beat = makeGmMarkedBeat({ deadline: futureDate });
     render(<BeatRow beat={beat} />, { wrapper: createWrapper() });
     expect(screen.getByText(/expires/i)).toBeInTheDocument();
+  });
+});
+
+describe('BeatRow — pending treasured sign-off prompt (#1853)', () => {
+  it('renders TreasuredSignoffPrompt with matching pendingSubjectIds when tenureId is set and a beat has pending subjects', () => {
+    const beat = makeGmMarkedBeat();
+    render(<BeatRow beat={beat} tenureId={7} pendingSignoffSubjectIds={[10, 20]} />, {
+      wrapper: createWrapper(),
+    });
+    const prompt = screen.getByTestId('treasured-signoff-prompt');
+    expect(prompt).toBeInTheDocument();
+    expect(prompt).toHaveAttribute('data-beat-id', String(beat.id));
+    expect(prompt).toHaveAttribute('data-tenure-id', '7');
+    expect(prompt).toHaveAttribute('data-pending-subject-ids', JSON.stringify([10, 20]));
+  });
+
+  it('does not render TreasuredSignoffPrompt when there are no pending subjects for this beat', () => {
+    const beat = makeGmMarkedBeat();
+    render(<BeatRow beat={beat} tenureId={7} pendingSignoffSubjectIds={[]} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByTestId('treasured-signoff-prompt')).not.toBeInTheDocument();
+  });
+
+  it('does not render TreasuredSignoffPrompt when pendingSignoffSubjectIds is undefined', () => {
+    const beat = makeGmMarkedBeat();
+    render(<BeatRow beat={beat} tenureId={7} />, { wrapper: createWrapper() });
+    expect(screen.queryByTestId('treasured-signoff-prompt')).not.toBeInTheDocument();
+  });
+
+  it('does not render TreasuredSignoffPrompt when tenureId is not provided, even with pending subjects', () => {
+    const beat = makeGmMarkedBeat();
+    render(<BeatRow beat={beat} pendingSignoffSubjectIds={[10]} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByTestId('treasured-signoff-prompt')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/stories/__tests__/ChangeMyGMDialog.test.tsx
+++ b/frontend/src/stories/__tests__/ChangeMyGMDialog.test.tsx
@@ -69,6 +69,7 @@ const makeStory = (overrides: Partial<Story> = {}): Story => ({
   active_gms: [],
   trust_requirements: '',
   character_sheet: 42,
+  tenure_id: null,
   chapters_count: 1,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',

--- a/frontend/src/stories/__tests__/SendStoryOOCDialog.test.tsx
+++ b/frontend/src/stories/__tests__/SendStoryOOCDialog.test.tsx
@@ -47,6 +47,7 @@ const mockStory: Story = {
   status: 'active',
   privacy: 'invite_only',
   character_sheet: 0,
+  tenure_id: null,
   primary_table: 7,
   active_gms: [],
   owners: [],

--- a/frontend/src/stories/__tests__/StoryAuthorPage.test.tsx
+++ b/frontend/src/stories/__tests__/StoryAuthorPage.test.tsx
@@ -119,6 +119,7 @@ const storyDetail: Story = {
   active_gms: [],
   trust_requirements: '',
   character_sheet: 1,
+  tenure_id: null,
   chapters_count: 0,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',

--- a/frontend/src/stories/__tests__/StoryAuthorTree.quickadd.test.tsx
+++ b/frontend/src/stories/__tests__/StoryAuthorTree.quickadd.test.tsx
@@ -93,6 +93,7 @@ const story: Story = {
   active_gms: [],
   trust_requirements: '',
   character_sheet: 1,
+  tenure_id: null,
   chapters_count: 1,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',

--- a/frontend/src/stories/__tests__/StoryAuthorTree.runcontrol.test.tsx
+++ b/frontend/src/stories/__tests__/StoryAuthorTree.runcontrol.test.tsx
@@ -102,6 +102,7 @@ const story: Story = {
   active_gms: [],
   trust_requirements: '',
   character_sheet: 1,
+  tenure_id: null,
   chapters_count: 1,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',

--- a/frontend/src/stories/__tests__/StoryFormDialog.test.tsx
+++ b/frontend/src/stories/__tests__/StoryFormDialog.test.tsx
@@ -86,6 +86,7 @@ const existingStory: Story = {
   active_gms: [],
   trust_requirements: '',
   character_sheet: 1,
+  tenure_id: null,
   chapters_count: 0,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',

--- a/frontend/src/stories/__tests__/queries.authoring.test.tsx
+++ b/frontend/src/stories/__tests__/queries.authoring.test.tsx
@@ -76,6 +76,7 @@ const mockStory = {
   active_gms: [],
   trust_requirements: '',
   character_sheet: 42,
+  tenure_id: null,
   chapters_count: 2,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-04-19T00:00:00Z',

--- a/frontend/src/stories/__tests__/queries.test.tsx
+++ b/frontend/src/stories/__tests__/queries.test.tsx
@@ -140,6 +140,7 @@ const mockStory = {
   active_gms: [],
   trust_requirements: '',
   character_sheet: 42,
+  tenure_id: null,
   chapters_count: 2,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-04-19T00:00:00Z',

--- a/frontend/src/stories/components/BeatList.tsx
+++ b/frontend/src/stories/components/BeatList.tsx
@@ -6,6 +6,7 @@
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { useBeatList, useAggregateBeatContributions } from '../queries';
+import { useMyPendingTreasuredSignoffs } from '@/boundaries/queries';
 import { BeatRow } from './BeatRow';
 
 interface BeatListProps {
@@ -15,9 +16,16 @@ interface BeatListProps {
    * Pass story.character_sheet for CHARACTER-scope stories.
    */
   characterSheetId?: number | null;
+  /**
+   * Roster tenure ID for the viewer's character on this story (#1853) —
+   * forwarded to BeatRow so it can render TreasuredSignoffPrompt when a
+   * beat has a pending sign-off. Pass story.character_sheet's tenure, same
+   * scope rule as characterSheetId.
+   */
+  tenureId?: number | null;
 }
 
-export function BeatList({ episodeId, characterSheetId }: BeatListProps) {
+export function BeatList({ episodeId, characterSheetId, tenureId }: BeatListProps) {
   const { data: beatsPage, isLoading: beatsLoading } = useBeatList({ episode: episodeId });
   const beats = beatsPage?.results ?? [];
 
@@ -46,6 +54,12 @@ export function BeatList({ episodeId, characterSheetId }: BeatListProps) {
     }
   }
 
+  const beatIds = beats.map((b) => b.id);
+  const { data: pendingSignoffs } = useMyPendingTreasuredSignoffs(tenureId != null ? beatIds : []);
+  const pendingByBeatId = new Map(
+    (pendingSignoffs ?? []).map((entry) => [entry.beat_id, entry.treasured_subject_ids])
+  );
+
   if (beatsLoading) {
     return (
       <div className="space-y-2">
@@ -68,6 +82,8 @@ export function BeatList({ episodeId, characterSheetId }: BeatListProps) {
           beat={beat}
           aggregateTotal={totalsByBeatId[beat.id] ?? 0}
           characterSheetId={characterSheetId}
+          tenureId={tenureId}
+          pendingSignoffSubjectIds={pendingByBeatId.get(beat.id)}
         />
       ))}
     </ul>

--- a/frontend/src/stories/components/BeatRow.tsx
+++ b/frontend/src/stories/components/BeatRow.tsx
@@ -5,10 +5,14 @@
  * resolution text for completed beats.  For AGGREGATE_THRESHOLD beats
  * with a known characterSheetId, also renders the "Contribute" action.
  * For GM_MARKED beats renders the "Mark" action only when beat.can_mark
- * is true (server signals the requesting user has permission).
+ * is true (server signals the requesting user has permission). When a
+ * player-safe query flags one of the viewer's own treasured subjects as
+ * staked-without-signoff on this beat, renders a targeted
+ * TreasuredSignoffPrompt (#1853).
  */
 
 import { formatRelativeTime } from '@/lib/relativeTime';
+import { TreasuredSignoffPrompt } from '@/boundaries/components/TreasuredSignoffPrompt';
 import { BeatOutcomeBadge } from './BeatOutcomeBadge';
 import { AggregateProgressBar } from './AggregateProgressBar';
 import { ContributeBeatDialog } from './ContributeBeatDialog';
@@ -25,9 +29,22 @@ interface BeatRowProps {
    * For CHARACTER-scope stories this is story.character_sheet.
    */
   characterSheetId?: number | null;
+  /** Roster tenure ID for the viewer's character on this story (#1853). */
+  tenureId?: number | null;
+  /**
+   * Treasured subject ids a player-safe query flagged as staked-without-
+   * signoff on this beat (#1853). Undefined/empty means nothing pending.
+   */
+  pendingSignoffSubjectIds?: number[];
 }
 
-export function BeatRow({ beat, aggregateTotal = 0, characterSheetId }: BeatRowProps) {
+export function BeatRow({
+  beat,
+  aggregateTotal = 0,
+  characterSheetId,
+  tenureId,
+  pendingSignoffSubjectIds,
+}: BeatRowProps) {
   const isAggregate = beat.predicate_type === 'aggregate_threshold';
   const isGmMarked = beat.predicate_type === 'gm_marked';
   const hasDeadline = beat.deadline != null;
@@ -71,6 +88,14 @@ export function BeatRow({ beat, aggregateTotal = 0, characterSheetId }: BeatRowP
 
       {outcome === 'success' && beat.player_resolution_text && (
         <p className="text-sm text-foreground/80">{beat.player_resolution_text}</p>
+      )}
+
+      {tenureId != null && pendingSignoffSubjectIds && pendingSignoffSubjectIds.length > 0 && (
+        <TreasuredSignoffPrompt
+          beatId={beat.id}
+          tenureId={tenureId}
+          pendingSubjectIds={pendingSignoffSubjectIds}
+        />
       )}
     </li>
   );

--- a/frontend/src/stories/components/CurrentEpisodePanel.tsx
+++ b/frontend/src/stories/components/CurrentEpisodePanel.tsx
@@ -13,9 +13,19 @@ interface CurrentEpisodePanelProps {
    * Pass story.character_sheet for CHARACTER-scope stories.
    */
   characterSheetId?: number | null;
+  /**
+   * Roster tenure ID forwarded to BeatList so it can auto-surface pending
+   * treasured-subject sign-offs on beats (#1853). Same scope rule as
+   * characterSheetId — pass the viewer's tenure for this story's character.
+   */
+  tenureId?: number | null;
 }
 
-export function CurrentEpisodePanel({ episodeId, characterSheetId }: CurrentEpisodePanelProps) {
+export function CurrentEpisodePanel({
+  episodeId,
+  characterSheetId,
+  tenureId,
+}: CurrentEpisodePanelProps) {
   const { data: episode, isLoading } = useEpisode(episodeId);
 
   if (isLoading) {
@@ -50,7 +60,7 @@ export function CurrentEpisodePanel({ episodeId, characterSheetId }: CurrentEpis
         <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
           Beats
         </h3>
-        <BeatList episodeId={episodeId} characterSheetId={characterSheetId} />
+        <BeatList episodeId={episodeId} characterSheetId={characterSheetId} tenureId={tenureId} />
       </div>
     </section>
   );

--- a/frontend/src/stories/pages/StoryDetailPage.tsx
+++ b/frontend/src/stories/pages/StoryDetailPage.tsx
@@ -139,6 +139,7 @@ function StoryDetailInner({ storyId }: StoryDetailInnerProps) {
         <CurrentEpisodePanel
           episodeId={activeEntry.current_episode_id}
           characterSheetId={story.character_sheet}
+          tenureId={story.tenure_id}
         />
       ) : (
         <section className="rounded-lg border bg-card p-4">

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -422,6 +422,18 @@ actions, backends, and service functions.
   (`place_functionary`/`remove_functionary`/`functionaries_in_room`); the room the caller stands
   in is resolved via `areas.services.get_room_profile`. Functionaries also surface on `look`
   (`Room.return_appearance` appends them, since they are object-less and never in `contents`).
+- **`story.py`**: `CmdStory` (`story`, #1495/#1853) — GM lifecycle actions + player self-service
+  under one namespace (mirrors `CmdGMTable`'s precedent of mixed permission tiers in one command).
+  GM subverbs (`complete <story-id>` / `resolve <episode-id> ...` / `promote <episode-id> ...` /
+  `mark <beat-id> ...`) delegate to `Action().run()` and are gated by the story's Lead GM or staff
+  status in the backing action layer — unchanged from #1495. Player subverbs are self-scoped, no
+  GM/staff gate: bare `story` / `story list` shows the caller's active stories
+  (`world.stories.services.dashboards.active_stories_for_account` — the same service
+  `MyActiveStoriesView` calls); `story beats <episode-id>` lists one of the caller's own active
+  episode's beats, flagging any staked-without-signoff treasured subject inline
+  (`player_pending_treasured_signoffs`); `story signoff <beat-id> <subject> [withdraw]`
+  grants/withdraws via `grant_treasured_signoff`/`withdraw_treasured_signoff` — the same service
+  functions `TreasuredSignoffViewSet` calls. No business logic in the command.
 - **`durance.py`**: `CmdDurance` (`durance`, Progression, #1700) — the Ritual of the Durance
   readiness hub + site-convene surface. Bare `durance`/`durance status` shows level, unlock
   gate, eligible paths, declared intent, and training-site presence. `durance intent <path>`

--- a/src/commands/story.py
+++ b/src/commands/story.py
@@ -1,8 +1,12 @@
-"""GM story lifecycle telnet namespace (#1495).
+"""Story telnet namespace: GM lifecycle actions + player self-service (#1495, #1853).
 
-A thin command face for the four story actions in ``actions.definitions.gm_stories``.
-Each subverb delegates directly to ``Action().run(actor=self.caller, **kwargs)``.
-No business logic lives here.
+GM subverbs (complete/resolve/promote/mark) delegate directly to
+``Action().run(actor=self.caller, **kwargs)`` and are gated by the story's
+Lead GM or staff status in the backing action layer — unchanged from #1495.
+
+Player subverbs (bare `story` / `list` / `beats` / `signoff`) are self-scoped
+reads/mutations over the caller's own account — no GM/staff gate, mirroring
+CmdGMTable's precedent of mixed permission tiers under one command namespace.
 """
 
 from __future__ import annotations
@@ -17,6 +21,11 @@ from commands.utils.gm_resolution import (
 
 _USAGE = (
     "Usage: story <subcommand>\n"
+    "  story                              — your active stories\n"
+    "  story list                         — same as bare `story`\n"
+    "  story beats <episode-id>           — beats in one of your active episodes\n"
+    "  story signoff <beat-id> <subject> [withdraw]\n"
+    "                                     — grant/withdraw a treasured sign-off\n"
     "  story complete <story-id>\n"
     "  story resolve <episode-id> [transition-id] [notes]\n"
     "  story promote <episode-id> <pitch|outline|plot>\n"
@@ -36,6 +45,7 @@ _SUBVERB_HANDLERS: dict[str, str] = {
     "resolve": "_handle_resolve",
     "promote": "_handle_promote",
     "mark": "_handle_mark",
+    "list": "_handle_list",
 }
 
 
@@ -51,6 +61,40 @@ class CmdStory(ArxNamespaceCommand):
     locks = "cmd:all()"
     _USAGE = _USAGE
     _SUBVERB_HANDLERS = _SUBVERB_HANDLERS
+
+    def func(self) -> None:
+        """Bare `story` is the player's active-stories listing; else route by subverb."""
+        raw = (self.args or "").strip()
+        if not raw:
+            self._handle_list("")
+            return
+        super().func()
+
+    def _handle_list(self, rest: str) -> None:
+        """Show the caller's active stories across all three scopes (#1853)."""
+        from world.stories.services.dashboards import active_stories_for_account  # noqa: PLC0415
+
+        result = active_stories_for_account(self.caller.account)
+        entries = [
+            *result["character_stories"],
+            *result["group_stories"],
+            *result["global_stories"],
+        ]
+        if not entries:
+            self.msg("You have no active stories.")
+            return
+        lines = ["Your active stories:"]
+        for entry in entries:
+            episode_bit = (
+                f' — currently in "{entry["current_episode_title"]}"'
+                if entry["current_episode_title"]
+                else ""
+            )
+            lines.append(
+                f"  [{entry['story_id']}] {entry['story_title']}{episode_bit} "
+                f"({entry['status_label']})"
+            )
+        self.msg("\n".join(lines))
 
     def _handle_complete(self, rest: str) -> None:
         """Parse ``complete <story-id>`` and dispatch CompleteStoryAction."""

--- a/src/commands/story.py
+++ b/src/commands/story.py
@@ -46,6 +46,7 @@ _SUBVERB_HANDLERS: dict[str, str] = {
     "promote": "_handle_promote",
     "mark": "_handle_mark",
     "list": "_handle_list",
+    "beats": "_handle_beats",
 }
 
 
@@ -94,6 +95,70 @@ class CmdStory(ArxNamespaceCommand):
                 f"  [{entry['story_id']}] {entry['story_title']}{episode_bit} "
                 f"({entry['status_label']})"
             )
+        self.msg("\n".join(lines))
+
+    def _handle_beats(self, rest: str) -> None:
+        """List a caller's-own-active-episode's beats, flagging pending sign-offs (#1853)."""
+        from world.stories.constants import BeatVisibility  # noqa: PLC0415
+        from world.stories.models import Beat  # noqa: PLC0415
+        from world.stories.services.boundaries import (  # noqa: PLC0415
+            player_pending_treasured_signoffs,
+        )
+        from world.stories.services.dashboards import active_stories_for_account  # noqa: PLC0415
+
+        episode_id = self._require_arg(rest, "Usage: story beats <episode-id>.")
+        if not episode_id.isdigit():
+            msg = "An episode must be specified by its numeric ID."
+            raise CommandError(msg)
+
+        result = active_stories_for_account(self.caller.account)
+        my_episode_ids = {
+            entry["current_episode_id"]
+            for entry in (
+                *result["character_stories"],
+                *result["group_stories"],
+                *result["global_stories"],
+            )
+            if entry["current_episode_id"] is not None
+        }
+        if int(episode_id) not in my_episode_ids:
+            msg = "That's not one of your active stories."
+            raise CommandError(msg)
+
+        beats = list(Beat.objects.filter(episode_id=episode_id).order_by("order"))
+        if not beats:
+            self.msg("No beats yet for that episode.")
+            return
+
+        player_data = getattr(self.caller.account, "player_data", None)  # noqa: GETATTR_LITERAL
+        pending_by_beat: dict[int, tuple[int, ...]] = {}
+        if player_data is not None:
+            for entry in player_pending_treasured_signoffs(player_data, beats):
+                pending_by_beat[entry.beat_id] = entry.treasured_subject_ids
+
+        from world.boundaries.models import TreasuredSubject  # noqa: PLC0415
+
+        pending_subject_ids = {tid for ids in pending_by_beat.values() for tid in ids}
+        label_by_id = dict(
+            TreasuredSubject.objects.filter(pk__in=pending_subject_ids).values_list(
+                "pk", "subject_label"
+            )
+        )
+
+        lines = ["Beats:"]
+        for beat in beats:
+            if beat.player_hint and beat.player_hint.strip():
+                title = beat.player_hint
+            elif beat.visibility == BeatVisibility.SECRET:
+                title = "(Hidden Beat)"
+            else:
+                title = "Beat"
+            outcome = beat.outcome or "unsatisfied"
+            line = f"  [{beat.pk}] {title} ({outcome})"
+            pending_ids = pending_by_beat.get(beat.pk, ())
+            for tid in pending_ids:
+                line += f"\n      SIGN-OFF NEEDED: {label_by_id.get(tid, '(unknown)')}"
+            lines.append(line)
         self.msg("\n".join(lines))
 
     def _handle_complete(self, rest: str) -> None:

--- a/src/commands/story.py
+++ b/src/commands/story.py
@@ -11,6 +11,8 @@ CmdGMTable's precedent of mixed permission tiers under one command namespace.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, TypeVar
+
 from commands.exceptions import CommandError
 from commands.namespace import ArxNamespaceCommand
 from commands.utils.gm_resolution import (
@@ -18,6 +20,11 @@ from commands.utils.gm_resolution import (
     resolve_numeric_beat_id_or_error,
     resolve_story_or_error,
 )
+
+if TYPE_CHECKING:
+    from world.boundaries.models import TreasuredSubject
+
+_SignoffMatchT = TypeVar("_SignoffMatchT")
 
 _USAGE = (
     "Usage: story <subcommand>\n"
@@ -39,6 +46,8 @@ _MARK_USAGE = "Usage: story mark <beat-id> <success|failure> [notes]"
 
 _MIN_PROMOTE_TOKENS = 2
 _MIN_MARK_TOKENS = 2
+_MIN_SIGNOFF_TOKENS = 2  # beat-id + at least one subject token
+_WITHDRAW_KEYWORD = "withdraw"
 
 _SUBVERB_HANDLERS: dict[str, str] = {
     "complete": "_handle_complete",
@@ -47,6 +56,7 @@ _SUBVERB_HANDLERS: dict[str, str] = {
     "mark": "_handle_mark",
     "list": "_handle_list",
     "beats": "_handle_beats",
+    "signoff": "_handle_signoff",
 }
 
 
@@ -231,3 +241,80 @@ class CmdStory(ArxNamespaceCommand):
             kwargs["gm_notes"] = gm_notes
 
         self._run_action(MarkBeatAction, **kwargs)
+
+    def _handle_signoff(self, rest: str) -> None:
+        """Grant or withdraw a treasured sign-off for a beat (#1853)."""
+        from world.boundaries.models import TreasuredSubject  # noqa: PLC0415
+        from world.stories.models import Beat, TreasuredSignoff  # noqa: PLC0415
+        from world.stories.services.boundaries import (  # noqa: PLC0415
+            grant_treasured_signoff,
+            player_pending_treasured_signoffs,
+            withdraw_treasured_signoff,
+        )
+
+        usage = "Usage: story signoff <beat-id> <subject> [withdraw]."
+        tokens = rest.split()
+        if len(tokens) < _MIN_SIGNOFF_TOKENS:
+            raise CommandError(usage)
+
+        beat_id = resolve_numeric_beat_id_or_error(tokens[0])
+        try:
+            beat = Beat.objects.get(pk=beat_id)
+        except Beat.DoesNotExist as exc:
+            msg = "No beat with that ID exists."
+            raise CommandError(msg) from exc
+
+        remaining = tokens[1:]
+        withdraw = bool(remaining) and remaining[-1].lower() == _WITHDRAW_KEYWORD
+        if withdraw:
+            remaining = remaining[:-1]
+        subject_token = " ".join(remaining).strip()
+        if not subject_token:
+            raise CommandError(usage)
+
+        player_data = getattr(self.caller.account, "player_data", None)  # noqa: GETATTR_LITERAL
+        if player_data is None:
+            msg = "You have no player identity to sign off with."
+            raise CommandError(msg)
+
+        if withdraw:
+            active_signoffs = TreasuredSignoff.objects.filter(
+                beat=beat, player_data=player_data, withdrawn_at__isnull=True
+            ).select_related("treasured_subject")
+            signoff = self._match_subject_token(
+                subject_token, [(s.treasured_subject, s) for s in active_signoffs]
+            )
+            if signoff is None:
+                msg = f"No active sign-off for '{subject_token}' on beat {beat.pk}."
+                raise CommandError(msg)
+            withdraw_treasured_signoff(signoff)
+            self.msg(f"Withdrawn: {signoff.treasured_subject.subject_label} on beat {beat.pk}.")
+            return
+
+        entries = player_pending_treasured_signoffs(player_data, [beat])
+        pending_ids: tuple[int, ...] = entries[0].treasured_subject_ids if entries else ()
+        candidates = list(TreasuredSubject.objects.filter(pk__in=pending_ids))
+        subject = self._match_subject_token(subject_token, [(s, s) for s in candidates])
+        if subject is None:
+            msg = f"No pending sign-off for '{subject_token}' on beat {beat.pk}."
+            raise CommandError(msg)
+        grant_treasured_signoff(beat, player_data, subject)
+        self.msg(f"Signed off: {subject.subject_label} on beat {beat.pk}.")
+
+    @staticmethod
+    def _match_subject_token(
+        token: str,
+        subject_and_result_pairs: list[tuple[TreasuredSubject, _SignoffMatchT]],
+    ) -> _SignoffMatchT | None:
+        """Match *token* (numeric pk or case-insensitive label) among the given
+        (TreasuredSubject, result) pairs, returning the matching result or None."""
+        if token.isdigit():
+            token_id = int(token)
+            for subject, result in subject_and_result_pairs:
+                if subject.pk == token_id:
+                    return result
+            return None
+        for subject, result in subject_and_result_pairs:
+            if subject.subject_label.lower() == token.lower():
+                return result
+        return None

--- a/src/commands/tests/test_story_command.py
+++ b/src/commands/tests/test_story_command.py
@@ -514,3 +514,46 @@ class CmdStoryPlayerSignoffTests(TestCase):
         messages = self._run(f"signoff {self.beat.pk} Signet Ring withdraw")
         joined = " ".join(messages)
         self.assertIn("no active sign-off", joined.lower())
+
+    def test_signoff_withdraw_cannot_touch_another_players_signoff(self) -> None:
+        from world.boundaries.factories import TreasuredSubjectFactory
+        from world.roster.factories import (
+            PlayerDataFactory,
+            RosterEntryFactory,
+            RosterTenureFactory,
+        )
+        from world.stories.constants import StakeSubjectKind
+        from world.stories.factories import StakeFactory
+        from world.stories.models import TreasuredSignoff
+        from world.stories.services.boundaries import grant_treasured_signoff
+
+        # A second, unrelated player who treasures a DIFFERENT subject, staked on the
+        # same beat, with an active sign-off of their own.
+        other_sheet = CharacterSheetFactory()
+        other_entry = RosterEntryFactory(character_sheet=other_sheet)
+        other_player_data = PlayerDataFactory()
+        other_tenure = RosterTenureFactory(roster_entry=other_entry, player_data=other_player_data)
+        other_treasured = TreasuredSubjectFactory(
+            owner=other_tenure,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Other Player's Locket",
+        )
+        StakeFactory(
+            beat=self.beat,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Other Player's Locket",
+        )
+        other_signoff = grant_treasured_signoff(self.beat, other_player_data, other_treasured)
+
+        # The FIRST caller (self.player_data / self.account) tries to withdraw the OTHER
+        # player's subject by its real label — must not find or touch it.
+        messages = self._run(f"signoff {self.beat.pk} Other Player's Locket withdraw")
+
+        joined = " ".join(messages)
+        self.assertIn("no active sign-off", joined.lower())
+        other_signoff.refresh_from_db()
+        self.assertTrue(other_signoff.active)
+        self.assertIsNone(other_signoff.withdrawn_at)
+        # And the caller's own unrelated signoff-count is untouched.
+        self.assertEqual(TreasuredSignoff.objects.filter(player_data=other_player_data).count(), 1)

--- a/src/commands/tests/test_story_command.py
+++ b/src/commands/tests/test_story_command.py
@@ -312,3 +312,100 @@ class CmdStoryPlayerListTests(TestCase):
 
         joined = " ".join(messages)
         self.assertIn(story.title, joined)
+
+
+class CmdStoryPlayerBeatsTests(TestCase):
+    """`story beats <episode-id>` — beats in one of the caller's active episodes (#1853)."""
+
+    def setUp(self) -> None:
+        from evennia_extensions.factories import AccountFactory, CharacterFactory
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.stories.factories import (
+            ChapterFactory,
+            EpisodeFactory,
+            StoryFactory,
+            StoryProgressFactory,
+        )
+
+        self.account = AccountFactory()
+        self.char = CharacterFactory()
+        self.char.db_account = self.account
+        self.char.save()
+        self.sheet = CharacterSheetFactory(character=self.char)
+
+        self.story = StoryFactory(scope=StoryScope.CHARACTER, character_sheet=self.sheet)
+        self.chapter = ChapterFactory(story=self.story, order=1)
+        self.episode = EpisodeFactory(chapter=self.chapter, order=1)
+        StoryProgressFactory(
+            story=self.story, character_sheet=self.sheet, current_episode=self.episode
+        )
+
+        self.caller = MagicMock()
+        self.caller.msg = MagicMock()
+        self.caller.account = self.account
+
+    def _run(self, args: str) -> list[str]:
+        cmd = _make_cmd(self.caller, args)
+        cmd.func()
+        return _messages(self.caller)
+
+    def test_beats_requires_episode_id(self) -> None:
+        messages = self._run("beats")
+        self.assertTrue(any("Usage" in m for m in messages))
+
+    def test_beats_rejects_episode_not_in_an_active_story_of_the_caller(self) -> None:
+        from world.stories.factories import EpisodeFactory
+
+        other_episode = EpisodeFactory(chapter=self.chapter, order=2)
+        messages = self._run(f"beats {other_episode.pk}")
+        joined = " ".join(messages)
+        self.assertIn("not one of your active stories", joined.lower())
+
+    def test_beats_lists_visible_beat_with_player_hint(self) -> None:
+        from world.stories.factories import BeatFactory
+
+        BeatFactory(episode=self.episode, player_hint="A stranger arrives.")
+        messages = self._run(f"beats {self.episode.pk}")
+        joined = " ".join(messages)
+        self.assertIn("A stranger arrives.", joined)
+
+    def test_beats_hides_secret_beat_with_no_hint(self) -> None:
+        from world.stories.constants import BeatVisibility
+        from world.stories.factories import BeatFactory
+
+        BeatFactory(episode=self.episode, player_hint="", visibility=BeatVisibility.SECRET)
+        messages = self._run(f"beats {self.episode.pk}")
+        joined = " ".join(messages)
+        self.assertIn("(Hidden Beat)", joined)
+
+    def test_beats_flags_pending_signoff(self) -> None:
+        from world.boundaries.factories import TreasuredSubjectFactory
+        from world.roster.factories import (
+            PlayerDataFactory,
+            RosterEntryFactory,
+            RosterTenureFactory,
+        )
+        from world.stories.constants import StakeSubjectKind
+        from world.stories.factories import BeatFactory, StakeFactory
+
+        beat = BeatFactory(episode=self.episode, player_hint="A duel is proposed.")
+        entry = RosterEntryFactory(character_sheet=self.sheet)
+        player_data = PlayerDataFactory(account=self.account)
+        tenure = RosterTenureFactory(roster_entry=entry, player_data=player_data)
+        TreasuredSubjectFactory(
+            owner=tenure,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Signet Ring",
+        )
+        StakeFactory(
+            beat=beat,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Signet Ring",
+        )
+
+        messages = self._run(f"beats {self.episode.pk}")
+
+        joined = " ".join(messages)
+        self.assertIn("SIGN-OFF NEEDED", joined)
+        self.assertIn("Signet Ring", joined)

--- a/src/commands/tests/test_story_command.py
+++ b/src/commands/tests/test_story_command.py
@@ -8,11 +8,15 @@ from django.test import TestCase
 
 from actions.types import ActionResult
 from commands.story import CmdStory
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.stories.constants import StoryScope
 from world.stories.factories import (
     BeatFactory,
     ChapterFactory,
     EpisodeFactory,
     StoryFactory,
+    StoryProgressFactory,
 )
 
 
@@ -34,19 +38,21 @@ class CmdStoryRoutingTests(TestCase):
     """Usage and unknown subcommand handling."""
 
     def setUp(self) -> None:
+        self.account = AccountFactory()
         self.caller = MagicMock()
         self.caller.msg = MagicMock()
+        self.caller.account = self.account
 
     def _run(self, args: str) -> list[str]:
         cmd = _make_cmd(self.caller, args)
         cmd.func()
         return _messages(self.caller)
 
-    def test_bare_command_shows_usage(self) -> None:
+    def test_bare_command_with_no_stories_says_so(self) -> None:
         messages = self._run("")
         self.assertTrue(
-            any("Usage" in m for m in messages),
-            f"Expected usage message; got {messages}",
+            any("no active stories" in m.lower() for m in messages),
+            f"Expected 'no active stories' message; got {messages}",
         )
 
     def test_unknown_subverb_shows_usage(self) -> None:
@@ -263,3 +269,46 @@ class CmdStoryResolutionTests(TestCase):
             any("numeric" in m.lower() for m in messages),
             f"Expected numeric-beat error; got {messages}",
         )
+
+
+class CmdStoryPlayerListTests(TestCase):
+    """Bare `story` / `story list` — the caller's own active stories (#1853)."""
+
+    def setUp(self) -> None:
+        self.account = AccountFactory()
+        self.char = CharacterFactory()
+        self.char.db_account = self.account
+        self.char.save()
+        self.sheet = CharacterSheetFactory(character=self.char)
+
+        self.caller = MagicMock()
+        self.caller.msg = MagicMock()
+        self.caller.account = self.account
+
+    def _run(self, args: str) -> list[str]:
+        cmd = _make_cmd(self.caller, args)
+        cmd.func()
+        return _messages(self.caller)
+
+    def test_bare_story_with_no_active_stories(self) -> None:
+        messages = self._run("")
+        joined = " ".join(messages)
+        self.assertIn("no active stories", joined.lower())
+
+    def test_bare_story_lists_active_character_story(self) -> None:
+        story = StoryFactory(scope=StoryScope.CHARACTER, character_sheet=self.sheet)
+        StoryProgressFactory(story=story, character_sheet=self.sheet, current_episode=None)
+
+        messages = self._run("")
+
+        joined = " ".join(messages)
+        self.assertIn(story.title, joined)
+
+    def test_story_list_is_an_explicit_alias_for_bare(self) -> None:
+        story = StoryFactory(scope=StoryScope.CHARACTER, character_sheet=self.sheet)
+        StoryProgressFactory(story=story, character_sheet=self.sheet, current_episode=None)
+
+        messages = self._run("list")
+
+        joined = " ".join(messages)
+        self.assertIn(story.title, joined)

--- a/src/commands/tests/test_story_command.py
+++ b/src/commands/tests/test_story_command.py
@@ -409,3 +409,108 @@ class CmdStoryPlayerBeatsTests(TestCase):
         joined = " ".join(messages)
         self.assertIn("SIGN-OFF NEEDED", joined)
         self.assertIn("Signet Ring", joined)
+
+
+class CmdStoryPlayerSignoffTests(TestCase):
+    """`story signoff <beat-id> <subject> [withdraw]` (#1853)."""
+
+    def setUp(self) -> None:
+        from evennia_extensions.factories import AccountFactory, CharacterFactory
+        from world.boundaries.factories import TreasuredSubjectFactory
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.roster.factories import (
+            PlayerDataFactory,
+            RosterEntryFactory,
+            RosterTenureFactory,
+        )
+        from world.stories.constants import StakeSubjectKind
+        from world.stories.factories import BeatFactory, StakeFactory
+
+        self.account = AccountFactory()
+        self.char = CharacterFactory()
+        self.char.db_account = self.account
+        self.char.save()
+        self.sheet = CharacterSheetFactory(character=self.char)
+        self.entry = RosterEntryFactory(character_sheet=self.sheet)
+        self.player_data = PlayerDataFactory(account=self.account)
+        self.tenure = RosterTenureFactory(roster_entry=self.entry, player_data=self.player_data)
+        self.treasured = TreasuredSubjectFactory(
+            owner=self.tenure,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Signet Ring",
+        )
+        self.beat = BeatFactory()
+        StakeFactory(
+            beat=self.beat,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Signet Ring",
+        )
+
+        self.caller = MagicMock()
+        self.caller.msg = MagicMock()
+        self.caller.account = self.account
+
+    def _run(self, args: str) -> list[str]:
+        cmd = _make_cmd(self.caller, args)
+        cmd.func()
+        return _messages(self.caller)
+
+    def test_signoff_requires_beat_and_subject(self) -> None:
+        messages = self._run(f"signoff {self.beat.pk}")
+        self.assertTrue(any("Usage" in m for m in messages))
+
+    def test_signoff_grants_by_subject_name(self) -> None:
+        from world.stories.models import TreasuredSignoff
+
+        messages = self._run(f"signoff {self.beat.pk} Signet Ring")
+
+        self.assertTrue(
+            TreasuredSignoff.objects.filter(
+                beat=self.beat,
+                player_data=self.player_data,
+                treasured_subject=self.treasured,
+                withdrawn_at__isnull=True,
+            ).exists()
+        )
+        joined = " ".join(messages)
+        self.assertIn("Signed off", joined)
+
+    def test_signoff_grants_by_subject_id(self) -> None:
+        from world.stories.models import TreasuredSignoff
+
+        self._run(f"signoff {self.beat.pk} {self.treasured.pk}")
+
+        self.assertTrue(
+            TreasuredSignoff.objects.filter(
+                beat=self.beat,
+                player_data=self.player_data,
+                treasured_subject=self.treasured,
+                withdrawn_at__isnull=True,
+            ).exists()
+        )
+
+    def test_signoff_unknown_subject_errors(self) -> None:
+        messages = self._run(f"signoff {self.beat.pk} Nonexistent Thing")
+        joined = " ".join(messages)
+        self.assertIn("no pending sign-off", joined.lower())
+
+    def test_signoff_withdraw_reopens_the_gate(self) -> None:
+        from world.stories.models import TreasuredSignoff
+        from world.stories.services.boundaries import grant_treasured_signoff
+
+        grant_treasured_signoff(self.beat, self.player_data, self.treasured)
+
+        messages = self._run(f"signoff {self.beat.pk} Signet Ring withdraw")
+
+        signoff = TreasuredSignoff.objects.get(
+            beat=self.beat, player_data=self.player_data, treasured_subject=self.treasured
+        )
+        self.assertIsNotNone(signoff.withdrawn_at)
+        joined = " ".join(messages)
+        self.assertIn("Withdrawn", joined)
+
+    def test_signoff_withdraw_unknown_active_signoff_errors(self) -> None:
+        messages = self._run(f"signoff {self.beat.pk} Signet Ring withdraw")
+        joined = " ".join(messages)
+        self.assertIn("no active sign-off", joined.lower())

--- a/src/schema.json
+++ b/src/schema.json
@@ -52051,12 +52051,14 @@ components:
           type: integer
           nullable: true
           description: |-
-            The current tenure of this CHARACTER-scope story's character, if any.
+            The current tenure of this CHARACTER-scope story's character (whoever is
+            currently playing them) — coincides with the viewer's own tenure only for
+            that player; other viewers get an inert value since
+            `TreasuredSignoffPrompt`'s own player-scoped queries return nothing for a
+            `tenure_id` that isn't theirs.
 
             Null for GROUP/GLOBAL-scope stories (no character_sheet) and for a
-            CHARACTER-scope story whose character has no current tenure. Lets the
-            frontend scope the #1853 pending-treasured-signoff auto-surfacing to
-            the viewer's own tenure without a second round-trip.
+            CHARACTER-scope story whose character has no current tenure.
           readOnly: true
         primary_table:
           type: integer

--- a/src/schema.json
+++ b/src/schema.json
@@ -52047,6 +52047,17 @@ components:
           type: integer
           description: The character this sheet belongs to
           readOnly: true
+        tenure_id:
+          type: integer
+          nullable: true
+          description: |-
+            The current tenure of this CHARACTER-scope story's character, if any.
+
+            Null for GROUP/GLOBAL-scope stories (no character_sheet) and for a
+            CHARACTER-scope story whose character has no current tenure. Lets the
+            frontend scope the #1853 pending-treasured-signoff auto-surfacing to
+            the viewer's own tenure without a second round-trip.
+          readOnly: true
         primary_table:
           type: integer
           readOnly: true
@@ -52082,6 +52093,7 @@ components:
       - id
       - owners
       - primary_table
+      - tenure_id
       - title
       - trust_requirements
       - updated_at

--- a/src/schema.json
+++ b/src/schema.json
@@ -24816,6 +24816,31 @@ paths:
       responses:
         '200':
           description: No response body
+  /api/stories/my-pending-signoffs/:
+    get:
+      operationId: stories_my_pending_signoffs_list
+      description: |-
+        GET /api/stories/my-pending-signoffs/?beats=1&beats=2 (#1853).
+
+        Player-safe (never GM-facing): for the requesting player's own account,
+        which of the given beats have one of THEIR OWN treasured subjects staked
+        without an active sign-off. Batched across beats — the caller passes the
+        beat ids it already has on screen (mirrors BeatStakeAvailabilityView's
+        multi-value query-param style, but scoped to the caller instead of a
+        GM-supplied party).
+      tags:
+      - stories
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PendingTreasuredSignoffs'
+          description: ''
   /api/stories/staff-workload/:
     get:
       operationId: stories_staff_workload_retrieve
@@ -46117,6 +46142,26 @@ components:
       - sinner_persona_name
       - sinner_sheet_id
       - strain_cost_per_unit
+    PendingTreasuredSignoffs:
+      type: object
+      description: |-
+        Player-safe wire shape for one world.stories.types.PendingTreasuredSignoffs entry (#1853).
+
+        Exposes only the requesting player's own beat_id + treasured_subject_ids —
+        the view-level query already guarantees no other player's data can appear
+        here (ADR-0033); this serializer adds no fields beyond that.
+      properties:
+        beat_id:
+          type: integer
+          readOnly: true
+        treasured_subject_ids:
+          type: array
+          items:
+            type: integer
+          readOnly: true
+      required:
+      - beat_id
+      - treasured_subject_ids
     PermitOfferDetails:
       type: object
       properties:

--- a/src/world/stories/serializers.py
+++ b/src/world/stories/serializers.py
@@ -238,12 +238,14 @@ class StoryDetailSerializer(serializers.ModelSerializer):
         return obj.get_trust_requirements_summary()
 
     def get_tenure_id(self, obj: Story) -> int | None:
-        """The current tenure of this CHARACTER-scope story's character, if any.
+        """The current tenure of this CHARACTER-scope story's character (whoever is
+        currently playing them) — coincides with the viewer's own tenure only for
+        that player; other viewers get an inert value since
+        `TreasuredSignoffPrompt`'s own player-scoped queries return nothing for a
+        `tenure_id` that isn't theirs.
 
         Null for GROUP/GLOBAL-scope stories (no character_sheet) and for a
-        CHARACTER-scope story whose character has no current tenure. Lets the
-        frontend scope the #1853 pending-treasured-signoff auto-surfacing to
-        the viewer's own tenure without a second round-trip.
+        CHARACTER-scope story whose character has no current tenure.
         """
         sheet = obj.character_sheet
         if sheet is None:

--- a/src/world/stories/serializers.py
+++ b/src/world/stories/serializers.py
@@ -3025,3 +3025,15 @@ class StakeAvailabilitySerializer(serializers.Serializer):
     available = serializers.IntegerField(read_only=True)
     blocked = serializers.IntegerField(read_only=True)
     needs_signoff = serializers.IntegerField(read_only=True)
+
+
+class PendingTreasuredSignoffsSerializer(serializers.Serializer):
+    """Player-safe wire shape for one world.stories.types.PendingTreasuredSignoffs entry (#1853).
+
+    Exposes only the requesting player's own beat_id + treasured_subject_ids —
+    the view-level query already guarantees no other player's data can appear
+    here (ADR-0033); this serializer adds no fields beyond that.
+    """
+
+    beat_id = serializers.IntegerField(read_only=True)
+    treasured_subject_ids = serializers.ListField(child=serializers.IntegerField(), read_only=True)

--- a/src/world/stories/serializers.py
+++ b/src/world/stories/serializers.py
@@ -191,6 +191,7 @@ class StoryDetailSerializer(serializers.ModelSerializer):
     owners = serializers.StringRelatedField(many=True, read_only=True)
     active_gms = GMProfileSerializer(many=True, read_only=True)
     character_sheet = serializers.PrimaryKeyRelatedField(read_only=True)
+    tenure_id = serializers.SerializerMethodField()
     primary_table = serializers.PrimaryKeyRelatedField(read_only=True)
     chapters_count = serializers.IntegerField(source="chapters.count", read_only=True)
     trust_requirements = serializers.SerializerMethodField()
@@ -210,6 +211,7 @@ class StoryDetailSerializer(serializers.ModelSerializer):
             "active_gms",
             "trust_requirements",
             "character_sheet",
+            "tenure_id",
             "primary_table",
             "chapters_count",
             "created_at",
@@ -223,6 +225,7 @@ class StoryDetailSerializer(serializers.ModelSerializer):
             "active_gms",
             "trust_requirements",
             "character_sheet",
+            "tenure_id",
             "primary_table",
             "chapters_count",
             "created_at",
@@ -233,6 +236,22 @@ class StoryDetailSerializer(serializers.ModelSerializer):
     def get_trust_requirements(self, obj):
         """Get trust requirements for this story"""
         return obj.get_trust_requirements_summary()
+
+    def get_tenure_id(self, obj: Story) -> int | None:
+        """The current tenure of this CHARACTER-scope story's character, if any.
+
+        Null for GROUP/GLOBAL-scope stories (no character_sheet) and for a
+        CHARACTER-scope story whose character has no current tenure. Lets the
+        frontend scope the #1853 pending-treasured-signoff auto-surfacing to
+        the viewer's own tenure without a second round-trip.
+        """
+        sheet = obj.character_sheet
+        if sheet is None:
+            return None
+        # OneToOne reverse accessor may not exist.
+        entry = getattr(sheet, "roster_entry", None)  # noqa: GETATTR_LITERAL
+        tenure = entry.current_tenure if entry else None
+        return tenure.pk if tenure else None
 
     def to_representation(self, instance: Story) -> dict[str, object]:
         """Gate GM-only authoring text for player-tier viewers (Task A3)."""

--- a/src/world/stories/services/boundaries.py
+++ b/src/world/stories/services/boundaries.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 
 from django.utils import timezone
 
-from world.stories.types import StakeAvailability, StakeBoundaryReport
+from world.stories.types import PendingTreasuredSignoffs, StakeAvailability, StakeBoundaryReport
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -341,3 +341,107 @@ def stake_availability(
         else:
             available += 1
     return StakeAvailability(available=available, blocked=blocked, needs_signoff=needs_signoff)
+
+
+def player_pending_treasured_signoffs(
+    player_data: PlayerData,
+    beats: Sequence[Beat],
+) -> list[PendingTreasuredSignoffs]:
+    """For each of ``beats``, which of ``player_data``'s own TreasuredSubjects are
+    staked on it without an active TreasuredSignoff (#1853).
+
+    Player-safe (ADR-0033): only ever reads this player's own TreasuredSubject/
+    TreasuredSignoff rows plus the given beats' Stake rows — never another
+    player's sheets, other stakes, hard-line info, or the GM's broader stake
+    plan. Batched: one query for the player's own TreasuredSubjects (scoped to
+    tenures where the player is the CURRENT player — ``end_date__isnull=True``,
+    mirroring ``_resolve_sheet_identity``'s "current tenure only" semantics),
+    one for Stake rows across all given beats, one for the player's active
+    TreasuredSignoff rows across all given beats. Reuses ``_subject_identity``
+    for matching — the same identity function ``_treasured_requires_signoff``
+    uses, so this never drifts from the enforcement seam's definition of
+    "match." Needs no CharacterSheet list at all (unlike the GM-side
+    function) since TreasuredSubject.owner is a RosterTenure directly.
+    """
+    from world.boundaries.models import TreasuredSubject  # noqa: PLC0415
+    from world.stories.models import Stake, TreasuredSignoff  # noqa: PLC0415
+
+    beats = list(beats)
+    if not beats:
+        return []
+
+    tenure_ids = list(
+        player_data.tenures.filter(end_date__isnull=True).values_list("pk", flat=True)
+    )
+    if not tenure_ids:
+        return []
+
+    subjects = list(TreasuredSubject.objects.filter(owner_id__in=tenure_ids))
+    if not subjects:
+        return []
+
+    subject_by_identity: dict[SubjectIdentity, int] = {
+        _subject_identity(
+            s.subject_kind,
+            s.subject_sheet_id,
+            s.subject_item_id,
+            s.subject_society_id,
+            s.subject_organization_id,
+            s.subject_label,
+        ): s.pk
+        for s in subjects
+    }
+
+    beat_ids = [b.pk for b in beats]
+    stake_rows = Stake.objects.filter(beat_id__in=beat_ids).values_list(
+        "beat_id",
+        "subject_kind",
+        "subject_sheet_id",
+        "subject_item_id",
+        "subject_society_id",
+        "subject_organization_id",
+        "subject_label",
+    )
+
+    matched_by_beat: dict[int, set[int]] = defaultdict(set)
+    for (
+        beat_id,
+        subject_kind,
+        subject_sheet_id,
+        subject_item_id,
+        subject_society_id,
+        subject_organization_id,
+        subject_label,
+    ) in stake_rows:
+        identity = _subject_identity(
+            subject_kind,
+            subject_sheet_id,
+            subject_item_id,
+            subject_society_id,
+            subject_organization_id,
+            subject_label,
+        )
+        treasured_id = subject_by_identity.get(identity)
+        if treasured_id is not None:
+            matched_by_beat[beat_id].add(treasured_id)
+
+    if not matched_by_beat:
+        return []
+
+    active_signoffs = set(
+        TreasuredSignoff.objects.filter(
+            beat_id__in=matched_by_beat.keys(),
+            player_data=player_data,
+            withdrawn_at__isnull=True,
+        ).values_list("beat_id", "treasured_subject_id")
+    )
+
+    result: list[PendingTreasuredSignoffs] = []
+    for beat_id, treasured_ids in matched_by_beat.items():
+        pending = sorted(tid for tid in treasured_ids if (beat_id, tid) not in active_signoffs)
+        if pending:
+            result.append(
+                PendingTreasuredSignoffs(beat_id=beat_id, treasured_subject_ids=tuple(pending))
+            )
+    result.sort(key=lambda e: e.beat_id)
+    return result

--- a/src/world/stories/services/boundaries.py
+++ b/src/world/stories/services/boundaries.py
@@ -370,9 +370,7 @@ def player_pending_treasured_signoffs(
     if not beats:
         return []
 
-    tenure_ids = list(
-        player_data.tenures.filter(end_date__isnull=True).values_list("pk", flat=True)
-    )
+    tenure_ids = [tenure.pk for tenure in player_data.cached_active_tenures]
     if not tenure_ids:
         return []
 

--- a/src/world/stories/services/dashboards.py
+++ b/src/world/stories/services/dashboards.py
@@ -13,10 +13,26 @@ Public API:
 
 from __future__ import annotations
 
-from world.stories.constants import ProgressStatus, SessionRequestStatus, StoryEpisodeStatus
+from typing import TYPE_CHECKING
+
+from world.stories.constants import (
+    ProgressStatus,
+    SessionRequestStatus,
+    StoryEpisodeStatus,
+    StoryScope,
+)
 from world.stories.exceptions import ProgressionRequirementNotMetError
-from world.stories.models import Episode
-from world.stories.types import AnyStoryProgress, StoryStatusSummary
+from world.stories.models import Episode, GlobalStoryProgress, GroupStoryProgress, StoryProgress
+from world.stories.types import (
+    AnyStoryProgress,
+    MyActiveStoriesResult,
+    MyActiveStoryEntry,
+    StoryStatusSummary,
+)
+
+if TYPE_CHECKING:
+    from django.contrib.auth.base_user import AbstractBaseUser
+    from django.contrib.auth.models import AnonymousUser
 
 # Days before a story's last_advanced_at is considered stale.
 STALE_STORY_DAYS = 14
@@ -181,3 +197,100 @@ def compute_story_status_line(progress: AnyStoryProgress) -> str:
     if summary.episode_title is None:
         return "Your story is being prepared. Check back soon."
     return f"Currently in “{summary.episode_title}.” The story continues."
+
+
+def _serialize_progress_entry(progress: AnyStoryProgress, scope: str) -> MyActiveStoryEntry:
+    """Build the dict shape shared by all three scope collectors below."""
+    story = progress.story
+    episode = progress.current_episode
+    summary = compute_story_status(progress)
+
+    current_episode_id: int | None = episode.pk if episode is not None else None
+
+    return {
+        "story_id": story.pk,
+        "story_title": story.title,
+        "scope": scope,
+        "current_episode_id": current_episode_id,
+        "current_episode_title": summary.episode_title,
+        "chapter_title": summary.chapter_title,
+        "status": summary.status,
+        "status_label": StoryEpisodeStatus(summary.status).label,
+        "progress_status": progress.status,
+        "chapter_order": summary.chapter_order,
+        "episode_order": summary.episode_order,
+        "open_session_request_id": summary.open_session_request_id,
+        "scheduled_event_id": summary.scheduled_event_id,
+        "scheduled_real_time": summary.scheduled_real_time,
+    }
+
+
+def _collect_character_stories(
+    account: AbstractBaseUser | AnonymousUser,
+) -> list[MyActiveStoryEntry]:
+    """Return active CHARACTER-scope progress entries owned by this account."""
+    qs = StoryProgress.objects.filter(
+        story__character_sheet__character__db_account=account,
+        is_active=True,
+    ).select_related(
+        "story",
+        "current_episode",
+        "current_episode__chapter",
+    )
+    return [_serialize_progress_entry(p, StoryScope.CHARACTER) for p in qs]
+
+
+def _collect_group_stories(
+    account: AbstractBaseUser | AnonymousUser,
+) -> list[MyActiveStoryEntry]:
+    """Return active GROUP-scope progress entries for tables this account belongs to."""
+    qs = (
+        GroupStoryProgress.objects.filter(
+            gm_table__memberships__persona__character_sheet__character__db_account=account,
+            gm_table__memberships__left_at__isnull=True,
+            is_active=True,
+        )
+        .select_related(
+            "story",
+            "current_episode",
+            "current_episode__chapter",
+        )
+        .distinct()
+    )
+    return [_serialize_progress_entry(p, StoryScope.GROUP) for p in qs]
+
+
+def _collect_global_stories(
+    account: AbstractBaseUser | AnonymousUser,
+) -> list[MyActiveStoryEntry]:
+    """Return active GLOBAL-scope progress entries where the account has a StoryParticipation."""
+    qs = (
+        GlobalStoryProgress.objects.filter(
+            story__participants__character__db_account=account,
+            story__participants__is_active=True,
+            is_active=True,
+        )
+        .select_related(
+            "story",
+            "current_episode",
+            "current_episode__chapter",
+        )
+        .distinct()
+    )
+    return [_serialize_progress_entry(p, StoryScope.GLOBAL) for p in qs]
+
+
+def active_stories_for_account(
+    account: AbstractBaseUser | AnonymousUser,
+) -> MyActiveStoriesResult:
+    """Active stories across all three scopes (CHARACTER / GROUP / GLOBAL) for *account*.
+
+    The shared seam behind both ``MyActiveStoriesView`` (web) and the telnet
+    ``story list`` subverb (#1853) — one query path, not two parallel
+    implementations of "what are my active stories."
+    """
+    return {
+        "character_stories": _collect_character_stories(account),
+        "group_stories": _collect_group_stories(account),
+        "global_stories": _collect_global_stories(account),
+    }

--- a/src/world/stories/tests/test_player_pending_signoffs_service.py
+++ b/src/world/stories/tests/test_player_pending_signoffs_service.py
@@ -1,0 +1,152 @@
+"""Tests for player_pending_treasured_signoffs (#1853)."""
+
+from django.test import TestCase
+
+from world.boundaries.factories import TreasuredSubjectFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
+from world.stories.constants import StakeSubjectKind
+from world.stories.factories import BeatFactory, StakeFactory
+from world.stories.services.boundaries import (
+    grant_treasured_signoff,
+    player_pending_treasured_signoffs,
+)
+
+
+def _sheet_with_player():
+    """A CharacterSheet with a live current tenure (roster_entry -> tenure -> player_data)."""
+    sheet = CharacterSheetFactory()
+    entry = RosterEntryFactory(character_sheet=sheet)
+    player_data = PlayerDataFactory()
+    tenure = RosterTenureFactory(roster_entry=entry, player_data=player_data)
+    return sheet, tenure, player_data
+
+
+class PlayerPendingTreasuredSignoffsTests(TestCase):
+    def test_flags_a_staked_treasured_subject_without_signoff(self):
+        beat = BeatFactory()
+        _sheet, tenure, player_data = _sheet_with_player()
+        treasured = TreasuredSubjectFactory(
+            owner=tenure,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+        StakeFactory(
+            beat=beat,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+
+        entries = player_pending_treasured_signoffs(player_data, [beat])
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].beat_id, beat.pk)
+        self.assertEqual(entries[0].treasured_subject_ids, (treasured.pk,))
+
+    def test_signed_off_subject_is_excluded(self):
+        beat = BeatFactory()
+        _sheet, tenure, player_data = _sheet_with_player()
+        treasured = TreasuredSubjectFactory(
+            owner=tenure,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+        StakeFactory(
+            beat=beat,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+        grant_treasured_signoff(beat, player_data, treasured)
+
+        entries = player_pending_treasured_signoffs(player_data, [beat])
+
+        self.assertEqual(entries, [])
+
+    def test_unrelated_stake_never_appears(self):
+        """A stake matching no treasured subject of this player produces no entry."""
+        beat = BeatFactory()
+        _sheet, _tenure, player_data = _sheet_with_player()
+        StakeFactory(beat=beat, template=None, subject_label="Ordinary wager")
+
+        entries = player_pending_treasured_signoffs(player_data, [beat])
+
+        self.assertEqual(entries, [])
+
+    def test_another_players_treasured_subject_never_appears(self):
+        """Player-safe: a different player's treasured subject match is invisible here."""
+        beat = BeatFactory()
+        _sheet, tenure, _other_player_data = _sheet_with_player()
+        TreasuredSubjectFactory(
+            owner=tenure,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+        StakeFactory(
+            beat=beat,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+        querying_player_data = PlayerDataFactory()
+
+        entries = player_pending_treasured_signoffs(querying_player_data, [beat])
+
+        self.assertEqual(entries, [])
+
+    def test_batches_across_multiple_beats(self):
+        beat_a = BeatFactory()
+        beat_b = BeatFactory()
+        _sheet, tenure, player_data = _sheet_with_player()
+        treasured = TreasuredSubjectFactory(
+            owner=tenure,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+        StakeFactory(
+            beat=beat_a,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+        StakeFactory(
+            beat=beat_b,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+
+        entries = player_pending_treasured_signoffs(player_data, [beat_a, beat_b])
+
+        self.assertEqual({e.beat_id for e in entries}, {beat_a.pk, beat_b.pk})
+        for entry in entries:
+            self.assertEqual(entry.treasured_subject_ids, (treasured.pk,))
+
+    def test_no_beats_returns_empty(self):
+        _sheet, _tenure, player_data = _sheet_with_player()
+        self.assertEqual(player_pending_treasured_signoffs(player_data, []), [])
+
+    def test_retired_tenure_is_not_matched(self):
+        """A treasured subject owned by a tenure that's no longer current is ignored."""
+        from django.utils import timezone
+
+        beat = BeatFactory()
+        _sheet, tenure, player_data = _sheet_with_player()
+        tenure.end_date = timezone.now()
+        tenure.save(update_fields=["end_date"])
+        TreasuredSubjectFactory(
+            owner=tenure,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+        StakeFactory(
+            beat=beat,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Grandmother's locket",
+        )
+
+        entries = player_pending_treasured_signoffs(player_data, [beat])
+
+        self.assertEqual(entries, [])

--- a/src/world/stories/tests/test_serializers_visibility_split.py
+++ b/src/world/stories/tests/test_serializers_visibility_split.py
@@ -21,6 +21,7 @@ from rest_framework.test import APITestCase
 from evennia_extensions.factories import AccountFactory, CharacterFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.gm.factories import GMProfileFactory, GMTableFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 from world.stories.constants import StoryMaturity, StoryScope
 from world.stories.factories import ChapterFactory, EpisodeFactory, StoryFactory
 from world.stories.serializers import (
@@ -353,3 +354,49 @@ class DefaultDenyVisibilityTests(TestCase):
             self.assertEqual(ep_data["description"], DESCRIPTION_SENTINEL)
             self.assertEqual(ep_data["consequences"], CONSEQUENCES_SENTINEL)
             self.assertEqual(ep_data["summary"], SUMMARY_SENTINEL)
+
+
+class StoryDetailTenureIdTests(TestCase):
+    """#1853: ``tenure_id`` lets the frontend scope pending-signoff surfacing.
+
+    Covers the null-safe FK chain ``character_sheet -> roster_entry ->
+    current_tenure -> pk`` on ``StoryDetailSerializer``.
+    """
+
+    def test_character_scope_story_with_current_tenure_returns_tenure_id(self):
+        """A CHARACTER-scope story whose character has a current tenure."""
+        sheet = CharacterSheetFactory()
+        roster_entry = RosterEntryFactory(character_sheet=sheet)
+        tenure = RosterTenureFactory(roster_entry=roster_entry)
+        story = StoryFactory(scope=StoryScope.CHARACTER, character_sheet=sheet)
+
+        data = StoryDetailSerializer(story, context={}).data
+
+        self.assertEqual(data["tenure_id"], tenure.pk)
+
+    def test_group_scope_story_has_no_character_sheet_and_null_tenure_id(self):
+        """A GROUP-scope story has no ``character_sheet`` — ``tenure_id`` is null."""
+        story = StoryFactory(scope=StoryScope.GROUP, character_sheet=None)
+
+        data = StoryDetailSerializer(story, context={}).data
+
+        self.assertIsNone(data["character_sheet"])
+        self.assertIsNone(data["tenure_id"])
+
+    def test_global_scope_story_has_no_character_sheet_and_null_tenure_id(self):
+        """A GLOBAL-scope story has no ``character_sheet`` — ``tenure_id`` is null."""
+        story = StoryFactory(scope=StoryScope.GLOBAL, character_sheet=None)
+
+        data = StoryDetailSerializer(story, context={}).data
+
+        self.assertIsNone(data["character_sheet"])
+        self.assertIsNone(data["tenure_id"])
+
+    def test_character_with_no_current_tenure_returns_null_tenure_id(self):
+        """A CHARACTER-scope story whose character has no roster tenure at all."""
+        sheet = CharacterSheetFactory()
+        story = StoryFactory(scope=StoryScope.CHARACTER, character_sheet=sheet)
+
+        data = StoryDetailSerializer(story, context={}).data
+
+        self.assertIsNone(data["tenure_id"])

--- a/src/world/stories/tests/test_views_my_pending_signoffs.py
+++ b/src/world/stories/tests/test_views_my_pending_signoffs.py
@@ -117,3 +117,12 @@ class MyPendingSignoffsResponseTest(APITestCase):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data == []
+
+    def test_non_numeric_beats_param_is_ignored_not_500(self):
+        account = AccountFactory()
+        self.client.force_authenticate(user=account)
+
+        response = self.client.get(MY_PENDING_SIGNOFFS_URL, {"beats": ["abc", "42"]})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []

--- a/src/world/stories/tests/test_views_my_pending_signoffs.py
+++ b/src/world/stories/tests/test_views_my_pending_signoffs.py
@@ -1,0 +1,119 @@
+"""Tests for PlayerPendingTreasuredSignoffsView — GET /api/stories/my-pending-signoffs/ (#1853)."""
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from core_management.test_utils import suppress_permission_errors
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.boundaries.factories import TreasuredSubjectFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
+from world.stories.constants import StakeSubjectKind
+from world.stories.factories import BeatFactory, StakeFactory
+from world.stories.services.boundaries import grant_treasured_signoff
+
+MY_PENDING_SIGNOFFS_URL = reverse("stories-my-pending-signoffs")
+
+
+def _account_with_treasured_subject(label: str):
+    """An Account whose active character owns a TreasuredSubject with *label*."""
+    account = AccountFactory()
+    char = CharacterFactory()
+    char.db_account = account
+    char.save()
+    sheet = CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet=sheet)
+    player_data = PlayerDataFactory(account=account)
+    tenure = RosterTenureFactory(roster_entry=entry, player_data=player_data)
+    treasured = TreasuredSubjectFactory(
+        owner=tenure,
+        subject_kind=StakeSubjectKind.CUSTOM,
+        subject_label=label,
+    )
+    return account, player_data, treasured
+
+
+class MyPendingSignoffsAuthTest(APITestCase):
+    @suppress_permission_errors
+    def test_unauthenticated_rejected(self):
+        response = self.client.get(MY_PENDING_SIGNOFFS_URL)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+
+class MyPendingSignoffsResponseTest(APITestCase):
+    def test_no_beats_query_param_returns_empty_list(self):
+        account = AccountFactory()
+        self.client.force_authenticate(user=account)
+        response = self.client.get(MY_PENDING_SIGNOFFS_URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []
+
+    def test_flags_beat_with_pending_signoff(self):
+        account, _player_data, treasured = _account_with_treasured_subject("Signet Ring")
+        beat = BeatFactory()
+        StakeFactory(
+            beat=beat,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Signet Ring",
+        )
+        self.client.force_authenticate(user=account)
+
+        response = self.client.get(MY_PENDING_SIGNOFFS_URL, {"beats": [beat.pk]})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == [{"beat_id": beat.pk, "treasured_subject_ids": [treasured.pk]}]
+
+    def test_signed_off_beat_is_omitted(self):
+        account, player_data, treasured = _account_with_treasured_subject("Signet Ring")
+        beat = BeatFactory()
+        StakeFactory(
+            beat=beat,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Signet Ring",
+        )
+        grant_treasured_signoff(beat, player_data, treasured)
+        self.client.force_authenticate(user=account)
+
+        response = self.client.get(MY_PENDING_SIGNOFFS_URL, {"beats": [beat.pk]})
+
+        assert response.data == []
+
+    def test_never_returns_another_players_pending_signoff(self):
+        _other_account, _other_player_data, _other_treasured = _account_with_treasured_subject(
+            "Signet Ring"
+        )
+        beat = BeatFactory()
+        StakeFactory(
+            beat=beat,
+            template=None,
+            subject_kind=StakeSubjectKind.CUSTOM,
+            subject_label="Signet Ring",
+        )
+        # The querying account has its OWN player_data and its OWN treasured subject
+        # (a different one) so this exercises the real cross-player identity-matching
+        # path in player_pending_treasured_signoffs, not just the no-player_data
+        # early return already covered by test_account_with_no_player_data_gets_empty_list.
+        querying_account, _querying_player_data, _querying_treasured = (
+            _account_with_treasured_subject("Unrelated Charm")
+        )
+        self.client.force_authenticate(user=querying_account)
+
+        response = self.client.get(MY_PENDING_SIGNOFFS_URL, {"beats": [beat.pk]})
+
+        assert response.data == []
+
+    def test_account_with_no_player_data_gets_empty_list(self):
+        account = AccountFactory()
+        beat = BeatFactory()
+        self.client.force_authenticate(user=account)
+
+        response = self.client.get(MY_PENDING_SIGNOFFS_URL, {"beats": [beat.pk]})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []

--- a/src/world/stories/types.py
+++ b/src/world/stories/types.py
@@ -172,6 +172,14 @@ class MyActiveStoryEntry(TypedDict):
     scheduled_real_time: datetime | None
 
 
+class MyActiveStoriesResult(TypedDict):
+    """Response shape for MyActiveStoriesView / active_stories_for_account (#1853)."""
+
+    character_stories: list[MyActiveStoryEntry]
+    group_stories: list[MyActiveStoryEntry]
+    global_stories: list[MyActiveStoryEntry]
+
+
 class EligibleTransitionEntry(TypedDict):
     """A single eligible Transition surfaced in the GM queue."""
 

--- a/src/world/stories/types.py
+++ b/src/world/stories/types.py
@@ -312,6 +312,21 @@ class StakeAvailability:
 
 
 @dataclass(frozen=True)
+class PendingTreasuredSignoffs:
+    """Player-safe pending-signoff tally for one beat (#1853).
+
+    Produced by ``world.stories.services.boundaries.player_pending_treasured_signoffs``.
+    Player-safe (ADR-0033): ``treasured_subject_ids`` names only the REQUESTING
+    player's own TreasuredSubjects that are staked on this beat without an
+    active sign-off — never another player's, never the GM's broader stake
+    plan, never a reason.
+    """
+
+    beat_id: int
+    treasured_subject_ids: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
 class StakesReadinessReport:
     """Result of validate_stakes_readiness (world.stories.services.stakes).
 

--- a/src/world/stories/urls.py
+++ b/src/world/stories/urls.py
@@ -16,6 +16,7 @@ from world.stories.views import (
     GMQueueView,
     GroupStoryProgressViewSet,
     MyActiveStoriesView,
+    PlayerPendingTreasuredSignoffsView,
     PlayerTrustViewSet,
     RiskCalibrationViewSet,
     SessionRequestViewSet,
@@ -81,6 +82,11 @@ urlpatterns = [
     # These MUST be registered before the router include so they take precedence
     # over the router's story-detail route (api/stories/{pk}/).
     path("api/stories/my-active/", MyActiveStoriesView.as_view(), name="stories-my-active"),
+    path(
+        "api/stories/my-pending-signoffs/",
+        PlayerPendingTreasuredSignoffsView.as_view(),
+        name="stories-my-pending-signoffs",
+    ),
     path("api/stories/gm-queue/", GMQueueView.as_view(), name="stories-gm-queue"),
     path(
         "api/stories/staff-workload/",

--- a/src/world/stories/views.py
+++ b/src/world/stories/views.py
@@ -3164,7 +3164,7 @@ class PlayerPendingTreasuredSignoffsView(APIView):
         if not hasattr(request.user, "player_data"):
             return Response([])
         player_data = cast(PlayerData, request.user.player_data)
-        beat_ids = request.query_params.getlist("beats")
+        beat_ids = [b for b in request.query_params.getlist("beats") if b.isdigit()]
         beats = list(Beat.objects.filter(pk__in=beat_ids))
         entries = player_pending_treasured_signoffs(player_data, beats)
         return Response(PendingTreasuredSignoffsSerializer(entries, many=True).data)

--- a/src/world/stories/views.py
+++ b/src/world/stories/views.py
@@ -167,6 +167,7 @@ from world.stories.serializers import (
     GroupStoryProgressSerializer,
     MarkBeatInputSerializer,
     OfferStoryToGMInputSerializer,
+    PendingTreasuredSignoffsSerializer,
     PlayerTrustSerializer,
     PromoteEpisodeInputSerializer,
     RejectClaimInputSerializer,
@@ -3139,3 +3140,31 @@ class BeatStakeAvailabilityView(APIView):
         sheets = list(CharacterSheet.objects.filter(pk__in=sheet_ids)) if sheet_ids else []
         availability = stake_availability(beat, sheets)
         return Response(StakeAvailabilitySerializer(availability).data)
+
+
+class PlayerPendingTreasuredSignoffsView(APIView):
+    """GET /api/stories/my-pending-signoffs/?beats=1&beats=2 (#1853).
+
+    Player-safe (never GM-facing): for the requesting player's own account,
+    which of the given beats have one of THEIR OWN treasured subjects staked
+    without an active sign-off. Batched across beats — the caller passes the
+    beat ids it already has on screen (mirrors BeatStakeAvailabilityView's
+    multi-value query-param style, but scoped to the caller instead of a
+    GM-supplied party).
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(responses=PendingTreasuredSignoffsSerializer(many=True))
+    def get(self, request: Request) -> Response:
+        from world.stories.services.boundaries import (  # noqa: PLC0415
+            player_pending_treasured_signoffs,
+        )
+
+        if not hasattr(request.user, "player_data"):
+            return Response([])
+        player_data = cast(PlayerData, request.user.player_data)
+        beat_ids = request.query_params.getlist("beats")
+        beats = list(Beat.objects.filter(pk__in=beat_ids))
+        entries = player_pending_treasured_signoffs(player_data, beats)
+        return Response(PendingTreasuredSignoffsSerializer(entries, many=True).data)

--- a/src/world/stories/views.py
+++ b/src/world/stories/views.py
@@ -4,8 +4,6 @@ from datetime import datetime
 from http import HTTPMethod
 from typing import TYPE_CHECKING, Any, cast
 
-from django.contrib.auth.base_user import AbstractBaseUser
-from django.contrib.auth.models import AnonymousUser
 from django.db import models, transaction
 from django.db.models import Count, Manager, Prefetch, QuerySet
 from django.shortcuts import get_object_or_404
@@ -207,7 +205,7 @@ from world.stories.serializers import (
     WithdrawOfferInputSerializer,
     stakes_summary_for_beat,
 )
-from world.stories.services.dashboards import STALE_STORY_DAYS, compute_story_status
+from world.stories.services.dashboards import STALE_STORY_DAYS
 from world.stories.services.era import advance_era, archive_era
 from world.stories.services.participation import create_story_participation
 from world.stories.services.progress import get_active_progress_for_story
@@ -219,7 +217,6 @@ from world.stories.types import (
     EligibleTransitionEntry,
     EpisodeReadyEntry,
     FrontierStoryEntry,
-    MyActiveStoryEntry,
     PendingClaimEntry,
     PerGMQueueDepthEntry,
     StaleStoryEntry,
@@ -1751,89 +1748,6 @@ class TransitionRequiredOutcomeViewSet(viewsets.ModelViewSet):
 # ---------------------------------------------------------------------------
 
 
-def _serialize_progress_entry(progress: AnyStoryProgress, scope: str) -> MyActiveStoryEntry:
-    """Build the dict shape shared by all three scope collectors in MyActiveStoriesView."""
-    from world.stories.constants import StoryEpisodeStatus  # noqa: PLC0415
-
-    story = progress.story
-    episode = progress.current_episode
-    summary = compute_story_status(progress)
-
-    current_episode_id: int | None = episode.pk if episode is not None else None
-
-    return {
-        "story_id": story.pk,
-        "story_title": story.title,
-        "scope": scope,
-        "current_episode_id": current_episode_id,
-        "current_episode_title": summary.episode_title,
-        "chapter_title": summary.chapter_title,
-        "status": summary.status,
-        "status_label": StoryEpisodeStatus(summary.status).label,
-        "progress_status": progress.status,
-        "chapter_order": summary.chapter_order,
-        "episode_order": summary.episode_order,
-        "open_session_request_id": summary.open_session_request_id,
-        "scheduled_event_id": summary.scheduled_event_id,
-        "scheduled_real_time": summary.scheduled_real_time,
-    }
-
-
-def _collect_character_stories(
-    account: AbstractBaseUser | AnonymousUser,
-) -> list[MyActiveStoryEntry]:
-    """Return active CHARACTER-scope progress entries owned by this account."""
-    qs = StoryProgress.objects.filter(
-        story__character_sheet__character__db_account=account,
-        is_active=True,
-    ).select_related(
-        "story",
-        "current_episode",
-        "current_episode__chapter",
-    )
-    return [_serialize_progress_entry(p, StoryScope.CHARACTER) for p in qs]
-
-
-def _collect_group_stories(
-    account: AbstractBaseUser | AnonymousUser,
-) -> list[MyActiveStoryEntry]:
-    """Return active GROUP-scope progress entries for tables this account belongs to."""
-    qs = (
-        GroupStoryProgress.objects.filter(
-            gm_table__memberships__persona__character_sheet__character__db_account=account,
-            gm_table__memberships__left_at__isnull=True,
-            is_active=True,
-        )
-        .select_related(
-            "story",
-            "current_episode",
-            "current_episode__chapter",
-        )
-        .distinct()
-    )
-    return [_serialize_progress_entry(p, StoryScope.GROUP) for p in qs]
-
-
-def _collect_global_stories(
-    account: AbstractBaseUser | AnonymousUser,
-) -> list[MyActiveStoryEntry]:
-    """Return active GLOBAL-scope progress entries where the account has a StoryParticipation."""
-    qs = (
-        GlobalStoryProgress.objects.filter(
-            story__participants__character__db_account=account,
-            story__participants__is_active=True,
-            is_active=True,
-        )
-        .select_related(
-            "story",
-            "current_episode",
-            "current_episode__chapter",
-        )
-        .distinct()
-    )
-    return [_serialize_progress_entry(p, StoryScope.GLOBAL) for p in qs]
-
-
 class MyActiveStoriesView(APIView):
     """GET /api/stories/my-active/
 
@@ -1846,17 +1760,9 @@ class MyActiveStoriesView(APIView):
 
     def get(self, request: Request) -> Response:
         """Return active stories for the authenticated account."""
-        account = request.user
-        character_stories = _collect_character_stories(account)
-        group_stories = _collect_group_stories(account)
-        global_stories = _collect_global_stories(account)
-        return Response(
-            {
-                "character_stories": character_stories,
-                "group_stories": group_stories,
-                "global_stories": global_stories,
-            }
-        )
+        from world.stories.services.dashboards import active_stories_for_account  # noqa: PLC0415
+
+        return Response(active_stories_for_account(request.user))
 
 
 def _serialize_eligible_transitions(


### PR DESCRIPTION
Closes #1853

## Summary

Surfaces pending treasured-subject sign-offs to the affected player without requiring a beat number, on both web and telnet.

- New player-safe query seam: `world.stories.services.boundaries.player_pending_treasured_signoffs(player_data, beats)` — batched, scoped strictly to the requesting player's own TreasuredSubject/TreasuredSignoff rows (ADR-0033).
- Web: new `GET /api/stories/my-pending-signoffs/` endpoint + a narrowed `TreasuredSignoffPrompt` mode, auto-wired onto Beat rows on the Story detail page (including a follow-up fix exposing `tenure_id` on `StoryDetailSerializer` so the feature reaches the real page end-to-end).
- Telnet: extends the existing `story` command (previously entirely GM-gated) with player-facing subverbs — bare `story`/`story list` (active stories), `story beats <episode-id>` (flags pending sign-offs inline), and `story signoff <beat-id> <subject> [withdraw]` (grant/withdraw, reusing the exact service functions the web ViewSet already calls) — full parity with web, including withdrawal.
- Refactor: extracted `MyActiveStoriesView`'s query logic into `active_stories_for_account`, the shared seam both web and telnet now call.
- Docs synced in `docs/systems/boundaries.md` and `src/commands/CLAUDE.md`.

Implemented via 9 SDD tasks, each independently spec+quality reviewed (several with a fix-and-re-review round), plus a final whole-branch review that caught one real gap (BeatList's query-to-prop wiring had no test coverage) which was fixed and re-verified.

## Follow-ups filed

- #1923

## Notes

- Spec: reviewed & approved on #1853 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean rebase onto origin/main (2 unrelated commits: #1917, #1916) — no conflicts, full stories/boundaries/commands test tiers re-verified green post-rebase.

<!-- last-addressed-comment: 0 -->