### PR TITLE
docs: friction-audit 2026-07-07 — subagent worktree anchoring, stall recovery, fresh-worktree makemigrations note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,17 @@ Explore/research agents). Two concrete failure modes motivate this:
   notifications re-invoke the main loop only — a subagent that backgrounds a
   command and ends its turn "waiting for the notification" dies silently holding
   uncommitted work (two stalls during #1909). Put a foreground-only instruction
-  in every implementer/fix dispatch prompt.
+  in every implementer/fix dispatch prompt. The instruction alone does not fully
+  prevent it (6+ recurrences on 2026-07-06/07) — when a subagent stalls this
+  way, the recovery is cheap and reliable: **resume it with a message** ordering
+  it to re-run the checks in the foreground and commit before ending its turn.
+- **Subagent dispatch prompts must anchor the worktree.** A subagent's FIRST
+  action must be `cd <worktree>` then `pwd` + `git status --short`, verifying
+  branch and tree before any edit; every path it edits and every test it runs
+  must live inside the worktree. An absolute worktree path in the prompt is not
+  enough — a subagent that skips the anchor step drifts into the shared main
+  checkout, where concurrent sessions clobber its uncommitted work (near-miss
+  on #2029).
 
 Destructive or approval-gated git operations (`reset --hard`, force-push) go
 alone in their own message. Never cite an issue/PR number that wasn't read

--- a/docs/evennia-quirks.md
+++ b/docs/evennia-quirks.md
@@ -17,6 +17,22 @@ arx manage makemigrations traits
 
 **Details**: See `core_management/CLAUDE.md` for full technical documentation of the solution.
 
+### makemigrations in a fresh worktree (no local dev DB)
+
+`arx manage makemigrations <app>` can fail in a freshly created worktree: the
+Evennia launcher requires `Account#1` (superuser) to exist before running *any*
+command — even schema-only ones — and worktrees don't carry over the main
+checkout's untracked local DB/`.env`, so `DATABASE_URL` falls back to the shared
+devcontainer Postgres (which may carry an unrelated `InconsistentMigrationHistory`).
+
+**Workaround (never touch the main dev DB):** create a disposable scratch
+Postgres DB on the same `db` host, run `python -m django migrate` and then
+`python -m django makemigrations <app>` directly against it (bypassing the
+`evennia` launcher's superuser pre-check), copy the generated migration file,
+and drop the scratch DB. Often the worktree's own `.venv` + SQLite fallback also
+works — try `arx manage makemigrations <app>` first; reach for the scratch DB
+only when the launcher blocks it.
+
 ### Evennia Integration Strategy
 - **Use Evennia Models**: Keep using Evennia's Account, ObjectDB, etc. - don't reinvent the wheel
 - **Extend via evennia_extensions**: Use the evennia_extensions app pattern for data storage that extends Evennia models


### PR DESCRIPTION
Applies the approved apply-now half of the 2026-07-07 friction audit (Tehom-ratified in-session):

- **CLAUDE.md** (Tool & Subagent Sequencing): dispatch prompts must anchor the subagent in its worktree as its FIRST action (cd + pwd + git status; near-miss on #2029 where an implementer edited the shared main checkout), and the documented recovery for subagents that background a test run and stall — resume with a foreground-finish message (6+ recurrences across two sessions).
- **docs/evennia-quirks.md**: the fresh-worktree makemigrations trap (Evennia launcher's Account#1 pre-check + shared-Postgres fallback) and the scratch-DB workaround.

Doc-only change; no runtime surface. The file-as-issue half of the audit (pipeline-script hardening, per-session test-DB isolation) is being filed as separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)