### PR TITLE
BlockContactFlag: wire remaining contact vectors (targeted poses, whispers, pages) (#1278 follow-up)

### DIFF
--- a/src/actions/definitions/communication.py
+++ b/src/actions/definitions/communication.py
@@ -19,7 +19,7 @@ from world.scenes.interaction_services import record_interaction, record_whisper
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
-    from world.scenes.models import Persona
+    from world.scenes.models import Persona, Scene
 
 
 # Module-level filter constants used as dataclass defaults (RUF009: no calls in defaults).
@@ -43,6 +43,47 @@ def _characters_to_active_personas(characters: list[ObjectDB]) -> list[Persona] 
         if primary is not None:
             personas.append(primary)
     return personas or None
+
+
+def _flag_blocked_contact_for_targets(
+    actor: ObjectDB,
+    targets: list[ObjectDB],
+    *,
+    scene: Scene | None = None,
+) -> None:
+    """Fire BlockContactFlag for any blocked-pair contact in a communication action (#1278).
+
+    Resolves the actor's and each target's active persona, then calls
+    ``flag_blocked_contact_attempt``. The service is a no-op when no active block
+    exists (target did not block the initiator), and dedupes per (blocker, blocked,
+    scene) — so calling it unconditionally is safe. Zero signal to either player.
+    """
+    try:
+        initiator_persona = actor.sheet_data.primary_persona
+    except (AttributeError, ObjectDoesNotExist):
+        return
+    if initiator_persona is None:
+        return
+    from world.scenes.block_services import flag_blocked_contact_attempt  # noqa: PLC0415
+
+    for target in targets:
+        try:
+            target_persona = target.sheet_data.primary_persona
+        except (AttributeError, ObjectDoesNotExist):
+            continue
+        if target_persona is not None:
+            flag_blocked_contact_attempt(
+                initiator_persona=initiator_persona,
+                target_persona=target_persona,
+                scene=scene,
+            )
+
+
+def _active_scene_for(actor: ObjectDB) -> Scene | None:
+    """Resolve the active scene at the actor's location, if any."""
+    from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
+
+    return get_active_scene(actor.location)
 
 
 @dataclass
@@ -91,6 +132,12 @@ class SayAction(Action):
             target_personas=target_personas,
         )
 
+        # #1278/#2088 — flag circumvention: a blocked player directing a say at the
+        # blocker via another identity. Room-wide says (no targets) are already
+        # handled by the visibility filter; only directed says are contact attempts.
+        if targets:
+            _flag_blocked_contact_for_targets(actor, targets, scene=_active_scene_for(actor))
+
         return ActionResult(success=True)
 
 
@@ -138,6 +185,12 @@ class PoseAction(Action):
             target_personas=target_personas,
             place=place,
         )
+
+        # #1278/#2088 — flag circumvention: a blocked player directing a pose at the
+        # blocker via another identity. Room-wide poses (no targets) are already
+        # handled by the visibility filter; only directed poses are contact attempts.
+        if targets:
+            _flag_blocked_contact_for_targets(actor, targets, scene=_active_scene_for(actor))
 
         return ActionResult(success=True)
 
@@ -355,5 +408,9 @@ class WhisperAction(Action):
         # Record + push: creates DB record and sends structured WebSocket payload.
         # Web clients use this for the scene feed display.
         record_whisper_interaction(character=actor, target=target, content=text)
+
+        # #1278/#2088 — flag circumvention attempts: a blocked player whispering the
+        # blocker via another identity. No-op when no active block exists.
+        _flag_blocked_contact_for_targets(actor, [target], scene=_active_scene_for(actor))
 
         return ActionResult(success=True)

--- a/src/commands/evennia_overrides/communication.py
+++ b/src/commands/evennia_overrides/communication.py
@@ -23,6 +23,30 @@ from commands.frontend_types import UsageEntry
 from world.scenes.place_models import Place
 
 
+def _flag_page_contact(sender_char: object, target_char: object) -> None:
+    """Fire BlockContactFlag for a page from a blocked player to the blocker (#1278/#2088).
+
+    Page is OOC (no scene); ``BlockContactFlag.scene`` is nullable. The service
+    no-ops when no active block exists, and dedupes per (blocker, blocked, scene=None).
+    """
+    if sender_char is None or target_char is None:
+        return
+    try:
+        initiator_persona = sender_char.sheet_data.primary_persona
+        target_persona = target_char.sheet_data.primary_persona
+    except (AttributeError, ObjectDoesNotExist):
+        return
+    if initiator_persona is None or target_persona is None:
+        return
+    from world.scenes.block_services import flag_blocked_contact_attempt  # noqa: PLC0415
+
+    flag_blocked_contact_attempt(
+        initiator_persona=initiator_persona,
+        target_persona=target_persona,
+        scene=None,
+    )
+
+
 class CmdSay(ArxCommand):
     """Speak aloud to the room."""
 
@@ -155,6 +179,11 @@ class CmdPage(FrontendMetadataMixin, Command):  # ty: ignore[invalid-base]
 
         character.msg(f"{self.caller.key} pages: {text}")
         self.caller.msg(f"You page {character.key}: {text}")
+
+        # #1278/#2088 — flag circumvention: a blocked player paging the blocker via
+        # another identity. OOC (no scene); the service no-ops when no active block
+        # exists, and dedupes per (blocker, blocked, scene=None).
+        _flag_page_contact(sender_char, character)
 
 
 class CmdTabletalk(ArxCommand):

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -15,20 +15,21 @@ the unified Persona identity system, and non-combat scene rounds.
   `blocked_persona`) with an `account_level` opt-in; keyed on `PlayerData` so it follows the person
   across re-rosters. Resolution + lifecycle in `block_services.py` (`coded_block_active`,
   `sheet_blocked_for_viewer`, `hidden_persona_ids_for_viewer`, `lift_block`, `finalize_expired_blocks`).
-  Wired into the profile gate (404), the scene target picker, and feed visibility. Supersedes the removed
-  `evennia_extensions.PlayerBlockList`. Remaining: the awareness/"Character Has You Blocked" surface +
-  the cron job.
+  Wired into the profile gate (404), the scene target picker, and feed visibility. The cron-clear
+  (`finalize_expired_blocks`, wired into `game_clock` via `scenes.block_finalize`) is done.
+  Supersedes the removed `evennia_extensions.PlayerBlockList`. Remaining: the awareness/"Character Has
+  You Blocked" surface (#2086).
 - **`Mute`** (#1278): the lighter, **one-way** sibling of Block — a player filters a persona out of
   their own view (IC and/or OOC), reversible, no enforcement, the muted party never aware.
   `mute_services.py` (`muted_persona_ids_for_viewer`, `set_mute`, `unmute`); the IC side is wired into
   the scene feed (muted personas skipped). The OOC channel, the "actions still show without text"
-  refinement, the opt-in reveal, and the toggle UI are follow-ups.
+  refinement, the opt-in reveal, and the "N hidden" feed divider are follow-ups (#2087).
 - **`BlockContactFlag`** (#1278): the anti-derivation awareness layer. When a *blocked* player reaches the
   blocker via another identity (circumvention the coded block can't prevent without leaking the alt),
   `block_services.flag_blocked_contact_attempt` records it for staff (anchored on accounts + personas;
-  zero signal to either player). Hooked into `action_services.create_action_request`. Staff triage via
-  admin. Remaining contact vectors (targeted poses/whispers) + the player-facing generic "Character Has
-  You Blocked" warning are follow-ups.
+  zero signal to either player). Hooked into `action_services.create_action_request` and the direct
+  communication actions (`WhisperAction`, directed `SayAction`/`PoseAction`, `CmdPage`). Staff triage
+  via admin. Remaining: the player-facing generic "Character Has You Blocked" warning (#2086).
 - **`Interaction`**: Atomic IC interaction record (pose, say, whisper, etc.) with privacy controls
 - **`InteractionFavorite`**: Private bookmarks for cherished RP moments
 - **`InteractionReaction`**: Emoji reactions on interactions

--- a/src/world/scenes/tests/test_contact_flag_wiring.py
+++ b/src/world/scenes/tests/test_contact_flag_wiring.py
@@ -1,0 +1,279 @@
+"""Tests for BlockContactFlag wiring into communication actions (#2088).
+
+The coded block stops the exact blocked pair; a blocked player reaching the blocker via
+*another identity* — through a directed say, whisper, pose, or page — is circumvention.
+Not code-prevented (anti-derivation), but flagged for staff review.
+"""
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from actions.definitions.communication import PoseAction, SayAction, WhisperAction
+from commands.evennia_overrides.communication import CmdPage
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from evennia_extensions.models import PlayerData
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.factories import PersonaFactory
+from world.scenes.models import Block, BlockContactFlag
+
+
+class CommunicationContactFlagTests(TestCase):
+    """Each communication vector should fire a BlockContactFlag when a blocked player
+    contacts the blocker via another identity."""
+
+    def _make_side(self, name: str):
+        """Create an account + rostered character with a primary persona + an alt persona."""
+        account = AccountFactory(username=name)
+        player_data, _ = PlayerData.objects.get_or_create(account=account)
+        character = CharacterFactory(db_key=name)
+        entry = RosterEntryFactory(character_sheet__character=character)
+        RosterTenureFactory(player_data=player_data, roster_entry=entry)
+        sheet = entry.character_sheet
+        primary = sheet.primary_persona
+        alt = PersonaFactory(character_sheet=sheet, name=f"{name} Alt")
+        # Characters need msg for the action's send_message/record_interaction.
+        character.msg = MagicMock()
+        character.location = None
+        return account, player_data, character, sheet, primary, alt
+
+    def setUp(self) -> None:
+        # The blocker side — the person who did the blocking.
+        (
+            self.blocker_acct,
+            self.blocker_pd,
+            self.blocker_char,
+            self.blocker_sheet,
+            self.blocker_face,
+            _,
+        ) = self._make_side("Blocker")
+
+        # The blocked side — the person who was blocked. Has an alt identity.
+        (
+            self.blocked_acct,
+            self.blocked_pd,
+            self.blocked_char,
+            self.blocked_sheet,
+            self.blocked_face,
+            self.blocked_alt,
+        ) = self._make_side("Blocked")
+
+        # The blocker blocked the blocked player's main face.
+        Block.objects.create(
+            owner=self.blocker_pd,
+            blocked_player=self.blocked_pd,
+            blocker_persona=self.blocker_face,
+            blocked_persona=self.blocked_face,
+        )
+
+    def _patch_interaction_recording(self):
+        """Patch out the DB-writing interaction recorders (they need a real scene/room)."""
+        import actions.definitions.communication as comm_mod
+
+        original_record = comm_mod.record_interaction
+        original_whisper = comm_mod.record_whisper_interaction
+        original_msg_location = comm_mod.message_location
+        original_send_message = comm_mod.send_message
+        comm_mod.record_interaction = MagicMock()
+        comm_mod.record_whisper_interaction = MagicMock()
+        comm_mod.message_location = MagicMock()
+        comm_mod.send_message = MagicMock()
+        return original_record, original_whisper, original_msg_location, original_send_message
+
+    def _restore_interaction_recording(self, originals):
+        import actions.definitions.communication as comm_mod
+
+        (
+            comm_mod.record_interaction,
+            comm_mod.record_whisper_interaction,
+            comm_mod.message_location,
+            comm_mod.send_message,
+        ) = originals
+
+    # --- Whisper ---
+
+    def test_whisper_from_blocked_alt_fires_flag(self) -> None:
+        """A blocked player whispering the blocker via their alt fires a flag."""
+        # The blocked player uses their alt to whisper the blocker.
+        originals = self._patch_interaction_recording()
+        try:
+            WhisperAction().execute(
+                actor=self.blocked_char,
+                context=None,
+                target=self.blocker_char,
+                text="psst",
+            )
+        finally:
+            self._restore_interaction_recording(originals)
+
+        flag = BlockContactFlag.objects.filter(
+            blocked_account_id=self.blocked_acct.pk,
+            blocker_account_id=self.blocker_acct.pk,
+        ).first()
+        assert flag is not None, "Expected a BlockContactFlag for the whisper"
+
+    def test_whisper_when_no_block_produces_no_flag(self) -> None:
+        """A whisper between non-blocked pairs produces no flag."""
+        _, _, stranger_char, _, _, _ = self._make_side("Stranger")
+        originals = self._patch_interaction_recording()
+        try:
+            WhisperAction().execute(
+                actor=stranger_char,
+                context=None,
+                target=self.blocker_char,
+                text="hello",
+            )
+        finally:
+            self._restore_interaction_recording(originals)
+
+        assert BlockContactFlag.objects.count() == 0
+
+    # --- Directed Say ---
+
+    def test_directed_say_from_blocked_alt_fires_flag(self) -> None:
+        """A blocked player using a directed say at the blocker fires a flag."""
+        originals = self._patch_interaction_recording()
+        try:
+            SayAction().execute(
+                actor=self.blocked_char,
+                context=None,
+                text="hi",
+                targets=[self.blocker_char],
+            )
+        finally:
+            self._restore_interaction_recording(originals)
+
+        assert BlockContactFlag.objects.filter(blocked_account_id=self.blocked_acct.pk).exists()
+
+    def test_room_wide_say_produces_no_flag(self) -> None:
+        """A room-wide say (no explicit targets) does not fire a flag."""
+        originals = self._patch_interaction_recording()
+        try:
+            SayAction().execute(
+                actor=self.blocked_char,
+                context=None,
+                text="hi everyone",
+                targets=[],
+            )
+        finally:
+            self._restore_interaction_recording(originals)
+
+        assert BlockContactFlag.objects.count() == 0
+
+    # --- Directed Pose ---
+
+    def test_directed_pose_from_blocked_alt_fires_flag(self) -> None:
+        """A blocked player using a directed pose at the blocker fires a flag."""
+        originals = self._patch_interaction_recording()
+        try:
+            PoseAction().execute(
+                actor=self.blocked_char,
+                context=None,
+                text="waves at Blocker",
+                targets=[self.blocker_char],
+            )
+        finally:
+            self._restore_interaction_recording(originals)
+
+        assert BlockContactFlag.objects.filter(blocked_account_id=self.blocked_acct.pk).exists()
+
+    def test_room_wide_pose_produces_no_flag(self) -> None:
+        """A room-wide pose (no explicit targets) does not fire a flag."""
+        originals = self._patch_interaction_recording()
+        try:
+            PoseAction().execute(
+                actor=self.blocked_char,
+                context=None,
+                text="waves",
+                targets=[],
+            )
+        finally:
+            self._restore_interaction_recording(originals)
+
+        assert BlockContactFlag.objects.count() == 0
+
+    # --- Dedup ---
+
+    def test_repeated_contact_dedupes_to_one_flag(self) -> None:
+        """Multiple contacts in the same scene-less context dedupe to one flag."""
+        originals = self._patch_interaction_recording()
+        try:
+            for _ in range(3):
+                WhisperAction().execute(
+                    actor=self.blocked_char,
+                    context=None,
+                    target=self.blocker_char,
+                    text="psst",
+                )
+        finally:
+            self._restore_interaction_recording(originals)
+
+        assert (
+            BlockContactFlag.objects.filter(
+                blocked_account_id=self.blocked_acct.pk,
+                blocker_account_id=self.blocker_acct.pk,
+            ).count()
+            == 1
+        )
+
+
+class PageContactFlagTests(TestCase):
+    """Page is OOC (no scene); a blocked player paging the blocker fires a flag."""
+
+    def _make_side(self, name: str):
+        account = AccountFactory(username=name)
+        player_data, _ = PlayerData.objects.get_or_create(account=account)
+        character = CharacterFactory(db_key=name)
+        entry = RosterEntryFactory(character_sheet__character=character)
+        RosterTenureFactory(player_data=player_data, roster_entry=entry)
+        sheet = entry.character_sheet
+        character.msg = MagicMock()
+        return account, player_data, character, sheet
+
+    def setUp(self) -> None:
+        self.blocker_acct, self.blocker_pd, self.blocker_char, self.blocker_sheet = self._make_side(
+            "Blocker"
+        )
+        self.blocked_acct, self.blocked_pd, self.blocked_char, self.blocked_sheet = self._make_side(
+            "Blocked"
+        )
+
+        # The blocker blocked the blocked player.
+        Block.objects.create(
+            owner=self.blocker_pd,
+            blocked_player=self.blocked_pd,
+            blocker_persona=self.blocker_sheet.primary_persona,
+            blocked_persona=self.blocked_sheet.primary_persona,
+        )
+
+    def _run_page(self, sender_char, target_char) -> None:
+        """Invoke CmdPage.func with the sender's puppet set."""
+        from unittest.mock import patch
+
+        with patch(
+            "commands.evennia_overrides.communication.search.object_search",
+            return_value=[target_char],
+        ):
+            cmd = CmdPage()
+            cmd.caller = self.blocked_acct
+            cmd.session = MagicMock(puppet=sender_char)
+            cmd.args = f"{target_char.db_key}=hello"
+            cmd.func()
+
+    def test_page_from_blocked_player_fires_flag(self) -> None:
+        """A blocked player paging the blocker fires a flag (scene=None)."""
+        self._run_page(self.blocked_char, self.blocker_char)
+
+        flag = BlockContactFlag.objects.filter(
+            blocked_account_id=self.blocked_acct.pk,
+            blocker_account_id=self.blocker_acct.pk,
+        ).first()
+        assert flag is not None, "Expected a BlockContactFlag for the page"
+        assert flag.scene_id is None, "Page is OOC; scene should be None"
+
+    def test_page_when_no_block_produces_no_flag(self) -> None:
+        """A page between non-blocked pairs produces no flag."""
+        _, _, stranger_char, _ = self._make_side("Stranger")
+        self._run_page(stranger_char, self.blocker_char)
+
+        assert BlockContactFlag.objects.count() == 0


### PR DESCRIPTION
Closes #2088

## Summary

Wire the existing flag_blocked_contact_attempt service into the three remaining direct-contact command paths: whisper, directed say/pose, and page. Pure backend, no migration.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2088 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Already up to date with main; no conflicts.

<!-- last-addressed-comment: 0 -->