### PR TITLE
feat: PERMIT-offer details panel in the Mission Studio role editor (#728 follow-up)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1613,7 +1613,9 @@ per-kind effect handler dispatch. Covers permits today; missions/loans/training/
 register as additional kinds.
 
 - **Models:** `NPCRole`, `NPCServiceOffer` (kind discriminator + draw_mode + eligibility_rule),
-  `PermitOfferDetails` (1:1 per-kind details; mirrors `ItemFacet` composition),
+  `PermitOfferDetails` (1:1 per-kind details; mirrors `ItemFacet` composition; fully
+  authorable over `/api/npc-services/permit-details/` since #1684 — building_kind FK,
+  default_approved_wards M2M, size cap, permit cost; `role` filter walks `offer__role_id`),
   `NPCStanding` (per-(PC persona, NPC persona); relocated from `world.missions.MissionGiverStanding`),
   `Functionary` (#1766 — a class-1 NPC placement = `NPCRole` + `room` FK; the non-piloted room-feature
   anchor for gameplay loops; see ADR-0070 for the Functionary/Standing NPC/Story NPC ontology),

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -27484,9 +27484,24 @@ export interface components {
       name?: string;
       description?: string;
     };
+    /**
+     * @description Staff CRUD for permit-kind offer details (#1684, closing #728's residual).
+     *
+     *     ``building_kind`` and ``default_approved_wards`` are PK-related writes; the
+     *     FE feeds them from the existing ``/api/buildings/building-kinds/`` and
+     *     areas list endpoints.
+     */
     PatchedPermitOfferDetailsRequest: {
       /** @description The NPCServiceOffer row this details model decorates. */
       offer?: number;
+      /** @description Which BuildingKind this offer issues permits for. Required for kind=PERMIT offers in Plan 3 (nullable in the schema so existing rows can migrate; runtime issuance asserts non-null). */
+      building_kind?: number | null;
+      /** @description Default set of wards the issued permit is valid in. Snapshotted onto BuildingPermitDetails.approved_wards at issuance time. */
+      default_approved_wards?: number[];
+      /** @description Default cap on ``target_size`` for buildings constructed under permits from this offer. */
+      default_max_target_size?: number;
+      /** @description Currency cost of the permit (approval fee — distinct from construction cost). Charged to the PC's account at grant time. */
+      permit_cost_currency?: number;
     };
     /**
      * @description Owner-authored ``PlayerBoundary`` CRUD shape.
@@ -28339,14 +28354,44 @@ export interface components {
       readonly beat_id: number;
       readonly treasured_subject_ids: number[];
     };
+    /**
+     * @description Staff CRUD for permit-kind offer details (#1684, closing #728's residual).
+     *
+     *     ``building_kind`` and ``default_approved_wards`` are PK-related writes; the
+     *     FE feeds them from the existing ``/api/buildings/building-kinds/`` and
+     *     areas list endpoints.
+     */
     PermitOfferDetails: {
       readonly id: number;
       /** @description The NPCServiceOffer row this details model decorates. */
       offer: number;
+      /** @description Which BuildingKind this offer issues permits for. Required for kind=PERMIT offers in Plan 3 (nullable in the schema so existing rows can migrate; runtime issuance asserts non-null). */
+      building_kind?: number | null;
+      /** @description Default set of wards the issued permit is valid in. Snapshotted onto BuildingPermitDetails.approved_wards at issuance time. */
+      default_approved_wards?: number[];
+      /** @description Default cap on ``target_size`` for buildings constructed under permits from this offer. */
+      default_max_target_size?: number;
+      /** @description Currency cost of the permit (approval fee — distinct from construction cost). Charged to the PC's account at grant time. */
+      permit_cost_currency?: number;
     };
+    /**
+     * @description Staff CRUD for permit-kind offer details (#1684, closing #728's residual).
+     *
+     *     ``building_kind`` and ``default_approved_wards`` are PK-related writes; the
+     *     FE feeds them from the existing ``/api/buildings/building-kinds/`` and
+     *     areas list endpoints.
+     */
     PermitOfferDetailsRequest: {
       /** @description The NPCServiceOffer row this details model decorates. */
       offer: number;
+      /** @description Which BuildingKind this offer issues permits for. Required for kind=PERMIT offers in Plan 3 (nullable in the schema so existing rows can migrate; runtime issuance asserts non-null). */
+      building_kind?: number | null;
+      /** @description Default set of wards the issued permit is valid in. Snapshotted onto BuildingPermitDetails.approved_wards at issuance time. */
+      default_approved_wards?: number[];
+      /** @description Default cap on ``target_size`` for buildings constructed under permits from this offer. */
+      default_max_target_size?: number;
+      /** @description Currency cost of the permit (approval fee — distinct from construction cost). Charged to the PC's account at grant time. */
+      permit_cost_currency?: number;
     };
     Persona: {
       readonly id: number;

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -50195,6 +50195,7 @@ export interface operations {
         page?: number;
         /** @description Number of results to return per page. */
         page_size?: number;
+        role?: number;
       };
       header?: never;
       path?: never;

--- a/frontend/src/npc_services/api.ts
+++ b/frontend/src/npc_services/api.ts
@@ -19,6 +19,8 @@ import type {
   NPCServiceOffer,
   NPCServiceOfferRequest,
   PaginatedResponse,
+  PermitOfferDetails,
+  PermitOfferDetailsRequest,
 } from './types';
 
 export { ApiValidationError, flattenErrorMessage } from '@/missions/api';
@@ -128,6 +130,37 @@ export function patchMissionDetails(
   body: Partial<MissionOfferDetailsRequest>
 ): Promise<MissionOfferDetails> {
   return writeJson(`${BASE_URL}/mission-details/${id}/`, 'PATCH', body);
+}
+
+// ---------------------------------------------------------------------------
+// PermitOfferDetails (per permit-kind offer, #1684)
+// ---------------------------------------------------------------------------
+
+export async function listPermitDetails(
+  filters: { offer?: number; role?: number; page_size?: number } = {}
+): Promise<PaginatedResponse<PermitOfferDetails>> {
+  const res = await apiFetch(`${BASE_URL}/permit-details/${buildQueryString(filters)}`);
+  if (!res.ok) throw new Error('Failed to load permit offer details');
+  return res.json();
+}
+
+export function createPermitDetails(body: PermitOfferDetailsRequest): Promise<PermitOfferDetails> {
+  return writeJson(`${BASE_URL}/permit-details/`, 'POST', body);
+}
+
+export function patchPermitDetails(
+  id: number,
+  body: Partial<PermitOfferDetailsRequest>
+): Promise<PermitOfferDetails> {
+  return writeJson(`${BASE_URL}/permit-details/${id}/`, 'PATCH', body);
+}
+
+/** Flat area list for the permit ward picker (#1684). One page covers the world (cap 200). */
+export async function listAreasFlat(): Promise<{ id: number; name: string }[]> {
+  const res = await apiFetch('/api/areas/?page_size=200');
+  if (!res.ok) throw new Error('Failed to load areas');
+  const data = await res.json();
+  return Array.isArray(data) ? data : data.results;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/npc_services/pages/NPCRoleEditorPage.tsx
+++ b/frontend/src/npc_services/pages/NPCRoleEditorPage.tsx
@@ -32,21 +32,26 @@ import {
   type PredicateNode,
 } from '@/missions/components/PredicateBuilder';
 import { useMissionTemplates, usePredicateLeaves } from '@/missions/queries';
+import { useBuildingKindsQuery } from '@/buildings/queries';
+import { useQuery } from '@tanstack/react-query';
 
-import { ApiValidationError, flattenErrorMessage } from '../api';
+import { ApiValidationError, flattenErrorMessage, listAreasFlat } from '../api';
 import {
   useCreateMissionDetails,
   useCreateOffer,
+  useCreatePermitDetails,
   useDeleteOffer,
   useDeleteRole,
   useMissionDetailsForRole,
   useOffersForRole,
   usePatchMissionDetails,
   usePatchOffer,
+  usePatchPermitDetails,
   usePatchRole,
+  usePermitDetailsForRole,
   useRole,
 } from '../queries';
-import type { MissionOfferDetails, NPCServiceOffer } from '../types';
+import type { MissionOfferDetails, NPCServiceOffer, PermitOfferDetails } from '../types';
 
 const EMPTY_RULE: PredicateNode = {};
 
@@ -178,10 +183,15 @@ function RoleFieldsCard({ roleId }: { roleId: number }) {
 function OffersSection({ roleId }: { roleId: number }) {
   const { data: offersData, isLoading } = useOffersForRole(roleId);
   const { data: detailsData } = useMissionDetailsForRole(roleId);
+  const { data: permitDetailsData } = usePermitDetailsForRole(roleId);
   const offers = offersData?.results ?? [];
   const detailsByOffer = new Map<number, MissionOfferDetails>();
   for (const d of detailsData?.results ?? []) {
     if (typeof d.offer === 'number') detailsByOffer.set(d.offer, d);
+  }
+  const permitDetailsByOffer = new Map<number, PermitOfferDetails>();
+  for (const d of permitDetailsData?.results ?? []) {
+    if (typeof d.offer === 'number') permitDetailsByOffer.set(d.offer, d);
   }
 
   return (
@@ -203,6 +213,7 @@ function OffersSection({ roleId }: { roleId: number }) {
               roleId={roleId}
               offer={offer}
               details={detailsByOffer.get(offer.id) ?? null}
+              permitDetails={permitDetailsByOffer.get(offer.id) ?? null}
             />
           ))
         )}
@@ -216,10 +227,12 @@ function OfferCard({
   roleId,
   offer,
   details,
+  permitDetails,
 }: {
   roleId: number;
   offer: NPCServiceOffer;
   details: MissionOfferDetails | null;
+  permitDetails: PermitOfferDetails | null;
 }) {
   const patchOffer = usePatchOffer(roleId);
   const patchDetails = usePatchMissionDetails(roleId);
@@ -415,6 +428,10 @@ function OfferCard({
           </p>
         ))}
 
+      {offer.kind === 'permit' && (
+        <PermitDetailsPanel roleId={roleId} offerId={offer.id} details={permitDetails} />
+      )}
+
       <PredicateBuilder label="Eligibility rule" value={rule} onChange={setRule} />
       {ruleErrors.length > 0 && <p className="text-sm text-destructive">{ruleErrors[0]}</p>}
 
@@ -431,6 +448,118 @@ function OfferCard({
         }
       >
         {patchOffer.isPending ? 'Saving…' : 'Save offer'}
+      </Button>
+    </div>
+  );
+}
+
+function PermitDetailsPanel({
+  roleId,
+  offerId,
+  details,
+}: {
+  roleId: number;
+  offerId: number;
+  details: PermitOfferDetails | null;
+}) {
+  const buildingKinds = useBuildingKindsQuery();
+  const areas = useQuery({ queryKey: ['areas', 'flat'], queryFn: listAreasFlat });
+  const createDetails = useCreatePermitDetails(roleId);
+  const patchDetails = usePatchPermitDetails(roleId);
+
+  const [buildingKind, setBuildingKind] = useState(details?.building_kind?.toString() ?? '');
+  const [wards, setWards] = useState<Set<number>>(
+    () => new Set((details?.default_approved_wards ?? []) as number[])
+  );
+  const [maxSize, setMaxSize] = useState(details?.default_max_target_size?.toString() ?? '');
+  const [cost, setCost] = useState(details?.permit_cost_currency?.toString() ?? '');
+
+  const toggleWard = (id: number) => {
+    setWards((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const save = () => {
+    const body = {
+      building_kind: numOrNull(buildingKind),
+      default_approved_wards: [...wards],
+      default_max_target_size: numOrNull(maxSize) ?? 10,
+      permit_cost_currency: numOrNull(cost) ?? 0,
+    };
+    if (details) {
+      patchDetails.mutate({ id: details.id, body });
+    } else {
+      createDetails.mutate({ offer: offerId, ...body });
+    }
+  };
+
+  const pending = createDetails.isPending || patchDetails.isPending;
+  const error = createDetails.error ?? patchDetails.error;
+
+  return (
+    <div className="space-y-3 rounded-md border border-dashed p-3">
+      <p className="text-xs font-medium text-muted-foreground">Permit details</p>
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Building kind">
+          <Select value={buildingKind} onValueChange={setBuildingKind}>
+            <SelectTrigger>
+              <SelectValue placeholder="Pick a building kind" />
+            </SelectTrigger>
+            <SelectContent>
+              {(buildingKinds.data?.results ?? []).map((kind) => (
+                <SelectItem key={kind.id} value={String(kind.id)}>
+                  {kind.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Max target size">
+          <Input
+            type="number"
+            value={maxSize}
+            onChange={(e) => setMaxSize(e.target.value)}
+            placeholder="default 10"
+          />
+        </Field>
+      </div>
+      <Field label="Permit cost (coppers — approval fee, not construction)">
+        <Input
+          type="number"
+          value={cost}
+          onChange={(e) => setCost(e.target.value)}
+          placeholder="0 = free"
+        />
+      </Field>
+      <Field label="Default approved wards">
+        {areas.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading areas…</p>
+        ) : (
+          <div className="grid max-h-40 grid-cols-2 gap-1 overflow-y-auto rounded-md border p-2">
+            {(areas.data ?? []).map((area) => (
+              <label key={area.id} className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={wards.has(area.id)}
+                  onChange={() => toggleWard(area.id)}
+                />
+                {area.name}
+              </label>
+            ))}
+          </div>
+        )}
+      </Field>
+      {error != null && (
+        <p className="text-sm text-destructive">
+          {errText(error, 'Could not save the permit details.')}
+        </p>
+      )}
+      <Button size="sm" variant="secondary" onClick={save} disabled={pending}>
+        {pending ? 'Saving…' : details ? 'Save permit details' : 'Create permit details'}
       </Button>
     </div>
   );

--- a/frontend/src/npc_services/queries.ts
+++ b/frontend/src/npc_services/queries.ts
@@ -6,15 +6,18 @@ import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tan
 import {
   createMissionDetails,
   createOffer,
+  createPermitDetails,
   createRole,
   deleteOffer,
   deleteRole,
   getRole,
   listMissionDetails,
   listOffers,
+  listPermitDetails,
   listRoles,
   patchMissionDetails,
   patchOffer,
+  patchPermitDetails,
   patchRole,
 } from './api';
 import type {
@@ -26,6 +29,8 @@ import type {
   NPCRole,
   NPCServiceOffer,
   MissionOfferDetails,
+  PermitOfferDetails,
+  PermitOfferDetailsRequest,
 } from './types';
 
 export const npcServiceKeys = {
@@ -38,6 +43,9 @@ export const npcServiceKeys = {
   missionDetails: () => [...npcServiceKeys.all, 'mission-details'] as const,
   missionDetailList: (roleId: number) =>
     [...npcServiceKeys.missionDetails(), 'list', roleId] as const,
+  permitDetails: () => [...npcServiceKeys.all, 'permit-details'] as const,
+  permitDetailList: (roleId: number) =>
+    [...npcServiceKeys.permitDetails(), 'list', roleId] as const,
 };
 
 export function useRoles(filters: NPCRoleFilters = {}): UseQueryResult<PaginatedResponse<NPCRole>> {
@@ -107,6 +115,34 @@ export function useDeleteRole() {
 function invalidateRoleOffers(qc: ReturnType<typeof useQueryClient>, roleId: number) {
   qc.invalidateQueries({ queryKey: npcServiceKeys.offerList(roleId) });
   qc.invalidateQueries({ queryKey: npcServiceKeys.missionDetailList(roleId) });
+  qc.invalidateQueries({ queryKey: npcServiceKeys.permitDetailList(roleId) });
+}
+
+export function usePermitDetailsForRole(
+  roleId: number | null
+): UseQueryResult<PaginatedResponse<PermitOfferDetails>> {
+  return useQuery({
+    queryKey: npcServiceKeys.permitDetailList(roleId ?? -1),
+    queryFn: () => listPermitDetails({ role: roleId as number, page_size: 200 }),
+    enabled: roleId !== null,
+  });
+}
+
+export function useCreatePermitDetails(roleId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: PermitOfferDetailsRequest) => createPermitDetails(body),
+    onSuccess: () => invalidateRoleOffers(qc, roleId),
+  });
+}
+
+export function usePatchPermitDetails(roleId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: number; body: Partial<PermitOfferDetailsRequest> }) =>
+      patchPermitDetails(id, body),
+    onSuccess: () => invalidateRoleOffers(qc, roleId),
+  });
 }
 
 export function useCreateOffer(roleId: number) {

--- a/frontend/src/npc_services/types.ts
+++ b/frontend/src/npc_services/types.ts
@@ -12,6 +12,8 @@ export type NPCServiceOffer = components['schemas']['NPCServiceOffer'];
 export type NPCServiceOfferRequest = components['schemas']['NPCServiceOfferRequest'];
 export type MissionOfferDetails = components['schemas']['MissionOfferDetails'];
 export type MissionOfferDetailsRequest = components['schemas']['MissionOfferDetailsRequest'];
+export type PermitOfferDetails = components['schemas']['PermitOfferDetails'];
+export type PermitOfferDetailsRequest = components['schemas']['PermitOfferDetailsRequest'];
 
 export interface PaginatedResponse<T> {
   count: number;

--- a/src/schema.json
+++ b/src/schema.json
@@ -19986,6 +19986,10 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
+      - in: query
+        name: role
+        schema:
+          type: number
       tags:
       - npc-services
       security:

--- a/src/schema.json
+++ b/src/schema.json
@@ -48738,10 +48738,40 @@ components:
           type: string
     PatchedPermitOfferDetailsRequest:
       type: object
+      description: |-
+        Staff CRUD for permit-kind offer details (#1684, closing #728's residual).
+
+        ``building_kind`` and ``default_approved_wards`` are PK-related writes; the
+        FE feeds them from the existing ``/api/buildings/building-kinds/`` and
+        areas list endpoints.
       properties:
         offer:
           type: integer
           description: The NPCServiceOffer row this details model decorates.
+        building_kind:
+          type: integer
+          nullable: true
+          description: Which BuildingKind this offer issues permits for. Required
+            for kind=PERMIT offers in Plan 3 (nullable in the schema so existing rows
+            can migrate; runtime issuance asserts non-null).
+        default_approved_wards:
+          type: array
+          items:
+            type: integer
+          description: Default set of wards the issued permit is valid in. Snapshotted
+            onto BuildingPermitDetails.approved_wards at issuance time.
+        default_max_target_size:
+          type: integer
+          maximum: 32767
+          minimum: 0
+          description: Default cap on ``target_size`` for buildings constructed under
+            permits from this offer.
+        permit_cost_currency:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: Currency cost of the permit (approval fee — distinct from construction
+            cost). Charged to the PC's account at grant time.
     PatchedPlayerBoundaryRequest:
       type: object
       description: |-
@@ -50205,6 +50235,12 @@ components:
       - treasured_subject_ids
     PermitOfferDetails:
       type: object
+      description: |-
+        Staff CRUD for permit-kind offer details (#1684, closing #728's residual).
+
+        ``building_kind`` and ``default_approved_wards`` are PK-related writes; the
+        FE feeds them from the existing ``/api/buildings/building-kinds/`` and
+        areas list endpoints.
       properties:
         id:
           type: integer
@@ -50212,15 +50248,69 @@ components:
         offer:
           type: integer
           description: The NPCServiceOffer row this details model decorates.
+        building_kind:
+          type: integer
+          nullable: true
+          description: Which BuildingKind this offer issues permits for. Required
+            for kind=PERMIT offers in Plan 3 (nullable in the schema so existing rows
+            can migrate; runtime issuance asserts non-null).
+        default_approved_wards:
+          type: array
+          items:
+            type: integer
+          description: Default set of wards the issued permit is valid in. Snapshotted
+            onto BuildingPermitDetails.approved_wards at issuance time.
+        default_max_target_size:
+          type: integer
+          maximum: 32767
+          minimum: 0
+          description: Default cap on ``target_size`` for buildings constructed under
+            permits from this offer.
+        permit_cost_currency:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: Currency cost of the permit (approval fee — distinct from construction
+            cost). Charged to the PC's account at grant time.
       required:
       - id
       - offer
     PermitOfferDetailsRequest:
       type: object
+      description: |-
+        Staff CRUD for permit-kind offer details (#1684, closing #728's residual).
+
+        ``building_kind`` and ``default_approved_wards`` are PK-related writes; the
+        FE feeds them from the existing ``/api/buildings/building-kinds/`` and
+        areas list endpoints.
       properties:
         offer:
           type: integer
           description: The NPCServiceOffer row this details model decorates.
+        building_kind:
+          type: integer
+          nullable: true
+          description: Which BuildingKind this offer issues permits for. Required
+            for kind=PERMIT offers in Plan 3 (nullable in the schema so existing rows
+            can migrate; runtime issuance asserts non-null).
+        default_approved_wards:
+          type: array
+          items:
+            type: integer
+          description: Default set of wards the issued permit is valid in. Snapshotted
+            onto BuildingPermitDetails.approved_wards at issuance time.
+        default_max_target_size:
+          type: integer
+          maximum: 32767
+          minimum: 0
+          description: Default cap on ``target_size`` for buildings constructed under
+            permits from this offer.
+        permit_cost_currency:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: Currency cost of the permit (approval fee — distinct from construction
+            cost). Charged to the PC's account at grant time.
       required:
       - offer
     Persona:

--- a/src/world/npc_services/filters.py
+++ b/src/world/npc_services/filters.py
@@ -62,6 +62,9 @@ class MissionOfferDetailsFilterSet(django_filters.FilterSet):
 
 class PermitOfferDetailsFilterSet(django_filters.FilterSet):
     offer = django_filters.NumberFilter(field_name="offer_id")
+    # No denormalized role on PermitOfferDetails (unlike mission details) — walk the
+    # FK so the role editor can fetch a role's permit details in one call (#1684).
+    role = django_filters.NumberFilter(field_name="offer__role_id")
     building_kind = django_filters.NumberFilter(field_name="building_kind_id")
 
     class Meta:

--- a/src/world/npc_services/serializers.py
+++ b/src/world/npc_services/serializers.py
@@ -83,9 +83,23 @@ class OfferCooldownSerializer(serializers.ModelSerializer):
 
 
 class PermitOfferDetailsSerializer(serializers.ModelSerializer):
+    """Staff CRUD for permit-kind offer details (#1684, closing #728's residual).
+
+    ``building_kind`` and ``default_approved_wards`` are PK-related writes; the
+    FE feeds them from the existing ``/api/buildings/building-kinds/`` and
+    areas list endpoints.
+    """
+
     class Meta:
         model = PermitOfferDetails
-        fields = ["id", "offer"]
+        fields = [
+            "id",
+            "offer",
+            "building_kind",
+            "default_approved_wards",
+            "default_max_target_size",
+            "permit_cost_currency",
+        ]
         read_only_fields = ["id"]
 
 

--- a/src/world/npc_services/tests/test_api_permit_details.py
+++ b/src/world/npc_services/tests/test_api_permit_details.py
@@ -1,0 +1,128 @@
+"""API tests for the widened ``PermitOfferDetailsSerializer`` (#1684).
+
+Closes #728's residual: the permit-details endpoint existed but exposed only
+``["id", "offer"]`` — the real authoring fields (building_kind FK, ward M2M,
+size cap, permit cost) weren't writable over the API. Mirrors
+``test_api_mission_details.py``'s shape.
+"""
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory
+from world.areas.factories import AreaFactory
+from world.buildings.factories import BuildingKindFactory
+from world.npc_services.constants import OfferKind
+from world.npc_services.factories import (
+    NPCRoleFactory,
+    NPCServiceOfferFactory,
+    PermitOfferDetailsFactory,
+)
+from world.npc_services.models import PermitOfferDetails
+
+
+def _staff_account(name: str):
+    account = AccountFactory(username=name)
+    account.is_staff = True
+    account.save(update_fields=["is_staff"])
+    return account
+
+
+class PermitOfferDetailsViewSetTests(TestCase):
+    URL = "/api/npc-services/permit-details/"
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.staff = _staff_account("staff-pod-api")
+        cls.role = NPCRoleFactory(name="pod-test-role")
+        cls.building_kind = BuildingKindFactory()
+        cls.ward_a = AreaFactory()
+        cls.ward_b = AreaFactory()
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.client.force_authenticate(self.staff)
+
+    def _make_permit_offer(self):
+        return NPCServiceOfferFactory(
+            role=self.role,
+            kind=OfferKind.PERMIT,
+            label="pod-test-offer",
+        )
+
+    def test_create_with_full_fields(self) -> None:
+        offer = self._make_permit_offer()
+        response = self.client.post(
+            self.URL,
+            {
+                "offer": offer.pk,
+                "building_kind": self.building_kind.pk,
+                "default_approved_wards": [self.ward_a.pk, self.ward_b.pk],
+                "default_max_target_size": 25,
+                "permit_cost_currency": 5000,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        details = PermitOfferDetails.objects.get(offer=offer)
+        self.assertEqual(details.building_kind, self.building_kind)
+        self.assertEqual(
+            set(details.default_approved_wards.values_list("pk", flat=True)),
+            {self.ward_a.pk, self.ward_b.pk},
+        )
+        self.assertEqual(details.default_max_target_size, 25)
+        self.assertEqual(details.permit_cost_currency, 5000)
+
+    def test_patch_updates_fk_and_m2m(self) -> None:
+        details = PermitOfferDetailsFactory(offer=self._make_permit_offer())
+        response = self.client.patch(
+            f"{self.URL}{details.pk}/",
+            {
+                "building_kind": self.building_kind.pk,
+                "default_approved_wards": [self.ward_b.pk],
+                "permit_cost_currency": 750,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        details.refresh_from_db()
+        self.assertEqual(details.building_kind, self.building_kind)
+        self.assertEqual(
+            list(details.default_approved_wards.values_list("pk", flat=True)),
+            [self.ward_b.pk],
+        )
+        self.assertEqual(details.permit_cost_currency, 750)
+
+    def test_read_exposes_all_fields(self) -> None:
+        details = PermitOfferDetailsFactory(offer=self._make_permit_offer())
+        response = self.client.get(f"{self.URL}{details.pk}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for field in (
+            "offer",
+            "building_kind",
+            "default_approved_wards",
+            "default_max_target_size",
+            "permit_cost_currency",
+        ):
+            self.assertIn(field, response.data)
+
+    def test_role_filter_walks_offer_fk(self) -> None:
+        mine = PermitOfferDetailsFactory(offer=self._make_permit_offer())
+        other_role = NPCRoleFactory(name="pod-other-role")
+        PermitOfferDetailsFactory(
+            offer=NPCServiceOfferFactory(
+                role=other_role, kind=OfferKind.PERMIT, label="pod-other-offer"
+            )
+        )
+        response = self.client.get(f"{self.URL}?role={self.role.pk}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual([row["id"] for row in response.data["results"]], [mine.pk])
+
+    def test_anonymous_denied(self) -> None:
+        client = APIClient()
+        response = client.get(self.URL)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )


### PR DESCRIPTION
Closes #1684

## Summary

PERMIT-offer details panel in the Mission Studio role editor (#1684, closing #728's residual). Widens PermitOfferDetailsSerializer to the real authoring fields (building_kind FK, default_approved_wards M2M, size cap, permit cost), adds a role filter walking offer__role_id, and adds a self-contained PermitDetailsPanel (building-kind picker from /api/buildings/building-kinds/, ward multi-select from /api/areas/, size/cost inputs, create-or-patch) rendered for kind=permit offers. Api types regenerated.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1684 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main cleanly (1 commit).

<!-- last-addressed-comment: 0 -->