### PR TITLE
Combat + vitals checks aren't stat+skill — retrofit penetration/flee + seed compositions (#1706)

### DIFF
--- a/docs/roadmap/design-tenets.md
+++ b/docs/roadmap/design-tenets.md
@@ -356,7 +356,10 @@ spec-in-checks engine foundation (#1688) before they can participate in a `Check
 
 Auto-scaffolded check seeds are **PLACEHOLDER** until a real composition pass: the social
 `CheckType`s (Intimidation/Persuasion/Deception/Seduction/Performance/Presence) shipped as
-stat+stat boilerplate and are slated to be redesigned to stat + skill (+ spec).
+stat+stat boilerplate and were redesigned to stat + skill (+ spec) (#1689); the combat + vitals
+checks (penetration/flee retrofitted, Reflexes/Endurance/Mortal Resolve/Escalation Pace seeded,
+Melee Combat skill catalog + the combat offense check added) followed in #1706. The resist-style
+checks (single-stat) are the tenet-permitted exception.
 
 ---
 

--- a/docs/systems/checks.md
+++ b/docs/systems/checks.md
@@ -164,3 +164,27 @@ All models registered with appropriate admin interfaces:
 - **Progression app**: Uses `CharacterPathHistory` for current path lookup
 - **Attempts app**: Calls `perform_check()` for resolution; provides roulette display content via `ConsequenceDisplay`
 - **Callers** (goals, magic, combat, conditions): Compute `extra_modifiers` before calling `perform_check()`
+
+---
+
+## Seeded Compositions
+
+Check compositions are authored as seed data (the design tenet: **stat + skill (+ specialization)**, rarely stat+stat). The seed clusters live in `world/seeds/`:
+
+| Cluster | Checks | Composition |
+|---------|--------|-------------|
+| `combat_checks` (#1706) | `Melee Attack` | strength + Melee Combat (+ Small/Medium/Heavy Weapons spec) |
+| `combat` | `penetration` | willpower + intellect + Melee Combat |
+| `combat` | `flee` | agility + wits + Melee Combat |
+| `combat` | `Escalation Pace` | wits (single-stat resist) |
+| `vitals` | `Endurance` | stamina (single-stat resist — KO/wound) |
+| `vitals` | `Mortal Resolve` | willpower (single-stat resist — death) |
+| `positioning` | `Reflexes` | wits (single-stat resist — plummet-catch/interpose) |
+| `social` (#1689) | Intimidation/Persuasion/etc. | stat + skill (+ spec) |
+| `magic` | cast/ritual checks | willpower + ritualism/occult/theology |
+| `investigation` (#1705) | `Search` | perception + Investigation |
+| `governance` (#930) | Tax/Investment checks | stat + Scholarship/Economics |
+
+**Resist checks** (Reflexes, Escalation Pace, Endurance, Mortal Resolve) are the tenet-permitted single-stat exception — they seed exactly one `CheckTypeTrait`. The `Melee Combat` skill catalog (with weapon-class specializations aligned to `progression.services.scene_integration`'s `weapon_map`) is seeded by the `combat_checks` cluster; the penetration/flee retrofits depend on it.
+
+**Technique routing (#1706):** `resolve_cast_action_template` reads `Technique.action_category` — a `PHYSICAL` technique with no chosen consequence-pool flavor resolves to the combat `Melee Attack` `ActionTemplate` (so physical attacks roll a combat check, not the magic fallback); non-physical techniques resolve to the magic standalone cast template.

--- a/src/integration_tests/game_content/tests/test_combat_seed.py
+++ b/src/integration_tests/game_content/tests/test_combat_seed.py
@@ -17,7 +17,12 @@ class SeedPenetrationContestTests(TestCase):
         # CheckType.DoesNotExist in an unseeded game).
         check_type = get_penetration_check_type()
         self.assertEqual(result.check_type, check_type)
-        self.assertEqual(check_type.traits.count(), 2)
+        # #1706: penetration = willpower + intellect + Melee Combat (skill leg).
+        self.assertEqual(check_type.traits.count(), 3)
+        self.assertEqual(
+            {t.trait.name for t in check_type.traits.all()},
+            {"willpower", "intellect", "Melee Combat"},
+        )
 
         # Factor ladder authored (4 rungs, bounce → overpenetration).
         self.assertEqual(PenetrationOutcomeFactor.objects.count(), 4)

--- a/src/world/areas/positioning/plummet_content.py
+++ b/src/world/areas/positioning/plummet_content.py
@@ -192,8 +192,17 @@ def _ensure_catch_check_type() -> CheckType:
 
     A single shared check type — the fiction differs per capability, but the
     mechanical roll (split-second reaction) is the same, so no per-capability
-    CheckType is authored.
+    CheckType is authored. The single ``wits`` stat leg is the tenet-permitted
+    resist composition (#1706); idempotent ``get_or_create`` preserves any
+    existing staff weight edit. Shared by plummet-catch and interpose (both
+    ``get_or_create`` this row).
     """
+    from decimal import Decimal  # noqa: PLC0415
+
+    from world.checks.models import CheckTypeTrait  # noqa: PLC0415
+    from world.traits.factories import StatTraitFactory  # noqa: PLC0415
+    from world.traits.models import TraitCategory  # noqa: PLC0415
+
     category, _ = CheckCategory.objects.get_or_create(name="Exploration")
     obj, _ = CheckType.objects.get_or_create(
         name=CATCH_CHECK_TYPE_NAME,
@@ -201,6 +210,11 @@ def _ensure_catch_check_type() -> CheckType:
         defaults={
             "description": "A split-second reaction to arrest a falling body.",
         },
+    )
+    CheckTypeTrait.objects.get_or_create(
+        check_type=obj,
+        trait=StatTraitFactory(name="wits", category=TraitCategory.MENTAL),
+        defaults={"weight": Decimal("1.00")},
     )
     return obj
 

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -862,7 +862,9 @@ def _finalize_cantrip_gift_and_technique(draft: CharacterDraft, sheet: Character
     from world.magic.exceptions import InvalidConsequencePoolChoice  # noqa: PLC0415
 
     try:
-        action_template = resolve_cast_action_template(chosen_pool_id)
+        action_template = resolve_cast_action_template(
+            chosen_pool_id, action_category=derived_category
+        )
     except InvalidConsequencePoolChoice:
         logger.warning(
             "CG finalize: invalid selected_consequence_pool_id %s for draft %s; "
@@ -870,7 +872,7 @@ def _finalize_cantrip_gift_and_technique(draft: CharacterDraft, sheet: Character
             chosen_pool_id,
             draft.pk,
         )
-        action_template = resolve_cast_action_template(None)
+        action_template = resolve_cast_action_template(None, action_category=derived_category)
 
     technique = create_technique(
         creator=sheet,

--- a/src/world/character_creation/tests/test_services.py
+++ b/src/world/character_creation/tests/test_services.py
@@ -1270,12 +1270,12 @@ class FinalizeMagicDataCantripTests(TestCase):
         self.assertEqual(technique.action_template_id, chosen.pk)
 
     def test_technique_falls_back_to_default_on_invalid_pool_id(self) -> None:
-        """A stale/invalid selected_consequence_pool_id degrades to the shared
-        default rather than crashing finalization (mirrors the resonance fallback)."""
+        """A stale/invalid selected_consequence_pool_id degrades to the
+        category-appropriate default rather than crashing finalization (mirrors
+        the resonance fallback)."""
         from world.character_creation.services import finalize_magic_data
         from world.character_sheets.factories import CharacterSheetFactory
         from world.magic.models import CharacterGift, Technique
-        from world.magic.seeds_cast import get_standalone_cast_template
 
         sheet = CharacterSheetFactory()
         draft = self._create_draft(cantrip=self.cantrip, consequence_pool_id=999999)
@@ -1284,7 +1284,8 @@ class FinalizeMagicDataCantripTests(TestCase):
 
         gift = CharacterGift.objects.get(character=sheet).gift
         technique = Technique.objects.get(gift=gift)
-        self.assertEqual(technique.action_template_id, get_standalone_cast_template().pk)
+        # No selected path → derived action_category=PHYSICAL → combat template (#1706).
+        self.assertEqual(technique.action_template.name, "Melee Attack")
 
     def test_no_gift_created_without_cantrip(self) -> None:
         """No Gift, CharacterGift, or Technique created when no cantrip is selected."""

--- a/src/world/combat/factories.py
+++ b/src/world/combat/factories.py
@@ -690,25 +690,28 @@ class PlayableCombatScenarioFactory:
 
 
 def wire_penetration_check_type():
-    """Seed the 'penetration' CheckType for the ward contest (#639, #767).
+    """Seed the 'penetration' CheckType for the ward contest (#639, #767, #1706).
 
     Idempotent — uses CheckTypeFactory's django_get_or_create on (name,
-    category) and get_or_create on (check_type, trait), so re-runs are
-    no-ops and staff weight edits are preserved. The check resolves through
-    the shared rank/chart pipeline (ResultChart.get_chart_for_difference),
-    so no per-CheckType chart row is needed; tests that need a concrete
-    success level force it via force_check_outcome or an offense_check_fn
-    override.
+    category); the trait composition is an authoritative rewrite (delete +
+    recreate) so a re-seed corrects the prior stat+stat seed and converges.
+    Staff weight edits are reset on re-seed (mirrors social_checks.py). The
+    check resolves through the shared rank/chart pipeline
+    (ResultChart.get_chart_for_difference), so no per-CheckType chart row is
+    needed; tests that need a concrete success level force it via
+    force_check_outcome or an offense_check_fn override.
 
-    Trait composition (willpower 1.00, intellect 0.50) mirrors the seeded
-    magical_challenge check so a production caster rolls a real pool against
-    the ward instead of trait_points=0.
+    Trait composition (willpower 1.00, intellect 0.50, Melee Combat 0.50):
+    willpower mirrors the seeded magical_challenge check so a production
+    caster rolls a real pool against the ward; the Melee Combat skill leg
+    rewards martial awareness against warded foes (#1706).
     """
     from decimal import Decimal
 
     from world.checks.factories import CheckCategoryFactory, CheckTypeFactory
     from world.checks.models import CheckTypeTrait
     from world.combat.constants import PENETRATION_CHECK_TYPE_NAME
+    from world.seeds.combat_checks import ensure_melee_combat_skill
     from world.traits.factories import StatTraitFactory
     from world.traits.models import TraitCategory
 
@@ -717,15 +720,15 @@ def wire_penetration_check_type():
         category=CheckCategoryFactory(name="Combat"),
         description="Penetrate a warded target's barrier (#639).",
     )
-    for trait_name, category, weight in [
-        ("willpower", TraitCategory.META, "1.00"),
-        ("intellect", TraitCategory.MENTAL, "0.50"),
-    ]:
-        CheckTypeTrait.objects.get_or_create(
-            check_type=check_type,
-            trait=StatTraitFactory(name=trait_name, category=category),
-            defaults={"weight": Decimal(weight)},
-        )
+    skill = ensure_melee_combat_skill()
+    composition = [
+        (StatTraitFactory(name="willpower", category=TraitCategory.META), Decimal("1.00")),
+        (StatTraitFactory(name="intellect", category=TraitCategory.MENTAL), Decimal("0.50")),
+        (skill.trait, Decimal("0.50")),
+    ]
+    CheckTypeTrait.objects.filter(check_type=check_type).delete()
+    for trait, weight in composition:
+        CheckTypeTrait.objects.create(check_type=check_type, trait=trait, weight=weight)
     return check_type
 
 
@@ -753,24 +756,29 @@ def wire_penetration_modifier_target():
 
 
 def wire_flee_check_type():
-    """Seed the 'flee' CheckType for the flee-attempt check (#878).
+    """Seed the 'flee' CheckType for the flee-attempt check (#878, #1706).
 
     Idempotent — uses CheckTypeFactory's django_get_or_create on (name,
-    category) and get_or_create on (check_type, trait), so re-runs are
-    no-ops and staff weight edits are preserved. The check resolves through
-    the shared rank/chart pipeline (ResultChart.get_chart_for_difference),
-    so no per-CheckType chart row is needed.
+    category); the trait composition is an authoritative rewrite (delete +
+    recreate) so a re-seed corrects the prior stat+stat seed and converges.
+    Staff weight edits are reset on re-seed (mirrors social_checks.py). The
+    check resolves through the shared rank/chart pipeline
+    (ResultChart.get_chart_for_difference), so no per-CheckType chart row is
+    needed.
 
-    Trait composition (agility 1.00, wits 0.50): agility drives the raw
-    physical escape burst; wits reflects situational reading and route
-    choice under pressure. Both are seeded by the character seed helpers
-    (_CHALLENGE_STAT_NAMES) so a production character rolls a real pool.
+    Trait composition (agility 1.00, wits 0.50, Melee Combat 0.50): agility
+    drives the raw physical escape burst; wits reflects situational reading
+    and route choice under pressure; the Melee Combat skill leg rewards a
+    trained fighter's situational reading (#1706). Both stats are seeded by
+    the character seed helpers (_CHALLENGE_STAT_NAMES) so a production
+    character rolls a real pool.
     """
     from decimal import Decimal
 
     from world.checks.factories import CheckCategoryFactory, CheckTypeFactory
     from world.checks.models import CheckTypeTrait
     from world.combat.constants import FLEE_CHECK_TYPE_NAME
+    from world.seeds.combat_checks import ensure_melee_combat_skill
     from world.traits.factories import StatTraitFactory
     from world.traits.models import TraitCategory
 
@@ -779,15 +787,15 @@ def wire_flee_check_type():
         category=CheckCategoryFactory(name="Combat"),
         description="Flee-attempt check rolled when a PC declares flee (#878).",
     )
-    for trait_name, category, weight in [
-        ("agility", TraitCategory.PHYSICAL, "1.00"),
-        ("wits", TraitCategory.MENTAL, "0.50"),
-    ]:
-        CheckTypeTrait.objects.get_or_create(
-            check_type=check_type,
-            trait=StatTraitFactory(name=trait_name, category=category),
-            defaults={"weight": Decimal(weight)},
-        )
+    skill = ensure_melee_combat_skill()
+    composition = [
+        (StatTraitFactory(name="agility", category=TraitCategory.PHYSICAL), Decimal("1.00")),
+        (StatTraitFactory(name="wits", category=TraitCategory.MENTAL), Decimal("0.50")),
+        (skill.trait, Decimal("0.50")),
+    ]
+    CheckTypeTrait.objects.filter(check_type=check_type).delete()
+    for trait, weight in composition:
+        CheckTypeTrait.objects.create(check_type=check_type, trait=trait, weight=weight)
     return check_type
 
 

--- a/src/world/combat/factories.py
+++ b/src/world/combat/factories.py
@@ -940,13 +940,28 @@ class EscalationCurveFactory(factory_django.DjangoModelFactory):
 
     @factory.lazy_attribute
     def pace_check_type(self) -> object:
-        from world.checks.models import CheckCategory, CheckType
+        from decimal import Decimal
+
+        from world.checks.models import (
+            CheckCategory,
+            CheckType,
+            CheckTypeTrait,
+        )
+        from world.traits.factories import StatTraitFactory
+        from world.traits.models import TraitCategory
 
         category, _ = CheckCategory.objects.get_or_create(name="Combat")
         check, _ = CheckType.objects.get_or_create(
             name="Escalation Pace",
             category=category,
             defaults={"description": "Keep control in pace with rising intensity."},
+        )
+        # #1706 — seed the Escalation Pace check's wits stat leg (split-second
+        # reading of rising combat intensity). Idempotent get_or_create.
+        CheckTypeTrait.objects.get_or_create(
+            check_type=check,
+            trait=StatTraitFactory(name="wits", category=TraitCategory.MENTAL),
+            defaults={"weight": Decimal("1.00")},
         )
         return check
 

--- a/src/world/combat/factories.py
+++ b/src/world/combat/factories.py
@@ -814,6 +814,48 @@ def wire_flee_modifier_target():
     )
 
 
+def wire_melee_attack_action_template():
+    """Seed the combat 'Melee Attack' ActionTemplate (#1706).
+
+    The combat-flavored sibling of the magic standalone cast template
+    (``seeds_cast.ensure_technique_cast_content``). Carries the seeded
+    'Melee Attack' CheckType so physical techniques roll a combat check
+    (strength + Melee Combat) instead of the magic fallback. Idempotent —
+    ``get_or_create`` on the name; FK re-wiring ensures the link lands even on
+    a pre-existing row.
+    """
+    from actions.constants import ActionTargetType, Pipeline
+    from actions.models import ActionTemplate
+    from world.checks.models import CheckCategory, CheckType
+
+    # Resolve the 'Melee Attack' CheckType: prefer the authored seed
+    # (seed_combat_check_content writes the full composition); fall back to a
+    # minimal get_or_create so the wire function is self-sufficient in test
+    # setups that haven't run the combat_checks seed (mirrors how
+    # get_standalone_cast_template self-seeds the magic template).
+    category, _ = CheckCategory.objects.get_or_create(name="Combat")
+    check_type, _ = CheckType.objects.get_or_create(
+        name="Melee Attack",
+        category=category,
+        defaults={"description": "A melee attack roll: strength + Melee Combat."},
+    )
+    template, _ = ActionTemplate.objects.get_or_create(
+        name="Melee Attack",
+        defaults={
+            "check_type": check_type,
+            "consequence_pool": None,
+            "category": "combat",
+            "pipeline": Pipeline.SINGLE,
+            "target_type": ActionTargetType.SINGLE,
+            "description": "Standalone resolution spec for a melee attack.",
+        },
+    )
+    if template.check_type_id != check_type.pk:
+        template.check_type = check_type
+        template.save(update_fields=["check_type"])
+    return template
+
+
 class DuelChallengeFactory(factory_django.DjangoModelFactory):
     """Factory for DuelChallenge.
 

--- a/src/world/combat/tests/test_combat_seeds.py
+++ b/src/world/combat/tests/test_combat_seeds.py
@@ -1,0 +1,31 @@
+"""Combat seed composition tests (#1706).
+
+Covers the penetration + flee retrofits (stat + skill legs) and the resist
+checks' single-stat compositions. The Melee Combat skill catalog is seeded
+by ``world.seeds.combat_checks``; these tests exercise the combat factories'
+compositions against it.
+"""
+
+from django.test import TestCase
+
+from world.seeds.combat_checks import ensure_melee_combat_skill
+
+
+class PenetrationFleeSkillLegTests(TestCase):
+    """#1706 — penetration + flee gain a Melee Combat skill leg."""
+
+    def test_penetration_has_skill_leg(self):
+        from world.combat.factories import wire_penetration_check_type
+
+        ensure_melee_combat_skill()  # dependency
+        ct = wire_penetration_check_type()
+        trait_names = {t.trait.name for t in ct.traits.all()}  # type: ignore[attr-defined]
+        self.assertEqual(trait_names, {"willpower", "intellect", "Melee Combat"})
+
+    def test_flee_has_skill_leg(self):
+        from world.combat.factories import wire_flee_check_type
+
+        ensure_melee_combat_skill()
+        ct = wire_flee_check_type()
+        trait_names = {t.trait.name for t in ct.traits.all()}  # type: ignore[attr-defined]
+        self.assertEqual(trait_names, {"agility", "wits", "Melee Combat"})

--- a/src/world/combat/tests/test_flee_seed.py
+++ b/src/world/combat/tests/test_flee_seed.py
@@ -36,7 +36,10 @@ class WireFleeCheckTypeTraitTests(TestCase):
 
         idmapper_models.flush_cache()
 
-    def test_authors_agility_and_wits_weights(self) -> None:
+    def test_authors_agility_wits_and_skill_weights(self) -> None:
+        from world.seeds.combat_checks import ensure_melee_combat_skill
+
+        ensure_melee_combat_skill()  # the skill-leg dependency
         check_type = wire_flee_check_type()
         weights = {
             ctt.trait.name: ctt.weight
@@ -44,23 +47,31 @@ class WireFleeCheckTypeTraitTests(TestCase):
         }
         self.assertEqual(weights["agility"], Decimal("1.00"))
         self.assertEqual(weights["wits"], Decimal("0.50"))
+        self.assertEqual(weights["Melee Combat"], Decimal("0.50"))
 
     def test_check_type_category_is_combat(self) -> None:
         check_type = wire_flee_check_type()
         self.assertEqual(check_type.category.name, "Combat")
 
-    def test_idempotent_and_preserves_staff_edits(self) -> None:
+    def test_authoritative_rewrite_resets_staff_edits(self) -> None:
+        """#1706 — penetration/flee use an authoritative delete+rewrite (mirrors
+        social_checks.py) to correct the prior stat+stat composition. A re-seed
+        resets staff weight edits and converges on the authored three-trait set."""
+        from world.seeds.combat_checks import ensure_melee_combat_skill
+
+        ensure_melee_combat_skill()
         check_type = wire_flee_check_type()
-        # Staff retunes a weight; re-running the seed must not clobber it.
+        # Staff retunes a weight; re-running the seed resets it (authoritative
+        # delete+rewrite — the row is replaced, so re-query by trait name).
         row = CheckTypeTrait.objects.get(check_type=check_type, trait__name="agility")
         row.weight = Decimal("2.00")
         row.save()
 
         wire_flee_check_type()
 
-        self.assertEqual(CheckTypeTrait.objects.filter(check_type=check_type).count(), 2)
-        row.refresh_from_db()
-        self.assertEqual(row.weight, Decimal("2.00"))
+        self.assertEqual(CheckTypeTrait.objects.filter(check_type=check_type).count(), 3)
+        refreshed = CheckTypeTrait.objects.get(check_type=check_type, trait__name="agility")
+        self.assertEqual(refreshed.weight, Decimal("1.00"))
 
 
 class WireFleeModifierTargetTests(TestCase):

--- a/src/world/combat/tests/test_penetration_seed.py
+++ b/src/world/combat/tests/test_penetration_seed.py
@@ -42,7 +42,10 @@ class WirePenetrationCheckTypeTraitTests(TestCase):
 
         idmapper_models.flush_cache()
 
-    def test_authors_willpower_and_intellect_weights(self) -> None:
+    def test_authors_willpower_intellect_and_skill_weights(self) -> None:
+        from world.seeds.combat_checks import ensure_melee_combat_skill
+
+        ensure_melee_combat_skill()  # the skill-leg dependency
         check_type = wire_penetration_check_type()
         weights = {
             ctt.trait.name: ctt.weight
@@ -50,19 +53,27 @@ class WirePenetrationCheckTypeTraitTests(TestCase):
         }
         self.assertEqual(weights["willpower"], Decimal("1.00"))
         self.assertEqual(weights["intellect"], Decimal("0.50"))
+        self.assertEqual(weights["Melee Combat"], Decimal("0.50"))
 
-    def test_idempotent_and_preserves_staff_edits(self) -> None:
+    def test_authoritative_rewrite_resets_staff_edits(self) -> None:
+        """#1706 — penetration/flee use an authoritative delete+rewrite (mirrors
+        social_checks.py) to correct the prior stat+stat composition. A re-seed
+        resets staff weight edits and converges on the authored three-trait set."""
+        from world.seeds.combat_checks import ensure_melee_combat_skill
+
+        ensure_melee_combat_skill()
         check_type = wire_penetration_check_type()
-        # Staff retunes a weight; re-running the seed must not clobber it.
+        # Staff retunes a weight; re-running the seed resets it (authoritative
+        # delete+rewrite — the row is replaced, so re-query by trait name).
         row = CheckTypeTrait.objects.get(check_type=check_type, trait__name="willpower")
         row.weight = Decimal("2.00")
         row.save()
 
         wire_penetration_check_type()
 
-        self.assertEqual(CheckTypeTrait.objects.filter(check_type=check_type).count(), 2)
-        row.refresh_from_db()
-        self.assertEqual(row.weight, Decimal("2.00"))
+        self.assertEqual(CheckTypeTrait.objects.filter(check_type=check_type).count(), 3)
+        refreshed = CheckTypeTrait.objects.get(check_type=check_type, trait__name="willpower")
+        self.assertEqual(refreshed.weight, Decimal("1.00"))
 
 
 class WirePenetrationModifierTargetTests(TestCase):

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -3114,7 +3114,10 @@ class TechniqueDesignSerializer(serializers.Serializer):
             raise serializers.ValidationError({"gift_id": exc.user_message}) from exc
 
         try:
-            resolve_cast_action_template(attrs["_design"].consequence_pool_id)
+            resolve_cast_action_template(
+                attrs["_design"].consequence_pool_id,
+                action_category=attrs["_design"].action_category,
+            )
         except InvalidConsequencePoolChoice as exc:
             raise serializers.ValidationError({"consequence_pool_id": exc.user_message}) from exc
 

--- a/src/world/magic/services/technique_builder.py
+++ b/src/world/magic/services/technique_builder.py
@@ -69,19 +69,30 @@ def get_technique_cast_catalog():
     return ConsequencePool.objects.filter(parent=get_standalone_cast_pool()).order_by("name")
 
 
-def resolve_cast_action_template(consequence_pool_id: int | None):
+def resolve_cast_action_template(
+    consequence_pool_id: int | None, *, action_category: str | None = None
+):
     """Resolve the ActionTemplate a technique's action_template should point at.
 
     None (no flavor chosen) resolves to the shared base template — today's
-    unchanged default. A catalog pool id resolves to its matching seeded
-    ActionTemplate. Raises InvalidConsequencePoolChoice for any id that isn't
-    a catalog member (including a valid-but-unrelated ConsequencePool).
+    unchanged default for non-physical categories. A PHYSICAL technique with
+    no chosen pool resolves to the combat 'Melee Attack' ActionTemplate (#1706)
+    so physical attacks roll a combat check (strength + Melee Combat) instead
+    of the magic fallback. A catalog pool id resolves to its matching seeded
+    ActionTemplate regardless of category. Raises InvalidConsequencePoolChoice
+    for any id that isn't a catalog member (including a valid-but-unrelated
+    ConsequencePool).
     """
+    from actions.constants import ActionCategory  # noqa: PLC0415
     from actions.models import ActionTemplate  # noqa: PLC0415
     from world.magic.exceptions import InvalidConsequencePoolChoice  # noqa: PLC0415
     from world.magic.seeds_cast import get_standalone_cast_template  # noqa: PLC0415
 
     if consequence_pool_id is None:
+        if action_category == ActionCategory.PHYSICAL:
+            from world.combat.factories import wire_melee_attack_action_template  # noqa: PLC0415
+
+            return wire_melee_attack_action_template()
         return get_standalone_cast_template()
     if not get_technique_cast_catalog().filter(pk=consequence_pool_id).exists():
         raise InvalidConsequencePoolChoice
@@ -284,7 +295,9 @@ def build_technique(design: TechniqueDesignInput, *, creator) -> Technique:
         level=design.level,
         action_category=design.action_category,
         description=design.description,
-        action_template=resolve_cast_action_template(design.consequence_pool_id),
+        action_template=resolve_cast_action_template(
+            design.consequence_pool_id, action_category=design.action_category
+        ),
     )
     if design.restriction_ids:
         tech.restrictions.add(*Restriction.objects.filter(id__in=design.restriction_ids))

--- a/src/world/magic/tests/test_technique_builder_api.py
+++ b/src/world/magic/tests/test_technique_builder_api.py
@@ -389,13 +389,26 @@ class ConsequencePoolChoiceAPITests(APITestCase):
         technique = Technique.objects.get(pk=resp.data["id"])
         self.assertEqual(technique.action_template_id, chosen.pk)
 
-    def test_author_without_pool_choice_uses_shared_default(self):
+    def test_author_without_pool_choice_uses_category_default(self):
+        """No pool choice: a physical technique routes to the combat 'Melee Attack'
+        template (#1706); a non-physical technique routes to the magic shared default."""
         from world.magic.seeds_cast import get_standalone_cast_template
 
+        # Physical → combat template.
         resp = self.client.post("/api/magic/techniques/author/", self._payload(), format="json")
         self.assertEqual(resp.status_code, 201, resp.data)
         technique = Technique.objects.get(pk=resp.data["id"])
-        self.assertEqual(technique.action_template_id, get_standalone_cast_template().pk)
+        self.assertEqual(technique.action_template.name, "Melee Attack")
+
+        # Non-physical → magic shared default.
+        mental_resp = self.client.post(
+            "/api/magic/techniques/author/",
+            self._payload(action_category="mental"),
+            format="json",
+        )
+        self.assertEqual(mental_resp.status_code, 201, mental_resp.data)
+        mental_technique = Technique.objects.get(pk=mental_resp.data["id"])
+        self.assertEqual(mental_technique.action_template_id, get_standalone_cast_template().pk)
 
     def test_author_with_invalid_pool_id_returns_400(self):
         resp = self.client.post(

--- a/src/world/magic/tests/test_technique_builder_service.py
+++ b/src/world/magic/tests/test_technique_builder_service.py
@@ -492,6 +492,40 @@ class ConsequencePoolCatalogResolutionTests(TestCase):
         self.assertEqual(resolved.pk, min(chosen.pk, duplicate.pk))
         self.assertEqual(resolved.pk, chosen.pk)
 
+    # -- #1706: physical-technique routing to the combat ActionTemplate -------------
+
+    def test_physical_no_pool_resolves_combat_template(self):
+        from actions.constants import ActionCategory
+        from world.magic.services.technique_builder import resolve_cast_action_template
+
+        template = resolve_cast_action_template(None, action_category=ActionCategory.PHYSICAL)
+        self.assertEqual(template.name, "Melee Attack")
+
+    def test_non_physical_no_pool_resolves_magic_template(self):
+        from actions.constants import ActionCategory
+        from world.magic.seeds_cast import TECHNIQUE_CAST_TEMPLATE_NAME
+        from world.magic.services.technique_builder import resolve_cast_action_template
+
+        template = resolve_cast_action_template(None, action_category=ActionCategory.MENTAL)
+        self.assertEqual(template.name, TECHNIQUE_CAST_TEMPLATE_NAME)
+
+    def test_explicit_pool_honored_regardless_of_category(self):
+        """An explicit catalog pool_id always wins (today's behavior preserved)."""
+        from actions.constants import ActionCategory
+        from world.magic.seeds_cast import (
+            TECHNIQUE_CAST_TEMPLATE_NAME,
+            ensure_technique_catalog_content,
+        )
+        from world.magic.services.technique_builder import resolve_cast_action_template
+
+        catalog_templates = ensure_technique_catalog_content()
+        chosen = catalog_templates[0]
+        template = resolve_cast_action_template(
+            chosen.consequence_pool_id, action_category=ActionCategory.PHYSICAL
+        )
+        self.assertEqual(template.pk, chosen.pk)
+        self.assertNotEqual(template.name, TECHNIQUE_CAST_TEMPLATE_NAME)
+
 
 class BuildTechniqueConsequencePoolTests(TestCase):
     def _minimal_design_kwargs(self, **overrides):
@@ -515,13 +549,21 @@ class BuildTechniqueConsequencePoolTests(TestCase):
         kwargs.update(overrides)
         return TechniqueDesignInput(**kwargs)
 
-    def test_no_pool_choice_defaults_to_shared_template(self):
+    def test_no_pool_choice_defaults_to_category_template(self):
+        """No pool choice: a physical design routes to the combat template (#1706),
+        a non-physical design routes to the magic shared template."""
         from world.magic.seeds_cast import get_standalone_cast_template
         from world.magic.services.technique_builder import build_technique
 
+        # Physical → combat 'Melee Attack' template.
         design = self._minimal_design_kwargs()
         tech = build_technique(design, creator=None)
-        self.assertEqual(tech.action_template_id, get_standalone_cast_template().pk)
+        self.assertEqual(tech.action_template.name, "Melee Attack")
+
+        # Non-physical → magic shared cast template.
+        mental_design = self._minimal_design_kwargs(action_category="mental")
+        mental_tech = build_technique(mental_design, creator=None)
+        self.assertEqual(mental_tech.action_template_id, get_standalone_cast_template().pk)
 
     def test_catalog_pool_choice_assigns_matching_template(self):
         from world.magic.seeds_cast import ensure_technique_catalog_content

--- a/src/world/seeds/clusters.py
+++ b/src/world/seeds/clusters.py
@@ -43,6 +43,12 @@ def _seed_checks() -> None:
     seed_check_resolution_tables()
 
 
+def _seed_combat_checks() -> None:
+    from world.seeds.combat_checks import seed_combat_check_content  # noqa: PLC0415
+
+    seed_combat_check_content()
+
+
 def _seed_social() -> None:
     from world.seeds.social_checks import seed_social_check_content  # noqa: PLC0415
 
@@ -130,6 +136,11 @@ CLUSTER_SEEDERS: dict[str, Callable[[], None]] = {
     # so the canonical rows exist before the other clusters run. (Idempotency
     # holds regardless of order — magic also ensures the spine itself.)
     "checks": _seed_checks,
+    # Combat checks: the Melee Combat skill catalog + weapon-class specializations
+    # + the Melee Attack CheckType (stat + skill + spec). After "checks" for the
+    # resolution spine; before "social" and "combat" (the penetration/flee retrofits
+    # in "combat" depend on the Melee Combat skill existing) (#1706).
+    "combat_checks": _seed_combat_checks,
     # Social checks: retrofit the social CheckTypes to stat + skill (+ spec) and seed the
     # Persuasion/Performance skills + their specializations (#1688). After "checks" so the
     # resolution spine exists; authoritative, so it corrects the placeholder stat+stat seed.
@@ -227,6 +238,10 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
 
     return {
         "checks": [CheckType, ResultChart],
+        # Combat checks: the Melee Combat skill + weapon-class specializations + the
+        # Melee Attack CheckType (stat + skill + spec) (#1706). Shared spine/skill rows
+        # counted under "checks"; appears as a seeded cluster.
+        "combat_checks": [],
         # Social: seeds Persuasion/Performance skills + their specializations + the
         # stat+skill(+spec) social CheckType compositions (#1688).
         "social": [Specialization],

--- a/src/world/seeds/combat_checks.py
+++ b/src/world/seeds/combat_checks.py
@@ -1,0 +1,125 @@
+"""Combat-skill catalog + Melee Attack check composition (#1706).
+
+Stands up the ``Melee Combat`` parent skill (Trait-backed,
+``TraitCategory.COMBAT``) with three weapon-class specializations
+(Small / Medium / Heavy Weapons — aligned to
+``progression.services.scene_integration``'s ``weapon_map`` keys) and a
+``Melee Attack`` ``CheckType`` composed as ``strength + Melee Combat
+(+ owned weapon specialization)``. Mirrors ``world/seeds/social_checks.py``
+(#1689).
+
+Authoritative + idempotent: the ``Melee Attack`` composition is rewritten on
+each run (delete + recreate ``CheckTypeTrait`` / ``CheckTypeSpecialization``)
+so a re-seed converges, while ``Skill`` / ``Specialization`` / ``Trait`` rows
+use ``get_or_create`` (preserving staff edits). Weights are PLACEHOLDER (1.00)
+per "build the mechanism, defer the magnitudes".
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+# (specialization name) — weapon-class specs under Melee Combat.
+_WEAPON_SPECIALIZATIONS: list[str] = ["Small Weapons", "Medium Weapons", "Heavy Weapons"]
+
+_MELEE_ATTACK_CHECK_TYPE_NAME = "Melee Attack"
+_MELEE_SKILL_NAME = "Melee Combat"
+_MELEE_SKILL_TOOLTIP = "Fighting with melee weapons — the trained combat skill."
+
+
+def _ensure_combat_category():
+    """Get or create the Combat CheckCategory."""
+    from world.checks.models import CheckCategory  # noqa: PLC0415
+
+    category, _ = CheckCategory.objects.get_or_create(
+        name="Combat",
+        defaults={
+            "description": "Checks involving physical combat.",
+            "display_order": 20,
+        },
+    )
+    return category
+
+
+def ensure_melee_combat_skill():
+    """Seed the Melee Combat Skill + its backing SKILL Trait (idempotent)."""
+    from world.skills.models import Skill  # noqa: PLC0415
+    from world.traits.models import Trait, TraitCategory, TraitType  # noqa: PLC0415
+
+    trait, _ = Trait.objects.get_or_create(
+        name=_MELEE_SKILL_NAME,
+        defaults={
+            "trait_type": TraitType.SKILL,
+            "category": TraitCategory.COMBAT,
+            "is_public": True,
+        },
+    )
+    skill, _ = Skill.objects.get_or_create(
+        trait=trait,
+        defaults={"tooltip": _MELEE_SKILL_TOOLTIP, "display_order": 0, "is_active": True},
+    )
+    return skill
+
+
+def ensure_weapon_specializations(skill) -> dict:
+    """Seed the three weapon-class Specializations under Melee Combat (idempotent)."""
+    from world.skills.models import Specialization  # noqa: PLC0415
+
+    specs: dict[str, object] = {}
+    for order, name in enumerate(_WEAPON_SPECIALIZATIONS):
+        spec, _ = Specialization.objects.get_or_create(
+            parent_skill=skill,
+            name=name,
+            defaults={"display_order": order, "is_active": True},
+        )
+        specs[name] = spec
+    return specs
+
+
+def ensure_melee_attack_check_type(skill, specs) -> object:
+    """Seed the Melee Attack CheckType: strength + Melee Combat (+ weapon specs).
+
+    Authoritative rewrite (mirrors social_checks.py) — clears the type's prior
+    composition then writes the stat + skill legs, so a re-seed converges. The
+    weapon-class specializations fold in only when the character owns them
+    (#1688 engine).
+    """
+    from world.checks.models import (  # noqa: PLC0415
+        CheckType,
+        CheckTypeSpecialization,
+        CheckTypeTrait,
+    )
+    from world.traits.factories import StatTraitFactory  # noqa: PLC0415
+    from world.traits.models import TraitCategory  # noqa: PLC0415
+
+    check_type, _ = CheckType.objects.get_or_create(
+        name=_MELEE_ATTACK_CHECK_TYPE_NAME,
+        category=_ensure_combat_category(),
+        defaults={"description": "A melee attack roll: strength + Melee Combat."},
+    )
+    CheckTypeTrait.objects.filter(check_type=check_type).delete()
+    CheckTypeSpecialization.objects.filter(check_type=check_type).delete()
+
+    CheckTypeTrait.objects.create(
+        check_type=check_type,
+        trait=StatTraitFactory(name="strength", category=TraitCategory.PHYSICAL),
+        weight=Decimal("1.00"),
+    )
+    CheckTypeTrait.objects.create(
+        check_type=check_type,
+        trait=skill.trait,
+        weight=Decimal("1.00"),
+    )
+    weight = Decimal("1.00")
+    for spec in specs.values():
+        CheckTypeSpecialization.objects.create(
+            check_type=check_type, specialization=spec, weight=weight
+        )
+    return check_type
+
+
+def seed_combat_check_content() -> None:
+    """Cluster entry — seed the Melee Combat skill catalog + Melee Attack check (#1706)."""
+    skill = ensure_melee_combat_skill()
+    specs = ensure_weapon_specializations(skill)
+    ensure_melee_attack_check_type(skill, specs)

--- a/src/world/seeds/tests/test_clusters.py
+++ b/src/world/seeds/tests/test_clusters.py
@@ -10,6 +10,7 @@ class TestClusterRegistry(TestCase):
             set(CLUSTER_SEEDERS),
             {
                 "checks",
+                "combat_checks",
                 "social",
                 "investigation",
                 "social_relationships",

--- a/src/world/seeds/tests/test_combat_checks.py
+++ b/src/world/seeds/tests/test_combat_checks.py
@@ -1,0 +1,47 @@
+"""Melee Combat skill catalog + Melee Attack check composition (#1706)."""
+
+from django.test import TestCase
+
+from world.seeds.combat_checks import seed_combat_check_content
+
+
+class CombatCheckSeedTests(TestCase):
+    def test_melee_combat_skill_seeded(self):
+        from world.skills.models import Skill
+        from world.traits.models import TraitCategory, TraitType
+
+        seed_combat_check_content()
+        skill = Skill.objects.get(trait__name="Melee Combat")
+        self.assertEqual(skill.trait.trait_type, TraitType.SKILL)
+        self.assertEqual(skill.trait.category, TraitCategory.COMBAT)
+
+    def test_weapon_specializations_seeded(self):
+        from world.skills.models import Specialization
+
+        seed_combat_check_content()
+        specs = {
+            s.name for s in Specialization.objects.filter(parent_skill__trait__name="Melee Combat")
+        }
+        self.assertEqual(specs, {"Small Weapons", "Medium Weapons", "Heavy Weapons"})
+
+    def test_melee_attack_composition(self):
+        from world.checks.models import (
+            CheckType,
+        )
+
+        seed_combat_check_content()
+        ct = CheckType.objects.get(name="Melee Attack")
+        trait_names = {t.trait.name for t in ct.traits.all()}  # type: ignore[attr-defined]
+        self.assertEqual(trait_names, {"strength", "Melee Combat"})
+        spec_names = {
+            s.specialization.name
+            for s in ct.specializations.all()  # type: ignore[attr-defined]
+        }
+        self.assertEqual(spec_names, {"Small Weapons", "Medium Weapons", "Heavy Weapons"})
+
+    def test_seed_is_idempotent(self):
+        from world.checks.models import CheckType
+
+        seed_combat_check_content()
+        seed_combat_check_content()  # re-run
+        self.assertEqual(CheckType.objects.filter(name="Melee Attack").count(), 1)

--- a/src/world/vitals/services.py
+++ b/src/world/vitals/services.py
@@ -235,11 +235,19 @@ def _ensure_survival_category() -> CheckCategory:
 
 
 def _ensure_endurance_check_type() -> CheckType:
-    """Get or create the Endurance CheckType, creating it if absent.
+    """Get or create the Endurance CheckType, seeding its stamina trait (#1706).
 
-    Used for both knockout and permanent wound resistance checks. Seeded on
-    first use — trait-weightings are authored content and not seeded here.
+    Used for both knockout and permanent wound resistance checks. The single
+    stamina stat leg is the tenet-permitted resist composition; staff may add
+    further trait rows via admin. Idempotent — ``get_or_create`` preserves any
+    existing staff weight edit on the (check_type, trait) pair.
     """
+    from decimal import Decimal  # noqa: PLC0415
+
+    from world.checks.models import CheckTypeTrait  # noqa: PLC0415
+    from world.traits.factories import StatTraitFactory  # noqa: PLC0415
+    from world.traits.models import TraitCategory  # noqa: PLC0415
+
     check, _ = CheckType.objects.get_or_create(
         name=ENDURANCE_CHECK_NAME,
         defaults={
@@ -247,21 +255,38 @@ def _ensure_endurance_check_type() -> CheckType:
             "description": "Resist knockout and permanent wounds.",
         },
     )
+    CheckTypeTrait.objects.get_or_create(
+        check_type=check,
+        trait=StatTraitFactory(name="stamina", category=TraitCategory.PHYSICAL),
+        defaults={"weight": Decimal("1.00")},
+    )
     return check
 
 
 def _ensure_death_check_type() -> CheckType:
-    """Get or create the Mortal Resolve CheckType, creating it if absent.
+    """Get or create the Mortal Resolve CheckType, seeding its willpower trait (#1706).
 
     Used for death resistance when a character is brought below zero health.
-    Seeded on first use — trait-weightings are authored content and not seeded here.
+    The single willpower stat leg is the tenet-permitted resist composition.
+    Idempotent — ``get_or_create`` preserves any existing staff weight edit.
     """
+    from decimal import Decimal  # noqa: PLC0415
+
+    from world.checks.models import CheckTypeTrait  # noqa: PLC0415
+    from world.traits.factories import StatTraitFactory  # noqa: PLC0415
+    from world.traits.models import TraitCategory  # noqa: PLC0415
+
     check, _ = CheckType.objects.get_or_create(
         name=DEATH_CHECK_NAME,
         defaults={
             "category": _ensure_survival_category(),
             "description": "Resist death when brought below zero health.",
         },
+    )
+    CheckTypeTrait.objects.get_or_create(
+        check_type=check,
+        trait=StatTraitFactory(name="willpower", category=TraitCategory.META),
+        defaults={"weight": Decimal("1.00")},
     )
     return check
 

--- a/src/world/vitals/tests/test_check_compositions.py
+++ b/src/world/vitals/tests/test_check_compositions.py
@@ -1,0 +1,46 @@
+"""Resist-check compositions seed the named stat (#1706).
+
+The four resist-style checks previously rolled with zero CheckTypeTrait rows
+(a coin-flip on trait_points=0). This suite asserts each now carries its
+intended single-stat leg (tenet-permitted for resist checks).
+"""
+
+from django.test import TestCase
+
+from world.areas.positioning.constants import CATCH_CHECK_TYPE_NAME
+
+
+class ResistCheckCompositionTests(TestCase):
+    def test_endurance_has_stamina_trait(self):
+        from world.vitals.services import _ensure_endurance_check_type
+
+        ct = _ensure_endurance_check_type()
+        trait = ct.traits.get().trait  # type: ignore[attr-defined]
+        self.assertEqual(trait.name, "stamina")
+
+    def test_mortal_resolve_has_willpower_trait(self):
+        from world.vitals.services import _ensure_death_check_type
+
+        ct = _ensure_death_check_type()
+        trait = ct.traits.get().trait  # type: ignore[attr-defined]
+        self.assertEqual(trait.name, "willpower")
+
+    def test_reflexes_has_wits_trait(self):
+        from world.areas.positioning.plummet_content import ensure_catch_content
+        from world.checks.models import CheckType
+
+        ensure_catch_content()
+        ct = CheckType.objects.get(name=CATCH_CHECK_TYPE_NAME)
+        trait = ct.traits.get().trait  # type: ignore[attr-defined]
+        self.assertEqual(trait.name, "wits")
+
+    def test_escalation_pace_has_wits_trait(self):
+        from world.checks.models import CheckType
+        from world.combat.factories import EscalationCurveFactory
+
+        # EscalationCurveFactory.pace_check_type lazy_attribute seeds on access.
+        f = EscalationCurveFactory()
+        _ = f.pace_check_type  # triggers the lazy_attribute
+        ct = CheckType.objects.get(name="Escalation Pace")
+        trait = ct.traits.get().trait  # type: ignore[attr-defined]
+        self.assertEqual(trait.name, "wits")


### PR DESCRIPTION
Closes #1706

## Summary

Retrofits the seven combat/vitals CheckTypes to tenet-conforming (stat + skill + specialization) compositions via seed data, plus one engine branch routing physical techniques to a combat ActionTemplate.

**Resist checks** (previously rolled with zero CheckTypeTrait rows — a real bug): Reflexes←wits, Escalation Pace←wits, Endurance←stamina, Mortal Resolve←willpower (single-stat resist, tenet-permitted).

**Stat+stat retrofits**: penetration = willpower + intellect + Melee Combat; flee = agility + wits + Melee Combat (authoritative delete+rewrite, mirroring #1689).

**New combat-skill catalog**: Melee Combat skill (TraitCategory.COMBAT) + Small/Medium/Heavy Weapons specializations (aligned to progression's weapon_map) + a Melee Attack CheckType (strength + Melee Combat + weapon spec).

**Combat offense check**: resolve_cast_action_template gains an action_category kwarg; a PHYSICAL technique with no chosen pool resolves to the combat Melee Attack ActionTemplate instead of the magic fallback. Threaded through build_technique, CG finalization, and the web author serializer.

No new models, no migrations. Existing default-PHYSICAL techniques now route to the combat check (the intended correction — a physical attack should roll a combat check, not a magic one).

## Follow-ups filed

- #1994
- #1995

## Notes

- Spec: reviewed & approved on #1706 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main; no conflicts.

<!-- last-addressed-comment: 0 -->