### PR TITLE
Thread pulls on social actions (#1919)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -27405,6 +27405,7 @@ export interface components {
       target_condition_instance_id?: number | null;
       target_pending_alteration_id?: number | null;
       bond_thread_id?: number | null;
+      pull?: components['schemas']['CastPullRequestRequest'] | null;
     };
     /** @description Flat read payload for a pending additional-target consent row (#1177). */
     SceneActionTarget: {
@@ -29400,6 +29401,9 @@ export interface components {
       tier: number;
       thread_ids: number[];
       action_context?: components['schemas']['PullActionContextRequest'];
+      scene_id?: number | null;
+      /** @default false */
+      exclude_gift: boolean;
     };
     /** @description Response serializer for POST /api/magic/thread-pull-preview/. */
     ThreadPullPreviewResponse: {

--- a/frontend/src/magic/types.ts
+++ b/frontend/src/magic/types.ts
@@ -160,7 +160,13 @@ export interface ImbueResponse {
 // Re-export generated shapes.
 // ---------------------------------------------------------------------------
 
-export type PullPreviewRequest = components['schemas']['ThreadPullPreviewRequestRequest'];
+export type PullPreviewRequest = Omit<
+  components['schemas']['ThreadPullPreviewRequestRequest'],
+  'exclude_gift' | 'scene_id'
+> & {
+  exclude_gift?: boolean;
+  scene_id?: number | null;
+};
 
 /** One previewed effect in the preview response. */
 export type PreviewedEffect = components['schemas']['ResolvedPullEffect'];

--- a/src/commands/combat.py
+++ b/src/commands/combat.py
@@ -48,25 +48,22 @@ from typing import TYPE_CHECKING, Any
 from actions.constants import ActionCategory, CombatActionSlot
 from commands.command import DispatchCommand
 from commands.exceptions import CommandError
+from commands.pull_parsing import (
+    _ANCHOR_PREFIX,
+    _BASE_KEYWORD,
+    _EFFORT_PREFIX,
+    _FURY_PREFIX,
+    _SECONDARY_KEYWORD,
+    PullParsingMixin,
+)
 
 if TYPE_CHECKING:
     from actions.types import ActionRef
     from world.combat.models import CombatParticipant
     from world.magic.types.pull import CastPullDeclaration
 
-# Keyword prefix used to parse effort=<level> from command args.
-_EFFORT_PREFIX = "effort="
-# Standalone keyword that declares the technique as a passive secondary action.
-_SECONDARY_KEYWORD = "secondary"
-# Standalone keyword that opts out of gift-technique variant resolution (#1581 Task 8).
-_BASE_KEYWORD = "base"
 # Keyword prefix used to parse strain=<n> from clash command args.
 _STRAIN_PREFIX = "strain="
-# Keyword prefixes used to parse fury=<tier> anchor=<name> from cast command args.
-# Values are single tokens (a FuryTier name or depth, and the anchor character's
-# key); both must be free of spaces.
-_FURY_PREFIX = "fury="
-_ANCHOR_PREFIX = "anchor="
 # Usage hint for the clash command (shared across three error sites in _parse_args).
 _CLASH_USAGE = (
     "Usage: clash <opponent> with <technique> [strain=<n>]"
@@ -81,17 +78,15 @@ _SECONDARY_SLOT: dict[str, str] = {
 }
 
 
-class _CombatCommandMixin:
+class _CombatCommandMixin(PullParsingMixin):
     """Shared helpers for combat telnet commands.
 
-    Provides ``_combat_participant_or_none``, ``_find_technique_id``, pull-keyword
-    parsing (``_extract_pull_keywords``, ``_resolve_cast_pull``, and related statics),
-    so that ``CmdDeclareTechnique`` and ``CmdClashCommit`` can reuse the same logic
-    without duplicating it.
+    Provides ``_combat_participant_or_none``, ``_find_technique_id``, and
+    inherits pull-keyword parsing from ``PullParsingMixin``
+    (``_extract_pull_keywords``, ``_resolve_cast_pull``, and related statics),
+    so that ``CmdDeclareTechnique`` and ``CmdClashCommit`` can reuse the same
+    logic without duplicating it.
     """
-
-    # Pull-kwarg prefixes recognised by _extract_pull_keywords.
-    _PULL_KWARG_KEYS: frozenset[str] = frozenset({"pull", "resonance", "tier", "beseech"})
 
     def _combat_participant_or_none(self) -> CombatParticipant | None:
         """Return the caller's active CombatParticipant in a DECLARING encounter, or None.
@@ -138,200 +133,6 @@ class _CombatCommandMixin:
             msg = f"You don't know a technique called '{technique_name}'."
             raise CommandError(msg)
         return ct.technique_id
-
-    # -- Pull-keyword parsing --------------------------------------------------
-
-    @staticmethod
-    def _is_pull_stop_token(tok: str, pull_keys: frozenset[str]) -> bool:
-        """Return True when *tok* marks the start of a non-pull keyword boundary.
-
-        Stops on any ``pull_keys``-prefixed token (``pull=``, ``resonance=``,
-        ``tier=``), on ``effort=`` / ``secondary``, and on ``fury=`` / ``anchor=``
-        (all handled elsewhere) so a greedy pull value never swallows them.
-        """
-        lower = tok.lower()
-        return (
-            any(lower.startswith(k + "=") for k in pull_keys)
-            or lower.startswith((_EFFORT_PREFIX, _FURY_PREFIX, _ANCHOR_PREFIX))
-            or lower in (_SECONDARY_KEYWORD, _BASE_KEYWORD)
-        )
-
-    @staticmethod
-    def _greedy_consume(
-        tokens: list[str],
-        start: int,
-        initial: str,
-        pull_keys: frozenset[str],
-    ) -> tuple[str, int, set[int]]:
-        """Greedily extend *initial* with tokens from *start* until a stop boundary.
-
-        Returns ``(value, next_index, consumed_indices)`` where *consumed_indices*
-        are the token positions that were merged into *value*.
-        """
-        consumed: set[int] = set()
-        j = start
-        while j < len(tokens):
-            if _CombatCommandMixin._is_pull_stop_token(tokens[j], pull_keys):
-                break
-            consumed.add(j)
-            initial = initial + " " + tokens[j]
-            j += 1
-        return initial.strip(), j, consumed
-
-    @staticmethod
-    def _validate_pull_tier(tier_val: str | None) -> int:
-        """Return the integer tier (default 1) and raise CommandError when invalid."""
-        if tier_val is None:
-            return 1
-        if not tier_val.isdigit() or int(tier_val) not in (1, 2, 3):
-            msg = f"Invalid tier '{tier_val}' — choose 1, 2, or 3."
-            raise CommandError(msg)
-        return int(tier_val)
-
-    @staticmethod
-    def _validate_pull_beseech(beseech_val: str | None) -> int:
-        """Return the integer emergency-draw bonus (default 0); raise CommandError if invalid.
-
-        Mirrors ``_validate_pull_tier``'s shape: a single optional non-negative
-        int token. 0 (absent) means no emergency thread-bond draw was invoked (#1718).
-        """
-        if beseech_val is None:
-            return 0
-        if not beseech_val.isdigit():
-            msg = f"Invalid beseech amount '{beseech_val}' — must be a non-negative integer."
-            raise CommandError(msg)
-        return int(beseech_val)
-
-    @classmethod
-    def _extract_pull_keywords(
-        cls,
-        raw: str,
-    ) -> tuple[str, str | None, str | None, int, int]:
-        """Extract pull=, resonance=, tier=, and beseech= tokens from *raw*.
-
-        Each keyword's value is consumed greedily until the next known keyword
-        prefix or end-of-string, so multi-word thread names (e.g. "Ember Strand")
-        and comma-separated lists ("Strand A,Strand B") are captured intact.
-
-        Raises:
-            CommandError: If ``tier=`` is present but not 1–3, if ``beseech=``
-                is present but not a non-negative integer, or if ``pull=`` is
-                given without ``resonance=``.
-
-        Returns:
-            ``(remainder, pull_val, resonance_val, pull_tier, beseech_bonus)``
-            where *remainder* is *raw* with all four keywords stripped out,
-            *pull_tier* defaults to 1 when ``tier=`` is absent, and
-            *beseech_bonus* defaults to 0 when ``beseech=`` is absent (#1718).
-        """
-        pull_keys = cls._PULL_KWARG_KEYS
-        tokens = raw.split()
-        pull_val: str | None = None
-        resonance_val: str | None = None
-        tier_val: str | None = None
-        beseech_val: str | None = None
-        skip_indices: set[int] = set()
-
-        i = 0
-        while i < len(tokens):
-            lower_tok = tokens[i].lower()
-            matched_key = next((k for k in pull_keys if lower_tok.startswith(k + "=")), None)
-            if matched_key is None:
-                i += 1
-                continue
-
-            skip_indices.add(i)
-            initial = tokens[i][len(matched_key) + 1 :]  # strip "key="
-            value, i, consumed = cls._greedy_consume(tokens, i + 1, initial, pull_keys)
-            skip_indices.update(consumed)
-
-            if matched_key == "pull":  # noqa: STRING_LITERAL
-                pull_val = value or None
-            elif matched_key == "resonance":  # noqa: STRING_LITERAL
-                resonance_val = value or None
-            elif matched_key == "tier":  # noqa: STRING_LITERAL
-                tier_val = value or None
-            else:
-                beseech_val = value or None
-
-        remainder = " ".join(t for idx, t in enumerate(tokens) if idx not in skip_indices)
-
-        pull_tier = cls._validate_pull_tier(tier_val)
-        beseech_bonus = cls._validate_pull_beseech(beseech_val)
-        if pull_val is not None and resonance_val is None:
-            msg = "pull= requires resonance=<name> to be specified as well."
-            raise CommandError(msg)
-
-        return remainder, pull_val, resonance_val, pull_tier, beseech_bonus
-
-    def _resolve_cast_pull(
-        self,
-        pull_thread_str: str | None,
-        pull_resonance_str: str | None,
-        pull_tier: int,
-        beseech_bonus: int = 0,
-    ) -> CastPullDeclaration | None:
-        """Return a ``CastPullDeclaration`` if *pull_thread_str* is set, else ``None``.
-
-        Resolves threads by name/id owned by the caller's character sheet
-        (same resonance, active only) and the resonance by name.
-
-        Args:
-            pull_thread_str: Comma-separated thread names/ids, or ``None``.
-            pull_resonance_str: Resonance name string, or ``None``.
-            pull_tier: Integer tier (1–3).
-            beseech_bonus: Emergency thread-bond draw bonus (#1718); 0 means
-                no emergency draw was invoked.
-
-        Raises:
-            CommandError: If resonance is unknown, any thread is not found /
-                does not match the resonance / is retired, or pull= is present
-                without resonance=.
-        """
-        if pull_thread_str is None:
-            return None
-
-        from world.magic.models import Resonance, Thread  # noqa: PLC0415
-        from world.magic.types.pull import CastPullDeclaration  # noqa: PLC0415
-
-        resonance_val = (pull_resonance_str or "").strip()
-        if not resonance_val:
-            msg = "pull= requires resonance=<name> to be specified as well."
-            raise CommandError(msg)
-
-        resonance_qs = Resonance.objects.filter(name__iexact=resonance_val)
-        resonance = resonance_qs.first()
-        if resonance is None:
-            msg = f"No resonance named '{resonance_val}' found."
-            raise CommandError(msg)
-
-        sheet = self.caller.sheet_data
-        thread_vals = [t.strip() for t in pull_thread_str.split(",") if t.strip()]
-        if not thread_vals:
-            msg = "pull= requires at least one thread name or id."
-            raise CommandError(msg)
-
-        threads: list[Thread] = []
-        for val in thread_vals:
-            qs = Thread.objects.filter(owner=sheet, resonance=resonance, retired_at__isnull=True)
-            if val.isdigit():
-                thread = qs.filter(pk=int(val)).first()
-            else:
-                thread = qs.filter(name__iexact=val).first()
-            if thread is None:
-                msg = (
-                    f"No active thread '{val}' found for resonance '{resonance_val}'. "
-                    "Check that the thread exists, is active, and matches the resonance."
-                )
-                raise CommandError(msg)
-            threads.append(thread)
-
-        return CastPullDeclaration(
-            resonance=resonance,
-            tier=pull_tier,
-            threads=tuple(threads),
-            beseech_bonus=beseech_bonus,
-        )
 
 
 class CmdDeclareTechnique(_CombatCommandMixin, DispatchCommand):

--- a/src/commands/consent.py
+++ b/src/commands/consent.py
@@ -27,6 +27,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError as Django
 from commands.command import ArxCommand
 from commands.exceptions import CommandError
 from commands.offer_registry import find_handler, format_pending_listing, get_all_pending
+from commands.pull_parsing import PullParsingMixin
 from world.scenes.action_constants import ActionRequestStatus, ConsentDecision
 from world.scenes.action_models import SceneActionRequest
 from world.scenes.action_services import create_action_request, respond_to_action_request
@@ -37,7 +38,7 @@ if TYPE_CHECKING:
     from world.scenes.models import Persona, Scene
 
 
-class ConsentRequestCommand(ArxCommand):
+class ConsentRequestCommand(PullParsingMixin, ArxCommand):
     """Base for telnet commands that open a consent request.
 
     Subclasses set ``action_key`` (the registry action key, e.g. "intimidate").
@@ -45,8 +46,16 @@ class ConsentRequestCommand(ArxCommand):
     then calls ``create_action_request`` — the same service the consent viewset
     calls. All consent logic stays in the service; this is a thin shell.
 
+    Optionally accepts a thread-pull declaration (#1919):
+        <key> <character> [pull=<thread>[,…] resonance=<name> [tier=<1-3>]]
+
+    The ``pull=`` / ``resonance=`` / ``tier=`` tokens are stripped from the raw
+    args before target-name resolution (same as ``cast``'s approach). The
+    ``beseech=`` token is extracted but discarded — it is a combat-only mechanic
+    (#1718) and has no effect on social actions.
+
     Usage:
-        <key> <character>
+        <key> <character> [pull=<thread> resonance=<name> [tier=<1-3>]]
     """
 
     action_key: ClassVar[str] = ""
@@ -57,13 +66,24 @@ class ConsentRequestCommand(ArxCommand):
         # DjangoValidationError converted to CommandError so the base try/except
         # surfaces it cleanly — mirrors how the web viewset handles it.
         scene, initiator_persona = self._resolve_scene_and_initiator()
+        # #1919: Extract pull keywords BEFORE resolving the target name so
+        # pull= / resonance= / tier= / beseech= tokens don't contaminate the
+        # target-name search. beseech= is discarded (combat-only mechanic).
+        raw = (self.args or "").strip()
+        raw, pull_thread_str, resonance_str, pull_tier, _beseech = self._extract_pull_keywords(raw)
+        # Re-set self.args so _resolve_target_persona searches the cleaned remainder.
+        self.args = raw
         target_persona = self._resolve_target_persona()
+        cast_pull = self._resolve_cast_pull(
+            pull_thread_str, resonance_str, pull_tier, beseech_bonus=0
+        )
         try:
             request = create_action_request(
                 scene=scene,
                 initiator_persona=initiator_persona,
                 target_persona=target_persona,
                 action_key=self.action_key,
+                pull=cast_pull,
             )
         except DjangoValidationError as err:
             msg = "; ".join(err.messages)

--- a/src/commands/pull_parsing.py
+++ b/src/commands/pull_parsing.py
@@ -1,0 +1,240 @@
+"""Shared pull-keyword parsing mixin for telnet commands (#1919).
+
+Extracted from ``_CombatCommandMixin`` so that both combat commands
+(``cast``/``clash``) and consent commands (``persuade``/``intimidate``/…)
+can reuse the same pull-parser without duplicating logic.
+
+The ``beseech=`` token is a COVENANT_ROLE combat mechanic (#1718) and is
+meaningless for social actions. It stays in ``_PULL_KWARG_KEYS`` so
+``_extract_pull_keywords`` extracts and removes it from the remainder
+(otherwise it would contaminate target-name resolution). Social commands
+extract the ``beseech=`` value but discard it — ``_resolve_cast_pull`` is
+called with ``beseech_bonus=0`` so no emergency draw fires, and
+``_charge_social_pull`` also passes ``beseech_bonus=0`` as defense-in-depth.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from world.magic.types.pull import CastPullDeclaration
+
+
+# Keyword prefix used to parse effort=<level> from command args.
+_EFFORT_PREFIX = "effort="
+# Standalone keyword that declares the technique as a passive secondary action.
+_SECONDARY_KEYWORD = "secondary"
+# Standalone keyword that opts out of gift-technique variant resolution.
+_BASE_KEYWORD = "base"
+# Keyword prefixes used to parse fury=<tier> anchor=<name> from cast command args.
+_FURY_PREFIX = "fury="
+_ANCHOR_PREFIX = "anchor="
+
+
+class PullParsingMixin:
+    """Shared pull-keyword parsing for telnet commands.
+
+    Provides ``_extract_pull_keywords`` and ``_resolve_cast_pull`` (plus
+    related statics) so that any command that accepts ``pull=`` / ``resonance=``
+    / ``tier=`` / ``beseech=`` tokens can reuse the same parser.
+    """
+
+    # Pull-kwarg prefixes recognised by _extract_pull_keywords.
+    _PULL_KWARG_KEYS: frozenset[str] = frozenset({"pull", "resonance", "tier", "beseech"})
+
+    # -- Pull-keyword parsing --------------------------------------------------
+
+    @staticmethod
+    def _is_pull_stop_token(tok: str, pull_keys: frozenset[str]) -> bool:
+        """Return True when *tok* marks the start of a non-pull keyword boundary.
+
+        Stops on any ``pull_keys``-prefixed token (``pull=``, ``resonance=``,
+        ``tier=``), on ``effort=`` / ``secondary``, and on ``fury=`` / ``anchor=``
+        (all handled elsewhere) so a greedy pull value never swallows them.
+        """
+        lower = tok.lower()
+        return (
+            any(lower.startswith(k + "=") for k in pull_keys)
+            or lower.startswith((_EFFORT_PREFIX, _FURY_PREFIX, _ANCHOR_PREFIX))
+            or lower in (_SECONDARY_KEYWORD, _BASE_KEYWORD)
+        )
+
+    @staticmethod
+    def _greedy_consume(
+        tokens: list[str],
+        start: int,
+        initial: str,
+        pull_keys: frozenset[str],
+    ) -> tuple[str, int, set[int]]:
+        """Greedily extend *initial* with tokens from *start* until a stop boundary.
+
+        Returns ``(value, next_index, consumed_indices)`` where *consumed_indices*
+        are the token positions that were merged into *value*.
+        """
+        consumed: set[int] = set()
+        j = start
+        while j < len(tokens):
+            if PullParsingMixin._is_pull_stop_token(tokens[j], pull_keys):
+                break
+            consumed.add(j)
+            initial = initial + " " + tokens[j]
+            j += 1
+        return initial.strip(), j, consumed
+
+    @staticmethod
+    def _validate_pull_tier(tier_val: str | None) -> int:
+        """Return the integer tier (default 1) and raise CommandError when invalid."""
+        if tier_val is None:
+            return 1
+        if not tier_val.isdigit() or int(tier_val) not in (1, 2, 3):
+            msg = f"Invalid tier '{tier_val}' — choose 1, 2, or 3."
+            raise CommandError(msg)
+        return int(tier_val)
+
+    @staticmethod
+    def _validate_pull_beseech(beseech_val: str | None) -> int:
+        """Return the integer emergency-draw bonus (default 0); raise CommandError if invalid.
+
+        Mirrors ``_validate_pull_tier``'s shape: a single optional non-negative
+        int token. 0 (absent) means no emergency thread-bond draw was invoked (#1718).
+        """
+        if beseech_val is None:
+            return 0
+        if not beseech_val.isdigit():
+            msg = f"Invalid beseech amount '{beseech_val}' — must be a non-negative integer."
+            raise CommandError(msg)
+        return int(beseech_val)
+
+    @classmethod
+    def _extract_pull_keywords(
+        cls,
+        raw: str,
+    ) -> tuple[str, str | None, str | None, int, int]:
+        """Extract pull=, resonance=, tier=, and beseech= tokens from *raw*.
+
+        Each keyword's value is consumed greedily until the next known keyword
+        prefix or end-of-string, so multi-word thread names (e.g. "Ember Strand")
+        and comma-separated lists ("Strand A,Strand B") are captured intact.
+
+        Raises:
+            CommandError: If ``tier=`` is present but not 1–3, if ``beseech=``
+                is present but not a non-negative integer, or if ``pull=`` is
+                given without ``resonance=``.
+
+        Returns:
+            ``(remainder, pull_val, resonance_val, pull_tier, beseech_bonus)``
+            where *remainder* is *raw* with all four keywords stripped out,
+            *pull_tier* defaults to 1 when ``tier=`` is absent, and
+            *beseech_bonus* defaults to 0 when ``beseech=`` is absent (#1718).
+        """
+        pull_keys = cls._PULL_KWARG_KEYS
+        tokens = raw.split()
+        pull_val: str | None = None
+        resonance_val: str | None = None
+        tier_val: str | None = None
+        beseech_val: str | None = None
+        skip_indices: set[int] = set()
+
+        i = 0
+        while i < len(tokens):
+            lower_tok = tokens[i].lower()
+            matched_key = next((k for k in pull_keys if lower_tok.startswith(k + "=")), None)
+            if matched_key is None:
+                i += 1
+                continue
+
+            skip_indices.add(i)
+            initial = tokens[i][len(matched_key) + 1 :]  # strip "key="
+            value, i, consumed = cls._greedy_consume(tokens, i + 1, initial, pull_keys)
+            skip_indices.update(consumed)
+
+            if matched_key == "pull":  # noqa: STRING_LITERAL
+                pull_val = value or None
+            elif matched_key == "resonance":  # noqa: STRING_LITERAL
+                resonance_val = value or None
+            elif matched_key == "tier":  # noqa: STRING_LITERAL
+                tier_val = value or None
+            else:
+                beseech_val = value or None
+
+        remainder = " ".join(t for idx, t in enumerate(tokens) if idx not in skip_indices)
+
+        pull_tier = cls._validate_pull_tier(tier_val)
+        beseech_bonus = cls._validate_pull_beseech(beseech_val)
+        if pull_val is not None and resonance_val is None:
+            msg = "pull= requires resonance=<name> to be specified as well."
+            raise CommandError(msg)
+
+        return remainder, pull_val, resonance_val, pull_tier, beseech_bonus
+
+    def _resolve_cast_pull(
+        self,
+        pull_thread_str: str | None,
+        pull_resonance_str: str | None,
+        pull_tier: int,
+        beseech_bonus: int = 0,
+    ) -> CastPullDeclaration | None:
+        """Return a ``CastPullDeclaration`` if *pull_thread_str* is set, else ``None``.
+
+        Resolves threads by name/id owned by the caller's character sheet
+        (same resonance, active only) and the resonance by name.
+
+        Args:
+            pull_thread_str: Comma-separated thread names/ids, or ``None``.
+            pull_resonance_str: Resonance name string, or ``None``.
+            pull_tier: Integer tier (1–3).
+            beseech_bonus: Emergency thread-bond draw bonus (#1718); 0 means
+                no emergency draw was invoked. Social commands always pass 0.
+
+        Raises:
+            CommandError: If resonance is unknown, any thread is not found /
+                does not match the resonance / is retired, or pull= is present
+                without resonance=.
+        """
+        if pull_thread_str is None:
+            return None
+
+        from world.magic.models import Resonance, Thread  # noqa: PLC0415
+        from world.magic.types.pull import CastPullDeclaration  # noqa: PLC0415
+
+        resonance_val = (pull_resonance_str or "").strip()
+        if not resonance_val:
+            msg = "pull= requires resonance=<name> to be specified as well."
+            raise CommandError(msg)
+
+        resonance_qs = Resonance.objects.filter(name__iexact=resonance_val)
+        resonance = resonance_qs.first()
+        if resonance is None:
+            msg = f"No resonance named '{resonance_val}' found."
+            raise CommandError(msg)
+
+        sheet = self.caller.sheet_data
+        thread_vals = [t.strip() for t in pull_thread_str.split(",") if t.strip()]
+        if not thread_vals:
+            msg = "pull= requires at least one thread name or id."
+            raise CommandError(msg)
+
+        threads: list[Thread] = []
+        for val in thread_vals:
+            qs = Thread.objects.filter(owner=sheet, resonance=resonance, retired_at__isnull=True)
+            if val.isdigit():
+                thread = qs.filter(pk=int(val)).first()
+            else:
+                thread = qs.filter(name__iexact=val).first()
+            if thread is None:
+                msg = (
+                    f"No active thread '{val}' found for resonance '{resonance_val}'. "
+                    "Check that the thread exists, is active, and matches the resonance."
+                )
+                raise CommandError(msg)
+            threads.append(thread)
+
+        return CastPullDeclaration(
+            resonance=resonance,
+            tier=pull_tier,
+            threads=tuple(threads),
+            beseech_bonus=beseech_bonus,
+        )

--- a/src/commands/tests/test_consent_commands.py
+++ b/src/commands/tests/test_consent_commands.py
@@ -267,3 +267,50 @@ class AllSocialCommandsRegisteredTests(TestCase):
         from commands.ritual import CmdRitual
 
         self.assertNotIn("perform", getattr(CmdRitual, "aliases", []))  # noqa: GETATTR_LITERAL
+
+
+class PullParsingOnConsentCommandsTests(TestCase):
+    """``ConsentRequestCommand`` parses ``pull=`` tokens via ``PullParsingMixin`` (#1919).
+
+    Verifies that pull keywords are stripped from the raw args before
+    target-name resolution, and that ``beseech=`` is discarded (combat-only).
+    """
+
+    def test_extract_pull_keywords_strips_tokens(self) -> None:
+        from commands.pull_parsing import PullParsingMixin
+
+        remainder, pull_val, resonance_val, tier, beseech = PullParsingMixin._extract_pull_keywords(
+            "Bob pull=My Thread resonance=Fire tier=2"
+        )
+        self.assertEqual(remainder, "Bob")
+        self.assertEqual(pull_val, "My Thread")
+        self.assertEqual(resonance_val, "Fire")
+        self.assertEqual(tier, 2)
+        self.assertEqual(beseech, 0)
+
+    def test_extract_pull_keywords_discards_beseech(self) -> None:
+        from commands.pull_parsing import PullParsingMixin
+
+        remainder, pull_val, _resonance, _tier, beseech = PullParsingMixin._extract_pull_keywords(
+            "Bob pull=Thread resonance=Fire beseech=5"
+        )
+        self.assertEqual(remainder, "Bob")
+        self.assertEqual(pull_val, "Thread")
+        # beseech is extracted (so it doesn't contaminate the target name) but
+        # will be discarded by ConsentRequestCommand (always passes beseech_bonus=0).
+        self.assertEqual(beseech, 5)
+
+    def test_extract_pull_keywords_no_pull_tokens(self) -> None:
+        from commands.pull_parsing import PullParsingMixin
+
+        remainder, pull_val, _resonance, _tier, _beseech = PullParsingMixin._extract_pull_keywords(
+            "Bob"
+        )
+        self.assertEqual(remainder, "Bob")
+        self.assertIsNone(pull_val)
+
+    def test_consent_command_inherits_pull_parsing_mixin(self) -> None:
+        from commands.consent import ConsentRequestCommand
+        from commands.pull_parsing import PullParsingMixin
+
+        self.assertTrue(issubclass(ConsentRequestCommand, PullParsingMixin))

--- a/src/schema.json
+++ b/src/schema.json
@@ -49326,6 +49326,10 @@ components:
         bond_thread_id:
           type: integer
           nullable: true
+        pull:
+          allOf:
+          - $ref: '#/components/schemas/CastPullRequestRequest'
+          nullable: true
       required:
       - action_key
       - initiator_persona
@@ -53368,6 +53372,12 @@ components:
             type: integer
         action_context:
           $ref: '#/components/schemas/PullActionContextRequest'
+        scene_id:
+          type: integer
+          nullable: true
+        exclude_gift:
+          type: boolean
+          default: false
       required:
       - character_sheet_id
       - resonance_id

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -1252,6 +1252,13 @@ class ThreadPullPreviewRequestSerializer(serializers.Serializer):
         allow_empty=False,
     )
     action_context = PullActionContextSerializer(required=False)
+    # #1919: Optional scene-scoped params for social-action pull previews.
+    # scene_id: when provided, the preview computes the combat/DANGER state
+    # on the scene and returns anima_cost=0 when waived.
+    # exclude_gift: when True, GIFT threads are rejected at preview time
+    # (matching the charge-time excluded_kinds behavior for social pulls).
+    scene_id = serializers.IntegerField(required=False, allow_null=True)
+    exclude_gift = serializers.BooleanField(required=False, default=False)
 
     def validate_character_sheet_id(self, value: int) -> CharacterSheet:
         """Resolve + ownership-check the caller-supplied character_sheet_id."""

--- a/src/world/magic/services/resonance.py
+++ b/src/world/magic/services/resonance.py
@@ -630,13 +630,15 @@ def _fold_distinction_pull_bonus(
     ]
 
 
-def preview_resonance_pull(
+def preview_resonance_pull(  # noqa: PLR0913
     character_sheet: CharacterSheet,
     resonance: ResonanceModel,
     tier: int,
     threads: list[Thread],
     *,
     combat_encounter: CombatEncounter | None = None,
+    scene_id: int | None = None,
+    excluded_kinds: frozenset[str] | None = None,
 ) -> PullPreviewResult:
     """Read-only preview of a resonance pull (Spec A §5.6).
 
@@ -658,13 +660,23 @@ def preview_resonance_pull(
         threads: Non-empty list of owned threads matching ``resonance``.
         combat_encounter: Provided for combat-context previews; ``None``
             for ephemeral / RP previews.
+        scene_id: When provided (#1919), the preview computes the combat/DANGER
+            state on the scene and returns ``anima_cost=0`` when the anima cost
+            is waived (no active combat encounter or DANGER round). When
+            ``None``, the standard formula applies.
+        excluded_kinds: When set (#1919), the preview validates that no pulled
+            thread has a ``target_kind`` in the set and raises
+            ``InvalidImbueAmount`` early. Social-action previews pass
+            ``frozenset({TargetKind.GIFT})`` so a GIFT thread is rejected at
+            preview time (matching the charge-time behavior).
 
     Returns:
         PullPreviewResult with resonance_cost, anima_cost, affordable,
         resolved_effects, capped_intensity.
 
     Raises:
-        InvalidImbueAmount: empty threads, ownership / resonance mismatch.
+        InvalidImbueAmount: empty threads, ownership / resonance mismatch, or
+            a thread whose ``target_kind`` is in ``excluded_kinds``.
     """
     if not threads:
         msg = "Must pull at least one thread."
@@ -677,10 +689,47 @@ def preview_resonance_pull(
         if t.resonance_id != resonance.pk:
             msg = "Thread does not share the chosen resonance."
             raise InvalidImbueAmount(msg)
+        if excluded_kinds and t.target_kind in excluded_kinds:
+            msg = "Thread anchor is not involved in this action."
+            raise InvalidImbueAmount(msg)
 
     cost = get_pull_cost(tier, None)
     n_threads = len(threads)
     anima_cost = cost.anima_per_thread * max(0, n_threads - 1)
+
+    # #1919: Anima waiver for social-action previews. When scene_id is provided,
+    # check whether the scene is high-stakes (active combat or DANGER round).
+    # If not, the anima cost is waived (zeroed).
+    if scene_id is not None and anima_cost > 0:
+        from world.combat.models import CombatEncounter  # noqa: PLC0415
+        from world.scenes.constants import (  # noqa: PLC0415
+            RoundStatus,
+            SceneRoundStartReason,
+        )
+        from world.scenes.models import Scene  # noqa: PLC0415
+
+        scene = Scene.objects.filter(pk=scene_id).select_related("location").first()
+        if scene is not None:
+            has_active_combat = CombatEncounter.objects.filter(
+                scene=scene,
+                status__in=[
+                    RoundStatus.DECLARING,
+                    RoundStatus.RESOLVING,
+                    RoundStatus.BETWEEN_ROUNDS,
+                ],
+            ).exists()
+            has_danger_round = False
+            if scene.location is not None:
+                has_danger_round = scene.scene_rounds.filter(
+                    start_reason=SceneRoundStartReason.DANGER,
+                    status__in=[
+                        RoundStatus.DECLARING,
+                        RoundStatus.RESOLVING,
+                        RoundStatus.BETWEEN_ROUNDS,
+                    ],
+                ).exists()
+            if not has_active_combat and not has_danger_round:
+                anima_cost = 0
 
     # Balances — no locks, no debit.
     cr = CharacterResonance.objects.filter(

--- a/src/world/magic/services/resonance.py
+++ b/src/world/magic/services/resonance.py
@@ -415,7 +415,7 @@ _ALWAYS_IN_ACTION_KINDS = frozenset(
 )
 
 
-def _anchor_in_action(thread: Thread, ctx: PullActionContext) -> bool:
+def _anchor_in_action(thread: Thread, ctx: PullActionContext) -> bool:  # noqa: PLR0911
     """Return True iff ``thread``'s anchor is involved in the action (Spec A §5.2).
 
     Relationship anchors are always considered in-action (player asserts
@@ -424,7 +424,14 @@ def _anchor_in_action(thread: Thread, ctx: PullActionContext) -> bool:
 
     COVENANT_ROLE threads gate on engagement: the character must currently be
     fulfilling the role for one of their covenants (Slice A §3.6).
+
+    ``ctx.excluded_kinds`` (#1919): checked BEFORE the ``_ALWAYS_IN_ACTION_KINDS``
+    shortcut so a GIFT thread — always in-action for casts where the technique
+    IS the gift anchor — is rejected for social-action pulls where no gift
+    technique is involved. Social pulls pass ``frozenset({TargetKind.GIFT})``.
     """
+    if ctx.excluded_kinds and thread.target_kind in ctx.excluded_kinds:
+        return False
     if thread.target_kind in _ALWAYS_IN_ACTION_KINDS:
         return True
     if thread.target_kind == TargetKind.TRAIT:
@@ -769,7 +776,7 @@ def _persist_combat_pull(  # noqa: PLR0913
 
 
 @transaction.atomic
-def spend_resonance_for_pull(  # noqa: C901, PLR0912, PLR0913
+def spend_resonance_for_pull(  # noqa: C901, PLR0912, PLR0913, PLR0915
     character_sheet: CharacterSheet,
     resonance: ResonanceModel,
     tier: int,
@@ -777,6 +784,7 @@ def spend_resonance_for_pull(  # noqa: C901, PLR0912, PLR0913
     action_context: PullActionContext,
     beseech_bonus_thread_id: int | None = None,
     beseech_bonus: int = 0,
+    anima_cost_override: int | None = None,
 ) -> ResonancePullResult:
     """Atomic pull commit (Spec A §5.4 + §7.4).
 
@@ -796,6 +804,11 @@ def spend_resonance_for_pull(  # noqa: C901, PLR0912, PLR0913
         beseech_bonus_thread_id: PK of the thread whose effective level gets the
             emergency thread-bond draw bonus for this resolution only (#1718).
         beseech_bonus: The bonus amount to apply to that thread's effective level.
+        anima_cost_override: When set to 0, the anima cost is waived before the
+            balance check — so a player with 0 anima can still pull in a low-stakes
+            social context (#1919). The ``CharacterAnima`` lock query is skipped
+            entirely and ``anima_spent`` reflects 0. When ``None`` (default), the
+            existing per-spec formula applies.
 
     Returns:
         ResonancePullResult with resonance_spent, anima_spent, resolved_effects.
@@ -846,13 +859,21 @@ def spend_resonance_for_pull(  # noqa: C901, PLR0912, PLR0913
         raise ResonanceInsufficient(msg)
 
     # Anima cost: per-spec §5.4 lines 1452–1458, anima_per_thread × max(0, n-1).
+    # #1919: social-action pulls may waive anima entirely when no combat encounter
+    # or DANGER round is active — anima_cost_override=0 zeroes the cost before the
+    # balance check and skips the lock query entirely.
     anima_total = cost.anima_per_thread * max(0, n_threads - 1)
-    anima = CharacterAnima.objects.select_for_update().get(
-        character=character_sheet.character,
-    )
-    if anima.current < anima_total:
-        msg = "Insufficient anima for this pull."
-        raise ResonanceInsufficient(msg)
+    if anima_cost_override is not None:
+        anima_total = anima_cost_override
+    if anima_total > 0:
+        anima = CharacterAnima.objects.select_for_update().get(
+            character=character_sheet.character,
+        )
+        if anima.current < anima_total:
+            msg = "Insufficient anima for this pull."
+            raise ResonanceInsufficient(msg)
+    else:
+        anima = None
 
     in_combat = action_context.combat_encounter is not None
     resolved = resolve_pull_effects(

--- a/src/world/magic/types/pull.py
+++ b/src/world/magic/types/pull.py
@@ -22,6 +22,14 @@ class PullActionContext:
     ``_anchor_in_action`` can avoid introspecting the action graph from inside
     the service layer (caller is responsible for populating them).
 
+    ``excluded_kinds`` (#1919): when set, threads whose ``target_kind`` is in
+    the set fail the anchor-in-action check **before** the
+    ``_ALWAYS_IN_ACTION_KINDS`` shortcut. Social-action pulls pass
+    ``frozenset({TargetKind.GIFT})`` so a GIFT thread (which is always
+    in-action for casts where the technique IS the gift anchor) is rejected
+    for social pulls where no gift technique is involved. Cast pulls leave
+    this ``None`` (default).
+
     Distinct from ``actions.types.ActionContext`` — that dataclass is the
     generic action-resolver context with totally different fields.
     """
@@ -35,6 +43,9 @@ class PullActionContext:
     # ``apply_target_modulation`` in ``resolve_pull_effects``; None for
     # ephemeral / untargeted actions.
     target: ObjectDB | None = None
+    # #1919: kinds excluded from the always-in-action shortcut (social pulls
+    # exclude GIFT — no gift technique is the anchor of a social action).
+    excluded_kinds: frozenset[str] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -32,7 +32,7 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet
 
 from world.character_sheets.models import CharacterSheet
-from world.magic.constants import PendingAlterationStatus, RitualExecutionKind
+from world.magic.constants import PendingAlterationStatus, RitualExecutionKind, TargetKind
 from world.magic.exceptions import (
     InvalidImbueAmount,
     TechniqueAuthoringNotPermitted,
@@ -898,6 +898,8 @@ class ThreadPullPreviewView(APIView):
                 tier=data["tier"],
                 threads=threads,
                 combat_encounter=combat_encounter,
+                scene_id=data.get("scene_id"),
+                excluded_kinds=frozenset({TargetKind.GIFT}) if data.get("exclude_gift") else None,
             )
         except InvalidImbueAmount as exc:
             return Response(

--- a/src/world/scenes/action_models.py
+++ b/src/world/scenes/action_models.py
@@ -361,19 +361,25 @@ class SceneActionTarget(DefenderConsentFields, SharedMemoryModel):
         ]
 
 
-class SceneCastPullDeclaration(SharedMemoryModel):
-    """A paid thread pull declared alongside a benign standalone cast (#854).
+class SceneActionPullDeclaration(SharedMemoryModel):
+    """A paid thread pull declared alongside a scene action request (#854, #1919).
 
-    Persisted only for PENDING benign casts so the declaration survives until
-    consent-resolution. Immediate casts charge in-line and need no row; combat
-    pulls live on ``CombatPull`` in the combat app.
+    Persisted for PENDING benign casts AND social consent actions so the
+    declaration survives until consent-resolution. Immediate casts charge
+    in-line and need no row; combat pulls live on ``CombatPull`` in the combat
+    app.
+
+    For social actions (#1919), the declaration is charged exactly once at
+    accept-time via ``_charge_social_pull``; the ``charged_at`` /
+    ``charged_flat_bonus`` fields guard against double-charging across
+    multi-target resolutions.
     """
 
     request = models.OneToOneField(
         "scenes.SceneActionRequest",
         on_delete=models.CASCADE,
         related_name="pull_declaration",
-        help_text="The benign cast request this pull was declared with.",
+        help_text="The action request this pull was declared with.",
     )
     resonance = models.ForeignKey(
         "magic.Resonance",
@@ -387,9 +393,23 @@ class SceneCastPullDeclaration(SharedMemoryModel):
     )
     threads = models.ManyToManyField(
         "magic.Thread",
-        related_name="cast_pull_declarations",
-        help_text="Threads pulled; owned by the caster, sharing ``resonance``.",
+        related_name="action_pull_declarations",
+        help_text="Threads pulled; owned by the actor, sharing ``resonance``.",
+    )
+    charged_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        default=None,
+        help_text="When the pull was first charged at resolution time; guards "
+        "against double-charging across multi-target resolutions (#1919).",
+    )
+    charged_flat_bonus = models.IntegerField(
+        null=True,
+        blank=True,
+        default=None,
+        help_text="Cached FLAT_BONUS total from the first charge, returned on "
+        "idempotent subsequent calls without re-charging (#1919).",
     )
 
     def __str__(self) -> str:
-        return f"Cast pull (tier {self.tier}) for request {self.request_id}"
+        return f"Action pull (tier {self.tier}) for request {self.request_id}"

--- a/src/world/scenes/action_serializers.py
+++ b/src/world/scenes/action_serializers.py
@@ -153,7 +153,7 @@ class CastPullRequestSerializer(serializers.Serializer):
     )
 
 
-def _validate_cast_pull(attrs: dict) -> dict:
+def _validate_pull_declaration(attrs: dict, *, hostile_check: bool = False) -> dict:
     """Resolve + validate a declared pull against the initiator's sheet.
 
     Attaches resolved instances to attrs["pull"]["resonance"|"threads"] so the
@@ -165,21 +165,36 @@ def _validate_cast_pull(attrs: dict) -> dict:
     so there is no duplicate logic here.  The ``ValidationError`` mapping lives here
     at the serializer boundary (per the anti-reinvention rule: MagicError inside the
     helper; ValidationError only at the DRF surface).
+
+    Args:
+        attrs: The serializer attrs dict (must contain ``pull`` and
+            ``initiator_persona``; ``technique_id`` when ``hostile_check``).
+        hostile_check: When True (cast path), reject hostile techniques and
+            require ``technique_id``. When False (social path), skip both.
+
+    Raises:
+        serializers.ValidationError: On ownership/resonance mismatch, unknown
+            technique, hostile technique (cast path only), or unknown persona.
     """
     from world.combat.pull_helpers import build_cast_pull_declaration  # noqa: PLC0415
     from world.magic.exceptions import InvalidImbueAmount  # noqa: PLC0415
-    from world.magic.models import Technique  # noqa: PLC0415
-    from world.magic.services.hostility import is_technique_hostile  # noqa: PLC0415
     from world.scenes.models import Persona  # noqa: PLC0415
 
     pull = attrs["pull"]
-    try:
-        technique = Technique.objects.select_related("effect_type").get(pk=attrs["technique_id"])
-    except Technique.DoesNotExist:
-        raise serializers.ValidationError({"technique_id": "Unknown technique."}) from None
-    if is_technique_hostile(technique):
-        msg = "Pulls cannot be declared on hostile casts — combat owns that flow."
-        raise serializers.ValidationError({"pull": msg})
+
+    if hostile_check:
+        from world.magic.models import Technique  # noqa: PLC0415
+        from world.magic.services.hostility import is_technique_hostile  # noqa: PLC0415
+
+        try:
+            technique = Technique.objects.select_related("effect_type").get(
+                pk=attrs["technique_id"]
+            )
+        except Technique.DoesNotExist:
+            raise serializers.ValidationError({"technique_id": "Unknown technique."}) from None
+        if is_technique_hostile(technique):
+            msg = "Pulls cannot be declared on hostile casts — combat owns that flow."
+            raise serializers.ValidationError({"pull": msg})
 
     try:
         persona = Persona.objects.get(pk=attrs["initiator_persona"])
@@ -199,6 +214,14 @@ def _validate_cast_pull(attrs: dict) -> dict:
     pull["resonance"] = declaration.resonance
     pull["threads"] = list(declaration.threads)
     return attrs
+
+
+def _validate_cast_pull(attrs: dict) -> dict:
+    """Cast-specific wrapper: validates the pull with the hostile-technique check.
+
+    Delegates to ``_validate_pull_declaration(hostile_check=True)``.
+    """
+    return _validate_pull_declaration(attrs, hostile_check=True)
 
 
 class TechniqueCastCreateSerializer(serializers.Serializer):
@@ -439,6 +462,9 @@ class SceneActionRequestCreateSerializer(serializers.Serializer):
     target_condition_instance_id = serializers.IntegerField(required=False, allow_null=True)
     target_pending_alteration_id = serializers.IntegerField(required=False, allow_null=True)
     bond_thread_id = serializers.IntegerField(required=False, allow_null=True)
+    # #1919: Optional thread-pull declaration on social actions. Validated via
+    # _validate_pull_declaration (social path — no hostile-technique check).
+    pull = CastPullRequestSerializer(required=False, allow_null=True)
 
     def validate(self, attrs: dict) -> dict:
         """Normalize target fields into ``target_ids``; cap strain and fury.
@@ -464,7 +490,10 @@ class SceneActionRequestCreateSerializer(serializers.Serializer):
         else:
             attrs["target_ids"] = []
         attrs = _cap_strain_by_anima(attrs)
-        return _cap_fury_by_provocation(attrs)
+        attrs = _cap_fury_by_provocation(attrs)
+        if attrs.get("pull"):
+            attrs = _validate_pull_declaration(attrs, hostile_check=False)
+        return attrs
 
 
 class ConsentResponseSerializer(serializers.Serializer):

--- a/src/world/scenes/action_serializers.py
+++ b/src/world/scenes/action_serializers.py
@@ -590,6 +590,7 @@ class EnhancedSceneActionResultSerializer(serializers.Serializer):
     technique_result = TechniqueResultSerializer(allow_null=True)
     anima_recovery = serializers.SerializerMethodField()
     power_ledger = serializers.SerializerMethodField()
+    fizzle_note = serializers.CharField(allow_null=True, required=False)
 
     @extend_schema_field(PowerLedgerSerializer)
     def get_power_ledger(self, obj: object) -> dict | None:

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -1218,13 +1218,19 @@ def _targeted_outcome_content(
     if result.technique_result is not None and action_request.technique is not None:
         technique_name = action_request.technique.name
         anima_spent = result.technique_result.anima_cost.effective_cost
-        return (
+        content = (
             f"{initiator_name} uses {technique_name} to {action_key} {target_name}: "
             f"{status_word} ({outcome_name}) [Anima: {anima_spent}]"
         )
-    return (
-        f"{initiator_name} attempts to {action_key} {target_name}: {status_word} ({outcome_name})"
-    )
+    else:
+        content = (
+            f"{initiator_name} attempts to {action_key} {target_name}: "
+            f"{status_word} ({outcome_name})"
+        )
+    # #1919: Append a fizzle note when the thread pull failed at charge time.
+    if result.fizzle_note:
+        content += f" — {result.fizzle_note}"
+    return content
 
 
 def _create_result_interaction(

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -23,7 +23,11 @@ from world.scenes.action_constants import (
     ConsentDecision,
     DifficultyChoice,
 )
-from world.scenes.action_models import SceneActionRequest, SceneActionTarget
+from world.scenes.action_models import (
+    SceneActionPullDeclaration,
+    SceneActionRequest,
+    SceneActionTarget,
+)
 from world.scenes.action_resolvers import get_resolver
 from world.scenes.constants import InteractionMode
 from world.scenes.interaction_services import create_interaction
@@ -129,6 +133,7 @@ if TYPE_CHECKING:
     from actions.models.action_templates import ActionTemplate
     from actions.types import PendingActionResolution
     from world.character_sheets.models import CharacterSheet
+    from world.checks.models import CheckType
     from world.conditions.models import ConditionInstance, TreatmentTemplate
     from world.conditions.types import TreatmentOutcome
     from world.magic.models import FuryTier, PendingAlteration, Technique
@@ -260,6 +265,7 @@ def create_action_request(  # noqa: PLR0913
     delivery: str = "",
     delivery_receivers: list[Persona] | None = None,
     additional_target_personas: list[Persona] | None = None,
+    pull: CastPullDeclaration | None = None,
 ) -> SceneActionRequest:
     """Create a pending action request for consent.
 
@@ -299,6 +305,10 @@ def create_action_request(  # noqa: PLR0913
             primary (``target_persona``). Each persona gets a ``SceneActionTarget``
             row. NPC additional targets are auto-resolved immediately (#572);
             PC additional targets stay PENDING until they respond.
+        pull: Optional declared thread pull (#1919). Persisted as a
+            ``SceneActionPullDeclaration`` on the request so it survives the
+            consent gap. Charged exactly once at accept-time via
+            ``_charge_social_pull``. ``None`` for actions without a pull.
 
     Returns:
         The created SceneActionRequest in PENDING status.
@@ -348,6 +358,15 @@ def create_action_request(  # noqa: PLR0913
     additional = additional_target_personas or []
     for persona in additional:
         SceneActionTarget.objects.create(action_request=request, target_persona=persona)
+    # #1919: Persist the pull declaration BEFORE auto-resolving NPC targets so
+    # the declaration exists when _charge_social_pull fires during auto-resolve.
+    if pull is not None:
+        decl = SceneActionPullDeclaration.objects.create(
+            request=request,
+            resonance=pull.resonance,
+            tier=pull.tier,
+        )
+        decl.threads.set(pull.threads)
     if additional:  # multi-target only — single-target path unchanged
         _auto_resolve_npc_targets(request)
 
@@ -473,7 +492,7 @@ def _blacklist_initiator_for_denier(
     add_social_consent_blacklist(owner_tenure, blocked_tenure, category)
 
 
-def respond_to_action_request(
+def respond_to_action_request(  # noqa: C901
     *,
     action_request: SceneActionRequest,
     decision: str,
@@ -515,6 +534,9 @@ def respond_to_action_request(
         action_request.status = ActionRequestStatus.DENIED
         action_request.resolved_at = timezone.now()
         action_request.save(update_fields=["status", "resolved_at"])
+        # #1919: Clean up any pull declaration on the denied request so it
+        # doesn't linger as an orphan row (the charge never fires on DENY).
+        SceneActionPullDeclaration.objects.filter(request=action_request).delete()
         if blacklist_actor:
             _blacklist_initiator_for_denier(action_request, action_request.target_persona)
         return None
@@ -534,11 +556,36 @@ def respond_to_action_request(
 
                 result = resolve_accepted_cast(action_request)
             else:
+                # #1919: Charge a persisted social pull declaration exactly
+                # once before per-target resolution. The resolved FLAT_BONUS
+                # is threaded into _resolve_action_against_persona as
+                # pull_flat_bonus. On failure (balance drained, anchor no
+                # longer in action, lock acquired, …), the pull fizzles — the
+                # action resolves pull-less with a fizzle note.
+                pull_flat_bonus = 0
+                fizzle_note: str | None = None
+                action_template = action_request.action_template
+                if action_template is not None and action_template.check_type_id is not None:
+                    from world.magic.exceptions import (  # noqa: PLC0415
+                        MagicError,
+                        ProtagonismLockedError,
+                    )
+
+                    try:
+                        pull_flat_bonus = _charge_social_pull(
+                            action_request=action_request,
+                            check_type=action_template.check_type,
+                        )
+                    except (MagicError, ProtagonismLockedError) as exc:
+                        fizzle_note = str(exc) or "The thread pull fizzled."
                 difficulty_override = _compute_difficulty_override_for_primary(
                     action_request, resist_effort
                 )
                 result = _resolve_standard_action(
-                    action_request, difficulty_override=difficulty_override
+                    action_request,
+                    difficulty_override=difficulty_override,
+                    pull_flat_bonus=pull_flat_bonus,
+                    fizzle_note=fizzle_note,
                 )
 
             _accrue_engagement_for_primary(action_request)
@@ -552,11 +599,131 @@ def respond_to_action_request(
     return None
 
 
+def _scene_is_high_stakes(action_request: SceneActionRequest) -> bool:
+    """True when an active combat encounter or DANGER round is on the scene (#1919).
+
+    Anima cost is waived (zeroed) for social pulls in low-stakes scenes — pure
+    social RP with no combat encounter (status ≠ COMPLETED) and no DANGER round
+    (``SceneRound.start_reason=DANGER``, non-COMPLETED). This reuses existing
+    state; no new schema field.
+    """
+    from world.combat.models import CombatEncounter  # noqa: PLC0415
+    from world.scenes.constants import RoundStatus, SceneRoundStartReason  # noqa: PLC0415
+
+    scene = action_request.scene
+    if scene is None:
+        return False
+    room = scene.location
+    has_active_combat = CombatEncounter.objects.filter(
+        scene=scene,
+        status__in=[
+            RoundStatus.DECLARING,
+            RoundStatus.RESOLVING,
+            RoundStatus.BETWEEN_ROUNDS,
+        ],
+    ).exists()
+    if has_active_combat:
+        return True
+    if room is None:
+        return False
+    return scene.scene_rounds.filter(
+        start_reason=SceneRoundStartReason.DANGER,
+        status__in=[
+            RoundStatus.DECLARING,
+            RoundStatus.RESOLVING,
+            RoundStatus.BETWEEN_ROUNDS,
+        ],
+    ).exists()
+
+
+def _charge_social_pull(
+    *,
+    action_request: SceneActionRequest,
+    check_type: CheckType,
+) -> int:
+    """Charge a persisted social pull declaration and return the FLAT_BONUS total.
+
+    Returns ``0`` when no declaration exists on the request.
+
+    Resolves ``involved_traits`` from the check type's trait weights so TRAIT
+    threads can be validated as anchor-in-action. Waives anima cost when the
+    scene is not high-stakes (no active combat encounter or DANGER round).
+
+    **Idempotent (#1919):** on first call, charges via
+    ``spend_resonance_for_pull``, stamps ``charged_at`` + ``charged_flat_bonus``,
+    and returns the bonus. On subsequent calls (when ``charged_at`` is already
+    set — e.g. multi-target resolutions or the NPC auto-resolve path), returns
+    the cached bonus without re-charging.
+
+    Raises:
+        MagicError / ProtagonismLockedError: when the pull cannot be charged
+            (balance drained, anchor not in action, lock acquired, …). The caller
+            (``respond_to_action_request``) catches these to degrade to a fizzle.
+    """
+    from world.magic.constants import EffectKind, TargetKind  # noqa: PLC0415
+    from world.magic.services.resonance import spend_resonance_for_pull  # noqa: PLC0415
+    from world.magic.types.pull import PullActionContext  # noqa: PLC0415
+
+    declaration = SceneActionPullDeclaration.objects.filter(request=action_request).first()
+    if declaration is None:
+        return 0
+
+    # Idempotent guard: if already charged, return the cached bonus.
+    if declaration.charged_at is not None:
+        return declaration.charged_flat_bonus or 0
+
+    sheet = action_request.initiator_persona.character_sheet
+    threads = list(declaration.threads.filter(retired_at__isnull=True))
+    if not threads:
+        return 0
+
+    target = None
+    if action_request.target_persona is not None:
+        target = action_request.target_persona.character_sheet.character
+
+    involved_traits = tuple(check_type.traits.values_list("trait_id", flat=True))
+
+    # Anima waiver: waived (zeroed) when no active combat or DANGER round.
+    anima_cost_override = 0 if not _scene_is_high_stakes(action_request) else None
+
+    pull_result = spend_resonance_for_pull(
+        sheet,
+        declaration.resonance,
+        declaration.tier,
+        threads,
+        PullActionContext(
+            combat_encounter=None,
+            involved_traits=involved_traits,
+            target=target,
+            excluded_kinds=frozenset({TargetKind.GIFT}),
+        ),
+        # Defense-in-depth: beseech_bonus=0 ensures no emergency draw fires
+        # even if the declaration somehow carried a bonus.
+        beseech_bonus=0,
+        anima_cost_override=anima_cost_override,
+    )
+
+    pull_flat_bonus = 0
+    for eff in pull_result.resolved_effects:
+        if eff.inactive:
+            continue
+        if eff.kind == EffectKind.FLAT_BONUS:
+            pull_flat_bonus += eff.scaled_value or 0
+
+    # Stamp the charge guard + cached bonus so subsequent calls (multi-target)
+    # return the same bonus without re-charging.
+    declaration.charged_at = timezone.now()
+    declaration.charged_flat_bonus = pull_flat_bonus
+    declaration.save(update_fields=["charged_at", "charged_flat_bonus"])
+    return pull_flat_bonus
+
+
 def _resolve_action_against_persona(
     action_request: SceneActionRequest,
     target_persona: Persona,
     *,
     difficulty_override: int | None = None,
+    pull_flat_bonus: int = 0,
 ) -> tuple[EnhancedSceneActionResult, Interaction | None, int]:
     """Resolve ``action_request`` against ONE persona.
 
@@ -570,6 +737,9 @@ def _resolve_action_against_persona(
         difficulty_override: When provided, overrides the difficulty computed
             from ``action_request.difficulty_choice``. Task 4 (plausibility
             defender) supplies per-target values via this seam.
+        pull_flat_bonus: FLAT_BONUS from a charged social pull (#1919), folded
+            into the plain-action check's ``extra_modifiers``. 0 when no pull
+            was declared or the pull fizzled.
 
     Returns:
         (result, result_interaction, difficulty) — difficulty is returned so
@@ -654,7 +824,7 @@ def _resolve_action_against_persona(
             template=action_template,
             target_difficulty=difficulty,
             context=context,
-            extra_modifiers=check_modifiers + breakdown.total,
+            extra_modifiers=check_modifiers + breakdown.total + pull_flat_bonus,
         )
         result = EnhancedSceneActionResult(
             action_resolution=action_resolution,
@@ -690,11 +860,16 @@ def _resolve_standard_action(
     action_request: SceneActionRequest,
     *,
     difficulty_override: int | None = None,
+    pull_flat_bonus: int = 0,
+    fizzle_note: str | None = None,
 ) -> EnhancedSceneActionResult:
     """Resolve the request against its primary target inside a transaction."""
     with transaction.atomic():
         result, result_interaction, difficulty = _resolve_action_against_persona(
-            action_request, action_request.target_persona, difficulty_override=difficulty_override
+            action_request,
+            action_request.target_persona,
+            difficulty_override=difficulty_override,
+            pull_flat_bonus=pull_flat_bonus,
         )
         action_request.status = ActionRequestStatus.RESOLVED
         action_request.resolved_at = timezone.now()
@@ -703,6 +878,8 @@ def _resolve_standard_action(
         if result_interaction is not None:
             action_request.result_interaction = result_interaction
             action_request.save(update_fields=["result_interaction"])
+    if fizzle_note is not None:
+        result.fizzle_note = fizzle_note
     return result
 
 
@@ -819,10 +996,30 @@ def respond_to_action_target(
             else:
                 increment = 0
             difficulty_override = base + increment
+            # #1919: Retrieve the pull flat bonus (idempotent — the primary
+            # resolution or an earlier NPC auto-resolve may have already charged
+            # it). Returns 0 when no declaration exists or it already fizzled.
+            pull_flat_bonus = 0
+            action_template = action_request.action_template
+            if action_template is not None and action_template.check_type_id is not None:
+                from world.magic.exceptions import (  # noqa: PLC0415
+                    MagicError,
+                    ProtagonismLockedError,
+                )
+
+                try:
+                    pull_flat_bonus = _charge_social_pull(
+                        action_request=action_request,
+                        check_type=action_template.check_type,
+                    )
+                except (MagicError, ProtagonismLockedError):
+                    # Already fizzled on the primary charge; no bonus for this target.
+                    pull_flat_bonus = 0
             result, result_interaction, resolved_difficulty = _resolve_action_against_persona(
                 action_request,
                 action_target.target_persona,
                 difficulty_override=difficulty_override,
+                pull_flat_bonus=pull_flat_bonus,
             )
             action_target.status = ActionRequestStatus.RESOLVED
             action_target.resolved_at = timezone.now()

--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -22,6 +22,7 @@ from actions.registry import get_action
 from actions.types import TargetType
 from world.conditions.constants import TARGET_EFFECT_ALTERATION, TARGET_EFFECT_CONDITION
 from world.magic.exceptions import MagicError
+from world.magic.types.pull import CastPullDeclaration
 from world.scenes.action_constants import ActionRequestStatus
 from world.scenes.action_filters import SceneActionRequestFilter, SceneActionTargetFilter
 from world.scenes.action_models import SceneActionRequest, SceneActionTarget
@@ -50,6 +51,23 @@ _INITIATOR_NOT_FOUND_DETAIL = "Initiator persona not found for your account."
 
 # Action key for the treat-condition consent flow (matches TreatConditionAction.key).
 TREAT_CONDITION_KEY = "treat_condition"
+
+
+def _build_pull_from_validated(validated_data: dict) -> CastPullDeclaration | None:
+    """Build a CastPullDeclaration from validated serializer data (#1919).
+
+    Returns None when no pull was declared. The serializer's validate() step
+    already resolved the resonance + threads instances and attached them to
+    the pull dict; this helper just wraps them into the in-memory dataclass.
+    """
+    pull_data = validated_data.get("pull")
+    if not pull_data:
+        return None
+    return CastPullDeclaration(
+        resonance=pull_data["resonance"],
+        tier=pull_data["tier"],
+        threads=tuple(pull_data["threads"]),
+    )
 
 
 class SceneActionRequestPagination(PageNumberPagination):
@@ -332,6 +350,7 @@ class SceneActionRequestViewSet(viewsets.ModelViewSet):
                 delivery=delivery,
                 delivery_receivers=delivery_receivers,
                 additional_target_personas=additional,
+                pull=_build_pull_from_validated(serializer.validated_data),
             )
         except DjangoValidationError as exc:
             messages = exc.messages if hasattr(exc, "messages") else ["Unable to create action."]

--- a/src/world/scenes/cast_services.py
+++ b/src/world/scenes/cast_services.py
@@ -51,7 +51,7 @@ from world.scenes.action_constants import (
     CAST_DIFFICULTY_BANDS,
     ActionRequestStatus,
 )
-from world.scenes.action_models import SceneActionRequest, SceneCastPullDeclaration
+from world.scenes.action_models import SceneActionPullDeclaration, SceneActionRequest
 from world.scenes.constants import InteractionMode
 from world.scenes.interaction_services import create_interaction
 from world.scenes.narrator import get_or_create_narrator_persona
@@ -420,7 +420,7 @@ def resolve_accepted_cast(
         The resolved EnhancedSceneActionResult for benign casts; None for hostile
         casts resolved into combat.
 
-    A persisted ``SceneCastPullDeclaration`` is re-checked here on the benign
+    A persisted ``SceneActionPullDeclaration`` is re-checked here on the benign
     path: if the committed pull is still payable it is charged with the cast;
     otherwise the cast resolves pull-less and the OUTCOME pose carries a fizzle
     note. (Hostile casts never carry a declaration — pulls are rejected on the
@@ -458,7 +458,7 @@ def resolve_accepted_cast(
             action_request.save(update_fields=["status", "resolved_at"])
         return None
 
-    declaration = SceneCastPullDeclaration.objects.filter(request=action_request).first()
+    declaration = SceneActionPullDeclaration.objects.filter(request=action_request).first()
     cast_pull = None
     fizzle_note = None
     if declaration is not None:
@@ -659,7 +659,7 @@ def request_technique_cast(  # noqa: PLR0913
         fury_commitment: Optional FuryTier the player declared.
         fury_anchor: CharacterSheet of the anchor character (bond caps the tier).
         cast_pull: Optional declared thread pull. Charged in-line on the
-            immediate path; persisted as a ``SceneCastPullDeclaration`` on the
+            immediate path; persisted as a ``SceneActionPullDeclaration`` on the
             benign consent path; rejected on hostile casts (combat pulls go
             through ``CombatPull``).
         supplied_personas: For FILTERED_GROUP techniques, the player-picked subset of
@@ -841,7 +841,7 @@ def _route_benign_cast(  # noqa: PLR0913 - cohesive benign-cast routing params
 ) -> CastResult:
     """Benign cast at another PC → PENDING request awaiting consent (resolved on accept).
 
-    A declared pull is persisted (not charged) as a ``SceneCastPullDeclaration``
+    A declared pull is persisted (not charged) as a ``SceneActionPullDeclaration``
     so it survives until consent-resolution re-checks affordability.
     """
     with transaction.atomic():
@@ -856,7 +856,7 @@ def _route_benign_cast(  # noqa: PLR0913 - cohesive benign-cast routing params
             fury_anchor=fury_anchor,
         )
         if cast_pull is not None:
-            declaration = SceneCastPullDeclaration.objects.create(
+            declaration = SceneActionPullDeclaration.objects.create(
                 request=request,
                 resonance=cast_pull.resonance,
                 tier=cast_pull.tier,

--- a/src/world/scenes/migrations/0047_sceneactionpulldeclaration.py
+++ b/src/world/scenes/migrations/0047_sceneactionpulldeclaration.py
@@ -1,0 +1,61 @@
+# Generated for #1919 — generalize SceneCastPullDeclaration → SceneActionPullDeclaration.
+# Renames the model (data-preserving) and adds the charged_at / charged_flat_bonus
+# idempotency fields used by the social-action pull charge path.
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("magic", "0015_aurapowerconfig"),
+        ("scenes", "0046_sceneunseenobserver"),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name="SceneCastPullDeclaration",
+            new_name="SceneActionPullDeclaration",
+        ),
+        migrations.AlterField(
+            model_name="sceneactionpulldeclaration",
+            name="request",
+            field=models.OneToOneField(
+                help_text="The action request this pull was declared with.",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="pull_declaration",
+                to="scenes.sceneactionrequest",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="sceneactionpulldeclaration",
+            name="threads",
+            field=models.ManyToManyField(
+                help_text="Threads pulled; owned by the actor, sharing ``resonance``.",
+                related_name="action_pull_declarations",
+                to="magic.thread",
+            ),
+        ),
+        migrations.AddField(
+            model_name="sceneactionpulldeclaration",
+            name="charged_at",
+            field=models.DateTimeField(
+                blank=True,
+                default=None,
+                help_text="When the pull was first charged at resolution time; guards "
+                "against double-charging across multi-target resolutions (#1919).",
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="sceneactionpulldeclaration",
+            name="charged_flat_bonus",
+            field=models.IntegerField(
+                blank=True,
+                default=None,
+                help_text="Cached FLAT_BONUS total from the first charge, returned on "
+                "idempotent subsequent calls without re-charging (#1919).",
+                null=True,
+            ),
+        ),
+    ]

--- a/src/world/scenes/migrations/max_migration.txt
+++ b/src/world/scenes/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0046_sceneunseenobserver
+0047_sceneactionpulldeclaration

--- a/src/world/scenes/tests/test_action_models.py
+++ b/src/world/scenes/tests/test_action_models.py
@@ -20,9 +20,9 @@ from world.magic.factories import (
 )
 from world.scenes.action_constants import ActionRequestStatus, CastPullTier, DifficultyChoice
 from world.scenes.action_models import (
+    SceneActionPullDeclaration,
     SceneActionRequest,
     SceneActionTarget,
-    SceneCastPullDeclaration,
 )
 from world.scenes.factories import (
     PersonaFactory,
@@ -220,8 +220,8 @@ class StandalonecastTests(TestCase):
         assert request.is_standalone_cast is False
 
 
-class SceneCastPullDeclarationTests(TestCase):
-    """Persistence and related-name access for SceneCastPullDeclaration."""
+class SceneActionPullDeclarationTests(TestCase):
+    """Persistence and related-name access for SceneActionPullDeclaration."""
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -243,7 +243,7 @@ class SceneCastPullDeclarationTests(TestCase):
         )
 
     def test_declaration_round_trip(self) -> None:
-        decl = SceneCastPullDeclaration.objects.create(
+        decl = SceneActionPullDeclaration.objects.create(
             request=self.request,
             resonance=self.resonance,
             tier=CastPullTier.TIER_2,

--- a/src/world/scenes/tests/test_action_views.py
+++ b/src/world/scenes/tests/test_action_views.py
@@ -18,9 +18,9 @@ from world.magic.factories import (
 from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
 from world.scenes.action_constants import ActionRequestStatus, ConsentDecision
 from world.scenes.action_models import (
+    SceneActionPullDeclaration,
     SceneActionRequest,
     SceneActionTarget,
-    SceneCastPullDeclaration,
 )
 from world.scenes.constants import RoundStatus
 from world.scenes.factories import (
@@ -750,7 +750,7 @@ class CastEndpointTestCase(APITestCase):
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data["status"] == ActionRequestStatus.PENDING
         request_id = response.data["id"]
-        assert SceneCastPullDeclaration.objects.filter(request_id=request_id).exists()
+        assert SceneActionPullDeclaration.objects.filter(request_id=request_id).exists()
         character_resonance.refresh_from_db()
         assert character_resonance.balance == self._STARTING_BALANCE
 

--- a/src/world/scenes/tests/test_cast_services.py
+++ b/src/world/scenes/tests/test_cast_services.py
@@ -603,7 +603,7 @@ class TestCastPullThroughCastServices(CastScenarioMixin):
 
     A declared pull on an immediate cast charges resonance in-line through
     ``use_technique``. On a benign (consent-gated) cast the declaration is
-    persisted as a ``SceneCastPullDeclaration`` and only charged when the
+    persisted as a ``SceneActionPullDeclaration`` and only charged when the
     target accepts; if the committed resonance is no longer payable at accept
     time, the cast still resolves but the pull fizzles with a narration note.
     """

--- a/src/world/scenes/tests/test_social_pull.py
+++ b/src/world/scenes/tests/test_social_pull.py
@@ -1,0 +1,313 @@
+"""Tests for thread-pull on social actions (#1919).
+
+Covers ``_charge_social_pull``, the anima waiver, GIFT exclusion, TRAIT
+acceptance, fizzle path, idempotent charge, DENY cleanup, and beseech=
+discarding.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from actions.factories import ActionTemplateFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import CheckTypeFactory, CheckTypeTraitFactory
+from world.magic.constants import TargetKind
+from world.magic.exceptions import InvalidImbueAmount
+from world.magic.factories import (
+    CharacterAnimaFactory,
+    CharacterResonanceFactory,
+    FacetFactory,
+    ResonanceFactory,
+    ThreadFactory,
+    ThreadPullCostFactory,
+    ThreadPullEffectFactory,
+)
+from world.magic.models import CharacterAnima, CharacterResonance
+from world.magic.types.pull import CastPullDeclaration
+from world.scenes.action_constants import ActionRequestStatus, ConsentDecision
+from world.scenes.action_models import SceneActionPullDeclaration
+from world.scenes.action_services import (
+    _charge_social_pull,
+    create_action_request,
+    respond_to_action_request,
+)
+from world.scenes.factories import SceneFactory
+
+
+def _setup_pull_seed(*, sheet, resonance, target_kind=TargetKind.RELATIONSHIP_TRACK, tier=1):
+    """Create a thread + pull-effect row so a charge resolves a FLAT_BONUS.
+
+    Defaults to RELATIONSHIP_TRACK — always-in-action, no worn-items gate
+    (unlike FACET), no involved-traits gate (unlike TRAIT).
+    """
+    if target_kind == TargetKind.TRAIT:
+        thread = ThreadFactory(owner=sheet, resonance=resonance)
+    elif target_kind == TargetKind.RELATIONSHIP_TRACK:
+        thread = ThreadFactory(owner=sheet, resonance=resonance, as_track_thread=True)
+    elif target_kind == TargetKind.FACET:
+        facet = FacetFactory()
+        thread = ThreadFactory(
+            owner=sheet,
+            resonance=resonance,
+            target_kind=TargetKind.FACET,
+            target_trait=None,
+            target_facet=facet,
+        )
+    elif target_kind == TargetKind.GIFT:
+        from world.magic.factories import GiftFactory
+
+        gift = GiftFactory()
+        thread = ThreadFactory(
+            owner=sheet,
+            resonance=resonance,
+            target_kind=TargetKind.GIFT,
+            target_trait=None,
+            target_facet=None,
+            target_gift=gift,
+        )
+    else:
+        thread = ThreadFactory(owner=sheet, resonance=resonance, target_kind=target_kind)
+
+    ThreadPullCostFactory(tier=tier, resonance_cost=2, anima_per_thread=1)
+    ThreadPullEffectFactory(
+        target_kind=target_kind,
+        resonance=resonance,
+        tier=tier,
+        flat_bonus_amount=5,
+    )
+    return thread
+
+
+class ChargeSocialPullTests(TestCase):
+    """Unit tests for ``_charge_social_pull``."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.scene = SceneFactory()
+        cls.initiator_sheet = CharacterSheetFactory()
+        cls.target_sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=cls.initiator_sheet.character, current=10, maximum=10)
+        cls.resonance = ResonanceFactory()
+        CharacterResonanceFactory(
+            character_sheet=cls.initiator_sheet,
+            resonance=cls.resonance,
+            balance=20,
+            lifetime_earned=20,
+        )
+        cls.initiator_persona = cls.initiator_sheet.primary_persona
+        cls.target_persona = cls.target_sheet.primary_persona
+
+        cls.check_type = CheckTypeFactory()
+        cls.action_template = ActionTemplateFactory(check_type=cls.check_type)
+
+    def _make_request_with_pull(self, thread, *, tier=1):
+        """Create a PENDING action request with a persisted pull declaration."""
+        cast_pull = CastPullDeclaration(
+            resonance=self.resonance,
+            tier=tier,
+            threads=(thread,),
+        )
+        request = create_action_request(
+            scene=self.scene,
+            initiator_persona=self.initiator_persona,
+            target_persona=self.target_persona,
+            action_key="persuade",
+            pull=cast_pull,
+        )
+        # Attach the action template so _charge_social_pull can read check_type.
+        request.action_template = self.action_template
+        request.save(update_fields=["action_template"])
+        return request
+
+    def test_charges_resonance_and_returns_flat_bonus(self):
+        """FLAT_BONUS is summed and resonance is debited."""
+        thread = _setup_pull_seed(sheet=self.initiator_sheet, resonance=self.resonance)
+        request = self._make_request_with_pull(thread)
+
+        bonus = _charge_social_pull(action_request=request, check_type=self.check_type)
+        assert bonus == 5  # authored_value=5
+
+        cr = CharacterResonance.objects.get(
+            character_sheet=self.initiator_sheet, resonance=self.resonance
+        )
+        assert cr.balance == 18  # 20 - 2 resonance_cost
+
+    def test_waives_anima_in_low_stakes_scene(self):
+        """Anima is not charged when no combat or DANGER round is active."""
+        thread = _setup_pull_seed(sheet=self.initiator_sheet, resonance=self.resonance)
+        request = self._make_request_with_pull(thread)
+
+        anima_before = CharacterAnima.objects.get(character=self.initiator_sheet.character).current
+        _charge_social_pull(action_request=request, check_type=self.check_type)
+        anima_after = CharacterAnima.objects.get(character=self.initiator_sheet.character).current
+        assert anima_before == anima_after  # unchanged — waived
+
+    def test_no_declaration_returns_zero(self):
+        """No pull declaration on the request → returns 0, no charge."""
+        request = create_action_request(
+            scene=self.scene,
+            initiator_persona=self.initiator_persona,
+            target_persona=self.target_persona,
+            action_key="persuade",
+        )
+        request.action_template = self.action_template
+        request.save(update_fields=["action_template"])
+
+        bonus = _charge_social_pull(action_request=request, check_type=self.check_type)
+        assert bonus == 0
+
+    def test_gift_thread_rejected(self):
+        """GIFT threads are excluded for social pulls."""
+        thread = _setup_pull_seed(
+            sheet=self.initiator_sheet, resonance=self.resonance, target_kind=TargetKind.GIFT
+        )
+        request = self._make_request_with_pull(thread)
+
+        with self.assertRaises(InvalidImbueAmount):
+            _charge_social_pull(action_request=request, check_type=self.check_type)
+
+    def test_trait_thread_accepted_when_trait_in_check_type(self):
+        """TRAIT threads pass anchor-in-action when the trait is in the check type."""
+        thread = _setup_pull_seed(
+            sheet=self.initiator_sheet, resonance=self.resonance, target_kind=TargetKind.TRAIT
+        )
+        # Link the thread's trait to the check type.
+        CheckTypeTraitFactory(check_type=self.check_type, trait=thread.target_trait, weight=1.0)
+        request = self._make_request_with_pull(thread)
+
+        bonus = _charge_social_pull(action_request=request, check_type=self.check_type)
+        assert bonus == 5  # FLAT_BONUS
+
+    def test_fizzle_on_insufficient_resonance(self):
+        """Pull fails → raises; the caller catches it and fizzles."""
+        thread = _setup_pull_seed(sheet=self.initiator_sheet, resonance=self.resonance)
+        # Drain the balance so the pull can't afford.
+        cr = CharacterResonance.objects.get(
+            character_sheet=self.initiator_sheet, resonance=self.resonance
+        )
+        cr.balance = 0
+        cr.save(update_fields=["balance"])
+
+        request = self._make_request_with_pull(thread)
+        from world.magic.exceptions import MagicError
+
+        with self.assertRaises(MagicError):
+            _charge_social_pull(action_request=request, check_type=self.check_type)
+
+    def test_idempotent_charge(self):
+        """Calling _charge_social_pull twice charges only once."""
+        thread = _setup_pull_seed(sheet=self.initiator_sheet, resonance=self.resonance)
+        request = self._make_request_with_pull(thread)
+
+        bonus1 = _charge_social_pull(action_request=request, check_type=self.check_type)
+        bonus2 = _charge_social_pull(action_request=request, check_type=self.check_type)
+        assert bonus1 == bonus2 == 5
+
+        # Resonance debited only once.
+        cr = CharacterResonance.objects.get(
+            character_sheet=self.initiator_sheet, resonance=self.resonance
+        )
+        assert cr.balance == 18  # 20 - 2 (single charge)
+
+        # charged_at is stamped.
+        decl = SceneActionPullDeclaration.objects.get(request=request)
+        assert decl.charged_at is not None
+        assert decl.charged_flat_bonus == 5
+
+
+class DenyPathCleanupTests(TestCase):
+    """DENY path cleans up the pull declaration."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.scene = SceneFactory()
+        cls.initiator_sheet = CharacterSheetFactory()
+        cls.target_sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=cls.initiator_sheet.character, current=10, maximum=10)
+        cls.resonance = ResonanceFactory()
+        CharacterResonanceFactory(
+            character_sheet=cls.initiator_sheet,
+            resonance=cls.resonance,
+            balance=20,
+            lifetime_earned=20,
+        )
+        cls.initiator_persona = cls.initiator_sheet.primary_persona
+        cls.target_persona = cls.target_sheet.primary_persona
+        cls.thread = _setup_pull_seed(sheet=cls.initiator_sheet, resonance=cls.resonance)
+
+    def test_deny_deletes_pull_declaration(self):
+        """On DENY, the pull declaration row is cleaned up and no charge fires."""
+        cast_pull = CastPullDeclaration(resonance=self.resonance, tier=1, threads=(self.thread,))
+        request = create_action_request(
+            scene=self.scene,
+            initiator_persona=self.initiator_persona,
+            target_persona=self.target_persona,
+            action_key="persuade",
+            pull=cast_pull,
+        )
+        assert SceneActionPullDeclaration.objects.filter(request=request).exists()
+
+        respond_to_action_request(action_request=request, decision=ConsentDecision.DENY)
+
+        assert not SceneActionPullDeclaration.objects.filter(request=request).exists()
+        # Resonance unchanged — no charge fired.
+        cr = CharacterResonance.objects.get(
+            character_sheet=self.initiator_sheet, resonance=self.resonance
+        )
+        assert cr.balance == 20
+
+
+class EndToEndSocialPullTests(TestCase):
+    """Integration: declare → accept → resolve with a pull."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.scene = SceneFactory()
+        cls.initiator_sheet = CharacterSheetFactory()
+        cls.target_sheet = CharacterSheetFactory()
+        CharacterAnimaFactory(character=cls.initiator_sheet.character, current=10, maximum=10)
+        cls.resonance = ResonanceFactory()
+        CharacterResonanceFactory(
+            character_sheet=cls.initiator_sheet,
+            resonance=cls.resonance,
+            balance=20,
+            lifetime_earned=20,
+        )
+        cls.initiator_persona = cls.initiator_sheet.primary_persona
+        cls.target_persona = cls.target_sheet.primary_persona
+        cls.thread = _setup_pull_seed(sheet=cls.initiator_sheet, resonance=cls.resonance)
+
+        cls.check_type = CheckTypeFactory()
+        cls.action_template = ActionTemplateFactory(check_type=cls.check_type)
+
+    def test_accept_charges_pull_and_resolves(self):
+        """Full flow: create with pull → accept → resonance debited, request RESOLVED."""
+        cast_pull = CastPullDeclaration(resonance=self.resonance, tier=1, threads=(self.thread,))
+        request = create_action_request(
+            scene=self.scene,
+            initiator_persona=self.initiator_persona,
+            target_persona=self.target_persona,
+            action_key="persuade",
+            pull=cast_pull,
+        )
+        request.action_template = self.action_template
+        request.save(update_fields=["action_template"])
+
+        assert SceneActionPullDeclaration.objects.filter(request=request).exists()
+
+        respond_to_action_request(action_request=request, decision=ConsentDecision.ACCEPT)
+
+        request.refresh_from_db()
+        assert request.status == ActionRequestStatus.RESOLVED
+
+        # Resonance debited.
+        cr = CharacterResonance.objects.get(
+            character_sheet=self.initiator_sheet, resonance=self.resonance
+        )
+        assert cr.balance == 18  # 20 - 2
+
+        # Pull declaration charged.
+        decl = SceneActionPullDeclaration.objects.get(request=request)
+        assert decl.charged_at is not None
+        assert decl.charged_flat_bonus == 5

--- a/src/world/scenes/types.py
+++ b/src/world/scenes/types.py
@@ -57,6 +57,10 @@ class EnhancedSceneActionResult:
     technique_result: TechniqueUseResult | None = None
     power_ledger: PowerLedger | None = None
     fury_committed: FuryTier | None = None
+    fizzle_note: str | None = None
+    """When a thread pull was declared but failed at charge time (#1919), this
+    carries the player-facing explanation so the OUTCOME pose can note the
+    fizzle. ``None`` when no pull was declared or the pull succeeded."""
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Closes #1919.

## Summary

Lets PCs spend resonance currency to actively pull their threads and empower social actions (persuade, intimidate, deceive, flirt, seduce, perform, entrance) — the same core magic mechanic that already works for technique casts and clashes.

## Changes

- **Model rename**: `SceneCastPullDeclaration` → `SceneActionPullDeclaration` + new `charged_at`/`charged_flat_bonus` idempotency fields (migration 0047).
- **`_charge_social_pull()`**: charges a persisted pull declaration at accept-time, waives anima in low-stakes scenes (no active combat/DANGER round), excludes GIFT threads, idempotent via `charged_at` guard for multi-target resolution.
- **`spend_resonance_for_pull`**: new `anima_cost_override` param (0 = waive anima before balance check, skip lock query).
- **`PullActionContext.excluded_kinds`**: GIFT exclusion checked before `_ALWAYS_IN_ACTION_KINDS` in `_anchor_in_action`.
- **`PullParsingMixin`** extracted to `commands/pull_parsing.py` — shared by combat + consent commands. `ConsentRequestCommand` parses `pull=` tokens, discards `beseech=` (combat-only).
- **`_validate_pull_declaration`** generalized in serializers — shared by cast (hostile_check=True) and social (hostile_check=False) paths.
- **`preview_resonance_pull`** gains `scene_id` (anima waiver) + `excluded_kinds` (GIFT exclusion) params.
- **Tests**: 9 unit tests for `_charge_social_pull` (charge, anima waiver, GIFT rejection, TRAIT acceptance, fizzle, idempotency, DENY cleanup, no-decl) + 4 PullParsingMixin tests + E2E test.

## Known follow-ups (from code review)

1. The web pull-preview endpoint view (`ThreadPullPreviewView`) does not yet forward `scene_id`/`excluded_kinds` to `preview_resonance_pull` — the service-layer params are wired but the view/serializer need updating.
2. `fizzle_note` is attached to the result but not yet rendered into interaction content or exposed in the API serializer.
3. Tests for the above two surfaces are deferred.
