### PR TITLE
Strategic battle map page: battles read API + React Flow front map + live unit dispositions + encounter drill-down

### DIFF
--- a/docs/adr/0095-battle-live-updates-are-ping-plus-refetch.md
+++ b/docs/adr/0095-battle-live-updates-are-ping-plus-refetch.md
@@ -1,0 +1,23 @@
+# Battle live updates are a slim BATTLE_STATE ping plus REST refetch, not a full-state WS payload
+
+The strategic battle-map page (#2009) needs live updates: a participant watching the map should
+see the round advance, VP change, and unit/place state shift as the GM resolves rounds, without
+reloading the page. We chose a slim WebSocket ping — `BATTLE_STATE` carries only
+`{battle_id, round_number}` (`web.webclient.message_types.BattleStatePayload`) — over pushing the
+full battle aggregate through the socket. On receipt, the frontend
+(`hooks/handleBattleStatePayload.ts`) applies no data from the payload at all; it just invalidates
+the React Query cache (`battleKeys.all`), which triggers a refetch of the same
+`GET /api/battles/<pk>/` aggregate (`BattleDetailSerializer`) the page already reads on load. This
+keeps `BattleDetailSerializer` the single source of truth for battle shape — there is no second,
+independently-maintained WS payload shape that can drift out of sync with the REST one as the
+aggregate grows (sides/places/units/participants/fortifications/vehicles). The ping is sent from
+`world.battles.services.notify_battle_state_changed`, called from `begin_battle_round`,
+`resolve_battle_round`, and `conclude_battle`, each deferring the send via
+`transaction.on_commit` — so it always fires after the triggering transaction actually commits,
+and a client that refetches on receipt is guaranteed to read committed state, never a
+partially-applied round. We rejected pushing the full aggregate over the socket (duplicates
+`BattleDetailSerializer`'s shape in a second, hand-maintained WS payload, with real drift risk as
+the aggregate evolves) and rejected polling (adds latency between a round resolving and the map
+updating, and wastes requests on inactive battles).
+
+> Status: accepted · Source: #2009

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -126,6 +126,7 @@ treat those names as hints to confirm, not gospel.
 - [0084 — Battle environment reads ambient weather via Battle.region, not the room graph](0084-battle-environment-reads-ambient-weather-via-battle-region.md)
 - [0085 — BattlePlace gains internal battle-map coordinates, additive to ADR-0081](0085-battleplace-internal-battle-map-coordinates.md)
 - [0085 — NPCStanding carries debt and petition-failure-streak, not CourtPact](0085-npcstanding-debt-and-petition-streak-are-generic.md)
+- [0095 — Battle live updates are a slim BATTLE_STATE ping plus REST refetch, not a full-state WS payload](0095-battle-live-updates-are-ping-plus-refetch.md)
 - [0091 — instantiate_situation mints Challenges via an authored target-object name; GM triggers it with a plain staff Action](0091-instantiate-situation-mints-challenges-gm-trigger.md) (supersedes ADR-0090)
 
 ### Gift & resonance economy

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -126,8 +126,8 @@ treat those names as hints to confirm, not gospel.
 - [0084 — Battle environment reads ambient weather via Battle.region, not the room graph](0084-battle-environment-reads-ambient-weather-via-battle-region.md)
 - [0085 — BattlePlace gains internal battle-map coordinates, additive to ADR-0081](0085-battleplace-internal-battle-map-coordinates.md)
 - [0085 — NPCStanding carries debt and petition-failure-streak, not CourtPact](0085-npcstanding-debt-and-petition-streak-are-generic.md)
-- [0095 — Battle live updates are a slim BATTLE_STATE ping plus REST refetch, not a full-state WS payload](0095-battle-live-updates-are-ping-plus-refetch.md)
 - [0091 — instantiate_situation mints Challenges via an authored target-object name; GM triggers it with a plain staff Action](0091-instantiate-situation-mints-challenges-gm-trigger.md) (supersedes ADR-0090)
+- [0095 — Battle live updates are a slim BATTLE_STATE ping plus REST refetch, not a full-state WS payload](0095-battle-live-updates-are-ping-plus-refetch.md)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -55,7 +55,13 @@ outcome** (a closed issue or a "SHIPPED" line is not proof). See the ledger's go
   dragon/kraken remain data variants (`VehicleKind`) pending their own end-to-end
   pass — no dedicated content, telnet reposition subcommand, reposition-movement
   resolution, or persistent-ship equivalent yet.
-  Deferred: battle writeup page (#1735).
+  Live strategic battle map shipped (#2009): read-only REST aggregate
+  (`GET /api/battles/`, `GET /api/battles/<pk>/`, scene-visibility-gated) + a
+  slim `BATTLE_STATE` WS ping (`{battle_id, round_number}`, sent post-commit
+  on round transitions/conclusion) driving a React Flow map page at
+  `/scenes/:id/battle` — see [battles.md](../systems/battles.md#web-surface-2009).
+  Deferred: a post-conclusion battle writeup page (#1735), which should reuse
+  `BattleDetailSerializer`'s aggregate shape rather than authoring a second one.
 - Mounts / charging / flying (P2, no-improv-flagged); ranged / archery enforcement.
 
 ## Reserved term: "clash"

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2882,7 +2882,22 @@ through abstract round-based VP mechanics. `Battle` is a 1:1 extension of `scene
   (the underlying `declare_battle_action`/`DeclareBattleActionAction` already
   supports REPOSITION generically) remain deferred. See
   [battles.md](battles.md#battlevehicle) for the full mechanism.
-- **Deferred follow-ups:** battle writeup page (#1735); naval/aerial embark actions
+- **REST/WS surface (#2009):** `BattleViewSet` (`IsAuthenticated`, scene-gated exactly like
+  `CombatEncounterViewSet` — staff unfiltered, else `scene__in=Scene.objects.viewable_by`,
+  404s a private battle rather than leaking a 403) exposes `GET /api/battles/` (list,
+  `?scene=`/`?outcome=` filters) and `GET /api/battles/<pk>/` (`BattleDetailSerializer` —
+  the single aggregate: sides → places (x/y/footprint/terrain/`controlled_by`/
+  `encounter_scene_id`/`vehicle`/`fortifications`) → units → participants (persona
+  id/name/thumbnail only)). `notify_battle_state_changed` sends a slim `BATTLE_STATE`
+  WS ping (`{battle_id, round_number}`, no battle data) to connected participants from
+  `begin_battle_round`/`resolve_battle_round`/`conclude_battle`, each via
+  `transaction.on_commit` (see ADR-0095: ping-plus-refetch, not a state payload push).
+  Frontend: `/scenes/:id/battle` — a read-only React Flow `BattleMapPage`, refetching
+  the aggregate via React Query on `BATTLE_STATE` receipt. See
+  [battles.md](battles.md#web-surface-2009) for the full contract.
+- **Deferred follow-ups:** battle writeup page (#1735 — should reuse
+  `BattleDetailSerializer`'s aggregate rather than authoring a second one; the live
+  strategic map itself shipped, #2009); naval/aerial embark actions
   and a dedicated REPOSITION telnet subcommand remain deferred (#1714) — the vehicle
   model, REPOSITION declaration and movement resolution, overlap-gated boarding, and
   hull-breach/living-mount-defeat ejection are built (see the Vehicles subsection

--- a/docs/systems/battles.md
+++ b/docs/systems/battles.md
@@ -1017,8 +1017,8 @@ Battles are location-less (`Battle.scene.location` is `None`), so the existing
 room/scene broadcast paths never reach participants — `BATTLE_STATE` is the
 dedicated seam. The payload (`web.webclient.message_types.BattleStatePayload`)
 carries only `{battle_id, round_number}` — no battle data itself; it is a slim
-"go refetch" ping, not a state push. Sent to every participant with an
-account, regardless of participant status
+"go refetch" ping, not a state push. Sent to every **connected** participant
+(`has_account` = live session), regardless of participant status
 (`character.msg(battle_state=((), payload))`) from three call sites —
 `begin_battle_round`, `resolve_battle_round`, `conclude_battle` — each wrapping
 the send in `transaction.on_commit(lambda: notify_battle_state_changed(battle))`

--- a/docs/systems/battles.md
+++ b/docs/systems/battles.md
@@ -1017,8 +1017,9 @@ Battles are location-less (`Battle.scene.location` is `None`), so the existing
 room/scene broadcast paths never reach participants — `BATTLE_STATE` is the
 dedicated seam. The payload (`web.webclient.message_types.BattleStatePayload`)
 carries only `{battle_id, round_number}` — no battle data itself; it is a slim
-"go refetch" ping, not a state push. Sent to every ACTIVE participant with an
-account (`character.msg(battle_state=((), payload))`) from three call sites —
+"go refetch" ping, not a state push. Sent to every participant with an
+account, regardless of participant status
+(`character.msg(battle_state=((), payload))`) from three call sites —
 `begin_battle_round`, `resolve_battle_round`, `conclude_battle` — each wrapping
 the send in `transaction.on_commit(lambda: notify_battle_state_changed(battle))`
 so it fires only once the round/conclusion transaction actually commits; a

--- a/docs/systems/battles.md
+++ b/docs/systems/battles.md
@@ -853,7 +853,7 @@ declaration. Telnet grammar for all four (`battle declare rout/rally/repel/hold 
 
 | What | Issue |
 |---|---|
-| Battle writeup / React page | #1735 |
+| Battle writeup / React page | partially built — the live strategic battle map (`/scenes/:id/battle`, [Web surface (#2009)](#web-surface-2009) below) shipped; a post-conclusion narrative writeup page is still deferred (#1735), and should reuse `BattleDetailSerializer`'s aggregate shape rather than authoring a second one |
 | Naval / aerial variants | partially built (`BattleVehicle`, `BattleActionKind.REPOSITION` + vehicle-commander gating + movement resolution, hull-breach/living-mount-defeat ejection + drowning/falling hazard, see below); a player-facing embark action and a dedicated telnet `CmdBattle` subcommand for REPOSITION still deferred (#1714) |
 | Siege variants | **built, see [Sieges (#1713)](#sieges-1713) below** |
 
@@ -977,6 +977,67 @@ token since a front may carry more than one structure and a `Fortification` has 
 name of its own (#1713). `open_siege_engine_encounter` remains the one exception:
 it has no `ChallengeChampionDuelAction`-style Action or telnet counterpart yet.
 
+## Web surface (#2009)
+
+The strategic battle map is a web-first read surface layered on top of the round
+flow above — no new mutation path; the GM/player Actions and telnet grammar
+already documented remain the only way to change battle state.
+
+### REST: `BattleViewSet` (`world/battles/views.py`, `world/battles/urls.py`)
+
+`ReadOnlyModelViewSet`, `IsAuthenticated`, `DjangoFilterBackend` on
+`scene`/`outcome`, `StandardResultsSetPagination` (`world.stories.pagination`):
+
+- `GET /api/battles/` — `BattleListSerializer` (id/name/scene_id/outcome/created_at),
+  filterable by `?scene=<id>` (a Scene has at most one Battle, 1:1 extension —
+  the frontend's `useBattleForSceneQuery` lists with `?scene=` and takes
+  `results[0]`) and `?outcome=<BattleOutcome>`.
+- `GET /api/battles/<pk>/` — `BattleDetailSerializer`, the single aggregate the
+  map page consumes: `sides` (`BattleSideSerializer` — role/VP/threshold/posture/
+  covenant) → `places` (`BattlePlaceSerializer` — name/terrain/`x`/`y`/
+  `footprint_radius`/`controlled_by_id`/`encounter_scene_id`/`vehicle`/
+  `fortifications`) → `units` (`BattleUnitSerializer`) and `participants`
+  (`BattleParticipantSerializer` — persona id/name/thumbnail only, never
+  account/username, matching the leak rule #1932 fixed). `encounter_scene_id`
+  surfaces the bridged `CombatEncounter`'s scene (#1236) for the panel's "View
+  encounter" link. `vehicle`/`fortifications` are read through
+  `Battle.state_cache`/the view's `to_attr` prefetches — zero extra queries per
+  place, never a bare related-manager query.
+
+**Visibility:** `_filter_readable` mirrors `CombatEncounterViewSet`'s rule
+exactly — staff see every battle unfiltered; everyone else is scoped to
+`scene__in=Scene.objects.viewable_by(user)`. A battle whose scene the caller
+can't view 404s on both list (simply absent) and detail (`test_non_participant_detail_is_404_not_403`)
+— no separate 403 branch, so a private battle's existence is never leaked to a
+non-viewer.
+
+### WebSocket: `BATTLE_STATE` ping (`world.battles.services.notify_battle_state_changed`)
+
+Battles are location-less (`Battle.scene.location` is `None`), so the existing
+room/scene broadcast paths never reach participants — `BATTLE_STATE` is the
+dedicated seam. The payload (`web.webclient.message_types.BattleStatePayload`)
+carries only `{battle_id, round_number}` — no battle data itself; it is a slim
+"go refetch" ping, not a state push. Sent to every ACTIVE participant with an
+account (`character.msg(battle_state=((), payload))`) from three call sites —
+`begin_battle_round`, `resolve_battle_round`, `conclude_battle` — each wrapping
+the send in `transaction.on_commit(lambda: notify_battle_state_changed(battle))`
+so it fires only once the round/conclusion transaction actually commits; a
+client that refetches on receipt always reads committed state. See
+**ADR-0095** for why this is a ping-plus-refetch design rather than a full
+state payload over the socket.
+
+### Frontend: `/scenes/:id/battle` (`frontend/src/battles/`)
+
+`BattleMapPage` (route registered in `App.tsx`) is a read-only React Flow
+canvas: `useBattleForSceneQuery` resolves the scene's one Battle, then
+`useBattleDetailQuery` fetches the aggregate `BattleMapCanvas` (places
+positioned by their `x`/`y`/`footprint_radius`) and `PlaceDetailPanel`
+(selected place's units/participants/fortifications, with a "View encounter"
+link to `/scenes/:id/combat` when `encounter_scene_id` is set) both read from.
+`hooks/handleBattleStatePayload.ts` handles the `BATTLE_STATE` WS message by
+calling `queryClient.invalidateQueries({ queryKey: battleKeys.all })` — no
+payload data is applied directly; invalidation alone triggers the refetch.
+
 ## Test Coverage
 
 - `src/world/battles/tests/test_constants.py` — enum smoke tests
@@ -1068,6 +1129,10 @@ it has no `ChallengeChampionDuelAction`-style Action or telnet counterpart yet.
   `start_fortification_upgrade`/`complete_fortification_upgrade`: target-level
   validation (`FortificationLevelExceedsMaximumError`), monotonic max-set on
   completion, idempotent re-application via the `applied_at` claim
+- `src/world/battles/tests/test_api.py` (#2009) — `BattleApiJourneyTest`: list/
+  detail aggregate shape, `?scene=`/`?outcome=` filters, staff-unfiltered vs.
+  `viewable_by`-scoped visibility, `test_non_participant_detail_is_404_not_403`
+  (no existence oracle), query-count assertions for the `to_attr` prefetches
 
 ## Integrates With
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { TidingsPage } from './tidings/pages/TidingsPage';
 import { JournalPage } from './missions/pages/JournalPage';
 import { SceneDetailPage } from './scenes/pages/SceneDetailPage';
 import { CombatScenePage } from './combat/pages/CombatScenePage';
+import { BattleMapPage } from './battles/pages/BattleMapPage';
 import MailPage from './mail/pages/MailPage';
 import { XpKudosPage } from './progression/XpKudosPage';
 import { EventsListPage } from '@/events/pages/EventsListPage';
@@ -319,6 +320,7 @@ function App() {
         <Route path="/scenes" element={<ScenesListPage />} />
         <Route path="/scenes/:id" element={<SceneDetailPage />} />
         <Route path="/scenes/:id/combat" element={<CombatScenePage />} />
+        <Route path="/scenes/:id/battle" element={<BattleMapPage />} />
         <Route path="/events" element={<EventsListPage />} />
         <Route
           path="/events/new"

--- a/frontend/src/battles/api.ts
+++ b/frontend/src/battles/api.ts
@@ -1,0 +1,28 @@
+import { apiFetch } from '@/evennia_replacements/api';
+
+import type { BattleDetail, PaginatedBattleListList } from './types';
+
+async function getJson<T>(url: string, fallbackError: string): Promise<T> {
+  const res = await apiFetch(url);
+  if (!res.ok) {
+    let detail = fallbackError;
+    try {
+      const data = (await res.json()) as { detail?: string };
+      if (typeof data.detail === 'string' && data.detail.trim()) {
+        detail = data.detail;
+      }
+    } catch {
+      // body wasn't JSON; keep the generic message
+    }
+    throw new Error(detail);
+  }
+  return (await res.json()) as T;
+}
+
+export function fetchBattlesForScene(sceneId: number): Promise<PaginatedBattleListList> {
+  return getJson(`/api/battles/?scene=${sceneId}`, 'Failed to load the battle.');
+}
+
+export function fetchBattleDetail(battleId: number): Promise<BattleDetail> {
+  return getJson(`/api/battles/${battleId}/`, 'Failed to load the battle.');
+}

--- a/frontend/src/battles/components/BattleMapCanvas.tsx
+++ b/frontend/src/battles/components/BattleMapCanvas.tsx
@@ -20,10 +20,10 @@ import {
   useNodesState,
 } from '@xyflow/react';
 
-import { computeBounds, planeToCanvas, radiusToPixels } from '../mapMath';
+import { centeredNodePosition, computeBounds, planeToCanvas, radiusToPixels } from '../mapMath';
 import type { BattleDetail } from '../types';
 import type { PlaceControlRole, PlaceNodeData } from './PlaceNode';
-import { PlaceNode } from './PlaceNode';
+import { MIN_SIZE_PX, PlaceNode } from './PlaceNode';
 
 import '@xyflow/react/dist/style.css';
 
@@ -58,13 +58,20 @@ function BattleMapCanvasInner({ detail, selectedPlaceId, onSelectPlace }: Battle
         place.controlled_by_id != null ? (roleBySideId.get(place.controlled_by_id) ?? null) : null;
       const role: PlaceControlRole =
         rawRole === 'attacker' || rawRole === 'defender' ? rawRole : null;
+      // Final rendered diameter, clamped so tiny footprints stay clickable —
+      // computed once here so both the node's size and its centered position
+      // (below) agree on the same value.
+      const sizePx = Math.max(
+        MIN_SIZE_PX,
+        Math.round(radiusToPixels(place.footprint_radius, bounds) * 2)
+      );
 
       const data: PlaceNodeData = {
         place,
         role,
         unitCount,
         pcCount,
-        sizePx: radiusToPixels(place.footprint_radius, bounds),
+        sizePx,
         selected: place.id === selectedPlaceId,
         onSelect: onSelectPlace,
       };
@@ -72,7 +79,9 @@ function BattleMapCanvasInner({ detail, selectedPlaceId, onSelectPlace }: Battle
       return {
         id: String(place.id),
         type: 'place',
-        position: planeToCanvas(place, bounds),
+        // React Flow positions nodes by top-left corner — offset by half the
+        // node's size so it's centered on the place's plane coordinate (#2009 review).
+        position: centeredNodePosition(planeToCanvas(place, bounds), sizePx),
         data,
         draggable: false,
       } satisfies Node;

--- a/frontend/src/battles/components/BattleMapCanvas.tsx
+++ b/frontend/src/battles/components/BattleMapCanvas.tsx
@@ -1,0 +1,125 @@
+/**
+ * BattleMapCanvas — the strategic battle map (#2009): places positioned on
+ * their plane coordinates, sized by footprint_radius, ringed by controlling
+ * side. Read-only: `nodesDraggable={false}` (Decision 1 — reposition is a
+ * future move action, #1712 explicitly did not build it). Clicking a place
+ * selects it for the detail panel.
+ *
+ * Composition mirrors `buildings/components/BuilderCanvas.tsx`:
+ * `ReactFlowProvider` wrapper, module-level `nodeTypes`, `Background` +
+ * `Controls`.
+ */
+
+import { useCallback, useEffect, useMemo } from 'react';
+import {
+  Background,
+  Controls,
+  type Node,
+  ReactFlow,
+  ReactFlowProvider,
+  useNodesState,
+} from '@xyflow/react';
+
+import { computeBounds, planeToCanvas, radiusToPixels } from '../mapMath';
+import type { BattleDetail } from '../types';
+import type { PlaceControlRole, PlaceNodeData } from './PlaceNode';
+import { PlaceNode } from './PlaceNode';
+
+import '@xyflow/react/dist/style.css';
+
+const nodeTypes = { place: PlaceNode };
+
+export interface BattleMapCanvasProps {
+  detail: BattleDetail;
+  selectedPlaceId: number | null;
+  onSelectPlace: (placeId: number) => void;
+}
+
+export function BattleMapCanvas(props: BattleMapCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <BattleMapCanvasInner {...props} />
+    </ReactFlowProvider>
+  );
+}
+
+function BattleMapCanvasInner({ detail, selectedPlaceId, onSelectPlace }: BattleMapCanvasProps) {
+  const computedNodes = useMemo<Node[]>(() => {
+    const { places, sides, units, participants } = detail;
+    const bounds = computeBounds(places);
+    const roleBySideId = new Map(sides.map((side) => [side.id, side.role ?? null]));
+
+    return places.map((place) => {
+      const unitCount = units.filter((unit) => unit.place_id === place.id).length;
+      const pcCount = participants.filter(
+        (participant) => participant.place_id === place.id
+      ).length;
+      const rawRole =
+        place.controlled_by_id != null ? (roleBySideId.get(place.controlled_by_id) ?? null) : null;
+      const role: PlaceControlRole =
+        rawRole === 'attacker' || rawRole === 'defender' ? rawRole : null;
+
+      const data: PlaceNodeData = {
+        place,
+        role,
+        unitCount,
+        pcCount,
+        sizePx: radiusToPixels(place.footprint_radius, bounds),
+        selected: place.id === selectedPlaceId,
+        onSelect: onSelectPlace,
+      };
+
+      return {
+        id: String(place.id),
+        type: 'place',
+        position: planeToCanvas(place, bounds),
+        data,
+        draggable: false,
+      } satisfies Node;
+    });
+  }, [detail, selectedPlaceId, onSelectPlace]);
+
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+
+  useEffect(() => {
+    setNodes(computedNodes);
+  }, [computedNodes, setNodes]);
+
+  const onNodeClick = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      const placeId = Number(node.id);
+      if (!Number.isNaN(placeId)) {
+        onSelectPlace(placeId);
+      }
+    },
+    [onSelectPlace]
+  );
+
+  if (detail.places.length === 0) {
+    return (
+      <div
+        className="flex h-full w-full items-center justify-center rounded-lg border border-border bg-card text-sm text-muted-foreground"
+        data-testid="battle-map-canvas-empty"
+      >
+        No places recorded for this battle yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-full" data-testid="battle-map-canvas">
+      <ReactFlow
+        nodes={nodes}
+        edges={[]}
+        nodeTypes={nodeTypes}
+        onNodesChange={onNodesChange}
+        onNodeClick={onNodeClick}
+        nodesDraggable={false}
+        fitView
+      >
+        <Background />
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/frontend/src/battles/components/PlaceDetailPanel.tsx
+++ b/frontend/src/battles/components/PlaceDetailPanel.tsx
@@ -91,7 +91,7 @@ export function PlaceDetailPanel({ place, sides, units, participants }: PlaceDet
               ) : (
                 <Shield className="h-4 w-4 shrink-0 text-muted-foreground" />
               )}
-              <span className="capitalize">{fort.kind}</span>
+              <span className="capitalize">{fort.kind ?? 'fortification'}</span>
               <Progress
                 value={integrityPercent(fort.integrity, fort.max_integrity)}
                 className="h-2 w-24"
@@ -126,10 +126,16 @@ export function PlaceDetailPanel({ place, sides, units, participants }: PlaceDet
               <div className="mt-1 flex items-center gap-2">
                 <span className="w-14 shrink-0 text-[10px] text-muted-foreground">Strength</span>
                 <Progress value={clampResourcePercent(unit.strength)} className="h-1.5 w-full" />
+                <span className="shrink-0 text-[10px] text-muted-foreground">
+                  {unit.strength ?? 0}/{MAX_RESOURCE}
+                </span>
               </div>
               <div className="mt-1 flex items-center gap-2">
                 <span className="w-14 shrink-0 text-[10px] text-muted-foreground">Morale</span>
                 <Progress value={clampResourcePercent(unit.morale)} className="h-1.5 w-full" />
+                <span className="shrink-0 text-[10px] text-muted-foreground">
+                  {unit.morale ?? 0}/{MAX_RESOURCE}
+                </span>
               </div>
             </div>
           ))

--- a/frontend/src/battles/components/PlaceDetailPanel.tsx
+++ b/frontend/src/battles/components/PlaceDetailPanel.tsx
@@ -1,0 +1,161 @@
+/**
+ * PlaceDetailPanel — the selected battle-map place's roster: units (strength/
+ * morale bars, status), player participants (persona name, status), objective
+ * holder, and fortifications with integrity. Links out to the bridged combat
+ * encounter (world/battles/serializers.py's `encounter_scene_id`, #1236) when
+ * one exists.
+ */
+
+import { Link } from 'react-router-dom';
+import { Shield, ShieldAlert } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+
+import type {
+  BattlePersonaSummary,
+  BattlePlace,
+  BattleParticipant,
+  BattleSide,
+  BattleUnit,
+} from '../types';
+
+export interface PlaceDetailPanelProps {
+  place: BattlePlace | null;
+  sides: BattleSide[];
+  units: BattleUnit[];
+  participants: BattleParticipant[];
+}
+
+/** Both strength and morale run 0..100 (world/battles/constants.py MAX_MORALE; strength starts at its 100 ceiling). */
+const MAX_RESOURCE = 100;
+
+function clampResourcePercent(value: number | undefined): number {
+  if (value == null) return 0;
+  return Math.max(0, Math.min(MAX_RESOURCE, value));
+}
+
+function integrityPercent(integrity: number | undefined, maxIntegrity: number | undefined): number {
+  if (!integrity || !maxIntegrity) return 0;
+  return Math.max(0, Math.min(100, Math.round((integrity / maxIntegrity) * 100)));
+}
+
+export function PlaceDetailPanel({ place, sides, units, participants }: PlaceDetailPanelProps) {
+  if (!place) {
+    return (
+      <div
+        className="rounded-lg border border-border bg-card p-6 text-center text-sm text-muted-foreground"
+        data-testid="battle-place-detail-empty"
+      >
+        Select a place on the map to see its units and participants.
+      </div>
+    );
+  }
+
+  const placeUnits = units.filter((unit) => unit.place_id === place.id);
+  const placeParticipants = participants.filter((participant) => participant.place_id === place.id);
+  const holder =
+    place.controlled_by_id != null
+      ? (sides.find((side) => side.id === place.controlled_by_id) ?? null)
+      : null;
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="battle-place-detail">
+      <div>
+        <h3 className="text-sm font-semibold text-foreground">{place.name}</h3>
+        <p className="text-xs text-muted-foreground" data-testid="battle-place-objective-holder">
+          {holder ? `Held by ${holder.covenant_name ?? holder.role ?? 'a side'}` : 'Uncontrolled'}
+        </p>
+        {place.encounter_scene_id != null && (
+          <Link
+            to={`/scenes/${place.encounter_scene_id}/combat`}
+            className="text-xs font-medium text-primary underline-offset-2 hover:underline"
+            data-testid="battle-place-view-encounter"
+          >
+            View encounter
+          </Link>
+        )}
+      </div>
+
+      {place.fortifications.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <h4 className="text-xs font-semibold uppercase text-muted-foreground">Fortifications</h4>
+          {place.fortifications.map((fort) => (
+            <div
+              key={fort.id}
+              className="flex items-center gap-2 text-xs"
+              data-testid="battle-fortification-row"
+            >
+              {fort.breached ? (
+                <ShieldAlert className="h-4 w-4 shrink-0 text-destructive" />
+              ) : (
+                <Shield className="h-4 w-4 shrink-0 text-muted-foreground" />
+              )}
+              <span className="capitalize">{fort.kind}</span>
+              <Progress
+                value={integrityPercent(fort.integrity, fort.max_integrity)}
+                className="h-2 w-24"
+              />
+              <span className="text-muted-foreground">
+                {fort.integrity}/{fort.max_integrity}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <h4 className="text-xs font-semibold uppercase text-muted-foreground">Units</h4>
+        {placeUnits.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No units at this front.</p>
+        ) : (
+          placeUnits.map((unit) => (
+            <div
+              key={unit.id}
+              className="rounded-md border border-border p-2"
+              data-testid="battle-unit-row"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="truncate text-xs font-medium text-foreground">{unit.name}</span>
+                {unit.status && (
+                  <Badge variant="outline" className="shrink-0">
+                    {unit.status}
+                  </Badge>
+                )}
+              </div>
+              <div className="mt-1 flex items-center gap-2">
+                <span className="w-14 shrink-0 text-[10px] text-muted-foreground">Strength</span>
+                <Progress value={clampResourcePercent(unit.strength)} className="h-1.5 w-full" />
+              </div>
+              <div className="mt-1 flex items-center gap-2">
+                <span className="w-14 shrink-0 text-[10px] text-muted-foreground">Morale</span>
+                <Progress value={clampResourcePercent(unit.morale)} className="h-1.5 w-full" />
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h4 className="text-xs font-semibold uppercase text-muted-foreground">Participants</h4>
+        {placeParticipants.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No player characters at this front.</p>
+        ) : (
+          placeParticipants.map((participant) => {
+            const persona = participant.persona as BattlePersonaSummary | null;
+            return (
+              <div
+                key={participant.id}
+                className="flex items-center justify-between gap-2 text-xs"
+                data-testid="battle-participant-row"
+              >
+                <span className="truncate">{persona?.name ?? 'Unknown'}</span>
+                {participant.status && <Badge variant="outline">{participant.status}</Badge>}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/battles/components/PlaceNode.tsx
+++ b/frontend/src/battles/components/PlaceNode.tsx
@@ -26,7 +26,12 @@ export interface PlaceNodeData extends Record<string, unknown> {
   role: PlaceControlRole;
   unitCount: number;
   pcCount: number;
-  /** Canvas diameter budget from radiusToPixels(place.footprint_radius, bounds). */
+  /**
+   * Final rendered diameter in canvas px — already
+   * ``Math.max(MIN_SIZE_PX, Math.round(radiusToPixels(...) * 2))`` (computed
+   * by BattleMapCanvas, which also uses it to center the node's position via
+   * ``centeredNodePosition``, see ../mapMath.ts).
+   */
   sizePx: number;
   selected: boolean;
   onSelect: (placeId: number) => void;
@@ -48,11 +53,11 @@ const VEHICLE_ICON: Record<string, LucideIcon> = {
   companion: PawPrint,
 };
 
-const MIN_SIZE_PX = 96;
+export const MIN_SIZE_PX = 96;
 
 function PlaceNodeComponent({ data }: NodeProps<PlaceNodeType>) {
   const { place, role, unitCount, pcCount, selected, sizePx } = data;
-  const size = Math.max(MIN_SIZE_PX, Math.round(sizePx * 2));
+  const size = sizePx;
   const roleKey = role ?? 'uncontrolled';
   const vehicle = place.vehicle as BattleVehicleSummary | null;
   const VehicleIcon = vehicle ? VEHICLE_ICON[vehicle.vehicle_kind] : null;

--- a/frontend/src/battles/components/PlaceNode.tsx
+++ b/frontend/src/battles/components/PlaceNode.tsx
@@ -1,0 +1,118 @@
+/**
+ * PlaceNode — one front/zone on the battle map canvas (#2009).
+ *
+ * Read-only: unlike the building builder's RoomNode, this never drags. Ring
+ * color shows which side (if any) holds the place as an objective; badges
+ * summarize unit/PC presence; a fortification icon flags breached state; a
+ * vehicle icon (by vehicle_kind) shows an embedded ship/mount occupying the
+ * place (BattleStateCache.vehicle_at_place, #1714).
+ */
+
+import { memo } from 'react';
+import { Handle, Position } from '@xyflow/react';
+import type { Node, NodeProps } from '@xyflow/react';
+import { Flame, PawPrint, Plane, Shield, ShieldAlert, Ship, Waves } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+
+import type { BattlePlace, BattleVehicleSummary } from '../types';
+
+export type PlaceControlRole = 'attacker' | 'defender' | null;
+
+export interface PlaceNodeData extends Record<string, unknown> {
+  place: BattlePlace;
+  /** The controlling side's role, resolved from BattlePlace.controlled_by_id. */
+  role: PlaceControlRole;
+  unitCount: number;
+  pcCount: number;
+  /** Canvas diameter budget from radiusToPixels(place.footprint_radius, bounds). */
+  sizePx: number;
+  selected: boolean;
+  onSelect: (placeId: number) => void;
+}
+
+export type PlaceNodeType = Node<PlaceNodeData>;
+
+const ROLE_RING: Record<'attacker' | 'defender' | 'uncontrolled', string> = {
+  attacker: 'border-destructive ring-2 ring-destructive/40',
+  defender: 'border-primary ring-2 ring-primary/40',
+  uncontrolled: 'border-border',
+};
+
+const VEHICLE_ICON: Record<string, LucideIcon> = {
+  ship: Ship,
+  airship: Plane,
+  dragon: Flame,
+  kraken: Waves,
+  companion: PawPrint,
+};
+
+const MIN_SIZE_PX = 96;
+
+function PlaceNodeComponent({ data }: NodeProps<PlaceNodeType>) {
+  const { place, role, unitCount, pcCount, selected, sizePx } = data;
+  const size = Math.max(MIN_SIZE_PX, Math.round(sizePx * 2));
+  const roleKey = role ?? 'uncontrolled';
+  const vehicle = place.vehicle as BattleVehicleSummary | null;
+  const VehicleIcon = vehicle ? VEHICLE_ICON[vehicle.vehicle_kind] : null;
+  const hasFortifications = place.fortifications.length > 0;
+  const hasBreach = place.fortifications.some((fort) => fort.breached);
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      style={{ width: size, height: size }}
+      className={`flex flex-col items-center justify-center gap-1 rounded-full border-2 bg-card p-2 text-center shadow-sm transition-colors hover:border-primary/60 ${ROLE_RING[roleKey]} ${
+        selected ? 'ring-4 ring-foreground/30' : ''
+      }`}
+      onClick={() => data.onSelect(place.id)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          data.onSelect(place.id);
+        }
+      }}
+      data-testid="battle-place-node"
+      data-place-id={place.id}
+    >
+      <Handle type="target" position={Position.Top} className="!opacity-0" />
+      <p className="max-w-full truncate text-xs font-semibold text-foreground">{place.name}</p>
+      {place.terrain_type && (
+        <Badge variant="outline" className="text-[10px]">
+          {place.terrain_type}
+        </Badge>
+      )}
+      <div className="flex flex-wrap items-center justify-center gap-1">
+        {unitCount > 0 && (
+          <Badge variant="secondary" className="text-[10px]">
+            {unitCount} unit{unitCount === 1 ? '' : 's'}
+          </Badge>
+        )}
+        {pcCount > 0 && (
+          <Badge variant="secondary" className="text-[10px]">
+            {pcCount} PC{pcCount === 1 ? '' : 's'}
+          </Badge>
+        )}
+      </div>
+      {(hasFortifications || VehicleIcon) && (
+        <div className="flex items-center gap-1 text-muted-foreground">
+          {hasFortifications &&
+            (hasBreach ? (
+              <ShieldAlert
+                className="h-4 w-4 text-destructive"
+                data-testid="battle-fortification-breached-icon"
+              />
+            ) : (
+              <Shield className="h-4 w-4" data-testid="battle-fortification-intact-icon" />
+            ))}
+          {VehicleIcon && <VehicleIcon className="h-4 w-4" data-testid="battle-vehicle-icon" />}
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="!opacity-0" />
+    </div>
+  );
+}
+
+export const PlaceNode = memo(PlaceNodeComponent);

--- a/frontend/src/battles/mapMath.test.ts
+++ b/frontend/src/battles/mapMath.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CANVAS_SIZE,
+  computeBounds,
+  PADDING,
+  planeToCanvas,
+  radiusToPixels,
+  type PlaneBounds,
+} from './mapMath';
+
+describe('computeBounds', () => {
+  it('spans the tightest box over known places plus padding', () => {
+    const bounds = computeBounds([
+      { x: 0, y: 0 },
+      { x: 10, y: 4 },
+    ]);
+    expect(bounds).toEqual({
+      minX: 0 - PADDING,
+      maxX: 10 + PADDING,
+      minY: 0 - PADDING,
+      maxY: 4 + PADDING,
+    });
+  });
+
+  it('pads a single place into a non-degenerate unit square', () => {
+    const bounds = computeBounds([{ x: 5, y: 5 }]);
+    expect(bounds).toEqual({
+      minX: 5 - PADDING,
+      maxX: 5 + PADDING,
+      minY: 5 - PADDING,
+      maxY: 5 + PADDING,
+    });
+    expect(bounds.maxX - bounds.minX).toBeGreaterThan(0);
+    expect(bounds.maxY - bounds.minY).toBeGreaterThan(0);
+  });
+
+  it('falls back to origin-centered bounds with no places', () => {
+    expect(computeBounds([])).toEqual({
+      minX: -PADDING,
+      maxX: PADDING,
+      minY: -PADDING,
+      maxY: PADDING,
+    });
+  });
+});
+
+describe('planeToCanvas', () => {
+  const bounds: PlaneBounds = { minX: 0, maxX: 10, minY: 0, maxY: 10 };
+
+  it('maps the bottom-left plane corner to the canvas origin', () => {
+    expect(planeToCanvas({ x: 0, y: 0 }, bounds)).toEqual({ x: 0, y: CANVAS_SIZE });
+  });
+
+  it('negates y — higher plane y (north) renders nearer the canvas top', () => {
+    const top = planeToCanvas({ x: 0, y: 10 }, bounds);
+    const bottom = planeToCanvas({ x: 0, y: 0 }, bounds);
+    expect(top.y).toBe(0);
+    expect(top.y).toBeLessThan(bottom.y);
+  });
+
+  it('scales x proportionally to the bounds span', () => {
+    expect(planeToCanvas({ x: 5, y: 0 }, bounds)).toEqual({ x: CANVAS_SIZE / 2, y: CANVAS_SIZE });
+  });
+});
+
+describe('radiusToPixels', () => {
+  it('scales a plane radius by the same factor as planeToCanvas', () => {
+    const bounds: PlaneBounds = { minX: 0, maxX: 10, minY: 0, maxY: 10 };
+    expect(radiusToPixels(2, bounds)).toBe(2 * (CANVAS_SIZE / 10));
+  });
+
+  it('falls back to a 1:1 scale for a zero-span bounds', () => {
+    const bounds: PlaneBounds = { minX: 5, maxX: 5, minY: 5, maxY: 5 };
+    expect(radiusToPixels(3, bounds)).toBe(3);
+  });
+});

--- a/frontend/src/battles/mapMath.test.ts
+++ b/frontend/src/battles/mapMath.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CANVAS_SIZE,
+  centeredNodePosition,
   computeBounds,
   PADDING,
   planeToCanvas,
@@ -73,5 +74,15 @@ describe('radiusToPixels', () => {
   it('falls back to a 1:1 scale for a zero-span bounds', () => {
     const bounds: PlaneBounds = { minX: 5, maxX: 5, minY: 5, maxY: 5 };
     expect(radiusToPixels(3, bounds)).toBe(3);
+  });
+});
+
+describe('centeredNodePosition', () => {
+  it('offsets a canvas point by half the node size on both axes', () => {
+    expect(centeredNodePosition({ x: 100, y: 200 }, 40)).toEqual({ x: 80, y: 180 });
+  });
+
+  it('is a no-op offset for a zero-size node', () => {
+    expect(centeredNodePosition({ x: 100, y: 200 }, 0)).toEqual({ x: 100, y: 200 });
   });
 });

--- a/frontend/src/battles/mapMath.ts
+++ b/frontend/src/battles/mapMath.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure map math for the battle map canvas (#2009).
+ *
+ * BattlePlace.x/y are the backend's plane coordinates (world/battles/models.py)
+ * — arbitrary floats on a strategic plane, not grid-cell integers like the
+ * building builder's grid_x/grid_y (buildings/gridMath.ts). planeToCanvas maps
+ * a place's plane point into React Flow canvas space: the plane grows "up"
+ * (north = +y) but the canvas grows down, so y is negated relative to the
+ * bounds — mirrors gridMath.ts's cellToPosition comment.
+ */
+
+export interface PlanePoint {
+  x: number;
+  y: number;
+}
+
+export interface PlaneBounds {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+/** Plane-unit padding added around the tightest bounding box of the places. */
+export const PADDING = 2;
+
+/** Canvas pixels spanned by the wider of the bounds' two axes. */
+export const CANVAS_SIZE = 800;
+
+/**
+ * Tight bounding box (+ padding) over a battle's places. A single place (or
+ * several coincident places) has zero extent on its own — padding always
+ * applies, so the result never degenerates to a zero-width/height box that
+ * planeToCanvas/radiusToPixels would have nothing to scale against.
+ */
+export function computeBounds(places: PlanePoint[]): PlaneBounds {
+  if (places.length === 0) {
+    return { minX: -PADDING, maxX: PADDING, minY: -PADDING, maxY: PADDING };
+  }
+  const xs = places.map((p) => p.x);
+  const ys = places.map((p) => p.y);
+  return {
+    minX: Math.min(...xs) - PADDING,
+    maxX: Math.max(...xs) + PADDING,
+    minY: Math.min(...ys) - PADDING,
+    maxY: Math.max(...ys) + PADDING,
+  };
+}
+
+/** Pixels-per-plane-unit, uniform across both axes so radii stay circular. */
+function scaleFor(bounds: PlaneBounds): number {
+  const width = bounds.maxX - bounds.minX;
+  const height = bounds.maxY - bounds.minY;
+  const span = Math.max(width, height);
+  return span > 0 ? CANVAS_SIZE / span : 1;
+}
+
+/** Plane point -> React Flow canvas position. y is negated (see module doc). */
+export function planeToCanvas(p: PlanePoint, bounds: PlaneBounds): { x: number; y: number } {
+  const scale = scaleFor(bounds);
+  return {
+    x: (p.x - bounds.minX) * scale,
+    y: (bounds.maxY - p.y) * scale,
+  };
+}
+
+/** Plane-unit radius (e.g. footprint_radius) -> canvas pixels, same scale as planeToCanvas. */
+export function radiusToPixels(r: number, bounds: PlaneBounds): number {
+  return r * scaleFor(bounds);
+}

--- a/frontend/src/battles/mapMath.ts
+++ b/frontend/src/battles/mapMath.ts
@@ -68,3 +68,18 @@ export function planeToCanvas(p: PlanePoint, bounds: PlaneBounds): { x: number; 
 export function radiusToPixels(r: number, bounds: PlaneBounds): number {
   return r * scaleFor(bounds);
 }
+
+/**
+ * Offset a canvas point (e.g. planeToCanvas's output) into a node's top-left
+ * position so the node is centered on that point rather than anchored there
+ * by its corner. React Flow positions nodes by top-left corner, but node
+ * sizes vary (PlaceNode clamps its rendered diameter at a minimum), so
+ * without this offset larger/smaller nodes visually drift off their place's
+ * true plane coordinate.
+ */
+export function centeredNodePosition(
+  point: { x: number; y: number },
+  sizePx: number
+): { x: number; y: number } {
+  return { x: point.x - sizePx / 2, y: point.y - sizePx / 2 };
+}

--- a/frontend/src/battles/pages/BattleMapPage.tsx
+++ b/frontend/src/battles/pages/BattleMapPage.tsx
@@ -1,0 +1,135 @@
+/**
+ * BattleMapPage — the strategic battle map (#2009).
+ *
+ * Route: /scenes/:id/battle
+ *
+ * Layout mirrors `combat/pages/CombatScenePage.tsx`'s C-frame shell: a header
+ * (battle name/round/per-side victory points) over a `grid-cols-[1fr_360px]`
+ * grid — the React Flow canvas on the left, the selected place's detail panel
+ * on the right.
+ *
+ * A Scene has at most one Battle (useBattleForSceneQuery, Task 3's 1:1
+ * lookup); once resolved, useBattleDetailQuery fetches the full aggregate
+ * (sides/places/units/participants) the canvas and panel both read from.
+ */
+
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { cn } from '@/lib/utils';
+
+import { BattleMapCanvas } from '../components/BattleMapCanvas';
+import { PlaceDetailPanel } from '../components/PlaceDetailPanel';
+import { useBattleDetailQuery, useBattleForSceneQuery } from '../queries';
+import type { BattleRoundSummary } from '../types';
+
+export function BattleMapPage() {
+  const { id = '' } = useParams();
+  const sceneId = Number(id);
+  const sceneIdValid = id !== '' && !Number.isNaN(sceneId);
+
+  const [selectedPlaceId, setSelectedPlaceId] = useState<number | null>(null);
+
+  const {
+    data: battle,
+    isLoading: battleLoading,
+    isError: battleErrored,
+  } = useBattleForSceneQuery(sceneIdValid ? sceneId : null);
+
+  const {
+    data: detail,
+    isLoading: detailLoading,
+    isError: detailErrored,
+  } = useBattleDetailQuery(battle?.id ?? null);
+
+  if (!sceneIdValid) {
+    return (
+      <div className="p-4 text-sm text-destructive" data-testid="battle-map-invalid-scene">
+        Invalid scene.
+      </div>
+    );
+  }
+
+  if (battleLoading) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground" data-testid="battle-map-loading">
+        Loading battle…
+      </div>
+    );
+  }
+
+  if (battleErrored) {
+    return (
+      <div className="p-4 text-sm text-destructive" data-testid="battle-map-error">
+        Failed to load the battle for this scene.
+      </div>
+    );
+  }
+
+  if (!battle) {
+    return (
+      <div className="p-6 text-center text-sm text-muted-foreground" data-testid="battle-map-empty">
+        No battle for this scene.
+      </div>
+    );
+  }
+
+  if (detailErrored) {
+    return (
+      <div className="p-4 text-sm text-destructive" data-testid="battle-map-detail-error">
+        Failed to load the battle map.
+      </div>
+    );
+  }
+
+  if (detailLoading || !detail) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground" data-testid="battle-map-detail-loading">
+        Loading battle map…
+      </div>
+    );
+  }
+
+  const round = detail.round as BattleRoundSummary | null;
+  const selectedPlace = detail.places.find((place) => place.id === selectedPlaceId) ?? null;
+
+  return (
+    <div className="flex h-full flex-col" data-testid="battle-map-page">
+      <div className="shrink-0 px-4 pt-4" data-testid="battle-map-header">
+        <h2 className="text-lg font-semibold text-foreground">{detail.name}</h2>
+        <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          <span data-testid="battle-map-round">
+            {round ? `Round ${round.number} (${round.status})` : 'No active round'}
+          </span>
+          {detail.sides.map((side) => (
+            <span key={side.id} data-testid="battle-map-side-vp">
+              {side.covenant_name ?? side.role ?? 'Side'}: {side.victory_points ?? 0}/
+              {side.victory_threshold ?? 0} VP
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div
+        className={cn('grid min-h-0 flex-1 grid-cols-[1fr_360px] gap-4 px-4 pb-4')}
+        data-testid="battle-map-grid"
+      >
+        <div className="min-h-0" data-testid="battle-map-canvas-column">
+          <BattleMapCanvas
+            detail={detail}
+            selectedPlaceId={selectedPlaceId}
+            onSelectPlace={setSelectedPlaceId}
+          />
+        </div>
+        <div className="min-h-0 overflow-y-auto" data-testid="battle-map-panel-column">
+          <PlaceDetailPanel
+            place={selectedPlace}
+            sides={detail.sides}
+            units={detail.units}
+            participants={detail.participants}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/battles/queries.ts
+++ b/frontend/src/battles/queries.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchBattleDetail, fetchBattlesForScene } from './api';
+
+export const battleKeys = {
+  all: ['battles'] as const,
+  detail: (battleId: number) => [...battleKeys.all, 'detail', battleId] as const,
+  forScene: (sceneId: number) => [...battleKeys.all, 'for-scene', sceneId] as const,
+};
+
+/**
+ * A Scene has at most one Battle (1:1 extension, world/battles/models.py) — this
+ * lists with `?scene=` and hands back the first result (or null) so callers get
+ * the single-battle shape they actually need.
+ */
+export function useBattleForSceneQuery(sceneId: number | null | undefined) {
+  return useQuery({
+    queryKey: battleKeys.forScene(sceneId ?? 0),
+    queryFn: async () => {
+      const data = await fetchBattlesForScene(sceneId!);
+      return data.results[0] ?? null;
+    },
+    enabled: sceneId != null,
+    staleTime: 30_000,
+  });
+}
+
+export function useBattleDetailQuery(battleId: number | null | undefined) {
+  return useQuery({
+    queryKey: battleKeys.detail(battleId ?? 0),
+    queryFn: () => fetchBattleDetail(battleId!),
+    enabled: battleId != null,
+    staleTime: 15_000,
+  });
+}

--- a/frontend/src/battles/types.ts
+++ b/frontend/src/battles/types.ts
@@ -19,3 +19,29 @@ export interface BattleStatePayload {
   battle_id: number;
   round_number: number | null;
 }
+
+/**
+ * BattleDetail nests a few backend dicts as untyped SerializerMethodField
+ * output — OpenAPI can't describe an ad-hoc dict shape, so these fields come
+ * through as ``{[key: string]: unknown} | null`` in the generated schema.
+ * These interfaces mirror the exact keys `world/battles/serializers.py` emits
+ * (BattleDetailSerializer.get_round, BattlePlaceSerializer.get_vehicle,
+ * BattleParticipantSerializer.get_persona) — same convention as
+ * `BattleStatePayload` above. Cast the loose field to these when reading it.
+ */
+export interface BattleRoundSummary {
+  number: number;
+  status: string;
+}
+
+export interface BattleVehicleSummary {
+  unit_id: number;
+  vehicle_kind: string;
+  is_structural: boolean;
+}
+
+export interface BattlePersonaSummary {
+  id: number;
+  name: string;
+  thumbnail_url: string | null;
+}

--- a/frontend/src/battles/types.ts
+++ b/frontend/src/battles/types.ts
@@ -1,0 +1,21 @@
+import type { components } from '@/generated/api';
+
+export type Battle = components['schemas']['BattleList'];
+export type BattleDetail = components['schemas']['BattleDetail'];
+export type BattleSide = components['schemas']['BattleSide'];
+export type BattlePlace = components['schemas']['BattlePlace'];
+export type BattleUnit = components['schemas']['BattleUnit'];
+export type BattleParticipant = components['schemas']['BattleParticipant'];
+export type PaginatedBattleListList = components['schemas']['PaginatedBattleListList'];
+
+/**
+ * Payload for the ``battle_state`` WS message (world/web/webclient/message_types.py
+ * ``BattleStatePayload``). Not part of the REST OpenAPI schema — this is a
+ * hand-authored mirror of the backend dataclass, same convention as
+ * ``RoulettePayload`` (components/roulette/types.ts). Carries no battle data
+ * itself; it's a slim ping telling clients to refetch the REST aggregate.
+ */
+export interface BattleStatePayload {
+  battle_id: number;
+  round_number: number | null;
+}

--- a/frontend/src/battles/types.ts
+++ b/frontend/src/battles/types.ts
@@ -44,4 +44,5 @@ export interface BattlePersonaSummary {
   id: number;
   name: string;
   thumbnail_url: string | null;
+  thumbnail_media_url: string | null;
 }

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -16381,7 +16381,15 @@ export interface components {
       status?: components['schemas']['BattleParticipantStatusEnum'];
       readonly side_id: number;
       readonly place_id: number | null;
-      /** @description Public persona identity only — id/name/thumbnail_url, never account/username. */
+      /**
+       * @description Public persona identity only — id/name/thumbnail(s), never account/username.
+       *
+       *     ``thumbnail_media_url`` mirrors ``world/combat/serializers.py``'s
+       *     ``get_thumbnail_media_url`` — the uploaded-portrait ``PlayerMedia`` FK,
+       *     already ``select_related``'d by the view's Prefetch (world/battles/views.py),
+       *     so this never issues a query. ``thumbnail_url`` is the legacy URLField,
+       *     kept alongside for callers still on it.
+       */
       readonly persona: {
         [key: string]: unknown;
       } | null;

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -734,6 +734,56 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/battles/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only battle aggregate API — list (slim) and detail (full aggregate).
+     *
+     *     Scene-gated exactly like ``CombatEncounterViewSet`` (world/combat/views.py):
+     *     a Battle is a 1:1 extension of scenes.Scene (world/battles/models.py), so
+     *     scene read-visibility alone decides who may see a battle. No participant
+     *     union needed — enlisting in a battle has no bearing here independent of
+     *     scene visibility.
+     */
+    get: operations['battles_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/battles/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only battle aggregate API — list (slim) and detail (full aggregate).
+     *
+     *     Scene-gated exactly like ``CombatEncounterViewSet`` (world/combat/views.py):
+     *     a Battle is a 1:1 extension of scenes.Scene (world/battles/models.py), so
+     *     scene read-visibility alone decides who may see a battle. No participant
+     *     union needed — enlisting in a battle has no bearing here independent of
+     *     scene visibility.
+     */
+    get: operations['battles_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/beats/': {
     parameters: {
       query?: never;
@@ -16290,6 +16340,119 @@ export interface components {
      * @enum {string}
      */
     BattleBindingEnum: 'standing' | 'campaign';
+    /** @description Full battle aggregate — sides, places, units, and participants. */
+    BattleDetail: {
+      readonly id: number;
+      name: string;
+      outcome?: components['schemas']['Outcome5d6Enum'];
+      /**
+       * @description Stakes axis for companion death-gating (#1873). EXTREME/LETHAL make companion death possible on defeat. Mirrors CombatEncounter.risk_level.
+       *
+       *     * `low` - Low
+       *     * `moderate` - Moderate
+       *     * `high` - High
+       *     * `extreme` - Extreme
+       *     * `lethal` - Lethal
+       */
+      risk_level?: components['schemas']['RiskLevelEnum'];
+      /** @description Set when a participant disconnects (#1899) — see maybe_pause_battle_for_disconnect. */
+      is_paused?: boolean;
+      /** @description The battle's current (latest non-completed) round, or None. */
+      readonly round: {
+        [key: string]: unknown;
+      } | null;
+      readonly sides: components['schemas']['BattleSide'][];
+      readonly places: components['schemas']['BattlePlace'][];
+      readonly units: components['schemas']['BattleUnit'][];
+      readonly participants: components['schemas']['BattleParticipant'][];
+    };
+    /** @description Slim row for the battle list endpoint. */
+    BattleList: {
+      readonly id: number;
+      name: string;
+      readonly scene_id: number;
+      outcome?: components['schemas']['Outcome5d6Enum'];
+      /** Format: date-time */
+      readonly created_at: string;
+    };
+    /** @description A player character enlisted in the battle, with their public persona face. */
+    BattleParticipant: {
+      readonly id: number;
+      status?: components['schemas']['BattleParticipantStatusEnum'];
+      readonly side_id: number;
+      readonly place_id: number | null;
+      /** @description Public persona identity only — id/name/thumbnail_url, never account/username. */
+      readonly persona: {
+        [key: string]: unknown;
+      } | null;
+    };
+    /**
+     * @description * `active` - Active
+     *     * `withdrawn` - Withdrawn
+     *     * `incapacitated` - Incapacitated
+     * @enum {string}
+     */
+    BattleParticipantStatusEnum: 'active' | 'withdrawn' | 'incapacitated';
+    /** @description A named front/zone, with its battle-map position and embedded structures. */
+    BattlePlace: {
+      readonly id: number;
+      name: string;
+      terrain_type?: components['schemas']['TerrainTypeEnum'];
+      /** @description Authored cost for a future reposition/movement action — not yet filed as an issue; #1712 explicitly did not build this. Data only. */
+      movement_cost?: number;
+      /** Format: double */
+      x: number;
+      /** Format: double */
+      y: number;
+      /** Format: double */
+      footprint_radius: number;
+      readonly controlled_by_id: number | null;
+      /** @description The scene backing this front's bridged CombatEncounter, if any (#1236). */
+      readonly encounter_scene_id: number | null;
+      /**
+       * @description Read the embedded vehicle, if any, through the battle's state cache.
+       *
+       *     Never a fresh query — ``BattleStateCache.vehicle_at_place`` is the
+       *     single source of truth for which vehicle occupies a place (#1714).
+       */
+      readonly vehicle: {
+        [key: string]: unknown;
+      } | null;
+      readonly fortifications: components['schemas']['Fortification'][];
+    };
+    /** @description One side in the battle, with its victory tally and fielding covenant. */
+    BattleSide: {
+      readonly id: number;
+      role?: components['schemas']['RoleEnum'];
+      victory_points?: number;
+      victory_threshold?: number;
+      posture?: components['schemas']['PostureEnum'];
+      readonly covenant_id: number | null;
+      readonly covenant_name: string | null;
+    };
+    /** @description An abstract typed force at a particular front (or embedded in a vehicle). */
+    BattleUnit: {
+      readonly id: number;
+      name: string;
+      /** @description Optional flavor tag (e.g. 'zombies-on-nightmares'). Narrative only — properties/capabilities/quality below drive mechanics. */
+      descriptor?: string;
+      quality?: components['schemas']['QualityEnum'];
+      status?: components['schemas']['BattleUnitStatusEnum'];
+      strength?: number;
+      /** @description Second resource alongside strength (#1712). status is always derived from whichever resource crosses its own threshold first — see world.battles.resolution._compute_unit_status. Unlike strength (starts at its ceiling), morale starts well below it — sitting near MAX_MORALE is rare. */
+      morale?: number;
+      /** @description Population data point mirroring CombatOpponent.swarm_count's naming/shape (#1794) — null means 'not a swarm-style unit'. No swarm-math resolution is wired against this field yet; that is left to #1714 (naval/aerial units) or a future issue that needs it. */
+      individual_count?: number | null;
+      readonly side_id: number;
+      readonly place_id: number | null;
+    };
+    /**
+     * @description * `active` - Active
+     *     * `routed` - Routed
+     *     * `destroyed` - Destroyed
+     * @enum {string}
+     */
+    BattleUnitStatusEnum: 'active' | 'routed' | 'destroyed';
     /** @description Full serializer for Beat including all Phase 2 predicate config fields. */
     Beat: {
       readonly id: number;
@@ -19590,6 +19753,24 @@ export interface components {
      * @enum {string}
      */
     FormTypeEnum: 'true' | 'alternate' | 'disguise';
+    /** @description A defensible structure at a BattlePlace. */
+    Fortification: {
+      readonly id: number;
+      kind?: components['schemas']['FortificationKindEnum'];
+      integrity?: number;
+      /** @description Snapshotted once at creation from BASE_INTEGRITY[kind] plus building.fortification_level * FORTIFICATION_LEVEL_INTEGRITY_BONUS, if building is set (#1713). See world.battles.services.create_fortification. */
+      max_integrity?: number;
+      breached?: boolean;
+      readonly defending_side_id: number;
+    };
+    /**
+     * @description * `wall` - Wall
+     *     * `gate` - Gate
+     *     * `battlement` - Battlement
+     *     * `hull` - Hull
+     * @enum {string}
+     */
+    FortificationKindEnum: 'wall' | 'gate' | 'battlement' | 'hull';
     /** @description A friend row — the friended character's name + which of your characters friended. */
     Friendship: {
       readonly id: number;
@@ -22297,6 +22478,20 @@ export interface components {
       name: string;
     };
     /**
+     * @description * `unresolved` - Unresolved
+     *     * `attacker_decisive` - Attacker — decisive
+     *     * `attacker_marginal` - Attacker — marginal
+     *     * `defender_marginal` - Defender — marginal
+     *     * `defender_decisive` - Defender — decisive
+     * @enum {string}
+     */
+    Outcome5d6Enum:
+      | 'unresolved'
+      | 'attacker_decisive'
+      | 'attacker_marginal'
+      | 'defender_marginal'
+      | 'defender_decisive';
+    /**
      * @description * `victory` - Victory
      *     * `defeat` - Defeat
      *     * `fled` - Fled
@@ -22490,6 +22685,21 @@ export interface components {
        */
       previous?: string | null;
       results: components['schemas']['AssistantGMClaim'][];
+    };
+    PaginatedBattleListList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['BattleList'][];
     };
     PaginatedBeatList: {
       /** @example 123 */
@@ -26639,6 +26849,13 @@ export interface components {
       readonly id: number;
       readonly name: string;
     };
+    /**
+     * @description * `balanced` - Balanced
+     *     * `aggressive` - Aggressive
+     *     * `defensive` - Defensive
+     * @enum {string}
+     */
+    PostureEnum: 'balanced' | 'aggressive' | 'defensive';
     /** @description Serializes a PowerLedger (entries + total) for the cast result payload. */
     PowerLedger: {
       entries: components['schemas']['PowerLedgerEntry'][];
@@ -26791,6 +27008,15 @@ export interface components {
       thread_id?: number | null;
       boundary_level?: number | null;
     };
+    /**
+     * @description * `militia` - Militia
+     *     * `levy` - Levy
+     *     * `trained` - Trained
+     *     * `veteran` - Veteran
+     *     * `elite` - Elite
+     * @enum {string}
+     */
+    QualityEnum: 'militia' | 'levy' | 'trained' | 'veteran' | 'elite';
     /** @description Serializer for QualityTier lookup records. */
     QualityTier: {
       readonly id: number;
@@ -27385,6 +27611,12 @@ export interface components {
      * @enum {string}
      */
     RoleContextEnum: 'informant' | 'contact' | 'personal_favor' | 'guard' | 'fan' | 'minor_ally';
+    /**
+     * @description * `attacker` - Attacker
+     *     * `defender` - Defender
+     * @enum {string}
+     */
+    RoleEnum: 'attacker' | 'defender';
     /** @description The owner build-HUD payload for one room (#1514). */
     RoomComfortBreakdown: {
       enclosure: string;
@@ -29540,6 +29772,26 @@ export interface components {
       sort_order?: number;
     };
     /**
+     * @description * `open` - Open
+     *     * `difficult` - Difficult
+     *     * `fortified` - Fortified
+     *     * `elevated` - Elevated
+     *     * `flooded` - Flooded
+     *     * `urban` - Urban
+     *     * `water` - Open water
+     *     * `aerial` - Open sky
+     * @enum {string}
+     */
+    TerrainTypeEnum:
+      | 'open'
+      | 'difficult'
+      | 'fortified'
+      | 'elevated'
+      | 'flooded'
+      | 'urban'
+      | 'water'
+      | 'aerial';
+    /**
      * @description Serializer for Thread records (Spec A §4.5).
      *
      *     Read: returns level / developed_points / resonance detail for display.
@@ -31439,6 +31691,66 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+    };
+  };
+  battles_list: {
+    parameters: {
+      query?: {
+        /**
+         * @description * `unresolved` - Unresolved
+         *     * `attacker_decisive` - Attacker — decisive
+         *     * `attacker_marginal` - Attacker — marginal
+         *     * `defender_marginal` - Defender — marginal
+         *     * `defender_decisive` - Defender — decisive
+         */
+        outcome?:
+          | 'attacker_decisive'
+          | 'attacker_marginal'
+          | 'defender_decisive'
+          | 'defender_marginal'
+          | 'unresolved';
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
+        scene?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedBattleListList'];
+        };
+      };
+    };
+  };
+  battles_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this battle. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['BattleDetail'];
+        };
       };
     };
   };

--- a/frontend/src/hooks/handleBattleStatePayload.ts
+++ b/frontend/src/hooks/handleBattleStatePayload.ts
@@ -1,0 +1,14 @@
+import type { BattleStatePayload } from '@/battles/types';
+import { battleKeys } from '@/battles/queries';
+import { queryClient } from '@/queryClient';
+
+/**
+ * Battles are location-less (their backing scene has no ``location``), so the
+ * existing scene/room broadcast paths never reach participants — ``battle_state``
+ * is the dedicated seam (see ``BattleStatePayload`` in
+ * ``src/web/webclient/message_types.py``). The payload carries no battle data
+ * itself; on receipt we just invalidate so the REST aggregate refetches.
+ */
+export function handleBattleStatePayload(_payload: BattleStatePayload) {
+  void queryClient.invalidateQueries({ queryKey: battleKeys.all });
+}

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -21,6 +21,8 @@ export const WS_MESSAGE_TYPE = {
   SCENE: 'scene',
   COMMAND_ERROR: 'command_error',
   ROULETTE_RESULT: 'roulette_result',
+  /** Inbound: slim ping — a battle's round transitioned; clients refetch the REST aggregate. */
+  BATTLE_STATE: 'battle_state',
   INTERACTION: 'interaction',
   PUPPET_CHANGED: 'puppet_changed',
   /** Inbound: result of an `execute_action` invocation. */

--- a/frontend/src/hooks/useGameSocket.ts
+++ b/frontend/src/hooks/useGameSocket.ts
@@ -22,6 +22,8 @@ import { handleCommandPayload } from './handleCommandPayload';
 import { handleInteractionPayload } from './handleInteractionPayload';
 import { handleRoulettePayload } from './handleRoulettePayload';
 import type { RoulettePayload } from '@/components/roulette/types';
+import { handleBattleStatePayload } from './handleBattleStatePayload';
+import type { BattleStatePayload } from '@/battles/types';
 
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -139,6 +141,11 @@ export function useGameSocket() {
 
           if (msgType === WS_MESSAGE_TYPE.ROULETTE_RESULT) {
             handleRoulettePayload(kwargs as unknown as RoulettePayload, dispatch);
+            return;
+          }
+
+          if (msgType === WS_MESSAGE_TYPE.BATTLE_STATE) {
+            handleBattleStatePayload(kwargs as unknown as BattleStatePayload);
             return;
           }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,24 +1,16 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Provider } from 'react-redux';
 import { store } from './store/store';
+import { queryClient } from './queryClient';
 import { AuthProvider } from './components/AuthProvider';
 import { ThemeProvider } from './components/theme-provider';
 import { RealmThemeProvider } from './components/realm-theme-provider';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import App from './App';
 import './index.css';
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 1000 * 60 * 5, // 5 minutes
-      retry: 2,
-    },
-  },
-});
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      retry: 2,
+    },
+  },
+});

--- a/src/schema.json
+++ b/src/schema.json
@@ -1017,6 +1017,90 @@ paths:
       responses:
         '200':
           description: No response body
+  /api/battles/:
+    get:
+      operationId: battles_list
+      description: |-
+        Read-only battle aggregate API — list (slim) and detail (full aggregate).
+
+        Scene-gated exactly like ``CombatEncounterViewSet`` (world/combat/views.py):
+        a Battle is a 1:1 extension of scenes.Scene (world/battles/models.py), so
+        scene read-visibility alone decides who may see a battle. No participant
+        union needed — enlisting in a battle has no bearing here independent of
+        scene visibility.
+      parameters:
+      - in: query
+        name: outcome
+        schema:
+          type: string
+          enum:
+          - attacker_decisive
+          - attacker_marginal
+          - defender_decisive
+          - defender_marginal
+          - unresolved
+        description: |-
+          * `unresolved` - Unresolved
+          * `attacker_decisive` - Attacker — decisive
+          * `attacker_marginal` - Attacker — marginal
+          * `defender_marginal` - Defender — marginal
+          * `defender_decisive` - Defender — decisive
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: scene
+        schema:
+          type: integer
+      tags:
+      - battles
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBattleListList'
+          description: ''
+  /api/battles/{id}/:
+    get:
+      operationId: battles_retrieve
+      description: |-
+        Read-only battle aggregate API — list (slim) and detail (full aggregate).
+
+        Scene-gated exactly like ``CombatEncounterViewSet`` (world/combat/views.py):
+        a Battle is a 1:1 extension of scenes.Scene (world/battles/models.py), so
+        scene read-visibility alone decides who may see a battle. No participant
+        union needed — enlisting in a battle has no bearing here independent of
+        scene visibility.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this battle.
+        required: true
+      tags:
+      - battles
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BattleDetail'
+          description: ''
   /api/beats/:
     get:
       operationId: beats_list
@@ -27591,6 +27675,286 @@ components:
       description: |-
         * `standing` - Standing (unit or banner — can rise again)
         * `campaign` - Campaign (one-time event — dissolves when done)
+    BattleDetail:
+      type: object
+      description: Full battle aggregate — sides, places, units, and participants.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 120
+        outcome:
+          $ref: '#/components/schemas/Outcome5d6Enum'
+        risk_level:
+          allOf:
+          - $ref: '#/components/schemas/RiskLevelEnum'
+          description: |-
+            Stakes axis for companion death-gating (#1873). EXTREME/LETHAL make companion death possible on defeat. Mirrors CombatEncounter.risk_level.
+
+            * `low` - Low
+            * `moderate` - Moderate
+            * `high` - High
+            * `extreme` - Extreme
+            * `lethal` - Lethal
+        is_paused:
+          type: boolean
+          description: Set when a participant disconnects (#1899) — see maybe_pause_battle_for_disconnect.
+        round:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: The battle's current (latest non-completed) round, or None.
+          readOnly: true
+        sides:
+          type: array
+          items:
+            $ref: '#/components/schemas/BattleSide'
+          readOnly: true
+        places:
+          type: array
+          items:
+            $ref: '#/components/schemas/BattlePlace'
+          readOnly: true
+        units:
+          type: array
+          items:
+            $ref: '#/components/schemas/BattleUnit'
+          readOnly: true
+        participants:
+          type: array
+          items:
+            $ref: '#/components/schemas/BattleParticipant'
+          readOnly: true
+      required:
+      - id
+      - name
+      - participants
+      - places
+      - round
+      - sides
+      - units
+    BattleList:
+      type: object
+      description: Slim row for the battle list endpoint.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 120
+        scene_id:
+          type: integer
+          readOnly: true
+        outcome:
+          $ref: '#/components/schemas/Outcome5d6Enum'
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - id
+      - name
+      - scene_id
+    BattleParticipant:
+      type: object
+      description: A player character enlisted in the battle, with their public persona
+        face.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/BattleParticipantStatusEnum'
+        side_id:
+          type: integer
+          readOnly: true
+        place_id:
+          type: integer
+          readOnly: true
+          nullable: true
+        persona:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: Public persona identity only — id/name/thumbnail_url, never
+            account/username.
+          readOnly: true
+      required:
+      - id
+      - persona
+      - place_id
+      - side_id
+    BattleParticipantStatusEnum:
+      enum:
+      - active
+      - withdrawn
+      - incapacitated
+      type: string
+      description: |-
+        * `active` - Active
+        * `withdrawn` - Withdrawn
+        * `incapacitated` - Incapacitated
+    BattlePlace:
+      type: object
+      description: A named front/zone, with its battle-map position and embedded structures.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 120
+        terrain_type:
+          $ref: '#/components/schemas/TerrainTypeEnum'
+        movement_cost:
+          type: integer
+          maximum: 32767
+          minimum: 0
+          description: 'Authored cost for a future reposition/movement action — not
+            yet filed as an issue; #1712 explicitly did not build this. Data only.'
+        x:
+          type: number
+          format: double
+        y:
+          type: number
+          format: double
+        footprint_radius:
+          type: number
+          format: double
+        controlled_by_id:
+          type: integer
+          readOnly: true
+          nullable: true
+        encounter_scene_id:
+          type: integer
+          nullable: true
+          description: The scene backing this front's bridged CombatEncounter, if
+            any (#1236).
+          readOnly: true
+        vehicle:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: |-
+            Read the embedded vehicle, if any, through the battle's state cache.
+
+            Never a fresh query — ``BattleStateCache.vehicle_at_place`` is the
+            single source of truth for which vehicle occupies a place (#1714).
+          readOnly: true
+        fortifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fortification'
+          readOnly: true
+      required:
+      - controlled_by_id
+      - encounter_scene_id
+      - footprint_radius
+      - fortifications
+      - id
+      - name
+      - vehicle
+      - x
+      - y
+    BattleSide:
+      type: object
+      description: One side in the battle, with its victory tally and fielding covenant.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        role:
+          $ref: '#/components/schemas/RoleEnum'
+        victory_points:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        victory_threshold:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        posture:
+          $ref: '#/components/schemas/PostureEnum'
+        covenant_id:
+          type: integer
+          readOnly: true
+          nullable: true
+        covenant_name:
+          type: string
+          nullable: true
+          readOnly: true
+      required:
+      - covenant_id
+      - covenant_name
+      - id
+    BattleUnit:
+      type: object
+      description: An abstract typed force at a particular front (or embedded in a
+        vehicle).
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 120
+        descriptor:
+          type: string
+          description: Optional flavor tag (e.g. 'zombies-on-nightmares'). Narrative
+            only — properties/capabilities/quality below drive mechanics.
+          maxLength: 80
+        quality:
+          $ref: '#/components/schemas/QualityEnum'
+        status:
+          $ref: '#/components/schemas/BattleUnitStatusEnum'
+        strength:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        morale:
+          type: integer
+          maximum: 32767
+          minimum: 0
+          description: Second resource alongside strength (#1712). status is always
+            derived from whichever resource crosses its own threshold first — see
+            world.battles.resolution._compute_unit_status. Unlike strength (starts
+            at its ceiling), morale starts well below it — sitting near MAX_MORALE
+            is rare.
+        individual_count:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+          description: 'Population data point mirroring CombatOpponent.swarm_count''s
+            naming/shape (#1794) — null means ''not a swarm-style unit''. No swarm-math
+            resolution is wired against this field yet; that is left to #1714 (naval/aerial
+            units) or a future issue that needs it.'
+        side_id:
+          type: integer
+          readOnly: true
+        place_id:
+          type: integer
+          readOnly: true
+          nullable: true
+      required:
+      - id
+      - name
+      - place_id
+      - side_id
+    BattleUnitStatusEnum:
+      enum:
+      - active
+      - routed
+      - destroyed
+      type: string
+      description: |-
+        * `active` - Active
+        * `routed` - Routed
+        * `destroyed` - Destroyed
     Beat:
       type: object
       description: Full serializer for Beat including all Phase 2 predicate config
@@ -34669,6 +35033,46 @@ components:
         * `true` - True Form
         * `alternate` - Alternate Form
         * `disguise` - Disguise
+    Fortification:
+      type: object
+      description: A defensible structure at a BattlePlace.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        kind:
+          $ref: '#/components/schemas/FortificationKindEnum'
+        integrity:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        max_integrity:
+          type: integer
+          maximum: 32767
+          minimum: 0
+          description: Snapshotted once at creation from BASE_INTEGRITY[kind] plus
+            building.fortification_level * FORTIFICATION_LEVEL_INTEGRITY_BONUS, if
+            building is set (#1713). See world.battles.services.create_fortification.
+        breached:
+          type: boolean
+        defending_side_id:
+          type: integer
+          readOnly: true
+      required:
+      - defending_side_id
+      - id
+    FortificationKindEnum:
+      enum:
+      - wall
+      - gate
+      - battlement
+      - hull
+      type: string
+      description: |-
+        * `wall` - Wall
+        * `gate` - Gate
+        * `battlement` - Battlement
+        * `hull` - Hull
     Friendship:
       type: object
       description: A friend row — the friended character's name + which of your characters
@@ -40134,6 +40538,20 @@ components:
       required:
       - id
       - name
+    Outcome5d6Enum:
+      enum:
+      - unresolved
+      - attacker_decisive
+      - attacker_marginal
+      - defender_marginal
+      - defender_decisive
+      type: string
+      description: |-
+        * `unresolved` - Unresolved
+        * `attacker_decisive` - Attacker — decisive
+        * `attacker_marginal` - Attacker — marginal
+        * `defender_marginal` - Defender — marginal
+        * `defender_decisive` - Defender — decisive
     Outcome88eEnum:
       enum:
       - victory
@@ -40481,6 +40899,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AssistantGMClaim'
+    PaginatedBattleListList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BattleList'
     PaginatedBeatList:
       type: object
       required:
@@ -47434,6 +47875,16 @@ components:
       required:
       - id
       - name
+    PostureEnum:
+      enum:
+      - balanced
+      - aggressive
+      - defensive
+      type: string
+      description: |-
+        * `balanced` - Balanced
+        * `aggressive` - Aggressive
+        * `defensive` - Defensive
     PowerLedger:
       type: object
       description: Serializes a PowerLedger (entries + total) for the cast result
@@ -47762,6 +48213,20 @@ components:
       required:
       - unlock_id
       - unlock_type
+    QualityEnum:
+      enum:
+      - militia
+      - levy
+      - trained
+      - veteran
+      - elite
+      type: string
+      description: |-
+        * `militia` - Militia
+        * `levy` - Levy
+        * `trained` - Trained
+        * `veteran` - Veteran
+        * `elite` - Elite
     QualityTier:
       type: object
       description: Serializer for QualityTier lookup records.
@@ -49045,6 +49510,14 @@ components:
         * `guard` - Guard
         * `fan` - Fan
         * `minor_ally` - Minor Ally
+    RoleEnum:
+      enum:
+      - attacker
+      - defender
+      type: string
+      description: |-
+        * `attacker` - Attacker
+        * `defender` - Defender
     RoomComfortBreakdown:
       type: object
       description: The owner build-HUD payload for one room (#1514).
@@ -53455,6 +53928,26 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
+    TerrainTypeEnum:
+      enum:
+      - open
+      - difficult
+      - fortified
+      - elevated
+      - flooded
+      - urban
+      - water
+      - aerial
+      type: string
+      description: |-
+        * `open` - Open
+        * `difficult` - Difficult
+        * `fortified` - Fortified
+        * `elevated` - Elevated
+        * `flooded` - Flooded
+        * `urban` - Urban
+        * `water` - Open water
+        * `aerial` - Open sky
     Thread:
       type: object
       description: |-

--- a/src/schema.json
+++ b/src/schema.json
@@ -27780,8 +27780,14 @@ components:
           type: object
           additionalProperties: {}
           nullable: true
-          description: Public persona identity only — id/name/thumbnail_url, never
-            account/username.
+          description: |-
+            Public persona identity only — id/name/thumbnail(s), never account/username.
+
+            ``thumbnail_media_url`` mirrors ``world/combat/serializers.py``'s
+            ``get_thumbnail_media_url`` — the uploaded-portrait ``PlayerMedia`` FK,
+            already ``select_related``'d by the view's Prefetch (world/battles/views.py),
+            so this never issues a query. ``thumbnail_url`` is the legacy URLField,
+            kept alongside for callers still on it.
           readOnly: true
       required:
       - id

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -37,6 +37,7 @@ urlpatterns = [
     path("api/vitals/", include("world.vitals.urls")),
     path("api/action-points/", include("world.action_points.urls")),
     path("api/areas/", include("world.areas.urls")),
+    path("api/battles/", include("world.battles.urls")),
     path("api/player-submissions/", include("world.player_submissions.urls")),
     path("api/staff-inbox/", include("world.staff_inbox.urls")),
     path("api/consent/", include("world.consent.urls")),

--- a/src/web/webclient/message_types.py
+++ b/src/web/webclient/message_types.py
@@ -18,6 +18,7 @@ class WebsocketMessageType(str, Enum):
     ACTION_RESULT = "action_result"
     INTERACTION = "interaction"
     ROULETTE_RESULT = "roulette_result"
+    BATTLE_STATE = "battle_state"
 
 
 @dataclass
@@ -117,3 +118,17 @@ class CommandErrorPayload:
 
     command: str
     error: str
+
+
+@dataclass
+class BattleStatePayload:
+    """Slim ping for ``battle_state`` messages.
+
+    Battles are location-less (their backing scene has no ``location``), so the
+    existing scene/room broadcast paths never reach participants — this is the
+    dedicated seam. Carries no battle data itself; clients refetch the REST
+    aggregate on receipt.
+    """
+
+    battle_id: int
+    round_number: int | None

--- a/src/world/battles/AGENT_GLOSSARY.md
+++ b/src/world/battles/AGENT_GLOSSARY.md
@@ -189,3 +189,14 @@ _Avoid_: hero, duelist (descriptive only).
 breadth of a declared battle-round action. `PLACE`/`SIDE` require the matching
 Command Tier on the declaring participant's side's covenant.
 _Avoid_: range, radius, AOE.
+
+**BATTLE_STATE ping**:
+The `BattleStatePayload` (#2009, `web.webclient.message_types`) WS message —
+`{battle_id, round_number}` only, no battle data. Sent to connected
+participants from `notify_battle_state_changed` (`world.battles.services`)
+after `begin_battle_round`/`resolve_battle_round`/`conclude_battle`, deferred
+via `transaction.on_commit`. A slim "go refetch" signal, not a state push —
+the frontend treats receipt as cache invalidation only (`battleKeys.all`),
+then reads the real state back from `GET /api/battles/<pk>/`
+(`BattleDetailSerializer`). See ADR-0095.
+_Avoid_: battle update, state push (implies the payload itself carries state).

--- a/src/world/battles/resolution.py
+++ b/src/world/battles/resolution.py
@@ -1206,7 +1206,8 @@ def resolve_battle_round(*, battle_round: BattleRound) -> BattleRoundResult:
     Surrounded participant's peril once via
     ``_advance_surrounded_participants`` (#1733) — gated by declaration
     this round or ``battle.afk_peril_override``. Sets
-    ``battle_round.status = COMPLETED`` at the end.
+    ``battle_round.status = COMPLETED`` at the end, then pings connected
+    participants via ``notify_battle_state_changed`` (#2009).
 
     Args:
         battle_round: The ``BattleRound`` in DECLARING or RESOLVING status.
@@ -1290,5 +1291,9 @@ def resolve_battle_round(*, battle_round: BattleRound) -> BattleRoundResult:
     battle_round.status = RoundStatus.COMPLETED
     battle_round.completed_at = timezone.now()
     battle_round.save(update_fields=["status", "completed_at"])
+
+    from world.battles.services import notify_battle_state_changed  # noqa: PLC0415
+
+    notify_battle_state_changed(battle)
 
     return result

--- a/src/world/battles/resolution.py
+++ b/src/world/battles/resolution.py
@@ -1207,7 +1207,8 @@ def resolve_battle_round(*, battle_round: BattleRound) -> BattleRoundResult:
     ``_advance_surrounded_participants`` (#1733) — gated by declaration
     this round or ``battle.afk_peril_override``. Sets
     ``battle_round.status = COMPLETED`` at the end, then pings connected
-    participants via ``notify_battle_state_changed`` (#2009).
+    participants via ``notify_battle_state_changed`` (#2009), deferred via
+    ``transaction.on_commit`` so it fires only once this transaction commits.
 
     Args:
         battle_round: The ``BattleRound`` in DECLARING or RESOLVING status.
@@ -1294,6 +1295,6 @@ def resolve_battle_round(*, battle_round: BattleRound) -> BattleRoundResult:
 
     from world.battles.services import notify_battle_state_changed  # noqa: PLC0415
 
-    notify_battle_state_changed(battle)
+    transaction.on_commit(lambda: notify_battle_state_changed(battle))
 
     return result

--- a/src/world/battles/serializers.py
+++ b/src/world/battles/serializers.py
@@ -1,0 +1,236 @@
+"""Serializers for the read-only battle aggregate API (#2009).
+
+``BattleDetailSerializer`` is the single aggregate payload the strategic
+battle-map page consumes: sides, places (with fortifications + any embedded
+vehicle), units, and participants, all nested under one Battle. Persona
+resolution follows ``world/combat/serializers.py``'s ``_primary_persona``
+pattern — reads ``CharacterSheet.cached_payload_personas`` and exposes only
+id/name/thumbnail_url (never account/username — see the leak rule that
+motivated #1932).
+"""
+
+from __future__ import annotations
+
+from django.core.exceptions import ObjectDoesNotExist
+from rest_framework import serializers
+
+from world.battles.models import (
+    Battle,
+    BattleParticipant,
+    BattlePlace,
+    BattleSide,
+    BattleUnit,
+    BattleVehicle,
+    Fortification,
+)
+from world.scenes.constants import PersonaType
+
+
+class FortificationSerializer(serializers.ModelSerializer):
+    """A defensible structure at a BattlePlace."""
+
+    defending_side_id = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = Fortification
+        fields = [
+            "id",
+            "kind",
+            "integrity",
+            "max_integrity",
+            "breached",
+            "defending_side_id",
+        ]
+
+
+class BattleVehicleSummarySerializer(serializers.ModelSerializer):
+    """Slim vehicle summary — read through BattleStateCache.vehicle_at_place, never a query."""
+
+    unit_id = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = BattleVehicle
+        fields = ["unit_id", "vehicle_kind", "is_structural"]
+
+
+class BattlePlaceSerializer(serializers.ModelSerializer):
+    """A named front/zone, with its battle-map position and embedded structures."""
+
+    # DecimalField columns explicitly coerced to numbers — ModelSerializer's
+    # default DecimalField renders as a string, which the battle-map page
+    # (a numeric x/y plot) cannot consume.
+    x = serializers.FloatField()
+    y = serializers.FloatField()
+    footprint_radius = serializers.FloatField()
+    controlled_by_id = serializers.IntegerField(read_only=True, allow_null=True)
+    encounter_scene_id = serializers.SerializerMethodField()
+    vehicle = serializers.SerializerMethodField()
+    # Sourced from the "cached_fortifications" to_attr the view's Prefetch
+    # populates (world/battles/views.py) — never the bare "fortifications"
+    # manager, which would re-query.
+    fortifications = FortificationSerializer(
+        many=True, read_only=True, source="cached_fortifications"
+    )
+
+    class Meta:
+        model = BattlePlace
+        fields = [
+            "id",
+            "name",
+            "terrain_type",
+            "movement_cost",
+            "x",
+            "y",
+            "footprint_radius",
+            "controlled_by_id",
+            "encounter_scene_id",
+            "vehicle",
+            "fortifications",
+        ]
+
+    def get_encounter_scene_id(self, obj: BattlePlace) -> int | None:
+        """The scene backing this front's bridged CombatEncounter, if any (#1236)."""
+        return obj.combat_encounter.scene_id if obj.combat_encounter_id else None
+
+    def get_vehicle(self, obj: BattlePlace) -> dict | None:
+        """Read the embedded vehicle, if any, through the battle's state cache.
+
+        Never a fresh query — ``BattleStateCache.vehicle_at_place`` is the
+        single source of truth for which vehicle occupies a place (#1714).
+        """
+        vehicle = obj.battle.state_cache.vehicle_at_place(obj.pk)
+        if vehicle is None:
+            return None
+        return BattleVehicleSummarySerializer(vehicle).data
+
+
+class BattleUnitSerializer(serializers.ModelSerializer):
+    """An abstract typed force at a particular front (or embedded in a vehicle)."""
+
+    side_id = serializers.IntegerField(read_only=True)
+    place_id = serializers.IntegerField(read_only=True, allow_null=True)
+
+    class Meta:
+        model = BattleUnit
+        fields = [
+            "id",
+            "name",
+            "descriptor",
+            "quality",
+            "status",
+            "strength",
+            "morale",
+            "individual_count",
+            "side_id",
+            "place_id",
+        ]
+
+
+class BattleParticipantSerializer(serializers.ModelSerializer):
+    """A player character enlisted in the battle, with their public persona face."""
+
+    side_id = serializers.IntegerField(read_only=True)
+    place_id = serializers.IntegerField(read_only=True, allow_null=True)
+    persona = serializers.SerializerMethodField()
+
+    class Meta:
+        model = BattleParticipant
+        fields = ["id", "status", "side_id", "place_id", "persona"]
+
+    def _primary_persona(self, obj: BattleParticipant):
+        """Resolve the participant's PRIMARY persona through the cached accessor.
+
+        Mirrors ``world/combat/serializers.py``'s ``_primary_persona`` — reads
+        ``CharacterSheet.cached_payload_personas`` so serialization issues no
+        per-row query when the view prefetches it.
+        """
+        try:
+            character_sheet = obj.character_sheet
+        except ObjectDoesNotExist:
+            return None
+        if character_sheet is None:
+            return None
+        for persona in character_sheet.cached_payload_personas:
+            if persona.persona_type == PersonaType.PRIMARY:
+                return persona
+        return None
+
+    def get_persona(self, obj: BattleParticipant) -> dict | None:
+        """Public persona identity only — id/name/thumbnail_url, never account/username."""
+        persona = self._primary_persona(obj)
+        if persona is None:
+            return None
+        return {
+            "id": persona.id,
+            "name": persona.name,
+            "thumbnail_url": persona.thumbnail_url or None,
+        }
+
+
+class BattleSideSerializer(serializers.ModelSerializer):
+    """One side in the battle, with its victory tally and fielding covenant."""
+
+    covenant_id = serializers.IntegerField(read_only=True, allow_null=True)
+    covenant_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = BattleSide
+        fields = [
+            "id",
+            "role",
+            "victory_points",
+            "victory_threshold",
+            "posture",
+            "covenant_id",
+            "covenant_name",
+        ]
+
+    def get_covenant_name(self, obj: BattleSide) -> str | None:
+        return obj.covenant.name if obj.covenant_id else None
+
+
+class BattleListSerializer(serializers.ModelSerializer):
+    """Slim row for the battle list endpoint."""
+
+    scene_id = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = Battle
+        fields = ["id", "name", "scene_id", "outcome", "created_at"]
+
+
+class BattleDetailSerializer(serializers.ModelSerializer):
+    """Full battle aggregate — sides, places, units, and participants."""
+
+    # Each nested list is sourced from the view's "cached_*" to_attr Prefetch
+    # (world/battles/views.py._detail_prefetches) rather than the bare related
+    # manager, so nesting costs zero extra queries.
+    round = serializers.SerializerMethodField()
+    sides = BattleSideSerializer(many=True, read_only=True, source="cached_sides")
+    places = BattlePlaceSerializer(many=True, read_only=True, source="cached_places")
+    units = BattleUnitSerializer(many=True, read_only=True, source="cached_units")
+    participants = BattleParticipantSerializer(
+        many=True, read_only=True, source="cached_participants"
+    )
+
+    class Meta:
+        model = Battle
+        fields = [
+            "id",
+            "name",
+            "outcome",
+            "risk_level",
+            "is_paused",
+            "round",
+            "sides",
+            "places",
+            "units",
+            "participants",
+        ]
+
+    def get_round(self, obj: Battle) -> dict | None:
+        """The battle's current (latest non-completed) round, or None."""
+        current = obj.current_round
+        if current is None:
+            return None
+        return {"number": current.round_number, "status": current.status}

--- a/src/world/battles/serializers.py
+++ b/src/world/battles/serializers.py
@@ -148,8 +148,6 @@ class BattleParticipantSerializer(serializers.ModelSerializer):
             character_sheet = obj.character_sheet
         except ObjectDoesNotExist:
             return None
-        if character_sheet is None:
-            return None
         for persona in character_sheet.cached_payload_personas:
             if persona.persona_type == PersonaType.PRIMARY:
                 return persona

--- a/src/world/battles/serializers.py
+++ b/src/world/battles/serializers.py
@@ -5,8 +5,8 @@ battle-map page consumes: sides, places (with fortifications + any embedded
 vehicle), units, and participants, all nested under one Battle. Persona
 resolution follows ``world/combat/serializers.py``'s ``_primary_persona``
 pattern — reads ``CharacterSheet.cached_payload_personas`` and exposes only
-id/name/thumbnail_url (never account/username — see the leak rule that
-motivated #1932).
+id/name/thumbnail_url/thumbnail_media_url (never account/username — see the
+leak rule that motivated #1932).
 """
 
 from __future__ import annotations
@@ -154,14 +154,23 @@ class BattleParticipantSerializer(serializers.ModelSerializer):
         return None
 
     def get_persona(self, obj: BattleParticipant) -> dict | None:
-        """Public persona identity only — id/name/thumbnail_url, never account/username."""
+        """Public persona identity only — id/name/thumbnail(s), never account/username.
+
+        ``thumbnail_media_url`` mirrors ``world/combat/serializers.py``'s
+        ``get_thumbnail_media_url`` — the uploaded-portrait ``PlayerMedia`` FK,
+        already ``select_related``'d by the view's Prefetch (world/battles/views.py),
+        so this never issues a query. ``thumbnail_url`` is the legacy URLField,
+        kept alongside for callers still on it.
+        """
         persona = self._primary_persona(obj)
         if persona is None:
             return None
+        thumbnail_media_url = persona.thumbnail.cloudinary_url if persona.thumbnail_id else None
         return {
             "id": persona.id,
             "name": persona.name,
             "thumbnail_url": persona.thumbnail_url or None,
+            "thumbnail_media_url": thumbnail_media_url,
         }
 
 

--- a/src/world/battles/services.py
+++ b/src/world/battles/services.py
@@ -485,7 +485,9 @@ def notify_battle_state_changed(battle: Battle) -> None:
     Battles are location-less (their backing scene has no ``location``), so the
     existing scene/room broadcast paths never reach participants -- this is the
     dedicated seam. Called after round transitions (begin_battle_round,
-    resolve_battle_round) and on conclusion (conclude_battle).
+    resolve_battle_round) and on conclusion (conclude_battle) -- always deferred
+    via ``transaction.on_commit`` at each call site, so it runs post-commit and a
+    client that refetches on receipt always sees committed state.
     """
     current = battle.current_round
     payload = asdict(
@@ -494,7 +496,7 @@ def notify_battle_state_changed(battle: Battle) -> None:
             round_number=current.round_number if current else None,
         )
     )
-    for participant in battle.participants.select_related("character_sheet"):
+    for participant in battle.participants.select_related("character_sheet__character"):
         character = participant.character_sheet.character
         if character is None or not character.has_account:
             continue
@@ -537,7 +539,7 @@ def begin_battle_round(*, battle: Battle) -> BattleRound:
         status=RoundStatus.DECLARING,
         round_started_at=timezone.now(),
     )
-    notify_battle_state_changed(battle)
+    transaction.on_commit(lambda: notify_battle_state_changed(battle))
     return new_round
 
 
@@ -827,7 +829,8 @@ def conclude_battle(*, battle: Battle, outcome: str) -> Battle:
     does not re-fire). After beat resolution, runs every hook registered via
     register_battle_conclusion_hook (#1832) — e.g. ships' apply_ship_battle_outcome.
     Pings connected participants via notify_battle_state_changed (#2009) last,
-    after every other side effect.
+    after every other side effect, deferred via transaction.on_commit so it
+    fires only once this transaction has actually committed.
 
     Args:
         battle: The ``Battle`` to conclude.
@@ -851,7 +854,7 @@ def conclude_battle(*, battle: Battle, outcome: str) -> Battle:
 
     resolve_battle_beats(battle)
     run_battle_conclusion_hooks(battle)
-    notify_battle_state_changed(battle)
+    transaction.on_commit(lambda: notify_battle_state_changed(battle))
 
     return battle
 

--- a/src/world/battles/services.py
+++ b/src/world/battles/services.py
@@ -8,12 +8,14 @@ directly.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import asdict
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from django.db import transaction
 from django.utils import timezone
 
+from web.webclient.message_types import BattleStatePayload
 from world.battles.beat_wiring import activate_stakes_for_battle, resolve_battle_beats
 from world.battles.conclusion_hooks import run_battle_conclusion_hooks
 from world.battles.constants import (
@@ -477,6 +479,28 @@ def enlist_participant(
     )
 
 
+def notify_battle_state_changed(battle: Battle) -> None:
+    """Slim BATTLE_STATE ping -> connected participants; clients refetch the REST aggregate.
+
+    Battles are location-less (their backing scene has no ``location``), so the
+    existing scene/room broadcast paths never reach participants -- this is the
+    dedicated seam. Called after round transitions (begin_battle_round,
+    resolve_battle_round) and on conclusion (conclude_battle).
+    """
+    current = battle.current_round
+    payload = asdict(
+        BattleStatePayload(
+            battle_id=battle.pk,
+            round_number=current.round_number if current else None,
+        )
+    )
+    for participant in battle.participants.select_related("character_sheet"):
+        character = participant.character_sheet.character
+        if character is None or not character.has_account:
+            continue
+        character.msg(battle_state=((), payload))
+
+
 @transaction.atomic
 def begin_battle_round(*, battle: Battle) -> BattleRound:
     """Close any open round and open a new DECLARING round.
@@ -507,12 +531,14 @@ def begin_battle_round(*, battle: Battle) -> BattleRound:
         else:
             next_number = last.round_number + 1
 
-    return BattleRound.objects.create(
+    new_round = BattleRound.objects.create(
         battle=battle,
         round_number=next_number,
         status=RoundStatus.DECLARING,
         round_started_at=timezone.now(),
     )
+    notify_battle_state_changed(battle)
+    return new_round
 
 
 # ---------------------------------------------------------------------------
@@ -800,6 +826,8 @@ def conclude_battle(*, battle: Battle, outcome: str) -> Battle:
     if the battle is already concluded, returns it unchanged (resolve_battle_beats
     does not re-fire). After beat resolution, runs every hook registered via
     register_battle_conclusion_hook (#1832) — e.g. ships' apply_ship_battle_outcome.
+    Pings connected participants via notify_battle_state_changed (#2009) last,
+    after every other side effect.
 
     Args:
         battle: The ``Battle`` to conclude.
@@ -823,6 +851,7 @@ def conclude_battle(*, battle: Battle, outcome: str) -> Battle:
 
     resolve_battle_beats(battle)
     run_battle_conclusion_hooks(battle)
+    notify_battle_state_changed(battle)
 
     return battle
 

--- a/src/world/battles/services.py
+++ b/src/world/battles/services.py
@@ -496,6 +496,11 @@ def notify_battle_state_changed(battle: Battle) -> None:
             round_number=current.round_number if current else None,
         )
     )
+    # A fresh, bounded query rather than BattleStateCache (participants_on_side/
+    # participants_on_place): the cache indexes rows by side/place, not "every
+    # participant", and neither cached row carries the character_sheet__character
+    # join this ping needs -- reading through it would still cost a
+    # per-participant query. One bounded query here, not a refetch of cached state.
     for participant in battle.participants.select_related("character_sheet__character"):
         character = participant.character_sheet.character
         if character is None or not character.has_account:

--- a/src/world/battles/tests/test_api.py
+++ b/src/world/battles/tests/test_api.py
@@ -9,6 +9,7 @@ visibility, world/scenes/managers.py), staff bypass it entirely.
 from __future__ import annotations
 
 from decimal import Decimal
+from unittest import mock
 
 from django.db import connection
 from django.test import TestCase
@@ -35,7 +36,7 @@ from world.battles.factories import (
     BattleVehicleFactory,
     FortificationFactory,
 )
-from world.battles.services import enlist_participant
+from world.battles.services import begin_battle_round, enlist_participant
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.factories import CombatEncounterFactory
 from world.covenants.factories import CovenantFactory
@@ -328,3 +329,44 @@ class BattleApiJourneyTest(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], self.battle.pk)
         self.assertEqual(results[0]["scene_id"], self.battle.scene_id)
+
+
+class BattleStatePingTest(TestCase):
+    """BATTLE_STATE ping seam (#2009 Task 2).
+
+    Battles are location-less (their backing scene has no ``location``), so the
+    existing scene/room broadcast paths never reach participants -- this
+    dedicated ping fills that gap on round transitions. Clients refetch the
+    REST aggregate on receipt; the payload itself carries no battle data.
+    """
+
+    def setUp(self) -> None:
+        self.battle = BattleFactory(name="Ping Battle")
+        self.side = BattleSideFactory(battle=self.battle, role=BattleSideRole.ATTACKER)
+
+    def test_begin_battle_round_pings_connected_participant(self) -> None:
+        sheet = CharacterSheetFactory()
+        enlist_participant(battle=self.battle, character_sheet=sheet, side=self.side)
+        character = sheet.character
+        # Object.has_account reads session count, not db_account -- fake a
+        # connected session so the ping's guard lets this participant through.
+        character.sessions.count = lambda: 1
+
+        with mock.patch.object(character, "msg") as mock_msg:
+            begin_battle_round(battle=self.battle)
+
+        mock_msg.assert_called_once_with(
+            battle_state=((), {"battle_id": self.battle.pk, "round_number": 1})
+        )
+
+    def test_begin_battle_round_skips_participant_without_account(self) -> None:
+        sheet = CharacterSheetFactory()
+        enlist_participant(battle=self.battle, character_sheet=sheet, side=self.side)
+        character = sheet.character
+
+        # No session attached: has_account is False, so the guard must skip
+        # this participant silently rather than erroring.
+        with mock.patch.object(character, "msg") as mock_msg:
+            begin_battle_round(battle=self.battle)
+
+        mock_msg.assert_not_called()

--- a/src/world/battles/tests/test_api.py
+++ b/src/world/battles/tests/test_api.py
@@ -1,0 +1,267 @@
+"""Journey test for the read-only battle aggregate API (#2009).
+
+Mirrors world/combat/tests/test_views.py's account/scene setup: an account
+is granted read access to a Battle's backing scene via SceneParticipation
+(Scene.objects.viewable_by is the single source of truth for scene
+visibility, world/scenes/managers.py), staff bypass it entirely.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.test import TestCase
+from rest_framework import status as http_status
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory
+from world.battles.constants import (
+    BattlePosture,
+    BattleSideRole,
+    BattleUnitStatus,
+    FortificationKind,
+    TerrainType,
+    UnitQuality,
+    VehicleKind,
+)
+from world.battles.factories import (
+    BattleFactory,
+    BattlePlaceFactory,
+    BattleRoundFactory,
+    BattleSideFactory,
+    BattleUnitFactory,
+    BattleVehicleFactory,
+    FortificationFactory,
+)
+from world.battles.services import enlist_participant
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.factories import CombatEncounterFactory
+from world.covenants.factories import CovenantFactory
+from world.scenes.constants import ScenePrivacyMode
+from world.scenes.factories import SceneParticipationFactory
+
+
+class BattleApiJourneyTest(TestCase):
+    """Covers list/detail shape, scene visibility, and the ?scene= filter."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.covenant = CovenantFactory(name="The Iron Vanguard")
+        cls.battle = BattleFactory(name="Siege of the Gate")
+        # Battle.save() auto-creates a PUBLIC scene; force PRIVATE so scene
+        # visibility actually gates the API (mirrors combat's precedent).
+        cls.battle.scene.privacy_mode = ScenePrivacyMode.PRIVATE
+        cls.battle.scene.save(update_fields=["privacy_mode"])
+
+        cls.attacker_side = BattleSideFactory(
+            battle=cls.battle,
+            role=BattleSideRole.ATTACKER,
+            covenant=cls.covenant,
+            victory_points=4,
+            victory_threshold=10,
+            posture=BattlePosture.BALANCED,
+        )
+        cls.defender_side = BattleSideFactory(
+            battle=cls.battle,
+            role=BattleSideRole.DEFENDER,
+        )
+
+        cls.place_ford = BattlePlaceFactory(
+            battle=cls.battle,
+            name="The Ford",
+            terrain_type=TerrainType.FLOODED,
+            movement_cost=2,
+            controlled_by=cls.attacker_side,
+            x=Decimal("10.5"),
+            y=Decimal("-3.0"),
+            footprint_radius=Decimal("2.0"),
+        )
+        cls.fortification = FortificationFactory(
+            place=cls.place_ford,
+            defending_side=cls.defender_side,
+            kind=FortificationKind.WALL,
+            integrity=5,
+            max_integrity=8,
+            breached=False,
+        )
+        cls.vehicle = BattleVehicleFactory(
+            unit__battle=cls.battle,
+            unit__side=cls.attacker_side,
+            place=cls.place_ford,
+            vehicle_kind=VehicleKind.SHIP,
+            is_structural=True,
+        )
+
+        cls.encounter = CombatEncounterFactory()
+        cls.place_yard = BattlePlaceFactory(
+            battle=cls.battle,
+            name="Statue Yard",
+            combat_encounter=cls.encounter,
+        )
+
+        cls.ground_unit = BattleUnitFactory(
+            battle=cls.battle,
+            side=cls.attacker_side,
+            place=cls.place_ford,
+            name="Vanguard Pikes",
+            descriptor="pike-and-shot",
+            quality=UnitQuality.VETERAN,
+            status=BattleUnitStatus.ACTIVE,
+            strength=80,
+            morale=60,
+            individual_count=1,
+        )
+        cls.defender_unit = BattleUnitFactory(
+            battle=cls.battle,
+            side=cls.defender_side,
+            place=cls.place_yard,
+            name="Garrison Levy",
+            descriptor="militia",
+            quality=UnitQuality.MILITIA,
+            status=BattleUnitStatus.ACTIVE,
+            strength=50,
+            morale=40,
+        )
+
+        cls.round = BattleRoundFactory(battle=cls.battle, round_number=3, status="declaring")
+
+        cls.pc_sheet = CharacterSheetFactory()
+        cls.pc_account = AccountFactory(username="battle_pc")
+        SceneParticipationFactory(scene=cls.battle.scene, account=cls.pc_account)
+        cls.participant = enlist_participant(
+            battle=cls.battle,
+            character_sheet=cls.pc_sheet,
+            side=cls.attacker_side,
+            place=cls.place_ford,
+        )
+
+        cls.staff_account = AccountFactory(username="battle_staff", is_staff=True)
+        cls.other_account = AccountFactory(username="battle_outsider")
+
+    def _assert_detail_shape(self, data: dict) -> None:
+        self.assertEqual(data["id"], self.battle.pk)
+        self.assertEqual(data["name"], "Siege of the Gate")
+        self.assertEqual(data["outcome"], self.battle.outcome)
+        self.assertEqual(data["risk_level"], self.battle.risk_level)
+        self.assertIs(data["is_paused"], False)
+        self.assertEqual(data["round"], {"number": 3, "status": "declaring"})
+
+        self._assert_sides_shape(data["sides"])
+        self._assert_places_shape(data["places"])
+        self._assert_units_shape(data["units"])
+        self._assert_participants_shape(data["participants"])
+
+    def _assert_sides_shape(self, sides: list[dict]) -> None:
+        sides_by_role = {side["role"]: side for side in sides}
+        attacker = sides_by_role["attacker"]
+        self.assertEqual(attacker["id"], self.attacker_side.pk)
+        self.assertEqual(attacker["victory_points"], 4)
+        self.assertEqual(attacker["victory_threshold"], 10)
+        self.assertEqual(attacker["posture"], "balanced")
+        self.assertEqual(attacker["covenant_id"], self.covenant.pk)
+        self.assertEqual(attacker["covenant_name"], "The Iron Vanguard")
+        defender = sides_by_role["defender"]
+        self.assertIsNone(defender["covenant_id"])
+        self.assertIsNone(defender["covenant_name"])
+
+    def _assert_places_shape(self, places: list[dict]) -> None:
+        places_by_name = {place["name"]: place for place in places}
+        ford = places_by_name["The Ford"]
+        self.assertEqual(ford["id"], self.place_ford.pk)
+        self.assertEqual(ford["terrain_type"], "flooded")
+        self.assertEqual(ford["movement_cost"], 2)
+        self.assertIsInstance(ford["x"], float)
+        self.assertIsInstance(ford["y"], float)
+        self.assertIsInstance(ford["footprint_radius"], float)
+        self.assertEqual(ford["x"], 10.5)
+        self.assertEqual(ford["y"], -3.0)
+        self.assertEqual(ford["footprint_radius"], 2.0)
+        self.assertEqual(ford["controlled_by_id"], self.attacker_side.pk)
+        self.assertIsNone(ford["encounter_scene_id"])
+        self.assertIsNotNone(ford["vehicle"])
+        self.assertEqual(ford["vehicle"]["unit_id"], self.vehicle.unit_id)
+        self.assertEqual(ford["vehicle"]["vehicle_kind"], "ship")
+        self.assertIs(ford["vehicle"]["is_structural"], True)
+        self.assertEqual(len(ford["fortifications"]), 1)
+        fort = ford["fortifications"][0]
+        self.assertEqual(fort["id"], self.fortification.pk)
+        self.assertEqual(fort["kind"], "wall")
+        self.assertEqual(fort["integrity"], 5)
+        self.assertEqual(fort["max_integrity"], 8)
+        self.assertIs(fort["breached"], False)
+        self.assertEqual(fort["defending_side_id"], self.defender_side.pk)
+
+        yard = places_by_name["Statue Yard"]
+        self.assertEqual(yard["encounter_scene_id"], self.encounter.scene_id)
+        self.assertIsNone(yard["vehicle"])
+        self.assertEqual(yard["fortifications"], [])
+
+    def _assert_units_shape(self, units: list[dict]) -> None:
+        units_by_name = {unit["name"]: unit for unit in units}
+        vanguard = units_by_name["Vanguard Pikes"]
+        self.assertEqual(vanguard["descriptor"], "pike-and-shot")
+        self.assertEqual(vanguard["quality"], "veteran")
+        self.assertEqual(vanguard["status"], "active")
+        self.assertEqual(vanguard["strength"], 80)
+        self.assertEqual(vanguard["morale"], 60)
+        self.assertEqual(vanguard["individual_count"], 1)
+        self.assertEqual(vanguard["side_id"], self.attacker_side.pk)
+        self.assertEqual(vanguard["place_id"], self.place_ford.pk)
+        garrison = units_by_name["Garrison Levy"]
+        self.assertEqual(garrison["side_id"], self.defender_side.pk)
+        self.assertEqual(garrison["place_id"], self.place_yard.pk)
+        # The vehicle's own unit is present too, with no place (#1714 invariant).
+        vehicle_unit = next(u for u in units if u["id"] == self.vehicle.unit_id)
+        self.assertIsNone(vehicle_unit["place_id"])
+
+    def _assert_participants_shape(self, participants: list[dict]) -> None:
+        self.assertEqual(len(participants), 1)
+        participant_data = participants[0]
+        self.assertEqual(participant_data["id"], self.participant.pk)
+        self.assertEqual(participant_data["status"], "active")
+        self.assertEqual(participant_data["side_id"], self.attacker_side.pk)
+        self.assertEqual(participant_data["place_id"], self.place_ford.pk)
+        self.assertEqual(participant_data["persona"]["id"], self.pc_sheet.primary_persona.pk)
+        self.assertEqual(participant_data["persona"]["name"], self.pc_sheet.primary_persona.name)
+        self.assertIsNone(participant_data["persona"]["thumbnail_url"])
+        self.assertNotIn("account", participant_data["persona"])
+        self.assertNotIn("username", participant_data["persona"])
+
+    def test_participant_can_retrieve_full_detail_shape(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.pc_account)
+        response = client.get(f"/api/battles/{self.battle.pk}/")
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self._assert_detail_shape(response.data)
+
+    def test_staff_can_retrieve_detail(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.staff_account)
+        response = client.get(f"/api/battles/{self.battle.pk}/")
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.battle.pk)
+
+    def test_non_participant_detail_is_404_not_403(self) -> None:
+        """No existence oracle — a private battle 404s for a non-viewer, not 403."""
+        client = APIClient()
+        client.force_authenticate(user=self.other_account)
+        response = client.get(f"/api/battles/{self.battle.pk}/")
+        self.assertEqual(response.status_code, http_status.HTTP_404_NOT_FOUND)
+
+    def test_list_excludes_battle_for_non_participant(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.other_account)
+        response = client.get("/api/battles/")
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        ids = [row["id"] for row in response.data["results"]]
+        self.assertNotIn(self.battle.pk, ids)
+
+    def test_scene_filter_returns_exactly_this_battle_for_participant(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.pc_account)
+        response = client.get(f"/api/battles/?scene={self.battle.scene_id}")
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], self.battle.pk)
+        self.assertEqual(results[0]["scene_id"], self.battle.scene_id)

--- a/src/world/battles/tests/test_api.py
+++ b/src/world/battles/tests/test_api.py
@@ -19,6 +19,7 @@ from rest_framework.test import APIClient
 
 from evennia_extensions.factories import AccountFactory
 from world.battles.constants import (
+    BattleOutcome,
     BattlePosture,
     BattleSideRole,
     BattleUnitStatus,
@@ -36,11 +37,13 @@ from world.battles.factories import (
     BattleVehicleFactory,
     FortificationFactory,
 )
-from world.battles.services import begin_battle_round, enlist_participant
+from world.battles.resolution import resolve_battle_round
+from world.battles.services import begin_battle_round, conclude_battle, enlist_participant
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.factories import CombatEncounterFactory
 from world.covenants.factories import CovenantFactory
-from world.scenes.constants import ScenePrivacyMode
+from world.roster.factories import PlayerMediaFactory
+from world.scenes.constants import RoundStatus, ScenePrivacyMode
 from world.scenes.factories import SceneParticipationFactory
 
 
@@ -227,6 +230,7 @@ class BattleApiJourneyTest(TestCase):
         self.assertEqual(participant_data["persona"]["id"], self.pc_sheet.primary_persona.pk)
         self.assertEqual(participant_data["persona"]["name"], self.pc_sheet.primary_persona.name)
         self.assertIsNone(participant_data["persona"]["thumbnail_url"])
+        self.assertIsNone(participant_data["persona"]["thumbnail_media_url"])
         self.assertNotIn("account", participant_data["persona"])
         self.assertNotIn("username", participant_data["persona"])
 
@@ -320,6 +324,21 @@ class BattleApiJourneyTest(TestCase):
             "issuing a per-row persona query (N+1 regression).",
         )
 
+    def test_participant_persona_thumbnail_media_url_resolves_uploaded_portrait(self) -> None:
+        """Mirrors combat's ``get_thumbnail_media_url`` parity (#2009 review):
+        the uploaded ``PlayerMedia`` portrait FK, not just the legacy URLField."""
+        media = PlayerMediaFactory()
+        persona = self.pc_sheet.primary_persona
+        persona.thumbnail = media
+        persona.save(update_fields=["thumbnail"])
+
+        client = APIClient()
+        client.force_authenticate(user=self.pc_account)
+        response = client.get(f"/api/battles/{self.battle.pk}/")
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        participant_data = response.data["participants"][0]
+        self.assertEqual(participant_data["persona"]["thumbnail_media_url"], media.cloudinary_url)
+
     def test_scene_filter_returns_exactly_this_battle_for_participant(self) -> None:
         client = APIClient()
         client.force_authenticate(user=self.pc_account)
@@ -380,3 +399,50 @@ class BattleStatePingTest(TestCase):
                 begin_battle_round(battle=self.battle)
 
         mock_msg.assert_not_called()
+
+    def test_resolve_battle_round_pings_connected_participant(self) -> None:
+        sheet = CharacterSheetFactory()
+        enlist_participant(battle=self.battle, character_sheet=sheet, side=self.side)
+        character = sheet.character
+        # Object.has_account reads session count, not db_account -- fake a
+        # connected session so the ping's guard lets this participant through.
+        character.sessions.count = lambda: 1
+        battle_round = BattleRoundFactory(
+            battle=self.battle, round_number=1, status=RoundStatus.DECLARING
+        )
+
+        with mock.patch.object(character, "msg") as mock_msg:
+            # Deferred via transaction.on_commit (same seam as begin_battle_round)
+            # -- capture without executing first to prove it hasn't fired mid-transaction.
+            with self.captureOnCommitCallbacks() as callbacks:
+                resolve_battle_round(battle_round=battle_round)
+            mock_msg.assert_not_called()
+            self.assertEqual(len(callbacks), 1)
+
+            for callback in callbacks:
+                callback()
+
+        # The round completes as part of resolution, so current_round is None
+        # by the time the deferred ping reads it.
+        mock_msg.assert_called_once_with(
+            battle_state=((), {"battle_id": self.battle.pk, "round_number": None})
+        )
+
+    def test_conclude_battle_pings_connected_participant(self) -> None:
+        sheet = CharacterSheetFactory()
+        enlist_participant(battle=self.battle, character_sheet=sheet, side=self.side)
+        character = sheet.character
+        character.sessions.count = lambda: 1
+
+        with mock.patch.object(character, "msg") as mock_msg:
+            with self.captureOnCommitCallbacks() as callbacks:
+                conclude_battle(battle=self.battle, outcome=BattleOutcome.ATTACKER_DECISIVE)
+            mock_msg.assert_not_called()
+            self.assertEqual(len(callbacks), 1)
+
+            for callback in callbacks:
+                callback()
+
+        mock_msg.assert_called_once_with(
+            battle_state=((), {"battle_id": self.battle.pk, "round_number": None})
+        )

--- a/src/world/battles/tests/test_api.py
+++ b/src/world/battles/tests/test_api.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from rest_framework import status as http_status
 from rest_framework.test import APIClient
 
@@ -255,6 +257,67 @@ class BattleApiJourneyTest(TestCase):
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         ids = [row["id"] for row in response.data["results"]]
         self.assertNotIn(self.battle.pk, ids)
+
+    def _build_battle_with_participants(self, num_participants: int):
+        """A standalone battle (own scene/side) enlisting `num_participants` PCs.
+
+        Kept separate from `self.battle`/setUpTestData deliberately: idmapper
+        caches model instances by pk process-wide, and Django's `to_attr`
+        prefetch skips re-fetching a lookup that's already set on an instance
+        (``is_to_attr_fetched`` in django/db/models/query.py) -- refetching the
+        *same* Battle pk within one test would let the second request's
+        prefetch silently no-op against the first request's cached attribute.
+        Two distinct Battle rows sidestep that entirely.
+        """
+        battle = BattleFactory()
+        side = BattleSideFactory(battle=battle)
+        for _ in range(num_participants):
+            enlist_participant(battle=battle, character_sheet=CharacterSheetFactory(), side=side)
+        return battle
+
+    def test_participant_persona_query_count_does_not_scale_with_participant_count(
+        self,
+    ) -> None:
+        """Regression guard for the N+1 the review on #2009 caught: the detail
+        view's participants Prefetch must nest a ``character_sheet__personas``
+        Prefetch (to_attr ``cached_payload_personas``) so
+        ``BattleParticipantSerializer._primary_persona`` never issues a
+        per-participant query. Query count must stay flat as participants grow.
+        """
+        client = APIClient()
+        client.force_authenticate(user=self.staff_account)
+
+        battle_one = self._build_battle_with_participants(1)
+        battle_many = self._build_battle_with_participants(3)
+
+        # Warm up on a third, throwaway battle first: the very first request
+        # in a test pays one-time costs (permission/content-type caching)
+        # that a naive first-vs-second comparison would misread as N+1 growth.
+        warmup_battle = self._build_battle_with_participants(1)
+        client.get(f"/api/battles/{warmup_battle.pk}/")
+
+        with CaptureQueriesContext(connection) as ctx_one:
+            response_one = client.get(f"/api/battles/{battle_one.pk}/")
+        self.assertEqual(response_one.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(len(response_one.data["participants"]), 1)
+        queries_one = len(ctx_one)
+
+        with CaptureQueriesContext(connection) as ctx_many:
+            response_many = client.get(f"/api/battles/{battle_many.pk}/")
+        self.assertEqual(response_many.status_code, http_status.HTTP_200_OK)
+        participants = response_many.data["participants"]
+        self.assertEqual(len(participants), 3)
+        for participant_data in participants:
+            self.assertIsNotNone(participant_data["persona"])
+        queries_many = len(ctx_many)
+
+        self.assertEqual(
+            queries_one,
+            queries_many,
+            f"Query count grew from {queries_one} (1 participant) to "
+            f"{queries_many} (3 participants) -- the participants Prefetch is "
+            "issuing a per-row persona query (N+1 regression).",
+        )
 
     def test_scene_filter_returns_exactly_this_battle_for_participant(self) -> None:
         client = APIClient()

--- a/src/world/battles/tests/test_api.py
+++ b/src/world/battles/tests/test_api.py
@@ -353,7 +353,16 @@ class BattleStatePingTest(TestCase):
         character.sessions.count = lambda: 1
 
         with mock.patch.object(character, "msg") as mock_msg:
-            begin_battle_round(battle=self.battle)
+            # The ping is deferred via transaction.on_commit (#2009 review) so a
+            # refetching client always sees committed state -- capture without
+            # executing first to prove it hasn't fired mid-transaction.
+            with self.captureOnCommitCallbacks() as callbacks:
+                begin_battle_round(battle=self.battle)
+            mock_msg.assert_not_called()
+            self.assertEqual(len(callbacks), 1)
+
+            for callback in callbacks:
+                callback()
 
         mock_msg.assert_called_once_with(
             battle_state=((), {"battle_id": self.battle.pk, "round_number": 1})
@@ -367,6 +376,7 @@ class BattleStatePingTest(TestCase):
         # No session attached: has_account is False, so the guard must skip
         # this participant silently rather than erroring.
         with mock.patch.object(character, "msg") as mock_msg:
-            begin_battle_round(battle=self.battle)
+            with self.captureOnCommitCallbacks(execute=True):
+                begin_battle_round(battle=self.battle)
 
         mock_msg.assert_not_called()

--- a/src/world/battles/urls.py
+++ b/src/world/battles/urls.py
@@ -1,0 +1,11 @@
+"""URL configuration for the battles read API (#2009)."""
+
+from rest_framework.routers import DefaultRouter
+
+from world.battles.views import BattleViewSet
+
+router = DefaultRouter()
+router.register("", BattleViewSet, basename="battles")
+
+app_name = "battles"
+urlpatterns = router.urls

--- a/src/world/battles/views.py
+++ b/src/world/battles/views.py
@@ -17,7 +17,8 @@ from world.battles.models import (
     Fortification,
 )
 from world.battles.serializers import BattleDetailSerializer, BattleListSerializer
-from world.scenes.models import Scene
+from world.scenes.constants import PersonaType
+from world.scenes.models import Persona, Scene
 from world.stories.pagination import StandardResultsSetPagination
 
 
@@ -73,13 +74,32 @@ class BattleViewSet(ReadOnlyModelViewSet):
             Prefetch("units", queryset=BattleUnit.objects.all(), to_attr="cached_units"),
             Prefetch(
                 "participants",
-                queryset=BattleParticipant.objects.select_related("character_sheet"),
+                queryset=BattleParticipant.objects.select_related(
+                    "character_sheet"
+                ).prefetch_related(
+                    # Pre-fill CharacterSheet.cached_payload_personas (a
+                    # @cached_property doubling as this to_attr target) so
+                    # BattleParticipantSerializer resolves the PRIMARY persona
+                    # with zero per-row queries. Queryset shape mirrors
+                    # world/combat/views.py's identical Prefetch (#630) and the
+                    # property's own documented fallback (must match exactly, or
+                    # prefetched vs. non-prefetched rows diverge).
+                    Prefetch(
+                        "character_sheet__personas",
+                        queryset=Persona.objects.filter(
+                            persona_type__in=[PersonaType.PRIMARY, PersonaType.ESTABLISHED]
+                        )
+                        .order_by("-persona_type", "created_at", "id")
+                        .select_related("thumbnail"),
+                        to_attr="cached_payload_personas",
+                    ),
+                ),
                 to_attr="cached_participants",
             ),
         ]
 
     def _base_queryset(self) -> QuerySet[Battle]:
-        qs = Battle.objects.select_related("scene").order_by("-created_at")
+        qs = Battle.objects.order_by("-created_at")
         if self.action == "retrieve":
             qs = qs.prefetch_related(*self._detail_prefetches())
         return qs

--- a/src/world/battles/views.py
+++ b/src/world/battles/views.py
@@ -1,0 +1,101 @@
+"""ViewSet for the read-only battle aggregate API (#2009)."""
+
+from __future__ import annotations
+
+from django.db.models import Prefetch, QuerySet
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.serializers import Serializer
+from rest_framework.viewsets import ReadOnlyModelViewSet
+
+from world.battles.models import (
+    Battle,
+    BattleParticipant,
+    BattlePlace,
+    BattleSide,
+    BattleUnit,
+    Fortification,
+)
+from world.battles.serializers import BattleDetailSerializer, BattleListSerializer
+from world.scenes.models import Scene
+from world.stories.pagination import StandardResultsSetPagination
+
+
+class BattleViewSet(ReadOnlyModelViewSet):
+    """Read-only battle aggregate API — list (slim) and detail (full aggregate).
+
+    Scene-gated exactly like ``CombatEncounterViewSet`` (world/combat/views.py):
+    a Battle is a 1:1 extension of scenes.Scene (world/battles/models.py), so
+    scene read-visibility alone decides who may see a battle. No participant
+    union needed — enlisting in a battle has no bearing here independent of
+    scene visibility.
+    """
+
+    permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["scene", "outcome"]
+    pagination_class = StandardResultsSetPagination
+
+    def get_serializer_class(self) -> type[Serializer]:
+        if self.action == "list":
+            return BattleListSerializer
+        return BattleDetailSerializer
+
+    def _detail_prefetches(self) -> list[Prefetch]:
+        """Explicit ``to_attr``-cached prefetches for the retrieve-only nested aggregate.
+
+        Every relation the detail serializer nests (sides/places/units/
+        participants, plus places' fortifications) is loaded via a ``Prefetch``
+        with ``to_attr`` — never a bare string — so the serializer's cache reads
+        cost zero extra queries (repo-wide PREFETCH_STRING rule).
+        ``BattleSideSerializer``/``BattlePlaceSerializer``/etc. read the
+        matching ``cached_*`` attrs via their ``source=`` kwarg.
+        """
+        return [
+            Prefetch(
+                "sides",
+                queryset=BattleSide.objects.select_related("covenant"),
+                to_attr="cached_sides",
+            ),
+            Prefetch(
+                "places",
+                queryset=BattlePlace.objects.select_related(
+                    "battle", "combat_encounter"
+                ).prefetch_related(
+                    Prefetch(
+                        "fortifications",
+                        queryset=Fortification.objects.all(),
+                        to_attr="cached_fortifications",
+                    ),
+                ),
+                to_attr="cached_places",
+            ),
+            Prefetch("units", queryset=BattleUnit.objects.all(), to_attr="cached_units"),
+            Prefetch(
+                "participants",
+                queryset=BattleParticipant.objects.select_related("character_sheet"),
+                to_attr="cached_participants",
+            ),
+        ]
+
+    def _base_queryset(self) -> QuerySet[Battle]:
+        qs = Battle.objects.select_related("scene").order_by("-created_at")
+        if self.action == "retrieve":
+            qs = qs.prefetch_related(*self._detail_prefetches())
+        return qs
+
+    def get_queryset(self) -> QuerySet[Battle]:
+        return self._filter_readable(self._base_queryset())
+
+    def _filter_readable(self, qs: QuerySet[Battle]) -> QuerySet[Battle]:
+        """Restrict list/retrieve to battles whose scene the caller may view.
+
+        Exact shape of ``CombatEncounterViewSet._filter_readable``
+        (world/combat/views.py:262-273) — staff see everything; everyone else
+        is scoped to ``Scene.objects.viewable_by``, the single source of truth
+        for scene read-visibility.
+        """
+        user = self.request.user
+        if getattr(user, "is_staff", False):  # noqa: GETATTR_LITERAL
+            return qs
+        return qs.filter(scene__in=Scene.objects.viewable_by(user)).distinct()


### PR DESCRIPTION
Closes #2009

## Summary

Live strategic battle map (#2009): battles read API (GET /api/battles/ + /<pk>/ aggregate over sides/places/units/participants/fortifications/vehicles, scene-visibility-gated with 404 no-oracle), BATTLE_STATE WS ping (slim {battle_id, round_number}, sent post-commit from begin/resolve/conclude — ADR-0095) with React Query refetch, and a read-only React Flow map page at /scenes/:id/battle (front canvas, place detail panel, encounter drill-down). No model changes or migrations.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2009 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: rebase strategy; origin/main unmoved since branch point (0 commits behind at sync)

<!-- last-addressed-comment: 0 -->