### PR TITLE
Scene.is_gm is never set for ordinary GM-run scenes — non-staff GMs cannot run combat, checks, or NPCs (web+telnet)

### DIFF
--- a/docs/roadmap/rp-scenes.md
+++ b/docs/roadmap/rp-scenes.md
@@ -170,6 +170,16 @@ GM and co-owner tooling for scene lifecycle and round-mode adjustment, delivered
 an acute peril ensures an ordinary STRICT `SceneRound(start_reason=DANGER)` that ticks the
 peril at presence-gated resolution and auto-ends when it clears.
 
+**GM enrollment for ordinary GM-run scenes — DONE (#2113):** `SceneParticipation.is_gm` — the
+predicate every GM-combat surface gates on — had only one production writer, the crossover
+Lead-GM path; an ordinary trust-tier GM running their own table's session never got flagged.
+Two writers now cover it: `enroll_present_table_gms(scene, room)` (`scene_admin_services.py`)
+auto-flags a present account that owns an ACTIVE `GMTable` with an *other* present character
+holding an active `GMTableMembership` on it, called from `StartSceneAction.execute()` on both
+the new-scene and mid-scene-join paths; `GrantSceneGMAction` (`scene gm <name>`, key
+`"grant_scene_gm"`) is the explicit fallback for cases auto-detection can't reach, gated on
+`actor_can_administer_scene` plus the target holding a `GMProfile`.
+
 ### Web Round-Mode Control — DONE (#1467, parity for #1445)
 
 Frontend parity for `scene round` (telnet):

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -486,13 +486,51 @@ from world.scenes.round_services import maybe_finish_empty_scene
 maybe_finish_empty_scene(room, *, leaving=None) -> None
 ```
 
+### GM enrollment (#2113)
+
+`SceneParticipation.is_gm` is the single predicate every GM-combat surface gates on
+(`Scene.is_gm`, `_actor_may_gm_encounter` in `actions/definitions/gm_combat.py`,
+`IsEncounterGMOrStaff`/`can_view_encounter_effects` in `world/combat/permissions.py`). Before
+#2113 the only production writer was the crossover-event path
+(`_enroll_lead_gm_on_scene`, `world/stories/services/crossover.py`, untouched by this work) — an
+ordinary trust-tier GM (the #1999/#2000 GMLevel ladder) running their own table's session never
+got flagged. Two writers now cover the gap:
+
+```python
+from world.scenes.scene_admin_services import enroll_present_table_gms
+
+# Auto-flag is_gm=True for any present account that owns an ACTIVE GMTable AND has at
+# least one OTHER present character whose active persona holds an active
+# GMTableMembership on that same table. Bare table ownership is not enough — a GM
+# merely passing through a stranger's room must not auto-become that scene's
+# adjudicator. Idempotent (update_or_create); never flips is_gm back to False.
+enroll_present_table_gms(scene, room) -> None
+```
+
+Called from `StartSceneAction.execute()` right after `add_present_as_co_owners` (new scene) and
+again on the mid-scene join branch (existing scene), so a table-owning GM arriving after scene
+start still gets flagged.
+
+**`GrantSceneGMAction`** (`key="grant_scene_gm"`, `src/actions/definitions/scenes.py`) is the
+fallback for cases auto-detection can't reach (pickup games, guest players, an Assistant GM the
+scene owner wants to co-adjudicate). Gated: the actor must already administer the scene
+(`actor_can_administer_scene`) and the named, present target account must hold a `GMProfile`
+(any level — approval is itself the trust gate, no `GMLevel` tier check here).
+`update_or_create`s the target's `SceneParticipation.is_gm=True`. Telnet: `scene gm <name>`
+(`CmdScene`, `src/commands/scene.py`). Web reaches the same Action through the generic
+available-actions dispatcher (mirrors `set_the_stage`); a minimal "Grant GM" control lives next
+to the co-owner list in `SceneHeader.tsx`, visible only when `actor_can_administer_scene` is true
+for the viewer.
+
 ### Lifecycle Actions
 
 **`StartSceneAction`** (`key="start_scene"`, `src/actions/definitions/scenes.py`)
 
 Creates a scene in the actor's current room via `ensure_scene_for_location`, then calls
-`add_present_as_co_owners` so every present PC is a co-owner. If an active scene already
-exists, the actor is recorded as a non-owner participant. Ungated — any character may invoke it.
+`add_present_as_co_owners` and `enroll_present_table_gms` so every present PC is a co-owner and
+any table-owning GM with a present member is auto-flagged `is_gm`. If an active scene already
+exists, the actor is recorded as a non-owner participant and `enroll_present_table_gms` runs
+again for the room. Ungated — any character may invoke it.
 
 **`FinishSceneAction`** (`key="finish_scene"`, `src/actions/definitions/scenes.py`)
 

--- a/frontend/src/combat/types.ts
+++ b/frontend/src/combat/types.ts
@@ -134,4 +134,6 @@ export interface DispatchActionRequest {
 export interface DispatchResult {
   backend: string;
   deferred: boolean;
+  /** Short human string from the action's result (DispatchResultSerializer.message). */
+  message?: string | null;
 }

--- a/frontend/src/scenes/components/SceneHeader.tsx
+++ b/frontend/src/scenes/components/SceneHeader.tsx
@@ -1,7 +1,12 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAppSelector } from '@/store/hooks';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+import { useDispatchPlayerAction } from '@/combat/queries';
 import { SceneDetail, updateScene, finishScene } from '../queries';
+import { fetchAvailableActions } from '../actionQueries';
+import type { PlayerAction } from '../actionTypes';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -11,6 +16,73 @@ import { RoundSettingsDialog } from './RoundSettingsDialog';
 interface Props {
   scene?: SceneDetail;
   onRefresh?: () => void;
+}
+
+/**
+ * Grant GM control (#2113) — the web face of `scene gm <name>`.
+ *
+ * Dispatches the `grant_scene_gm` registry action through the same generic
+ * available-actions seam `set_the_stage` uses (RoomPositionsPanel). Rendered
+ * only for scene owners on an active scene; the backend Action re-checks
+ * `actor_can_administer_scene` and the target's GMProfile, so this control is
+ * a convenience, never the gate.
+ */
+function GrantSceneGMControl() {
+  const [targetName, setTargetName] = useState('');
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const activeCharacterName = useAppSelector((state) => state.game.active);
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
+  const characterId = useMemo(
+    () => myRosterEntries.find((e) => e.name === activeCharacterName)?.character_id ?? null,
+    [myRosterEntries, activeCharacterName]
+  );
+
+  const { data: actionsData } = useQuery({
+    queryKey: ['available-actions', characterId],
+    queryFn: () => fetchAvailableActions(characterId!),
+    enabled: characterId !== null,
+  });
+  const availableActions: PlayerAction[] = actionsData?.results ?? [];
+  const grantAction =
+    availableActions.find(
+      (a) => a.ref.backend === 'registry' && a.ref.registry_key === 'grant_scene_gm'
+    ) ?? null;
+
+  const { mutateAsync: dispatchAction, isPending } = useDispatchPlayerAction(characterId ?? 0);
+
+  if (!grantAction || characterId === null) return null;
+
+  const submit = () => {
+    const name = targetName.trim();
+    if (!name) return;
+    dispatchAction({ ref: grantAction.ref, kwargs: { target_name: name } })
+      .then((result) => {
+        setFeedback(result.message ?? `GM status granted to ${name}.`);
+        setTargetName('');
+      })
+      .catch((err: unknown) =>
+        setFeedback(err instanceof Error ? err.message : 'Could not grant GM status.')
+      );
+  };
+
+  return (
+    <div className="mb-2" data-testid="grant-scene-gm">
+      <div className="flex items-center gap-2">
+        <Input
+          className="h-8 w-48"
+          placeholder="Character name"
+          value={targetName}
+          onChange={(e) => setTargetName(e.target.value)}
+          aria-label="Grant GM target character name"
+        />
+        <Button size="sm" variant="outline" onClick={submit} disabled={isPending}>
+          Grant GM
+        </Button>
+      </div>
+      {feedback && <p className="mt-1 text-xs text-muted-foreground">{feedback}</p>}
+    </div>
+  );
 }
 
 export function SceneHeader({ scene, onRefresh }: Props) {
@@ -99,6 +171,7 @@ export function SceneHeader({ scene, onRefresh }: Props) {
           <RoundSettingsDialog scene={scene} />
         </div>
       )}
+      {scene.is_owner && scene.is_active && <GrantSceneGMControl />}
       {scene.is_active && (
         <p className="mb-4 text-xs text-muted-foreground">
           Auto-refreshes every minute while active

--- a/src/actions/definitions/scenes.py
+++ b/src/actions/definitions/scenes.py
@@ -7,13 +7,16 @@ from typing import TYPE_CHECKING, Any
 
 from actions.base import Action
 from actions.types import ActionContext, ActionResult, TargetType
+from commands.exceptions import CommandError
 
 # Re-use the same NOT_IN_A_ROOM_MESSAGE constant (defined in rounds.py and checked here).
 NOT_IN_A_ROOM_MESSAGE = "You are not in a room."
 
 if TYPE_CHECKING:
+    from evennia.accounts.models import AccountDB
     from evennia.objects.models import ObjectDB
 
+    from world.character_sheets.models import CharacterSheet
     from world.scenes.models import Scene
 
 
@@ -48,6 +51,7 @@ class StartSceneAction(Action):
         from world.scenes.place_services import ensure_scene_for_location  # noqa: PLC0415
         from world.scenes.scene_admin_services import (  # noqa: PLC0415
             add_present_as_co_owners,
+            enroll_present_table_gms,
             resolve_actor_account,
         )
 
@@ -59,6 +63,7 @@ class StartSceneAction(Action):
         if scene is None:
             scene = ensure_scene_for_location(room)
             add_present_as_co_owners(scene, room)
+            enroll_present_table_gms(scene, room)
             return ActionResult(success=True, message="A scene begins.")
 
         # Scene already exists — join the actor as a non-owner participant.
@@ -71,6 +76,8 @@ class StartSceneAction(Action):
                 account=account,
                 defaults={"is_owner": False},
             )
+        # A table-owning GM arriving after scene start still gets flagged (#2113).
+        enroll_present_table_gms(scene, room)
         return ActionResult(success=True, message="A scene is already active here.")
 
 
@@ -116,3 +123,100 @@ class FinishSceneAction(Action):
 
         finish_scene_full(scene, by_account=resolve_actor_account(actor))
         return ActionResult(success=True, message="The scene comes to a close.")
+
+
+def _resolve_gm_grant_target(
+    actor: ObjectDB,
+    room: ObjectDB,
+    target_name: str,
+) -> tuple[CharacterSheet, AccountDB] | ActionResult:
+    """Resolve + validate a ``scene gm <name>`` target.
+
+    Returns ``(target_sheet, target_account)`` on success, or the failure
+    ``ActionResult`` to return immediately. Extracted from ``execute()`` to keep
+    its own return-statement count low (PLR0911), mirroring
+    ``gm_combat.py``'s ``_validate_add_opponent_kwargs`` pattern.
+    """
+    from commands.utils.gm_resolution import resolve_character_sheet_in_room  # noqa: PLC0415
+    from world.gm.models import GMProfile  # noqa: PLC0415
+    from world.scenes.scene_admin_services import resolve_actor_account  # noqa: PLC0415
+
+    target_name = target_name.strip()
+    if not target_name:
+        return ActionResult(success=False, message="Name a present character.")
+
+    try:
+        target_sheet = resolve_character_sheet_in_room(actor, target_name, room=room)
+    except CommandError as err:
+        return ActionResult(success=False, message=str(err))
+
+    target_account = resolve_actor_account(target_sheet.character)
+    if target_account is None:
+        return ActionResult(
+            success=False,
+            message="That character has no controlling account.",
+        )
+
+    try:
+        target_account.gm_profile  # noqa: B018 - side effect: triggers reverse lookup
+    except GMProfile.DoesNotExist:
+        return ActionResult(success=False, message="That account is not an approved GM.")
+
+    return target_sheet, target_account
+
+
+@dataclass
+class GrantSceneGMAction(Action):
+    """Explicitly grant ``is_gm`` to a present, approved GM account (#2113).
+
+    The fallback for cases ``enroll_present_table_gms`` auto-detection can't reach
+    (pickup games, guest players, an Assistant GM the scene owner wants to
+    co-adjudicate). Gated: the actor must already administer the scene
+    (``actor_can_administer_scene`` — is_gm / co-owner / staff / is_story_runner) and
+    the target account must hold a ``GMProfile`` (any level — approval is itself the
+    trust gate; no ``GMLevel`` tier check here).
+    """
+
+    key: str = "grant_scene_gm"
+    name: str = "Grant Scene GM"
+    icon: str = "shield"
+    category: str = "scenes"
+    target_type: TargetType = TargetType.AREA
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.scenes.models import SceneParticipation  # noqa: PLC0415
+        from world.scenes.scene_admin_services import actor_can_administer_scene  # noqa: PLC0415
+
+        room = actor.location
+        if room is None:
+            return ActionResult(success=False, message=NOT_IN_A_ROOM_MESSAGE)
+
+        scene = _active_scene_for_room(room)
+        if scene is None:
+            return ActionResult(success=False, message="There is no active scene here.")
+
+        if not actor_can_administer_scene(actor, scene):
+            return ActionResult(
+                success=False,
+                message="Only the scene's GM or an owner can grant GM status.",
+            )
+
+        resolved = _resolve_gm_grant_target(actor, room, kwargs.get("target_name") or "")
+        if isinstance(resolved, ActionResult):
+            return resolved
+        target_sheet, target_account = resolved
+
+        SceneParticipation.objects.update_or_create(
+            scene=scene,
+            account=target_account,
+            defaults={"is_gm": True},
+        )
+        return ActionResult(
+            success=True,
+            message=f"{target_sheet.character} is now a GM of this scene.",
+        )

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -251,7 +251,7 @@ from actions.definitions.scene_reactions import (
     ToggleFavoriteAction,
     ToggleReactionAction,
 )
-from actions.definitions.scenes import FinishSceneAction, StartSceneAction
+from actions.definitions.scenes import FinishSceneAction, GrantSceneGMAction, StartSceneAction
 from actions.definitions.ships import (
     CommissionShipAction,
     RepairShipAction,
@@ -406,6 +406,7 @@ _ALL_ACTIONS: list[Action] = [
     CastTechniqueAction(),
     StartSceneAction(),
     FinishSceneAction(),
+    GrantSceneGMAction(),
     BeginEncounterRoundAction(),
     ResolveEncounterRoundAction(),
     AddOpponentAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -256,6 +256,7 @@ class ActionRegistryTests(TestCase):
             "combat_leave",
             "start_scene",
             "finish_scene",
+            "grant_scene_gm",
             "add_encounter_participant",
             "add_opponent",
             "begin_encounter_round",

--- a/src/actions/tests/test_scene_actions.py
+++ b/src/actions/tests/test_scene_actions.py
@@ -6,9 +6,10 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from actions.definitions.scenes import FinishSceneAction, StartSceneAction
+from actions.definitions.scenes import FinishSceneAction, GrantSceneGMAction, StartSceneAction
 from evennia_extensions.factories import CharacterFactory, GMCharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.factories import GMProfileFactory
 from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 from world.scenes.factories import SceneFactory, SceneOwnerParticipationFactory
 from world.scenes.models import Scene, SceneParticipation
@@ -195,6 +196,105 @@ class FinishSceneActionTests(TestCase):
         actor.location = None
 
         result = FinishSceneAction().execute(actor)
+
+        assert result.success is False
+        assert "not in a room" in result.message.lower()
+
+
+class GrantSceneGMActionTests(TestCase):
+    """GrantSceneGMAction: fallback ``scene gm <name>`` grant (#2113)."""
+
+    def test_owner_grants_gm_to_present_approved_gm(self):
+        """A scene co-owner may grant is_gm to a present account holding a GMProfile."""
+        room = _make_room("GrantRoom1")
+        owner, owner_account = _create_pc_with_account("GrantOwner", location=room)
+        target, target_account = _create_pc_with_account("GrantTarget", location=room)
+        GMProfileFactory(account=target_account)
+        scene = SceneFactory(location=room, is_active=True)
+        SceneOwnerParticipationFactory(scene=scene, account=owner_account)
+
+        result = GrantSceneGMAction().execute(owner, target_name=target.db_key)
+
+        assert result.success is True
+        assert SceneParticipation.objects.filter(
+            scene=scene, account=target_account, is_gm=True
+        ).exists()
+
+    def test_non_admin_actor_is_denied(self):
+        """A present PC who does not administer the scene cannot grant GM status."""
+        room = _make_room("GrantRoom2")
+        non_admin, _non_admin_account = _create_pc_with_account("NonAdmin", location=room)
+        target, target_account = _create_pc_with_account("GrantTarget2", location=room)
+        GMProfileFactory(account=target_account)
+        scene = SceneFactory(location=room, is_active=True)
+        # non_admin has no SceneParticipation row -> not an owner, not GM, not staff.
+
+        result = GrantSceneGMAction().execute(non_admin, target_name=target.db_key)
+
+        assert result.success is False
+        assert not SceneParticipation.objects.filter(
+            scene=scene, account=target_account, is_gm=True
+        ).exists()
+
+    def test_target_without_gm_profile_is_refused(self):
+        """A present target account with no GMProfile is refused."""
+        room = _make_room("GrantRoom3")
+        owner, owner_account = _create_pc_with_account("GrantOwner3", location=room)
+        target, target_account = _create_pc_with_account("GrantTarget3", location=room)
+        # No GMProfile created for target_account.
+        scene = SceneFactory(location=room, is_active=True)
+        SceneOwnerParticipationFactory(scene=scene, account=owner_account)
+
+        result = GrantSceneGMAction().execute(owner, target_name=target.db_key)
+
+        assert result.success is False
+        assert "not an approved gm" in result.message.lower()
+        assert not SceneParticipation.objects.filter(
+            scene=scene, account=target_account, is_gm=True
+        ).exists()
+
+    def test_staff_character_can_grant(self):
+        """A staff/story-runner character (GMCharacter) can grant regardless of ownership."""
+        room = _make_room("GrantRoom4")
+        gm_runner = GMCharacterFactory(db_key="GrantGMRunner", location=room)
+        target, target_account = _create_pc_with_account("GrantTarget4", location=room)
+        GMProfileFactory(account=target_account)
+        scene = SceneFactory(location=room, is_active=True)
+
+        result = GrantSceneGMAction().execute(gm_runner, target_name=target.db_key)
+
+        assert result.success is True
+        assert SceneParticipation.objects.filter(
+            scene=scene, account=target_account, is_gm=True
+        ).exists()
+
+    def test_unknown_target_name_fails(self):
+        """A target name that matches no present character fails with a clear message."""
+        room = _make_room("GrantRoom5")
+        owner, owner_account = _create_pc_with_account("GrantOwner5", location=room)
+        scene = SceneFactory(location=room, is_active=True)
+        SceneOwnerParticipationFactory(scene=scene, account=owner_account)
+
+        result = GrantSceneGMAction().execute(owner, target_name="NoSuchCharacter")
+
+        assert result.success is False
+
+    def test_no_active_scene_returns_failure(self):
+        """GrantSceneGMAction fails when no active scene exists in the room."""
+        room = _make_room("GrantRoom6")
+        owner, _owner_account = _create_pc_with_account("GrantOwner6", location=room)
+
+        result = GrantSceneGMAction().execute(owner, target_name="Anyone")
+
+        assert result.success is False
+        assert "no active scene" in result.message.lower()
+
+    def test_returns_failure_when_not_in_room(self):
+        """Actor not in a room gets a failure result."""
+        actor = CharacterFactory(db_key="NoRoomGrant")
+        actor.location = None
+
+        result = GrantSceneGMAction().execute(actor, target_name="Anyone")
 
         assert result.success is False
         assert "not in a room" in result.message.lower()

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -106,6 +106,23 @@ actions, backends, and service functions.
   `get_all_pending`, `find_handler` — pure-Python in-process registry; no DB model.
 - **`offer_response.py`**: `CmdDecline` (`decline`) — registry-offer decline; see also
   extended `CmdAccept` in `consent.py`.
+- **`scene.py`**: `CmdScene` (`scene`) — the scene-lifecycle namespace, thin over the Actions in
+  `actions/definitions/scenes.py`: `scene start [name]` (`StartSceneAction`, also enrolls any
+  present table-owning GM via `enroll_present_table_gms`, #2113), `scene finish`
+  (`FinishSceneAction`), `scene gm <name>` (`GrantSceneGMAction`, #2113 — the fallback GM grant
+  for cases auto-enrollment can't reach: gated on `actor_can_administer_scene` + the target
+  holding a `GMProfile`), `scene round [...]` (`SetRoundModeAction`, `actions/definitions/
+  rounds.py`), `scene succor <ally>` / `scene interpose <ally>` (`SuccorSceneAction`/
+  `InterposeSceneAction`, #1744/#1316), bare `scene`/`scene status` (read-only round status, no
+  action). Web reaches `StartSceneAction`/`FinishSceneAction`/`GrantSceneGMAction` through the
+  same generic available-actions dispatcher. See "Scene Administration" in
+  `docs/systems/scenes.md`. No business logic in the command.
+- **`encounter.py`**: `CmdEncounter` (`encounter`, #1494) — the GM combat-encounter lifecycle
+  namespace, thin over the eight Actions in `actions/definitions/gm_combat.py` (`begin`/
+  `resolve`/`add`/`default`/`addpc`/`removepc`/`pause`/`end`). Every subverb is gated by
+  `_actor_may_gm_encounter` (staff or `encounter.scene.is_gm(account)`) in the Action layer —
+  reads the same `SceneParticipation.is_gm` flag `enroll_present_table_gms`/
+  `GrantSceneGMAction`/`_enroll_lead_gm_on_scene` write (#2113). No business logic in the command.
 - **`consent.py`**: `ConsentRequestCommand` (base), `CmdIntimidate`, `CmdPersuade`, `CmdDeceive`, `CmdFlirt`, `CmdPerform`, `CmdEntrance`, `CmdRestoreSense` — telnet shells for social consent-flow actions (#1337/#1338); `CmdAccept` (extended to check offer registry first; consent
   fall-through unchanged), `CmdDeny` — target responses. All call `create_action_request` / `respond_to_action_request` — the same service the web viewset calls.
 - **`social/grievance.py`**: `CmdGrievance` (`+grievance`, #1429) — the telnet face of the secret-victim grievance prompt; thin over `world.secrets.services.register_secret_grievance` (the same service the web `/api/secrets/grievance/` endpoint calls). A wronged character picks a `GrievanceOption` for a secret they've learned; it applies a one-sided relationship swing toward the perpetrator.

--- a/src/commands/scene.py
+++ b/src/commands/scene.py
@@ -3,6 +3,7 @@
 Thin telnet face of scene-lifecycle Actions:
     ``scene start [name]``               — StartSceneAction
     ``scene finish``                     — FinishSceneAction
+    ``scene gm <name>``                  — GrantSceneGMAction (#2113)
     ``scene round <mode> [knobs]``       — SetRoundModeAction
     ``scene succor <ally>``              — SuccorSceneAction (#1744)
     ``scene interpose <ally>``           — InterposeSceneAction (#1316)
@@ -29,6 +30,7 @@ _USAGE = (
     "Usage: scene <subcommand>\n"
     "  scene start [name]                — start a scene here\n"
     "  scene finish                      — finish the active scene\n"
+    "  scene gm <name>                   — grant GM status to a present approved GM\n"
     "  scene round [open|pose_order|strict] [quorum=<pct>] [cap=<n>] [lock=on/off]\n"
     "  scene succor <ally>               — shelter an ally from a hazard this round\n"
     "  scene interpose <ally>            — guard an ally from sudden non-combat harm this round\n"
@@ -66,6 +68,11 @@ class CmdScene(ArxCommand):
     **Finish the active scene:**
         ``scene finish``
 
+    **Grant GM status to a present approved GM:**
+        ``scene gm <name>`` (#2113) — fallback when auto-enrollment misses a table-owning
+        GM's session (pickup games, guest players, an Assistant GM); the actor must already
+        administer the scene and the target must hold a GMProfile.
+
     **Set the round mode:**
         ``scene round [open|pose_order|strict] [quorum=<pct>] [cap=<n>] [lock=on/off]``
         Example: ``scene round strict quorum=70 cap=2 lock=on``
@@ -96,6 +103,8 @@ class CmdScene(ArxCommand):
             self._handle_start(rest)
         elif first == "finish":  # noqa: STRING_LITERAL
             self._handle_finish()
+        elif first == "gm":  # noqa: STRING_LITERAL
+            self._handle_gm(rest)
         elif first == "round":  # noqa: STRING_LITERAL
             self._handle_round(rest)
         elif first == "succor":  # noqa: STRING_LITERAL
@@ -126,6 +135,18 @@ class CmdScene(ArxCommand):
         from actions.definitions.scenes import FinishSceneAction  # noqa: PLC0415
 
         result = FinishSceneAction().run(actor=self.caller)
+        if result.message:
+            self.msg(result.message)
+
+    def _handle_gm(self, rest: str) -> None:
+        """Dispatch GrantSceneGMAction, forwarding the named target."""
+        from actions.definitions.scenes import GrantSceneGMAction  # noqa: PLC0415
+
+        target_name = rest.strip()
+        if not target_name:
+            self.msg("Usage: scene gm <name>.")
+            return
+        result = GrantSceneGMAction().run(actor=self.caller, target_name=target_name)
         if result.message:
             self.msg(result.message)
 

--- a/src/commands/tests/test_scene_command.py
+++ b/src/commands/tests/test_scene_command.py
@@ -13,6 +13,7 @@ from django.test import TestCase
 from commands.scene import CmdScene
 from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.factories import GMProfileFactory
 from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 from world.scenes.constants import RoundStatus, SceneRoundMode, SceneRoundStartReason
 from world.scenes.factories import (
@@ -20,7 +21,7 @@ from world.scenes.factories import (
     SceneOwnerParticipationFactory,
     SceneRoundParticipantFactory,
 )
-from world.scenes.models import Scene, SceneRound
+from world.scenes.models import Scene, SceneParticipation, SceneRound
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -128,6 +129,72 @@ class CmdSceneFinishTests(TestCase):
         _run_cmd(non_owner, "finish")
         self.scene.refresh_from_db()
         self.assertTrue(self.scene.is_active)
+
+
+# ---------------------------------------------------------------------------
+# scene gm
+# ---------------------------------------------------------------------------
+
+
+class CmdSceneGmTests(TestCase):
+    """``scene gm <name>`` dispatches GrantSceneGMAction (#2113)."""
+
+    def setUp(self):
+        self.room = _make_room("GmRoom")
+        self.owner, self.owner_account = _create_pc_with_account("GmOwner", location=self.room)
+        self.owner.msg = MagicMock()
+        self.target, self.target_account = _create_pc_with_account("GmTarget", location=self.room)
+        self.scene = SceneFactory(location=self.room, is_active=True)
+        SceneOwnerParticipationFactory(scene=self.scene, account=self.owner_account)
+
+    def test_gm_grants_to_present_approved_gm(self):
+        """A scene owner grants GM status to a present GMProfile holder."""
+        GMProfileFactory(account=self.target_account)
+
+        messages = _run_cmd(self.owner, f"gm {self.target.db_key}")
+
+        self.assertTrue(
+            SceneParticipation.objects.filter(
+                scene=self.scene, account=self.target_account, is_gm=True
+            ).exists()
+        )
+        self.assertTrue(messages, "Expected at least one message after scene gm grant")
+
+    def test_gm_missing_name_shows_usage(self):
+        """``scene gm`` with no name shows the usage message."""
+        messages = _run_cmd(self.owner, "gm")
+        self.assertTrue(
+            any("usage: scene gm" in m.lower() for m in messages),
+            f"Expected usage message; got: {messages}",
+        )
+
+    def test_gm_denied_for_non_admin_actor(self):
+        """A present PC who doesn't administer the scene cannot grant GM status."""
+        GMProfileFactory(account=self.target_account)
+        non_admin, _acc = _create_pc_with_account("GmNonAdmin", location=self.room)
+        non_admin.msg = MagicMock()
+
+        _run_cmd(non_admin, f"gm {self.target.db_key}")
+
+        self.assertFalse(
+            SceneParticipation.objects.filter(
+                scene=self.scene, account=self.target_account, is_gm=True
+            ).exists()
+        )
+
+    def test_gm_denied_for_target_without_gm_profile(self):
+        """A present target with no GMProfile is refused."""
+        messages = _run_cmd(self.owner, f"gm {self.target.db_key}")
+
+        self.assertFalse(
+            SceneParticipation.objects.filter(
+                scene=self.scene, account=self.target_account, is_gm=True
+            ).exists()
+        )
+        self.assertTrue(
+            any("not an approved gm" in m.lower() for m in messages),
+            f"Expected a not-approved-GM message; got: {messages}",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/commands/tests/test_scene_gm_enrollment_e2e.py
+++ b/src/commands/tests/test_scene_gm_enrollment_e2e.py
@@ -1,0 +1,192 @@
+"""E2E telnet journey: auto-enrollment of a table-owning GM's scene GM flag (#2113).
+
+Before this fix, ``SceneParticipation.is_gm`` was only ever written by the crossover
+lead-GM path — an ordinary trust-tier GM running their own table's session never
+got flagged, so every GM-combat surface (``_actor_may_gm_encounter``,
+``IsEncounterGMOrStaff``, effect visibility) silently refused them. These tests
+drive the real telnet path (``scene start`` -> ``encounter begin``/``encounter add``)
+to prove the auto-enrollment now unblocks a non-staff table GM, and that a GM with
+no present table member is correctly left unflagged.
+
+SQLite-compatible.
+DbHolder trap: all Evennia ObjectDB instances live in setUp, never setUpTestData.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from actions.definitions.gm_combat import _actor_may_gm_encounter
+from commands.encounter import CmdEncounter
+from commands.scene import CmdScene
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import OpponentTier
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+    ThreatPoolFactory,
+    seed_scaling_defaults,
+)
+from world.combat.models import CombatOpponent
+from world.gm.constants import GMTableStatus
+from world.gm.factories import GMProfileFactory, GMTableFactory, GMTableMembershipFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.models import Scene, SceneParticipation
+
+
+def _create_room(label: str) -> object:
+    return ObjectDBFactory(db_key=label, db_typeclass_path="typeclasses.rooms.Room")
+
+
+def _create_pc_with_account(db_key: str, room=None):
+    """Create a PC character in *room* with a live roster tenure.
+
+    Returns (character, account, character_sheet).
+    """
+    account = AccountFactory(username=f"gme2e_{db_key.lower()}")
+    kwargs = {"db_key": db_key}
+    if room is not None:
+        kwargs["location"] = room
+    char = CharacterFactory(**kwargs)
+    sheet = CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet=sheet)
+    RosterTenureFactory(roster_entry=entry, player_data__account=account, end_date=None)
+    return char, account, sheet
+
+
+def _run_scene_cmd(caller, args: str) -> list[str]:
+    caller.msg = MagicMock()
+    cmd = CmdScene()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"scene {args}".strip()
+    cmd.func()
+    return [str(c.args[0]) for c in caller.msg.call_args_list if c.args]
+
+
+def _run_encounter_cmd(caller, args: str) -> list[str]:
+    caller.msg = MagicMock()
+    cmd = CmdEncounter()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"encounter {args}".strip()
+    cmd.func()
+    return [str(c.args[0]) for c in caller.msg.call_args_list if c.args]
+
+
+class TableOwningGMAutoEnrollmentJourneyTest(TestCase):
+    """A table-owning GM with a present table member gets is_gm=True at scene start."""
+
+    def setUp(self) -> None:
+        self.room = _create_room("TableGMRoom")
+        self.gm_actor, self.gm_account, self.gm_sheet = _create_pc_with_account(
+            "TableGM", room=self.room
+        )
+        self.player_actor, self.player_account, self.player_sheet = _create_pc_with_account(
+            "TablePlayer", room=self.room
+        )
+        self.profile = GMProfileFactory(account=self.gm_account)
+        self.table = GMTableFactory(gm=self.profile, status=GMTableStatus.ACTIVE)
+        GMTableMembershipFactory(table=self.table, persona=self.player_sheet.primary_persona)
+
+    def test_scene_start_flags_table_owning_gm(self) -> None:
+        """``scene start`` auto-flags the table-owning GM's participation."""
+        _run_scene_cmd(self.gm_actor, "start")
+
+        scene = Scene.objects.get(location=self.room, is_active=True)
+        self.assertTrue(
+            SceneParticipation.objects.filter(
+                scene=scene, account=self.gm_account, is_gm=True
+            ).exists()
+        )
+
+    def test_actor_may_gm_encounter_passes_for_enrolled_gm(self) -> None:
+        """The real permission gate combat surfaces use now passes (was the whole bug)."""
+        _run_scene_cmd(self.gm_actor, "start")
+        scene = Scene.objects.get(location=self.room, is_active=True)
+
+        encounter = CombatEncounterFactory(room=self.room, scene=scene)
+
+        self.assertTrue(_actor_may_gm_encounter(self.gm_actor, encounter))
+
+    def test_encounter_begin_and_add_succeed_via_telnet(self) -> None:
+        """``encounter begin`` and ``encounter add`` succeed for the auto-enrolled GM."""
+        _run_scene_cmd(self.gm_actor, "start")
+        scene = Scene.objects.get(location=self.room, is_active=True)
+
+        seed_scaling_defaults()
+        threat_pool = ThreatPoolFactory(name="soldiers")
+        encounter = CombatEncounterFactory(room=self.room, scene=scene)
+        # ``encounter begin`` requires at least one active opponent (mirrors
+        # test_encounter_gm_lifecycle_e2e's seeded Grunt).
+        CombatOpponentFactory(encounter=encounter, name="Grunt", tier=OpponentTier.MOOK)
+
+        from world.vitals.models import CharacterVitals
+
+        CharacterVitals.objects.get_or_create(
+            character_sheet=self.player_sheet,
+            defaults={"health": 50, "max_health": 50, "base_max_health": 50},
+        )
+        CombatParticipantFactory(encounter=encounter, character_sheet=self.player_sheet)
+
+        msgs = _run_encounter_cmd(self.gm_actor, "begin")
+        self.assertIn("round begins", " ".join(msgs).lower())
+
+        msgs = _run_encounter_cmd(
+            self.gm_actor,
+            f"add Soldier {OpponentTier.MOOK} {threat_pool.name}",
+        )
+        self.assertIn("opponent 'soldier' added", " ".join(msgs).lower())
+        self.assertTrue(CombatOpponent.objects.filter(encounter=encounter, name="Soldier").exists())
+
+
+class GMAloneInStrangersRoomTest(TestCase):
+    """A GM with an active table but no present table member is NOT flagged (#2113)."""
+
+    def setUp(self) -> None:
+        self.room = _create_room("StrangerRoom")
+        self.gm_actor, self.gm_account, self.gm_sheet = _create_pc_with_account(
+            "PassingGM", room=self.room
+        )
+        self.stranger_actor, self.stranger_account, self.stranger_sheet = _create_pc_with_account(
+            "Stranger", room=self.room
+        )
+        self.profile = GMProfileFactory(account=self.gm_account)
+        # Active table exists, but the stranger present is not a member of it.
+        GMTableFactory(gm=self.profile, status=GMTableStatus.ACTIVE)
+
+    def test_scene_start_does_not_flag_gm(self) -> None:
+        """``scene start`` leaves the GM's participation is_gm=False."""
+        _run_scene_cmd(self.gm_actor, "start")
+
+        scene = Scene.objects.get(location=self.room, is_active=True)
+        self.assertFalse(
+            SceneParticipation.objects.filter(
+                scene=scene, account=self.gm_account, is_gm=True
+            ).exists()
+        )
+
+    def test_actor_may_gm_encounter_still_refuses(self) -> None:
+        """Combat-GM permission stays refused — no member-present, no auto-grant."""
+        _run_scene_cmd(self.gm_actor, "start")
+        scene = Scene.objects.get(location=self.room, is_active=True)
+
+        encounter = CombatEncounterFactory(room=self.room, scene=scene)
+
+        self.assertFalse(_actor_may_gm_encounter(self.gm_actor, encounter))
+
+    def test_encounter_begin_refused_via_telnet(self) -> None:
+        """``encounter begin`` refuses the un-enrolled GM through the real telnet path."""
+        _run_scene_cmd(self.gm_actor, "start")
+        scene = Scene.objects.get(location=self.room, is_active=True)
+        CombatEncounterFactory(room=self.room, scene=scene)
+
+        msgs = _run_encounter_cmd(self.gm_actor, "begin")
+        self.assertTrue(
+            any("gm or staff" in m.lower() for m in msgs),
+            f"Expected a permission-refusal message; got: {msgs}",
+        )

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -7,7 +7,17 @@ the unified Persona identity system, and non-combat scene rounds.
 
 ### `models.py`
 - **`Scene`**: Primary scene entity with title, status, location, summary, privacy_mode
-- **`SceneParticipation`**: Account participation tracking in scenes
+- **`SceneParticipation`**: Account participation tracking in scenes. `is_gm` is the single
+  predicate every GM-combat surface gates on (`Scene.is_gm`, `_actor_may_gm_encounter`,
+  `IsEncounterGMOrStaff`). Two writers (#2113): `_enroll_lead_gm_on_scene`
+  (`world/stories/services/crossover.py`) for crossover Lead GMs, and
+  `scene_admin_services.enroll_present_table_gms` — auto-flags a present account that owns
+  an ACTIVE `GMTable` with an *other* present character holding an active
+  `GMTableMembership` on it; called from `StartSceneAction.execute()` on both the
+  new-scene and mid-scene-join paths. `GrantSceneGMAction` (`scene gm <name>`,
+  `actions/definitions/scenes.py`) is the fallback explicit grant for cases
+  auto-detection can't reach, gated on `actor_can_administer_scene` + target `GMProfile`.
+  See "Scene Administration" in `docs/systems/scenes.md` for the full design.
 - **`Persona`**: Unified identity model with PersonaType (PRIMARY/ESTABLISHED/TEMPORARY/ALTERNATE). FK to CharacterSheet
   (source of truth); partial unique constraint ensures one PRIMARY per sheet
 - **`PersonaDiscovery`**: Records that a character discovered two personas are the same person

--- a/src/world/scenes/scene_admin_services.py
+++ b/src/world/scenes/scene_admin_services.py
@@ -1,9 +1,10 @@
 """Scene administration permission helpers.
 
-Four public surfaces:
+Five public surfaces:
   - ``actor_can_administer_scene`` — permission gate for admin actions.
   - ``resolve_actor_account`` — controlling account for a character actor.
   - ``add_present_as_co_owners`` — co-ownership grant for all present PCs.
+  - ``enroll_present_table_gms`` — auto is_gm grant for a present table-owning GM (#2113).
   - ``finish_scene_full`` — full scene-finish orchestration (finish, rewards, fatigue, broadcast).
 """
 
@@ -75,6 +76,74 @@ def add_present_as_co_owners(scene: Scene, room: ObjectDB) -> None:
             scene=scene,
             account=account,
             defaults={"is_owner": True},
+        )
+
+
+def enroll_present_table_gms(scene: Scene, room: ObjectDB) -> None:
+    """Auto-flag ``is_gm=True`` for a present GM running their own table (#2113).
+
+    Walks ``room.contents`` once (mirrors ``add_present_as_co_owners``'s object/account
+    resolution) to build the present-accounts and present-personas sets, keyed by which
+    account controls which persona. For each present account holding a ``GMProfile``,
+    checks whether any of their ACTIVE ``GMTable`` rows has an active
+    ``GMTableMembership`` (``left_at__isnull=True``) whose persona belongs to a
+    *different* present character — bare table ownership is not enough: a GM merely
+    passing through a stranger's room must not auto-become that scene's adjudicator.
+
+    Called right after ``add_present_as_co_owners`` in ``StartSceneAction.execute`` and
+    again from the mid-scene join branch, so a table-owning GM arriving after scene
+    start still gets flagged. Idempotent (``update_or_create``); never flips ``is_gm``
+    back to False — only ever grants.
+
+    No query-in-loop concern: one combined ``GMTableMembership`` query per present-GM
+    account, bounded by room occupancy (matches ``add_present_as_co_owners``'s cost
+    profile).
+    """
+    from world.gm.constants import GMTableStatus  # noqa: PLC0415
+    from world.gm.models import GMProfile, GMTableMembership  # noqa: PLC0415
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+    accounts_present: dict[int, AccountDB] = {}
+    persona_account_ids: dict[int, int] = {}
+    for obj in room.contents:
+        try:
+            sheet = obj.sheet_data
+        except (AttributeError, ObjectDoesNotExist):
+            continue
+        account = obj.active_account
+        if account is None:
+            continue
+        accounts_present[account.id] = account
+        persona = active_persona_for_sheet(sheet)
+        persona_account_ids[persona.id] = account.id
+
+    for account_id, account in accounts_present.items():
+        try:
+            profile = account.gm_profile
+        except GMProfile.DoesNotExist:
+            continue
+
+        other_present_persona_ids = [
+            persona_id
+            for persona_id, owning_account_id in persona_account_ids.items()
+            if owning_account_id != account_id
+        ]
+        if not other_present_persona_ids:
+            continue
+
+        member_present = GMTableMembership.objects.filter(
+            table__gm=profile,
+            table__status=GMTableStatus.ACTIVE,
+            left_at__isnull=True,
+            persona_id__in=other_present_persona_ids,
+        ).exists()
+        if not member_present:
+            continue
+
+        SceneParticipation.objects.update_or_create(
+            scene=scene,
+            account=account,
+            defaults={"is_gm": True},
         )
 
 

--- a/src/world/scenes/tests/test_scene_admin_services.py
+++ b/src/world/scenes/tests/test_scene_admin_services.py
@@ -12,6 +12,8 @@ from evennia_extensions.factories import (
     ObjectDBFactory,
 )
 from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.constants import GMTableStatus
+from world.gm.factories import GMProfileFactory, GMTableFactory, GMTableMembershipFactory
 from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 from world.scenes.factories import (
     SceneFactory,
@@ -22,6 +24,7 @@ from world.scenes.models import SceneParticipation
 from world.scenes.scene_admin_services import (
     actor_can_administer_scene,
     add_present_as_co_owners,
+    enroll_present_table_gms,
     finish_scene_full,
     resolve_actor_account,
 )
@@ -41,6 +44,22 @@ def _create_pc_with_account(db_key: str, location=None):
     tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
     account = tenure.player_data.account
     return char, account
+
+
+def _create_pc_with_sheet(db_key: str, location=None):
+    """Create a PC character with a live roster tenure, returning the sheet too.
+
+    Returns (character, account, character_sheet).
+    """
+    kwargs = {"db_key": db_key}
+    if location is not None:
+        kwargs["location"] = location
+    char = CharacterFactory(**kwargs)
+    sheet = CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet=sheet)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    account = tenure.player_data.account
+    return char, account, sheet
 
 
 class ResolveActorAccountTests(TestCase):
@@ -237,3 +256,125 @@ class FinishSceneFullTests(TestCase):
         mock_broadcast.assert_not_called()
         scene.refresh_from_db()
         assert scene.date_finished == first_date_finished
+
+
+class EnrollPresentTableGMsTests(TestCase):
+    """Auto-``is_gm`` grant for a present table-owning GM (#2113)."""
+
+    def _make_room(self, label: str):
+        return ObjectDBFactory(db_key=label, db_typeclass_path="typeclasses.rooms.Room")
+
+    def test_flags_gm_with_present_table_member(self):
+        """A GM with an ACTIVE table and a present member is flagged is_gm=True."""
+        room = self._make_room("GmRoom1")
+        _gm_char, gm_account, _gm_sheet = _create_pc_with_sheet("GM1", location=room)
+        _player_char, _player_account, player_sheet = _create_pc_with_sheet(
+            "Player1", location=room
+        )
+        profile = GMProfileFactory(account=gm_account)
+        table = GMTableFactory(gm=profile, status=GMTableStatus.ACTIVE)
+        GMTableMembershipFactory(table=table, persona=player_sheet.primary_persona)
+        scene = SceneFactory()
+
+        enroll_present_table_gms(scene, room)
+
+        assert SceneParticipation.objects.filter(
+            scene=scene, account=gm_account, is_gm=True
+        ).exists()
+
+    def test_does_not_flag_gm_with_stranger_present(self):
+        """A GM with an ACTIVE table but no present member is left is_gm=False."""
+        room = self._make_room("GmRoom2")
+        _gm_char, gm_account, _gm_sheet = _create_pc_with_sheet("GM2", location=room)
+        _stranger_char, _stranger_account, _stranger_sheet = _create_pc_with_sheet(
+            "Stranger2", location=room
+        )
+        profile = GMProfileFactory(account=gm_account)
+        GMTableFactory(gm=profile, status=GMTableStatus.ACTIVE)
+        scene = SceneFactory()
+
+        enroll_present_table_gms(scene, room)
+
+        assert not SceneParticipation.objects.filter(scene=scene, account=gm_account).exists()
+
+    def test_does_not_flag_gm_alone_in_room(self):
+        """A GM alone in the room (no other present PC at all) is not flagged."""
+        room = self._make_room("GmRoom3")
+        _gm_char, gm_account, _gm_sheet = _create_pc_with_sheet("GM3", location=room)
+        profile = GMProfileFactory(account=gm_account)
+        GMTableFactory(gm=profile, status=GMTableStatus.ACTIVE)
+        scene = SceneFactory()
+
+        enroll_present_table_gms(scene, room)
+
+        assert not SceneParticipation.objects.filter(scene=scene, account=gm_account).exists()
+
+    def test_archived_table_does_not_flag(self):
+        """An ARCHIVED table (even with a present member) does not grant is_gm."""
+        room = self._make_room("GmRoom4")
+        _gm_char, gm_account, _gm_sheet = _create_pc_with_sheet("GM4", location=room)
+        _player_char, _player_account, player_sheet = _create_pc_with_sheet(
+            "Player4", location=room
+        )
+        profile = GMProfileFactory(account=gm_account)
+        table = GMTableFactory(gm=profile, status=GMTableStatus.ARCHIVED)
+        GMTableMembershipFactory(table=table, persona=player_sheet.primary_persona)
+        scene = SceneFactory()
+
+        enroll_present_table_gms(scene, room)
+
+        assert not SceneParticipation.objects.filter(scene=scene, account=gm_account).exists()
+
+    def test_left_membership_does_not_flag(self):
+        """A soft-left membership (left_at set) does not count as present."""
+        from django.utils import timezone
+
+        room = self._make_room("GmRoom5")
+        _gm_char, gm_account, _gm_sheet = _create_pc_with_sheet("GM5", location=room)
+        _player_char, _player_account, player_sheet = _create_pc_with_sheet(
+            "Player5", location=room
+        )
+        profile = GMProfileFactory(account=gm_account)
+        table = GMTableFactory(gm=profile, status=GMTableStatus.ACTIVE)
+        GMTableMembershipFactory(
+            table=table,
+            persona=player_sheet.primary_persona,
+            left_at=timezone.now(),
+        )
+        scene = SceneFactory()
+
+        enroll_present_table_gms(scene, room)
+
+        assert not SceneParticipation.objects.filter(scene=scene, account=gm_account).exists()
+
+    def test_non_gm_accounts_untouched(self):
+        """Present accounts without a GMProfile never get is_gm."""
+        room = self._make_room("GmRoom6")
+        _char_a, account_a = _create_pc_with_account("Alice6", location=room)
+        _char_b, account_b = _create_pc_with_account("Bob6", location=room)
+        scene = SceneFactory()
+
+        enroll_present_table_gms(scene, room)
+
+        assert not SceneParticipation.objects.filter(
+            scene=scene, account__in=[account_a, account_b]
+        ).exists()
+
+    def test_does_not_downgrade_existing_owner_flag(self):
+        """Gaining is_gm never clears a pre-existing is_owner=True on the same row."""
+        room = self._make_room("GmRoom7")
+        _gm_char, gm_account, _gm_sheet = _create_pc_with_sheet("GM7", location=room)
+        _player_char, _player_account, player_sheet = _create_pc_with_sheet(
+            "Player7", location=room
+        )
+        profile = GMProfileFactory(account=gm_account)
+        table = GMTableFactory(gm=profile, status=GMTableStatus.ACTIVE)
+        GMTableMembershipFactory(table=table, persona=player_sheet.primary_persona)
+        scene = SceneFactory()
+        SceneOwnerParticipationFactory(scene=scene, account=gm_account)
+
+        enroll_present_table_gms(scene, room)
+
+        participation = SceneParticipation.objects.get(scene=scene, account=gm_account)
+        assert participation.is_owner is True
+        assert participation.is_gm is True


### PR DESCRIPTION
Closes #2113

## Summary

Fixes the structural bug where SceneParticipation.is_gm was only ever set by the crossover path, locking every non-staff GM out of combat encounters, checks, and NPC improvisation on both surfaces. New enroll_present_table_gms auto-flags a present account owning an ACTIVE GMTable when another present character is an active member of that table (wired into StartSceneAction on start and mid-scene join); new scene gm <name> grant verb (GrantSceneGMAction, actor must administer the scene, target must hold a GMProfile) covers pickup games/guests/AGMs, with a matching web control. Crossover enrollment and staff bypasses untouched (regression-tested). E2E: telnet scene start -> encounter begin/add now succeed for a trust-tier GM.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2113 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: rebased onto origin/main, no conflicts

<!-- last-addressed-comment: 0 -->