### PR TITLE
docs: renumber GM-trust ADR 0095→0097 (number collision)

### DIFF
--- a/docs/adr/0097-gm-trust-is-gmprofile-level.md
+++ b/docs/adr/0097-gm-trust-is-gmprofile-level.md
@@ -1,4 +1,4 @@
-# 0095 — GM trust is `GMProfile.level`, capped by `GMLevelCap`, advanced only via `promote_gm`
+# 0097 — GM trust is `GMProfile.level`, capped by `GMLevelCap`, advanced only via `promote_gm`
 
 **Status:** Accepted
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -162,4 +162,4 @@ treat those names as hints to confirm, not gospel.
 - [0082 — Scandal is a derived per-society judgment; reach forks at act birth](0082-scandal-reach-derived-at-act-birth.md)
 - [0085 — The offer→staked-beat link lives on MissionOfferDetails, not NPCServiceOffer](0085-offer-to-beat-link-on-missionofferdetails.md)
 - [0087 — Building renovation swaps the catalog BuildingKind row, not per-building flags](0087-building-renovation-catalog-kind-reassignment.md)
-- [0095 — GM trust is `GMProfile.level`, capped by `GMLevelCap`, advanced only via `promote_gm`](0095-gm-trust-is-gmprofile-level.md)
+- [0097 — GM trust is `GMProfile.level`, capped by `GMLevelCap`, advanced only via `promote_gm`](0097-gm-trust-is-gmprofile-level.md)

--- a/docs/roadmap/combat-build-history.md
+++ b/docs/roadmap/combat-build-history.md
@@ -152,7 +152,7 @@ an NPC at a bar) where concrete NPC objects aren't needed.
 - **Stakes is a gate, not a stat multiplier:** `validate_stakes_requirement(encounter, gm)`
   enforces a per-stakes minimum party average level + minimum GM trust, **reusing the existing
   `stories` trust system** (`PlayerTrust.gm_trust_level`, `TrustLevel`) — no new GM-auth concept
-  (superseded by `GMProfile.level` — ADR-0095, #2000).
+  (superseded by `GMProfile.level` — ADR-0097, #2000).
 - **Wiring + API:** `add_opponent` auto-fills omitted stats (and boss phases) from the formula
   when `max_health` is omitted (explicit values always win); read-only
   `GET /api/combat/{id}/opponent-defaults/?tier=…` previews the computed block + a non-blocking

--- a/docs/roadmap/gm-system.md
+++ b/docs/roadmap/gm-system.md
@@ -61,14 +61,14 @@ The GM system defines these role relationships; the stories app uses them for pe
 - Rewards tie into existing XP/codex/kudos systems, not a new reward pipeline
 
 ### Trust and Feedback ✅ (#2000)
-- **`GMProfile.level` is the canonical trust ladder** — see ADR-0095. `GMLevelCap`
+- **`GMProfile.level` is the canonical trust ladder** — see ADR-0097. `GMLevelCap`
   (one row per `GMLevel`, seeded via `seed_default_gm_level_caps`) holds the
   per-level caps: `max_beat_risk`, `allow_custom_stakes`, `allow_global_scope_authoring`.
   Staff-tunable in admin, not hardcoded.
 - **Advancement is staff-only and audited** — `world.gm.services.promote_gm` is the
   only path that changes `profile.level` (promotion or demotion); every call writes a
   `GMLevelChange` row (old level, new level, `changed_by`, `reason`). No automatic
-  feedback-driven promotion yet (deliberately deferred — see ADR-0095).
+  feedback-driven promotion yet (deliberately deferred — see ADR-0097).
 - **Evidence for the promotion decision** — `gm_evidence_summary(profile)` aggregates
   stories currently running, beats completed by risk tier, feedback by trust category,
   and the `GMLevelChange` audit trail, for a staff reviewer deciding on a level change.
@@ -113,7 +113,7 @@ The GM system defines these role relationships; the stories app uses them for pe
 - ✅ GM level TextChoices (STARTING/JUNIOR/GM/EXPERIENCED/SENIOR)
 - ✅ GMApplication ViewSet (create for players, list/review/update for staff, filters)
 - ✅ Staff inbox integration (GM applications appear as triage category)
-- ✅ Trust/feedback — `GMProfile.level` is canonical (ADR-0095); ladder built out in
+- ✅ Trust/feedback — `GMProfile.level` is canonical (ADR-0097); ladder built out in
   full in #2000 (see "Trust and Feedback" above) — `GMLevelCap`, `promote_gm` +
   `GMLevelChange` audit, `gm_evidence_summary`
 - Permission checks deferred to individual commands (each checks `GMProfile.level` as needed)

--- a/docs/roadmap/stories-gm.md
+++ b/docs/roadmap/stories-gm.md
@@ -44,7 +44,7 @@ What changes:
   runnable). Scope is **not** trust-gated. GROUP anchors to the GM table's
   people and/or an optional covenant seam.
 - **Risk** is a plain `Beat.risk` integer (no RiskTier model). The trust→risk ladder
-  has since arrived (#2000, ADR-0095): non-staff GMs are capped at their
+  has since arrived (#2000, ADR-0097): non-staff GMs are capped at their
   `GMLevelCap.max_beat_risk`/`allow_custom_stakes` (staff still bypass); see
   `docs/roadmap/gm-system.md`'s "Trust and Feedback" section.
 - **Per-story OOC notes ledger** (author + timestamp), separate from
@@ -55,7 +55,7 @@ via placeholder GM-mark. Sequenced follow-ups (each its own brainstorm):
 (1) Mission/Challenge engine via existing `resolve_challenge`,
 (2) Situation/Encounter resolution + Sessions,
 (3) consequence + reward computation (where risk numbers gain meaning),
-(4) ✅ GM leveling / the trust→risk gating hook (#2000 — see ADR-0095;
+(4) ✅ GM leveling / the trust→risk gating hook (#2000 — see ADR-0097;
 the automatic *feedback-driven earning curve* is still deliberately deferred,
 promotion is staff-only for now),
 (5) covenant entity.

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1046,7 +1046,7 @@ Character lifecycle management with web-first applications and player anonymity.
 
 ### GM
 Player-GM identity, tables, roster recruitment, and the trust ladder that caps what a
-GM at a given level may author (#2000, ADR-0095).
+GM at a given level may author (#2000, ADR-0097).
 
 - **Models:** `GMProfile` (OneToOne account, `level: GMLevel`, `approved_at`/`approved_by`,
   `last_active_at` stub), `GMApplication` (freeform text, staff response, one PENDING
@@ -1100,7 +1100,7 @@ GM at a given level may author (#2000, ADR-0095).
 - **Source:** `src/world/gm/`
 - **Glossary:** `src/world/gm/AGENT_GLOSSARY.md`
 - **Details:** [../roadmap/gm-system.md](../roadmap/gm-system.md),
-  [../adr/0095-gm-trust-is-gmprofile-level.md](../adr/0095-gm-trust-is-gmprofile-level.md)
+  [../adr/0097-gm-trust-is-gmprofile-level.md](../adr/0097-gm-trust-is-gmprofile-level.md)
 
 ### Scenes
 Roleplay session recording with participant tracking, interaction logging, persona-based identity, social

--- a/docs/systems/stakes.md
+++ b/docs/systems/stakes.md
@@ -697,7 +697,7 @@ isn't enough on POST):
 - `StakeSerializer` additionally validates the beat's declared risk falls within
   `[template.min_risk, template.max_risk]` (by `risk_index`), and gates the
   template-null (custom) path to staff or a non-staff GM whose
-  `GMLevelCap.allow_custom_stakes` permits it (#2000, ADR-0095), mirroring
+  `GMLevelCap.allow_custom_stakes` permits it (#2000, ADR-0097), mirroring
   `BeatSerializer.validate`'s risk gate (also `GMLevelCap`-driven, via
   `_gm_max_risk`/`_gm_allows_custom_stakes` in `world/stories/serializers.py`);
 - `StakeRewardLineSerializer` additionally refuses non-WIN-column resolutions

--- a/src/world/gm/AGENT_GLOSSARY.md
+++ b/src/world/gm/AGENT_GLOSSARY.md
@@ -21,7 +21,7 @@ A GM (`GMProfile`) who has claimed a single `agm_eligible` beat session to run, 
 _Avoid_: co-GM, helper GM, sub-GM.
 
 **GM Level**:
-A GM's trust tier (`GMProfile.level`, the `GMLevel` enum: STARTING/JUNIOR/GM/EXPERIENCED/SENIOR), canonical since #2000 (ADR-0095) — the single source of GM trust; supersedes the dead `PlayerTrust.gm_trust_level` field, which was removed. Ordered via `GM_LEVEL_ORDER`/`gm_level_index`; consumed by `stories.BeatSerializer`'s risk gate, `stories.StakeSerializer`'s custom-stakes gate, and `combat.StakesLevelRequirement.minimum_gm_level`.
+A GM's trust tier (`GMProfile.level`, the `GMLevel` enum: STARTING/JUNIOR/GM/EXPERIENCED/SENIOR), canonical since #2000 (ADR-0097) — the single source of GM trust; supersedes the dead `PlayerTrust.gm_trust_level` field, which was removed. Ordered via `GM_LEVEL_ORDER`/`gm_level_index`; consumed by `stories.BeatSerializer`'s risk gate, `stories.StakeSerializer`'s custom-stakes gate, and `combat.StakesLevelRequirement.minimum_gm_level`.
 _Avoid_: GM trust level (on PlayerTrust — that field is gone), trust score.
 
 **Level Cap**:


### PR DESCRIPTION
Two concurrently-merged branches both minted ADR-0095 (PR #2053 battle-live-updates, PR #2054 GM trust ladder), leaving two 0095 files on main. Battle keeps 0095 as first-merged; the GM-trust ADR becomes **0097** (0096 is taken by the casts ADR). All cross-references updated (README index, gm-system/stories-gm/combat-build-history roadmaps, stakes.md, INDEX.md, gm glossary); battle-context references untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)