### PR TITLE
Covenant lifecycle rituals never seeded — formation/induction/banner-call/mentor-bond unreachable in a live game

### DIFF
--- a/docs/roadmap/covenants.md
+++ b/docs/roadmap/covenants.md
@@ -436,8 +436,12 @@ weave Threads anchored on a `CovenantRole` and invest resonance in them.
   to the fired service.
 - **Covenant ritual wrappers** — `create_covenant_via_session` and
   `induct_member_via_session` thin shims around Slice A services;
-  `CovenantFormationRitualFactory` and `CovenantInductionRitualFactory` that seed
-  the Ritual rows on startup.
+  `CovenantFormationRitualFactory` and `CovenantInductionRitualFactory` build the
+  backing Ritual rows. **Reachability fixed in #2114** — until then these factories
+  were called only from tests, so `ritual draft "Covenant Formation"` failed on a
+  real server; `wire_covenant_lifecycle_rituals()` (`world.magic.factories`) now
+  seeds Formation/Induction plus Call the Banners/Mentor's Vow/Renew the
+  Oath/Organization Induction from `seed_magic_dev()`, reachable via the Big Button.
 - **Soul Tether BILATERAL retrofit** — Soul Tether ritual factory now `BILATERAL`
   with sineater + sinner role choices; `accept_soul_tether_via_session` wrapper.
   `soul_tether_rescue` stays `SINGLE_ACTOR` (rescue inherently can't require
@@ -754,7 +758,11 @@ ritual; the session coordinates) + the conditions system (`apply_condition`,
   participant's OWN recorded condition rather than a single shared template.
 
 `wire_covenant_rite_content()` seeds the "Renew the Oath" reference rite plus the
-following role/level-banded stat packages (all effects `scales_with_severity=True`):
+following role/level-banded stat packages (all effects `scales_with_severity=True`).
+**Reachability fixed in #2114** — until then this helper was called only from tests;
+`wire_covenant_lifecycle_rituals()` (`world.magic.factories`) now calls it from
+`seed_magic_dev()` so the rite (Ritual + `CovenantRite` sidecar + packages together)
+exists in a real deploy, not only under test setup:
 
 | Role | Level band | Condition | Stats buffed |
 |---|---|---|---|

--- a/docs/systems/covenants.md
+++ b/docs/systems/covenants.md
@@ -75,7 +75,10 @@ axes are orthogonal — never re-merge them.
   - `max_sidekicks_per_mentor` (PositiveSmallInt, nullable; null = unlimited) — cap on
     active bonds per mentor per covenant.
   - `updated_at` / `updated_by` — audit timestamps. Seeded via
-    `seed_mentor_bond_defaults()` in factories.py; staff-tunable in Django admin.
+    `seed_mentor_bond_defaults()` in factories.py, called from
+    `wire_covenant_lifecycle_rituals()` (`world.magic.factories`, #2114) as part of
+    `seed_magic_dev()` — reachable in a real deploy, not only under test setup.
+    Staff-tunable in Django admin (re-running the seed resets to authored defaults).
 
 - **`MentorBond`** — one active bond record per (covenant, sidekick_sheet) pair (via
   partial unique constraint `unique_active_sidekick_bond`). Dissolved bonds are retained
@@ -177,7 +180,8 @@ axes are orthogonal — never re-merge them.
   **Vow gate**. Raises `VowGateError` if the character's raw primary level is outside
   the covenant band AND they have no active bond (as mentor or sidekick) in this
   covenant. Called by `add_member`; `create_covenant` (formation) is ungated. Gate is
-  inactive when `MentorBondConfig` has not been seeded.
+  inactive only if `MentorBondConfig` has never been seeded at all (e.g. a DB that
+  predates #2114 and hasn't re-run `seed_magic_dev()`) — a fresh deploy always seeds it.
 
 ### Mentor's Vow ritual service
 

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -924,6 +924,40 @@ evaluated in `accrue_corruption` on the Sineater's own casting path. Value deriv
 - `StageAdvanceBonusResult` — outcome of the Sineater's stage-advance response.
 - `RescueOutcome` — frozen dataclass; severity_reduced, stage_before/after, strain_taken.
 
+### Covenant Lifecycle Content (#2114)
+
+The full covenant lifecycle — formation, induction, banner-call rise, mentor bonding,
+the mid-battle oath rite, and generic-org induction — is built session machinery
+(`world.covenants.services` / `world.societies.membership_services`), but every
+`Ritual` row a player would `ritual draft "<name>"` to trigger it previously existed
+only in test factories. `wire_covenant_lifecycle_rituals()` in `factories.py`, which
+`seed_magic_dev()` calls (#2114) right after `wire_soul_tether_content()`, seeds:
+
+- **"Covenant Formation"** — `create_covenant_via_session` (DURANCE + BATTLE only;
+  COURT formation is intentionally out of scope, per ADR-0057)
+- **"Covenant Induction"** — `induct_member_via_session`
+- **"Call the Banners"** — `rise_battle_covenant_via_session`
+- **"Mentor's Vow"** — `establish_mentor_bond_via_session`
+- **"Renew the Oath"** — `perform_covenant_rite`, seeded via the existing
+  `wire_covenant_rite_content()` (`world.covenants.factories`) rather than the bare
+  `RenewTheOathRitualFactory()` — `perform_covenant_rite` reads
+  `session.ritual.covenant_rite`, a required `CovenantRite` sidecar the bare Ritual
+  factory does not create, so the bare factory alone would seed a Ritual that crashes
+  on fire. `wire_covenant_rite_content()` creates the Ritual + `CovenantRite` sidecar +
+  role/level-band stat packages together.
+- **"Organization Induction"** — `induct_organization_member_via_session`
+  (`world.societies.membership_services`)
+
+Also resets the `MentorBondConfig` singleton (pk=1) to its authored defaults via
+`seed_mentor_bond_defaults()` — unlike the Ritual rows above (which preserve staff
+edits via `django_get_or_create`), this is a pre-launch tuning-knob reset by design
+(`update_or_create`), same treatment as other authored-defaults singletons.
+
+Like Soul Tether, this content previously existed only under test setup — without it,
+no player could ever found/join/grow a covenant, revive a dormant war covenant, form a
+mentor bond, fire the mid-battle oath rite, or join an ordinary organization through
+play; `covenant`/`org` (telnet)/REST could only manage state staff planted by hand.
+
 ### Dramatic Moment Tagging (#545 / #1139)
 
 `models/dramatic_moment.py` — Staff-initiated scene moments that grant both resonance

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -2358,6 +2358,72 @@ def wire_soul_tether_content() -> object:
     )
 
 
+def wire_covenant_lifecycle_rituals() -> object:
+    """Idempotent seed for the covenant/org lifecycle Ritual rows (#2114).
+
+    Without this, the fully-built formation/induction/banner-call/mentor-bond
+    session machinery is unreachable — the Ritual rows that ``ritual draft``
+    resolves by name exist only in test factories.
+
+    Creates (get_or_create on name):
+    - "Covenant Formation" Ritual — create_covenant_via_session (DURANCE/BATTLE)
+    - "Covenant Induction" Ritual — induct_member_via_session
+    - "Call the Banners" Ritual — rise_battle_covenant_via_session
+    - "Mentor's Vow" Ritual — establish_mentor_bond_via_session
+    - "Renew the Oath" Ritual — perform_covenant_rite (via ``wire_covenant_rite_content()``,
+      NOT the bare ``RenewTheOathRitualFactory()`` — ``perform_covenant_rite`` reads
+      ``session.ritual.covenant_rite``, a required OneToOne sidecar the bare Ritual
+      factory does not create; ``wire_covenant_rite_content()`` is the existing,
+      already-idempotent helper that creates the Ritual + CovenantRite sidecar +
+      role/level-band stat packages together, and was — like every ritual here —
+      previously called only from tests. Using the bare factory would seed a
+      Ritual that crashes on fire.)
+    - "Organization Induction" Ritual — induct_organization_member_via_session
+
+    Also resets the ``MentorBondConfig`` singleton (pk=1) to its authored
+    defaults via ``seed_mentor_bond_defaults()`` — that helper intentionally
+    uses ``update_or_create`` (pre-launch authored tuning knobs, not
+    player-editable content), unlike the Ritual rows above which preserve
+    staff edits across re-runs.
+
+    Returns a ``CovenantLifecycleContent`` dataclass with references to all
+    created rows. Safe to call multiple times — does not create duplicates.
+    """
+    from dataclasses import dataclass
+
+    from world.covenants.factories import seed_mentor_bond_defaults, wire_covenant_rite_content
+
+    @dataclass(frozen=True)
+    class CovenantLifecycleContent:
+        formation_ritual: object
+        induction_ritual: object
+        banner_call_ritual: object
+        mentors_vow_ritual: object
+        renew_the_oath_ritual: object
+        covenant_rite: object
+        org_induction_ritual: object
+        mentor_bond_config: object
+
+    formation = CovenantFormationRitualFactory()
+    induction = CovenantInductionRitualFactory()
+    banner_call = BattleCovenantRiseRitualFactory()
+    mentors_vow = MentorsVowRitualFactory()
+    covenant_rite = wire_covenant_rite_content()
+    org_induction = OrganizationInductionRitualFactory()
+    mentor_bond_config = seed_mentor_bond_defaults()
+
+    return CovenantLifecycleContent(
+        formation_ritual=formation,
+        induction_ritual=induction,
+        banner_call_ritual=banner_call,
+        mentors_vow_ritual=mentors_vow,
+        renew_the_oath_ritual=covenant_rite.ritual,
+        covenant_rite=covenant_rite,
+        org_induction_ritual=org_induction,
+        mentor_bond_config=mentor_bond_config,
+    )
+
+
 def author_reference_corruption_content() -> None:
     """Seed 1 Primal + 1 Abyssal reference Corruption content set.
 

--- a/src/world/magic/tests/test_covenant_lifecycle_rituals_seed.py
+++ b/src/world/magic/tests/test_covenant_lifecycle_rituals_seed.py
@@ -1,0 +1,262 @@
+"""Tests for wire_covenant_lifecycle_rituals() seeding (#2114).
+
+Proves the covenant/org lifecycle Ritual rows + MentorBondConfig singleton are
+reachable from a fresh DB via seed_magic_dev() (the Big Button path,
+CLUSTER_SEEDERS["magic"]) — not just from test factories — and that
+re-running the seed is idempotent per the spec's user story 7.
+
+Also proves "Renew the Oath" is genuinely fireable (not just a bare Ritual
+row): perform_covenant_rite reads session.ritual.covenant_rite, a required
+OneToOne sidecar that the bare RenewTheOathRitualFactory() does not create —
+wire_covenant_lifecycle_rituals() must delegate to the existing
+wire_covenant_rite_content() helper instead.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.covenants.constants import CovenantType
+from world.covenants.factories import CovenantRoleFactory
+from world.covenants.models import Covenant, CovenantRite, MentorBondConfig
+from world.magic.constants import (
+    ParticipantState,
+    ParticipationRule,
+    ReferenceKind,
+    RitualExecutionKind,
+)
+from world.magic.factories import wire_covenant_lifecycle_rituals
+from world.magic.models import Ritual
+from world.magic.models.sessions import (
+    RitualSession,
+    RitualSessionParticipant,
+    RitualSessionReference,
+)
+from world.seeds.game_content.magic import seed_magic_dev
+from world.societies.factories import OrganizationFactory, OrganizationMembershipFactory
+from world.societies.models import OrganizationMembership
+
+_EXPECTED_RITUALS: dict[str, str] = {
+    "Covenant Formation": "world.covenants.services.create_covenant_via_session",
+    "Covenant Induction": "world.covenants.services.induct_member_via_session",
+    "Call the Banners": "world.covenants.services.rise_battle_covenant_via_session",
+    "Mentor's Vow": "world.covenants.services.establish_mentor_bond_via_session",
+    "Renew the Oath": "world.covenants.services.perform_covenant_rite",
+    "Organization Induction": (
+        "world.societies.membership_services.induct_organization_member_via_session"
+    ),
+}
+
+
+class CovenantLifecycleRitualsSeedTests(TestCase):
+    """A fresh-DB seed_magic_dev() run (the Big Button path) yields every
+    covenant-lifecycle Ritual row, findable by exact name and dispatch-ready."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.result = seed_magic_dev()
+
+    def test_all_covenant_lifecycle_rituals_seeded_with_correct_dispatch(self) -> None:
+        for name, service_path in _EXPECTED_RITUALS.items():
+            ritual = Ritual.objects.get(name=name)
+            self.assertEqual(ritual.execution_kind, RitualExecutionKind.SERVICE)
+            self.assertEqual(ritual.service_function_path, service_path)
+
+    def test_formation_ritual_serves_durance_and_battle_only(self) -> None:
+        """Decision #5: coverage is DURANCE + BATTLE only; COURT is out of scope."""
+        ritual = Ritual.objects.get(name="Covenant Formation")
+        covenant_type_field = next(
+            f for f in ritual.input_schema["fields"] if f["name"] == "covenant_type"
+        )
+        self.assertEqual(set(covenant_type_field["options"]), {"DURANCE", "BATTLE"})
+
+    def test_renew_the_oath_has_covenant_rite_sidecar(self) -> None:
+        """perform_covenant_rite reads session.ritual.covenant_rite — the sidecar
+        must exist, not just the bare Ritual row (else firing crashes)."""
+        ritual = Ritual.objects.get(name="Renew the Oath")
+        rite = CovenantRite.objects.get(ritual=ritual)
+        self.assertEqual(rite.ritual_id, ritual.pk)
+        self.assertIsNotNone(rite.granted_condition)
+
+    def test_mentor_bond_config_singleton_seeded(self) -> None:
+        config = MentorBondConfig.objects.get(pk=1)
+        self.assertIsNotNone(config.band_width)
+
+    def test_covenant_lifecycle_content_returned_from_seed_magic_dev(self) -> None:
+        content = self.result.covenant_lifecycle_content
+        self.assertEqual(content.formation_ritual.name, "Covenant Formation")
+        self.assertEqual(content.induction_ritual.name, "Covenant Induction")
+        self.assertEqual(content.banner_call_ritual.name, "Call the Banners")
+        self.assertEqual(content.mentors_vow_ritual.name, "Mentor's Vow")
+        self.assertEqual(content.renew_the_oath_ritual.name, "Renew the Oath")
+        self.assertEqual(content.org_induction_ritual.name, "Organization Induction")
+        self.assertIsNotNone(content.mentor_bond_config)
+        self.assertIsInstance(content.covenant_rite, CovenantRite)
+
+
+class WireCovenantLifecycleRitualsIdempotencyTests(TestCase):
+    """Re-running wire_covenant_lifecycle_rituals() on a populated DB is a no-op
+    for the Ritual/CovenantRite rows and preserves staff edits (user story 7)."""
+
+    def test_second_run_creates_no_duplicate_rituals(self) -> None:
+        wire_covenant_lifecycle_rituals()
+        count_after_first = Ritual.objects.filter(name__in=_EXPECTED_RITUALS).count()
+        self.assertEqual(count_after_first, len(_EXPECTED_RITUALS))
+
+        wire_covenant_lifecycle_rituals()
+        count_after_second = Ritual.objects.filter(name__in=_EXPECTED_RITUALS).count()
+        self.assertEqual(count_after_second, len(_EXPECTED_RITUALS))
+        self.assertEqual(CovenantRite.objects.count(), 1)
+
+    def test_staff_edit_to_ritual_survives_second_run(self) -> None:
+        wire_covenant_lifecycle_rituals()
+        ritual = Ritual.objects.get(name="Mentor's Vow")
+        ritual.description = "Staff-edited description."
+        ritual.save(update_fields=["description"])
+
+        wire_covenant_lifecycle_rituals()
+
+        ritual.refresh_from_db()
+        self.assertEqual(ritual.description, "Staff-edited description.")
+
+    def test_staff_edit_to_covenant_rite_survives_second_run(self) -> None:
+        wire_covenant_lifecycle_rituals()
+        ritual = Ritual.objects.get(name="Renew the Oath")
+        rite = CovenantRite.objects.get(ritual=ritual)
+        rite.min_covenant_level = 99
+        rite.save(update_fields=["min_covenant_level"])
+
+        wire_covenant_lifecycle_rituals()
+
+        rite.refresh_from_db()
+        self.assertEqual(rite.min_covenant_level, 99)
+
+    def test_mentor_bond_config_reset_to_authored_defaults_each_run(self) -> None:
+        """MentorBondConfig is a pre-launch tuning knob (update_or_create by
+        design — see seed_mentor_bond_defaults docstring), unlike the Ritual
+        rows above, which preserve staff edits."""
+        wire_covenant_lifecycle_rituals()
+        config = MentorBondConfig.objects.get(pk=1)
+        config.band_width = 999
+        config.save(update_fields=["band_width"])
+
+        wire_covenant_lifecycle_rituals()
+
+        config.refresh_from_db()
+        self.assertNotEqual(config.band_width, 999)
+
+
+class SeededFormationRitualDispatchTests(TestCase):
+    """Prove the seed_magic_dev()-seeded "Covenant Formation" Ritual row (not a
+    freshly-built factory row) resolves and dispatches to create_covenant_via_session."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        seed_magic_dev()
+
+    def test_seeded_formation_ritual_fires_and_creates_covenant(self) -> None:
+        from world.covenants.services import create_covenant_via_session
+
+        ritual = Ritual.objects.get(name="Covenant Formation")
+        self.assertEqual(ritual.participation_rule, ParticipationRule.FORMATION)
+
+        initiator = CharacterSheetFactory()
+        invitee = CharacterSheetFactory()
+        role_for_initiator = CovenantRoleFactory(covenant_type=CovenantType.DURANCE)
+        role_for_invitee = CovenantRoleFactory(covenant_type=CovenantType.DURANCE)
+
+        session = RitualSession.objects.create(
+            ritual=ritual,
+            initiator=initiator,
+            session_kwargs={
+                "name": "The Seeded Circle",
+                "covenant_type": CovenantType.DURANCE,
+                "sworn_objective": "Prove the seeded ritual dispatches.",
+            },
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+        p_init = RitualSessionParticipant.objects.create(
+            session=session,
+            character_sheet=initiator,
+            state=ParticipantState.ACCEPTED,
+        )
+        p_inv = RitualSessionParticipant.objects.create(
+            session=session,
+            character_sheet=invitee,
+            state=ParticipantState.ACCEPTED,
+        )
+        RitualSessionReference.objects.create(
+            session=session,
+            participant=p_init,
+            kind=ReferenceKind.COVENANT_ROLE,
+            ref_covenant_role=role_for_initiator,
+        )
+        RitualSessionReference.objects.create(
+            session=session,
+            participant=p_inv,
+            kind=ReferenceKind.COVENANT_ROLE,
+            ref_covenant_role=role_for_invitee,
+        )
+
+        covenant = create_covenant_via_session(session=session)
+
+        self.assertIsInstance(covenant, Covenant)
+        self.assertEqual(covenant.name, "The Seeded Circle")
+        self.assertEqual(covenant.covenant_type, CovenantType.DURANCE)
+
+
+class SeededOrganizationInductionRitualDispatchTests(TestCase):
+    """Prove the seed_magic_dev()-seeded "Organization Induction" Ritual row
+    resolves and dispatches to induct_organization_member_via_session."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        seed_magic_dev()
+
+    def test_seeded_org_induction_ritual_fires_and_creates_membership(self) -> None:
+        from world.societies.membership_services import induct_organization_member_via_session
+
+        ritual = Ritual.objects.get(name="Organization Induction")
+        self.assertEqual(ritual.participation_rule, ParticipationRule.BILATERAL)
+
+        org = OrganizationFactory()
+        leader_sheet = CharacterSheetFactory()
+        OrganizationMembershipFactory(
+            organization=org,
+            persona=leader_sheet.primary_persona,
+            rank=1,
+        )
+        candidate_sheet = CharacterSheetFactory()
+
+        session = RitualSession.objects.create(
+            ritual=ritual,
+            initiator=leader_sheet,
+            session_kwargs={},
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+        RitualSessionReference.objects.create(
+            session=session,
+            participant=None,
+            kind=ReferenceKind.ORGANIZATION,
+            ref_organization=org,
+        )
+        RitualSessionParticipant.objects.create(
+            session=session,
+            character_sheet=leader_sheet,
+            state=ParticipantState.ACCEPTED,
+        )
+        RitualSessionParticipant.objects.create(
+            session=session,
+            character_sheet=candidate_sheet,
+            state=ParticipantState.ACCEPTED,
+        )
+
+        membership = induct_organization_member_via_session(session=session)
+
+        self.assertIsInstance(membership, OrganizationMembership)
+        self.assertEqual(membership.persona, candidate_sheet.primary_persona)
+        self.assertEqual(membership.organization, org)
+        self.assertIsNone(membership.left_at)

--- a/src/world/seeds/clusters.py
+++ b/src/world/seeds/clusters.py
@@ -312,7 +312,7 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
     from world.items.market.models import MarketSquare  # noqa: PLC0415
     from world.items.models import ItemTemplate, Style  # noqa: PLC0415
     from world.justice.models import CrimeKind  # noqa: PLC0415
-    from world.magic.models import Affinity, Resonance  # noqa: PLC0415
+    from world.magic.models import Affinity, Resonance, Ritual  # noqa: PLC0415
     from world.magic.models.techniques import Technique  # noqa: PLC0415
     from world.progression.models import KudosSourceCategory  # noqa: PLC0415
     from world.projects.models import ContributionMethod  # noqa: PLC0415
@@ -344,7 +344,11 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
         # Social combat: 4 CheckTypes + Inspired condition + Charming Word
         # technique (#2015). Represented by Technique (the charm technique).
         "social_combat": [Technique],
-        "magic": [Affinity, Resonance],
+        # Ritual counts the covenant/org lifecycle rituals seeded by
+        # wire_covenant_lifecycle_rituals() (#2114) alongside Rite of Imbuing/
+        # Atonement and the Soul Tether rituals — so operators can see the
+        # covenant-lifecycle content landed after the Big Button run.
+        "magic": [Affinity, Resonance, Ritual],
         # Style also carries the seeded aesthetic vocabulary spread across the four
         # audacity tiers (#2029).
         "items": [ItemTemplate, Style],

--- a/src/world/seeds/game_content/magic.py
+++ b/src/world/seeds/game_content/magic.py
@@ -2355,6 +2355,11 @@ class MagicDevSeedResult:
     ``soul_tether_content`` holds the Soul Tether authored content (Rituals,
     ConditionTemplates, TriggerDefinitions) seeded by wire_soul_tether_content()
     (#2027) — without this, Soul Tether formation is unreachable in a live game.
+    ``covenant_lifecycle_content`` holds the covenant/org lifecycle Rituals
+    (Covenant Formation, Covenant Induction, Call the Banners, Mentor's Vow,
+    Renew the Oath, Organization Induction) + the MentorBondConfig singleton
+    seeded by wire_covenant_lifecycle_rituals() (#2114) — without this, the
+    fully-built covenant session machinery is unreachable in a live game.
     """
 
     config: MagicConfigResult
@@ -2369,6 +2374,7 @@ class MagicDevSeedResult:
     technique_cast_template: ActionTemplate
     relationship_track_thread_unlock: RelationshipTrackThreadUnlockResult
     soul_tether_content: object
+    covenant_lifecycle_content: object
 
 
 def seed_facet_thread_unlock() -> FacetThreadUnlockResult:
@@ -2496,15 +2502,23 @@ def seed_magic_dev() -> MagicDevSeedResult:
         soul_tether_rescue), Tether Strain / Soul Tether Active ConditionTemplates,
         and the two reactive TriggerDefinitions (#2027). Previously created only
         in tests/factories — Soul Tether was unreachable in a live game.
+    13. ``wire_covenant_lifecycle_rituals()`` — Covenant/org lifecycle Rituals
+        (Covenant Formation, Covenant Induction, Call the Banners, Mentor's Vow,
+        Renew the Oath, Organization Induction) + the MentorBondConfig singleton
+        (#2114). Previously created only in tests/factories — the fully-built
+        covenant session machinery was unreachable in a live game.
 
     All writes are idempotent (get_or_create throughout). Re-running on a
-    populated database is a no-op; staff edits to existing rows are preserved.
+    populated database is a no-op; staff edits to existing rows are preserved
+    (the MentorBondConfig singleton is the one exception — it is reset to its
+    authored defaults on every run, same as other pre-launch tuning knobs).
 
     Returns:
         MagicDevSeedResult composing all sub-results.
     """
     from world.magic.factories import (  # noqa: PLC0415
         author_reference_corruption_content,
+        wire_covenant_lifecycle_rituals,
         wire_soul_tether_content,
     )
     from world.magic.services import seed_thread_survivability_tuning  # noqa: PLC0415
@@ -2534,6 +2548,7 @@ def seed_magic_dev() -> MagicDevSeedResult:
     technique_cast_template = ensure_technique_cast_content()
     ensure_technique_catalog_content()
     soul_tether_content = wire_soul_tether_content()
+    covenant_lifecycle_content = wire_covenant_lifecycle_rituals()
     from world.seeds.game_content.combos import seed_combo_palette  # noqa: PLC0415
 
     seed_combo_palette()
@@ -2551,4 +2566,5 @@ def seed_magic_dev() -> MagicDevSeedResult:
         technique_cast_template=technique_cast_template,
         relationship_track_thread_unlock=relationship_track_thread_unlock,
         soul_tether_content=soul_tether_content,
+        covenant_lifecycle_content=covenant_lifecycle_content,
     )


### PR DESCRIPTION
Closes #2114

## Summary

Seeds the six covenant-lifecycle rituals (Formation, Induction, Banner Call, Mentor's Vow, Renew the Oath, Organization Induction) + MentorBondConfig via wire_covenant_lifecycle_rituals(), riding seed_magic_dev() / CLUSTER_SEEDERS[magic] so the admin Big Button covers them; Ritual added to the game-setup inventory. Idempotent (staff edits survive re-seed). Deviation from spec pseudocode: Renew the Oath seeds via the existing wire_covenant_rite_content() because the bare factory omits the required CovenantRite sidecar and would crash on fire. Docs updated in tandem (magic CLAUDE.md, systems/covenants.md, roadmap/covenants.md).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2114 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: rebased onto origin/main, no conflicts

<!-- last-addressed-comment: 0 -->