### PR TITLE
Telnet weave for relationship threads (+ remaining anchor kinds) + own-bond ownership assertion

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -332,6 +332,8 @@ Powers, affinities, auras, resonances, threads-as-currency, rituals, and Mage Sc
   cardinality field `Technique.target_type`)
 - **Exceptions (used by services + views):** `AnchorCapExceeded`,
   `InvalidImbueAmount`, `ResonanceInsufficient`, `WeavingUnlockMissing`,
+  `RelationshipBondNotOwned` (weaving a RELATIONSHIP_TRACK/RELATIONSHIP_CAPSTONE
+  thread on a track/capstone row whose `relationship.source` isn't the weaver, #2033),
   `XPInsufficient`, `RitualComponentError`,
   `NoMatchingWornFacetItemsError` (FACET thread pull with no worn matching item),
   `InvalidCastTarget` (`world/magic/services/targeting.py`; raised by `validate_cast_target`

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -1405,8 +1405,15 @@ the legacy ThreadType lookup no longer exists.
   `character_sheet_id` — no implicit first-sheet selection.
 - Service functions raise typed exceptions with `user_message` properties
   (`AnchorCapExceeded`, `InvalidImbueAmount`, `ResonanceInsufficient`,
-  `WeavingUnlockMissing`, `XPInsufficient`, `RitualComponentError`). Views
-  surface those messages as HTTP 400 detail (never raw `str(exc)`).
+  `WeavingUnlockMissing`, `RelationshipBondNotOwned`, `XPInsufficient`,
+  `RitualComponentError`). Views surface those messages as HTTP 400 detail
+  (never raw `str(exc)`).
+- `weave_thread` asserts relationship-bond ownership for RELATIONSHIP_TRACK /
+  RELATIONSHIP_CAPSTONE anchors (`target.relationship.source == character_sheet`,
+  raising `RelationshipBondNotOwned`, #2033) — the unlock gate alone is not
+  sufficient because track-progress/capstone rows can belong to any
+  character's relationship. Guards both the web serializer path and the
+  telnet `weave` command, which converge on the same service.
 - `ThreadViewSet` uses `IsThreadOwner` permission plus ownership filtering
   in `get_queryset()`; staff see all.
 

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -1410,10 +1410,19 @@ the legacy ThreadType lookup no longer exists.
   (never raw `str(exc)`).
 - `weave_thread` asserts relationship-bond ownership for RELATIONSHIP_TRACK /
   RELATIONSHIP_CAPSTONE anchors (`target.relationship.source == character_sheet`,
-  raising `RelationshipBondNotOwned`, #2033) — the unlock gate alone is not
-  sufficient because track-progress/capstone rows can belong to any
-  character's relationship. Guards both the web serializer path and the
-  telnet `weave` command, which converge on the same service.
+  raising `RelationshipBondNotOwned`, #2033) **after** the `ThreadWeavingUnlock`
+  gate — the unlock gate alone is not sufficient because track-progress/capstone
+  rows can belong to any character's relationship, but ordering the ownership
+  check second means an unlocked-but-unauthorized direct-service caller sees
+  `WeavingUnlockMissing` first, never confirming a foreign row's existence.
+  This assertion is defense-in-depth for direct service callers only:
+  `ThreadSerializer._resolve_target` (web) and the telnet `_resolve_track_anchor`
+  /`_resolve_capstone_anchor` resolvers (`commands/weave.py`) both scope their
+  target lookup to `relationship__source=<requesting character_sheet>`, so
+  neither route can hand `weave_thread` a foreign row in the first place — a
+  foreign id 400s with the same "does not exist" message a bogus id would
+  produce, closing the existence/ownership oracle the unscoped lookup used to
+  expose (#2033 adversarial review fix).
 - `ThreadViewSet` uses `IsThreadOwner` permission plus ownership filtering
   in `get_queryset()`; staff see all.
 

--- a/frontend/src/magic/CLAUDE.md
+++ b/frontend/src/magic/CLAUDE.md
@@ -319,11 +319,12 @@ Confirmation dialog for retiring a thread. Calls `useRetireThread`.
 
 ### `components/threads/WeaveThreadWizard.tsx`
 
-Multi-step wizard for weaving a new thread. Step 1: select `TargetKind` (FACET and
-COVENANT_ROLE fully enabled; TRAIT/TECHNIQUE/Relationship stubbed "coming soon"). The
-bare ROOM anchor was removed (#879/#1199) — room-anchored threads now use the dedicated
-SANCTUM slot-based weaving flow, not this generic wizard. Step 2: select anchor.
-Step 3: name + description + confirm. Calls `useWeaveThread`.
+Multi-step wizard for weaving a new thread. Step 1: select `TargetKind` (TRAIT, TECHNIQUE,
+FACET, SANCTUM, COVENANT_ROLE, and RELATIONSHIP_TRACK are all live; RELATIONSHIP_CAPSTONE
+is the one kind still stubbed "coming soon", #2033). The bare ROOM anchor was removed
+(#879/#1199) — room-anchored threads now use the dedicated SANCTUM slot-based weaving flow,
+not this generic wizard. Step 2: select anchor. Step 3: name + description + confirm.
+Calls `useWeaveThread`.
 
 ### `components/threads/TeachingOfferCard.tsx`
 

--- a/src/actions/definitions/threads.py
+++ b/src/actions/definitions/threads.py
@@ -44,6 +44,8 @@ class WeaveThreadAction(Action):
         from world.covenants.exceptions import CovenantRoleNeverHeldError  # noqa: PLC0415
         from world.magic.exceptions import (  # noqa: PLC0415
             MantleNotClearedError,
+            RelationshipBondNotOwned,
+            TechniqueNotOwned,
             UnsupportedGiftResonanceError,
             WeavingUnlockMissing,
         )
@@ -64,6 +66,8 @@ class WeaveThreadAction(Action):
             CovenantRoleNeverHeldError,
             MantleNotClearedError,
             UnsupportedGiftResonanceError,
+            RelationshipBondNotOwned,
+            TechniqueNotOwned,
         ) as exc:
             return ActionResult(success=False, message=exc.user_message)
 

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -156,10 +156,22 @@ actions, backends, and service functions.
     any site. `parse_draft`: no-op (officiant supplies nothing extra at draft time).
   Unregistered rituals use the base `RitualDraftAdapter` (no-op empty parses — the behavior
   before adapters were introduced). `get_adapter(ritual)` is the public entry point.
-- **`weave.py`**: `CmdWeaveThread` (`weave`) — telnet face of `WeaveThreadAction`;
-  parses `weave resonance=<name> trait=<name or id> [name=<...>]` (TRAIT anchor only — the
-  reference grammar; other anchor kinds are extended by the thread-weaving journey
-  issue). Proves the direct-viewset→Action telnet pattern (#1337)
+- **`weave.py`**: `CmdWeaveThread` (`weave`) — telnet face of `WeaveThreadAction`; parses
+  `weave resonance=<name> <anchor>=<value> [name=<...>]`, one anchor kwarg per call (#2033
+  extends the original TRAIT-only reference grammar to mirror `ThreadSerializer
+  ._resolve_target`'s `TargetKind` coverage): `trait=<name or id>`,
+  `track=<partner>/<track name>` (the caller's OWN developed `RelationshipTrackProgress`
+  toward the named partner — partner name resolves via `search_or_raise`, the same
+  found/not-found/numbered-disambiguation convention every other command uses),
+  `capstone=<id or title>` (one of the caller's OWN recorded `RelationshipCapstone` rows),
+  `facet=<name or id>`, `technique=<name or id>` (signature thread; caller must know it),
+  `role=<name or id>` (covenant role), `mantle=<name or id>`. SANCTUM (own slot grammar,
+  `commands/sanctum.py`) and GIFT (CG/latent-provision only) are not reachable from this
+  generic grammar. `weave_thread` (`world/magic/services/threads.py`) asserts ownership on
+  the RELATIONSHIP_TRACK/RELATIONSHIP_CAPSTONE anchors (`relationship.source ==
+  character_sheet`, raising `RelationshipBondNotOwned`) — protects the web path too, since
+  both routes converge on the same service call. Proves the direct-viewset→Action telnet
+  pattern (#1337)
 - **`alterations.py`**: `CmdMageScar` (`magescar`) — telnet face of `ResolveAlterationAction` (#1490); lists and resolves pending Mage Scars by library template or scratch-authored fields. Uses namespaced `magescar list` / `magescar resolve <id> ...` subcommands.
 - **`imbue.py`**: `CmdImbue` (`imbue`) — finisher for the Rite of Imbuing CEREMONY;
   parses `imbue thread=<name|id> amount=<n>`. Requires an active `PendingRitualEffect`

--- a/src/commands/tests/test_weave_command.py
+++ b/src/commands/tests/test_weave_command.py
@@ -1,4 +1,4 @@
-"""Tests for CmdWeaveThread — the thin telnet shell over WeaveThreadAction (#1337)."""
+"""Tests for CmdWeaveThread — the thin telnet shell over WeaveThreadAction (#1337, #2033)."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase
 
+from commands.exceptions import CommandError
 from commands.weave import CmdWeaveThread
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.constants import TargetKind
@@ -16,6 +17,12 @@ from world.magic.factories import (
     WeavingCeremonyFactory,
 )
 from world.magic.models import PendingRitualEffect, Thread
+from world.relationships.factories import (
+    CharacterRelationshipFactory,
+    RelationshipCapstoneFactory,
+    RelationshipTrackFactory,
+    RelationshipTrackProgressFactory,
+)
 from world.traits.factories import TraitFactory
 
 
@@ -84,3 +91,212 @@ class CmdWeaveThreadTests(TestCase):
         PendingRitualEffect.objects.get_or_create(character=self.sheet, ritual=self.weaving_ritual)
         self._run(f"resonance=Embers trait={self.trait.pk}")
         self.assertTrue(Thread.objects.filter(owner=self.sheet, resonance=self.resonance).exists())
+
+    def test_specifying_two_anchors_reports_error(self) -> None:
+        self._run(f"resonance=Embers trait={self.trait.pk} facet=1")
+        self.assertFalse(Thread.objects.filter(owner=self.sheet, resonance=self.resonance).exists())
+        self.character.msg.assert_called()
+
+
+class CmdWeaveThreadRelationshipTrackTests(TestCase):
+    """``weave track=<partner>/<track name>`` — RELATIONSHIP_TRACK anchor (#2033)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.partner_sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory(name="Embers")
+        cls.track = RelationshipTrackFactory(name="Trust")
+        cls.relationship = CharacterRelationshipFactory(source=cls.sheet, target=cls.partner_sheet)
+        cls.progress = RelationshipTrackProgressFactory(
+            relationship=cls.relationship, track=cls.track, developed_points=10
+        )
+        unlock = ThreadWeavingUnlockFactory(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            unlock_trait=None,
+            unlock_track=cls.track,
+        )
+        CharacterThreadWeavingUnlockFactory(character=cls.sheet, unlock=unlock, xp_spent=100)
+        cls.weaving_ritual = WeavingCeremonyFactory()
+
+    def setUp(self) -> None:
+        self.character = self.sheet.character
+        self.character.msg = MagicMock()
+        self.character.search = MagicMock(return_value=self.partner_sheet.character)
+        PendingRitualEffect.objects.get_or_create(character=self.sheet, ritual=self.weaving_ritual)
+
+    def _run(self, args: str) -> None:
+        cmd = CmdWeaveThread()
+        cmd.caller = self.character
+        cmd.args = args
+        cmd.raw_string = f"weave {args}"
+        cmd.func()
+
+    def test_weave_creates_relationship_track_thread(self) -> None:
+        self._run("resonance=Embers track=Marcus/Trust")
+        self.assertTrue(
+            Thread.objects.filter(
+                owner=self.sheet,
+                resonance=self.resonance,
+                target_kind=TargetKind.RELATIONSHIP_TRACK,
+                target_relationship_track=self.progress,
+            ).exists()
+        )
+        self.character.msg.assert_called()
+
+    def test_weave_track_missing_slash_reports_error(self) -> None:
+        self._run("resonance=Embers track=Marcus")
+        self.assertFalse(Thread.objects.filter(owner=self.sheet).exists())
+        self.character.msg.assert_called()
+
+    def test_weave_track_unknown_partner_reports_error(self) -> None:
+        self.character.search = MagicMock(return_value=None)
+        self._run("resonance=Embers track=Nobody/Trust")
+        self.assertFalse(Thread.objects.filter(owner=self.sheet).exists())
+        self.character.msg.assert_called()
+
+    def test_weave_track_undeveloped_track_reports_error(self) -> None:
+        self._run("resonance=Embers track=Marcus/Respect")
+        self.assertFalse(Thread.objects.filter(owner=self.sheet).exists())
+        self.character.msg.assert_called()
+
+
+class CmdWeaveThreadRelationshipCapstoneTests(TestCase):
+    """``weave capstone=<id or title>`` — RELATIONSHIP_CAPSTONE anchor (#2033)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.partner_sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory(name="Embers")
+        cls.track = RelationshipTrackFactory(name="Trust")
+        cls.relationship = CharacterRelationshipFactory(source=cls.sheet, target=cls.partner_sheet)
+        cls.capstone = RelationshipCapstoneFactory(
+            relationship=cls.relationship,
+            author=cls.sheet,
+            track=cls.track,
+            title="TheVow",
+        )
+        unlock = ThreadWeavingUnlockFactory(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            unlock_trait=None,
+            unlock_track=cls.track,
+        )
+        CharacterThreadWeavingUnlockFactory(character=cls.sheet, unlock=unlock, xp_spent=100)
+        cls.weaving_ritual = WeavingCeremonyFactory()
+
+    def setUp(self) -> None:
+        self.character = self.sheet.character
+        self.character.msg = MagicMock()
+        PendingRitualEffect.objects.get_or_create(character=self.sheet, ritual=self.weaving_ritual)
+
+    def _run(self, args: str) -> None:
+        cmd = CmdWeaveThread()
+        cmd.caller = self.character
+        cmd.args = args
+        cmd.raw_string = f"weave {args}"
+        cmd.func()
+
+    def test_weave_creates_capstone_thread_by_id(self) -> None:
+        self._run(f"resonance=Embers capstone={self.capstone.pk}")
+        self.assertTrue(
+            Thread.objects.filter(
+                owner=self.sheet,
+                target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+                target_capstone=self.capstone,
+            ).exists()
+        )
+        self.character.msg.assert_called()
+
+    def test_weave_creates_capstone_thread_by_title(self) -> None:
+        self._run("resonance=Embers capstone=TheVow")
+        self.assertTrue(
+            Thread.objects.filter(
+                owner=self.sheet,
+                target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+                target_capstone=self.capstone,
+            ).exists()
+        )
+
+    def test_weave_capstone_unknown_reports_error(self) -> None:
+        self._run("resonance=Embers capstone=99999")
+        self.assertFalse(Thread.objects.filter(owner=self.sheet).exists())
+        self.character.msg.assert_called()
+
+
+class CmdWeaveThreadAnchorResolutionTests(TestCase):
+    """Direct ``resolve_action_args()`` calls proving each new anchor kwarg dispatches
+    to the correct ``TargetKind`` and resolves the right target object (#2033).
+
+    Full weave-success gating for these anchor kinds (unlock/ownership/mantle
+    clearance) is already covered by the service-level tests in
+    ``world/magic/tests/``; this class proves only the command-layer parsing +
+    resolution wiring this issue adds.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory(name="Embers")
+
+    def setUp(self) -> None:
+        self.character = self.sheet.character
+
+    def _cmd(self, args: str) -> CmdWeaveThread:
+        cmd = CmdWeaveThread()
+        cmd.caller = self.character
+        cmd.args = args
+        cmd.raw_string = f"weave {args}"
+        return cmd
+
+    def test_resolve_facet_anchor_by_id(self) -> None:
+        from world.magic.factories import FacetFactory
+
+        facet = FacetFactory()
+        result = self._cmd(f"resonance=Embers facet={facet.pk}").resolve_action_args()
+        self.assertEqual(result["target_kind"], TargetKind.FACET)
+        self.assertEqual(result["target"], facet)
+
+    def test_resolve_facet_anchor_unknown_reports_error(self) -> None:
+        with self.assertRaises(CommandError):
+            self._cmd("resonance=Embers facet=NoSuchFacet").resolve_action_args()
+
+    def test_resolve_technique_anchor_by_id(self) -> None:
+        from world.magic.factories import TechniqueFactory
+
+        technique = TechniqueFactory()
+        result = self._cmd(f"resonance=Embers technique={technique.pk}").resolve_action_args()
+        self.assertEqual(result["target_kind"], TargetKind.TECHNIQUE)
+        self.assertEqual(result["target"], technique)
+
+    def test_resolve_technique_anchor_unknown_reports_error(self) -> None:
+        with self.assertRaises(CommandError):
+            self._cmd("resonance=Embers technique=999999").resolve_action_args()
+
+    def test_resolve_role_anchor_by_id(self) -> None:
+        from world.covenants.factories import CovenantRoleFactory
+
+        role = CovenantRoleFactory()
+        result = self._cmd(f"resonance=Embers role={role.pk}").resolve_action_args()
+        self.assertEqual(result["target_kind"], TargetKind.COVENANT_ROLE)
+        self.assertEqual(result["target"], role)
+
+    def test_resolve_role_anchor_unknown_reports_error(self) -> None:
+        with self.assertRaises(CommandError):
+            self._cmd("resonance=Embers role=NoSuchRole").resolve_action_args()
+
+    def test_resolve_mantle_anchor_by_id(self) -> None:
+        from world.items.factories import MantleFactory
+
+        mantle = MantleFactory()
+        result = self._cmd(f"resonance=Embers mantle={mantle.pk}").resolve_action_args()
+        self.assertEqual(result["target_kind"], TargetKind.MANTLE)
+        self.assertEqual(result["target"], mantle)
+
+    def test_resolve_mantle_anchor_unknown_reports_error(self) -> None:
+        with self.assertRaises(CommandError):
+            self._cmd("resonance=Embers mantle=NoSuchMantle").resolve_action_args()
+
+    def test_specifying_no_anchor_reports_error(self) -> None:
+        with self.assertRaises(CommandError):
+            self._cmd("resonance=Embers").resolve_action_args()

--- a/src/commands/weave.py
+++ b/src/commands/weave.py
@@ -94,7 +94,9 @@ class CmdWeaveThread(ArxCommand):
         from world.magic.models import Resonance  # noqa: PLC0415
 
         args = self.require_args(
-            "Weave what? (weave resonance=<name> trait=<id> [name=<thread name>])"
+            "Weave what? (weave resonance=<name> "
+            "trait=|track=|capstone=|facet=|technique=|role=|mantle=<value> "
+            "[name=<thread name>])"
         )
         parsed = self._parse_kwargs(args)
 

--- a/src/commands/weave.py
+++ b/src/commands/weave.py
@@ -1,14 +1,33 @@
-"""Telnet ``weave`` command — the thin shell over WeaveThreadAction (#1337).
+"""Telnet ``weave`` command — the thin shell over WeaveThreadAction (#1337, #2033).
 
 Thin telnet face of ``actions.definitions.threads.WeaveThreadAction``. Parses
-``weave resonance=<name> trait=<name or id> [name=<thread name>]`` into the action's
-kwargs and delegates; all eligibility/creation logic lives in the action + the
-``weave_thread`` service. The web path uses the same action via the thread viewset.
+``weave resonance=<name> <anchor>=<value> [name=<thread name>]`` into the
+action's kwargs and delegates; all eligibility/creation logic lives in the
+action + the ``weave_thread`` service. The web path uses the same action via
+the thread viewset — ``ThreadSerializer._resolve_target``
+(``world/magic/serializers.py``) performs the matching target resolution for
+the web POST body; this command mirrors its ``TargetKind`` coverage.
 
-Reference-grammar scope: the worked example supports the **TRAIT** anchor only
-(``trait=<name or id>``). Other anchor kinds (covenant role, facet, mantle, technique,
-relationship track/capstone, sanctum) are extended by the thread-weaving journey
-issue — this command is the direct-viewset→Action telnet pattern proof.
+Supported anchor kwargs (exactly one required per invocation):
+    ``trait=<name or id>``            — TargetKind.TRAIT
+    ``track=<partner>/<track name>``  — TargetKind.RELATIONSHIP_TRACK (the
+        caller's OWN developed ``RelationshipTrackProgress`` toward the named
+        partner; the partner name resolves via Evennia's standard
+        ``search()`` — ambiguous names get the usual numbered-disambiguation
+        message)
+    ``capstone=<id or title>``        — TargetKind.RELATIONSHIP_CAPSTONE (one
+        of the caller's OWN recorded capstones)
+    ``facet=<name or id>``            — TargetKind.FACET
+    ``technique=<name or id>``        — TargetKind.TECHNIQUE (signature
+        thread; the caller must already know the technique)
+    ``role=<name or id>``             — TargetKind.COVENANT_ROLE
+    ``mantle=<name or id>``           — TargetKind.MANTLE
+
+Not reachable from this generic grammar: SANCTUM (woven via ``sanctum
+weave``, a room-anchored verb with its own slot grammar — see
+``commands/sanctum.py``) and GIFT (committed automatically via
+``provision_latent_gift_thread`` / the species-gift pipeline, never authored
+freehand by name/id).
 """
 
 from __future__ import annotations
@@ -23,23 +42,47 @@ from commands.exceptions import CommandError
 # rest of the line so thread names may contain spaces.
 _RESONANCE_KWARG = "resonance"
 _TRAIT_KWARG = "trait"
+_TRACK_KWARG = "track"
+_CAPSTONE_KWARG = "capstone"
+_FACET_KWARG = "facet"
+_TECHNIQUE_KWARG = "technique"
+_ROLE_KWARG = "role"
+_MANTLE_KWARG = "mantle"
 _NAME_KWARG = "name"
+
+# Every recognized anchor-kind kwarg, in the order shown to players on error.
+_ANCHOR_KWARGS: tuple[str, ...] = (
+    _TRAIT_KWARG,
+    _TRACK_KWARG,
+    _CAPSTONE_KWARG,
+    _FACET_KWARG,
+    _TECHNIQUE_KWARG,
+    _ROLE_KWARG,
+    _MANTLE_KWARG,
+)
 
 
 class CmdWeaveThread(ArxCommand):
-    """Weave a new thread anchored to a trait you are unlocked for.
+    """Weave a new thread anchored to something you are unlocked for.
 
-    Telnet grammar (TRAIT anchor only; the journey issue extends other kinds):
-        ``weave resonance=<name> trait=<name or id>``
-        ``weave resonance=<name> trait=<name or id> name=<thread name>``
+    Telnet grammar (exactly one anchor kwarg per invocation):
+        ``weave resonance=<name> trait=<name or id> [name=<thread name>]``
+        ``weave resonance=<name> track=<partner>/<track name> [name=<...>]``
+        ``weave resonance=<name> capstone=<id or title> [name=<...>]``
+        ``weave resonance=<name> facet=<name or id> [name=<...>]``
+        ``weave resonance=<name> technique=<name or id> [name=<...>]``
+        ``weave resonance=<name> role=<name or id> [name=<...>]``
+        ``weave resonance=<name> mantle=<name or id> [name=<...>]``
 
-    Example:
+    Examples:
         ``weave resonance=Embers trait=Bravery name=Ember of the First Hearth``
         ``weave resonance=Embers trait=5 name=Ember of the First Hearth``
+        ``weave resonance=Embers track=Marcus/Trust name=Bound to Marcus``
 
-    ``resonance`` and ``trait`` are required; ``name`` is optional and captures
-    the rest of the line (so it may contain spaces). The thread's resonance and
-    trait anchor are resolved here; everything else is the action's concern.
+    ``resonance`` and exactly one anchor kwarg are required; ``name`` is
+    optional and captures the rest of the line (so it may contain spaces).
+    The thread's resonance and anchor are resolved here; everything else is
+    the action's concern.
     """
 
     key = "weave"
@@ -47,10 +90,8 @@ class CmdWeaveThread(ArxCommand):
     action = WeaveThreadAction()
 
     def resolve_action_args(self) -> dict[str, Any]:
-        """Parse ``weave resonance=<name> trait=<name or id> [name=<...>]`` into action kwargs."""
-        from world.magic.constants import TargetKind  # noqa: PLC0415
+        """Parse ``weave resonance=<name> <anchor>=<value> [name=<...>]`` into action kwargs."""
         from world.magic.models import Resonance  # noqa: PLC0415
-        from world.traits.models import Trait  # noqa: PLC0415
 
         args = self.require_args(
             "Weave what? (weave resonance=<name> trait=<id> [name=<thread name>])"
@@ -66,30 +107,153 @@ class CmdWeaveThread(ArxCommand):
             msg = f"There is no resonance called '{resonance_name}'."
             raise CommandError(msg)
 
-        trait_val = parsed.get(_TRAIT_KWARG, "").strip()
-        if not trait_val:
-            msg = "Specify a trait anchor: trait=<name or id>."
+        present = [kwarg for kwarg in _ANCHOR_KWARGS if parsed.get(kwarg, "").strip()]
+        if not present:
+            options = ", ".join(f"{kwarg}=" for kwarg in _ANCHOR_KWARGS)
+            msg = f"Specify an anchor: {options}."
             raise CommandError(msg)
-        trait = self.resolve_by_name_or_id(
-            Trait,
-            trait_val,
-            not_found_msg=f"No trait found for '{trait_val}'.",
-        )
+        if len(present) > 1:
+            msg = f"Specify only one anchor kwarg at a time ({', '.join(present)} given)."
+            raise CommandError(msg)
+        anchor_kwarg = present[0]
+        anchor_value = parsed[anchor_kwarg].strip()
+        target_kind, target = self._resolve_anchor(anchor_kwarg, anchor_value)
 
         return {
-            "target_kind": TargetKind.TRAIT,
-            "target": trait,
+            "target_kind": target_kind,
+            "target": target,
             "resonance": resonance,
             "name": parsed.get(_NAME_KWARG, "").strip(),
         }
+
+    def _resolve_anchor(self, anchor_kwarg: str, value: str) -> tuple[str, Any]:
+        """Dispatch to the per-anchor-kind resolver; returns ``(target_kind, target)``."""
+        resolvers = {
+            _TRAIT_KWARG: self._resolve_trait_anchor,
+            _TRACK_KWARG: self._resolve_track_anchor,
+            _CAPSTONE_KWARG: self._resolve_capstone_anchor,
+            _FACET_KWARG: self._resolve_facet_anchor,
+            _TECHNIQUE_KWARG: self._resolve_technique_anchor,
+            _ROLE_KWARG: self._resolve_role_anchor,
+            _MANTLE_KWARG: self._resolve_mantle_anchor,
+        }
+        return resolvers[anchor_kwarg](value)
+
+    def _resolve_trait_anchor(self, value: str) -> tuple[str, Any]:
+        from world.magic.constants import TargetKind  # noqa: PLC0415
+        from world.traits.models import Trait  # noqa: PLC0415
+
+        trait = self.resolve_by_name_or_id(
+            Trait, value, not_found_msg=f"No trait found for '{value}'."
+        )
+        return TargetKind.TRAIT, trait
+
+    def _resolve_facet_anchor(self, value: str) -> tuple[str, Any]:
+        from world.magic.constants import TargetKind  # noqa: PLC0415
+        from world.magic.models import Facet  # noqa: PLC0415
+
+        facet = self.resolve_by_name_or_id(
+            Facet, value, not_found_msg=f"No facet found for '{value}'."
+        )
+        return TargetKind.FACET, facet
+
+    def _resolve_technique_anchor(self, value: str) -> tuple[str, Any]:
+        from world.magic.constants import TargetKind  # noqa: PLC0415
+        from world.magic.models import Technique  # noqa: PLC0415
+
+        technique = self.resolve_by_name_or_id(
+            Technique, value, not_found_msg=f"No technique found for '{value}'."
+        )
+        return TargetKind.TECHNIQUE, technique
+
+    def _resolve_role_anchor(self, value: str) -> tuple[str, Any]:
+        from world.covenants.models import CovenantRole  # noqa: PLC0415
+        from world.magic.constants import TargetKind  # noqa: PLC0415
+
+        role = self.resolve_by_name_or_id(
+            CovenantRole, value, not_found_msg=f"No covenant role found for '{value}'."
+        )
+        return TargetKind.COVENANT_ROLE, role
+
+    def _resolve_mantle_anchor(self, value: str) -> tuple[str, Any]:
+        from world.items.models import Mantle  # noqa: PLC0415
+        from world.magic.constants import TargetKind  # noqa: PLC0415
+
+        mantle = self.resolve_by_name_or_id(
+            Mantle, value, not_found_msg=f"No mantle found for '{value}'."
+        )
+        return TargetKind.MANTLE, mantle
+
+    def _resolve_capstone_anchor(self, value: str) -> tuple[str, Any]:
+        """Resolve one of the CALLER's OWN recorded ``RelationshipCapstone`` rows."""
+        from world.magic.constants import TargetKind  # noqa: PLC0415
+        from world.relationships.models import RelationshipCapstone  # noqa: PLC0415
+
+        sheet = self.caller.sheet_data
+        capstone = self.resolve_by_name_or_id(
+            RelationshipCapstone,
+            value,
+            field="title",
+            not_found_msg=f"You have no recorded capstone matching '{value}'.",
+            relationship__source=sheet,
+        )
+        return TargetKind.RELATIONSHIP_CAPSTONE, capstone
+
+    def _resolve_track_anchor(self, value: str) -> tuple[str, Any]:
+        """Resolve the CALLER's OWN ``RelationshipTrackProgress`` toward a named partner.
+
+        Grammar: ``track=<partner>/<track name>`` — a single whitespace-delimited
+        token split on the first ``/``. Partner-name ambiguity is reported via
+        ``search_or_raise`` — the same Evennia ``search()``
+        found/not-found/numbered-disambiguation convention every other
+        command uses (e.g. ``CmdRelationship._resolve_target_sheet``).
+        """
+        from world.magic.constants import TargetKind  # noqa: PLC0415
+        from world.relationships.models import RelationshipTrackProgress  # noqa: PLC0415
+
+        partner_token, sep, track_name = value.partition("/")
+        partner_token = partner_token.strip()
+        track_name = track_name.strip()
+        if not sep or not partner_token or not track_name:
+            msg = "Specify track=<partner>/<track name>."
+            raise CommandError(msg)
+
+        partner = self.search_or_raise(
+            partner_token, not_found_msg=f"Could not find '{partner_token}'."
+        )
+        # Same shape as CmdRelationship._resolve_target_sheet: non-character
+        # objects have no sheet_data attribute / row.
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        try:
+            partner_sheet = partner.sheet_data
+        except (AttributeError, ObjectDoesNotExist) as exc:
+            msg = f"'{partner_token}' has no character sheet."
+            raise CommandError(msg) from exc
+        if partner_sheet is None:
+            msg = f"'{partner_token}' has no character sheet."
+            raise CommandError(msg)
+
+        sheet = self.caller.sheet_data
+        progress = RelationshipTrackProgress.objects.filter(
+            relationship__source=sheet,
+            relationship__target=partner_sheet,
+            track__name__iexact=track_name,
+        ).first()
+        if progress is None:
+            msg = f"You have no developed '{track_name}' track with {partner_token}."
+            raise CommandError(msg)
+        return TargetKind.RELATIONSHIP_TRACK, progress
 
     @staticmethod
     def _parse_kwargs(args: str) -> dict[str, str]:
         """Parse ``key=value`` tokens, left to right.
 
-        ``resonance`` and ``trait`` are single whitespace-delimited tokens; once a
-        ``name=`` token is seen, the remainder of the line (including spaces) is its
-        value, so thread names may contain spaces.
+        Every anchor kwarg (``trait``/``track``/``capstone``/``facet``/
+        ``technique``/``role``/``mantle``) plus ``resonance`` are single
+        whitespace-delimited tokens; once a ``name=`` token is seen, the
+        remainder of the line (including spaces) is its value, so thread
+        names may contain spaces.
         """
         out: dict[str, str] = {}
         tokens = args.split()

--- a/src/integration_tests/pipeline/test_weave_relationship_track_e2e.py
+++ b/src/integration_tests/pipeline/test_weave_relationship_track_e2e.py
@@ -1,0 +1,149 @@
+"""Telnet E2E: weaving a RELATIONSHIP_TRACK thread + imbuing it (#2033).
+
+Proves the ``weave track=<partner>/<track name>`` grammar added by #2033 reaches
+the real ``WeaveThreadAction`` → ``weave_thread`` seam exactly like the
+TRAIT-anchored reference grammar (#1337), and that the kind-agnostic
+``imbue`` finisher accepts the resulting thread with no special-casing.
+
+Steps:
+  1. CmdRitual → Rite of Weaving ceremony  → PendingRitualEffect (weaving)
+  2. CmdWeaveThread → ``weave resonance=<r> track=<partner>/<track>``
+     → RELATIONSHIP_TRACK Thread row created, anchored to the caller's OWN
+       ``RelationshipTrackProgress`` toward the partner, effect consumed
+  3. CmdRitual → Rite of Imbuing ceremony  → PendingRitualEffect (imbuing)
+  4. CmdImbue → imbue the woven thread     → developed_points advances,
+     effect consumed (imbue is kind-agnostic — no RELATIONSHIP_TRACK-specific
+     code path exists or is needed)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.imbue import CmdImbue
+from commands.ritual import CmdRitual
+from commands.weave import CmdWeaveThread
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.constants import TargetKind
+from world.magic.factories import (
+    CharacterResonanceFactory,
+    CharacterThreadWeavingUnlockFactory,
+    ImbuingRitualFactory,
+    ResonanceFactory,
+    ThreadWeavingUnlockFactory,
+    WeavingCeremonyFactory,
+)
+from world.magic.models import PendingRitualEffect, Thread
+from world.relationships.factories import (
+    CharacterRelationshipFactory,
+    RelationshipTrackFactory,
+    RelationshipTrackProgressFactory,
+)
+
+
+class WeaveRelationshipTrackImbueE2ETests(TestCase):
+    """RELATIONSHIP_TRACK weave, end to end via telnet, then imbued."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.partner_sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory(name="Embers")
+        cls.track = RelationshipTrackFactory(name="Trust")
+
+        cls.relationship = CharacterRelationshipFactory(source=cls.sheet, target=cls.partner_sheet)
+        # developed_points=50 → anchor_cap=50 (RELATIONSHIP_TRACK anchor cap is
+        # the track-progress row's own developed_points), plenty of room for
+        # the level-0 → 5 imbue advance below.
+        cls.progress = RelationshipTrackProgressFactory(
+            relationship=cls.relationship, track=cls.track, developed_points=50
+        )
+
+        unlock = ThreadWeavingUnlockFactory(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            unlock_trait=None,
+            unlock_track=cls.track,
+        )
+        CharacterThreadWeavingUnlockFactory(character=cls.sheet, unlock=unlock, xp_spent=100)
+
+        cls.weaving_ritual = WeavingCeremonyFactory()
+        cls.imbuing_ritual = ImbuingRitualFactory()
+
+        # Resonance balance: enough to imbue (amount=5).
+        CharacterResonanceFactory(
+            character_sheet=cls.sheet,
+            resonance=cls.resonance,
+            balance=20,
+            lifetime_earned=20,
+        )
+
+    def _cmd_ritual(self, character: object, ritual_name: str) -> None:
+        cmd = CmdRitual()
+        cmd.caller = character
+        cmd.args = ritual_name
+        cmd.raw_string = f"ritual {ritual_name}"
+        cmd.func()
+
+    def test_weave_relationship_track_then_imbue(self) -> None:
+        character = self.sheet.character
+        character.msg = MagicMock()
+        character.search = MagicMock(return_value=self.partner_sheet.character)
+
+        # Step 1: Rite of Weaving ceremony.
+        self._cmd_ritual(character, self.weaving_ritual.name)
+        self.assertTrue(
+            PendingRitualEffect.objects.filter(
+                character=self.sheet, ritual=self.weaving_ritual
+            ).exists(),
+            "Step 1: PendingRitualEffect for Rite of Weaving must exist after ceremony.",
+        )
+
+        # Step 2: weave the RELATIONSHIP_TRACK thread via the real telnet command.
+        cmd = CmdWeaveThread()
+        cmd.caller = character
+        cmd.args = "resonance=Embers track=Partner/Trust name=Bound to Partner"
+        cmd.raw_string = f"weave {cmd.args}"
+        cmd.func()
+
+        thread = Thread.objects.get(owner=self.sheet, name="Bound to Partner")
+        self.assertEqual(thread.target_kind, TargetKind.RELATIONSHIP_TRACK)
+        self.assertEqual(thread.target_relationship_track, self.progress)
+        self.assertEqual(thread.resonance, self.resonance)
+        self.assertFalse(
+            PendingRitualEffect.objects.filter(
+                character=self.sheet, ritual=self.weaving_ritual
+            ).exists(),
+            "Step 2: PendingRitualEffect for Rite of Weaving must be consumed after weave.",
+        )
+
+        # Step 3: Rite of Imbuing ceremony.
+        self._cmd_ritual(character, self.imbuing_ritual.name)
+        self.assertTrue(
+            PendingRitualEffect.objects.filter(
+                character=self.sheet, ritual=self.imbuing_ritual
+            ).exists(),
+            "Step 3: PendingRitualEffect for Rite of Imbuing must exist after ceremony.",
+        )
+
+        # Step 4: imbue — kind-agnostic finisher accepts the RELATIONSHIP_TRACK thread.
+        level_before = thread.level  # 0
+        cmd_imbue = CmdImbue()
+        cmd_imbue.caller = character
+        cmd_imbue.args = "thread=Bound to Partner amount=5"
+        cmd_imbue.raw_string = f"imbue {cmd_imbue.args}"
+        cmd_imbue.func()
+
+        thread.refresh_from_db()
+        self.assertGreater(
+            thread.level,
+            level_before,
+            "Step 4: Thread level must advance after imbuing 5 resonance.",
+        )
+        self.assertFalse(
+            PendingRitualEffect.objects.filter(
+                character=self.sheet, ritual=self.imbuing_ritual
+            ).exists(),
+            "Step 4: PendingRitualEffect for Rite of Imbuing must be consumed after imbue.",
+        )

--- a/src/world/magic/exceptions.py
+++ b/src/world/magic/exceptions.py
@@ -451,6 +451,17 @@ class TechniqueNotOwned(MagicError):
     user_message = "You do not know this technique."
 
 
+class RelationshipBondNotOwned(MagicError):
+    """Raised when weaving a RELATIONSHIP_TRACK/RELATIONSHIP_CAPSTONE thread on a
+    relationship-track or capstone row the weaving character does not itself hold
+    (i.e. the row's ``relationship.source`` is a different CharacterSheet, #2033).
+    Protects both the telnet and web (``ThreadSerializer``) weave paths — the two
+    relationship-kind anchors are the only ones whose owning row can belong to
+    someone else's relationship."""
+
+    user_message = "That isn't your own relationship bond to weave a thread on."
+
+
 # =============================================================================
 # Signature-bonus selection exceptions (#1582)
 # =============================================================================

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -843,12 +843,29 @@ class ThreadSerializer(serializers.ModelSerializer):
         target_id = attrs.get("target_id")
         if target_kind is None or target_id is None:
             return attrs
-        attrs["_target"] = self._resolve_target(target_kind, target_id)
+        # ``character_sheet_id`` is already resolved to a CharacterSheet instance by
+        # validate_character_sheet_id (field-level validators run before this
+        # object-level validate()). Required to scope the RELATIONSHIP_TRACK/
+        # RELATIONSHIP_CAPSTONE lookup below to the requester's own rows (#2033).
+        character_sheet = attrs.get("character_sheet_id")
+        attrs["_target"] = self._resolve_target(target_kind, target_id, character_sheet)
         return attrs
 
     @staticmethod
-    def _resolve_target(target_kind: str, target_id: int) -> object:
-        """Look up the target model instance for a given (target_kind, target_id)."""
+    def _resolve_target(
+        target_kind: str, target_id: int, character_sheet: CharacterSheet | None
+    ) -> object:
+        """Look up the target model instance for a given (target_kind, target_id).
+
+        For RELATIONSHIP_TRACK/RELATIONSHIP_CAPSTONE, the lookup is scoped to rows
+        owned by ``character_sheet`` (mirrors the telnet resolvers
+        ``_resolve_track_anchor``/``_resolve_capstone_anchor`` in ``commands/weave.py``).
+        Without this, any authenticated player could probe foreign relationship rows
+        by id and distinguish "doesn't exist" from "exists but isn't mine" from the
+        error message/status alone — an existence/ownership oracle over other
+        players' secret relationship rows (#2033). Scoping the query means a foreign
+        row now 404s exactly like a nonexistent one.
+        """
         # In-function imports avoid app-boot circular deps (magic ↔ traits ↔ relationships).
         from world.covenants.models import CovenantRole  # noqa: PLC0415
         from world.items.models import Mantle  # noqa: PLC0415
@@ -877,8 +894,11 @@ class ThreadSerializer(serializers.ModelSerializer):
         if model is None:
             msg = f"Unsupported target_kind: {target_kind!r}."
             raise serializers.ValidationError(msg)
+        lookup: dict[str, object] = {"pk": target_id}
+        if target_kind in (TargetKind.RELATIONSHIP_TRACK, TargetKind.RELATIONSHIP_CAPSTONE):
+            lookup["relationship__source"] = character_sheet
         try:
-            return model.objects.get(pk=target_id)
+            return model.objects.get(**lookup)
         except model.DoesNotExist as exc:
             msg = f"{target_kind} target with id={target_id} does not exist."
             raise serializers.ValidationError(msg) from exc

--- a/src/world/magic/services/threads.py
+++ b/src/world/magic/services/threads.py
@@ -31,6 +31,7 @@ from world.magic.exceptions import (
     AnchorCapExceeded,
     InvalidImbueAmount,
     MantleNotClearedError,
+    RelationshipBondNotOwned,
     WeavingUnlockMissing,
     XPInsufficient,
 )
@@ -479,7 +480,7 @@ def _has_weaving_unlock(
 
 
 @transaction.atomic
-def weave_thread(  # noqa: PLR0913
+def weave_thread(  # noqa: PLR0913, C901
     character_sheet: CharacterSheet,
     target_kind: str,
     target: object,
@@ -509,6 +510,9 @@ def weave_thread(  # noqa: PLR0913
         WeavingUnlockMissing: If the character lacks the required weaving unlock.
         CovenantRoleNeverHeldError: If target_kind is COVENANT_ROLE and the
                 character has never held the role.
+        RelationshipBondNotOwned: If target_kind is RELATIONSHIP_TRACK or
+                RELATIONSHIP_CAPSTONE and the target's relationship is not the
+                weaving character's own (relationship.source != character_sheet).
     """
     from world.magic.constants import TargetKind  # noqa: PLC0415
 
@@ -516,6 +520,14 @@ def weave_thread(  # noqa: PLR0913
         return _weave_gift_thread(
             character_sheet, target, resonance, name=name, description=description
         )
+    if target_kind in (TargetKind.RELATIONSHIP_TRACK, TargetKind.RELATIONSHIP_CAPSTONE):
+        # Both RelationshipTrackProgress and RelationshipCapstone expose
+        # ``.relationship``; only the relationship's own source may weave a
+        # thread on it — the unlock check below is necessary but not
+        # sufficient (#2033), since the two rows can belong to ANY
+        # character's relationship, not just the caller's.
+        if target.relationship.source_id != character_sheet.pk:  # type: ignore[union-attr]
+            raise RelationshipBondNotOwned
     if target_kind == TargetKind.COVENANT_ROLE:
         from world.covenants.exceptions import CovenantRoleNeverHeldError  # noqa: PLC0415
 

--- a/src/world/magic/services/threads.py
+++ b/src/world/magic/services/threads.py
@@ -520,14 +520,6 @@ def weave_thread(  # noqa: PLR0913, C901
         return _weave_gift_thread(
             character_sheet, target, resonance, name=name, description=description
         )
-    if target_kind in (TargetKind.RELATIONSHIP_TRACK, TargetKind.RELATIONSHIP_CAPSTONE):
-        # Both RelationshipTrackProgress and RelationshipCapstone expose
-        # ``.relationship``; only the relationship's own source may weave a
-        # thread on it — the unlock check below is necessary but not
-        # sufficient (#2033), since the two rows can belong to ANY
-        # character's relationship, not just the caller's.
-        if target.relationship.source_id != character_sheet.pk:  # type: ignore[union-attr]
-            raise RelationshipBondNotOwned
     if target_kind == TargetKind.COVENANT_ROLE:
         from world.covenants.exceptions import CovenantRoleNeverHeldError  # noqa: PLC0415
 
@@ -545,6 +537,21 @@ def weave_thread(  # noqa: PLR0913, C901
     elif not _has_weaving_unlock(character_sheet, target_kind, target):
         msg = "Character lacks the required ThreadWeavingUnlock for this anchor."
         raise WeavingUnlockMissing(msg)
+
+    if target_kind in (TargetKind.RELATIONSHIP_TRACK, TargetKind.RELATIONSHIP_CAPSTONE):
+        # Both RelationshipTrackProgress and RelationshipCapstone expose
+        # ``.relationship``; only the relationship's own source may weave a
+        # thread on it. Checked AFTER the unlock gate above (#2033 adversarial
+        # review): this is defense-in-depth for direct service callers only —
+        # the API (ThreadSerializer._resolve_target) now scopes its lookup to
+        # the requester's own rows, and the telnet resolvers
+        # (_resolve_track_anchor/_resolve_capstone_anchor in commands/weave.py)
+        # are already scoped, so neither can reach this branch with a foreign
+        # row. Ordering it after the unlock check means an unlocked-but-
+        # unauthorized caller sees WeavingUnlockMissing first, never learning
+        # whether the foreign row even exists.
+        if target.relationship.source_id != character_sheet.pk:  # type: ignore[union-attr]
+            raise RelationshipBondNotOwned
 
     # A signature (TECHNIQUE) thread requires that the character actually knows
     # the technique being signed (#1582).

--- a/src/world/magic/tests/test_api.py
+++ b/src/world/magic/tests/test_api.py
@@ -278,6 +278,96 @@ class ThreadViewSetTests(APITestCase):
         self.assertIn("FACET", str(response.data))
 
     # ------------------------------------------------------------------
+    # RELATIONSHIP_TRACK ownership tests (#2033)
+    # ------------------------------------------------------------------
+
+    def test_create_relationship_track_thread_rejects_foreign_ownership(self) -> None:
+        """The web path must reject weaving a RELATIONSHIP_TRACK thread on a
+        track-progress row belonging to SOMEONE ELSE's relationship, even
+        though the requesting sheet holds a matching RELATIONSHIP_TRACK
+        ThreadWeavingUnlock — ``ThreadSerializer`` previously let this through
+        since only the unlock gate (not ownership) was checked (#2033).
+        """
+        from world.relationships.factories import (
+            CharacterRelationshipFactory,
+            RelationshipTrackFactory,
+            RelationshipTrackProgressFactory,
+        )
+
+        track = RelationshipTrackFactory()
+        unlock = ThreadWeavingUnlockFactory(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            unlock_trait=None,
+            unlock_track=track,
+        )
+        CharacterThreadWeavingUnlockFactory(character=self.sheet, unlock=unlock)
+
+        foreign_relationship = CharacterRelationshipFactory(
+            source=self.other_sheet, target=CharacterSheetFactory()
+        )
+        foreign_progress = RelationshipTrackProgressFactory(
+            relationship=foreign_relationship, track=track, developed_points=10
+        )
+
+        self.client.force_authenticate(user=self.account)
+        response = self.client.post(
+            reverse("magic:thread-list"),
+            {
+                "resonance": self.resonance.pk,
+                "target_kind": TargetKind.RELATIONSHIP_TRACK,
+                "target_id": foreign_progress.pk,
+                "character_sheet_id": self.sheet.pk,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(
+            Thread.objects.filter(
+                owner=self.sheet, target_relationship_track=foreign_progress
+            ).exists()
+        )
+
+    def test_create_relationship_track_thread_succeeds_for_own_row(self) -> None:
+        """Sanity check: weaving the CALLER's own track-progress row still works."""
+        from world.relationships.factories import (
+            CharacterRelationshipFactory,
+            RelationshipTrackFactory,
+            RelationshipTrackProgressFactory,
+        )
+
+        track = RelationshipTrackFactory()
+        unlock = ThreadWeavingUnlockFactory(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            unlock_trait=None,
+            unlock_track=track,
+        )
+        CharacterThreadWeavingUnlockFactory(character=self.sheet, unlock=unlock)
+
+        own_relationship = CharacterRelationshipFactory(
+            source=self.sheet, target=CharacterSheetFactory()
+        )
+        own_progress = RelationshipTrackProgressFactory(
+            relationship=own_relationship, track=track, developed_points=10
+        )
+
+        self.client.force_authenticate(user=self.account)
+        response = self.client.post(
+            reverse("magic:thread-list"),
+            {
+                "resonance": self.resonance.pk,
+                "target_kind": TargetKind.RELATIONSHIP_TRACK,
+                "target_id": own_progress.pk,
+                "character_sheet_id": self.sheet.pk,
+                "name": "Bound to Marcus",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertTrue(
+            Thread.objects.filter(owner=self.sheet, target_relationship_track=own_progress).exists()
+        )
+
+    # ------------------------------------------------------------------
     # COVENANT_ROLE thread creation tests
     # ------------------------------------------------------------------
 

--- a/src/world/magic/tests/test_api.py
+++ b/src/world/magic/tests/test_api.py
@@ -287,6 +287,18 @@ class ThreadViewSetTests(APITestCase):
         though the requesting sheet holds a matching RELATIONSHIP_TRACK
         ThreadWeavingUnlock — ``ThreadSerializer`` previously let this through
         since only the unlock gate (not ownership) was checked (#2033).
+
+        Closing the oracle means a foreign row must be *indistinguishable* from
+        a nonexistent one: ``ThreadSerializer._resolve_target`` now scopes its
+        lookup to ``relationship__source=<requesting sheet>``, so a foreign pk
+        simply doesn't match the query and 400s with the same "does not exist"
+        message a bogus pk would produce — never the ownership-specific
+        ``RelationshipBondNotOwned`` message, which would leak that the row
+        exists and belongs to someone else. Proven here by requesting the SAME
+        pk twice — once while it's a real foreign row, once after it's deleted
+        (genuinely nonexistent) — and asserting the two 400 bodies are
+        byte-identical. That equality *is* the security property under test,
+        not an incidental assertion.
         """
         from world.relationships.factories import (
             CharacterRelationshipFactory,
@@ -308,24 +320,39 @@ class ThreadViewSetTests(APITestCase):
         foreign_progress = RelationshipTrackProgressFactory(
             relationship=foreign_relationship, track=track, developed_points=10
         )
+        foreign_progress_pk = foreign_progress.pk
 
         self.client.force_authenticate(user=self.account)
-        response = self.client.post(
-            reverse("magic:thread-list"),
-            {
-                "resonance": self.resonance.pk,
-                "target_kind": TargetKind.RELATIONSHIP_TRACK,
-                "target_id": foreign_progress.pk,
-                "character_sheet_id": self.sheet.pk,
-            },
-            format="json",
+        post_kwargs = {
+            "resonance": self.resonance.pk,
+            "target_kind": TargetKind.RELATIONSHIP_TRACK,
+            "target_id": foreign_progress_pk,
+            "character_sheet_id": self.sheet.pk,
+        }
+        foreign_response = self.client.post(
+            reverse("magic:thread-list"), post_kwargs, format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(foreign_response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(
             Thread.objects.filter(
-                owner=self.sheet, target_relationship_track=foreign_progress
+                owner=self.sheet, target_relationship_track_id=foreign_progress_pk
             ).exists()
         )
+        # The ownership-specific message must never reach the API caller — it
+        # would confirm the row exists and belongs to someone else.
+        self.assertNotIn("isn't your own relationship bond", str(foreign_response.data))
+        self.assertIn(
+            f"RELATIONSHIP_TRACK target with id={foreign_progress_pk} does not exist.",
+            str(foreign_response.data),
+        )
+
+        # Same pk, now genuinely nonexistent — must produce the SAME 400 body.
+        foreign_progress.delete()
+        nonexistent_response = self.client.post(
+            reverse("magic:thread-list"), post_kwargs, format="json"
+        )
+        self.assertEqual(nonexistent_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(foreign_response.data, nonexistent_response.data)
 
     def test_create_relationship_track_thread_succeeds_for_own_row(self) -> None:
         """Sanity check: weaving the CALLER's own track-progress row still works."""

--- a/src/world/magic/tests/test_weave_relationship_ownership.py
+++ b/src/world/magic/tests/test_weave_relationship_ownership.py
@@ -1,0 +1,144 @@
+"""Tests for the RELATIONSHIP_TRACK/RELATIONSHIP_CAPSTONE ownership assertion in
+``weave_thread`` (#2033).
+
+A character may only weave a thread anchored on a relationship-track or
+capstone row that belongs to THEIR OWN ``CharacterRelationship``
+(``relationship.source``) — never someone else's relationship, even when
+they hold a matching ``ThreadWeavingUnlock``. Before #2033, ``weave_thread``
+checked the unlock only; a character who happened to hold ANY
+RELATIONSHIP_TRACK unlock could weave a thread anchored on ANY character's
+track-progress row.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.constants import TargetKind
+from world.magic.exceptions import RelationshipBondNotOwned
+from world.magic.factories import (
+    CharacterThreadWeavingUnlockFactory,
+    ResonanceFactory,
+    ThreadWeavingUnlockFactory,
+)
+from world.magic.models import Thread
+from world.magic.services import weave_thread
+from world.relationships.factories import (
+    CharacterRelationshipFactory,
+    RelationshipCapstoneFactory,
+    RelationshipTrackFactory,
+    RelationshipTrackProgressFactory,
+)
+
+
+class RelationshipTrackOwnershipTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.other_sheet = CharacterSheetFactory()
+        cls.partner_sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory()
+        cls.track = RelationshipTrackFactory()
+        unlock = ThreadWeavingUnlockFactory(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            unlock_trait=None,
+            unlock_track=cls.track,
+        )
+        # Both sheets hold the matching unlock — the unlock gate alone would let
+        # either weave a RELATIONSHIP_TRACK thread; ownership must still gate it.
+        CharacterThreadWeavingUnlockFactory(character=cls.sheet, unlock=unlock)
+        CharacterThreadWeavingUnlockFactory(character=cls.other_sheet, unlock=unlock)
+
+        other_relationship = CharacterRelationshipFactory(
+            source=cls.other_sheet, target=cls.partner_sheet
+        )
+        cls.other_progress = RelationshipTrackProgressFactory(
+            relationship=other_relationship, track=cls.track, developed_points=10
+        )
+
+    def test_weaving_anothers_track_row_raises(self) -> None:
+        pre_count = Thread.objects.filter(owner=self.sheet).count()
+        with self.assertRaises(RelationshipBondNotOwned):
+            weave_thread(
+                character_sheet=self.sheet,
+                target_kind=TargetKind.RELATIONSHIP_TRACK,
+                target=self.other_progress,
+                resonance=self.resonance,
+            )
+        self.assertEqual(Thread.objects.filter(owner=self.sheet).count(), pre_count)
+
+    def test_weaving_own_track_row_succeeds(self) -> None:
+        own_relationship = CharacterRelationshipFactory(
+            source=self.sheet, target=self.partner_sheet
+        )
+        own_progress = RelationshipTrackProgressFactory(
+            relationship=own_relationship, track=self.track, developed_points=10
+        )
+
+        thread = weave_thread(
+            character_sheet=self.sheet,
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            target=own_progress,
+            resonance=self.resonance,
+        )
+
+        self.assertEqual(thread.owner, self.sheet)
+        self.assertEqual(thread.target_relationship_track, own_progress)
+
+
+class RelationshipCapstoneOwnershipTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.other_sheet = CharacterSheetFactory()
+        cls.partner_sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory()
+        cls.track = RelationshipTrackFactory()
+        unlock = ThreadWeavingUnlockFactory(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            unlock_trait=None,
+            unlock_track=cls.track,
+        )
+        CharacterThreadWeavingUnlockFactory(character=cls.sheet, unlock=unlock)
+        CharacterThreadWeavingUnlockFactory(character=cls.other_sheet, unlock=unlock)
+
+        other_relationship = CharacterRelationshipFactory(
+            source=cls.other_sheet, target=cls.partner_sheet
+        )
+        cls.other_capstone = RelationshipCapstoneFactory(
+            relationship=other_relationship,
+            author=cls.other_sheet,
+            track=cls.track,
+        )
+
+    def test_weaving_anothers_capstone_raises(self) -> None:
+        pre_count = Thread.objects.filter(owner=self.sheet).count()
+        with self.assertRaises(RelationshipBondNotOwned):
+            weave_thread(
+                character_sheet=self.sheet,
+                target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+                target=self.other_capstone,
+                resonance=self.resonance,
+            )
+        self.assertEqual(Thread.objects.filter(owner=self.sheet).count(), pre_count)
+
+    def test_weaving_own_capstone_succeeds(self) -> None:
+        own_relationship = CharacterRelationshipFactory(
+            source=self.sheet, target=self.partner_sheet
+        )
+        own_capstone = RelationshipCapstoneFactory(
+            relationship=own_relationship,
+            author=self.sheet,
+            track=self.track,
+        )
+
+        thread = weave_thread(
+            character_sheet=self.sheet,
+            target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+            target=own_capstone,
+            resonance=self.resonance,
+        )
+
+        self.assertEqual(thread.owner, self.sheet)
+        self.assertEqual(thread.target_capstone, own_capstone)


### PR DESCRIPTION
Closes #2033

## Summary

Epic #2024 surface-parity + security item: telnet weave grammar extended from TRAIT-only to all serializer-supported anchor kinds — track=<partner>/<track>, capstone=, facet=, technique=, role=, mantle= — each resolving the caller's own typed target and dispatching the existing WeaveThreadAction (relationship threads, the heart of the relationship→power loop, are finally weavable from telnet). Two security hardenings ride along: (1) a new service-level own-bond assertion in weave_thread closes a pre-existing hole where the web API permitted weaving threads on OTHER characters' relationship rows; (2) after adversarial review flagged that the naive check ordering created an existence/ownership oracle via distinct error messages, the API target lookup for relationship kinds is scoped to the requester's own rows (foreign and nonexistent ids return byte-identical 400s — asserted as such in tests) and the unlock gate runs before the ownership assertion. Also fixes a latent uncaught TechniqueNotOwned on the technique-weave path and stale docs (weave scope docstring, commands CLAUDE.md, frontend magic CLAUDE.md wizard claim).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2033 (in the issue body)
- Brainstorm/plan: skipped (feature with code-verified spec on the issue body; user pre-authorized implementation)
- Sync-with-main: Rebased onto origin/main cleanly (2 commits). Focused module tests green; full regression left to CI per user directive.

<!-- last-addressed-comment: 0 -->