### PR TITLE
GM adjudication toolkit: catalog check invocation (never invention), GM awards, condition application

### DIFF
--- a/docs/adr/0110-gm-content-is-catalog-and-adaptation-never-invention.md
+++ b/docs/adr/0110-gm-content-is-catalog-and-adaptation-never-invention.md
@@ -1,0 +1,19 @@
+# GM content is catalog + adaptation, never invention
+
+Situations, challenges, encounters, and checks are **pre-built, browsable, adaptable authored
+content** — a GM running a live table discovers and applies the fitting catalog row (with
+bounded, reason-carrying situational modifiers), never composes new mechanics ad hoc. #2118's
+`InvokeCatalogCheckAction` is the concrete instance: a GM may invoke any authored `CheckType` at
+a `DifficultyChoice` band and shift it by at most one band with a required reason, but no code
+path accepts a free-form stat/skill pair, an integer difficulty, or a consequence-pool
+reference — `perform_check` resolves it and `ConsequenceOutcome`/consequence pools are never
+selected, composed, or fired from this surface. We rejected a free-form invocation grammar
+(stat + skill + difficulty, chosen live) even though it is the more flexible tool: Arx I ran
+without this kind of system, so every GM invented checks and stakes freely at the table, and the
+result was rulings of non-canonicity between tables and players denied meaningful, consistent
+stories. This ADR governs future GM-content surfaces generally, not just checks — the same
+catalog-first shape applies to `SetSituationAction` (#1895), `SetTheStageAction` (#1498), and any
+GM-facing authoring tool built after it: build the catalog, make it fast to search, and gate
+invention itself, not just its consequences.
+
+> Status: accepted · Source: issue #2118 (rev 2 ruling by Tehom, 2026-07-09)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,6 +95,7 @@ treat those names as hints to confirm, not gospel.
 - [0028 — Web-first: not wired into React = not implemented](0028-web-first-not-wired-into-react-is-not-implemented.md)
 - [0029 — Named/public faces are always shown by name](0029-named-public-faces-are-always-shown-by-name.md)
 - [0030 — GMs author story trees; outcomes resolve by player roll, not fiat](0030-gms-author-story-trees-outcomes-resolve-by-roll.md)
+- [0110 — GM content is catalog + adaptation, never invention](0110-gm-content-is-catalog-and-adaptation-never-invention.md)
 - [0031 — Exact numbers in the ledger, descriptive labels in the fiction](0031-exact-numbers-in-the-ledger-labels-in-the-fiction.md)
 - [0032 — Constrained bystander reactions](0032-constrained-bystander-reactions.md)
 - [0033 — Privacy / RP-leak prevention is MVP-gating](0033-privacy-is-mvp-gating.md)

--- a/docs/roadmap/gm-system.md
+++ b/docs/roadmap/gm-system.md
@@ -101,6 +101,20 @@ The GM system defines these role relationships; the stories app uses them for pe
   blocker.
 - Frontend (evidence panel + promote action on a staff GM-review page) is a
   deliberate scope note, not a silent skip — it rides the GM dashboard work (#2004).
+- **GM adjudication toolkit ✅ (#2118, ADR-0110)** — the fast-follow promised in the
+  #2117 note above: `IsSceneGMPrerequisite` (`actions/prerequisites.py`) scopes three
+  new Actions to the actor's **own running scene** (`Scene.is_gm`, #2113), not the
+  orthogonal staff bit or general GM-trust alone. `InvokeCatalogCheckAction`
+  (`gm_invoke_check`) is the "umpire check-modifier tooling" Phase 4 called out as a
+  potential future phase — a GM invokes an authored `CheckType` at a
+  `DifficultyChoice` band via `perform_check`, with an optional ±1-band `edge`/
+  `setback` shift (a required, echoed reason) standing in for the "GM applies +2
+  difficulty" idea — never a free integer modifier, and never a stat/skill pair or a
+  consequence-pool selection (the governing invariant: catalog-only invocation,
+  never invention). `GMAwardAction` (`gm_award_progression`) and
+  `GMApplyConditionAction` (`gm_apply_condition`) round out the toolkit, both
+  additionally gated on `MinimumGMLevelPrerequisite(GMLevel.JUNIOR)`. Telnet: `gm
+  check`/`gm award`/`gm condition` on `CmdGMDashboard` (`commands/gm_ops.py`).
 
 ### Staff Character and Staff Tooling
 - Staff has commands to edit world state, manage GMs, override any system
@@ -170,9 +184,19 @@ Things that belong to Stories instead:
 - Audit trail via story beat history
 
 Potential GM-specific tooling that may warrant a future phase:
-- Umpire check-modifier tooling (GM applies `+2 difficulty` or
-  `+2 advantage` to an in-progress check based on RP context)
-- This is GM *shaping* outcomes without *deciding* them
+- ✅ **Umpire check-modifier tooling — delivered as #2118's `InvokeCatalogCheckAction`.**
+  A GM invokes an authored `CheckType` at a `DifficultyChoice` band, with an optional
+  ±1-band `edge`/`setback` shift (never a free integer modifier). This is GM *shaping*
+  outcomes without *deciding* them — `perform_check` still resolves by player roll
+  (ADR-0030), and the shift is catalog-bounded, not fiat (ADR-0110).
+- `GMAwardAction`/`GMApplyConditionAction` (#2118) are a deliberate, narrow exception
+  to "rewards are not a GM concern" above: they exist specifically because the
+  story-beat automatic-award pipeline (`award_scene_development_points`) has zero
+  production callers and is bug-for-bug broken (reads a nonexistent `scene.title`) —
+  see #2118's spec. They are fiat (JUNIOR-tier GM trust required, unlike the
+  no-floor check-invocation verb) and meant for improvised story moments the broken
+  pipeline can't reach, not a replacement for story-beat rewards once that pipeline
+  is fixed or reviving `award_scene_development_points` is designed properly.
 
 ### Phase 5 — Dashboards and UI (deferred until after Stories)
 The GM dashboard is story-shaped, not roster-shaped. What GMs actually

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1179,14 +1179,32 @@ GM at a given level may author (#2000, ADR-0097).
   `gm_evidence_summary` services the web actions call. `gm dashboard` gains an
   "Open group requests: N" line + `gm claim <request-id>` (#2119), dispatching
   `stories.ClaimGroupStoryRequestAction`.
+- **Adjudication toolkit (#2118, ADR-0110):** `IsSceneGMPrerequisite` (`actions/prerequisites.py`
+  — staff bypass, else `Scene.is_gm(actor.active_account)` on the actor's active scene) gates
+  three catalog-only Actions in `actions/definitions/gm_adjudication.py`:
+  `InvokeCatalogCheckAction` (key `gm_invoke_check` — invokes an authored `CheckType` at a
+  `DifficultyChoice` band via `perform_check`, plus a `find`/list catalog-search mode; never an
+  integer difficulty or a consequence-pool reference), `GMAwardAction` (key
+  `gm_award_progression` — `award_xp`/`award_development_points` with
+  `ProgressionReason.GM_AWARD`, gated additionally on `MinimumGMLevelPrerequisite(GMLevel
+  .JUNIOR)`), `GMApplyConditionAction` (key `gm_apply_condition` — `apply_condition` against an
+  authored `ConditionTemplate` via `get_by_name`, same JUNIOR floor). Telnet: `gm check [find
+  <term>]` / `gm check <char> <check-type>=<band> [edge=<reason>|setback=<reason>]`, `gm award
+  <char> xp=<amount>|dev=<trait> amount=<n> [reason=<text>]`, `gm condition <char>
+  condition=<name> [severity=<n>] [duration=<n>] [note=<text>]` (`commands/gm_ops.py`'s
+  `CmdGMDashboard`).
 - **Integrates with:** stories (`GMTable.primary_stories`, risk/custom-stakes gates;
   `GroupStoryRequest.claimed_by` → `GMProfile`, #2119 — claiming creates the GROUP
   Story and seats the covenant via `join_table`), combat (`StakesLevelRequirement
   .minimum_gm_level`), roster (`GMRosterInvite` → `RosterApplication`), scenes
-  (`GMTableMembership` pinned to `Persona`)
+  (`GMTableMembership` pinned to `Persona`, `Scene.is_gm` for the adjudication
+  toolkit's gate), checks (`InvokeCatalogCheckAction` → `perform_check`),
+  progression (`GMAwardAction` → `award_xp`/`award_development_points`), conditions
+  (`GMApplyConditionAction` → `apply_condition`)
 - **Source:** `src/world/gm/`
 - **Glossary:** `src/world/gm/AGENT_GLOSSARY.md`
 - **Details:** [../roadmap/gm-system.md](../roadmap/gm-system.md),
+  [../adr/0110-gm-content-is-catalog-and-adaptation-never-invention.md](../adr/0110-gm-content-is-catalog-and-adaptation-never-invention.md),
   [../adr/0097-gm-trust-is-gmprofile-level.md](../adr/0097-gm-trust-is-gmprofile-level.md)
 
 ### Scenes

--- a/docs/systems/checks.md
+++ b/docs/systems/checks.md
@@ -163,7 +163,37 @@ All models registered with appropriate admin interfaces:
 - **Classes app**: Uses `Aspect` and `PathAspect` for aspect bonus calculation, `CharacterClassLevel` for character level
 - **Progression app**: Uses `CharacterPathHistory` for current path lookup
 - **Attempts app**: Calls `perform_check()` for resolution; provides roulette display content via `ConsequenceDisplay`
-- **Callers** (goals, magic, combat, conditions): Compute `extra_modifiers` before calling `perform_check()`
+- **Callers** (goals, magic, combat, conditions, GM adjudication): Compute `extra_modifiers` before calling `perform_check()`
+
+---
+
+## GM Ad-Hoc Catalog Invocation (#2118)
+
+The one GM-invocable caller of `perform_check` for moments no pre-authored system covers.
+**Governing invariant (ADR-0110): catalog-only invocation — GMs can never invent checks or
+select/compose/fire a consequence pool.** `InvokeCatalogCheckAction`
+(`actions/definitions/gm_adjudication.py`, registry key `gm_invoke_check`) is the sole entry
+point:
+
+- **Check reference**: an authored `CheckType`, resolved pk-or-name against the shared catalog
+  only (`resolve_model_by_pk_or_name`, scoped to `is_active=True`); unresolvable refuses with a
+  hint back to the discovery surface (`gm check find <term>`) rather than accepting free text.
+- **Difficulty**: a `DifficultyChoice` band member only — no integer parameter exists on any
+  code path.
+- **Situational modifier**: at most one band of `edge` (easier) or `setback` (harder) shift, each
+  requiring a free-text reason that is echoed into the result. Never an integer offset.
+- **Result**: number-free — only `CheckResult.outcome_name` reaches the message (never
+  `total_points`/`trait_points`/`success_level`/the roll), and it goes to the invoking GM only
+  (ADR-0031). No audit model records the invocation; the GM narrates the outcome via pose.
+- **Discovery**: `find`/list mode (no target) searches the catalog by name, stat+skill trait, or
+  description snippet — the paved road to finding the right check instead of inventing one.
+
+Gated by `IsSceneGMPrerequisite` (`actions/prerequisites.py` — staff bypass, else
+`Scene.is_gm(actor.active_account)` on the actor's active scene). Telnet: `gm check [find
+<term>]` / `gm check <character> <check-type>=<band> [edge=<reason>|setback=<reason>]`
+(`commands/gm_ops.py`). Sibling actions `GMAwardAction` (`gm_award_progression`) and
+`GMApplyConditionAction` (`gm_apply_condition`) round out the GM adjudication toolkit — see
+`docs/systems/INDEX.md` and `docs/roadmap/gm-system.md`.
 
 ---
 

--- a/src/actions/definitions/gm_adjudication.py
+++ b/src/actions/definitions/gm_adjudication.py
@@ -1,0 +1,481 @@
+"""GM adjudication toolkit: catalog check invocation, GM awards, condition application (#2118).
+
+Governing invariant (RATIFIED -- Tehom, 2026-07-09): **GMs can never invent checks
+or consequence pools on whim.** Every code path in this module resolves against an
+authored catalog row (``CheckType``, a ``DifficultyChoice`` band, a ``Trait``, or a
+``ConditionTemplate``) -- there is no integer difficulty parameter, no free-form
+stat/skill passthrough, and no ``ConsequenceOutcome``/consequence-pool reference
+anywhere here. ``InvokeCatalogCheckAction`` fires ``perform_check`` and returns a
+graded, number-free result to the invoking GM only; it never selects, composes, or
+fires a consequence pool.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from actions.base import Action
+from actions.prerequisites import IsSceneGMPrerequisite, MinimumGMLevelPrerequisite, Prerequisite
+from actions.types import ActionContext, ActionResult, TargetType
+from commands.exceptions import CommandError
+from commands.utils.gm_resolution import resolve_model_by_pk_or_name
+from world.gm.constants import GMLevel
+from world.scenes.action_constants import DIFFICULTY_VALUES, DifficultyChoice
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from world.checks.models import CheckType
+
+# Ascending TRIVIAL..HARROWING order -- DIFFICULTY_VALUES is authored in this order
+# and dicts preserve insertion order, so this is the single source of truth for
+# "one band up/down" shifts (Decision 3: at most one band, never an integer offset).
+_DIFFICULTY_ORDER: tuple[str, ...] = tuple(DIFFICULTY_VALUES.keys())
+
+_CATALOG_HINT = "No such check -- try `gm check find <term>`."
+_FIND_RESULT_LIMIT = 15
+_DESCRIPTION_SNIPPET_LEN = 80
+
+# GMAwardAction.award_type values.
+_AWARD_TYPE_XP = "xp"
+_AWARD_TYPE_DEVELOPMENT = "development"
+
+
+def _check_type_summary(check_type: CheckType) -> str:
+    """Return the "stat+skill" trait pairing summary for a catalog listing row."""
+    names = [
+        ctt.trait.name for ctt in check_type.traits.select_related("trait").order_by("-weight")
+    ]
+    return " + ".join(names) if names else "(no traits configured)"
+
+
+def _description_snippet(check_type: CheckType) -> str:
+    text = (check_type.description or "").strip()
+    if len(text) <= _DESCRIPTION_SNIPPET_LEN:
+        return text
+    return text[: _DESCRIPTION_SNIPPET_LEN - 1].rstrip() + "..."
+
+
+def _format_catalog_row(check_type: CheckType) -> str:
+    return (
+        f"[{check_type.pk}] {check_type.name} ({_check_type_summary(check_type)})"
+        f" -- {_description_snippet(check_type)}"
+    )
+
+
+def _search_catalog(query: str) -> list[CheckType]:
+    """Search the authored, active CheckType catalog by name, trait, or description.
+
+    The discovery road (Decision 4): a bare search or empty query lists the catalog
+    head so finding the right check is always the paved path, never invention.
+    """
+    from django.db.models import Q  # noqa: PLC0415
+
+    from world.checks.models import CheckType  # noqa: PLC0415
+
+    qs = CheckType.objects.filter(is_active=True).select_related("category")
+    query = query.strip()
+    if query:
+        qs = qs.filter(
+            Q(name__icontains=query)
+            | Q(description__icontains=query)
+            | Q(traits__trait__name__icontains=query)
+        ).distinct()
+    return list(
+        qs.order_by("category__display_order", "display_order", "name")[:_FIND_RESULT_LIMIT]
+    )
+
+
+def _shift_band(band: str, *, easier: bool) -> str | None:
+    """Shift *band* exactly one step toward TRIVIAL (easier) or HARROWING (harder).
+
+    Returns ``None`` when the shift would go out of bounds -- callers must refuse
+    rather than clamp (Decision 3).
+    """
+    index = _DIFFICULTY_ORDER.index(band)
+    new_index = index - 1 if easier else index + 1
+    if new_index < 0 or new_index >= len(_DIFFICULTY_ORDER):
+        return None
+    return _DIFFICULTY_ORDER[new_index]
+
+
+def _resolve_shift(
+    difficulty: str, edge_reason: str, setback_reason: str
+) -> tuple[str, str] | ActionResult:
+    """Return ``(effective_band, shift_note)`` for *difficulty*, or a failure result.
+
+    Extracted from ``InvokeCatalogCheckAction._invoke`` to keep its own
+    return-statement count low (PLR0911) -- mirrors the
+    ``_resolve_add_opponent_inputs`` pattern in ``gm_combat.py``.
+    """
+    if edge_reason and setback_reason:
+        return ActionResult(success=False, message="Shift with edge or setback, not both.")
+    if edge_reason:
+        shifted = _shift_band(difficulty, easier=True)
+        if shifted is None:
+            return ActionResult(success=False, message="Already at the easiest band.")
+        return shifted, f" [edge -> {DifficultyChoice(shifted).label}: {edge_reason}]"
+    if setback_reason:
+        shifted = _shift_band(difficulty, easier=False)
+        if shifted is None:
+            return ActionResult(success=False, message="Already at the hardest band.")
+        return shifted, f" [setback -> {DifficultyChoice(shifted).label}: {setback_reason}]"
+    return difficulty, ""
+
+
+@dataclass
+class InvokeCatalogCheckAction(Action):
+    """Invoke an authored ``CheckType`` at a ``DifficultyChoice`` band, or search it (#2118).
+
+    Catalog-only per the RATIFIED invariant above. The only inputs are a
+    ``check_type_ref`` (pk-or-name, resolved against the shared catalog only --
+    unresolvable refuses with a hint back to ``find``), a ``difficulty`` band
+    (validated against ``DifficultyChoice`` -- no integers accepted anywhere), and
+    an optional ``edge_reason``/``setback_reason`` (mutually exclusive) shifting the
+    band by exactly one step, echoed into the result. Fires ``perform_check`` as-is
+    -- it never selects, composes, or fires a ``ConsequenceOutcome``/consequence
+    pool, and no parameter on this action could.
+
+    Two modes, discriminated by the ``target`` kwarg:
+    - No ``target``: discovery/find mode. Optional ``query`` searches the catalog
+      by name, stat+skill trait, or description snippet; omitted lists the head of
+      the catalog. The paved road to finding the right check (Decision 4).
+    - ``target`` set: invoke mode, described above.
+
+    The result is graded and number-free (``CheckResult.outcome_name`` only --
+    never raw points/roll/success_level) and goes to the invoking GM only; no
+    audit model records it (Decision 6) -- the GM narrates via pose.
+    """
+
+    key: str = "gm_invoke_check"
+    name: str = "Invoke Catalog Check"
+    icon: str = "dice"
+    category: str = "gm"
+    target_type: TargetType = TargetType.SINGLE
+    objectdb_target_kwargs: ClassVar[frozenset[str]] = frozenset({"target"})
+
+    def get_prerequisites(self) -> list[Prerequisite]:
+        return [IsSceneGMPrerequisite()]
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        target = kwargs.get("target")
+        if target is None:
+            return self._find(kwargs)
+        return self._invoke(target, kwargs)
+
+    def _find(self, kwargs: dict[str, Any]) -> ActionResult:
+        query = str(kwargs.get("query") or "")
+        matches = _search_catalog(query)
+        if not matches:
+            message = f"No checks matched {query!r}." if query.strip() else "The catalog is empty."
+            return ActionResult(success=True, message=message)
+        header = f"Checks matching {query.strip()!r}:" if query.strip() else "Check catalog:"
+        lines = [header, *(_format_catalog_row(ct) for ct in matches)]
+        return ActionResult(success=True, message="\n".join(lines))
+
+    def _invoke(self, target: ObjectDB, kwargs: dict[str, Any]) -> ActionResult:
+        from world.checks.models import CheckType  # noqa: PLC0415
+        from world.checks.services import perform_check  # noqa: PLC0415
+
+        check_type_ref = str(kwargs.get("check_type_ref") or "").strip()
+        if not check_type_ref:
+            return ActionResult(success=False, message=_CATALOG_HINT)
+
+        try:
+            check_type = resolve_model_by_pk_or_name(
+                CheckType,
+                check_type_ref,
+                qs=CheckType.objects.filter(is_active=True),
+                not_found_msg=_CATALOG_HINT,
+            )
+        except CommandError as err:
+            return ActionResult(success=False, message=str(err))
+
+        difficulty = kwargs.get("difficulty")
+        if difficulty not in DifficultyChoice.values:
+            return ActionResult(
+                success=False,
+                message="Pick a difficulty band: " + ", ".join(DifficultyChoice.values) + ".",
+            )
+
+        edge_reason = str(kwargs.get("edge_reason") or "").strip()
+        setback_reason = str(kwargs.get("setback_reason") or "").strip()
+
+        shift_result = _resolve_shift(difficulty, edge_reason, setback_reason)
+        if isinstance(shift_result, ActionResult):
+            return shift_result
+        effective_band, shift_note = shift_result
+
+        result = perform_check(
+            target,
+            check_type,
+            target_difficulty=DIFFICULTY_VALUES[effective_band],
+        )
+        band_label = DifficultyChoice(difficulty).label
+        message = (
+            f"{target.key}: {check_type.name} ({band_label}){shift_note} -> {result.outcome_name}"
+        )
+        return ActionResult(success=True, message=message)
+
+
+@dataclass
+class GMAwardAction(Action):
+    """JUNIOR-tier GM action: award XP or development points to a participant (#2118).
+
+    Wraps ``award_xp``/``award_development_points``
+    (``world/progression/services/awards.py``) with ``ProgressionReason.GM_AWARD``
+    and ``gm=actor.active_account`` -- the first production caller of the
+    pre-existing ``gm=`` kwarg + ``GM_AWARD`` reason. Gated on
+    ``IsSceneGMPrerequisite`` + ``MinimumGMLevelPrerequisite(GMLevel.JUNIOR)`` (staff
+    bypass preserved) -- pure fiat, the same trust bar as
+    ``GrantItemAction``/``SetSituationAction``.
+    """
+
+    key: str = "gm_award_progression"
+    name: str = "GM Award"
+    icon: str = "star"
+    category: str = "gm"
+    target_type: TargetType = TargetType.SINGLE
+    objectdb_target_kwargs: ClassVar[frozenset[str]] = frozenset({"target"})
+
+    def get_prerequisites(self) -> list[Prerequisite]:
+        return [IsSceneGMPrerequisite(), MinimumGMLevelPrerequisite(GMLevel.JUNIOR)]
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        target = kwargs.get("target")
+        if target is None:
+            return ActionResult(success=False, message="A target character is required.")
+
+        award_type = str(kwargs.get("award_type") or "").strip().lower()
+        description = str(kwargs.get("description") or "").strip()
+
+        if award_type == _AWARD_TYPE_XP:
+            return self._award_xp(actor, target, kwargs.get("amount"), description)
+        if award_type == _AWARD_TYPE_DEVELOPMENT:
+            return self._award_development(actor, target, kwargs, description)
+        return ActionResult(success=False, message="award_type must be 'xp' or 'development'.")
+
+    def _award_xp(
+        self,
+        actor: ObjectDB,
+        target: ObjectDB,
+        amount: Any,
+        description: str,
+    ) -> ActionResult:
+        from world.progression.services.awards import award_xp  # noqa: PLC0415
+        from world.progression.types import ProgressionReason  # noqa: PLC0415
+
+        account = getattr(target, "active_account", None)  # noqa: GETATTR_LITERAL
+        if account is None:
+            return ActionResult(success=False, message=f"{target.key} has no controlling account.")
+
+        amount_int = _coerce_positive_int(amount)
+        if amount_int is None:
+            return ActionResult(success=False, message="amount must be a positive whole number.")
+
+        gm_account = getattr(actor, "active_account", None)  # noqa: GETATTR_LITERAL
+        try:
+            award_xp(
+                account,
+                amount_int,
+                reason=ProgressionReason.GM_AWARD,
+                description=description,
+                gm=gm_account,
+            )
+        except ValueError as exc:
+            return ActionResult(success=False, message=str(exc))
+
+        return ActionResult(success=True, message=f"Awarded {amount_int} XP to {target.key}.")
+
+    def _award_development(
+        self,
+        actor: ObjectDB,
+        target: ObjectDB,
+        kwargs: dict[str, Any],
+        description: str,
+    ) -> ActionResult:
+        from world.progression.services.awards import award_development_points  # noqa: PLC0415
+        from world.progression.types import DevelopmentSource, ProgressionReason  # noqa: PLC0415
+        from world.traits.models import Trait  # noqa: PLC0415
+
+        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        if sheet is None:
+            return ActionResult(success=False, message=f"{target.key} has no character sheet.")
+
+        trait_ref = str(kwargs.get("trait_ref") or "").strip()
+        if not trait_ref:
+            return ActionResult(
+                success=False, message="A trait is required for development points."
+            )
+
+        try:
+            trait = resolve_model_by_pk_or_name(
+                Trait,
+                trait_ref,
+                not_found_msg=f"No trait named {trait_ref!r}.",
+            )
+        except CommandError as err:
+            return ActionResult(success=False, message=str(err))
+
+        amount_int = _coerce_positive_int(kwargs.get("amount"))
+        if amount_int is None:
+            return ActionResult(success=False, message="amount must be a positive whole number.")
+
+        gm_account = getattr(actor, "active_account", None)  # noqa: GETATTR_LITERAL
+        try:
+            award_development_points(
+                sheet,
+                trait,
+                DevelopmentSource.OTHER,
+                amount_int,
+                reason=ProgressionReason.GM_AWARD,
+                description=description,
+                gm=gm_account,
+            )
+        except ValueError as exc:
+            return ActionResult(success=False, message=str(exc))
+
+        return ActionResult(
+            success=True,
+            message=f"Awarded {amount_int} development point(s) in {trait.name} to {target.key}.",
+        )
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    """Return ``value`` as a positive int, or ``None`` if it isn't one.
+
+    Fails loud (returns None -> caller refuses) rather than silently coercing a
+    negative/zero amount to something valid.
+    """
+    try:
+        amount = int(value)
+    except (TypeError, ValueError):
+        return None
+    return amount if amount > 0 else None
+
+
+def _resolve_condition_target(kwargs: dict[str, Any]) -> tuple[Any, Any] | ActionResult:
+    """Return ``(target, template)`` or a failure ``ActionResult``.
+
+    Extracted from ``GMApplyConditionAction.execute`` to keep its own
+    return-statement count low (PLR0911) -- mirrors the
+    ``_resolve_add_opponent_inputs`` pattern in ``gm_combat.py``.
+    """
+    from world.conditions.models import ConditionTemplate  # noqa: PLC0415
+
+    target = kwargs.get("target")
+    if target is None:
+        return ActionResult(success=False, message="A target character is required.")
+
+    condition_ref = str(kwargs.get("condition_ref") or "").strip()
+    if not condition_ref:
+        return ActionResult(success=False, message="A condition name is required.")
+
+    try:
+        template = ConditionTemplate.get_by_name(condition_ref)
+    except ConditionTemplate.DoesNotExist:
+        return ActionResult(success=False, message=f"No condition named {condition_ref!r}.")
+
+    return target, template
+
+
+def _resolve_condition_bounds(kwargs: dict[str, Any]) -> tuple[int, int | None] | ActionResult:
+    """Return ``(severity, duration_rounds)`` overrides, or a failure ``ActionResult``.
+
+    Fails loud on a non-positive override rather than silently clamping one
+    (Decision 5); an absent kwarg falls back to ``apply_condition``'s own
+    authored default (severity 1; ``template.default_duration_value``).
+    """
+    severity = 1
+    severity_raw = kwargs.get("severity")
+    if severity_raw is not None:
+        coerced = _coerce_positive_int(severity_raw)
+        if coerced is None:
+            return ActionResult(success=False, message="severity must be a positive whole number.")
+        severity = coerced
+
+    duration_rounds = None
+    duration_raw = kwargs.get("duration_rounds")
+    if duration_raw is not None:
+        coerced = _coerce_positive_int(duration_raw)
+        if coerced is None:
+            return ActionResult(
+                success=False, message="duration_rounds must be a positive whole number."
+            )
+        duration_rounds = coerced
+
+    return severity, duration_rounds
+
+
+@dataclass
+class GMApplyConditionAction(Action):
+    """JUNIOR-tier GM action: apply an authored ``ConditionTemplate`` by fiat (#2118).
+
+    Catalog-bounded like the check verb: only an authored ``ConditionTemplate``
+    (resolved via ``ConditionTemplate.get_by_name`` -- exact name, matching the
+    hot-path lookup every other production caller uses) may be applied; there is
+    no free-form mechanical effect. ``severity``/``duration_rounds`` are optional
+    overrides of ``apply_condition``'s own authored defaults (severity 1;
+    ``template.default_duration_value``); the model defines no upper bound on
+    either field, so Decision 5 is honored by failing loud on a non-positive
+    value rather than silently clamping one. ``note`` is narration only (stored as
+    ``source_description``) -- it never becomes a mechanical effect. Gated on
+    ``IsSceneGMPrerequisite`` + ``MinimumGMLevelPrerequisite(GMLevel.JUNIOR)``.
+    """
+
+    key: str = "gm_apply_condition"
+    name: str = "Apply Condition"
+    icon: str = "sparkles"
+    category: str = "gm"
+    target_type: TargetType = TargetType.SINGLE
+    objectdb_target_kwargs: ClassVar[frozenset[str]] = frozenset({"target"})
+
+    def get_prerequisites(self) -> list[Prerequisite]:
+        return [IsSceneGMPrerequisite(), MinimumGMLevelPrerequisite(GMLevel.JUNIOR)]
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.conditions.services import apply_condition  # noqa: PLC0415
+
+        resolved = _resolve_condition_target(kwargs)
+        if isinstance(resolved, ActionResult):
+            return resolved
+        target, template = resolved
+
+        bounds = _resolve_condition_bounds(kwargs)
+        if isinstance(bounds, ActionResult):
+            return bounds
+        severity, duration_rounds = bounds
+
+        note = str(kwargs.get("note") or "").strip()
+
+        result = apply_condition(
+            target,
+            template,
+            severity=severity,
+            duration_rounds=duration_rounds,
+            source_character=actor,
+            source_description=note,
+        )
+        if not result.success:
+            return ActionResult(
+                success=False,
+                message=f"{template.name} was not applied ({result.message}).",
+            )
+
+        return ActionResult(success=True, message=f"{target.key} is now {template.name}.")

--- a/src/actions/prerequisites.py
+++ b/src/actions/prerequisites.py
@@ -161,6 +161,39 @@ class MinimumGMLevelPrerequisite(Prerequisite):
 
 
 @dataclass
+class IsSceneGMPrerequisite(Prerequisite):
+    """Actor must be staff, or the GM of the active scene at their location (#2118).
+
+    Staff bypass, else resolves the actor's active scene
+    (``get_active_scene``, ``world/scenes/interaction_services.py:38``) and requires
+    ``scene.is_gm(actor.active_account)``. Strict sibling of
+    ``actor_can_administer_scene`` -- deliberately excludes scene co-owners, so
+    administering a scene does not by itself grant catalog-check/award/condition
+    adjudication power. Mirrors ``_actor_may_gm_encounter``
+    (``actions/definitions/gm_combat.py:72-79``), including its refusal message.
+    """
+
+    def is_met(
+        self,
+        actor: ObjectDB,
+        target: ObjectDB | None = None,
+        context: dict | None = None,
+    ) -> tuple[bool, str]:
+        from commands.utils.gm_resolution import resolve_account_or_none  # noqa: PLC0415
+        from core_management.permissions import is_staff_observer  # noqa: PLC0415
+        from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
+
+        if is_staff_observer(actor):
+            return True, ""
+
+        account = resolve_account_or_none(actor)
+        scene = get_active_scene(getattr(actor, "location", None))  # noqa: GETATTR_LITERAL
+        if scene is not None and scene.is_gm(account):
+            return True, ""
+        return False, "Only the scene's GM or staff can do that."
+
+
+@dataclass
 class IsRoomTenantPrerequisite(Prerequisite):
     """The actor's active persona must actively tenant the room they're standing in (#670)."""
 

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -101,6 +101,11 @@ from actions.definitions.gift_acquisition import (
     AcceptThreadWeavingOfferAction,
     PurchaseGiftUnlockAction,
 )
+from actions.definitions.gm_adjudication import (
+    GMApplyConditionAction,
+    GMAwardAction,
+    InvokeCatalogCheckAction,
+)
 from actions.definitions.gm_combat import (
     AddEncounterParticipantAction,
     AddOpponentAction,
@@ -545,6 +550,10 @@ _ALL_ACTIONS: list[Action] = [
     PurchaseGiftUnlockAction(),
     AcceptTechniqueOfferAction(),
     AcceptThreadWeavingOfferAction(),
+    # #2118 — GM adjudication toolkit: catalog check invocation, awards, conditions.
+    InvokeCatalogCheckAction(),
+    GMAwardAction(),
+    GMApplyConditionAction(),
 ]
 
 # Lookup by key

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -382,6 +382,10 @@ class ActionRegistryTests(TestCase):
             "request_gm_for_covenant",
             "claim_group_story_request",
             "withdraw_group_story_request",
+            # #2118 — GM adjudication toolkit: catalog check invocation, awards, conditions.
+            "gm_invoke_check",
+            "gm_award_progression",
+            "gm_apply_condition",
         }
         assert set(ACTIONS_BY_KEY.keys()) == expected_keys
 

--- a/src/actions/tests/test_gm_adjudication_actions.py
+++ b/src/actions/tests/test_gm_adjudication_actions.py
@@ -1,0 +1,529 @@
+"""Tests for the GM adjudication toolkit Actions (#2118).
+
+Covers ``InvokeCatalogCheckAction``, ``GMAwardAction``, ``GMApplyConditionAction`` --
+permission journeys (scene-GM pass, non-GM refusal, staff bypass, JUNIOR floor on
+award/condition) and the RATIFIED no-invention invariant: no code path accepts a
+stat/skill pair, an integer difficulty, or any consequence-pool reference from a GM.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.test import TestCase
+
+from actions.definitions.gm_adjudication import (
+    GMApplyConditionAction,
+    GMAwardAction,
+    InvokeCatalogCheckAction,
+)
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import CheckCategoryFactory, CheckTypeFactory, CheckTypeTraitFactory
+from world.conditions.factories import ConditionTemplateFactory
+from world.conditions.models import ConditionInstance
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory
+from world.progression.models import DevelopmentPoints, ExperiencePointsData
+from world.progression.types import ProgressionReason
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.action_constants import DifficultyChoice
+from world.scenes.factories import SceneFactory, SceneParticipationFactory
+from world.traits.factories import CheckSystemSetupFactory, TraitFactory
+from world.traits.models import (
+    CharacterTraitValue,
+    CheckRank,
+    PointConversionRange,
+    ResultChart,
+    Trait,
+    TraitCategory,
+    TraitType,
+)
+
+
+def _room(*, db_key: str = "AdjudicationRoom") -> object:
+    return ObjectDBFactory(db_key=db_key, db_typeclass_path="typeclasses.rooms.Room")
+
+
+def _pc_in_room(room: object, *, db_key: str) -> tuple[object, object]:
+    """Return (Character, Account) -- a PC with a live roster tenure, located in *room*."""
+    char = CharacterFactory(db_key=db_key, location=room)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    return char, tenure.player_data.account
+
+
+class GMAdjudicationActionsTestBase(TestCase):
+    """Shared fixture: room, scene, GM/non-GM/staff actors, a check catalog + target.
+
+    Built in ``setUp`` (per test), not ``setUpTestData`` -- Character typeclass
+    instances hold an Evennia ``DbHolder`` attribute proxy that Django's
+    ``setUpTestData`` cannot deepcopy for per-test isolation (mirrors
+    ``GMCombatActionTestBase`` in ``test_gm_combat_actions.py``).
+    """
+
+    def setUp(self) -> None:
+        Trait.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        ResultChart.clear_cache()
+
+        CheckSystemSetupFactory.create()
+        PointConversionRange.objects.get_or_create(
+            trait_type=TraitType.STAT,
+            min_value=1,
+            defaults={"max_value": 100, "points_per_level": 1},
+        )
+        for rank_val, min_pts, name in [
+            (0, 0, "AdjNone"),
+            (1, 10, "AdjNovice"),
+            (2, 25, "AdjCompetent"),
+            (3, 50, "AdjExpert"),
+        ]:
+            CheckRank.objects.get_or_create(
+                rank=rank_val, defaults={"min_points": min_pts, "name": name}
+            )
+
+        self.room = _room()
+        self.scene = SceneFactory(location=self.room)
+
+        self.gm_actor, self.gm_account = _pc_in_room(self.room, db_key="GMActor")
+        GMProfileFactory(account=self.gm_account, level=GMLevel.JUNIOR)
+        SceneParticipationFactory(scene=self.scene, account=self.gm_account, is_gm=True)
+
+        self.starting_gm_actor, self.starting_gm_account = _pc_in_room(
+            self.room, db_key="StartingGMActor"
+        )
+        GMProfileFactory(account=self.starting_gm_account, level=GMLevel.STARTING)
+        SceneParticipationFactory(scene=self.scene, account=self.starting_gm_account, is_gm=True)
+
+        self.player_actor, self.player_account = _pc_in_room(self.room, db_key="PlayerActor")
+        SceneParticipationFactory(scene=self.scene, account=self.player_account, is_gm=False)
+
+        self.staff_account = AccountFactory(username="staff_adjudication", is_staff=True)
+        self.staff_actor = CharacterFactory(db_key="StaffActor", location=self.room)
+        self.staff_actor.db_account = self.staff_account
+        self.staff_actor.save()
+
+        self.target, self.target_account = _pc_in_room(self.room, db_key="TargetActor")
+
+        self.check_trait, _ = Trait.objects.get_or_create(
+            name="adj_check_strength",
+            defaults={"trait_type": TraitType.STAT, "category": TraitCategory.PHYSICAL},
+        )
+        self.check_category = CheckCategoryFactory(name="adj_check_combat")
+        self.check_type = CheckTypeFactory(name="Power Strike", category=self.check_category)
+        CheckTypeTraitFactory(
+            check_type=self.check_type, trait=self.check_trait, weight=Decimal("1.0")
+        )
+
+        self.dev_trait = TraitFactory(name="adj_dev_skill", trait_type=TraitType.SKILL)
+
+        self.condition_template = ConditionTemplateFactory(name="Adjudication Winded")
+
+        CharacterTraitValue.objects.get_or_create(
+            character=self.target, trait=self.check_trait, defaults={"value": 30}
+        )
+
+
+class InvokeCatalogCheckActionPermissionTests(GMAdjudicationActionsTestBase):
+    def test_non_gm_is_refused(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.player_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.HARD,
+        )
+        self.assertFalse(result.success)
+        self.assertIn("scene's GM or staff", result.message)
+
+    def test_scene_gm_can_invoke(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.HARD,
+        )
+        self.assertTrue(result.success)
+
+    def test_staff_bypasses_scene_gm_gate(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.staff_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.HARD,
+        )
+        self.assertTrue(result.success)
+
+    def test_no_level_floor_required_for_check_invocation(self) -> None:
+        """A STARTING-tier scene GM may still invoke checks (ADR-0030: player-roll resolved)."""
+        result = InvokeCatalogCheckAction().run(
+            actor=self.starting_gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.HARD,
+        )
+        self.assertTrue(result.success)
+
+
+class InvokeCatalogCheckActionInvocationTests(GMAdjudicationActionsTestBase):
+    def test_unresolvable_check_ref_refuses_with_discovery_hint(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref="Nonexistent Check",
+            difficulty=DifficultyChoice.HARD,
+        )
+        self.assertFalse(result.success)
+        self.assertIn("gm check find", result.message)
+
+    def test_check_resolves_by_pk(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=str(self.check_type.pk),
+            difficulty=DifficultyChoice.NORMAL,
+        )
+        self.assertTrue(result.success)
+        self.assertIn(self.check_type.name, result.message)
+
+    def test_integer_difficulty_is_rejected(self) -> None:
+        """No code path accepts an integer difficulty -- only DifficultyChoice bands."""
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=60,
+        )
+        self.assertFalse(result.success)
+        self.assertIn("difficulty band", result.message)
+
+    def test_all_difficulty_bands_resolve_and_are_number_free(self) -> None:
+        for band in DifficultyChoice.values:
+            result = InvokeCatalogCheckAction().run(
+                actor=self.gm_actor,
+                target=self.target,
+                check_type_ref=self.check_type.name,
+                difficulty=band,
+            )
+            self.assertTrue(result.success, band)
+            self.assertFalse(
+                any(ch.isdigit() for ch in result.message),
+                f"band {band} leaked a number: {result.message!r}",
+            )
+
+    def test_stat_skill_and_consequence_pool_kwargs_are_never_consumed(self) -> None:
+        """Extra invention-shaped kwargs (stat/skill/consequence pool refs) are inert.
+
+        No parameter on this Action's code path reads them -- passing them changes
+        nothing about the outcome, proving there is no hidden invention surface.
+        """
+        baseline = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.TRIVIAL,
+        )
+        with_extras = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.TRIVIAL,
+            stat="strength",
+            skill="athletics",
+            consequence_pool_id=999,
+            consequence_pool="whatever",
+        )
+        self.assertTrue(baseline.success)
+        self.assertTrue(with_extras.success)
+
+
+class InvokeCatalogCheckActionShiftTests(GMAdjudicationActionsTestBase):
+    def test_edge_shifts_exactly_one_band_easier_and_echoes_reason(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.HARD,
+            edge_reason="an ally braces the ladder",
+        )
+        self.assertTrue(result.success)
+        self.assertIn("edge", result.message)
+        self.assertIn("Normal", result.message)
+        self.assertIn("an ally braces the ladder", result.message)
+
+    def test_setback_shifts_exactly_one_band_harder_and_echoes_reason(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.HARD,
+            setback_reason="the footing is treacherous",
+        )
+        self.assertTrue(result.success)
+        self.assertIn("setback", result.message)
+        self.assertIn("Daunting", result.message)
+        self.assertIn("the footing is treacherous", result.message)
+
+    def test_edge_and_setback_together_is_rejected(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.HARD,
+            edge_reason="help",
+            setback_reason="hindrance",
+        )
+        self.assertFalse(result.success)
+
+    def test_edge_beyond_trivial_is_refused_not_clamped(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.TRIVIAL,
+            edge_reason="help",
+        )
+        self.assertFalse(result.success)
+        self.assertIn("easiest", result.message)
+
+    def test_setback_beyond_harrowing_is_refused_not_clamped(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.HARROWING,
+            setback_reason="hindrance",
+        )
+        self.assertFalse(result.success)
+        self.assertIn("hardest", result.message)
+
+    def test_shift_without_reason_is_a_noop_band(self) -> None:
+        """An empty edge/setback reason is treated as not shifting at all."""
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.HARD,
+            edge_reason="",
+        )
+        self.assertTrue(result.success)
+        self.assertNotIn("edge", result.message)
+
+
+class InvokeCatalogCheckActionFindTests(GMAdjudicationActionsTestBase):
+    def test_find_with_no_target_lists_catalog(self) -> None:
+        result = InvokeCatalogCheckAction().run(actor=self.gm_actor)
+        self.assertTrue(result.success)
+        self.assertIn(self.check_type.name, result.message)
+
+    def test_find_by_name_matches(self) -> None:
+        result = InvokeCatalogCheckAction().run(actor=self.gm_actor, query="Power")
+        self.assertTrue(result.success)
+        self.assertIn(self.check_type.name, result.message)
+
+    def test_find_by_trait_matches(self) -> None:
+        result = InvokeCatalogCheckAction().run(actor=self.gm_actor, query="adj_check_strength")
+        self.assertTrue(result.success)
+        self.assertIn(self.check_type.name, result.message)
+
+    def test_find_with_no_matches(self) -> None:
+        result = InvokeCatalogCheckAction().run(actor=self.gm_actor, query="zzz_no_such_check")
+        self.assertTrue(result.success)
+        self.assertNotIn(self.check_type.name, result.message)
+
+    def test_find_requires_no_gm_level_floor_but_still_needs_scene_gm(self) -> None:
+        result = InvokeCatalogCheckAction().run(actor=self.player_actor, query="Power")
+        self.assertFalse(result.success)
+
+
+class GMAwardActionTests(GMAdjudicationActionsTestBase):
+    def test_non_gm_is_refused(self) -> None:
+        result = GMAwardAction().run(
+            actor=self.player_actor, target=self.target, award_type="xp", amount=10
+        )
+        self.assertFalse(result.success)
+
+    def test_junior_floor_enforced(self) -> None:
+        result = GMAwardAction().run(
+            actor=self.starting_gm_actor, target=self.target, award_type="xp", amount=10
+        )
+        self.assertFalse(result.success)
+        self.assertIn("Junior GM", result.message)
+
+    def test_staff_bypasses_junior_floor(self) -> None:
+        result = GMAwardAction().run(
+            actor=self.staff_actor, target=self.target, award_type="xp", amount=10
+        )
+        self.assertTrue(result.success)
+
+    def test_award_xp_creates_transaction_with_gm_reason(self) -> None:
+        from world.progression.models import XPTransaction
+
+        result = GMAwardAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            award_type="xp",
+            amount=15,
+            description="heroic rescue",
+        )
+        self.assertTrue(result.success)
+        xp_data = ExperiencePointsData.objects.get(account=self.target_account)
+        self.assertEqual(xp_data.total_earned, 15)
+        txn = XPTransaction.objects.get(account=self.target_account)
+        self.assertEqual(txn.reason, ProgressionReason.GM_AWARD)
+        self.assertEqual(txn.gm, self.gm_account)
+        self.assertEqual(txn.description, "heroic rescue")
+
+    def test_award_xp_rejects_non_positive_amount(self) -> None:
+        result = GMAwardAction().run(
+            actor=self.gm_actor, target=self.target, award_type="xp", amount=0
+        )
+        self.assertFalse(result.success)
+        self.assertFalse(ExperiencePointsData.objects.filter(account=self.target_account).exists())
+
+    def test_award_development_creates_transaction(self) -> None:
+        result = GMAwardAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            award_type="development",
+            trait_ref=self.dev_trait.name,
+            amount=5,
+            description="training montage",
+        )
+        self.assertTrue(result.success)
+        dp = DevelopmentPoints.objects.get(
+            character_sheet=self.target.sheet_data, trait=self.dev_trait
+        )
+        self.assertEqual(dp.total_earned, 5)
+
+    def test_award_development_requires_trait_ref(self) -> None:
+        result = GMAwardAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            award_type="development",
+            amount=5,
+        )
+        self.assertFalse(result.success)
+
+    def test_invalid_award_type_is_rejected(self) -> None:
+        result = GMAwardAction().run(
+            actor=self.gm_actor, target=self.target, award_type="legend", amount=5
+        )
+        self.assertFalse(result.success)
+
+
+class GMApplyConditionActionTests(GMAdjudicationActionsTestBase):
+    def test_non_gm_is_refused(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.player_actor,
+            target=self.target,
+            condition_ref=self.condition_template.name,
+        )
+        self.assertFalse(result.success)
+
+    def test_junior_floor_enforced(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.starting_gm_actor,
+            target=self.target,
+            condition_ref=self.condition_template.name,
+        )
+        self.assertFalse(result.success)
+        self.assertIn("Junior GM", result.message)
+
+    def test_staff_bypasses_junior_floor(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.staff_actor,
+            target=self.target,
+            condition_ref=self.condition_template.name,
+        )
+        self.assertTrue(result.success)
+
+    def test_apply_condition_creates_instance_with_source_character(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            condition_ref=self.condition_template.name,
+            note="knocked down by the blast",
+        )
+        self.assertTrue(result.success)
+        instance = ConditionInstance.objects.get(
+            target=self.target, condition=self.condition_template
+        )
+        self.assertEqual(instance.source_character, self.gm_actor)
+        self.assertEqual(instance.source_description, "knocked down by the blast")
+        self.assertEqual(instance.severity, 1)
+
+    def test_unresolvable_condition_is_refused(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            condition_ref="No Such Condition",
+        )
+        self.assertFalse(result.success)
+
+    def test_severity_override_is_honored(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            condition_ref=self.condition_template.name,
+            severity=3,
+        )
+        self.assertTrue(result.success)
+        instance = ConditionInstance.objects.get(
+            target=self.target, condition=self.condition_template
+        )
+        self.assertEqual(instance.severity, 3)
+
+    def test_non_positive_severity_fails_loud_not_clamped(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            condition_ref=self.condition_template.name,
+            severity=0,
+        )
+        self.assertFalse(result.success)
+        self.assertFalse(
+            ConditionInstance.objects.filter(
+                target=self.target, condition=self.condition_template
+            ).exists()
+        )
+
+    def test_non_positive_duration_fails_loud_not_clamped(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            condition_ref=self.condition_template.name,
+            duration_rounds=-1,
+        )
+        self.assertFalse(result.success)
+        self.assertFalse(
+            ConditionInstance.objects.filter(
+                target=self.target, condition=self.condition_template
+            ).exists()
+        )
+
+    def test_duration_override_is_honored(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            condition_ref=self.condition_template.name,
+            duration_rounds=7,
+        )
+        self.assertTrue(result.success)
+        instance = ConditionInstance.objects.get(
+            target=self.target, condition=self.condition_template
+        )
+        self.assertEqual(instance.rounds_remaining, 7)
+
+    def test_omitted_duration_uses_template_default(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.gm_actor,
+            target=self.target,
+            condition_ref=self.condition_template.name,
+        )
+        self.assertTrue(result.success)
+        instance = ConditionInstance.objects.get(
+            target=self.target, condition=self.condition_template
+        )
+        self.assertEqual(instance.rounds_remaining, self.condition_template.default_duration_value)

--- a/src/actions/tests/test_prerequisites.py
+++ b/src/actions/tests/test_prerequisites.py
@@ -2,8 +2,12 @@
 
 from django.test import TestCase
 
-from actions.prerequisites import MinimumGMLevelPrerequisite, PendingRitualEffectPrerequisite
-from evennia_extensions.factories import AccountFactory, CharacterFactory
+from actions.prerequisites import (
+    IsSceneGMPrerequisite,
+    MinimumGMLevelPrerequisite,
+    PendingRitualEffectPrerequisite,
+)
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.gm.constants import GMLevel
 from world.gm.factories import GMProfileFactory
@@ -11,6 +15,7 @@ from world.magic.constants import RitualExecutionKind
 from world.magic.factories import CharacterResonanceFactory, RitualFactory
 from world.magic.models import PendingRitualEffect
 from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.factories import SceneFactory, SceneParticipationFactory
 
 
 def _gm_actor(level: str, *, db_key: str = "GMActor") -> object:
@@ -75,6 +80,62 @@ class MinimumGMLevelPrerequisiteTests(TestCase):
         met, reason = MinimumGMLevelPrerequisite(GMLevel.JUNIOR).is_met(actor)
         self.assertFalse(met)
         self.assertIn("Junior GM", reason)
+
+
+def _room(*, db_key: str = "PrereqRoom") -> object:
+    return ObjectDBFactory(db_key=db_key, db_typeclass_path="typeclasses.rooms.Room")
+
+
+def _actor_in_room(room: object, *, db_key: str = "Actor") -> tuple[object, object]:
+    """Return (Character, Account) -- the character is located in *room*."""
+    char = CharacterFactory(db_key=db_key, location=room)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    return char, tenure.player_data.account
+
+
+class IsSceneGMPrerequisiteTests(TestCase):
+    """IsSceneGMPrerequisite (#2118) -- staff bypass + Scene.is_gm on the actor's active scene."""
+
+    def setUp(self) -> None:
+        self.room = _room()
+        self.scene = SceneFactory(location=self.room)
+
+    def test_staff_bypasses_regardless_of_scene_gm_status(self) -> None:
+        actor = _plain_actor(db_key="StaffCheckBypass", is_staff=True)
+        met, reason = IsSceneGMPrerequisite().is_met(actor)
+        self.assertTrue(met)
+        self.assertEqual(reason, "")
+
+    def test_scene_gm_passes(self) -> None:
+        actor, account = _actor_in_room(self.room, db_key="SceneGM")
+        SceneParticipationFactory(scene=self.scene, account=account, is_gm=True)
+        met, reason = IsSceneGMPrerequisite().is_met(actor)
+        self.assertTrue(met)
+        self.assertEqual(reason, "")
+
+    def test_non_gm_scene_participant_is_refused(self) -> None:
+        actor, account = _actor_in_room(self.room, db_key="NonGMParticipant")
+        SceneParticipationFactory(scene=self.scene, account=account, is_gm=False)
+        met, reason = IsSceneGMPrerequisite().is_met(actor)
+        self.assertFalse(met)
+        self.assertEqual(reason, "Only the scene's GM or staff can do that.")
+
+    def test_scene_co_owner_without_gm_flag_is_refused(self) -> None:
+        """Administering a scene (co-owner) does not by itself grant adjudication power."""
+        actor, account = _actor_in_room(self.room, db_key="CoOwner")
+        SceneParticipationFactory(scene=self.scene, account=account, is_owner=True, is_gm=False)
+        met, reason = IsSceneGMPrerequisite().is_met(actor)
+        self.assertFalse(met)
+        self.assertEqual(reason, "Only the scene's GM or staff can do that.")
+
+    def test_no_active_scene_is_refused(self) -> None:
+        empty_room = _room(db_key="EmptyPrereqRoom")
+        actor, _account = _actor_in_room(empty_room, db_key="NoSceneActor")
+        met, reason = IsSceneGMPrerequisite().is_met(actor)
+        self.assertFalse(met)
+        self.assertEqual(reason, "Only the scene's GM or staff can do that.")
 
 
 class PendingRitualEffectPrerequisiteTests(TestCase):

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -388,6 +388,18 @@ actions, backends, and service functions.
   to a *reach*: `gemit <msg>` (game-wide), `gemit/society <a>,<b> = <msg>`, or `gemit/org <a>,<b> =
   <msg>` (members of those societies/orgs, by active persona). No body is ever generated. Player/
   covenant-targeted story emits are a separate, non-public tool — not this command.
+- **`gm_ops.py`**: `CmdGMDashboard` (`gm`, alias `gmdashboard`) — `gm dashboard` (#2004, the
+  GM's queue/tables/evidence read-out) plus the GM adjudication toolkit subverbs (#2118),
+  thin `parse_kv_and_flags` parsing + `action.run()` over the three Actions in
+  `actions/definitions/gm_adjudication.py`: `gm check [find <term>]` / `gm check <character>
+  <check-type>=<band> [edge=<reason>|setback=<reason>]` (`InvokeCatalogCheckAction` — a
+  multi-word check-type name must be referenced by pk, since the check-type name IS the
+  key token and can't be pre-registered as a multiword key), `gm award <character>
+  xp=<amount>|dev=<trait> amount=<n> [reason=<text>]` (`GMAwardAction`), `gm condition
+  <character> condition=<name> [severity=<n>] [duration=<n>] [note=<text>]`
+  (`GMApplyConditionAction`). `CmdGMIdle` (`gmidle`, staff-only `perm(Admin)`) — idle GM
+  tables. No business logic in the command; permission gating (`IsSceneGMPrerequisite` +
+  `MinimumGMLevelPrerequisite` where applicable) lives entirely in the Actions.
 - **`gm_tables.py`**: `CmdGMTable` (`gmtable`, #1505) — basic telnet parity for GM-table admin
   (the React `frontend/src/tables/` module is the primary surface). Thin over `world.gm.services`,
   subverb-dispatched: `gmtable [list]`, `gmtable create <name>[=<desc>]`, `gmtable members <id>`,

--- a/src/commands/gm_ops.py
+++ b/src/commands/gm_ops.py
@@ -92,6 +92,7 @@ class CmdGMDashboard(ArxCommand):
 
         result = ClaimGroupStoryRequestAction().run(actor=self.caller, request_id=int(rest))
         self.msg(result.message)
+
     def _resolve_target(self, name: str) -> Any:
         """Resolve a co-located character by name; raises CommandError if absent."""
         room = self.caller.location

--- a/src/commands/gm_ops.py
+++ b/src/commands/gm_ops.py
@@ -3,16 +3,45 @@
 Thin over the same services the web ``GMDashboardView`` and
 ``StaffWorkloadView`` call. ``gm dashboard`` is GM-gated; ``gm idle`` is
 staff-only (``perm(Admin)``).
+
+``gm check``/``gm award``/``gm condition`` (#2118) are the GM adjudication
+toolkit's telnet face — thin ``resolve_action_args()``-style parsing +
+``action.run()`` over ``InvokeCatalogCheckAction``/``GMAwardAction``/
+``GMApplyConditionAction`` (``actions/definitions/gm_adjudication.py``), the
+same seam the web available-actions dispatcher uses.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 from commands.command import ArxCommand
 from commands.exceptions import CommandError
+from commands.parsing import parse_kv_and_flags
+from commands.utils.gm_resolution import resolve_character_sheet_in_room
 
 _USAGE_DASHBOARD = "Usage: gm dashboard"
 _USAGE_IDLE = "Usage: gm idle"
 _USAGE_CLAIM = "Usage: gm claim <request-id>"
+_USAGE_CHECK = (
+    "Usage: gm check [find <term>] | gm check <character> <check-type>=<band>"
+    " [edge=<reason>|setback=<reason>]"
+)
+_USAGE_AWARD = (
+    "Usage: gm award <character> xp=<amount> [reason=<text>]"
+    " | gm award <character> dev=<trait> amount=<n> [reason=<text>]"
+)
+_USAGE_CONDITION = (
+    "Usage: gm condition <character> condition=<name> [severity=<n>] [duration=<n>] [note=<text>]"
+)
+
+# parse_kv_and_flags key names -- module constants so the STRING_LITERAL lint's
+# comparison/membership check doesn't see bare identifier-shaped literals.
+_KEY_XP = "xp"
+_KEY_DEV = "dev"
+_KEY_SEVERITY = "severity"
+_KEY_DURATION = "duration"
+_KEY_NOTE = "note"
 
 
 class CmdGMDashboard(ArxCommand):
@@ -21,6 +50,11 @@ class CmdGMDashboard(ArxCommand):
     Usage:
       gm dashboard
       gm claim <request-id>
+      gm check [find <term>]
+      gm check <character> <check-type>=<band> [edge=<reason>|setback=<reason>]
+      gm award <character> xp=<amount> [reason=<text>]
+      gm award <character> dev=<trait> amount=<n> [reason=<text>]
+      gm condition <character> condition=<name> [severity=<n>] [duration=<n>] [note=<text>]
     """
 
     key = "gm"
@@ -30,12 +64,20 @@ class CmdGMDashboard(ArxCommand):
     action = None
 
     def func(self) -> None:
-        """Render a text summary of the GM dashboard, or claim a group story request."""
+        """Route the leading subverb, falling back to the dashboard render."""
         try:
             raw = (self.args or "").strip()
-            tokens = raw.split(None, 1)
-            if tokens and tokens[0].lower() == "claim":  # noqa: STRING_LITERAL
-                self._claim(tokens[1] if len(tokens) > 1 else "")
+            tokens = raw.split(maxsplit=1)
+            first = tokens[0].lower() if tokens else ""
+            rest = tokens[1].strip() if len(tokens) > 1 else ""
+            if first == "claim":  # noqa: STRING_LITERAL
+                self._claim(rest)
+            elif first == "check":  # noqa: STRING_LITERAL
+                self._handle_check(rest)
+            elif first == "award":  # noqa: STRING_LITERAL
+                self._handle_award(rest)
+            elif first == "condition":  # noqa: STRING_LITERAL
+                self._handle_condition(rest)
             else:
                 self._render()
         except CommandError as err:
@@ -50,6 +92,128 @@ class CmdGMDashboard(ArxCommand):
 
         result = ClaimGroupStoryRequestAction().run(actor=self.caller, request_id=int(rest))
         self.msg(result.message)
+    def _resolve_target(self, name: str) -> Any:
+        """Resolve a co-located character by name; raises CommandError if absent."""
+        room = self.caller.location
+        if room is None:
+            msg = "You are not in a room."
+            raise CommandError(msg)
+        sheet = resolve_character_sheet_in_room(self.caller, name, room=room)
+        return sheet.character
+
+    def _handle_check(self, rest: str) -> None:
+        """Dispatch InvokeCatalogCheckAction -- find/list mode or invoke mode."""
+        from actions.definitions.gm_adjudication import InvokeCatalogCheckAction  # noqa: PLC0415
+
+        tokens = rest.split(maxsplit=1)
+        first = tokens[0] if tokens else ""
+        if first in ("", "find"):  # noqa: STRING_LITERAL
+            query = tokens[1].strip() if len(tokens) > 1 else ""
+            result = InvokeCatalogCheckAction().run(actor=self.caller, query=query)
+            if result.message:
+                self.msg(result.message)
+            return
+
+        char_name = first
+        kv_rest = tokens[1] if len(tokens) > 1 else ""
+        # The check-type reference IS the key (e.g. "Grapple=hard") -- it can't be
+        # pre-registered as a multiword key since it's arbitrary/unknown ahead of
+        # parsing, so a multi-word check name must be referenced by pk here (mirrors
+        # the documented multi-word-name limitation in parse_targets_from_text).
+        try:
+            kwargs, _flags = parse_kv_and_flags(
+                kv_rest,
+                multiword_keys=frozenset({"edge", "setback"}),
+                known_flags=frozenset(),
+            )
+        except CommandError:
+            raise CommandError(_USAGE_CHECK) from None
+        edge_reason = kwargs.pop("edge", None)
+        setback_reason = kwargs.pop("setback", None)
+        if len(kwargs) != 1:
+            raise CommandError(_USAGE_CHECK)
+        ((check_type_ref, difficulty),) = kwargs.items()
+
+        target = self._resolve_target(char_name)
+        run_kwargs: dict[str, Any] = {
+            "target": target,
+            "check_type_ref": check_type_ref,
+            "difficulty": difficulty,
+        }
+        if edge_reason:
+            run_kwargs["edge_reason"] = edge_reason
+        if setback_reason:
+            run_kwargs["setback_reason"] = setback_reason
+
+        result = InvokeCatalogCheckAction().run(actor=self.caller, **run_kwargs)
+        if result.message:
+            self.msg(result.message)
+
+    def _handle_award(self, rest: str) -> None:
+        """Dispatch GMAwardAction -- xp=<amount> or dev=<trait> amount=<n>."""
+        from actions.definitions.gm_adjudication import GMAwardAction  # noqa: PLC0415
+
+        tokens = rest.split(maxsplit=1)
+        if not tokens:
+            raise CommandError(_USAGE_AWARD)
+        char_name = tokens[0]
+        kv_rest = tokens[1] if len(tokens) > 1 else ""
+        kwargs, _flags = parse_kv_and_flags(
+            kv_rest,
+            multiword_keys=frozenset({"reason"}),
+            known_flags=frozenset(),
+        )
+        reason = kwargs.pop("reason", "")
+
+        target = self._resolve_target(char_name)
+        run_kwargs: dict[str, Any] = {"target": target, "description": reason}
+        if _KEY_XP in kwargs:
+            run_kwargs["award_type"] = "xp"
+            run_kwargs["amount"] = kwargs[_KEY_XP]
+        elif _KEY_DEV in kwargs:
+            run_kwargs["award_type"] = "development"
+            run_kwargs["trait_ref"] = kwargs[_KEY_DEV]
+            run_kwargs["amount"] = kwargs.get("amount")
+        else:
+            raise CommandError(_USAGE_AWARD)
+
+        result = GMAwardAction().run(actor=self.caller, **run_kwargs)
+        if result.message:
+            self.msg(result.message)
+
+    def _handle_condition(self, rest: str) -> None:
+        """Dispatch GMApplyConditionAction -- condition=<name> [severity=][duration=][note=]."""
+        from actions.definitions.gm_adjudication import GMApplyConditionAction  # noqa: PLC0415
+
+        tokens = rest.split(maxsplit=1)
+        if not tokens:
+            raise CommandError(_USAGE_CONDITION)
+        char_name = tokens[0]
+        kv_rest = tokens[1] if len(tokens) > 1 else ""
+        kwargs, _flags = parse_kv_and_flags(
+            kv_rest,
+            multiword_keys=frozenset({"condition", "note"}),
+            known_flags=frozenset(),
+        )
+        condition_ref = kwargs.get("condition")
+        if not condition_ref:
+            raise CommandError(_USAGE_CONDITION)
+
+        target = self._resolve_target(char_name)
+        run_kwargs: dict[str, Any] = {
+            "target": target,
+            "condition_ref": condition_ref,
+        }
+        if _KEY_SEVERITY in kwargs:
+            run_kwargs["severity"] = kwargs[_KEY_SEVERITY]
+        if _KEY_DURATION in kwargs:
+            run_kwargs["duration_rounds"] = kwargs[_KEY_DURATION]
+        if _KEY_NOTE in kwargs:
+            run_kwargs["note"] = kwargs[_KEY_NOTE]
+
+        result = GMApplyConditionAction().run(actor=self.caller, **run_kwargs)
+        if result.message:
+            self.msg(result.message)
 
     def _render(self) -> None:
         raw = (self.args or "").strip().lower()

--- a/src/commands/tests/test_gm_ops_adjudication.py
+++ b/src/commands/tests/test_gm_ops_adjudication.py
@@ -1,0 +1,208 @@
+"""Telnet tests for the GM adjudication toolkit subverbs (#2118).
+
+``gm check`` / ``gm award`` / ``gm condition`` on ``CmdGMDashboard`` --
+thin parsing + ``action.run()`` over ``InvokeCatalogCheckAction`` /
+``GMAwardAction`` / ``GMApplyConditionAction``. These tests exercise the
+telnet-layer grammar (usage errors, subverb routing); the full permission
+matrix and catalog-only invariant are covered by
+``actions/tests/test_gm_adjudication_actions.py``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.gm_ops import CmdGMDashboard
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import CheckCategoryFactory, CheckTypeFactory, CheckTypeTraitFactory
+from world.conditions.factories import ConditionTemplateFactory
+from world.conditions.models import ConditionInstance
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory
+from world.progression.models import ExperiencePointsData
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+from world.scenes.factories import SceneFactory, SceneParticipationFactory
+from world.traits.factories import CheckSystemSetupFactory, TraitFactory
+from world.traits.models import (
+    CharacterTraitValue,
+    CheckRank,
+    PointConversionRange,
+    ResultChart,
+    Trait,
+    TraitCategory,
+    TraitType,
+)
+
+
+def _room(*, db_key: str = "GMOpsRoom") -> object:
+    return ObjectDBFactory(db_key=db_key, db_typeclass_path="typeclasses.rooms.Room")
+
+
+def _pc_in_room(room: object, *, db_key: str) -> tuple[object, object]:
+    char = CharacterFactory(db_key=db_key, location=room)
+    CharacterSheetFactory(character=char)
+    entry = RosterEntryFactory(character_sheet__character=char)
+    tenure = RosterTenureFactory(roster_entry=entry, end_date=None)
+    return char, tenure.player_data.account
+
+
+def _run_cmd(caller: object, args: str) -> list[str]:
+    cmd = CmdGMDashboard()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.raw_string = f"gm {args}".strip()
+    cmd.func()
+    return [str(c.args[0]) for c in caller.msg.call_args_list if c.args]
+
+
+class GMOpsAdjudicationTestBase(TestCase):
+    """Room + scene + JUNIOR-tier scene-GM caller + target + a check/condition catalog."""
+
+    def setUp(self) -> None:
+        Trait.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        ResultChart.clear_cache()
+
+        CheckSystemSetupFactory.create()
+        PointConversionRange.objects.get_or_create(
+            trait_type=TraitType.STAT,
+            min_value=1,
+            defaults={"max_value": 100, "points_per_level": 1},
+        )
+        for rank_val, min_pts, name in [
+            (0, 0, "GMOpsNone"),
+            (1, 10, "GMOpsNovice"),
+            (2, 25, "GMOpsCompetent"),
+            (3, 50, "GMOpsExpert"),
+        ]:
+            CheckRank.objects.get_or_create(
+                rank=rank_val, defaults={"min_points": min_pts, "name": name}
+            )
+
+        self.room = _room()
+        self.scene = SceneFactory(location=self.room)
+
+        self.gm_actor, self.gm_account = _pc_in_room(self.room, db_key="GMOpsGM")
+        GMProfileFactory(account=self.gm_account, level=GMLevel.JUNIOR)
+        SceneParticipationFactory(scene=self.scene, account=self.gm_account, is_gm=True)
+        self.gm_actor.msg = MagicMock()
+
+        self.player_actor, self.player_account = _pc_in_room(self.room, db_key="GMOpsPlayer")
+        SceneParticipationFactory(scene=self.scene, account=self.player_account, is_gm=False)
+        self.player_actor.msg = MagicMock()
+
+        self.target, self.target_account = _pc_in_room(self.room, db_key="GMOpsTarget")
+
+        self.check_trait, _ = Trait.objects.get_or_create(
+            name="gmops_check_strength",
+            defaults={"trait_type": TraitType.STAT, "category": TraitCategory.PHYSICAL},
+        )
+        self.check_category = CheckCategoryFactory(name="gmops_check_combat")
+        self.check_type = CheckTypeFactory(name="Grapple", category=self.check_category)
+        CheckTypeTraitFactory(
+            check_type=self.check_type, trait=self.check_trait, weight=Decimal("1.0")
+        )
+        CharacterTraitValue.objects.get_or_create(
+            character=self.target, trait=self.check_trait, defaults={"value": 30}
+        )
+
+        self.dev_trait = TraitFactory(name="gmops_dev_skill", trait_type=TraitType.SKILL)
+        self.condition_template = ConditionTemplateFactory(name="GMOps Winded")
+
+
+class CmdGMCheckTests(GMOpsAdjudicationTestBase):
+    def test_bare_check_lists_catalog(self) -> None:
+        messages = _run_cmd(self.gm_actor, "check")
+        self.assertTrue(any(self.check_type.name in m for m in messages))
+
+    def test_check_find_with_term(self) -> None:
+        messages = _run_cmd(self.gm_actor, "check find Grapple")
+        self.assertTrue(any(self.check_type.name in m for m in messages))
+
+    def test_check_invoke_resolves_and_messages_caller(self) -> None:
+        messages = _run_cmd(self.gm_actor, f"check {self.target.key} {self.check_type.name}=hard")
+        self.assertTrue(messages)
+        self.assertTrue(any(self.check_type.name in m for m in messages))
+
+    def test_check_invoke_with_edge_reason(self) -> None:
+        messages = _run_cmd(
+            self.gm_actor,
+            f"check {self.target.key} {self.check_type.name}=hard edge=ally braces the door",
+        )
+        joined = " ".join(messages)
+        self.assertIn("edge", joined)
+        self.assertIn("ally braces the door", joined)
+
+    def test_check_missing_band_shows_usage(self) -> None:
+        messages = _run_cmd(self.gm_actor, f"check {self.target.key} justatoken")
+        self.assertTrue(any("Usage: gm check" in m for m in messages))
+
+    def test_check_unknown_target_reports_not_found(self) -> None:
+        messages = _run_cmd(self.gm_actor, f"check NoSuchCharacter {self.check_type.name}=hard")
+        self.assertTrue(any("here" in m.lower() or "no character" in m.lower() for m in messages))
+
+    def test_non_gm_is_refused(self) -> None:
+        messages = _run_cmd(
+            self.player_actor, f"check {self.target.key} {self.check_type.name}=hard"
+        )
+        self.assertTrue(any("scene's GM or staff" in m for m in messages))
+
+
+class CmdGMAwardTests(GMOpsAdjudicationTestBase):
+    def test_award_xp(self) -> None:
+        messages = _run_cmd(self.gm_actor, f"award {self.target.key} xp=20 reason=good pose")
+        self.assertTrue(any("20" in m and "XP" in m for m in messages))
+        xp_data = ExperiencePointsData.objects.get(account=self.target_account)
+        self.assertEqual(xp_data.total_earned, 20)
+
+    def test_award_development(self) -> None:
+        messages = _run_cmd(
+            self.gm_actor,
+            f"award {self.target.key} dev={self.dev_trait.name} amount=4",
+        )
+        self.assertTrue(messages)
+        self.assertFalse(any("Usage" in m for m in messages))
+
+    def test_award_missing_type_shows_usage(self) -> None:
+        messages = _run_cmd(self.gm_actor, f"award {self.target.key} amount=5")
+        self.assertTrue(any("Usage: gm award" in m for m in messages))
+
+    def test_non_gm_is_refused(self) -> None:
+        messages = _run_cmd(self.player_actor, f"award {self.target.key} xp=20")
+        self.assertTrue(len(messages) > 0)
+        self.assertFalse(ExperiencePointsData.objects.filter(account=self.target_account).exists())
+
+
+class CmdGMConditionTests(GMOpsAdjudicationTestBase):
+    def test_apply_condition(self) -> None:
+        messages = _run_cmd(
+            self.gm_actor,
+            f"condition {self.target.key} condition={self.condition_template.name}"
+            " note=knocked flat",
+        )
+        self.assertTrue(any(self.condition_template.name in m for m in messages))
+        self.assertTrue(
+            ConditionInstance.objects.filter(
+                target=self.target, condition=self.condition_template
+            ).exists()
+        )
+
+    def test_condition_missing_condition_key_shows_usage(self) -> None:
+        messages = _run_cmd(self.gm_actor, f"condition {self.target.key} severity=2")
+        self.assertTrue(any("Usage: gm condition" in m for m in messages))
+
+    def test_non_gm_is_refused(self) -> None:
+        messages = _run_cmd(
+            self.player_actor,
+            f"condition {self.target.key} condition={self.condition_template.name}",
+        )
+        self.assertFalse(
+            ConditionInstance.objects.filter(
+                target=self.target, condition=self.condition_template
+            ).exists()
+        )
+        self.assertTrue(len(messages) > 0)


### PR DESCRIPTION
Closes #2118

## Summary

GM adjudication toolkit under the ratified catalog-only invariant (ADR-0110: GM content is catalog + adaptation, never invention — with the Arx I lesson recorded). InvokeCatalogCheckAction accepts ONLY an authored CheckType + DifficultyChoice band + at most one band of edge/setback with a required echoed reason — no stat/skill pair, integer difficulty, or consequence-pool parameter exists on any path (negative-tested); gm check find ships discovery. GMAwardAction/GMApplyConditionAction (JUNIOR floor via #2117's prerequisite + #2113's IsSceneGMPrerequisite) give scene GMs first-class XP/dev awards and authored-condition application. Rebase resolved the expected gm_ops.py/test_base.py/INDEX.md overlap with merged #2119 (union of subverbs + registry keys); actions 1014 OK + commands 1007 OK post-merge.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2118 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: rebased onto origin/main; resolved 6 conflict hunks across gm_ops.py/test_base.py/INDEX.md from the #2119 overlap; both affected suites re-run green

<!-- last-addressed-comment: 0 -->