### PR TITLE
Block: player-facing 'Character Has You Blocked' awareness surface (#1278 follow-up)

### DIFF
--- a/frontend/src/covenants/pages/CovenantDetailPage.tsx
+++ b/frontend/src/covenants/pages/CovenantDetailPage.tsx
@@ -104,16 +104,18 @@ function MemberRow({
 
   const role = membership.covenant_role;
   const characterSheetId = membership.character_sheet;
+  const isBlocked = membership.display_name === 'a member has blocked you';
   // can_kick is true when: viewer has the capability, target is not own row, target is active,
   // and target has a strictly higher tier number (lower authority) than the viewer.
   const canKick =
     viewerCapabilities.can_kick &&
     !isOwnMembership &&
     membership.is_active &&
-    membership.rank.tier > viewerRankTier;
+    membership.rank.tier > viewerRankTier &&
+    !isBlocked;
   // Rank assignment (promote/demote) is offered to managers on any active member.
   const canAssignRank =
-    viewerCapabilities.can_manage_ranks && membership.is_active && ranks.length > 0;
+    viewerCapabilities.can_manage_ranks && membership.is_active && ranks.length > 0 && !isBlocked;
 
   function handleAssignRank(rankId: number) {
     if (rankId !== membership.rank.id) {
@@ -139,12 +141,14 @@ function MemberRow({
 
   return (
     <div
-      className="flex items-center justify-between gap-4 rounded-md border px-4 py-3"
+      className={`flex items-center justify-between gap-4 rounded-md border px-4 py-3${isBlocked ? 'opacity-50' : ''}`}
       data-testid="member-row"
     >
       <div className="min-w-0 flex-1 space-y-0.5">
         <div className="flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium">Character #{characterSheetId}</span>
+          <span className="text-sm font-medium">
+            {membership.display_name ?? `Character #${characterSheetId}`}
+          </span>
           <Badge variant="secondary" className="text-xs">
             {membership.rank.name}
           </Badge>

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -18331,6 +18331,13 @@ export interface components {
       readonly can_engage: boolean;
       readonly engage_blocked_reason: string | null;
       readonly viewer_capabilities: components['schemas']['ViewerCapabilities'];
+      /**
+       * @description The member's display name, or a generic placeholder if they blocked the viewer (#2086).
+       *
+       *     When the viewer is blocked by this member's player, returns "a member has blocked you"
+       *     — never the member's name or identity. Staff always see the real character name.
+       */
+      readonly display_name: string;
     };
     /** @description Serializer for character drafts. */
     CharacterDraft: {

--- a/src/schema.json
+++ b/src/schema.json
@@ -31354,12 +31354,21 @@ components:
           allOf:
           - $ref: '#/components/schemas/ViewerCapabilities'
           readOnly: true
+        display_name:
+          type: string
+          description: |-
+            The member's display name, or a generic placeholder if they blocked the viewer (#2086).
+
+            When the viewer is blocked by this member's player, returns "a member has blocked you"
+            — never the member's name or identity. Staff always see the real character name.
+          readOnly: true
       required:
       - anchor_role
       - can_engage
       - character_sheet
       - covenant
       - covenant_role
+      - display_name
       - engage_blocked_reason
       - engaged
       - id

--- a/src/world/covenants/serializers.py
+++ b/src/world/covenants/serializers.py
@@ -128,6 +128,7 @@ class CharacterCovenantRoleSerializer(serializers.ModelSerializer):
     can_engage = serializers.SerializerMethodField()
     engage_blocked_reason = serializers.SerializerMethodField()
     viewer_capabilities = serializers.SerializerMethodField()
+    display_name = serializers.SerializerMethodField()
 
     class Meta:
         model = CharacterCovenantRole
@@ -145,6 +146,7 @@ class CharacterCovenantRoleSerializer(serializers.ModelSerializer):
             "can_engage",
             "engage_blocked_reason",
             "viewer_capabilities",
+            "display_name",
         ]
         read_only_fields = fields
 
@@ -218,6 +220,21 @@ class CharacterCovenantRoleSerializer(serializers.ModelSerializer):
                     "can_manage_ranks": viewer_membership.rank.can_manage_ranks,
                 }
         return self.context[cache_key]  # type: ignore[return-value]
+
+    def get_display_name(self, obj: CharacterCovenantRole) -> str:
+        """The member's display name, or a generic placeholder if they blocked the viewer (#2086).
+
+        When the viewer is blocked by this member's player, returns "a member has blocked you"
+        — never the member's name or identity. Staff always see the real character name.
+        """
+        from world.scenes.block_services import member_blocked_viewer  # noqa: PLC0415
+
+        request = self.context.get("request")
+        if request is None or not request.user.is_authenticated:
+            return f"Character #{obj.character_sheet_id}"
+        if member_blocked_viewer(viewer_account=request.user, member_sheet=obj.character_sheet):
+            return "a member has blocked you"
+        return f"Character #{obj.character_sheet_id}"
 
 
 class CovenantSerializer(serializers.ModelSerializer):

--- a/src/world/covenants/serializers.py
+++ b/src/world/covenants/serializers.py
@@ -1,5 +1,6 @@
 """DRF serializers for covenants API."""
 
+from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -232,8 +233,11 @@ class CharacterCovenantRoleSerializer(serializers.ModelSerializer):
         request = self.context.get("request")
         if request is None or not request.user.is_authenticated:
             return f"Character #{obj.character_sheet_id}"
-        if member_blocked_viewer(viewer_account=request.user, member_sheet=obj.character_sheet):
-            return "a member has blocked you"
+        try:
+            if member_blocked_viewer(viewer_account=request.user, member_sheet=obj.character_sheet):
+                return "a member has blocked you"
+        except ObjectDoesNotExist:
+            pass  # No roster entry on this sheet — show the normal name.
         return f"Character #{obj.character_sheet_id}"
 
 

--- a/src/world/covenants/tests/test_membership_block_placeholder.py
+++ b/src/world/covenants/tests/test_membership_block_placeholder.py
@@ -1,0 +1,131 @@
+"""Tests for the 'Character Has You Blocked' membership-list placeholder (#2086).
+
+When a blocked player views a covenant membership list that includes the blocker,
+the blocker's row shows a generic "a member has blocked you" placeholder — never
+the member's name, rank, or role. The blocker viewing the blocked player sees
+the normal display. Staff always see the normal display.
+"""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory
+from evennia_extensions.models import PlayerData
+from world.character_sheets.factories import CharacterSheetFactory
+from world.covenants.factories import (
+    CharacterCovenantRoleFactory,
+    CovenantFactory,
+    CovenantRoleFactory,
+)
+from world.roster.factories import (
+    PlayerDataFactory,
+    RosterEntryFactory,
+    RosterTenureFactory,
+)
+from world.scenes.models import Block
+
+
+def _make_played_sheet(account, name):
+    """Create a sheet + roster entry + current tenure for an account."""
+    sheet = CharacterSheetFactory()
+    entry = RosterEntryFactory(character_sheet=sheet)
+    player_data = PlayerDataFactory(account=account)
+    RosterTenureFactory(roster_entry=entry, player_data=player_data, end_date=None)
+    return sheet
+
+
+class MembershipListBlockPlaceholderTests(TestCase):
+    """The covenant member roster shows a placeholder for a member who blocked the viewer."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # The blocker side.
+        cls.blocker_acct = AccountFactory(username="blocker")
+        cls.blocker_sheet = _make_played_sheet(cls.blocker_acct, "Blocker")
+
+        # The blocked side.
+        cls.blocked_acct = AccountFactory(username="blocked")
+        cls.blocked_sheet = _make_played_sheet(cls.blocked_acct, "Blocked")
+
+        # The covenant both are members of.
+        cls.cov = CovenantFactory()
+        cls.role = CovenantRoleFactory()
+        cls.blocker_membership = CharacterCovenantRoleFactory(
+            character_sheet=cls.blocker_sheet,
+            covenant=cls.cov,
+            covenant_role=cls.role,
+        )
+        cls.blocked_membership = CharacterCovenantRoleFactory(
+            character_sheet=cls.blocked_sheet,
+            covenant=cls.cov,
+            covenant_role=cls.role,
+        )
+
+        # The blocker blocked the blocked player's persona.
+        cls.blocker_pd = PlayerData.objects.get(account=cls.blocker_acct)
+        cls.blocked_pd = PlayerData.objects.get(account=cls.blocked_acct)
+        Block.objects.create(
+            owner=cls.blocker_pd,
+            blocked_player=cls.blocked_pd,
+            blocker_persona=cls.blocker_sheet.primary_persona,
+            blocked_persona=cls.blocked_sheet.primary_persona,
+        )
+
+    def test_blocked_viewer_sees_placeholder_for_blocker(self) -> None:
+        """The blocked player sees 'a member has blocked you' for the blocker's row."""
+        client = APIClient()
+        client.force_authenticate(user=self.blocked_acct)
+        response = client.get(f"/api/covenants/character-roles/?covenant={self.cov.pk}")
+        self.assertEqual(response.status_code, 200)
+        rows = response.data["results"]
+        # Find the blocker's row by character_sheet PK.
+        blocker_row = next(r for r in rows if r["character_sheet"] == self.blocker_sheet.pk)
+        self.assertEqual(blocker_row["display_name"], "a member has blocked you")
+
+    def test_blocked_viewer_sees_own_name_normally(self) -> None:
+        """The blocked player sees their own row normally (not the placeholder)."""
+        client = APIClient()
+        client.force_authenticate(user=self.blocked_acct)
+        response = client.get(f"/api/covenants/character-roles/?covenant={self.cov.pk}")
+        self.assertEqual(response.status_code, 200)
+        rows = response.data["results"]
+        own_row = next(r for r in rows if r["character_sheet"] == self.blocked_sheet.pk)
+        self.assertNotEqual(own_row["display_name"], "a member has blocked you")
+
+    def test_blocker_sees_blocked_player_normally(self) -> None:
+        """The blocker sees the blocked player's row normally (no suppression on blocker's side)."""
+        client = APIClient()
+        client.force_authenticate(user=self.blocker_acct)
+        response = client.get(f"/api/covenants/character-roles/?covenant={self.cov.pk}")
+        self.assertEqual(response.status_code, 200)
+        rows = response.data["results"]
+        blocked_row = next(r for r in rows if r["character_sheet"] == self.blocked_sheet.pk)
+        self.assertNotEqual(blocked_row["display_name"], "a member has blocked you")
+
+    def test_staff_sees_real_names(self) -> None:
+        """Staff always see real names — no placeholder."""
+        staff = AccountFactory(username="staff", is_staff=True)
+        client = APIClient()
+        client.force_authenticate(user=staff)
+        response = client.get(f"/api/covenants/character-roles/?covenant={self.cov.pk}")
+        self.assertEqual(response.status_code, 200)
+        rows = response.data["results"]
+        for row in rows:
+            self.assertNotEqual(row["display_name"], "a member has blocked you")
+
+    def test_non_blocked_pair_sees_normal_names(self) -> None:
+        """A third party with no block sees normal names for both members."""
+        stranger = AccountFactory(username="stranger")
+        stranger_sheet = _make_played_sheet(stranger, "Stranger")
+        CharacterCovenantRoleFactory(
+            character_sheet=stranger_sheet,
+            covenant=self.cov,
+            covenant_role=self.role,
+        )
+        client = APIClient()
+        client.force_authenticate(user=stranger)
+        response = client.get(f"/api/covenants/character-roles/?covenant={self.cov.pk}")
+        self.assertEqual(response.status_code, 200)
+        rows = response.data["results"]
+        for row in rows:
+            self.assertNotEqual(row["display_name"], "a member has blocked you")

--- a/src/world/covenants/views.py
+++ b/src/world/covenants/views.py
@@ -106,10 +106,12 @@ class CharacterCovenantRoleViewSet(viewsets.ReadOnlyModelViewSet):
         ).order_by("-joined_at")
         if self.request.user.is_staff:
             return qs
-        # Non-staff: scope to character sheets the user currently plays.
+        # Non-staff: show all members of covenants the user is currently a member of.
+        # The member's display_name field suppresses identity for blocked pairs (#2086).
         return qs.filter(
-            character_sheet__roster_entry__tenures__end_date__isnull=True,
-            character_sheet__roster_entry__tenures__player_data__account=self.request.user,
+            covenant__memberships__left_at__isnull=True,
+            covenant__memberships__character_sheet__roster_entry__tenures__end_date__isnull=True,
+            covenant__memberships__character_sheet__roster_entry__tenures__player_data__account=self.request.user,
         ).distinct()
 
     @action(

--- a/src/world/covenants/views.py
+++ b/src/world/covenants/views.py
@@ -106,12 +106,18 @@ class CharacterCovenantRoleViewSet(viewsets.ReadOnlyModelViewSet):
         ).order_by("-joined_at")
         if self.request.user.is_staff:
             return qs
-        # Non-staff: show all members of covenants the user is currently a member of.
-        # The member's display_name field suppresses identity for blocked pairs (#2086).
+        if self.action == "list":
+            # Non-staff list: show all members of covenants the user is currently a member of.
+            # The display_name field suppresses identity for blocked pairs (#2086).
+            return qs.filter(
+                covenant__memberships__left_at__isnull=True,
+                covenant__memberships__character_sheet__roster_entry__tenures__end_date__isnull=True,
+                covenant__memberships__character_sheet__roster_entry__tenures__player_data__account=self.request.user,
+            ).distinct()
+        # Non-staff retrieve/action: scope to character sheets the user currently plays.
         return qs.filter(
-            covenant__memberships__left_at__isnull=True,
-            covenant__memberships__character_sheet__roster_entry__tenures__end_date__isnull=True,
-            covenant__memberships__character_sheet__roster_entry__tenures__player_data__account=self.request.user,
+            character_sheet__roster_entry__tenures__end_date__isnull=True,
+            character_sheet__roster_entry__tenures__player_data__account=self.request.user,
         ).distinct()
 
     @action(

--- a/src/world/scenes/block_services.py
+++ b/src/world/scenes/block_services.py
@@ -147,6 +147,37 @@ def sheet_blocked_for_viewer(*, viewer_account: Any, sheet: CharacterSheet) -> b
     return _active_blocks().filter(conditions).exists()
 
 
+def member_blocked_viewer(*, viewer_account: Any, member_sheet: CharacterSheet) -> bool:
+    """True if the member's player has an active block against the viewer (#2086).
+
+    The one-directional check for membership-list display: "this member blocked you."
+    Unlike ``sheet_blocked_for_viewer`` (which is symmetric — either direction hides
+    the sheet), this checks only the *member blocked the viewer* direction, because
+    the placeholder should only appear for the blocked player, not for the blocker
+    (who already knows the persona they blocked).
+
+    Staff bypass: returns False for staff (they see real names everywhere).
+    """
+    if viewer_account is None or not getattr(viewer_account, "is_authenticated", False):  # noqa: GETATTR_LITERAL
+        return False
+    if getattr(viewer_account, "is_staff", False):  # noqa: GETATTR_LITERAL
+        return False
+
+    roster_entry = member_sheet.roster_entry
+    current = roster_entry.current_tenure if roster_entry is not None else None
+    if current is None:
+        return False
+    member_player = current.player_data
+
+    # The member's player blocked the viewer's account — persona-scoped (the
+    # member's face is the blocker) or account-level (all their faces block).
+    return (
+        _active_blocks()
+        .filter(Q(owner=member_player, blocked_player__account=viewer_account))
+        .exists()
+    )
+
+
 def hidden_persona_ids_for_viewer(*, viewer_account: Any) -> set[int]:
     """Persona ids whose content is hidden from this viewer by an active block (#1278).
 


### PR DESCRIPTION
Closes #2086

## Summary

When a blocked player views a covenant membership list that includes the blocker, the blocker's row shows a generic 'a member has blocked you' placeholder — never the member's name. Serializer-level suppression reusing coded_block_active; no model changes. Widened the character-roles viewset queryset so non-staff see all members of their covenants (previously only their own row).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2086 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Already up to date with main; no conflicts.

<!-- last-addressed-comment: 0 -->