### PR TITLE
feat: web Guise-Sheet authoring form — author a cover persona's bio in the React UI (#1270 follow-up)

### DIFF
--- a/docs/systems/appearance_and_identity.md
+++ b/docs/systems/appearance_and_identity.md
@@ -72,10 +72,13 @@ artist changes persona with an *identical* body; a curse changes the body and
   stays the real face's bio (presented by PRIMARY). `scenes.services.set_persona_profile` is the
   **sole mutator** (PRIMARY rejected; narrative text only — **lineage stays display-only**, every
   *mechanical* lineage read pinned to `true_profile` via the sheet's forwarding properties).
-  Authored on telnet via `persona profile <name> [concept=… quote=… personality=… background=…]`;
-  the web profile serializer already renders the *presented* face's profile cover-aware (slices
-  1–3), so a guise authored anywhere shows correctly — a dedicated **web authoring form** is the
-  remaining follow-up. (Telnet `@sheet` is self/staff-only, so a non-privileged viewer never sees
+  Authored on telnet via `persona profile <name> [concept=… quote=… personality=… background=…]`
+  and on the web (#1682) via `POST /api/personas/set-profile/` (`PersonaViewSet.set_profile` —
+  ownership-gated like set-active; absent fields stay untouched, blank fields clear), reached
+  from the persona switcher's "Edit guise sheet…" dialog (`GuiseSheetDialog`, prefilled from
+  the `guise_*` read fields now on `PersonaSerializer`). The web profile serializer renders the
+  *presented* face's profile cover-aware (slices 1–3), so a guise authored anywhere shows
+  correctly. (Telnet `@sheet` is self/staff-only, so a non-privileged viewer never sees
   another's cover there; the `<cover> (<real>)` reveal is a web-profile concern.)
 - **Named/public personas** (PRIMARY, ESTABLISHED) render **by name to everyone** —
   the accessibility guarantee.

--- a/frontend/src/game/components/GuiseSheetDialog.tsx
+++ b/frontend/src/game/components/GuiseSheetDialog.tsx
@@ -1,0 +1,130 @@
+/**
+ * GuiseSheetDialog — author a cover persona's fabricated bio (#1682).
+ *
+ * The web face of the #1270 Guise Sheet: a cover/established persona needs its
+ * OWN concept/quote/personality/background so the absence of a bio doesn't
+ * instantly out it as fake. Prefills from the persona's current guise fields;
+ * saving writes the full four-field state (clearing a field is a real edit).
+ * Never offered for the PRIMARY face — the real bio lives on the sheet.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+import { useSetPersonaProfileMutation, type SwitchablePersona } from '../personaQueries';
+
+interface GuiseSheetDialogProps {
+  persona: SwitchablePersona;
+  characterSheetId: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function GuiseSheetDialog({
+  persona,
+  characterSheetId,
+  open,
+  onOpenChange,
+}: GuiseSheetDialogProps) {
+  const save = useSetPersonaProfileMutation(characterSheetId);
+  const [concept, setConcept] = useState(persona.guise_concept);
+  const [quote, setQuote] = useState(persona.guise_quote);
+  const [personality, setPersonality] = useState(persona.guise_personality);
+  const [background, setBackground] = useState(persona.guise_background);
+
+  // Re-prefill whenever the dialog opens (the persona's saved bio may have changed).
+  useEffect(() => {
+    if (open) {
+      setConcept(persona.guise_concept);
+      setQuote(persona.guise_quote);
+      setPersonality(persona.guise_personality);
+      setBackground(persona.guise_background);
+      save.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- prefill only on open/persona change
+  }, [open, persona.id]);
+
+  const submit = () => {
+    save.mutate(
+      { personaId: persona.id, body: { concept, quote, personality, background } },
+      { onSuccess: () => onOpenChange(false) }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Guise sheet — {persona.name}</DialogTitle>
+          <DialogDescription>
+            The bio this cover identity presents to the world. A guise with no story outs itself;
+            give it one.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="guise-concept">Concept</Label>
+            <Input
+              id="guise-concept"
+              value={concept}
+              onChange={(e) => setConcept(e.target.value)}
+              placeholder="Wandering scholar of little consequence"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="guise-quote">Quote</Label>
+            <Input
+              id="guise-quote"
+              value={quote}
+              onChange={(e) => setQuote(e.target.value)}
+              placeholder="A motto this identity lives by"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="guise-personality">Personality</Label>
+            <Textarea
+              id="guise-personality"
+              value={personality}
+              onChange={(e) => setPersonality(e.target.value)}
+              rows={3}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="guise-background">Background</Label>
+            <Textarea
+              id="guise-background"
+              value={background}
+              onChange={(e) => setBackground(e.target.value)}
+              rows={4}
+            />
+          </div>
+          {save.isError && (
+            <p className="text-sm text-destructive">
+              {save.error instanceof Error ? save.error.message : 'Could not save the guise sheet.'}
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={save.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={save.isPending}>
+            {save.isPending ? 'Saving…' : 'Save guise sheet'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/game/components/PersonaSwitcher.tsx
+++ b/frontend/src/game/components/PersonaSwitcher.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { PersonaAvatar, type PersonaAvatarSource } from '@/components/PersonaAvatar';
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -16,6 +17,7 @@ import {
   useSetActivePersonaMutation,
   type SwitchablePersona,
 } from '../personaQueries';
+import { GuiseSheetDialog } from './GuiseSheetDialog';
 
 interface PersonaSwitcherProps {
   characterSheetId: number;
@@ -39,10 +41,13 @@ function avatarSource(p: SwitchablePersona): PersonaAvatarSource {
  * Shows the worn identity and, when the character has more than one face, lets the
  * player switch via `POST /api/personas/set-active/`. The worn face is made
  * deliberately obvious so a player never acts as the wrong identity by accident.
+ * A worn non-primary face also offers "Edit guise sheet…" (#1682) — its
+ * fabricated bio, authored via `POST /api/personas/set-profile/`.
  */
 export function PersonaSwitcher({ characterSheetId, activePersonaId }: PersonaSwitcherProps) {
   const { data: personas = [] } = useCharacterPersonasQuery(characterSheetId);
   const setActive = useSetActivePersonaMutation();
+  const [guiseOpen, setGuiseOpen] = useState(false);
 
   const worn = useMemo(
     () =>
@@ -60,40 +65,60 @@ export function PersonaSwitcher({ characterSheetId, activePersonaId }: PersonaSw
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        className="flex items-center gap-1.5 rounded px-2 py-1 text-sm font-medium ring-1 ring-primary/40 hover:bg-accent disabled:opacity-50"
-        disabled={setActive.isPending}
-        title="Switch which identity you are presenting as"
-      >
-        <span>{worn.name}</span>
-        <span className="text-xs text-muted-foreground" aria-hidden>
-          ▾
-        </span>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-56">
-        <DropdownMenuLabel>Presenting as</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuRadioGroup
-          value={worn.id.toString()}
-          onValueChange={(value) => {
-            const id = Number(value);
-            if (id !== worn.id) {
-              setActive.mutate(id);
-            }
-          }}
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="flex items-center gap-1.5 rounded px-2 py-1 text-sm font-medium ring-1 ring-primary/40 hover:bg-accent disabled:opacity-50"
+          disabled={setActive.isPending}
+          title="Switch which identity you are presenting as"
         >
-          {personas.map((p) => (
-            <DropdownMenuRadioItem key={p.id} value={p.id.toString()} className="gap-2">
-              <PersonaAvatar source={avatarSource(p)} size="sm" />
-              <span className="flex flex-col">
-                <span>{p.name}</span>
-                <span className="text-xs text-muted-foreground">{TYPE_LABEL[p.persona_type]}</span>
-              </span>
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <span>{worn.name}</span>
+          <span className="text-xs text-muted-foreground" aria-hidden>
+            ▾
+          </span>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-56">
+          <DropdownMenuLabel>Presenting as</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuRadioGroup
+            value={worn.id.toString()}
+            onValueChange={(value) => {
+              const id = Number(value);
+              if (id !== worn.id) {
+                setActive.mutate(id);
+              }
+            }}
+          >
+            {personas.map((p) => (
+              <DropdownMenuRadioItem key={p.id} value={p.id.toString()} className="gap-2">
+                <PersonaAvatar source={avatarSource(p)} size="sm" />
+                <span className="flex flex-col">
+                  <span>{p.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {TYPE_LABEL[p.persona_type]}
+                  </span>
+                </span>
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+          {worn.persona_type !== 'primary' && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={() => setGuiseOpen(true)}>
+                Edit guise sheet…
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {worn.persona_type !== 'primary' && (
+        <GuiseSheetDialog
+          persona={worn}
+          characterSheetId={characterSheetId}
+          open={guiseOpen}
+          onOpenChange={setGuiseOpen}
+        />
+      )}
+    </>
   );
 }

--- a/frontend/src/game/components/__tests__/PersonaSwitcher.test.tsx
+++ b/frontend/src/game/components/__tests__/PersonaSwitcher.test.tsx
@@ -12,6 +12,13 @@ const { state, mutate } = vi.hoisted(() => ({
 vi.mock('../../personaQueries', () => ({
   useCharacterPersonasQuery: () => ({ data: state.personas }),
   useSetActivePersonaMutation: () => ({ mutate, isPending: false }),
+  useSetPersonaProfileMutation: () => ({
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
 }));
 
 function persona(

--- a/frontend/src/game/components/__tests__/PersonaSwitcher.test.tsx
+++ b/frontend/src/game/components/__tests__/PersonaSwitcher.test.tsx
@@ -26,6 +26,10 @@ function persona(
     is_fake_name: type === 'temporary',
     thumbnail_url: null,
     thumbnail_media_url: null,
+    guise_concept: '',
+    guise_quote: '',
+    guise_personality: '',
+    guise_background: '',
   };
 }
 

--- a/frontend/src/game/personaQueries.ts
+++ b/frontend/src/game/personaQueries.ts
@@ -12,6 +12,19 @@ export interface SwitchablePersona {
   is_fake_name: boolean;
   thumbnail_url: string | null;
   thumbnail_media_url: string | null;
+  /** #1682 — the guise's fabricated bio (empty strings when unauthored). */
+  guise_concept: string;
+  guise_quote: string;
+  guise_personality: string;
+  guise_background: string;
+}
+
+/** #1682 — the four authorable Guise-Sheet fields. */
+export interface GuiseProfileBody {
+  concept: string;
+  quote: string;
+  personality: string;
+  background: string;
 }
 
 const personaKeys = {
@@ -32,6 +45,10 @@ async function fetchCharacterPersonas(characterSheetId: number): Promise<Switcha
       is_fake_name?: boolean;
       thumbnail_url?: string | null;
       thumbnail_media_url?: string | null;
+      guise_concept?: string;
+      guise_quote?: string;
+      guise_personality?: string;
+      guise_background?: string;
     }>;
   };
   return (data.results ?? []).map((p) => ({
@@ -41,6 +58,10 @@ async function fetchCharacterPersonas(characterSheetId: number): Promise<Switcha
     is_fake_name: p.is_fake_name ?? false,
     thumbnail_url: p.thumbnail_url ?? null,
     thumbnail_media_url: p.thumbnail_media_url ?? null,
+    guise_concept: p.guise_concept ?? '',
+    guise_quote: p.guise_quote ?? '',
+    guise_personality: p.guise_personality ?? '',
+    guise_background: p.guise_background ?? '',
   }));
 }
 
@@ -75,6 +96,31 @@ export function useSetActivePersonaMutation() {
     mutationFn: (personaId: number) => setActivePersona(personaId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['my-roster-entries'] });
+    },
+  });
+}
+
+async function setPersonaProfile(personaId: number, body: GuiseProfileBody): Promise<void> {
+  const res = await apiFetch('/api/personas/set-profile/', {
+    method: 'POST',
+    body: JSON.stringify({ persona_id: personaId, ...body }),
+  });
+  if (!res.ok) {
+    const detail = (await res.json().catch(() => null)) as string[] | null;
+    throw new Error(Array.isArray(detail) ? detail[0] : 'Could not save the guise sheet.');
+  }
+}
+
+/** #1682 — author a cover persona's Guise Sheet; refreshes the persona list on save. */
+export function useSetPersonaProfileMutation(characterSheetId: number | null) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ personaId, body }: { personaId: number; body: GuiseProfileBody }) =>
+      setPersonaProfile(personaId, body),
+    onSuccess: () => {
+      if (characterSheetId !== null) {
+        qc.invalidateQueries({ queryKey: personaKeys.forCharacterSheet(characterSheetId) });
+      }
     },
   });
 }

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -12991,6 +12991,31 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/personas/set-profile/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description #1682 — author a cover persona's Guise Sheet from the web.
+     *
+     *     Wires the shipped #1270 service to the primary surface: the face must
+     *     be one of the played character's own personas (a foreign or unknown id
+     *     is rejected uniformly, mirroring set-active); PRIMARY is rejected by
+     *     the service (the real bio is the sheet's ``true_profile``). Absent
+     *     fields stay untouched (partial edits are safe); blank fields clear.
+     */
+    post: operations['personas_set_profile_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/personas/spread-specializations/': {
     parameters: {
       query?: never;
@@ -28586,6 +28611,10 @@ export interface components {
        *     Defaults to True when there is no tenure or preference row.
        */
       readonly allow_social_actions: boolean;
+      readonly guise_concept: string;
+      readonly guise_quote: string;
+      readonly guise_personality: string;
+      readonly guise_background: string;
     };
     /**
      * @description One warrant row on the viewer's own crime tab — tiers only, never the raw number.
@@ -30462,6 +30491,20 @@ export interface components {
     /** @description POST body for the #981 set-active-persona endpoint. */
     SetActivePersonaRequestRequest: {
       persona_id: number;
+    };
+    /**
+     * @description POST body for the #1682 set-profile endpoint — author a guise's bio.
+     *
+     *     Every bio field is optional and None-preserving: an ABSENT field leaves the
+     *     stored value untouched (the ``set_persona_profile`` contract, so partial
+     *     edits are safe), while a PRESENT-but-blank field explicitly clears it.
+     */
+    SetPersonaProfileRequestRequest: {
+      persona_id: number;
+      concept?: string;
+      quote?: string;
+      personality?: string;
+      background?: string;
     };
     /**
      * @description POST body for the #1445 set-round-mode endpoint.
@@ -51351,6 +51394,29 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['ActivePersonaResult'];
+        };
+      };
+    };
+  };
+  personas_set_profile_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SetPersonaProfileRequestRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Persona'];
         };
       };
     };

--- a/src/schema.json
+++ b/src/schema.json
@@ -21118,6 +21118,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/ActivePersonaResult'
           description: ''
+  /api/personas/set-profile/:
+    post:
+      operationId: personas_set_profile_create
+      description: |-
+        #1682 — author a cover persona's Guise Sheet from the web.
+
+        Wires the shipped #1270 service to the primary surface: the face must
+        be one of the played character's own personas (a foreign or unknown id
+        is rejected uniformly, mirroring set-active); PRIMARY is rejected by
+        the service (the real bio is the sheet's ``true_profile``). Absent
+        fields stay untouched (partial edits are safe); blank fields clear.
+      tags:
+      - personas
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetPersonaProfileRequestRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Persona'
+          description: ''
   /api/personas/spread-specializations/:
     get:
       operationId: personas_spread_specializations_list
@@ -50633,9 +50661,25 @@ components:
             characters (#1181); the backend still enforces the full gate at dispatch.
             Defaults to True when there is no tenure or preference row.
           readOnly: true
+        guise_concept:
+          type: string
+          readOnly: true
+        guise_quote:
+          type: string
+          readOnly: true
+        guise_personality:
+          type: string
+          readOnly: true
+        guise_background:
+          type: string
+          readOnly: true
       required:
       - allow_social_actions
       - character_sheet
+      - guise_background
+      - guise_concept
+      - guise_personality
+      - guise_quote
       - id
       - name
       - roster_entry
@@ -54583,6 +54627,29 @@ components:
         persona_id:
           type: integer
           minimum: 1
+      required:
+      - persona_id
+    SetPersonaProfileRequestRequest:
+      type: object
+      description: |-
+        POST body for the #1682 set-profile endpoint — author a guise's bio.
+
+        Every bio field is optional and None-preserving: an ABSENT field leaves the
+        stored value untouched (the ``set_persona_profile`` contract, so partial
+        edits are safe), while a PRESENT-but-blank field explicitly clears it.
+      properties:
+        persona_id:
+          type: integer
+          minimum: 1
+        concept:
+          type: string
+          maxLength: 255
+        quote:
+          type: string
+        personality:
+          type: string
+        background:
+          type: string
       required:
       - persona_id
     SetRoundModeRequestRequest:

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -236,6 +236,13 @@ Key service functions for scene round lifecycle:
     anonymous mask, optionally applying a #1110 disguise overlay + switching the worn face). PRIMARY
     is never created here. Creation copies **no** descriptors from sibling faces — the
     descriptor-never-auto-attach privacy invariant (#1109) holds structurally.
+  - **Guise-Sheet authoring (#1682):** `set-profile` POST action — the web face of
+    `scenes.services.set_persona_profile` (sole mutator; PRIMARY rejected). Ownership-gated
+    like `set_active` (own-sheet personas only, uniform rejection); absent fields stay
+    untouched, blank fields clear. `PersonaSerializer` exposes read-only `guise_concept` /
+    `guise_quote` / `guise_personality` / `guise_background` so the switcher's
+    `GuiseSheetDialog` (`frontend/src/game/components/`) prefills. Telnet parity:
+    `persona profile <name> …` (#1270).
 - **`SceneSummaryRevisionViewSet`**: Summary revision management
 
 ### `friend_views.py` (#1727)

--- a/src/world/scenes/serializers.py
+++ b/src/world/scenes/serializers.py
@@ -21,6 +21,12 @@ class PersonaSerializer(serializers.ModelSerializer):
     roster_entry = serializers.SerializerMethodField()
     thumbnail_media_url = serializers.SerializerMethodField()
     allow_social_actions = serializers.SerializerMethodField()
+    # #1682 — the guise's fabricated bio (null profile → empty strings), so the
+    # web authoring dialog can prefill and blank-clears stay safe.
+    guise_concept = serializers.SerializerMethodField()
+    guise_quote = serializers.SerializerMethodField()
+    guise_personality = serializers.SerializerMethodField()
+    guise_background = serializers.SerializerMethodField()
 
     class Meta:
         model = Persona
@@ -35,8 +41,24 @@ class PersonaSerializer(serializers.ModelSerializer):
             "thumbnail_media_url",
             "roster_entry",
             "allow_social_actions",
+            "guise_concept",
+            "guise_quote",
+            "guise_personality",
+            "guise_background",
         ]
         read_only_fields = ["roster_entry", "allow_social_actions"]
+
+    def get_guise_concept(self, obj: Persona) -> str:
+        return obj.profile.concept if obj.profile_id else ""
+
+    def get_guise_quote(self, obj: Persona) -> str:
+        return obj.profile.quote if obj.profile_id else ""
+
+    def get_guise_personality(self, obj: Persona) -> str:
+        return obj.profile.personality if obj.profile_id else ""
+
+    def get_guise_background(self, obj: Persona) -> str:
+        return obj.profile.background if obj.profile_id else ""
 
     def get_thumbnail_media_url(self, obj: Persona) -> str | None:
         if obj.thumbnail_id is None:
@@ -462,6 +484,21 @@ class CreateMaskRequestSerializer(serializers.Serializer):
     """POST body for the #1127 create-mask endpoint — a temporary anonymous face."""
 
     name = serializers.CharField(max_length=255)
+
+
+class SetPersonaProfileRequestSerializer(serializers.Serializer):
+    """POST body for the #1682 set-profile endpoint — author a guise's bio.
+
+    Every bio field is optional and None-preserving: an ABSENT field leaves the
+    stored value untouched (the ``set_persona_profile`` contract, so partial
+    edits are safe), while a PRESENT-but-blank field explicitly clears it.
+    """
+
+    persona_id = serializers.IntegerField(min_value=1)
+    concept = serializers.CharField(required=False, allow_blank=True, max_length=255)
+    quote = serializers.CharField(required=False, allow_blank=True)
+    personality = serializers.CharField(required=False, allow_blank=True)
+    background = serializers.CharField(required=False, allow_blank=True)
 
 
 class SetRoundModeRequestSerializer(serializers.Serializer):

--- a/src/world/scenes/tests/test_persona_creation.py
+++ b/src/world/scenes/tests/test_persona_creation.py
@@ -224,3 +224,72 @@ class CreatePersonaEndpointTests(TestCase):
             puppet=None,
         )
         assert resp.status_code == 400
+
+
+class SetPersonaProfileEndpointTests(TestCase):
+    """The #1682 set-profile endpoint — web authoring of a cover persona's Guise Sheet."""
+
+    URL = "/api/scenes/personas/set-profile/"
+
+    def setUp(self):
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        self.cover = create_persona(self.sheet, name="Cover Face", persona_type="established")
+        self.factory = APIRequestFactory()
+
+    def _post(self, body, *, puppet):
+        request = self.factory.post(self.URL, body, format="json")
+        user = SimpleNamespace(is_authenticated=True, is_staff=False, puppet=puppet)
+        force_authenticate(request, user=user)
+        return PersonaViewSet.as_view({"post": "set_profile"})(request)
+
+    def test_authors_the_guise_bio(self):
+        resp = self._post(
+            {
+                "persona_id": self.cover.pk,
+                "concept": "Wandering scholar",
+                "quote": "Knowledge owes no landlord.",
+            },
+            puppet=self.character,
+        )
+        assert resp.status_code == 200
+        self.cover.refresh_from_db()
+        assert self.cover.profile is not None
+        assert self.cover.profile.concept == "Wandering scholar"
+        assert self.cover.profile.quote == "Knowledge owes no landlord."
+
+    def test_partial_edit_preserves_other_fields(self):
+        set_persona_profile(self.cover, concept="Original", quote="Keep me")
+        resp = self._post(
+            {"persona_id": self.cover.pk, "concept": "Updated"}, puppet=self.character
+        )
+        assert resp.status_code == 200
+        self.cover.refresh_from_db()
+        assert self.cover.profile.concept == "Updated"
+        assert self.cover.profile.quote == "Keep me"
+
+    def test_blank_field_explicitly_clears(self):
+        set_persona_profile(self.cover, concept="Erase me")
+        resp = self._post({"persona_id": self.cover.pk, "concept": ""}, puppet=self.character)
+        assert resp.status_code == 200
+        self.cover.refresh_from_db()
+        assert self.cover.profile.concept == ""
+
+    def test_primary_rejected_with_user_message(self):
+        resp = self._post(
+            {"persona_id": self.sheet.primary_persona.pk, "concept": "nope"},
+            puppet=self.character,
+        )
+        assert resp.status_code == 400
+
+    def test_foreign_persona_rejected_uniformly(self):
+        other = CharacterSheetFactory()
+        foreign = create_persona(other, name="Not Yours", persona_type="established")
+        resp = self._post({"persona_id": foreign.pk, "concept": "hijack"}, puppet=self.character)
+        assert resp.status_code == 400
+        foreign.refresh_from_db()
+        assert foreign.profile is None
+
+    def test_no_played_character_400(self):
+        resp = self._post({"persona_id": self.cover.pk, "concept": "x"}, puppet=None)
+        assert resp.status_code == 400

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -51,6 +51,7 @@ from world.scenes.serializers import (
     ScenesSpotlightSerializer,
     SceneSummaryRevisionSerializer,
     SetActivePersonaRequestSerializer,
+    SetPersonaProfileRequestSerializer,
     SetRoundModeRequestSerializer,
 )
 from world.scenes.services import broadcast_scene_message
@@ -546,6 +547,50 @@ class PersonaViewSet(
         except PersonaCreationError as exc:
             raise serializers.ValidationError(exc.user_message) from exc
         return Response(PersonaSerializer(mask).data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        request=SetPersonaProfileRequestSerializer,
+        responses={200: PersonaSerializer},
+        tags=["personas"],
+    )
+    @action(
+        detail=False,
+        methods=[HTTPMethod.POST],
+        url_path="set-profile",
+        permission_classes=[permissions.IsAuthenticated],
+    )
+    def set_profile(self, request: Request) -> Response:
+        """#1682 — author a cover persona's Guise Sheet from the web.
+
+        Wires the shipped #1270 service to the primary surface: the face must
+        be one of the played character's own personas (a foreign or unknown id
+        is rejected uniformly, mirroring set-active); PRIMARY is rejected by
+        the service (the real bio is the sheet's ``true_profile``). Absent
+        fields stay untouched (partial edits are safe); blank fields clear.
+        """
+        from world.scenes.services import GuiseProfileError, set_persona_profile  # noqa: PLC0415
+
+        body = SetPersonaProfileRequestSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        sheet = self._played_sheet(request)
+        persona = Persona.objects.filter(
+            pk=body.validated_data["persona_id"], character_sheet=sheet
+        ).first()
+        if persona is None:
+            msg = "That is not one of your identities."
+            raise serializers.ValidationError(msg)
+        data = body.validated_data
+        try:
+            set_persona_profile(
+                persona,
+                concept=data.get("concept"),
+                quote=data.get("quote"),
+                personality=data.get("personality"),
+                background=data.get("background"),
+            )
+        except GuiseProfileError as exc:
+            raise serializers.ValidationError(exc.user_message) from exc
+        return Response(PersonaSerializer(persona).data, status=status.HTTP_200_OK)
 
     @extend_schema(responses=RenownSerializer, tags=["personas"])
     @action(detail=True, methods=[HTTPMethod.GET])


### PR DESCRIPTION
Closes #1682

## Summary

Web Guise-Sheet authoring form (#1682, closing #1270's residual). Adds PersonaViewSet.set-profile POST action + SetPersonaProfileRequestSerializer wiring the shipped set_persona_profile service to the web — ownership-gated exactly like set-active (own-sheet personas only, uniform rejection), PRIMARY rejected by the service, absent fields untouched / blank fields clear. PersonaSerializer gains read-only guise_concept/quote/personality/background for dialog prefill. FE: GuiseSheetDialog reached from the persona switcher's 'Edit guise sheet…' item (non-primary faces only) + useSetPersonaProfileMutation. Lineage stays display-only (out of scope, unchanged); api types regenerated.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1682 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main cleanly (1 commit).

<!-- last-addressed-comment: 0 -->