### PR TITLE
docs: friction-audit fixes — subagent foreground rule, exit-code pipes, test-run lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,11 @@ Explore/research agents). Two concrete failure modes motivate this:
 - **Batched mutating tool calls cascade-cancel**: when one call in a parallel
   batch errors or hits an approval prompt, the harness cancels every sibling
   in that batch, and most of the intended work silently doesn't run.
+- **Subagents must run every command in the foreground.** Background completion
+  notifications re-invoke the main loop only — a subagent that backgrounds a
+  command and ends its turn "waiting for the notification" dies silently holding
+  uncommitted work (two stalls during #1909). Put a foreground-only instruction
+  in every implementer/fix dispatch prompt.
 
 Destructive or approval-gated git operations (`reset --hard`, force-push) go
 alone in their own message. Never cite an issue/PR number that wasn't read
@@ -288,7 +293,11 @@ See "Completing a Unit of Work.")
 
 Run the fast SQLite tier for the apps you changed, then push and **monitor the PR**,
 fixing what CI catches. **CI is the full-regression gate** — run a local
-`just regression` only to reproduce a CI failure the fast tier doesn't surface. For
+`just regression` only to reproduce a CI failure the fast tier doesn't surface.
+**Never pipe exit-code-bearing commands (`arx test`, `git commit`) through
+`tail`/`head`** — the pipe masks the exit code and buries the OK/FAILED summary
+(false-green runs on #947/#948; a silently aborted commit reopened #927). Run
+them bare (backgrounded if long) and read the full output. For
 the per-app tier table, recipes, `@tag("postgres")` decisions, the `--keepdb`
 pitfall, invocation gotchas (`world.`-prefixed test paths, no `-v`, `uv run` for
 ruff/pre-commit), and the "never rely on Evennia defaults in service functions"

--- a/tools/skills/running-tests/SKILL.md
+++ b/tools/skills/running-tests/SKILL.md
@@ -126,6 +126,24 @@ See `src/world/checks/tests/test_legend_award_handler.py:189-195` for the canoni
 
 Then push and **monitor the PR**. CI runs the full Postgres parity suite on every PR (6 parallel shards, ~2,500 tests each) — let it catch regressions and fix what it reports there. Run a local `just regression` only to reproduce a CI failure the fast tier doesn't surface.
 
+## Background-run lifecycle (kills, hangs, branch switches)
+
+A background `arx test` run holds live shared state; three recurring traps:
+
+- **After killing a run, reset the test DB before relaunching.** A killed run
+  can leave a stale PG session on `test_arxiidev`; the next run then blocks at
+  the destroy/create step or errors "database is being accessed by other
+  users." Fix: `pg_terminate_backend` the `test_arxiidev` sessions and
+  `DROP DATABASE IF EXISTS test_arxiidev` via psql, then relaunch.
+- **"Creating test database..." silence up to ~5 minutes is NORMAL on PG** —
+  it's ~80 migrations applying with no streamed output, not a hang. Check
+  `pg_stat_activity` before killing: an active/committing session is healthy;
+  an idle blocked session is the stale-session trap above.
+- **Never `git checkout` while a background run is live.** Runs read source
+  files live from the shared tree; a mid-run branch switch makes modules
+  inconsistent and produces bogus import tracebacks. Finish or kill the run
+  first (then see the reset step above).
+
 ## `--keepdb` and faithful local repro
 
 CI always starts from a fresh DB. To reproduce a CI failure locally, run without `--keepdb` so Evennia setup objects (Limbo room #2, default Account #1) and prior-run state don't leak in:


### PR DESCRIPTION
Promotes three field-validated workarounds from session memory into durable directives, per the workflow-friction-audit process (5-entry threshold reached 2026-07-06):

- **CLAUDE.md / Tool & Subagent Sequencing:** subagents must run every command in the foreground — background completion notifications only re-invoke the main loop, so a subagent that ends its turn waiting dies silently (two stalls during #1909).
- **CLAUDE.md / Testing:** never pipe exit-code-bearing commands (`arx test`, `git commit`) through `tail`/`head` — masked exit codes produced false-green runs (#947/#948) and a silently aborted commit (#927 reopen).
- **running-tests skill:** new "Background-run lifecycle" section — stale PG session reset after killing a run, the ~5-minute "Creating test database" silence is normal, and no branch switches during a live background run.

Docs-only; no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)