### PR TITLE
GM tools still gate on Evennia perm(Admin), not the GMLevel trust ladder: setstage, setsituation, grant_item, pemit

### DIFF
--- a/docs/roadmap/gm-system.md
+++ b/docs/roadmap/gm-system.md
@@ -81,6 +81,24 @@ The GM system defines these role relationships; the stories app uses them for pe
   GM's level (staff bypass unchanged); `combat.StakesLevelRequirement.minimum_gm_level`
   gates a stakes-level requirement against `gm_account.gm_profile.level`
   (no profile → STARTING).
+- **Table-running tools ✅ (#2117)** — `setstage`/`setsituation`/`pemit`/`grant_item` used to gate
+  on the orthogonal Evennia staff bit, leaving a trust-tier GM with no staff flag unable to stage
+  positions, spawn a situation, narrate privately, or hand out story loot. All four now route
+  through `MinimumGMLevelPrerequisite(minimum_level)` (`actions/prerequisites.py`) — a reusable
+  Prerequisite generalizing `validate_stakes_requirement`'s staff-bypass + `gm_level_index`
+  compare, with a missing `GMProfile` always failing (unlike the stakes-requirement's
+  no-profile-treated-as-STARTING compromise, since these tools must also exclude non-GM accounts
+  outright). Tiered by risk: `SetTheStageAction`/`PemitAction` at STARTING (cosmetic/reversible),
+  `SetSituationAction`/`GrantItemAction` at JUNIOR (mints live `Challenge` rows / permanent
+  `ItemInstance` grants). `GrantItemAction` (`actions/definitions/items.py`) is new — `grant_item`
+  had no Action at all before this (`action = None`, business logic inline in the command,
+  violating the thin-command invariant). Each telnet command's Evennia lock also loosened from
+  `perm(Admin)`/`perm(Builder)` to `cmd:all()` (mirrors `commands/encounter.py`) since real
+  authorization now lives entirely in the Action's prerequisite. Deliberately NOT scoped to "the
+  scene the GM is running" (`Scene.is_gm`, #2113) — `setstage`/`setsituation` are legitimately used
+  before a scene exists (staging a room ahead of players arriving); scoping `grant_item`/
+  `setsituation` to the caller's own running scene is a fast-follow once #2113 ships, not a
+  blocker.
 - Frontend (evidence panel + promote action on a staff GM-review page) is a
   deliberate scope note, not a silent skip — it rides the GM dashboard work (#2004).
 

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -664,8 +664,8 @@ effects for graph mutation and flight).
 - **Actions:** `MoveToPositionAction` (`registry_key="move_to_position"`), `TakePositionAction`
   (`registry_key="take_position"` — voluntary PRIMARY/FEATURE entry for an UNPLACED actor,
   #2005), `GMPlaceInPositionAction` (`registry_key="gm_place_in_position"` — staff/scene-GM
-  unchecked placement, #2005) + staff-only `SetTheStageAction`
-  (`registry_key="set_the_stage"`, `StaffOnlyPrerequisite`)
+  unchecked placement, #2005) + `SetTheStageAction` (`registry_key="set_the_stage"`, gated on
+  `MinimumGMLevelPrerequisite(GMLevel.STARTING)`, staff bypass preserved, #2117)
 - **Telnet:** `CmdPosition` (`position` / `position <name>`, #2005) — list/take/move face over
   `TakePositionAction`/`MoveToPositionAction`, room-scoped name resolution; see
   [areas.md](areas.md) "Telnet" section
@@ -2481,10 +2481,11 @@ crafting framework and check-driven facet/style attachment.
     - `grant_touchstone_item_to_character(*, character_sheet, template, granted_by=None)
       -> ItemInstance` — creates one `ItemInstance` of `template`, held by
       `character_sheet`. `granted_by` is audit-only, never surfaced to the recipient
-      (mirrors `award_kudos`). Called by `CmdGrantItem` (staff telnet, `perm(Admin)`,
-      `grant_item <character>=<item template name>`, `src/commands/grant_item.py`) and by
-      the Mission `DeedRewardSink.ITEM` reward sink (`world.missions.services.rewards
-      ._route_line`, `IMMEDIATE`-dispatched, not queued)
+      (mirrors `award_kudos`). Called by `GrantItemAction` (`registry_key="grant_item"`,
+      gated on `MinimumGMLevelPrerequisite(GMLevel.JUNIOR)`, staff bypass preserved, #2117)
+      via telnet `CmdGrantItem` (`grant_item <character>=<item template name>`,
+      `src/commands/grant_item.py`) and by the Mission `DeedRewardSink.ITEM` reward sink
+      (`world.missions.services.rewards._route_line`, `IMMEDIATE`-dispatched, not queued)
 - **Predicates on `ItemInstance`:**
   - `differs_from_template` — True if instance has any per-instance data (custom name/desc,
     lore_value, quality_tier, facets, or non-CREATED provenance); gates soft- vs. hard-delete
@@ -3307,9 +3308,9 @@ Self-contained game actions that own prerequisites, execution, and events.
 - **Key Classes:** `Action` (base dataclass), `Prerequisite`, `ActionResult`, `ActionAvailability`
 - **Registry:** `get_action(key)`, `get_actions_for_target_type(target_type)`, `ACTIONS_BY_KEY`
 - **Target Types:** `SELF`, `SINGLE`, `AREA`, `FILTERED_GROUP`
-- **Concrete Actions:** `LookAction`, `InventoryAction`, `SayAction`, `PoseAction`, `WhisperAction`, `GetAction`, `DropAction`, `GiveAction`, `TraverseExitAction`, `HomeAction`, `EquipAction`, `UnequipAction`, `PutInAction`, `TakeOutAction`, `UseItemAction`, `ActivatePermitAction`, `MoveToPositionAction`, `SetTheStageAction`, `PerformRitualAction` (ritual dispatch — SERVICE/FLOW runs immediately; CEREMONY creates `PendingRitualEffect`), `WeaveThreadAction` (CEREMONY finisher — consumes pending Rite of Weaving effect, calls `weave_thread`), `ImbueThreadAction` (CEREMONY finisher — consumes pending Rite of Imbuing effect, calls `spend_resonance_for_imbuing`), `RestAction` (fatigue rest — spend AP to gain `well_rested`; gated by own home + outside combat, #1491/#1524), `CreateFirstImpressionAction` / `CreateDevelopmentAction` / `CreateCapstoneAction` / `RedistributePointsAction` (relationship-building verbs — record first impressions, develop permanent points, mark capstones, redistribute between tracks; shared by telnet `CmdRelationship` and web `RelationshipUpdateViewSet`, #1485), `GiveWriteupKudosAction` / `FileWriteupComplaintAction` (writeup feedback — subject commends a writeup; any viewer files a bad-faith complaint for staff triage; shared by `CmdRelationship` and `RelationshipUpdateViewSet`, #1537)
+- **Concrete Actions:** `LookAction`, `InventoryAction`, `SayAction`, `PoseAction`, `WhisperAction`, `GetAction`, `DropAction`, `GiveAction`, `TraverseExitAction`, `HomeAction`, `EquipAction`, `UnequipAction`, `PutInAction`, `TakeOutAction`, `UseItemAction`, `ActivatePermitAction`, `GrantItemAction` (JUNIOR-tier GM narrative item grant, #707/#2117), `MoveToPositionAction`, `SetTheStageAction`, `PerformRitualAction` (ritual dispatch — SERVICE/FLOW runs immediately; CEREMONY creates `PendingRitualEffect`), `WeaveThreadAction` (CEREMONY finisher — consumes pending Rite of Weaving effect, calls `weave_thread`), `ImbueThreadAction` (CEREMONY finisher — consumes pending Rite of Imbuing effect, calls `spend_resonance_for_imbuing`), `RestAction` (fatigue rest — spend AP to gain `well_rested`; gated by own home + outside combat, #1491/#1524), `CreateFirstImpressionAction` / `CreateDevelopmentAction` / `CreateCapstoneAction` / `RedistributePointsAction` (relationship-building verbs — record first impressions, develop permanent points, mark capstones, redistribute between tracks; shared by telnet `CmdRelationship` and web `RelationshipUpdateViewSet`, #1485), `GiveWriteupKudosAction` / `FileWriteupComplaintAction` (writeup feedback — subject commends a writeup; any viewer files a bad-faith complaint for staff triage; shared by `CmdRelationship` and `RelationshipUpdateViewSet`, #1537)
 - **Pattern:** `action.run(actor, **kwargs)` → applies enhancements → **enforces prerequisites (hard gate)** → charges AP/fatigue → executes → returns `ActionResult`
-- **Prerequisites:** `get_prerequisites()` is load-bearing; `run()` calls `check_availability()` against post-enhancement kwargs. Prerequisites read action-specific kwargs via `context["kwargs"]`. Shipped: `StaffOnlyPrerequisite`, `HoldsItemPrerequisite`, `ItemUsablePrerequisite`, `OnUseTargetPrerequisite`.
+- **Prerequisites:** `get_prerequisites()` is load-bearing; `run()` calls `check_availability()` against post-enhancement kwargs. Prerequisites read action-specific kwargs via `context["kwargs"]`. Shipped: `StaffOnlyPrerequisite`, `MinimumGMLevelPrerequisite` (#2117 — staff bypass + `GMProfile.level` >= a configured `GMLevel` tier, generalizing `world.combat.scaling.validate_stakes_requirement`'s pattern; gates `SetTheStageAction`/`PemitAction` at STARTING and `SetSituationAction`/`GrantItemAction` at JUNIOR), `HoldsItemPrerequisite`, `ItemUsablePrerequisite`, `OnUseTargetPrerequisite`.
 - **Integrates with:** service functions (direct calls), commands (telnet compatibility), flows (future: complex triggers)
 - **Not Yet Built:** `SyntheticAction` model, event emission, `CharacterCapabilities` facade, on-demand availability endpoint
 - **Telnet convergence convention (ratified #1337):** the three player-action dispatch

--- a/docs/systems/areas.md
+++ b/docs/systems/areas.md
@@ -214,9 +214,9 @@ AERIAL_PROPERTY_NAME = "aerial"  # ObjectProperty tag set on airborne objects
 | `MoveToPositionAction` | `move_to_position` | none | Dispatched with `ActionRef(registry_key="move_to_position", position_id=<pk>)`; surfaced via `get_player_actions` |
 | `TakePositionAction` | `take_position` | none | Voluntary entry for an UNPLACED actor; dispatched with `ActionRef(registry_key="take_position", position_id=<pk>)`; surfaced via `get_player_actions` for PRIMARY/FEATURE positions only (#2005) |
 | `GMPlaceInPositionAction` | `gm_place_in_position` | none (gate is in-body, not a `Prerequisite`) | Staff OR active-scene GM (mirrors `_actor_may_gm_battle`; no active scene means staff-only) — wraps the unchecked `place_in_position`. `ActionRef(registry_key="gm_place_in_position", position_id=<pk>, target_object_id=<ObjectDB pk co-located with actor>)` (#2005) |
-| `SetTheStageAction` | `set_the_stage` | `StaffOnlyPrerequisite` | Dispatched with `ActionRef(registry_key="set_the_stage", blueprint_id=<pk>, replace=False)`; surfaced via `get_player_actions` when the room's `RoomProfile.default_blueprint` is set. `ActionRef` carries a `blueprint_id` field for this. |
+| `SetTheStageAction` | `set_the_stage` | `MinimumGMLevelPrerequisite(GMLevel.STARTING)` (staff bypass preserved, #2117) | Dispatched with `ActionRef(registry_key="set_the_stage", blueprint_id=<pk>, replace=False)`; surfaced via `get_player_actions` when the room's `RoomProfile.default_blueprint` is set. `ActionRef` carries a `blueprint_id` field for this. |
 
-The `_set_the_stage_actions(character)` helper in `src/actions/player_interface.py` surfaces one quick-action using the room's `default_blueprint` for staff.
+The `_set_the_stage_actions(character)` helper in `src/actions/player_interface.py` surfaces one quick-action using the room's `default_blueprint` for any actor who passes `MinimumGMLevelPrerequisite(GMLevel.STARTING)` (STARTING-tier GM trust or higher, staff bypass preserved, #2117) — the same gate `SetTheStageAction` itself enforces, so a caller who can see the quick action can always execute it.
 
 ### Telnet [BUILT & WIRED]
 

--- a/docs/systems/items.md
+++ b/docs/systems/items.md
@@ -313,12 +313,14 @@ There is no `Shop`/`Vendor`/`Merchant` model or purchase service anywhere in thi
 codebase. Touchstones and reagents (and any other story-earned item) are acquired
 narratively, through two channels:
 
-- **GM staff grant** — `grant_touchstone_item_to_character(*, character_sheet, template,
+- **GM grant** — `grant_touchstone_item_to_character(*, character_sheet, template,
   granted_by=None)` (`world.items.services.narrative_grants`) creates one `ItemInstance`
   of a given `ItemTemplate`, held by the recipient's `CharacterSheet`. `granted_by` is
   audit-only (not surfaced to the recipient, mirroring `award_kudos`'s
-  don't-leak-the-staff-hand precedent). Staff-facing telnet command: `CmdGrantItem`
-  (`grant_item <character>=<item template name>`, `perm(Admin)`,
+  don't-leak-the-staff-hand precedent). Reached through `GrantItemAction`
+  (`actions/definitions/items.py`, registry key `grant_item`, gated on
+  `MinimumGMLevelPrerequisite(GMLevel.JUNIOR)`, staff bypass preserved, #2117)
+  via telnet `CmdGrantItem` (`grant_item <character>=<item template name>`,
   `src/commands/grant_item.py`).
 - **Mission reward** — `DeedRewardSink.ITEM` (`world.missions.constants`) on a
   `MissionDeedRewardLine` dispatches `IMMEDIATE` (not queued/cron): `_route_line`

--- a/docs/systems/mechanics.md
+++ b/docs/systems/mechanics.md
@@ -83,8 +83,10 @@ Traps, instantiated at a location by a staff-triggered Action.
     `instantiate_challenge()`). All wrapped in one `transaction.atomic()` block.
 - **Trigger:** `SetSituationAction` (`actions/definitions/situations.py`) +
   `CmdSetSituation` (`commands/setsituation.py`, telnet key `setsituation`) —
-  staff-only, in-scene verb mirroring `SetTheStageAction`/`CmdSetStage`. No
-  duplicate-instantiation guard (intentional — see ADR-0091).
+  gated on `MinimumGMLevelPrerequisite(GMLevel.JUNIOR)` (staff bypass
+  preserved, #2117), in-scene verb mirroring `SetTheStageAction`/`CmdSetStage`
+  (STARTING tier). No duplicate-instantiation guard (intentional — see
+  ADR-0091).
 - **Admin:** `SituationTemplateAdmin` has `SituationChallengeLinkInline` and
   `SituationTrapLinkInline` for authoring.
 - **Integrates with:** room_features (`Trap` model, `check_room_traps_on_entry`),

--- a/src/actions/definitions/communication.py
+++ b/src/actions/definitions/communication.py
@@ -9,10 +9,11 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from actions.base import Action
 from actions.constants import ActionCategory, TargetKind
-from actions.prerequisites import Prerequisite, StaffOnlyPrerequisite
+from actions.prerequisites import MinimumGMLevelPrerequisite, Prerequisite
 from actions.types import ActionContext, ActionResult, TargetFilters, TargetType
 from flows.scene_data_manager import SceneDataManager
 from flows.service_functions.communication import message_location, send_message
+from world.gm.constants import GMLevel
 from world.scenes.constants import InteractionMode
 from world.scenes.interaction_services import record_interaction, record_whisper_interaction
 
@@ -308,7 +309,7 @@ class MutterAction(Action):
 
 @dataclass
 class PemitAction(Action):
-    """Staff-only private narrative emit to an explicit receiver list (#906).
+    """STARTING-tier GM private narrative emit to an explicit receiver list (#906).
 
     The Arx 1 "pemit": GM narration delivered only to the listed characters.
     Rides the receiver-scoped EMIT path — the persisted interaction carries
@@ -316,6 +317,10 @@ class PemitAction(Action):
     scene log never shows more than the room heard). Works inside scenes
     (record_interaction resolves the active scene from the room) and at
     room level outside scenes (persists scene-less), per the #906 ruling.
+
+    Gated on ``MinimumGMLevelPrerequisite(GMLevel.STARTING)`` (#2117; staff
+    bypass preserved) -- pure private narration, no state change beyond a
+    receiver-scoped Interaction row, same risk class as staging.
     """
 
     key: str = "pemit"
@@ -329,7 +334,7 @@ class PemitAction(Action):
     result_event: str | None = "pemit"
 
     def get_prerequisites(self) -> list[Prerequisite]:
-        return [StaffOnlyPrerequisite()]
+        return [MinimumGMLevelPrerequisite(GMLevel.STARTING)]
 
     def execute(
         self,

--- a/src/actions/definitions/items.py
+++ b/src/actions/definitions/items.py
@@ -14,6 +14,7 @@ from actions.prerequisites import (
     CanStealPrerequisite,
     HoldsItemPrerequisite,
     ItemUsablePrerequisite,
+    MinimumGMLevelPrerequisite,
     OnUseTargetPrerequisite,
     Prerequisite,
 )
@@ -29,6 +30,7 @@ from flows.service_functions.inventory import (
     take_out,
     unequip,
 )
+from world.gm.constants import GMLevel
 from world.items.constants import ContainerAccessPolicy
 from world.items.exceptions import InventoryError, ItemError
 from world.items.services.usage import use_item
@@ -516,3 +518,79 @@ class UseItemAction(Action):
                 "applied_effect_count": len(result.applied_effects),
             },
         )
+
+
+@dataclass
+class GrantItemAction(Action):
+    """JUNIOR-tier GM action: grant an ItemTemplate to a target character (#707, #2117).
+
+    Ad-hoc narrative item grant -- for story-earned moments where a GM
+    hand-awards a specific touchstone or reagent. No shop/merchant system
+    exists in this codebase; this action IS the acquisition channel. Wraps
+    ``world.items.services.narrative_grants.grant_touchstone_item_to_character``
+    (the same service the Mission ITEM reward sink calls).
+
+    Dispatch convention
+    -------------------
+    REGISTRY ActionRef: ``registry_key="grant_item"``, ``target_name=<str>``,
+    ``template_name=<str>``. Resolution (target search + template lookup)
+    happens in ``execute()``, mirroring the pre-#2117 ``CmdGrantItem._run``
+    lookups exactly (including the global-search breadth, unchanged by this
+    fix -- see the #2117 spec's deferred-follow-up note).
+
+    Gated on ``MinimumGMLevelPrerequisite(GMLevel.JUNIOR)`` (staff bypass
+    preserved) -- creates a permanent ItemInstance with no shop/economy
+    backstop to reverse it, the same "proven, not just approved" bar as
+    ``SetSituationAction``.
+    """
+
+    key: str = "grant_item"
+    name: str = "Grant Item"
+    icon: str = "gift"
+    category: str = "gm"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SELF
+
+    def get_prerequisites(self) -> list[Prerequisite]:
+        return [MinimumGMLevelPrerequisite(GMLevel.JUNIOR)]
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.items.models import ItemTemplate  # noqa: PLC0415
+        from world.items.services.narrative_grants import (  # noqa: PLC0415
+            grant_touchstone_item_to_character,
+        )
+
+        target_name = (kwargs.get("target_name") or "").strip()
+        template_name = (kwargs.get("template_name") or "").strip()
+        if not target_name or not template_name:
+            return ActionResult(
+                success=False,
+                message="Usage: grant_item <character>=<item template name>",
+            )
+
+        target = actor.search(target_name, global_search=True)
+        if target is None:
+            # search() already messaged the actor with a not-found/ambiguous notice.
+            return ActionResult(success=False)
+
+        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        if sheet is None:
+            return ActionResult(success=False, message="That is not a character.")
+
+        template = ItemTemplate.objects.filter(name__iexact=template_name).first()
+        if template is None:
+            return ActionResult(
+                success=False,
+                message=f"No item template found named '{template_name}'.",
+            )
+
+        granted_by = getattr(actor, "account", None)  # noqa: GETATTR_LITERAL
+        grant_touchstone_item_to_character(
+            character_sheet=sheet, template=template, granted_by=granted_by
+        )
+        return ActionResult(success=True, message=f"Granted '{template.name}' to {target.key}.")

--- a/src/actions/definitions/positioning.py
+++ b/src/actions/definitions/positioning.py
@@ -9,7 +9,7 @@ from evennia.objects.models import ObjectDB
 
 from actions.base import Action
 from actions.constants import ActionCategory
-from actions.prerequisites import StaffOnlyPrerequisite
+from actions.prerequisites import MinimumGMLevelPrerequisite
 from actions.types import ActionContext, ActionResult, TargetType
 from commands.utils.gm_resolution import resolve_account_or_none
 from flows.scene_data_manager import SceneDataManager
@@ -22,6 +22,7 @@ from world.areas.positioning.services import (
     place_in_position,
     take_position,
 )
+from world.gm.constants import GMLevel
 
 
 @dataclass
@@ -248,7 +249,7 @@ class GMPlaceInPositionAction(Action):
 
 @dataclass
 class SetTheStageAction(Action):
-    """Staff-only action: instantiate a PositionBlueprint into the actor's current room.
+    """STARTING-tier GM action: instantiate a PositionBlueprint into the actor's current room.
 
     Dispatch convention
     -------------------
@@ -258,6 +259,10 @@ class SetTheStageAction(Action):
     The dispatch layer passes ``ref.blueprint_id`` as a kwarg; this action
     resolves it to a ``PositionBlueprint`` instance and delegates to
     ``services.instantiate_blueprint``.
+
+    Gated on ``MinimumGMLevelPrerequisite(GMLevel.STARTING)`` (#2117; staff
+    bypass preserved) rather than staff alone -- a position blueprint carries
+    no mechanical consequence, so any approved GM may stage one.
     """
 
     key: str = "set_the_stage"
@@ -268,7 +273,7 @@ class SetTheStageAction(Action):
     target_type: TargetType = TargetType.SELF
 
     def get_prerequisites(self) -> list:
-        return [StaffOnlyPrerequisite()]
+        return [MinimumGMLevelPrerequisite(GMLevel.STARTING)]
 
     def execute(
         self,

--- a/src/actions/definitions/situations.py
+++ b/src/actions/definitions/situations.py
@@ -1,4 +1,4 @@
-"""Staff-only Action: instantiate a SituationTemplate into the actor's room (#1895)."""
+"""JUNIOR-GM-tier Action: instantiate a SituationTemplate into the actor's room (#1895)."""
 
 from __future__ import annotations
 
@@ -10,20 +10,25 @@ from evennia.objects.models import ObjectDB
 
 from actions.base import Action
 from actions.constants import ActionCategory
-from actions.prerequisites import StaffOnlyPrerequisite
+from actions.prerequisites import MinimumGMLevelPrerequisite
 from actions.types import ActionContext, ActionResult, TargetType
+from world.gm.constants import GMLevel
 from world.mechanics.models import SituationTemplate
 from world.mechanics.situation_services import instantiate_situation
 
 
 @dataclass
 class SetSituationAction(Action):
-    """Staff-only action: instantiate a SituationTemplate into the actor's current room.
+    """JUNIOR-tier GM action: instantiate a SituationTemplate into the actor's current room.
 
     Dispatch convention
     -------------------
     REGISTRY ActionRef: ``registry_key="set_situation"``,
     ``situation_template_id=<SituationTemplate.pk>``.
+
+    Gated on ``MinimumGMLevelPrerequisite(GMLevel.JUNIOR)`` (#2117; staff
+    bypass preserved) -- this mints live ``Challenge``/``ChallengeInstance``
+    rows (ADR-0091), one tier above bare approval.
     """
 
     key: str = "set_situation"
@@ -34,7 +39,7 @@ class SetSituationAction(Action):
     target_type: TargetType = TargetType.SELF
 
     def get_prerequisites(self) -> list:
-        return [StaffOnlyPrerequisite()]
+        return [MinimumGMLevelPrerequisite(GMLevel.JUNIOR)]
 
     def execute(
         self,

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -998,21 +998,26 @@ def _positioning_actions(character: ObjectDB) -> list[PlayerAction]:
 
 
 def _set_the_stage_actions(character: ObjectDB) -> list[PlayerAction]:
-    """Surface a ``set_the_stage`` ``PlayerAction`` for staff when the room has a default blueprint.
+    """Surface a ``set_the_stage`` ``PlayerAction`` when the room has a default blueprint.
 
     Only emits an action when ALL of the following are true:
-    - The actor passes ``is_staff_observer`` (avoids the model query for non-staff).
+    - The actor passes ``MinimumGMLevelPrerequisite(GMLevel.STARTING)`` -- STARTING-tier
+      GM trust or higher, staff bypass preserved (#2117; mirrors the gate
+      ``SetTheStageAction.get_prerequisites()`` itself enforces, so a caller who can see
+      this quick action can always execute it).
     - The actor has a current location.
     - The location has a ``RoomProfile`` with ``default_blueprint`` set.
 
     A single ``PlayerAction`` is offered using the room's ``default_blueprint``.
-    Staff who want to apply a different blueprint can pass an arbitrary
+    A GM who wants to apply a different blueprint can pass an arbitrary
     ``blueprint_id`` in the kwargs via the API; this surface only provides the
     one-click default-blueprint quick action.
     """
-    from core_management.permissions import is_staff_observer  # noqa: PLC0415
+    from actions.prerequisites import MinimumGMLevelPrerequisite  # noqa: PLC0415
+    from world.gm.constants import GMLevel  # noqa: PLC0415
 
-    if not is_staff_observer(character):
+    available, _reason = MinimumGMLevelPrerequisite(GMLevel.STARTING).is_met(character)
+    if not available:
         return []
 
     location = character.location

--- a/src/actions/prerequisites.py
+++ b/src/actions/prerequisites.py
@@ -112,6 +112,55 @@ class StaffOnlyPrerequisite(Prerequisite):
 
 
 @dataclass
+class MinimumGMLevelPrerequisite(Prerequisite):
+    """Actor must hold at least ``minimum_level`` GM trust, with a staff bypass (#2117).
+
+    Generalizes the staff-bypass + ``gm_level_index`` compare proven in
+    ``world.combat.scaling.validate_stakes_requirement`` into a reusable
+    Prerequisite for table-running GM tools (setstage/setsituation/pemit/grant_item).
+
+    A missing ``GMProfile`` always fails -- even against a ``STARTING``
+    requirement -- since ``STARTING`` still means "approved GM," not "any
+    account." This deliberately differs from ``validate_stakes_requirement``,
+    which treats a missing profile as ``STARTING`` (that function only ever
+    runs against an account already GMing a live encounter; this Prerequisite
+    also has to exclude accounts with no GM standing at all).
+    """
+
+    minimum_level: str
+
+    def is_met(
+        self,
+        actor: ObjectDB,
+        target: ObjectDB | None = None,
+        context: dict | None = None,
+    ) -> tuple[bool, str]:
+        from core_management.permissions import is_staff_observer  # noqa: PLC0415
+        from world.gm.constants import GMLevel, gm_level_index  # noqa: PLC0415
+        from world.gm.models import GMProfile  # noqa: PLC0415
+
+        if is_staff_observer(actor):
+            return True, ""
+
+        try:
+            account = actor.active_account
+        except AttributeError:
+            account = None
+        if account is None:
+            return False, "GM trust required."
+
+        try:
+            level = account.gm_profile.level
+        except GMProfile.DoesNotExist:
+            return False, "GM trust required."
+
+        if gm_level_index(level) < gm_level_index(self.minimum_level):
+            required_display = GMLevel(self.minimum_level).label
+            return False, f"Requires {required_display} or higher."
+        return True, ""
+
+
+@dataclass
 class IsRoomTenantPrerequisite(Prerequisite):
     """The actor's active persona must actively tenant the room they're standing in (#670)."""
 

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -124,6 +124,7 @@ from actions.definitions.investigation import SearchAction
 from actions.definitions.items import (
     ActivatePermitAction,
     EquipAction,
+    GrantItemAction,
     PutInAction,
     SetContainerPolicyAction,
     StealAction,
@@ -349,6 +350,7 @@ _ALL_ACTIONS: list[Action] = [
     GiveCoinsAction(),
     ActivatePermitAction(),
     UseItemAction(),
+    GrantItemAction(),
     # #1866 — crafting telnet coverage.
     AttachFacetAction(),
     DetachFacetAction(),

--- a/src/actions/tests/test_actions.py
+++ b/src/actions/tests/test_actions.py
@@ -15,13 +15,15 @@ from world.conditions.factories import (
     ConditionTemplateFactory,
 )
 from world.conditions.services import register_detection
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory
 from world.items.constants import BodyRegion, EquipmentLayer, OwnershipEventType
 from world.items.factories import ItemInstanceFactory
 from world.items.models import EquippedItem, OwnershipEvent
 from world.mechanics.constants import ChallengeType
 from world.mechanics.factories import ChallengeTemplateFactory
 from world.mechanics.models import ChallengeInstance
-from world.roster.factories import RosterEntryFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 
 
 class LookActionTests(TestCase):
@@ -225,7 +227,7 @@ class WhisperActionTests(TestCase):
 
 
 class PemitActionTests(TestCase):
-    """Staff-only private narrative emit (#906)."""
+    """GM private narrative emit, gated on STARTING-tier GM trust or staff (#906/#2117)."""
 
     def _staff_actor(self, room):
         account = AccountFactory(username="pemit_staff", is_staff=True)
@@ -236,6 +238,19 @@ class PemitActionTests(TestCase):
         )
         actor.db_account = account
         actor.save()
+        return actor
+
+    def _gm_actor(self, room, level, *, db_key="TrustGM"):
+        """Return a Character with a live roster tenure + GMProfile at ``level``."""
+        actor = ObjectDBFactory(
+            db_key=db_key,
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        CharacterSheetFactory(character=actor)
+        entry = RosterEntryFactory(character_sheet__character=actor)
+        tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+        GMProfileFactory(account=tenure.player_data.account, level=level)
         return actor
 
     def test_pemit_delivers_to_receivers_only(self):
@@ -264,7 +279,7 @@ class PemitActionTests(TestCase):
         recv_msg.assert_called_once()
         bystander_msg.assert_not_called()
 
-    def test_pemit_rejects_non_staff(self):
+    def test_pemit_rejects_non_staff_non_gm(self):
         from actions.definitions.communication import PemitAction
 
         room = ObjectDBFactory(db_key="Room", db_typeclass_path="typeclasses.rooms.Room")
@@ -284,9 +299,9 @@ class PemitActionTests(TestCase):
         action = PemitAction()
         result = action.run(actor, receivers=[receiver], text="sneaky")
         assert result.success is False
-        assert "Staff only" in result.message
+        assert "GM trust required." in result.message
 
-    def test_pemit_availability_requires_staff(self):
+    def test_pemit_availability_requires_gm_trust(self):
         from actions.definitions.communication import PemitAction
 
         room = ObjectDBFactory(db_key="Room", db_typeclass_path="typeclasses.rooms.Room")
@@ -300,6 +315,22 @@ class PemitActionTests(TestCase):
         actor.save()
         availability = PemitAction().check_availability(actor)
         assert availability.available is False
+
+    def test_pemit_starting_gm_succeeds(self):
+        """A STARTING-tier GM (no staff flag) may pemit (#2117)."""
+        from actions.definitions.communication import PemitAction
+
+        room = ObjectDBFactory(db_key="Room", db_typeclass_path="typeclasses.rooms.Room")
+        actor = self._gm_actor(room, GMLevel.STARTING)
+        receiver = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room,
+        )
+        CharacterSheetFactory(character=receiver)
+        with patch.object(receiver, "msg"):
+            result = PemitAction().run(actor, receivers=[receiver], text="A whisper of magic.")
+        assert result.success is True
 
     def test_pemit_without_receivers_fails(self):
         from actions.definitions.communication import PemitAction

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -198,6 +198,7 @@ class ActionRegistryTests(TestCase):
             "home",
             "activate_permit",
             "use_item",
+            "grant_item",
             "craft_attach_facet",
             "craft_detach_facet",
             "craft_attach_style",

--- a/src/actions/tests/test_get_player_actions_enhancements.py
+++ b/src/actions/tests/test_get_player_actions_enhancements.py
@@ -95,7 +95,11 @@ class GetPlayerActionsEnhancementsTests(TestCase):
 
 
 class GetPlayerActionsQueryCountTests(TestCase):
-    """get_player_actions performs <= 13 queries for a non-trivial setup."""
+    """get_player_actions performs a bounded query count for a non-trivial setup.
+
+    See the inline comment on the assertion below for the running per-feature
+    budget breakdown and the current bound.
+    """
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -142,9 +146,17 @@ class GetPlayerActionsQueryCountTests(TestCase):
         # now issues one Position query for PRIMARY/FEATURE entry positions in the room (instead
         # of returning [] with zero extra queries) — +1 over the prior baseline of 14. Raise only
         # with a documented justification — the goal remains a single-digit-ish cost.
+        # #2117 (GM-trust quick-action gate): _set_the_stage_actions used to short-circuit on
+        # the cheap, no-query is_staff_observer check for every non-staff caller. It now
+        # evaluates MinimumGMLevelPrerequisite(GMLevel.STARTING), which for a non-staff,
+        # non-GM actor chases active_account (sheet_data -> roster_entry, one failing
+        # RosterEntry lookup here since this character has no roster tenure at all) before
+        # concluding no quick action applies — +1 over the prior baseline of 15. Necessary:
+        # the surfacing gate must match the Action's own prerequisite, or a trust-tier GM
+        # could execute set_the_stage but never see the quick action.
         self.assertLessEqual(
             len(ctx.captured_queries),
-            15,
+            16,
             f"get_player_actions issued {len(ctx.captured_queries)} queries: "
             f"{[q['sql'] for q in ctx.captured_queries]}",
         )

--- a/src/actions/tests/test_items_actions.py
+++ b/src/actions/tests/test_items_actions.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from actions.constants import TargetKind
 from actions.definitions.items import (
     EquipAction,
+    GrantItemAction,
     PutInAction,
     TakeOutAction,
     UnequipAction,
@@ -27,14 +28,17 @@ from evennia_extensions.factories import (
     ObjectDBFactory,
 )
 from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory
 from world.items.constants import BodyRegion, EquipmentLayer
 from world.items.factories import (
     ItemInstanceFactory,
     ItemTemplateFactory,
     TemplateSlotFactory,
 )
-from world.items.models import EquippedItem
+from world.items.models import EquippedItem, ItemInstance
 from world.items.services import equip_item
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 
 
 class EquipActionTests(TestCase):
@@ -640,3 +644,86 @@ class UseItemTechniqueGrantTests(TestCase):
         assert CharacterTechnique.objects.filter(
             character=self.sheet, technique=self.technique
         ).exists()
+
+
+class GrantItemActionTests(TestCase):
+    """JUNIOR-tier GM item grant (#707/#2117) -- the Action `grant_item` (formerly
+    `action = None` on ``CmdGrantItem``, business logic inline in the command)."""
+
+    def _gm_actor(self, level: str, *, db_key: str = "GrantItemGM") -> object:
+        actor = CharacterFactory(db_key=db_key)
+        CharacterSheetFactory(character=actor)
+        entry = RosterEntryFactory(character_sheet__character=actor)
+        tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+        GMProfileFactory(account=tenure.player_data.account, level=level)
+        return actor
+
+    def _staff_actor(self, *, db_key: str = "GrantItemStaff") -> object:
+        account = AccountFactory(username=f"account_{db_key}", is_staff=True)
+        actor = CharacterFactory(db_key=db_key)
+        actor.db_account = account
+        actor.save()
+        return actor
+
+    def setUp(self) -> None:
+        self.target = CharacterFactory(db_key="GrantItemTarget")
+        self.target_sheet = CharacterSheetFactory(character=self.target)
+        self.template = ItemTemplateFactory(name="Ashen Betrayer's Blade")
+
+    def test_junior_gm_grants_item(self) -> None:
+        actor = self._gm_actor(GMLevel.JUNIOR)
+        with patch.object(actor, "search", return_value=self.target):
+            result = GrantItemAction().run(
+                actor, target_name=self.target.key, template_name=self.template.name
+            )
+        assert result.success is True
+        assert ItemInstance.objects.filter(
+            template=self.template, holder_character_sheet=self.target_sheet
+        ).exists()
+
+    def test_starting_gm_below_junior_tier_is_blocked(self) -> None:
+        actor = self._gm_actor(GMLevel.STARTING)
+        with patch.object(actor, "search", return_value=self.target):
+            result = GrantItemAction().run(
+                actor, target_name=self.target.key, template_name=self.template.name
+            )
+        assert result.success is False
+        assert "Junior GM" in result.message
+        assert not ItemInstance.objects.filter(holder_character_sheet=self.target_sheet).exists()
+
+    def test_missing_gm_profile_is_blocked(self) -> None:
+        actor = CharacterFactory(db_key="GrantItemNoProfile")
+        actor.db_account = AccountFactory(username="grant_item_no_profile", is_staff=False)
+        actor.save()
+        with patch.object(actor, "search", return_value=self.target):
+            result = GrantItemAction().run(
+                actor, target_name=self.target.key, template_name=self.template.name
+            )
+        assert result.success is False
+        assert result.message == "GM trust required."
+        assert not ItemInstance.objects.filter(holder_character_sheet=self.target_sheet).exists()
+
+    def test_staff_bypass_grants_item(self) -> None:
+        actor = self._staff_actor()
+        with patch.object(actor, "search", return_value=self.target):
+            result = GrantItemAction().run(
+                actor, target_name=self.target.key, template_name=self.template.name
+            )
+        assert result.success is True
+        assert ItemInstance.objects.filter(
+            template=self.template, holder_character_sheet=self.target_sheet
+        ).exists()
+
+    def test_unknown_template_fails(self) -> None:
+        actor = self._staff_actor(db_key="GrantItemStaffUnknown")
+        with patch.object(actor, "search", return_value=self.target):
+            result = GrantItemAction().run(
+                actor, target_name=self.target.key, template_name="Nonexistent Item"
+            )
+        assert result.success is False
+        assert "No item template found" in result.message
+
+    def test_missing_kwargs_fails(self) -> None:
+        actor = self._staff_actor(db_key="GrantItemStaffMissing")
+        result = GrantItemAction().run(actor)
+        assert result.success is False

--- a/src/actions/tests/test_positioning_actions.py
+++ b/src/actions/tests/test_positioning_actions.py
@@ -1,11 +1,12 @@
-"""Tests for SetTheStageAction — staff-gated blueprint instantiation.
+"""Tests for SetTheStageAction — GM-trust-gated blueprint instantiation (#2117).
 
 Covers:
-- (a) Non-staff actor → check_availability().available is False.
+- (a) Non-staff, non-GM actor → check_availability().available is False.
 - (b) Staff actor with a blueprint → execute creates live Positions in the room.
 - (c) Missing blueprint_id → ActionResult(success=False).
 - (d) _set_the_stage_actions: staff character with default_blueprint surfaces one PlayerAction.
 - (e) _set_the_stage_actions: non-staff character surfaces nothing.
+- (f) STARTING-tier GM (no staff flag) → check_availability().available is True (#2117).
 """
 
 from __future__ import annotations
@@ -14,9 +15,13 @@ import django.test
 
 from actions.constants import ActionBackend
 from actions.definitions.positioning import SetTheStageAction
-from evennia_extensions.factories import AccountFactory, RoomProfileFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory, RoomProfileFactory
 from world.areas.positioning.factories import PositionBlueprintFactory
 from world.areas.positioning.models import Position
+from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 
 
 def _make_staff_character(key: str, room) -> object:
@@ -53,8 +58,22 @@ def _make_player_character(key: str, room) -> object:
     return char
 
 
+def _make_gm_character(key: str, room, level: str) -> object:
+    """Return a Character with a live roster tenure + GMProfile at ``level``.
+
+    ``MinimumGMLevelPrerequisite`` reads ``active_account``, which requires a
+    real ``RosterTenure`` -- not just ``char.db_account``.
+    """
+    char = CharacterFactory(db_key=key, location=room)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    GMProfileFactory(account=tenure.player_data.account, level=level)
+    return char
+
+
 class TestSetTheStageActionAvailability(django.test.TestCase):
-    """check_availability gates on StaffOnlyPrerequisite."""
+    """check_availability gates on MinimumGMLevelPrerequisite(GMLevel.STARTING) (#2117)."""
 
     def setUp(self) -> None:
         from evennia import create_object
@@ -64,12 +83,12 @@ class TestSetTheStageActionAvailability(django.test.TestCase):
         self.player_char = _make_player_character("PlayerActor", self.room)
 
     def test_non_staff_actor_is_unavailable(self) -> None:
-        """Non-staff actor → available is False."""
+        """Non-staff, non-GM actor → available is False."""
         action = SetTheStageAction()
         availability = action.check_availability(self.player_char, target=None)
         self.assertFalse(
             availability.available,
-            "Non-staff should not be able to SetTheStage",
+            "Non-staff, non-GM should not be able to SetTheStage",
         )
 
     def test_staff_actor_is_available(self) -> None:
@@ -79,6 +98,16 @@ class TestSetTheStageActionAvailability(django.test.TestCase):
         self.assertTrue(
             availability.available,
             f"Staff should be able to SetTheStage; reasons: {availability.reasons}",
+        )
+
+    def test_starting_gm_actor_is_available(self) -> None:
+        """STARTING-tier GM (no staff flag) → available is True (#2117)."""
+        gm_char = _make_gm_character("StartingGM", self.room, GMLevel.STARTING)
+        action = SetTheStageAction()
+        availability = action.check_availability(gm_char, target=None)
+        self.assertTrue(
+            availability.available,
+            f"STARTING-tier GM should be able to SetTheStage; reasons: {availability.reasons}",
         )
 
 
@@ -181,4 +210,27 @@ class TestSetTheStageActionsPlayerInterface(django.test.TestCase):
             len(set_stage_actions),
             0,
             "Non-staff should not see set_the_stage actions",
+        )
+
+    def test_starting_gm_character_gets_set_the_stage_action(self) -> None:
+        """STARTING-tier GM (no staff flag) sees the quick-action too (#2117).
+
+        ``_set_the_stage_actions`` used to hardcode an ``is_staff_observer``
+        surfacing gate separate from the Action's own prerequisite -- fixing
+        only ``SetTheStageAction.get_prerequisites()`` would have left a
+        trust-tier GM unable to even discover the one-click quick action.
+        """
+        from actions.player_interface import get_player_actions
+
+        gm_char = _make_gm_character("StartingGMInterface", self.room, GMLevel.STARTING)
+        actions = get_player_actions(gm_char)
+        set_stage_actions = [
+            a
+            for a in actions
+            if a.backend == ActionBackend.REGISTRY and a.ref.registry_key == "set_the_stage"
+        ]
+        self.assertEqual(
+            len(set_stage_actions),
+            1,
+            f"Expected exactly 1 set_the_stage action, got: {set_stage_actions}",
         )

--- a/src/actions/tests/test_prerequisites.py
+++ b/src/actions/tests/test_prerequisites.py
@@ -2,10 +2,79 @@
 
 from django.test import TestCase
 
-from actions.prerequisites import PendingRitualEffectPrerequisite
+from actions.prerequisites import MinimumGMLevelPrerequisite, PendingRitualEffectPrerequisite
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory
 from world.magic.constants import RitualExecutionKind
 from world.magic.factories import CharacterResonanceFactory, RitualFactory
 from world.magic.models import PendingRitualEffect
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+
+
+def _gm_actor(level: str, *, db_key: str = "GMActor") -> object:
+    """Return a Character with a live roster tenure + GMProfile at ``level``.
+
+    Mirrors ``world/scenes/tests/test_scene_admin_services.py``'s
+    ``_create_pc_with_account`` helper -- ``active_account`` requires a real
+    ``RosterTenure``, not just ``char.db_account``.
+    """
+    char = CharacterFactory(db_key=db_key)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    account = tenure.player_data.account
+    GMProfileFactory(account=account, level=level)
+    return char
+
+
+def _plain_actor(*, db_key: str = "PlainActor", is_staff: bool = False) -> object:
+    """Return a Character connected to a plain (non-GM) account."""
+    char = CharacterFactory(db_key=db_key)
+    account = AccountFactory(username=f"account_{db_key}", is_staff=is_staff)
+    char.db_account = account
+    char.save()
+    return char
+
+
+class MinimumGMLevelPrerequisiteTests(TestCase):
+    """MinimumGMLevelPrerequisite (#2117) -- staff bypass + GMProfile.level tier compare."""
+
+    def test_staff_bypasses_regardless_of_gm_profile(self) -> None:
+        actor = _plain_actor(db_key="StaffBypass", is_staff=True)
+        met, reason = MinimumGMLevelPrerequisite(GMLevel.SENIOR).is_met(actor)
+        self.assertTrue(met)
+        self.assertEqual(reason, "")
+
+    def test_missing_gm_profile_is_refused_even_at_starting_tier(self) -> None:
+        actor = _plain_actor(db_key="NoProfile")
+        met, reason = MinimumGMLevelPrerequisite(GMLevel.STARTING).is_met(actor)
+        self.assertFalse(met)
+        self.assertEqual(reason, "GM trust required.")
+
+    def test_actor_with_no_account_is_refused(self) -> None:
+        actor = CharacterFactory(db_key="NoAccount")
+        met, reason = MinimumGMLevelPrerequisite(GMLevel.STARTING).is_met(actor)
+        self.assertFalse(met)
+        self.assertEqual(reason, "GM trust required.")
+
+    def test_gm_at_exact_tier_passes(self) -> None:
+        actor = _gm_actor(GMLevel.JUNIOR, db_key="ExactTier")
+        met, reason = MinimumGMLevelPrerequisite(GMLevel.JUNIOR).is_met(actor)
+        self.assertTrue(met)
+        self.assertEqual(reason, "")
+
+    def test_gm_above_tier_passes(self) -> None:
+        actor = _gm_actor(GMLevel.SENIOR, db_key="AboveTier")
+        met, _reason = MinimumGMLevelPrerequisite(GMLevel.JUNIOR).is_met(actor)
+        self.assertTrue(met)
+
+    def test_gm_below_tier_is_refused_with_tier_specific_message(self) -> None:
+        actor = _gm_actor(GMLevel.STARTING, db_key="BelowTier")
+        met, reason = MinimumGMLevelPrerequisite(GMLevel.JUNIOR).is_met(actor)
+        self.assertFalse(met)
+        self.assertIn("Junior GM", reason)
 
 
 class PendingRitualEffectPrerequisiteTests(TestCase):

--- a/src/actions/tests/test_situations.py
+++ b/src/actions/tests/test_situations.py
@@ -1,12 +1,16 @@
-"""Tests for SetSituationAction (#1895)."""
+"""Tests for SetSituationAction (#1895, JUNIOR-tier gate #2117)."""
 
 from django.test import TestCase
 from evennia import create_object
 
 from actions.definitions.situations import SetSituationAction
 from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory
 from world.mechanics.factories import SituationTemplateFactory, SituationTrapLinkFactory
 from world.mechanics.models import SituationInstance
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 
 
 def _make_room(key: str = "The Solar") -> object:
@@ -25,6 +29,15 @@ class SetSituationActionTest(TestCase):
         account = AccountFactory(is_staff=False)
         character = CharacterFactory(db_key="onlooker", location=_make_room("Onlooker's Room"))
         character.db_account = account
+        return character
+
+    def _gm_character(self, level: str, *, db_key: str = "trust-gm") -> object:
+        """Return a Character with a live roster tenure + GMProfile at ``level``."""
+        character = CharacterFactory(db_key=db_key, location=_make_room(f"{db_key}'s Room"))
+        CharacterSheetFactory(character=character)
+        entry = RosterEntryFactory(character_sheet__character=character)
+        tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+        GMProfileFactory(account=tenure.player_data.account, level=level)
         return character
 
     def test_missing_template_id_fails(self) -> None:
@@ -64,6 +77,32 @@ class SetSituationActionTest(TestCase):
         result = action.run(actor, situation_template_id=template.pk)
 
         assert result.success is False
+        assert SituationInstance.objects.filter(template=template).count() == 0
+
+    def test_junior_gm_instantiates_situation(self) -> None:
+        """A JUNIOR-tier GM (no staff flag) may setsituation (#2117)."""
+        action = SetSituationAction()
+        actor = self._gm_character(GMLevel.JUNIOR, db_key="junior-gm")
+        template = SituationTemplateFactory()
+
+        result = action.run(actor, situation_template_id=template.pk)
+
+        assert result.success is True
+        assert SituationInstance.objects.filter(
+            template=template,
+            location=actor.location,
+        ).exists()
+
+    def test_starting_gm_below_junior_tier_is_blocked(self) -> None:
+        """A STARTING-tier GM is below the JUNIOR gate and is refused (#2117)."""
+        action = SetSituationAction()
+        actor = self._gm_character(GMLevel.STARTING, db_key="starting-gm")
+        template = SituationTemplateFactory()
+
+        result = action.run(actor, situation_template_id=template.pk)
+
+        assert result.success is False
+        assert "Junior GM" in result.message
         assert SituationInstance.objects.filter(template=template).count() == 0
 
     def test_missing_room_profile_with_trap_link_fails_cleanly(self) -> None:

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -48,7 +48,10 @@ actions, backends, and service functions.
 
 ### Command Files
 - **`evennia_overrides/perception.py`**: `CmdLook`, `CmdInventory`
-- **`evennia_overrides/communication.py`**: `CmdSay`, `CmdWhisper`, `CmdPose`, `CmdPage`
+- **`evennia_overrides/communication.py`**: `CmdSay`, `CmdWhisper`, `CmdPose`, `CmdPage`,
+  `CmdPemit` (`pemit <name>[,<name>...]=<text>`, `cmd:all()`, #906/#2117 — private GM narration to
+  specific characters via `PemitAction`, gated on `MinimumGMLevelPrerequisite(GMLevel.STARTING)`,
+  staff bypass preserved)
 - **`evennia_overrides/movement.py`**: `CmdGet`, `CmdDrop`, `CmdGive` (#1909: swaps to
   `GiveCoinsAction` when the item-name text parses as money via `parse_coppers`),
   `CmdHome`
@@ -438,21 +441,32 @@ actions, backends, and service functions.
   that anyone may `project/donate` toward (freed the instant it's funded). The same service backs
   the web `DemandRansomView` (`POST /api/gm/demand-ransom/`). Thin over the service — no business
   logic in the command (mirrors `gemit`).
-- **`grant_item.py`**: `CmdGrantItem` (`grant_item`, staff-only `perm(Admin)`, #707) — the ad-hoc
-  narrative item grant surface. `grant_item <character>=<item template name>` resolves the target
-  by name (`self.caller.search(..., global_search=True)`) and calls
+- **`grant_item.py`**: `CmdGrantItem` (`grant_item`, `cmd:all()`, #707/#2117) — the ad-hoc
+  narrative item grant surface. `grant_item <character>=<item template name>` parses the raw text
+  into `target_name`/`template_name` kwargs and delegates to `GrantItemAction` (key `grant_item`,
+  REGISTRY backend, `actions/definitions/items.py`) via `action.run()` — the same seam every other
+  `ArxCommand` uses. The Action resolves the target by name
+  (`actor.search(..., global_search=True)`) and calls
   `world.items.services.narrative_grants.grant_touchstone_item_to_character` to create one
   `ItemInstance` of the named `ItemTemplate`, held by the target's `CharacterSheet`. No shop/
   merchant system exists in this codebase — this command IS the acquisition channel for
   story-earned touchstones/reagents (a GM hand-awarding a specific item after a story beat).
-  Thin over the service — no business logic in the command (mirrors `demandransom`/`gemit`).
-- **`setstage.py`**: `CmdSetStage` (`setstage`, staff `perm(Admin)`, #1498) — telnet face of
-  `SetTheStageAction` (key `set_the_stage`, REGISTRY backend). A staff caller instantiates a
-  `PositionBlueprint` into their current room: `setstage` shows this room's positions + default
-  blueprint, `setstage list` lists all blueprints by pk, `setstage <name|id>` instantiates one,
-  `setstage <name|id> replace` replaces the room's existing position grid. Thin `ArxCommand` over
-  `action.run()` (same seam as the web quick-action `_set_the_stage_actions`); staff-gated by
-  `StaffOnlyPrerequisite`. No business logic in the command.
+  Gated on `MinimumGMLevelPrerequisite(GMLevel.JUNIOR)` (staff bypass preserved) — requires
+  JUNIOR-tier GM trust or higher, not a staff flag. No business logic in the command.
+- **`setstage.py`**: `CmdSetStage` (`setstage`, `cmd:all()`, #1498/#2117) — telnet face of
+  `SetTheStageAction` (key `set_the_stage`, REGISTRY backend). A STARTING-tier-or-higher GM (or
+  staff) caller instantiates a `PositionBlueprint` into their current room: `setstage` shows this
+  room's positions + default blueprint, `setstage list` lists all blueprints by pk, `setstage
+  <name|id>` instantiates one, `setstage <name|id> replace` replaces the room's existing position
+  grid. Thin `ArxCommand` over `action.run()` (same seam as the web quick-action
+  `_set_the_stage_actions`); gated by `MinimumGMLevelPrerequisite(GMLevel.STARTING)` (staff bypass
+  preserved). No business logic in the command.
+- **`setsituation.py`**: `CmdSetSituation` (`setsituation`, `cmd:all()`, #1895/#2117) — telnet face
+  of `SetSituationAction` (key `set_situation`, REGISTRY backend). A JUNIOR-tier-or-higher GM (or
+  staff) caller instantiates an authored `SituationTemplate` into their current room via
+  `action.run()`. Gated by `MinimumGMLevelPrerequisite(GMLevel.JUNIOR)` (staff bypass preserved) —
+  mints live `Challenge`/`ChallengeInstance` rows, one tier above bare approval. No business logic
+  in the command.
 - **`persona.py`**: `CmdPersona` (`persona`, alias `wear-face`, #1347) — list, create, or switch
   faces. Bare `persona`/`persona list` renders all the caller's personas (marking the active one
   `◄ active`). `persona <name>`/`wear-face <name>` resolves the name among the caller's own faces

--- a/src/commands/evennia_overrides/communication.py
+++ b/src/commands/evennia_overrides/communication.py
@@ -302,17 +302,21 @@ class CmdMutter(ArxCommand):
 
 
 class CmdPemit(ArxCommand):
-    """Staff-only private narrative emit to specific characters (#906).
+    """GM private narrative emit to specific characters (#906).
 
     Usage: pemit <name>[,<name>...]=<text>
 
     Delivers GM narration only to the listed characters; the persisted
     interaction is receiver-scoped, so nobody else (or the log) sees more
     than the receivers heard. Works in and out of scenes.
+
+    Requires STARTING-tier GM trust or higher (or staff) -- gated by
+    ``PemitAction``'s ``MinimumGMLevelPrerequisite`` (#2117). The command
+    lock is ``cmd:all()``; real authorization lives entirely in the Action.
     """
 
     key = "pemit"
-    locks = "cmd:perm(Builder)"
+    locks = "cmd:all()"
     action = PemitAction()
 
     def resolve_action_args(self) -> dict[str, Any]:

--- a/src/commands/grant_item.py
+++ b/src/commands/grant_item.py
@@ -1,16 +1,22 @@
-"""CmdGrantItem — staff command for ad-hoc narrative item grants (#707).
+"""CmdGrantItem — GM command for ad-hoc narrative item grants (#707, #2117).
 
 For story-earned moments (harvesting a component from a defeated NPC,
 finding something at a shrine) where a GM hand-awards a specific touchstone
 or reagent, rather than the character purchasing it (no shop/merchant
 system exists in this codebase — this IS the acquisition channel). Thin
-over ``world.items.services.narrative_grants.grant_touchstone_item_to_character``
-(the same service the Mission ITEM reward sink calls). Staff-only for now
-(``perm(Admin)``), mirroring ``gemit``/``demandransom``/``setstage``.
+telnet face of ``GrantItemAction`` (``actions/definitions/items.py``), which
+wraps ``world.items.services.narrative_grants
+.grant_touchstone_item_to_character`` (the same service the Mission ITEM
+reward sink calls). Requires JUNIOR-tier GM trust or higher (or staff) —
+gated by the Action's ``MinimumGMLevelPrerequisite`` (#2117). The command
+lock is ``cmd:all()``; real authorization lives entirely in the Action.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
+from actions.definitions.items import GrantItemAction
 from commands.command import ArxCommand
 from commands.exceptions import CommandError
 
@@ -18,55 +24,28 @@ _USAGE = "Usage: grant_item <character>=<item template name>"
 
 
 class CmdGrantItem(ArxCommand):
-    """Grant a specific item template to a character (staff).
+    """Grant a specific item template to a character (GM).
 
     Creates one ItemInstance of the named template, held by the target
     character. Use for story-earned narrative grants (loot, GM rewards) —
     there is no shop system to buy these from instead.
+
+    Requires JUNIOR-tier GM trust or higher (or staff).
 
     Usage:
       grant_item <character>=<item template name>
     """
 
     key = "grant_item"
-    locks = "cmd:perm(Admin)"
+    locks = "cmd:all()"
     help_category = "Staff"
-    action = None
+    action = GrantItemAction()
 
-    def func(self) -> None:
-        try:
-            self._run()
-        except CommandError as exc:
-            self.msg(str(exc))
-
-    def _run(self) -> None:
-        from world.items.models import ItemTemplate  # noqa: PLC0415
-        from world.items.services.narrative_grants import (  # noqa: PLC0415
-            grant_touchstone_item_to_character,
-        )
-
+    def resolve_action_args(self) -> dict[str, Any]:
         raw = (self.args or "").strip()
         if "=" not in raw:
             raise CommandError(_USAGE)
         name, template_name = (part.strip() for part in raw.split("=", 1))
         if not name or not template_name:
             raise CommandError(_USAGE)
-
-        target = self.caller.search(name, global_search=True)
-        if target is None:
-            return  # search() already messaged the caller.
-
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
-        if sheet is None:
-            msg = "That is not a character."
-            raise CommandError(msg)
-
-        template = ItemTemplate.objects.filter(name__iexact=template_name).first()
-        if template is None:
-            msg = f"No item template found named '{template_name}'."
-            raise CommandError(msg)
-
-        grant_touchstone_item_to_character(
-            character_sheet=sheet, template=template, granted_by=self.account
-        )
-        self.msg(f"Granted '{template.name}' to {target.key}.")
+        return {"target_name": name, "template_name": template_name}

--- a/src/commands/setsituation.py
+++ b/src/commands/setsituation.py
@@ -1,8 +1,10 @@
 """Telnet face of SetSituationAction (#1895).
 
-Thin command: a staff caller instantiates a SituationTemplate into their
-current room. Delegates to SetSituationAction via action.run() -- the same
-seam the web quick-action would reach.
+Thin command: a JUNIOR-tier-or-higher GM (or staff) caller instantiates a
+SituationTemplate into their current room. Delegates to SetSituationAction
+via action.run() -- the same seam the web quick-action would reach. The
+command lock is ``cmd:all()`` -- real authorization lives entirely in the
+Action's ``MinimumGMLevelPrerequisite`` (#2117).
 """
 
 from __future__ import annotations
@@ -18,7 +20,8 @@ from world.mechanics.models import SituationTemplate
 class CmdSetSituation(ArxCommand):
     """Instantiate an authored Situation in your current room.
 
-    Staff-only. You must be standing in the room to trigger it.
+    Requires JUNIOR-tier GM trust or higher (or staff). You must be standing
+    in the room to trigger it.
 
     Usage:
       setsituation <name|id>    -- instantiate <name|id> into this room
@@ -26,7 +29,7 @@ class CmdSetSituation(ArxCommand):
 
     key = "setsituation"
     aliases: list[str] = []
-    locks = "cmd:perm(Admin)"
+    locks = "cmd:all()"
     help_category = "Building"
     action = SetSituationAction()
 

--- a/src/commands/setstage.py
+++ b/src/commands/setstage.py
@@ -1,8 +1,11 @@
 """Telnet face of SetTheStageAction (#1498).
 
-Thin command: a staff caller instantiates a ``PositionBlueprint`` into their
-current room. Delegates to ``SetTheStageAction`` via ``action.run()`` -- the
-same seam the web quick-action (``_set_the_stage_actions``) reaches.
+Thin command: a STARTING-tier-or-higher GM (or staff) caller instantiates a
+``PositionBlueprint`` into their current room. Delegates to
+``SetTheStageAction`` via ``action.run()`` -- the same seam the web
+quick-action (``_set_the_stage_actions``) reaches. The command lock is
+``cmd:all()`` -- real authorization lives entirely in the Action's
+``MinimumGMLevelPrerequisite`` (#2117).
 """
 
 from __future__ import annotations
@@ -21,7 +24,8 @@ _LIST_SUBVERB = "list"
 class CmdSetStage(ArxCommand):
     """Set the stage in your current room -- apply a position blueprint.
 
-    Staff-only. You must be standing in the room to stage.
+    Requires STARTING-tier GM trust or higher (or staff). You must be
+    standing in the room to stage.
 
     Usage:
       setstage                       -- show this room's positions
@@ -36,7 +40,7 @@ class CmdSetStage(ArxCommand):
 
     key = "setstage"
     aliases: list[str] = []
-    locks = "cmd:perm(Admin)"
+    locks = "cmd:all()"
     help_category = "Building"
     action = SetTheStageAction()
 

--- a/src/commands/tests/test_grant_item.py
+++ b/src/commands/tests/test_grant_item.py
@@ -1,4 +1,4 @@
-"""Tests for CmdGrantItem (#707).
+"""Tests for CmdGrantItem (#707), gated on JUNIOR-tier GM trust or staff (#2117).
 
 Mirrors the ``caller.search`` mock pattern used across the command tests
 (e.g. ``test_relationships_command.py``): the caller is a real
@@ -14,10 +14,13 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 
 from commands.grant_item import CmdGrantItem
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory
 from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory
 from world.items.factories import ItemTemplateFactory
 from world.items.models import ItemInstance
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 
 
 def _build_cmd(caller, args: str = "") -> CmdGrantItem:
@@ -28,11 +31,21 @@ def _build_cmd(caller, args: str = "") -> CmdGrantItem:
     return cmd
 
 
+def _make_gm(character, level: str) -> None:
+    """Attach a live roster tenure + GMProfile at ``level`` to ``character``."""
+    CharacterSheetFactory(character=character)
+    entry = RosterEntryFactory(character_sheet__character=character)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    GMProfileFactory(account=tenure.player_data.account, level=level)
+
+
 class CmdGrantItemTests(TestCase):
     def setUp(self) -> None:
         self.staff_character = CharacterFactory()
         self.staff_character.msg = MagicMock()
         self.staff_character.search = MagicMock()
+        self.staff_character.db_account = AccountFactory(is_staff=True)
+        self.staff_character.save()
         self.target_character = CharacterFactory()
         self.target_sheet = CharacterSheetFactory(character=self.target_character)
         self.template = ItemTemplateFactory(name="Hand of the Betrayer")
@@ -78,7 +91,9 @@ class CmdGrantItemTests(TestCase):
         cmd = _build_cmd(self.staff_character, "justaname")
         cmd.func()
 
-        self.staff_character.msg.assert_called_with(
+        # ArxCommand's default func() (now used, since action is no longer None)
+        # sends both the plain-text message and a structured command_error payload.
+        self.staff_character.msg.assert_any_call(
             "Usage: grant_item <character>=<item template name>"
         )
 
@@ -91,3 +106,47 @@ class CmdGrantItemTests(TestCase):
         cmd.func()
 
         self.staff_character.msg.assert_not_called()
+
+
+class CmdGrantItemGMTrustTests(TestCase):
+    """Trust-tier journeys for the JUNIOR-tier GrantItemAction gate (#2117)."""
+
+    def setUp(self) -> None:
+        self.target_character = CharacterFactory()
+        self.target_sheet = CharacterSheetFactory(character=self.target_character)
+        self.template = ItemTemplateFactory(name="Hand of the Betrayer")
+
+    def _caller(self) -> object:
+        caller = CharacterFactory()
+        caller.msg = MagicMock()
+        caller.search = MagicMock(return_value=self.target_character)
+        return caller
+
+    def test_junior_gm_succeeds(self) -> None:
+        caller = self._caller()
+        _make_gm(caller, GMLevel.JUNIOR)
+        cmd = _build_cmd(caller, f"{self.target_character.key}=Hand of the Betrayer")
+        cmd.func()
+
+        assert ItemInstance.objects.filter(
+            template=self.template, holder_character_sheet=self.target_sheet
+        ).exists()
+
+    def test_starting_gm_below_junior_tier_is_blocked(self) -> None:
+        caller = self._caller()
+        _make_gm(caller, GMLevel.STARTING)
+        cmd = _build_cmd(caller, f"{self.target_character.key}=Hand of the Betrayer")
+        cmd.func()
+
+        caller.msg.assert_called_with("Requires Junior GM or higher.")
+        assert not ItemInstance.objects.filter(holder_character_sheet=self.target_sheet).exists()
+
+    def test_missing_gm_profile_is_blocked(self) -> None:
+        caller = self._caller()
+        caller.db_account = AccountFactory(is_staff=False)
+        caller.save()
+        cmd = _build_cmd(caller, f"{self.target_character.key}=Hand of the Betrayer")
+        cmd.func()
+
+        caller.msg.assert_called_with("GM trust required.")
+        assert not ItemInstance.objects.filter(holder_character_sheet=self.target_sheet).exists()

--- a/src/commands/tests/test_setstage_command.py
+++ b/src/commands/tests/test_setstage_command.py
@@ -4,9 +4,13 @@ from django.test import TestCase
 
 from commands.exceptions import CommandError
 from commands.setstage import CmdSetStage
-from evennia_extensions.factories import AccountFactory, RoomProfileFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory, RoomProfileFactory
 from world.areas.positioning.factories import PositionBlueprintFactory
 from world.areas.positioning.models import Position
+from world.character_sheets.factories import CharacterSheetFactory
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 
 
 class SetStageParseTests(TestCase):
@@ -63,6 +67,23 @@ def _make_staff_character(key: str, room) -> object:
 def _make_nonstaff_character(key: str, room) -> object:
     """Return an Evennia character connected to a non-staff account."""
     return _make_character(key, room, is_staff=False)
+
+
+def _make_gm_character(key: str, room, level: str) -> object:
+    """Return a Character with a live roster tenure + GMProfile at ``level``.
+
+    ``MinimumGMLevelPrerequisite`` reads ``active_account``, which requires a
+    real ``RosterTenure`` -- not just ``char.db_account`` (mirrors
+    ``world/scenes/tests/test_scene_admin_services.py``'s
+    ``_create_pc_with_account`` helper).
+    """
+    char = CharacterFactory(db_key=key, location=room)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    account = tenure.player_data.account
+    GMProfileFactory(account=account, level=level)
+    return char
 
 
 def _make_room(key: str = "The Solar") -> object:
@@ -129,7 +150,8 @@ class SetStageRunTests(TestCase):
 
         assert Position.objects.filter(room=room).count() == 1
 
-    def test_nonstaff_caller_is_blocked_by_staff_only_prerequisite(self) -> None:
+    def test_nonstaff_non_gm_caller_is_blocked(self) -> None:
+        """A caller with no GMProfile at all is refused (#2117)."""
         room = _make_room()
         caller = _make_nonstaff_character("poser", room)
         bp = PositionBlueprintFactory(name="Lone Dais")
@@ -139,8 +161,21 @@ class SetStageRunTests(TestCase):
 
         msgs = self._run("Lone Dais", caller)
 
-        assert any("Staff only." in m for m in msgs)
+        assert any("GM trust required." in m for m in msgs)
         assert Position.objects.filter(room=room).count() == 0
+
+    def test_starting_gm_caller_succeeds(self) -> None:
+        """A STARTING-tier GM (no staff flag) can setstage (#2117)."""
+        room = _make_room()
+        caller = _make_gm_character("starter", room, GMLevel.STARTING)
+        bp = PositionBlueprintFactory(name="Lone Dais")
+        from world.areas.positioning.services import add_blueprint_position
+
+        add_blueprint_position(bp, "Center", description="The centre")
+
+        self._run("Lone Dais", caller)
+
+        assert Position.objects.filter(room=room).count() == 1
 
     def test_setstage_replace_replaces_existing_position_grid(self) -> None:
         room = _make_room()


### PR DESCRIPTION
Closes #2117

## Summary

Moves the four table-running tools off the Evennia staff bit onto the GMLevel trust ladder: new reusable MinimumGMLevelPrerequisite (staff bypass preserved; missing GMProfile always refuses); setstage/pemit gate at STARTING, setsituation/grant_item at JUNIOR; grant_item gains a real GrantItemAction closing its Action-seam bypass; all four command locks loosened to cmd:all() so the Action prerequisite is the real gate (encounter precedent). Also fixes a second hidden staff gate the spec's intent required: the web quick-action surfacing for set_the_stage had its own is_staff check — a trust GM could have executed the action but never seen the button.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2117 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: rebased onto origin/main (post-#2131), no conflicts

<!-- last-addressed-comment: 0 -->