### PR TITLE
BeatViewSet list() leaks internal_description + SECRET beats to any authenticated user

### DIFF
--- a/src/world/stories/serializers.py
+++ b/src/world/stories/serializers.py
@@ -1009,6 +1009,28 @@ class BeatSerializer(serializers.ModelSerializer):
             return False
         return CanMarkBeat().has_object_permission(request, None, obj)  # type: ignore[arg-type]
 
+    def to_representation(self, instance: Beat) -> dict[str, Any]:
+        """Gate ``internal_description`` for non-privileged viewers (#1923).
+
+        ``internal_description`` is GM-only authoring text (the real predicate
+        + meaning). It must not surface to players — mirroring the story-log
+        contract (``visible_internal_description`` is ``None`` unless the
+        viewer's role is staff/lead_gm) and the ``_gm_text_gate`` pattern.
+        Privilege is decided by the shared ``can_view_story_gm_text``
+        predicate (staff / Lead GM / story owner). When there is no request in
+        context we default to the most-restrictive treatment so the field
+        never leaks by default.
+        """
+        from world.stories.permissions import can_view_story_gm_text  # noqa: PLC0415
+
+        data = super().to_representation(instance)
+        request = self.context.get("request")
+        user = request.user if request is not None else None
+        story = instance.episode.chapter.story
+        if user is None or not can_view_story_gm_text(user, story):
+            data["internal_description"] = None
+        return data
+
     def validate(self, attrs: Any) -> Any:
         """Mirror Beat.clean() so predicate-type invariants surface as 400 responses."""
         # Build complete picture for clean(): existing values + incoming attrs.

--- a/src/world/stories/tests/test_beat_visibility_1923.py
+++ b/src/world/stories/tests/test_beat_visibility_1923.py
@@ -1,0 +1,177 @@
+"""Tests for BeatViewSet list visibility scoping (#1923).
+
+Covers the security gap where ``BeatViewSet.list()`` had no queryset-level
+story-visibility filter: any authenticated user could enumerate every beat of
+any episode — including SECRET beats and the GM-only ``internal_description``
+field — regardless of story privacy or participation.
+
+The fix adds ``BeatViewSet.get_queryset()`` (mirroring
+``IsStoryOwnerOrStaff._can_read_story`` at the queryset level) and gates
+``internal_description`` in ``BeatSerializer.to_representation``.
+"""
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.stories.constants import BeatVisibility
+from world.stories.factories import (
+    BeatFactory,
+    ChapterFactory,
+    EpisodeFactory,
+    PrivateStoryFactory,
+    StoryFactory,
+    StoryParticipationFactory,
+)
+
+
+def _character_with_account(account):
+    """Return an ObjectDB character whose ``db_account`` is ``account``."""
+    char = CharacterFactory()
+    char.db_account = account
+    char.save()
+    return char
+
+
+class BeatListVisibilityTest(APITestCase):
+    """``GET /api/beats/`` must only surface beats the viewer may read."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = AccountFactory(is_staff=True)
+
+        # --- PRIVATE story with two beats (one VISIBLE, one SECRET) ---
+        cls.owner = AccountFactory()
+        cls.private_story = PrivateStoryFactory(owners=[cls.owner])
+        cls.private_chapter = ChapterFactory(story=cls.private_story)
+        cls.private_episode = EpisodeFactory(chapter=cls.private_chapter)
+        cls.private_visible_beat = BeatFactory(
+            episode=cls.private_episode,
+            visibility=BeatVisibility.VISIBLE,
+            internal_description="GM-only private beat detail",
+        )
+        cls.private_secret_beat = BeatFactory(
+            episode=cls.private_episode,
+            visibility=BeatVisibility.SECRET,
+            internal_description="GM-only secret beat detail",
+        )
+
+        # A non-owner, non-participant account.
+        cls.outsider = AccountFactory()
+
+        # An active participant in the private story.
+        cls.participant = AccountFactory()
+        cls.participant_char = _character_with_account(cls.participant)
+        cls.participation = StoryParticipationFactory(
+            story=cls.private_story,
+            character=cls.participant_char,
+            is_active=True,
+            trusted_by_owner=False,
+        )
+
+    # --- queryset scoping -------------------------------------------------
+
+    def test_outsider_cannot_list_private_story_beats(self):
+        """A non-owner/non-participant sees no beats from a PRIVATE story."""
+        self.client.force_authenticate(user=self.outsider)
+        response = self.client.get(reverse("beat-list"))
+        assert response.status_code == status.HTTP_200_OK
+        beat_ids = {b["id"] for b in response.data["results"]}
+        assert self.private_visible_beat.id not in beat_ids
+        assert self.private_secret_beat.id not in beat_ids
+
+    def test_owner_can_list_private_story_beats(self):
+        """The story owner sees non-SECRET beats of their private story."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get(reverse("beat-list"))
+        assert response.status_code == status.HTTP_200_OK
+        beat_ids = {b["id"] for b in response.data["results"]}
+        assert self.private_visible_beat.id in beat_ids
+
+    def test_participant_can_list_private_story_beats(self):
+        """An active participant sees non-SECRET beats of the private story."""
+        self.client.force_authenticate(user=self.participant)
+        response = self.client.get(reverse("beat-list"))
+        assert response.status_code == status.HTTP_200_OK
+        beat_ids = {b["id"] for b in response.data["results"]}
+        assert self.private_visible_beat.id in beat_ids
+
+    def test_staff_sees_all_beats_including_secret(self):
+        """Staff bypass the queryset filter entirely, including SECRET beats."""
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.get(reverse("beat-list"))
+        assert response.status_code == status.HTTP_200_OK
+        beat_ids = {b["id"] for b in response.data["results"]}
+        assert self.private_visible_beat.id in beat_ids
+        assert self.private_secret_beat.id in beat_ids
+
+    # --- SECRET beat exclusion -------------------------------------------
+
+    def test_non_staff_never_sees_secret_beats(self):
+        """SECRET beats are excluded from list for every non-staff viewer."""
+        for user in (self.owner, self.participant):
+            self.client.force_authenticate(user=user)
+            response = self.client.get(reverse("beat-list"))
+            beat_ids = {b["id"] for b in response.data["results"]}
+            assert self.private_secret_beat.id not in beat_ids
+
+    def test_episode_filter_still_scoped(self):
+        """``?episode=<id>`` does not bypass the visibility filter."""
+        self.client.force_authenticate(user=self.outsider)
+        url = reverse("beat-list")
+        response = self.client.get(url, {"episode": self.private_episode.id})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["results"] == []
+
+
+class BeatInternalDescriptionGateTest(APITestCase):
+    """``internal_description`` must not leak to non-privileged viewers."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = AccountFactory(is_staff=True)
+        cls.owner = AccountFactory()
+        cls.outsider = AccountFactory()
+
+        # PUBLIC story so the outsider *can* see the beat — the test is
+        # about the field-level gate, not queryset scoping.
+        cls.story = StoryFactory(owners=[cls.owner])
+        cls.chapter = ChapterFactory(story=cls.story)
+        cls.episode = EpisodeFactory(chapter=cls.chapter)
+        cls.beat = BeatFactory(
+            episode=cls.episode,
+            visibility=BeatVisibility.VISIBLE,
+            internal_description="GM-only secret predicate detail",
+        )
+
+    def test_staff_sees_internal_description(self):
+        self.client.force_authenticate(user=self.staff)
+        url = reverse("beat-detail", kwargs={"pk": self.beat.pk})
+        response = self.client.get(url)
+        assert response.data["internal_description"] == "GM-only secret predicate detail"
+
+    def test_owner_sees_internal_description(self):
+        self.client.force_authenticate(user=self.owner)
+        url = reverse("beat-detail", kwargs={"pk": self.beat.pk})
+        response = self.client.get(url)
+        assert response.data["internal_description"] == "GM-only secret predicate detail"
+
+    def test_outsider_does_not_see_internal_description(self):
+        """A non-owner (even of a PUBLIC story) gets ``None``."""
+        self.client.force_authenticate(user=self.outsider)
+        url = reverse("beat-detail", kwargs={"pk": self.beat.pk})
+        response = self.client.get(url)
+        assert response.data["internal_description"] is None
+
+    def test_internal_description_stripped_in_list_too(self):
+        """The field-level gate applies on list, not just retrieve."""
+        self.client.force_authenticate(user=self.outsider)
+        response = self.client.get(reverse("beat-list"))
+        assert response.status_code == status.HTTP_200_OK
+        for beat in response.data["results"]:
+            if beat["id"] == self.beat.id:
+                assert beat["internal_description"] is None
+                return
+        msg = "beat not found in list results"
+        raise AssertionError(msg)

--- a/src/world/stories/tests/test_serializers_beat.py
+++ b/src/world/stories/tests/test_serializers_beat.py
@@ -302,7 +302,7 @@ class BeatViewSetPermissionsTest(APITestCase):
         assert response.status_code == status.HTTP_200_OK
 
     def test_authenticated_can_list(self):
-        """list is allowed for any authenticated user (object-level enforced on retrieve)."""
+        """A non-owner can list beats of a PUBLIC story (story-visibility scoping)."""
         self.client.force_authenticate(user=self.non_owner)
         response = self.client.get(reverse("beat-list"))
         assert response.status_code == status.HTTP_200_OK

--- a/src/world/stories/views.py
+++ b/src/world/stories/views.py
@@ -24,6 +24,7 @@ from world.character_sheets.models import CharacterSheet
 from world.narrative.permissions import IsStoryLeadGMOrStaff
 from world.stories.constants import (
     AssistantClaimStatus,
+    BeatVisibility,
     SessionRequestStatus,
     StoryScope,
 )
@@ -1388,6 +1389,73 @@ class BeatViewSet(viewsets.ModelViewSet):
     pagination_class = StandardResultsSetPagination
     ordering_fields = ["order", "created_at", "updated_at"]
     ordering = ["episode", "order"]
+
+    def get_queryset(self) -> QuerySet[Beat]:
+        """Scope the Beat queryset by story read-visibility (#1923).
+
+        ``IsBeatStoryOwnerOrStaff.has_permission`` only checks authentication,
+        and DRF's ``list()`` never calls ``has_object_permission`` per row — so
+        without a queryset filter any authenticated user could enumerate every
+        beat of any episode, including SECRET beats. This mirrors the read
+        rule ``IsBeatStoryOwnerOrStaff.has_object_permission`` delegates to
+        (``IsStoryOwnerOrStaff._can_read_story``) at the queryset level:
+
+        - Staff: all beats.
+        - PUBLIC story: visible to all authenticated users.
+        - PRIVATE story: owners or active participants.
+        - INVITE_ONLY story: owners or active *trusted* participants.
+        - Non-staff viewers never see SECRET beats (matching the story-log
+          contract, where SECRET beats surface only on completion for the
+          player who completed them).
+
+        ``retrieve``/``update``/etc. still get the real per-object check via
+        ``has_object_permission``; this filter only narrows ``list()``.
+        """
+        from world.stories.types import StoryPrivacy  # noqa: PLC0415
+
+        qs = super().get_queryset()
+        user = self.request.user
+
+        if not user.is_authenticated:
+            return qs.none()
+
+        if user.is_staff:
+            return qs
+
+        # Story FK chain: beat -> episode -> chapter -> story.
+        story__ = "episode__chapter__story__"
+
+        # PUBLIC stories are readable by any authenticated user.
+        public_q = models.Q(**{f"{story__}privacy": StoryPrivacy.PUBLIC})
+
+        # PRIVATE / INVITE_ONLY: owners ...
+        owned_q = models.Q(**{f"{story__}owners": user})
+
+        # ... or active participants. INVITE_ONLY additionally requires
+        # trusted_by_owner (mirrors _can_read_story's invite-only branch).
+        participant_q = models.Q(
+            **{f"{story__}participants__character__db_account": user},
+            **{f"{story__}participants__is_active": True},
+        )
+        trusted_participant_q = participant_q & models.Q(
+            **{f"{story__}participants__trusted_by_owner": True},
+        )
+
+        private_q = owned_q | participant_q
+        invite_only_q = owned_q | trusted_participant_q
+
+        visible_q = (
+            public_q
+            | (models.Q(**{f"{story__}privacy": StoryPrivacy.PRIVATE}) & private_q)
+            | (models.Q(**{f"{story__}privacy": StoryPrivacy.INVITE_ONLY}) & invite_only_q)
+        )
+
+        # SECRET beats are never surfaced to non-staff via the list endpoint
+        # (matching the story-log contract — they surface only on completion).
+        secret_q = models.Q(visibility=BeatVisibility.SECRET)
+        visible_q &= ~secret_q
+
+        return qs.filter(visible_q).distinct()
 
     @action(
         detail=True,


### PR DESCRIPTION
Closes #1923

## Summary

BeatViewSet.list() had no queryset-level story-visibility filter: IsBeatStoryOwnerOrStaff.has_permission only checks authentication, and DRF's list() never calls has_object_permission per row. Any authenticated user could GET /api/beats/?episode=<id> for any episode and enumerate every beat — including SECRET-visibility beats and the GM-only internal_description field — regardless of story privacy or participation.

This fixes both attack surfaces:

1. **Queryset scoping** — BeatViewSet.get_queryset() now mirrors IsStoryOwnerOrStaff._can_read_story at the queryset level: PUBLIC stories visible to all authenticated users, PRIVATE/INVITE_ONLY scoped to owners/participants (trusted for invite-only), and SECRET beats excluded for non-staff (matching the story-log contract where SECRET beats surface only on completion).

2. **Field-level gating** — internal_description is now stripped in BeatSerializer.to_representation for non-privileged viewers via the shared can_view_story_gm_text predicate (staff/Lead GM/story owner), mirroring the existing _gm_text_gate pattern and story-log visible_internal_description contract.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1923 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: Already up to date with main; no conflicts.

<!-- last-addressed-comment: 0 -->