### PR TITLE
Audit authored ThreadPullEffect amounts against thread_level_multiplier's new low-level ramp

### DIFF
--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -354,15 +354,15 @@ class TestSeedThreadPullCatalogCreation(TestCase):
 
         flat = self.result.pull_effects[EffectKind.FLAT_BONUS]
         self.assertEqual(flat.tier, 1)
-        self.assertEqual(flat.flat_bonus_amount, 2)
+        self.assertEqual(flat.flat_bonus_amount, 10)
 
         bump = self.result.pull_effects[EffectKind.INTENSITY_BUMP]
         self.assertEqual(bump.tier, 2)
-        self.assertEqual(bump.intensity_bump_amount, 1)
+        self.assertEqual(bump.intensity_bump_amount, 10)
 
         vital = self.result.pull_effects[EffectKind.VITAL_BONUS]
         self.assertEqual(vital.tier, 0)
-        self.assertEqual(vital.vital_bonus_amount, 5)
+        self.assertEqual(vital.vital_bonus_amount, 10)
         from world.magic.constants import VitalBonusTarget
 
         self.assertEqual(vital.vital_target, VitalBonusTarget.MAX_HEALTH)

--- a/src/world/covenants/factories.py
+++ b/src/world/covenants/factories.py
@@ -721,6 +721,12 @@ def wire_covenant_role_powers_catalog() -> "tuple[CovenantRole, list[CapabilityT
     # ------------------------------------------------------------------
     # Per resonance: tier-0 passive CAPABILITY_GRANT + a tier-1 active pull.
     # Keyed (target_kind, resonance, tier, min_thread_level) — the unique lookup.
+    #
+    # FLAT_BONUS/INTENSITY_BUMP amounts use 10 (not 3/1) per #1845:
+    # thread_level_multiplier(1) == 0.1 (#1718's corrected ramp) and
+    # scaled_value = round(authored * multiplier); amounts below 6 round to 0
+    # at low thread levels, silently defeating the pull. 10 clears the floor
+    # with margin — same rationale as the Court catalog below.
     # ------------------------------------------------------------------
     ThreadPullEffect.objects.get_or_create(
         target_kind=TargetKind.COVENANT_ROLE,
@@ -743,7 +749,7 @@ def wire_covenant_role_powers_catalog() -> "tuple[CovenantRole, list[CapabilityT
         min_thread_level=0,
         defaults={
             "effect_kind": EffectKind.FLAT_BONUS,
-            "flat_bonus_amount": 3,
+            "flat_bonus_amount": 10,
             "narrative_snippet": (
                 "You pull harder on the war-fire and it surges — a blaze of borrowed "
                 "fury behind the blow."
@@ -772,7 +778,7 @@ def wire_covenant_role_powers_catalog() -> "tuple[CovenantRole, list[CapabilityT
         min_thread_level=0,
         defaults={
             "effect_kind": EffectKind.INTENSITY_BUMP,
-            "intensity_bump_amount": 1,
+            "intensity_bump_amount": 10,
             "narrative_snippet": (
                 "You draw the singing edge taut and it answers — every line of the "
                 "strike sharpened a degree past mortal keenness."

--- a/src/world/magic/tests/test_relationship_pull_content.py
+++ b/src/world/magic/tests/test_relationship_pull_content.py
@@ -51,7 +51,7 @@ class RelationshipPullContentTests(TestCase):
         self.assertIsNotNone(tier0)
         self.assertEqual(tier0.effect_kind, EffectKind.VITAL_BONUS)
         self.assertEqual(tier0.vital_target, VitalBonusTarget.DAMAGE_TAKEN_REDUCTION)
-        self.assertEqual(tier0.vital_bonus_amount, 3)
+        self.assertEqual(tier0.vital_bonus_amount, 10)
 
     def test_tier1_is_vital_bonus_death_save(self):
         """Tier 1 is VITAL_BONUS with DEATH_SAVE."""
@@ -66,7 +66,7 @@ class RelationshipPullContentTests(TestCase):
         self.assertIsNotNone(tier1)
         self.assertEqual(tier1.effect_kind, EffectKind.VITAL_BONUS)
         self.assertEqual(tier1.vital_target, VitalBonusTarget.DEATH_SAVE)
-        self.assertEqual(tier1.vital_bonus_amount, 5)
+        self.assertEqual(tier1.vital_bonus_amount, 10)
 
     def test_tier2_is_resistance(self):
         """Tier 2 is RESISTANCE with null damage_type (all types)."""
@@ -96,7 +96,7 @@ class RelationshipPullContentTests(TestCase):
         self.assertIsNotNone(tier3)
         self.assertEqual(tier3.effect_kind, EffectKind.VITAL_BONUS)
         self.assertEqual(tier3.vital_target, VitalBonusTarget.KNOCKOUT_RESIST)
-        self.assertEqual(tier3.vital_bonus_amount, 5)
+        self.assertEqual(tier3.vital_bonus_amount, 10)
 
 
 class RelationshipCapstoneModulationTests(TestCase):

--- a/src/world/seeds/game_content/magic.py
+++ b/src/world/seeds/game_content/magic.py
@@ -1837,9 +1837,9 @@ def seed_thread_pull_catalog() -> ThreadPullCatalogResult:
     - Resonance "Tideborne" — canonical reference resonance for the catalog
     - CapabilityType "endurance" — used by the CAPABILITY_GRANT effect
     - ThreadPullEffect rows:
-        - FLAT_BONUS (tier=1, min_thread_level=0, flat_bonus_amount=2)
-        - INTENSITY_BUMP (tier=2, min_thread_level=0, intensity_bump_amount=1)
-        - VITAL_BONUS (tier=0, min_thread_level=0, vital_bonus_amount=5, MAX_HEALTH)
+        - FLAT_BONUS (tier=1, min_thread_level=0, flat_bonus_amount=10)
+        - INTENSITY_BUMP (tier=2, min_thread_level=0, intensity_bump_amount=10)
+        - VITAL_BONUS (tier=0, min_thread_level=0, vital_bonus_amount=10, MAX_HEALTH)
         - CAPABILITY_GRANT (tier=3, min_thread_level=5, capability=endurance)
 
     Returns:
@@ -1899,7 +1899,7 @@ def seed_thread_pull_catalog() -> ThreadPullCatalogResult:
         min_thread_level=0,
         defaults={
             "effect_kind": EffectKind.FLAT_BONUS,
-            "flat_bonus_amount": 2,
+            "flat_bonus_amount": 10,
         },
     )
     pull_effects[EffectKind.FLAT_BONUS] = flat_bonus_effect
@@ -1911,7 +1911,7 @@ def seed_thread_pull_catalog() -> ThreadPullCatalogResult:
         min_thread_level=0,
         defaults={
             "effect_kind": EffectKind.INTENSITY_BUMP,
-            "intensity_bump_amount": 1,
+            "intensity_bump_amount": 10,
         },
     )
     pull_effects[EffectKind.INTENSITY_BUMP] = intensity_bump_effect
@@ -1923,7 +1923,7 @@ def seed_thread_pull_catalog() -> ThreadPullCatalogResult:
         min_thread_level=0,
         defaults={
             "effect_kind": EffectKind.VITAL_BONUS,
-            "vital_bonus_amount": 5,
+            "vital_bonus_amount": 10,
             "vital_target": VitalBonusTarget.MAX_HEALTH,
         },
     )
@@ -2245,7 +2245,10 @@ def ensure_relationship_pull_content() -> None:
         if resonance is None:
             continue
 
-        # Tier 0 (passive): VITAL_BONUS(DAMAGE_TAKEN_REDUCTION, 3)
+        # Tier 0 (passive): VITAL_BONUS(DAMAGE_TAKEN_REDUCTION, 10)
+        # Amount bumped from 3 → 10 per #1845: thread_level_multiplier(level 1) = 0.1
+        # (#1718's corrected ramp), so round(3 * 0.1) = round(0.3) = 0 — a no-op
+        # bonus at low thread levels. 10 clears the floor with margin.
         ThreadPullEffect.objects.get_or_create(
             target_kind=TargetKind.RELATIONSHIP_TRACK,
             resonance=resonance,
@@ -2253,13 +2256,15 @@ def ensure_relationship_pull_content() -> None:
             min_thread_level=0,
             defaults={
                 "effect_kind": EffectKind.VITAL_BONUS,
-                "vital_bonus_amount": 3,
+                "vital_bonus_amount": 10,
                 "vital_target": VitalBonusTarget.DAMAGE_TAKEN_REDUCTION,
                 "narrative_snippet": "The bond sustains you, reducing harm.",
             },
         )
 
-        # Tier 1 (paid): VITAL_BONUS(DEATH_SAVE, 5)
+        # Tier 1 (paid): VITAL_BONUS(DEATH_SAVE, 10)
+        # Amount bumped from 5 → 10 per #1845: round(5 * 0.1) = round(0.5) = 0
+        # (banker's rounding) at level 1. 10 clears the floor with margin.
         ThreadPullEffect.objects.get_or_create(
             target_kind=TargetKind.RELATIONSHIP_TRACK,
             resonance=resonance,
@@ -2267,7 +2272,7 @@ def ensure_relationship_pull_content() -> None:
             min_thread_level=0,
             defaults={
                 "effect_kind": EffectKind.VITAL_BONUS,
-                "vital_bonus_amount": 5,
+                "vital_bonus_amount": 10,
                 "vital_target": VitalBonusTarget.DEATH_SAVE,
                 "narrative_snippet": "Fighting for them steadies your hand against death.",
             },
@@ -2286,7 +2291,9 @@ def ensure_relationship_pull_content() -> None:
             },
         )
 
-        # Tier 3 (paid): VITAL_BONUS(KNOCKOUT_RESIST, 5)
+        # Tier 3 (paid): VITAL_BONUS(KNOCKOUT_RESIST, 10)
+        # Amount bumped from 5 → 10 per #1845: round(5 * 0.1) = round(0.5) = 0
+        # (banker's rounding) at level 1. 10 clears the floor with margin.
         ThreadPullEffect.objects.get_or_create(
             target_kind=TargetKind.RELATIONSHIP_TRACK,
             resonance=resonance,
@@ -2294,7 +2301,7 @@ def ensure_relationship_pull_content() -> None:
             min_thread_level=0,
             defaults={
                 "effect_kind": EffectKind.VITAL_BONUS,
-                "vital_bonus_amount": 5,
+                "vital_bonus_amount": 10,
                 "vital_target": VitalBonusTarget.KNOCKOUT_RESIST,
                 "narrative_snippet": "The deepest bond refuses to fall.",
             },


### PR DESCRIPTION
Closes #1845

## Summary

Audits authored ThreadPullEffect flat_bonus_amount/intensity_bump_amount/vital_bonus_amount values against #1718's corrected thread_level_multiplier ramp (levels 1-9 scale as level/10) and bumps seed-catalog values that rounded to 0 at low thread levels.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1845 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: Clean rebase against main, no conflicts.

<!-- last-addressed-comment: 0 -->