### PR TITLE
chore: resolve 50 SonarCloud-tagged issues (S1192, S3776, S3735)

### DIFF
--- a/frontend/src/buildings/queries.ts
+++ b/frontend/src/buildings/queries.ts
@@ -131,9 +131,9 @@ export function useRoomBuilderAction(characterId: number, buildingId: number | n
     onSuccess: (message: string) => {
       toast.success(message);
       if (buildingId != null) {
-        void queryClient.invalidateQueries({ queryKey: buildingKeys.manager(buildingId) });
+        queryClient.invalidateQueries({ queryKey: buildingKeys.manager(buildingId) });
       }
-      void queryClient.invalidateQueries({ queryKey: [...buildingKeys.all, 'room-comfort'] });
+      queryClient.invalidateQueries({ queryKey: [...buildingKeys.all, 'room-comfort'] });
     },
     onError: (error: Error) => {
       toast.error(error.message);

--- a/frontend/src/game/components/RoomPanel.tsx
+++ b/frontend/src/game/components/RoomPanel.tsx
@@ -63,7 +63,7 @@ export function RoomPanel({
     onSuccess: (message: string) => {
       toast.success(message);
       if (room) {
-        void queryClient.invalidateQueries({ queryKey: buildingKeys.forRoom(room.id) });
+        queryClient.invalidateQueries({ queryKey: buildingKeys.forRoom(room.id) });
       }
       if (character) {
         send(character, 'look');

--- a/frontend/src/org_books/pages/OrgBooksPage.tsx
+++ b/frontend/src/org_books/pages/OrgBooksPage.tsx
@@ -160,7 +160,7 @@ function OrgBooksInner({ orgId }: { orgId: number }) {
             if (!dialogOpen) setSummon(null);
           }}
           onConcluded={() => {
-            void queryClient.invalidateQueries({ queryKey: orgBooksKeys.books(orgId) });
+            queryClient.invalidateQueries({ queryKey: orgBooksKeys.books(orgId) });
           }}
         />
       )}

--- a/src/actions/definitions/locations.py
+++ b/src/actions/definitions/locations.py
@@ -30,6 +30,8 @@ from actions.prerequisites import (
 )
 from actions.types import ActionResult, TargetType
 
+_NOT_PART_OF_BUILDING_MESSAGE = "This room isn't part of a building."
+
 if TYPE_CHECKING:
     from actions.types import ActionContext
 
@@ -466,7 +468,7 @@ class SetBuildingStyleAction(_RoomBuilderAction):
             return ActionResult(success=False, message=_no_room_message(kwargs))
         building = building_for_room(room)
         if building is None:
-            return ActionResult(success=False, message="This room isn't part of a building.")
+            return ActionResult(success=False, message=_NOT_PART_OF_BUILDING_MESSAGE)
         style_name = (kwargs.get("style") or "").strip()
         if not style_name:
             options = ", ".join(
@@ -612,7 +614,7 @@ class CommissionDecorationAction(_RoomBuilderAction):
             return ActionResult(success=False, message=_no_room_message(kwargs))
         building = building_for_room(room)
         if building is None:
-            return ActionResult(success=False, message="This room isn't part of a building.")
+            return ActionResult(success=False, message=_NOT_PART_OF_BUILDING_MESSAGE)
         template = ProjectTemplate.objects.filter(pk=kwargs.get("template_id")).first()
         if template is None:
             return ActionResult(success=False, message="No such decoration template.")
@@ -656,7 +658,7 @@ class StartExtensionAction(_RoomBuilderAction):
             return ActionResult(success=False, message=_no_room_message(kwargs))
         building = building_for_room(room)
         if building is None:
-            return ActionResult(success=False, message="This room isn't part of a building.")
+            return ActionResult(success=False, message=_NOT_PART_OF_BUILDING_MESSAGE)
         try:
             added = int(kwargs.get("added_budget") or 0)
         except (TypeError, ValueError):
@@ -801,7 +803,7 @@ class StartBuildingRenovationAction(_RoomBuilderAction):
             return ActionResult(success=False, message=_no_room_message(kwargs))
         building = building_for_room(room)
         if building is None:
-            return ActionResult(success=False, message="This room isn't part of a building.")
+            return ActionResult(success=False, message=_NOT_PART_OF_BUILDING_MESSAGE)
         target = (kwargs.get("target_kind") or "").strip()
         if not target:
             lines = [

--- a/src/actions/definitions/ships.py
+++ b/src/actions/definitions/ships.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
 #: (hull is ``Building.fortification_level``, raised via ``start_ship_hull_upgrade``).
 _HULL_STAT = "hull"
 
+_NO_SUCH_SHIP_MESSAGE = "No such ship."
+
 
 def _resolve_ship(actor: ObjectDB, kwargs: dict[str, Any]) -> ShipDetails | None:
     """The action's target ship: the ``ship`` kwarg (a ``ShipDetails``
@@ -140,7 +142,7 @@ class UpgradeShipAction(Action):
 
         ship = _resolve_ship(actor, kwargs)
         if ship is None:
-            return ActionResult(success=False, message="No such ship.")
+            return ActionResult(success=False, message=_NO_SUCH_SHIP_MESSAGE)
         stat = kwargs.get("stat")
         target_level = kwargs.get("target_level")
         if not stat or target_level is None:
@@ -198,7 +200,7 @@ class RepairShipAction(Action):
 
         ship = _resolve_ship(actor, kwargs)
         if ship is None:
-            return ActionResult(success=False, message="No such ship.")
+            return ActionResult(success=False, message=_NO_SUCH_SHIP_MESSAGE)
         persona = active_persona_for_sheet(actor.sheet_data)
         project = start_ship_repair(persona=persona, ship=ship)
         return ActionResult(
@@ -231,7 +233,7 @@ class ShipStatusAction(Action):
     ) -> ActionResult:
         ship = _resolve_ship(actor, kwargs)
         if ship is None:
-            return ActionResult(success=False, message="No such ship.")
+            return ActionResult(success=False, message=_NO_SUCH_SHIP_MESSAGE)
         data = {
             "ship_id": ship.pk,
             "effective_handling": ship.effective_handling(),

--- a/src/actions/prerequisites.py
+++ b/src/actions/prerequisites.py
@@ -11,6 +11,9 @@ from typing import TYPE_CHECKING, Any
 
 CANNOT_BE_USED_MESSAGE = "That can't be used."
 CANNOT_SEE_MESSAGE = "You can't see that."
+NO_ACTIVE_CHARACTER_MESSAGE = "No active character."
+ONLY_CHARACTERS_MESSAGE = "Only characters can do that."
+NOT_HOLDING_MESSAGE = "You aren't holding that."
 
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
@@ -58,7 +61,7 @@ class HasCharacterSheetPrerequisite(Prerequisite):
         try:
             actor.sheet_data  # noqa: B018
         except (AttributeError, ObjectDoesNotExist):
-            return False, "No active character."
+            return False, NO_ACTIVE_CHARACTER_MESSAGE
         return True, ""
 
 
@@ -82,7 +85,7 @@ class HoldsCapabilityPrerequisite(Prerequisite):
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
-            return False, "No active character."
+            return False, NO_ACTIVE_CHARACTER_MESSAGE
         capability = CapabilityType.objects.filter(name=self.capability_name).first()
         if capability is None:
             return False, "You cannot shift forms at will."
@@ -129,7 +132,7 @@ class IsRoomTenantPrerequisite(Prerequisite):
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
-            return False, "Only characters can do that."
+            return False, ONLY_CHARACTERS_MESSAGE
         persona = active_persona_for_sheet(sheet)
         if is_tenant(persona, room):
             return True, ""
@@ -211,7 +214,7 @@ class IsExitRoomOwnerPrerequisite(Prerequisite):
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
-            return False, "Only characters can do that."
+            return False, ONLY_CHARACTERS_MESSAGE
         persona = active_persona_for_sheet(sheet)
         if is_owner(persona, room) or is_tenant(persona, room):
             return True, ""
@@ -238,7 +241,7 @@ class HoldsItemPrerequisite(Prerequisite):
         if instance is None:
             return False, "That isn't an item."
         if not ItemState(instance, context=None).is_in_possession(actor):
-            return False, "You aren't holding that."
+            return False, NOT_HOLDING_MESSAGE
         return True, ""
 
 
@@ -260,7 +263,7 @@ class OwnsOutfitPrerequisite(Prerequisite):
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
-            return False, "No active character."
+            return False, NO_ACTIVE_CHARACTER_MESSAGE
         if outfit.character_sheet_id == sheet.pk:
             return True, ""
         return False, "That isn't your outfit."
@@ -296,9 +299,9 @@ class OwnsItemInstancePrerequisite(Prerequisite):
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
-            return False, "You aren't holding that."
+            return False, NOT_HOLDING_MESSAGE
         if item_instance.holder_character_sheet_id != sheet.pk:
-            return False, "You aren't holding that."
+            return False, NOT_HOLDING_MESSAGE
         return True, ""
 
 
@@ -532,7 +535,7 @@ class IsShipOwnerPrerequisite(Prerequisite):
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
-            return False, "Only characters can do that."
+            return False, ONLY_CHARACTERS_MESSAGE
         persona = active_persona_for_sheet(sheet)
         if ship.building.owner_persona_id == persona.pk:
             return True, ""

--- a/src/commands/battle.py
+++ b/src/commands/battle.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
     from actions.types import ActionResult
     from world.battles.models import BattleParticipant, BattleUnit
 
+_PLACE_PREFIX = "place "
+
 
 class CmdBattle(ArxCommand):
     """Manage your participation in a large-scale battle.
@@ -396,10 +398,10 @@ class CmdBattle(ArxCommand):
                 target_side=target_side,
             )
 
-        if name.lower().startswith("place "):  # noqa: STRING_LITERAL
+        if name.lower().startswith(_PLACE_PREFIX):  # noqa: STRING_LITERAL
             from world.battles.models import BattlePlace  # noqa: PLC0415
 
-            place_name = name[len("place ") :].strip()
+            place_name = name[len(_PLACE_PREFIX) :].strip()
             place = BattlePlace.objects.filter(
                 battle=participant.battle, name__iexact=place_name
             ).first()
@@ -453,10 +455,10 @@ class CmdBattle(ArxCommand):
         from world.battles.constants import BattleActionScope  # noqa: PLC0415
         from world.battles.models import BattlePlace  # noqa: PLC0415
 
-        if not name.lower().startswith("place "):  # noqa: STRING_LITERAL
+        if not name.lower().startswith(_PLACE_PREFIX):  # noqa: STRING_LITERAL
             msg = f"Usage: battle declare {verb} place <name> with <technique>"
             raise CommandError(msg)
-        place_name = name[len("place ") :].strip()
+        place_name = name[len(_PLACE_PREFIX) :].strip()
         participant = self._resolve_participant()
         technique = self._resolve_technique(participant, technique_name)
         place = BattlePlace.objects.filter(
@@ -492,9 +494,9 @@ class CmdBattle(ArxCommand):
             f"Usage: battle declare {verb} place <name> fortification "
             f"<wall|gate|battlement> with <technique>"
         )
-        if not name.lower().startswith("place "):  # noqa: STRING_LITERAL
+        if not name.lower().startswith(_PLACE_PREFIX):  # noqa: STRING_LITERAL
             raise CommandError(usage)
-        remainder = name[len("place ") :]
+        remainder = name[len(_PLACE_PREFIX) :]
         if " fortification " not in remainder:  # noqa: STRING_LITERAL
             raise CommandError(usage)
         place_name, kind_token = remainder.split(" fortification ", 1)
@@ -549,10 +551,10 @@ class CmdBattle(ArxCommand):
                 scope=BattleActionScope.BATTLE,
             )
 
-        if name.lower().startswith("place "):  # noqa: STRING_LITERAL
+        if name.lower().startswith(_PLACE_PREFIX):  # noqa: STRING_LITERAL
             from world.battles.models import BattlePlace  # noqa: PLC0415
 
-            place_name = name[len("place ") :].strip()
+            place_name = name[len(_PLACE_PREFIX) :].strip()
             place = BattlePlace.objects.filter(
                 battle=participant.battle, name__iexact=place_name
             ).first()

--- a/src/commands/currency.py
+++ b/src/commands/currency.py
@@ -19,6 +19,7 @@ from commands.command import ArxCommand
 from commands.exceptions import CommandError
 
 _SECURE_USAGE = "Usage: secure <container>=<open|friends|owner_only>"
+_DEFAULT_LOCKS = "cmd:all()"
 
 
 class CmdDeposit(ArxCommand):
@@ -28,7 +29,7 @@ class CmdDeposit(ArxCommand):
     """
 
     key = "deposit"
-    locks = "cmd:all()"
+    locks = _DEFAULT_LOCKS
     action = DepositCoinsAction()
 
     def resolve_action_args(self) -> dict[str, Any]:
@@ -48,7 +49,7 @@ class CmdSteal(ArxCommand):
     """
 
     key = "steal"
-    locks = "cmd:all()"
+    locks = _DEFAULT_LOCKS
     action = StealAction()
 
     def resolve_action_args(self) -> dict[str, Any]:
@@ -75,7 +76,7 @@ class CmdSecure(ArxCommand):
     """
 
     key = "secure"
-    locks = "cmd:all()"
+    locks = _DEFAULT_LOCKS
     action = SetContainerPolicyAction()
 
     def resolve_action_args(self) -> dict[str, Any]:

--- a/src/world/battles/services.py
+++ b/src/world/battles/services.py
@@ -520,7 +520,7 @@ def begin_battle_round(*, battle: Battle) -> BattleRound:
 # ---------------------------------------------------------------------------
 
 
-def declare_battle_action(  # noqa: PLR0913, PLR0912, C901 - many declaration facets + checks
+def declare_battle_action(  # noqa: PLR0913, C901 - many declaration facets + checks
     *,
     participant: BattleParticipant,
     action_kind: str,
@@ -603,29 +603,20 @@ def declare_battle_action(  # noqa: PLR0913, PLR0912, C901 - many declaration fa
         raise TechniqueNotBattleReadyError
 
     if (
-        action_kind in (BattleActionKind.REPEL, BattleActionKind.HOLD)
+        action_kind in (BattleActionKind.REPEL, BattleActionKind.HOLD, BattleActionKind.REPOSITION)
         and scope != BattleActionScope.PLACE
     ):
         raise PlaceScopeRequiredError
 
-    if action_kind == BattleActionKind.REPOSITION and scope != BattleActionScope.PLACE:
-        raise PlaceScopeRequiredError
-
     if action_kind == BattleActionKind.SET_ENVIRONMENT:
-        if scope not in (BattleActionScope.BATTLE, BattleActionScope.PLACE):
-            raise InvalidEnvironmentScopeError
-        if technique.target_weather_type_id is None:
-            raise MissingEnvironmentTargetError
+        _validate_environment_action(scope=scope, technique=technique)
 
     if action_kind == BattleActionKind.REPOSITION:
         _validate_vehicle_command(participant=participant, target_place=target_place)
     elif scope in (BattleActionScope.PLACE, BattleActionScope.SIDE, BattleActionScope.BATTLE):
         _validate_command_scope(participant=participant, scope=scope)
 
-    if scope == BattleActionScope.PLACE and target_place is None:
-        raise MissingScopeTargetError
-    if scope == BattleActionScope.SIDE and target_side is None:
-        raise MissingScopeTargetError
+    _validate_scope_target(scope=scope, target_place=target_place, target_side=target_side)
 
     if (
         action_kind in (BattleActionKind.STRIKE, BattleActionKind.ROUT)
@@ -640,18 +631,7 @@ def declare_battle_action(  # noqa: PLR0913, PLR0912, C901 - many declaration fa
         and target_unit is not None
         and participant.place_id is not None
     ):
-        # A vehicle's own BattleUnit never has place set (see BattleVehicle's
-        # docstring) — resolve its paired vehicle's place so a STRIKE against
-        # the vehicle's own unit is gated the same as a BREACH against its hull.
-        target_unit_place = target_unit.place
-        if target_unit_place is None and hasattr(target_unit, "vehicle"):  # noqa: GETATTR_LITERAL
-            target_unit_place = target_unit.vehicle.place
-        if (
-            target_unit_place is not None
-            and target_unit_place.pk != participant.place_id
-            and not places_overlap(target_unit_place, participant.place)
-        ):
-            raise PlacesDoNotOverlapError
+        _validate_unit_place_overlap(participant=participant, target_unit=target_unit)
 
     if action_kind in (BattleActionKind.BREACH, BattleActionKind.FORTIFY):
         _validate_fortification_target(
@@ -659,15 +639,11 @@ def declare_battle_action(  # noqa: PLR0913, PLR0912, C901 - many declaration fa
             action_kind=action_kind,
             target_fortification=target_fortification,
         )
-        if (
-            action_kind == BattleActionKind.BREACH
-            and target_fortification is not None
-            and hasattr(target_fortification.place, "vehicle")  # noqa: GETATTR_LITERAL
-            and participant.place_id is not None
-            and target_fortification.place_id != participant.place_id
-            and not places_overlap(target_fortification.place, participant.place)
-        ):
-            raise PlacesDoNotOverlapError
+        _validate_fortification_place_overlap(
+            participant=participant,
+            action_kind=action_kind,
+            target_fortification=target_fortification,
+        )
 
     declaration, _ = BattleActionDeclaration.objects.update_or_create(
         battle_round=battle_round,
@@ -687,6 +663,65 @@ def declare_battle_action(  # noqa: PLR0913, PLR0912, C901 - many declaration fa
         },
     )
     return declaration
+
+
+def _validate_environment_action(*, scope: str, technique: Technique) -> None:
+    """Validate a SET_ENVIRONMENT declaration's scope and weather target."""
+    if scope not in (BattleActionScope.BATTLE, BattleActionScope.PLACE):
+        raise InvalidEnvironmentScopeError
+    if technique.target_weather_type_id is None:
+        raise MissingEnvironmentTargetError
+
+
+def _validate_scope_target(
+    *,
+    scope: str,
+    target_place: BattlePlace | None,
+    target_side: BattleSide | None,
+) -> None:
+    """Raise ``MissingScopeTargetError`` when a scope's required target is absent."""
+    if scope == BattleActionScope.PLACE and target_place is None:
+        raise MissingScopeTargetError
+    if scope == BattleActionScope.SIDE and target_side is None:
+        raise MissingScopeTargetError
+
+
+def _validate_unit_place_overlap(
+    *, participant: BattleParticipant, target_unit: BattleUnit
+) -> None:
+    """Raise ``PlacesDoNotOverlapError`` when a UNIT target is out of range.
+
+    A vehicle's own BattleUnit never has place set (see BattleVehicle's
+    docstring) — resolve its paired vehicle's place so a STRIKE against the
+    vehicle's own unit is gated the same as a BREACH against its hull.
+    """
+    target_unit_place = target_unit.place
+    if target_unit_place is None and hasattr(target_unit, "vehicle"):  # noqa: GETATTR_LITERAL
+        target_unit_place = target_unit.vehicle.place
+    if (
+        target_unit_place is not None
+        and target_unit_place.pk != participant.place_id
+        and not places_overlap(target_unit_place, participant.place)
+    ):
+        raise PlacesDoNotOverlapError
+
+
+def _validate_fortification_place_overlap(
+    *,
+    participant: BattleParticipant,
+    action_kind: str,
+    target_fortification: Fortification | None,
+) -> None:
+    """Raise ``PlacesDoNotOverlapError`` when a BREACH target is out of range."""
+    if (
+        action_kind == BattleActionKind.BREACH
+        and target_fortification is not None
+        and hasattr(target_fortification.place, "vehicle")  # noqa: GETATTR_LITERAL
+        and participant.place_id is not None
+        and target_fortification.place_id != participant.place_id
+        and not places_overlap(target_fortification.place, participant.place)
+    ):
+        raise PlacesDoNotOverlapError
 
 
 def _validate_command_scope(*, participant: BattleParticipant, scope: str) -> None:

--- a/src/world/buildings/factories.py
+++ b/src/world/buildings/factories.py
@@ -19,6 +19,7 @@ from world.buildings.models import (
 # factories below. Centralized to avoid the duplicated-literal SonarCloud
 # smell (python:S1192).
 _PERSONA_FACTORY = "world.scenes.factories.PersonaFactory"
+_PROJECT_FACTORY_PATH = "world.projects.factories.ProjectFactory"
 
 
 class BuildingKindFactory(DjangoModelFactory):
@@ -94,7 +95,7 @@ class BuildingConstructionDetailsFactory(DjangoModelFactory):
     class Meta:
         model = BuildingConstructionDetails
 
-    project = factory.SubFactory("world.projects.factories.ProjectFactory")
+    project = factory.SubFactory(_PROJECT_FACTORY_PATH)
     permit_details = factory.SubFactory(BuildingPermitDetailsFactory)
     ward = factory.SubFactory("world.areas.factories.AreaFactory", level=30)  # WARD
     target_size = 5
@@ -106,7 +107,7 @@ class FortificationUpgradeDetailsFactory(DjangoModelFactory):
     class Meta:
         model = FortificationUpgradeDetails
 
-    project = factory.SubFactory("world.projects.factories.ProjectFactory")
+    project = factory.SubFactory(_PROJECT_FACTORY_PATH)
     building = factory.SubFactory(BuildingFactory)
     target_level = 1
     applied_at = None
@@ -116,7 +117,7 @@ class BuildingRenovationDetailsFactory(DjangoModelFactory):
     class Meta:
         model = BuildingRenovationDetails
 
-    project = factory.SubFactory("world.projects.factories.ProjectFactory")
+    project = factory.SubFactory(_PROJECT_FACTORY_PATH)
     building = factory.SubFactory(BuildingFactory)
     target_kind = factory.SubFactory(BuildingKindFactory)
     applied_at = None
@@ -126,7 +127,7 @@ class BuildingUpgradeDetailsFactory(DjangoModelFactory):
     class Meta:
         model = BuildingUpgradeDetails
 
-    project = factory.SubFactory("world.projects.factories.ProjectFactory")
+    project = factory.SubFactory(_PROJECT_FACTORY_PATH)
     building = factory.SubFactory(BuildingFactory)
     new_target_size = 6
     applied_at = None

--- a/src/world/buildings/models.py
+++ b/src/world/buildings/models.py
@@ -33,6 +33,7 @@ from world.locations.constants import StatKey
 # Cross-app FK string constants. Django resolves these lazily at app-ready
 # time; centralizing them here avoids the "literal duplicated N times" SonarCloud
 # code smell and gives a single grep target if the source model ever moves.
+_BUILDING_MODEL_PATH = "buildings.Building"
 _PROJECT_FK = "projects.Project"
 _POLISH_CATEGORY_FK = "buildings.PolishCategory"
 _PERSONA_FK = "scenes.Persona"
@@ -507,7 +508,7 @@ class BuildingExtensionDetails(SharedMemoryModel):
         primary_key=True,
     )
     building = models.ForeignKey(
-        "buildings.Building",
+        _BUILDING_MODEL_PATH,
         on_delete=models.CASCADE,
         related_name="extension_details",
     )
@@ -545,7 +546,7 @@ class FortificationUpgradeDetails(SharedMemoryModel):
         primary_key=True,
     )
     building = models.ForeignKey(
-        "buildings.Building",
+        _BUILDING_MODEL_PATH,
         on_delete=models.CASCADE,
         related_name="fortification_upgrade_details",
     )
@@ -593,7 +594,7 @@ class BuildingRenovationDetails(SharedMemoryModel):
         primary_key=True,
     )
     building = models.ForeignKey(
-        "buildings.Building",
+        _BUILDING_MODEL_PATH,
         on_delete=models.CASCADE,
         related_name="renovation_details",
     )
@@ -639,7 +640,7 @@ class BuildingUpgradeDetails(SharedMemoryModel):
         primary_key=True,
     )
     building = models.ForeignKey(
-        "buildings.Building",
+        _BUILDING_MODEL_PATH,
         on_delete=models.CASCADE,
         related_name="upgrade_details",
     )
@@ -685,7 +686,7 @@ class InteriorDesignDetails(SharedMemoryModel):
         related_name="design_details",
     )
     building = models.ForeignKey(
-        "buildings.Building",
+        _BUILDING_MODEL_PATH,
         on_delete=models.CASCADE,
         related_name="design_details",
     )

--- a/src/world/buildings/views.py
+++ b/src/world/buildings/views.py
@@ -64,6 +64,8 @@ _CHARACTER_ID_PARAM = OpenApiParameter(
     description="ObjectDB id of the viewing character (must be your own).",
 )
 
+_CHARACTER_NOT_FOUND = "Character not found."
+
 
 def _viewer_persona(request: Request) -> Persona | None:
     """The active persona of the ``?character_id=`` character, if the account plays it."""
@@ -117,7 +119,7 @@ class BuildingManagerViewSet(viewsets.ViewSet):
         """GET /api/buildings/manager/<building_id>/ — the full manager payload."""
         persona = _viewer_persona(request)
         if persona is None:
-            return Response({"detail": "Character not found."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"detail": _CHARACTER_NOT_FOUND}, status=status.HTTP_404_NOT_FOUND)
         building = (
             Building.objects.select_related("area", "kind", "architectural_style", "entry_room")
             .filter(pk=pk)
@@ -205,7 +207,7 @@ class BuildingManagerViewSet(viewsets.ViewSet):
         """GET /api/buildings/manager/for-room/<room_id>/ — ids + permission flags only."""
         persona = _viewer_persona(request)
         if persona is None:
-            return Response({"detail": "Character not found."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"detail": _CHARACTER_NOT_FOUND}, status=status.HTTP_404_NOT_FOUND)
         profile = RoomProfile.objects.filter(objectdb_id=room_id).select_related("objectdb").first()
         if profile is None:
             return Response({"detail": "No such room."}, status=status.HTTP_404_NOT_FOUND)
@@ -237,7 +239,7 @@ class BuildingManagerViewSet(viewsets.ViewSet):
         """
         persona = _viewer_persona(request)
         if persona is None:
-            return Response({"detail": "Character not found."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"detail": _CHARACTER_NOT_FOUND}, status=status.HTTP_404_NOT_FOUND)
         profile = RoomProfile.objects.filter(objectdb_id=room_id).select_related("objectdb").first()
         if profile is None:
             return Response({"detail": "No such room."}, status=status.HTTP_404_NOT_FOUND)

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -2611,6 +2611,33 @@ def _emit_opponent_pre_apply(
     return pre_payload.amount, pre_payload.amount <= 0
 
 
+def _resolve_opponent_defeat(opponent: CombatOpponent, source_sheet: CharacterSheet | None) -> bool:
+    """Resolve whether an opponent at 0 HP is actually defeated.
+
+    Story-criticality check: prevent death if the NPC is load-bearing for a
+    story the attacker isn't part of (#1874). When death is prevented, the
+    NPC flees instead and ``False`` is returned. Otherwise the opponent's
+    status is set to DEFEATED and ``True`` is returned.
+    """
+    from world.stories.flee_services import flee_story_critical_npc  # noqa: PLC0415
+    from world.stories.npc_protection import (  # noqa: PLC0415
+        is_death_prevented_by_story,
+    )
+
+    npc_sheet = None
+    if opponent.objectdb is not None:
+        try:
+            npc_sheet = opponent.objectdb.sheet_data
+        except AttributeError:
+            npc_sheet = None
+    attacker = source_sheet.character if source_sheet else None
+    if npc_sheet is not None and is_death_prevented_by_story(npc_sheet, attacker):
+        flee_story_critical_npc(opponent, attacker)
+        return False
+    opponent.status = OpponentStatus.DEFEATED
+    return True
+
+
 def apply_damage_to_opponent(  # noqa: PLR0913
     opponent: CombatOpponent,
     raw_damage: int,
@@ -2666,25 +2693,7 @@ def apply_damage_to_opponent(  # noqa: PLR0913
     # Hero Killer cannot be defeated -- narrative immunity ("you must run").
     defeated = opponent.health <= 0 and opponent.tier != OpponentTier.HERO_KILLER
     if defeated:
-        # Story-criticality check: prevent death if NPC is load-bearing
-        # for a story the attacker isn't part of (#1874).
-        from world.stories.flee_services import flee_story_critical_npc  # noqa: PLC0415
-        from world.stories.npc_protection import (  # noqa: PLC0415
-            is_death_prevented_by_story,
-        )
-
-        npc_sheet = None
-        if opponent.objectdb is not None:
-            try:
-                npc_sheet = opponent.objectdb.sheet_data
-            except AttributeError:
-                npc_sheet = None
-        attacker = source_sheet.character if source_sheet else None
-        if npc_sheet is not None and is_death_prevented_by_story(npc_sheet, attacker):
-            flee_story_critical_npc(opponent, attacker)
-            defeated = False
-        else:
-            opponent.status = OpponentStatus.DEFEATED
+        defeated = _resolve_opponent_defeat(opponent, source_sheet)
 
     opponent.save(update_fields=["health", "probing_current", "status"])
 

--- a/src/world/covenants/models.py
+++ b/src/world/covenants/models.py
@@ -579,64 +579,78 @@ class CharacterCovenantRole(SharedMemoryModel):
         if self.engaged and self.left_at is not None:
             raise ValidationError({"engaged": "Engaged row cannot have left_at set."})
         if self.engaged:
-            same_type_engaged = (
-                CharacterCovenantRole.objects.filter(
-                    character_sheet=self.character_sheet,
-                    covenant__covenant_type=self.covenant.covenant_type,
-                    engaged=True,
-                    left_at__isnull=True,
-                )
-                .exclude(pk=self.pk)
-                .exists()
+            self._validate_engaged_exclusivity()
+
+    def _validate_engaged_exclusivity(self) -> None:
+        """At most one engaged active role per covenant type + per special role.
+
+        Guards against a second engaged active membership of the same covenant
+        type, a second engaged Supreme Commander, and a second engaged Champion.
+        """
+        if self._another_same_type_engaged_exists():
+            raise ValidationError(
+                {
+                    "engaged": (
+                        "Another engaged active membership of the same covenant type "
+                        "exists for this character."
+                    ),
+                }
             )
-            if same_type_engaged:
+        if self.covenant_role.command_tier == CommandTier.SUPREME:
+            if self._another_engaged_supreme_exists():
                 raise ValidationError(
                     {
                         "engaged": (
-                            "Another engaged active membership of the same covenant type "
-                            "exists for this character."
+                            "Another engaged Supreme Commander already exists for this covenant."
                         ),
                     }
                 )
-            if self.covenant_role.command_tier == CommandTier.SUPREME:
-                other_supreme = (
-                    CharacterCovenantRole.objects.filter(
-                        covenant=self.covenant,
-                        covenant_role__command_tier=CommandTier.SUPREME,
-                        engaged=True,
-                        left_at__isnull=True,
-                    )
-                    .exclude(pk=self.pk)
-                    .exists()
+        if self.covenant_role.is_champion_role:
+            if self._another_engaged_champion_exists():
+                raise ValidationError(
+                    {
+                        "engaged": ("Another engaged Champion already exists for this covenant."),
+                    }
                 )
-                if other_supreme:
-                    raise ValidationError(
-                        {
-                            "engaged": (
-                                "Another engaged Supreme Commander already exists for this "
-                                "covenant."
-                            ),
-                        }
-                    )
-            if self.covenant_role.is_champion_role:
-                other_champion = (
-                    CharacterCovenantRole.objects.filter(
-                        covenant=self.covenant,
-                        covenant_role__is_champion_role=True,
-                        engaged=True,
-                        left_at__isnull=True,
-                    )
-                    .exclude(pk=self.pk)
-                    .exists()
-                )
-                if other_champion:
-                    raise ValidationError(
-                        {
-                            "engaged": (
-                                "Another engaged Champion already exists for this covenant."
-                            ),
-                        }
-                    )
+
+    def _another_same_type_engaged_exists(self) -> bool:
+        """True if another active engaged membership of the same covenant type exists."""
+        return (
+            CharacterCovenantRole.objects.filter(
+                character_sheet=self.character_sheet,
+                covenant__covenant_type=self.covenant.covenant_type,
+                engaged=True,
+                left_at__isnull=True,
+            )
+            .exclude(pk=self.pk)
+            .exists()
+        )
+
+    def _another_engaged_supreme_exists(self) -> bool:
+        """True if another engaged Supreme Commander exists for this covenant."""
+        return (
+            CharacterCovenantRole.objects.filter(
+                covenant=self.covenant,
+                covenant_role__command_tier=CommandTier.SUPREME,
+                engaged=True,
+                left_at__isnull=True,
+            )
+            .exclude(pk=self.pk)
+            .exists()
+        )
+
+    def _another_engaged_champion_exists(self) -> bool:
+        """True if another engaged Champion exists for this covenant."""
+        return (
+            CharacterCovenantRole.objects.filter(
+                covenant=self.covenant,
+                covenant_role__is_champion_role=True,
+                engaged=True,
+                left_at__isnull=True,
+            )
+            .exclude(pk=self.pk)
+            .exists()
+        )
 
     def __str__(self) -> str:
         state = "active" if self.left_at is None else "ended"

--- a/src/world/items/crafting/services.py
+++ b/src/world/items/crafting/services.py
@@ -144,6 +144,29 @@ class CraftingQuote:
     station_status: StationStatus | None = None
 
 
+def _station_status_snapshot(station: object | None) -> tuple[StationStatus, bool]:
+    """Build a ``StationStatus`` from a resolved lab station.
+
+    Returns ``(status, broken)`` where ``broken`` is True when the station is
+    missing or broken — the caller uses it to narrow ``affordable`` to False.
+    """
+    if station is None:
+        return (
+            StationStatus(present=False, durability=0, max_durability=0, is_broken=True),
+            True,
+        )
+    return (
+        StationStatus(
+            present=True,
+            durability=station.durability,
+            max_durability=station.max_durability,
+            is_broken=station.is_broken,
+            feature_instance_id=station.feature_instance_id,
+        ),
+        station.is_broken,
+    )
+
+
 def build_crafting_quote(
     *,
     kind: CraftingRecipeKind,
@@ -243,21 +266,9 @@ def build_crafting_quote(
     station_status: StationStatus | None = None
     if recipe.requires_station:
         station = _resolve_active_lab_station(crafter_character)
-        if station is None:
-            station_status = StationStatus(
-                present=False, durability=0, max_durability=0, is_broken=True
-            )
+        station_status, station_broken = _station_status_snapshot(station)
+        if station_broken:
             affordable = False
-        else:
-            station_status = StationStatus(
-                present=True,
-                durability=station.durability,
-                max_durability=station.max_durability,
-                is_broken=station.is_broken,
-                feature_instance_id=station.feature_instance_id,
-            )
-            if station.is_broken:
-                affordable = False
 
     # 7. Failure risk from consequence pool ---
     consequence_rows = list(

--- a/src/world/magic/audere_majora.py
+++ b/src/world/magic/audere_majora.py
@@ -245,7 +245,26 @@ def eligible_paths_for_threshold(character: ObjectDB, threshold: AudereMajoraThr
     return list(path.child_paths.filter(stage=threshold.target_stage, is_active=True))
 
 
-def _evaluate_majora_gates(  # noqa: PLR0911, C901
+def _check_class_level_unlock_gate(character: ObjectDB) -> bool:
+    """Gate 8: if a ClassLevelUnlock is authored for the character's next level,
+    its requirements must be met. No authored unlock = no gate (fail-open)."""
+    from world.progression.models import ClassLevelUnlock  # noqa: PLC0415
+    from world.progression.services.advancement import primary_class_level  # noqa: PLC0415
+    from world.progression.services.spends import check_requirements_for_unlock  # noqa: PLC0415
+
+    cl = primary_class_level(character)
+    if cl is None:
+        return True
+    unlock = ClassLevelUnlock.objects.filter(
+        character_class=cl.character_class, target_level=cl.level + 1
+    ).first()
+    if unlock is None:
+        return True
+    requirements_met, _failed = check_requirements_for_unlock(character, unlock)
+    return requirements_met
+
+
+def _evaluate_majora_gates(  # noqa: PLR0911
     character: ObjectDB, runtime_intensity: int, sheet: CharacterSheet
 ) -> tuple[AudereMajoraThreshold | None, int]:
     """Run all Audere Majora eligibility gates, returning the threshold + stage.
@@ -307,19 +326,8 @@ def _evaluate_majora_gates(  # noqa: PLR0911, C901
     if not eligible_paths_for_threshold(character, threshold):
         return None, 0
 
-    from world.progression.models import ClassLevelUnlock  # noqa: PLC0415
-    from world.progression.services.advancement import primary_class_level  # noqa: PLC0415
-    from world.progression.services.spends import check_requirements_for_unlock  # noqa: PLC0415
-
-    cl = primary_class_level(character)
-    if cl is not None:
-        unlock = ClassLevelUnlock.objects.filter(
-            character_class=cl.character_class, target_level=cl.level + 1
-        ).first()
-        if unlock is not None:
-            requirements_met, _failed = check_requirements_for_unlock(character, unlock)
-            if not requirements_met:
-                return None, 0
+    if not _check_class_level_unlock_gate(character):
+        return None, 0
 
     return threshold, stage_order
 

--- a/src/world/magic/seeds_cast.py
+++ b/src/world/magic/seeds_cast.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from actions.models import ActionTemplate, ConsequencePool
 
 TECHNIQUE_CAST_TEMPLATE_NAME = "Technique Cast"
 TECHNIQUE_CAST_CHECK_TYPE_NAME = "Technique Cast"
@@ -170,14 +174,6 @@ def ensure_technique_catalog_content():
     Returns the list of catalog ActionTemplate rows (created or pre-existing),
     in `_CATALOG_POOLS` order.
     """
-    from actions.models import (  # noqa: PLC0415
-        ActionTemplate,
-        ConsequencePool,
-        ConsequencePoolEntry,
-    )
-    from world.checks.models import Consequence  # noqa: PLC0415
-    from world.traits.factories import CheckOutcomeFactory  # noqa: PLC0415
-
     base_template = ensure_technique_cast_content()
     base_pool = base_template.consequence_pool
     check_type = base_template.check_type
@@ -186,59 +182,92 @@ def ensure_technique_catalog_content():
 
     templates = []
     for flavor in _CATALOG_POOLS:
-        pool_name = _catalog_pool_name(flavor["name"])
-        pool, _ = ConsequencePool.objects.get_or_create(
-            name=pool_name,
-            defaults={"description": flavor["description"], "parent": base_pool},
-        )
-        if pool.parent_id != base_pool.pk:
-            pool.parent = base_pool
-            pool.save(update_fields=["parent"])
-
-        for outcome_name, label, weight in flavor["extra_consequences"]:
-            outcome = CheckOutcomeFactory(name=outcome_name)
-            consequence, _ = Consequence.objects.get_or_create(
-                outcome_tier=outcome,
-                label=label,
-                defaults={"weight": weight, "character_loss": False},
-            )
-            ConsequencePoolEntry.objects.get_or_create(pool=pool, consequence=consequence)
-
-        for outcome_name, override_weight in flavor["weight_overrides"].items():
-            consequence = Consequence.objects.get(
-                outcome_tier__name=outcome_name, label=base_label_by_tier[outcome_name]
-            )
-            entry, _ = ConsequencePoolEntry.objects.get_or_create(
-                pool=pool,
-                consequence=consequence,
-                defaults={"weight_override": override_weight},
-            )
-            if entry.weight_override != override_weight:
-                entry.weight_override = override_weight
-                entry.save(update_fields=["weight_override"])
-
-        template_name = _catalog_template_name(flavor["name"])
-        template, _ = ActionTemplate.objects.get_or_create(
-            name=template_name,
-            defaults={
-                "check_type": check_type,
-                "consequence_pool": pool,
-                "category": "magic",
-                "pipeline": base_template.pipeline,
-                "target_type": base_template.target_type,
-                "description": (
-                    f"Standalone resolution spec for casting a technique ({flavor['name']} flavor)."
-                ),
-            },
-        )
-        changed = []
-        if template.check_type_id != check_type.pk:
-            template.check_type = check_type
-            changed.append("check_type")
-        if template.consequence_pool_id != pool.pk:
-            template.consequence_pool = pool
-            changed.append("consequence_pool")
-        if changed:
-            template.save(update_fields=changed)
-        templates.append(template)
+        pool = _ensure_catalog_pool(flavor, base_pool)
+        _ensure_catalog_extra_consequences(flavor, pool)
+        _apply_catalog_weight_overrides(flavor, pool, base_label_by_tier)
+        templates.append(_ensure_catalog_template(flavor, pool, base_template, check_type))
     return templates
+
+
+def _ensure_catalog_pool(flavor: dict, base_pool: ConsequencePool) -> ConsequencePool:
+    """Get-or-create the per-flavor child ConsequencePool, reparenting if needed."""
+    from actions.models import ConsequencePool  # noqa: PLC0415
+
+    pool_name = _catalog_pool_name(flavor["name"])
+    pool, _ = ConsequencePool.objects.get_or_create(
+        name=pool_name,
+        defaults={"description": flavor["description"], "parent": base_pool},
+    )
+    if pool.parent_id != base_pool.pk:
+        pool.parent = base_pool
+        pool.save(update_fields=["parent"])
+    return pool
+
+
+def _ensure_catalog_extra_consequences(flavor: dict, pool: ConsequencePool) -> None:
+    """Get-or-create the flavor's extra consequence entries on ``pool``."""
+    from actions.models import ConsequencePoolEntry  # noqa: PLC0415
+    from world.checks.models import Consequence  # noqa: PLC0415
+    from world.traits.factories import CheckOutcomeFactory  # noqa: PLC0415
+
+    for outcome_name, label, weight in flavor["extra_consequences"]:
+        outcome = CheckOutcomeFactory(name=outcome_name)
+        consequence, _ = Consequence.objects.get_or_create(
+            outcome_tier=outcome,
+            label=label,
+            defaults={"weight": weight, "character_loss": False},
+        )
+        ConsequencePoolEntry.objects.get_or_create(pool=pool, consequence=consequence)
+
+
+def _apply_catalog_weight_overrides(
+    flavor: dict, pool: ConsequencePool, base_label_by_tier: dict[str, str]
+) -> None:
+    """Apply the flavor's weight overrides onto shared base-tier consequences."""
+    from actions.models import ConsequencePoolEntry  # noqa: PLC0415
+    from world.checks.models import Consequence  # noqa: PLC0415
+
+    for outcome_name, override_weight in flavor["weight_overrides"].items():
+        consequence = Consequence.objects.get(
+            outcome_tier__name=outcome_name, label=base_label_by_tier[outcome_name]
+        )
+        entry, _ = ConsequencePoolEntry.objects.get_or_create(
+            pool=pool,
+            consequence=consequence,
+            defaults={"weight_override": override_weight},
+        )
+        if entry.weight_override != override_weight:
+            entry.weight_override = override_weight
+            entry.save(update_fields=["weight_override"])
+
+
+def _ensure_catalog_template(
+    flavor: dict, pool: ConsequencePool, base_template: ActionTemplate, check_type
+) -> ActionTemplate:
+    """Get-or-create the per-flavor ActionTemplate, reconciling divergent fields."""
+    from actions.models import ActionTemplate  # noqa: PLC0415
+
+    template_name = _catalog_template_name(flavor["name"])
+    template, _ = ActionTemplate.objects.get_or_create(
+        name=template_name,
+        defaults={
+            "check_type": check_type,
+            "consequence_pool": pool,
+            "category": "magic",
+            "pipeline": base_template.pipeline,
+            "target_type": base_template.target_type,
+            "description": (
+                f"Standalone resolution spec for casting a technique ({flavor['name']} flavor)."
+            ),
+        },
+    )
+    changed = []
+    if template.check_type_id != check_type.pk:
+        template.check_type = check_type
+        changed.append("check_type")
+    if template.consequence_pool_id != pool.pk:
+        template.consequence_pool = pool
+        changed.append("consequence_pool")
+    if changed:
+        template.save(update_fields=changed)
+    return template

--- a/src/world/magic/services/resonance.py
+++ b/src/world/magic/services/resonance.py
@@ -271,8 +271,61 @@ _SOURCE_REQUIRED_KWARG: dict[str, Callable[..., tuple[object | None, str]]] = {
 }
 
 
+def _check_imbue_level_advance(  # noqa: PLR0913
+    thread: Thread,
+    next_level: int,
+    cap: int,
+    character_sheet: CharacterSheet,
+    *,
+    amount: int,
+    imbue_multiplier: int,
+) -> tuple[bool, str, list[str]]:
+    """Evaluate whether a thread can advance to ``next_level``.
+
+    Returns ``(should_advance, blocked_by, blocked_requirement_messages)``.
+    When ``should_advance`` is ``False``, ``blocked_by`` names the gate that
+    stopped advancement (or ``"NONE"`` if the bucket is simply exhausted and
+    ``blocked_requirement_messages`` carries crossing-requirement failures.
+    """
+    cost = max((thread.level - 9) * 100, 1) * imbue_multiplier
+    if thread.developed_points < cost:
+        if amount == 0:
+            return False, "INSUFFICIENT_BUCKET", []
+        return False, "NONE", []
+    if next_level % 10 == 0:
+        unlocked = ThreadLevelUnlock.objects.filter(
+            thread=thread,
+            unlocked_level=next_level,
+        ).exists()
+        if not unlocked:
+            return False, "XP_LOCK", []
+    if is_crossing_level(next_level):
+        from world.progression.services.spends import (  # noqa: PLC0415
+            check_requirements_for_thread_crossing,
+        )
+
+        threshold = ThreadCrossingThreshold.objects.filter(
+            target_kind=thread.target_kind,
+            level=next_level,
+        ).first()
+        if threshold is not None:
+            met, failed = check_requirements_for_thread_crossing(
+                character_sheet.character, threshold
+            )
+            if not met:
+                return False, "CROSSING_REQUIREMENT", failed
+    if next_level > cap:
+        blocked_by = (
+            "PATH_CAP"
+            if compute_path_cap(character_sheet) < compute_anchor_cap(thread)
+            else "ANCHOR_CAP"
+        )
+        return False, blocked_by, []
+    return True, "NONE", []
+
+
 @transaction.atomic
-def spend_resonance_for_imbuing(  # noqa: C901, PLR0912, PLR0915
+def spend_resonance_for_imbuing(
     character_sheet: CharacterSheet,
     thread: Thread,
     amount: int,
@@ -330,45 +383,18 @@ def spend_resonance_for_imbuing(  # noqa: C901, PLR0912, PLR0915
     blocked_requirement_messages: list[str] = []
     imbue_multiplier = get_imbue_cost_multiplier(thread.target_kind)
     while True:
-        n = thread.level
-        next_level = n + 1
-        cost = max((n - 9) * 100, 1) * imbue_multiplier  # sub-10 levels cost 1 dp each
-        if thread.developed_points < cost:
-            if amount == 0:
-                blocked_by = "INSUFFICIENT_BUCKET"
+        next_level = thread.level + 1
+        should_advance, blocked_by, blocked_requirement_messages = _check_imbue_level_advance(
+            thread,
+            next_level,
+            cap,
+            character_sheet,
+            amount=amount,
+            imbue_multiplier=imbue_multiplier,
+        )
+        if not should_advance:
             break
-        if next_level % 10 == 0:
-            unlocked = ThreadLevelUnlock.objects.filter(
-                thread=thread,
-                unlocked_level=next_level,
-            ).exists()
-            if not unlocked:
-                blocked_by = "XP_LOCK"
-                break
-        if is_crossing_level(next_level):
-            from world.progression.services.spends import (  # noqa: PLC0415
-                check_requirements_for_thread_crossing,
-            )
-
-            threshold = ThreadCrossingThreshold.objects.filter(
-                target_kind=thread.target_kind,
-                level=next_level,
-            ).first()
-            if threshold is not None:
-                met, failed = check_requirements_for_thread_crossing(
-                    character_sheet.character, threshold
-                )
-                if not met:
-                    blocked_by = "CROSSING_REQUIREMENT"
-                    blocked_requirement_messages = failed
-                    break
-        if next_level > cap:
-            blocked_by = (
-                "PATH_CAP"
-                if compute_path_cap(character_sheet) < compute_anchor_cap(thread)
-                else "ANCHOR_CAP"
-            )
-            break
+        cost = max((thread.level - 9) * 100, 1) * imbue_multiplier
         thread.level = next_level
         thread.developed_points -= cost
 
@@ -632,6 +658,72 @@ def _fold_distinction_pull_bonus(
     ]
 
 
+def _validate_pull_threads(
+    threads: list[Thread],
+    character_sheet: CharacterSheet,
+    resonance: ResonanceModel,
+    excluded_kinds: frozenset[str] | None,
+) -> None:
+    """Validate ownership, same-resonance, and excluded-kinds for pull threads.
+
+    Raises ``InvalidImbueAmount`` on the first failing thread.
+    """
+    for t in threads:
+        if t.owner_id != character_sheet.pk:
+            msg = "Thread not owned by character."
+            raise InvalidImbueAmount(msg)
+        if t.resonance_id != resonance.pk:
+            msg = "Thread does not share the chosen resonance."
+            raise InvalidImbueAmount(msg)
+        if excluded_kinds and t.target_kind in excluded_kinds:
+            msg = "Thread anchor is not involved in this action."
+            raise InvalidImbueAmount(msg)
+
+
+def _check_anima_waiver(scene_id: int | None, anima_cost: int) -> int:
+    """Return the (possibly zeroed) anima cost after scene waiver checks (#1919).
+
+    When ``scene_id`` is provided and ``anima_cost`` is positive, checks
+    whether the scene is high-stakes (active combat or DANGER round). If not,
+    the anima cost is waived (zeroed).
+    """
+    if scene_id is None or anima_cost <= 0:
+        return anima_cost
+
+    from world.combat.models import CombatEncounter  # noqa: PLC0415
+    from world.scenes.constants import (  # noqa: PLC0415
+        RoundStatus,
+        SceneRoundStartReason,
+    )
+    from world.scenes.models import Scene  # noqa: PLC0415
+
+    scene = Scene.objects.filter(pk=scene_id).select_related("location").first()
+    if scene is None:
+        return anima_cost
+
+    has_active_combat = CombatEncounter.objects.filter(
+        scene=scene,
+        status__in=[
+            RoundStatus.DECLARING,
+            RoundStatus.RESOLVING,
+            RoundStatus.BETWEEN_ROUNDS,
+        ],
+    ).exists()
+    has_danger_round = False
+    if scene.location is not None:
+        has_danger_round = scene.scene_rounds.filter(
+            start_reason=SceneRoundStartReason.DANGER,
+            status__in=[
+                RoundStatus.DECLARING,
+                RoundStatus.RESOLVING,
+                RoundStatus.BETWEEN_ROUNDS,
+            ],
+        ).exists()
+    if not has_active_combat and not has_danger_round:
+        return 0
+    return anima_cost
+
+
 def preview_resonance_pull(  # noqa: PLR0913
     character_sheet: CharacterSheet,
     resonance: ResonanceModel,
@@ -684,16 +776,7 @@ def preview_resonance_pull(  # noqa: PLR0913
         msg = "Must pull at least one thread."
         raise InvalidImbueAmount(msg)
 
-    for t in threads:
-        if t.owner_id != character_sheet.pk:
-            msg = "Thread not owned by character."
-            raise InvalidImbueAmount(msg)
-        if t.resonance_id != resonance.pk:
-            msg = "Thread does not share the chosen resonance."
-            raise InvalidImbueAmount(msg)
-        if excluded_kinds and t.target_kind in excluded_kinds:
-            msg = "Thread anchor is not involved in this action."
-            raise InvalidImbueAmount(msg)
+    _validate_pull_threads(threads, character_sheet, resonance, excluded_kinds)
 
     cost = get_pull_cost(tier, None)
     n_threads = len(threads)
@@ -702,36 +785,7 @@ def preview_resonance_pull(  # noqa: PLR0913
     # #1919: Anima waiver for social-action previews. When scene_id is provided,
     # check whether the scene is high-stakes (active combat or DANGER round).
     # If not, the anima cost is waived (zeroed).
-    if scene_id is not None and anima_cost > 0:
-        from world.combat.models import CombatEncounter  # noqa: PLC0415
-        from world.scenes.constants import (  # noqa: PLC0415
-            RoundStatus,
-            SceneRoundStartReason,
-        )
-        from world.scenes.models import Scene  # noqa: PLC0415
-
-        scene = Scene.objects.filter(pk=scene_id).select_related("location").first()
-        if scene is not None:
-            has_active_combat = CombatEncounter.objects.filter(
-                scene=scene,
-                status__in=[
-                    RoundStatus.DECLARING,
-                    RoundStatus.RESOLVING,
-                    RoundStatus.BETWEEN_ROUNDS,
-                ],
-            ).exists()
-            has_danger_round = False
-            if scene.location is not None:
-                has_danger_round = scene.scene_rounds.filter(
-                    start_reason=SceneRoundStartReason.DANGER,
-                    status__in=[
-                        RoundStatus.DECLARING,
-                        RoundStatus.RESOLVING,
-                        RoundStatus.BETWEEN_ROUNDS,
-                    ],
-                ).exists()
-            if not has_active_combat and not has_danger_round:
-                anima_cost = 0
+    anima_cost = _check_anima_waiver(scene_id, anima_cost)
 
     # Balances — no locks, no debit.
     cr = CharacterResonance.objects.filter(
@@ -826,8 +880,36 @@ def _persist_combat_pull(  # noqa: PLR0913
         )
 
 
+def _validate_pull_threads_for_commit(
+    threads: list[Thread],
+    character_sheet: CharacterSheet,
+    resonance: ResonanceModel,
+    action_context: PullActionContext,
+) -> None:
+    """Validate ownership, resonance match, anchor involvement, and facet items.
+
+    Raises ``InvalidImbueAmount``, ``CovenantRoleNotEngagedError``, or
+    ``NoMatchingWornFacetItemsError`` on the first failing thread.
+    """
+    for t in threads:
+        if t.owner_id != character_sheet.pk:
+            msg = "Thread not owned by character."
+            raise InvalidImbueAmount(msg)
+        if t.resonance_id != resonance.pk:
+            msg = "Thread does not share the chosen resonance."
+            raise InvalidImbueAmount(msg)
+        if not _anchor_in_action(t, action_context):
+            if t.target_kind == TargetKind.COVENANT_ROLE:
+                raise CovenantRoleNotEngagedError
+            msg = "Thread anchor is not involved in this action."
+            raise InvalidImbueAmount(msg)
+        if t.target_kind == TargetKind.FACET:
+            if not character_sheet.character.equipped_items.item_facets_for(t.target_facet):
+                raise NoMatchingWornFacetItemsError
+
+
 @transaction.atomic
-def spend_resonance_for_pull(  # noqa: C901, PLR0912, PLR0913, PLR0915
+def spend_resonance_for_pull(  # noqa: PLR0913, C901
     character_sheet: CharacterSheet,
     resonance: ResonanceModel,
     tier: int,
@@ -881,21 +963,7 @@ def spend_resonance_for_pull(  # noqa: C901, PLR0912, PLR0913, PLR0915
     cost = get_pull_cost(tier, None)
     n_threads = len(threads)
 
-    for t in threads:
-        if t.owner_id != character_sheet.pk:
-            msg = "Thread not owned by character."
-            raise InvalidImbueAmount(msg)
-        if t.resonance_id != resonance.pk:
-            msg = "Thread does not share the chosen resonance."
-            raise InvalidImbueAmount(msg)
-        if not _anchor_in_action(t, action_context):
-            if t.target_kind == TargetKind.COVENANT_ROLE:
-                raise CovenantRoleNotEngagedError
-            msg = "Thread anchor is not involved in this action."
-            raise InvalidImbueAmount(msg)
-        if t.target_kind == TargetKind.FACET:
-            if not character_sheet.character.equipped_items.item_facets_for(t.target_facet):
-                raise NoMatchingWornFacetItemsError
+    _validate_pull_threads_for_commit(threads, character_sheet, resonance, action_context)
 
     # select_for_update on cr + anima so concurrent ephemeral pulls cannot
     # both pass the balance check against an unlocked read and double-spend.

--- a/src/world/magic/services/technique_acquisition.py
+++ b/src/world/magic/services/technique_acquisition.py
@@ -30,6 +30,32 @@ if TYPE_CHECKING:
     from world.magic.models import CharacterTechnique, Technique
 
 
+def _training_room_discounted_ap_cost(ap_cost: int, location: object | None) -> int:
+    """Return ``ap_cost`` reduced by an active Training Room feature (#675).
+
+    When ``location`` is provided and a ``RoomProfile`` with an active Training
+    Room is found, the discount is ``level × TRAINING_ROOM_AP_DISCOUNT_PER_LEVEL``
+    (floored at 0). Otherwise the cost is unchanged.
+    """
+    if location is None:
+        return ap_cost
+    from evennia_extensions.models import RoomProfile  # noqa: PLC0415
+    from world.room_features.constants import (  # noqa: PLC0415
+        TRAINING_ROOM_AP_DISCOUNT_PER_LEVEL,
+    )
+    from world.room_features.services import (  # noqa: PLC0415
+        active_training_room_in,
+    )
+
+    room_profile = RoomProfile.objects.filter(objectdb=location).first()
+    if room_profile is None:
+        return ap_cost
+    training_room = active_training_room_in(room_profile)
+    if training_room is None:
+        return ap_cost
+    return max(0, ap_cost - training_room.level * TRAINING_ROOM_AP_DISCOUNT_PER_LEVEL)
+
+
 @transaction.atomic
 def learn_technique(  # noqa: PLR0913
     learner: CharacterSheet,
@@ -90,24 +116,7 @@ def learn_technique(  # noqa: PLR0913
     if ap_cost > 0:
         from world.magic.exceptions import MagicError  # noqa: PLC0415
 
-        effective_ap_cost = ap_cost
-        if location is not None:
-            from evennia_extensions.models import RoomProfile  # noqa: PLC0415
-            from world.room_features.constants import (  # noqa: PLC0415
-                TRAINING_ROOM_AP_DISCOUNT_PER_LEVEL,
-            )
-            from world.room_features.services import (  # noqa: PLC0415
-                active_training_room_in,
-            )
-
-            room_profile = RoomProfile.objects.filter(objectdb=location).first()
-            if room_profile is not None:
-                training_room = active_training_room_in(room_profile)
-                if training_room is not None:
-                    effective_ap_cost = max(
-                        0,
-                        ap_cost - training_room.level * TRAINING_ROOM_AP_DISCOUNT_PER_LEVEL,
-                    )
+        effective_ap_cost = _training_room_discounted_ap_cost(ap_cost, location)
 
         pool = ActionPointPool.get_or_create_for_character(learner.character)
         if not pool.can_afford(effective_ap_cost):

--- a/src/world/mechanics/factories.py
+++ b/src/world/mechanics/factories.py
@@ -40,6 +40,8 @@ from world.mechanics.models import (
     TraitCapabilityDerivation,
 )
 
+_CHECK_TYPE_FACTORY_PATH = "world.checks.factories.CheckTypeFactory"
+
 
 class ModifierCategoryFactory(DjangoModelFactory):
     """Factory for creating ModifierCategory instances."""
@@ -345,7 +347,7 @@ class ChallengeApproachFactory(DjangoModelFactory):
 
     challenge_template = factory.SubFactory(ChallengeTemplateFactory)
     application = factory.SubFactory(ApplicationFactory)
-    check_type = factory.SubFactory("world.checks.factories.CheckTypeFactory")
+    check_type = factory.SubFactory(_CHECK_TYPE_FACTORY_PATH)
     display_name = factory.Sequence(lambda n: f"Approach{n}")
     custom_description = factory.Faker("sentence")
 
@@ -398,8 +400,8 @@ class SituationTrapLinkFactory(DjangoModelFactory):
     situation_template = factory.SubFactory(SituationTemplateFactory)
     name = factory.Sequence(lambda n: f"situation-trap-{n}")
     consequence_pool = factory.SubFactory("actions.factories.ConsequencePoolFactory")
-    detect_check_type = factory.SubFactory("world.checks.factories.CheckTypeFactory")
-    disarm_check_type = factory.SubFactory("world.checks.factories.CheckTypeFactory")
+    detect_check_type = factory.SubFactory(_CHECK_TYPE_FACTORY_PATH)
+    disarm_check_type = factory.SubFactory(_CHECK_TYPE_FACTORY_PATH)
     detect_difficulty = 20
     disarm_difficulty = 20
     is_hidden = True
@@ -436,7 +438,7 @@ class ContextConsequencePoolFactory(DjangoModelFactory):
 
     property = factory.SubFactory(PropertyFactory)
     consequence_pool = factory.SubFactory(ConsequencePoolFactory)
-    check_type = factory.SubFactory("world.checks.factories.CheckTypeFactory")
+    check_type = factory.SubFactory(_CHECK_TYPE_FACTORY_PATH)
     description = ""
 
 

--- a/src/world/mechanics/models.py
+++ b/src/world/mechanics/models.py
@@ -35,6 +35,8 @@ from world.mechanics.constants import (
     ResolutionType,
 )
 
+_DAMAGE_TYPE_MODEL_PATH = "conditions.DamageType"
+
 
 class ModifierCategoryManager(NaturalKeyManager):
     """Manager for ModifierCategory with natural key support."""
@@ -153,7 +155,7 @@ class ModifierTarget(NaturalKeyMixin, SharedMemoryModel):
         help_text="The check type this target represents (check category only).",
     )
     target_damage_type = models.OneToOneField(
-        "conditions.DamageType",
+        _DAMAGE_TYPE_MODEL_PATH,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -644,7 +646,7 @@ class PropertyDamageModifier(NaturalKeyMixin, SharedMemoryModel):
         related_name="damage_modifiers",
     )
     damage_type = models.ForeignKey(
-        "conditions.DamageType",
+        _DAMAGE_TYPE_MODEL_PATH,
         on_delete=models.CASCADE,
         null=True,
         blank=True,
@@ -667,7 +669,7 @@ class PropertyDamageModifier(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["property", "damage_type"]
-        dependencies = ["mechanics.Property", "conditions.DamageType"]
+        dependencies = ["mechanics.Property", _DAMAGE_TYPE_MODEL_PATH]
 
     def __str__(self) -> str:
         dt_name = self.damage_type.name if self.damage_type else "ALL"

--- a/src/world/missions/models.py
+++ b/src/world/missions/models.py
@@ -43,6 +43,8 @@ from world.missions.constants import (
 )
 from world.societies.constants import RenownMagnitude, RenownReach, RenownRisk
 
+_PERSONA_MODEL_PATH = "scenes.Persona"
+
 # MissionOptionRouteReward XOR (route, candidate) — module-level so the
 # clean() messages stay readable and the magic 2 has a name.
 _ERR_REWARD_NO_PARENT = "Exactly one of route or candidate must be set; both are null."
@@ -1129,7 +1131,7 @@ class MissionInstance(SharedMemoryModel):
     # Null for trigger-based / legacy seed rows; SET_NULL on Persona delete so
     # we keep the run record.
     accepted_as_persona = models.ForeignKey(
-        "scenes.Persona",
+        _PERSONA_MODEL_PATH,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -1224,12 +1226,12 @@ class MissionInvite(SharedMemoryModel):
         related_name="invites",
     )
     target_persona = models.ForeignKey(
-        "scenes.Persona",
+        _PERSONA_MODEL_PATH,
         on_delete=models.CASCADE,
         related_name="mission_invites_received",
     )
     invited_by = models.ForeignKey(
-        "scenes.Persona",
+        _PERSONA_MODEL_PATH,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1730,7 +1732,7 @@ class MissionRiskAcknowledgement(SharedMemoryModel):
         related_name="mission_risk_acknowledgements",
     )
     persona = models.ForeignKey(
-        "scenes.Persona",
+        _PERSONA_MODEL_PATH,
         on_delete=models.CASCADE,
         related_name="mission_risk_acknowledgements",
     )

--- a/src/world/missions/services/rewards.py
+++ b/src/world/missions/services/rewards.py
@@ -298,7 +298,35 @@ def _route_crime_watch(
     crime_watch.flag_crime(line, room=room)
 
 
-def _route_line(  # noqa: PLR0913, PLR0911 — one early-return branch per (kind, sink) pair
+def _deliver_immediate_money(line: MissionDeedRewardLine) -> None:
+    """Deliver an IMMEDIATE MONEY line, falling back to the stub when sheet-less."""
+    try:
+        sheet = line.recipient.sheet_data
+    except Exception:  # noqa: BLE001 - sheet-less recipient: keep stub fallback
+        sheet = None
+    if sheet is not None:
+        deliver_mission_money(recipient_sheet=sheet, amount=line.amount, ref=line.ref)
+    else:
+        money_stub.deliver_money(line)
+
+
+def _route_unbuilt_propagation(
+    line: MissionDeedRewardLine, *, sink: str, skip_unbuilt: bool
+) -> None:
+    """Route a not-yet-built PROPAGATION sink (RUMOR).
+
+    When ``skip_unbuilt`` is True the line is logged and skipped; otherwise the
+    rumor stub is invoked (always raises in 5b.1, rolling back the apply).
+    """
+    if skip_unbuilt:
+        logger.info(
+            "apply_deed_rewards: skipping not-yet-built %s line pk=%d (#1765)", sink, line.pk
+        )
+        return
+    rumor_stub.propagate_rumor(line)  # always raises in 5b.1
+
+
+def _route_line(  # noqa: PLR0913 — one early-return branch per (kind, sink) pair
     deed: MissionDeedRecord,
     line: MissionDeedRewardLine,
     enqueued: list[MissionRewardQueue],
@@ -337,14 +365,7 @@ def _route_line(  # noqa: PLR0913, PLR0911 — one early-return branch per (kind
         return
 
     if kind == DeedRewardKind.IMMEDIATE and sink == DeedRewardSink.MONEY:
-        try:
-            sheet = line.recipient.sheet_data
-        except Exception:  # noqa: BLE001 - sheet-less recipient: keep stub fallback
-            sheet = None
-        if sheet is not None:
-            deliver_mission_money(recipient_sheet=sheet, amount=line.amount, ref=line.ref)
-        else:
-            money_stub.deliver_money(line)
+        _deliver_immediate_money(line)
         stub_calls.append(StubCallRecord(sink=sink, line_id=line.pk))
         return
 
@@ -369,12 +390,7 @@ def _route_line(  # noqa: PLR0913, PLR0911 — one early-return branch per (kind
     # The not-yet-built RUMOR sink — skipped-and-logged when a caller opts
     # out, else the stub raises (rolls back).
     if kind == DeedRewardKind.PROPAGATION and sink in _UNBUILT_PROPAGATION_SINKS:
-        if skip_unbuilt:
-            logger.info(
-                "apply_deed_rewards: skipping not-yet-built %s line pk=%d (#1765)", sink, line.pk
-            )
-            return
-        rumor_stub.propagate_rumor(line)  # always raises in 5b.1
+        _route_unbuilt_propagation(line, sink=sink, skip_unbuilt=skip_unbuilt)
         return
 
     # Anything else is an author error — the (kind, sink) pair has no

--- a/src/world/npc_services/models.py
+++ b/src/world/npc_services/models.py
@@ -27,6 +27,8 @@ from world.npc_services.constants import DrawMode, OfferKind, RegardTargetType
 # Cross-app FK string for the Persona model, referenced by several fields below.
 # Centralized to avoid the duplicated-literal SonarCloud smell (python:S1192).
 _PERSONA_FK = "scenes.Persona"
+_ORG_MODEL_PATH = "societies.Organization"
+_NPC_OFFER_DETAILS_HELP_TEXT = "The NPCServiceOffer row this details model decorates."
 
 
 class NPCStanding(SharedMemoryModel):
@@ -146,7 +148,7 @@ class NPCRole(SharedMemoryModel):
         ),
     )
     faction_affiliation = models.ForeignKey(
-        "societies.Organization",
+        _ORG_MODEL_PATH,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -571,7 +573,7 @@ class PermitOfferDetails(SharedMemoryModel):
         NPCServiceOffer,
         on_delete=models.CASCADE,
         related_name="permit_offer_details",
-        help_text="The NPCServiceOffer row this details model decorates.",
+        help_text=_NPC_OFFER_DETAILS_HELP_TEXT,
     )
     building_kind = models.ForeignKey(
         "buildings.BuildingKind",
@@ -627,7 +629,7 @@ class LoanOfferDetails(SharedMemoryModel):
         NPCServiceOffer,
         on_delete=models.CASCADE,
         related_name="loan_offer_details",
-        help_text="The NPCServiceOffer row this details model decorates.",
+        help_text=_NPC_OFFER_DETAILS_HELP_TEXT,
     )
     principal = models.PositiveBigIntegerField(
         help_text="Coppers lent on acceptance. PLACEHOLDER magnitudes."
@@ -637,7 +639,7 @@ class LoanOfferDetails(SharedMemoryModel):
         help_text="Monthly interest in basis points. PLACEHOLDER magnitudes.",
     )
     creditor_organization = models.ForeignKey(
-        "societies.Organization",
+        _ORG_MODEL_PATH,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -699,7 +701,7 @@ class NpcRegard(DiscriminatorMixin, SharedMemoryModel):
         help_text="Any persona (PC or NPC) this opinion is about. Set iff target_type=PERSONA.",
     )
     target_organization = models.ForeignKey(
-        "societies.Organization",
+        _ORG_MODEL_PATH,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -771,7 +773,7 @@ class CourtGrantOfferDetails(SharedMemoryModel):
         NPCServiceOffer,
         on_delete=models.CASCADE,
         related_name="court_grant_offer_details",
-        help_text="The NPCServiceOffer row this details model decorates.",
+        help_text=_NPC_OFFER_DETAILS_HELP_TEXT,
     )
     covenant = models.ForeignKey(
         "covenants.Covenant",

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -492,7 +492,88 @@ def _blacklist_initiator_for_denier(
     add_social_consent_blacklist(owner_tenure, blocked_tenure, category)
 
 
-def respond_to_action_request(  # noqa: C901
+def _deny_action_request(action_request: SceneActionRequest, blacklist_actor: bool) -> None:
+    """Mark an action request as denied and clean up its pull declaration.
+
+    #1919: The pull declaration is removed so it doesn't linger as an orphan
+    row (the charge never fires on DENY). Optionally blacklists the initiator
+    for the denier's antagonism category (#1698).
+    """
+    action_request.status = ActionRequestStatus.DENIED
+    action_request.resolved_at = timezone.now()
+    action_request.save(update_fields=["status", "resolved_at"])
+    SceneActionPullDeclaration.objects.filter(request=action_request).delete()
+    if blacklist_actor:
+        _blacklist_initiator_for_denier(action_request, action_request.target_persona)
+
+
+def _charge_primary_pull_flat_bonus(
+    action_request: SceneActionRequest,
+) -> tuple[int, str | None]:
+    """Charge the primary target's social pull, returning (flat_bonus, fizzle_note).
+
+    #1919: Charges a persisted social pull declaration exactly once before
+    per-target resolution. The resolved FLAT_BONUS is threaded into
+    _resolve_action_against_persona as pull_flat_bonus. On failure (balance
+    drained, anchor no longer in action, lock acquired, …), the pull fizzles —
+    the action resolves pull-less with a fizzle note.
+    """
+    pull_flat_bonus = 0
+    fizzle_note: str | None = None
+    action_template = action_request.action_template
+    if action_template is not None and action_template.check_type_id is not None:
+        from world.magic.exceptions import (  # noqa: PLC0415
+            MagicError,
+            ProtagonismLockedError,
+        )
+
+        try:
+            pull_flat_bonus = _charge_social_pull(
+                action_request=action_request,
+                check_type=action_template.check_type,
+            )
+        except (MagicError, ProtagonismLockedError) as exc:
+            fizzle_note = str(exc) or "The thread pull fizzled."
+    return pull_flat_bonus, fizzle_note
+
+
+def _resolve_accepted_action_request(
+    action_request: SceneActionRequest, resist_effort: str
+) -> EnhancedSceneActionResult | None:
+    """Resolve an accepted action request via the appropriate pipeline.
+
+    Dispatches to a custom resolver, the standalone-cast pipeline, or the
+    standard action pipeline (charging the social pull first).
+    """
+    custom_resolver = CUSTOM_ACTION_RESOLVERS.get(action_request.action_key)
+    if custom_resolver is not None:
+        return custom_resolver(action_request)
+    if action_request.is_standalone_cast:
+        from world.scenes.cast_services import resolve_accepted_cast  # noqa: PLC0415
+
+        return resolve_accepted_cast(action_request)
+    pull_flat_bonus, fizzle_note = _charge_primary_pull_flat_bonus(action_request)
+    difficulty_override = _compute_difficulty_override_for_primary(action_request, resist_effort)
+    return _resolve_standard_action(
+        action_request,
+        difficulty_override=difficulty_override,
+        pull_flat_bonus=pull_flat_bonus,
+        fizzle_note=fizzle_note,
+    )
+
+
+def _invoke_action_resolver(
+    action_request: SceneActionRequest, result: EnhancedSceneActionResult | None
+) -> None:
+    """Fire the registered resolver for an action request's result, if any."""
+    if result is None:
+        return
+    resolver = get_resolver(action_request.action_key)
+    if resolver is not None:
+        resolver(action_request, result)
+
+
+def respond_to_action_request(
     *,
     action_request: SceneActionRequest,
     decision: str,
@@ -531,14 +612,7 @@ def respond_to_action_request(  # noqa: C901
         return None
 
     if decision == ConsentDecision.DENY:
-        action_request.status = ActionRequestStatus.DENIED
-        action_request.resolved_at = timezone.now()
-        action_request.save(update_fields=["status", "resolved_at"])
-        # #1919: Clean up any pull declaration on the denied request so it
-        # doesn't linger as an orphan row (the charge never fires on DENY).
-        SceneActionPullDeclaration.objects.filter(request=action_request).delete()
-        if blacklist_actor:
-            _blacklist_initiator_for_denier(action_request, action_request.target_persona)
+        _deny_action_request(action_request, blacklist_actor)
         return None
 
     if decision == ConsentDecision.ACCEPT:
@@ -548,51 +622,10 @@ def respond_to_action_request(  # noqa: C901
             action_request.resist_effort_level = resist_effort
             action_request.save(update_fields=["difficulty_choice", "resist_effort_level"])
 
-            custom_resolver = CUSTOM_ACTION_RESOLVERS.get(action_request.action_key)
-            if custom_resolver is not None:
-                result = custom_resolver(action_request)
-            elif action_request.is_standalone_cast:
-                from world.scenes.cast_services import resolve_accepted_cast  # noqa: PLC0415
-
-                result = resolve_accepted_cast(action_request)
-            else:
-                # #1919: Charge a persisted social pull declaration exactly
-                # once before per-target resolution. The resolved FLAT_BONUS
-                # is threaded into _resolve_action_against_persona as
-                # pull_flat_bonus. On failure (balance drained, anchor no
-                # longer in action, lock acquired, …), the pull fizzles — the
-                # action resolves pull-less with a fizzle note.
-                pull_flat_bonus = 0
-                fizzle_note: str | None = None
-                action_template = action_request.action_template
-                if action_template is not None and action_template.check_type_id is not None:
-                    from world.magic.exceptions import (  # noqa: PLC0415
-                        MagicError,
-                        ProtagonismLockedError,
-                    )
-
-                    try:
-                        pull_flat_bonus = _charge_social_pull(
-                            action_request=action_request,
-                            check_type=action_template.check_type,
-                        )
-                    except (MagicError, ProtagonismLockedError) as exc:
-                        fizzle_note = str(exc) or "The thread pull fizzled."
-                difficulty_override = _compute_difficulty_override_for_primary(
-                    action_request, resist_effort
-                )
-                result = _resolve_standard_action(
-                    action_request,
-                    difficulty_override=difficulty_override,
-                    pull_flat_bonus=pull_flat_bonus,
-                    fizzle_note=fizzle_note,
-                )
+            result = _resolve_accepted_action_request(action_request, resist_effort)
 
             _accrue_engagement_for_primary(action_request)
-            if result is not None:
-                resolver = get_resolver(action_request.action_key)
-                if resolver is not None:
-                    resolver(action_request, result)
+            _invoke_action_resolver(action_request, result)
 
         return result
 
@@ -926,6 +959,80 @@ def _persona_is_npc(persona: Persona) -> bool:
     return persona.character_sheet.character.db_account is None
 
 
+def _deny_action_target(action_target: SceneActionTarget, blacklist_actor: bool) -> None:
+    """Mark an action target row as denied, optionally blacklisting the initiator."""
+    action_target.status = ActionRequestStatus.DENIED
+    action_target.resolved_at = timezone.now()
+    action_target.save(update_fields=["status", "resolved_at"])
+    if blacklist_actor:
+        _blacklist_initiator_for_denier(action_target.action_request, action_target.target_persona)
+
+
+def _compute_target_difficulty_override(
+    action_request: SceneActionRequest,
+    action_target: SceneActionTarget,
+    resist_effort: str,
+) -> int:
+    """Compute the difficulty override for an accepted target row.
+
+    Persists the defender's plausibility band on the target row, then passes it
+    as difficulty_override so the per-target band is used for resolution (the
+    target's band lives on SceneActionTarget, not the request). Applies resist
+    fatigue when a resist effort is supplied.
+    """
+    from world.scenes.social_difficulty import resolved_base_difficulty  # noqa: PLC0415
+
+    base = resolved_base_difficulty(
+        action_request=action_request,
+        difficulty_choice=action_target.difficulty_choice,
+        target_sheet=action_target.target_persona.character_sheet,
+    )
+    if resist_effort:
+        from actions.constants import ActionCategory  # noqa: PLC0415
+        from world.checks.services import compute_resist_increment  # noqa: PLC0415
+        from world.fatigue.services import apply_fatigue  # noqa: PLC0415
+
+        increment = compute_resist_increment(
+            action_target.target_persona.character_sheet.character,
+            resist_effort,
+        )
+        apply_fatigue(
+            action_target.target_persona.character_sheet,
+            ActionCategory.SOCIAL,
+            RESIST_FATIGUE_BASE,
+            resist_effort,
+        )
+    else:
+        increment = 0
+    return base + increment
+
+
+def _charge_target_pull_flat_bonus(action_request: SceneActionRequest) -> int:
+    """Retrieve the pull flat bonus for an additional target (idempotent).
+
+    #1919: The primary resolution or an earlier NPC auto-resolve may have
+    already charged it. Returns 0 when no declaration exists or it already
+    fizzled (the primary charge's fizzle note already covers the request).
+    """
+    pull_flat_bonus = 0
+    action_template = action_request.action_template
+    if action_template is not None and action_template.check_type_id is not None:
+        from world.magic.exceptions import (  # noqa: PLC0415
+            MagicError,
+            ProtagonismLockedError,
+        )
+
+        try:
+            pull_flat_bonus = _charge_social_pull(
+                action_request=action_request,
+                check_type=action_template.check_type,
+            )
+        except (MagicError, ProtagonismLockedError):
+            # Already fizzled on the primary charge; no bonus for this target.
+            pull_flat_bonus = 0
+    return pull_flat_bonus
+
+
 def respond_to_action_target(
     *,
     action_target: SceneActionTarget,
@@ -954,67 +1061,18 @@ def respond_to_action_target(
     if action_target.status != ActionRequestStatus.PENDING:
         return None
     if decision == ConsentDecision.DENY:
-        action_target.status = ActionRequestStatus.DENIED
-        action_target.resolved_at = timezone.now()
-        action_target.save(update_fields=["status", "resolved_at"])
-        if blacklist_actor:
-            _blacklist_initiator_for_denier(
-                action_target.action_request, action_target.target_persona
-            )
+        _deny_action_target(action_target, blacklist_actor)
         return None
     if decision == ConsentDecision.ACCEPT:
         action_request = action_target.action_request
         with transaction.atomic():
-            # Persist defender's plausibility band on the target row, then pass it
-            # as difficulty_override so the per-target band is used for resolution
-            # (the target's band lives on SceneActionTarget, not the request).
             if difficulty is not None:
                 action_target.difficulty_choice = difficulty
             action_target.resist_effort_level = resist_effort
-            from world.scenes.social_difficulty import resolved_base_difficulty  # noqa: PLC0415
-
-            base = resolved_base_difficulty(
-                action_request=action_request,
-                difficulty_choice=action_target.difficulty_choice,
-                target_sheet=action_target.target_persona.character_sheet,
+            difficulty_override = _compute_target_difficulty_override(
+                action_request, action_target, resist_effort
             )
-            if resist_effort:
-                from actions.constants import ActionCategory  # noqa: PLC0415
-                from world.checks.services import compute_resist_increment  # noqa: PLC0415
-                from world.fatigue.services import apply_fatigue  # noqa: PLC0415
-
-                increment = compute_resist_increment(
-                    action_target.target_persona.character_sheet.character,
-                    resist_effort,
-                )
-                apply_fatigue(
-                    action_target.target_persona.character_sheet,
-                    ActionCategory.SOCIAL,
-                    RESIST_FATIGUE_BASE,
-                    resist_effort,
-                )
-            else:
-                increment = 0
-            difficulty_override = base + increment
-            # #1919: Retrieve the pull flat bonus (idempotent — the primary
-            # resolution or an earlier NPC auto-resolve may have already charged
-            # it). Returns 0 when no declaration exists or it already fizzled.
-            pull_flat_bonus = 0
-            action_template = action_request.action_template
-            if action_template is not None and action_template.check_type_id is not None:
-                from world.magic.exceptions import (  # noqa: PLC0415
-                    MagicError,
-                    ProtagonismLockedError,
-                )
-
-                try:
-                    pull_flat_bonus = _charge_social_pull(
-                        action_request=action_request,
-                        check_type=action_template.check_type,
-                    )
-                except (MagicError, ProtagonismLockedError):
-                    # Already fizzled on the primary charge; no bonus for this target.
-                    pull_flat_bonus = 0
+            pull_flat_bonus = _charge_target_pull_flat_bonus(action_request)
             result, result_interaction, resolved_difficulty = _resolve_action_against_persona(
                 action_request,
                 action_target.target_persona,
@@ -1043,9 +1101,7 @@ def respond_to_action_target(
             # Runs once per accepted target; resolvers registered for multi-target
             # actions must keep cast-level side-effects idempotent. result is None only
             # for hostile consent-accepts (empty action_key → no resolver).
-            resolver = get_resolver(action_request.action_key)
-            if resolver is not None and result is not None:
-                resolver(action_request, result)
+            _invoke_action_resolver(action_request, result)
         return result
     return None
 

--- a/src/world/scenes/presence.py
+++ b/src/world/scenes/presence.py
@@ -122,11 +122,7 @@ def who_listing(viewer_account: object | None = None) -> list[WhoEntry]:
     """
     from time import time  # noqa: PLC0415
 
-    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
     from evennia import SESSION_HANDLER  # noqa: PLC0415
-
-    from world.conditions.services import is_concealed  # noqa: PLC0415
-    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
     now = time()
     idle_by_puppet: dict[int, float] = {}
@@ -143,19 +139,39 @@ def who_listing(viewer_account: object | None = None) -> list[WhoEntry]:
 
     entries: list[WhoEntry] = []
     for puppet_id, puppet in puppets_by_id.items():
-        if hidden_from_viewer(puppet, viewer_account):
-            continue
-        # puppets_by_id is typed loosely (`object`) to match this module's other
-        # puppet-handling helpers; is_concealed's real ObjectDB param is a runtime
-        # guarantee (puppet is always a session's live Character), not a static one.
-        if is_concealed(cast("ObjectDB", puppet)):
-            continue
-        try:
-            sheet = puppet.sheet_data
-        except (AttributeError, ObjectDoesNotExist):
-            continue
-        persona = active_persona_for_sheet(sheet)
-        idle = IDLE_AWAY if puppet.ndb.appear_afk else idle_bucket(idle_by_puppet[puppet_id])
-        entries.append(WhoEntry(name=persona.display_ic(), idle=idle))
+        entry = _who_entry_for_puppet(puppet, puppet_id, idle_by_puppet[puppet_id], viewer_account)
+        if entry is not None:
+            entries.append(entry)
     entries.sort(key=lambda entry: entry.name.lower())
     return entries
+
+
+def _who_entry_for_puppet(
+    puppet: object,
+    _puppet_id: int,
+    idle: float,
+    viewer_account: object | None,
+) -> WhoEntry | None:
+    """Build a single ``WhoEntry`` for ``puppet``, or None to omit it.
+
+    Omits a hidden or concealed character, or one whose sheet can't be resolved.
+    """
+    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+    from world.conditions.services import is_concealed  # noqa: PLC0415
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+    if hidden_from_viewer(puppet, viewer_account):
+        return None
+    # puppets_by_id is typed loosely (`object`) to match this module's other
+    # puppet-handling helpers; is_concealed's real ObjectDB param is a runtime
+    # guarantee (puppet is always a session's live Character), not a static one.
+    if is_concealed(cast("ObjectDB", puppet)):
+        return None
+    try:
+        sheet = puppet.sheet_data
+    except (AttributeError, ObjectDoesNotExist):
+        return None
+    persona = active_persona_for_sheet(sheet)
+    idle_value = IDLE_AWAY if puppet.ndb.appear_afk else idle_bucket(idle)
+    return WhoEntry(name=persona.display_ic(), idle=idle_value)

--- a/src/world/societies/scandal.py
+++ b/src/world/societies/scandal.py
@@ -50,6 +50,8 @@ if TYPE_CHECKING:
     from world.scenes.models import Persona, Scene
     from world.societies.models import LegendEntry, PhilosophicalArchetype, Society
 
+_HOUSEHOLD_COMMAND = "Household Command"
+
 
 @dataclass(frozen=True)
 class DeedReachResult:
@@ -152,8 +154,8 @@ WITNESS_APPROACHES: tuple[WitnessApproach, ...] = (
     ),
     WitnessApproach(
         key="household",
-        label="Household Command",
-        check_type_name="Household Command",
+        label=_HOUSEHOLD_COMMAND,
+        check_type_name=_HOUSEHOLD_COMMAND,
         household_only=True,
     ),
 )
@@ -270,7 +272,7 @@ def _run_containment_check(
         charm = handler.get_trait_value("charm")
         presence = handler.get_trait_value("presence")
         if household:
-            preferred = "Household Command"
+            preferred = _HOUSEHOLD_COMMAND
         else:
             preferred = "Con" if charm >= presence else "Intimidation"
         check_type = (

--- a/src/world/societies/serializers.py
+++ b/src/world/societies/serializers.py
@@ -12,6 +12,8 @@ from world.societies.models import (
     OrganizationReputation,
 )
 
+_ORGANIZATION_NAME_SOURCE = "organization.name"
+
 
 class OrganizationRankSerializer(serializers.ModelSerializer):
     class Meta:
@@ -45,7 +47,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
 
 class OrganizationMembershipSerializer(serializers.ModelSerializer):
-    organization_name = serializers.CharField(source="organization.name", read_only=True)
+    organization_name = serializers.CharField(source=_ORGANIZATION_NAME_SOURCE, read_only=True)
     persona_name = serializers.CharField(source="persona.name", read_only=True)
     rank = OrganizationRankSerializer(read_only=True)
     title = serializers.CharField(source="get_title", read_only=True)
@@ -74,7 +76,7 @@ class OrganizationMembershipSerializer(serializers.ModelSerializer):
 class OrganizationReputationSerializer(serializers.ModelSerializer):
     """A persona's standing with an organization — named tier only, never the raw value."""
 
-    organization_name = serializers.CharField(source="organization.name", read_only=True)
+    organization_name = serializers.CharField(source=_ORGANIZATION_NAME_SOURCE, read_only=True)
     tier = serializers.SerializerMethodField()
 
     class Meta:
@@ -92,7 +94,7 @@ class OrganizationReputationSerializer(serializers.ModelSerializer):
 
 
 class OrganizationMembershipOfferSerializer(serializers.ModelSerializer):
-    organization_name = serializers.CharField(source="organization.name", read_only=True)
+    organization_name = serializers.CharField(source=_ORGANIZATION_NAME_SOURCE, read_only=True)
     from_persona_name = serializers.CharField(source="from_persona.name", read_only=True)
     to_persona_name = serializers.SerializerMethodField()
 

--- a/src/world/stories/models.py
+++ b/src/world/stories/models.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
 # Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
 ACCOUNT_DB_MODEL = "accounts.AccountDB"
 CONSEQUENCE_POOL_MODEL = "actions.ConsequencePool"
+STORY_BEAT_MODEL = "stories.Beat"
+STAKE_MODEL = "stories.Stake"
 
 # Foreclosure wrap-up annotation: the nullable resolved_at/resolved_by pair shared
 # by all three progress models (StoryProgress / GroupStoryProgress / GlobalStoryProgress).
@@ -1149,7 +1151,7 @@ class EpisodeProgressionRequirement(SharedMemoryModel):
         related_name="progression_requirements",
     )
     beat = models.ForeignKey(
-        "stories.Beat",
+        STORY_BEAT_MODEL,
         on_delete=models.CASCADE,
         related_name="gating_for_episodes",
     )
@@ -1188,7 +1190,7 @@ class TransitionRequiredOutcome(SharedMemoryModel):
         related_name="required_outcomes",
     )
     beat = models.ForeignKey(
-        "stories.Beat",
+        STORY_BEAT_MODEL,
         on_delete=models.CASCADE,
         related_name="routing_for_transitions",
     )
@@ -1200,7 +1202,7 @@ class TransitionRequiredOutcome(SharedMemoryModel):
         help_text="Required beat outcome; blank on stake-level rows.",
     )
     stake = models.ForeignKey(
-        "stories.Stake",
+        STAKE_MODEL,
         null=True,
         blank=True,
         on_delete=models.CASCADE,
@@ -2091,7 +2093,7 @@ class Stake(SharedMemoryModel):
     contracts.
     """
 
-    beat = models.ForeignKey("stories.Beat", on_delete=models.CASCADE, related_name="stakes")
+    beat = models.ForeignKey(STORY_BEAT_MODEL, on_delete=models.CASCADE, related_name="stakes")
     template = models.ForeignKey(
         "stories.StakeTemplate",
         null=True,
@@ -2169,7 +2171,7 @@ class StakeResolution(SharedMemoryModel):
     consequence pools -> process_damage_consequences).
     """
 
-    stake = models.ForeignKey("stories.Stake", on_delete=models.CASCADE, related_name="resolutions")
+    stake = models.ForeignKey(STAKE_MODEL, on_delete=models.CASCADE, related_name="resolutions")
     column = models.CharField(max_length=12, choices=StakeResolutionColumn.choices)
     outcome_key = models.CharField(
         max_length=40,
@@ -2347,7 +2349,7 @@ class StakeContractActivation(SharedMemoryModel):
     """
 
     beat = models.ForeignKey(
-        "stories.Beat", on_delete=models.CASCADE, related_name="stake_activations"
+        STORY_BEAT_MODEL, on_delete=models.CASCADE, related_name="stake_activations"
     )
     locked_at = models.DateTimeField(auto_now_add=True)
     resolved_at = models.DateTimeField(null=True, blank=True)
@@ -2394,7 +2396,7 @@ class StakeOutcome(SharedMemoryModel):
     """
 
     stake = models.ForeignKey(
-        "stories.Stake",
+        STAKE_MODEL,
         on_delete=models.CASCADE,
         related_name="outcomes",
     )
@@ -2442,7 +2444,7 @@ class TreasuredSignoff(SharedMemoryModel):
     WITHDRAWAL column at completion."""
 
     beat = models.ForeignKey(
-        "stories.Beat",
+        STORY_BEAT_MODEL,
         on_delete=models.CASCADE,
         related_name="treasured_signoffs",
     )

--- a/src/world/stories/serializers.py
+++ b/src/world/stories/serializers.py
@@ -68,6 +68,8 @@ from world.stories.types import (
     StoryLogEpisodeEntry,
 )
 
+_STAKES_LOCKED_MESSAGE = "This beat's stakes contract is locked by an open activation."
+
 # ---------------------------------------------------------------------------
 # Wave 6: Era lifecycle serializer
 # ---------------------------------------------------------------------------
@@ -1078,28 +1080,7 @@ class BeatSerializer(serializers.ModelSerializer):
         # user.is_staff is safe on AccountDB and AnonymousUser; bool() guards None.
         is_staff = bool(user is not None and user.is_staff)
 
-        # Ownership gate (#1770 PR1 review, fold-in): DRF never calls
-        # has_object_permission on create, so IsBeatStoryOwnerOrStaff alone lets
-        # any authenticated user POST a Beat onto anyone's episode. Enforce the
-        # same ownership walk here via the shared predicate. On re-point (the
-        # episode FK is being changed), both the old and new episode's story
-        # must be owned by the requesting user.
-        from world.stories.permissions import user_owns_episode_story  # noqa: PLC0415
-
-        if not is_staff:
-            episode = merged.get("episode")
-            old_episode = self.instance.episode if self.instance is not None else None
-            is_repoint = (
-                old_episode is not None and episode is not None and old_episode.pk != episode.pk
-            )
-            owners_ok = episode is not None and user_owns_episode_story(cast(Any, user), episode)
-            if is_repoint:
-                owners_ok = owners_ok and user_owns_episode_story(
-                    cast(Any, user), cast(Episode, old_episode)
-                )
-            if not owners_ok:
-                msg = "You do not have permission to author a beat on this episode."
-                raise serializers.ValidationError(msg)
+        self._check_beat_ownership(user, is_staff, merged)
 
         if merged_risk != RenownRisk.NONE and not is_staff:
             raise serializers.ValidationError(
@@ -1111,6 +1092,33 @@ class BeatSerializer(serializers.ModelSerializer):
                 }
             )
         return attrs
+
+    def _check_beat_ownership(self, user: Any, is_staff: bool, merged: dict[str, Any]) -> None:
+        """Reject the write unless staff or the requesting user owns the episode's story.
+
+        #1770 PR1 review, fold-in: DRF never calls has_object_permission on
+        create, so IsBeatStoryOwnerOrStaff alone lets any authenticated user
+        POST a Beat onto anyone's episode. Enforce the same ownership walk here
+        via the shared predicate. On re-point (the episode FK is being changed),
+        both the old and new episode's story must be owned by the requesting user.
+        """
+        from world.stories.permissions import user_owns_episode_story  # noqa: PLC0415
+
+        if is_staff:
+            return
+        episode = merged.get("episode")
+        old_episode = self.instance.episode if self.instance is not None else None
+        is_repoint = (
+            old_episode is not None and episode is not None and old_episode.pk != episode.pk
+        )
+        owners_ok = episode is not None and user_owns_episode_story(cast(Any, user), episode)
+        if is_repoint:
+            owners_ok = owners_ok and user_owns_episode_story(
+                cast(Any, user), cast(Episode, old_episode)
+            )
+        if not owners_ok:
+            msg = "You do not have permission to author a beat on this episode."
+            raise serializers.ValidationError(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -1212,28 +1220,38 @@ class TransitionRequiredOutcomeSerializer(serializers.ModelSerializer):
         beat = merged.get("beat")
 
         if stake is not None:
-            if not required_stake_column:
-                raise serializers.ValidationError(
-                    {"required_stake_column": "Required when stake is set."}
-                )
-            if required_outcome:
-                msg = "Must be blank when stake is set (stake rows route on the stake column)."
-                raise serializers.ValidationError({"required_outcome": msg})
-            if beat is not None and stake.beat_id != beat.pk:
-                raise serializers.ValidationError(
-                    {"stake": "The stake must belong to this requirement's beat."}
-                )
+            self._validate_stake_row(stake, required_stake_column, required_outcome, beat)
         else:
-            if not required_outcome:
-                raise serializers.ValidationError(
-                    {"required_outcome": "Required when stake is not set."}
-                )
-            if required_stake_column:
-                raise serializers.ValidationError(
-                    {"required_stake_column": "Only allowed when stake is set."}
-                )
+            self._validate_outcome_row(required_outcome, required_stake_column)
 
         return attrs
+
+    def _validate_stake_row(
+        self, stake: Any, required_stake_column: str, required_outcome: str, beat: Any
+    ) -> None:
+        """Validate a stake-level predicate row (stake set, outcome blank)."""
+        if not required_stake_column:
+            raise serializers.ValidationError(
+                {"required_stake_column": "Required when stake is set."}
+            )
+        if required_outcome:
+            msg = "Must be blank when stake is set (stake rows route on the stake column)."
+            raise serializers.ValidationError({"required_outcome": msg})
+        if beat is not None and stake.beat_id != beat.pk:
+            raise serializers.ValidationError(
+                {"stake": "The stake must belong to this requirement's beat."}
+            )
+
+    def _validate_outcome_row(self, required_outcome: str, required_stake_column: str) -> None:
+        """Validate a beat-level predicate row (outcome set, stake null)."""
+        if not required_outcome:
+            raise serializers.ValidationError(
+                {"required_outcome": "Required when stake is not set."}
+            )
+        if required_stake_column:
+            raise serializers.ValidationError(
+                {"required_stake_column": "Only allowed when stake is set."}
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -2381,7 +2399,7 @@ def _check_stake_beat_lock(beat: Any, old_beat: Any, is_repoint: bool) -> None:
     beats_to_check = [beat] if not is_repoint else [beat, old_beat]
     for candidate in beats_to_check:
         if candidate is not None and get_open_activation(candidate) is not None:
-            msg = "This beat's stakes contract is locked by an open activation."
+            msg = _STAKES_LOCKED_MESSAGE
             raise serializers.ValidationError(msg)
 
 
@@ -2601,8 +2619,6 @@ class StakeSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs: Any) -> Any:
         """Ownership gate, two-sided lock check, template defaulting/banding, custom-stake gate."""
-        from world.stories.services.stakes import risk_index  # noqa: PLC0415
-
         existing: dict[str, Any] = {}
         if self.instance is not None:
             for field_name in ("beat", "template", "subject_kind", "severity"):
@@ -2627,44 +2643,54 @@ class StakeSerializer(serializers.ModelSerializer):
         template = merged.get("template")
 
         if template is not None:
-            if beat is not None:
-                beat_idx = risk_index(beat.risk)
-                band_lo = risk_index(template.min_risk)
-                band_hi = risk_index(template.max_risk)
-                if not band_lo <= beat_idx <= band_hi:
-                    raise serializers.ValidationError(
-                        {
-                            "template": (
-                                f"Template {template.name!r} is banded for risk "
-                                f"{template.min_risk}-{template.max_risk}; "
-                                f"this beat is declared at {beat.risk}."
-                            )
-                        }
-                    )
-            attrs.setdefault("subject_kind", template.subject_kind)
-            attrs.setdefault("severity", template.severity)
+            self._apply_template_defaults(template, beat, attrs)
         else:
-            if not is_staff:
-                raise serializers.ValidationError(
-                    {
-                        "template": (
-                            "Only staff may author custom stakes (template=null). "
-                            "Use a StakeTemplate instead."
-                        )
-                    }
-                )
-            if merged.get("subject_kind") is None:
-                raise serializers.ValidationError(
-                    {"subject_kind": "subject_kind is required when template is null."}
-                )
-            if merged.get("severity") is None:
-                raise serializers.ValidationError(
-                    {"severity": "severity is required when template is null."}
-                )
+            self._validate_custom_stake(is_staff, merged)
 
         self._check_boundaries(beat, attrs)
 
         return attrs
+
+    def _apply_template_defaults(self, template: Any, beat: Any, attrs: Any) -> None:
+        """Band the template against the beat's risk and default subject fields."""
+        from world.stories.services.stakes import risk_index  # noqa: PLC0415
+
+        if beat is not None:
+            beat_idx = risk_index(beat.risk)
+            band_lo = risk_index(template.min_risk)
+            band_hi = risk_index(template.max_risk)
+            if not band_lo <= beat_idx <= band_hi:
+                raise serializers.ValidationError(
+                    {
+                        "template": (
+                            f"Template {template.name!r} is banded for risk "
+                            f"{template.min_risk}-{template.max_risk}; "
+                            f"this beat is declared at {beat.risk}."
+                        )
+                    }
+                )
+        attrs.setdefault("subject_kind", template.subject_kind)
+        attrs.setdefault("severity", template.severity)
+
+    def _validate_custom_stake(self, is_staff: bool, merged: dict[str, Any]) -> None:
+        """Gate custom stakes (template=null) to staff and require subject fields."""
+        if not is_staff:
+            raise serializers.ValidationError(
+                {
+                    "template": (
+                        "Only staff may author custom stakes (template=null). "
+                        "Use a StakeTemplate instead."
+                    )
+                }
+            )
+        if merged.get("subject_kind") is None:
+            raise serializers.ValidationError(
+                {"subject_kind": "subject_kind is required when template is null."}
+            )
+        if merged.get("severity") is None:
+            raise serializers.ValidationError(
+                {"severity": "severity is required when template is null."}
+            )
 
     def _candidate_stake(self, beat: Any, attrs: Any) -> Stake:
         """An unsaved Stake carrying this write's effective field values.
@@ -2743,9 +2769,6 @@ class StakeRewardLineSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs: Any) -> Any:
         """Ownership gate + two-sided lock check via the (possibly re-pointed) resolution."""
-        from world.stories.permissions import user_owns_beat_story  # noqa: PLC0415
-        from world.stories.services.stakes import get_open_activation  # noqa: PLC0415
-
         old_resolution = self.instance.resolution if self.instance is not None else None
         resolution = attrs.get("resolution") or old_resolution
         is_repoint = (
@@ -2759,38 +2782,9 @@ class StakeRewardLineSerializer(serializers.ModelSerializer):
         # user.is_staff is safe on AccountDB and AnonymousUser; bool() guards None.
         is_staff = bool(user is not None and user.is_staff)
 
-        # Ownership gate: DRF never calls has_object_permission on create, so
-        # IsStakeRewardLineBeatStoryOwnerOrStaff alone would let any
-        # authenticated user POST a reward line onto anyone's resolution.
-        # Ownership before lock — a non-owner probing a foreign resolution
-        # must get the permission error, never learn the lock state.
-        if not is_staff:
-            owners_ok = resolution is not None and user_owns_beat_story(
-                cast(Any, user), resolution.stake.beat
-            )
-            if is_repoint:
-                owners_ok = owners_ok and user_owns_beat_story(
-                    cast(Any, user), old_resolution.stake.beat
-                )
-            if not owners_ok:
-                msg = "You do not have permission to author a reward line on this resolution."
-                raise serializers.ValidationError(msg)
+        self._check_reward_line_ownership(user, is_staff, resolution, old_resolution, is_repoint)
 
-        # Lock check: re-pointing to/from a resolution whose beat is locked is
-        # rejected either way — check both sides when re-pointing.
-        # Completed-beat check (#1770 PR3 review): once the completion tail
-        # closes the activation (with stakes possibly pending a GM pick), the
-        # open-activation lock no longer bites — without this check reward
-        # lines could be re-authored after the contract ran and pay out on
-        # the stale activation's readiness verdict.
-        resolutions_to_check = [resolution] if not is_repoint else [resolution, old_resolution]
-        for candidate in resolutions_to_check:
-            if candidate is not None and get_open_activation(candidate.stake.beat) is not None:
-                msg = "This beat's stakes contract is locked by an open activation."
-                raise serializers.ValidationError(msg)
-            if candidate is not None and candidate.stake.beat.outcome != BeatOutcome.UNSATISFIED:
-                msg = "This beat has completed; its stakes contract can no longer be edited."
-                raise serializers.ValidationError(msg)
+        self._check_resolution_lock(resolution, old_resolution, is_repoint)
 
         # WIN-column only (#1770 PR3 review): a "consolation" line on a
         # LOSS/WITHDRAWAL branch would be silently inert — refuse it.
@@ -2802,6 +2796,57 @@ class StakeRewardLineSerializer(serializers.ModelSerializer):
         self._validate_sink_shape(attrs)
 
         return attrs
+
+    def _check_reward_line_ownership(
+        self, user: Any, is_staff: bool, resolution: Any, old_resolution: Any, is_repoint: bool
+    ) -> None:
+        """Reject the write unless staff or the requesting user owns the resolution's beat story.
+
+        #1770 PR3 review: DRF never calls has_object_permission on create, so
+        IsStakeRewardLineBeatStoryOwnerOrStaff alone would let any authenticated
+        user POST a reward line onto anyone's resolution. Ownership before lock
+        — a non-owner probing a foreign resolution must get the permission
+        error, never learn the lock state.
+        """
+        from world.stories.permissions import user_owns_beat_story  # noqa: PLC0415
+
+        if is_staff:
+            return
+        owners_ok = resolution is not None and user_owns_beat_story(
+            cast(Any, user), resolution.stake.beat
+        )
+        if is_repoint:
+            owners_ok = owners_ok and user_owns_beat_story(
+                cast(Any, user), old_resolution.stake.beat
+            )
+        if not owners_ok:
+            msg = "You do not have permission to author a reward line on this resolution."
+            raise serializers.ValidationError(msg)
+
+    def _check_resolution_lock(
+        self, resolution: Any, old_resolution: Any, is_repoint: bool
+    ) -> None:
+        """Reject the write if any involved resolution's beat is locked or completed.
+
+        #1770 PR3 review: re-pointing to/from a resolution whose beat is locked
+        is rejected either way. Once the completion tail closes the activation
+        (with stakes possibly pending a GM pick), the open-activation lock no
+        longer bites — without the completed-beat check reward lines could be
+        re-authored after the contract ran and pay out on the stale activation's
+        readiness verdict.
+        """
+        from world.stories.services.stakes import get_open_activation  # noqa: PLC0415
+
+        resolutions_to_check = [resolution] if not is_repoint else [resolution, old_resolution]
+        for candidate in resolutions_to_check:
+            if candidate is None:
+                continue
+            if get_open_activation(candidate.stake.beat) is not None:
+                msg = _STAKES_LOCKED_MESSAGE
+                raise serializers.ValidationError(msg)
+            if candidate.stake.beat.outcome != BeatOutcome.UNSATISFIED:
+                msg = "This beat has completed; its stakes contract can no longer be edited."
+                raise serializers.ValidationError(msg)
 
     def _validate_sink_shape(self, attrs: Any) -> None:
         """Resonance required iff sink=RESONANCE (mirrors StakeRewardLine.clean)."""
@@ -2855,9 +2900,6 @@ class StakeResolutionSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs: Any) -> Any:
         """Ownership gate + two-sided lock check via the (possibly re-pointed) stake."""
-        from world.stories.permissions import user_owns_beat_story  # noqa: PLC0415
-        from world.stories.services.stakes import get_open_activation  # noqa: PLC0415
-
         old_stake = self.instance.stake if self.instance is not None else None
         stake = attrs.get("stake") or old_stake
         is_repoint = old_stake is not None and stake is not None and old_stake.pk != stake.pk
@@ -2867,42 +2909,57 @@ class StakeResolutionSerializer(serializers.ModelSerializer):
         # user.is_staff is safe on AccountDB and AnonymousUser; bool() guards None.
         is_staff = bool(user is not None and user.is_staff)
 
-        # Ownership gate (#1770 PR1 review): DRF never calls has_object_permission
-        # on create, so IsStakeResolutionBeatStoryOwnerOrStaff alone lets any
-        # authenticated user POST a StakeResolution onto anyone's stake. Enforce
-        # the same ownership walk here. On re-point, both the old and new
-        # stake's beat's story must be owned. Ownership before lock (#1770
-        # review): a non-owner probing a foreign stake must get the permission
-        # error, never learn the lock state.
-        if not is_staff:
-            owners_ok = stake is not None and user_owns_beat_story(cast(Any, user), stake.beat)
-            if is_repoint:
-                owners_ok = owners_ok and user_owns_beat_story(cast(Any, user), old_stake.beat)
-            if not owners_ok:
-                msg = "You do not have permission to author a resolution on this stake."
-                raise serializers.ValidationError(msg)
-
-        # Lock check (#1770 PR1 review): re-pointing to/from a stake whose beat
-        # is locked is rejected either way — check both sides when re-pointing.
-        # Completed-beat check (#1770 PR3 review): the open-activation lock
-        # alone leaves a hole — the completion tail closes the activation
-        # while stakes can still pend for a GM pick, which would reopen
-        # editing on a contract that already ran. Contract editing ends when
-        # the beat completes (pillar 8's spirit).
-        stakes_to_check = [stake] if not is_repoint else [stake, old_stake]
-        for candidate in stakes_to_check:
-            if candidate is not None and get_open_activation(candidate.beat) is not None:
-                msg = "This beat's stakes contract is locked by an open activation."
-                raise serializers.ValidationError(msg)
-            if candidate is not None and candidate.beat.outcome != BeatOutcome.UNSATISFIED:
-                msg = "This beat has completed; its stakes contract can no longer be edited."
-                raise serializers.ValidationError(msg)
+        self._enforce_ownership_gate(stake, old_stake, is_repoint, user, is_staff)
+        self._enforce_lock_state(stake, old_stake, is_repoint)
 
         self._validate_writer_payloads(attrs, stake)
 
         self._validate_writer_payloads(attrs, stake)
 
         return attrs
+
+    def _enforce_ownership_gate(
+        self, stake: Any, old_stake: Any, is_repoint: bool, user: Any, is_staff: bool
+    ) -> None:
+        """Ownership gate (#1770 PR1 review).
+
+        DRF never calls has_object_permission on create, so
+        IsStakeResolutionBeatStoryOwnerOrStaff alone lets any authenticated user
+        POST a StakeResolution onto anyone's stake. Enforce the same ownership
+        walk here. On re-point, both the old and new stake's beat's story must be
+        owned. Ownership before lock (#1770 review): a non-owner probing a
+        foreign stake must get the permission error, never learn the lock state.
+        """
+        from world.stories.permissions import user_owns_beat_story  # noqa: PLC0415
+
+        if is_staff:
+            return
+        owners_ok = stake is not None and user_owns_beat_story(cast(Any, user), stake.beat)
+        if is_repoint:
+            owners_ok = owners_ok and user_owns_beat_story(cast(Any, user), old_stake.beat)
+        if not owners_ok:
+            msg = "You do not have permission to author a resolution on this stake."
+            raise serializers.ValidationError(msg)
+
+    def _enforce_lock_state(self, stake: Any, old_stake: Any, is_repoint: bool) -> None:
+        """Lock check (#1770 PR1 review) + completed-beat check (#1770 PR3 review).
+
+        Re-pointing to/from a stake whose beat is locked is rejected either way —
+        check both sides when re-pointing. The open-activation lock alone leaves a
+        hole — the completion tail closes the activation while stakes can still
+        pend for a GM pick, which would reopen editing on a contract that already
+        ran. Contract editing ends when the beat completes (pillar 8's spirit).
+        """
+        from world.stories.services.stakes import get_open_activation  # noqa: PLC0415
+
+        stakes_to_check = [stake] if not is_repoint else [stake, old_stake]
+        for candidate in stakes_to_check:
+            if candidate is not None and get_open_activation(candidate.beat) is not None:
+                msg = _STAKES_LOCKED_MESSAGE
+                raise serializers.ValidationError(msg)
+            if candidate is not None and candidate.beat.outcome != BeatOutcome.UNSATISFIED:
+                msg = "This beat has completed; its stakes contract can no longer be edited."
+                raise serializers.ValidationError(msg)
 
     def _validate_writer_payloads(self, attrs: Any, stake: Any) -> None:
         """Pillar-12 no-fiat guard on the writer payloads (#1770 PR2).

--- a/src/world/stories/services/stake_resolution.py
+++ b/src/world/stories/services/stake_resolution.py
@@ -212,34 +212,10 @@ def resolve_stakes_for_completion(  # noqa: PLR0913
     for stake in stakes:
         if stake.pk in already_resolved:
             continue
-        if withdrawal:
-            resolution = _branch_for_column(stake, StakeResolutionColumn.WITHDRAWAL)
-            if resolution is None:
-                # No authored withdrawal branch: the stake pends with the
-                # beat's PENDING_GM_REVIEW for a GM's constrained pick.
-                continue
-            column = StakeResolutionColumn.WITHDRAWAL
-        elif stake.pk in withdrawn_stake_ids:
-            # #1771 story 5: the stake's treasured subject had its sign-off
-            # withdrawn on this beat — a revoked-consent wager never grades
-            # WIN/LOSS, even though the beat itself resolves normally.
-            column = StakeResolutionColumn.WITHDRAWAL
-            resolution = _branch_for_column(stake, column)
-            if resolution is None:
-                # No authored WITHDRAWAL branch: pend for a GM's constrained
-                # pick, same semantics as the whole-encounter withdrawal path.
-                continue
-        else:
-            column = _machine_column_for_stake(stake, outcome)
-            resolution = _branch_for_column(
-                stake, column, prefer_lifecycle_state=_subject_lifecycle_state(stake)
-            )
-            if resolution is not None:
-                # A lifecycle-state match may have selected a branch on the
-                # OTHER column (#1760 — e.g. a DEAD/CAPTURED override firing
-                # LOSS on a beat-level SUCCESS); record the branch's actual
-                # column, not the outcome-derived default.
-                column = resolution.column
+        picked = _select_stake_resolution(stake, outcome, withdrawal, withdrawn_stake_ids)
+        if picked is None:
+            continue
+        resolution, column = picked
         outcomes.append(
             _fire_branch_and_record(
                 stake=stake,
@@ -254,6 +230,53 @@ def resolve_stakes_for_completion(  # noqa: PLR0913
             )
         )
     return outcomes
+
+
+def _select_stake_resolution(
+    stake: Stake,
+    outcome: BeatOutcome,
+    withdrawal: bool,
+    withdrawn_stake_ids: set[int],
+) -> tuple[StakeResolution | None, StakeResolutionColumn] | None:
+    """Pick the (resolution, column) for a single open stake, or None to skip.
+
+    Returns None (pend for a GM's constrained pick) when the selected branch is
+    unauthored. The three top-level branches mirror ``resolve_stakes_for_completion``:
+
+    - ``withdrawal`` (combat FLED/ABANDONED): only the WITHDRAWAL branch fires.
+    - revoked-consent subject (#1771 story 5): a WITHDRAWAL column is forced.
+    - otherwise the beat outcome maps to a column (WIN/LOSS), with a
+      lifecycle-state match (#1760) potentially selecting the other column.
+    """
+    if withdrawal:
+        resolution = _branch_for_column(stake, StakeResolutionColumn.WITHDRAWAL)
+        if resolution is None:
+            # No authored withdrawal branch: the stake pends with the
+            # beat's PENDING_GM_REVIEW for a GM's constrained pick.
+            return None
+        return resolution, StakeResolutionColumn.WITHDRAWAL
+    if stake.pk in withdrawn_stake_ids:
+        # #1771 story 5: the stake's treasured subject had its sign-off
+        # withdrawn on this beat — a revoked-consent wager never grades
+        # WIN/LOSS, even though the beat itself resolves normally.
+        column = StakeResolutionColumn.WITHDRAWAL
+        resolution = _branch_for_column(stake, column)
+        if resolution is None:
+            # No authored WITHDRAWAL branch: pend for a GM's constrained
+            # pick, same semantics as the whole-encounter withdrawal path.
+            return None
+        return resolution, column
+    column = _machine_column_for_stake(stake, outcome)
+    resolution = _branch_for_column(
+        stake, column, prefer_lifecycle_state=_subject_lifecycle_state(stake)
+    )
+    if resolution is not None:
+        # A lifecycle-state match may have selected a branch on the
+        # OTHER column (#1760 — e.g. a DEAD/CAPTURED override firing
+        # LOSS on a beat-level SUCCESS); record the branch's actual
+        # column, not the outcome-derived default.
+        column = resolution.column
+    return resolution, column
 
 
 def _machine_column_for_stake(

--- a/src/world/stories/services/stakes.py
+++ b/src/world/stories/services/stakes.py
@@ -132,16 +132,34 @@ def _jeopardy_reachable(beat: Beat, max_hops: int) -> bool:
             )
             for transition in transitions:
                 target = transition.target_episode
-                if target is None or target.maturity == StoryMaturity.PITCH:
+                reachable = _downstream_episode_reaches_removal(target, transition, episode_id)
+                if reachable is None:
                     continue
-                if not _transition_follows_failure(transition, episode_id):
-                    continue
-                if any(_beat_offers_removal(downstream) for downstream in target.beats.all()):
+                if reachable is True:
                     return True
                 next_frontier.add(target.pk)
         frontier = next_frontier
         if not frontier:
             break
+    return False
+
+
+def _downstream_episode_reaches_removal(
+    target: object, transition: Transition, episode_id: int
+) -> bool | None:
+    """Whether a failure-following transition's target episode reaches removal.
+
+    Returns ``True`` when the target episode has a beat offering removal (the
+    cascade terminates there); ``False`` when it is a valid next hop to enqueue;
+    ``None`` when the transition should be skipped (no target, PITCH maturity, or
+    not a failure-following transition).
+    """
+    if target is None or target.maturity == StoryMaturity.PITCH:
+        return None
+    if not _transition_follows_failure(transition, episode_id):
+        return None
+    if any(_beat_offers_removal(downstream) for downstream in target.beats.all()):
+        return True
     return False
 
 


### PR DESCRIPTION
## Summary

Resolves all 50 open SonarCloud-tagged issues in a single pass. Each rule category was addressed with behavior-preserving refactors — no business logic changed.

### S1192 — Duplicated string literals → constants (23 issues)

Extracted duplicated string literals into module-level constants across 15 files. The literals were primarily:
- Django model FK strings (e.g. `"stories.Beat"`, `"buildings.Building"`)
- User-facing error messages (e.g. `"No such ship."`, `"Character not found."`)
- Lock strings, help_text, and factory SubFactory paths

### S3776 — Cognitive complexity → extract helpers (23 issues)

Refactored 23 functions across 12 files to reduce cognitive complexity below the threshold of 15. Each refactor extracts nested conditional logic into well-named private helper functions. All side effects execute in the same order within the same transaction blocks.

### S3735 — TypeScript `void` operator removal (4 issues)

Removed the `void` operator from fire-and-forget `invalidateQueries` calls in 3 frontend files. The returned promise is already properly handled by React Query's internal lifecycle.

## Issues closed

Closes #1935
Closes #1936
Closes #1937
Closes #1938
Closes #1939
Closes #1940
Closes #1941
Closes #1942
Closes #1943
Closes #1944
Closes #1945
Closes #1946
Closes #1947
Closes #1948
Closes #1949
Closes #1950
Closes #1951
Closes #1952
Closes #1953
Closes #1954
Closes #1955
Closes #1956
Closes #1957
Closes #1958
Closes #1959
Closes #1960
Closes #1961
Closes #1962
Closes #1963
Closes #1964
Closes #1965
Closes #1966
Closes #1967
Closes #1968
Closes #1969
Closes #1970
Closes #1971
Closes #1972
Closes #1973
Closes #1974
Closes #1975
Closes #1976
Closes #1977
Closes #1978
Closes #1979
Closes #1980
Closes #1981
Closes #1982
Closes #1983
Closes #1984

## Test plan

- [x] `pnpm typecheck` passes (frontend)
- [x] `just test-fast actions` — 904 tests, 0 failures
- [x] Refactored module tests pass: `world.magic.tests`, `world.stories.tests`, `world.societies.tests`, `world.mechanics.tests`, `world.scenes.tests`, `world.combat.tests`, `world.covenants.tests`, `world.battles.tests`, `world.npc_services.tests`, `world.missions.tests` — 1700+ tests, 0 failures
- [x] Pre-commit hooks all pass (ruff, eslint, prettier, typecheck)
- [ ] CI full suite