### PR TITLE
Companion player surface: telnet command + web writes + ReleaseCompanionAction (#1918)

### DIFF
--- a/docs/systems/companions.md
+++ b/docs/systems/companions.md
@@ -39,12 +39,53 @@ a companion arriving in a room shouldn't spring any of them.
 gated by `HasCompanionCapacityPrerequisite`, executes via the existing
 `perform_check` primitive against `CompanionArchetype.bind_difficulty`.
 
+`actions.definitions.companions.ReleaseCompanionAction` (`release_companion`
+key, #1918) — releases a bonded companion: destroys its live object, sets
+`released_at`, keeps the row. Reuses `_resolve_owned_companion` for
+ownership + active validation (mirrors `CompanionFightAction`/
+`DeployCompanionAction`).
+
 ## API
 
 `world.companions.views.{CompanionViewSet, CompanionArchetypeViewSet}` —
-read-only, mounted at `/api/companions/` (`companions` and
-`companion-archetypes` router routes). Binding happens via the Action
-dispatch seam, not a ViewSet write.
+mounted at `/api/companions/` (`companions` and `companion-archetypes`
+router routes). Read endpoints are read-only; write endpoints converge on
+`action.run()` via `PuppetActorMixin` (same pattern as `SanctumViewSet`).
+
+### Write endpoints (#1918)
+
+| Endpoint | Method | Body | Returns |
+|---|---|---|---|
+| `/api/companions/companions/bind/` | POST | `{archetype_id, gift_id, name}` | `{companion_id}` (201) / `{detail}` (400) |
+| `/api/companions/companions/{id}/release/` | POST | — | `{}` (200) / `{detail}` (400) |
+| `/api/companions/companions/{id}/fight/` | POST | — | `{opponent_id}` (200) / `{detail}` (400) |
+| `/api/companions/companions/{id}/deploy/` | POST | — | `{vehicle_id}` (200) / `{detail}` (400) |
+
+Detail-level endpoints (`release`/`fight`/`deploy`) scope the companion via
+`get_queryset` (the caller's active companions); a foreign companion returns
+404. The Action's `_resolve_owned_companion` re-validates ownership — defense
+in depth, and keeps the Action usable from telnet where the id comes from text.
+
+## Player surfaces
+
+### Telnet (`companion` command, #1918)
+
+`commands.companion.CmdCompanion` (`companion` key) — a `DispatchCommand`
+routing subverbs through `dispatch_player_action` (the same REGISTRY seam the
+web uses). Mirrors `CmdSanctum`.
+
+```
+companion                             — status hub (active companions + capacity)
+companion status                      — (same)
+companion list                        — (same)
+companion bind archetype=<name|id> gift=<name|id> name=<text>
+companion release <name|id>
+companion fight <name|id>             — requires active encounter
+companion deploy <name|id>            — requires active battle
+```
+
+`name=` must be the final token on `bind` (it greedily consumes the rest of
+the line so names with spaces work).
 
 ## Consent-delegation (governing principle, not built)
 
@@ -59,7 +100,11 @@ follow-up, not before there's a real consumer.
 ## Deferred (see #672 issue body for the full list)
 
 - NPCAsset informant/contact promotion mechanic (separate follow-up issue).
-- Combat participation (`CombatOpponent` ally / `BattleVehicle` bridge).
+- Combat participation mechanics — the player surface now exists (`companion
+  fight`/`companion deploy` + web `fight`/`deploy` endpoints, #1918), bridging
+  companions into encounters/battles via `CompanionFightAction`/
+  `DeployCompanionAction`. The deeper combat-participation logic (targeting,
+  companion orders, round-by-round control) remains future work.
 - Enthralling/dominating an existing full-Persona NPC or PC (`needs-design`) —
   also needs the delegated-consent extension above.
 - Other domains (necromancer, elemental, construct, spirit) reusing this

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -3419,7 +3419,14 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** @description Read endpoints for the player's own active companions. */
+    /**
+     * @description Read + action endpoints for the player's companion surface.
+     *
+     *     `list`/`retrieve` return the caller's own active companions (read-only).
+     *     POST actions delegate to the four Actions in
+     *     ``actions/definitions/companions.py``; ``ActionResult`` fields map 1:1 to
+     *     the response bodies so the contract matches ``SanctumViewSet`` (#1918).
+     */
     get: operations['companions_companions_list'];
     put?: never;
     post?: never;
@@ -3436,10 +3443,105 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** @description Read endpoints for the player's own active companions. */
+    /**
+     * @description Read + action endpoints for the player's companion surface.
+     *
+     *     `list`/`retrieve` return the caller's own active companions (read-only).
+     *     POST actions delegate to the four Actions in
+     *     ``actions/definitions/companions.py``; ``ActionResult`` fields map 1:1 to
+     *     the response bodies so the contract matches ``SanctumViewSet`` (#1918).
+     */
     get: operations['companions_companions_retrieve'];
     put?: never;
     post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/companions/companions/{id}/deploy/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description Deploy a companion into a battle — ``POST /api/companions/companions/{id}/deploy/``.
+     *
+     *     Wraps :class:`actions.definitions.companions.DeployCompanionAction`.
+     */
+    post: operations['companions_companions_deploy_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/companions/companions/{id}/fight/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description Commit a companion into combat — ``POST /api/companions/companions/{id}/fight/``.
+     *
+     *     Wraps :class:`actions.definitions.companions.CompanionFightAction`.
+     */
+    post: operations['companions_companions_fight_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/companions/companions/{id}/release/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description Release a bonded companion — ``POST /api/companions/companions/{id}/release/``.
+     *
+     *     Wraps :class:`actions.definitions.companions.ReleaseCompanionAction`.
+     *     The companion id comes from the URL; ``get_queryset`` scopes it to the
+     *     caller's active companions (foreign → 404). The Action re-validates
+     *     ownership via ``_resolve_owned_companion`` (defense in depth).
+     */
+    post: operations['companions_companions_release_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/companions/companions/bind/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description Bind a new companion — ``POST /api/companions/companions/bind/``.
+     *
+     *     Body: ``{archetype_id, gift_id, name}``.
+     *     Wraps :class:`actions.definitions.companions.BindCompanionAction`.
+     */
+    post: operations['companions_companions_bind_create'];
     delete?: never;
     options?: never;
     head?: never;
@@ -34757,6 +34859,91 @@ export interface operations {
         /** @description A unique integer value identifying this Companion. */
         id: number;
       };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Companion'];
+        };
+      };
+    };
+  };
+  companions_companions_deploy_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this Companion. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Companion'];
+        };
+      };
+    };
+  };
+  companions_companions_fight_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this Companion. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Companion'];
+        };
+      };
+    };
+  };
+  companions_companions_release_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this Companion. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Companion'];
+        };
+      };
+    };
+  };
+  companions_companions_bind_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
       cookie?: never;
     };
     requestBody?: never;

--- a/src/actions/definitions/companions.py
+++ b/src/actions/definitions/companions.py
@@ -174,3 +174,28 @@ class DeployCompanionAction(Action):
             message=f"{companion.name} is deployed into the battle!",
             data={"vehicle_id": vehicle.pk},
         )
+
+
+@dataclass
+class ReleaseCompanionAction(Action):
+    """Release a bonded companion — destroy its live object, keep the row (#1918)."""
+
+    key: str = "release_companion"
+    name: str = "Release Companion"
+    icon: str = "door-open"
+    category: str = "companions"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(self, actor, context=None, **kwargs) -> ActionResult:
+        from world.companions.services import release_companion  # noqa: PLC0415
+
+        companion_id = kwargs.get("companion_id")
+        if not companion_id:
+            return ActionResult(success=False, message="Pick a companion to release.")
+        companion, failure = _resolve_owned_companion(actor, companion_id)
+        if failure is not None:
+            return failure
+        name = companion.name
+        release_companion(companion)
+        return ActionResult(success=True, message=f"{name} is released from your bond.")

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -35,6 +35,7 @@ from actions.definitions.companions import (
     BindCompanionAction,
     CompanionFightAction,
     DeployCompanionAction,
+    ReleaseCompanionAction,
 )
 from actions.definitions.conditions import treat_condition
 from actions.definitions.consent_preferences import (
@@ -429,6 +430,7 @@ _ALL_ACTIONS: list[Action] = [
     BindCompanionAction(),
     CompanionFightAction(),
     DeployCompanionAction(),
+    ReleaseCompanionAction(),
 ]
 
 # Lookup by key

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -329,6 +329,7 @@ class ActionRegistryTests(TestCase):
             "bind_companion",
             "companion_fight",
             "deploy_companion",
+            "release_companion",
         }
         assert set(ACTIONS_BY_KEY.keys()) == expected_keys
 

--- a/src/actions/tests/test_companion_actions.py
+++ b/src/actions/tests/test_companion_actions.py
@@ -138,3 +138,104 @@ class BindCompanionActionTests(TestCase):
         from world.companions.models import Companion
 
         self.assertFalse(Companion.objects.filter(name="Ghost").exists())
+
+
+class ReleaseCompanionActionTests(TestCase):
+    """Tests for ReleaseCompanionAction (#1918) — the release-via-Action seam."""
+
+    def setUp(self) -> None:
+        from evennia import create_object
+
+        self.room = create_object("typeclasses.rooms.Room", key="Release Test Room")
+        self.sheet = CharacterSheetFactory()
+        self.owner = self.sheet.character
+        self.owner.location = self.room
+        self.owner.save()
+        self.gift = ensure_companion_content()
+        self.resonance = self.gift.resonances.first()
+        grant_gift_to_character(self.sheet, self.gift, resonance=self.resonance)
+        from world.companions.models import CompanionArchetype
+        from world.magic.constants import TargetKind
+        from world.magic.models.threads import Thread
+
+        self.archetype = CompanionArchetype.objects.get(name="Hawk")
+        thread = Thread.objects.get(
+            owner=self.sheet, target_kind=TargetKind.GIFT, target_gift=self.gift
+        )
+        thread.level = 10
+        thread.save(update_fields=["level"])
+
+    def _bind_companion(self, name: str = "Skree"):
+        """Bind a companion via the Action with a forced-success check roll."""
+        from actions.definitions.companions import BindCompanionAction
+        from world.checks.test_helpers import force_check_outcome
+        from world.traits.factories import CheckOutcomeFactory
+
+        success = CheckOutcomeFactory(name=f"Forced Release Success {name}", success_level=5)
+        with force_check_outcome(success):
+            result = BindCompanionAction().run(
+                actor=self.owner,
+                gift_id=self.gift.pk,
+                archetype_id=self.archetype.pk,
+                name=name,
+            )
+        self.assertTrue(result.success, result.message)
+        return result.data["companion_id"]
+
+    def test_release_succeeds(self) -> None:
+        from evennia.objects.models import ObjectDB
+
+        from actions.definitions.companions import ReleaseCompanionAction
+        from world.companions.models import Companion
+
+        companion_id = self._bind_companion()
+        companion = Companion.objects.get(pk=companion_id)
+        object_id = companion.objectdb_id
+
+        result = ReleaseCompanionAction().run(actor=self.owner, companion_id=companion_id)
+
+        self.assertTrue(result.success, result.message)
+        self.assertIn("released from your bond", result.message)
+        companion.refresh_from_db()
+        self.assertIsNotNone(companion.released_at)
+        self.assertFalse(companion.is_active)
+        self.assertFalse(ObjectDB.objects.filter(pk=object_id).exists())
+
+    def test_release_rejected_for_foreign_companion(self) -> None:
+        from actions.definitions.companions import ReleaseCompanionAction
+        from world.companions.models import Companion
+
+        companion_id = self._bind_companion()
+        # A second character who does NOT own this companion.
+        other_sheet = CharacterSheetFactory()
+
+        result = ReleaseCompanionAction().run(
+            actor=other_sheet.character, companion_id=companion_id
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("not your companion", result.message)
+        # The companion is untouched.
+        companion = Companion.objects.get(pk=companion_id)
+        self.assertTrue(companion.is_active)
+
+    def test_release_rejected_for_already_released(self) -> None:
+        from actions.definitions.companions import ReleaseCompanionAction
+
+        companion_id = self._bind_companion()
+        # Release once via the Action, then attempt to release again.
+        first = ReleaseCompanionAction().run(actor=self.owner, companion_id=companion_id)
+        self.assertTrue(first.success)
+
+        second = ReleaseCompanionAction().run(actor=self.owner, companion_id=companion_id)
+
+        self.assertFalse(second.success)
+        self.assertIn("no longer active", second.message)
+
+    def test_release_without_companion_id_fails(self) -> None:
+        from actions.definitions.companions import ReleaseCompanionAction
+
+        result = ReleaseCompanionAction().run(actor=self.owner)
+
+        self.assertFalse(result.success)
+        self.assertIn("Pick a companion", result.message)

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -400,6 +400,15 @@ actions, backends, and service functions.
   `sanctum dissolve`, `sanctum absorb`, `sanctum sever <thread name|id>`.
   Namespaced subverbs avoid exit/channel/alias collisions (mirrors `CmdCombat`). No
   business logic in the command.
+- **`companion.py`**: `CmdCompanion` (`companion`, #1918) — the companion lifecycle namespace. One
+  `DispatchCommand` routes a leading subverb (`bind` / `fight` / `deploy` / `release`) through
+  `dispatch_player_action` — the same seam the web `CompanionViewSet` uses — reaching the Actions in
+  `actions/definitions/companions.py`. Bare `companion`/`companion status`/`companion list` = status hub
+  (active companions + remaining capacity). Grammar:
+  `companion bind archetype=<name|id> gift=<name|id> name=<text>`,
+  `companion release <name|id>`, `companion fight <name|id>`, `companion deploy <name|id>`.
+  Namespaced subverbs avoid exit/channel/alias collisions (mirrors `CmdSanctum`/`CmdCombat`).
+  No business logic in the command.
 - **`crafting_station.py`**: `CmdLabStation` (`station`, #1234) — the Lab
   crafting-station namespace. One `DispatchCommand` routes a leading subverb
   (`station install [level=<n>]` / `station upgrade level=<n>` / `station repair

--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -23,6 +23,31 @@ if TYPE_CHECKING:
     from actions.types import ActionRef, DispatchResult
 
 
+def parse_greedy_kwargs(args: str, *, greedy_key: str | None = None) -> dict[str, str]:
+    """Parse ``key=value`` tokens, left to right.
+
+    When *greedy_key* is set and encountered, its value greedily consumes the
+    rest of the line (so free text with spaces works). All other values are
+    single whitespace-delimited tokens. Tokens that contain no ``=`` are
+    silently skipped (positional leftovers).
+    """
+    out: dict[str, str] = {}
+    tokens = args.split()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if "=" not in token:
+            index += 1
+            continue
+        key, _, value = token.partition("=")
+        if greedy_key is not None and key == greedy_key:
+            out[greedy_key] = " ".join([value, *tokens[index + 1 :]]).strip()
+            break
+        out[key] = value
+        index += 1
+    return out
+
+
 class ArxCommand(Command):
     """Base command class for Arx II.
 

--- a/src/commands/companion.py
+++ b/src/commands/companion.py
@@ -1,0 +1,247 @@
+"""Companion telnet command — the ``companion <subverb>`` namespace (#1918).
+
+Routes the companion lifecycle verbs through ``dispatch_player_action`` — the
+same REGISTRY seam the web uses. No new game logic lives here.
+
+Mirrors ``CmdSanctum`` (subverb routing + status-hub pattern). The verbs live
+under the ``companion`` namespace because several (bind, release) would collide
+with existing bare keys.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from actions.constants import ActionBackend
+from commands.command import DispatchCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from actions.types import ActionRef
+
+# subverb → registry action key.
+_SUBVERBS: dict[str, str] = {
+    "bind": "bind_companion",
+    "fight": "companion_fight",
+    "deploy": "deploy_companion",
+    "release": "release_companion",
+}
+# "list" and "status" are handled locally (status hub), not dispatched.
+
+# Bare ``companion status`` / ``companion list`` are aliases for the hub.
+_HUB_SUBVERBS = frozenset({"status", "list"})
+
+# Telnet kwarg token keys used by _parse_kwargs / resolve_action_args.
+_ARCHETYPE_KWARG = "archetype"
+_GIFT_KWARG = "gift"
+_NAME_KWARG = "name"
+
+# Subverbs whose only kwarg is bind's parsed kwargs.
+_BIND_SUBVERB = "bind"
+
+# Subverbs that take a single bare companion identifier (positional, not key=value).
+_POSITIONAL_SUBVERBS = frozenset({"release", "fight", "deploy"})
+
+
+def _parse_kwargs(args: str) -> dict[str, str]:
+    """Parse ``key=value`` tokens, left to right.
+
+    ``name`` greedily consumes the rest of the line so companion names may
+    contain spaces (and must be the final token). All other values are single
+    whitespace-delimited tokens. Tokens that contain no ``=`` are silently
+    skipped (positional leftovers).
+    """
+    out: dict[str, str] = {}
+    tokens = args.split()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if "=" not in token:
+            index += 1
+            continue
+        key, _, value = token.partition("=")
+        if key == _NAME_KWARG:
+            out[_NAME_KWARG] = " ".join([value, *tokens[index + 1 :]]).strip()
+            break
+        out[key] = value
+        index += 1
+    return out
+
+
+class CmdCompanion(DispatchCommand):
+    """Manage your bonded companions — bind, release, fight, deploy (#1918).
+
+    Usage:
+        companion                             — list active companions + capacity
+        companion status                      — (same)
+        companion list                        — (same)
+        companion bind archetype=<name|id> gift=<name|id> name=<text>
+                                              — bind a new companion
+        companion release <name|id>           — release a bonded companion
+        companion fight <name|id>             — commit a companion into combat
+        companion deploy <name|id>            — deploy a companion into a battle
+
+    ``name=`` must be the final token on ``bind`` (it greedily consumes the rest
+    of the line so names with spaces work).
+    """
+
+    key = "companion"
+    locks = "cmd:all()"
+
+    _subverb: str = ""
+    _rest: str = ""
+
+    def func(self) -> None:
+        """Route the leading subverb; bare ``companion``/``status``/``list`` shows the hub."""
+        raw = (self.args or "").strip()
+        if not raw or raw.lower() in _HUB_SUBVERBS:
+            self._show_status_hub()
+            return
+        parts = raw.split(maxsplit=1)
+        self._subverb = parts[0].lower()
+        self._rest = parts[1].strip() if len(parts) > 1 else ""
+        if self._subverb not in _SUBVERBS:
+            options = ", ".join(_SUBVERBS)
+            self.msg(f"Unknown companion action '{self._subverb}'. Try: {options}.")
+            return
+        super().func()  # resolve_action_ref + resolve_action_args + dispatch
+
+    def resolve_action_ref(self) -> ActionRef:
+        """Build a REGISTRY ActionRef for the parsed subverb."""
+        from actions.types import ActionRef  # noqa: PLC0415
+
+        return ActionRef(backend=ActionBackend.REGISTRY, registry_key=_SUBVERBS[self._subverb])
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        """Resolve the subverb's arguments into dispatch kwargs."""
+        if self._subverb == _BIND_SUBVERB:
+            return self._args_bind(_parse_kwargs(self._rest))
+        if self._subverb in _POSITIONAL_SUBVERBS:
+            return {"companion_id": self._resolve_companion_id(self._rest)}
+        return {}  # all subverbs gated in func(); this path is unreachable
+
+    # -- per-subverb argument resolvers ----------------------------------------
+
+    def _sheet(self) -> Any:
+        """Return the caller's CharacterSheet, or raise CommandError if none."""
+        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        if sheet is None:
+            msg = "You have no character sheet."
+            raise CommandError(msg)
+        return sheet
+
+    def _resolve_archetype(self, value: str) -> Any:
+        """Resolve *value* (name iexact or pk) to a CompanionArchetype."""
+        from world.companions.models import CompanionArchetype  # noqa: PLC0415
+
+        if not value:
+            msg = "Specify an archetype: archetype=<name|id>."
+            raise CommandError(msg)
+        if value.isdigit():
+            archetype = CompanionArchetype.objects.filter(pk=int(value)).first()
+        else:
+            archetype = CompanionArchetype.objects.filter(name__iexact=value).first()
+        if archetype is None:
+            msg = f"No companion archetype found for '{value}'."
+            raise CommandError(msg)
+        return archetype
+
+    def _resolve_owned_gift(self, value: str) -> Any:
+        """Resolve *value* (gift name iexact or pk) to a CharacterGift owned by the caller.
+
+        Scopes the lookup to ``CharacterGift.objects.filter(character=sheet)`` so
+        the caller can never reference a gift they don't own.
+        """
+        from world.magic.models.gifts import CharacterGift  # noqa: PLC0415
+
+        if not value:
+            msg = "Specify a gift: gift=<name|id>."
+            raise CommandError(msg)
+        sheet = self._sheet()
+        if value.isdigit():
+            char_gift = CharacterGift.objects.filter(character=sheet, gift_id=int(value)).first()
+        else:
+            char_gift = CharacterGift.objects.filter(
+                character=sheet, gift__name__iexact=value
+            ).first()
+        if char_gift is None:
+            msg = f"You do not own a gift matching '{value}'."
+            raise CommandError(msg)
+        return char_gift.gift
+
+    def _resolve_companion_id(self, value: str) -> int:
+        """Resolve *value* (companion name iexact or pk) to a pk of an active owned companion."""
+        from world.companions.models import Companion  # noqa: PLC0415
+
+        value = value.strip()
+        if not value:
+            msg = f"Specify a companion: companion {self._subverb} <name|id>."
+            raise CommandError(msg)
+        sheet = self._sheet()
+        qs = Companion.objects.filter(owner=sheet, released_at__isnull=True)
+        if value.isdigit():
+            companion = qs.filter(pk=int(value)).first()
+        else:
+            companion = qs.filter(name__iexact=value).first()
+        if companion is None:
+            msg = f"No active companion found for '{value}'."
+            raise CommandError(msg)
+        return companion.pk
+
+    def _args_bind(self, parsed: dict[str, str]) -> dict[str, Any]:
+        """Resolve bind kwargs: archetype_id, gift_id, name."""
+        archetype = self._resolve_archetype(parsed.get(_ARCHETYPE_KWARG, ""))
+        gift = self._resolve_owned_gift(parsed.get(_GIFT_KWARG, ""))
+        name = parsed.get(_NAME_KWARG, "").strip()
+        if not name:
+            msg = "Specify a name: name=<text> (must be the final token)."
+            raise CommandError(msg)
+        return {
+            "archetype_id": archetype.pk,
+            "gift_id": gift.pk,
+            "name": name,
+        }
+
+    # -- status hub ------------------------------------------------------------
+
+    def _show_status_hub(self) -> None:
+        """List the caller's active companions + remaining capacity per gift."""
+        lines = ["|wCompanion actions|n: bind, release, fight, deploy"]
+
+        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        if sheet is None:
+            self.msg("\n".join(lines))
+            return
+
+        active = self.caller.companions.active()
+        if not active:
+            lines.append("You have no active companions.")
+        else:
+            lines.append("Your active companions:")
+            lines.extend(
+                f"  #{c.pk} — {c.name} ({c.archetype.name}, cost {c.archetype.capacity_cost})"
+                for c in active
+            )
+
+        lines.extend(self._capacity_lines(sheet))
+        self.msg("\n".join(lines))
+
+    def _capacity_lines(self, sheet: Any) -> list[str]:
+        """Lines showing remaining Companion Capacity per granting gift."""
+        from world.companions.services import (  # noqa: PLC0415
+            NoCompanionThreadError,
+            companion_capacity,
+            used_companion_capacity,
+        )
+
+        lines: list[str] = []
+        for char_gift in sheet.character_gifts.all():
+            gift = char_gift.gift
+            try:
+                used = used_companion_capacity(sheet, gift)
+                total = companion_capacity(sheet, gift)
+            except NoCompanionThreadError:
+                continue  # gift has no GIFT thread → no capacity to show
+            remaining = total - used
+            lines.append(f"  {gift.name}: {used}/{total} capacity ({remaining} remaining)")
+        return lines

--- a/src/commands/companion.py
+++ b/src/commands/companion.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from actions.constants import ActionBackend
-from commands.command import DispatchCommand
+from commands.command import DispatchCommand, parse_greedy_kwargs
 from commands.exceptions import CommandError
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ _SUBVERBS: dict[str, str] = {
 # Bare ``companion status`` / ``companion list`` are aliases for the hub.
 _HUB_SUBVERBS = frozenset({"status", "list"})
 
-# Telnet kwarg token keys used by _parse_kwargs / resolve_action_args.
+# Telnet kwarg token keys used by resolve_action_args.
 _ARCHETYPE_KWARG = "archetype"
 _GIFT_KWARG = "gift"
 _NAME_KWARG = "name"
@@ -43,31 +43,6 @@ _BIND_SUBVERB = "bind"
 
 # Subverbs that take a single bare companion identifier (positional, not key=value).
 _POSITIONAL_SUBVERBS = frozenset({"release", "fight", "deploy"})
-
-
-def _parse_kwargs(args: str) -> dict[str, str]:
-    """Parse ``key=value`` tokens, left to right.
-
-    ``name`` greedily consumes the rest of the line so companion names may
-    contain spaces (and must be the final token). All other values are single
-    whitespace-delimited tokens. Tokens that contain no ``=`` are silently
-    skipped (positional leftovers).
-    """
-    out: dict[str, str] = {}
-    tokens = args.split()
-    index = 0
-    while index < len(tokens):
-        token = tokens[index]
-        if "=" not in token:
-            index += 1
-            continue
-        key, _, value = token.partition("=")
-        if key == _NAME_KWARG:
-            out[_NAME_KWARG] = " ".join([value, *tokens[index + 1 :]]).strip()
-            break
-        out[key] = value
-        index += 1
-    return out
 
 
 class CmdCompanion(DispatchCommand):
@@ -117,7 +92,7 @@ class CmdCompanion(DispatchCommand):
     def resolve_action_args(self) -> dict[str, Any]:
         """Resolve the subverb's arguments into dispatch kwargs."""
         if self._subverb == _BIND_SUBVERB:
-            return self._args_bind(_parse_kwargs(self._rest))
+            return self._args_bind(parse_greedy_kwargs(self._rest, greedy_key=_NAME_KWARG))
         if self._subverb in _POSITIONAL_SUBVERBS:
             return {"companion_id": self._resolve_companion_id(self._rest)}
         return {}  # all subverbs gated in func(); this path is unreachable

--- a/src/commands/companion.py
+++ b/src/commands/companion.py
@@ -132,6 +132,17 @@ class CmdCompanion(DispatchCommand):
             raise CommandError(msg)
         return sheet
 
+    @staticmethod
+    def _resolve_by_name_or_pk(qs: Any, value: str, *, pk_field: str, name_field: str) -> Any:
+        """Resolve *value* (digit → pk lookup, else iexact name) on *qs*.
+
+        Returns the first match or None. The caller validates and raises
+        ``CommandError`` with a context-specific message on None.
+        """
+        if value.isdigit():
+            return qs.filter(**{pk_field: int(value)}).first()
+        return qs.filter(**{name_field: value}).first()
+
     def _resolve_archetype(self, value: str) -> Any:
         """Resolve *value* (name iexact or pk) to a CompanionArchetype."""
         from world.companions.models import CompanionArchetype  # noqa: PLC0415
@@ -139,10 +150,12 @@ class CmdCompanion(DispatchCommand):
         if not value:
             msg = "Specify an archetype: archetype=<name|id>."
             raise CommandError(msg)
-        if value.isdigit():
-            archetype = CompanionArchetype.objects.filter(pk=int(value)).first()
-        else:
-            archetype = CompanionArchetype.objects.filter(name__iexact=value).first()
+        archetype = self._resolve_by_name_or_pk(
+            CompanionArchetype.objects,
+            value,
+            pk_field="pk",
+            name_field="name__iexact",
+        )
         if archetype is None:
             msg = f"No companion archetype found for '{value}'."
             raise CommandError(msg)
@@ -160,12 +173,12 @@ class CmdCompanion(DispatchCommand):
             msg = "Specify a gift: gift=<name|id>."
             raise CommandError(msg)
         sheet = self._sheet()
-        if value.isdigit():
-            char_gift = CharacterGift.objects.filter(character=sheet, gift_id=int(value)).first()
-        else:
-            char_gift = CharacterGift.objects.filter(
-                character=sheet, gift__name__iexact=value
-            ).first()
+        char_gift = self._resolve_by_name_or_pk(
+            CharacterGift.objects.filter(character=sheet),
+            value,
+            pk_field="gift_id",
+            name_field="gift__name__iexact",
+        )
         if char_gift is None:
             msg = f"You do not own a gift matching '{value}'."
             raise CommandError(msg)
@@ -180,11 +193,12 @@ class CmdCompanion(DispatchCommand):
             msg = f"Specify a companion: companion {self._subverb} <name|id>."
             raise CommandError(msg)
         sheet = self._sheet()
-        qs = Companion.objects.filter(owner=sheet, released_at__isnull=True)
-        if value.isdigit():
-            companion = qs.filter(pk=int(value)).first()
-        else:
-            companion = qs.filter(name__iexact=value).first()
+        companion = self._resolve_by_name_or_pk(
+            Companion.objects.filter(owner=sheet, released_at__isnull=True),
+            value,
+            pk_field="pk",
+            name_field="name__iexact",
+        )
         if companion is None:
             msg = f"No active companion found for '{value}'."
             raise CommandError(msg)

--- a/src/commands/companion.py
+++ b/src/commands/companion.py
@@ -36,6 +36,8 @@ _ARCHETYPE_KWARG = "archetype"
 _GIFT_KWARG = "gift"
 _NAME_KWARG = "name"
 
+_MAX_NAME_LENGTH = 100
+
 # Subverbs whose only kwarg is bind's parsed kwargs.
 _BIND_SUBVERB = "bind"
 
@@ -195,6 +197,9 @@ class CmdCompanion(DispatchCommand):
         name = parsed.get(_NAME_KWARG, "").strip()
         if not name:
             msg = "Specify a name: name=<text> (must be the final token)."
+            raise CommandError(msg)
+        if len(name) > _MAX_NAME_LENGTH:
+            msg = "Companion names must be 100 characters or fewer."
             raise CommandError(msg)
         return {
             "archetype_id": archetype.pk,

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -26,6 +26,7 @@ from commands.captivity import CmdDemandRansom
 from commands.combat import CmdClashCommit, CmdDeclareTechnique
 from commands.combat_maneuvers import CmdCombat
 from commands.comfort import CmdComfort
+from commands.companion import CmdCompanion
 from commands.conditions import CmdTreatCondition
 from commands.consent import (
     CmdAccept,
@@ -186,6 +187,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             # #1497 — sanctum lifecycle telnet namespace (install/homecoming/purging/
             # weave/dissolve/absorb/sever).
             CmdSanctum,
+            # #1918 — companion lifecycle telnet namespace (bind/fight/deploy/release).
+            CmdCompanion,
             # #1582 — signature-bonus selection namespace (set/clear/list).
             CmdSignature,
             CmdWeaveThread,

--- a/src/commands/tests/test_companion_command.py
+++ b/src/commands/tests/test_companion_command.py
@@ -111,7 +111,8 @@ class CompanionCommandKwargsTests(TestCase):
             patch("world.magic.models.gifts.CharacterGift.objects") as cg_obj,
         ):
             arch_obj.filter.return_value.first.return_value = mock_archetype
-            cg_obj.filter.return_value.first.return_value = mock_char_gift
+            # gift resolution: _resolve_by_name_or_pk chains .filter().filter().first()
+            cg_obj.filter.return_value.filter.return_value.first.return_value = mock_char_gift
 
             kwargs = cmd.resolve_action_args()
 
@@ -137,7 +138,7 @@ class CompanionCommandKwargsTests(TestCase):
             patch("world.magic.models.gifts.CharacterGift.objects") as cg_obj,
         ):
             arch_obj.filter.return_value.first.return_value = mock_archetype
-            cg_obj.filter.return_value.first.return_value = mock_char_gift
+            cg_obj.filter.return_value.filter.return_value.first.return_value = mock_char_gift
 
             kwargs = cmd.resolve_action_args()
 
@@ -159,7 +160,7 @@ class CompanionCommandKwargsTests(TestCase):
             patch("world.magic.models.gifts.CharacterGift.objects") as cg_obj,
         ):
             arch_obj.filter.return_value.first.return_value = mock_archetype
-            cg_obj.filter.return_value.first.return_value = mock_char_gift
+            cg_obj.filter.return_value.filter.return_value.first.return_value = mock_char_gift
 
             with self.assertRaises(CommandError):
                 cmd.resolve_action_args()
@@ -315,7 +316,7 @@ class CompanionCommandDispatchTests(TestCase):
             patch(_DISPATCH, return_value=result) as dispatch,
         ):
             arch_obj.filter.return_value.first.return_value = mock_archetype
-            cg_obj.filter.return_value.first.return_value = mock_char_gift
+            cg_obj.filter.return_value.filter.return_value.first.return_value = mock_char_gift
 
             cmd.func()
 

--- a/src/commands/tests/test_companion_command.py
+++ b/src/commands/tests/test_companion_command.py
@@ -1,0 +1,399 @@
+"""Unit tests for CmdCompanion — the ``companion <subverb>`` namespace (#1918).
+
+Covers: subverb-map completeness, required-arg missing error paths, resolved-kwargs
+assertions for bind / release / fight / deploy, and full func() dispatch with mocked
+``dispatch_player_action``. Mirrors the mock-caller style of ``test_sanctum_command.py``
+and ``test_combat_maneuvers_command.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from actions.constants import ActionBackend
+from actions.types import ActionResult, DispatchResult
+from commands.companion import _SUBVERBS, CmdCompanion
+from commands.exceptions import CommandError
+
+_DISPATCH = "commands.command.dispatch_player_action"
+
+
+def _make_cmd(args: str) -> CmdCompanion:
+    cmd = CmdCompanion()
+    cmd.caller = MagicMock()
+    cmd.args = args
+    cmd.raw_string = f"companion {args}"
+    cmd.cmdname = "companion"
+    return cmd
+
+
+class CompanionCommandParsingTests(TestCase):
+    def test_subverb_map_covers_four_ops(self) -> None:
+        self.assertEqual(set(_SUBVERBS), {"bind", "fight", "deploy", "release"})
+
+    def test_unknown_subverb_messages_and_does_not_dispatch(self) -> None:
+        cmd = _make_cmd("frobnicate")
+        with patch(_DISPATCH) as dispatch:
+            cmd.func()
+        dispatch.assert_not_called()
+        cmd.caller.msg.assert_called()
+
+    def test_bare_companion_shows_status_hub(self) -> None:
+        cmd = _make_cmd("")
+        with patch(_DISPATCH) as dispatch:
+            cmd.func()
+        dispatch.assert_not_called()
+        cmd.caller.msg.assert_called_once()
+        self.assertIn("Companion actions", cmd.caller.msg.call_args.args[0])
+
+    def test_status_subverb_shows_status_hub(self) -> None:
+        cmd = _make_cmd("status")
+        with patch(_DISPATCH) as dispatch:
+            cmd.func()
+        dispatch.assert_not_called()
+        cmd.caller.msg.assert_called_once()
+
+    def test_list_subverb_shows_status_hub(self) -> None:
+        cmd = _make_cmd("list")
+        with patch(_DISPATCH) as dispatch:
+            cmd.func()
+        dispatch.assert_not_called()
+        cmd.caller.msg.assert_called_once()
+
+
+class CompanionCommandRefTests(TestCase):
+    """resolve_action_ref returns a REGISTRY ActionRef for each subverb."""
+
+    def _cmd_with_subverb(self, subverb: str) -> CmdCompanion:
+        cmd = _make_cmd(subverb)
+        cmd._subverb = subverb
+        return cmd
+
+    def test_bind_ref(self) -> None:
+        ref = self._cmd_with_subverb("bind").resolve_action_ref()
+        self.assertEqual(ref.backend, ActionBackend.REGISTRY)
+        self.assertEqual(ref.registry_key, "bind_companion")
+
+    def test_fight_ref(self) -> None:
+        ref = self._cmd_with_subverb("fight").resolve_action_ref()
+        self.assertEqual(ref.registry_key, "companion_fight")
+
+    def test_deploy_ref(self) -> None:
+        ref = self._cmd_with_subverb("deploy").resolve_action_ref()
+        self.assertEqual(ref.registry_key, "deploy_companion")
+
+    def test_release_ref(self) -> None:
+        ref = self._cmd_with_subverb("release").resolve_action_ref()
+        self.assertEqual(ref.registry_key, "release_companion")
+
+
+class CompanionCommandKwargsTests(TestCase):
+    """resolve_action_args returns the correct resolved kwargs per subverb."""
+
+    def test_bind_resolves_archetype_gift_and_name(self) -> None:
+        cmd = _make_cmd("bind archetype=Hawk gift=Beastlord name=Skree")
+        cmd._subverb = "bind"
+        cmd._rest = "archetype=Hawk gift=Beastlord name=Skree"
+
+        mock_sheet = MagicMock()
+        cmd.caller.sheet_data = mock_sheet
+        mock_archetype = MagicMock()
+        mock_archetype.pk = 7
+        mock_gift = MagicMock()
+        mock_gift.pk = 3
+        mock_char_gift = MagicMock()
+        mock_char_gift.gift = mock_gift
+
+        with (
+            patch("world.companions.models.CompanionArchetype.objects") as arch_obj,
+            patch("world.magic.models.gifts.CharacterGift.objects") as cg_obj,
+        ):
+            arch_obj.filter.return_value.first.return_value = mock_archetype
+            cg_obj.filter.return_value.first.return_value = mock_char_gift
+
+            kwargs = cmd.resolve_action_args()
+
+        self.assertEqual(kwargs["archetype_id"], 7)
+        self.assertEqual(kwargs["gift_id"], 3)
+        self.assertEqual(kwargs["name"], "Skree")
+
+    def test_bind_name_greedy_consumes_spaces(self) -> None:
+        cmd = _make_cmd("bind archetype=Hawk gift=Beastlord name=Brave Hawk")
+        cmd._subverb = "bind"
+        cmd._rest = "archetype=Hawk gift=Beastlord name=Brave Hawk"
+
+        cmd.caller.sheet_data = MagicMock()
+        mock_archetype = MagicMock()
+        mock_archetype.pk = 1
+        mock_gift = MagicMock()
+        mock_gift.pk = 2
+        mock_char_gift = MagicMock()
+        mock_char_gift.gift = mock_gift
+
+        with (
+            patch("world.companions.models.CompanionArchetype.objects") as arch_obj,
+            patch("world.magic.models.gifts.CharacterGift.objects") as cg_obj,
+        ):
+            arch_obj.filter.return_value.first.return_value = mock_archetype
+            cg_obj.filter.return_value.first.return_value = mock_char_gift
+
+            kwargs = cmd.resolve_action_args()
+
+        self.assertEqual(kwargs["name"], "Brave Hawk")
+
+    def test_bind_missing_name_raises_command_error(self) -> None:
+        cmd = _make_cmd("bind archetype=Hawk gift=Beastlord")
+        cmd._subverb = "bind"
+        cmd._rest = "archetype=Hawk gift=Beastlord"
+
+        cmd.caller.sheet_data = MagicMock()
+        mock_archetype = MagicMock()
+        mock_archetype.pk = 1
+        mock_char_gift = MagicMock()
+        mock_char_gift.gift = MagicMock(pk=2)
+
+        with (
+            patch("world.companions.models.CompanionArchetype.objects") as arch_obj,
+            patch("world.magic.models.gifts.CharacterGift.objects") as cg_obj,
+        ):
+            arch_obj.filter.return_value.first.return_value = mock_archetype
+            cg_obj.filter.return_value.first.return_value = mock_char_gift
+
+            with self.assertRaises(CommandError):
+                cmd.resolve_action_args()
+
+    def test_bind_missing_archetype_raises_command_error(self) -> None:
+        cmd = _make_cmd("bind gift=Beastlord name=Skree")
+        cmd._subverb = "bind"
+        cmd._rest = "gift=Beastlord name=Skree"
+
+        with self.assertRaises(CommandError):
+            cmd.resolve_action_args()
+
+    def test_release_resolves_companion_id_by_id(self) -> None:
+        cmd = _make_cmd("release 42")
+        cmd._subverb = "release"
+        cmd._rest = "42"
+
+        cmd.caller.sheet_data = MagicMock()
+        mock_companion = MagicMock()
+        mock_companion.pk = 42
+
+        with patch("world.companions.models.Companion.objects") as comp_obj:
+            qs = MagicMock()
+            qs.filter.return_value.first.return_value = mock_companion
+            comp_obj.filter.return_value = qs
+
+            kwargs = cmd.resolve_action_args()
+
+        self.assertEqual(kwargs["companion_id"], 42)
+
+    def test_release_resolves_companion_id_by_name(self) -> None:
+        cmd = _make_cmd("release Skree")
+        cmd._subverb = "release"
+        cmd._rest = "Skree"
+
+        cmd.caller.sheet_data = MagicMock()
+        mock_companion = MagicMock()
+        mock_companion.pk = 99
+
+        with patch("world.companions.models.Companion.objects") as comp_obj:
+            qs = MagicMock()
+            qs.filter.return_value.first.return_value = mock_companion
+            comp_obj.filter.return_value = qs
+
+            kwargs = cmd.resolve_action_args()
+
+        self.assertEqual(kwargs["companion_id"], 99)
+
+    def test_release_missing_arg_raises_command_error(self) -> None:
+        cmd = _make_cmd("release")
+        cmd._subverb = "release"
+        cmd._rest = ""
+
+        cmd.caller.sheet_data = MagicMock()
+        with self.assertRaises(CommandError):
+            cmd.resolve_action_args()
+
+    def test_release_not_found_raises_command_error(self) -> None:
+        cmd = _make_cmd("release Ghost")
+        cmd._subverb = "release"
+        cmd._rest = "Ghost"
+
+        cmd.caller.sheet_data = MagicMock()
+        with patch("world.companions.models.Companion.objects") as comp_obj:
+            qs = MagicMock()
+            qs.filter.return_value.first.return_value = None
+            comp_obj.filter.return_value = qs
+
+            with self.assertRaises(CommandError):
+                cmd.resolve_action_args()
+
+    def test_fight_resolves_companion_id(self) -> None:
+        cmd = _make_cmd("fight Skree")
+        cmd._subverb = "fight"
+        cmd._rest = "Skree"
+
+        cmd.caller.sheet_data = MagicMock()
+        mock_companion = MagicMock()
+        mock_companion.pk = 5
+
+        with patch("world.companions.models.Companion.objects") as comp_obj:
+            qs = MagicMock()
+            qs.filter.return_value.first.return_value = mock_companion
+            comp_obj.filter.return_value = qs
+
+            kwargs = cmd.resolve_action_args()
+
+        self.assertEqual(kwargs["companion_id"], 5)
+
+    def test_deploy_resolves_companion_id(self) -> None:
+        cmd = _make_cmd("deploy Skree")
+        cmd._subverb = "deploy"
+        cmd._rest = "Skree"
+
+        cmd.caller.sheet_data = MagicMock()
+        mock_companion = MagicMock()
+        mock_companion.pk = 8
+
+        with patch("world.companions.models.Companion.objects") as comp_obj:
+            qs = MagicMock()
+            qs.filter.return_value.first.return_value = mock_companion
+            comp_obj.filter.return_value = qs
+
+            kwargs = cmd.resolve_action_args()
+
+        self.assertEqual(kwargs["companion_id"], 8)
+
+
+class CompanionCommandDispatchTests(TestCase):
+    """Full func() dispatch tests — mock dispatch_player_action to assert kwargs."""
+
+    def test_release_dispatches_with_companion_id(self) -> None:
+        cmd = _make_cmd("release 42")
+        cmd.caller.sheet_data = MagicMock()
+        mock_companion = MagicMock()
+        mock_companion.pk = 42
+        result = DispatchResult(
+            backend=ActionBackend.REGISTRY,
+            deferred=False,
+            detail=ActionResult(success=True, message="Skree is released."),
+        )
+        with (
+            patch("world.companions.models.Companion.objects") as comp_obj,
+            patch(_DISPATCH, return_value=result) as dispatch,
+        ):
+            qs = MagicMock()
+            qs.filter.return_value.first.return_value = mock_companion
+            comp_obj.filter.return_value = qs
+            cmd.func()
+
+        dispatch.assert_called_once()
+        _, ref, kwargs = dispatch.call_args.args
+        self.assertEqual(ref.registry_key, "release_companion")
+        self.assertEqual(kwargs["companion_id"], 42)
+
+    def test_bind_dispatches_with_resolved_kwargs(self) -> None:
+        cmd = _make_cmd("bind archetype=Hawk gift=Beastlord name=Skree")
+        cmd.caller.sheet_data = MagicMock()
+        mock_archetype = MagicMock()
+        mock_archetype.pk = 7
+        mock_gift = MagicMock()
+        mock_gift.pk = 3
+        mock_char_gift = MagicMock()
+        mock_char_gift.gift = mock_gift
+        result = DispatchResult(
+            backend=ActionBackend.REGISTRY,
+            deferred=False,
+            detail=ActionResult(success=True, message="Skree the Hawk is now bonded."),
+        )
+        with (
+            patch("world.companions.models.CompanionArchetype.objects") as arch_obj,
+            patch("world.magic.models.gifts.CharacterGift.objects") as cg_obj,
+            patch(_DISPATCH, return_value=result) as dispatch,
+        ):
+            arch_obj.filter.return_value.first.return_value = mock_archetype
+            cg_obj.filter.return_value.first.return_value = mock_char_gift
+
+            cmd.func()
+
+        dispatch.assert_called_once()
+        _, ref, kwargs = dispatch.call_args.args
+        self.assertEqual(ref.registry_key, "bind_companion")
+        self.assertEqual(kwargs["archetype_id"], 7)
+        self.assertEqual(kwargs["gift_id"], 3)
+        self.assertEqual(kwargs["name"], "Skree")
+
+    def test_fight_dispatches_with_companion_id(self) -> None:
+        cmd = _make_cmd("fight Skree")
+        cmd.caller.sheet_data = MagicMock()
+        mock_companion = MagicMock()
+        mock_companion.pk = 11
+        result = DispatchResult(
+            backend=ActionBackend.REGISTRY,
+            deferred=False,
+            detail=ActionResult(success=True, message="Skree joins the fight!"),
+        )
+        with (
+            patch("world.companions.models.Companion.objects") as comp_obj,
+            patch(_DISPATCH, return_value=result) as dispatch,
+        ):
+            qs = MagicMock()
+            qs.filter.return_value.first.return_value = mock_companion
+            comp_obj.filter.return_value = qs
+            cmd.func()
+
+        dispatch.assert_called_once()
+        _, ref, kwargs = dispatch.call_args.args
+        self.assertEqual(ref.registry_key, "companion_fight")
+        self.assertEqual(kwargs["companion_id"], 11)
+
+    def test_deploy_dispatches_with_companion_id(self) -> None:
+        cmd = _make_cmd("deploy Skree")
+        cmd.caller.sheet_data = MagicMock()
+        mock_companion = MagicMock()
+        mock_companion.pk = 14
+        result = DispatchResult(
+            backend=ActionBackend.REGISTRY,
+            deferred=False,
+            detail=ActionResult(success=True, message="Skree is deployed!"),
+        )
+        with (
+            patch("world.companions.models.Companion.objects") as comp_obj,
+            patch(_DISPATCH, return_value=result) as dispatch,
+        ):
+            qs = MagicMock()
+            qs.filter.return_value.first.return_value = mock_companion
+            comp_obj.filter.return_value = qs
+            cmd.func()
+
+        dispatch.assert_called_once()
+        _, ref, kwargs = dispatch.call_args.args
+        self.assertEqual(ref.registry_key, "deploy_companion")
+        self.assertEqual(kwargs["companion_id"], 14)
+
+
+class CompanionCommandStatusHubTests(TestCase):
+    """The status hub lists active companions + capacity."""
+
+    def test_no_sheet_shows_actions_header(self) -> None:
+        cmd = _make_cmd("")
+        cmd.caller.sheet_data = None
+        with patch(_DISPATCH) as dispatch:
+            cmd.func()
+        dispatch.assert_not_called()
+        cmd.caller.msg.assert_called_once()
+        self.assertIn("Companion actions", cmd.caller.msg.call_args.args[0])
+
+    def test_no_active_companions_shows_empty_message(self) -> None:
+        cmd = _make_cmd("")
+        cmd.caller.sheet_data = MagicMock()
+        cmd.caller.companions.active.return_value = []
+        cmd.caller.sheet_data.character_gifts.all.return_value = []
+        with patch(_DISPATCH) as dispatch:
+            cmd.func()
+        dispatch.assert_not_called()
+        msg = cmd.caller.msg.call_args.args[0]
+        self.assertIn("no active companions", msg)

--- a/src/schema.json
+++ b/src/schema.json
@@ -5021,7 +5021,13 @@ paths:
   /api/companions/companions/:
     get:
       operationId: companions_companions_list
-      description: Read endpoints for the player's own active companions.
+      description: |-
+        Read + action endpoints for the player's companion surface.
+
+        `list`/`retrieve` return the caller's own active companions (read-only).
+        POST actions delegate to the four Actions in
+        ``actions/definitions/companions.py``; ``ActionResult`` fields map 1:1 to
+        the response bodies so the contract matches ``SanctumViewSet`` (#1918).
       parameters:
       - in: query
         name: archetype__domain
@@ -5059,7 +5065,13 @@ paths:
   /api/companions/companions/{id}/:
     get:
       operationId: companions_companions_retrieve
-      description: Read endpoints for the player's own active companions.
+      description: |-
+        Read + action endpoints for the player's companion surface.
+
+        `list`/`retrieve` return the caller's own active companions (read-only).
+        POST actions delegate to the four Actions in
+        ``actions/definitions/companions.py``; ``ActionResult`` fields map 1:1 to
+        the response bodies so the contract matches ``SanctumViewSet`` (#1918).
       parameters:
       - in: path
         name: id
@@ -5067,6 +5079,103 @@ paths:
           type: integer
         description: A unique integer value identifying this Companion.
         required: true
+      tags:
+      - companions
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Companion'
+          description: ''
+  /api/companions/companions/{id}/deploy/:
+    post:
+      operationId: companions_companions_deploy_create
+      description: |-
+        Deploy a companion into a battle — ``POST /api/companions/companions/{id}/deploy/``.
+
+        Wraps :class:`actions.definitions.companions.DeployCompanionAction`.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Companion.
+        required: true
+      tags:
+      - companions
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Companion'
+          description: ''
+  /api/companions/companions/{id}/fight/:
+    post:
+      operationId: companions_companions_fight_create
+      description: |-
+        Commit a companion into combat — ``POST /api/companions/companions/{id}/fight/``.
+
+        Wraps :class:`actions.definitions.companions.CompanionFightAction`.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Companion.
+        required: true
+      tags:
+      - companions
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Companion'
+          description: ''
+  /api/companions/companions/{id}/release/:
+    post:
+      operationId: companions_companions_release_create
+      description: |-
+        Release a bonded companion — ``POST /api/companions/companions/{id}/release/``.
+
+        Wraps :class:`actions.definitions.companions.ReleaseCompanionAction`.
+        The companion id comes from the URL; ``get_queryset`` scopes it to the
+        caller's active companions (foreign → 404). The Action re-validates
+        ownership via ``_resolve_owned_companion`` (defense in depth).
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Companion.
+        required: true
+      tags:
+      - companions
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Companion'
+          description: ''
+  /api/companions/companions/bind/:
+    post:
+      operationId: companions_companions_bind_create
+      description: |-
+        Bind a new companion — ``POST /api/companions/companions/bind/``.
+
+        Body: ``{archetype_id, gift_id, name}``.
+        Wraps :class:`actions.definitions.companions.BindCompanionAction`.
       tags:
       - companions
       security:

--- a/src/world/companions/serializers.py
+++ b/src/world/companions/serializers.py
@@ -21,3 +21,16 @@ class CompanionSerializer(serializers.ModelSerializer):
         model = Companion
         fields = ["id", "name", "archetype", "bonded_at", "released_at"]
         read_only_fields = fields
+
+
+class BindActionSerializer(serializers.Serializer):
+    """Body serializer for the ``POST /api/companions/companions/bind/`` endpoint.
+
+    Mirrors ``HomecomingActionSerializer`` (sanctum) — the view resolves the
+    actor via ``PuppetActorMixin`` and calls ``BindCompanionAction().run()``;
+    ownership/validity of the gift and archetype is validated inside the Action.
+    """
+
+    archetype_id = serializers.IntegerField()
+    gift_id = serializers.IntegerField()
+    name = serializers.CharField(max_length=100)

--- a/src/world/companions/tests/test_e2e_bind_journey.py
+++ b/src/world/companions/tests/test_e2e_bind_journey.py
@@ -80,12 +80,70 @@ class CompanionBindJourneyTests(EvenniaTestCase):
         self.assertFalse(Companion.objects.filter(name="Ghost").exists())
 
         # Release the Wolf — object gone, row persists with released_at set.
-        from world.companions.services import release_companion
+        # Uses ReleaseCompanionAction (the Action seam), not the service directly (#1918).
+        from evennia.objects.models import ObjectDB
+
+        from actions.definitions.companions import ReleaseCompanionAction
 
         fang = Companion.objects.get(name="Fang")
         object_id = fang.objectdb_id
-        release_companion(fang)
-        from evennia.objects.models import ObjectDB
+        release_result = ReleaseCompanionAction().run(actor=self.owner, companion_id=fang.pk)
+        self.assertTrue(release_result.success, release_result.message)
 
         self.assertFalse(ObjectDB.objects.filter(pk=object_id).exists())
         self.assertTrue(Companion.objects.filter(pk=fang.pk, released_at__isnull=False).exists())
+
+    def test_bind_deploy_release_journey(self) -> None:
+        """Full bind → deploy → release loop through the Action seam (#1918).
+
+        Proves the three Actions compose end-to-end: bind creates the
+        companion, deploy bridges it into a battle vehicle, release tears
+        down the live object while keeping the row.
+        """
+        from actions.definitions.companions import (
+            BindCompanionAction,
+            DeployCompanionAction,
+            ReleaseCompanionAction,
+        )
+        from world.battles.factories import BattleFactory, BattleSideFactory
+        from world.battles.models import BattleParticipant, BattleParticipantStatus
+        from world.checks.test_helpers import force_check_outcome
+        from world.combat.constants import RiskLevel
+        from world.companions.models import Companion, CompanionArchetype
+        from world.traits.factories import CheckOutcomeFactory
+
+        # 1. Bind a companion.
+        hawk = CompanionArchetype.objects.get(name="Hawk")
+        success = CheckOutcomeFactory(name="Journey Deploy Success", success_level=5)
+        with force_check_outcome(success):
+            result = BindCompanionAction().run(
+                actor=self.owner, gift_id=self.gift.pk, archetype_id=hawk.pk, name="Skree"
+            )
+        self.assertTrue(result.success, result.message)
+        companion = Companion.objects.get(name="Skree")
+
+        # 2. Deploy into a battle (mirrors test_combat_bridge_e2e.py's fixture pattern).
+        battle = BattleFactory(risk_level=RiskLevel.LOW)
+        side = BattleSideFactory(battle=battle)
+        BattleParticipant.objects.create(
+            battle=battle,
+            character_sheet=self.sheet,
+            side=side,
+            status=BattleParticipantStatus.ACTIVE,
+        )
+        deploy_result = DeployCompanionAction().run(actor=self.owner, companion_id=companion.pk)
+        self.assertTrue(deploy_result.success, deploy_result.message)
+        self.assertIn("vehicle_id", deploy_result.data)
+
+        # 3. Release the companion via the Action seam.
+        object_id = companion.objectdb_id
+        release_result = ReleaseCompanionAction().run(actor=self.owner, companion_id=companion.pk)
+        self.assertTrue(release_result.success, release_result.message)
+        self.assertIn("released from your bond", release_result.message)
+
+        from evennia.objects.models import ObjectDB
+
+        companion.refresh_from_db()
+        self.assertIsNotNone(companion.released_at)
+        self.assertFalse(companion.is_active)
+        self.assertFalse(ObjectDB.objects.filter(pk=object_id).exists())

--- a/src/world/companions/tests/test_views.py
+++ b/src/world/companions/tests/test_views.py
@@ -1,11 +1,34 @@
-"""Tests for the companions read-only API (#672)."""
+"""Tests for the companions API (#672)."""
 
 from __future__ import annotations
 
-from rest_framework.test import APITestCase
+from types import SimpleNamespace
+from unittest.mock import patch
 
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
+
+from actions.types import ActionResult
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
 from world.companions.factories import CompanionArchetypeFactory, CompanionFactory
+from world.companions.views import CompanionViewSet
 from world.roster.factories import RosterTenureFactory
+
+
+def _actor_user(character):
+    """Fake authenticated user whose ``puppet`` is ``character``."""
+    return SimpleNamespace(
+        is_authenticated=True,
+        is_staff=False,
+        pk=character.db_account_id,
+        puppet=character,
+    )
+
+
+def _no_puppet_user():
+    """Fake authenticated user with no puppet — actor cannot be resolved."""
+    return SimpleNamespace(is_authenticated=True, is_staff=False, pk=None, puppet=None)
 
 
 class CompanionViewSetTests(APITestCase):
@@ -47,3 +70,196 @@ class CompanionArchetypeViewSetTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         names = [row["name"] for row in response.data]
         self.assertIn(archetype.name, names)
+
+
+# ===========================================================================
+# Write endpoints — bind / release / fight / deploy (#1918)
+#
+# Each endpoint converges on action.run() via PuppetActorMixin, mirroring
+# SanctumViewSet's HTTP contract: success → 200/201 with result.data; failure
+# → 400 {"detail": result.message}; no-puppet → 400 {"detail": "No active character."}.
+# The Actions are mocked so these tests exercise the view wiring, not the
+# game logic (that's covered by test_companion_actions.py).
+# ===========================================================================
+
+
+_VIEWS = "world.companions.views"
+
+
+class CompanionWriteEndpointTestBase(TestCase):
+    """Common setup for the write endpoint tests."""
+
+    def setUp(self) -> None:
+        self.character = CharacterFactory()
+        self.sheet = CharacterSheetFactory(character=self.character)
+        self.factory = APIRequestFactory()
+
+    # -- helpers --------------------------------------------------------------
+
+    def _ok_result(self, data: dict) -> ActionResult:
+        return ActionResult(success=True, message="ok", data=data)
+
+    def _fail_result(self, message: str = "Something went wrong.") -> ActionResult:
+        return ActionResult(success=False, message=message, data={})
+
+    def _list_post(self, action_name, puppet, payload):
+        url = f"/api/companions/companions/{action_name}/"
+        request = self.factory.post(url, payload, format="json")
+        force_authenticate(request, user=puppet)
+        view = CompanionViewSet.as_view({"post": action_name})
+        return view(request)
+
+    def _detail_post(self, action_name, puppet, pk, payload=None):
+        url = f"/api/companions/companions/{pk}/{action_name}/"
+        request = self.factory.post(url, payload or {}, format="json")
+        force_authenticate(request, user=puppet)
+        view = CompanionViewSet.as_view({"post": action_name})
+        return view(request, pk=str(pk))
+
+
+class BindEndpointTests(CompanionWriteEndpointTestBase):
+    def test_bind_success_returns_201_with_companion_id(self) -> None:
+        with patch(f"{_VIEWS}.BindCompanionAction") as mock_cls:
+            mock_cls.return_value.run.return_value = self._ok_result({"companion_id": 42})
+            resp = self._list_post(
+                "bind",
+                _actor_user(self.character),
+                {"archetype_id": 1, "gift_id": 2, "name": "Skree"},
+            )
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.data["companion_id"], 42)
+
+    def test_bind_failure_returns_400_with_detail(self) -> None:
+        with patch(f"{_VIEWS}.BindCompanionAction") as mock_cls:
+            mock_cls.return_value.run.return_value = self._fail_result(
+                "Not enough Companion Capacity."
+            )
+            resp = self._list_post(
+                "bind",
+                _actor_user(self.character),
+                {"archetype_id": 1, "gift_id": 2, "name": "Fang"},
+            )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.data["detail"], "Not enough Companion Capacity.")
+
+    def test_bind_no_puppet_returns_400(self) -> None:
+        resp = self._list_post(
+            "bind",
+            _no_puppet_user(),
+            {"archetype_id": 1, "gift_id": 2, "name": "Skree"},
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("active character", resp.data["detail"].lower())
+
+    def test_bind_missing_fields_returns_400(self) -> None:
+        """Invalid serializer body (missing required fields) → 400."""
+        resp = self._list_post("bind", _actor_user(self.character), {"archetype_id": 1})
+
+        self.assertEqual(resp.status_code, 400)
+
+
+class ReleaseEndpointTests(CompanionWriteEndpointTestBase):
+    def test_release_success_returns_200(self) -> None:
+        companion = CompanionFactory(owner=self.sheet)
+        with (
+            patch.object(CompanionViewSet, "get_object", return_value=companion),
+            patch(f"{_VIEWS}.ReleaseCompanionAction") as mock_cls,
+        ):
+            mock_cls.return_value.run.return_value = self._ok_result({})
+            resp = self._detail_post("release", _actor_user(self.character), companion.pk)
+
+        self.assertEqual(resp.status_code, 200)
+
+    def test_release_failure_returns_400_with_detail(self) -> None:
+        companion = CompanionFactory(owner=self.sheet)
+        with (
+            patch.object(CompanionViewSet, "get_object", return_value=companion),
+            patch(f"{_VIEWS}.ReleaseCompanionAction") as mock_cls,
+        ):
+            mock_cls.return_value.run.return_value = self._fail_result("No longer active.")
+            resp = self._detail_post("release", _actor_user(self.character), companion.pk)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.data["detail"], "No longer active.")
+
+    def test_release_no_puppet_returns_400(self) -> None:
+        companion = CompanionFactory(owner=self.sheet)
+        with patch.object(CompanionViewSet, "get_object", return_value=companion):
+            resp = self._detail_post("release", _no_puppet_user(), companion.pk)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("active character", resp.data["detail"].lower())
+
+    def test_cannot_release_other_players_companion(self) -> None:
+        """A foreign companion is not in the caller's queryset → 404.
+
+        ``get_object`` raises ``Http404`` when the pk is not in the caller's
+        scoped queryset (a foreign companion would be excluded). We patch it
+        to simulate that queryset-scope behavior, since the SimpleNamespace
+        test user has no roster chain for a real queryset resolution.
+        """
+        from rest_framework.exceptions import NotFound
+
+        other_sheet = CharacterSheetFactory()
+        foreign = CompanionFactory(owner=other_sheet)
+        with patch.object(CompanionViewSet, "get_object", side_effect=NotFound):
+            resp = self._detail_post("release", _actor_user(self.character), foreign.pk)
+
+        self.assertEqual(resp.status_code, 404)
+
+
+class FightEndpointTests(CompanionWriteEndpointTestBase):
+    def test_fight_success_returns_200_with_opponent_id(self) -> None:
+        companion = CompanionFactory(owner=self.sheet)
+        with (
+            patch.object(CompanionViewSet, "get_object", return_value=companion),
+            patch(f"{_VIEWS}.CompanionFightAction") as mock_cls,
+        ):
+            mock_cls.return_value.run.return_value = self._ok_result({"opponent_id": 7})
+            resp = self._detail_post("fight", _actor_user(self.character), companion.pk)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["opponent_id"], 7)
+
+    def test_fight_requires_active_combat_returns_400(self) -> None:
+        companion = CompanionFactory(owner=self.sheet)
+        with (
+            patch.object(CompanionViewSet, "get_object", return_value=companion),
+            patch(f"{_VIEWS}.CompanionFightAction") as mock_cls,
+        ):
+            mock_cls.return_value.run.return_value = self._fail_result(
+                "You are not in active combat."
+            )
+            resp = self._detail_post("fight", _actor_user(self.character), companion.pk)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.data["detail"], "You are not in active combat.")
+
+
+class DeployEndpointTests(CompanionWriteEndpointTestBase):
+    def test_deploy_success_returns_200_with_vehicle_id(self) -> None:
+        companion = CompanionFactory(owner=self.sheet)
+        with (
+            patch.object(CompanionViewSet, "get_object", return_value=companion),
+            patch(f"{_VIEWS}.DeployCompanionAction") as mock_cls,
+        ):
+            mock_cls.return_value.run.return_value = self._ok_result({"vehicle_id": 9})
+            resp = self._detail_post("deploy", _actor_user(self.character), companion.pk)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["vehicle_id"], 9)
+
+    def test_deploy_requires_active_battle_returns_400(self) -> None:
+        companion = CompanionFactory(owner=self.sheet)
+        with (
+            patch.object(CompanionViewSet, "get_object", return_value=companion),
+            patch(f"{_VIEWS}.DeployCompanionAction") as mock_cls,
+        ):
+            mock_cls.return_value.run.return_value = self._fail_result("You are not in a battle.")
+            resp = self._detail_post("deploy", _actor_user(self.character), companion.pk)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.data["detail"], "You are not in a battle.")

--- a/src/world/companions/tests/test_views.py
+++ b/src/world/companions/tests/test_views.py
@@ -238,6 +238,17 @@ class FightEndpointTests(CompanionWriteEndpointTestBase):
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.data["detail"], "You are not in active combat.")
 
+    def test_cannot_fight_other_players_companion(self) -> None:
+        """A foreign companion is not in the caller's queryset → 404."""
+        from rest_framework.exceptions import NotFound
+
+        other_sheet = CharacterSheetFactory()
+        foreign = CompanionFactory(owner=other_sheet)
+        with patch.object(CompanionViewSet, "get_object", side_effect=NotFound):
+            resp = self._detail_post("fight", _actor_user(self.character), foreign.pk)
+
+        self.assertEqual(resp.status_code, 404)
+
 
 class DeployEndpointTests(CompanionWriteEndpointTestBase):
     def test_deploy_success_returns_200_with_vehicle_id(self) -> None:
@@ -263,3 +274,14 @@ class DeployEndpointTests(CompanionWriteEndpointTestBase):
 
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.data["detail"], "You are not in a battle.")
+
+    def test_cannot_deploy_other_players_companion(self) -> None:
+        """A foreign companion is not in the caller's queryset → 404."""
+        from rest_framework.exceptions import NotFound
+
+        other_sheet = CharacterSheetFactory()
+        foreign = CompanionFactory(owner=other_sheet)
+        with patch.object(CompanionViewSet, "get_object", side_effect=NotFound):
+            resp = self._detail_post("deploy", _actor_user(self.character), foreign.pk)
+
+        self.assertEqual(resp.status_code, 404)

--- a/src/world/companions/views.py
+++ b/src/world/companions/views.py
@@ -1,8 +1,8 @@
 """Companion API views (#672).
 
-Read-only surface mirroring world/ships/views.py's ShipViewSet: writes
-(binding) stay on action.run() via BindCompanionAction (Task 8) — no write
-endpoint exists here.
+Read surface + write endpoints (bind/release/fight/deploy) that converge on
+``action.run()`` via ``PuppetActorMixin`` — the same pattern as
+``SanctumViewSet`` (#1497).
 """
 
 from __future__ import annotations
@@ -10,13 +10,26 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import viewsets
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
+from actions.definitions.companions import (
+    BindCompanionAction,
+    CompanionFightAction,
+    DeployCompanionAction,
+    ReleaseCompanionAction,
+)
 from world.companions.filters import CompanionFilterSet
 from world.companions.models import Companion, CompanionArchetype
-from world.companions.serializers import CompanionArchetypeSerializer, CompanionSerializer
+from world.companions.serializers import (
+    BindActionSerializer,
+    CompanionArchetypeSerializer,
+    CompanionSerializer,
+)
+from world.magic.views_actor import PuppetActorMixin
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
@@ -26,6 +39,10 @@ if TYPE_CHECKING:
 
 class CompanionPagination(PageNumberPagination):
     page_size = 50
+
+
+#: Error detail returned when the request has no active character to act as.
+NO_ACTIVE_CHARACTER_DETAIL = "No active character."
 
 
 def _active_persona_for_request(request: Request) -> Persona | None:
@@ -44,8 +61,14 @@ def _active_persona_for_request(request: Request) -> Persona | None:
     return active_persona_for_sheet(entry.character_sheet)
 
 
-class CompanionViewSet(viewsets.ReadOnlyModelViewSet):
-    """Read endpoints for the player's own active companions."""
+class CompanionViewSet(PuppetActorMixin, viewsets.ReadOnlyModelViewSet):
+    """Read + action endpoints for the player's companion surface.
+
+    `list`/`retrieve` return the caller's own active companions (read-only).
+    POST actions delegate to the four Actions in
+    ``actions/definitions/companions.py``; ``ActionResult`` fields map 1:1 to
+    the response bodies so the contract matches ``SanctumViewSet`` (#1918).
+    """
 
     serializer_class = CompanionSerializer
     permission_classes = [IsAuthenticated]
@@ -60,6 +83,88 @@ class CompanionViewSet(viewsets.ReadOnlyModelViewSet):
         return Companion.objects.filter(
             owner=persona.character_sheet, released_at__isnull=True
         ).select_related("archetype")
+
+    # ------------------------------------------------------------------
+    # Write endpoints — converge on action.run()
+    # ------------------------------------------------------------------
+
+    @action(detail=False, methods=["post"], url_path="bind")
+    def bind(self, request):
+        """Bind a new companion — ``POST /api/companions/companions/bind/``.
+
+        Body: ``{archetype_id, gift_id, name}``.
+        Wraps :class:`actions.definitions.companions.BindCompanionAction`.
+        """
+        serializer = BindActionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        actor = self._resolve_actor(request)
+        if actor is None:
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
+        result = BindCompanionAction().run(
+            actor=actor,
+            archetype_id=serializer.validated_data["archetype_id"],
+            gift_id=serializer.validated_data["gift_id"],
+            name=serializer.validated_data["name"],
+        )
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(result.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=["post"], url_path="release")
+    def release(self, request, pk=None):
+        """Release a bonded companion — ``POST /api/companions/companions/{id}/release/``.
+
+        Wraps :class:`actions.definitions.companions.ReleaseCompanionAction`.
+        The companion id comes from the URL; ``get_queryset`` scopes it to the
+        caller's active companions (foreign → 404). The Action re-validates
+        ownership via ``_resolve_owned_companion`` (defense in depth).
+        """
+        companion = self.get_object()
+        actor = self._resolve_actor(request)
+        if actor is None:
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
+        result = ReleaseCompanionAction().run(actor=actor, companion_id=companion.pk)
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(result.data)
+
+    @action(detail=True, methods=["post"], url_path="fight")
+    def fight(self, request, pk=None):
+        """Commit a companion into combat — ``POST /api/companions/companions/{id}/fight/``.
+
+        Wraps :class:`actions.definitions.companions.CompanionFightAction`.
+        """
+        companion = self.get_object()
+        actor = self._resolve_actor(request)
+        if actor is None:
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
+        result = CompanionFightAction().run(actor=actor, companion_id=companion.pk)
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(result.data)
+
+    @action(detail=True, methods=["post"], url_path="deploy")
+    def deploy(self, request, pk=None):
+        """Deploy a companion into a battle — ``POST /api/companions/companions/{id}/deploy/``.
+
+        Wraps :class:`actions.definitions.companions.DeployCompanionAction`.
+        """
+        companion = self.get_object()
+        actor = self._resolve_actor(request)
+        if actor is None:
+            return Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
+        result = DeployCompanionAction().run(actor=actor, companion_id=companion.pk)
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(result.data)
 
 
 class CompanionArchetypeViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
## Summary

Closes the coverage-gap for the companion system (#672/#1918): the engine (models, services, 3 Actions, read-only API) was fully built and tested but unreachable by players.

### What's added
- **`ReleaseCompanionAction`** — new Action wrapping the existing `release_companion` service (thin: validate ownership + active via `_resolve_owned_companion`, call service).
- **`CmdCompanion`** — `DispatchCommand` routing `bind`/`fight`/`deploy`/`release` through `dispatch_player_action`. Mirrors `CmdSanctum` (subverb dict, `_parse_kwargs`, per-subverb arg resolvers, status hub).
- **Web write surface** — `@action` methods on `CompanionViewSet` (`bind`/`release`/`fight`/`deploy`) converging on `action.run()` via `PuppetActorMixin`. Mirrors `SanctumViewSet`.
- **`BindActionSerializer`** for the bind endpoint body.
- **E2E journey test** — bind → deploy → release loop through the Action seam.

### Test results
- `actions` suite: 885 tests pass (includes 4 new `ReleaseCompanionAction` tests + registry exact-match)
- `commands` suite: 25 new command tests pass
- `world.companions` suite: 17 view + 2 E2E tests pass (all new write endpoints + 404 paths)
- All runs on SQLite fast tier (`--sqlite`)

### Design decisions
- Telnet uses `dispatch_player_action`; web uses `action.run()` directly — mirrors the `CmdSanctum`/`SanctumViewSet` split.
- No consent gate (ADR-0024 — companion binding is not consent-gated).
- No new combat/battle logic — `CompanionFightAction`/`DeployCompanionAction` already exist.
- No changes to capacity/bind mechanics.

Closes #1918