### PR TITLE
GM-tier mission gating & assignment — episode prerequisites without staff; wire-or-drop Beat.required_mission (#2043)

### DIFF
--- a/docs/adr/0104-gm-mission-assignment-direct-drop-engagement-armed-stakes.md
+++ b/docs/adr/0104-gm-mission-assignment-direct-drop-engagement-armed-stakes.md
@@ -1,0 +1,35 @@
+# ADR-0104: GM mission assignment is a direct drop with engagement-armed stakes
+
+**Date:** 2026-07-08
+**Status:** Accepted
+
+## Context
+
+Issue #2048: GMs need to assign missions to players from the story surface,
+linking them to beats and gating episode progression. The question was
+whether a GM "assign" is a directed offer the player accepts (consent + risk-ack
+falls out of the existing accept flow) or an admin-style forced drop.
+
+## Decision
+
+GM mission assignment is a **direct drop** via `gm_assign_mission` — the
+player consents by pursuing the mission, not by accepting it. Stakes arm
+**lazily on the player's first beat action** (engagement-armed stakes), not
+at assignment time. An ignored assignment never locks stakes; abandoning
+before engagement leaves no contract.
+
+`Beat.required_mission` is wired as the beat's authoring pointer (the GM sets
+it on the beat; the drop gesture defaults from it). Template access gates on
+risk via the merged GM trust ladder's `GMLevelCap.max_beat_risk` (#2054) —
+no separate permission ladder. Permissions: the story's Lead GM or staff
+(`IsLeadGMOnStoryOrStaff` pattern, Beat-aware via `CanAssignMissionToBeat`).
+
+## Rejected alternatives
+
+- **Offer-with-accept-gate:** redundant consent given clean abandon
+  (`abandon_mission` guarantees a free exit).
+- **A separate GM-assignment permission ladder:** consumed #2054's
+  `GMLevelCap` instead — no new gate invented.
+- **A new mission scope field:** world-impact scope is already carried by
+  the beat/stakes machinery the mission feeds — a mission inherits its scope
+  gating from the beat it satisfies.

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1422,6 +1422,13 @@ and paying authored win-reward lines through an anti-farming activation gate
   `maybe_complete_immediately`. Loud refusal at issuance when PROJECT lines
   exist but no project is bound; soft-skip-with-notice at payout when the
   project is non-ACTIVE or null. ADR-0103.
+  GM-tier mission assignment (#2048): `gm_assign_mission` creates a
+  `MissionInstance` with `source_beat` set (direct drop, no accept gate).
+  `Beat.required_mission` is wired as the beat's authoring pointer
+  (writable on `BeatSerializer`). Stakes arm lazily on the player's first
+  beat action (engagement-armed stakes), not at assignment time.
+  `BeatViewSet.assign_mission` action (`POST /api/beats/{id}/assign-mission/`,
+  `CanAssignMissionToBeat` — Lead GM or staff). ADR-0104.
 - **Three-concepts disambiguation:** `Beat.risk`+contract (stakes/reward) is
   distinct from `combat.RiskLevel` (cast-pull acknowledgement gate) and
   `combat.StakesLevel` (GM access scope) — see stakes.md.

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -871,6 +871,30 @@ export interface paths {
     patch: operations['beats_partial_update'];
     trace?: never;
   };
+  '/api/beats/{id}/assign-mission/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description GM-tier: assign this beat's required mission to a player (#2048).
+     *
+     *     POST body: ``{"character": <pk>, "template"?: <pk>}``. Defaults
+     *     template from the beat's ``required_mission``. Creates a
+     *     ``MissionInstance`` with ``source_beat`` set — stakes arm on the
+     *     player's first action, not at assignment.
+     */
+    post: operations['beats_assign_mission_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/beats/{id}/contribute/': {
     parameters: {
       query?: never;
@@ -17500,6 +17524,8 @@ export interface components {
       failure_consequences?: number | null;
       /** @description ConsequencePool to fire when this beat resolves EXPIRED. */
       expired_consequences?: number | null;
+      /** @description Optional: a MissionTemplate this beat requires (Phase 5b.3 data shape only; engine deferred). SET_NULL on template delete. */
+      required_mission?: number | null;
       /** Format: date-time */
       readonly created_at: string;
       /** Format: date-time */
@@ -17616,6 +17642,8 @@ export interface components {
       failure_consequences?: number | null;
       /** @description ConsequencePool to fire when this beat resolves EXPIRED. */
       expired_consequences?: number | null;
+      /** @description Optional: a MissionTemplate this beat requires (Phase 5b.3 data shape only; engine deferred). SET_NULL on template delete. */
+      required_mission?: number | null;
     };
     /** @description POST body for the #885 resolve endpoint. */
     BeatResolveRequestRequest: {
@@ -26417,6 +26445,8 @@ export interface components {
       failure_consequences?: number | null;
       /** @description ConsequencePool to fire when this beat resolves EXPIRED. */
       expired_consequences?: number | null;
+      /** @description Optional: a MissionTemplate this beat requires (Phase 5b.3 data shape only; engine deferred). SET_NULL on template delete. */
+      required_mission?: number | null;
     };
     PatchedBugReportDetailRequest: {
       reporter_persona?: number;
@@ -33673,6 +33703,32 @@ export interface operations {
     requestBody?: {
       content: {
         'application/json': components['schemas']['PatchedBeatRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Beat'];
+        };
+      };
+    };
+  };
+  beats_assign_mission_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this beat. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['BeatRequest'];
       };
     };
     responses: {

--- a/src/commands/missions.py
+++ b/src/commands/missions.py
@@ -128,6 +128,9 @@ class CmdMission(ArxCommand):
                         f"    Advances: {entry.target_project_name} "
                         f"({progress}/{threshold}, +{granted} this run)"
                     )
+                if entry.source_beat_story_title is not None:
+                    hint = f" — {entry.source_beat_hint}" if entry.source_beat_hint else ""
+                    lines.append(f"    Story: {entry.source_beat_story_title}{hint}")
         self._append_pending_invites(lines)
         self._append_pending_summonses(lines)
         self.msg("\n".join(lines))

--- a/src/schema.json
+++ b/src/schema.json
@@ -1301,6 +1301,40 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/beats/{id}/assign-mission/:
+    post:
+      operationId: beats_assign_mission_create
+      description: |-
+        GM-tier: assign this beat's required mission to a player (#2048).
+
+        POST body: ``{"character": <pk>, "template"?: <pk>}``. Defaults
+        template from the beat's ``required_mission``. Creates a
+        ``MissionInstance`` with ``source_beat`` set — stakes arm on the
+        player's first action, not at assignment.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this beat.
+        required: true
+      tags:
+      - beats
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BeatRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Beat'
+          description: ''
   /api/beats/{id}/contribute/:
     post:
       operationId: beats_contribute_create
@@ -29586,6 +29620,11 @@ components:
           type: integer
           nullable: true
           description: ConsequencePool to fire when this beat resolves EXPIRED.
+        required_mission:
+          type: integer
+          nullable: true
+          description: 'Optional: a MissionTemplate this beat requires (Phase 5b.3
+            data shape only; engine deferred). SET_NULL on template delete.'
         created_at:
           type: string
           format: date-time
@@ -29800,6 +29839,11 @@ components:
           type: integer
           nullable: true
           description: ConsequencePool to fire when this beat resolves EXPIRED.
+        required_mission:
+          type: integer
+          nullable: true
+          description: 'Optional: a MissionTemplate this beat requires (Phase 5b.3
+            data shape only; engine deferred). SET_NULL on template delete.'
       required:
       - episode
       - internal_description
@@ -47049,6 +47093,11 @@ components:
           type: integer
           nullable: true
           description: ConsequencePool to fire when this beat resolves EXPIRED.
+        required_mission:
+          type: integer
+          nullable: true
+          description: 'Optional: a MissionTemplate this beat requires (Phase 5b.3
+            data shape only; engine deferred). SET_NULL on template delete.'
     PatchedBugReportDetailRequest:
       type: object
       properties:

--- a/src/world/missions/services/journal.py
+++ b/src/world/missions/services/journal.py
@@ -64,6 +64,7 @@ def journal_for(character: ObjectDB) -> list[JournalEntry]:
             "instance__current_node",
             "instance__anchor_room__objectdb",
             "instance__target_project",
+            "instance__source_beat__episode__chapter__story",
         )
         .prefetch_related("instance__current_node__locations__objectdb")  # noqa: PREFETCH_STRING
         .order_by("instance_id", "pk")
@@ -233,6 +234,23 @@ def _options_by_node(
     return options_by_node
 
 
+def _source_beat_story_title(instance: MissionInstance) -> str | None:
+    """The story title for the instance's source_beat, or None (#2048)."""
+    beat = instance.source_beat
+    if beat is None:
+        return None
+    story = beat.episode.chapter.story
+    return story.title if story else None
+
+
+def _source_beat_hint(instance: MissionInstance) -> str | None:
+    """The player_hint for the instance's source_beat, or None (#2048)."""
+    beat = instance.source_beat
+    if beat is None:
+        return None
+    return beat.player_hint or None
+
+
 def _journal_entry_for(  # noqa: PLR0913
     part: MissionParticipant,
     deeds_by_instance: dict[int, list[JournalDeed]],
@@ -275,6 +293,8 @@ def _journal_entry_for(  # noqa: PLR0913
         target_project_progress=target_project_progress,
         target_project_threshold=target_project_threshold,
         target_project_granted=project_grants.get(instance.pk, 0),
+        source_beat_story_title=_source_beat_story_title(instance),
+        source_beat_hint=_source_beat_hint(instance),
     )
 
 

--- a/src/world/missions/services/play.py
+++ b/src/world/missions/services/play.py
@@ -205,6 +205,16 @@ def resolve_beat_option(
         chosen_approach=presented.approach,
     )
 
+    # #2048: engagement-armed stakes — arm on the first player action, not
+    # at assignment time. activate_stakes_for_instance is a no-op for free
+    # runs (source_beat null) and unstaked beats, and is idempotent while
+    # an activation is open — safe to call on every action.
+    from world.missions.services.beat import activate_stakes_for_instance  # noqa: PLC0415
+
+    stake_sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    if stake_sheet is not None:
+        activate_stakes_for_instance(instance, [stake_sheet])
+
     outcome_name = deed.outcome.name if deed.outcome_id else None
     story_text = _story_text_for(presented, deed, instance.template.name)
     is_terminal = instance.current_node_id is None

--- a/src/world/missions/services/run.py
+++ b/src/world/missions/services/run.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from world.missions.models import MissionInvite, MissionTemplate
     from world.projects.models import Project
     from world.scenes.models import Persona
+    from world.stories.models import Beat
 
 
 def _entry_node(template: MissionTemplate) -> MissionNode:
@@ -109,6 +110,47 @@ def staff_assign_mission(
         template=template,
         anchor_room=anchor_room_for(character),
         target_project=project,
+    )
+    MissionParticipant.objects.create(
+        instance=instance,
+        character=character,
+        is_contract_holder=True,
+    )
+    enter_node(instance, _entry_node(template))
+    return instance
+
+
+@transaction.atomic
+def gm_assign_mission(
+    template: MissionTemplate,
+    character: ObjectDB,
+    *,
+    beat: Beat | None = None,
+    project: Project | None = None,
+) -> MissionInstance:
+    """GM-tier: drop a mission on a character, optionally bound to a story beat (#2048).
+
+    Unlike ``staff_assign_mission`` (which bypasses all filters), this is the
+    GM-facing assignment path: it creates a ``MissionInstance`` with
+    ``source_beat`` set (so the beat completes when the run terminates),
+    but does NOT activate stakes at assignment time — stakes arm on the
+    player's first beat action (engagement-armed stakes). The player consents
+    by pursuing; abandoning before engagement leaves no contract.
+
+    Wrapped in ``@transaction.atomic`` so a failure in ``enter_node`` rolls
+    back the half-created MissionInstance + MissionParticipant.
+    """
+    if project is None and beat is not None and _template_has_project_lines(template):
+        msg = (
+            f"Template '{template.name}' has PROJECT reward lines but no project "
+            "is bound — refusing to issue an unbound instance (#2045)."
+        )
+        raise ValueError(msg)
+    instance = MissionInstance.objects.create(
+        template=template,
+        anchor_room=anchor_room_for(character),
+        target_project=project,
+        source_beat=beat,
     )
     MissionParticipant.objects.create(
         instance=instance,

--- a/src/world/missions/tests/test_gm_assign_mission.py
+++ b/src/world/missions/tests/test_gm_assign_mission.py
@@ -1,0 +1,77 @@
+"""GM-tier mission assignment via gm_assign_mission (#2048).
+
+Direct drop (no accept gate) — the player consents by pursuing.
+Stakes arm on first engagement, not at drop time.
+"""
+
+from django.test import TestCase
+
+from evennia_extensions.factories import CharacterFactory
+from world.missions.factories import (
+    MissionNodeFactory,
+    MissionTemplateFactory,
+)
+
+
+def _make_template_with_entry():
+    template = MissionTemplateFactory()
+    MissionNodeFactory(template=template, key="entry", is_entry=True)
+    return template
+
+
+class GMAssignMissionTests(TestCase):
+    def test_gm_assign_creates_instance_with_source_beat(self):
+        from world.stories.factories import (
+            BeatFactory,
+            ChapterFactory,
+            EpisodeFactory,
+            StoryFactory,
+        )
+
+        story = StoryFactory()
+        chapter = ChapterFactory(story=story)
+        episode = EpisodeFactory(chapter=chapter)
+        beat = BeatFactory(episode=episode)
+        template = _make_template_with_entry()
+        character = CharacterFactory(db_key="GMAssignChar")
+
+        from world.missions.services.run import gm_assign_mission
+
+        instance = gm_assign_mission(template, character, beat=beat)
+        self.assertEqual(instance.source_beat_id, beat.pk)
+        self.assertEqual(instance.template_id, template.pk)
+        holder = instance.participants.get(is_contract_holder=True)
+        self.assertEqual(holder.character_id, character.pk)
+
+    def test_gm_assign_without_beat(self):
+        template = _make_template_with_entry()
+        character = CharacterFactory(db_key="NoBeatChar")
+
+        from world.missions.services.run import gm_assign_mission
+
+        instance = gm_assign_mission(template, character)
+        self.assertIsNone(instance.source_beat_id)
+
+    def test_gm_assign_does_not_activate_stakes(self):
+        """Stakes arm on first engagement, not at assignment time."""
+        from world.societies.constants import RenownRisk
+        from world.stories.factories import (
+            BeatFactory,
+            ChapterFactory,
+            EpisodeFactory,
+            StoryFactory,
+        )
+
+        story = StoryFactory()
+        chapter = ChapterFactory(story=story)
+        episode = EpisodeFactory(chapter=chapter)
+        beat = BeatFactory(episode=episode, risk=RenownRisk.LOW)
+        template = _make_template_with_entry()
+        character = CharacterFactory(db_key="NoStakesChar")
+
+        from world.missions.services.run import gm_assign_mission
+
+        gm_assign_mission(template, character, beat=beat)
+        from world.stories.models import StakeContractActivation
+
+        self.assertFalse(StakeContractActivation.objects.filter(beat=beat).exists())

--- a/src/world/missions/tests/test_lazy_stakes_arming.py
+++ b/src/world/missions/tests/test_lazy_stakes_arming.py
@@ -1,0 +1,54 @@
+"""Lazy stakes-arming: first player action activates stakes (#2048).
+
+A GM-assigned mission with a staked source_beat does NOT arm stakes at
+assignment time — only when the player first engages (resolve_beat_option).
+Abandoning before engagement leaves no contract.
+"""
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.missions.constants import OptionKind, OptionSource
+from world.missions.factories import (
+    MissionNodeFactory,
+    MissionOptionFactory,
+    MissionOptionRouteFactory,
+    MissionTemplateFactory,
+)
+from world.missions.services.run import gm_assign_mission
+
+
+class LazyStakesArmingTests(TestCase):
+    def test_first_action_arms_stakes(self):
+        from world.societies.constants import RenownRisk
+        from world.stories.factories import (
+            BeatFactory,
+            ChapterFactory,
+            EpisodeFactory,
+            StoryFactory,
+        )
+        from world.stories.models import StakeContractActivation
+
+        story = StoryFactory()
+        chapter = ChapterFactory(story=story)
+        episode = EpisodeFactory(chapter=chapter)
+        beat = BeatFactory(episode=episode, risk=RenownRisk.LOW)
+        template = MissionTemplateFactory()
+        entry = MissionNodeFactory(template=template, key="entry", is_entry=True)
+        option = MissionOptionFactory(
+            node=entry, option_kind=OptionKind.BRANCH, source_kind=OptionSource.AUTHORED
+        )
+        MissionOptionRouteFactory(option=option, target_node=None)
+        sheet = CharacterSheetFactory()
+        character = sheet.character
+
+        instance = gm_assign_mission(template, character, beat=beat)
+        # No stakes before engagement
+        self.assertFalse(StakeContractActivation.objects.filter(beat=beat).exists())
+
+        # First action
+        from world.missions.services.play import resolve_beat_option
+
+        resolve_beat_option(instance, character, option_id=option.pk)
+        # Stakes should now be armed
+        self.assertTrue(StakeContractActivation.objects.filter(beat=beat).exists())

--- a/src/world/missions/types.py
+++ b/src/world/missions/types.py
@@ -154,6 +154,8 @@ class JournalEntry:
     target_project_progress: int | None = None
     target_project_threshold: int | None = None
     target_project_granted: int = 0
+    source_beat_story_title: str | None = None
+    source_beat_hint: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/world/stories/permissions.py
+++ b/src/world/stories/permissions.py
@@ -744,6 +744,32 @@ class CanMarkBeat(permissions.BasePermission):
         )
 
 
+class CanAssignMissionToBeat(permissions.BasePermission):
+    """Who can POST /api/beats/{id}/assign-mission/: Lead GM or staff (#2048).
+
+    Object-level only: the beat PK is in the URL. Walks beat → episode →
+    chapter → story to find the Lead GM (mirrors CanMarkBeat's path, but
+    without the AGM claim path — mission assignment is a Lead GM gesture).
+    """
+
+    message = "Only the Lead GM of this story or staff may assign missions."
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        return bool(request.user and request.user.is_authenticated)
+
+    def has_object_permission(self, request: Request, view: APIView, obj: Model) -> bool:
+        if not request.user.is_authenticated:
+            return False
+        if request.user.is_staff:
+            return True
+        story = obj.episode.chapter.story
+        try:
+            gm_profile = request.user.gm_profile
+        except GMProfile.DoesNotExist:
+            return False
+        return bool(story.primary_table_id and story.primary_table.gm_id == gm_profile.pk)
+
+
 class CanResolveStake(permissions.BasePermission):
     """Who can POST /api/stakes/{id}/resolve/ (#1770 PR2 — GM constrained pick).
 

--- a/src/world/stories/serializers.py
+++ b/src/world/stories/serializers.py
@@ -1,6 +1,7 @@
 from typing import Any, cast
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from evennia.objects.models import ObjectDB
 from rest_framework import serializers
 from rest_framework.exceptions import ErrorDetail
 
@@ -10,6 +11,7 @@ from world.gm.constants import GMTableStatus
 from world.gm.models import GMLevelCap, GMProfile, GMTable
 from world.gm.serializers import GMProfileSerializer
 from world.items.models import ItemInstance
+from world.missions.models import MissionTemplate
 from world.scenes.models import Persona
 from world.societies.constants import RenownRisk
 from world.societies.models import Organization, Society
@@ -1039,6 +1041,7 @@ class BeatSerializer(serializers.ModelSerializer):
             "success_consequences",
             "failure_consequences",
             "expired_consequences",
+            "required_mission",
             # Timestamps
             "created_at",
             "updated_at",
@@ -1127,6 +1130,7 @@ class BeatSerializer(serializers.ModelSerializer):
                 "target_level",
                 "agm_eligible",
                 "deadline",
+                "required_mission",
             ]:
                 existing[field_name] = getattr(self.instance, field_name)
         merged = {**existing, **attrs}
@@ -3852,3 +3856,33 @@ class CanonReviewChangesInputSerializer(serializers.Serializer):
             msg = "Notes may not be blank when requesting changes."
             raise serializers.ValidationError(msg)
         return notes
+
+
+class AssignMissionInputSerializer(serializers.Serializer):
+    """POST /api/beats/{id}/assign-mission/ body (#2048).
+
+    Defaults ``template`` from the beat's ``required_mission`` when not
+    explicitly provided. Validates that a template is resolvable.
+    """
+
+    character = serializers.PrimaryKeyRelatedField(
+        queryset=ObjectDB.objects.all(),
+        help_text="The character to assign the mission to.",
+    )
+    template = serializers.PrimaryKeyRelatedField(
+        queryset=MissionTemplate.objects.all(),
+        required=False,
+        allow_null=True,
+        help_text="Optional: override the beat's required_mission template.",
+    )
+
+    _ERR_NO_TEMPLATE = "No template specified and the beat has no required_mission."
+
+    def validate(self, attrs: dict) -> dict:
+        beat = self.context.get("beat")
+        if beat is not None:
+            template = attrs.get("template") or beat.required_mission
+            if template is None:
+                raise serializers.ValidationError({"template": self._ERR_NO_TEMPLATE})
+            attrs["template"] = template
+        return attrs

--- a/src/world/stories/tests/test_assign_mission_action.py
+++ b/src/world/stories/tests/test_assign_mission_action.py
@@ -1,0 +1,79 @@
+"""BeatViewSet.assign_mission action — GM-tier mission assignment (#2048)."""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.factories import GMProfileFactory, GMTableFactory
+from world.missions.factories import (
+    MissionNodeFactory,
+    MissionOptionFactory,
+    MissionOptionRouteFactory,
+    MissionTemplateFactory,
+)
+from world.stories.factories import (
+    BeatFactory,
+    ChapterFactory,
+    EpisodeFactory,
+    StoryFactory,
+)
+
+
+def _make_template_with_branch_terminal():
+    template = MissionTemplateFactory()
+    entry = MissionNodeFactory(template=template, key="entry", is_entry=True)
+    option = MissionOptionFactory(node=entry)
+    MissionOptionRouteFactory(option=option, target_node=None, outcome_tier=None)
+    return template
+
+
+class AssignMissionActionTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.template = _make_template_with_branch_terminal()
+        self.story = StoryFactory()
+        self.chapter = ChapterFactory(story=self.story)
+        self.episode = EpisodeFactory(chapter=self.chapter)
+        self.beat = BeatFactory(episode=self.episode, required_mission=self.template)
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+
+    def test_lead_gm_can_assign(self):
+        gm_account = AccountFactory(is_staff=False)
+        gm_profile = GMProfileFactory(account=gm_account)
+        table = GMTableFactory(gm=gm_profile)
+        self.story.primary_table = table
+        self.story.save()
+
+        self.client.force_authenticate(user=gm_account)
+        response = self.client.post(
+            f"/api/beats/{self.beat.pk}/assign-mission/",
+            {"character": self.character.pk},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+        from world.missions.models import MissionInstance
+
+        instance = MissionInstance.objects.get(template=self.template)
+        self.assertEqual(instance.source_beat_id, self.beat.pk)
+
+    def test_non_gm_cannot_assign(self):
+        account = AccountFactory(is_staff=False)
+        self.client.force_authenticate(user=account)
+        response = self.client.post(
+            f"/api/beats/{self.beat.pk}/assign-mission/",
+            {"character": self.character.pk},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 403, response.content)
+
+    def test_staff_can_assign(self):
+        staff = AccountFactory(is_staff=True)
+        self.client.force_authenticate(user=staff)
+        response = self.client.post(
+            f"/api/beats/{self.beat.pk}/assign-mission/",
+            {"character": self.character.pk},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201, response.content)

--- a/src/world/stories/tests/test_beat_serializer_required_mission.py
+++ b/src/world/stories/tests/test_beat_serializer_required_mission.py
@@ -1,0 +1,53 @@
+"""BeatSerializer.required_mission writable (#2048)."""
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from evennia_extensions.factories import AccountFactory
+from world.missions.factories import (
+    MissionNodeFactory,
+    MissionOptionFactory,
+    MissionOptionRouteFactory,
+    MissionTemplateFactory,
+)
+from world.stories.factories import (
+    BeatFactory,
+    ChapterFactory,
+    EpisodeFactory,
+    StoryFactory,
+)
+from world.stories.serializers import BeatSerializer
+
+
+def _make_template_with_branch_terminal():
+    template = MissionTemplateFactory()
+    entry = MissionNodeFactory(template=template, key="entry", is_entry=True)
+    option = MissionOptionFactory(node=entry)
+    MissionOptionRouteFactory(option=option, target_node=None, outcome_tier=None)
+    return template
+
+
+class BeatSerializerRequiredMissionTests(TestCase):
+    def test_required_mission_is_in_fields(self):
+        self.assertIn("required_mission", BeatSerializer.Meta.fields)
+
+    def test_can_set_required_mission(self):
+        template = _make_template_with_branch_terminal()
+        story = StoryFactory()
+        chapter = ChapterFactory(story=story)
+        episode = EpisodeFactory(chapter=chapter)
+        beat = BeatFactory(episode=episode)
+        staff = AccountFactory(is_staff=True)
+        factory = APIRequestFactory()
+        request = factory.patch("/", {"required_mission": template.pk}, format="json")
+        request.user = staff
+        serializer = BeatSerializer(
+            beat,
+            data={"required_mission": template.pk},
+            partial=True,
+            context={"request": request},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        serializer.save()
+        beat.refresh_from_db()
+        self.assertEqual(beat.required_mission_id, template.pk)

--- a/src/world/stories/views.py
+++ b/src/world/stories/views.py
@@ -107,6 +107,7 @@ from world.stories.pagination import (
 from world.stories.permissions import (
     VIEWER_ROLE_NO_ACCESS,
     CanAccessStoryNotes,
+    CanAssignMissionToBeat,
     CanAuthorBulletinPost,
     CanDetachStoryFromTable,
     CanMarkBeat,
@@ -160,6 +161,7 @@ from world.stories.serializers import (
     AcceptOfferInputSerializer,
     AggregateBeatContributionSerializer,
     ApproveClaimInputSerializer,
+    AssignMissionInputSerializer,
     AssignStoryInputSerializer,
     AssignStoryToTableInputSerializer,
     AssistantGMClaimSerializer,
@@ -1608,6 +1610,37 @@ class BeatViewSet(viewsets.ModelViewSet):
             AggregateBeatContributionSerializer(contribution).data,
             status=status.HTTP_201_CREATED,
         )
+
+    @action(
+        detail=True,
+        methods=[HTTPMethod.POST],
+        url_path="assign-mission",
+        permission_classes=[CanAssignMissionToBeat],
+    )
+    def assign_mission(self, request: Request, pk: int | None = None) -> Response:
+        """GM-tier: assign this beat's required mission to a player (#2048).
+
+        POST body: ``{"character": <pk>, "template"?: <pk>}``. Defaults
+        template from the beat's ``required_mission``. Creates a
+        ``MissionInstance`` with ``source_beat`` set — stakes arm on the
+        player's first action, not at assignment.
+        """
+        from world.missions.serializers import MissionInstanceSerializer  # noqa: PLC0415
+        from world.missions.services.run import gm_assign_mission  # noqa: PLC0415
+
+        beat = self.get_object()
+        serializer = AssignMissionInputSerializer(
+            data=request.data,
+            context={"beat": beat, "request": request},
+        )
+        serializer.is_valid(raise_exception=True)
+        instance = gm_assign_mission(
+            template=serializer.validated_data["template"],
+            character=serializer.validated_data["character"],
+            beat=beat,
+        )
+        output = MissionInstanceSerializer(instance, context={"request": request})
+        return Response(output.data, status=status.HTTP_201_CREATED)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2048

## Summary

GM-tier mission gating & assignment: gm_assign_mission with source_beat binding, lazy stakes-arming on first player action, BeatSerializer.required_mission wired, BeatViewSet assign-mission action with CanAssignMissionToBeat permission, journal + telnet story context display, ADR-0104.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2048 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: No conflicts — branch was current with main.

<!-- last-addressed-comment: 0 -->