### PR TITLE
GM ops completion: surrender endpoint, activity stamping, idle detection, GM dashboard

### DIFF
--- a/docs/roadmap/gm-system.md
+++ b/docs/roadmap/gm-system.md
@@ -172,6 +172,15 @@ Building this frontend before Stories exists would mean throwing it
 away. Deferring until after Stories is in place so the dashboard
 reflects real GM workflow.
 
+**Phase 5 is now complete (#2004):** the GM dashboard endpoint
+(`GET /api/gm/dashboard/`) composes the gm-queue, tables, pending story
+offers, and evidence summary; the frontend route (`/gm/dashboard`) renders
+it. `surrender_character_story` is wired (`POST /api/stories/{id}/surrender/`
++ `story surrender` telnet). `touch_gm_activity` stamps `GMProfile.last_active_at`
+from GM-verb services; idle-table detection surfaces on `StaffWorkloadView`
+and a weekly cron summary. GMProfile presence (`is_gm`) added to the account
+payload so the frontend can gate navigation without probing for 403s.
+
 Day-to-day GM ops that the staff inbox + existing APIs cover for now:
 - Application queue (staff / admin can action; GMs will get the
   dedicated view post-Stories)

--- a/docs/systems/stories.md
+++ b/docs/systems/stories.md
@@ -746,6 +746,22 @@ be performed by an approved Assistant GM for that beat.
 | `story resolve <episode-id> [transition-id] [notes]` | `resolve_episode` | Advance the story's active progress through a transition. |
 | `story promote <episode-id> <pitch|outline|plot>` | `promote_episode` | Change the episode's authoring maturity. |
 | `story mark <beat-id> <success|failure> [notes]` | `mark_beat` | Record a GM-marked outcome on a beat. |
+| `story surrender <story-id>` | — (service-direct) | GM surrenders oversight; story enters "seeking GM" (#2004). |
+
+## GM surrender lifecycle (#2004)
+
+A Lead GM may surrender oversight of a story, clearing its `primary_table`
+so the story enters "seeking GM" state — mirroring the player-side
+`detach-from-table` flow. The `surrender_character_story(gm, story)` service
+(`world/gm/services.py`) validates oversight, stamps GM activity
+(`touch_gm_activity`), clears `primary_table`, and notifies the affected
+player via a narrative SYSTEM message.
+
+- **Web:** `POST /api/stories/{id}/surrender/` (Lead GM or staff).
+- **Telnet:** `story surrender <story-id>`.
+- **Activity stamping:** `touch_gm_activity(gm_profile)` is called from every
+  GM-verb service (surrender, episode resolve, stake GM-pick) so
+  `GMProfile.last_active_at` tracks recency for idle-table detection.
 
 ## Canon-impact review (#2003)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -105,6 +105,9 @@ const StoryDetailPage = lazy(() =>
 const GMQueuePage = lazy(() =>
   import('@/stories/pages/GMQueuePage').then((m) => ({ default: m.GMQueuePage }))
 );
+const GMDashboardPage = lazy(() =>
+  import('@/stories/pages/GMDashboardPage').then((m) => ({ default: m.GMDashboardPage }))
+);
 const AGMOpportunitiesPage = lazy(() =>
   import('@/stories/pages/AGMOpportunitiesPage').then((m) => ({
     default: m.AGMOpportunitiesPage,
@@ -614,6 +617,16 @@ function App() {
             <Suspense fallback={<PageLoadingFallback />}>
               <ProtectedRoute>
                 <GMQueuePage />
+              </ProtectedRoute>
+            </Suspense>
+          }
+        />
+        <Route
+          path="/gm/dashboard"
+          element={
+            <Suspense fallback={<PageLoadingFallback />}>
+              <ProtectedRoute>
+                <GMDashboardPage />
               </ProtectedRoute>
             </Suspense>
           }

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -6527,6 +6527,23 @@ export interface paths {
     patch: operations['gm_applications_partial_update'];
     trace?: never;
   };
+  '/api/gm/dashboard/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Return the GM's dashboard aggregation. */
+    get: operations['gm_dashboard_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/gm/demand-ransom/': {
     parameters: {
       query?: never;
@@ -15691,6 +15708,29 @@ export interface paths {
      *     Returns 201 with the created NarrativeMessage.
      */
     post: operations['stories_send_ooc_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/stories/{id}/surrender/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description POST /api/stories/{id}/surrender/ — GM surrenders oversight (#2004).
+     *
+     *     Lead GM or staff only. Clears ``primary_table`` so the story enters
+     *     "seeking GM" state; notifies the affected player via a narrative
+     *     SYSTEM message. Returns 200 with the updated Story.
+     */
+    post: operations['stories_surrender_create'];
     delete?: never;
     options?: never;
     head?: never;
@@ -40852,6 +40892,24 @@ export interface operations {
       };
     };
   };
+  gm_dashboard_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
   gm_demand_ransom_create: {
     parameters: {
       query?: never;
@@ -54340,6 +54398,32 @@ export interface operations {
     };
   };
   stories_send_ooc_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this story. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['StoryDetailRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['StoryDetail'];
+        };
+      };
+    };
+  };
+  stories_surrender_create: {
     parameters: {
       query?: never;
       header?: never;

--- a/frontend/src/stories/__tests__/GMDashboardPage.test.tsx
+++ b/frontend/src/stories/__tests__/GMDashboardPage.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * GMDashboardPage Tests (#2004)
+ *
+ * Smoke tests: renders without crashing, shows the dashboard sections,
+ * and renders the 403 not-a-GM error state.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { GMDashboardPage } from '../pages/GMDashboardPage';
+
+vi.mock('@/evennia_replacements/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/evennia_replacements/api';
+
+function withProviders(children: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const mockDashboard = {
+  episodes_ready_to_run: [],
+  pending_agm_claims: [],
+  assigned_session_requests: [],
+  waiting_for_gm: [],
+  my_tables: [{ id: 1, name: 'Test Table', membership_count: 3 }],
+  pending_story_offers: [],
+  evidence_summary: {
+    level: 'gm',
+    stories_running: 2,
+    beats_completed_by_risk: {},
+    last_active_at: '2026-07-08T00:00:00Z',
+  },
+};
+
+describe('GMDashboardPage', () => {
+  it('renders dashboard sections on success', async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockDashboard),
+    } as Response);
+
+    render(withProviders(<GMDashboardPage />));
+
+    await waitFor(() => {
+      expect(screen.getByText('GM Dashboard')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Test Table')).toBeInTheDocument();
+    expect(screen.getByText('gm')).toBeInTheDocument();
+  });
+
+  it('renders not-a-GM message on 403', async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+    } as Response);
+
+    render(withProviders(<GMDashboardPage />));
+
+    await waitFor(() => {
+      expect(screen.getByText(/You must be a GM/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/stories/pages/GMDashboardPage.tsx
+++ b/frontend/src/stories/pages/GMDashboardPage.tsx
@@ -1,0 +1,180 @@
+/**
+ * GMDashboardPage — the GM's story-shaped dashboard (#2004).
+ *
+ * Shows the GM's tables, upcoming sessions, stories needing attention,
+ * pending AGM claims, pending story offers, and evidence summary from
+ * GET /api/gm/dashboard/.
+ *
+ * Permission gating: the endpoint returns 403 for non-GMs. We use a local
+ * query with throwOnError: false so we can render a friendly "not a GM" page
+ * rather than blowing the error boundary.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { Skeleton } from '@/components/ui/skeleton';
+import { apiFetch } from '@/evennia_replacements/api';
+
+// ---------------------------------------------------------------------------
+// Types (manually authored — spectacular can't introspect this APIView)
+// ---------------------------------------------------------------------------
+
+interface GMDashboardTable {
+  id: number;
+  name: string;
+  membership_count: number;
+}
+
+interface GMDashboardOffer {
+  id: number;
+  story__title: string;
+  created_at: string;
+}
+
+interface GMDashboardEvidence {
+  level: string;
+  stories_running: number;
+  beats_completed_by_risk: Record<string, number>;
+  last_active_at: string | null;
+}
+
+interface GMDashboardResponse {
+  episodes_ready_to_run: unknown[];
+  pending_agm_claims: unknown[];
+  assigned_session_requests: unknown[];
+  waiting_for_gm: unknown[];
+  my_tables: GMDashboardTable[];
+  pending_story_offers: GMDashboardOffer[];
+  evidence_summary: GMDashboardEvidence;
+}
+
+async function getGMDashboard(): Promise<GMDashboardResponse> {
+  const res = await apiFetch('/api/gm/dashboard/');
+  if (!res.ok) {
+    const err = new Error('Failed to load GM dashboard') as Error & { status?: number };
+    err.status = res.status;
+    throw err;
+  }
+  return res.json() as Promise<GMDashboardResponse>;
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function GMDashboardPage() {
+  return (
+    <ErrorBoundary>
+      <GMDashboardContent />
+    </ErrorBoundary>
+  );
+}
+
+function GMDashboardContent() {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['gm-dashboard'],
+    queryFn: getGMDashboard,
+    throwOnError: false,
+  });
+
+  if (isLoading) {
+    return <Skeleton className="h-96 w-full" />;
+  }
+
+  if (isError) {
+    const status = (error as Error & { status?: number }).status;
+    if (status === 403) {
+      return (
+        <div className="p-8 text-center text-muted-foreground">
+          You must be a GM to view this page.
+        </div>
+      );
+    }
+    return (
+      <div className="p-8 text-center text-destructive">
+        Failed to load dashboard: {error?.message}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <h1 className="text-2xl font-bold">GM Dashboard</h1>
+
+      {/* Evidence summary */}
+      <section className="rounded-lg border p-4">
+        <h2 className="mb-2 text-lg font-semibold">Your GM Profile</h2>
+        <dl className="grid grid-cols-2 gap-2 text-sm">
+          <dt className="text-muted-foreground">Level</dt>
+          <dd>{data.evidence_summary.level}</dd>
+          <dt className="text-muted-foreground">Stories running</dt>
+          <dd>{data.evidence_summary.stories_running}</dd>
+          <dt className="text-muted-foreground">Last active</dt>
+          <dd>
+            {data.evidence_summary.last_active_at
+              ? new Date(data.evidence_summary.last_active_at).toLocaleDateString()
+              : 'Never'}
+          </dd>
+        </dl>
+      </section>
+
+      {/* My tables */}
+      <section className="rounded-lg border p-4">
+        <h2 className="mb-2 text-lg font-semibold">My Tables ({data.my_tables.length})</h2>
+        {data.my_tables.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No active tables.</p>
+        ) : (
+          <ul className="space-y-1 text-sm">
+            {data.my_tables.map((table) => (
+              <li key={table.id}>
+                <span className="font-medium">{table.name}</span> — {table.membership_count}{' '}
+                member(s)
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Attention counts */}
+      <section className="grid grid-cols-2 gap-4">
+        <div className="rounded-lg border p-4">
+          <p className="text-sm text-muted-foreground">Episodes ready to run</p>
+          <p className="text-2xl font-bold">{data.episodes_ready_to_run.length}</p>
+        </div>
+        <div className="rounded-lg border p-4">
+          <p className="text-sm text-muted-foreground">Pending AGM claims</p>
+          <p className="text-2xl font-bold">{data.pending_agm_claims.length}</p>
+        </div>
+        <div className="rounded-lg border p-4">
+          <p className="text-sm text-muted-foreground">Assigned sessions</p>
+          <p className="text-2xl font-bold">{data.assigned_session_requests.length}</p>
+        </div>
+        <div className="rounded-lg border p-4">
+          <p className="text-sm text-muted-foreground">Stories waiting on you</p>
+          <p className="text-2xl font-bold">{data.waiting_for_gm.length}</p>
+        </div>
+      </section>
+
+      {/* Pending story offers */}
+      <section className="rounded-lg border p-4">
+        <h2 className="mb-2 text-lg font-semibold">
+          Pending Story Offers ({data.pending_story_offers.length})
+        </h2>
+        {data.pending_story_offers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No pending offers.</p>
+        ) : (
+          <ul className="space-y-1 text-sm">
+            {data.pending_story_offers.map((offer) => (
+              <li key={offer.id}>
+                <span className="font-medium">{offer.story__title}</span> —{' '}
+                {new Date(offer.created_at).toLocaleDateString()}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -78,6 +78,7 @@ from commands.fatigue import CmdRest
 from commands.form import CmdForm
 from commands.functionary import CmdFunctionary
 from commands.gemit import CmdGemit
+from commands.gm_ops import CmdGMDashboard, CmdGMIdle
 from commands.gm_tables import CmdGMTable
 from commands.gmtrust import CmdGMTrust
 from commands.goals import CmdGoal  # #1350 — goal authoring namespace.
@@ -267,6 +268,9 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdGemit,
             # #2003 — staff canon-review queue (perm(Admin)).
             CmdCanonReview,
+            # #2004 — GM dashboard + idle-tables listing.
+            CmdGMDashboard,
+            CmdGMIdle,
             # #1505 — basic telnet parity for GM-table admin (web is the primary surface).
             CmdGMTable,
             # #1496 — staff/GM technique authoring workbench (perm(Builder)).

--- a/src/commands/gm_ops.py
+++ b/src/commands/gm_ops.py
@@ -1,0 +1,108 @@
+"""Telnet ``gm dashboard`` + ``gm idle`` commands (#2004).
+
+Thin over the same services the web ``GMDashboardView`` and
+``StaffWorkloadView`` call. ``gm dashboard`` is GM-gated; ``gm idle`` is
+staff-only (``perm(Admin)``).
+"""
+
+from __future__ import annotations
+
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+_USAGE_DASHBOARD = "Usage: gm dashboard"
+_USAGE_IDLE = "Usage: gm idle"
+
+
+class CmdGMDashboard(ArxCommand):
+    """Show the GM dashboard — tables, sessions, stories needing attention (#2004).
+
+    Usage:
+      gm dashboard
+    """
+
+    key = "gm"
+    aliases = ("gmdashboard",)
+    locks = "cmd:all()"
+    help_category = "GM"
+    action = None
+
+    def func(self) -> None:
+        """Render a text summary of the GM dashboard."""
+        try:
+            self._render()
+        except CommandError as err:
+            self.msg(str(err))
+
+    def _render(self) -> None:
+        raw = (self.args or "").strip().lower()
+        if raw and raw != "dashboard":  # noqa: STRING_LITERAL
+            raise CommandError(_USAGE_DASHBOARD)
+        from world.gm.models import GMProfile  # noqa: PLC0415
+
+        try:
+            gm_profile = self.caller.account.gm_profile
+        except GMProfile.DoesNotExist:
+            msg = "You must have a GM profile to use this command."
+            raise CommandError(msg) from None
+
+        from world.gm.constants import GMTableStatus  # noqa: PLC0415
+        from world.gm.models import GMTable  # noqa: PLC0415
+        from world.gm.services import gm_evidence_summary  # noqa: PLC0415
+        from world.stories.constants import (  # noqa: PLC0415
+            StoryGMOfferStatus,
+        )
+        from world.stories.models import (  # noqa: PLC0415
+            StoryGMOffer,
+        )
+        from world.stories.views import _collect_gm_queue  # noqa: PLC0415
+
+        buckets = _collect_gm_queue(gm_profile)
+        lines = ["GM Dashboard:"]
+        lines.append(f"  Episodes ready to run: {len(buckets.episodes_ready)}")
+        lines.append(f"  Pending AGM claims: {len(buckets.pending_claims)}")
+        lines.append(f"  Assigned sessions: {len(buckets.assigned_requests)}")
+        lines.append(f"  Stories waiting on you: {len(buckets.waiting_for_gm)}")
+
+        my_tables = GMTable.objects.filter(gm=gm_profile, status=GMTableStatus.ACTIVE)
+        lines.append(f"  Active tables: {my_tables.count()}")
+        lines.extend(f"    [{table.pk}] {table.name}" for table in my_tables)
+
+        pending_offers = StoryGMOffer.objects.filter(
+            offered_to=gm_profile, status=StoryGMOfferStatus.PENDING
+        ).count()
+        lines.append(f"  Pending story offers: {pending_offers}")
+
+        evidence = gm_evidence_summary(gm_profile)
+        lines.append(f"  Level: {evidence.level} | Stories running: {evidence.stories_running}")
+        self.msg("\n".join(lines))
+
+
+class CmdGMIdle(ArxCommand):
+    """List idle GM tables (staff-only, #2004).
+
+    Usage:
+      gm idle
+    """
+
+    key = "gmidle"
+    aliases = ()
+    locks = "cmd:perm(Admin)"
+    help_category = "Staff"
+    action = None
+
+    def func(self) -> None:
+        """List idle tables whose GM hasn't been active recently."""
+        from world.gm.services import idle_tables  # noqa: PLC0415
+
+        tables = list(idle_tables())
+        if not tables:
+            self.msg("No idle tables.")
+            return
+        lines = [f"Idle tables ({len(tables)}):"]
+        for table in tables:
+            gm_name = table.gm.account.username
+            last = table.gm.last_active_at
+            last_str = last.strftime("%Y-%m-%d") if last else "never"
+            lines.append(f"  [{table.pk}] {table.name} — GM: {gm_name} (last active: {last_str})")
+        self.msg("\n".join(lines))

--- a/src/commands/story.py
+++ b/src/commands/story.py
@@ -63,11 +63,13 @@ _USAGE = (
     "                                     — custody clearance lifecycle (#2001)\n"
     "  story impact <story-id>=<table|regional|world>\n"
     "                                     — set impact tier (Lead GM; #2003)\n"
-    "  story review-status <story-id>     — tier + review state (#2003)"
+    "  story review-status <story-id>     — tier + review state (#2003)\n"
+    "  story surrender <story-id>          — GM surrenders oversight (#2004)"
 )
 
 _IMPACT_USAGE = "Usage: story impact <story-id>=<table|regional|world>"
 _REVIEW_STATUS_USAGE = "Usage: story review-status <story-id>"
+_SURRENDER_USAGE = "Usage: story surrender <story-id>"
 
 _COMPLETE_USAGE = "Usage: story complete <story-id>"
 _RESOLVE_USAGE = "Usage: story resolve <episode-id> [transition-id] [notes]"
@@ -178,6 +180,7 @@ _SUBVERB_HANDLERS: dict[str, str] = {
     "crossover": "_handle_crossover",
     "impact": "_handle_impact",
     "review-status": "_handle_review_status",
+    "surrender": "_handle_surrender",
 }
 
 
@@ -1257,6 +1260,35 @@ class CmdStory(ArxNamespaceCommand):
         else:
             lines.append("Canon review: none requested")
         self.msg("\n".join(lines))
+
+    def _handle_surrender(self, rest: str) -> None:
+        """GM surrenders oversight of a story (#2004).
+
+        ``story surrender <story-id>`` — Lead GM only; clears the story's
+        primary_table so it enters "seeking GM" state. Mirrors the web
+        ``POST /api/stories/{id}/surrender/`` endpoint.
+        """
+        from world.gm.models import GMProfile  # noqa: PLC0415
+        from world.gm.services import surrender_character_story  # noqa: PLC0415
+        from world.stories.permissions import user_owns_or_leads_story  # noqa: PLC0415
+
+        tokens = rest.split()
+        if not tokens:
+            raise CommandError(_SURRENDER_USAGE)
+        story = resolve_story_or_error(tokens[0])
+
+        account = self.caller.account
+        is_staff = bool(account and account.is_staff)
+        if not is_staff and not user_owns_or_leads_story(account, story):
+            msg = "You do not own or lead this story."
+            raise CommandError(msg)
+        try:
+            gm_profile = account.gm_profile
+        except GMProfile.DoesNotExist:
+            msg = "You must have a GM profile to surrender a story."
+            raise CommandError(msg) from None
+        surrender_character_story(gm_profile, story)
+        self.msg(f"Surrendered oversight of {story.title}. It is now seeking a GM.")
 
     def _get_crossover_or_error(self, invite_id: int) -> CrossoverInvite:
         from world.stories.models import CrossoverInvite  # noqa: PLC0415

--- a/src/commands/tests/test_gm_ops_command.py
+++ b/src/commands/tests/test_gm_ops_command.py
@@ -1,0 +1,119 @@
+"""Telnet tests for GM ops commands (#2004): ``story surrender``, ``gm dashboard``, ``gm idle``."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.gm_ops import CmdGMDashboard, CmdGMIdle
+from commands.story import CmdStory
+from evennia_extensions.factories import AccountFactory
+from world.gm.factories import GMProfileFactory, GMTableFactory
+from world.stories.factories import StoryFactory
+
+
+def _make_story_cmd(caller, args: str) -> CmdStory:
+    cmd = CmdStory()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"story {args}".strip()
+    return cmd
+
+
+def _make_dashboard_cmd(caller, args: str) -> CmdGMDashboard:
+    cmd = CmdGMDashboard()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"gm {args}".strip()
+    return cmd
+
+
+def _make_idle_cmd(caller, args: str) -> CmdGMIdle:
+    cmd = CmdGMIdle()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = "gmidle"
+    return cmd
+
+
+def _messages(caller: MagicMock) -> list[str]:
+    return [str(c.args[0]) for c in caller.msg.call_args_list if c.args]
+
+
+class StorySurrenderCommandTests(TestCase):
+    def setUp(self) -> None:
+        self.owner = AccountFactory()
+        self.gm_profile = GMProfileFactory(account=self.owner)
+        self.table = GMTableFactory(gm=self.gm_profile)
+        self.story = StoryFactory(primary_table=self.table, owners=[self.owner])
+        self.caller = MagicMock()
+        self.caller.msg = MagicMock()
+        self.caller.account = self.owner
+
+    def _run(self, args: str) -> list[str]:
+        cmd = _make_story_cmd(self.caller, args)
+        cmd.func()
+        return _messages(self.caller)
+
+    def test_surrender_clears_primary_table(self) -> None:
+        self._run(f"surrender {self.story.pk}")
+        self.story.refresh_from_db()
+        self.assertIsNone(self.story.primary_table)
+
+    def test_non_owner_cannot_surrender(self) -> None:
+        non_owner = AccountFactory()
+        self.caller.account = non_owner
+        self._run(f"surrender {self.story.pk}")
+        self.story.refresh_from_db()
+        self.assertIsNotNone(self.story.primary_table)
+
+
+class GMDashboardCommandTests(TestCase):
+    def setUp(self) -> None:
+        self.gm_account = AccountFactory()
+        self.gm_profile = GMProfileFactory(account=self.gm_account)
+        self.table = GMTableFactory(gm=self.gm_profile)
+        self.caller = MagicMock()
+        self.caller.msg = MagicMock()
+        self.caller.account = self.gm_account
+
+    def _run(self, args: str) -> list[str]:
+        cmd = _make_dashboard_cmd(self.caller, args)
+        cmd.func()
+        return _messages(self.caller)
+
+    def test_dashboard_shows_table(self) -> None:
+        messages = self._run("dashboard")
+        joined = " ".join(messages)
+        self.assertIn("GM Dashboard", joined)
+        self.assertIn(self.table.name, joined)
+
+    def test_non_gm_rejected(self) -> None:
+        non_gm = AccountFactory()
+        self.caller.account = non_gm
+        messages = self._run("dashboard")
+        self.assertTrue(any("GM profile" in m for m in messages))
+
+
+class GMIdleCommandTests(TestCase):
+    def setUp(self) -> None:
+        self.staff = AccountFactory(is_staff=True)
+        self.caller = MagicMock()
+        self.caller.msg = MagicMock()
+        self.caller.account = self.staff
+
+    def _run(self, args: str) -> list[str]:
+        cmd = _make_idle_cmd(self.caller, args)
+        cmd.func()
+        return _messages(self.caller)
+
+    def test_no_idle_tables(self) -> None:
+        messages = self._run("")
+        self.assertTrue(any("no idle" in m.lower() for m in messages))
+
+    def test_shows_idle_table(self) -> None:
+        gm = GMProfileFactory()  # last_active_at is None → idle
+        table = GMTableFactory(gm=gm)
+        messages = self._run("")
+        self.assertTrue(any(table.name in m for m in messages))

--- a/src/schema.json
+++ b/src/schema.json
@@ -10249,6 +10249,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/GMApplicationDetail'
           description: ''
+  /api/gm/dashboard/:
+    get:
+      operationId: gm_dashboard_retrieve
+      description: Return the GM's dashboard aggregation.
+      tags:
+      - gm
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          description: No response body
   /api/gm/demand-ransom/:
     post:
       operationId: gm_demand_ransom_create
@@ -26027,6 +26038,39 @@ paths:
         NarrativeMessageDelivery rows with category=STORY.
 
         Returns 201 with the created NarrativeMessage.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this story.
+        required: true
+      tags:
+      - stories
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StoryDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StoryDetail'
+          description: ''
+  /api/stories/{id}/surrender/:
+    post:
+      operationId: stories_surrender_create
+      description: |-
+        POST /api/stories/{id}/surrender/ — GM surrenders oversight (#2004).
+
+        Lead GM or staff only. Clears ``primary_table`` so the story enters
+        "seeking GM" state; notifies the affected player via a narrative
+        SYSTEM message. Returns 200 with the updated Story.
       parameters:
       - in: path
         name: id

--- a/src/web/api/serializers.py
+++ b/src/web/api/serializers.py
@@ -102,6 +102,7 @@ class AccountPlayerSerializer(serializers.ModelSerializer):
     email_verified = serializers.SerializerMethodField()
     can_create_characters = serializers.SerializerMethodField()
     is_staff = serializers.BooleanField(read_only=True)
+    is_gm = serializers.SerializerMethodField()
     avatar_url = serializers.SerializerMethodField()
     available_characters = serializers.SerializerMethodField()
     pending_applications = serializers.SerializerMethodField()
@@ -117,6 +118,16 @@ class AccountPlayerSerializer(serializers.ModelSerializer):
     def get_can_create_characters(self, obj):
         """Check if user can create new characters."""
         return obj.player_data.can_apply_for_characters()
+
+    def get_is_gm(self, obj) -> bool:
+        """Whether this account has a GMProfile (#2004)."""
+        from world.gm.models import GMProfile  # noqa: PLC0415
+
+        try:
+            obj.gm_profile  # noqa: B018 - side effect: triggers reverse OneToOne lookup
+        except GMProfile.DoesNotExist:
+            return False
+        return True
 
     def get_avatar_url(self, obj):
         """Get player's avatar URL if available."""
@@ -153,6 +164,7 @@ class AccountPlayerSerializer(serializers.ModelSerializer):
             "email_verified",
             "can_create_characters",
             "is_staff",
+            "is_gm",
             "avatar_url",
             "available_characters",
             "pending_applications",

--- a/src/web/tests/test_account_player_serializer_full_payload.py
+++ b/src/web/tests/test_account_player_serializer_full_payload.py
@@ -98,9 +98,28 @@ class AccountPlayerSerializerFullPayloadTests(TestCase):
             "email_verified",
             "can_create_characters",
             "is_staff",
+            "is_gm",
             "avatar_url",
         ]:
             assert field in data, f"missing existing field: {field}"
+
+    def test_is_gm_true_for_gm_account(self) -> None:
+        from world.gm.factories import GMProfileFactory
+
+        gm_account = AccountFactory()
+        GMProfileFactory(account=gm_account)
+        data = AccountPlayerSerializer(
+            gm_account,
+            context=build_account_payload_context(gm_account),
+        ).data
+        assert data["is_gm"] is True
+
+    def test_is_gm_false_for_non_gm_account(self) -> None:
+        data = AccountPlayerSerializer(
+            self.account,
+            context=build_account_payload_context(self.account),
+        ).data
+        assert data["is_gm"] is False
 
 
 class AccountPayloadQueryCountTests(TestCase):

--- a/src/world/game_clock/tasks.py
+++ b/src/world/game_clock/tasks.py
@@ -51,6 +51,7 @@ def weekly_rollover_task() -> None:
         ("AP weekly regen", batch_ap_weekly_regen),
         ("weekly economy", _run_weekly_economy),
         ("social engagement kudos grant", _run_social_engagement_grant),
+        ("idle table summary", _run_idle_table_summary),
     ]
 
     for name, processor in processors:
@@ -65,6 +66,17 @@ def _run_weekly_economy() -> None:
     from world.currency.services import run_weekly_economy
 
     run_weekly_economy()
+
+
+def _run_idle_table_summary() -> None:
+    """Log a summary of idle GM tables for staff awareness (#2004)."""
+    from world.gm.services import idle_tables
+
+    tables = list(idle_tables())
+    if not tables:
+        return
+    names = ", ".join(f"{t.name} (GM: {t.gm.account.username})" for t in tables)
+    logger.info("Idle table summary: %d idle table(s): %s", len(tables), names)
 
 
 def _run_social_engagement_grant() -> None:

--- a/src/world/gm/services.py
+++ b/src/world/gm/services.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone
 
 from world.gm.constants import GMLevel, GMTableStatus
@@ -95,6 +96,26 @@ def transfer_ownership(table: GMTable, new_gm: GMProfile) -> None:
     """Reassign a table to a different GM. Staff-only action."""
     table.gm = new_gm
     table.save(update_fields=["gm"])
+
+
+# Staff-tunable threshold (days) for idle-table detection (#2004).
+# A GMTable whose GM's last_active_at is older than this is "idle".
+IDLE_TABLE_THRESHOLD_DAYS = 14
+
+
+def idle_tables(threshold_days: int = IDLE_TABLE_THRESHOLD_DAYS) -> QuerySet[GMTable]:
+    """ACTIVE tables whose GM's ``last_active_at`` is older than the threshold (#2004).
+
+    Returns tables whose GM has never been active (``last_active_at IS NULL``)
+    or whose last activity predates the cutoff. Used by the StaffWorkloadView
+    idle-tables section and the weekly cron summary.
+    """
+    cutoff = timezone.now() - timedelta(days=threshold_days)
+    return (
+        GMTable.objects.filter(status=GMTableStatus.ACTIVE)
+        .select_related("gm__account")
+        .filter(Q(gm__last_active_at__lt=cutoff) | Q(gm__last_active_at__isnull=True))
+    )
 
 
 @transaction.atomic
@@ -237,6 +258,37 @@ def surrender_character_story(gm: GMProfile, story: Story) -> None:
     touch_gm_activity(gm)
     story.primary_table = None
     story.save(update_fields=["primary_table"])
+    _notify_surrender(story, gm)
+
+
+def _notify_surrender(story: Story, gm: GMProfile) -> None:
+    """Best-effort narrative SYSTEM message to the affected player (#2004).
+
+    Notifies the story's character_sheet owner that their GM has surrendered
+    oversight. Skips gracefully when no character_sheet is resolvable (GROUP/
+    GLOBAL stories have no single affected player).
+    """
+    from world.narrative.constants import NarrativeCategory  # noqa: PLC0415
+    from world.narrative.services import send_narrative_message  # noqa: PLC0415
+
+    character_sheet = story.character_sheet
+    if character_sheet is None:
+        return
+    try:
+        send_narrative_message(
+            recipients=[character_sheet],
+            body=(
+                f"Your GM has surrendered oversight of your story "
+                f"'{story.title}'. It is now seeking a new GM."
+            ),
+            category=NarrativeCategory.SYSTEM,
+            sender_account=gm.account,
+            related_story=story,
+        )
+    except Exception:
+        import logging  # noqa: PLC0415
+
+        logging.getLogger(__name__).exception("surrender notification failed")
 
 
 @transaction.atomic

--- a/src/world/gm/services.py
+++ b/src/world/gm/services.py
@@ -28,6 +28,17 @@ if TYPE_CHECKING:
 DEFAULT_INVITE_DURATION_DAYS = 30
 
 
+def touch_gm_activity(gm_profile: GMProfile) -> None:
+    """Stamp ``GMProfile.last_active_at`` to now (#2004).
+
+    Single seam (no signal, ADR-0009) called from every GM-verb service so a
+    GM's activity is tracked for idle-table detection. Idempotent and cheap
+    (one ``update_fields`` write); safe to call repeatedly.
+    """
+    gm_profile.last_active_at = timezone.now()
+    gm_profile.save(update_fields=["last_active_at"])
+
+
 def get_notification_target_for_gm(gm_profile: GMProfile) -> CharacterSheet | None:
     """Resolve the CharacterSheet to use as the notification recipient for a GM.
 
@@ -223,6 +234,7 @@ def surrender_character_story(gm: GMProfile, story: Story) -> None:
     if story.primary_table is None or story.primary_table.gm != gm:
         msg = "You do not oversee this story."
         raise ValidationError(msg)
+    touch_gm_activity(gm)
     story.primary_table = None
     story.save(update_fields=["primary_table"])
 

--- a/src/world/gm/tests/test_activity_stamping.py
+++ b/src/world/gm/tests/test_activity_stamping.py
@@ -1,0 +1,35 @@
+"""Tests for touch_gm_activity + activity stamping from GM verbs (#2004)."""
+
+from django.test import TestCase
+
+from world.gm.factories import GMProfileFactory, GMTableFactory
+from world.gm.services import surrender_character_story, touch_gm_activity
+from world.stories.factories import StoryFactory
+
+
+class TouchGmActivityTests(TestCase):
+    def test_stamps_last_active_at(self) -> None:
+        gm = GMProfileFactory()
+        self.assertIsNone(gm.last_active_at)
+        touch_gm_activity(gm)
+        gm.refresh_from_db()
+        self.assertIsNotNone(gm.last_active_at)
+
+    def test_is_idempotent_and_updates(self) -> None:
+        gm = GMProfileFactory()
+        touch_gm_activity(gm)
+        first = gm.last_active_at
+        touch_gm_activity(gm)
+        gm.refresh_from_db()
+        self.assertGreaterEqual(gm.last_active_at, first)
+
+
+class SurrenderStampsActivityTests(TestCase):
+    def test_surrender_stamps_gm_activity(self) -> None:
+        gm = GMProfileFactory()
+        table = GMTableFactory(gm=gm)
+        story = StoryFactory(primary_table=table)
+        self.assertIsNone(gm.last_active_at)
+        surrender_character_story(gm, story)
+        gm.refresh_from_db()
+        self.assertIsNotNone(gm.last_active_at)

--- a/src/world/gm/tests/test_activity_stamping.py
+++ b/src/world/gm/tests/test_activity_stamping.py
@@ -33,3 +33,68 @@ class SurrenderStampsActivityTests(TestCase):
         surrender_character_story(gm, story)
         gm.refresh_from_db()
         self.assertIsNotNone(gm.last_active_at)
+
+
+class GMVerbActivityStampingTests(TestCase):
+    """Each GM-verb service that receives a gm_profile stamps activity (#2004)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.stories.factories import seed_default_risk_calibrations
+
+        seed_default_risk_calibrations()
+
+    def test_resolve_episode_stamps_resolved_by(self) -> None:
+        from world.stories.constants import (
+            BeatPredicateType,
+            StoryMaturity,
+        )
+        from world.stories.factories import (
+            BeatFactory,
+            ChapterFactory,
+            EpisodeFactory,
+            StoryFactory,
+            StoryProgressFactory,
+            TransitionFactory,
+        )
+        from world.stories.services.episodes import resolve_episode
+
+        gm = GMProfileFactory()
+        self.assertIsNone(gm.last_active_at)
+        story = StoryFactory()
+        chapter = ChapterFactory(story=story, is_active=True, maturity=StoryMaturity.PLOT)
+        episode = EpisodeFactory(chapter=chapter)
+        BeatFactory(episode=episode, predicate_type=BeatPredicateType.GM_MARKED)
+        progress = StoryProgressFactory(story=story, current_episode=episode)
+        transition = TransitionFactory(source_episode=episode)
+        resolve_episode(progress=progress, chosen_transition=transition, resolved_by=gm)
+        gm.refresh_from_db()
+        self.assertIsNotNone(gm.last_active_at)
+
+    def test_resolve_stake_by_gm_pick_stamps(self) -> None:
+        from world.societies.constants import RenownRisk
+        from world.stories.constants import (
+            BeatPredicateType,
+            StakeResolutionColumn,
+            StakeSeverity,
+        )
+        from world.stories.factories import (
+            BeatFactory,
+            StakeFactory,
+            StakeResolutionFactory,
+        )
+        from world.stories.services.stake_resolution import resolve_stake_by_gm_pick
+
+        gm = GMProfileFactory()
+        self.assertIsNone(gm.last_active_at)
+        beat = BeatFactory(
+            risk=RenownRisk.HIGH,
+            target_level=4,
+            predicate_type=BeatPredicateType.OUTCOME_TIER,
+        )
+        stake = StakeFactory(beat=beat, severity=StakeSeverity.DIRE)
+        StakeResolutionFactory(stake=stake, column=StakeResolutionColumn.WIN)
+        StakeResolutionFactory(stake=stake, column=StakeResolutionColumn.LOSS)
+        resolve_stake_by_gm_pick(stake, column=StakeResolutionColumn.WIN, gm_profile=gm)
+        gm.refresh_from_db()
+        self.assertIsNotNone(gm.last_active_at)

--- a/src/world/gm/tests/test_gm_dashboard.py
+++ b/src/world/gm/tests/test_gm_dashboard.py
@@ -1,0 +1,48 @@
+"""Tests for GET /api/gm/dashboard/ — the GM dashboard aggregation (#2004)."""
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory
+from world.gm.factories import GMProfileFactory, GMTableFactory
+
+
+class GMDashboardViewTest(APITestCase):
+    """GET /api/gm/dashboard/ — IsGM-gated dashboard aggregation."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.gm_account = AccountFactory()
+        cls.gm_profile = GMProfileFactory(account=cls.gm_account)
+        cls.gm_table = GMTableFactory(gm=cls.gm_profile)
+        cls.non_gm_account = AccountFactory()
+
+    def test_gm_can_access_dashboard(self) -> None:
+        self.client.force_authenticate(user=self.gm_account)
+        url = reverse("gm:gm-dashboard")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.data
+        # All expected sections present.
+        for key in [
+            "episodes_ready_to_run",
+            "pending_agm_claims",
+            "assigned_session_requests",
+            "waiting_for_gm",
+            "my_tables",
+            "pending_story_offers",
+            "evidence_summary",
+        ]:
+            self.assertIn(key, data)
+        # The GM's table appears in my_tables.
+        table_ids = [t["id"] for t in data["my_tables"]]
+        self.assertIn(self.gm_table.pk, table_ids)
+        # Evidence summary carries the GM's level.
+        self.assertEqual(data["evidence_summary"]["level"], self.gm_profile.level)
+
+    def test_non_gm_rejected(self) -> None:
+        self.client.force_authenticate(user=self.non_gm_account)
+        url = reverse("gm:gm-dashboard")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)

--- a/src/world/gm/tests/test_idle_detection.py
+++ b/src/world/gm/tests/test_idle_detection.py
@@ -1,0 +1,45 @@
+"""Tests for idle-table detection (#2004): staleness query + StaffWorkload section."""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from world.gm.factories import GMProfileFactory, GMTableFactory
+from world.gm.services import idle_tables, touch_gm_activity
+
+
+class IdleTablesQueryTests(TestCase):
+    def test_active_table_with_recent_activity_is_not_idle(self) -> None:
+        gm = GMProfileFactory()
+        touch_gm_activity(gm)
+        GMTableFactory(gm=gm)
+        self.assertEqual(idle_tables().count(), 0)
+
+    def test_active_table_with_null_last_active_is_idle(self) -> None:
+        gm = GMProfileFactory()  # last_active_at is None
+        GMTableFactory(gm=gm)
+        self.assertEqual(idle_tables().count(), 1)
+
+    def test_active_table_with_old_activity_is_idle(self) -> None:
+        gm = GMProfileFactory()
+        gm.last_active_at = timezone.now() - timedelta(days=30)
+        gm.save(update_fields=["last_active_at"])
+        GMTableFactory(gm=gm)
+        self.assertEqual(idle_tables().count(), 1)
+
+    def test_archived_table_is_not_idle(self) -> None:
+        from world.gm.constants import GMTableStatus
+
+        gm = GMProfileFactory()  # never active
+        GMTableFactory(gm=gm, status=GMTableStatus.ARCHIVED)
+        self.assertEqual(idle_tables().count(), 0)
+
+    def test_threshold_is_configurable(self) -> None:
+        gm = GMProfileFactory()
+        gm.last_active_at = timezone.now() - timedelta(days=5)
+        gm.save(update_fields=["last_active_at"])
+        GMTableFactory(gm=gm)
+        # 5 days ago is idle at threshold=4, not idle at threshold=7
+        self.assertEqual(idle_tables(threshold_days=4).count(), 1)
+        self.assertEqual(idle_tables(threshold_days=7).count(), 0)

--- a/src/world/gm/tests/test_surrender_endpoint.py
+++ b/src/world/gm/tests/test_surrender_endpoint.py
@@ -1,0 +1,66 @@
+"""Tests for POST /api/stories/{id}/surrender/ — GM surrenders oversight (#2004)."""
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.factories import GMProfileFactory, GMTableFactory
+from world.narrative.models import NarrativeMessage
+from world.stories.constants import StoryScope
+from world.stories.factories import StoryFactory
+
+
+class StorySurrenderEndpointTest(APITestCase):
+    """POST /api/stories/{id}/surrender/ — Lead GM surrenders oversight."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.lead_gm_account = AccountFactory()
+        cls.lead_gm_profile = GMProfileFactory(account=cls.lead_gm_account)
+        cls.gm_table = GMTableFactory(gm=cls.lead_gm_profile)
+        cls.non_gm_account = AccountFactory()
+        cls.character_sheet = CharacterSheetFactory()
+
+    def _make_story(self) -> object:
+        return StoryFactory(
+            owners=[self.lead_gm_account],
+            primary_table=self.gm_table,
+            scope=StoryScope.CHARACTER,
+            character_sheet=self.character_sheet,
+        )
+
+    def test_lead_gm_can_surrender(self) -> None:
+        story = self._make_story()
+        self.client.force_authenticate(user=self.lead_gm_account)
+        url = reverse("story-surrender", kwargs={"pk": story.pk})
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        story.refresh_from_db()
+        self.assertIsNone(story.primary_table)
+
+    def test_non_gm_cannot_surrender(self) -> None:
+        story = self._make_story()
+        self.client.force_authenticate(user=self.non_gm_account)
+        url = reverse("story-surrender", kwargs={"pk": story.pk})
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        story.refresh_from_db()
+        self.assertIsNotNone(story.primary_table)
+
+    def test_surrender_notifies_player(self) -> None:
+        story = self._make_story()
+        self.client.force_authenticate(user=self.lead_gm_account)
+        url = reverse("story-surrender", kwargs={"pk": story.pk})
+        self.client.post(url)
+        self.assertTrue(NarrativeMessage.objects.filter(related_story=story).exists())
+
+    def test_surrender_stamps_gm_activity(self) -> None:
+        story = self._make_story()
+        self.assertIsNone(self.lead_gm_profile.last_active_at)
+        self.client.force_authenticate(user=self.lead_gm_account)
+        url = reverse("story-surrender", kwargs={"pk": story.pk})
+        self.client.post(url)
+        self.lead_gm_profile.refresh_from_db()
+        self.assertIsNotNone(self.lead_gm_profile.last_active_at)

--- a/src/world/gm/urls.py
+++ b/src/world/gm/urls.py
@@ -8,6 +8,7 @@ from world.gm.views import (
     GMApplicationActionView,
     GMApplicationQueueView,
     GMApplicationViewSet,
+    GMDashboardView,
     GMInviteClaimView,
     GMProfileViewSet,
     GMRosterInviteViewSet,
@@ -39,4 +40,5 @@ urlpatterns = [
         name="gm-application-action",
     ),
     path("demand-ransom/", DemandRansomView.as_view(), name="gm-demand-ransom"),
+    path("dashboard/", GMDashboardView.as_view(), name="gm-dashboard"),
 ]

--- a/src/world/gm/views.py
+++ b/src/world/gm/views.py
@@ -461,3 +461,66 @@ class DemandRansomView(APIView):
             {"project_id": project.pk, "threshold_target": project.threshold_target},
             status=status.HTTP_201_CREATED,
         )
+
+
+class GMDashboardView(APIView):
+    """GET /api/gm/dashboard/ — the GM's story-shaped dashboard (#2004).
+
+    Composes the existing gm-queue (episodes ready, pending AGM claims,
+    assigned sessions, waiting-for-GM) with the GM's tables, pending story
+    offers, and evidence summary. Role-gated via IsGM.
+    """
+
+    permission_classes = [IsGM]
+
+    def get(self, request: Request) -> Response:
+        """Return the GM's dashboard aggregation."""
+        from world.gm.services import gm_evidence_summary  # noqa: PLC0415
+        from world.stories.constants import (  # noqa: PLC0415
+            StoryGMOfferStatus,
+        )
+        from world.stories.models import (  # noqa: PLC0415
+            StoryGMOffer,
+        )
+        from world.stories.views import _collect_gm_queue  # noqa: PLC0415
+
+        gm_profile = request.user.gm_profile
+
+        # Reuse the existing gm-queue aggregation.
+        buckets = _collect_gm_queue(gm_profile)
+
+        # My tables with basic counts.
+        my_tables = list(
+            GMTable.objects.filter(gm=gm_profile, status=GMTableStatus.ACTIVE)
+            .annotate(
+                membership_count=Count("memberships", filter=Q(memberships__left_at__isnull=True)),
+            )
+            .values("id", "name", "membership_count")
+        )
+
+        # Pending story offers addressed to this GM.
+        pending_offers = list(
+            StoryGMOffer.objects.filter(
+                offered_to=gm_profile, status=StoryGMOfferStatus.PENDING
+            ).values("id", "story__title", "created_at")
+        )
+
+        # Evidence summary (self-view of what staff sees).
+        evidence = gm_evidence_summary(gm_profile)
+
+        return Response(
+            {
+                "episodes_ready_to_run": buckets.episodes_ready,
+                "pending_agm_claims": buckets.pending_claims,
+                "assigned_session_requests": buckets.assigned_requests,
+                "waiting_for_gm": buckets.waiting_for_gm,
+                "my_tables": my_tables,
+                "pending_story_offers": pending_offers,
+                "evidence_summary": {
+                    "level": evidence.level,
+                    "stories_running": evidence.stories_running,
+                    "beats_completed_by_risk": evidence.beats_completed_by_risk,
+                    "last_active_at": evidence.last_active_at,
+                },
+            }
+        )

--- a/src/world/stories/AGENT_GLOSSARY.md
+++ b/src/world/stories/AGENT_GLOSSARY.md
@@ -154,3 +154,20 @@ nothing pays) via `validate_stakes_readiness`'s canon-review problem. Surfaced
 on the staff `StaffWorkloadView` pending-queue and decided via the
 `canonreview` telnet command or `CanonReviewViewSet` web verbs.
 _Avoid_: sign-off (that's `TreasuredSignoff` / custody), approval gate.
+
+**Surrender** (GM):
+A Lead GM releasing oversight of a story — `surrender_character_story(gm, story)`
+(#2004) clears `primary_table` so the story enters "seeking GM" state,
+mirroring the player-side `detach-from-table`. Stamps GM activity and notifies
+the affected player via a narrative SYSTEM message. Wired via
+`POST /api/stories/{id}/surrender/` and `story surrender <story-id>` telnet.
+_Avoid_: abandon, drop (use surrender for the GM-side release; detach for the player-side).
+
+**Idle Table**:
+An ACTIVE `GMTable` whose GM's `last_active_at` is older than a staff-tunable
+threshold (`IDLE_TABLE_THRESHOLD_DAYS`, default 14) or null — surfaced on
+`StaffWorkloadView`'s `idle_tables` section and a weekly cron summary
+(`_run_idle_table_summary`). Reassignment drives the existing
+`transfer_ownership` service. `last_active_at` is stamped by
+`touch_gm_activity` from every GM-verb service.
+_Avoid_: stale table (staleness is a story-progress concept; idle is a GM-activity concept).

--- a/src/world/stories/services/episodes.py
+++ b/src/world/stories/services/episodes.py
@@ -126,6 +126,12 @@ def resolve_episode(
         # durably committed but the status left stale.
         _reconcile_status_after_advance(progress)
 
+    # Stamp GM activity (#2004) — the resolution succeeded.
+    if resolved_by is not None:
+        from world.gm.services import touch_gm_activity  # noqa: PLC0415
+
+        touch_gm_activity(resolved_by)
+
     # Narrative notification — fans out a NarrativeMessage per recipient.
     from world.stories.services.narrative import notify_episode_resolution  # noqa: PLC0415
 

--- a/src/world/stories/services/stake_resolution.py
+++ b/src/world/stories/services/stake_resolution.py
@@ -551,7 +551,7 @@ def resolve_stake_by_gm_pick(  # noqa: PLR0913 - mirrors record_gm_marked_outcom
     activation = _activation_for_gm_pick(stake.beat)
 
     with transaction.atomic():
-        return _fire_branch_and_record(
+        outcome = _fire_branch_and_record(
             stake=stake,
             resolution=resolution,
             column=column,
@@ -563,6 +563,14 @@ def resolve_stake_by_gm_pick(  # noqa: PLR0913 - mirrors record_gm_marked_outcom
             resolved_by=gm_profile,
             gm_notes=gm_notes,
         )
+
+    # Stamp GM activity (#2004) — the pick succeeded.
+    if gm_profile is not None:
+        from world.gm.services import touch_gm_activity  # noqa: PLC0415
+
+        touch_gm_activity(gm_profile)
+
+    return outcome
 
 
 def _activation_for_gm_pick(beat: Beat) -> StakeContractActivation | None:

--- a/src/world/stories/tests/test_views_staff_workload.py
+++ b/src/world/stories/tests/test_views_staff_workload.py
@@ -51,7 +51,7 @@ STAFF_WORKLOAD_URL = reverse("stories-staff-workload")
 # N=12 with episode-bearing rows that exercise the eligibility batch path.
 # +1 for the pending_canon_reviews section (#2003) — a single select_related
 # scan independent of N.
-BOUNDED_QUERY_COUNT = 27
+BOUNDED_QUERY_COUNT = 28
 
 
 class StaffWorkloadAuthTest(APITestCase):
@@ -99,6 +99,7 @@ class StaffWorkloadResponseShapeTest(APITestCase):
             "open_session_requests_count",
             "counts_by_scope",
             "pending_canon_reviews",
+            "idle_tables",
         ]:
             assert key in response.data, f"Missing key: {key}"
 

--- a/src/world/stories/views.py
+++ b/src/world/stories/views.py
@@ -564,6 +564,33 @@ class StoryViewSet(viewsets.ModelViewSet):
     @action(
         detail=True,
         methods=[HTTPMethod.POST],
+        url_path="surrender",
+        permission_classes=[IsLeadGMOnStoryOrStaff],
+    )
+    def surrender(self, request: Request, pk: int | None = None) -> Response:
+        """POST /api/stories/{id}/surrender/ — GM surrenders oversight (#2004).
+
+        Lead GM or staff only. Clears ``primary_table`` so the story enters
+        "seeking GM" state; notifies the affected player via a narrative
+        SYSTEM message. Returns 200 with the updated Story.
+        """
+        from world.gm.models import GMProfile  # noqa: PLC0415
+        from world.gm.services import surrender_character_story  # noqa: PLC0415
+
+        story = self.get_object()
+        try:
+            gm_profile = request.user.gm_profile
+        except GMProfile.DoesNotExist:
+            return Response(
+                {"detail": "You must have a GM profile to surrender a story."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        surrender_character_story(gm_profile, story)
+        return Response(StoryDetailSerializer(story, context={"request": request}).data)
+
+    @action(
+        detail=True,
+        methods=[HTTPMethod.POST],
         url_path="assign-to-scope",
         permission_classes=[IsLeadGMOnStoryOrStaff],
     )
@@ -2848,6 +2875,20 @@ class StaffWorkloadView(APIView):
             for review in pending_canon_reviews()
         ]
 
+        # --- idle tables (#2004) ---
+        from world.gm.services import idle_tables  # noqa: PLC0415
+
+        idle_tables_payload = [
+            {
+                "table_id": table.pk,
+                "table_name": table.name,
+                "gm_profile_id": table.gm_id,
+                "gm_name": table.gm.account.username,
+                "last_active_at": table.gm.last_active_at,
+            }
+            for table in idle_tables()
+        ]
+
         return Response(
             {
                 "per_gm_queue_depth": per_gm_queue,
@@ -2858,6 +2899,7 @@ class StaffWorkloadView(APIView):
                 "open_session_requests_count": open_session_req_count,
                 "counts_by_scope": counts_by_scope,
                 "pending_canon_reviews": pending_canon_reviews_payload,
+                "idle_tables": idle_tables_payload,
             }
         )
 


### PR DESCRIPTION
Closes #2004

## Summary

Wires the operational loose ends (surrender endpoint, activity stamping, idle detection) and builds the story-shaped GM dashboard. Surrender: POST /api/stories/{id}/surrender/ + story surrender telnet, over the existing surrender_character_story service, with player notification. Activity stamping: touch_gm_activity helper stamped from surrender, resolve_episode, and resolve_stake_by_gm_pick. Idle detection: staleness query on GMProfile.last_active_at, StaffWorkloadView idle_tables section, weekly cron summary. GM dashboard: GET /api/gm/dashboard/ composing gm-queue + tables + offers + evidence, with a /gm/dashboard frontend route. Account payload gains is_gm (GMProfile presence) so the frontend can gate navigation without 403 probing. Telnet: story surrender, gm dashboard, gm idle (staff).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2004 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased 6 commits onto origin/main — no conflicts.

<!-- last-addressed-comment: 0 -->