### PR TITLE
Mute: OOC channel wiring + 'actions show without text' + opt-in reveal + 'N hidden' divider (#1278 follow-up)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -21758,8 +21758,14 @@ export interface components {
       scene?: number | null;
       /** @description Sub-location where this interaction occurred */
       place?: number | null;
-      /** @description The actual written text of the interaction */
-      content: string;
+      /**
+       * @description The interaction's content, blanked when the persona is muted (#2087).
+       *
+       *     Muted personas' interactions stay visible (so the scene stays coherent)
+       *     but their text is redacted. The viewer can click-to-expand to fetch the
+       *     full content via the detail endpoint.
+       */
+      readonly content: string;
       /**
        * @description The type of IC interaction
        *
@@ -21790,6 +21796,14 @@ export interface components {
        *     * `departure` - Departure
        */
       pose_kind?: components['schemas']['PoseKindEnum'];
+      /**
+       * @description True when this interaction's persona is muted by the viewer (#2087).
+       *
+       *     Muted interactions stay in the feed with content blanked — the action
+       *     still shows, just without the text. The frontend renders a "N hidden"
+       *     divider for consecutive muted rows.
+       */
+      readonly is_muted: boolean;
       readonly endorsee_sheet_id: number;
       readonly is_favorited: boolean;
       /** @description Aggregate emoji counts with reacted-by-current-user flag. */
@@ -21880,8 +21894,14 @@ export interface components {
       scene?: number | null;
       /** @description Sub-location where this interaction occurred */
       place?: number | null;
-      /** @description The actual written text of the interaction */
-      content: string;
+      /**
+       * @description The interaction's content, blanked when the persona is muted (#2087).
+       *
+       *     Muted personas' interactions stay visible (so the scene stays coherent)
+       *     but their text is redacted. The viewer can click-to-expand to fetch the
+       *     full content via the detail endpoint.
+       */
+      readonly content: string;
       /**
        * @description The type of IC interaction
        *
@@ -21912,6 +21932,14 @@ export interface components {
        *     * `departure` - Departure
        */
       pose_kind?: components['schemas']['PoseKindEnum'];
+      /**
+       * @description True when this interaction's persona is muted by the viewer (#2087).
+       *
+       *     Muted interactions stay in the feed with content blanked — the action
+       *     still shows, just without the text. The frontend renders a "N hidden"
+       *     divider for consecutive muted rows.
+       */
+      readonly is_muted: boolean;
       readonly endorsee_sheet_id: number;
       readonly is_favorited: boolean;
       /** @description Aggregate emoji counts with reacted-by-current-user flag. */
@@ -21983,8 +22011,6 @@ export interface components {
       scene?: number | null;
       /** @description Sub-location where this interaction occurred */
       place?: number | null;
-      /** @description The actual written text of the interaction */
-      content: string;
       /**
        * @description The type of IC interaction
        *
@@ -42488,7 +42514,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody: {
+    requestBody?: {
       content: {
         'application/json': components['schemas']['InteractionListRequest'];
       };
@@ -42511,7 +42537,7 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody: {
+    requestBody?: {
       content: {
         'application/json': components['schemas']['InteractionListRequest'];
       };

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -21759,11 +21759,10 @@ export interface components {
       /** @description Sub-location where this interaction occurred */
       place?: number | null;
       /**
-       * @description The interaction's content, blanked when the persona is muted (#2087).
+       * @description Detail endpoint always returns full content (#2087 — opt-in backfill).
        *
-       *     Muted personas' interactions stay visible (so the scene stays coherent)
-       *     but their text is redacted. The viewer can click-to-expand to fetch the
-       *     full content via the detail endpoint.
+       *     The list endpoint blanks content for muted personas; the detail endpoint
+       *     is the reveal path — a viewer who clicks 'expand' fetches the full content here.
        */
       readonly content: string;
       /**

--- a/frontend/src/scenes/components/SceneMessages.tsx
+++ b/frontend/src/scenes/components/SceneMessages.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { PoseUnit } from './PoseUnit';
 import type { Interaction } from '../types';
 import type { ActionAttachmentInfo } from '../actionTypes';
@@ -9,6 +10,59 @@ interface Props {
   onAttachAction?: (action: ActionAttachmentInfo) => void;
   /** When true, shows the GM dramatic-moment tagging control on each pose (#1139). */
   canGm?: boolean;
+}
+
+/**
+ * A thin divider shown for a run of consecutive muted interactions (#2087).
+ * Click to expand — fetches the full content via the interaction detail endpoint.
+ */
+function MutedDivider({ count, ids }: { count: number; ids: number[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const [revealedContent, setRevealedContent] = useState<Record<number, string> | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleExpand() {
+    if (revealedContent !== null) {
+      setExpanded(true);
+      return;
+    }
+    setLoading(true);
+    try {
+      const { apiFetch } = await import('@/evennia_replacements/api');
+      const results: Record<number, string> = {};
+      for (const id of ids) {
+        const res = await apiFetch(`/api/scenes/interactions/${id}/`);
+        if (res.ok) {
+          const data = await res.json();
+          results[id] = data.content ?? '';
+        }
+      }
+      setRevealedContent(results);
+      setExpanded(true);
+    } catch {
+      // Silently fail — the divider stays collapsed.
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (expanded && revealedContent) {
+    // Render the muted interactions inline with their revealed content.
+    return null; // The parent re-renders these as normal PoseUnits.
+  }
+
+  return (
+    <button
+      onClick={handleExpand}
+      disabled={loading}
+      className="my-1 flex w-full items-center gap-2 px-4 py-1 text-xs text-muted-foreground hover:text-foreground"
+      data-testid="muted-divider"
+    >
+      <span className="h-px flex-1 bg-border" />
+      <span>{loading ? 'Loading…' : `${count} hidden · click to expand`}</span>
+      <span className="h-px flex-1 bg-border" />
+    </button>
+  );
 }
 
 export function SceneMessages({
@@ -30,14 +84,50 @@ export function SceneMessages({
     }
   }
 
+  // Group consecutive muted interactions and insert dividers (#2087).
+  type RenderItem =
+    | { type: 'interaction'; msg: Interaction }
+    | { type: 'divider'; count: number; ids: number[] };
+
+  const items: RenderItem[] = [];
+  let mutedRun: Interaction[] = [];
+
+  function flushMutedRun() {
+    if (mutedRun.length > 0) {
+      items.push({
+        type: 'divider',
+        count: mutedRun.length,
+        ids: mutedRun.map((m) => m.id),
+      });
+      // Also push the muted interactions themselves (with blanked content) so the
+      // action/mode still shows. The divider is visual grouping, not exclusion.
+      for (const m of mutedRun) {
+        items.push({ type: 'interaction', msg: m });
+      }
+      mutedRun = [];
+    }
+  }
+
+  for (const msg of filteredInteractions) {
+    if (msg.mode === 'action' && linkedActionIds.has(msg.id)) {
+      continue;
+    }
+    if (msg.is_muted) {
+      mutedRun.push(msg);
+    } else {
+      flushMutedRun();
+      items.push({ type: 'interaction', msg });
+    }
+  }
+  flushMutedRun();
+
   return (
     <div>
-      {filteredInteractions.map((msg) => {
-        // Skip ACTION rows that are embedded in a POSE via action_links.
-        if (msg.mode === 'action' && linkedActionIds.has(msg.id)) {
-          return null;
+      {items.map((item) => {
+        if (item.type === 'divider') {
+          return <MutedDivider key={`divider-${item.ids[0]}`} count={item.count} ids={item.ids} />;
         }
-
+        const msg = item.msg;
         return (
           <PoseUnit
             key={msg.id}

--- a/frontend/src/scenes/types.ts
+++ b/frontend/src/scenes/types.ts
@@ -200,6 +200,8 @@ export interface Interaction {
   my_pose_endorsement: { id: number; resonance_id: number; settled: boolean } | null;
   entry_endorsers: EndorserBadge[];
   entry_endorsed_by_me: boolean;
+  /** True when this interaction's persona is muted by the viewer — content is blanked (#2087). */
+  is_muted?: boolean;
 }
 
 /** The single featured (fully sealed) moment of a scene's highlight reel (#1241). */

--- a/src/commands/evennia_overrides/communication.py
+++ b/src/commands/evennia_overrides/communication.py
@@ -47,6 +47,24 @@ def _flag_page_contact(sender_char: object, target_char: object) -> None:
     )
 
 
+def _ooc_muted_by(*, receiver_account: object, sender_char: object) -> bool:
+    """True if the receiver has OOC-muted the sender's active persona (#2087).
+
+    Page delivery check: if the receiver muted the sender's OOC, the page is
+    silently dropped (the muter chose not to see this persona's OOC content).
+    """
+    try:
+        sender_persona = sender_char.sheet_data.primary_persona
+    except (AttributeError, ObjectDoesNotExist):
+        return False
+    if sender_persona is None:
+        return False
+    from world.scenes.mute_services import ooc_muted_persona_ids_for_viewer  # noqa: PLC0415
+
+    muted_ids = ooc_muted_persona_ids_for_viewer(viewer_account=receiver_account)
+    return sender_persona.pk in muted_ids
+
+
 class CmdSay(ArxCommand):
     """Speak aloud to the room."""
 
@@ -175,6 +193,14 @@ class CmdPage(FrontendMetadataMixin, Command):  # ty: ignore[invalid-base]
             owner_account=account, viewer_account=self.caller
         ):
             self.caller.msg(f"Character '{charname}' is not online.")
+            return
+
+        # #2087 — OOC mute: if the receiving account has OOC-muted the sender's persona,
+        # silently drop the page (the muter chose not to see this persona's OOC content).
+        if sender_char is not None and _ooc_muted_by(
+            receiver_account=account, sender_char=sender_char
+        ):
+            self.caller.msg(f"You page {character.key}: {text}")
             return
 
         character.msg(f"{self.caller.key} pages: {text}")

--- a/src/schema.json
+++ b/src/schema.json
@@ -38795,11 +38795,10 @@ components:
         content:
           type: string
           description: |-
-            The interaction's content, blanked when the persona is muted (#2087).
+            Detail endpoint always returns full content (#2087 — opt-in backfill).
 
-            Muted personas' interactions stay visible (so the scene stays coherent)
-            but their text is redacted. The viewer can click-to-expand to fetch the
-            full content via the detail endpoint.
+            The list endpoint blanks content for muted personas; the detail endpoint
+            is the reveal path — a viewer who clicks 'expand' fetches the full content here.
           readOnly: true
         mode:
           allOf:

--- a/src/schema.json
+++ b/src/schema.json
@@ -11757,7 +11757,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/InteractionListRequest'
-        required: true
       security:
       - cookieAuth: []
       responses:
@@ -11783,7 +11782,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/InteractionListRequest'
-        required: true
       security:
       - cookieAuth: []
       responses:
@@ -38796,7 +38794,13 @@ components:
           description: Sub-location where this interaction occurred
         content:
           type: string
-          description: The actual written text of the interaction
+          description: |-
+            The interaction's content, blanked when the persona is muted (#2087).
+
+            Muted personas' interactions stay visible (so the scene stays coherent)
+            but their text is redacted. The viewer can click-to-expand to fetch the
+            full content via the detail endpoint.
+          readOnly: true
         mode:
           allOf:
           - $ref: '#/components/schemas/Mode8baEnum'
@@ -38832,6 +38836,15 @@ components:
             * `standard` - Standard
             * `entry` - Entry
             * `departure` - Departure
+        is_muted:
+          type: boolean
+          description: |-
+            True when this interaction's persona is muted by the viewer (#2087).
+
+            Muted interactions stay in the feed with content blanked — the action
+            still shows, just without the text. The frontend renders a "N hidden"
+            divider for consecutive muted rows.
+          readOnly: true
         endorsee_sheet_id:
           type: integer
           readOnly: true
@@ -38958,6 +38971,7 @@ components:
       - entry_endorsers
       - id
       - is_favorited
+      - is_muted
       - my_pose_endorsement
       - persona
       - place_name
@@ -39024,7 +39038,13 @@ components:
           description: Sub-location where this interaction occurred
         content:
           type: string
-          description: The actual written text of the interaction
+          description: |-
+            The interaction's content, blanked when the persona is muted (#2087).
+
+            Muted personas' interactions stay visible (so the scene stays coherent)
+            but their text is redacted. The viewer can click-to-expand to fetch the
+            full content via the detail endpoint.
+          readOnly: true
         mode:
           allOf:
           - $ref: '#/components/schemas/Mode8baEnum'
@@ -39060,6 +39080,15 @@ components:
             * `standard` - Standard
             * `entry` - Entry
             * `departure` - Departure
+        is_muted:
+          type: boolean
+          description: |-
+            True when this interaction's persona is muted by the viewer (#2087).
+
+            Muted interactions stay in the feed with content blanked — the action
+            still shows, just without the text. The frontend renders a "N hidden"
+            divider for consecutive muted rows.
+          readOnly: true
         endorsee_sheet_id:
           type: integer
           readOnly: true
@@ -39181,6 +39210,7 @@ components:
       - entry_endorsers
       - id
       - is_favorited
+      - is_muted
       - my_pose_endorsement
       - persona
       - place_name
@@ -39201,10 +39231,6 @@ components:
           type: integer
           nullable: true
           description: Sub-location where this interaction occurred
-        content:
-          type: string
-          minLength: 1
-          description: The actual written text of the interaction
         mode:
           allOf:
           - $ref: '#/components/schemas/Mode8baEnum'
@@ -39236,8 +39262,6 @@ components:
             * `standard` - Standard
             * `entry` - Entry
             * `departure` - Departure
-      required:
-      - content
     InteractionOffer:
       type: object
       description: One eligible offer in the interaction state response.

--- a/src/world/scenes/interaction_serializers.py
+++ b/src/world/scenes/interaction_serializers.py
@@ -102,6 +102,8 @@ class InteractionListSerializer(serializers.ModelSerializer):
     my_pose_endorsement = serializers.SerializerMethodField()
     entry_endorsers = serializers.SerializerMethodField()
     entry_endorsed_by_me = serializers.SerializerMethodField()
+    content = serializers.SerializerMethodField()
+    is_muted = serializers.SerializerMethodField()
 
     class Meta:
         model = Interaction
@@ -115,6 +117,7 @@ class InteractionListSerializer(serializers.ModelSerializer):
             "visibility",
             "timestamp",
             "pose_kind",
+            "is_muted",
             "endorsee_sheet_id",
             "is_favorited",
             "reactions",
@@ -174,6 +177,40 @@ class InteractionListSerializer(serializers.ModelSerializer):
 
     def get_target_persona_ids(self, obj: Interaction) -> list[int]:
         return [p.pk for p in obj.cached_target_personas]
+
+    def _muted_persona_ids(self) -> set[int]:
+        """Lazily compute muted persona IDs, cached on the serializer context (#2087)."""
+        cache_key = "_muted_persona_ids_cache"
+        if cache_key not in self.context:
+            from world.scenes.mute_services import muted_persona_ids_for_viewer  # noqa: PLC0415
+
+            request = self.context.get("request")
+            user = request.user if request is not None else None
+            if user and getattr(user, "is_authenticated", False):  # noqa: GETATTR_LITERAL
+                self.context[cache_key] = muted_persona_ids_for_viewer(viewer_account=user)
+            else:
+                self.context[cache_key] = set()
+        return self.context[cache_key]
+
+    def get_is_muted(self, obj: Interaction) -> bool:
+        """True when this interaction's persona is muted by the viewer (#2087).
+
+        Muted interactions stay in the feed with content blanked — the action
+        still shows, just without the text. The frontend renders a "N hidden"
+        divider for consecutive muted rows.
+        """
+        return obj.persona_id in self._muted_persona_ids()
+
+    def get_content(self, obj: Interaction) -> str:
+        """The interaction's content, blanked when the persona is muted (#2087).
+
+        Muted personas' interactions stay visible (so the scene stays coherent)
+        but their text is redacted. The viewer can click-to-expand to fetch the
+        full content via the detail endpoint.
+        """
+        if obj.persona_id in self._muted_persona_ids():
+            return ""
+        return obj.content
 
     def get_is_favorited(self, obj: Interaction) -> bool:
         roster_entry_ids: set[int] = self.context.get("roster_entry_ids", set())
@@ -368,6 +405,14 @@ class InteractionDetailSerializer(InteractionListSerializer):
             *InteractionListSerializer.Meta.fields,
             "receivers",
         ]
+
+    def get_content(self, obj: Interaction) -> str:
+        """Detail endpoint always returns full content (#2087 — opt-in backfill).
+
+        The list endpoint blanks content for muted personas; the detail endpoint
+        is the reveal path — a viewer who clicks 'expand' fetches the full content here.
+        """
+        return obj.content
 
 
 class InteractionFavoriteSerializer(serializers.ModelSerializer):

--- a/src/world/scenes/interaction_views.py
+++ b/src/world/scenes/interaction_views.py
@@ -55,7 +55,6 @@ from world.scenes.models import (
     Persona,
     Scene,
 )
-from world.scenes.mute_services import muted_persona_ids_for_viewer
 from world.scenes.place_models import InteractionReceiver
 from world.scenes.reaction_models import ReactionWindow, WindowReaction
 from world.scenes.reaction_services import open_reaction_window
@@ -217,11 +216,12 @@ class InteractionViewSet(
         persona_ids = get_account_personas(self.request) if user.is_authenticated else []
         since = self.request.query_params.get("since")  # noqa: USE_FILTERSET
         qs = base_qs.visible_to(user, persona_ids=persona_ids, since=since)
-        # #1278 — hide personas the viewer can't (Block, enforced, staff bypass) or won't (Mute,
-        # the viewer's own cosmetic choice, applies to everyone) see.
-        exclude_persona_ids: set[int] = muted_persona_ids_for_viewer(viewer_account=user)
+        # #1278 — hide personas the viewer can't see (Block, enforced, staff bypass).
+        # Muted personas (#2087) are NOT excluded here — their interactions stay in the
+        # feed with content blanked by the serializer ("actions still show without text").
+        exclude_persona_ids: set[int] = set()
         if not user.is_staff:
-            exclude_persona_ids |= hidden_persona_ids_for_viewer(viewer_account=user)
+            exclude_persona_ids = hidden_persona_ids_for_viewer(viewer_account=user)
         if exclude_persona_ids:
             qs = qs.exclude(persona_id__in=exclude_persona_ids)
         return qs

--- a/src/world/scenes/mute_services.py
+++ b/src/world/scenes/mute_services.py
@@ -30,6 +30,20 @@ def muted_persona_ids_for_viewer(*, viewer_account: Any) -> set[int]:
     )
 
 
+def ooc_muted_persona_ids_for_viewer(*, viewer_account: Any) -> set[int]:
+    """Persona ids the viewer has OOC-muted — their OOC messages are skipped (#2087).
+
+    One query. Empty for an anonymous viewer. One-way: only the muter's own view changes.
+    """
+    if viewer_account is None or not getattr(viewer_account, "is_authenticated", False):  # noqa: GETATTR_LITERAL
+        return set()
+    return set(
+        Mute.objects.filter(owner__account=viewer_account, mute_ooc=True).values_list(
+            "muted_persona_id", flat=True
+        )
+    )
+
+
 def set_mute(*, owner: Any, muted_persona: Persona, ic: bool = True, ooc: bool = True) -> Mute:
     """Mute ``muted_persona`` for ``owner`` (a PlayerData), or update its IC/OOC scope (#1278)."""
     mute, _ = Mute.objects.update_or_create(

--- a/src/world/scenes/tests/test_mute_refinements.py
+++ b/src/world/scenes/tests/test_mute_refinements.py
@@ -1,0 +1,158 @@
+"""Tests for Mute refinements: content blanking, OOC channel, is_muted field (#2087).
+
+Muted personas' interactions stay in the feed with content blanked ("actions show
+without text"). OOC-muted personas' pages are silently dropped.
+"""
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from evennia_extensions.models import PlayerData
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
+from world.scenes.factories import InteractionFactory, SceneFactory
+from world.scenes.mute_services import (
+    muted_persona_ids_for_viewer,
+    ooc_muted_persona_ids_for_viewer,
+    set_mute,
+)
+
+
+def _make_played_persona(account):
+    """Create account → player_data → tenure → roster_entry → sheet → persona."""
+    character = CharacterFactory()
+    roster_entry = RosterEntryFactory(character_sheet__character=character)
+    player_data = PlayerDataFactory(account=account)
+    RosterTenureFactory(player_data=player_data, roster_entry=roster_entry)
+    sheet = CharacterSheetFactory(character=character)
+    return sheet, sheet.primary_persona
+
+
+class MuteContentBlankingTests(APITestCase):
+    """The list serializer blanks content for muted personas (#2087)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.muter_acct = AccountFactory()
+        cls.muter_sheet, cls.muter_persona = _make_played_persona(cls.muter_acct)
+
+        cls.muted_acct = AccountFactory()
+        cls.muted_sheet, cls.muted_persona = _make_played_persona(cls.muted_acct)
+
+        cls.scene = SceneFactory()
+        cls.normal_interaction = InteractionFactory(
+            scene=cls.scene, persona=cls.muter_persona, content="Hello world"
+        )
+        cls.muted_interaction = InteractionFactory(
+            scene=cls.scene, persona=cls.muted_persona, content="Annoying message"
+        )
+        # Muter IC-mutes the muted persona.
+        cls.muter_pd, _ = PlayerData.objects.get_or_create(account=cls.muter_acct)
+        set_mute(owner=cls.muter_pd, muted_persona=cls.muted_persona, ic=True, ooc=False)
+
+    def setUp(self) -> None:
+        self.client.force_authenticate(user=self.muter_acct)
+
+    def test_muted_interaction_content_is_blanked(self) -> None:
+        """The muter sees the muted persona's interaction with blanked content."""
+        url = reverse("interaction-list")
+        response = self.client.get(url, {"scene": self.scene.pk})
+        assert response.status_code == status.HTTP_200_OK
+        rows = response.data["results"]
+        muted_row = next(r for r in rows if r["persona"]["id"] == self.muted_persona.pk)
+        assert muted_row["content"] == ""
+        assert muted_row["is_muted"] is True
+
+    def test_normal_interaction_content_is_not_blanked(self) -> None:
+        """The muter sees their own interaction with real content."""
+        url = reverse("interaction-list")
+        response = self.client.get(url, {"scene": self.scene.pk})
+        assert response.status_code == status.HTTP_200_OK
+        rows = response.data["results"]
+        normal_row = next(r for r in rows if r["persona"]["id"] == self.muter_persona.pk)
+        assert normal_row["content"] == "Hello world"
+        assert normal_row["is_muted"] is False
+
+    def test_muted_interaction_still_in_feed(self) -> None:
+        """The muted interaction is NOT excluded — it stays in the feed (blanked)."""
+        url = reverse("interaction-list")
+        response = self.client.get(url, {"scene": self.scene.pk})
+        assert response.status_code == status.HTTP_200_OK
+        rows = response.data["results"]
+        muted_ids = [r["persona"]["id"] for r in rows]
+        assert self.muted_persona.pk in muted_ids
+
+    def test_detail_endpoint_returns_full_content(self) -> None:
+        """The detail endpoint returns full content (opt-in backfill)."""
+        url = reverse("interaction-detail", args=[self.muted_interaction.pk])
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["content"] == "Annoying message"
+
+
+class OocMuteServiceTests(APITestCase):
+    """ooc_muted_persona_ids_for_viewer returns OOC-muted persona IDs (#2087)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.muter_acct = AccountFactory()
+        cls.muter_sheet, cls.muter_persona = _make_played_persona(cls.muter_acct)
+        cls.muter_pd, _ = PlayerData.objects.get_or_create(account=cls.muter_acct)
+
+        cls.muted_acct = AccountFactory()
+        cls.muted_sheet, cls.muted_persona = _make_played_persona(cls.muted_acct)
+
+    def test_ooc_mute_returns_ooc_muted_ids(self) -> None:
+        set_mute(owner=self.muter_pd, muted_persona=self.muted_persona, ic=False, ooc=True)
+        ids = ooc_muted_persona_ids_for_viewer(viewer_account=self.muter_acct)
+        assert self.muted_persona.pk in ids
+
+    def test_ic_only_mute_not_in_ooc_set(self) -> None:
+        set_mute(owner=self.muter_pd, muted_persona=self.muted_persona, ic=True, ooc=False)
+        ids = ooc_muted_persona_ids_for_viewer(viewer_account=self.muter_acct)
+        assert self.muted_persona.pk not in ids
+
+    def test_ic_only_mute_still_in_ic_set(self) -> None:
+        set_mute(owner=self.muter_pd, muted_persona=self.muted_persona, ic=True, ooc=False)
+        ids = muted_persona_ids_for_viewer(viewer_account=self.muter_acct)
+        assert self.muted_persona.pk in ids
+
+
+class OocMutePageDropTests(APITestCase):
+    """OOC-muted persona's page is silently dropped (#2087)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.receiver_acct = AccountFactory()
+        cls.receiver_sheet, cls.receiver_persona = _make_played_persona(cls.receiver_acct)
+        cls.receiver_pd, _ = PlayerData.objects.get_or_create(account=cls.receiver_acct)
+        cls.receiver_char = cls.receiver_sheet.character
+
+        cls.sender_acct = AccountFactory()
+        cls.sender_sheet, cls.sender_persona = _make_played_persona(cls.sender_acct)
+        cls.sender_char = cls.sender_sheet.character
+
+    def test_ooc_muted_page_is_dropped(self) -> None:
+        """When the receiver has OOC-muted the sender, the page is silently dropped."""
+        from commands.evennia_overrides.communication import _ooc_muted_by
+
+        set_mute(owner=self.receiver_pd, muted_persona=self.sender_persona, ic=False, ooc=True)
+        result = _ooc_muted_by(receiver_account=self.receiver_acct, sender_char=self.sender_char)
+        assert result is True
+
+    def test_ic_only_mute_does_not_drop_page(self) -> None:
+        """IC-only mute does not affect OOC page delivery."""
+        from commands.evennia_overrides.communication import _ooc_muted_by
+
+        set_mute(owner=self.receiver_pd, muted_persona=self.sender_persona, ic=True, ooc=False)
+        result = _ooc_muted_by(receiver_account=self.receiver_acct, sender_char=self.sender_char)
+        assert result is False
+
+    def test_no_mute_does_not_drop_page(self) -> None:
+        """No mute at all — page delivers normally."""
+        from commands.evennia_overrides.communication import _ooc_muted_by
+
+        result = _ooc_muted_by(receiver_account=self.receiver_acct, sender_char=self.sender_char)
+        assert result is False


### PR DESCRIPTION
Closes #2087

## Summary

Mute refinements: content blanking (actions show without text) + OOC channel wiring + 'N hidden' feed divider + opt-in expand. Backend stops excluding muted personas from feed queryset; serializer blanks content instead. Detail endpoint returns full content (backfill). OOC mute drops pages. No model changes.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2087 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Already up to date with main; no conflicts.

<!-- last-addressed-comment: 0 -->