### PR TITLE
Web reward parity: style endorsement UI, first-kudos on a pose, writeup commend button

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -128,11 +128,16 @@ Powers, affinities, auras, resonances, threads-as-currency, rituals, and Mage Sc
     FK, `resonance` FK (PROTECT), `persona_snapshot` FK to `scenes.Persona` (SET_NULL),
     unique `(endorser_sheet, interaction)`), `SceneEntryEndorsement` (immediate flat
     grant; same FK shape, unique `(endorser_sheet, endorsee_sheet, scene)`),
-    `ResonanceGrant` (universal audit ledger — discriminator `source` + typed source FKs).
-    Read surface: `InteractionListSerializer` now nests `pose_kind`, `endorsee_sheet_id`,
-    `endorsable_resonances`, `pose_endorsers`/`my_pose_endorsement`,
-    `entry_endorsers`/`entry_endorsed_by_me` on every `GET /api/interactions/?scene=<id>`
-    row. Frontend: `EndorsementControl` in `PoseUnit` (`frontend/src/scenes/components/`).
+    `StylePresentationEndorsement` (#1152 — immediate flat grant like scene-entry, keyed
+    on the endorsee's claimed resonance rather than a pose; immutable, create+retrieve
+    only, no settlement/delete), `ResonanceGrant` (universal audit ledger —
+    discriminator `source` + typed source FKs). Read surface: `InteractionListSerializer`
+    now nests `pose_kind`, `endorsee_sheet_id`, `endorsable_resonances`,
+    `pose_endorsers`/`my_pose_endorsement`, `entry_endorsers`/`entry_endorsed_by_me` on
+    every `GET /api/interactions/?scene=<id>` row. Frontend: `EndorsementControl` in
+    `PoseUnit` (`frontend/src/scenes/components/`) — `kind` prop is `'pose' | 'entry' |
+    'style'` (style added #2031), POSTing to `pose-endorsements/` /
+    `scene-entry-endorsements/` / `style-presentation-endorsements/` respectively.
   - **Aura drift (#1737):** `CharacterAura`'s stored percentages recompute from
     `CharacterResonance.lifetime_earned` on every `grant_resonance()` call, firing
     achievements on authored `AuraAffinityThreshold` crossings; see magic.md
@@ -3317,6 +3322,16 @@ writeup kudos/complaint feedback.
   response). Both dispatch `RelationshipBumpAction` (key `"relationship_bump"`). Not
   consent-gated (private write to the actor's own regard, ADR-0024); bumps render only
   in the actor's own relationship views; the target is never notified.
+- **Writeup list route (#2031):** `RelationshipUpdateViewSet` also mixes in `ListModelMixin`
+  for `GET /api/relationships/relationship-updates/` — narrow (not a general writeup
+  browser): tenure-scoped to `RelationshipUpdate` rows whose parent relationship's `target`
+  is a character the requesting account currently holds a **RosterTenure** on, SHARED/PUBLIC
+  visibility only. `?relationship=`/`?track=`/`?subject_character=<CharacterSheet pk>`
+  filters (`RelationshipUpdateFilter`); the last narrows a multi-character account down to
+  one owned sheet. Frontend: the commend button on the "Writeups" subsection of
+  `RelationshipsSection` (`frontend/src/components/character/RelationshipsSection.tsx`, own-
+  sheet gated), fed by `frontend/src/relationships/` (`api.ts`/`queries.ts`), POSTs
+  `{writeup_type: "update", writeup_id}` to `.../kudos/`.
 - **Admin:** `WriteupComplaint` registered for staff triage (no player-facing complaint UI)
 - **Actions:** `GiveWriteupKudosAction` (key `"give_writeup_kudos"`),
   `FileWriteupComplaintAction` (key `"file_writeup_complaint"`),
@@ -3325,7 +3340,8 @@ writeup kudos/complaint feedback.
 - **Integrates with:** mechanics (modifier gating), character_sheets (CharacterSheet FK),
   scenes (optional `linked_scene` defaults to the caller's active scene), progression
   (XP + `award_kudos`)
-- **Source:** `src/world/relationships/`
+- **Source:** `src/world/relationships/`; frontend: `frontend/src/relationships/` +
+  `frontend/src/components/character/RelationshipsSection.tsx`
 
 ---
 

--- a/frontend/src/components/character/RelationshipsSection.tsx
+++ b/frontend/src/components/character/RelationshipsSection.tsx
@@ -1,26 +1,45 @@
 /**
  * RelationshipsSection
  *
- * Composed panel for character relationships. Two sub-sections:
+ * Composed panel for character relationships. Three sub-sections:
  * 1. Soul Tethers — SoulTetherStatusPanel displaying active tether bonds.
- * 2. Notes — free-text relationship entries from CharacterData.relationships.
+ * 2. Writeups — commendable relationship writeups about the OWN character (#2031).
+ * 3. Notes — free-text relationship entries from CharacterData.relationships.
  */
+
+import { useState } from 'react';
 
 import type { CharacterData } from '@/roster/types';
 import { SoulTetherStatusPanel } from '@/magic/components/SoulTetherStatusPanel';
 import { useMyTetherBonds } from '@/magic/queries';
+import { useGiveWriteupKudos, useMyWriteups } from '@/relationships/queries';
 
 interface RelationshipsSectionProps {
   relationships?: CharacterData['relationships'];
   /** The CharacterSheet PK for the viewed character. Passed to SoulTetherStatusPanel. */
   characterSheetId?: number;
+  /**
+   * True only when viewing the CALLER's own character sheet.
+   *
+   * The writeups list endpoint (GET /api/relationships/relationship-updates/)
+   * is scoped to the requesting user, not the viewed character — it always
+   * returns the caller's own commendable writeups. Fetching/rendering it on
+   * another character's sheet would silently show the viewer's writeups under
+   * the wrong character's tab, so this flag gates both the query and the
+   * subsection's render (#2031).
+   */
+  isMyCharacter?: boolean;
 }
 
 export function RelationshipsSection({
   relationships,
   characterSheetId,
+  isMyCharacter = false,
 }: RelationshipsSectionProps) {
   const { data: bonds = [] } = useMyTetherBonds(characterSheetId ?? null);
+  const { data: writeups = [] } = useMyWriteups(isMyCharacter);
+  const giveKudos = useGiveWriteupKudos();
+  const [kudosError, setKudosError] = useState<string | null>(null);
 
   const relationshipIds = bonds.map((b) => b.relationship_id);
 
@@ -28,6 +47,18 @@ export function RelationshipsSection({
   for (const bond of bonds) {
     bondedCharacterNames[bond.relationship_id] = bond.bonded_character_name;
   }
+
+  const handleCommend = (writeupId: number) => {
+    setKudosError(null);
+    giveKudos.mutate(
+      { writeup_type: 'update', writeup_id: writeupId },
+      {
+        onError: (err) => {
+          setKudosError(err instanceof Error ? err.message : 'Failed to commend this writeup');
+        },
+      }
+    );
+  };
 
   return (
     <section>
@@ -40,6 +71,41 @@ export function RelationshipsSection({
           callerSheetId={characterSheetId}
           bondedCharacterNames={bondedCharacterNames}
         />
+
+        {/* Sub-section: Writeups (only shown when writeups exist) */}
+        {writeups.length > 0 && (
+          <div>
+            <h4 className="text-lg font-medium">Writeups</h4>
+            {kudosError && (
+              <p role="alert" className="text-sm text-destructive">
+                {kudosError}
+              </p>
+            )}
+            <ul className="space-y-4">
+              {writeups.map((writeup) => (
+                <li key={writeup.id} className="border-b pb-3">
+                  <p className="font-medium">{writeup.title}</p>
+                  <p className="text-sm text-muted-foreground">By {writeup.author_name}</p>
+                  <p className="mt-1">{writeup.writeup}</p>
+                  <div className="mt-2 flex items-center gap-3">
+                    <span className="text-sm text-muted-foreground">
+                      {writeup.kudos_count} kudos
+                    </span>
+                    {!writeup.viewer_has_kudosed && (
+                      <button
+                        type="button"
+                        onClick={() => handleCommend(writeup.id)}
+                        disabled={giveKudos.isPending}
+                      >
+                        Commend
+                      </button>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         {/* Sub-section: Notes (free-text) */}
         <div>

--- a/frontend/src/components/character/RelationshipsSection.tsx
+++ b/frontend/src/components/character/RelationshipsSection.tsx
@@ -22,11 +22,18 @@ interface RelationshipsSectionProps {
    * True only when viewing the CALLER's own character sheet.
    *
    * The writeups list endpoint (GET /api/relationships/relationship-updates/)
-   * is scoped to the requesting user, not the viewed character — it always
-   * returns the caller's own commendable writeups. Fetching/rendering it on
-   * another character's sheet would silently show the viewer's writeups under
-   * the wrong character's tab, so this flag gates both the query and the
-   * subsection's render (#2031).
+   * is scoped to the requesting user's *account* (tenure-based — every
+   * character the account currently owns), not to any single viewed
+   * character. `characterSheetId` is passed through as `?subject_character=`
+   * to narrow the account-wide set down to just the viewed character's
+   * writeups, so a multi-character account's sibling writeups never leak
+   * onto the wrong sheet's tab (fix wave, Finding 2). `isMyCharacter` itself
+   * mirrors `useMyRosterEntriesQuery`'s tenure-based ownership check
+   * (CharacterSheetPage.tsx), which now has the SAME tenure semantics as the
+   * backend's subject scoping — so gating on it here is correct for any
+   * owned character, not just the currently-puppeted one. It still gates
+   * both the query and the subsection's render, so a foreign-sheet viewer
+   * neither fetches nor sees this subsection.
    */
   isMyCharacter?: boolean;
 }
@@ -37,7 +44,7 @@ export function RelationshipsSection({
   isMyCharacter = false,
 }: RelationshipsSectionProps) {
   const { data: bonds = [] } = useMyTetherBonds(characterSheetId ?? null);
-  const { data: writeups = [] } = useMyWriteups(isMyCharacter);
+  const { data: writeups = [] } = useMyWriteups(characterSheetId, isMyCharacter);
   const giveKudos = useGiveWriteupKudos();
   const [kudosError, setKudosError] = useState<string | null>(null);
 

--- a/frontend/src/components/character/__tests__/RelationshipsSection.test.tsx
+++ b/frontend/src/components/character/__tests__/RelationshipsSection.test.tsx
@@ -180,7 +180,9 @@ describe('RelationshipsSection', () => {
 
   describe('Writeups sub-section', () => {
     it('renders nothing when there are no writeups', () => {
-      vi.mocked(useMyWriteups).mockReturnValue({ data: [] } as ReturnType<typeof useMyWriteups>);
+      vi.mocked(useMyWriteups).mockReturnValue({
+        data: [],
+      } as unknown as ReturnType<typeof useMyWriteups>);
 
       render(<RelationshipsSection isMyCharacter characterSheetId={42} />, {
         wrapper: createWrapper(),

--- a/frontend/src/components/character/__tests__/RelationshipsSection.test.tsx
+++ b/frontend/src/components/character/__tests__/RelationshipsSection.test.tsx
@@ -8,9 +8,12 @@
  * 4. SoulTetherStatusPanel is rendered with bond data from useMyTetherBonds.
  * 5. characterSheetId is forwarded to SoulTetherStatusPanel (via callerSheetId).
  * 6. Bond relationship IDs and bonded names are passed to SoulTetherStatusPanel.
+ * 7. Writeups sub-section (#2031): renders with kudos_count, Commend button
+ *    hidden when viewer_has_kudosed, exact POST body, 400 message rendered,
+ *    empty writeups list renders nothing.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -51,6 +54,20 @@ vi.mock('@/magic/queries', () => ({
 }));
 
 import { useMyTetherBonds } from '@/magic/queries';
+
+// ---------------------------------------------------------------------------
+// Mock the relationships module (writeups + commend mutation). Default: no
+// writeups, mutate is a no-op spy. Individual tests override via vi.mocked().
+// ---------------------------------------------------------------------------
+
+const mockMutate = vi.fn();
+
+vi.mock('@/relationships/queries', () => ({
+  useMyWriteups: vi.fn(() => ({ data: [] })),
+  useGiveWriteupKudos: vi.fn(() => ({ mutate: mockMutate, isPending: false })),
+}));
+
+import { useMyWriteups } from '@/relationships/queries';
 
 // ---------------------------------------------------------------------------
 // Wrapper
@@ -155,5 +172,165 @@ describe('RelationshipsSection', () => {
     // Both sub-sections present
     expect(screen.getByTestId('soul-tether-status-panel')).toBeInTheDocument();
     expect(screen.getByText('Old ally from the siege')).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Writeups sub-section (#2031)
+  // -------------------------------------------------------------------------
+
+  describe('Writeups sub-section', () => {
+    it('renders nothing when there are no writeups', () => {
+      vi.mocked(useMyWriteups).mockReturnValue({ data: [] } as ReturnType<typeof useMyWriteups>);
+
+      render(<RelationshipsSection isMyCharacter characterSheetId={42} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.queryByRole('heading', { name: /writeups/i })).not.toBeInTheDocument();
+    });
+
+    it('renders a writeup with title, author, writeup text, and kudos_count', () => {
+      vi.mocked(useMyWriteups).mockReturnValue({
+        data: [
+          {
+            id: 1,
+            author: 5,
+            author_name: 'Marek',
+            title: 'A Debt Repaid',
+            writeup: 'They stood by me when it mattered most.',
+            track: 1,
+            track_name: 'Trust',
+            points_earned: 3,
+            coloring: '',
+            visibility: 'shared',
+            is_first_impression: false,
+            linked_scene: null,
+            created_at: '2026-01-01T00:00:00Z',
+            kudos_count: 4,
+            viewer_has_kudosed: false,
+          },
+        ],
+      } as unknown as ReturnType<typeof useMyWriteups>);
+
+      render(<RelationshipsSection isMyCharacter characterSheetId={42} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByRole('heading', { name: /writeups/i })).toBeInTheDocument();
+      expect(screen.getByText('A Debt Repaid')).toBeInTheDocument();
+      expect(screen.getByText(/Marek/)).toBeInTheDocument();
+      expect(screen.getByText('They stood by me when it mattered most.')).toBeInTheDocument();
+      expect(screen.getByText(/4 kudos/)).toBeInTheDocument();
+    });
+
+    it('shows the Commend button when viewer_has_kudosed is false', () => {
+      vi.mocked(useMyWriteups).mockReturnValue({
+        data: [
+          {
+            id: 1,
+            author_name: 'Marek',
+            title: 'A Debt Repaid',
+            writeup: 'writeup text',
+            kudos_count: 0,
+            viewer_has_kudosed: false,
+          },
+        ],
+      } as unknown as ReturnType<typeof useMyWriteups>);
+
+      render(<RelationshipsSection isMyCharacter characterSheetId={42} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByRole('button', { name: /commend/i })).toBeInTheDocument();
+    });
+
+    it('hides the Commend button when viewer_has_kudosed is true', () => {
+      vi.mocked(useMyWriteups).mockReturnValue({
+        data: [
+          {
+            id: 1,
+            author_name: 'Marek',
+            title: 'A Debt Repaid',
+            writeup: 'writeup text',
+            kudos_count: 1,
+            viewer_has_kudosed: true,
+          },
+        ],
+      } as unknown as ReturnType<typeof useMyWriteups>);
+
+      render(<RelationshipsSection isMyCharacter characterSheetId={42} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.queryByRole('button', { name: /commend/i })).not.toBeInTheDocument();
+    });
+
+    it('POSTs the exact kudos body when Commend is clicked', () => {
+      vi.mocked(useMyWriteups).mockReturnValue({
+        data: [
+          {
+            id: 77,
+            author_name: 'Marek',
+            title: 'A Debt Repaid',
+            writeup: 'writeup text',
+            kudos_count: 0,
+            viewer_has_kudosed: false,
+          },
+        ],
+      } as unknown as ReturnType<typeof useMyWriteups>);
+      mockMutate.mockClear();
+
+      render(<RelationshipsSection isMyCharacter characterSheetId={42} />, {
+        wrapper: createWrapper(),
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /commend/i }));
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      expect(mockMutate).toHaveBeenCalledWith(
+        { writeup_type: 'update', writeup_id: 77 },
+        expect.objectContaining({ onError: expect.any(Function) })
+      );
+    });
+
+    it('renders the exact server message verbatim when the commend POST fails', async () => {
+      vi.mocked(useMyWriteups).mockReturnValue({
+        data: [
+          {
+            id: 77,
+            author_name: 'Marek',
+            title: 'A Debt Repaid',
+            writeup: 'writeup text',
+            kudos_count: 0,
+            viewer_has_kudosed: false,
+          },
+        ],
+      } as unknown as ReturnType<typeof useMyWriteups>);
+      mockMutate.mockImplementation(
+        (_body: unknown, { onError }: { onError: (err: unknown) => void }) => {
+          onError(new Error('You have already commended this writeup.'));
+        }
+      );
+
+      render(<RelationshipsSection isMyCharacter characterSheetId={42} />, {
+        wrapper: createWrapper(),
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /commend/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('You have already commended this writeup.')).toBeInTheDocument();
+      });
+    });
+
+    it('does not fetch writeups when isMyCharacter is false', () => {
+      vi.mocked(useMyWriteups).mockClear();
+
+      render(<RelationshipsSection characterSheetId={42} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(useMyWriteups).toHaveBeenCalledWith(false);
+    });
   });
 });

--- a/frontend/src/components/character/__tests__/RelationshipsSection.test.tsx
+++ b/frontend/src/components/character/__tests__/RelationshipsSection.test.tsx
@@ -330,7 +330,17 @@ describe('RelationshipsSection', () => {
         wrapper: createWrapper(),
       });
 
-      expect(useMyWriteups).toHaveBeenCalledWith(false);
+      expect(useMyWriteups).toHaveBeenCalledWith(42, false);
+    });
+
+    it('passes characterSheetId as subject_character narrowing to useMyWriteups', () => {
+      vi.mocked(useMyWriteups).mockClear();
+
+      render(<RelationshipsSection isMyCharacter characterSheetId={99} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(useMyWriteups).toHaveBeenCalledWith(99, true);
     });
   });
 });

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -13967,7 +13967,13 @@ export interface paths {
      *     writeup browser. Scoped to writeups where the caller's character is the
      *     parent relationship's ``target`` (the writeup's commendable subject) and
      *     visibility is SHARED or PUBLIC; PRIVATE and GOSSIP writeups never appear
-     *     here regardless of subject.
+     *     here regardless of subject. Subject eligibility is tenure-based (current,
+     *     un-ended ``RosterTenure``, mirroring ``get_account_for_character``), not
+     *     Evennia's live-puppet ``db_account`` field, so a subject browsing while
+     *     not currently puppeting the character still sees writeups they can
+     *     legally commend. ``?subject_character=<CharacterSheet pk>`` narrows to one
+     *     owned character sheet (see ``RelationshipUpdateFilter``) for accounts with
+     *     several owned characters.
      */
     get: operations['relationships_relationship_updates_list'];
     put?: never;

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -13950,6 +13950,34 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/relationships/relationship-updates/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Mutation actions for relationship-building verbs, plus a narrow list route.
+     *
+     *     Detail/browsing of relationship state in general remains on
+     *     CharacterRelationshipViewSet; the ``list`` action here exists only to feed
+     *     the commend button on the requesting user's own writeups-about-them (the
+     *     subject side of ``give_writeup_kudos``'s rule) — it is not a general
+     *     writeup browser. Scoped to writeups where the caller's character is the
+     *     parent relationship's ``target`` (the writeup's commendable subject) and
+     *     visibility is SHARED or PUBLIC; PRIVATE and GOSSIP writeups never appear
+     *     here regardless of subject.
+     */
+    get: operations['relationships_relationship_updates_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/relationships/relationship-updates/capstone/': {
     parameters: {
       query?: never;
@@ -25943,6 +25971,21 @@ export interface components {
       previous?: string | null;
       results: components['schemas']['RelationshipCapstone'][];
     };
+    PaginatedRelationshipUpdateList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['RelationshipUpdate'][];
+    };
     PaginatedRiskCalibrationList: {
       /** @example 123 */
       count: number;
@@ -29288,6 +29331,52 @@ export interface components {
       readonly total_points: number;
       /** @description Return the name of the current tier, or None if no tier reached. */
       readonly current_tier_name: string | null;
+    };
+    /** @description Serializer for relationship updates. */
+    RelationshipUpdate: {
+      readonly id: number;
+      /** @description The character who wrote this update */
+      readonly author: number;
+      readonly author_name: string;
+      /** @description Brief title summarizing the update */
+      readonly title: string;
+      /** @description Narrative writeup describing how the relationship developed */
+      readonly writeup: string;
+      /** @description The track that gains points from this update */
+      readonly track: number;
+      readonly track_name: string;
+      /** @description Points earned: increases capacity and sets temporary value base */
+      readonly points_earned: number;
+      /**
+       * @description Emotional coloring for first impressions (blank for normal updates)
+       *
+       *     * `positive` - Positive
+       *     * `neutral` - Neutral
+       *     * `negative` - Negative
+       */
+      readonly coloring: components['schemas']['ColoringEnum'];
+      /**
+       * @description Who can see this update
+       *
+       *     * `private` - Private
+       *     * `shared` - Shared
+       *     * `gossip` - Gossip
+       *     * `public` - Public
+       */
+      readonly visibility: components['schemas']['VisibilityFdaEnum'];
+      /** @description Whether this is a first impression update */
+      readonly is_first_impression: boolean;
+      /** @description Optional scene this update is based on */
+      readonly linked_scene: number | null;
+      /**
+       * Format: date-time
+       * @description When this update was created
+       */
+      readonly created_at: string;
+      /** @description Return pre-annotated kudos count, or fall back to a query. */
+      readonly kudos_count: number;
+      /** @description Return True if the request user has kudosed this update. */
+      readonly viewer_has_kudosed: boolean;
     };
     /**
      * @description Full renown payload for a single persona.
@@ -52600,6 +52689,28 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['RelationshipCapstone'];
+        };
+      };
+    };
+  };
+  relationships_relationship_updates_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedRelationshipUpdateList'];
         };
       };
     };

--- a/frontend/src/relationships/api.ts
+++ b/frontend/src/relationships/api.ts
@@ -1,0 +1,74 @@
+/**
+ * Relationships API functions (#2031)
+ *
+ * Covers the read surface backing the commend button on relationship
+ * writeups: GET /api/relationships/relationship-updates/ (subject-scoped —
+ * only SHARED/PUBLIC writeups where the requesting user's character is the
+ * parent relationship's target, i.e. the writeup's commendable subject; see
+ * RelationshipUpdateViewSet.get_queryset) and POST .../kudos/ to commend one.
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+import type { components } from '@/generated/api';
+
+export type RelationshipWriteup = components['schemas']['RelationshipUpdate'];
+export type GiveWriteupKudosRequest = components['schemas']['WriteupKudosWriteRequest'];
+
+const RELATIONSHIP_UPDATES_URL = '/api/relationships/relationship-updates';
+
+function jsonHeaders(): HeadersInit {
+  return { 'Content-Type': 'application/json' };
+}
+
+/**
+ * GET /api/relationships/relationship-updates/
+ *
+ * Returns SHARED/PUBLIC writeups where the requesting user's character is
+ * the subject — the writeups the caller may commend. This is NOT a general
+ * writeup browser: the endpoint is scoped to the requesting user, so it
+ * only makes sense to call this while viewing the caller's own sheet.
+ */
+export async function getMyWriteups(): Promise<RelationshipWriteup[]> {
+  const res = await apiFetch(`${RELATIONSHIP_UPDATES_URL}/?page_size=100`);
+  if (!res.ok) throw new Error('Failed to load relationship writeups');
+  const data = (await res.json()) as { results?: RelationshipWriteup[] } | RelationshipWriteup[];
+  return Array.isArray(data) ? data : (data.results ?? []);
+}
+
+/**
+ * Parse the kudos endpoint's failure body: `{success: false, message}`.
+ *
+ * This is NOT the DRF `{detail}` shape `readErrorDetail` (lib/errors) parses,
+ * so that helper is not reusable here — the kudos/complaint actions return
+ * their own `result.message` from the underlying Action, not a DRF exception.
+ */
+async function readKudosErrorMessage(res: Response, fallback: string): Promise<never> {
+  let message = fallback;
+  try {
+    const data = (await res.json()) as { message?: string };
+    if (typeof data.message === 'string' && data.message.trim()) {
+      message = data.message;
+    }
+  } catch {
+    // body wasn't JSON; keep the fallback
+  }
+  throw new Error(message);
+}
+
+/**
+ * POST /api/relationships/relationship-updates/kudos/
+ *
+ * The writeup's subject commends it, awarding the author kudos points.
+ * Rejected with the exact `WriteupFeedbackError.user_message` on 400
+ * (already-commended, non-subject, private writeup, etc).
+ */
+export async function giveWriteupKudos(body: GiveWriteupKudosRequest): Promise<void> {
+  const res = await apiFetch(`${RELATIONSHIP_UPDATES_URL}/kudos/`, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    await readKudosErrorMessage(res, 'Failed to commend this writeup');
+  }
+}

--- a/frontend/src/relationships/api.ts
+++ b/frontend/src/relationships/api.ts
@@ -2,10 +2,11 @@
  * Relationships API functions (#2031)
  *
  * Covers the read surface backing the commend button on relationship
- * writeups: GET /api/relationships/relationship-updates/ (subject-scoped —
- * only SHARED/PUBLIC writeups where the requesting user's character is the
- * parent relationship's target, i.e. the writeup's commendable subject; see
- * RelationshipUpdateViewSet.get_queryset) and POST .../kudos/ to commend one.
+ * writeups: GET /api/relationships/relationship-updates/ (tenure-scoped —
+ * only SHARED/PUBLIC writeups where the requesting user's account currently
+ * holds tenure over the parent relationship's target, i.e. the writeup's
+ * commendable subject; see RelationshipUpdateViewSet.get_queryset) and POST
+ * .../kudos/ to commend one.
  */
 
 import { apiFetch } from '@/evennia_replacements/api';
@@ -23,13 +24,23 @@ function jsonHeaders(): HeadersInit {
 /**
  * GET /api/relationships/relationship-updates/
  *
- * Returns SHARED/PUBLIC writeups where the requesting user's character is
- * the subject — the writeups the caller may commend. This is NOT a general
- * writeup browser: the endpoint is scoped to the requesting user, so it
- * only makes sense to call this while viewing the caller's own sheet.
+ * Returns SHARED/PUBLIC writeups where the requesting user's account holds
+ * tenure over the subject character — the writeups the caller may commend.
+ * This is NOT a general writeup browser: the endpoint is scoped to the
+ * requesting user's tenure-owned characters, so it only makes sense to call
+ * this while viewing one of the caller's own sheets.
+ *
+ * Pass `subjectCharacterId` (the viewed CharacterSheet pk) to narrow to that
+ * one owned character's writeups — required for accounts with more than one
+ * owned character, so a sibling character's writeups don't get mislabeled as
+ * belonging to the one currently being viewed (fix wave, Finding 2).
  */
-export async function getMyWriteups(): Promise<RelationshipWriteup[]> {
-  const res = await apiFetch(`${RELATIONSHIP_UPDATES_URL}/?page_size=100`);
+export async function getMyWriteups(subjectCharacterId?: number): Promise<RelationshipWriteup[]> {
+  const params = new URLSearchParams({ page_size: '100' });
+  if (subjectCharacterId != null) {
+    params.set('subject_character', String(subjectCharacterId));
+  }
+  const res = await apiFetch(`${RELATIONSHIP_UPDATES_URL}/?${params.toString()}`);
   if (!res.ok) throw new Error('Failed to load relationship writeups');
   const data = (await res.json()) as { results?: RelationshipWriteup[] } | RelationshipWriteup[];
   return Array.isArray(data) ? data : (data.results ?? []);

--- a/frontend/src/relationships/queries.ts
+++ b/frontend/src/relationships/queries.ts
@@ -1,0 +1,46 @@
+/**
+ * React Query hooks for the relationships module (#2031).
+ *
+ * Currently covers the writeups-commend surface only. Follows the same
+ * key-factory + hook shape as frontend/src/magic/queries.ts.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import * as api from './api';
+import type { GiveWriteupKudosRequest } from './api';
+
+export const relationshipsKeys = {
+  all: ['relationships'] as const,
+  writeups: () => [...relationshipsKeys.all, 'writeups'] as const,
+};
+
+/**
+ * GET the caller's commendable writeups (subject-scoped, SHARED/PUBLIC only).
+ *
+ * Pass `enabled=false` when viewing a character sheet that is NOT the
+ * caller's own — the endpoint is requester-scoped (subject = the
+ * authenticated user), so fetching it while viewing another character's
+ * sheet would return the *viewer's* writeups, not the viewed character's.
+ */
+export function useMyWriteups(enabled = true) {
+  return useQuery({
+    queryKey: relationshipsKeys.writeups(),
+    queryFn: api.getMyWriteups,
+    enabled,
+  });
+}
+
+/**
+ * Commend a relationship writeup. Invalidates the writeups list so
+ * kudos_count/viewer_has_kudosed refresh on success.
+ */
+export function useGiveWriteupKudos() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: GiveWriteupKudosRequest) => api.giveWriteupKudos(body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: relationshipsKeys.writeups() }).catch(() => {});
+    },
+  });
+}

--- a/frontend/src/relationships/queries.ts
+++ b/frontend/src/relationships/queries.ts
@@ -12,21 +12,36 @@ import type { GiveWriteupKudosRequest } from './api';
 
 export const relationshipsKeys = {
   all: ['relationships'] as const,
-  writeups: () => [...relationshipsKeys.all, 'writeups'] as const,
+  /**
+   * `writeups()` (no arg) is the shared prefix used to invalidate every
+   * subject-scoped variant at once; `writeups(subjectCharacterId)` is the
+   * specific key a given sheet's query is cached under.
+   */
+  writeups: (subjectCharacterId?: number) =>
+    subjectCharacterId == null
+      ? ([...relationshipsKeys.all, 'writeups'] as const)
+      : ([...relationshipsKeys.all, 'writeups', subjectCharacterId] as const),
 };
 
 /**
- * GET the caller's commendable writeups (subject-scoped, SHARED/PUBLIC only).
+ * GET the caller's commendable writeups about one owned character
+ * (tenure-scoped, SHARED/PUBLIC only).
+ *
+ * `subjectCharacterId` (the viewed CharacterSheet pk) is threaded into both
+ * the request (`?subject_character=`) and the query key — required because
+ * the endpoint is scoped to the requester's *account*, which may tenure-own
+ * more than one character; without narrowing, a multi-character account's
+ * Writeups subsection would show every owned character's writeups under
+ * whichever sheet happens to be open (fix wave, Finding 2).
  *
  * Pass `enabled=false` when viewing a character sheet that is NOT the
- * caller's own — the endpoint is requester-scoped (subject = the
- * authenticated user), so fetching it while viewing another character's
- * sheet would return the *viewer's* writeups, not the viewed character's.
+ * caller's own — fetching it on a foreign sheet would return the *viewer's*
+ * own writeups, not the viewed character's.
  */
-export function useMyWriteups(enabled = true) {
+export function useMyWriteups(subjectCharacterId?: number, enabled = true) {
   return useQuery({
-    queryKey: relationshipsKeys.writeups(),
-    queryFn: api.getMyWriteups,
+    queryKey: relationshipsKeys.writeups(subjectCharacterId),
+    queryFn: () => api.getMyWriteups(subjectCharacterId),
     enabled,
   });
 }

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -149,6 +149,7 @@ export function CharacterSheetPage() {
           <RelationshipsSection
             relationships={entry.character.relationships}
             characterSheetId={entry.character.id}
+            isMyCharacter={isMyCharacter}
           />
         </TabsContent>
 

--- a/frontend/src/scenes/__tests__/reactToInteraction.test.ts
+++ b/frontend/src/scenes/__tests__/reactToInteraction.test.ts
@@ -1,0 +1,53 @@
+import { vi } from 'vitest';
+
+vi.mock('@/evennia_replacements/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/evennia_replacements/api';
+import { reactToInteraction } from '../queries';
+
+function mockOkResponse() {
+  return { ok: true, status: 200, json: () => Promise.resolve({}) } as Response;
+}
+
+function mockDetailErrorResponse(detail: string[]) {
+  return { ok: false, status: 400, json: () => Promise.resolve({ detail }) } as Response;
+}
+
+describe('reactToInteraction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs to /api/reaction-windows/react-to-interaction/ with the exact kudos body', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(mockOkResponse());
+
+    await reactToInteraction({
+      persona_id: 7,
+      interaction_id: 99,
+      kind: 'kudos',
+      choice: 'kudos',
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/reaction-windows/react-to-interaction/', {
+      method: 'POST',
+      body: JSON.stringify({
+        persona_id: 7,
+        interaction_id: 99,
+        kind: 'kudos',
+        choice: 'kudos',
+      }),
+    });
+  });
+
+  it('throws with the first message from a 400 detail array', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      mockDetailErrorResponse(['Already gave kudos on this pose.'])
+    );
+
+    await expect(
+      reactToInteraction({ persona_id: 7, interaction_id: 99, kind: 'kudos', choice: 'kudos' })
+    ).rejects.toThrow('Already gave kudos on this pose.');
+  });
+});

--- a/frontend/src/scenes/components/EndorsementControl.tsx
+++ b/frontend/src/scenes/components/EndorsementControl.tsx
@@ -1,22 +1,32 @@
 /**
- * EndorsementControl (#1138) — resonance-picker + endorser badge strip for
- * both pose endorsements (weekly PoseEndorsement) and scene-entry endorsements
- * (immediate SceneEntryEndorsement). Mounts inside PoseUnit.
+ * EndorsementControl (#1138, #2031) — resonance-picker + endorser badge strip
+ * for pose endorsements (weekly PoseEndorsement), scene-entry endorsements
+ * (immediate SceneEntryEndorsement), and style-presentation endorsements
+ * (immediate StylePresentationEndorsement). Mounts inside PoseUnit.
  *
  * Props:
  *   interaction — the full Interaction payload including endorsement state.
  *   sceneId     — forwarded to mutation hooks for cache invalidation.
- *   kind        — 'pose' | 'entry'; drives which mutation fires and which
- *                 badge list / retract affordance is shown.
+ *   kind        — 'pose' | 'entry' | 'style'; drives which mutation fires and
+ *                 which badge list / retract affordance is shown.
  *
  * Hidden entirely when:
  *   - endorsable_resonances is empty (nothing to endorse with)
  *   - the pose belongs to the viewer (self-endorsement guard)
  *   - mode === 'whisper' or visibility === 'very_private'
- *   - kind='entry' and endorsee_sheet_id is null (impossible in practice but typed)
+ *   - kind='entry'|'style' and endorsee_sheet_id is null (impossible in
+ *     practice but typed)
  *
  * For kind='entry': shows a display-only "Endorsed ✓" indicator when
  * entry_endorsed_by_me is true (entry endorsements are permanent — no retract).
+ *
+ * For kind='style': the Interaction payload carries no persisted
+ * "endorsed by me" flag (verified against
+ * `world.scenes.interaction_serializers.InteractionSerializer` — it only
+ * exposes `entry_endorsed_by_me`), so the endorsed-✓ indicator is derived from
+ * the create-mutation's own `isSuccess` state instead (immutable — no retract,
+ * same as entry). A failed style endorsement's backend error (e.g. "not
+ * wearing a bound style") is surfaced verbatim via the mutation's `error`.
  */
 
 import { useMemo } from 'react';
@@ -32,6 +42,7 @@ import {
   useCreatePoseEndorsement,
   useDeletePoseEndorsement,
   useCreateSceneEntryEndorsement,
+  useCreateStyleEndorsement,
 } from '../queries';
 import type { Interaction, EndorserBadge } from '../types';
 
@@ -42,7 +53,7 @@ import type { Interaction, EndorserBadge } from '../types';
 export interface EndorsementControlProps {
   interaction: Interaction;
   sceneId: string;
-  kind: 'pose' | 'entry';
+  kind: 'pose' | 'entry' | 'style';
 }
 
 // ---------------------------------------------------------------------------
@@ -82,6 +93,7 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
   const createPose = useCreatePoseEndorsement(sceneId);
   const deletePose = useDeletePoseEndorsement(sceneId);
   const createEntry = useCreateSceneEntryEndorsement(sceneId);
+  const createStyle = useCreateStyleEndorsement(sceneId);
 
   // Map resonance id → name for badge tooltips — memoized, unconditional.
   const resonanceMap = useMemo(
@@ -101,24 +113,35 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
     return null;
   }
 
-  // endorsee_sheet_id is typed number | null; for kind='entry' it must be present.
-  // If it's somehow null (impossible in practice but typed), hide rather than coerce.
-  if (kind === 'entry' && interaction.endorsee_sheet_id == null) {
+  // endorsee_sheet_id is typed number | null; for kind='entry'|'style' it must
+  // be present. If it's somehow null (impossible in practice but typed), hide
+  // rather than coerce.
+  if ((kind === 'entry' || kind === 'style') && interaction.endorsee_sheet_id == null) {
     return null;
   }
 
   // ----- Data for this kind -----------------------------------------------
   const isPose = kind === 'pose';
+  const isEntry = kind === 'entry';
+  const isStyle = kind === 'style';
   const endorsers: EndorserBadge[] = isPose
     ? interaction.pose_endorsers
-    : interaction.entry_endorsers;
+    : isEntry
+      ? interaction.entry_endorsers
+      : [];
 
   // ----- Handlers ---------------------------------------------------------
   function handlePickResonance(resonanceId: number) {
     if (isPose) {
       createPose.mutate({ interaction: interaction.id, resonance: resonanceId });
-    } else {
+    } else if (isStyle) {
       // endorsee_sheet_id is guaranteed non-null here by the guard above.
+      createStyle.mutate({
+        endorsee_sheet: interaction.endorsee_sheet_id!,
+        scene: Number(sceneId),
+        resonance: resonanceId,
+      });
+    } else {
       createEntry.mutate({
         endorsee_sheet: interaction.endorsee_sheet_id!,
         scene: Number(sceneId),
@@ -128,11 +151,21 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
   }
 
   // ----- Render -----------------------------------------------------------
-  const isPending = isPose ? createPose.isPending : createEntry.isPending;
+  const isPending = isPose
+    ? createPose.isPending
+    : isStyle
+      ? createStyle.isPending
+      : createEntry.isPending;
   const myEndorsement = isPose ? interaction.my_pose_endorsement : null;
   const isEndorsed = myEndorsement != null;
-  const isEntryEndorsedByMe = !isPose && interaction.entry_endorsed_by_me;
-  const label = isPose ? 'Endorse' : 'Endorse entry';
+  // Entry's endorsed state is a persisted server flag; style has none (see
+  // module docstring), so it's derived from the create-mutation's own
+  // isSuccess — the mutation hook instance persists across re-renders of this
+  // component, so the indicator sticks once the immediate grant succeeds.
+  const isImmutableEndorsedByMe =
+    (isEntry && interaction.entry_endorsed_by_me) || (isStyle && createStyle.isSuccess);
+  const label = isPose ? 'Endorse' : isStyle ? 'Endorse style' : 'Endorse entry';
+  const activeError = isPose ? createPose.error : isStyle ? createStyle.error : createEntry.error;
 
   return (
     <div
@@ -153,10 +186,10 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
         >
           Retract
         </button>
-      ) : isEntryEndorsedByMe ? (
-        /* Entry endorsements are permanent — no retract affordance, just a display indicator. */
+      ) : isImmutableEndorsedByMe ? (
+        /* Entry/style endorsements are permanent — no retract affordance, just a display indicator. */
         <span
-          data-testid="entry-endorsed-indicator"
+          data-testid={`${kind}-endorsed-indicator`}
           className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-300"
         >
           Endorsed ✓
@@ -190,6 +223,13 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
           resonanceName={resonanceMap.get(badge.resonance_id) ?? String(badge.resonance_id)}
         />
       ))}
+
+      {/* Backend error — meaningful text (e.g. "not wearing a bound style"), surfaced verbatim. */}
+      {activeError && (
+        <span data-testid="endorsement-error" className="text-xs text-destructive">
+          {activeError.message}
+        </span>
+      )}
     </div>
   );
 }

--- a/frontend/src/scenes/components/PoseUnit.test.tsx
+++ b/frontend/src/scenes/components/PoseUnit.test.tsx
@@ -433,7 +433,7 @@ describe('PoseUnit endorsement control mounting', () => {
     vi.clearAllMocks();
   });
 
-  it('ENTRY pose renders TWO endorsement controls (pose + entry)', () => {
+  it('ENTRY pose renders THREE endorsement controls (pose + entry + style)', () => {
     const interaction = makeInteraction({
       mode: 'pose',
       pose_kind: 'entry',
@@ -447,9 +447,10 @@ describe('PoseUnit endorsement control mounting', () => {
 
     expect(screen.getByTestId('endorsement-control-pose')).toBeInTheDocument();
     expect(screen.getByTestId('endorsement-control-entry')).toBeInTheDocument();
+    expect(screen.getByTestId('endorsement-control-style')).toBeInTheDocument();
   });
 
-  it('STANDARD pose renders ONE endorsement control (pose only)', () => {
+  it('STANDARD pose renders pose + style controls, no entry', () => {
     const interaction = makeInteraction({
       mode: 'pose',
       pose_kind: 'standard',
@@ -462,6 +463,7 @@ describe('PoseUnit endorsement control mounting', () => {
     );
 
     expect(screen.getByTestId('endorsement-control-pose')).toBeInTheDocument();
+    expect(screen.getByTestId('endorsement-control-style')).toBeInTheDocument();
     expect(screen.queryByTestId('endorsement-control-entry')).toBeNull();
   });
 
@@ -479,9 +481,10 @@ describe('PoseUnit endorsement control mounting', () => {
 
     expect(screen.queryByTestId('endorsement-control-pose')).toBeNull();
     expect(screen.queryByTestId('endorsement-control-entry')).toBeNull();
+    expect(screen.queryByTestId('endorsement-control-style')).toBeNull();
   });
 
-  it('standalone ACTION branch also renders an endorsement control', () => {
+  it('standalone ACTION branch also renders pose + style endorsement controls', () => {
     const interaction = makeInteraction({
       mode: 'action',
       pose_kind: 'standard',
@@ -494,6 +497,7 @@ describe('PoseUnit endorsement control mounting', () => {
     );
 
     expect(screen.getByTestId('endorsement-control-pose')).toBeInTheDocument();
+    expect(screen.getByTestId('endorsement-control-style')).toBeInTheDocument();
   });
 
   // WHISPER and VERY_PRIVATE suppression is tested at the correct layer:

--- a/frontend/src/scenes/components/PoseUnit.tsx
+++ b/frontend/src/scenes/components/PoseUnit.tsx
@@ -191,6 +191,7 @@ export function PoseUnit({
         {interaction.pose_kind === 'entry' && (
           <EndorsementControl interaction={interaction} sceneId={sceneId} kind="entry" />
         )}
+        <EndorsementControl interaction={interaction} sceneId={sceneId} kind="style" />
       </div>
     );
   }
@@ -306,6 +307,7 @@ export function PoseUnit({
       {interaction.pose_kind === 'entry' && (
         <EndorsementControl interaction={interaction} sceneId={sceneId} kind="entry" />
       )}
+      <EndorsementControl interaction={interaction} sceneId={sceneId} kind="style" />
     </div>
   );
 }

--- a/frontend/src/scenes/components/PoseUnit.tsx
+++ b/frontend/src/scenes/components/PoseUnit.tsx
@@ -265,7 +265,11 @@ export function PoseUnit({
         <PoseUnitDetailPanel actionInteractionIds={actionInteractionIds} />
       )}
 
-      <ReactionStrip windows={interaction.reaction_windows ?? []} sceneId={sceneId} />
+      <ReactionStrip
+        windows={interaction.reaction_windows ?? []}
+        sceneId={sceneId}
+        interactionId={interaction.id}
+      />
 
       {/* Dramatic-moment tag badges (#1139) */}
       {dramaticTags.length > 0 && (

--- a/frontend/src/scenes/components/ReactionStrip.test.tsx
+++ b/frontend/src/scenes/components/ReactionStrip.test.tsx
@@ -7,6 +7,7 @@ import type { ReactionWindowPayload } from '../types';
 
 vi.mock('../queries', () => ({
   reactToWindow: vi.fn(),
+  reactToInteraction: vi.fn(),
 }));
 
 vi.mock('@/roster/queries', () => ({
@@ -31,7 +32,10 @@ vi.mock('@/store/hooks', () => ({
 }));
 
 import { ReactionStrip } from './ReactionStrip';
-import { reactToWindow } from '../queries';
+import { reactToWindow, reactToInteraction } from '../queries';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+
+const INTERACTION_ID = 99;
 
 function makeWindow(overrides: Partial<ReactionWindowPayload> = {}): ReactionWindowPayload {
   return {
@@ -50,6 +54,20 @@ function makeWindow(overrides: Partial<ReactionWindowPayload> = {}): ReactionWin
   };
 }
 
+function makeKudosWindow(overrides: Partial<ReactionWindowPayload> = {}): ReactionWindowPayload {
+  return {
+    id: 6,
+    kind: 'kudos',
+    is_open: true,
+    public: true,
+    choices: [{ slug: 'kudos', label: 'Kudos' }],
+    reactions: [],
+    counts: {},
+    my_reaction: null,
+    ...overrides,
+  };
+}
+
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
@@ -62,25 +80,32 @@ function createWrapper() {
 describe('ReactionStrip', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useMyRosterEntriesQuery).mockReturnValue({
+      data: [
+        {
+          id: 1,
+          name: 'TestChar',
+          character_id: 42,
+          profile_picture_url: null,
+          primary_persona_id: 7,
+          active_persona_id: 7,
+        },
+      ],
+    } as never);
   });
 
   it('renders a chip per choice with counts', () => {
-    render(<ReactionStrip windows={[makeWindow()]} sceneId="1" />, {
+    render(<ReactionStrip windows={[makeWindow()]} sceneId="1" interactionId={INTERACTION_ID} />, {
       wrapper: createWrapper(),
     });
     expect(screen.getByText('Moonlight 1')).toBeInTheDocument();
     expect(screen.getByText('Thorns')).toBeInTheDocument();
   });
 
-  it('renders nothing without windows', () => {
-    render(<ReactionStrip windows={[]} sceneId="1" />, { wrapper: createWrapper() });
-    expect(screen.queryByTestId('reaction-strip')).not.toBeInTheDocument();
-  });
-
   it('fires the mutation with the chosen slug', async () => {
     const user = userEvent.setup();
     vi.mocked(reactToWindow).mockResolvedValue(undefined);
-    render(<ReactionStrip windows={[makeWindow()]} sceneId="1" />, {
+    render(<ReactionStrip windows={[makeWindow()]} sceneId="1" interactionId={INTERACTION_ID} />, {
       wrapper: createWrapper(),
     });
     await user.click(screen.getByText('Thorns'));
@@ -90,18 +115,83 @@ describe('ReactionStrip', () => {
   });
 
   it('disables chips once the viewer has reacted', () => {
-    render(<ReactionStrip windows={[makeWindow({ my_reaction: '11' })]} sceneId="1" />, {
-      wrapper: createWrapper(),
-    });
+    render(
+      <ReactionStrip
+        windows={[makeWindow({ my_reaction: '11' })]}
+        sceneId="1"
+        interactionId={INTERACTION_ID}
+      />,
+      { wrapper: createWrapper() }
+    );
     expect(screen.getByText('Moonlight 1')).toBeDisabled();
     expect(screen.getByText('Thorns')).toBeDisabled();
   });
 
   it('settled windows render read-only with a closed note', () => {
-    render(<ReactionStrip windows={[makeWindow({ is_open: false })]} sceneId="1" />, {
-      wrapper: createWrapper(),
-    });
+    render(
+      <ReactionStrip
+        windows={[makeWindow({ is_open: false })]}
+        sceneId="1"
+        interactionId={INTERACTION_ID}
+      />,
+      { wrapper: createWrapper() }
+    );
     expect(screen.getByText('(scene closed)')).toBeInTheDocument();
     expect(screen.getByText('Moonlight 1')).toBeDisabled();
+  });
+
+  // --- First-kudos chip (#2031) ---------------------------------------
+
+  it('renders a kudos chip when no kudos window exists yet, even with no windows at all', () => {
+    render(<ReactionStrip windows={[]} sceneId="1" interactionId={INTERACTION_ID} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByTestId('reaction-strip')).toBeInTheDocument();
+    expect(screen.getByText('Kudos')).toBeInTheDocument();
+  });
+
+  it('does not render a duplicate kudos chip when an open kudos window exists', () => {
+    render(
+      <ReactionStrip windows={[makeKudosWindow()]} sceneId="1" interactionId={INTERACTION_ID} />,
+      { wrapper: createWrapper() }
+    );
+    expect(screen.getAllByText('Kudos')).toHaveLength(1);
+  });
+
+  it('POSTs the exact kudos body via reactToInteraction on click', async () => {
+    const user = userEvent.setup();
+    vi.mocked(reactToInteraction).mockResolvedValue(undefined);
+    render(<ReactionStrip windows={[]} sceneId="1" interactionId={INTERACTION_ID} />, {
+      wrapper: createWrapper(),
+    });
+    await user.click(screen.getByText('Kudos'));
+    await waitFor(() => {
+      expect(reactToInteraction).toHaveBeenCalledWith({
+        persona_id: 7,
+        interaction_id: INTERACTION_ID,
+        kind: 'kudos',
+        choice: 'kudos',
+      });
+    });
+  });
+
+  it('disables the kudos chip when no persona is resolved', () => {
+    vi.mocked(useMyRosterEntriesQuery).mockReturnValue({ data: [] } as never);
+    render(<ReactionStrip windows={[]} sceneId="1" interactionId={INTERACTION_ID} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByText('Kudos')).toBeDisabled();
+  });
+
+  it('surfaces the 400 detail message when the kudos POST fails', async () => {
+    const user = userEvent.setup();
+    vi.mocked(reactToInteraction).mockRejectedValue(new Error('Already gave kudos on this pose.'));
+    render(<ReactionStrip windows={[]} sceneId="1" interactionId={INTERACTION_ID} />, {
+      wrapper: createWrapper(),
+    });
+    await user.click(screen.getByText('Kudos'));
+    await waitFor(() => {
+      expect(screen.getByText('Already gave kudos on this pose.')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/scenes/components/ReactionStrip.tsx
+++ b/frontend/src/scenes/components/ReactionStrip.tsx
@@ -52,8 +52,6 @@ export function ReactionStrip({ windows, sceneId, interactionId }: ReactionStrip
 
   const hasKudosWindow = windows.some((window) => window.kind === KUDOS_KIND);
 
-  if (windows.length === 0 && hasKudosWindow) return null;
-
   return (
     <div data-testid="reaction-strip" className="mt-1 flex flex-col gap-1">
       {windows.map((window) => {

--- a/frontend/src/scenes/components/ReactionStrip.tsx
+++ b/frontend/src/scenes/components/ReactionStrip.tsx
@@ -3,20 +3,29 @@
  * event's card. Renders one row per open (or settled, read-only) reaction
  * window: a chip per choice with its count; the viewer's own reaction is
  * highlighted. One tap reacts; settled windows render counts only.
+ *
+ * Also renders the first-kudos chip (#2031): when no kudos-kind window has
+ * been lazily opened on this pose yet, a standalone "Kudos" chip lazily
+ * opens one via reactToInteraction. Once a kudos window exists it takes
+ * over via the normal per-window row above — no duplicate chip.
  */
 import { useMemo } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
-import { reactToWindow } from '../queries';
+import { reactToWindow, reactToInteraction } from '../queries';
 import type { ReactionWindowPayload } from '../types';
+
+// Matches ReactionWindowKind.KUDOS's wire value (src/world/scenes/constants.py).
+const KUDOS_KIND = 'kudos';
 
 interface ReactionStripProps {
   windows: ReactionWindowPayload[];
   sceneId: string;
+  interactionId: number;
 }
 
-export function ReactionStrip({ windows, sceneId }: ReactionStripProps) {
+export function ReactionStrip({ windows, sceneId, interactionId }: ReactionStripProps) {
   const queryClient = useQueryClient();
   // Resolve the viewer's acting persona (mirrors PersonaContextMenu).
   const activeCharacterName = useAppSelector((state) => state.game.active);
@@ -30,8 +39,20 @@ export function ReactionStrip({ windows, sceneId }: ReactionStripProps) {
       reactToWindow(windowId, { persona_id: personaId as number, choice }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
   });
+  const kudosMutation = useMutation({
+    mutationFn: () =>
+      reactToInteraction({
+        persona_id: personaId as number,
+        interaction_id: interactionId,
+        kind: KUDOS_KIND,
+        choice: KUDOS_KIND,
+      }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
+  });
 
-  if (windows.length === 0) return null;
+  const hasKudosWindow = windows.some((window) => window.kind === KUDOS_KIND);
+
+  if (windows.length === 0 && hasKudosWindow) return null;
 
   return (
     <div data-testid="reaction-strip" className="mt-1 flex flex-col gap-1">
@@ -72,6 +93,26 @@ export function ReactionStrip({ windows, sceneId }: ReactionStripProps) {
           </div>
         );
       })}
+      {!hasKudosWindow && (
+        <div className="flex flex-wrap items-center gap-1">
+          <button
+            type="button"
+            title="Kudos"
+            disabled={personaId == null || kudosMutation.isPending}
+            onClick={() => kudosMutation.mutate()}
+            className={`rounded-full border px-2 py-0.5 text-xs transition-colors ${
+              personaId == null
+                ? 'border-muted-foreground/20 opacity-60'
+                : 'border-muted-foreground/30 hover:border-amber-500/60'
+            }`}
+          >
+            Kudos
+          </button>
+          {kudosMutation.isError && (
+            <span className="text-xs text-destructive">{kudosMutation.error.message}</span>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/scenes/components/__tests__/EndorsementControl.test.tsx
+++ b/frontend/src/scenes/components/__tests__/EndorsementControl.test.tsx
@@ -17,6 +17,24 @@ import type { Interaction } from '../../types';
 const mockCreatePoseEndorsement = vi.fn();
 const mockDeletePoseEndorsement = vi.fn();
 const mockCreateSceneEntryEndorsement = vi.fn();
+const mockCreateStyleEndorsement = vi.fn();
+
+// Mutable mutation-state stand-in for useCreateStyleEndorsement — style
+// endorsements carry no persisted "endorsed by me" flag on the Interaction
+// payload (verified: the backend serializer only exposes entry_endorsed_by_me),
+// so the component derives its endorsed-indicator + error display from the
+// mutation object's isSuccess/isError/error, same as react-query would return.
+let styleMutationState: {
+  isPending: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  error: Error | null;
+} = {
+  isPending: false,
+  isSuccess: false,
+  isError: false,
+  error: null,
+};
 
 vi.mock('../../queries', () => ({
   useCreatePoseEndorsement: (_sceneId: string) => ({
@@ -30,6 +48,10 @@ vi.mock('../../queries', () => ({
   useCreateSceneEntryEndorsement: (_sceneId: string) => ({
     mutate: mockCreateSceneEntryEndorsement,
     isPending: false,
+  }),
+  useCreateStyleEndorsement: (_sceneId: string) => ({
+    mutate: mockCreateStyleEndorsement,
+    ...styleMutationState,
   }),
 }));
 
@@ -353,5 +375,129 @@ describe('EndorsementControl — kind="entry"', () => {
     expect(mockCreateSceneEntryEndorsement).not.toHaveBeenCalled();
     // Suppress unused variable warning — user is needed for async setup but no interaction fires.
     void user;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: kind="style" (#2031)
+// ---------------------------------------------------------------------------
+
+describe('EndorsementControl — kind="style"', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    styleMutationState = { isPending: false, isSuccess: false, isError: false, error: null };
+  });
+
+  it('shows an Endorse style button', () => {
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="style" />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByRole('button', { name: /endorse style/i })).toBeInTheDocument();
+  });
+
+  it('clicking Endorse style opens a picker listing endorsable_resonances', async () => {
+    const user = userEvent.setup();
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="style" />, {
+      wrapper: createWrapper(),
+    });
+    await user.click(screen.getByRole('button', { name: /endorse style/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Courage')).toBeInTheDocument();
+      expect(screen.getByText('Wisdom')).toBeInTheDocument();
+    });
+  });
+
+  it('selecting a resonance calls style mutation with { endorsee_sheet, scene, resonance }', async () => {
+    const user = userEvent.setup();
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="style" />, {
+      wrapper: createWrapper(),
+    });
+    await user.click(screen.getByRole('button', { name: /endorse style/i }));
+    await waitFor(() => screen.getByText('Courage'));
+    await user.click(screen.getByText('Courage'));
+    expect(mockCreateStyleEndorsement).toHaveBeenCalledWith({
+      endorsee_sheet: 20,
+      scene: 1,
+      resonance: 5,
+    });
+  });
+
+  it('does NOT show a retract button for style endorsements', () => {
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="style" />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.queryByRole('button', { name: /retract/i })).toBeNull();
+  });
+
+  it('hides entirely when endorsable_resonances is empty', () => {
+    const { container } = render(
+      <EndorsementControl
+        interaction={makeInteraction({ endorsable_resonances: [] })}
+        sceneId="1"
+        kind="style"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides for whisper mode', () => {
+    const { container } = render(
+      <EndorsementControl
+        interaction={makeInteraction({ mode: 'whisper' })}
+        sceneId="1"
+        kind="style"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides for very_private visibility', () => {
+    const { container } = render(
+      <EndorsementControl
+        interaction={makeInteraction({ visibility: 'very_private' })}
+        sceneId="1"
+        kind="style"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides and fires no mutation when endorsee_sheet_id is null (safe null guard)', async () => {
+    const { container } = render(
+      <EndorsementControl
+        interaction={makeInteraction({ endorsee_sheet_id: null })}
+        sceneId="1"
+        kind="style"
+      />,
+      { wrapper: createWrapper() }
+    );
+    expect(container.firstChild).toBeNull();
+    expect(mockCreateStyleEndorsement).not.toHaveBeenCalled();
+  });
+
+  it('shows an endorsed indicator (not the picker) once the style mutation succeeds', () => {
+    styleMutationState = { isPending: false, isSuccess: true, isError: false, error: null };
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="style" />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByTestId('style-endorsed-indicator')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /endorse style/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /retract/i })).toBeNull();
+  });
+
+  it('surfaces the backend error message verbatim when the style mutation fails', () => {
+    styleMutationState = {
+      isPending: false,
+      isSuccess: false,
+      isError: true,
+      error: new Error('You are not wearing a bound style.'),
+    };
+    render(<EndorsementControl interaction={makeInteraction()} sceneId="1" kind="style" />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByText('You are not wearing a bound style.')).toBeInTheDocument();
   });
 });

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -223,6 +223,23 @@ export async function reactToWindow(
   }
 }
 
+export async function reactToInteraction(body: {
+  persona_id: number;
+  interaction_id: number;
+  kind: string;
+  choice: string;
+}): Promise<void> {
+  const res = await apiFetch('/api/reaction-windows/react-to-interaction/', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const data = (await res.json().catch(() => null)) as { detail?: string[] | string } | null;
+    const detail = Array.isArray(data?.detail) ? data.detail[0] : data?.detail;
+    throw new Error(detail || 'Failed to react');
+  }
+}
+
 export async function createPoseEndorsement(body: { interaction: number; resonance: number }) {
   const res = await apiFetch('/api/magic/pose-endorsements/', {
     method: 'POST',

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -274,6 +274,36 @@ export function useCreateSceneEntryEndorsement(sceneId: string) {
   });
 }
 
+/**
+ * Style-presentation endorsement (#2031). Mirrors createSceneEntryEndorsement's
+ * shape — endorser is resolved server-side; immutable (no retract). Backend
+ * error messages are meaningful ("not wearing a bound style", etc.) and must
+ * surface verbatim, so the `detail` string is extracted like setRoundMode's idiom.
+ */
+export async function createStyleEndorsement(body: {
+  endorsee_sheet: number;
+  scene: number;
+  resonance: number;
+}) {
+  const res = await apiFetch('/api/magic/style-presentation-endorsements/', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const data = (await res.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(data?.detail || 'Failed to endorse style');
+  }
+  return res.json();
+}
+
+export function useCreateStyleEndorsement(sceneId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createStyleEndorsement,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
+  });
+}
+
 export function useSetRoundMode(sceneId: string) {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/schema.json
+++ b/src/schema.json
@@ -22862,6 +22862,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/RelationshipCapstone'
           description: ''
+  /api/relationships/relationship-updates/:
+    get:
+      operationId: relationships_relationship_updates_list
+      description: |-
+        Mutation actions for relationship-building verbs, plus a narrow list route.
+
+        Detail/browsing of relationship state in general remains on
+        CharacterRelationshipViewSet; the ``list`` action here exists only to feed
+        the commend button on the requesting user's own writeups-about-them (the
+        subject side of ``give_writeup_kudos``'s rule) — it is not a general
+        writeup browser. Scoped to writeups where the caller's character is the
+        parent relationship's ``target`` (the writeup's commendable subject) and
+        visibility is SHARED or PUBLIC; PRIVATE and GOSSIP writeups never appear
+        here regardless of subject.
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      tags:
+      - relationships
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRelationshipUpdateList'
+          description: ''
   /api/relationships/relationship-updates/capstone/:
     post:
       operationId: relationships_relationship_updates_capstone_create
@@ -46223,6 +46255,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RelationshipCapstone'
+    PaginatedRelationshipUpdateList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/RelationshipUpdate'
     PaginatedRiskCalibrationList:
       type: object
       required:
@@ -52160,6 +52215,99 @@ components:
       - track
       - track_name
       - track_sign
+    RelationshipUpdate:
+      type: object
+      description: Serializer for relationship updates.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        author:
+          type: integer
+          description: The character who wrote this update
+          readOnly: true
+        author_name:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+          description: Brief title summarizing the update
+        writeup:
+          type: string
+          readOnly: true
+          description: Narrative writeup describing how the relationship developed
+        track:
+          type: integer
+          readOnly: true
+          description: The track that gains points from this update
+        track_name:
+          type: string
+          readOnly: true
+        points_earned:
+          type: integer
+          readOnly: true
+          description: 'Points earned: increases capacity and sets temporary value
+            base'
+        coloring:
+          allOf:
+          - $ref: '#/components/schemas/ColoringEnum'
+          readOnly: true
+          description: |-
+            Emotional coloring for first impressions (blank for normal updates)
+
+            * `positive` - Positive
+            * `neutral` - Neutral
+            * `negative` - Negative
+        visibility:
+          allOf:
+          - $ref: '#/components/schemas/VisibilityFdaEnum'
+          readOnly: true
+          description: |-
+            Who can see this update
+
+            * `private` - Private
+            * `shared` - Shared
+            * `gossip` - Gossip
+            * `public` - Public
+        is_first_impression:
+          type: boolean
+          readOnly: true
+          description: Whether this is a first impression update
+        linked_scene:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: Optional scene this update is based on
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: When this update was created
+        kudos_count:
+          type: integer
+          description: Return pre-annotated kudos count, or fall back to a query.
+          readOnly: true
+        viewer_has_kudosed:
+          type: boolean
+          description: Return True if the request user has kudosed this update.
+          readOnly: true
+      required:
+      - author
+      - author_name
+      - coloring
+      - created_at
+      - id
+      - is_first_impression
+      - kudos_count
+      - linked_scene
+      - points_earned
+      - title
+      - track
+      - track_name
+      - viewer_has_kudosed
+      - visibility
+      - writeup
     Renown:
       type: object
       description: |-

--- a/src/schema.json
+++ b/src/schema.json
@@ -22875,7 +22875,13 @@ paths:
         writeup browser. Scoped to writeups where the caller's character is the
         parent relationship's ``target`` (the writeup's commendable subject) and
         visibility is SHARED or PUBLIC; PRIVATE and GOSSIP writeups never appear
-        here regardless of subject.
+        here regardless of subject. Subject eligibility is tenure-based (current,
+        un-ended ``RosterTenure``, mirroring ``get_account_for_character``), not
+        Evennia's live-puppet ``db_account`` field, so a subject browsing while
+        not currently puppeting the character still sees writeups they can
+        legally commend. ``?subject_character=<CharacterSheet pk>`` narrows to one
+        owned character sheet (see ``RelationshipUpdateFilter``) for accounts with
+        several owned characters.
       parameters:
       - name: page
         required: false

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -812,6 +812,12 @@ resonance picker remains a needs-design follow-up. Proven end-to-end by
 **API surfaces (`views.py`):**
 - `PoseEndorsementViewSet` - POST /api/magic/pose-endorsements/ + DELETE-if-unsettled
 - `SceneEntryEndorsementViewSet` - POST-only (delete deferred with ResonanceGrantReversal)
+- `StylePresentationEndorsementViewSet` - POST /api/magic/style-presentation-endorsements/ +
+  GET detail (create + retrieve only; immutable, no delete/settlement). Frontend caller
+  (#2031): `EndorsementControl` (`kind='style'`, `frontend/src/scenes/components/`), mounted
+  in `PoseUnit` alongside the pose/entry kinds. Endorsed-✓ has no persisted per-viewer flag on
+  the `Interaction` payload (unlike entry's `entry_endorsed_by_me`), so the control derives it
+  from the create-mutation's own `isSuccess` for the session.
 - `ResonanceGrantViewSet` - Read-only, user-scoped. FilterSet on source/resonance/date range.
 
 **Telnet surfaces (`commands/endorse.py`, `commands/fashion.py` — #1340):**

--- a/src/world/relationships/CLAUDE.md
+++ b/src/world/relationships/CLAUDE.md
@@ -127,13 +127,21 @@ The positive relationship-building loop is reachable from both web and telnet:
   Relationship state list/detail reads live on `CharacterRelationshipViewSet` (read-only).
   The same `RelationshipUpdateViewSet` also mixes in `ListModelMixin` for a narrow `GET`
   list route (#2031) — **not** a general writeup browser: scoped to `RelationshipUpdate`
-  rows where the requesting user's character is the parent relationship's `target` (the
-  writeup's commendable subject, matching `give_writeup_kudos`'s subject rule) and
-  visibility is SHARED or PUBLIC (PRIVATE/GOSSIP never appear here regardless of subject).
-  Supports `?relationship=`/`?track=` filters. Feeds the commend button on the frontend's
-  own-sheet Relationships tab. Read serializers expose `kudos_count` and
-  `viewer_has_kudosed` on every writeup row (annotated via `Count`/`Exists` to avoid N+1).
-  Complaints never appear in any player-facing serializer.
+  rows where the requesting user's account has a **current RosterTenure** (mirroring
+  `world.roster.selectors.get_account_for_character`) over the parent relationship's
+  `target` (the writeup's commendable subject, matching `give_writeup_kudos`'s subject
+  rule) and visibility is SHARED or PUBLIC (PRIVATE/GOSSIP never appear here regardless
+  of subject). Deliberately tenure-based rather than Evennia's live-puppet `db_account`
+  field — a subject browsing while not currently puppeting the character must still see
+  writeups they can legally commend. Supports `?relationship=`/`?track=` filters, plus
+  `?subject_character=<CharacterSheet pk>` (#2031 fix wave) to narrow the (possibly
+  multi-character) tenure-scoped set down to one owned sheet — it can only narrow, never
+  widen, past the requester's own tenure-owned characters. Feeds the commend button on
+  the frontend's own-sheet Relationships tab, which passes the viewed character's pk as
+  `subject_character` so a multi-character account's Writeups subsection never mislabels
+  a sibling character's writeups as the viewed character's. Read serializers expose
+  `kudos_count` and `viewer_has_kudosed` on every writeup row (annotated via
+  `Count`/`Exists` to avoid N+1). Complaints never appear in any player-facing serializer.
 - **Telnet** — `CmdRelationship` (`relationship <subverb>`) runs the same Actions; it adds
   telnet-only `relationship list` and `relationship show <name|#>` read surfaces (the web provides
   these implicitly).

--- a/src/world/relationships/CLAUDE.md
+++ b/src/world/relationships/CLAUDE.md
@@ -123,10 +123,17 @@ ADR-0015 (no polymorphism).
 The positive relationship-building loop is reachable from both web and telnet:
 
 - **Web** — `RelationshipUpdateViewSet` exposes four POST endpoints (`first_impression` /
-  `develop` / `capstone` / `redistribute`) that dispatch the Actions via `action.run()`. List/
-  detail reads live on `CharacterRelationshipViewSet` (read-only). Read serializers expose
-  `kudos_count` and `viewer_has_kudosed` on every writeup row (annotated via `Count`/`Exists`
-  to avoid N+1). Complaints never appear in any player-facing serializer.
+  `develop` / `capstone` / `redistribute`) that dispatch the Actions via `action.run()`.
+  Relationship state list/detail reads live on `CharacterRelationshipViewSet` (read-only).
+  The same `RelationshipUpdateViewSet` also mixes in `ListModelMixin` for a narrow `GET`
+  list route (#2031) — **not** a general writeup browser: scoped to `RelationshipUpdate`
+  rows where the requesting user's character is the parent relationship's `target` (the
+  writeup's commendable subject, matching `give_writeup_kudos`'s subject rule) and
+  visibility is SHARED or PUBLIC (PRIVATE/GOSSIP never appear here regardless of subject).
+  Supports `?relationship=`/`?track=` filters. Feeds the commend button on the frontend's
+  own-sheet Relationships tab. Read serializers expose `kudos_count` and
+  `viewer_has_kudosed` on every writeup row (annotated via `Count`/`Exists` to avoid N+1).
+  Complaints never appear in any player-facing serializer.
 - **Telnet** — `CmdRelationship` (`relationship <subverb>`) runs the same Actions; it adds
   telnet-only `relationship list` and `relationship show <name|#>` read surfaces (the web provides
   these implicitly).

--- a/src/world/relationships/filters.py
+++ b/src/world/relationships/filters.py
@@ -3,7 +3,7 @@
 from django.db.models import Q, QuerySet
 import django_filters
 
-from world.relationships.models import RelationshipCapstone
+from world.relationships.models import RelationshipCapstone, RelationshipUpdate
 
 
 class RelationshipCapstoneFilter(django_filters.FilterSet):
@@ -28,3 +28,32 @@ class RelationshipCapstoneFilter(django_filters.FilterSet):
     ) -> QuerySet[RelationshipCapstone]:
         """Return capstones whose relationship involves the given character sheet."""
         return queryset.filter(Q(relationship__source_id=value) | Q(relationship__target_id=value))
+
+
+class RelationshipUpdateFilter(django_filters.FilterSet):
+    """Filter the writeup-commend list by relationship/track, or narrow to one subject.
+
+    ``?subject_character=<CharacterSheet pk>`` narrows
+    ``RelationshipUpdateViewSet``'s already tenure-scoped queryset (see its
+    ``get_queryset``) down to writeups whose parent relationship's subject
+    (``target``) is that specific sheet. This exists so an account with
+    several owned characters can request "just this one sheet's writeups"
+    instead of every owned character's — it can only *narrow* the result,
+    never widen it, since the base queryset is already restricted to the
+    requester's own tenure-owned subject characters.
+    """
+
+    subject_character = django_filters.NumberFilter(method="filter_by_subject_character")
+
+    class Meta:
+        model = RelationshipUpdate
+        fields = ["relationship", "track", "subject_character"]
+
+    def filter_by_subject_character(
+        self,
+        queryset: QuerySet[RelationshipUpdate],
+        name: str,
+        value: int,
+    ) -> QuerySet[RelationshipUpdate]:
+        """Return writeups whose relationship's subject (target) is the given sheet."""
+        return queryset.filter(relationship__target_id=value)

--- a/src/world/relationships/tests/test_update_list_viewset.py
+++ b/src/world/relationships/tests/test_update_list_viewset.py
@@ -1,0 +1,191 @@
+"""Tests for RelationshipUpdateViewSet's list route (#2031, commend button read surface).
+
+Scoped narrowly to the commend use-case: only writeups where the requesting user's
+character is the relationship's SUBJECT (``relationship.target``, matching
+``give_writeup_kudos``'s subject rule) and visibility is SHARED or PUBLIC. Mirrors
+``RelationshipCapstoneViewSet``'s annotated read pattern (see test_capstone_viewset.py)
+but scopes by target/subject instead of author.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.relationships.constants import TrackSign, UpdateVisibility
+from world.relationships.factories import (
+    CharacterRelationshipFactory,
+    RelationshipTrackFactory,
+    RelationshipUpdateFactory,
+)
+from world.relationships.models import WriteupKudos
+
+
+class RelationshipUpdateListViewSetTests(TestCase):
+    """Tests for RelationshipUpdateViewSet's list action."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """Set up test data shared across all tests."""
+        User = get_user_model()
+
+        # The viewer/subject account and their character sheet — writeups are
+        # "about" this sheet (relationship.target == subject_sheet).
+        cls.subject_account = User.objects.create_user(
+            username="update_list_subject", password="testpass"
+        )
+        cls.subject_sheet = CharacterSheetFactory()
+        cls.subject_sheet.character.db_account = cls.subject_account
+        cls.subject_sheet.character.save()
+
+        # The author account/sheet — writes about the subject.
+        cls.author_account = User.objects.create_user(
+            username="update_list_author", password="testpass"
+        )
+        cls.author_sheet = CharacterSheetFactory()
+        cls.author_sheet.character.db_account = cls.author_account
+        cls.author_sheet.character.save()
+
+        # A third party, entirely uninvolved.
+        cls.third_sheet = CharacterSheetFactory()
+
+        cls.track = RelationshipTrackFactory(name="UpdateListTrack", sign=TrackSign.POSITIVE)
+
+        # subject is the TARGET here — this is the eligible direction.
+        cls.rel_author_subject = CharacterRelationshipFactory(
+            source=cls.author_sheet, target=cls.subject_sheet
+        )
+        # subject is the SOURCE here — writeups on this relationship are about
+        # the author, not the subject, so they must be excluded.
+        cls.rel_subject_author = CharacterRelationshipFactory(
+            source=cls.subject_sheet, target=cls.author_sheet
+        )
+        # Relationship with no subject involvement at all.
+        cls.rel_third = CharacterRelationshipFactory(
+            source=cls.third_sheet, target=cls.author_sheet
+        )
+
+        cls.update_shared = RelationshipUpdateFactory(
+            relationship=cls.rel_author_subject,
+            author=cls.author_sheet,
+            track=cls.track,
+            title="Shared About Subject",
+            visibility=UpdateVisibility.SHARED,
+        )
+        cls.update_public = RelationshipUpdateFactory(
+            relationship=cls.rel_author_subject,
+            author=cls.author_sheet,
+            track=cls.track,
+            title="Public About Subject",
+            visibility=UpdateVisibility.PUBLIC,
+        )
+        cls.update_private = RelationshipUpdateFactory(
+            relationship=cls.rel_author_subject,
+            author=cls.author_sheet,
+            track=cls.track,
+            title="Private About Subject",
+            visibility=UpdateVisibility.PRIVATE,
+        )
+        cls.update_gossip = RelationshipUpdateFactory(
+            relationship=cls.rel_author_subject,
+            author=cls.author_sheet,
+            track=cls.track,
+            title="Gossip About Subject",
+            visibility=UpdateVisibility.GOSSIP,
+        )
+        cls.update_wrong_direction = RelationshipUpdateFactory(
+            relationship=cls.rel_subject_author,
+            author=cls.subject_sheet,
+            track=cls.track,
+            title="About The Author Not Subject",
+            visibility=UpdateVisibility.SHARED,
+        )
+        cls.update_third_party = RelationshipUpdateFactory(
+            relationship=cls.rel_third,
+            author=cls.third_sheet,
+            track=cls.track,
+            title="Unrelated Third Party Update",
+            visibility=UpdateVisibility.SHARED,
+        )
+
+    def setUp(self) -> None:
+        """Set up test client."""
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.subject_account)
+
+    def test_list_returns_shared_and_public_writeups_about_subject(self) -> None:
+        """List returns only SHARED/PUBLIC writeups where subject is the target."""
+        response = self.client.get("/api/relationships/relationship-updates/")
+        assert response.status_code == status.HTTP_200_OK
+        data = self._get_results(response.data)
+        titles = [u["title"] for u in data]
+        assert "Shared About Subject" in titles
+        assert "Public About Subject" in titles
+
+    def test_list_excludes_private_writeup(self) -> None:
+        """PRIVATE writeups about the subject are excluded."""
+        response = self.client.get("/api/relationships/relationship-updates/")
+        data = self._get_results(response.data)
+        titles = [u["title"] for u in data]
+        assert "Private About Subject" not in titles
+
+    def test_list_excludes_gossip_writeup(self) -> None:
+        """GOSSIP writeups about the subject are excluded (only SHARED/PUBLIC)."""
+        response = self.client.get("/api/relationships/relationship-updates/")
+        data = self._get_results(response.data)
+        titles = [u["title"] for u in data]
+        assert "Gossip About Subject" not in titles
+
+    def test_list_excludes_writeup_where_subject_is_not_target(self) -> None:
+        """Writeups on a relationship where the subject is the SOURCE are excluded."""
+        response = self.client.get("/api/relationships/relationship-updates/")
+        data = self._get_results(response.data)
+        titles = [u["title"] for u in data]
+        assert "About The Author Not Subject" not in titles
+
+    def test_list_excludes_unrelated_third_party_writeup(self) -> None:
+        """Writeups on relationships not involving the subject at all are excluded."""
+        response = self.client.get("/api/relationships/relationship-updates/")
+        data = self._get_results(response.data)
+        titles = [u["title"] for u in data]
+        assert "Unrelated Third Party Update" not in titles
+
+    def test_unauthenticated_request_rejected(self) -> None:
+        """Unauthenticated requests are rejected with 401 or 403."""
+        self.client.force_authenticate(user=None)
+        response = self.client.get("/api/relationships/relationship-updates/")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    def test_list_carries_kudos_count_and_viewer_has_kudosed(self) -> None:
+        """Response rows carry annotated kudos_count and viewer_has_kudosed."""
+        WriteupKudos.objects.create(account=self.subject_account, update=self.update_shared)
+        response = self.client.get("/api/relationships/relationship-updates/")
+        data = self._get_results(response.data)
+        by_title = {u["title"]: u for u in data}
+        assert by_title["Shared About Subject"]["kudos_count"] == 1
+        assert by_title["Shared About Subject"]["viewer_has_kudosed"] is True
+        assert by_title["Public About Subject"]["kudos_count"] == 0
+        assert by_title["Public About Subject"]["viewer_has_kudosed"] is False
+
+    def test_list_filters_by_relationship(self) -> None:
+        """?relationship=<pk> narrows to writeups on that relationship."""
+        url = f"/api/relationships/relationship-updates/?relationship={self.rel_author_subject.pk}"
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = self._get_results(response.data)
+        titles = [u["title"] for u in data]
+        assert "Shared About Subject" in titles
+        assert "Public About Subject" in titles
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _get_results(self, response_data: dict | list) -> list:
+        """Extract results from paginated or non-paginated response."""
+        if isinstance(response_data, dict) and "results" in response_data:
+            return response_data["results"]
+        return response_data

--- a/src/world/relationships/tests/test_update_list_viewset.py
+++ b/src/world/relationships/tests/test_update_list_viewset.py
@@ -1,13 +1,19 @@
 """Tests for RelationshipUpdateViewSet's list route (#2031, commend button read surface).
 
 Scoped narrowly to the commend use-case: only writeups where the requesting user's
-character is the relationship's SUBJECT (``relationship.target``, matching
-``give_writeup_kudos``'s subject rule) and visibility is SHARED or PUBLIC. Mirrors
-``RelationshipCapstoneViewSet``'s annotated read pattern (see test_capstone_viewset.py)
-but scopes by target/subject instead of author.
+account holds a *current RosterTenure* over the relationship's SUBJECT
+(``relationship.target``, matching ``give_writeup_kudos``'s subject rule) and
+visibility is SHARED or PUBLIC. Mirrors ``RelationshipCapstoneViewSet``'s annotated
+read pattern (see test_capstone_viewset.py) but scopes by target/subject instead of
+author.
+
+Ownership is provisioned via ``RosterTenure`` (the pattern ``test_writeup_feedback_api.py``
+uses for ``give_writeup_kudos``), **not** ``db_account`` — ``db_account`` is Evennia's
+live-puppet field, cleared on unpuppet, and does not reflect roster ownership (fix wave,
+Finding 1: a subject browsing while not currently puppeting the character must still see
+their commendable writeups).
 """
 
-from django.contrib.auth import get_user_model
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -20,6 +26,18 @@ from world.relationships.factories import (
     RelationshipUpdateFactory,
 )
 from world.relationships.models import WriteupKudos
+from world.roster.factories import RosterTenureFactory
+
+
+def _make_linked_account(character_sheet):
+    """Create a RosterTenure linking character_sheet.character to a fresh account.
+
+    Deliberately does NOT touch ``db_account`` — ownership here is tenure-based,
+    matching how ``get_account_for_character``/``give_writeup_kudos`` resolve the
+    subject, and how a real player is linked to a roster character.
+    """
+    tenure = RosterTenureFactory(roster_entry__character_sheet__character=character_sheet.character)
+    return tenure.player_data.account
 
 
 class RelationshipUpdateListViewSetTests(TestCase):
@@ -28,27 +46,28 @@ class RelationshipUpdateListViewSetTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         """Set up test data shared across all tests."""
-        User = get_user_model()
-
         # The viewer/subject account and their character sheet — writeups are
-        # "about" this sheet (relationship.target == subject_sheet).
-        cls.subject_account = User.objects.create_user(
-            username="update_list_subject", password="testpass"
-        )
+        # "about" this sheet (relationship.target == subject_sheet). Linked via
+        # RosterTenure, NOT db_account (the live-puppet field) — this account is
+        # NOT currently puppeting subject_sheet's character in most tests below,
+        # proving the endpoint is reachable regardless of puppet state.
         cls.subject_sheet = CharacterSheetFactory()
-        cls.subject_sheet.character.db_account = cls.subject_account
-        cls.subject_sheet.character.save()
+        cls.subject_account = _make_linked_account(cls.subject_sheet)
 
         # The author account/sheet — writes about the subject.
-        cls.author_account = User.objects.create_user(
-            username="update_list_author", password="testpass"
-        )
         cls.author_sheet = CharacterSheetFactory()
-        cls.author_sheet.character.db_account = cls.author_account
-        cls.author_sheet.character.save()
+        cls.author_account = _make_linked_account(cls.author_sheet)
 
         # A third party, entirely uninvolved.
         cls.third_sheet = CharacterSheetFactory()
+
+        # A second character owned by the SAME subject account, for the
+        # ?subject_character= narrowing tests.
+        cls.subject_alt_sheet = CharacterSheetFactory()
+        RosterTenureFactory(
+            roster_entry__character_sheet=cls.subject_alt_sheet,
+            player_data=cls.subject_account.player_data,
+        )
 
         cls.track = RelationshipTrackFactory(name="UpdateListTrack", sign=TrackSign.POSITIVE)
 
@@ -64,6 +83,10 @@ class RelationshipUpdateListViewSetTests(TestCase):
         # Relationship with no subject involvement at all.
         cls.rel_third = CharacterRelationshipFactory(
             source=cls.third_sheet, target=cls.author_sheet
+        )
+        # A relationship about the subject's SECOND character.
+        cls.rel_author_subject_alt = CharacterRelationshipFactory(
+            source=cls.author_sheet, target=cls.subject_alt_sheet
         )
 
         cls.update_shared = RelationshipUpdateFactory(
@@ -106,6 +129,13 @@ class RelationshipUpdateListViewSetTests(TestCase):
             author=cls.third_sheet,
             track=cls.track,
             title="Unrelated Third Party Update",
+            visibility=UpdateVisibility.SHARED,
+        )
+        cls.update_about_alt = RelationshipUpdateFactory(
+            relationship=cls.rel_author_subject_alt,
+            author=cls.author_sheet,
+            track=cls.track,
+            title="Shared About Subject's Second Character",
             visibility=UpdateVisibility.SHARED,
         )
 
@@ -180,6 +210,49 @@ class RelationshipUpdateListViewSetTests(TestCase):
         titles = [u["title"] for u in data]
         assert "Shared About Subject" in titles
         assert "Public About Subject" in titles
+
+    def test_list_reachable_when_subject_not_currently_puppeting(self) -> None:
+        """A tenure-owned, not-currently-puppeted subject still sees their writeups.
+
+        Regression for Finding 1: the old queryset filtered on
+        ``relationship__target__character__db_account``, Evennia's live-puppet field,
+        which is cleared on unpuppet. Confirm ``subject_sheet.character.db_account``
+        is unset here (proving the account is NOT puppeting) while the tenure-linked
+        writeup is still listed.
+        """
+        assert self.subject_sheet.character.db_account_id is None
+        response = self.client.get("/api/relationships/relationship-updates/")
+        assert response.status_code == status.HTTP_200_OK
+        titles = [u["title"] for u in self._get_results(response.data)]
+        assert "Shared About Subject" in titles
+
+    def test_subject_character_narrows_to_one_owned_character(self) -> None:
+        """?subject_character=<pk> narrows to writeups about that owned sheet only."""
+        url = f"/api/relationships/relationship-updates/?subject_character={self.subject_sheet.pk}"
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        titles = [u["title"] for u in self._get_results(response.data)]
+        assert "Shared About Subject" in titles
+        assert "Public About Subject" in titles
+        assert "Shared About Subject's Second Character" not in titles
+
+    def test_subject_character_narrows_to_other_owned_character(self) -> None:
+        """?subject_character=<other pk> narrows to the OTHER owned sheet's writeups."""
+        url = (
+            "/api/relationships/relationship-updates/"
+            f"?subject_character={self.subject_alt_sheet.pk}"
+        )
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        titles = [u["title"] for u in self._get_results(response.data)]
+        assert titles == ["Shared About Subject's Second Character"]
+
+    def test_subject_character_cannot_widen_to_unowned_character(self) -> None:
+        """?subject_character=<unowned pk> narrows to nothing — it can't widen access."""
+        url = f"/api/relationships/relationship-updates/?subject_character={self.third_sheet.pk}"
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert self._get_results(response.data) == []
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/world/relationships/views.py
+++ b/src/world/relationships/views.py
@@ -13,7 +13,7 @@ from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
 
 from world.mechanics.models import ModifierTarget
 from world.relationships.constants import UpdateVisibility
-from world.relationships.filters import RelationshipCapstoneFilter
+from world.relationships.filters import RelationshipCapstoneFilter, RelationshipUpdateFilter
 from world.relationships.models import (
     CharacterRelationship,
     HybridRelationshipType,
@@ -180,14 +180,20 @@ class RelationshipUpdateViewSet(ListModelMixin, GenericViewSet):
     writeup browser. Scoped to writeups where the caller's character is the
     parent relationship's ``target`` (the writeup's commendable subject) and
     visibility is SHARED or PUBLIC; PRIVATE and GOSSIP writeups never appear
-    here regardless of subject.
+    here regardless of subject. Subject eligibility is tenure-based (current,
+    un-ended ``RosterTenure``, mirroring ``get_account_for_character``), not
+    Evennia's live-puppet ``db_account`` field, so a subject browsing while
+    not currently puppeting the character still sees writeups they can
+    legally commend. ``?subject_character=<CharacterSheet pk>`` narrows to one
+    owned character sheet (see ``RelationshipUpdateFilter``) for accounts with
+    several owned characters.
     """
 
     permission_classes = [IsAuthenticated]
     serializer_class = FirstImpressionWriteSerializer
     pagination_class = PageNumberPagination
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["relationship", "track"]
+    filterset_class = RelationshipUpdateFilter
 
     def get_serializer_class(self):  # type: ignore[override]
         """Return the write serializer matching the current action."""
@@ -203,15 +209,33 @@ class RelationshipUpdateViewSet(ListModelMixin, GenericViewSet):
         return mapping.get(self.action, FirstImpressionWriteSerializer)
 
     def get_queryset(self):  # type: ignore[override]
-        """Return SHARED/PUBLIC writeups about the caller's character (subject side).
+        """Return SHARED/PUBLIC writeups about the caller's tenure-owned subject character(s).
 
-        Annotates ``kudos_count``/``viewer_has_kudosed`` the same way
-        ``RelationshipCapstoneViewSet`` does, to avoid N+1 queries when serializing.
+        Subject eligibility mirrors ``world.roster.selectors.get_account_for_character``'s
+        tenure join — a current (``end_date__isnull=True``) ``RosterTenure`` — rather than
+        the live-puppet ``db_account`` field: a subject browsing their sheet while not
+        currently puppeting that character must still see (and be able to commend)
+        writeups about them.
+
+        The eligible subject pks are resolved via a separate ``.distinct()`` lookup and
+        applied to the annotated queryset with ``pk__in`` rather than joining ``tenures``
+        directly alongside the ``Count``/``Exists`` annotations — joining the to-many
+        ``tenures`` relation on the same query as those aggregates would risk inflating
+        ``kudos_count`` if a character ever had more than one current tenure row (should
+        not happen, but isn't DB-enforced).
         """
         user = self.request.user
+        eligible_ids = (
+            RelationshipUpdate.objects.filter(
+                relationship__target__roster_entry__tenures__player_data__account=user,
+                relationship__target__roster_entry__tenures__end_date__isnull=True,
+            )
+            .values_list("pk", flat=True)
+            .distinct()
+        )
         return (
             RelationshipUpdate.objects.filter(
-                relationship__target__character__db_account=user,
+                pk__in=eligible_ids,
                 visibility__in=[UpdateVisibility.SHARED, UpdateVisibility.PUBLIC],
             )
             .select_related("author", "author__character", "track", "relationship")

--- a/src/world/relationships/views.py
+++ b/src/world/relationships/views.py
@@ -5,12 +5,14 @@ from django.db.models import Count, Exists, OuterRef, Prefetch
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.mixins import ListModelMixin
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
 
 from world.mechanics.models import ModifierTarget
+from world.relationships.constants import UpdateVisibility
 from world.relationships.filters import RelationshipCapstoneFilter
 from world.relationships.models import (
     CharacterRelationship,
@@ -35,6 +37,7 @@ from world.relationships.serializers import (
     RelationshipCapstoneSerializer,
     RelationshipConditionSerializer,
     RelationshipTrackSerializer,
+    RelationshipUpdateSerializer,
     WriteupComplaintWriteSerializer,
     WriteupKudosWriteSerializer,
 )
@@ -167,19 +170,29 @@ class RelationshipCapstoneViewSet(ReadOnlyModelViewSet):
         )
 
 
-class RelationshipUpdateViewSet(GenericViewSet):
-    """Write-only endpoints for relationship-building verbs.
+class RelationshipUpdateViewSet(ListModelMixin, GenericViewSet):
+    """Mutation actions for relationship-building verbs, plus a narrow list route.
 
-    List/detail relationship state remains on CharacterRelationshipViewSet;
-    this ViewSet only exposes the four mutation actions.
+    Detail/browsing of relationship state in general remains on
+    CharacterRelationshipViewSet; the ``list`` action here exists only to feed
+    the commend button on the requesting user's own writeups-about-them (the
+    subject side of ``give_writeup_kudos``'s rule) — it is not a general
+    writeup browser. Scoped to writeups where the caller's character is the
+    parent relationship's ``target`` (the writeup's commendable subject) and
+    visibility is SHARED or PUBLIC; PRIVATE and GOSSIP writeups never appear
+    here regardless of subject.
     """
 
     permission_classes = [IsAuthenticated]
     serializer_class = FirstImpressionWriteSerializer
+    pagination_class = PageNumberPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["relationship", "track"]
 
     def get_serializer_class(self):  # type: ignore[override]
         """Return the write serializer matching the current action."""
         mapping = {
+            "list": RelationshipUpdateSerializer,
             "first_impression": FirstImpressionWriteSerializer,
             "develop": DevelopmentWriteSerializer,
             "capstone": CapstoneWriteSerializer,
@@ -188,6 +201,28 @@ class RelationshipUpdateViewSet(GenericViewSet):
             "complaint": WriteupComplaintWriteSerializer,
         }
         return mapping.get(self.action, FirstImpressionWriteSerializer)
+
+    def get_queryset(self):  # type: ignore[override]
+        """Return SHARED/PUBLIC writeups about the caller's character (subject side).
+
+        Annotates ``kudos_count``/``viewer_has_kudosed`` the same way
+        ``RelationshipCapstoneViewSet`` does, to avoid N+1 queries when serializing.
+        """
+        user = self.request.user
+        return (
+            RelationshipUpdate.objects.filter(
+                relationship__target__character__db_account=user,
+                visibility__in=[UpdateVisibility.SHARED, UpdateVisibility.PUBLIC],
+            )
+            .select_related("author", "author__character", "track", "relationship")
+            .annotate(
+                kudos_count=Count("writeupkudos_set"),
+                viewer_has_kudosed=Exists(
+                    WriteupKudos.objects.filter(account_id=user.pk, update=OuterRef("pk"))
+                ),
+            )
+            .order_by("-created_at")
+        )
 
     def _resolve_target_sheet(self, target_persona_id: int):
         """Resolve a target persona ID to its CharacterSheet."""

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -256,6 +256,19 @@ Key service functions for scene round lifecycle:
   `world.scenes.reaction_toggle_services.toggle_interaction_reaction` (the sole mutator), the same
   seam telnet `CmdReact` reaches via `ToggleReactionAction` (#1341).
 
+### `reaction_views.py` (#904)
+- **`ReactionWindowViewSet`**: action-only viewset over `ReactionWindow`/`WindowReaction`
+  (`reaction_models.py`). `react` (detail POST) records a reaction on an existing window via
+  `react_to_window`; `react-to-interaction` (custom list POST, #911) lazily opens a
+  `lazy_open` window kind (e.g. `kudos`) on an `Interaction` that has none yet via
+  `react_to_interaction`, then records the reaction in one call. Reads ride the interaction
+  feed — windows serialize inline on their event; all eligibility lives in the two services.
+  Frontend caller (#2031): `ReactionStrip`'s first-kudos chip
+  (`frontend/src/scenes/components/ReactionStrip.tsx`) calls `POST
+  /api/reaction-windows/react-to-interaction/` with `kind: "kudos"` when the pose has no
+  kudos-kind window yet (including the previously-null empty-windows case); once a kudos
+  window exists the normal per-window row takes over and the chip disappears.
+
 ### `serializers.py`
 - Scene and persona serialization for API responses
 - Participant data serialization


### PR DESCRIPTION
Closes #2031

## Summary

Closes the web-parity gap for three player-to-player appreciation rewards that were telnet-only in practice (#2031): (1) EndorsementControl gains kind='style' — style endorsements from scene poses via /api/magic/style-presentation-endorsements/, picker driven by the endorsee's claimed resonances (endorsable_resonances verified endorsee-scoped), backend errors verbatim; (2) ReactionStrip gains a first-kudos chip — POST /api/reaction-windows/react-to-interaction/ lazily opens the kudos window on a pose's first web kudos (previously impossible from web); (3) writeup commend — the spec predicted no serializer changes, but code verification showed relationship writeups had NO web read surface at all, so this adds a deliberately narrow list route on RelationshipUpdateViewSet (tenure-scoped to writeups whose subject the account owns, SHARED/PUBLIC only, ?subject_character= narrowing) plus a Writeups subsection with commend button in RelationshipsSection. A review-caught fix makes the read scoping tenure-based (matching give_writeup_kudos) rather than live-puppet db_account, with a not-currently-puppeted regression test. Known accepted notes: commend POSTs still require a live puppet (shared dispatch-layer constraint of all six #1485 feedback verbs — errors surface verbatim); RelationshipCapstoneViewSet and _award_pose_kudos retain the latent live-puppet db_account pattern (untouched here, telnet parity holds; under-inclusion not leakage); style endorsed-state is session-local (no server flag; duplicate POST 400s cleanly); drf-spectacular omits DjangoFilterBackend params on these viewsets (pre-existing).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2031 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main mid-work (one keep-both docs conflict in docs/systems/INDEX.md vs #2132); post-rebase: 183 relationships tests OK, 89 frontend tests OK, typecheck clean, no api-type drift.

<!-- last-addressed-comment: 0 -->