### PR TITLE
Telnet resonance visibility: balances on the sheet + a grant-history view

### DIFF
--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -160,6 +160,24 @@ Closes the `#1328` telnet-coverage gap for technique authoring. Surfaces built:
 The `PlayerPolicy` seam and web `author` endpoint are already wired; the player-tier gate
 is a permissive `TODO` in `technique_builder.py`.
 
+## Telnet resonance visibility (#2032 — BUILT)
+
+Telnet players could earn and spend `CharacterResonance.balance` (thread pulls, imbuing,
+sanctum weaving, entry flourishes, pose endorsements, ...) but had no telnet surface that
+ever rendered it. Two read-only faces now expose it, both reading the same
+handler/service the web uses — no parallel query pipeline:
+
+- **`sheet/magic`** (`commands/account/sheet_sections.py`) gained a `Resonance:` block —
+  every claimed resonance's balance + lifetime earned, from `_build_magic_resonances`
+  (`world/character_sheets/serializers.py`), which reads `character.resonances`
+  (`CharacterResonanceHandler`, the cached identity-mapped accessor). Folded into
+  `MagicSection.resonances`, shared by telnet and the web Magic tab.
+- **`resonance`** (`commands/resonance.py`, new command key) — bare `resonance` reuses the
+  same builder for the balance listing; `resonance history [<name>]` shows the caller's
+  last 10 `ResonanceGrant` rows (newest first, source label), optionally narrowed to one
+  claimed resonance, via `resonance_grant_history_for_sheet`
+  (`world/magic/services/gain.py`) — mirrors `ResonanceGrantViewSet`'s ordering.
+
 ## Ritual of the Durance (#1352 — BUILT)
 
 The within-tier class-level advancement ceremony is complete. Magic's contribution:

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -990,6 +990,23 @@ Resonance Gain" in `docs/systems/INDEX.md`). Current values:
   (#1834); typed source FK `source_character_distinction`. See "Distinction → Resonance
   (#1834)" in `docs/systems/distinctions.md` for the model + reconcile/accelerator services.
 
+**Telnet visibility (#2032).** Balances were earnable/spendable via telnet (pulls, imbuing,
+sanctum weaving) but had no telnet surface showing `CharacterResonance.balance` at all. Two
+read-only faces now expose it, both reading the same handler/service the web uses (no parallel
+query pipeline):
+- `sheet/magic` (`commands/account/sheet_sections.py`) — a `Resonance:` block listing every
+  claimed resonance's balance + lifetime earned, built by
+  `_build_magic_resonances` (`world/character_sheets/serializers.py`), which reads
+  `character.resonances` (`CharacterResonanceHandler`, the cached identity-mapped accessor —
+  not a fresh query). Folded into `MagicSection.resonances` so telnet and the web Magic tab
+  share one data path.
+- `resonance` (`commands/resonance.py`, key `resonance`) — bare `resonance` reuses
+  `_build_magic_resonances` for the same balance listing; `resonance history [<name>]` shows
+  the caller's last 10 `ResonanceGrant` rows (newest first, source label via
+  `get_source_display()`), optionally narrowed to one claimed resonance, via
+  `resonance_grant_history_for_sheet` (`world/magic/services/gain.py`) — mirrors
+  `ResonanceGrantViewSet`'s `-granted_at` ordering.
+
 `ACCELERATED_GAIN_SOURCES` / `NON_ACCELERATED_GAIN_SOURCES` (`world/magic/constants.py`,
 ADR-0041) partition every `GainSource` member (a total-classification test enforces this):
 perception/presence-driven sources a character actively performs to be seen (`POSE_ENDORSEMENT`,

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -164,6 +164,14 @@ actions, backends, and service functions.
 - **`imbue.py`**: `CmdImbue` (`imbue`) — finisher for the Rite of Imbuing CEREMONY;
   parses `imbue thread=<name|id> amount=<n>`. Requires an active `PendingRitualEffect`
   for Rite of Imbuing; calls `spend_resonance_for_imbuing` to advance thread level.
+- **`resonance.py`**: `CmdResonance` (`resonance`, #2032) — read-only spendable-resonance
+  visibility. Bare `resonance` lists claimed resonances (balance + lifetime earned) via
+  `_build_magic_resonances` (`world/character_sheets/serializers.py`, the same builder
+  `sheet/magic` reads — no parallel query pipeline); `resonance history [<name>]` shows the
+  caller's last 10 `ResonanceGrant` rows (newest first, source label), optionally narrowed to
+  one resonance, via `resonance_grant_history_for_sheet`
+  (`world/magic/services/gain.py`) — mirrors `ResonanceGrantViewSet`'s ordering. No business
+  logic in the command.
 - **`combat.py`**: Two commands sharing a `_CombatCommandMixin` (provides
   `_combat_participant_or_none` and `_find_technique_id`). Both subclass `DispatchCommand`
   — business logic lives entirely in the dispatcher and service layer, never in the command.
@@ -593,9 +601,11 @@ actions, backends, and service functions.
   `achievements.CharacterTitle`; cosmetic, mirrors the web Titles tab); `distinction`
   (`sheet/distinction`, #1446 — your distinctions, secret-badged, over the shared
   `_build_distinctions` builder, mirroring the web Distinctions tab); `magic` (`sheet/magic`,
-  #1446 — gifts/techniques/motif/aura over the shared `_build_magic` builder, mirroring the web
-  Magic tab; describe-only — casting/weaving/rituals stay in-scene, per "the sheet describes; the
-  scene does" in `design-tenets.md`); `status` (`sheet/status`, #1446 — condition, fatigue, and
+  #1446 — gifts/techniques/motif/aura/**resonance balances** (#2032) over the shared
+  `_build_magic` builder, mirroring the web Magic tab; describe-only — casting/weaving/rituals
+  stay in-scene, per "the sheet describes; the scene does" in `design-tenets.md`; resonance
+  *history* is a separate read surface, `resonance history` (`commands/resonance.py`));
+  `status` (`sheet/status`, #1446 — condition, fatigue, and
   anima as qualitative words (wound band, fatigue zones, `anima_band_for`), plus coin
   (`format_coppers`) and weekly AP (current/effective-maximum/banked); self-only, read-only,
   mirroring the web Status tab). Each is thin over its app's data. Add a section: a renderer

--- a/src/commands/account/sheet_sections.py
+++ b/src/commands/account/sheet_sections.py
@@ -394,6 +394,13 @@ def _render_magic_section(command: Command) -> list[str]:
     aura = magic["aura"]
     if aura and aura["glimpse_story"]:
         lines.append(f"  Aura: {aura['glimpse_story']}")
+    resonances = magic["resonances"]
+    if resonances:
+        lines.append("  Resonance:")
+        lines.extend(
+            f"    {entry['name']}: {entry['balance']} (lifetime {entry['lifetime_earned']})"
+            for entry in resonances
+        )
     return lines
 
 

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -97,6 +97,7 @@ from commands.progression_rewards import CmdKudos, CmdPathIntent, CmdRandomScene
 from commands.projects import CmdProject
 from commands.react import CmdReact
 from commands.relationships import CmdRelationship
+from commands.resonance import CmdResonance
 from commands.ritual import CmdRitual
 from commands.sanctum import CmdSanctum
 from commands.scene import CmdScene
@@ -337,6 +338,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdLabStation,
             # #1832 — ship commission/upgrade/repair/status namespace.
             CmdShip,
+            # #2032 — spendable resonance balances + grant history (bare/history subverbs).
+            CmdResonance,
         )
         for command_cls in command_classes:
             self.add(command_cls())

--- a/src/commands/resonance.py
+++ b/src/commands/resonance.py
@@ -1,0 +1,126 @@
+"""Telnet ``resonance`` command (#2032) — spendable resonance balances + grant history.
+
+Telnet players could earn and spend resonance (thread pulls, imbuing, sanctum weaving,
+entry flourishes, pose endorsements, ...) but had no surface at all showing
+``CharacterResonance.balance``. This is the read-only telnet face of the same data the
+sheet's ``sheet/magic`` section (``_build_magic_resonances``) and the web audit ledger
+(``ResonanceGrantViewSet`` / ``resonance_grant_history_for_sheet``) read — no parallel
+query pipeline.
+
+    resonance                    — your claimed resonances: balance + lifetime earned
+    resonance history [<name>]   — your last 10 ResonanceGrant rows, newest first,
+                                    optionally narrowed to one claimed resonance
+
+Namespaced subverb (``resonance history``) mirrors ``CmdDurance``/``CmdSanctum`` — avoids
+a bare top-level ``history`` key that could collide with exits/channels/aliases.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from world.character_sheets.models import CharacterSheet
+
+_HISTORY_SUBVERB = "history"
+_HISTORY_LIMIT = 10
+_NO_IDENTITY = "You have no active character to check resonance with."
+
+
+class CmdResonance(ArxCommand):
+    """Check your spendable resonance balances and grant history.
+
+    Usage:
+        resonance                  — list your claimed resonances (balance + lifetime earned)
+        resonance history          — your last 10 resonance grants, newest first
+        resonance history <name>   — same, narrowed to one claimed resonance
+    """
+
+    key = "resonance"
+    locks = "cmd:all()"
+    action = None
+
+    def func(self) -> None:
+        """Bare ``resonance`` shows balances; ``resonance history [<name>]`` shows the ledger."""
+        try:
+            sheet = self._viewer_sheet()
+        except CommandError as err:
+            self.caller.msg(str(err))
+            return
+
+        raw = (self.args or "").strip()
+        if not raw:
+            self._balances(sheet)
+            return
+
+        parts = raw.split(maxsplit=1)
+        subverb = parts[0].lower()
+        rest = parts[1].strip() if len(parts) > 1 else ""
+
+        try:
+            if subverb == _HISTORY_SUBVERB:
+                self._history(sheet, rest)
+            else:
+                self.caller.msg(f"Unknown resonance action '{subverb}'. Try: history.")
+        except CommandError as err:
+            self.caller.msg(str(err))
+
+    def _viewer_sheet(self) -> CharacterSheet:
+        """The caller's own sheet. Raises ``CommandError`` if the caller has none."""
+        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        if sheet is None:
+            raise CommandError(_NO_IDENTITY)
+        return sheet
+
+    def _balances(self, sheet: CharacterSheet) -> None:
+        """List the caller's claimed resonances with balance + lifetime earned."""
+        from world.character_sheets.serializers import (  # noqa: PLC0415
+            _build_magic_resonances,
+        )
+
+        entries = _build_magic_resonances(sheet.character)
+        if not entries:
+            self.caller.msg("You have not claimed any resonance yet.")
+            return
+
+        lines = ["|wYour resonance:|n"]
+        lines.extend(
+            f"  {entry['name']}: {entry['balance']} (lifetime {entry['lifetime_earned']})"
+            for entry in entries
+        )
+        self.caller.msg("\n".join(lines))
+
+    def _history(self, sheet: CharacterSheet, name: str) -> None:
+        """Show the caller's last ``_HISTORY_LIMIT`` grants, newest first."""
+        from world.magic.models import Resonance  # noqa: PLC0415
+        from world.magic.services.gain import resonance_grant_history_for_sheet  # noqa: PLC0415
+
+        resonance = None
+        if name:
+            try:
+                resonance = Resonance.objects.get(name__iexact=name)
+            except Resonance.DoesNotExist as exc:
+                msg = f"No such resonance '{name}'."
+                raise CommandError(msg) from exc
+
+        grants = resonance_grant_history_for_sheet(sheet, resonance=resonance, limit=_HISTORY_LIMIT)
+        if not grants:
+            scope = f" for {resonance.name}" if resonance else ""
+            self.caller.msg(f"No resonance grants{scope} yet.")
+            return
+
+        header = (
+            f"|wYour resonance history ({resonance.name}):|n"
+            if resonance
+            else ("|wYour resonance history:|n")
+        )
+        lines = [header]
+        lines.extend(
+            f"  {grant.granted_at:%Y-%m-%d %H:%M} — {grant.resonance.name} "
+            f"+{grant.amount} ({grant.get_source_display()})"
+            for grant in grants
+        )
+        self.caller.msg("\n".join(lines))

--- a/src/commands/tests/test_resonance_command.py
+++ b/src/commands/tests/test_resonance_command.py
@@ -1,0 +1,171 @@
+"""Unit tests for CmdResonance — spendable resonance balances + grant history (#2032).
+
+Covers:
+  (a) bare ``resonance`` lists claimed resonances with balance + lifetime earned.
+  (b) bare ``resonance`` with no claimed resonances shows a sane empty-state message.
+  (c) ``resonance history`` shows recent grants newest-first with their source label.
+  (d) ``resonance history <name>`` narrows to one claimed resonance.
+  (e) ``resonance history`` with no grants shows a sane empty-state message.
+  (f) an unknown resonance name in ``resonance history`` surfaces an error.
+  (g) unknown subverbs are handled gracefully.
+
+Uses the _run() harness pattern, matching test_durance_command.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.resonance import CmdResonance
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.constants import GainSource
+from world.magic.factories import CharacterResonanceFactory, ResonanceFactory
+from world.magic.models import ResonanceGrant
+
+
+def _run(cmd_cls, caller, args=""):
+    """Build a command instance and call func(); return the list of msg strings."""
+    cmd = cmd_cls()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"{cmd_cls.key} {args}".strip()
+    caller.msg = MagicMock()
+    cmd.func()
+    return [str(c.args[0]) for c in caller.msg.call_args_list if c.args]
+
+
+class ResonanceBalancesTests(TestCase):
+    """Bare ``resonance`` renders claimed-resonance balances."""
+
+    def setUp(self) -> None:
+        self.char = CharacterFactory(db_key="ResonanceBalanceChar")
+        self.sheet = CharacterSheetFactory(character=self.char)
+
+    def test_no_character_sheet_shows_error(self) -> None:
+        bare_char = CharacterFactory(db_key="NoSheetChar")
+        msgs = _run(CmdResonance, bare_char)
+        combined = "\n".join(msgs)
+        self.assertIn("no active character", combined.lower())
+
+    def test_empty_state_when_no_claimed_resonances(self) -> None:
+        msgs = _run(CmdResonance, self.char)
+        combined = "\n".join(msgs)
+        self.assertIn("not claimed any resonance", combined.lower())
+
+    def test_lists_balance_and_lifetime_earned(self) -> None:
+        CharacterResonanceFactory(
+            character_sheet=self.sheet,
+            resonance=ResonanceFactory(name="Ember"),
+            balance=15,
+            lifetime_earned=40,
+        )
+
+        msgs = _run(CmdResonance, self.char)
+        combined = "\n".join(msgs)
+
+        self.assertIn("Ember", combined)
+        self.assertIn("15", combined)
+        self.assertIn("40", combined)
+
+    def test_status_subverb_not_required(self) -> None:
+        """Bare and no-arg both hit the same balances path (no separate subverb needed)."""
+        msgs = _run(CmdResonance, self.char, "")
+        combined = "\n".join(msgs)
+        self.assertIn("resonance", combined.lower())
+
+
+class ResonanceHistoryTests(TestCase):
+    """``resonance history [<name>]`` shows recent ResonanceGrant rows."""
+
+    def setUp(self) -> None:
+        self.char = CharacterFactory(db_key="ResonanceHistoryChar")
+        self.sheet = CharacterSheetFactory(character=self.char)
+        self.ember = ResonanceFactory(name="Ember")
+        self.frost = ResonanceFactory(name="Frost")
+        CharacterResonanceFactory(character_sheet=self.sheet, resonance=self.ember, balance=5)
+        CharacterResonanceFactory(character_sheet=self.sheet, resonance=self.frost, balance=3)
+
+    def test_empty_state_when_no_grants(self) -> None:
+        msgs = _run(CmdResonance, self.char, "history")
+        combined = "\n".join(msgs)
+        self.assertIn("no resonance grants", combined.lower())
+
+    def test_shows_grant_with_source_label(self) -> None:
+        ResonanceGrant.objects.create(
+            character_sheet=self.sheet,
+            resonance=self.ember,
+            amount=25,
+            source=GainSource.STAFF_GRANT,
+        )
+
+        msgs = _run(CmdResonance, self.char, "history")
+        combined = "\n".join(msgs)
+
+        self.assertIn("Ember", combined)
+        self.assertIn("25", combined)
+        self.assertIn(GainSource.STAFF_GRANT.label, combined)
+
+    def test_history_narrowed_to_named_resonance(self) -> None:
+        ResonanceGrant.objects.create(
+            character_sheet=self.sheet,
+            resonance=self.ember,
+            amount=25,
+            source=GainSource.STAFF_GRANT,
+        )
+        ResonanceGrant.objects.create(
+            character_sheet=self.sheet,
+            resonance=self.frost,
+            amount=7,
+            source=GainSource.STAFF_GRANT,
+        )
+
+        msgs = _run(CmdResonance, self.char, "history Frost")
+        combined = "\n".join(msgs)
+
+        self.assertIn("Frost", combined)
+        self.assertIn("7", combined)
+        self.assertNotIn("Ember", combined)
+
+    def test_unknown_resonance_name_surfaces_error(self) -> None:
+        msgs = _run(CmdResonance, self.char, "history Nonexistent")
+        combined = "\n".join(msgs)
+        self.assertIn("No such resonance", combined)
+
+    def test_multiple_grants_all_render(self) -> None:
+        """Strict newest-first ordering is exercised at the service level
+        (resonance_grant_history_for_sheet, world/magic/tests/test_gain_services.py) —
+        this just confirms the command renders every returned row."""
+        ResonanceGrant.objects.create(
+            character_sheet=self.sheet,
+            resonance=self.ember,
+            amount=1,
+            source=GainSource.STAFF_GRANT,
+        )
+        ResonanceGrant.objects.create(
+            character_sheet=self.sheet,
+            resonance=self.ember,
+            amount=2,
+            source=GainSource.STAFF_GRANT,
+        )
+
+        msgs = _run(CmdResonance, self.char, "history")
+        combined = "\n".join(msgs)
+        self.assertIn("+1", combined)
+        self.assertIn("+2", combined)
+
+
+class ResonanceUnknownSubverbTests(TestCase):
+    """Unknown subverbs surface a helpful error, not an exception."""
+
+    def setUp(self) -> None:
+        self.char = CharacterFactory(db_key="ResonanceUnknownSubChar")
+        CharacterSheetFactory(character=self.char)
+
+    def test_unknown_subverb_shows_error_message(self) -> None:
+        msgs = _run(CmdResonance, self.char, "frobnicate")
+        combined = "\n".join(msgs)
+        self.assertIn("frobnicate", combined)
+        self.assertIn("Unknown", combined)

--- a/src/world/character_sheets/serializers.py
+++ b/src/world/character_sheets/serializers.py
@@ -38,6 +38,7 @@ from world.character_sheets.types import (
     PathHistoryEntry,
     PersonaEntry,
     PronounsData,
+    ResonanceBalanceEntry,
     SheetVisibility,
     SkillEntry,
     SkillRef,
@@ -663,11 +664,31 @@ def _build_magic_aura(character: ObjectDB) -> AuraData | None:
     )
 
 
+def _build_magic_resonances(character: ObjectDB) -> list[ResonanceBalanceEntry]:
+    """Build the claimed-resonance balances sub-section (#2032).
+
+    Reads the character's cached ``resonances`` handler (``CharacterResonanceHandler``,
+    ``typeclasses.characters.Character.resonances``) rather than issuing a fresh
+    query — the same identity-mapped source every other resonance-balance reader
+    (thread pulls, imbuing, sanctum) uses. Sorted by name for stable rendering.
+    """
+    entries = [
+        ResonanceBalanceEntry(
+            name=cr.resonance.name,
+            balance=cr.balance,
+            lifetime_earned=cr.lifetime_earned,
+        )
+        for cr in character.resonances.all()
+    ]
+    entries.sort(key=lambda entry: entry["name"])
+    return entries
+
+
 def _build_magic(sheet: CharacterSheet) -> MagicSection | None:
-    """Build the magic section with gifts, motif, anima ritual, and aura.
+    """Build the magic section with gifts, motif, anima ritual, aura, and resonances.
 
     Returns ``None`` when the character has no magic data at all (no gifts,
-    no motif, no anima ritual, and no aura).
+    no motif, no anima ritual, no aura, and no claimed resonances).
     """
     character = sheet.character
 
@@ -675,9 +696,16 @@ def _build_magic(sheet: CharacterSheet) -> MagicSection | None:
     motif_data = _build_magic_motif(sheet)
     anima_ritual_data = _build_magic_anima_ritual(sheet)
     aura_data = _build_magic_aura(character)
+    resonances = _build_magic_resonances(character)
 
     # Return None if no magic data exists at all
-    if not gifts and motif_data is None and anima_ritual_data is None and aura_data is None:
+    if (
+        not gifts
+        and motif_data is None
+        and anima_ritual_data is None
+        and aura_data is None
+        and not resonances
+    ):
         return None
 
     return MagicSection(
@@ -685,6 +713,7 @@ def _build_magic(sheet: CharacterSheet) -> MagicSection | None:
         motif=motif_data,
         anima_ritual=anima_ritual_data,
         aura=aura_data,
+        resonances=resonances,
     )
 
 

--- a/src/world/character_sheets/tests/test_sheet_distinction_magic_sections.py
+++ b/src/world/character_sheets/tests/test_sheet_distinction_magic_sections.py
@@ -11,7 +11,12 @@ from django.test import TestCase
 from commands.account.sheet_sections import SHEET_SECTIONS
 from world.character_sheets.factories import CharacterFactory, CharacterSheetFactory
 from world.distinctions.factories import CharacterDistinctionFactory, DistinctionFactory
-from world.magic.factories import CharacterGiftFactory, GiftFactory
+from world.magic.factories import (
+    CharacterGiftFactory,
+    CharacterResonanceFactory,
+    GiftFactory,
+    ResonanceFactory,
+)
 from world.secrets.factories import SecretFactory
 
 
@@ -77,3 +82,19 @@ class SheetMagicSectionTests(TestCase):
     def test_empty_state(self) -> None:
         lines = SHEET_SECTIONS["magic"](_command_for(self.character))
         self.assertEqual(lines, ["Nothing is known of your magic."])
+
+    def test_lists_resonance_balances(self) -> None:
+        """#2032 — claimed resonances render with balance + lifetime earned."""
+        CharacterResonanceFactory(
+            character_sheet=self.sheet,
+            resonance=ResonanceFactory(name="Ember"),
+            balance=15,
+            lifetime_earned=40,
+        )
+
+        lines = SHEET_SECTIONS["magic"](_command_for(self.character))
+        text = "\n".join(lines)
+
+        self.assertIn("Ember", text)
+        self.assertIn("15", text)
+        self.assertIn("40", text)

--- a/src/world/character_sheets/tests/test_viewset.py
+++ b/src/world/character_sheets/tests/test_viewset.py
@@ -47,6 +47,7 @@ from world.magic.constants import RitualExecutionKind
 from world.magic.factories import (
     CharacterAuraFactory,
     CharacterGiftFactory,
+    CharacterResonanceFactory,
     CharacterTechniqueFactory,
     FacetFactory,
     GiftFactory,
@@ -1097,6 +1098,14 @@ class TestMagicSectionFull(TestCase):
             glimpse_story="A vision of iron chains.",
         )
 
+        # --- Claimed resonance balance (#2032) ---
+        cls.character_resonance = CharacterResonanceFactory(
+            character_sheet=cls.sheet,
+            resonance=cls.resonance_resolve,
+            balance=15,
+            lifetime_earned=40,
+        )
+
     def setUp(self) -> None:
         self.client = APIClient()
         self.client.force_authenticate(user=self.player.account)
@@ -1114,9 +1123,9 @@ class TestMagicSectionFull(TestCase):
         assert magic is not None
 
     def test_magic_has_all_expected_keys(self) -> None:
-        """Magic section contains gifts, motif, anima_ritual, and aura."""
+        """Magic section contains gifts, motif, anima_ritual, aura, and resonances (#2032)."""
         magic = self._get_magic()
-        expected_keys = {"gifts", "motif", "anima_ritual", "aura"}
+        expected_keys = {"gifts", "motif", "anima_ritual", "aura", "resonances"}
         assert set(magic.keys()) == expected_keys
 
     # --- Gift tests ---
@@ -1216,6 +1225,21 @@ class TestMagicSectionFull(TestCase):
         """Aura entry contains the glimpse story."""
         magic = self._get_magic()
         assert magic["aura"]["glimpse_story"] == "A vision of iron chains."
+
+    # --- Resonance balance tests (#2032) ---
+
+    def test_resonances_list_length(self) -> None:
+        """Resonances list contains one entry per claimed CharacterResonance row."""
+        magic = self._get_magic()
+        assert len(magic["resonances"]) == 1
+
+    def test_resonance_balance_and_lifetime_earned(self) -> None:
+        """Resonance entry contains name, balance, and lifetime earned."""
+        magic = self._get_magic()
+        entry = magic["resonances"][0]
+        assert entry["name"] == "Resolve"
+        assert entry["balance"] == 15
+        assert entry["lifetime_earned"] == 40
 
 
 class TestMagicNull(TestCase):
@@ -1956,9 +1980,13 @@ class TestCharacterSheetQueryCount(TestCase):
                query — the band is derived from inches, not stored on the sheet)
         24-26. Session management (savepoint, update, release)
         27.    block gate — one indexed exists() check (#1278, get_object)
+        28.    character resonances (CharacterResonanceHandler._by_resonance —
+               _build_magic_resonances reads character.resonances for the sheet's
+               new resonance-balance sub-section, #2032; the handler's one cached
+               query, not a fresh SELECT per resonance)
         """
         url = f"/api/character-sheets/{self.character.pk}/"
-        with self.assertNumQueries(27):
+        with self.assertNumQueries(28):
             response = self.client.get(url)
         assert response.status_code == 200
         # Verify all sections are populated
@@ -2165,14 +2193,20 @@ class TestPrefetchCompleteness(TestCase):
 
     def test_magic_zero_queries(self) -> None:
         sheet = self._get_sheet()
-        # 1 query: a Trait FK access in _build_magic is not covered by
-        # _MAGIC_SELECT_RELATED / _MAGIC_PREFETCH_RELATED. Previously this
-        # test asserted 0 queries because earlier tests in the class warmed
-        # the SharedMemoryModel identity map with the Trait row; the project
-        # test runner now flushes the identity map between tests for
-        # production parity (see core.testing), exposing the real count.
-        # Tracked as a prefetch-coverage gap for a follow-up PR.
-        with self.assertNumQueries(1):
+        # 2 queries:
+        #   1. a Trait FK access in _build_magic is not covered by
+        #      _MAGIC_SELECT_RELATED / _MAGIC_PREFETCH_RELATED. Previously this
+        #      test asserted 0 queries because earlier tests in the class warmed
+        #      the SharedMemoryModel identity map with the Trait row; the project
+        #      test runner now flushes the identity map between tests for
+        #      production parity (see core.testing), exposing the real count.
+        #      Tracked as a prefetch-coverage gap for a follow-up PR.
+        #   2. character.resonances (CharacterResonanceHandler._by_resonance, #2032) —
+        #      _build_magic_resonances reads the character's claimed CharacterResonance
+        #      rows via the handler; not part of _MAGIC_PREFETCH_RELATED (a per-Character
+        #      handler, not a CharacterSheet-rooted prefetch), so it costs its one cached
+        #      query here — not an N+1, since the handler is called once.
+        with self.assertNumQueries(2):
             _build_magic(sheet)
 
     def test_story_zero_queries(self) -> None:

--- a/src/world/character_sheets/types.py
+++ b/src/world/character_sheets/types.py
@@ -183,6 +183,14 @@ class AuraThemingData(TypedDict):
     abyssal: Decimal
 
 
+class ResonanceBalanceEntry(TypedDict):
+    """A claimed resonance with its spendable balance and lifetime-earned total (#2032)."""
+
+    name: str
+    balance: int
+    lifetime_earned: int
+
+
 class MagicSection(TypedDict):
     """The magic section of the character sheet API response."""
 
@@ -190,6 +198,7 @@ class MagicSection(TypedDict):
     motif: MotifSection | None
     anima_ritual: AnimaRitualSection | None
     aura: AuraData | None
+    resonances: list[ResonanceBalanceEntry]
 
 
 class StorySection(TypedDict):

--- a/src/world/magic/services/gain.py
+++ b/src/world/magic/services/gain.py
@@ -80,6 +80,7 @@ from world.magic.models import (
     PoseEndorsement,
     Resonance,
     ResonanceGainConfig,
+    ResonanceGrant,
     SceneEntryEndorsement,
 )
 from world.magic.types import (
@@ -216,6 +217,25 @@ def get_residence_resonances(sheet: CharacterSheet) -> set[Resonance]:
     claimed_ids = set(sheet.resonances.values_list("resonance_id", flat=True))
     matched_ids = tagged_ids & claimed_ids
     return set(Resonance.objects.filter(pk__in=matched_ids))
+
+
+def resonance_grant_history_for_sheet(
+    sheet: CharacterSheet,
+    *,
+    resonance: Resonance | None = None,
+    limit: int = 10,
+) -> list[ResonanceGrant]:
+    """Return this character's most recent ``ResonanceGrant`` rows, newest first.
+
+    Mirrors ``ResonanceGrantViewSet``'s ordering (``-granted_at``) and user-scoping
+    shape (`world/magic/views.py`) — the single read path for both the web audit
+    ledger and the telnet ``resonance history`` command. Optionally narrowed to one
+    claimed resonance.
+    """
+    qs = ResonanceGrant.objects.filter(character_sheet=sheet).select_related("resonance")
+    if resonance is not None:
+        qs = qs.filter(resonance=resonance)
+    return list(qs.order_by("-granted_at")[:limit])
 
 
 @transaction.atomic

--- a/src/world/magic/tests/test_gain_services.py
+++ b/src/world/magic/tests/test_gain_services.py
@@ -775,3 +775,62 @@ class ProtagonismLockResonanceGainTests(TestCase):
 
         # The settlement result should reflect 1 settled endorsement
         self.assertEqual(result.endorsements_settled, 1)
+
+
+class ResonanceGrantHistoryForSheetTests(TestCase):
+    """Tests for resonance_grant_history_for_sheet (#2032 telnet resonance history)."""
+
+    def test_newest_first_and_limit(self) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.constants import GainSource
+        from world.magic.factories import ResonanceFactory
+        from world.magic.models import ResonanceGrant
+        from world.magic.services.gain import resonance_grant_history_for_sheet
+
+        sheet = CharacterSheetFactory()
+        resonance = ResonanceFactory()
+        grants = [
+            ResonanceGrant.objects.create(
+                character_sheet=sheet,
+                resonance=resonance,
+                amount=amount,
+                source=GainSource.STAFF_GRANT,
+            )
+            for amount in range(1, 13)
+        ]
+
+        history = resonance_grant_history_for_sheet(sheet, limit=10)
+
+        self.assertEqual(len(history), 10)
+        # Newest-first: highest pk (last created) leads.
+        self.assertEqual(history[0].pk, grants[-1].pk)
+        self.assertEqual(history[-1].pk, grants[-10].pk)
+
+    def test_narrowed_to_one_resonance(self) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.constants import GainSource
+        from world.magic.factories import ResonanceFactory
+        from world.magic.models import ResonanceGrant
+        from world.magic.services.gain import resonance_grant_history_for_sheet
+
+        sheet = CharacterSheetFactory()
+        ember = ResonanceFactory(name="Ember")
+        frost = ResonanceFactory(name="Frost")
+        ResonanceGrant.objects.create(
+            character_sheet=sheet, resonance=ember, amount=5, source=GainSource.STAFF_GRANT
+        )
+        ResonanceGrant.objects.create(
+            character_sheet=sheet, resonance=frost, amount=9, source=GainSource.STAFF_GRANT
+        )
+
+        history = resonance_grant_history_for_sheet(sheet, resonance=frost)
+
+        self.assertEqual(len(history), 1)
+        self.assertEqual(history[0].resonance, frost)
+
+    def test_empty_for_sheet_with_no_grants(self) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.services.gain import resonance_grant_history_for_sheet
+
+        sheet = CharacterSheetFactory()
+        self.assertEqual(resonance_grant_history_for_sheet(sheet), [])


### PR DESCRIPTION
Closes #2032

## Summary

Epic #2024 surface-parity item: telnet players could earn and spend resonance but never see it. Adds (1) a Resonance block in the sheet's magic section (name, balance, lifetime earned) built from the cached CharacterResonanceHandler via _build_magic_resonances — one shared data path for web and telnet, +1 constant query proven by updated count assertions; (2) a narrow CmdResonance command: bare 'resonance' lists balances, 'resonance history [<name>]' shows the last 10 ResonanceGrant ledger rows (source label, amount, date), mirroring ResonanceGrantViewSet ordering/filtering via a new resonance_grant_history_for_sheet service. Command resolves only the caller's own sheet (no cross-character ledger access). Docs updated (commands CLAUDE.md, systems/magic.md, roadmap/magic.md). Adversarial review: no defects.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2032 (in the issue body)
- Brainstorm/plan: skipped (feature with code-verified spec on the issue body; user pre-authorized implementation)
- Sync-with-main: Rebased onto origin/main after PR #2041 merged; focused suite re-run green post-rebase.

<!-- last-addressed-comment: 0 -->