### PR TITLE
Skill dev points silently discarded at XP boundaries (19/29/39/49) — TraitRatingUnlock has zero service callers

### DIFF
--- a/docs/systems/progression.md
+++ b/docs/systems/progression.md
@@ -71,7 +71,7 @@ from world.progression.types import (
 | Model | Purpose | Key Fields |
 |-------|---------|------------|
 | `ClassLevelUnlock` | Unlocking a new level in a character class | `character_class`, `target_level` |
-| `TraitRatingUnlock` | Unlocking a major trait rating threshold | `trait`, `target_rating` (divisible by 10) |
+| `TraitRatingUnlock` | Unlocking a major trait rating threshold. Wired for skill XP boundaries via `purchase_skill_breakthrough` (`world.skills.services`, #2115) — `trait` resolves to `Skill.trait`, `target_rating` to the skill's next rating (20/30/40/50) | `trait`, `target_rating` (divisible by 10) |
 | `CharacterUnlock` | Records what class levels a character has unlocked | `character`, `character_class`, `target_level`, `unlocked_date`, `xp_spent` |
 
 ### Requirements (Abstract Hierarchy)
@@ -394,10 +394,10 @@ transactions = award_scene_development_points(scene, participants, awards)
 ### Unlock Shop
 
 - `GET /api/progression/unlocks/` — List purchasable unlocks for the played character; returns a paginated wrapper (`{ count, next, previous, page_size, num_pages, current_page, results: [...] }`)
-  - Items are discriminated by `unlock_type`: `class_level` (authored `ClassLevelUnlock`) or `thread_xp_lock` (next `ThreadXPLockedLevel` boundary)
+  - Items are discriminated by `unlock_type`: `class_level` (authored `ClassLevelUnlock`), `thread_xp_lock` (next `ThreadXPLockedLevel` boundary), or `skill_breakthrough` (a skill parked at an XP boundary, via `world.skills.services.skills_at_boundary`, #2115) — the `skill_id` field is populated for that variant; `requirements_met=False`/`locked_reason="Not yet authored"` when no `TraitRatingUnlock` exists yet for that boundary
   - Query parameter `unlock_type` filters the list to a single variant
   - Requires a played character (set by the Evennia session / test client)
-- `POST /api/progression/unlocks/purchase/` — Purchase an unlock with XP; body `{ unlock_type, class_level_unlock_id }` or `{ unlock_type, thread_id, boundary_level }`; dispatches `PurchaseUnlockAction` (`registry_key="purchase_unlock"`) and returns the action result on success
+- `POST /api/progression/unlocks/purchase/` — Purchase an unlock with XP; body `{ unlock_type, class_level_unlock_id }`, `{ unlock_type, thread_id, boundary_level }`, or `{ unlock_type: "skill_breakthrough", skill_id }`; dispatches `PurchaseUnlockAction` (`registry_key="purchase_unlock"`) and returns the action result on success
 
 ### Account Progression Dashboard
 - `GET /api/progression/account/` - Current user's XP balance, kudos balance, recent transactions, and claim options
@@ -474,15 +474,19 @@ Dispatches `ManageTrainingAction` (`registry_key="manage_training"`) through the
 ### `progression` — Browse/purchase XP unlocks
 
 ```
-progression unlocks              — list class-level and thread XP-lock unlocks
+progression unlocks              — list class-level, thread XP-lock, and skill-breakthrough
+                                    unlocks
 progression unlock class=<id>    — purchase a class-level unlock
 progression unlock thread=<id> level=<n>
                                  — purchase a thread XP-lock boundary
+progression unlock skill=<id>    — purchase a skill's XP-boundary breakthrough (#2115)
 ```
 
 `progression unlocks` reads the same service functions as `GET /api/progression/unlocks/`.
 `progression unlock` dispatches `PurchaseUnlockAction`
-(`registry_key="purchase_unlock"`).
+(`registry_key="purchase_unlock"`). See `docs/systems/skills.md`'s "XP Boundaries" section
+for the skill-breakthrough purchase's mechanics (rust payoff, ephemeral dev points,
+`purchase_skill_breakthrough`).
 
 ### `kudos` — Claim kudos for XP (#1348)
 

--- a/docs/systems/skills.md
+++ b/docs/systems/skills.md
@@ -48,6 +48,37 @@ Character skills and specializations with development tracking, linked to the Tr
 - Only affects parent skills; specializations are immune
 - Encourages specialization over jack-of-all-trades builds
 
+### XP Boundaries (19, 29, 39, 49) — plateau, not a stop (#2115)
+
+A skill value ending in 9 (`_is_at_xp_boundary`, `services.py`) is a **breakthrough
+plateau**: training keeps paying off rust (a boundary-parked skill can still "blow the
+rust off"), but any surplus dev points beyond the rust payoff **dissipate** — they are
+deliberately ephemeral, never banked and never silently discarded. Every dissipation is
+reported: `_apply_development_to_skill` returns a plateau message
+("`<skill>` is at threshold `<N>.0` — training maintains, does not advance until the
+breakthrough is unlocked.") which `process_weekly_training` folds into the
+`DevelopmentTransaction.description` audit row. The same rule applies when a level-up's
+overflow lands exactly on a boundary — the overflow dissipates with the same message
+rather than banking or silently zeroing.
+
+The gate clears via `purchase_skill_breakthrough(character, skill)` — an XP spend against
+an authored `progression.TraitRatingUnlock` (`trait=skill.trait,
+target_rating=skill_value.value + 1`), mirroring `spend_xp_on_unlock`'s XP-debit pattern.
+The purchase does not itself grant a level (ADR-0053: XP buys the unlock that gates, never
+the grant) — it clears `skill_value.value` to the target rating and resets
+`development_points` to 0, so training resumes accruing from zero (no retroactive credit
+for points that dissipated while gated). `skills_at_boundary(character)` is the selector
+that surfaces every gated skill (with its authored XP cost, or `authored=False` when staff
+hasn't authored a breakthrough for that boundary yet) — feeds the `training` listing's
+plateau annotation, the `progression unlocks` listing's `[skill]` section, and the
+character-sheet `SkillEntry.at_boundary` flag. Reachable via
+`progression unlock skill=<id>` (telnet) or the `PurchaseUnlockAction`
+`unlock_type="skill_breakthrough"` branch (web/telnet convergence point) — see
+`docs/systems/progression.md`'s Unlock Shop section. A default breakthrough catalog (flat
+placeholder costs at each skill's 20/30/40/50 boundaries) is seeded by
+`world.seeds.game_content.skills.seed_skill_breakthrough_catalog()` (the `"skills"`
+cluster), so no skill is a landmine with no purchasable unlock out of the box.
+
 ### CG Point Budget
 - Path points (default 50): Suggested by path template, freely redistributable
 - Free points (default 60): Player's choice

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -28699,10 +28699,11 @@ export interface components {
     /**
      * @description Discriminated list item for purchasable progression unlocks.
      *
-     *     Two ``unlock_type`` variants are supported:
+     *     Three ``unlock_type`` variants are supported:
      *
      *     - ``class_level`` — purchase a class/level unlock with XP.
      *     - ``thread_xp_lock`` — purchase the next XP-locked boundary on a thread.
+     *     - ``skill_breakthrough`` — purchase a skill's XP-boundary breakthrough (#2115).
      */
     ProgressionUnlockItem: {
       unlock_type: string;
@@ -28721,6 +28722,7 @@ export interface components {
       thread_resonance_name: string | null;
       thread_target_kind: string | null;
       dev_points_to_boundary: number | null;
+      skill_id: number | null;
     };
     /**
      * @description Validate a staff-driven promotion/demotion before it reaches ``promote_gm`` (#2000).
@@ -28795,14 +28797,16 @@ export interface components {
       class_level_unlock_id?: number | null;
       thread_id?: number | null;
       boundary_level?: number | null;
+      skill_id?: number | null;
     };
     /** @description Response serializer for a completed unlock purchase. */
     PurchaseUnlockResponse: {
       unlock_type: string;
-      unlock_id: number | null;
+      unlock_id?: number | null;
       thread_level_unlock_id?: number | null;
       thread_id?: number | null;
       boundary_level?: number | null;
+      skill_id?: number | null;
     };
     /**
      * @description * `militia` - Militia
@@ -32488,9 +32492,10 @@ export interface components {
     /**
      * @description * `class_level` - Class Level
      *     * `thread_xp_lock` - Thread XP Lock
+     *     * `skill_breakthrough` - Skill Breakthrough
      * @enum {string}
      */
-    UnlockTypeEnum: 'class_level' | 'thread_xp_lock';
+    UnlockTypeEnum: 'class_level' | 'thread_xp_lock' | 'skill_breakthrough';
     /**
      * @description Input for PATCH /api/table-bulletin-posts/{id}/.
      *

--- a/src/actions/definitions/progression.py
+++ b/src/actions/definitions/progression.py
@@ -220,9 +220,9 @@ class ManageTrainingAction(Action):
 
 @dataclass
 class PurchaseUnlockAction(Action):
-    """Purchase a class-level or thread XP-lock unlock with XP.
+    """Purchase a class-level, thread XP-lock, or skill-breakthrough unlock with XP.
 
-    Both unlock types spend account XP through their respective service
+    All three unlock types spend account XP through their respective service
     functions; this action is a thin action.run() wrapper around them.
     """
 
@@ -235,6 +235,7 @@ class PurchaseUnlockAction(Action):
 
     _UNLOCK_TYPE_CLASS_LEVEL = "class_level"
     _UNLOCK_TYPE_THREAD_XP_LOCK = "thread_xp_lock"
+    _UNLOCK_TYPE_SKILL_BREAKTHROUGH = "skill_breakthrough"
 
     def execute(
         self,
@@ -251,6 +252,7 @@ class PurchaseUnlockAction(Action):
         from world.magic.models import Thread  # noqa: PLC0415
         from world.magic.types.alterations import AlterationGateError  # noqa: PLC0415
         from world.progression.models import ClassLevelUnlock  # noqa: PLC0415
+        from world.skills.models import Skill  # noqa: PLC0415
 
         unlock_type = kwargs.get("unlock_type")
 
@@ -259,9 +261,12 @@ class PurchaseUnlockAction(Action):
                 return self._purchase_class_level(actor, kwargs)
             if unlock_type == self._UNLOCK_TYPE_THREAD_XP_LOCK:
                 return self._purchase_thread_xp_lock(actor, kwargs)
+            if unlock_type == self._UNLOCK_TYPE_SKILL_BREAKTHROUGH:
+                return self._purchase_skill_breakthrough(actor, kwargs)
         except (
             ClassLevelUnlock.DoesNotExist,
             Thread.DoesNotExist,
+            Skill.DoesNotExist,
             CharacterSheet.DoesNotExist,
             AlterationGateError,
             InvalidImbueAmount,
@@ -280,8 +285,9 @@ class PurchaseUnlockAction(Action):
             success=False,
             message=(
                 "Invalid or missing unlock_type. "
-                f"Expected '{self._UNLOCK_TYPE_CLASS_LEVEL}' or "
-                f"'{self._UNLOCK_TYPE_THREAD_XP_LOCK}'."
+                f"Expected '{self._UNLOCK_TYPE_CLASS_LEVEL}', "
+                f"'{self._UNLOCK_TYPE_THREAD_XP_LOCK}', or "
+                f"'{self._UNLOCK_TYPE_SKILL_BREAKTHROUGH}'."
             ),
         )
 
@@ -340,5 +346,30 @@ class PurchaseUnlockAction(Action):
                 "thread_level_unlock_id": thread_level_unlock.pk,
                 "thread_id": thread.pk,
                 "boundary_level": boundary_level,
+            },
+        )
+
+    def _purchase_skill_breakthrough(
+        self,
+        actor: ObjectDB,
+        kwargs: dict[str, Any],
+    ) -> ActionResult:
+        """Purchase a skill's XP-boundary breakthrough for the actor (#2115)."""
+        from world.skills.models import Skill  # noqa: PLC0415
+        from world.skills.services import purchase_skill_breakthrough  # noqa: PLC0415
+
+        skill_id = kwargs.get("skill_id")
+        if skill_id is None:
+            return ActionResult(success=False, message="skill_id is required.")
+        skill = Skill.objects.get(pk=skill_id)
+        success, message = purchase_skill_breakthrough(actor, skill)
+        if not success:
+            return ActionResult(success=False, message=message)
+        return ActionResult(
+            success=True,
+            message=message,
+            data={
+                "unlock_type": self._UNLOCK_TYPE_SKILL_BREAKTHROUGH,
+                "skill_id": skill.pk,
             },
         )

--- a/src/actions/tests/test_progression.py
+++ b/src/actions/tests/test_progression.py
@@ -14,11 +14,14 @@ from world.progression.models import (
     CharacterUnlock,
     ClassLevelUnlock,
     ClassXPCost,
+    TraitRatingUnlock,
+    TraitXPCost,
     XPCostChart,
     XPCostEntry,
 )
 from world.scenes.factories import PersonaFactory
 from world.skills.factories import (
+    CharacterSkillValueFactory,
     SkillFactory,
     SpecializationFactory,
     TrainingAllocationFactory,
@@ -404,3 +407,92 @@ class PurchaseUnlockActionTests(TestCase):
 
         self.assertFalse(result.success)
         self.assertIn("class_level_unlock_id is required", result.message.lower())
+
+    def _authored_skill_breakthrough(self, skill, *, target_rating: int, xp_cost: int):
+        """Author a TraitRatingUnlock + its XP cost for ``skill`` (#2115)."""
+        chart = XPCostChart.objects.create(name=f"Breakthrough Chart {skill.pk}")
+        XPCostEntry.objects.create(chart=chart, level=target_rating, xp_cost=xp_cost)
+        TraitXPCost.objects.create(trait=skill.trait, cost_chart=chart)
+        return TraitRatingUnlock.objects.create(trait=skill.trait, target_rating=target_rating)
+
+    def test_purchase_skill_breakthrough_success(self):
+        """Can purchase a skill breakthrough when the actor has enough XP (#2115)."""
+        character, _sheet, account = self._create_character_with_account()
+        skill = SkillFactory()
+        skill_value = CharacterSkillValueFactory(character=character, skill=skill, value=19)
+        self._authored_skill_breakthrough(skill, target_rating=20, xp_cost=100)
+        self._set_xp(account, total_earned=150)
+
+        result = PurchaseUnlockAction().run(
+            actor=character,
+            unlock_type="skill_breakthrough",
+            skill_id=skill.pk,
+        )
+
+        self.assertTrue(result.success)
+        self.assertIn("breakthrough", result.message.lower())
+        self.assertEqual(result.data["unlock_type"], "skill_breakthrough")
+        self.assertEqual(result.data["skill_id"], skill.pk)
+        skill_value.refresh_from_db()
+        self.assertEqual(skill_value.value, 20)
+
+    def test_purchase_skill_breakthrough_insufficient_xp(self):
+        """Purchasing a skill breakthrough fails without enough XP (#2115)."""
+        character, _sheet, account = self._create_character_with_account()
+        skill = SkillFactory()
+        CharacterSkillValueFactory(character=character, skill=skill, value=19)
+        self._authored_skill_breakthrough(skill, target_rating=20, xp_cost=100)
+        self._set_xp(account, total_earned=50)
+
+        result = PurchaseUnlockAction().run(
+            actor=character,
+            unlock_type="skill_breakthrough",
+            skill_id=skill.pk,
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("insufficient xp", result.message.lower())
+
+    def test_purchase_skill_breakthrough_duplicate_fails(self):
+        """A second purchase attempt fails once the gate is already cleared (#2115)."""
+        character, _sheet, account = self._create_character_with_account()
+        skill = SkillFactory()
+        CharacterSkillValueFactory(character=character, skill=skill, value=19)
+        self._authored_skill_breakthrough(skill, target_rating=20, xp_cost=100)
+        self._set_xp(account, total_earned=300)
+
+        first = PurchaseUnlockAction().run(
+            actor=character, unlock_type="skill_breakthrough", skill_id=skill.pk
+        )
+        self.assertTrue(first.success)
+
+        second = PurchaseUnlockAction().run(
+            actor=character, unlock_type="skill_breakthrough", skill_id=skill.pk
+        )
+        self.assertFalse(second.success)
+        self.assertIn("not at a breakthrough boundary", second.message.lower())
+
+    def test_purchase_skill_breakthrough_missing_skill_id(self):
+        """A missing skill_id returns a clean failure, not a TypeError (#2115)."""
+        character, _sheet, _account = self._create_character_with_account()
+
+        result = PurchaseUnlockAction().run(
+            actor=character,
+            unlock_type="skill_breakthrough",
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("skill_id is required", result.message.lower())
+
+    def test_purchase_skill_breakthrough_unknown_skill_id(self):
+        """An unknown skill_id returns a clean failure, not a raw DoesNotExist (#2115)."""
+        character, _sheet, account = self._create_character_with_account()
+        self._set_xp(account, total_earned=150)
+
+        result = PurchaseUnlockAction().run(
+            actor=character,
+            unlock_type="skill_breakthrough",
+            skill_id=999999,
+        )
+
+        self.assertFalse(result.success)

--- a/src/commands/progression.py
+++ b/src/commands/progression.py
@@ -45,6 +45,7 @@ _OPERATION_REMOVE = "remove"
 # PurchaseUnlockAction unlock types.
 _UNLOCK_TYPE_CLASS_LEVEL = "class_level"
 _UNLOCK_TYPE_THREAD_XP_LOCK = "thread_xp_lock"
+_UNLOCK_TYPE_SKILL_BREAKTHROUGH = "skill_breakthrough"
 
 # Keys returned by get_available_unlocks_for_character.
 _AVAILABLE_KEY = "available"
@@ -199,12 +200,14 @@ class CmdTraining(DispatchCommand):
         """Render the caller's training allocations and weekly AP budget."""
         from world.action_points.models import ActionPointConfig  # noqa: PLC0415
         from world.skills.models import TrainingAllocation  # noqa: PLC0415
+        from world.skills.services import skills_at_boundary  # noqa: PLC0415
 
         allocations = TrainingAllocation.objects.filter(character=self.caller).select_related(
             "skill",
             "specialization",
             "mentor",
         )
+        gated_skill_ids = {prospect.skill.pk for prospect in skills_at_boundary(self.caller)}
 
         total_ap = sum(allocation.ap_amount for allocation in allocations)
         weekly_budget = ActionPointConfig.get_weekly_regen()
@@ -215,12 +218,17 @@ class CmdTraining(DispatchCommand):
             lines.append("No training allocations set.")
         else:
             for allocation in allocations:
+                plateau = ""
                 if allocation.skill is not None:
                     target = allocation.skill.name
+                    if allocation.skill.pk in gated_skill_ids:
+                        plateau = " [at threshold — breakthrough required]"
                 else:
                     target = allocation.specialization.name
                 mentor = f" (mentor: {allocation.mentor.name})" if allocation.mentor else ""
-                lines.append(f"[{allocation.pk}] {target}: {allocation.ap_amount} AP{mentor}")
+                lines.append(
+                    f"[{allocation.pk}] {target}: {allocation.ap_amount} AP{mentor}{plateau}"
+                )
 
         self.msg("\n".join(lines))
 
@@ -238,10 +246,13 @@ class CmdProgressionUnlock(DispatchCommand):
     """Browse and purchase progression unlocks with XP.
 
     Usage:
-        progression unlocks             — list available class-level and thread XP-lock unlocks
+        progression unlocks             — list available class-level, thread XP-lock, and
+                                           skill-breakthrough unlocks
         progression unlock class=<id>   — purchase a class-level unlock
         progression unlock thread=<id> level=<n>
                                         — purchase a thread XP-lock boundary
+        progression unlock skill=<id>   — purchase a skill breakthrough (clears an XP-boundary
+                                           plateau so training resumes; #2115)
     """
 
     key = "progression"
@@ -281,26 +292,31 @@ class CmdProgressionUnlock(DispatchCommand):
         parsed = _parse_assignment_args(self._rest)
         class_id = parsed.get(_KEY_CLASS)
         thread_id = parsed.get(_KEY_THREAD)
+        skill_id = parsed.get(_KEY_SKILL)
         level = parsed.get(_KEY_LEVEL)
 
-        has_class = class_id is not None
-        has_thread = thread_id is not None
-
-        if has_class and has_thread:
-            msg = "Provide either class=<id> or thread=<id>, not both."
+        provided_count = sum(x is not None for x in (class_id, thread_id, skill_id))
+        if provided_count > 1:
+            msg = "Provide exactly one of class=<id>, thread=<id>, or skill=<id>."
             raise CommandError(msg)
-        if has_class:
+
+        if class_id is not None:
             return {
                 "unlock_type": _UNLOCK_TYPE_CLASS_LEVEL,
                 "class_level_unlock_id": _require_positive_int(class_id, _KEY_CLASS),
             }
-        if has_thread:
+        if thread_id is not None:
             return {
                 "unlock_type": _UNLOCK_TYPE_THREAD_XP_LOCK,
                 "thread_id": _require_positive_int(thread_id, _KEY_THREAD),
                 "boundary_level": _require_positive_int(level, _KEY_LEVEL),
             }
-        msg = "Provide class=<id> or thread=<id> level=<n>."
+        if skill_id is not None:
+            return {
+                "unlock_type": _UNLOCK_TYPE_SKILL_BREAKTHROUGH,
+                "skill_id": _require_positive_int(skill_id, _KEY_SKILL),
+            }
+        msg = "Provide class=<id>, thread=<id> level=<n>, or skill=<id>."
         raise CommandError(msg)
 
     def _show_listing(self) -> None:
@@ -322,6 +338,7 @@ class CmdProgressionUnlock(DispatchCommand):
         lines.extend(self._render_class_unlock_entries(entries))
         if sheet is not None:
             lines.extend(self._render_thread_unlocks(sheet, has_entries=bool(entries)))
+        lines.extend(self._render_skill_breakthroughs(character, has_entries=bool(entries)))
 
         self.msg("\n".join(lines))
 
@@ -364,4 +381,32 @@ class CmdProgressionUnlock(DispatchCommand):
             lines.append(
                 f"[thread] {thread_name} level {prospect.boundary_level}: {prospect.xp_cost} XP"
             )
+        return lines
+
+    def _render_skill_breakthroughs(
+        self,
+        character: Any,
+        *,
+        has_entries: bool,
+    ) -> list[str]:
+        """Return rendered lines for skill XP-boundary breakthroughs (#2115)."""
+        from world.skills.services import skills_at_boundary  # noqa: PLC0415
+
+        prospects = skills_at_boundary(character)
+        if not prospects:
+            if has_entries:
+                return []
+            return ["No skill breakthroughs available."]
+        lines = ["", "Skill breakthroughs:"]
+        for prospect in prospects:
+            rating = prospect.next_rating / 10
+            if prospect.authored:
+                lines.append(
+                    f"[skill] {prospect.skill.name} breakthrough to {rating:.1f}: "
+                    f"{prospect.xp_cost} XP"
+                )
+            else:
+                lines.append(
+                    f"[skill] {prospect.skill.name} at threshold {rating:.1f}: not yet authored"
+                )
         return lines

--- a/src/commands/tests/test_progression_commands.py
+++ b/src/commands/tests/test_progression_commands.py
@@ -309,6 +309,16 @@ class CmdProgressionUnlockDispatchTests(TestCase):
         self.assertEqual(kwargs["boundary_level"], 10)
 
     @patch("commands.command.dispatch_player_action")
+    def test_unlock_skill_dispatches_skill_breakthrough_kwargs(self, mock_dispatch):
+        """``progression unlock skill=<id>`` dispatches skill_breakthrough kwargs (#2115)."""
+        mock_dispatch.return_value = self.success_result
+        _make_progression_cmd(self.character, "unlock skill=9").func()
+        _, ref, kwargs = mock_dispatch.call_args.args
+        self.assertEqual(ref.registry_key, "purchase_unlock")
+        self.assertEqual(kwargs["unlock_type"], "skill_breakthrough")
+        self.assertEqual(kwargs["skill_id"], 9)
+
+    @patch("commands.command.dispatch_player_action")
     def test_failure_message_surfaces_to_caller(self, mock_dispatch):
         mock_dispatch.return_value = DispatchResult(
             backend=ActionBackend.REGISTRY,
@@ -345,7 +355,7 @@ class CmdProgressionUnlockErrorTests(TestCase):
 
     def test_unlock_both_class_and_thread_raises(self):
         _make_progression_cmd(self.character, "unlock class=1 thread=2 level=10").func()
-        self.assertIn("not both", self._all_msg_text())
+        self.assertIn("exactly one", self._all_msg_text())
 
     def test_unlock_thread_missing_level_raises(self):
         _make_progression_cmd(self.character, "unlock thread=2").func()

--- a/src/schema.json
+++ b/src/schema.json
@@ -51120,10 +51120,11 @@ components:
       description: |-
         Discriminated list item for purchasable progression unlocks.
 
-        Two ``unlock_type`` variants are supported:
+        Three ``unlock_type`` variants are supported:
 
         - ``class_level`` — purchase a class/level unlock with XP.
         - ``thread_xp_lock`` — purchase the next XP-locked boundary on a thread.
+        - ``skill_breakthrough`` — purchase a skill's XP-boundary breakthrough (#2115).
       properties:
         unlock_type:
           type: string
@@ -51169,6 +51170,9 @@ components:
         dev_points_to_boundary:
           type: integer
           nullable: true
+        skill_id:
+          type: integer
+          nullable: true
       required:
       - boundary_level
       - class_level_unlock_id
@@ -51177,6 +51181,7 @@ components:
       - display_name
       - locked_reason
       - requirements_met
+      - skill_id
       - target_level
       - thread_id
       - thread_level
@@ -51317,6 +51322,9 @@ components:
         boundary_level:
           type: integer
           nullable: true
+        skill_id:
+          type: integer
+          nullable: true
       required:
       - unlock_type
     PurchaseUnlockResponse:
@@ -51337,8 +51345,10 @@ components:
         boundary_level:
           type: integer
           nullable: true
+        skill_id:
+          type: integer
+          nullable: true
       required:
-      - unlock_id
       - unlock_type
     QualityEnum:
       enum:
@@ -58614,10 +58624,12 @@ components:
       enum:
       - class_level
       - thread_xp_lock
+      - skill_breakthrough
       type: string
       description: |-
         * `class_level` - Class Level
         * `thread_xp_lock` - Thread XP Lock
+        * `skill_breakthrough` - Skill Breakthrough
     UpdateBulletinPostInput:
       type: object
       description: |-

--- a/src/world/character_sheets/serializers.py
+++ b/src/world/character_sheets/serializers.py
@@ -71,6 +71,7 @@ from world.roster.models import RosterTenure
 from world.scenes.constants import PersonaType
 from world.scenes.models import Persona
 from world.skills.models import CharacterSkillValue, CharacterSpecializationValue
+from world.skills.services import is_skill_at_xp_boundary
 from world.traits.models import CharacterTraitValue, TraitType
 
 # --- Tiny helpers for nested {id, name} representations ---
@@ -484,6 +485,7 @@ def _build_skills(sheet: CharacterSheet) -> list[SkillEntry]:
             SkillEntry(
                 skill=SkillRef(id=skill.pk, name=skill.name, category=skill.category),
                 value=csv.value,
+                at_boundary=is_skill_at_xp_boundary(csv.value),
                 specializations=spec_by_skill.get(skill.pk, []),
             )
         )

--- a/src/world/character_sheets/tests/test_viewset.py
+++ b/src/world/character_sheets/tests/test_viewset.py
@@ -673,10 +673,10 @@ class TestSkillsSection(TestCase):
         assert len(skills) == 1
 
     def test_skill_entry_structure(self) -> None:
-        """Each skill entry has {skill: {id, name, category}, value, specializations}."""
+        """Each skill entry has {skill, value, at_boundary, specializations} (#2115)."""
         skills = self._get_skills()
         entry = skills[0]
-        assert set(entry.keys()) == {"skill", "value", "specializations"}
+        assert set(entry.keys()) == {"skill", "value", "at_boundary", "specializations"}
         assert set(entry["skill"].keys()) == {"id", "name", "category"}
 
     def test_skill_entry_values(self) -> None:
@@ -687,6 +687,16 @@ class TestSkillsSection(TestCase):
         assert entry["skill"]["name"] == "Melee"
         assert entry["skill"]["category"] == TraitCategory.COMBAT
         assert entry["value"] == 30
+        assert entry["at_boundary"] is False
+
+    def test_skill_entry_at_boundary_true_when_gated(self) -> None:
+        """A skill parked at an XP boundary (19/29/39/49) reports at_boundary=True (#2115)."""
+        gated_skill = SkillFactory(trait__name="Gated Skill", trait__category=TraitCategory.COMBAT)
+        CharacterSkillValueFactory(character=self.character, skill=gated_skill, value=29)
+
+        skills = self._get_skills()
+        entry = next(e for e in skills if e["skill"]["id"] == gated_skill.pk)
+        assert entry["at_boundary"] is True
 
     def test_skill_specializations(self) -> None:
         """Skill entry contains nested specializations with id, name, value."""

--- a/src/world/character_sheets/types.py
+++ b/src/world/character_sheets/types.py
@@ -90,6 +90,7 @@ class SkillEntry(TypedDict):
 
     skill: SkillRef
     value: int
+    at_boundary: bool
     specializations: list[SpecializationEntry]
 
 

--- a/src/world/progression/serializers/unlocks.py
+++ b/src/world/progression/serializers/unlocks.py
@@ -8,10 +8,11 @@ from rest_framework import serializers
 class ProgressionUnlockItemSerializer(serializers.Serializer):
     """Discriminated list item for purchasable progression unlocks.
 
-    Two ``unlock_type`` variants are supported:
+    Three ``unlock_type`` variants are supported:
 
     - ``class_level`` — purchase a class/level unlock with XP.
     - ``thread_xp_lock`` — purchase the next XP-locked boundary on a thread.
+    - ``skill_breakthrough`` — purchase a skill's XP-boundary breakthrough (#2115).
     """
 
     unlock_type = serializers.CharField()
@@ -35,16 +36,21 @@ class ProgressionUnlockItemSerializer(serializers.Serializer):
     thread_target_kind = serializers.CharField(allow_null=True)
     dev_points_to_boundary = serializers.IntegerField(allow_null=True)
 
+    # Skill-breakthrough fields (#2115)
+    skill_id = serializers.IntegerField(allow_null=True)
+
 
 class PurchaseUnlockSerializer(serializers.Serializer):
     """Input serializer for purchasing a progression unlock."""
 
     UNLOCK_TYPE_CLASS_LEVEL = "class_level"
     UNLOCK_TYPE_THREAD_XP_LOCK = "thread_xp_lock"
+    UNLOCK_TYPE_SKILL_BREAKTHROUGH = "skill_breakthrough"
 
     UNLOCK_TYPE_CHOICES = [
         (UNLOCK_TYPE_CLASS_LEVEL, "Class Level"),
         (UNLOCK_TYPE_THREAD_XP_LOCK, "Thread XP Lock"),
+        (UNLOCK_TYPE_SKILL_BREAKTHROUGH, "Skill Breakthrough"),
     ]
 
     unlock_type = serializers.ChoiceField(choices=UNLOCK_TYPE_CHOICES)
@@ -54,6 +60,7 @@ class PurchaseUnlockSerializer(serializers.Serializer):
     )
     thread_id = serializers.IntegerField(required=False, allow_null=True)
     boundary_level = serializers.IntegerField(required=False, allow_null=True)
+    skill_id = serializers.IntegerField(required=False, allow_null=True)
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         """Ensure the right IDs are supplied for the chosen unlock type."""
@@ -75,6 +82,12 @@ class PurchaseUnlockSerializer(serializers.Serializer):
                 )
             return attrs
 
+        if unlock_type == self.UNLOCK_TYPE_SKILL_BREAKTHROUGH:
+            if attrs.get("skill_id") is None:
+                msg = "skill_id is required for skill_breakthrough unlocks."
+                raise serializers.ValidationError({"skill_id": msg})
+            return attrs
+
         msg = f"Invalid unlock_type: {unlock_type}."
         raise serializers.ValidationError({"unlock_type": msg})
 
@@ -83,7 +96,8 @@ class PurchaseUnlockResponseSerializer(serializers.Serializer):
     """Response serializer for a completed unlock purchase."""
 
     unlock_type = serializers.CharField()
-    unlock_id = serializers.IntegerField(allow_null=True)
+    unlock_id = serializers.IntegerField(allow_null=True, required=False)
     thread_level_unlock_id = serializers.IntegerField(required=False, allow_null=True)
     thread_id = serializers.IntegerField(required=False, allow_null=True)
     boundary_level = serializers.IntegerField(required=False, allow_null=True)
+    skill_id = serializers.IntegerField(required=False, allow_null=True)

--- a/src/world/progression/services/spends.py
+++ b/src/world/progression/services/spends.py
@@ -274,8 +274,13 @@ def get_available_unlocks_for_character(
         else:
             locked.append(unlock_info)
 
-    # Note: Trait rating unlocks are handled differently now
-    # They auto-apply through development points, so no need to track here
+    # Note: Trait rating unlocks (skill XP-boundary breakthroughs, #2115) are handled
+    # by world.skills.services.skills_at_boundary + purchase_skill_breakthrough — a
+    # separate seam from this ClassLevelUnlock-only listing/purchase pair, since a
+    # skill breakthrough's precondition ("parked at a boundary") isn't expressed as
+    # an AbstractUnlockRequirement. ProgressionUnlockViewSet.list() calls
+    # skills_at_boundary() directly to fold skill_breakthrough items into the same
+    # paginated response.
 
     return AvailableUnlocks(
         available=available,

--- a/src/world/progression/tests/test_skill_development.py
+++ b/src/world/progression/tests/test_skill_development.py
@@ -21,6 +21,8 @@ from world.progression.services.skill_development import (
     process_weekly_skill_development,
 )
 from world.progression.types import DevelopmentSource
+from world.skills.factories import CharacterSkillValueFactory, SkillFactory
+from world.skills.models import CharacterSkillValue
 from world.traits.factories import TraitFactory
 from world.traits.models import CharacterTraitValue
 
@@ -331,6 +333,66 @@ class AwardCheckDevelopmentTest(TestCase):
         assert usage2 is not None
         assert usage2["check_count"] == 2
         assert usage2["points_earned"] == 15
+
+
+class AwardCheckDevelopmentSkillIndependenceTest(TestCase):
+    """#2115 regression: check-driven dev never touches ``CharacterSkillValue``.
+
+    Weekly training (``world.skills.services._apply_development_to_skill``) and
+    check-driven dev (``award_check_development``) are two independently-tracked
+    "skill value" write paths (see the #2115 spec's "Verified interaction with
+    check-driven dev" finding). This PR only fixes the training path's
+    XP-boundary discard bug; it must not change check-driven dev's behavior —
+    including that it stays oblivious to XP boundaries on ``CharacterSkillValue``.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.character = ObjectDB.objects.create(db_key="SkillIndependenceChar")
+        cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
+        cls.skill = SkillFactory()
+        cls.category = CheckCategory.objects.create(name="test_skill_independence_category")
+        cls.check_type = CheckType.objects.create(
+            name="skill_independence_check",
+            category=cls.category,
+        )
+        CheckTypeTrait.objects.create(check_type=cls.check_type, trait=cls.skill.trait, weight=1.0)
+
+    def setUp(self) -> None:
+        DevelopmentPoints.flush_instance_cache()
+        WeeklySkillUsage.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        DevelopmentPoints.objects.filter(character_sheet=self.sheet).delete()
+        WeeklySkillUsage.objects.filter(character_sheet=self.sheet).delete()
+        CharacterTraitValue.objects.filter(character=self.character).delete()
+        CharacterSkillValue.objects.filter(character=self.character).delete()
+        # Parked at an XP boundary — proves award_check_development ignores it.
+        self.skill_value = CharacterSkillValueFactory(
+            character=self.character,
+            skill=self.skill,
+            value=19,
+            development_points=0,
+            rust_points=0,
+        )
+
+    def test_award_check_development_leaves_character_skill_value_untouched(self) -> None:
+        """award_check_development writes DevelopmentPoints/CharacterTraitValue only."""
+        award_check_development(
+            character_sheet=self.sheet,
+            check_type=self.check_type,
+            effort_level=EffortLevel.MEDIUM,
+            path_level=1,
+        )
+
+        dp = DevelopmentPoints.objects.get(character_sheet=self.sheet, trait=self.skill.trait)
+        assert dp.total_earned == 10
+
+        self.skill_value.refresh_from_db()
+        # A boundary-parked skill value is completely untouched by check-driven dev —
+        # no dev points added, no rust payoff, no level change.
+        assert self.skill_value.value == 19
+        assert self.skill_value.development_points == 0
+        assert self.skill_value.rust_points == 0
 
 
 class RustDebtPayoffTest(TestCase):

--- a/src/world/progression/tests/test_unlock_views.py
+++ b/src/world/progression/tests/test_unlock_views.py
@@ -19,9 +19,12 @@ from world.progression.models import (
     CharacterUnlock,
     ClassLevelUnlock,
     ClassXPCost,
+    TraitRatingUnlock,
+    TraitXPCost,
     XPCostChart,
     XPCostEntry,
 )
+from world.skills.factories import CharacterSkillValueFactory, SkillFactory
 
 
 class UnlockShopViewTests(TestCase):
@@ -80,6 +83,17 @@ class UnlockShopViewTests(TestCase):
             _trait_value=30,
             _path_stage=2,
         )
+
+    def _create_gated_skill(self, *, xp_cost: int | None = None):
+        """Create a skill parked at an XP boundary (#2115), optionally with an authored cost."""
+        skill = SkillFactory()
+        CharacterSkillValueFactory(character=self.character, skill=skill, value=19)
+        if xp_cost is not None:
+            chart = XPCostChart.objects.create(name=f"Breakthrough Chart {skill.pk}")
+            XPCostEntry.objects.create(chart=chart, level=20, xp_cost=xp_cost)
+            TraitXPCost.objects.create(trait=skill.trait, cost_chart=chart)
+            TraitRatingUnlock.objects.create(trait=skill.trait, target_rating=20)
+        return skill
 
     def test_list_includes_class_level_and_thread_xp_lock_items(self):
         """GET returns both class-level and thread XP-lock unlock items."""
@@ -238,3 +252,57 @@ class UnlockShopViewTests(TestCase):
         self.client.force_authenticate(user=None)
         response = self.client.get("/api/progression/unlocks/")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_includes_skill_breakthrough_item(self):
+        """GET includes an authored skill_breakthrough item for a gated skill (#2115)."""
+        skill = self._create_gated_skill(xp_cost=75)
+
+        response = self.client.get("/api/progression/unlocks/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        item = next(i for i in results if i["unlock_type"] == "skill_breakthrough")
+        self.assertEqual(item["skill_id"], skill.pk)
+        self.assertEqual(item["xp_cost"], 75)
+        self.assertTrue(item["requirements_met"])
+        self.assertIsNone(item["locked_reason"])
+
+    def test_list_marks_unauthored_skill_breakthrough_as_locked(self):
+        """An unauthored breakthrough surfaces as not-yet-purchasable, not silently absent."""
+        skill = self._create_gated_skill(xp_cost=None)
+
+        response = self.client.get("/api/progression/unlocks/")
+
+        results = response.data["results"]
+        item = next(i for i in results if i["unlock_type"] == "skill_breakthrough")
+        self.assertEqual(item["skill_id"], skill.pk)
+        self.assertFalse(item["requirements_met"])
+        self.assertEqual(item["locked_reason"], "Not yet authored")
+
+    def test_purchase_skill_breakthrough_success(self):
+        """POST purchase can buy a skill breakthrough when XP is available (#2115)."""
+        skill = self._create_gated_skill(xp_cost=100)
+        self._set_xp(150)
+
+        response = self.client.post(
+            "/api/progression/unlocks/purchase/",
+            {"unlock_type": "skill_breakthrough", "skill_id": skill.pk},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unlock_type"], "skill_breakthrough")
+        self.assertEqual(response.data["skill_id"], skill.pk)
+
+    def test_purchase_skill_breakthrough_insufficient_xp(self):
+        """POST purchase fails with 400 when XP is insufficient for a skill breakthrough."""
+        skill = self._create_gated_skill(xp_cost=100)
+        self._set_xp(50)
+
+        response = self.client.post(
+            "/api/progression/unlocks/purchase/",
+            {"unlock_type": "skill_breakthrough", "skill_id": skill.pk},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/src/world/progression/views.py
+++ b/src/world/progression/views.py
@@ -73,6 +73,7 @@ from world.progression.services.voting import (
     get_votes_by_voter,
 )
 from world.roster.models import RosterEntry
+from world.skills.services import skills_at_boundary
 from world.stories.pagination import StandardResultsSetPagination
 
 # Default and maximum transaction limit for pagination
@@ -554,6 +555,7 @@ class ProgressionUnlockViewSet(viewsets.GenericViewSet):
                     "thread_resonance_name": None,
                     "thread_target_kind": None,
                     "dev_points_to_boundary": None,
+                    "skill_id": None,
                 },
             )
 
@@ -580,6 +582,32 @@ class ProgressionUnlockViewSet(viewsets.GenericViewSet):
                     "thread_resonance_name": resonance.name if resonance is not None else None,
                     "thread_target_kind": thread.target_kind,
                     "dev_points_to_boundary": prospect.dev_points_to_boundary,
+                    "skill_id": None,
+                },
+            )
+
+        for skill_prospect in skills_at_boundary(character):
+            skill = skill_prospect.skill
+            rating = skill_prospect.next_rating / 10
+            items.append(
+                {
+                    "unlock_type": "skill_breakthrough",
+                    "display_name": f"{skill.name} Breakthrough to {rating:.1f}",
+                    "xp_cost": skill_prospect.xp_cost or 0,
+                    "requirements_met": skill_prospect.authored,
+                    "locked_reason": None if skill_prospect.authored else "Not yet authored",
+                    "class_level_unlock_id": None,
+                    "class_name": None,
+                    "target_level": None,
+                    "thread_id": None,
+                    "boundary_level": None,
+                    "thread_name": None,
+                    "thread_level": None,
+                    "thread_resonance_id": None,
+                    "thread_resonance_name": None,
+                    "thread_target_kind": None,
+                    "dev_points_to_boundary": None,
+                    "skill_id": skill.pk,
                 },
             )
 
@@ -604,6 +632,8 @@ class ProgressionUnlockViewSet(viewsets.GenericViewSet):
         action_kwargs: dict[str, Any] = {"unlock_type": data["unlock_type"]}
         if data["unlock_type"] == PurchaseUnlockSerializer.UNLOCK_TYPE_CLASS_LEVEL:
             action_kwargs["class_level_unlock_id"] = data["class_level_unlock_id"]
+        elif data["unlock_type"] == PurchaseUnlockSerializer.UNLOCK_TYPE_SKILL_BREAKTHROUGH:
+            action_kwargs["skill_id"] = data["skill_id"]
         else:
             action_kwargs["thread_id"] = data["thread_id"]
             action_kwargs["boundary_level"] = data["boundary_level"]

--- a/src/world/seeds/clusters.py
+++ b/src/world/seeds/clusters.py
@@ -183,6 +183,14 @@ def _seed_covenant_roles() -> None:
     seed_role_catalog_content()
 
 
+def _seed_skills() -> None:
+    from world.seeds.game_content.skills import (  # noqa: PLC0415
+        seed_skill_breakthrough_catalog,
+    )
+
+    seed_skill_breakthrough_catalog()
+
+
 CLUSTER_SEEDERS: dict[str, Callable[[], None]] = {
     # The checks spine owns the global resolution charts/outcomes; seed it first
     # so the canonical rows exist before the other clusters run. (Idempotency
@@ -266,6 +274,13 @@ CLUSTER_SEEDERS: dict[str, Callable[[], None]] = {
     # archetype action scaling for the 3 canonical roles (#2022). After "items"
     # (creates the role rows + gear compat) and "magic" (EffectType/Style/Gift).
     "covenant_roles": _seed_covenant_roles,
+    # Skill breakthroughs: default TraitRatingUnlock catalog at every skill's four
+    # XP boundaries (20/30/40/50), so the #2115 breakthrough purchase is always
+    # reachable instead of a landmine. Registered LAST — it iterates every
+    # currently-seeded Skill row, so it must run after every cluster that seeds
+    # new skills (combat_checks/social/investigation/governance/stealth); safe to
+    # re-run (idempotent) after authoring a skill outside those clusters.
+    "skills": _seed_skills,
 }
 
 
@@ -314,7 +329,7 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
     from world.justice.models import CrimeKind  # noqa: PLC0415
     from world.magic.models import Affinity, Resonance  # noqa: PLC0415
     from world.magic.models.techniques import Technique  # noqa: PLC0415
-    from world.progression.models import KudosSourceCategory  # noqa: PLC0415
+    from world.progression.models import KudosSourceCategory, TraitRatingUnlock  # noqa: PLC0415
     from world.projects.models import ContributionMethod  # noqa: PLC0415
     from world.relationships.models import RelationshipCondition  # noqa: PLC0415
     from world.room_features.models import RoomFeatureKind  # noqa: PLC0415
@@ -389,4 +404,7 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
         # Covenant role catalog: granted gifts + techniques + capabilities +
         # archetype scaling for the 3 canonical roles (#2022).
         "covenant_roles": [],
+        # Skill breakthroughs: default TraitRatingUnlock catalog at every skill's
+        # four XP boundaries (#2115).
+        "skills": [TraitRatingUnlock],
     }

--- a/src/world/seeds/game_content/skills.py
+++ b/src/world/seeds/game_content/skills.py
@@ -1,0 +1,58 @@
+"""Default skill-breakthrough catalog seed (#2115).
+
+Every skill's four XP boundaries (20/30/40/50) need a purchasable
+``TraitRatingUnlock`` or the breakthrough purchase is a landmine no player can
+ever clear — mirrors the #2116(a) authored-unlock landmine pattern. Seeds one
+shared ``XPCostChart`` ("Skill Breakthroughs") with a flat placeholder cost
+curve, then a ``TraitXPCost`` + four ``TraitRatingUnlock`` rows per ``Skill``.
+
+Idempotent throughout (get_or_create / update_or_create). Content only — no
+data migration (ADR-0013). Must run *after* every cluster that seeds new
+``Skill`` rows (``combat_checks``/``social``/``investigation``/``governance``/
+``stealth``) since it iterates ``Skill.objects.all()`` at call time; re-run
+this seeder (it is idempotent) after authoring a new skill outside those
+clusters.
+"""
+
+from __future__ import annotations
+
+_CHART_NAME = "Skill Breakthroughs"
+
+# Flat placeholder cost curve — staff-tunable content, not a final economy
+# (mirrors the sanctum touchstone precedent: minimum reachable, not tuned).
+_FLAT_COST_PER_BOUNDARY: dict[int, int] = {
+    20: 50,
+    30: 100,
+    40: 150,
+    50: 200,
+}
+
+
+def seed_skill_breakthrough_catalog() -> None:
+    """Idempotently seed the shared skill-breakthrough XP-cost chart + unlocks."""
+    from world.progression.models import (  # noqa: PLC0415
+        TraitRatingUnlock,
+        TraitXPCost,
+        XPCostChart,
+        XPCostEntry,
+    )
+    from world.skills.models import Skill  # noqa: PLC0415
+
+    chart, _ = XPCostChart.objects.update_or_create(
+        name=_CHART_NAME,
+        defaults={
+            "description": "Default placeholder cost curve for skill XP-boundary breakthroughs.",
+            "is_active": True,
+        },
+    )
+    for level, cost in _FLAT_COST_PER_BOUNDARY.items():
+        XPCostEntry.objects.update_or_create(
+            chart=chart,
+            level=level,
+            defaults={"xp_cost": cost},
+        )
+
+    for skill in Skill.objects.select_related("trait").all():
+        TraitXPCost.objects.get_or_create(trait=skill.trait, cost_chart=chart)
+        for rating in _FLAT_COST_PER_BOUNDARY:
+            TraitRatingUnlock.objects.get_or_create(trait=skill.trait, target_rating=rating)

--- a/src/world/seeds/tests/test_clusters.py
+++ b/src/world/seeds/tests/test_clusters.py
@@ -36,6 +36,7 @@ class TestClusterRegistry(TestCase):
                 "kinship",
                 "houses",
                 "covenant_roles",
+                "skills",
             },
         )
 

--- a/src/world/skills/CLAUDE.md
+++ b/src/world/skills/CLAUDE.md
@@ -70,6 +70,15 @@ Parent skills and specializations for character abilities. Skills are linked to 
 - `apply_weekly_rust(trained_skills)` — adds rust to untrained skills
 - `run_weekly_skill_cron()` — orchestrator: training then rust
 
+**XP-Boundary Breakthrough (#2115):**
+- `purchase_skill_breakthrough(character, skill) -> tuple[bool, str]` — spends XP against
+  an authored `TraitRatingUnlock` to clear a boundary-parked skill's gate; resets
+  `development_points` to 0 (no retroactive credit)
+- `skills_at_boundary(character) -> list[SkillBreakthroughProspect]` — selector listing every
+  gated skill with its authored XP cost (or `authored=False` if unauthored)
+- `is_skill_at_xp_boundary(value) -> bool` — public wrapper for boundary-check, used by
+  `character_sheets` serialization for the `SkillEntry.at_boundary` flag
+
 ### Training Formula
 ```
 base_gain = 5 × AP × path_level
@@ -80,7 +89,17 @@ dev_points = base_gain + mentor_bonus
 ### Development Costs
 - Level N to N+1 costs `(N - 9) × 100` dev points
 - Overflow carries across levels
-- XP boundaries at 19, 29, 39, 49 block advancement until XP purchase
+- XP boundaries at 19, 29, 39, 49 are a **plateau, not banking** (#2115): a boundary-parked
+  skill still pays off rust from incoming dev points, but any surplus beyond that payoff
+  **dissipates** — never banked, never silently discarded. `_apply_development_to_skill`
+  returns a plateau message on dissipation (also folded into the weekly
+  `DevelopmentTransaction.description`); `purchase_skill_breakthrough(character, skill)`
+  spends XP against an authored `progression.TraitRatingUnlock` to clear the gate, resetting
+  `development_points` to 0 (training resumes from zero — no retroactive credit for
+  dissipated points). `skills_at_boundary(character)` surfaces every gated skill (with its
+  authored XP cost, if any) for display. Reachable via `progression unlock skill=<id>`
+  (`PurchaseUnlockAction` `unlock_type="skill_breakthrough"`); default breakthroughs are
+  seeded by the `"skills"` cluster (`world.seeds.game_content.skills`).
 - Specializations have no XP boundaries
 
 ### Rust System

--- a/src/world/skills/services.py
+++ b/src/world/skills/services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING
 
@@ -383,21 +384,44 @@ def _is_at_xp_boundary(value: int) -> bool:
     return value % 10 == _XP_BOUNDARY_DIGIT and _XP_BOUNDARY_MIN <= value <= _XP_BOUNDARY_MAX
 
 
-def _apply_development_to_skill(skill_value: CharacterSkillValue, dev_points: int) -> None:
-    """Apply development points to a skill, handling rust payoff, level-ups, and overflow.
+def is_skill_at_xp_boundary(value: int) -> bool:
+    """Public wrapper for :func:`_is_at_xp_boundary` (#2115).
 
-    Dev points pay off rust first, then count toward advancement. Mutates the
-    ``skill_value`` instance in place and saves it. If the skill is at an XP
-    boundary (19, 29, 39, 49), all points are wasted.
+    Lets other apps (e.g. character-sheet serialization) check boundary state
+    without reaching into a private helper.
+    """
+    return _is_at_xp_boundary(value)
+
+
+def _boundary_message(skill: Skill, next_rating: int) -> str:
+    """Plateau message shown when dev points dissipate at an XP boundary (#2115)."""
+    return (
+        f"{skill.name} is at threshold {next_rating / 10:.1f} — training maintains, "
+        "does not advance until the breakthrough is unlocked."
+    )
+
+
+def _apply_development_to_skill(skill_value: CharacterSkillValue, dev_points: int) -> str | None:
+    """Apply development points to a skill, handling rust payoff, level-ups, and plateau.
+
+    Dev points pay off rust first, always — even while the skill is parked at an
+    XP boundary (19, 29, 39, 49), so training/use can still "blow the rust off" a
+    gated skill (#2115). Any surplus beyond the rust payoff dissipates at a
+    boundary: development points are deliberately ephemeral (the 2026-07-09
+    ephemerality ruling) — never banked, never silently discarded. The same
+    dissipation (with the same visible message) applies to overflow from a
+    level-up that lands exactly on a boundary. Mutates ``skill_value`` in place
+    and saves it.
 
     Args:
         skill_value: The CharacterSkillValue to develop.
         dev_points: Development points to apply.
-    """
-    if _is_at_xp_boundary(skill_value.value):
-        return
 
-    # Pay off rust first
+    Returns:
+        A plateau message when points dissipated at a boundary this call,
+        else ``None``.
+    """
+    # Pay off rust first — always, even when parked at a boundary.
     remaining = dev_points
     if skill_value.rust_points > 0:
         if remaining >= skill_value.rust_points:
@@ -407,20 +431,158 @@ def _apply_development_to_skill(skill_value: CharacterSkillValue, dev_points: in
             skill_value.rust_points -= remaining
             remaining = 0
 
+    if _is_at_xp_boundary(skill_value.value):
+        message = _boundary_message(skill_value.skill, skill_value.value + 1) if remaining else None
+        skill_value.development_points = 0
+        skill_value.save()
+        return message
+
     # Apply remaining to development
     remaining += skill_value.development_points
 
+    message = None
     cost = _development_cost(skill_value.value)
     while remaining >= cost:
         remaining -= cost
         skill_value.value += 1
         if _is_at_xp_boundary(skill_value.value):
+            if remaining > 0:
+                message = _boundary_message(skill_value.skill, skill_value.value + 1)
             remaining = 0
             break
         cost = _development_cost(skill_value.value)
 
     skill_value.development_points = remaining
     skill_value.save()
+    return message
+
+
+def purchase_skill_breakthrough(character: ObjectDB, skill: Skill) -> tuple[bool, str]:
+    """Spend XP to break through a skill's XP-boundary plateau (#2115).
+
+    Wires the pre-existing but never-called ``TraitRatingUnlock`` model through
+    the same ``purchase_unlock`` seam as class-level/thread unlocks
+    (``spend_xp_on_unlock``'s pattern). The purchase does not itself grant a
+    level (ADR-0053: XP buys the unlock that gates, never the grant) — it just
+    clears the gate. Because dev points earned while gated dissipate rather than
+    bank (the 2026-07-09 ephemerality ruling), there is nothing to retroactively
+    apply: training simply resumes accruing from zero once the gate is clear.
+
+    Args:
+        character: The character purchasing the breakthrough.
+        skill: The gated skill.
+
+    Returns:
+        ``(success, message)`` — mirrors ``spend_xp_on_unlock``'s contract.
+    """
+    from world.progression.models import TraitRatingUnlock, XPTransaction  # noqa: PLC0415
+    from world.progression.services.awards import get_or_create_xp_tracker  # noqa: PLC0415
+
+    try:
+        skill_value = CharacterSkillValue.objects.get(character=character, skill=skill)
+    except CharacterSkillValue.DoesNotExist:
+        return False, f"{skill.name} has no recorded value for this character."
+
+    if not _is_at_xp_boundary(skill_value.value):
+        return False, f"{skill.name} is not at a breakthrough boundary."
+
+    target_rating = skill_value.value + 1
+    try:
+        unlock = TraitRatingUnlock.objects.get(trait=skill.trait, target_rating=target_rating)
+    except TraitRatingUnlock.DoesNotExist:
+        return (
+            False,
+            f"No breakthrough authored for {skill.name} at this level — contact staff.",
+        )
+
+    xp_cost = unlock.get_xp_cost_for_character(character)
+    account = character.account
+
+    with transaction.atomic():
+        if xp_cost > 0:
+            xp_tracker = get_or_create_xp_tracker(account)
+            if not xp_tracker.spend_xp(xp_cost):
+                return (
+                    False,
+                    f"Insufficient XP (need {xp_cost}, have {xp_tracker.current_available}).",
+                )
+            XPTransaction.objects.create(
+                account=account,
+                amount=-xp_cost,
+                reason=ProgressionReason.XP_PURCHASE,
+                description=f"Breakthrough: {skill.name} to {target_rating / 10:.1f}",
+                character=character,
+            )
+
+        skill_value.value = target_rating
+        skill_value.development_points = 0
+        skill_value.save()
+
+    return (
+        True,
+        f"Breakthrough! {skill.name} rises to {target_rating / 10:.1f} — training resumes.",
+    )
+
+
+@dataclass(frozen=True)
+class SkillBreakthroughProspect:
+    """A skill parked at an XP boundary, with its breakthrough cost if authored (#2115)."""
+
+    skill: Skill
+    next_rating: int
+    xp_cost: int | None
+    authored: bool
+
+
+def skills_at_boundary(character: ObjectDB) -> list[SkillBreakthroughProspect]:
+    """Return the character's skills currently parked at an XP boundary (#2115).
+
+    Feeds the ``progression unlock`` listing and the sheet skills section's
+    ``at_boundary`` flag — so a player sees why a skill stalled, and what the
+    breakthrough costs, before burning a session wondering.
+
+    Args:
+        character: The character whose skills to check.
+
+    Returns:
+        One :class:`SkillBreakthroughProspect` per gated skill; ``authored`` is
+        False (and ``xp_cost`` is None) when staff hasn't authored a
+        ``TraitRatingUnlock`` for that boundary yet.
+    """
+    from world.progression.models import TraitRatingUnlock  # noqa: PLC0415
+
+    gated = [
+        sv
+        for sv in CharacterSkillValue.objects.filter(character=character).select_related(
+            "skill__trait"
+        )
+        if _is_at_xp_boundary(sv.value)
+    ]
+    if not gated:
+        return []
+
+    trait_ids = [sv.skill.trait_id for sv in gated]
+    target_ratings = [sv.value + 1 for sv in gated]
+    unlocks = {
+        (u.trait_id, u.target_rating): u
+        for u in TraitRatingUnlock.objects.filter(
+            trait_id__in=trait_ids, target_rating__in=target_ratings
+        )
+    }
+
+    prospects: list[SkillBreakthroughProspect] = []
+    for sv in gated:
+        next_rating = sv.value + 1
+        unlock = unlocks.get((sv.skill.trait_id, next_rating))
+        prospects.append(
+            SkillBreakthroughProspect(
+                skill=sv.skill,
+                next_rating=next_rating,
+                xp_cost=unlock.get_xp_cost_for_character(character) if unlock else None,
+                authored=unlock is not None,
+            )
+        )
+    return prospects
 
 
 def _apply_development_to_specialization(
@@ -493,6 +655,7 @@ def process_weekly_training() -> dict[int, set[int]]:
             allocation, _teaching_skill=teaching_skill, _path_levels=path_levels
         )
 
+        plateau_message: str | None = None
         if allocation.skill:
             trait = allocation.skill.trait
             skill_value, _created = CharacterSkillValue.objects.get_or_create(
@@ -500,7 +663,7 @@ def process_weekly_training() -> dict[int, set[int]]:
                 skill=allocation.skill,
                 defaults={"value": 10, "development_points": 0, "rust_points": 0},
             )
-            _apply_development_to_skill(skill_value, dev_points)
+            plateau_message = _apply_development_to_skill(skill_value, dev_points)
             trained_skills[character.pk].add(allocation.skill.pk)
         elif allocation.specialization:
             trait = allocation.specialization.parent_skill.trait
@@ -518,13 +681,16 @@ def process_weekly_training() -> dict[int, set[int]]:
         from world.character_sheets.models import CharacterSheet  # noqa: PLC0415
 
         sheet, _ = CharacterSheet.objects.get_or_create(character=character)
+        description = f"Weekly training: {allocation}"
+        if plateau_message:
+            description = f"{description} — {plateau_message}"
         DevelopmentTransaction.objects.create(
             character_sheet=sheet,
             trait=trait,
             source=DevelopmentSource.TRAINING,
             amount=dev_points,
             reason=ProgressionReason.SYSTEM_AWARD,
-            description=f"Weekly training: {allocation}",
+            description=description,
         )
 
         # Consume AP. Training still processes if pool is missing or has

--- a/src/world/skills/tests/test_breakthrough.py
+++ b/src/world/skills/tests/test_breakthrough.py
@@ -1,0 +1,238 @@
+"""Tests for the #2115 XP-boundary plateau fix and breakthrough purchase.
+
+Covers the rev-2 ephemerality ruling (no banking — dev points pay rust then
+dissipate at a boundary, always with a visible message) and
+``purchase_skill_breakthrough`` clearing the gate so training resumes from
+zero (no retroactive credit).
+"""
+
+from django.test import TestCase
+from evennia.accounts.models import AccountDB
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.progression.factories import ExperiencePointsDataFactory
+from world.progression.models import TraitRatingUnlock, TraitXPCost, XPCostChart, XPCostEntry
+from world.progression.models.rewards import ExperiencePointsData
+from world.skills.factories import CharacterSkillValueFactory, SkillFactory
+from world.skills.services import (
+    _apply_development_to_skill,
+    purchase_skill_breakthrough,
+    skills_at_boundary,
+)
+
+
+class BoundaryPlateauTests(TestCase):
+    """#2115 rev-2: dev points pay rust then dissipate at a boundary, with a message."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.identity = CharacterSheetFactory()
+        self.character = self.identity.character
+        self.skill = SkillFactory()
+
+    def test_boundary_rusty_skill_rust_paid_surplus_dissipates_with_message(self) -> None:
+        """At a boundary, incoming dev points pay off rust; surplus dissipates loudly."""
+        skill_value = CharacterSkillValueFactory(
+            character=self.character,
+            skill=self.skill,
+            value=19,
+            development_points=0,
+            rust_points=50,
+        )
+        message = _apply_development_to_skill(skill_value, 80)
+        skill_value.refresh_from_db()
+        self.assertEqual(skill_value.rust_points, 0)
+        self.assertEqual(skill_value.value, 19)
+        self.assertEqual(skill_value.development_points, 0)
+        self.assertIsNotNone(message)
+        assert message is not None
+        self.assertIn("threshold", message.lower())
+
+    def test_boundary_clean_skill_all_dissipates_with_message(self) -> None:
+        """At a boundary with no rust, all incoming dev points dissipate loudly."""
+        skill_value = CharacterSkillValueFactory(
+            character=self.character,
+            skill=self.skill,
+            value=19,
+            development_points=0,
+            rust_points=0,
+        )
+        message = _apply_development_to_skill(skill_value, 80)
+        skill_value.refresh_from_db()
+        self.assertEqual(skill_value.value, 19)
+        self.assertEqual(skill_value.development_points, 0)
+        self.assertIsNotNone(message)
+
+    def test_boundary_rust_fully_absorbs_dev_points_no_message(self) -> None:
+        """When rust payoff exactly consumes the award, nothing dissipates — no message."""
+        skill_value = CharacterSkillValueFactory(
+            character=self.character,
+            skill=self.skill,
+            value=19,
+            development_points=0,
+            rust_points=100,
+        )
+        message = _apply_development_to_skill(skill_value, 60)
+        skill_value.refresh_from_db()
+        self.assertEqual(skill_value.rust_points, 40)
+        self.assertEqual(skill_value.development_points, 0)
+        self.assertIsNone(message)
+
+    def test_overflow_on_level_up_to_boundary_dissipates_with_message(self) -> None:
+        """Overflow from a level-up that lands exactly on a boundary dissipates loudly."""
+        skill_value = CharacterSkillValueFactory(
+            character=self.character,
+            skill=self.skill,
+            value=18,
+            development_points=0,
+            rust_points=0,
+        )
+        # Cost 18->19 = (18-9)*100 = 900. Give 950: overflow of 50 lands on the boundary.
+        message = _apply_development_to_skill(skill_value, 950)
+        skill_value.refresh_from_db()
+        self.assertEqual(skill_value.value, 19)
+        self.assertEqual(skill_value.development_points, 0)
+        self.assertIsNotNone(message)
+
+    def test_not_at_boundary_unaffected(self) -> None:
+        """Away from a boundary, dev points accumulate normally with no message."""
+        skill_value = CharacterSkillValueFactory(
+            character=self.character,
+            skill=self.skill,
+            value=11,
+            development_points=0,
+            rust_points=0,
+        )
+        message = _apply_development_to_skill(skill_value, 80)
+        skill_value.refresh_from_db()
+        self.assertEqual(skill_value.value, 11)
+        self.assertEqual(skill_value.development_points, 80)
+        self.assertIsNone(message)
+
+
+class SkillsAtBoundaryTests(TestCase):
+    """Tests for the ``skills_at_boundary`` selector (#2115)."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.identity = CharacterSheetFactory()
+        self.character = self.identity.character
+
+    def test_empty_when_no_skills_gated(self) -> None:
+        CharacterSkillValueFactory(character=self.character, skill=SkillFactory(), value=15)
+        self.assertEqual(skills_at_boundary(self.character), [])
+
+    def test_reports_gated_skill_without_authored_unlock(self) -> None:
+        skill = SkillFactory()
+        CharacterSkillValueFactory(character=self.character, skill=skill, value=19)
+        prospects = skills_at_boundary(self.character)
+        self.assertEqual(len(prospects), 1)
+        self.assertEqual(prospects[0].skill, skill)
+        self.assertEqual(prospects[0].next_rating, 20)
+        self.assertFalse(prospects[0].authored)
+        self.assertIsNone(prospects[0].xp_cost)
+
+    def test_reports_authored_xp_cost(self) -> None:
+        skill = SkillFactory()
+        CharacterSkillValueFactory(character=self.character, skill=skill, value=19)
+        chart = XPCostChart.objects.create(name="Test Breakthrough Chart")
+        XPCostEntry.objects.create(chart=chart, level=20, xp_cost=100)
+        TraitXPCost.objects.create(trait=skill.trait, cost_chart=chart)
+        TraitRatingUnlock.objects.create(trait=skill.trait, target_rating=20)
+
+        prospects = skills_at_boundary(self.character)
+        self.assertEqual(len(prospects), 1)
+        self.assertTrue(prospects[0].authored)
+        self.assertEqual(prospects[0].xp_cost, 100)
+
+
+class PurchaseSkillBreakthroughTests(TestCase):
+    """Tests for ``purchase_skill_breakthrough`` (#2115)."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.account = AccountDB.objects.create(username="breakthrutester", email="a@a.com")
+        self.identity = CharacterSheetFactory()
+        self.character = self.identity.character
+        self.character.db_account = self.account
+        self.character.save()
+        self.skill = SkillFactory()
+
+    def _authored_unlock(self, *, target_rating: int, xp_cost: int) -> TraitRatingUnlock:
+        chart = XPCostChart.objects.create(name=f"Chart {target_rating}-{self.skill.pk}")
+        XPCostEntry.objects.create(chart=chart, level=target_rating, xp_cost=xp_cost)
+        TraitXPCost.objects.create(trait=self.skill.trait, cost_chart=chart)
+        return TraitRatingUnlock.objects.create(trait=self.skill.trait, target_rating=target_rating)
+
+    def _set_xp(self, *, total_earned: int) -> None:
+        ExperiencePointsDataFactory(account=self.account, total_earned=total_earned, total_spent=0)
+
+    def test_fails_when_not_at_boundary(self) -> None:
+        CharacterSkillValueFactory(character=self.character, skill=self.skill, value=15)
+        success, message = purchase_skill_breakthrough(self.character, self.skill)
+        self.assertFalse(success)
+        self.assertIn("not at a breakthrough boundary", message.lower())
+
+    def test_fails_when_no_unlock_authored(self) -> None:
+        CharacterSkillValueFactory(character=self.character, skill=self.skill, value=19)
+        success, message = purchase_skill_breakthrough(self.character, self.skill)
+        self.assertFalse(success)
+        self.assertIn("no breakthrough authored", message.lower())
+
+    def test_fails_with_insufficient_xp(self) -> None:
+        CharacterSkillValueFactory(character=self.character, skill=self.skill, value=19)
+        self._authored_unlock(target_rating=20, xp_cost=100)
+        self._set_xp(total_earned=50)
+
+        success, message = purchase_skill_breakthrough(self.character, self.skill)
+        self.assertFalse(success)
+        self.assertIn("insufficient xp", message.lower())
+
+    def test_success_clears_gate_and_resumes_from_zero(self) -> None:
+        """A successful purchase clears the gate; training resumes from zero (no retroactive
+        credit) even if development_points is nonzero at purchase time."""
+        skill_value = CharacterSkillValueFactory(
+            character=self.character,
+            skill=self.skill,
+            value=19,
+            development_points=0,
+            rust_points=0,
+        )
+        self._authored_unlock(target_rating=20, xp_cost=100)
+        self._set_xp(total_earned=150)
+
+        success, message = purchase_skill_breakthrough(self.character, self.skill)
+        self.assertTrue(success, msg=message)
+        self.assertIn("breakthrough", message.lower())
+
+        skill_value.refresh_from_db()
+        self.assertEqual(skill_value.value, 20)
+        self.assertEqual(skill_value.development_points, 0)
+
+        xp_tracker = ExperiencePointsData.objects.get(account=self.account)
+        self.assertEqual(xp_tracker.total_spent, 100)
+
+        # Training resumes normally now that the gate is clear.
+        post_message = _apply_development_to_skill(skill_value, 50)
+        skill_value.refresh_from_db()
+        self.assertIsNone(post_message)
+        self.assertEqual(skill_value.development_points, 50)
+
+    def test_duplicate_purchase_fails_once_cleared(self) -> None:
+        """A second purchase attempt fails — the skill is no longer at a boundary."""
+        CharacterSkillValueFactory(
+            character=self.character,
+            skill=self.skill,
+            value=19,
+            development_points=0,
+            rust_points=0,
+        )
+        self._authored_unlock(target_rating=20, xp_cost=100)
+        self._set_xp(total_earned=300)
+
+        first_success, _ = purchase_skill_breakthrough(self.character, self.skill)
+        self.assertTrue(first_success)
+
+        second_success, second_message = purchase_skill_breakthrough(self.character, self.skill)
+        self.assertFalse(second_success)
+        self.assertIn("not at a breakthrough boundary", second_message.lower())

--- a/src/world/skills/tests/test_training.py
+++ b/src/world/skills/tests/test_training.py
@@ -537,7 +537,7 @@ class ProcessWeeklyTrainingTests(TestCase):
         self.assertEqual(self.student_skill.development_points, 200)
 
     def test_stops_at_x9_boundary(self) -> None:
-        """Dev points are wasted at X9 boundaries (19, 29, etc.)."""
+        """Dev points dissipate at X9 boundaries (19, 29, etc.) — never banked (#2115)."""
         self.student_skill.value = 19
         self.student_skill.save()
         TrainingAllocation.objects.create(
@@ -547,7 +547,37 @@ class ProcessWeeklyTrainingTests(TestCase):
         )
         process_weekly_training()
         self.student_skill.refresh_from_db()
-        # At boundary, points wasted
+        # At boundary, surplus dissipates rather than banking.
+        self.assertEqual(self.student_skill.value, 19)
+        self.assertEqual(self.student_skill.development_points, 0)
+
+    def test_boundary_dissipation_is_reported_in_audit_trail(self) -> None:
+        """The plateau message from a boundary dissipation lands in the audit description."""
+        self.student_skill.value = 19
+        self.student_skill.save()
+        TrainingAllocation.objects.create(
+            character=self.student,
+            skill=self.skill,
+            ap_amount=10,
+        )
+        process_weekly_training()
+        txn = DevelopmentTransaction.objects.get(character_sheet_id=self.student.pk)
+        self.assertIn("threshold", txn.description.lower())
+
+    def test_boundary_still_pays_off_rust(self) -> None:
+        """A boundary-parked skill still pays down rust from incoming dev points (#2115)."""
+        self.student_skill.value = 19
+        self.student_skill.rust_points = 30
+        self.student_skill.save()
+        TrainingAllocation.objects.create(
+            character=self.student,
+            skill=self.skill,
+            ap_amount=10,
+        )
+        process_weekly_training()
+        self.student_skill.refresh_from_db()
+        # base = 5 * 10 * 1 = 50. 30 pays off rust; the remaining 20 dissipates.
+        self.assertEqual(self.student_skill.rust_points, 0)
         self.assertEqual(self.student_skill.value, 19)
         self.assertEqual(self.student_skill.development_points, 0)
 


### PR DESCRIPTION
Closes #2115

## Summary

Fixes the silent discard of dev points at skill XP boundaries (19/29/39/49): the boundary check now runs AFTER rust payoff, so boundary-parked skills can still be maintained; surplus dissipates with a visible plateau message (rev-2 ruling: dev points are ephemeral — no banking). Wires the TraitRatingUnlock breakthrough purchase through progression unlock skill=<id> (telnet) and ProgressionUnlockViewSet (web), adds boundary visibility to progression/training listings and the sheet SkillEntry, and seeds a flat-cost breakthrough catalog via a new skills cluster (Big Button covered). No migrations — reuses existing models.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2115 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: rebased onto origin/main, no conflicts

<!-- last-addressed-comment: 0 -->