### PR TITLE
Tactical placement wiring: enter/take a Position, GM placement, positioned opponent spawn, telnet movement

### DIFF
--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -22,6 +22,13 @@ outcome** (a closed issue or a "SHIPPED" line is not proof). See the ledger's go
   non-combat scene rounds (#1744, ADR-0069) — the environmental-DoT sibling of INTERPOSE.
 - Escalation → Audere offer → accept → real power change.
 - Multi-PC group combos (effect-type × resonance).
+- **Tactical placement, end-to-end (#2005).** Voluntary `take_position` (entry onto the
+  position graph), GM `gm_place_in_position` (unchecked staging teleport), and positioned
+  opponent spawn (`add_opponent(..., position=...)`) close the last placement gaps —
+  ADJACENT-reach technique gating now binds against a real, populated position graph rather
+  than defaulting everyone to the same spot (journey test in `world/combat/tests/
+  test_declare_reach_gate.py`). Full telnet parity: `position` / `position <name>`
+  (`CmdPosition`) lists/takes/moves the same way the web position panel does.
 
 ## WIRED-UNPROVEN (treat as not-done — write the journey test, fix what it exposes)
 

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -659,8 +659,14 @@ effects for graph mutation and flight).
 - **Shared serializers** (`positioning/serializers.py`): `PositionSummarySerializer`,
   `PositionAdjacencyItemSerializer`, `PersonaPositionSerializer` (used by both combat
   and scenes layers)
-- **Actions:** `MoveToPositionAction` (`registry_key="move_to_position"`) + staff-only
-  `SetTheStageAction` (`registry_key="set_the_stage"`, `StaffOnlyPrerequisite`)
+- **Actions:** `MoveToPositionAction` (`registry_key="move_to_position"`), `TakePositionAction`
+  (`registry_key="take_position"` — voluntary PRIMARY/FEATURE entry for an UNPLACED actor,
+  #2005), `GMPlaceInPositionAction` (`registry_key="gm_place_in_position"` — staff/scene-GM
+  unchecked placement, #2005) + staff-only `SetTheStageAction`
+  (`registry_key="set_the_stage"`, `StaffOnlyPrerequisite`)
+- **Telnet:** `CmdPosition` (`position` / `position <name>`, #2005) — list/take/move face over
+  `TakePositionAction`/`MoveToPositionAction`, room-scoped name resolution; see
+  [areas.md](areas.md) "Telnet" section
 - **Scene API:** `SceneDetailSerializer` exposes `positions`, `position_adjacency`,
   `persona_positions`
 - **Frontend:** `MovementActions` (shared, in `frontend/src/combat/components/`) +
@@ -673,10 +679,12 @@ effects for graph mutation and flight).
 - **Gated blueprint edges (built — #1216):** `BlueprintEdge.gating_challenge_template` →
   `instantiate_blueprint` mints a live `ChallengeInstance` via `instantiate_challenge`
   (`world.mechanics.challenge_resolution`) on staging.
-- **Integrates with:** combat (`CombatParticipant.current_position` / `CombatOpponent.current_position`),
+- **Integrates with:** combat (`CombatParticipant.current_position` / `CombatOpponent.current_position`;
+  `add_opponent(..., position=...)` spawns an opponent already placed, #2005),
   mechanics (Challenge/gating + `ConsequenceEffect` reshape handlers),
   flows (`EventName.FELL` reactive seam),
-  actions (`MoveToPositionAction` / `SetTheStageAction`)
+  actions (`MoveToPositionAction` / `TakePositionAction` / `GMPlaceInPositionAction` /
+  `SetTheStageAction`), commands (`CmdPosition`, #2005)
 - **Source:** `src/world/areas/positioning/`
 - **Details:** [areas.md](areas.md)
 ### Instances

--- a/docs/systems/areas.md
+++ b/docs/systems/areas.md
@@ -218,6 +218,23 @@ AERIAL_PROPERTY_NAME = "aerial"  # ObjectProperty tag set on airborne objects
 
 The `_set_the_stage_actions(character)` helper in `src/actions/player_interface.py` surfaces one quick-action using the room's `default_blueprint` for staff.
 
+### Telnet [BUILT & WIRED]
+
+**`src/commands/positions.py`** — `CmdPosition` (`position`, #2005), the telnet face of the
+position graph, mirroring `CmdPlaces`' shape:
+
+- Bare `position` — lists the caller's current room's staged positions with their kind,
+  occupants, and ADJACENT-reach adjacency (via `room_position_adjacency`), or reports
+  `"This room has no positions staged."` when the room has none.
+- `position <name>` — resolves a `Position` by name scoped to the caller's room
+  (case-insensitive exact match, falling back to a unique prefix match) and calls
+  `TakePositionAction().run(caller, position_id=...)` when the caller is unplaced
+  (`position_of(caller) is None`), else `MoveToPositionAction().run(caller, position_id=...)`.
+  Ineligible-kind, non-adjacent, and gated/immobile failures surface the action's own
+  `ActionResult.message` verbatim (no separate telnet error copy).
+
+Registered in `commands/default_cmdsets.py` alongside `CmdPlaces`.
+
 ### Shared Serializers [BUILT & WIRED]
 
 **`src/world/areas/positioning/serializers.py`** — imported by both combat and scenes layers:

--- a/docs/systems/areas.md
+++ b/docs/systems/areas.md
@@ -200,7 +200,8 @@ AERIAL_PROPERTY_NAME = "aerial"  # ObjectProperty tag set on airborne objects
 
 | Function | Summary |
 |----------|---------|
-| `place_in_position(objectdb, position)` | Idempotent unconditional placement (staff / setup) |
+| `place_in_position(objectdb, position)` | Idempotent unconditional placement (staff / setup); the UNCHECKED primitive — bypasses entry-kind + mobility (#2005) |
+| `take_position(objectdb, position)` | Voluntary entry onto the position graph for an UNPLACED actor — restricted to PRIMARY/FEATURE entry kinds + MOVEMENT capability (#2005) |
 | `move_to_position(objectdb, target)` | Voluntary move — validates same room, current placement, adjacency, passability, gating challenge, MOVEMENT capability |
 | `force_move_to_position(objectdb, target)` | Bypass capability + edge checks (staff/consequence) |
 
@@ -211,6 +212,8 @@ AERIAL_PROPERTY_NAME = "aerial"  # ObjectProperty tag set on airborne objects
 | Action | Registry Key | Prerequisite | Notes |
 |--------|-------------|--------------|-------|
 | `MoveToPositionAction` | `move_to_position` | none | Dispatched with `ActionRef(registry_key="move_to_position", position_id=<pk>)`; surfaced via `get_player_actions` |
+| `TakePositionAction` | `take_position` | none | Voluntary entry for an UNPLACED actor; dispatched with `ActionRef(registry_key="take_position", position_id=<pk>)`; surfaced via `get_player_actions` for PRIMARY/FEATURE positions only (#2005) |
+| `GMPlaceInPositionAction` | `gm_place_in_position` | none (gate is in-body, not a `Prerequisite`) | Staff OR active-scene GM (mirrors `_actor_may_gm_battle`; no active scene means staff-only) — wraps the unchecked `place_in_position`. `ActionRef(registry_key="gm_place_in_position", position_id=<pk>, target_object_id=<ObjectDB pk co-located with actor>)` (#2005) |
 | `SetTheStageAction` | `set_the_stage` | `StaffOnlyPrerequisite` | Dispatched with `ActionRef(registry_key="set_the_stage", blueprint_id=<pk>, replace=False)`; surfaced via `get_player_actions` when the room's `RoomProfile.default_blueprint` is set. `ActionRef` carries a `blueprint_id` field for this. |
 
 The `_set_the_stage_actions(character)` helper in `src/actions/player_interface.py` surfaces one quick-action using the room's `default_blueprint` for staff.

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -16067,6 +16067,32 @@ export interface components {
     ActivePersonaResult: {
       readonly active_persona_id: number;
     };
+    /**
+     * @description Write serializer for adding an opponent to an encounter.
+     *
+     *     ``tier`` is required.  ``max_health`` is optional — when omitted the scaling
+     *     formula fills every stat field automatically (Task 5 auto-fill mode).
+     *     All other stat fields are optional overrides.
+     *
+     *     ``position_id`` (#2005) is optional; when supplied it must name a Position
+     *     in the encounter's own room — validated against the encounter's room here
+     *     so a mismatched position never reaches the service layer.
+     *
+     *     Expects ``encounter`` and ``request`` in serializer context (provided by the
+     *     view) so that ``validate()`` can run the stakes gate.
+     */
+    AddOpponentRequest: {
+      name: string;
+      tier: components['schemas']['Tier756Enum'];
+      max_health?: number | null;
+      threat_pool_id: number;
+      /** @default  */
+      description: string;
+      /** @default 0 */
+      soak_value: number;
+      probing_threshold?: number | null;
+      position_id?: number | null;
+    };
     /** @description Read-only serializer for AggregateBeatContribution ledger rows. */
     AggregateBeatContribution: {
       readonly id: number;
@@ -22086,7 +22112,7 @@ export interface components {
       readonly objectdb_id: number | null;
       name: string;
       description?: string;
-      tier: components['schemas']['OpponentTierEnum'];
+      tier: components['schemas']['Tier756Enum'];
       health: number;
       max_health: number;
       /** @description Soak value — GM/staff only. */
@@ -22156,7 +22182,7 @@ export interface components {
     OpponentRequest: {
       name: string;
       description?: string;
-      tier: components['schemas']['OpponentTierEnum'];
+      tier: components['schemas']['Tier756Enum'];
       health: number;
       max_health: number;
       probing_current?: number;
@@ -22170,15 +22196,6 @@ export interface components {
      * @enum {string}
      */
     OpponentStatusEnum: 'active' | 'defeated' | 'fled';
-    /**
-     * @description * `swarm` - Swarm
-     *     * `mook` - Mook
-     *     * `elite` - Elite
-     *     * `boss` - Boss
-     *     * `hero_killer` - Hero Killer
-     * @enum {string}
-     */
-    OpponentTierEnum: 'swarm' | 'mook' | 'elite' | 'boss' | 'hero_killer';
     /**
      * @description * `branch` - Branch
      *     * `check` - Check
@@ -29758,6 +29775,15 @@ export interface components {
      */
     Tier3f5Enum: 1 | 2 | 3 | 4 | 5;
     /**
+     * @description * `swarm` - Swarm
+     *     * `mook` - Mook
+     *     * `elite` - Elite
+     *     * `boss` - Boss
+     *     * `hero_killer` - Hero Killer
+     * @enum {string}
+     */
+    Tier756Enum: 'swarm' | 'mook' | 'elite' | 'boss' | 'hero_killer';
+    /**
      * @description * `dawn` - Dawn
      *     * `day` - Day
      *     * `dusk` - Dusk
@@ -34411,7 +34437,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['EncounterDetailRequest'];
+        'application/json': components['schemas']['AddOpponentRequest'];
       };
     };
     responses: {

--- a/src/actions/definitions/gm_combat.py
+++ b/src/actions/definitions/gm_combat.py
@@ -257,6 +257,7 @@ class AddOpponentAction(Action):
         context: ActionContext | None = None,
         **kwargs: Any,
     ) -> ActionResult:
+        from world.areas.positioning.exceptions import PositionError  # noqa: PLC0415
         from world.combat.services import add_opponent  # noqa: PLC0415
 
         encounter, error = _active_encounter_for_gm(actor)
@@ -279,6 +280,9 @@ class AddOpponentAction(Action):
             )
         except ValueError as err:
             return ActionResult(success=False, message=str(err))
+        except PositionError as exc:
+            # A position in a different room than the encounter's spawn room.
+            return ActionResult(success=False, message=exc.user_message)
 
         return ActionResult(
             success=True,

--- a/src/actions/definitions/gm_combat.py
+++ b/src/actions/definitions/gm_combat.py
@@ -195,6 +195,51 @@ class ResolveEncounterRoundAction(Action):
         return ActionResult(success=True, message="The round resolves.")
 
 
+def _resolve_add_opponent_inputs(
+    kwargs: dict[str, Any],
+) -> tuple[str, str, object, str, object] | ActionResult:
+    """Resolve + validate ``AddOpponentAction`` kwargs.
+
+    Returns ``(name, tier, threat_pool, description, position)`` on success,
+    or the failure ``ActionResult`` to return immediately. Extracted from
+    ``execute()`` to keep its own return-statement count low (PLR0911).
+    """
+    from world.areas.positioning.models import Position  # noqa: PLC0415
+    from world.combat.models import ThreatPool  # noqa: PLC0415
+
+    name = kwargs.get("name")
+    tier = kwargs.get("tier")
+    threat_pool_id = kwargs.get("threat_pool_id")
+    description = kwargs.get("description", "")
+    position_id = kwargs.get("position_id")
+
+    if not name or not tier or threat_pool_id is None:
+        return ActionResult(
+            success=False,
+            message="Name, tier, and threat pool are required.",
+        )
+    if tier not in OpponentTier.values:
+        return ActionResult(success=False, message="Invalid opponent tier.")
+
+    try:
+        pool = resolve_model_by_pk_or_name(
+            ThreatPool,
+            str(threat_pool_id),
+            not_found_msg=f"No threat pool named {threat_pool_id!r} found.",
+        )
+    except CommandError as err:
+        return ActionResult(success=False, message=str(err))
+
+    position = None
+    if position_id is not None:
+        try:
+            position = Position.objects.get(pk=position_id)
+        except Position.DoesNotExist:
+            return ActionResult(success=False, message="That position does not exist.")
+
+    return name, tier, pool, description, position
+
+
 @dataclass
 class AddOpponentAction(Action):
     """Add an NPC opponent to the active encounter."""
@@ -212,34 +257,16 @@ class AddOpponentAction(Action):
         context: ActionContext | None = None,
         **kwargs: Any,
     ) -> ActionResult:
-        from world.combat.models import ThreatPool  # noqa: PLC0415
         from world.combat.services import add_opponent  # noqa: PLC0415
 
         encounter, error = _active_encounter_for_gm(actor)
         if error:
             return error
 
-        name = kwargs.get("name")
-        tier = kwargs.get("tier")
-        threat_pool_id = kwargs.get("threat_pool_id")
-        description = kwargs.get("description", "")
-
-        if not name or not tier or threat_pool_id is None:
-            return ActionResult(
-                success=False,
-                message="Name, tier, and threat pool are required.",
-            )
-        if tier not in OpponentTier.values:
-            return ActionResult(success=False, message="Invalid opponent tier.")
-
-        try:
-            pool = resolve_model_by_pk_or_name(
-                ThreatPool,
-                str(threat_pool_id),
-                not_found_msg=f"No threat pool named {threat_pool_id!r} found.",
-            )
-        except CommandError as err:
-            return ActionResult(success=False, message=str(err))
+        resolved = _resolve_add_opponent_inputs(kwargs)
+        if isinstance(resolved, ActionResult):
+            return resolved
+        name, tier, pool, description, position = resolved
 
         try:
             opponent = add_opponent(
@@ -248,6 +275,7 @@ class AddOpponentAction(Action):
                 tier=tier,
                 threat_pool=pool,
                 description=description,
+                position=position,
             )
         except ValueError as err:
             return ActionResult(success=False, message=str(err))

--- a/src/actions/definitions/positioning.py
+++ b/src/actions/definitions/positioning.py
@@ -11,11 +11,17 @@ from actions.base import Action
 from actions.constants import ActionCategory
 from actions.prerequisites import StaffOnlyPrerequisite
 from actions.types import ActionContext, ActionResult, TargetType
+from commands.utils.gm_resolution import resolve_account_or_none
 from flows.scene_data_manager import SceneDataManager
 from flows.service_functions.communication import send_room_state
 from world.areas.positioning.exceptions import PositionError
 from world.areas.positioning.models import Position, PositionBlueprint
-from world.areas.positioning.services import instantiate_blueprint, move_to_position, take_position
+from world.areas.positioning.services import (
+    instantiate_blueprint,
+    move_to_position,
+    place_in_position,
+    take_position,
+)
 
 
 @dataclass
@@ -120,6 +126,122 @@ class TakePositionAction(Action):
         sdm = context.scene_data if context else SceneDataManager()
         actor_state = sdm.initialize_state_for_object(actor)
         send_room_state(actor_state)
+
+        return ActionResult(success=True)
+
+
+_ERR_NO_GM_PERMISSION = "Only staff or the scene's GM can do that."
+_ERR_NO_POSITION = "Place at which position?"
+_ERR_NO_TARGET = "Place which object?"
+_ERR_TARGET_NOT_FOUND = "That object does not exist."
+_ERR_TARGET_NOT_CO_LOCATED = "That object is not here."
+_ERR_POSITION_NOT_FOUND = "That position does not exist."
+
+
+def _actor_may_gm_place(actor: ObjectDB) -> bool:
+    """True when *actor* is staff, or the GM of the active scene in their room.
+
+    Mirrors ``_actor_may_gm_battle`` (``actions/definitions/battles.py``), but
+    the scene is derived from the actor's current room rather than an
+    existing Battle. No active scene in the room means staff-only.
+    """
+    from actions.definitions.scenes import _active_scene_for_room  # noqa: PLC0415
+
+    account = resolve_account_or_none(actor)
+    if account is None:
+        return False
+    if account.is_staff:
+        return True
+    room = actor.location
+    if room is None:
+        return False
+    scene = _active_scene_for_room(room)
+    return scene is not None and scene.is_gm(account)
+
+
+def _resolve_gm_place_target(
+    actor: ObjectDB, target_object_id: int, position_id: int
+) -> tuple[ObjectDB, Position] | ActionResult:
+    """Resolve + validate the (target, position) pair for GM placement.
+
+    Returns an error ``ActionResult`` when the target doesn't exist, isn't
+    co-located with *actor*, or the position doesn't exist.
+    """
+    try:
+        target = ObjectDB.objects.get(pk=target_object_id)
+    except ObjectDB.DoesNotExist:
+        return ActionResult(success=False, message=_ERR_TARGET_NOT_FOUND)
+    if target.db_location_id != actor.db_location_id:
+        return ActionResult(success=False, message=_ERR_TARGET_NOT_CO_LOCATED)
+    try:
+        position = Position.objects.get(pk=position_id)
+    except Position.DoesNotExist:
+        return ActionResult(success=False, message=_ERR_POSITION_NOT_FOUND)
+    return target, position
+
+
+@dataclass
+class GMPlaceInPositionAction(Action):
+    """GM/staff unchecked placement of a co-located object (#2005).
+
+    Wraps ``place_in_position`` — the UNCHECKED primitive that bypasses
+    entry-kind and mobility validation by design. This is the staging /
+    staff-teleport counterpart to the validated ``TakePositionAction``.
+
+    Gate: staff OR the GM of the active scene in the actor's current room
+    (mirrors ``_actor_may_gm_battle``). No active scene means staff-only.
+    Deliberately does NOT use ``StaffOnlyPrerequisite`` — placement is a
+    GM verb, not a staff-exclusive one.
+
+    Dispatch convention
+    -------------------
+    REGISTRY ActionRef: ``registry_key="gm_place_in_position"``,
+    ``position_id=<Position.pk>``, ``target_object_id=<ObjectDB.pk>``.
+
+    ``target_object_id`` must resolve to an ObjectDB co-located with the
+    actor (same ``db_location``); this action does not use the ObjectDB
+    target-resolution path (``target_type=SELF``, mirroring
+    ``MoveToPositionAction``/``TakePositionAction``), since ``position_id``
+    also needs manual resolution.
+    """
+
+    key: str = "gm_place_in_position"
+    name: str = "Place in Position"
+    icon: str = "crosshairs"
+    category: str = "gm"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        if not _actor_may_gm_place(actor):
+            return ActionResult(success=False, message=_ERR_NO_GM_PERMISSION)
+
+        position_id = kwargs.get("position_id")
+        if position_id is None:
+            return ActionResult(success=False, message=_ERR_NO_POSITION)
+
+        target_object_id = kwargs.get("target_object_id")
+        if target_object_id is None:
+            return ActionResult(success=False, message=_ERR_NO_TARGET)
+
+        resolved = _resolve_gm_place_target(actor, target_object_id, position_id)
+        if isinstance(resolved, ActionResult):
+            return resolved
+        target, position = resolved
+
+        try:
+            place_in_position(target, position)
+        except PositionError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+
+        sdm = context.scene_data if context else SceneDataManager()
+        target_state = sdm.initialize_state_for_object(target)
+        send_room_state(target_state)
 
         return ActionResult(success=True)
 

--- a/src/actions/definitions/positioning.py
+++ b/src/actions/definitions/positioning.py
@@ -15,7 +15,7 @@ from flows.scene_data_manager import SceneDataManager
 from flows.service_functions.communication import send_room_state
 from world.areas.positioning.exceptions import PositionError
 from world.areas.positioning.models import Position, PositionBlueprint
-from world.areas.positioning.services import instantiate_blueprint, move_to_position
+from world.areas.positioning.services import instantiate_blueprint, move_to_position, take_position
 
 
 @dataclass
@@ -61,6 +61,59 @@ class MoveToPositionAction(Action):
 
         try:
             move_to_position(actor, target)
+        except PositionError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+
+        sdm = context.scene_data if context else SceneDataManager()
+        actor_state = sdm.initialize_state_for_object(actor)
+        send_room_state(actor_state)
+
+        return ActionResult(success=True)
+
+
+@dataclass
+class TakePositionAction(Action):
+    """Voluntary entry onto the position graph for an UNPLACED actor (#2005).
+
+    Position is NOT an ObjectDB, so this action does not use the ObjectDB
+    target resolution path. The destination is passed as ``position_id``
+    (an int pk) in the action kwargs, mirroring ``MoveToPositionAction``.
+
+    Dispatch convention
+    -------------------
+    REGISTRY ActionRef: ``registry_key="take_position"``,
+    ``position_id=<Position.pk>``.
+
+    The dispatch layer passes the ref's ``position_id`` as a kwarg; this
+    action resolves it to a ``Position`` instance and delegates to
+    ``services.take_position``. Restricted to PRIMARY/FEATURE entry-point
+    kinds by the service; ELEVATED/AERIAL/etc. are unreachable this way.
+    """
+
+    key: str = "take_position"
+    name: str = "Take position"
+    icon: str = "map-marker"
+    category: str = "movement"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        position_id = kwargs.get("position_id")
+        if position_id is None:
+            return ActionResult(success=False, message="Take position where?")
+
+        try:
+            target = Position.objects.get(pk=position_id)
+        except Position.DoesNotExist:
+            return ActionResult(success=False, message="That position does not exist.")
+
+        try:
+            take_position(actor, target)
         except PositionError as exc:
             return ActionResult(success=False, message=exc.user_message)
 

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -904,12 +904,15 @@ def _positioning_actions(character: ObjectDB) -> list[PlayerAction]:
     handled by the service's ``reachable_positions`` function (BFS), but this
     action picker only offers single-hop moves so the player makes one step at a time.
 
-    If the character is not placed in any position (unplaced or no positioning graph
-    in the room), returns an empty list — no error is raised.
+    If the character is not placed in any position, surfaces a take_position
+    ``PlayerAction`` for each PRIMARY/FEATURE (entry-point) position in the room
+    instead (#2005) — the voluntary entry onto the graph. If the room has no
+    positioning graph at all (unstaged), returns an empty list — no error is raised.
     """
     from django.db.models import Q  # noqa: PLC0415
 
-    from world.areas.positioning.models import PositionEdge  # noqa: PLC0415
+    from world.areas.positioning.constants import PositionKind  # noqa: PLC0415
+    from world.areas.positioning.models import Position, PositionEdge  # noqa: PLC0415
     from world.areas.positioning.services import (  # noqa: PLC0415
         adjacent_open_positions,
         position_of,
@@ -917,7 +920,24 @@ def _positioning_actions(character: ObjectDB) -> list[PlayerAction]:
 
     current = position_of(character)
     if current is None:
-        return []
+        entry_positions = Position.objects.filter(
+            room=character.location,
+            kind__in=(PositionKind.PRIMARY, PositionKind.FEATURE),
+        )
+        return [
+            PlayerAction(
+                backend=ActionBackend.REGISTRY,
+                display_name=f"Take position: {position.name}",
+                ref=ActionRef(
+                    backend=ActionBackend.REGISTRY,
+                    registry_key="take_position",
+                    position_id=position.pk,
+                ),
+                description=position.description,
+                action_category=ActionCategory.PHYSICAL,
+            )
+            for position in entry_positions
+        ]
 
     result: list[PlayerAction] = []
     for edge in adjacent_open_positions(current):

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -177,6 +177,7 @@ from actions.definitions.perception import InventoryAction, LookAction, LookAtIt
 from actions.definitions.personas import SetActivePersonaAction
 from actions.definitions.places import JoinPlaceAction, LeavePlaceAction
 from actions.definitions.positioning import (
+    GMPlaceInPositionAction,
     MoveToPositionAction,
     SetTheStageAction,
     TakePositionAction,
@@ -341,6 +342,7 @@ _ALL_ACTIONS: list[Action] = [
     HomeAction(),
     MoveToPositionAction(),
     TakePositionAction(),
+    GMPlaceInPositionAction(),
     SetTheStageAction(),
     SetSituationAction(),
     PerformRitualAction(),

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -176,7 +176,11 @@ from actions.definitions.outfits import (
 from actions.definitions.perception import InventoryAction, LookAction, LookAtItemAction
 from actions.definitions.personas import SetActivePersonaAction
 from actions.definitions.places import JoinPlaceAction, LeavePlaceAction
-from actions.definitions.positioning import MoveToPositionAction, SetTheStageAction
+from actions.definitions.positioning import (
+    MoveToPositionAction,
+    SetTheStageAction,
+    TakePositionAction,
+)
 from actions.definitions.progression import ManageTrainingAction, PurchaseUnlockAction
 from actions.definitions.progression_rewards import (
     CastVoteAction,
@@ -336,6 +340,7 @@ _ALL_ACTIONS: list[Action] = [
     TraverseExitAction(),
     HomeAction(),
     MoveToPositionAction(),
+    TakePositionAction(),
     SetTheStageAction(),
     SetSituationAction(),
     PerformRitualAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -198,6 +198,7 @@ class ActionRegistryTests(TestCase):
             "craft_detach_facet",
             "craft_attach_style",
             "move_to_position",
+            "take_position",
             "set_the_stage",
             "set_situation",
             "start_round",

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -199,6 +199,7 @@ class ActionRegistryTests(TestCase):
             "craft_attach_style",
             "move_to_position",
             "take_position",
+            "gm_place_in_position",
             "set_the_stage",
             "set_situation",
             "start_round",

--- a/src/actions/tests/test_get_player_actions_enhancements.py
+++ b/src/actions/tests/test_get_player_actions_enhancements.py
@@ -137,11 +137,14 @@ class GetPlayerActionsQueryCountTests(TestCase):
         # active Thread list to find the matching GIFT thread — one fixed-cost Thread SELECT (via
         # CharacterThreadHandler._all). The CharacterSheet fetch is shared between the variant
         # resolver and the identity-stream calculation via a _sheet pass-through (no duplicate
-        # round-trip). Both additions are fixed-cost over the #520 baseline of 12. Raise only with
-        # a documented justification — the goal remains a single-digit-ish cost.
+        # round-trip). Both additions are fixed-cost over the #520 baseline of 12.
+        # #2005 (take_position picker): the character here is unplaced, so _positioning_actions
+        # now issues one Position query for PRIMARY/FEATURE entry positions in the room (instead
+        # of returning [] with zero extra queries) — +1 over the prior baseline of 14. Raise only
+        # with a documented justification — the goal remains a single-digit-ish cost.
         self.assertLessEqual(
             len(ctx.captured_queries),
-            14,
+            15,
             f"get_player_actions issued {len(ctx.captured_queries)} queries: "
             f"{[q['sql'] for q in ctx.captured_queries]}",
         )

--- a/src/actions/tests/test_gm_combat_actions.py
+++ b/src/actions/tests/test_gm_combat_actions.py
@@ -222,6 +222,29 @@ class AddOpponentActionTests(GMCombatActionTestBase):
         result = AddOpponentAction().run(self.gm_actor, name="", tier="")
         self.assertFalse(result.success)
 
+    def test_cross_room_position_fails_without_orphaning_opponent(self) -> None:
+        """Task 4 fold-in (#2005): a cross-room position surfaces a failure
+
+        ActionResult and leaves no saved-but-unplaced CombatOpponent behind.
+        """
+        from world.areas.positioning.services import create_position
+
+        other_room = _make_room("OtherRoomForPosition")
+        position = create_position(other_room, "elsewhere")
+
+        result = AddOpponentAction().run(
+            self.gm_actor,
+            name="Misplaced Mook",
+            tier=OpponentTier.MOOK,
+            threat_pool_id=str(self.pool.pk),
+            position_id=position.pk,
+        )
+
+        self.assertFalse(result.success)
+        self.assertFalse(
+            CombatOpponent.objects.filter(encounter=self.encounter, name="Misplaced Mook").exists()
+        )
+
 
 class AddEncounterParticipantActionTests(GMCombatActionTestBase):
     """AddEncounterParticipantAction enrolls a PC in the encounter."""

--- a/src/actions/tests/test_gm_place_in_position_action.py
+++ b/src/actions/tests/test_gm_place_in_position_action.py
@@ -1,0 +1,141 @@
+"""Tests for GMPlaceInPositionAction — GM/staff unchecked placement (#2005).
+
+Covers the gate precedent shared with ``_actor_may_gm_battle``
+(``actions/definitions/battles.py``): staff always passes; otherwise the
+actor's account must be the GM of the active scene in the actor's room.
+No active scene means only staff may place. ``place_in_position`` is the
+unchecked primitive (bypasses entry-kind + mobility), so staff/GM placement
+succeeds even at an ELEVATED position.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from actions.definitions.positioning import GMPlaceInPositionAction
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.areas.positioning.constants import PositionKind
+from world.areas.positioning.factories import PositionFactory
+from world.areas.positioning.services import position_of
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.factories import SceneFactory, SceneParticipationFactory
+
+
+def _make_room(label: str) -> object:
+    from evennia import create_object
+
+    return create_object("typeclasses.rooms.Room", key=label, nohome=True)
+
+
+def _make_actor_with_account(db_key: str, room: object, account: object) -> object:
+    """Create a PC in *room* whose ``active_account`` is *account*."""
+    char = CharacterFactory(db_key=db_key, location=room)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    RosterTenureFactory(
+        roster_entry=entry,
+        player_data__account=account,
+        end_date=None,
+    )
+    return char
+
+
+class GMPlaceInPositionActionTests(TestCase):
+    """Gate + execution behavior for gm_place_in_position."""
+
+    def setUp(self) -> None:
+        self.room = _make_room("GMPlaceRoom")
+        self.throne = PositionFactory(room=self.room, name="throne", kind=PositionKind.PRIMARY)
+        self.sky = PositionFactory(room=self.room, name="sky", kind=PositionKind.ELEVATED)
+
+        self.staff_account = AccountFactory(username="gmplace_staff", is_staff=True)
+        self.staff_actor = _make_actor_with_account(
+            "gmplace_staff_actor", self.room, self.staff_account
+        )
+
+        self.gm_account = AccountFactory(username="gmplace_gm")
+        self.gm_actor = _make_actor_with_account("gmplace_gm_actor", self.room, self.gm_account)
+
+        self.player_account = AccountFactory(username="gmplace_player")
+        self.player_actor = _make_actor_with_account(
+            "gmplace_player_actor", self.room, self.player_account
+        )
+
+        self.scene = SceneFactory(location=self.room)
+        SceneParticipationFactory(scene=self.scene, account=self.gm_account, is_gm=True)
+        SceneParticipationFactory(scene=self.scene, account=self.player_account, is_gm=False)
+
+        self.npc = CharacterFactory(db_key="gmplace_npc", location=self.room)
+
+    def test_staff_can_place_at_any_kind_including_elevated(self) -> None:
+        result = GMPlaceInPositionAction().run(
+            self.staff_actor,
+            position_id=self.sky.pk,
+            target_object_id=self.npc.pk,
+        )
+        self.assertTrue(result.success, result.message)
+        current = position_of(self.npc)
+        self.assertIsNotNone(current)
+        self.assertEqual(current.pk, self.sky.pk)
+
+    def test_scene_gm_can_place(self) -> None:
+        result = GMPlaceInPositionAction().run(
+            self.gm_actor,
+            position_id=self.throne.pk,
+            target_object_id=self.npc.pk,
+        )
+        self.assertTrue(result.success, result.message)
+        current = position_of(self.npc)
+        self.assertIsNotNone(current)
+        self.assertEqual(current.pk, self.throne.pk)
+
+    def test_plain_player_denied(self) -> None:
+        result = GMPlaceInPositionAction().run(
+            self.player_actor,
+            position_id=self.throne.pk,
+            target_object_id=self.npc.pk,
+        )
+        self.assertFalse(result.success)
+        self.assertIsNone(position_of(self.npc))
+
+    def test_non_co_located_target_denied(self) -> None:
+        other_room = _make_room("GMPlaceOtherRoom")
+        elsewhere_npc = CharacterFactory(db_key="gmplace_elsewhere_npc", location=other_room)
+
+        result = GMPlaceInPositionAction().run(
+            self.staff_actor,
+            position_id=self.throne.pk,
+            target_object_id=elsewhere_npc.pk,
+        )
+        self.assertFalse(result.success)
+        self.assertIsNone(position_of(elsewhere_npc))
+
+    def test_no_active_scene_staff_only(self) -> None:
+        bare_room = _make_room("GMPlaceBareRoom")
+        bare_position = PositionFactory(room=bare_room, name="bare", kind=PositionKind.PRIMARY)
+
+        bare_staff_account = AccountFactory(username="gmplace_bare_staff_acct", is_staff=True)
+        staff_actor = _make_actor_with_account("gmplace_bare_staff", bare_room, bare_staff_account)
+        gm_account = AccountFactory(username="gmplace_bare_gm_acct")
+        gm_actor = _make_actor_with_account("gmplace_bare_gm_actor", bare_room, gm_account)
+        bare_npc = CharacterFactory(db_key="gmplace_bare_npc", location=bare_room)
+
+        # No active Scene exists in bare_room, so even a would-be GM is denied.
+        denied = GMPlaceInPositionAction().run(
+            gm_actor,
+            position_id=bare_position.pk,
+            target_object_id=bare_npc.pk,
+        )
+        self.assertFalse(denied.success)
+        self.assertIsNone(position_of(bare_npc))
+
+        allowed = GMPlaceInPositionAction().run(
+            staff_actor,
+            position_id=bare_position.pk,
+            target_object_id=bare_npc.pk,
+        )
+        self.assertTrue(allowed.success, allowed.message)
+        current = position_of(bare_npc)
+        self.assertIsNotNone(current)
+        self.assertEqual(current.pk, bare_position.pk)

--- a/src/actions/tests/test_take_position_action.py
+++ b/src/actions/tests/test_take_position_action.py
@@ -125,7 +125,8 @@ class TestTakePositionActionDispatch(django.test.TestCase):
         result = dispatch_player_action(self.actor, ref, kwargs={})
 
         self.assertFalse(result.deferred)
-        self.assertTrue(result.detail.success, f"Take position failed: {result.detail.message}")  # type: ignore[union-attr]
+        detail = result.detail
+        self.assertTrue(detail.success, f"Take position failed: {detail.message}")  # type: ignore[union-attr]
         current = position_of(self.actor)
         self.assertIsNotNone(current)
         self.assertEqual(current.pk, self.throne.pk)  # type: ignore[union-attr]

--- a/src/actions/tests/test_take_position_action.py
+++ b/src/actions/tests/test_take_position_action.py
@@ -1,0 +1,161 @@
+"""Tests for TakePositionAction and its surfacing in get_player_actions (#2005).
+
+Covers:
+- (a) get_player_actions: an unplaced actor in a staged room (has PRIMARY/FEATURE
+  positions) surfaces one take_position PlayerAction per entry-kind position.
+- (b) get_player_actions: a placed actor's move_to_position options are unchanged
+  (no take_position options appear).
+- (c) get_player_actions: an unplaced actor in an unstaged room (no positions at
+  all) surfaces no take_position options.
+- (d) dispatch_player_action / TakePositionAction.run: success + failure paths.
+"""
+
+from __future__ import annotations
+
+import django.test
+
+from actions.constants import ActionBackend
+from actions.types import ActionRef
+from world.areas.positioning.constants import PositionKind
+from world.areas.positioning.factories import PositionFactory
+from world.areas.positioning.services import connect_positions, place_in_position, position_of
+
+
+def _make_character_in_room(room: object) -> object:
+    """Create a Character located in room via Evennia's create_object."""
+    from evennia import create_object
+
+    return create_object(
+        "typeclasses.characters.Character",
+        key="TestTaker",
+        location=room,
+        nohome=True,
+    )
+
+
+class TestTakePositionPicker(django.test.TestCase):
+    """get_player_actions surfaces take_position options for unplaced actors."""
+
+    def setUp(self) -> None:
+        from evennia import create_object
+
+        self.room = create_object("typeclasses.rooms.Room", key="TakePosPickerRoom", nohome=True)
+        self.throne = PositionFactory(room=self.room, name="throne", kind=PositionKind.PRIMARY)
+        self.hearth = PositionFactory(room=self.room, name="hearth", kind=PositionKind.FEATURE)
+        # AERIAL kind must never be offered as a voluntary entry point.
+        self.sky = PositionFactory(room=self.room, name="sky", kind=PositionKind.AERIAL)
+
+    def test_unplaced_actor_offered_one_action_per_entry_position(self) -> None:
+        from actions.player_interface import get_player_actions
+
+        actor = _make_character_in_room(self.room)
+        actions = get_player_actions(actor)
+        take_actions = [
+            a
+            for a in actions
+            if a.backend == ActionBackend.REGISTRY and a.ref.registry_key == "take_position"
+        ]
+        position_ids = {a.ref.position_id for a in take_actions}
+        self.assertEqual(
+            position_ids,
+            {self.throne.pk, self.hearth.pk},
+            f"Expected throne+hearth take_position options, got: {take_actions}",
+        )
+
+    def test_placed_actor_gets_no_take_position_options(self) -> None:
+        """A placed actor sees move options, not take_position options."""
+        from actions.player_interface import get_player_actions
+
+        actor = _make_character_in_room(self.room)
+        connect_positions(self.throne, self.hearth, is_passable=True)
+        place_in_position(actor, self.throne)
+
+        actions = get_player_actions(actor)
+        take_actions = [
+            a
+            for a in actions
+            if a.backend == ActionBackend.REGISTRY and a.ref.registry_key == "take_position"
+        ]
+        move_actions = [
+            a
+            for a in actions
+            if a.backend == ActionBackend.REGISTRY and a.ref.registry_key == "move_to_position"
+        ]
+        self.assertEqual(take_actions, [])
+        move_position_ids = {a.ref.position_id for a in move_actions}
+        self.assertIn(self.hearth.pk, move_position_ids)
+
+    def test_unstaged_room_offers_no_take_position_options(self) -> None:
+        """A room with no positions at all surfaces no take_position options."""
+        from evennia import create_object
+
+        from actions.player_interface import get_player_actions
+
+        bare_room = create_object("typeclasses.rooms.Room", key="BareRoom", nohome=True)
+        actor = _make_character_in_room(bare_room)
+
+        actions = get_player_actions(actor)
+        take_actions = [
+            a
+            for a in actions
+            if a.backend == ActionBackend.REGISTRY and a.ref.registry_key == "take_position"
+        ]
+        self.assertEqual(take_actions, [])
+
+
+class TestTakePositionActionDispatch(django.test.TestCase):
+    """dispatch_player_action with a take_position REGISTRY ref places the actor."""
+
+    def setUp(self) -> None:
+        from evennia import create_object
+
+        self.room = create_object("typeclasses.rooms.Room", key="TakePosDispatchRoom", nohome=True)
+        self.throne = PositionFactory(room=self.room, name="throne_d", kind=PositionKind.PRIMARY)
+        self.sky = PositionFactory(room=self.room, name="sky_d", kind=PositionKind.AERIAL)
+        self.actor = _make_character_in_room(self.room)
+
+    def test_dispatch_places_actor_at_entry_position(self) -> None:
+        from actions.player_interface import dispatch_player_action
+
+        ref = ActionRef(
+            backend=ActionBackend.REGISTRY,
+            registry_key="take_position",
+            position_id=self.throne.pk,
+        )
+        result = dispatch_player_action(self.actor, ref, kwargs={})
+
+        self.assertFalse(result.deferred)
+        self.assertTrue(result.detail.success, f"Take position failed: {result.detail.message}")  # type: ignore[union-attr]
+        current = position_of(self.actor)
+        self.assertIsNotNone(current)
+        self.assertEqual(current.pk, self.throne.pk)  # type: ignore[union-attr]
+
+    def test_dispatch_to_non_entry_kind_fails_gracefully(self) -> None:
+        from actions.player_interface import dispatch_player_action
+
+        ref = ActionRef(
+            backend=ActionBackend.REGISTRY,
+            registry_key="take_position",
+            position_id=self.sky.pk,
+        )
+        result = dispatch_player_action(self.actor, ref, kwargs={})
+
+        self.assertFalse(result.deferred)
+        self.assertFalse(result.detail.success)  # type: ignore[union-attr]
+        self.assertIsNone(position_of(self.actor))
+
+    def test_dispatch_already_placed_fails_gracefully(self) -> None:
+        from actions.player_interface import dispatch_player_action
+
+        place_in_position(self.actor, self.throne)
+        other = PositionFactory(room=self.room, name="other_d", kind=PositionKind.FEATURE)
+        ref = ActionRef(
+            backend=ActionBackend.REGISTRY,
+            registry_key="take_position",
+            position_id=other.pk,
+        )
+        result = dispatch_player_action(self.actor, ref, kwargs={})
+
+        self.assertFalse(result.deferred)
+        self.assertFalse(result.detail.success)  # type: ignore[union-attr]
+        self.assertIn("move", result.detail.message.lower())  # type: ignore[union-attr]

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -88,6 +88,14 @@ actions, backends, and service functions.
   (telnet has no pk to reference); `places leave` leaves whichever Place the
   caller's active persona currently occupies. Calls `JoinPlaceAction`/
   `LeavePlaceAction` (`actions/definitions/places.py`) directly.
+- **`positions.py`**: `CmdPosition` (`position`, #2005) — the telnet face of the tactical
+  position graph, mirroring `CmdPlaces`' shape. Bare `position` lists the caller's current
+  room's staged positions with kind, occupants, and ADJACENT-reach adjacency (or
+  `"This room has no positions staged."`); `position <name>` resolves a `Position` by name
+  scoped to the caller's room (case-insensitive exact, then unique-prefix) and dispatches
+  `TakePositionAction` when the caller is unplaced, else `MoveToPositionAction`
+  (`actions/definitions/positioning.py`) — the same seam the web position panel uses.
+  Ineligible/gated/non-adjacent failures surface the action's own error text verbatim.
 - **`door.py`**: `CmdLock`/`CmdUnlock` (`lock`/`unlock`, #1866) — real
   implementation (replacing the former stubs) dispatching to `LockAction`/
   `UnlockAction` (`actions/definitions/doors.py`). Room-owner/tenant gated via the

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -91,6 +91,7 @@ from commands.organizations import CmdOrg
 from commands.outfit import CmdOutfit  # #1866
 from commands.persona import CmdPersona
 from commands.places import CmdPlaces  # #1866
+from commands.positions import CmdPosition  # #2005
 from commands.presence import CmdAfk, CmdHide
 from commands.progression import CmdProgressionUnlock, CmdTraining
 from commands.progression_rewards import CmdKudos, CmdPathIntent, CmdRandomScene, CmdVote
@@ -333,6 +334,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdOutfit,
             # #1866 — places join/leave telnet namespace.
             CmdPlaces,
+            # #2005 — tactical position graph: list/take/move telnet namespace.
+            CmdPosition,
             # #1234 — Lab crafting station install/upgrade/repair namespace.
             CmdLabStation,
             # #1832 — ship commission/upgrade/repair/status namespace.

--- a/src/commands/positions.py
+++ b/src/commands/positions.py
@@ -1,0 +1,113 @@
+"""Positions telnet command — the ``position`` namespace (#2005).
+
+Bare ``position`` lists the caller's current room's staged positions with
+their occupants and ADJACENT-reach adjacency, or reports the room as
+unstaged. ``position <name>`` resolves a Position by name scoped to the
+caller's room (telnet has no pk to reference; case-insensitive exact match,
+falling back to a unique prefix match, mirroring ``CmdPlaces``) and
+dispatches ``TakePositionAction`` when the caller is not yet placed anywhere,
+or ``MoveToPositionAction`` when already placed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from actions.definitions.positioning import MoveToPositionAction, TakePositionAction
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from world.areas.positioning.models import Position
+
+
+class CmdPosition(ArxCommand):
+    """Enter or move within your current room's tactical position graph.
+
+    Usage:
+        position
+        position <name>
+    """
+
+    key = "position"
+    locks = "cmd:all()"
+
+    def func(self) -> None:
+        raw = (self.args or "").strip()
+        if not raw:
+            self._list_positions()
+            return
+        try:
+            self._do_position(raw)
+        except CommandError as err:
+            self.msg(str(err))
+            self.msg(command_error={"error": str(err), "command": self.raw_string or ""})
+
+    def _list_positions(self) -> None:
+        from world.areas.positioning.models import ObjectPosition, Position  # noqa: PLC0415
+        from world.areas.positioning.services import room_position_adjacency  # noqa: PLC0415
+
+        room = self.caller.location
+        if room is None:
+            self.msg("You aren't anywhere.")
+            return
+        positions = list(Position.objects.filter(room=room).order_by("pk"))
+        if not positions:
+            self.msg("This room has no positions staged.")
+            return
+
+        name_by_id = {p.pk: p.name for p in positions}
+        adjacency = {a.position_id: a.adjacent_position_ids for a in room_position_adjacency(room)}
+        occupants_by_position: dict[int, list[str]] = {p.pk: [] for p in positions}
+        for obj_pos in ObjectPosition.objects.filter(position__room=room).select_related(
+            "objectdb", "position"
+        ):
+            occupants_by_position.setdefault(obj_pos.position_id, []).append(obj_pos.objectdb.key)
+
+        lines = ["Positions here:"]
+        for p in positions:
+            occupants = occupants_by_position.get(p.pk, [])
+            occupants_text = ", ".join(occupants) if occupants else "empty"
+            adjacent_names = [
+                name_by_id[pid] for pid in adjacency.get(p.pk, []) if pid in name_by_id
+            ]
+            adjacent_text = ", ".join(adjacent_names) if adjacent_names else "none"
+            lines.append(
+                f"  {p.name} ({p.get_kind_display()}) — "
+                f"occupants: {occupants_text}; adjacent: {adjacent_text}"
+            )
+        self.msg("\n".join(lines))
+
+    def _resolve_position(self, room: object, name: str) -> Position:
+        from world.areas.positioning.models import Position  # noqa: PLC0415
+
+        positions = list(Position.objects.filter(room=room))
+        lname = name.lower()
+        for position in positions:
+            if position.name.lower() == lname:
+                return position
+        prefix_matches = [p for p in positions if p.name.lower().startswith(lname)]
+        if len(prefix_matches) == 1:
+            return prefix_matches[0]
+        if len(prefix_matches) > 1:
+            names = ", ".join(p.name for p in prefix_matches)
+            msg = f"'{name}' is ambiguous: {names}."
+            raise CommandError(msg)
+        msg = f"No such position here: '{name}'."
+        raise CommandError(msg)
+
+    def _do_position(self, name: str) -> None:
+        from world.areas.positioning.services import position_of  # noqa: PLC0415
+
+        room = self.caller.location
+        if room is None:
+            msg = "You aren't anywhere."
+            raise CommandError(msg)
+        position = self._resolve_position(room, name)
+
+        if position_of(self.caller) is None:
+            result = TakePositionAction().run(self.caller, position_id=position.pk)
+        else:
+            result = MoveToPositionAction().run(self.caller, position_id=position.pk)
+        if result.message:
+            self.msg(result.message)

--- a/src/commands/tests/test_positions.py
+++ b/src/commands/tests/test_positions.py
@@ -1,0 +1,131 @@
+"""Tests for CmdPosition — position / position <name> (#2005)."""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from commands.positions import CmdPosition
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+from world.areas.positioning.constants import PositionKind
+from world.areas.positioning.factories import PositionFactory
+from world.areas.positioning.services import connect_positions, place_in_position, position_of
+
+
+class CmdPositionTests(TestCase):
+    def _caller(self, room):
+        # No CharacterSheet attached (mirrors world/areas/positioning/tests/test_take_position.py):
+        # _can_move() treats a sheet-less ObjectDB as a non-character, always movable, without
+        # requiring the MOVEMENT CapabilityType seed data.
+        return CharacterFactory(db_key=f"CmdPositionAlice{room.pk}", location=room)
+
+    def _run(self, caller, args: str) -> list[str]:
+        cmd = CmdPosition()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.raw_string = f"position {args}"
+        messages: list[str] = []
+        cmd.msg = lambda *a, **kw: messages.append(a[0] if a else "")  # noqa: ARG005
+        cmd.func()
+        return messages
+
+    def test_bare_lists_positions_with_occupants(self):
+        room = ObjectDBFactory(db_key="CmdPositionRoom", db_typeclass_path="typeclasses.rooms.Room")
+        caller = self._caller(room)
+        throne = PositionFactory(room=room, name="throne", kind=PositionKind.PRIMARY)
+        place_in_position(caller, throne)
+
+        messages = self._run(caller, "")
+
+        assert any("throne" in m and "CmdPositionAlice" in m for m in messages)
+
+    def test_bare_unstaged_room_reports_not_staged(self):
+        room = ObjectDBFactory(
+            db_key="CmdPositionRoomUnstaged", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = self._caller(room)
+
+        messages = self._run(caller, "")
+
+        assert any("no positions staged" in m for m in messages)
+
+    def test_unplaced_actor_dispatches_take_position(self):
+        room = ObjectDBFactory(
+            db_key="CmdPositionRoomTake", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = self._caller(room)
+        throne = PositionFactory(room=room, name="throne", kind=PositionKind.PRIMARY)
+
+        self._run(caller, "throne")
+
+        current = position_of(caller)
+        assert current is not None
+        assert current.pk == throne.pk
+
+    def test_placed_actor_dispatches_move_to_adjacent_position(self):
+        room = ObjectDBFactory(
+            db_key="CmdPositionRoomMove", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = self._caller(room)
+        throne = PositionFactory(room=room, name="throne", kind=PositionKind.PRIMARY)
+        hearth = PositionFactory(room=room, name="hearth", kind=PositionKind.FEATURE)
+        connect_positions(throne, hearth, is_passable=True)
+        place_in_position(caller, throne)
+
+        self._run(caller, "hearth")
+
+        current = position_of(caller)
+        assert current is not None
+        assert current.pk == hearth.pk
+
+    def test_unplaced_actor_targeting_ineligible_kind_surfaces_action_error(self):
+        room = ObjectDBFactory(
+            db_key="CmdPositionRoomIneligible", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = self._caller(room)
+        PositionFactory(room=room, name="sky", kind=PositionKind.AERIAL)
+
+        messages = self._run(caller, "sky")
+
+        assert any("cannot enter" in m.lower() for m in messages)
+        assert position_of(caller) is None
+
+    def test_placed_actor_targeting_non_adjacent_position_surfaces_action_error(self):
+        room = ObjectDBFactory(
+            db_key="CmdPositionRoomBlocked", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = self._caller(room)
+        throne = PositionFactory(room=room, name="throne", kind=PositionKind.PRIMARY)
+        PositionFactory(room=room, name="hearth", kind=PositionKind.FEATURE)
+        # No edge connecting throne and hearth.
+        place_in_position(caller, throne)
+
+        messages = self._run(caller, "hearth")
+
+        assert any("no path" in m.lower() for m in messages)
+        current = position_of(caller)
+        assert current is not None
+        assert current.pk == throne.pk
+
+    def test_unknown_name_errors(self):
+        room = ObjectDBFactory(
+            db_key="CmdPositionRoomUnknown", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = self._caller(room)
+        PositionFactory(room=room, name="throne", kind=PositionKind.PRIMARY)
+
+        messages = self._run(caller, "nowhere")
+
+        assert any("No such position" in m for m in messages)
+
+    def test_unique_prefix_resolves_position(self):
+        room = ObjectDBFactory(
+            db_key="CmdPositionRoomPrefix", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        caller = self._caller(room)
+        throne = PositionFactory(room=room, name="throne", kind=PositionKind.PRIMARY)
+
+        self._run(caller, "thr")
+
+        current = position_of(caller)
+        assert current is not None
+        assert current.pk == throne.pk

--- a/src/schema.json
+++ b/src/schema.json
@@ -4353,7 +4353,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EncounterDetailRequest'
+              $ref: '#/components/schemas/AddOpponentRequest'
         required: true
       security:
       - cookieAuth: []
@@ -27094,6 +27094,51 @@ components:
           readOnly: true
       required:
       - active_persona_id
+    AddOpponentRequest:
+      type: object
+      description: |-
+        Write serializer for adding an opponent to an encounter.
+
+        ``tier`` is required.  ``max_health`` is optional — when omitted the scaling
+        formula fills every stat field automatically (Task 5 auto-fill mode).
+        All other stat fields are optional overrides.
+
+        ``position_id`` (#2005) is optional; when supplied it must name a Position
+        in the encounter's own room — validated against the encounter's room here
+        so a mismatched position never reaches the service layer.
+
+        Expects ``encounter`` and ``request`` in serializer context (provided by the
+        view) so that ``validate()`` can run the stakes gate.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        tier:
+          $ref: '#/components/schemas/Tier756Enum'
+        max_health:
+          type: integer
+          minimum: 1
+          nullable: true
+        threat_pool_id:
+          type: integer
+        description:
+          type: string
+          minLength: 1
+          default: ''
+        soak_value:
+          type: integer
+          default: 0
+        probing_threshold:
+          type: integer
+          nullable: true
+        position_id:
+          type: integer
+          nullable: true
+      required:
+      - name
+      - threat_pool_id
+      - tier
     AggregateBeatContribution:
       type: object
       description: Read-only serializer for AggregateBeatContribution ledger rows.
@@ -39658,7 +39703,7 @@ components:
         description:
           type: string
         tier:
-          $ref: '#/components/schemas/OpponentTierEnum'
+          $ref: '#/components/schemas/Tier756Enum'
         health:
           type: integer
           maximum: 2147483647
@@ -39807,7 +39852,7 @@ components:
         description:
           type: string
         tier:
-          $ref: '#/components/schemas/OpponentTierEnum'
+          $ref: '#/components/schemas/Tier756Enum'
         health:
           type: integer
           maximum: 2147483647
@@ -39841,20 +39886,6 @@ components:
         * `active` - Active
         * `defeated` - Defeated
         * `fled` - Fled
-    OpponentTierEnum:
-      enum:
-      - swarm
-      - mook
-      - elite
-      - boss
-      - hero_killer
-      type: string
-      description: |-
-        * `swarm` - Swarm
-        * `mook` - Mook
-        * `elite` - Elite
-        * `boss` - Boss
-        * `hero_killer` - Hero Killer
     OptionKindEnum:
       enum:
       - branch
@@ -53835,6 +53866,20 @@ components:
         * `3` - Touched
         * `4` - Marked Profoundly
         * `5` - Remade
+    Tier756Enum:
+      enum:
+      - swarm
+      - mook
+      - elite
+      - boss
+      - hero_killer
+      type: string
+      description: |-
+        * `swarm` - Swarm
+        * `mook` - Mook
+        * `elite` - Elite
+        * `boss` - Boss
+        * `hero_killer` - Hero Killer
     TimePhaseEnum:
       enum:
       - dawn

--- a/src/world/areas/positioning/AGENT_GLOSSARY.md
+++ b/src/world/areas/positioning/AGENT_GLOSSARY.md
@@ -18,3 +18,7 @@ _Avoid_: fall, drop, falling
 
 **Knockback** (combat term, not positioning-owned):
 See `world/combat/AGENT_GLOSSARY.md` — positioning provides the `AWAY_FROM_ACTOR` destination primitive; combat owns the term and authoring surface.
+
+**Take a position** (#2005):
+An unplaced actor's voluntary first entry onto a room's position graph — restricted to PRIMARY/FEATURE positions (the ground entry kinds) and gated on the MOVEMENT capability, via `take_position()`/`TakePositionAction`/telnet `position <name>`. Distinct from moving (`move_to_position`, which requires already being placed and an edge to the destination) and from GM placement (`place_in_position`, the unchecked primitive that bypasses both restrictions).
+_Avoid_: enter a position, join the grid, spawn onto the graph

--- a/src/world/areas/positioning/services.py
+++ b/src/world/areas/positioning/services.py
@@ -483,6 +483,8 @@ _ERR_MOVE_UNPLACED = "You are not placed in any position yet."
 _ERR_MOVE_NO_PATH = "There is no path to there."
 _ERR_MOVE_BLOCKED = "The way is blocked."
 _ERR_MOVE_IMMOBILE = "You cannot move."
+_ERR_TAKE_ALREADY_PLACED = "You are already placed somewhere — move instead."
+_ERR_TAKE_NOT_ENTRY = "You cannot enter the position graph there."
 
 
 def place_in_position(objectdb: ObjectDB, position: Position) -> ObjectPosition:
@@ -498,6 +500,28 @@ def place_in_position(objectdb: ObjectDB, position: Position) -> ObjectPosition:
         defaults={"position": position},
     )
     return obj_pos
+
+
+_ENTRY_KINDS = (PositionKind.PRIMARY, PositionKind.FEATURE)
+
+
+def take_position(objectdb: ObjectDB, position: Position) -> ObjectPosition:
+    """Voluntary entry onto the position graph for an UNPLACED actor (#2005).
+
+    Restricted to ground entry-point kinds so voluntary entry can't bypass
+    gating challenges, blocks_flight, or chasm/fall semantics (spec Decision 1);
+    ELEVATED/AERIAL/etc. are reached through move_to_position / enter_aerial.
+    place_in_position stays the unchecked staff/system primitive.
+    """
+    if position.room_id != objectdb.db_location_id:
+        raise PositionError(_ERR_PLACE_CROSS_ROOM)
+    if position_of(objectdb) is not None:
+        raise PositionError(_ERR_TAKE_ALREADY_PLACED)
+    if position.kind not in _ENTRY_KINDS:
+        raise PositionError(_ERR_TAKE_NOT_ENTRY)
+    if not _can_move(objectdb):
+        raise PositionTransitionError(_ERR_MOVE_IMMOBILE)
+    return place_in_position(objectdb, position)
 
 
 def move_to_position(objectdb: ObjectDB, target: Position) -> ObjectPosition:

--- a/src/world/areas/positioning/tests/test_take_position.py
+++ b/src/world/areas/positioning/tests/test_take_position.py
@@ -1,0 +1,138 @@
+"""Tests for take_position — voluntary entry onto the position graph (#2005).
+
+Uses setUp (not setUpTestData): Evennia ObjectDB instances (DbHolder) are not
+deepcopyable and would break setUpTestData's copy step (see test_aerial.py).
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from django.test import TestCase
+
+from world.areas.positioning.constants import PositionKind
+from world.areas.positioning.exceptions import PositionError, PositionTransitionError
+from world.areas.positioning.services import (
+    create_position,
+    place_in_position,
+    position_of,
+    take_position,
+)
+
+
+class TakePositionEligibleKindTests(TestCase):
+    """PRIMARY and FEATURE positions are valid voluntary entry points."""
+
+    def setUp(self) -> None:
+        from evennia import create_object
+
+        from evennia_extensions.factories import CharacterFactory
+
+        self.room = create_object("typeclasses.rooms.Room", key="TakePosRoom", nohome=True)
+        self.primary = create_position(self.room, "throne", kind=PositionKind.PRIMARY)
+        self.feature = create_position(self.room, "hearth", kind=PositionKind.FEATURE)
+        self.actor = CharacterFactory(location=self.room)
+
+    def test_primary_position_succeeds(self) -> None:
+        obj_pos = take_position(self.actor, self.primary)
+        self.assertEqual(obj_pos.position_id, self.primary.pk)
+        self.assertEqual(position_of(self.actor).pk, self.primary.pk)
+
+    def test_feature_position_succeeds(self) -> None:
+        obj_pos = take_position(self.actor, self.feature)
+        self.assertEqual(obj_pos.position_id, self.feature.pk)
+        self.assertEqual(position_of(self.actor).pk, self.feature.pk)
+
+
+class TakePositionIneligibleKindTests(TestCase):
+    """Non-entry-point kinds (AERIAL/ELEVATED/CHASM/BARRIER_SIDE) reject voluntary entry."""
+
+    def setUp(self) -> None:
+        from evennia import create_object
+
+        from evennia_extensions.factories import CharacterFactory
+
+        self.room = create_object("typeclasses.rooms.Room", key="TakePosKindRoom", nohome=True)
+        self.actor = CharacterFactory(location=self.room)
+
+    def _assert_kind_rejected(self, kind: str) -> None:
+        position = create_position(self.room, f"pos_{kind}", kind=kind)
+        with self.assertRaises(PositionError):
+            take_position(self.actor, position)
+        self.assertIsNone(position_of(self.actor), f"{kind} entry must not place the actor")
+
+    def test_aerial_kind_raises(self) -> None:
+        self._assert_kind_rejected(PositionKind.AERIAL)
+
+    def test_elevated_kind_raises(self) -> None:
+        self._assert_kind_rejected(PositionKind.ELEVATED)
+
+    def test_chasm_kind_raises(self) -> None:
+        self._assert_kind_rejected(PositionKind.CHASM)
+
+    def test_barrier_side_kind_raises(self) -> None:
+        self._assert_kind_rejected(PositionKind.BARRIER_SIDE)
+
+
+class TakePositionAlreadyPlacedTests(TestCase):
+    """An actor already placed somewhere must be told to move instead."""
+
+    def setUp(self) -> None:
+        from evennia import create_object
+
+        from evennia_extensions.factories import CharacterFactory
+
+        self.room = create_object("typeclasses.rooms.Room", key="TakePosPlacedRoom", nohome=True)
+        self.first = create_position(self.room, "first", kind=PositionKind.PRIMARY)
+        self.second = create_position(self.room, "second", kind=PositionKind.FEATURE)
+        self.actor = CharacterFactory(location=self.room)
+        place_in_position(self.actor, self.first)
+
+    def test_already_placed_raises(self) -> None:
+        with self.assertRaises(PositionError) as ctx:
+            take_position(self.actor, self.second)
+        self.assertIn("move", ctx.exception.user_message.lower())
+        # The actor must remain at its original position.
+        self.assertEqual(position_of(self.actor).pk, self.first.pk)
+
+
+class TakePositionCrossRoomTests(TestCase):
+    """A position in a different room than the actor's location is rejected."""
+
+    def setUp(self) -> None:
+        from evennia import create_object
+
+        from evennia_extensions.factories import CharacterFactory
+
+        self.room = create_object("typeclasses.rooms.Room", key="TakePosCrossRoomA", nohome=True)
+        self.other_room = create_object(
+            "typeclasses.rooms.Room", key="TakePosCrossRoomB", nohome=True
+        )
+        self.other_position = create_position(
+            self.other_room, "elsewhere", kind=PositionKind.PRIMARY
+        )
+        self.actor = CharacterFactory(location=self.room)
+
+    def test_cross_room_raises(self) -> None:
+        with self.assertRaises(PositionError):
+            take_position(self.actor, self.other_position)
+        self.assertIsNone(position_of(self.actor))
+
+
+class TakePositionImmobileTests(TestCase):
+    """An actor that cannot move (MOVEMENT capability <= 0) cannot voluntarily enter."""
+
+    def setUp(self) -> None:
+        from evennia import create_object
+
+        from evennia_extensions.factories import CharacterFactory
+
+        self.room = create_object("typeclasses.rooms.Room", key="TakePosImmobileRoom", nohome=True)
+        self.position = create_position(self.room, "spot", kind=PositionKind.PRIMARY)
+        self.actor = CharacterFactory(location=self.room)
+
+    def test_immobile_actor_raises(self) -> None:
+        with mock.patch("world.areas.positioning.services._can_move", return_value=False):
+            with self.assertRaises(PositionTransitionError):
+                take_position(self.actor, self.position)
+        self.assertIsNone(position_of(self.actor))

--- a/src/world/combat/reach.py
+++ b/src/world/combat/reach.py
@@ -1,7 +1,8 @@
 """Positional reach predicate for combat technique targeting (Task 3 / #533).
 
 Wraps position_reachable with leniency for unpositioned rooms and combatants.
-A LATER task wires this into declare-time validation — do NOT call from services yet.
+Wired into declare-time validation via ``_validate_technique_reach``
+(``world/combat/services.py``), which is called from ``declare_action``.
 """
 
 from __future__ import annotations

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -1095,6 +1095,10 @@ class AddOpponentSerializer(serializers.Serializer):
     formula fills every stat field automatically (Task 5 auto-fill mode).
     All other stat fields are optional overrides.
 
+    ``position_id`` (#2005) is optional; when supplied it must name a Position
+    in the encounter's own room — validated against the encounter's room here
+    so a mismatched position never reaches the service layer.
+
     Expects ``encounter`` and ``request`` in serializer context (provided by the
     view) so that ``validate()`` can run the stakes gate.
     """
@@ -1109,9 +1113,11 @@ class AddOpponentSerializer(serializers.Serializer):
         required=False,
         allow_null=True,
     )
+    position_id = serializers.IntegerField(required=False, allow_null=True)
 
     def validate(self, attrs: dict) -> dict:
-        """Run stakes requirement gate for the encounter + requesting user."""
+        """Run stakes requirement gate + validate position_id against the encounter's room."""
+        from world.areas.positioning.models import Position  # noqa: PLC0415
         from world.combat.scaling import (  # noqa: PLC0415
             StakesRequirementError,
             validate_stakes_requirement,
@@ -1124,6 +1130,13 @@ class AddOpponentSerializer(serializers.Serializer):
                 validate_stakes_requirement(encounter, cast(AccountDB, request.user))
             except StakesRequirementError as exc:
                 raise serializers.ValidationError({"non_field_errors": exc.user_message}) from exc
+
+        position_id = attrs.get("position_id")
+        if position_id is not None and encounter is not None:
+            if not Position.objects.filter(pk=position_id, room=encounter.room).exists():
+                raise serializers.ValidationError(
+                    {"position_id": "That position is not in this encounter's room."}
+                )
         return attrs
 
 

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from actions.models.consequence_pools import ConsequencePool
     from flows.events.payloads import DamageSource
     from typeclasses.characters import Character
+    from world.areas.positioning.models import Position
     from world.character_sheets.models import CharacterSheet
     from world.checks.models import CheckType
     from world.checks.types import CheckResult, ModifierBreakdown, PendingResolution
@@ -1522,6 +1523,7 @@ def add_opponent(  # noqa: PLR0913 - opponent creation requires all stat fields
     auto_phases: bool = True,
     persona: Persona | None = None,
     existing_objectdb: ObjectDB | None = None,
+    position: Position | None = None,
 ) -> CombatOpponent:
     """Create a CombatOpponent. Three sources for the ObjectDB:
 
@@ -1537,6 +1539,11 @@ def add_opponent(  # noqa: PLR0913 - opponent creation requires all stat fields
     values always win over the formula.  Pass ``auto_phases=False`` to skip
     automatic ``BossPhase`` creation for BOSS-tier opponents (manual mode also
     creates no phases, since no block is computed).
+
+    ``position`` (#2005) places the resolved objectdb there via
+    ``place_in_position`` — the unchecked staging primitive, not the validated
+    voluntary-entry one — once the opponent's objectdb is known. Omitted
+    (default) leaves the opponent unplaced, matching legacy behavior.
     """
     from world.combat.scaling import compute_opponent_stat_block  # noqa: PLC0415
 
@@ -1590,6 +1597,15 @@ def add_opponent(  # noqa: PLR0913 - opponent creation requires all stat fields
     )
     opp.full_clean()
     opp.save()
+
+    if position is not None:
+        from typing import cast  # noqa: PLC0415
+
+        from world.areas.positioning.services import place_in_position  # noqa: PLC0415
+
+        # _resolve_objectdb_for_opponent is annotated tuple[object, bool];
+        # every branch actually returns an ObjectDB (Character or CombatNPC).
+        place_in_position(cast("ObjectDB", objectdb), position)
 
     # --- Auto-generate BossPhase rows from the computed block ---
     if tier == OpponentTier.BOSS and auto_phases and block is not None and block.phases:

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -1542,8 +1542,11 @@ def add_opponent(  # noqa: PLR0913 - opponent creation requires all stat fields
 
     ``position`` (#2005) places the resolved objectdb there via
     ``place_in_position`` — the unchecked staging primitive, not the validated
-    voluntary-entry one — once the opponent's objectdb is known. Omitted
-    (default) leaves the opponent unplaced, matching legacy behavior.
+    voluntary-entry one — once the opponent's objectdb is known. The room match
+    is validated *before* the ``CombatOpponent`` row is persisted, so a
+    cross-room ``position`` raises ``PositionError`` with no saved-but-unplaced
+    opponent left behind. Omitted (default) leaves the opponent unplaced,
+    matching legacy behavior.
     """
     from world.combat.scaling import compute_opponent_stat_block  # noqa: PLC0415
 
@@ -1573,6 +1576,18 @@ def add_opponent(  # noqa: PLR0913 - opponent creation requires all stat fields
     objectdb, is_ephemeral = _resolve_objectdb_for_opponent(
         encounter, name, persona, existing_objectdb
     )
+
+    if position is not None and position.room_id != objectdb.db_location_id:
+        # Validate the room match before persisting the CombatOpponent row below —
+        # the resolved objectdb is known now, so a bad position fails fast instead
+        # of leaving a saved-but-unplaced opponent behind a failure ActionResult
+        # (Task 4 fold-in, #2005). The post-save place_in_position call further
+        # down re-checks the identical invariant; it can no longer fail once
+        # execution reaches it.
+        from world.areas.positioning.exceptions import PositionError  # noqa: PLC0415
+
+        msg = "That position is not in the same room as the opponent."
+        raise PositionError(msg)
 
     opp = CombatOpponent(
         encounter=encounter,

--- a/src/world/combat/tests/test_add_opponent.py
+++ b/src/world/combat/tests/test_add_opponent.py
@@ -83,6 +83,33 @@ class AddOpponentTests(EvenniaTestCase):
         )
         self.assertEqual(position_of(opp.objectdb), position)
 
+    def test_add_opponent_cross_room_position_raises_before_persisting_opponent(self):
+        """Task 4 fold-in (#2005): a cross-room position must not orphan an opponent row."""
+        from world.areas.positioning.exceptions import PositionError
+        from world.areas.positioning.services import create_position
+        from world.combat.factories import CombatEncounterFactory, ThreatPoolFactory
+        from world.combat.models import CombatOpponent
+        from world.combat.services import add_opponent
+
+        encounter = CombatEncounterFactory()
+        pool = ThreatPoolFactory()
+        other_room = create_object("typeclasses.rooms.Room", key="OtherRoom", nohome=True)
+        position = create_position(other_room, "elsewhere")
+
+        with self.assertRaises(PositionError):
+            add_opponent(
+                encounter,
+                name="Misplaced Goblin",
+                tier="mook",
+                max_health=20,
+                threat_pool=pool,
+                position=position,
+            )
+
+        self.assertFalse(
+            CombatOpponent.objects.filter(encounter=encounter, name="Misplaced Goblin").exists()
+        )
+
     def test_add_opponent_without_position_leaves_objectdb_unplaced(self):
         """Backward compat: omitted position= leaves the opponent unplaced."""
         from world.combat.factories import CombatEncounterFactory, ThreatPoolFactory

--- a/src/world/combat/tests/test_add_opponent.py
+++ b/src/world/combat/tests/test_add_opponent.py
@@ -3,6 +3,8 @@
 from evennia import create_object
 from evennia.utils.test_resources import EvenniaTestCase
 
+from world.areas.positioning.services import position_of
+
 
 class AddOpponentTests(EvenniaTestCase):
     def test_add_opponent_creates_ephemeral_objectdb(self):
@@ -60,6 +62,43 @@ class AddOpponentTests(EvenniaTestCase):
         )
         self.assertFalse(opp.objectdb_is_ephemeral)
         self.assertEqual(opp.objectdb, existing)
+
+    def test_add_opponent_with_position_places_objectdb(self):
+        """Task 3 (#2005): passing position= places the resolved objectdb there."""
+        from world.areas.positioning.services import create_position
+        from world.combat.factories import CombatEncounterFactory, ThreatPoolFactory
+        from world.combat.services import add_opponent
+
+        encounter = CombatEncounterFactory()
+        pool = ThreatPoolFactory()
+        position = create_position(encounter.room, "spawn_pos")
+
+        opp = add_opponent(
+            encounter,
+            name="Positioned Goblin",
+            tier="mook",
+            max_health=20,
+            threat_pool=pool,
+            position=position,
+        )
+        self.assertEqual(position_of(opp.objectdb), position)
+
+    def test_add_opponent_without_position_leaves_objectdb_unplaced(self):
+        """Backward compat: omitted position= leaves the opponent unplaced."""
+        from world.combat.factories import CombatEncounterFactory, ThreatPoolFactory
+        from world.combat.services import add_opponent
+
+        encounter = CombatEncounterFactory()
+        pool = ThreatPoolFactory()
+
+        opp = add_opponent(
+            encounter,
+            name="Unplaced Goblin",
+            tier="mook",
+            max_health=20,
+            threat_pool=pool,
+        )
+        self.assertIsNone(position_of(opp.objectdb))
 
     def test_add_opponent_raises_when_no_room_for_ephemeral(self):
         from world.combat.factories import CombatEncounterFactory, ThreatPoolFactory

--- a/src/world/combat/tests/test_declare_reach_gate.py
+++ b/src/world/combat/tests/test_declare_reach_gate.py
@@ -168,6 +168,93 @@ class DeclareActionReachGateLenientTests(TestCase):
         self.assertEqual(action.focused_opponent_target, self.opponent)
 
 
+class DeclareActionReachGateSpawnedOpponentJourneyTests(TestCase):
+    """Journey payoff (#2005): reach gating binds for real combatants placed at
+    spawn time via ``add_opponent(position=...)`` — not just objects placed
+    after the fact via ``place_in_position``.
+    """
+
+    def setUp(self) -> None:
+        from evennia import create_object
+
+        self.room = create_object("typeclasses.rooms.Room", key="JourneyRoom", nohome=True)
+        self.pos_a = create_position(self.room, "journey_pos_a")
+        self.pos_b = create_position(self.room, "journey_pos_b")
+        self.pos_c = create_position(self.room, "journey_pos_c")
+        connect_positions(self.pos_a, self.pos_b, is_passable=True)
+        # pos_c is deliberately left unconnected to pos_a (non-adjacent).
+
+        self.effect_type = EffectTypeFactory(name="JourneyAtk", base_power=20)
+        self.gift = GiftFactory()
+
+        self.encounter = CombatEncounterFactory(
+            status=RoundStatus.DECLARING, round_number=1, room=self.room
+        )
+        self.participant = CombatParticipantFactory(encounter=self.encounter)
+        _wire_vitals(self.participant)
+
+        # PC placed at position A.
+        self.attacker_objectdb = self.participant.character_sheet.character
+        self.attacker_objectdb.move_to(self.room, quiet=True)
+        place_in_position(self.attacker_objectdb, self.pos_a)
+
+        self.technique = TechniqueFactory(
+            gift=self.gift,
+            effect_type=self.effect_type,
+            action_category=ActionCategory.PHYSICAL,
+            reach=TechniqueReach.ADJACENT,
+        )
+
+    def test_opponent_spawned_non_adjacent_is_out_of_reach(self) -> None:
+        """Opponent spawned at C (non-adjacent to A) is out of reach for ADJACENT."""
+        from world.combat.factories import ThreatPoolFactory
+        from world.combat.services import add_opponent
+
+        pool = ThreatPoolFactory()
+        opponent = add_opponent(
+            self.encounter,
+            name="Journey Foe (far)",
+            tier="mook",
+            max_health=20,
+            threat_pool=pool,
+            position=self.pos_c,
+        )
+
+        with self.assertRaises(ActionDispatchError) as cm:
+            declare_action(
+                self.participant,
+                focused_action=self.technique,
+                focused_category=ActionCategory.PHYSICAL,
+                effort_level=EffortLevel.MEDIUM,
+                focused_opponent_target=opponent,
+            )
+        self.assertEqual(cm.exception.code, ActionDispatchError.TARGET_OUT_OF_REACH)
+
+    def test_opponent_spawned_adjacent_is_accepted(self) -> None:
+        """Opponent spawned at B (adjacent to A) is accepted for ADJACENT reach."""
+        from world.combat.factories import ThreatPoolFactory
+        from world.combat.services import add_opponent
+
+        pool = ThreatPoolFactory()
+        opponent = add_opponent(
+            self.encounter,
+            name="Journey Foe (near)",
+            tier="mook",
+            max_health=20,
+            threat_pool=pool,
+            position=self.pos_b,
+        )
+
+        action = declare_action(
+            self.participant,
+            focused_action=self.technique,
+            focused_category=ActionCategory.PHYSICAL,
+            effort_level=EffortLevel.MEDIUM,
+            focused_opponent_target=opponent,
+        )
+        self.assertEqual(action.focused_opponent_target, opponent)
+
+
 class DispatchOutOfReachReturns400Tests(TestCase):
     """DispatchActionView returns HTTP 400 when technique reach is violated.
 

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -24,6 +24,7 @@ from actions.constants import ActionBackend
 from actions.errors import ActionDispatchError
 from actions.player_interface import dispatch_player_action
 from actions.types import ActionRef, ActionResult, DispatchResult
+from world.areas.positioning.models import Position
 from world.character_sheets.models import CharacterSheet
 from world.combat.constants import (
     ClashStatus,
@@ -363,6 +364,7 @@ class CombatEncounterViewSet(ModelViewSet):
         ]
         return self._serialize_encounter(request, encounter)
 
+    @extend_schema(request=AddOpponentSerializer)
     @action(detail=True, methods=[HTTPMethod.POST])
     def add_opponent(self, request: Request, pk: int | None = None) -> Response:
         """Add an NPC opponent to the encounter (GM action)."""
@@ -374,6 +376,10 @@ class CombatEncounterViewSet(ModelViewSet):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         pool = get_object_or_404(ThreatPool, pk=data["threat_pool_id"])
+        position = None
+        position_id = data.get("position_id")
+        if position_id is not None:
+            position = get_object_or_404(Position, pk=position_id)
         new_opponent = add_opponent(
             encounter,
             name=data["name"],
@@ -383,6 +389,7 @@ class CombatEncounterViewSet(ModelViewSet):
             description=data.get("description", ""),
             soak_value=data.get("soak_value", 0),
             probing_threshold=data.get("probing_threshold"),
+            position=position,
         )
         # Update cached opponent list in-place
         encounter.opponents_cached.append(new_opponent)

--- a/src/world/companions/services.py
+++ b/src/world/companions/services.py
@@ -128,11 +128,18 @@ def materialize_companion_as_combat_opponent(
 
     Returns:
         The created CombatOpponent (ALLY, sourced from archetype stats).
+
+    Position defaults to the owner's current position (#2005): a companion
+    fights at its owner's side unless placed otherwise. ``owner`` is a
+    CharacterSheet; ``owner.character`` is the ObjectDB OneToOne. Unplaced
+    owners (or unpositioned rooms) leave the companion unplaced too.
     """
+    from world.areas.positioning.services import position_of  # noqa: PLC0415
     from world.combat.constants import CombatAllegiance  # noqa: PLC0415
     from world.combat.services import add_opponent  # noqa: PLC0415
 
     archetype = companion.archetype
+    owner_position = position_of(companion.owner.character)
 
     opponent = add_opponent(
         encounter,
@@ -142,6 +149,7 @@ def materialize_companion_as_combat_opponent(
         max_health=archetype.max_health,
         soak_value=archetype.soak_value,
         existing_objectdb=companion.objectdb,
+        position=owner_position,
     )
 
     opponent.allegiance = CombatAllegiance.ALLY

--- a/src/world/companions/tests/test_combat_bridge.py
+++ b/src/world/companions/tests/test_combat_bridge.py
@@ -2,6 +2,7 @@
 
 from django.test import TestCase
 
+from world.areas.positioning.services import create_position, place_in_position, position_of
 from world.battles.constants import VehicleKind
 from world.battles.factories import BattleFactory, BattleSideFactory
 from world.combat.constants import CombatAllegiance
@@ -54,6 +55,36 @@ class MaterializeCompanionAsCombatOpponentTests(TestCase):
         self.assertEqual(opponent.tier, "elite")
         # The companion's objectdb is the opponent's ObjectDB (not ephemeral).
         self.assertEqual(opponent.objectdb, obj)
+
+    def test_defaults_to_owners_current_position(self):
+        """Task 3 (#2005): materialization places the companion at the owner's position."""
+        from evennia.utils.create import create_object
+
+        from typeclasses.companions import CompanionObject
+
+        archetype = CompanionArchetypeFactory(max_health=75, soak_value=12, tier="elite")
+        companion = CompanionFactory(archetype=archetype)
+
+        encounter = CombatEncounterFactory()
+        threat_pool = ThreatPoolFactory()
+
+        # Owner's character and the companion's objectdb both live in the encounter room.
+        owner_character = companion.owner.character
+        owner_character.move_to(encounter.room, quiet=True)
+        owner_position = create_position(encounter.room, "owner_pos")
+        place_in_position(owner_character, owner_position)
+
+        obj = create_object(CompanionObject, key=companion.name, location=encounter.room)
+        companion.objectdb = obj
+        companion.save(update_fields=["objectdb"])
+
+        opponent = materialize_companion_as_combat_opponent(
+            companion,
+            encounter,
+            threat_pool=threat_pool,
+        )
+
+        self.assertEqual(position_of(opponent.objectdb), owner_position)
 
 
 class MaterializeCompanionAsBattleVehicleTests(TestCase):


### PR DESCRIPTION
Closes #2005

## Summary

Tactical placement wiring (#2005): voluntary take_position entry (PRIMARY/FEATURE kinds, MOVEMENT-gated), GM place-in-position action (scene-GM gated, unchecked primitive), positioned opponent spawn (add_opponent position param + web/action passthrough + companion default), and the telnet position command — closing the no-voluntary-path-onto-the-position-graph hole. Journey test proves reach gating now binds (ADJACENT technique fails cross-room, succeeds adjacent). Per-task reviews ran on all 4 tasks (all approved; 3 fold-in fixes); the final whole-branch review pass was deliberately skipped for session wrap-up — CI + human PR review are the remaining gates.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2005 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: branch cut from da8857c6 (main HEAD at implementation start); not re-synced — merge queue re-tests on latest main

<!-- last-addressed-comment: 0 -->