### PR TITLE
RELATIONSHIP_TRACK + RELATIONSHIP_CAPSTONE threads — bond expressions at crossings

### DIFF
--- a/src/commands/crossing.py
+++ b/src/commands/crossing.py
@@ -42,15 +42,22 @@ class CmdCrossing(ArxCommand):
         )
 
         offers = PendingCrossingOffer.objects.filter(thread__owner=sheet).select_related(
-            "thread__resonance", "thread__target_trait"
+            "thread__resonance",
+            "thread__target_trait",
+            "thread__target_facet",
+            "thread__target_relationship_track__track",
+            "thread__target_relationship_track__relationship__target__character",
+            "thread__target_capstone__relationship__target__character",
         )
         if not offers:
             self.msg("You have no pending crossing offers.")
             return
         for offer in offers:
-            trait_name = offer.thread.target_trait.name if offer.thread.target_trait else "???"
+            from world.magic.crossing.handlers import _anchor_label_for  # noqa: PLC0415
+
+            anchor_label = _anchor_label_for(offer.thread)
             res_name = offer.thread.resonance.name if offer.thread.resonance else "???"
-            self.msg(f"|wCrossing level {offer.crossing_level}|n - {res_name} {trait_name}")
+            self.msg(f"|wCrossing level {offer.crossing_level}|n - {res_name} {anchor_label}")
             options = CrossingOption.objects.filter(
                 target_kind=offer.thread.target_kind,
                 resonance=offer.thread.resonance,

--- a/src/world/magic/crossing/handlers.py
+++ b/src/world/magic/crossing/handlers.py
@@ -8,9 +8,12 @@ Each handler is registered against a ``TargetKind`` in ``MagicConfig.ready()``.
 - ``TechniqueCrossingHandler`` (TECHNIQUE) executes a ceremony beat at
   crossings. The signature-bonus gating itself is subissue #1988; this
   handler just ensures the crossing isn't silent.
-- The remaining five kinds (FACET, RELATIONSHIP_TRACK,
-  RELATIONSHIP_CAPSTONE, MANTLE, SANCTUM) are stubs that log a debug no-op.
-  Each is replaced with real logic in its subissue (#1990–#1993).
+- ``RelationshipTrackCrossingHandler`` (RELATIONSHIP_TRACK) and
+  ``RelationshipCapstoneCrossingHandler`` (RELATIONSHIP_CAPSTONE) use the
+  ``_CrossingChoiceHandler`` base — the same player-choice pattern as TRAIT
+  and FACET (#1991).
+- The remaining three kinds (MANTLE, SANCTUM) are stubs that log a debug
+  no-op. Each is replaced with real logic in its subissue (#1992–#1993).
 """
 
 from __future__ import annotations
@@ -317,14 +320,44 @@ class TraitCrossingHandler(_CrossingChoiceHandler):
     target_kind = TargetKind.TRAIT
 
 
+def _anchor_label_for(thread: Thread) -> str:
+    """Return a human-readable label for the thread's anchor entity.
+
+    Used by ``_compose_crossing_message`` and ``CmdCrossing._list_offers`` so
+    the crossing announcement references the right anchor (partner name for
+    relationship threads, trait/facet name for those kinds) instead of a
+    generic placeholder.
+    """
+    kind = thread.target_kind
+    fallback = {
+        TargetKind.TRAIT: "trait",  # noqa: STRING_LITERAL
+        TargetKind.FACET: "facet",  # noqa: STRING_LITERAL
+        TargetKind.RELATIONSHIP_TRACK: "relationship",  # noqa: STRING_LITERAL
+        TargetKind.RELATIONSHIP_CAPSTONE: "capstone",  # noqa: STRING_LITERAL
+    }.get(kind, "thread")  # noqa: STRING_LITERAL
+    if kind == TargetKind.TRAIT and thread.target_trait is not None:
+        return thread.target_trait.name
+    if kind == TargetKind.FACET and thread.target_facet is not None:
+        return thread.target_facet.name
+    if kind == TargetKind.RELATIONSHIP_TRACK:
+        track = thread.target_relationship_track
+        if track is not None:
+            partner_name = track.relationship.target.character.db_key
+            return f"bond with {partner_name} ({track.track.name})"
+    if kind == TargetKind.RELATIONSHIP_CAPSTONE:
+        cap = thread.target_capstone
+        if cap is not None:
+            partner_name = cap.relationship.target.character.db_key
+            return f"capstone '{cap.title}' with {partner_name}"
+    return fallback
+
+
 def _compose_crossing_message(thread: Thread, crossing_level: int) -> str:
     """Build a resonance-flavored crossing announcement."""
     resonance_name = thread.resonance.name if thread.resonance else "your resonance"
-    trait_name = ""
-    if thread.target_trait is not None:
-        trait_name = thread.target_trait.name
+    anchor_label = _anchor_label_for(thread)
     return (
-        f"Your {resonance_name}-resonant {trait_name or 'trait'} thread "
+        f"Your {resonance_name}-resonant {anchor_label} thread "
         f"has crossed a threshold (level {crossing_level}). "
         f"Use 'crossing list' to choose how it manifests."
     )
@@ -374,18 +407,27 @@ class FacetCrossingHandler(_CrossingChoiceHandler):
     target_kind = TargetKind.FACET
 
 
-class RelationshipTrackCrossingHandler(_StubCrossingHandler):
-    """RELATIONSHIP_TRACK thread crossing — stub (#1991)."""
+class RelationshipTrackCrossingHandler(_CrossingChoiceHandler):
+    """RELATIONSHIP_TRACK thread crossing — player-chosen bond expression (#1991).
+
+    At each crossing level, creates a PendingCrossingOffer for the player to
+    choose a resonance-matched bond expression. The buff is always-on (a
+    relationship bond is intrinsic — not wear-gated like FACET).
+    """
 
     target_kind = TargetKind.RELATIONSHIP_TRACK
-    _subissue = "#1991"
 
 
-class RelationshipCapstoneCrossingHandler(_StubCrossingHandler):
-    """RELATIONSHIP_CAPSTONE thread crossing — stub (#1991)."""
+class RelationshipCapstoneCrossingHandler(_CrossingChoiceHandler):
+    """RELATIONSHIP_CAPSTONE thread crossing — player-chosen bond expression (#1991).
+
+    Coordinates with Soul Tether (Spec B): the ceremony is a personalization
+    layer only. It does not touch ``hollow_current``, ``hollow_max``, or any
+    Soul Tether service. The Hollow continues to function normally — deepening
+    the Hollow at crossings is a separate Spec B follow-up.
+    """
 
     target_kind = TargetKind.RELATIONSHIP_CAPSTONE
-    _subissue = "#1991"
 
 
 class MantleCrossingHandler(_StubCrossingHandler):

--- a/src/world/magic/tests/test_crossing.py
+++ b/src/world/magic/tests/test_crossing.py
@@ -456,3 +456,325 @@ class ResolveCrossingOfferActionTests(TestCase):
         self.assertTrue(
             CrossingChoice.objects.filter(thread=self.thread, crossing_level=3).exists()
         )
+
+
+# ---------------------------------------------------------------------------
+# RELATIONSHIP_TRACK + RELATIONSHIP_CAPSTONE crossing tests (#1991)
+# ---------------------------------------------------------------------------
+
+
+class RelationshipTrackCrossingHandlerTests(TestCase):
+    """RELATIONSHIP_TRACK thread crossing — player-chosen bond expression."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import ResonanceFactory, ThreadFactory
+
+        cls.sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory()
+        cls.thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            as_track_thread=True,
+            level=2,
+        )
+        cls.condition_template = _make_condition_template()
+        cls.option = CrossingOption.objects.create(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            resonance=cls.resonance,
+            crossing_level=3,
+            name="Burning devotion",
+            description="Your fire-resonant bond blazes with protective warmth.",
+            condition_template=cls.condition_template,
+            is_default=True,
+        )
+
+    def test_crossing_creates_pending_offer(self) -> None:
+        from world.magic.crossing.handlers import RelationshipTrackCrossingHandler
+
+        self.thread.level = 3
+        with patch("world.magic.crossing.handlers.execute_ceremony_beat") as mock_beat:
+            handler = RelationshipTrackCrossingHandler()
+            handler.execute(thread=self.thread, starting_level=2, new_level=3)
+            mock_beat.assert_called_once()
+        self.assertTrue(PendingCrossingOffer.objects.filter(thread=self.thread).exists())
+
+    def test_non_crossing_level_no_offer(self) -> None:
+        from world.magic.crossing.handlers import RelationshipTrackCrossingHandler
+
+        self.thread.level = 4
+        with patch("world.magic.crossing.handlers.execute_ceremony_beat") as mock_beat:
+            handler = RelationshipTrackCrossingHandler()
+            handler.execute(thread=self.thread, starting_level=3, new_level=4)
+            mock_beat.assert_not_called()
+        self.assertFalse(PendingCrossingOffer.objects.filter(thread=self.thread).exists())
+
+    def test_multi_crossing_auto_resolves_lower(self) -> None:
+        """Crossing from 2->11 auto-resolves 3 and 6, offers 11."""
+        from world.magic.crossing.handlers import RelationshipTrackCrossingHandler
+
+        CrossingOption.objects.create(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            resonance=self.resonance,
+            crossing_level=6,
+            name="Greater devotion",
+            condition_template=self.condition_template,
+            is_default=True,
+        )
+        CrossingOption.objects.create(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            resonance=self.resonance,
+            crossing_level=11,
+            name="Master devotion",
+            condition_template=self.condition_template,
+            is_default=True,
+        )
+        self.thread.level = 11
+        with patch("world.magic.crossing.handlers.execute_ceremony_beat"):
+            handler = RelationshipTrackCrossingHandler()
+            handler.execute(thread=self.thread, starting_level=2, new_level=11)
+        self.assertTrue(
+            CrossingChoice.objects.filter(thread=self.thread, crossing_level=3).exists()
+        )
+        self.assertTrue(
+            CrossingChoice.objects.filter(thread=self.thread, crossing_level=6).exists()
+        )
+        self.assertTrue(
+            PendingCrossingOffer.objects.filter(thread=self.thread, crossing_level=11).exists()
+        )
+
+
+class RelationshipCapstoneCrossingHandlerTests(TestCase):
+    """RELATIONSHIP_CAPSTONE thread crossing — player-chosen bond expression."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import ResonanceFactory, ThreadFactory
+
+        cls.sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory()
+        cls.thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            as_capstone_thread=True,
+            level=2,
+        )
+        cls.condition_template = _make_condition_template()
+        cls.option = CrossingOption.objects.create(
+            target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+            resonance=cls.resonance,
+            crossing_level=3,
+            name="Eternal bond",
+            description="Your capstone bond deepens into permanence.",
+            condition_template=cls.condition_template,
+            is_default=True,
+        )
+
+    def test_crossing_creates_pending_offer(self) -> None:
+        from world.magic.crossing.handlers import RelationshipCapstoneCrossingHandler
+
+        self.thread.level = 3
+        with patch("world.magic.crossing.handlers.execute_ceremony_beat") as mock_beat:
+            handler = RelationshipCapstoneCrossingHandler()
+            handler.execute(thread=self.thread, starting_level=2, new_level=3)
+            mock_beat.assert_called_once()
+        self.assertTrue(PendingCrossingOffer.objects.filter(thread=self.thread).exists())
+
+    def test_multi_crossing_auto_resolves_lower(self) -> None:
+        """Crossing from 2->11 auto-resolves 3 and 6, offers 11."""
+        from world.magic.crossing.handlers import RelationshipCapstoneCrossingHandler
+
+        CrossingOption.objects.create(
+            target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+            resonance=self.resonance,
+            crossing_level=6,
+            name="Greater bond",
+            condition_template=self.condition_template,
+            is_default=True,
+        )
+        CrossingOption.objects.create(
+            target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+            resonance=self.resonance,
+            crossing_level=11,
+            name="Master bond",
+            condition_template=self.condition_template,
+            is_default=True,
+        )
+        self.thread.level = 11
+        with patch("world.magic.crossing.handlers.execute_ceremony_beat"):
+            handler = RelationshipCapstoneCrossingHandler()
+            handler.execute(thread=self.thread, starting_level=2, new_level=11)
+        self.assertTrue(
+            CrossingChoice.objects.filter(thread=self.thread, crossing_level=3).exists()
+        )
+        self.assertTrue(
+            CrossingChoice.objects.filter(thread=self.thread, crossing_level=6).exists()
+        )
+        self.assertTrue(
+            PendingCrossingOffer.objects.filter(thread=self.thread, crossing_level=11).exists()
+        )
+
+
+class RelationshipCrossingResolutionTests(TestCase):
+    """resolve_crossing_offer works for RELATIONSHIP_TRACK and RELATIONSHIP_CAPSTONE."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import ResonanceFactory, ThreadFactory
+
+        cls.sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory()
+        cls.track_thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            as_track_thread=True,
+            level=3,
+        )
+        cls.capstone_thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            as_capstone_thread=True,
+            level=3,
+        )
+        cls.condition_template = _make_condition_template()
+        cls.track_option = CrossingOption.objects.create(
+            target_kind=TargetKind.RELATIONSHIP_TRACK,
+            resonance=cls.resonance,
+            crossing_level=3,
+            name="Burning devotion",
+            condition_template=cls.condition_template,
+        )
+        cls.capstone_option = CrossingOption.objects.create(
+            target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+            resonance=cls.resonance,
+            crossing_level=3,
+            name="Eternal bond",
+            condition_template=cls.condition_template,
+        )
+
+    def test_resolve_track_offer(self) -> None:
+        from world.magic.services.crossing import resolve_crossing_offer
+
+        offer = PendingCrossingOffer.objects.create(
+            thread=self.track_thread,
+            crossing_level=3,
+        )
+        result = resolve_crossing_offer(offer, option=self.track_option)
+        self.assertEqual(result.option_name, "Burning devotion")
+        self.assertTrue(
+            CrossingChoice.objects.filter(thread=self.track_thread, crossing_level=3).exists()
+        )
+        self.assertFalse(PendingCrossingOffer.objects.filter(pk=offer.pk).exists())
+
+    def test_resolve_capstone_offer(self) -> None:
+        from world.magic.services.crossing import resolve_crossing_offer
+
+        offer = PendingCrossingOffer.objects.create(
+            thread=self.capstone_thread,
+            crossing_level=3,
+        )
+        result = resolve_crossing_offer(offer, option=self.capstone_option)
+        self.assertEqual(result.option_name, "Eternal bond")
+        self.assertTrue(
+            CrossingChoice.objects.filter(thread=self.capstone_thread, crossing_level=3).exists()
+        )
+        self.assertFalse(PendingCrossingOffer.objects.filter(pk=offer.pk).exists())
+
+    def test_resolve_wrong_kind_raises_stale(self) -> None:
+        """Resolving a track offer with a capstone option raises StaleError."""
+        from world.magic.exceptions import CrossingOfferStaleError
+        from world.magic.services.crossing import resolve_crossing_offer
+
+        offer = PendingCrossingOffer.objects.create(
+            thread=self.track_thread,
+            crossing_level=3,
+        )
+        with self.assertRaises(CrossingOfferStaleError):
+            resolve_crossing_offer(offer, option=self.capstone_option)
+        self.assertFalse(PendingCrossingOffer.objects.filter(pk=offer.pk).exists())
+
+
+class SoulTetherNonInterferenceTests(TestCase):
+    """RELATIONSHIP_CAPSTONE crossing does not touch Soul Tether Hollow state."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import ResonanceFactory, ThreadFactory
+
+        cls.sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory()
+        cls.thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            as_capstone_thread=True,
+            level=2,
+            hollow_current=5,
+        )
+        cls.condition_template = _make_condition_template()
+        cls.option = CrossingOption.objects.create(
+            target_kind=TargetKind.RELATIONSHIP_CAPSTONE,
+            resonance=cls.resonance,
+            crossing_level=3,
+            name="Deepened hollow",
+            condition_template=cls.condition_template,
+            is_default=True,
+        )
+
+    def test_crossing_does_not_change_hollow_current(self) -> None:
+        """The crossing ceremony must not touch hollow_current."""
+        from world.magic.crossing.handlers import RelationshipCapstoneCrossingHandler
+
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.hollow_current, 5)
+
+        self.thread.level = 3
+        with patch("world.magic.crossing.handlers.execute_ceremony_beat"):
+            handler = RelationshipCapstoneCrossingHandler()
+            handler.execute(thread=self.thread, starting_level=2, new_level=3)
+
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.hollow_current, 5)
+
+
+class AnchorLabelTests(TestCase):
+    """_anchor_label_for resolves relationship anchors correctly."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import ResonanceFactory, ThreadFactory
+
+        cls.sheet = CharacterSheetFactory()
+        cls.resonance = ResonanceFactory()
+        cls.track_thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            as_track_thread=True,
+            level=2,
+        )
+        cls.capstone_thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            as_capstone_thread=True,
+            level=2,
+        )
+
+    def test_track_anchor_label_includes_partner_and_track(self) -> None:
+        from world.magic.crossing.handlers import _anchor_label_for
+
+        label = _anchor_label_for(self.track_thread)
+        self.assertIn("bond with", label)
+        track = self.track_thread.target_relationship_track
+        self.assertIn(track.track.name, label)
+
+    def test_capstone_anchor_label_includes_title_and_partner(self) -> None:
+        from world.magic.crossing.handlers import _anchor_label_for
+
+        label = _anchor_label_for(self.capstone_thread)
+        self.assertIn("capstone", label)
+        cap = self.capstone_thread.target_capstone
+        self.assertIn(cap.title, label)

--- a/src/world/magic/tests/test_crossing_ceremony.py
+++ b/src/world/magic/tests/test_crossing_ceremony.py
@@ -43,10 +43,8 @@ class CrossingRegistryTests(TestCase):
         self.assertIsNotNone(get_crossing_handler(TargetKind.COVENANT_ROLE))
 
     def test_stub_handlers_registered(self) -> None:
-        """The 4 remaining stub kinds have handlers that execute without error."""
+        """The 2 remaining stub kinds have handlers that execute without error."""
         stub_kinds = [
-            TargetKind.RELATIONSHIP_TRACK,
-            TargetKind.RELATIONSHIP_CAPSTONE,
             TargetKind.MANTLE,
             TargetKind.SANCTUM,
         ]

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -1748,12 +1748,23 @@ class PendingCrossingOfferViewSet(viewsets.ReadOnlyModelViewSet):
             PendingCrossingOffer,
         )
 
-        return _account_scoped_offer_queryset(
-            PendingCrossingOffer,
-            self.request.user,
-            "thread",
-            "thread__resonance",
-            "thread__target_trait",
+        sheets = CharacterSheet.objects.filter(
+            roster_entry__tenures__player_data__account=self.request.user,
+            roster_entry__tenures__end_date__isnull=True,
+        )
+        return (
+            PendingCrossingOffer.objects.filter(thread__owner__in=sheets)
+            .select_related(
+                "thread",
+                "thread__resonance",
+                "thread__target_trait",
+                "thread__target_facet",
+                "thread__target_relationship_track__track",
+                "thread__target_relationship_track__relationship__target__character",
+                "thread__target_capstone__relationship__target__character",
+            )
+            .order_by("-created_at")
+            .distinct()
         )
 
 


### PR DESCRIPTION
Closes #1991

## Summary

Replace the two stub crossing handlers (RelationshipTrackCrossingHandler and RelationshipCapstoneCrossingHandler) with real _CrossingChoiceHandler subclasses, following the exact pattern TRAIT (#1989) and FACET (#1990) established.

At each PathStage crossing (3, 6, 11, 16, 21), the player chooses a resonance-flavored bond expression from an authored catalog (CrossingOption), with a ceremony beat (achievement + codex + narrative). The buff is an acquisition-agnostic ConditionTemplate whose ConditionModifierEffect rows define the stat/check modifiers.

Key changes:
- Replace stub handlers with _CrossingChoiceHandler subclasses (4 lines each)
- Extract _anchor_label_for() from _compose_crossing_message for relationship anchors
- Generalize CmdCrossing._list_offers (fixes latent FACET display bug)
- Extend web select_related for relationship FK chains
- Fix pre-existing bug: PendingCrossingOfferViewSet queryset filtered on nonexistent character_sheet__ field
- Update stub-handler tests; add journey tests + Soul Tether non-interference test

No new models, no migration. The RELATIONSHIP_CAPSTONE ceremony is a personalization layer only — it does not touch hollow_current or any Soul Tether service.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1991 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Already up to date with main

<!-- last-addressed-comment: 0 -->