### PR TITLE
MANTLE threads — resonance-flavored mantle power manifestation at crossings

### DIFF
--- a/src/commands/crossing.py
+++ b/src/commands/crossing.py
@@ -45,6 +45,7 @@ class CmdCrossing(ArxCommand):
             "thread__resonance",
             "thread__target_trait",
             "thread__target_facet",
+            "thread__target_mantle",
             "thread__target_relationship_track__track",
             "thread__target_relationship_track__relationship__target__character",
             "thread__target_capstone__relationship__target__character",

--- a/src/world/magic/crossing/handlers.py
+++ b/src/world/magic/crossing/handlers.py
@@ -12,8 +12,10 @@ Each handler is registered against a ``TargetKind`` in ``MagicConfig.ready()``.
   ``RelationshipCapstoneCrossingHandler`` (RELATIONSHIP_CAPSTONE) use the
   ``_CrossingChoiceHandler`` base — the same player-choice pattern as TRAIT
   and FACET (#1991).
-- The remaining three kinds (MANTLE, SANCTUM) are stubs that log a debug
-  no-op. Each is replaced with real logic in its subissue (#1992–#1993).
+- ``MantleCrossingHandler`` (MANTLE) uses the ``_CrossingChoiceHandler`` base
+  — the same player-choice pattern as TRAIT and FACET (#1992).
+- The remaining kind (SANCTUM) is a stub that logs a debug no-op. It is
+  replaced with real logic in its subissue (#1993).
 """
 
 from __future__ import annotations

--- a/src/world/magic/crossing/handlers.py
+++ b/src/world/magic/crossing/handlers.py
@@ -349,6 +349,8 @@ def _anchor_label_for(thread: Thread) -> str:
         if cap is not None:
             partner_name = cap.relationship.target.character.db_key
             return f"capstone '{cap.title}' with {partner_name}"
+    if kind == TargetKind.MANTLE and thread.target_mantle is not None:
+        return thread.target_mantle.name
     return fallback
 
 

--- a/src/world/magic/crossing/handlers.py
+++ b/src/world/magic/crossing/handlers.py
@@ -432,11 +432,17 @@ class RelationshipCapstoneCrossingHandler(_CrossingChoiceHandler):
     target_kind = TargetKind.RELATIONSHIP_CAPSTONE
 
 
-class MantleCrossingHandler(_StubCrossingHandler):
-    """MANTLE thread crossing — stub (#1992)."""
+class MantleCrossingHandler(_CrossingChoiceHandler):
+    """MANTLE thread crossing — player-chosen mantle personalization.
+
+    At each crossing level (3, 6, 11, 16, 21), creates a PendingCrossingOffer
+    for the player to choose how the mantle's power reshapes to match their
+    resonance. The chosen buff is always-on (the thread IS the attunement bond
+    — not wear-gated like FACET). Skipped lower crossings are auto-resolved
+    with the is_default option.
+    """
 
     target_kind = TargetKind.MANTLE
-    _subissue = "#1992"
 
 
 class SanctumCrossingHandler(_StubCrossingHandler):

--- a/src/world/magic/tests/test_crossing.py
+++ b/src/world/magic/tests/test_crossing.py
@@ -778,3 +778,39 @@ class AnchorLabelTests(TestCase):
         self.assertIn("capstone", label)
         cap = self.capstone_thread.target_capstone
         self.assertIn(cap.title, label)
+
+
+# ---------------------------------------------------------------------------
+# MANTLE crossing tests (#1992)
+# ---------------------------------------------------------------------------
+
+
+class MantleAnchorLabelTests(TestCase):
+    """_anchor_label_for returns the mantle name for MANTLE threads."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia_extensions.factories import CharacterFactory
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.items.factories import MantleFactory
+        from world.magic.constants import TargetKind
+        from world.magic.factories import ResonanceFactory, ThreadFactory
+
+        cls.character_obj = CharacterFactory(db_key="MantleAnchorChar")
+        cls.sheet = CharacterSheetFactory(character=cls.character_obj, primary_persona=False)
+        cls.resonance = ResonanceFactory()
+        cls.mantle = MantleFactory(name="Dawnbringer")
+        cls.thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            level=3,
+            target_kind=TargetKind.MANTLE,
+            target_mantle=cls.mantle,
+            target_trait=None,
+        )
+
+    def test_mantle_anchor_label_returns_mantle_name(self) -> None:
+        from world.magic.crossing.handlers import _anchor_label_for
+
+        label = _anchor_label_for(self.thread)
+        self.assertEqual(label, "Dawnbringer")

--- a/src/world/magic/tests/test_crossing.py
+++ b/src/world/magic/tests/test_crossing.py
@@ -814,3 +814,67 @@ class MantleAnchorLabelTests(TestCase):
 
         label = _anchor_label_for(self.thread)
         self.assertEqual(label, "Dawnbringer")
+
+
+class MantleCrossingHandlerTests(TestCase):
+    """MANTLE thread crossing creates offers + auto-resolves skipped levels."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia_extensions.factories import CharacterFactory
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.items.factories import MantleFactory
+        from world.magic.constants import TargetKind
+        from world.magic.factories import ResonanceFactory, ThreadFactory
+
+        cls.character_obj = CharacterFactory(db_key="MantleCrossingChar")
+        cls.sheet = CharacterSheetFactory(character=cls.character_obj, primary_persona=False)
+        cls.resonance = ResonanceFactory()
+        cls.mantle = MantleFactory(name="MantleCrossingMantle")
+        cls.thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            level=2,
+            target_kind=TargetKind.MANTLE,
+            target_mantle=cls.mantle,
+            target_trait=None,
+        )
+
+    def test_single_crossing_creates_offer(self) -> None:
+        """Imbue 2->3 creates a PendingCrossingOffer for level 3."""
+        from unittest.mock import patch
+
+        from world.magic.crossing.handlers import MantleCrossingHandler
+        from world.magic.models.crossing import PendingCrossingOffer
+
+        self.thread.level = 3
+        with patch("world.magic.crossing.handlers.execute_ceremony_beat"):
+            handler = MantleCrossingHandler()
+            handler.execute(thread=self.thread, starting_level=2, new_level=3)
+        self.assertTrue(
+            PendingCrossingOffer.objects.filter(thread=self.thread, crossing_level=3).exists()
+        )
+
+    def test_multi_crossing_auto_resolves_and_creates_offer(self) -> None:
+        """Imbue 2->11 auto-resolves levels 3+6, creates offer for 11."""
+        from unittest.mock import patch
+
+        from world.magic.crossing.handlers import MantleCrossingHandler
+        from world.magic.models.crossing import PendingCrossingOffer
+
+        self.thread.level = 11
+        with patch("world.magic.crossing.handlers.execute_ceremony_beat"):
+            handler = MantleCrossingHandler()
+            handler.execute(thread=self.thread, starting_level=2, new_level=11)
+        self.assertTrue(
+            PendingCrossingOffer.objects.filter(thread=self.thread, crossing_level=11).exists()
+        )
+
+    def test_no_op_when_no_level_gain(self) -> None:
+        """If new_level <= starting_level, nothing happens."""
+        from world.magic.crossing.handlers import MantleCrossingHandler
+        from world.magic.models.crossing import PendingCrossingOffer
+
+        handler = MantleCrossingHandler()
+        handler.execute(thread=self.thread, starting_level=3, new_level=3)
+        self.assertFalse(PendingCrossingOffer.objects.filter(thread=self.thread).exists())

--- a/src/world/magic/tests/test_crossing.py
+++ b/src/world/magic/tests/test_crossing.py
@@ -878,3 +878,89 @@ class MantleCrossingHandlerTests(TestCase):
         handler = MantleCrossingHandler()
         handler.execute(thread=self.thread, starting_level=3, new_level=3)
         self.assertFalse(PendingCrossingOffer.objects.filter(thread=self.thread).exists())
+
+
+class MantleCrossingResolveTests(TestCase):
+    """Resolve a MANTLE crossing offer via the service + action seam."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia_extensions.factories import CharacterFactory
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.conditions.factories import ConditionTemplateFactory
+        from world.items.factories import MantleFactory
+        from world.magic.constants import TargetKind
+        from world.magic.factories import ResonanceFactory, ThreadFactory
+        from world.magic.models.crossing import CrossingOption
+
+        cls.character_obj = CharacterFactory(db_key="MantleResolveChar")
+        cls.sheet = CharacterSheetFactory(character=cls.character_obj, primary_persona=False)
+        cls.resonance = ResonanceFactory()
+        cls.mantle = MantleFactory(name="MantleResolveMantle")
+        cls.thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            level=3,
+            target_kind=TargetKind.MANTLE,
+            target_mantle=cls.mantle,
+            target_trait=None,
+        )
+        cls.condition_template = ConditionTemplateFactory()
+        cls.option = CrossingOption.objects.create(
+            target_kind=TargetKind.MANTLE,
+            resonance=cls.resonance,
+            crossing_level=3,
+            name="Flame-forged edge",
+            description="The mantle's blade ignites with your resonance.",
+            condition_template=cls.condition_template,
+        )
+
+    def setUp(self) -> None:
+        from world.magic.models.crossing import PendingCrossingOffer
+
+        self.offer = PendingCrossingOffer.objects.create(
+            thread=self.thread,
+            crossing_level=3,
+        )
+
+    def test_resolve_mantle_offer(self) -> None:
+        """resolve_crossing_offer creates a CrossingChoice and deletes the offer."""
+        from world.magic.models.crossing import CrossingChoice, PendingCrossingOffer
+        from world.magic.services.crossing import resolve_crossing_offer
+
+        result = resolve_crossing_offer(self.offer, option=self.option)
+        self.assertEqual(result.option_name, "Flame-forged edge")
+        self.assertTrue(
+            CrossingChoice.objects.filter(thread=self.thread, crossing_level=3).exists()
+        )
+        self.assertFalse(PendingCrossingOffer.objects.filter(pk=self.offer.pk).exists())
+
+    def test_resolve_wrong_kind_raises_stale(self) -> None:
+        """Resolving a MANTLE offer with a TRAIT option raises StaleError."""
+        from world.magic.constants import TargetKind
+        from world.magic.exceptions import CrossingOfferStaleError
+        from world.magic.models.crossing import CrossingOption
+        from world.magic.services.crossing import resolve_crossing_offer
+
+        trait_option = CrossingOption.objects.create(
+            target_kind=TargetKind.TRAIT,
+            resonance=self.resonance,
+            crossing_level=3,
+            name="Wrong kind option",
+            condition_template=self.condition_template,
+        )
+        with self.assertRaises(CrossingOfferStaleError):
+            resolve_crossing_offer(self.offer, option=trait_option)
+
+    def test_action_seam_resolves_mantle_offer(self) -> None:
+        """ResolveCrossingOfferAction.run succeeds for a MANTLE offer."""
+        from actions.definitions.crossing import ResolveCrossingOfferAction
+        from world.magic.models.crossing import CrossingChoice
+
+        actor = self.sheet.character
+        action = ResolveCrossingOfferAction()
+        result = action.run(actor=actor, offer=self.offer, option=self.option)
+        self.assertTrue(result.success)
+        self.assertTrue(
+            CrossingChoice.objects.filter(thread=self.thread, crossing_level=3).exists()
+        )

--- a/src/world/magic/tests/test_crossing_ceremony.py
+++ b/src/world/magic/tests/test_crossing_ceremony.py
@@ -43,9 +43,8 @@ class CrossingRegistryTests(TestCase):
         self.assertIsNotNone(get_crossing_handler(TargetKind.COVENANT_ROLE))
 
     def test_stub_handlers_registered(self) -> None:
-        """The 2 remaining stub kinds have handlers that execute without error."""
+        """The 1 remaining stub kind has a handler that executes without error."""
         stub_kinds = [
-            TargetKind.MANTLE,
             TargetKind.SANCTUM,
         ]
         for kind in stub_kinds:

--- a/src/world/mechanics/services.py
+++ b/src/world/mechanics/services.py
@@ -349,6 +349,7 @@ def equipment_walk_total(
         + vow_stat_scaling_bonus(character, target)
         + vow_gear_scaling_bonus(character, target)
         + passive_mantle_bonuses(character, target)
+        + passive_mantle_crossing_bonuses(character, target)
         + passive_motif_style_bonuses(character, target)
     )
 
@@ -472,6 +473,40 @@ def passive_mantle_bonuses(sheet: object, target: ModifierTarget) -> int:
         for effect in effects:
             base = effect.flat_bonus_amount or 0
             total += base * max(1, thread.level)
+    return total
+
+
+def passive_mantle_crossing_bonuses(sheet: object, target: ModifierTarget) -> int:
+    """Sum ConditionModifierEffect from MANTLE thread crossing choices (always-on).
+
+    For each MANTLE-kind thread with crossing choices, reads the choice's
+    option.condition_template's ConditionModifierEffect rows for ``target``
+    and sums them. Always-on -- the thread IS the attunement bond, so the
+    crossing buff is active regardless of whether the mantle item is equipped.
+
+    Composes with ``passive_mantle_bonuses`` in ``equipment_walk_total`` --
+    the crossing buff is a personal layer on top of the global tier-0 passive.
+    """
+    from world.conditions.models import ConditionModifierEffect  # noqa: PLC0415
+    from world.magic.constants import TargetKind  # noqa: PLC0415
+    from world.magic.models.crossing import CrossingChoice  # noqa: PLC0415
+
+    char = sheet.character
+    if not hasattr(char, "threads"):  # noqa: GETATTR_LITERAL
+        return 0
+    total = 0
+    for thread in char.threads.threads_of_kind(TargetKind.MANTLE):
+        choices = CrossingChoice.objects.filter(thread=thread).select_related(
+            "option__condition_template"
+        )
+        for choice in choices:
+            template = choice.option.condition_template
+            effects = ConditionModifierEffect.objects.filter(
+                condition=template,
+                modifier_target=target,
+            )
+            for effect in effects:
+                total += effect.value
     return total
 
 
@@ -826,6 +861,7 @@ def equipment_walk_total_unblended(sheet: object, target: ModifierTarget) -> int
         + vow_stat_scaling_bonus(sheet, target)
         + vow_gear_scaling_bonus(sheet, target)
         + passive_mantle_bonuses(sheet, target)
+        + passive_mantle_crossing_bonuses(sheet, target)
         + passive_motif_style_bonuses(sheet, target)
     )
 

--- a/src/world/mechanics/tests/test_mantle_crossing_bonus.py
+++ b/src/world/mechanics/tests/test_mantle_crossing_bonus.py
@@ -1,0 +1,123 @@
+"""Tests for passive_mantle_crossing_bonuses — MANTLE crossing buff in equipment_walk_total (#1992).
+
+Pipeline: build sheet + MANTLE-kind Thread + CrossingChoice (ConditionTemplate with
+ConditionModifierEffect) -> call equipment_walk_total(sheet, target) -> assert the
+crossing buff's ConditionModifierEffect value is included.
+
+Always-on: the buff contributes even when the character is NOT wearing/holding the
+mantle item (unlike FACET, which is wear-gated).
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+
+class MantleCrossingBonusPipelineTests(TestCase):
+    """Happy path: a MANTLE thread crossing choice contributes via equipment_walk_total."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia_extensions.factories import CharacterFactory
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.conditions.factories import (
+            ConditionModifierEffectFactory,
+            ConditionTemplateFactory,
+        )
+        from world.items.factories import MantleFactory
+        from world.magic.constants import TargetKind
+        from world.magic.factories import ResonanceFactory, ThreadFactory
+        from world.magic.models.crossing import CrossingChoice, CrossingOption
+        from world.mechanics.factories import ModifierCategoryFactory, ModifierTargetFactory
+
+        cls.effect_value = 7
+
+        # 1. Character + CharacterSheet
+        cls.character_obj = CharacterFactory(db_key="MantleCrossingBonusChar")
+        cls.sheet = CharacterSheetFactory(character=cls.character_obj, primary_persona=False)
+
+        # 2. Resonance + ModifierTarget linked via target_resonance
+        cls.resonance = ResonanceFactory()
+        cls.resonance_category = ModifierCategoryFactory(name="resonance")
+        cls.target = ModifierTargetFactory(
+            name="MantleCrossingBonusTarget",
+            category=cls.resonance_category,
+            target_resonance=cls.resonance,
+        )
+
+        # 3. Mantle + MANTLE-kind Thread
+        cls.mantle = MantleFactory(name="MantleCrossingBonusMantle")
+        cls.thread = ThreadFactory(
+            owner=cls.sheet,
+            resonance=cls.resonance,
+            level=3,
+            target_kind=TargetKind.MANTLE,
+            target_mantle=cls.mantle,
+            target_trait=None,
+        )
+
+        # 4. CrossingOption + CrossingChoice (the crossing buff)
+        cls.condition_template = ConditionTemplateFactory()
+        ConditionModifierEffectFactory(
+            condition=cls.condition_template,
+            modifier_target=cls.target,
+            value=cls.effect_value,
+        )
+        cls.option = CrossingOption.objects.create(
+            target_kind=TargetKind.MANTLE,
+            resonance=cls.resonance,
+            crossing_level=3,
+            name="Mantle crossing buff",
+            condition_template=cls.condition_template,
+        )
+        CrossingChoice.objects.create(
+            thread=cls.thread,
+            crossing_level=3,
+            option=cls.option,
+        )
+
+    def test_crossing_bonus_in_equipment_walk_total(self) -> None:
+        """equipment_walk_total includes the MANTLE crossing buff value."""
+        from world.mechanics.services import equipment_walk_total
+
+        self.character_obj.threads.invalidate()
+        self.character_obj.equipped_items.invalidate()
+
+        result = equipment_walk_total(self.sheet, self.target)
+        self.assertEqual(result, self.effect_value)
+
+    def test_crossing_bonus_always_on_without_equipment(self) -> None:
+        """The crossing buff contributes even with no items equipped (always-on)."""
+        from world.mechanics.services import equipment_walk_total
+
+        self.character_obj.threads.invalidate()
+        self.character_obj.equipped_items.invalidate()
+
+        # No items equipped at all -- buff still contributes
+        result = equipment_walk_total(self.sheet, self.target)
+        self.assertEqual(result, self.effect_value)
+
+
+class MantleCrossingBonusNoThreadTests(TestCase):
+    """Negative path: no MANTLE thread -> 0 via equipment_walk_total."""
+
+    def test_no_mantle_thread_returns_zero(self) -> None:
+        from evennia_extensions.factories import CharacterFactory
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.factories import ResonanceFactory
+        from world.mechanics.factories import ModifierCategoryFactory, ModifierTargetFactory
+        from world.mechanics.services import equipment_walk_total
+
+        char = CharacterFactory(db_key="MantleCrossingNoThreadChar")
+        sheet = CharacterSheetFactory(character=char, primary_persona=False)
+        resonance = ResonanceFactory()
+
+        resonance_category = ModifierCategoryFactory(name="resonance")
+        target = ModifierTargetFactory(
+            name="MantleCrossingNoThreadTarget",
+            category=resonance_category,
+            target_resonance=resonance,
+        )
+
+        result = equipment_walk_total(sheet, target)
+        self.assertEqual(result, 0)


### PR DESCRIPTION
Closes #1992

## Summary

Replace the MantleCrossingHandler stub with the _CrossingChoiceHandler pattern, so MANTLE threads get the same player-choice crossing flow as TRAIT/FACET/RELATIONSHIP threads. At each PathStage crossing (3, 6, 11, 16, 21), the player chooses how the mantle's power reshapes to match their resonance — personalizing the artifact itself.

Four code changes, zero new models/commands/actions/views:
1. Swap MantleCrossingHandler from _StubCrossingHandler to _CrossingChoiceHandler
2. Add MANTLE case to _anchor_label_for (crossing messages name the mantle)
3. New passive_mantle_crossing_bonuses walker in equipment_walk_total + _unblended (always-on, mirroring FACET minus wear-gate)
4. Add thread__target_mantle to CmdCrossing._list_offers select_related

All infrastructure is reused: CrossingOption, CrossingChoice, PendingCrossingOffer, resolve_crossing_offer, ResolveCrossingOfferAction, CmdCrossing, and CrossingRespondView are all target_kind-agnostic.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1992 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased on main, no conflicts.

<!-- last-addressed-comment: 0 -->