### PR TITLE
Telnet onboarding + visibility polish: web pointers at the front door, email path, raw XP balance display

### DIFF
--- a/docs/roadmap/ooc-social.md
+++ b/docs/roadmap/ooc-social.md
@@ -78,6 +78,31 @@ stakes-contract engine's `check_stake_boundaries` seam (#1770 PR4's allow-all st
   hard-line-excluded queries, counts-only GM reads) — not by convention.
 - **Details:** `docs/systems/boundaries.md`, ADR-0086.
 
+## Built — Telnet Onboarding Front Door (#2122)
+
+Chargen/roster stay web-first by design, but the telnet front door itself was a dead end
+with no signpost, and telnet-only accounts had no way to satisfy the web app's verified-email
+gate. Three small, additive polish items (part of the #2112 launch-content-bootstrap slate):
+
+- **Web pointers.** `settings.FRONTEND_URL` (promoted from five inline `env("FRONTEND_URL",
+  ...)` calls in `settings.py`) now appears on the connection screen
+  (`server/conf/connection_screens.py`) and the characterless post-login message
+  (`typeclasses/accounts.py::at_post_login`), so a telnet-only player always has a path to the
+  web roster/application/chargen flow.
+- **`roster status`.** Own-pending-application status only (`CmdRoster`,
+  `commands/account/account_info.py`) — roster browsing stays web-only, per the existing
+  by-design boundary; this needed no listing/browsing UI, just a status line.
+- **`account email <address>`.** A subverb on `CmdAccount` that sets/updates the account's
+  primary allauth `EmailAddress` and sends the confirmation email — the telnet path to satisfy
+  `can_apply_for_characters()`'s verified-email gate for `create <user> <pass>`-registered
+  accounts (which collect no email otherwise). `can_apply_for_characters()` itself is
+  unchanged.
+- **XP balance.** `progression unlocks` now shows the caller's XP balance + last-5
+  `XPTransaction` rows (previously it only leaked into failed-purchase error text).
+
+Details: `docs/systems/roster.md`'s "Telnet Surface (#2122)" section, `docs/systems
+/progression.md`'s Telnet Commands section, `commands/CLAUDE.md`.
+
 ## What's Needed for MVP
 - Friend list system — explicit friend tracking with online status
 - Player finder — who's online, who's in scenes, who's looking for RP

--- a/docs/systems/progression.md
+++ b/docs/systems/progression.md
@@ -498,6 +498,14 @@ progression unlock skill=<id>    — purchase a skill's XP-boundary breakthrough
 for the skill-breakthrough purchase's mechanics (rust payoff, ephemeral dev points,
 `purchase_skill_breakthrough`).
 
+`progression unlocks` also prepends the caller's **XP balance** (`ExperiencePointsData
+.current_available`) and last-5 `XPTransaction` rows (#2122) — the only telnet display of
+account XP; previously it only leaked into failed-purchase error text. Account lookup mirrors
+`CmdKudos._show_balance`'s pattern exactly (`get_account_for_character`, `world.roster
+.selectors`), so a stray character with no active tenure reports a zero balance rather than
+erroring. Deliberately not duplicated onto `sheet` — one canonical place avoids two surfaces to
+keep in sync (see `CmdProgressionUnlock._render_xp_balance` in `commands/progression.py`).
+
 ### `kudos` — Claim kudos for XP (#1348)
 
 ```

--- a/docs/systems/roster.md
+++ b/docs/systems/roster.md
@@ -130,6 +130,25 @@ mail.mark_read()   # Sets read_date to now
 mail.get_thread_messages()
 ```
 
+---
+
+## Telnet Surface (#2122)
+
+Roster browsing and applying stay web-only, by design. The one telnet exception is
+**own-status only** — a player checking on applications they've already submitted, which
+needs no listing/browsing UI:
+
+- `roster` / `roster status` (`commands/account/account_info.py`, `CmdRoster`, registered in
+  `AccountCmdSet`) — reads `self.account.player_data.get_pending_applications()` (the same
+  `PlayerData` method the web `/api/user/` payload's `pending_applications` field already
+  calls). Scoped to the caller's own `PlayerData` — no id-based lookup exists on the command,
+  so one account's applications can never surface another's.
+
+The telnet front door itself (connection screen + the characterless post-login message,
+`server/conf/connection_screens.py` / `typeclasses/accounts.py::at_post_login`) now points at
+`settings.FRONTEND_URL` so a telnet-only player has a path to the web roster/application/chargen
+flow in the first place.
+
 ### FamilyMember
 
 ```python

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -645,6 +645,10 @@ actions, backends, and service functions.
   precondition of the Durance advance — `advance_class_level_via_session`/
   `convene_durance_at_site` additionally require the purchased `CharacterUnlock` receipt
   alongside `check_requirements_for_unlock`; see `world/progression/CLAUDE.md`'s multi-gate rule.
+  **#2122:** `progression unlocks` also prepends the caller's XP balance
+  (`ExperiencePointsData.current_available`) + last-5 `XPTransaction` rows, mirroring
+  `CmdKudos._show_balance`'s account-scoped lookup pattern — previously the balance only
+  leaked into failed-purchase error text. Not duplicated onto `sheet`.
 - **`gift_learning.py`**: `CmdLearn` (`learn`, #2116) — the gift/technique/thread-weaving
   acquisition namespace. One `DispatchCommand` routes a leading subverb (`gift <id>` /
   `technique <id>` / `thread <id>`) through `dispatch_player_action` — the same seam the web
@@ -720,7 +724,28 @@ actions, backends, and service functions.
 - **`evennia_overrides/builder.py`**: `CmdDig`, `CmdOpen`, `CmdLink`, `CmdUnlink` (Evennia overrides)
 
 ### Account Commands (`account/`)
-- **`account_info.py`**: `CmdAccount` — account information display
+- **`account_info.py`**: `CmdAccount` (`@account`/`account`) — bare shows account information
+  display; `account email <address>` (#2122) sets/updates the account's primary allauth
+  `EmailAddress` and (re)sends the confirmation email — the telnet path to satisfy
+  `can_apply_for_characters()`'s verified-email gate for `create <user> <pass>`-registered
+  accounts, which collect no email otherwise. Operates on `self.account` only (no
+  target-account argument — can't touch another account's email). Calls
+  `EmailAddress.set_as_primary()` + `EmailAddress.send_confirmation(request=None,
+  signup=False)` directly rather than the higher-level `EmailAddress.objects.add_email()` /
+  `send_verification_email_to_address()` helper — that helper additionally calls
+  `django.contrib.messages.add_message(request, ...)`, which requires a real `HttpRequest`
+  with message-storage middleware and raises `TypeError` on `request=None` outside an HTTP
+  request/response cycle (this project has `django.contrib.messages` installed via Evennia's
+  default settings). `send_confirmation(request=None, ...)` is itself a documented allauth
+  call shape (confirmations sent outside a request context) and is safe here because
+  `settings.FRONTEND_URL` / `HEADLESS_FRONTEND_URLS` is always an absolute URL, so allauth's
+  `render_url` never dereferences `request.build_absolute_uri`. `can_apply_for_characters()`
+  (`evennia_extensions/models.py`) is unchanged — this command only gives telnet-only accounts
+  a path to satisfy it. Also home to `CmdRoster` (`roster`/`roster status`, #2122) — read-only
+  status of the caller's own pending `RosterApplication` rows via `PlayerData
+  .get_pending_applications()`; roster browsing stays web-only (by design), scoped to the
+  caller's own `PlayerData` (no id-based lookup exists, so it can't leak another account's
+  applications).
 - **`character_switching.py`**: `CmdIC`, `CmdCharacters` — character switching
 - **`sheet.py`**: `CmdSheet` — the character sheet **hub**. Bare `sheet` shows the overview;
   `sheet/<section>` dispatches to a section (mirroring the web sheet tabs). The sheet is the

--- a/src/commands/account/account_info.py
+++ b/src/commands/account/account_info.py
@@ -2,20 +2,36 @@
 Account information commands for ArxII.
 """
 
+import re
 from typing import ClassVar
 
+from allauth.account.models import EmailAddress
 from evennia import Command
+
+# Minimal sanity check — full validation (deliverability, MX, etc.) is out of scope;
+# allauth's own EmailAddress field validation runs on save.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+_SUBVERB_STATUS = "status"
+_SUBVERB_EMAIL = "email"
 
 
 class CmdAccount(Command):  # ty: ignore[invalid-base]
     """
-    Show account information and settings.
+    Show account information, or set/update your account email.
 
     Usage:
         @account
+        account email <address>
 
-    Displays your account information, preferences, and current session status.
-    This shows OOC account-level information, not character information.
+    Bare ``@account``/``account`` shows your account information, preferences,
+    and current session status (OOC account-level info, not character info).
+
+    ``account email <address>`` sets your account's primary email address and
+    (re)sends a verification link — the same allauth confirmation flow the web
+    signup form uses. Telnet-registered accounts (``create <user> <pass>``
+    collects no email) have no other way to satisfy the verified-email gate
+    that character applications require (#2122).
     """
 
     key = "@account"
@@ -24,6 +40,23 @@ class CmdAccount(Command):  # ty: ignore[invalid-base]
     help_category = "Account"
 
     def func(self) -> None:
+        """Route: bare → info display; ``email <address>`` → set/update email."""
+        raw = (self.args or "").strip()
+        if not raw:
+            self._show_info()
+            return
+
+        parts = raw.split(maxsplit=1)
+        subverb = parts[0].lower()
+        rest = parts[1].strip() if len(parts) > 1 else ""
+
+        if subverb == _SUBVERB_EMAIL:
+            self._set_email(rest)
+            return
+
+        self.caller.msg(f"Unknown account command '{subverb}'. Try: email <address>.")
+
+    def _show_info(self) -> None:
         """Display account information."""
         account = self.account
         player_data = account.player_data
@@ -69,3 +102,97 @@ class CmdAccount(Command):  # ty: ignore[invalid-base]
                 self.caller.msg(f"  GM Notes: {player_data.gm_notes}")
             else:
                 self.caller.msg("  GM Notes: None")
+
+    def _set_email(self, address: str) -> None:
+        """Set/update the account's primary email and send a confirmation link.
+
+        Operates on ``self.account`` only — there is no target-account argument,
+        so a caller can never touch another account's email (#2122 leak analysis).
+
+        allauth API note (resolved at implementation time — allauth 65.14.1
+        installed here): the higher-level ``EmailAddress.objects.add_email(request,
+        ...)`` / ``send_verification_email_to_address`` path additionally calls
+        ``django.contrib.messages.add_message(request, ...)``, which requires a
+        real ``HttpRequest`` with message-storage middleware attached and raises
+        ``TypeError`` when ``request`` is ``None`` outside an HTTP request/response
+        cycle (this project has ``django.contrib.messages`` installed, via
+        Evennia's default settings). We therefore call the lower-level
+        ``EmailAddress.set_as_primary()`` + ``EmailAddress.send_confirmation()``
+        directly — the same model API the higher-level helper delegates to for
+        actually sending the mail, minus the messages-framework side effect
+        (irrelevant here; this command sends its own telnet confirmation line).
+        ``send_confirmation(request=None, ...)`` is itself a documented, supported
+        call shape (see ``DefaultAccountAdapter.get_email_confirmation_url``'s
+        docstring: confirmations sent outside a request context may pass
+        ``request=None``) and is safe here because ``HEADLESS_FRONTEND_URLS`` /
+        ``settings.FRONTEND_URL`` is always an absolute URL, so allauth's
+        ``render_url`` never dereferences ``request.build_absolute_uri``.
+        """
+        address = address.strip()
+        if not address or not _EMAIL_RE.match(address):
+            self.caller.msg(f"'{address}' doesn't look like a valid email address.")
+            return
+
+        address = address.lower()
+        account = self.account
+        email_address, _created = EmailAddress.objects.get_or_create(
+            user=account,
+            email=address,
+            defaults={"email": address},
+        )
+        email_address.set_as_primary()
+
+        if email_address.verified:
+            self.caller.msg(f"Your account email is already set and verified: {address}")
+            return
+
+        email_address.send_confirmation(request=None, signup=False)
+        self.caller.msg(
+            f"Account email set to {address}. A verification link has been sent — "
+            "verify it to unlock character applications.",
+        )
+
+
+class CmdRoster(Command):  # ty: ignore[invalid-base]
+    """
+    Check your own pending roster application(s).
+
+    Usage:
+        roster
+        roster status
+
+    Shows the status of applications you've already submitted. Roster
+    browsing and applying for new characters happens on the website
+    (see the connection screen or ``@account`` for the URL) — this
+    command is a read-only status check, not a browse/apply surface
+    (#2122).
+    """
+
+    key = "roster"
+    aliases: ClassVar[list[str]] = []
+    locks = "cmd:all()"
+    help_category = "Account"
+
+    def func(self) -> None:
+        """Show the caller's own pending roster applications."""
+        raw = (self.args or "").strip().lower()
+        if raw and raw != _SUBVERB_STATUS:
+            self.caller.msg(f"Unknown roster command '{raw}'. Try: roster status.")
+            return
+
+        # Scoped to the caller's own PlayerData only — mirrors
+        # RosterEntryViewSet's owned-scope filter (#2122 leak analysis);
+        # no id-based lookup exists on this command.
+        pending = self.account.player_data.get_pending_applications()
+
+        if not pending:
+            self.caller.msg("You have no pending roster applications.")
+            return
+
+        lines = ["Your pending roster applications:"]
+        lines.extend(
+            f"  {application.character.key} — {application.get_status_display()} "
+            f"(applied {application.applied_date:%Y-%m-%d})"
+            for application in pending
+        )
+        self.caller.msg("\n".join(lines))

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -16,7 +16,7 @@ own cmdsets by inheriting from them or directly from `evennia.CmdSet`.
 
 from evennia import default_cmds
 
-from commands.account.account_info import CmdAccount
+from commands.account.account_info import CmdAccount, CmdRoster
 from commands.account.character_switching import CmdCharacters, CmdIC
 from commands.account.prompt_reply import CmdPromptReply
 from commands.account.sheet import CmdSheet
@@ -392,6 +392,8 @@ class AccountCmdSet(default_cmds.AccountCmdSet):
         self.add(CmdSheet())
         self.add(CmdPage())
         self.add(CmdPromptReply())
+        # #2122 — own-status-only roster check (browsing stays web-first).
+        self.add(CmdRoster())
 
 
 class UnloggedinCmdSet(default_cmds.UnloggedinCmdSet):

--- a/src/commands/progression.py
+++ b/src/commands/progression.py
@@ -29,6 +29,9 @@ _KEY_CLASS = "class"
 _KEY_THREAD = "thread"
 _KEY_LEVEL = "level"
 
+# Number of recent XPTransaction rows shown on the ``progression unlocks`` listing (#2122).
+_RECENT_XP_TRANSACTION_COUNT = 5
+
 # Subverbs
 _SUBVERB_LIST = "list"
 _SUBVERB_ADD = "add"
@@ -320,7 +323,7 @@ class CmdProgressionUnlock(DispatchCommand):
         raise CommandError(msg)
 
     def _show_listing(self) -> None:
-        """Render available class-level and thread XP-lock unlocks."""
+        """Render the caller's XP balance/history, then available unlocks."""
         from world.progression.services.spends import (  # noqa: PLC0415
             get_available_unlocks_for_character,
         )
@@ -334,13 +337,45 @@ class CmdProgressionUnlock(DispatchCommand):
         available = get_available_unlocks_for_character(character)
         entries = list(available[_AVAILABLE_KEY]) + list(available[_LOCKED_KEY])
 
-        lines = ["Available progression unlocks:"]
+        lines = self._render_xp_balance(character)
+        lines.append("Available progression unlocks:")
         lines.extend(self._render_class_unlock_entries(entries))
         if sheet is not None:
             lines.extend(self._render_thread_unlocks(sheet, has_entries=bool(entries)))
         lines.extend(self._render_skill_breakthroughs(character, has_entries=bool(entries)))
 
         self.msg("\n".join(lines))
+
+    def _render_xp_balance(self, character: Any) -> list[str]:
+        """Return the caller's XP balance + last-5 XPTransaction lines (#2122).
+
+        Mirrors ``CmdKudos._show_balance``'s account-scoped lookup pattern so telnet
+        players don't have to trigger a failed purchase just to see what they have.
+        """
+        from world.progression.models import (  # noqa: PLC0415
+            ExperiencePointsData,
+            XPTransaction,
+        )
+        from world.roster.selectors import get_account_for_character  # noqa: PLC0415
+
+        account = get_account_for_character(character)
+        if account is None:
+            return ["XP available: 0 (no active character on the roster)", ""]
+
+        points = ExperiencePointsData.objects.filter(account=account).first()
+        available = points.current_available if points else 0
+        lines = [f"XP available: {available}"]
+
+        recent = XPTransaction.objects.filter(account=account)[:_RECENT_XP_TRANSACTION_COUNT]
+        if recent:
+            lines.append("Recent XP transactions:")
+            lines.extend(
+                f"  {'+' if txn.amount >= 0 else ''}{txn.amount} XP — "
+                f"{txn.get_reason_display()} ({txn.transaction_date:%Y-%m-%d})"
+                for txn in recent
+            )
+        lines.append("")
+        return lines
 
     def _render_class_unlock_entries(self, entries: list[DetailedUnlockEntry]) -> list[str]:
         """Return rendered lines for class-level unlocks."""

--- a/src/commands/tests/test_account_info_command.py
+++ b/src/commands/tests/test_account_info_command.py
@@ -1,0 +1,163 @@
+"""Tests for #2122's telnet onboarding + visibility polish additions to
+``commands/account/account_info.py``:
+
+- ``CmdRoster`` (``roster``/``roster status``) — own pending applications only.
+- ``CmdAccount``'s new ``account email <address>`` subverb.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from allauth.account.models import EmailAddress
+from django.test import TestCase
+
+from commands.account.account_info import CmdAccount, CmdRoster
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.roster.factories import PlayerDataFactory, RosterApplicationFactory
+from world.roster.models.choices import ApplicationStatus
+
+
+def _make_roster_cmd(account, args=""):
+    cmd = CmdRoster()
+    cmd.account = account
+    cmd.caller = account
+    cmd.args = args
+    cmd.raw_string = f"roster {args}".strip()
+    cmd.cmdname = "roster"
+    return cmd
+
+
+def _make_account_cmd(account, args=""):
+    cmd = CmdAccount()
+    cmd.account = account
+    cmd.caller = account
+    cmd.args = args
+    cmd.raw_string = f"account {args}".strip()
+    cmd.cmdname = "account"
+    return cmd
+
+
+class CmdRosterStatusTests(TestCase):
+    """``roster status`` shows only the caller's own pending applications."""
+
+    def setUp(self):
+        self.account = AccountFactory()
+        self.player_data = self.account.player_data  # ensure PlayerData exists
+        self.account.msg = MagicMock()
+
+    def _sent_text(self, args=""):
+        cmd = _make_roster_cmd(self.account, args)
+        cmd.func()
+        return "\n".join(str(c.args[0]) for c in self.account.msg.call_args_list)
+
+    def test_no_pending_applications(self):
+        sent = self._sent_text()
+        self.assertIn("no pending roster applications", sent.lower())
+
+    def test_bare_and_status_are_equivalent(self):
+        character = CharacterFactory(db_key="Applicant")
+        RosterApplicationFactory(
+            player_data=self.account.player_data,
+            character=character,
+            status=ApplicationStatus.PENDING,
+        )
+        bare = self._sent_text("")
+        self.account.msg.reset_mock()
+        status = self._sent_text("status")
+        self.assertIn(character.key, bare)
+        self.assertIn(character.key, status)
+
+    def test_own_pending_application_shown(self):
+        character = CharacterFactory(db_key="Hopeful")
+        RosterApplicationFactory(
+            player_data=self.account.player_data,
+            character=character,
+            status=ApplicationStatus.PENDING,
+        )
+        sent = self._sent_text("status")
+        self.assertIn("Hopeful", sent)
+        self.assertIn("Pending", sent)
+
+    def test_approved_application_not_shown(self):
+        character = CharacterFactory(db_key="AlreadyIn")
+        RosterApplicationFactory(
+            player_data=self.account.player_data,
+            character=character,
+            status=ApplicationStatus.APPROVED,
+        )
+        sent = self._sent_text("status")
+        self.assertIn("no pending roster applications", sent.lower())
+
+    def test_another_accounts_application_never_shown(self):
+        """Leak negative (#2122 leak analysis) — scoped to the caller's own PlayerData."""
+        other_player_data = PlayerDataFactory()
+        other_character = CharacterFactory(db_key="NotYours")
+        RosterApplicationFactory(
+            player_data=other_player_data,
+            character=other_character,
+            status=ApplicationStatus.PENDING,
+        )
+        sent = self._sent_text("status")
+        self.assertNotIn("NotYours", sent)
+        self.assertIn("no pending roster applications", sent.lower())
+
+    def test_unknown_subverb_reports_usage(self):
+        sent = self._sent_text("browse")
+        self.assertIn("Unknown roster command", sent)
+
+
+class CmdAccountEmailTests(TestCase):
+    """``account email <address>`` sets/updates the primary email + confirmation (#2122)."""
+
+    def setUp(self):
+        self.account = AccountFactory()
+        self.player_data = self.account.player_data  # ensure PlayerData exists
+        self.account.msg = MagicMock()
+
+    def _run(self, args):
+        cmd = _make_account_cmd(self.account, args)
+        cmd.func()
+        return "\n".join(str(c.args[0]) for c in self.account.msg.call_args_list)
+
+    def test_invalid_address_rejected(self):
+        sent = self._run("email not-an-email")
+        self.assertIn("doesn't look like a valid email address", sent)
+        self.assertFalse(EmailAddress.objects.filter(user=self.account).exists())
+
+    def test_sets_unverified_primary_email_and_sends_confirmation(self):
+        sent = self._run("email newplayer@example.com")
+
+        email_address = EmailAddress.objects.get(user=self.account, email="newplayer@example.com")
+        self.assertTrue(email_address.primary)
+        self.assertFalse(email_address.verified)
+        self.assertIn("verification link has been sent", sent)
+
+        # can_apply_for_characters stays False until verification (#2122 journey).
+        self.assertFalse(self.account.player_data.can_apply_for_characters())
+
+    def test_verifying_flips_can_apply_for_characters(self):
+        self._run("email newplayer@example.com")
+        email_address = EmailAddress.objects.get(user=self.account, email="newplayer@example.com")
+
+        email_address.verified = True
+        email_address.save(update_fields=["verified"])
+
+        self.assertTrue(self.account.player_data.can_apply_for_characters())
+
+    def test_rerunning_on_already_verified_email_is_a_no_op_message(self):
+        self._run("email newplayer@example.com")
+        email_address = EmailAddress.objects.get(user=self.account, email="newplayer@example.com")
+        email_address.verified = True
+        email_address.save(update_fields=["verified"])
+        self.account.msg.reset_mock()
+
+        sent = self._run("email newplayer@example.com")
+        self.assertIn("already set and verified", sent)
+
+    def test_only_touches_own_account(self):
+        """No target-account argument exists — the command can't touch another account's email."""
+        other = AccountFactory()
+        _ = other.player_data
+        self._run("email newplayer@example.com")
+        self.assertFalse(EmailAddress.objects.filter(user=other).exists())

--- a/src/commands/tests/test_progression_commands.py
+++ b/src/commands/tests/test_progression_commands.py
@@ -12,6 +12,10 @@ from actions.types import ActionResult, DispatchResult
 from commands.progression import CmdProgressionUnlock, CmdTraining
 from world.action_points.models import ActionPointConfig
 from world.character_sheets.factories import CharacterSheetFactory
+from world.progression.factories import ExperiencePointsDataFactory, XPTransactionFactory
+from world.progression.models import ExperiencePointsData, XPTransaction
+from world.progression.types import ProgressionReason
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 from world.scenes.factories import PersonaFactory
 from world.skills.factories import SkillFactory, SpecializationFactory
 from world.skills.models import TrainingAllocation
@@ -271,6 +275,92 @@ class CmdProgressionUnlockListTests(TestCase):
             ):
                 _make_progression_cmd(self.character, "unlocks").func()
         self.character.msg.assert_called_once()
+
+
+class CmdProgressionUnlockXPBalanceTests(TestCase):
+    """``progression unlocks`` shows the caller's XP balance + recent transactions (#2122)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+        cls.character = cls.sheet.character
+        entry = RosterEntryFactory(character_sheet=cls.sheet)
+        cls.tenure = RosterTenureFactory(roster_entry=entry)
+        cls.account = cls.tenure.player_data.account
+
+    def setUp(self):
+        ExperiencePointsData.flush_instance_cache()
+        XPTransaction.flush_instance_cache()
+        self.character.msg = MagicMock()
+
+    def _listing_text(self) -> str:
+        with (
+            patch(
+                "world.progression.services.spends.get_available_unlocks_for_character",
+                return_value={"available": [], "locked": []},
+            ),
+            patch("world.magic.services.threads.near_xp_lock_threads", return_value=[]),
+        ):
+            _make_progression_cmd(self.character).func()
+        return "\n".join(str(c.args[0]) for c in self.character.msg.call_args_list)
+
+    def test_no_active_character_reports_zero(self):
+        stray_sheet = CharacterSheetFactory()
+        cmd_text = ""
+        with (
+            patch(
+                "world.progression.services.spends.get_available_unlocks_for_character",
+                return_value={"available": [], "locked": []},
+            ),
+            patch("world.magic.services.threads.near_xp_lock_threads", return_value=[]),
+        ):
+            stray_sheet.character.msg = MagicMock()
+            _make_progression_cmd(stray_sheet.character, cmd_text).func()
+        sent = "\n".join(str(c.args[0]) for c in stray_sheet.character.msg.call_args_list)
+        self.assertIn("XP available: 0", sent)
+
+    def test_balance_shown_with_no_transactions(self):
+        ExperiencePointsDataFactory(account=self.account, total_earned=40, total_spent=15)
+        sent = self._listing_text()
+        self.assertIn("XP available: 25", sent)
+
+    def test_recent_transactions_rendered(self):
+        ExperiencePointsDataFactory(account=self.account, total_earned=100, total_spent=10)
+        XPTransactionFactory(
+            account=self.account,
+            amount=20,
+            reason=ProgressionReason.KUDOS_CLAIM,
+            description="Kudos claim",
+        )
+        XPTransactionFactory(
+            account=self.account,
+            amount=-10,
+            reason=ProgressionReason.XP_PURCHASE,
+            description="Unlock purchase",
+        )
+        sent = self._listing_text()
+        self.assertIn("XP available: 90", sent)
+        self.assertIn("Recent XP transactions:", sent)
+        self.assertIn("+20 XP", sent)
+        self.assertIn("-10 XP", sent)
+
+    def test_only_last_five_transactions_rendered(self):
+        # Rendering is "{sign}{amount} XP — {reason display} (...)" — no description field
+        # (per spec), so use uniquely-identifiable amounts (1001..1007) to tell rows apart.
+        ExperiencePointsDataFactory(account=self.account, total_earned=100, total_spent=0)
+        for index in range(7):
+            XPTransactionFactory(
+                account=self.account,
+                amount=1001 + index,
+                reason=ProgressionReason.KUDOS_CLAIM,
+            )
+        sent = self._listing_text()
+        # Most recently created 5 of 7 (highest amounts, since XPTransaction orders
+        # -transaction_date and the loop created them in ascending amount order).
+        rendered_count = sum(f"+{1001 + index} XP" in sent for index in range(7))
+        self.assertEqual(rendered_count, 5)
+        self.assertNotIn("+1001 XP", sent)
+        self.assertNotIn("+1002 XP", sent)
 
 
 class CmdProgressionUnlockDispatchTests(TestCase):

--- a/src/server/conf/connection_screens.py
+++ b/src/server/conf/connection_screens.py
@@ -33,7 +33,10 @@ CONNECTION_SCREEN = """
 
  If you have spaces in your username, enclose it in quotes.
  Enter |whelp|n for more info. |wlook|n will re-show this screen.
+
+ Play in your browser: |w{}|n
 |b==============================================================|n""".format(
     settings.SERVERNAME,
     utils.get_evennia_version("short"),
+    settings.FRONTEND_URL,
 )

--- a/src/server/conf/settings.py
+++ b/src/server/conf/settings.py
@@ -210,6 +210,12 @@ FALL_IMPACT_PER_LEVEL = env.int("FALL_IMPACT_PER_LEVEL", default=5)
 # TEMPORARY masks are not capped here (throwaway). PLACEHOLDER magnitude.
 MAX_ESTABLISHED_PERSONAS_PER_SHEET = env.int("MAX_ESTABLISHED_PERSONAS_PER_SHEET", default=5)
 
+# Web frontend base URL — the React app's origin. Referenced by allauth's
+# headless redirect config below, CSRF_TRUSTED_ORIGINS, and telnet-side
+# signposts (connection screen, characterless post-login message; #2122)
+# so telnet players always have a pointer to the web front door.
+FRONTEND_URL = env("FRONTEND_URL", default="http://localhost:3000")
+
 # Django Allauth configuration
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
@@ -224,23 +230,16 @@ ACCOUNT_LOGIN_METHODS = {"username", "email"}  # Support both username and email
 ACCOUNT_SIGNUP_FIELDS = ["email*", "username*", "password1*", "password2*"]
 LOGIN_REDIRECT_URL = "/"
 ACCOUNT_LOGOUT_REDIRECT_URL = "/"
-ACCOUNT_EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL = (
-    env("FRONTEND_URL", default="http://localhost:3000") + "/login?verified=true"
-)
+ACCOUNT_EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL = FRONTEND_URL + "/login?verified=true"
 
 # Django-allauth headless configuration
 HEADLESS_ONLY = True  # Use headless API mode with custom email verification
 HEADLESS_FRONTEND_URLS = {
-    "account_confirm_email": env("FRONTEND_URL", default="http://localhost:3000")
+    "account_confirm_email": FRONTEND_URL
     + "/verify-email/{key}",  # Go to frontend, which will call API
-    "account_reset_password": env("FRONTEND_URL", default="http://localhost:3000")
-    + "/reset-password",
-    "account_reset_password_from_key": env(
-        "FRONTEND_URL",
-        default="http://localhost:3000",
-    )
-    + "/reset-password/{key}",
-    "account_signup": env("FRONTEND_URL", default="http://localhost:3000") + "/signup",
+    "account_reset_password": FRONTEND_URL + "/reset-password",
+    "account_reset_password_from_key": FRONTEND_URL + "/reset-password/{key}",
+    "account_signup": FRONTEND_URL + "/signup",
 }
 
 # Social auth providers
@@ -436,6 +435,9 @@ if DEBUG:
     )
 
 # Add frontend URL if specified (for ngrok, production domains, etc.)
+# Kept as its own env() lookup (default="") rather than settings.FRONTEND_URL:
+# FRONTEND_URL defaults to http://localhost:3000, but CSRF_TRUSTED_ORIGINS should
+# only gain an entry when the operator has explicitly configured a frontend URL.
 frontend_url = env("FRONTEND_URL", default="")
 if frontend_url:
     CSRF_TRUSTED_ORIGINS.append(frontend_url)

--- a/src/typeclasses/accounts.py
+++ b/src/typeclasses/accounts.py
@@ -22,6 +22,7 @@ several more options for customizing the Guest account system.
 
 """
 
+from django.conf import settings
 from django.utils.functional import cached_property
 from evennia.accounts.accounts import DefaultAccount, DefaultGuest
 
@@ -296,7 +297,9 @@ class Account(DefaultAccount):
             session.msg("Use '@ic <character>' to control a character.")
         else:
             session.msg(
-                "You have no available characters. Contact staff for character access.",
+                "You have no available characters. Visit "
+                f"{settings.FRONTEND_URL} to browse the roster and apply for a "
+                "character, or contact staff for access.",
             )
 
     def at_post_create_character(self, character, **kwargs):

--- a/src/typeclasses/tests/test_cmdset_updates.py
+++ b/src/typeclasses/tests/test_cmdset_updates.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
 
@@ -21,6 +22,21 @@ class CommandUpdateTests(TestCase):
             with patch("typeclasses.accounts.DefaultAccount.at_post_login"):
                 account.at_post_login(session=session)
         session.msg.assert_any_call(commands=(["cmd"], {}))
+
+    def test_at_post_login_characterless_message_points_to_web(self):
+        """#2122 — the no-characters login message signposts the web app."""
+        session = MagicMock()
+        account = AccountFactory(typeclass="typeclasses.accounts.Account")
+        account.sessions.all = MagicMock(return_value=[session])
+        account.get_available_characters = MagicMock(return_value=[])
+        with patch("typeclasses.accounts.serialize_cmdset", return_value=["cmd"]):
+            with patch("typeclasses.accounts.DefaultAccount.at_post_login"):
+                account.at_post_login(session=session)
+
+        texts = [str(call.args[0]) for call in session.msg.call_args_list if call.args]
+        combined = "\n".join(texts)
+        self.assertIn(settings.FRONTEND_URL, combined)
+        self.assertIn("no available characters", combined.lower())
 
     def test_at_post_puppet_sends_commands(self):
         session1 = MagicMock()

--- a/src/typeclasses/tests/test_connection_screen_web_pointer.py
+++ b/src/typeclasses/tests/test_connection_screen_web_pointer.py
@@ -1,0 +1,17 @@
+"""#2122 — the telnet connection screen signposts the web app.
+
+The connection screen is the very first thing a telnet-only player sees, before
+any account exists. It has no dispatch seam — just a formatted module-level
+string — so this is a direct string-content assertion (per the spec's Testing
+section).
+"""
+
+from django.conf import settings
+from django.test import TestCase
+
+
+class ConnectionScreenWebPointerTests(TestCase):
+    def test_connection_screen_mentions_frontend_url(self):
+        from server.conf.connection_screens import CONNECTION_SCREEN
+
+        self.assertIn(settings.FRONTEND_URL, CONNECTION_SCREEN)


### PR DESCRIPTION
Closes #2122

## Summary

Closes the telnet front-door dead end: FRONTEND_URL promoted to a named setting and signposted on the connection screen + characterless post-login message (CSRF trusted-origins deliberately keeps its own empty-default lookup to avoid silently trusting localhost in prod); new roster status (own pending applications only, leak-scoped); account email <address> so telnet-registered accounts can finally satisfy the verified-email application gate — implemented via allauth's lower-level get_or_create + send_confirmation(request=None) because the high-level add_email path crashes without an HTTP request (messages framework); XP balance + last-5 transactions on progression unlocks mirroring the kudos balance pattern.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2122 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: branch already current with origin/main

<!-- last-addressed-comment: 0 -->