### PR TITLE
Combat casts must roll the caster's own stat+skill check, not the willpower+occult fallback

### DIFF
--- a/docs/adr/0095-casts-roll-the-casters-personal-check-in-every-path.md
+++ b/docs/adr/0095-casts-roll-the-casters-personal-check-in-every-path.md
@@ -1,0 +1,21 @@
+# ADR-0095: Casts roll the caster's personal check in every path
+
+**Status:** Accepted (2026-07-06) · **Issue:** #2014
+
+Every technique cast — standalone scene cast, combat round cast, and clash
+contribution — resolves its check through `resolve_cast_check_type`
+(`world/magic/services/anima.py`): the caster's provisioned personal magic
+check (their anima-ritual stat+skill CheckType, #1306) always wins; an
+`ActionTemplate.check_type` is a fallback for unprovisioned casters, never an
+override. Before this, combat and clash read `template.check_type` directly,
+so every combat cast rolled the shared willpower+occult fallback and a
+charm-built caster's identity was erased the moment a fight started —
+contradicting the recorded design ("every caster rolls *their own* magic
+check", `src/world/magic/CLAUDE.md` §Standalone Casting) and the stat+skill
+tenet. Rejected alternative: template-as-override precedence (an authored
+template check beating the personal check) — #1320's catalog templates
+deliberately share one check_type, so no authored content relies on
+per-template divergence, and an override rule would silently re-homogenize
+casters again. Calibration note: the Monte Carlo tuning simulator's synthetic
+party is unprovisioned and unaffected; live provisioned PCs may see win-rate
+drift.

--- a/docs/adr/0095-casts-roll-the-casters-personal-check-in-every-path.md
+++ b/docs/adr/0095-casts-roll-the-casters-personal-check-in-every-path.md
@@ -2,13 +2,15 @@
 
 **Status:** Accepted (2026-07-06) · **Issue:** #2014
 
-Every technique cast — standalone scene cast, combat round cast, and clash
-contribution — resolves its check through `resolve_cast_check_type`
-(`world/magic/services/anima.py`): the caster's provisioned personal magic
-check (their anima-ritual stat+skill CheckType, #1306) always wins; an
-`ActionTemplate.check_type` is a fallback for unprovisioned casters, never an
-override. Before this, combat and clash read `template.check_type` directly,
-so every combat cast rolled the shared willpower+occult fallback and a
+Every technique cast — standalone scene cast, combat round cast, clash
+contribution, and battle technique resolution — resolves its check through
+`resolve_cast_check_type` (`world/magic/services/anima.py`): the caster's
+provisioned personal magic check (their anima-ritual stat+skill CheckType,
+#1306) always wins; an `ActionTemplate.check_type` is a fallback for
+unprovisioned casters, never an override. Before this, combat, clash, and
+battle resolution (`BattleTechniqueResolver.__call__`,
+`world/battles/resolution.py`) read `template.check_type` directly, so every
+combat/battle cast rolled the shared willpower+occult fallback and a
 charm-built caster's identity was erased the moment a fight started —
 contradicting the recorded design ("every caster rolls *their own* magic
 check", `src/world/magic/CLAUDE.md` §Standalone Casting) and the stat+skill

--- a/docs/adr/0096-casts-roll-the-casters-personal-check-in-every-path.md
+++ b/docs/adr/0096-casts-roll-the-casters-personal-check-in-every-path.md
@@ -1,4 +1,4 @@
-# ADR-0095: Casts roll the caster's personal check in every path
+# ADR-0096: Casts roll the caster's personal check in every path
 
 **Status:** Accepted (2026-07-06) · **Issue:** #2014
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -128,7 +128,7 @@ treat those names as hints to confirm, not gospel.
 - [0085 — NPCStanding carries debt and petition-failure-streak, not CourtPact](0085-npcstanding-debt-and-petition-streak-are-generic.md)
 - [0091 — instantiate_situation mints Challenges via an authored target-object name; GM triggers it with a plain staff Action](0091-instantiate-situation-mints-challenges-gm-trigger.md) (supersedes ADR-0090)
 - [0095 — Battle live updates are a slim BATTLE_STATE ping plus REST refetch, not a full-state WS payload](0095-battle-live-updates-are-ping-plus-refetch.md)
-- [0095 — Casts roll the caster's personal check in every path](0095-casts-roll-the-casters-personal-check-in-every-path.md)
+- [0096 — Casts roll the caster's personal check in every path](0096-casts-roll-the-casters-personal-check-in-every-path.md)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -128,6 +128,7 @@ treat those names as hints to confirm, not gospel.
 - [0085 — NPCStanding carries debt and petition-failure-streak, not CourtPact](0085-npcstanding-debt-and-petition-streak-are-generic.md)
 - [0091 — instantiate_situation mints Challenges via an authored target-object name; GM triggers it with a plain staff Action](0091-instantiate-situation-mints-challenges-gm-trigger.md) (supersedes ADR-0090)
 - [0095 — Battle live updates are a slim BATTLE_STATE ping plus REST refetch, not a full-state WS payload](0095-battle-live-updates-are-ping-plus-refetch.md)
+- [0095 — Casts roll the caster's personal check in every path](0095-casts-roll-the-casters-personal-check-in-every-path.md)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/architecture/technique-use-pipeline.md
+++ b/docs/architecture/technique-use-pipeline.md
@@ -57,7 +57,7 @@ intensity-vs-power table in §6.
 
 ---
 
-## 3. Entry points — three ways a cast starts
+## 3. Entry points — four ways a cast starts
 
 Every path converges on `use_technique`. Prerequisites (the caster knows the
 technique; the technique has a castable `action_template`; hostility/consent rules)
@@ -68,6 +68,7 @@ are enforced at the entry layer, before `use_technique` runs.
 | **Scene cast (non-combat)** | `request_technique_cast` → `_resolve_cast` (`world/scenes/cast_services.py`) | Routes to immediate (self/room/no-target), benign (PENDING consent), or hostile (seeds/feeds a combat encounter). |
 | **Combat round** | `_resolve_pc_action` → `resolve_combat_technique` (`world/combat/services.py`) | Builds a `CombatTechniqueResolver` and passes it as the resolve function. |
 | **Clash contribution** | `commit_to_clash` (`world/combat/clash.py`) | Check-only resolve function — no damage; power drives `outcome_to_delta` → clash progress. |
+| **Battle technique resolution** | `resolve_battle_technique` (`world/battles/resolution.py`) | Casts a `BattleActionDeclaration`'s technique through the real magic envelope — converges on `use_technique` like the others, so anima/Soulfray/mishap and Audere escalation apply normally; the result routes to unit attrition / VP. |
 
 Hostile scene casts against another PC may park as a PENDING `SceneActionRequest`
 until the target consents; on accept the request re-routes through the same lifecycle.
@@ -82,10 +83,12 @@ flowchart TD
         A["Scene cast<br/>request_technique_cast"]
         B["Combat round<br/>resolve_combat_technique"]
         C["Clash<br/>commit_to_clash"]
+        D["Battle round<br/>resolve_battle_technique"]
     end
     A --> UT
     B --> UT
     C --> UT
+    D --> UT
     UT(["use_technique — canonical lifecycle"])
     UT --> S1["1 · runtime stats → INTENSITY + control<br/>get_runtime_technique_stats"]
     S1 --> S2["2 · effective anima cost<br/>control_delta = control − intensity (+ strain)"]

--- a/docs/architecture/technique-use-pipeline.md
+++ b/docs/architecture/technique-use-pipeline.md
@@ -104,9 +104,11 @@ flowchart TD
     RES -- "scene" --> RSCENE["start_action_resolution — check"]
     RES -- "combat" --> RCOMBAT["CombatTechniqueResolver<br/>COMBAT_PULL → PENETRATION → damage + conditions"]
     RES -- "clash" --> RCLASH["perform_check → outcome_to_delta<br/>→ clash progress (no damage)"]
+    RES -- "battle" --> RBATTLE["resolve_battle_technique<br/>perform_check → battle effect deltas"]
     RSCENE --> CONS
     RCOMBAT --> CONS
     RCLASH --> CONS
+    RBATTLE --> CONS
     CONS["10 · consequences (read INTENSITY):<br/>Soulfray · control mishap · fatigue ·<br/>Audere / Audere Majora offers ·<br/>resonance attribution · corruption ·<br/>environment backfire / defile"]
     CONS --> EV["11 · emit TECHNIQUE_CAST + TECHNIQUE_AFFECTED (frozen)"]
     EV --> NARR["12 · narration — render_*_outcome_narration<br/>+ power_outcome_clause (ward / environment)"]

--- a/docs/architecture/unified-player-action.md
+++ b/docs/architecture/unified-player-action.md
@@ -91,6 +91,13 @@ and `ChallengeApproach.action_template`
 > `approach.check_type`; registry → `template.check_type`. `action_template`
 > is carried on the descriptor only when present (combat techniques, registry
 > templates, override challenge approaches).
+>
+> **Superseded (2026-07-06, #2014, ADR-0095):** combat no longer reads
+> `technique.action_template.check_type` directly. Every cast path — combat,
+> clash, and standalone — now resolves the offense check via
+> `resolve_cast_check_type` (`world/magic/services/anima.py`): the caster's
+> provisioned personal magic check wins; the template's `check_type` is only a
+> fallback for an unprovisioned caster.
 
 "CheckType belongs in the action layer, defined once" holds — realized via the
 `CheckType` that every backend already resolves. The combat bug is still that
@@ -118,7 +125,10 @@ it. Scope = "player does thing with their character."
    `offense_check_type` from `Technique.action_template.check_type`;
    `action_template` becomes **required** for combat-usable techniques (explicit
    config error, no silent no-op, no "legacy"). Add `focused_ally_target` to the
-   `/dispatch/` path. **This is the #1 fix.**
+   `/dispatch/` path. **This is the #1 fix.** (Superseded 2026-07-06, #2014,
+   ADR-0095: the direct `action_template.check_type` read is now only the
+   unprovisioned-caster fallback inside `resolve_cast_check_type`, not the
+   sourcing itself.)
 4. **Combat-agnostic tempo seam** — `get_active_round_context(character)`;
    combat is the sole implementor; no general-scene provider, no plugin
    framework.
@@ -280,6 +290,9 @@ them costs a round is pre-existing combat-design, not this interface's concern.
 - In `_resolve_pc_action` (`src/world/combat/services.py:1764`),
   `offense_check_type` is derived from
   `action.focused_action.action_template.check_type` — not received as `None`.
+  (Superseded 2026-07-06, #2014, ADR-0095: now derived from
+  `resolve_cast_check_type`, which prefers the caster's personal check and
+  falls back to this `action_template.check_type` only when unprovisioned.)
 - The silent `if offense_check_type is not None` no-op guard is **deleted**. A
   combat-usable technique with no `action_template` is a configuration error
   that raises a typed exception, never a silent skip.

--- a/docs/architecture/unified-player-action.md
+++ b/docs/architecture/unified-player-action.md
@@ -92,7 +92,7 @@ and `ChallengeApproach.action_template`
 > is carried on the descriptor only when present (combat techniques, registry
 > templates, override challenge approaches).
 >
-> **Superseded (2026-07-06, #2014, ADR-0095):** combat no longer reads
+> **Superseded (2026-07-06, #2014, ADR-0096):** combat no longer reads
 > `technique.action_template.check_type` directly. Every cast path — combat,
 > clash, and standalone — now resolves the offense check via
 > `resolve_cast_check_type` (`world/magic/services/anima.py`): the caster's
@@ -126,7 +126,7 @@ it. Scope = "player does thing with their character."
    `action_template` becomes **required** for combat-usable techniques (explicit
    config error, no silent no-op, no "legacy"). Add `focused_ally_target` to the
    `/dispatch/` path. **This is the #1 fix.** (Superseded 2026-07-06, #2014,
-   ADR-0095: the direct `action_template.check_type` read is now only the
+   ADR-0096: the direct `action_template.check_type` read is now only the
    unprovisioned-caster fallback inside `resolve_cast_check_type`, not the
    sourcing itself.)
 4. **Combat-agnostic tempo seam** — `get_active_round_context(character)`;
@@ -290,7 +290,7 @@ them costs a round is pre-existing combat-design, not this interface's concern.
 - In `_resolve_pc_action` (`src/world/combat/services.py:1764`),
   `offense_check_type` is derived from
   `action.focused_action.action_template.check_type` — not received as `None`.
-  (Superseded 2026-07-06, #2014, ADR-0095: now derived from
+  (Superseded 2026-07-06, #2014, ADR-0096: now derived from
   `resolve_cast_check_type`, which prefers the caster's personal check and
   falls back to this `action_template.check_type` only when unprovisioned.)
 - The silent `if offense_check_type is not None` no-op guard is **deleted**. A

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2922,9 +2922,11 @@ through abstract round-based VP mechanics. `Battle` is a 1:1 extension of `scene
   for `SET_ENVIRONMENT` casts, #1715; military-grade
   `summon_ally(payload.military=True)` now reading `payload.properties`/
   `payload.capabilities`, #1711/#1794), mechanics (`Property` via `BattleUnit.properties`;
-  `HasProperties`/`HasCapabilities` `Protocol`s, #1794), checks (`perform_check` sourced from the
-  cast technique's `action_template.check_type`, via `use_technique`; `select_consequence`
-  for the Surrounded entry roll and resist checks, #1733), combat
+  `HasProperties`/`HasCapabilities` `Protocol`s, #1794), checks (`perform_check` sourced from
+  `resolve_cast_check_type` — the caster's provisioned personal magic check, falling back to
+  the cast technique's `action_template.check_type` only when unprovisioned, ADR-0095 — via
+  `use_technique`; `select_consequence` for the Surrounded entry roll and resist checks,
+  #1733), combat
   (`BattlePlace.combat_encounter` bridge, now wired for Champion duels, #1710, and
   siege-engine skirmishes, #1713; shared `RoundStatus` / `AbstractRound`), covenants
   (`BattleSide.covenant`; `CovenantRole.command_tier`/`.is_champion_role`, #1710), stories

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2924,7 +2924,7 @@ through abstract round-based VP mechanics. `Battle` is a 1:1 extension of `scene
   `payload.capabilities`, #1711/#1794), mechanics (`Property` via `BattleUnit.properties`;
   `HasProperties`/`HasCapabilities` `Protocol`s, #1794), checks (`perform_check` sourced from
   `resolve_cast_check_type` — the caster's provisioned personal magic check, falling back to
-  the cast technique's `action_template.check_type` only when unprovisioned, ADR-0095 — via
+  the cast technique's `action_template.check_type` only when unprovisioned, ADR-0096 — via
   `use_technique`; `select_consequence` for the Surrounded entry roll and resist checks,
   #1733), combat
   (`BattlePlace.combat_encounter` bridge, now wired for Champion duels, #1710, and

--- a/docs/systems/battles.md
+++ b/docs/systems/battles.md
@@ -312,18 +312,20 @@ character's ACTIVE `BattleParticipant` whose `battle.scene.is_active=True`, orde
 
 `resolve_battle_technique(*, declaration) -> CheckResult | None` casts `declaration.technique`
 through the real magic envelope (`world.magic.services.use_technique`) rather than a generic
-shared check. Routing through `use_technique` means the check is sourced from the caster's
-actual technique (`technique.action_template.check_type`), anima cost / Soulfray accumulation
-apply normally, and the Audere / Audere Majora escalation hook fires automatically (it's
-wired inside `use_technique` itself — no separate battle-side call site is needed).
-`confirm_soulfray_risk=True` because a batch round-resolve cannot pause mid-batch for one
-participant's consent prompt. Returns `None` (treated as `success_level=0`, a failure) if the
-cast is interrupted before resolution (e.g. a reactive PRE_CAST cancellation).
+shared check. Routing through `use_technique` means the check is sourced from
+`resolve_cast_check_type(character, template)` (`world/magic/services/anima.py`, ADR-0095) —
+the caster's provisioned personal magic check when they have one, falling back to the
+technique's `action_template.check_type` only for an unprovisioned caster — anima cost /
+Soulfray accumulation apply normally, and the Audere / Audere Majora escalation hook fires
+automatically (it's wired inside `use_technique` itself — no separate battle-side call site
+is needed). `confirm_soulfray_risk=True` because a batch round-resolve cannot pause mid-batch
+for one participant's consent prompt. Returns `None` (treated as `success_level=0`, a failure)
+if the cast is interrupted before resolution (e.g. a reactive PRE_CAST cancellation).
 
 `BattleTechniqueResolver` is the `resolve_fn` dataclass passed to `use_technique`; its
-`__call__` rolls the declared technique's own check via `perform_check` — battle applies no
-damage-profile/condition logic of its own, that stays in `resolve_battle_round`'s
-STRIKE/SUPPORT/failure routing below.
+`__call__` resolves the check type via `resolve_cast_check_type` and rolls it via
+`perform_check` — battle applies no damage-profile/condition logic of its own, that stays in
+`resolve_battle_round`'s STRIKE/SUPPORT/failure routing below.
 
 ### `resolve_battle_round` (`src/world/battles/resolution.py`)
 
@@ -1160,9 +1162,11 @@ payload data is applied directly; invalidation alone triggers the refetch.
   (#1794), implemented by both `BattleUnit` and `character_sheets.CharacterSheet` — the
   modifier stack's `_property_affinity_modifier`/`_terrain_property_modifier` read either
   kind of holder with no `isinstance` branching.
-- **Checks** — `perform_check`, sourced from the cast technique's
-  `action_template.check_type` (via `use_technique`), not a generic battle-wide `CheckType`;
-  the Surrounded entry roll and per-round resist checks are dispatched through
+- **Checks** — `perform_check`, sourced from `resolve_cast_check_type` (ADR-0095: the
+  caster's provisioned personal magic check, falling back to the cast technique's
+  `action_template.check_type` only when unprovisioned) via `use_technique`, not a generic
+  battle-wide `CheckType`; the Surrounded entry roll and per-round resist checks are
+  dispatched through
   `world.checks.consequence_resolution.select_consequence` against authored
   `ConsequencePool` rows (#1733)
 - **Combat** — `BattlePlace.combat_encounter` bridge seam, now wired for Champion duels

--- a/docs/systems/battles.md
+++ b/docs/systems/battles.md
@@ -313,7 +313,7 @@ character's ACTIVE `BattleParticipant` whose `battle.scene.is_active=True`, orde
 `resolve_battle_technique(*, declaration) -> CheckResult | None` casts `declaration.technique`
 through the real magic envelope (`world.magic.services.use_technique`) rather than a generic
 shared check. Routing through `use_technique` means the check is sourced from
-`resolve_cast_check_type(character, template)` (`world/magic/services/anima.py`, ADR-0095) —
+`resolve_cast_check_type(character, template)` (`world/magic/services/anima.py`, ADR-0096) —
 the caster's provisioned personal magic check when they have one, falling back to the
 technique's `action_template.check_type` only for an unprovisioned caster — anima cost /
 Soulfray accumulation apply normally, and the Audere / Audere Majora escalation hook fires
@@ -1162,7 +1162,7 @@ payload data is applied directly; invalidation alone triggers the refetch.
   (#1794), implemented by both `BattleUnit` and `character_sheets.CharacterSheet` — the
   modifier stack's `_property_affinity_modifier`/`_terrain_property_modifier` read either
   kind of holder with no `isinstance` branching.
-- **Checks** — `perform_check`, sourced from `resolve_cast_check_type` (ADR-0095: the
+- **Checks** — `perform_check`, sourced from `resolve_cast_check_type` (ADR-0096: the
   caster's provisioned personal magic check, falling back to the cast technique's
   `action_template.check_type` only when unprovisioned) via `use_technique`, not a generic
   battle-wide `CheckType`; the Surrounded entry roll and per-round resist checks are

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -482,6 +482,7 @@ def _combat_actions(
     # character; fury tiers are a small authored catalog; anchors are the
     # caster's consented relationships with a non-zero bond.
     from world.magic.models import FuryTier  # noqa: PLC0415
+    from world.magic.services.anima import resolve_cast_check_type  # noqa: PLC0415
     from world.magic.services.capability_requirements import (  # noqa: PLC0415
         technique_performable,
     )
@@ -524,7 +525,9 @@ def _combat_actions(
         if not technique_performable(character, technique):
             continue
         template = technique.action_template  # guaranteed non-None: queryset filters isnull=False
-        check_type = template.check_type
+        # #2014: the caster's own provisioned magic check wins over the template's
+        # fallback (ADR-0095) — mirrors what the resolver actually rolls at dispatch.
+        check_type = resolve_cast_check_type(character, template)
         ref = ActionRef(
             backend=ActionBackend.COMBAT,
             technique_id=technique.pk,

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -526,7 +526,7 @@ def _combat_actions(
             continue
         template = technique.action_template  # guaranteed non-None: queryset filters isnull=False
         # #2014: the caster's own provisioned magic check wins over the template's
-        # fallback (ADR-0095) — mirrors what the resolver actually rolls at dispatch.
+        # fallback (ADR-0096) — mirrors what the resolver actually rolls at dispatch.
         check_type = resolve_cast_check_type(character, template)
         ref = ActionRef(
             backend=ActionBackend.COMBAT,

--- a/src/actions/tests/test_player_interface.py
+++ b/src/actions/tests/test_player_interface.py
@@ -243,6 +243,36 @@ class TestGetPlayerActionsCombatBackend(django.test.TestCase):
         self.assertIsInstance(action.check_type, CheckType)
         self.assertEqual(action.check_type.pk, self.check_type.pk)
 
+    def test_combat_action_check_type_prefers_personal_check_when_provisioned(self) -> None:
+        """#2014: when the caster is provisioned with a personal magic check,
+        the COMBAT PlayerAction.check_type must be THEIR check, not the
+        template's fallback — the action-picker UI must show the same check
+        the resolver actually rolls (resolve_cast_check_type)."""
+        from evennia.accounts.models import AccountDB
+
+        from actions.player_interface import get_player_actions
+        from world.magic.constants import RitualExecutionKind
+        from world.magic.factories import RitualCheckConfigFactory
+        from world.magic.models.rituals import Ritual
+
+        account = AccountDB.objects.create(username=f"combat_check_{id(self)}")
+        ritual = Ritual.objects.create(
+            name=f"combat_check_ritual_{id(self)}",
+            author_account=account,
+            execution_kind=RitualExecutionKind.SCENE_ACTION,
+        )
+        config = RitualCheckConfigFactory(ritual=ritual)
+        self.character.db_account = account
+        self.character.save(update_fields=["db_account"])
+
+        actions = get_player_actions(self.character)
+        combat_actions = [a for a in actions if a.backend == ActionBackend.COMBAT]
+        self.assertTrue(len(combat_actions) >= 1)
+        action = combat_actions[0]
+
+        self.assertEqual(action.check_type.pk, config.check_type.pk)
+        self.assertNotEqual(action.check_type.pk, self.template.check_type.pk)
+
     def test_combat_action_has_action_template(self) -> None:
         """COMBAT PlayerAction.action_template is the technique's action_template."""
         from actions.models import ActionTemplate

--- a/src/world/battles/resolution.py
+++ b/src/world/battles/resolution.py
@@ -18,7 +18,7 @@ the real magic envelope (``use_technique``). Routing through ``use_technique``
 (rather than a generic shared check) means the check is sourced from
 ``resolve_cast_check_type`` — the caster's provisioned personal magic check
 when they have one, falling back to the technique's
-``action_template.check_type`` only for an unprovisioned caster (ADR-0095) —
+``action_template.check_type`` only for an unprovisioned caster (ADR-0096) —
 anima/Soulfray/mishap apply normally, and Audere/Audere Majora escalation
 fires automatically (it's wired inside ``use_technique`` itself, Step 8c — no
 separate call site is needed here). ``resolve_battle_round`` calls

--- a/src/world/battles/resolution.py
+++ b/src/world/battles/resolution.py
@@ -15,8 +15,10 @@ destroyed unit lists, and a casualty list for the caller to display or log.
 This module also provides ``BattleTechniqueResolver`` and
 ``resolve_battle_technique``, which cast a declaration's ``technique`` through
 the real magic envelope (``use_technique``). Routing through ``use_technique``
-(rather than a generic shared check) means the check is sourced from the
-player's actual technique (``technique.action_template.check_type``),
+(rather than a generic shared check) means the check is sourced from
+``resolve_cast_check_type`` — the caster's provisioned personal magic check
+when they have one, falling back to the technique's
+``action_template.check_type`` only for an unprovisioned caster (ADR-0095) —
 anima/Soulfray/mishap apply normally, and Audere/Audere Majora escalation
 fires automatically (it's wired inside ``use_technique`` itself, Step 8c — no
 separate call site is needed here). ``resolve_battle_round`` calls
@@ -346,7 +348,9 @@ class BattleTechniqueResolver:
         ledger: PowerLedger,  # noqa: ARG002 — battle doesn't use the power ledger
         extra_modifiers: int = 0,
     ) -> BattleTechniqueResolution:
-        check_type = self.technique.action_template.check_type
+        from world.magic.services.anima import resolve_cast_check_type  # noqa: PLC0415
+
+        check_type = resolve_cast_check_type(self.character, self.technique.action_template)
         total_modifiers = extra_modifiers + self._battle_modifier_stack()
         check_result = perform_check(self.character, check_type, extra_modifiers=total_modifiers)
         return BattleTechniqueResolution(check_result=check_result)

--- a/src/world/battles/tests/test_resolution.py
+++ b/src/world/battles/tests/test_resolution.py
@@ -134,6 +134,73 @@ class BattleTechniqueResolverTests(TestCase):
 
         self.assertIs(check_result, fake_result)
 
+    def test_resolve_battle_technique_rolls_personal_check_when_provisioned(self) -> None:
+        """#2014: a provisioned caster's battle technique cast rolls THEIR check,
+        not the technique's action_template check_type — mirrors
+        world.combat.tests.test_clash_commit.CommitToClashTests
+        .test_commit_rolls_personal_check_when_provisioned.
+
+        Patches ``world.battles.resolution.perform_check`` (not
+        ``world.checks.services.perform_check``) because ``resolution.py`` imports
+        ``perform_check`` at module scope (``from world.checks.services import
+        perform_check``) rather than re-importing it inside the function on every
+        call the way ``world.combat.clash`` does — patching the services module
+        would not intercept the module-level-bound name in ``resolution``.
+        """
+        from evennia.accounts.models import AccountDB
+
+        from world.battles.resolution import resolve_battle_technique
+        from world.battles.services import (
+            add_side,
+            begin_battle_round,
+            create_battle,
+            declare_battle_action,
+            enlist_participant,
+        )
+        from world.checks.test_helpers import force_check_outcome
+        from world.magic.constants import RitualExecutionKind
+        from world.magic.factories import RitualCheckConfigFactory
+        from world.magic.models.rituals import Ritual
+        from world.traits.factories import CheckOutcomeFactory
+
+        account = AccountDB.objects.create(username=f"battle_resolution_cc_{id(self)}")
+        ritual = Ritual.objects.create(
+            name=f"battle_resolution_cc_ritual_{id(self)}",
+            author_account=account,
+            execution_kind=RitualExecutionKind.SCENE_ACTION,
+        )
+        config = RitualCheckConfigFactory(ritual=ritual)
+        self.sheet.character.db_account = account
+        self.sheet.character.save(update_fields=["db_account"])
+
+        battle = create_battle(name="Resolver Personal Check Battle")
+        side = add_side(battle=battle, role=BattleSideRole.ATTACKER)
+        participant = enlist_participant(battle=battle, character_sheet=self.sheet, side=side)
+        begin_battle_round(battle=battle)
+        declaration = declare_battle_action(
+            participant=participant,
+            action_kind=BattleActionKind.SUPPORT,
+            technique=self.technique,
+        )
+
+        success_outcome = CheckOutcomeFactory(name="battle_resolution_cc_success", success_level=1)
+
+        captured = []
+        from world.checks.services import perform_check as real_perform_check
+
+        def recording_perform_check(objectdb, check_type, **kwargs):
+            captured.append(check_type)
+            return real_perform_check(objectdb, check_type, **kwargs)
+
+        with (
+            force_check_outcome(success_outcome),
+            patch("world.battles.resolution.perform_check", recording_perform_check),
+        ):
+            resolve_battle_technique(declaration=declaration)
+
+        self.assertEqual(captured, [config.check_type])
+        self.assertNotEqual(config.check_type, self.technique.action_template.check_type)
+
 
 class DeclareBattleActionTests(TestCase):
     def setUp(self) -> None:

--- a/src/world/combat/clash.py
+++ b/src/world/combat/clash.py
@@ -206,8 +206,8 @@ def commit_to_clash(  # noqa: PLR0913
         )
         raise ValueError(msg)
 
-    # 1. Derive the check type from the technique's action_template (mirrors
-    #    _resolve_pc_action in services.py: ``template.check_type``).
+    # 1. Resolve the check via the shared cast-check rule (ADR-0095): the
+    #    caster's personal magic check when provisioned, else the template's.
     template = technique.action_template
     if template is None:
         msg = (
@@ -216,7 +216,9 @@ def commit_to_clash(  # noqa: PLR0913
             "combat use by assigning an ActionTemplate with a check_type."
         )
         raise ValueError(msg)
-    check_type = template.check_type
+    from world.magic.services.anima import resolve_cast_check_type  # noqa: PLC0415
+
+    check_type = resolve_cast_check_type(objectdb, template)
 
     # 2. Convert strain commitment to a power_intensity_bonus (diminishing-returns curve).
     #    Strain no longer modifies the check roll — the check reflects skill + affinity +

--- a/src/world/combat/clash.py
+++ b/src/world/combat/clash.py
@@ -206,7 +206,7 @@ def commit_to_clash(  # noqa: PLR0913
         )
         raise ValueError(msg)
 
-    # 1. Resolve the check via the shared cast-check rule (ADR-0095): the
+    # 1. Resolve the check via the shared cast-check rule (ADR-0096): the
     #    caster's personal magic check when provisioned, else the template's.
     template = technique.action_template
     if template is None:

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -5558,7 +5558,7 @@ def resolve_round(  # noqa: PLR0915 - orchestration function; already at the
         offense_check_fn: Optional ``perform_check`` override for PC offense.
             The offense_check_type is now sourced from ``resolve_cast_check_type``
             (the caster's personal check, falling back to the declared technique's
-            action_template.check_type only when unprovisioned, ADR-0095) — it is
+            action_template.check_type only when unprovisioned, ADR-0096) — it is
             no longer passed externally.
 
     Returns:

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -3999,11 +3999,15 @@ def _resolve_pc_action(
         template = technique.action_template
         if template is None:
             raise ActionDispatchError(ActionDispatchError.TECHNIQUE_NOT_COMBAT_READY)
+        from world.magic.services.anima import resolve_cast_check_type  # noqa: PLC0415
+
         combat_result = resolve_combat_technique(
             participant=participant,
             action=action,
             fatigue_category=fatigue_category,
-            offense_check_type=template.check_type,
+            offense_check_type=resolve_cast_check_type(
+                participant.character_sheet.character, template
+            ),
             offense_check_fn=offense_check_fn,
         )
         outcome.damage_results.extend(combat_result.damage_results)

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -5556,8 +5556,10 @@ def resolve_round(  # noqa: PLR0915 - orchestration function; already at the
         defense_check_fn: Optional ``perform_check`` override for PC defense.
         defense_check_type: The CheckType used for defensive rolls.
         offense_check_fn: Optional ``perform_check`` override for PC offense.
-            The offense_check_type is now sourced from the declared technique's
-            action_template.check_type — it is no longer passed externally.
+            The offense_check_type is now sourced from ``resolve_cast_check_type``
+            (the caster's personal check, falling back to the declared technique's
+            action_template.check_type only when unprovisioned, ADR-0095) — it is
+            no longer passed externally.
 
     Returns:
         ``RoundResolutionResult`` with outcomes and phase transitions.

--- a/src/world/combat/tests/test_clash_commit.py
+++ b/src/world/combat/tests/test_clash_commit.py
@@ -415,6 +415,58 @@ class CommitToClashTests(TestCase):
 
         self.assertIsNone(result.clash_interaction)
 
+    # -------------------------------------------------------------------------
+    # 7. #2014 — the caster's personal check wins over the template's fallback
+    # -------------------------------------------------------------------------
+
+    def test_commit_rolls_personal_check_when_provisioned(self) -> None:
+        """#2014: a provisioned caster's clash contribution rolls THEIR check."""
+        from evennia.accounts.models import AccountDB
+
+        from world.magic.constants import RitualExecutionKind
+        from world.magic.factories import RitualCheckConfigFactory
+        from world.magic.models.rituals import Ritual
+
+        character_sheet, _anima = self._make_character_with_anima()
+        technique = self._make_technique_with_template(anima_cost=3)
+
+        account = AccountDB.objects.create(username=f"clash_cc_{id(self)}")
+        ritual = Ritual.objects.create(
+            name=f"clash_cc_ritual_{id(self)}",
+            author_account=account,
+            execution_kind=RitualExecutionKind.SCENE_ACTION,
+        )
+        config = RitualCheckConfigFactory(ritual=ritual)
+        character_sheet.character.db_account = account
+        character_sheet.character.save(update_fields=["db_account"])
+
+        captured = []
+        from world.checks.services import perform_check as real_perform_check
+
+        def recording_perform_check(objectdb, check_type, **kwargs):
+            captured.append(check_type)
+            return real_perform_check(objectdb, check_type, **kwargs)
+
+        with (
+            force_check_outcome(self.success_outcome),
+            patch(
+                "world.checks.services.perform_check",
+                recording_perform_check,
+            ),
+        ):
+            commit_to_clash(
+                character_sheet=character_sheet,
+                technique=technique,
+                clash=self.clash,
+                strain_commitment=0,
+                action_slot="FOCUSED",
+                config_clash=self.config_clash,
+                config_strain=self.config_strain,
+            )
+
+        self.assertEqual(captured, [config.check_type])
+        self.assertNotEqual(config.check_type, technique.action_template.check_type)
+
 
 class CommitToClashLethalFlagTests(TestCase):
     """commit_to_clash threads lethal=clash.encounter.is_lethal into use_technique (#1182).

--- a/src/world/combat/tests/test_combat_technique_resolver.py
+++ b/src/world/combat/tests/test_combat_technique_resolver.py
@@ -741,8 +741,10 @@ class NonAttackPCActionRoutingTests(TestCase):
         from world.combat.types import CombatTechniqueResolution
 
         # Build encounter / participant / technique (no base_power => non-attack)
-        # action_template with check_type is required — _resolve_pc_action now derives
-        # offense_check_type from technique.action_template.check_type.
+        # action_template with check_type is required — _resolve_pc_action derives
+        # offense_check_type via resolve_cast_check_type, which falls back to
+        # technique.action_template.check_type for this unprovisioned caster
+        # (ADR-0095).
         check_type = CheckTypeFactory()
         encounter = CombatEncounterFactory(round_number=1)
         sheet = CharacterSheetFactory()

--- a/src/world/combat/tests/test_combat_technique_resolver.py
+++ b/src/world/combat/tests/test_combat_technique_resolver.py
@@ -744,7 +744,7 @@ class NonAttackPCActionRoutingTests(TestCase):
         # action_template with check_type is required — _resolve_pc_action derives
         # offense_check_type via resolve_cast_check_type, which falls back to
         # technique.action_template.check_type for this unprovisioned caster
-        # (ADR-0095).
+        # (ADR-0096).
         check_type = CheckTypeFactory()
         encounter = CombatEncounterFactory(round_number=1)
         sheet = CharacterSheetFactory()

--- a/src/world/combat/tests/test_duels_integration.py
+++ b/src/world/combat/tests/test_duels_integration.py
@@ -120,7 +120,7 @@ def _build_combat_technique(*, action_category: str = ActionCategory.PHYSICAL, r
 
     action_template is required by _resolve_pc_action (resolve_cast_check_type
     falls back to template.check_type for the offense check type when the
-    caster is unprovisioned, ADR-0095).
+    caster is unprovisioned, ADR-0096).
     """
     check_type = CheckTypeFactory()
     kwargs = {

--- a/src/world/combat/tests/test_duels_integration.py
+++ b/src/world/combat/tests/test_duels_integration.py
@@ -118,8 +118,9 @@ def _build_combat_technique(*, action_category: str = ActionCategory.PHYSICAL, r
     instead of calling TechniqueDamageProfileFactory separately, which would
     violate the unique_untyped_damage_profile_per_technique constraint.
 
-    action_template is required by _resolve_pc_action (it reads
-    template.check_type for the offense check type).
+    action_template is required by _resolve_pc_action (resolve_cast_check_type
+    falls back to template.check_type for the offense check type when the
+    caster is unprovisioned, ADR-0095).
     """
     check_type = CheckTypeFactory()
     kwargs = {

--- a/src/world/combat/tests/test_round_orchestrator.py
+++ b/src/world/combat/tests/test_round_orchestrator.py
@@ -1105,3 +1105,127 @@ class ResolveDeclaredChallengesTests(TestCase):
                 character=participant_eligible.character_sheet.character,
             ).exists(),
         )
+
+
+class OffenseCheckSourceTests(TestCase):
+    """#2014: the offense check is the caster's personal check when provisioned."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from decimal import Decimal
+
+        cls.effect_attack = EffectTypeFactory(name="Attack", base_power=20)
+        cls.gift = GiftFactory()
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=2, multiplier=Decimal("1.00"), label="Full"
+        )
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=1, multiplier=Decimal("0.50"), label="Partial"
+        )
+
+    def _setup_encounter(self):
+        """Create a simple encounter: 1 PC, 1 mook, declaration phase.
+
+        Copied from ResolveRoundBasicTests._setup_encounter — sets up the full
+        magic pipeline requirements (CharacterAnima, CharacterEngagement, room
+        location) so tests can pass an offense_check_fn to route through
+        resolve_combat_technique.
+        """
+        encounter = CombatEncounterFactory(
+            status=RoundStatus.DECLARING,
+            round_number=1,
+        )
+        pool = ThreatPoolFactory()
+        entry = ThreatPoolEntryFactory(pool=pool, base_damage=30)
+        opponent = CombatOpponentFactory(
+            encounter=encounter,
+            tier=OpponentTier.MOOK,
+            health=50,
+            max_health=50,
+            threat_pool=pool,
+        )
+        sheet = CharacterSheetFactory()
+        participant = CombatParticipantFactory(
+            encounter=encounter,
+            character_sheet=sheet,
+        )
+        CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
+        CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
+        CharacterEngagementFactory(character=sheet.character)
+        room = ObjectDB.objects.create(
+            db_key="TestRoomOffenseCheckSource",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        sheet.character.location = room
+        sheet.character.save()
+
+        technique = TechniqueFactory(
+            gift=self.gift,
+            effect_type=self.effect_attack,
+            action_template=ActionTemplateFactory(check_type=CheckTypeFactory()),
+        )
+        action = CombatRoundAction.objects.create(
+            participant=participant,
+            round_number=1,
+            focused_category=ActionCategory.PHYSICAL,
+            focused_action=technique,
+            focused_opponent_target=opponent,
+        )
+        # NPC action targeting the PC
+        npc_action = CombatOpponentAction.objects.create(
+            opponent=opponent,
+            round_number=1,
+            threat_entry=entry,
+        )
+        npc_action.targets.add(participant)
+
+        return encounter, participant, opponent, action, npc_action
+
+    def _recording_check_fn(self, captured):
+        """Wrap this file's existing offense_check_fn fake so it also records."""
+
+        def inner(*args, **kwargs):  # type: ignore[no-untyped-def]
+            return MagicMock(success_level=2)
+
+        def check_fn(character, check_type, extra_modifiers=0, fatigue_penalty=0):
+            captured.append(check_type)
+            return inner(
+                character,
+                check_type,
+                extra_modifiers=extra_modifiers,
+                fatigue_penalty=fatigue_penalty,
+            )
+
+        return check_fn
+
+    def test_unprovisioned_pc_rolls_template_check(self) -> None:
+        encounter, _participant, _opponent, action, _npc_action = self._setup_encounter()
+        technique = action.focused_action
+        captured = []
+        resolve_round(encounter, offense_check_fn=self._recording_check_fn(captured))
+        self.assertEqual(captured, [technique.action_template.check_type])
+
+    def test_provisioned_pc_rolls_personal_check(self) -> None:
+        from evennia.accounts.models import AccountDB
+
+        from world.magic.constants import RitualExecutionKind
+        from world.magic.factories import RitualCheckConfigFactory
+        from world.magic.models.rituals import Ritual
+
+        encounter, participant, _opponent, action, _npc_action = self._setup_encounter()
+        technique = action.focused_action
+        character = participant.character_sheet.character
+        account = AccountDB.objects.create(username=f"combat_cc_{id(self)}")
+        ritual = Ritual.objects.create(
+            name=f"combat_cc_ritual_{id(self)}",
+            author_account=account,
+            execution_kind=RitualExecutionKind.SCENE_ACTION,
+        )
+        config = RitualCheckConfigFactory(ritual=ritual)
+        character.db_account = account
+        character.save(update_fields=["db_account"])
+
+        captured = []
+        resolve_round(encounter, offense_check_fn=self._recording_check_fn(captured))
+        self.assertEqual(captured, [config.check_type])
+        self.assertNotEqual(config.check_type, technique.action_template.check_type)

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -196,7 +196,12 @@ casting never hard-fails with "no template." The resolution chain:
   (`seeds_checks.py`) synthesizes a `CheckType` named after the character (pattern
   `character_magic_check_type_name(character_sheet)`) that weights the character's
   personal stat + skill. `get_character_cast_check(character)` (`services/anima.py`)
-  resolves this check type for use by the cast pipeline.
+  resolves this check type for use by the cast pipeline. `resolve_cast_check_type(character,
+  template)` (`services/anima.py`) is the single resolver every cast path calls: it
+  returns the personal check when the caster is provisioned, else falls back to
+  `template.check_type` (ADR-0095) — standalone casts, combat round casts, and clash
+  contributions all go through it, so none of them can silently roll the shared
+  template check for a provisioned caster.
 - **Anima ritual alignment** — `provision_player_anima_ritual` (`services/anima.py`)
   points the anima ritual's `RitualCheckConfig.check_type` at the same per-character
   check type, so the anima ritual and technique casts always roll the same personal check.
@@ -211,8 +216,11 @@ casting never hard-fails with "no template." The resolution chain:
   of the base pool seeded by `seeds_cast.ensure_technique_catalog_content()`. Each
   catalog entry has its own `ActionTemplate` (same `check_type`/`pipeline`/
   `target_type` as the shared template — only `consequence_pool` differs) so
-  combat's direct read of `technique.action_template.check_type` is unaffected by
-  which flavor was picked. Resolution: `technique_builder.resolve_cast_action_template()`.
+  the flavor pick cannot affect the rolled check: **every** cast path (standalone,
+  combat, clash) resolves the check via `resolve_cast_check_type` (personal check
+  first, template fallback — ADR-0095), and none of them read
+  `technique.action_template.check_type` directly anymore. Resolution:
+  `technique_builder.resolve_cast_action_template()`.
 
 Follow-ups deferred to later issues: the optional resonance→aspect mapping. (The
 targeting model — targeting validity + AoE + per-technique target constraints +

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -199,9 +199,10 @@ casting never hard-fails with "no template." The resolution chain:
   resolves this check type for use by the cast pipeline. `resolve_cast_check_type(character,
   template)` (`services/anima.py`) is the single resolver every cast path calls: it
   returns the personal check when the caster is provisioned, else falls back to
-  `template.check_type` (ADR-0095) — standalone casts, combat round casts, and clash
-  contributions all go through it, so none of them can silently roll the shared
-  template check for a provisioned caster.
+  `template.check_type` (ADR-0095) — standalone casts, combat round casts, clash
+  contributions, and battle technique resolution (`world/battles/resolution.py`)
+  all go through it, so none of them can silently roll the shared template check
+  for a provisioned caster.
 - **Anima ritual alignment** — `provision_player_anima_ritual` (`services/anima.py`)
   points the anima ritual's `RitualCheckConfig.check_type` at the same per-character
   check type, so the anima ritual and technique casts always roll the same personal check.
@@ -217,8 +218,11 @@ casting never hard-fails with "no template." The resolution chain:
   catalog entry has its own `ActionTemplate` (same `check_type`/`pipeline`/
   `target_type` as the shared template — only `consequence_pool` differs) so
   the flavor pick cannot affect the rolled check: **every** cast path (standalone,
-  combat, clash) resolves the check via `resolve_cast_check_type` (personal check
-  first, template fallback — ADR-0095), and none of them read
+  combat, clash, battle technique resolution in `world/battles/resolution.py`)
+  resolves the check via `resolve_cast_check_type` (personal check first, template
+  fallback — ADR-0095) — as does the combat availability descriptor
+  (`actions/player_interface.py`), so the action-picker UI shows the same check
+  the resolver rolls — and none of them read
   `technique.action_template.check_type` directly anymore. Resolution:
   `technique_builder.resolve_cast_action_template()`.
 

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -199,7 +199,7 @@ casting never hard-fails with "no template." The resolution chain:
   resolves this check type for use by the cast pipeline. `resolve_cast_check_type(character,
   template)` (`services/anima.py`) is the single resolver every cast path calls: it
   returns the personal check when the caster is provisioned, else falls back to
-  `template.check_type` (ADR-0095) — standalone casts, combat round casts, clash
+  `template.check_type` (ADR-0096) — standalone casts, combat round casts, clash
   contributions, and battle technique resolution (`world/battles/resolution.py`)
   all go through it, so none of them can silently roll the shared template check
   for a provisioned caster.
@@ -220,7 +220,7 @@ casting never hard-fails with "no template." The resolution chain:
   the flavor pick cannot affect the rolled check: **every** cast path (standalone,
   combat, clash, battle technique resolution in `world/battles/resolution.py`)
   resolves the check via `resolve_cast_check_type` (personal check first, template
-  fallback — ADR-0095) — as does the combat availability descriptor
+  fallback — ADR-0096) — as does the combat availability descriptor
   (`actions/player_interface.py`), so the action-picker UI shows the same check
   the resolver rolls — and none of them read
   `technique.action_template.check_type` directly anymore. Resolution:

--- a/src/world/magic/services/__init__.py
+++ b/src/world/magic/services/__init__.py
@@ -33,6 +33,7 @@ from world.magic.services.anima import (
     get_character_anima_ritual,
     get_character_cast_check,
     provision_player_anima_ritual,
+    resolve_cast_check_type,
 )
 from world.magic.services.resonance import (
     _anchor_in_action,  # external: world.magic.tests.test_pull_service
@@ -124,6 +125,7 @@ __all__ = [
     "recompute_max_health_with_threads",
     "reconcile_ritual_knowledge",
     "resolve_and_consume_ritual_components",
+    "resolve_cast_check_type",
     "resolve_pending_alteration",
     "resolve_pull_effects",
     "seed_thread_survivability_tuning",

--- a/src/world/magic/services/anima.py
+++ b/src/world/magic/services/anima.py
@@ -72,7 +72,7 @@ def get_character_cast_check(character):  # noqa: OBJECTDB_PARAM — Evennia cha
 
 
 def resolve_cast_check_type(character, template):  # noqa: OBJECTDB_PARAM — Evennia character
-    """The CheckType a technique cast rolls, for EVERY cast path (ADR-0095).
+    """The CheckType a technique cast rolls, for EVERY cast path (ADR-0096).
 
     Precedence: the caster's provisioned personal magic check always wins;
     an ActionTemplate's ``check_type`` is a fallback, never an override.

--- a/src/world/magic/services/anima.py
+++ b/src/world/magic/services/anima.py
@@ -71,6 +71,20 @@ def get_character_cast_check(character):  # noqa: OBJECTDB_PARAM — Evennia cha
     return ritual.check_config.check_type
 
 
+def resolve_cast_check_type(character, template):  # noqa: OBJECTDB_PARAM — Evennia character
+    """The CheckType a technique cast rolls, for EVERY cast path (ADR-0095).
+
+    Precedence: the caster's provisioned personal magic check always wins;
+    an ActionTemplate's ``check_type`` is a fallback, never an override.
+    Returns None only when the caster is unprovisioned AND ``template`` is None
+    (callers that require a concrete check guard ``template is None`` first).
+    """
+    personal = get_character_cast_check(character)
+    if personal is not None:
+        return personal
+    return template.check_type if template is not None else None
+
+
 @transaction.atomic
 def perform_anima_ritual(
     character_sheet: CharacterSheet,

--- a/src/world/magic/tests/test_character_cast_check.py
+++ b/src/world/magic/tests/test_character_cast_check.py
@@ -328,3 +328,43 @@ class GetCharacterCastCheckTests(TestCase):
         ct = get_character_cast_check(sheet.character)
         self.assertIsNotNone(ct)
         self.assertEqual(ct.name, character_magic_check_type_name(sheet))
+
+
+class ResolveCastCheckTypeTests(TestCase):
+    """Precedence: personal check -> template check -> None (ADR-0095)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from actions.factories import ActionTemplateFactory
+
+        cls.sheet = CharacterSheetFactory()
+        cls.template = ActionTemplateFactory()
+
+    def test_unprovisioned_falls_back_to_template_check(self):
+        from world.magic.services.anima import resolve_cast_check_type
+
+        ct = resolve_cast_check_type(self.sheet.character, self.template)
+        self.assertEqual(ct, self.template.check_type)
+
+    def test_no_template_and_unprovisioned_returns_none(self):
+        from world.magic.services.anima import resolve_cast_check_type
+
+        self.assertIsNone(resolve_cast_check_type(self.sheet.character, None))
+
+    def test_provisioned_personal_check_wins_over_template(self):
+        from world.magic.factories import RitualCheckConfigFactory
+        from world.magic.services.anima import resolve_cast_check_type
+
+        account = AccountDB.objects.create(username=f"resolve_cc_{id(self)}")
+        ritual = Ritual.objects.create(
+            name=f"resolve_cc_ritual_{id(self)}",
+            author_account=account,
+            execution_kind=RitualExecutionKind.SCENE_ACTION,
+        )
+        config = RitualCheckConfigFactory(ritual=ritual)
+        self.sheet.character.db_account = account
+        self.sheet.character.save(update_fields=["db_account"])
+
+        ct = resolve_cast_check_type(self.sheet.character, self.template)
+        self.assertEqual(ct, config.check_type)
+        self.assertNotEqual(ct, self.template.check_type)

--- a/src/world/magic/tests/test_character_cast_check.py
+++ b/src/world/magic/tests/test_character_cast_check.py
@@ -331,7 +331,7 @@ class GetCharacterCastCheckTests(TestCase):
 
 
 class ResolveCastCheckTypeTests(TestCase):
-    """Precedence: personal check -> template check -> None (ADR-0095)."""
+    """Precedence: personal check -> template check -> None (ADR-0096)."""
 
     @classmethod
     def setUpTestData(cls):

--- a/src/world/scenes/cast_services.py
+++ b/src/world/scenes/cast_services.py
@@ -116,15 +116,15 @@ def _resolve_cast(  # noqa: PLR0913 - cohesive cast-resolution params
     if no fury).
     """
     from world.magic.services import use_technique  # noqa: PLC0415
-    from world.magic.services.anima import get_character_cast_check  # noqa: PLC0415
+    from world.magic.services.anima import resolve_cast_check_type  # noqa: PLC0415
     from world.magic.services.cast_threads import applicable_threads_for_cast  # noqa: PLC0415
 
     action_template = technique.action_template
     context = ResolutionContext(character=character, target=target)
 
-    # The cast rolls the CASTER'S personal magic check (their anima-ritual check);
-    # falls back to the template's own check (None) when no ritual is provisioned.
-    cast_check = get_character_cast_check(character)
+    # The cast rolls the CASTER'S personal magic check, falling back to the
+    # template's own check — the shared rule every cast path uses (ADR-0095).
+    cast_check = resolve_cast_check_type(character, action_template)
 
     from world.magic.services.fury import run_fury_for_action  # noqa: PLC0415
 

--- a/src/world/scenes/cast_services.py
+++ b/src/world/scenes/cast_services.py
@@ -123,7 +123,7 @@ def _resolve_cast(  # noqa: PLR0913 - cohesive cast-resolution params
     context = ResolutionContext(character=character, target=target)
 
     # The cast rolls the CASTER'S personal magic check, falling back to the
-    # template's own check — the shared rule every cast path uses (ADR-0095).
+    # template's own check — the shared rule every cast path uses (ADR-0096).
     cast_check = resolve_cast_check_type(character, action_template)
 
     from world.magic.services.fury import run_fury_for_action  # noqa: PLC0415


### PR DESCRIPTION
Closes #2014

## Summary

Every technique-cast path now resolves its offense check through one shared helper, resolve_cast_check_type (world/magic/services/anima.py): the caster's provisioned personal magic check (their anima-ritual stat+skill CheckType, #1306) always wins; an ActionTemplate's check_type is a fallback for unprovisioned casters, never an override (ADR-0096). Five call sites converged: standalone scene cast, combat round cast (_resolve_pc_action), clash contributions (commit_to_clash), battle technique resolution (battles/resolution.py — a fourth site found during implementation), and the combat action-picker availability descriptor (player_interface.py — a fifth site caught by the whole-branch review, so the UI shows the same check the resolver rolls). Each site has a red-first test proving a provisioned charm-built caster rolls THEIR check; docs corrected in tandem (magic CLAUDE.md, technique-use-pipeline.md now lists four entry points, battles.md, INDEX.md, unified-player-action.md superseded-notes). Notes: (1) outcome-level assertions use the house pattern of capturing the CheckType at the perform_check boundary (per the approved spec's 'and/or' testing clause) — no real-dice outcome-delta E2E was added; (2) pre-existing edge: Ritual.author_account is SET_NULL, so an orphaned null-account ritual could theoretically match a db_account-less NPC — predates this branch, unchanged; (3) tuning simulator parties are unprovisioned, so dashboard numbers are unaffected.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2014 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main; one conflict (docs/adr/README.md — merge queue assigned 0095 to battle-live-updates first), resolved by renumbering our ADR to 0096 across all 15 referencing files.

<!-- last-addressed-comment: 0 -->