### PR TITLE
One play surface: threading, actions, and casting where players actually play (#2155)

### DIFF
--- a/docs/adr/0111-one-play-surface-game-absorbs-scene-toolset.md
+++ b/docs/adr/0111-one-play-surface-game-absorbs-scene-toolset.md
@@ -1,0 +1,20 @@
+# One play surface — `/game` absorbs the scene toolset; `/scenes/:id` is the record page
+
+The #2155 webclient audit found the scene toolset (threading, action attachment, places,
+consent, composer modes) fully built but mounted only on `/scenes/:id`, while the live `/game`
+view — where sessions, sockets, puppets, and movement actually live — rendered a flat monospace
+log with no threading; #2156 closes this by making `GamePage` the composition root: it calls
+`useSceneInteractions` + `useThreading` once for the active session's scene and feeds the result
+to the left sidebar, center feed, and toolset, while `/scenes/:id` keeps `SceneInteractionPanel`
+unchanged as the historical record/detail page. We rejected the reverse — making `/scenes/:id`
+primary and redirecting play there — because sessions, WebSocket connections, puppet/character
+switching, and movement are already anchored to `/game`; re-homing them to the scene page would
+require duplicating or relocating that entire live-connection substrate for no gain, whereas the
+toolset itself is comparatively cheap to lift into the existing play surface. This slate also
+ratifies the chat-bubble presentation bar: the primary feed renders each interaction as an
+avatar-thumbnail chat bubble (author, timestamp, prose, reactions) — monospace/terminal styling
+on the primary feed is a defect, not an acceptable variant; system/channel/error output stays a
+separate muted, compact, chat-app-style notice lane, never blended into the bubble feed. See
+issue #2156.
+
+> Status: accepted · Source: issue #2156, epic #2155

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,6 +54,7 @@ treat those names as hints to confirm, not gospel.
 - [0005 — Reactive behavior is a separate flows/triggers/events engine](0005-reactive-behavior-is-a-separate-flows-engine.md)
 - [0006 — Scenes are provisional by default; never auto-persist RP](0006-scenes-are-provisional-never-auto-persist-rp.md)
 - [0091 — GANG_TURF resolves TIERED_PERIOD via a per-kind resolver registry, not a shared accessor](0091-gang-turf-tiered-period.md)
+- [0111 — One play surface — `/game` absorbs the scene toolset; `/scenes/:id` is the record page](0111-one-play-surface-game-absorbs-scene-toolset.md)
 
 ### Database & modeling
 - [0007 — No JSON fields; every setting is a typed, queryable column](0007-no-json-fields-typed-queryable-columns.md)

--- a/docs/roadmap/rp-scenes.md
+++ b/docs/roadmap/rp-scenes.md
@@ -238,21 +238,39 @@ called `set_active_persona` directly (bypassing `action.run()`); telnet had no w
 
 ### Frontend UX (highest priority)
 
-> **Status correction (2026-07-10 audit, epic #2155):** much of this is now BUILT but
-> mounted only on `/scenes/:id`, not the live `/game` view — the two-surface split is
-> the core gap. See `docs/audits/2026-07-10-webclient-rp-ux-audit.md`; unifying the
-> surfaces is #2156.
+> **Status correction (2026-07-10 audit, epic #2155) — RESOLVED (#2156):** the
+> two-surface split flagged by the audit (built-on-`/scenes/:id`-only, absent from
+> `/game`) is closed. `GamePage` is now the composition root: it derives the active
+> session's scene, composes `useSceneInteractions` + `useThreading` once, and feeds
+> the result to `ConversationSidebar` (thread sidebar, unread badges, filter modal),
+> the center feed (chat-bubble `PoseUnit`s + `SystemLane`), and the scene toolset
+> (actions/places/consent/composer modes incl. tabletalk) — all on `/game`.
+> `/scenes/:id` remains the unchanged record/detail page (`SceneInteractionPanel`).
+> What was built: one-play-surface composition on `/game`; per-thread unread
+> backed by session last-seen (with a scene-load baseline scalar so mid-session
+> new threads badge correctly); `PoseUnit` restyled as avatar-bubble chat cards
+> (author, timestamp, prose, reactions — no monospace/terminal styling) with
+> avatar-click opening a `CharacterCardDrawer` in place (Friend/Whisper actions);
+> `viewer_is_present` on `PlaceSerializer`; pose co-location validation
+> (`submit-pose` rejects a pose into a located scene the actor isn't physically
+> in); and the `/game` places query fixed to key off the scene's room id rather
+> than the scene id. See `docs/systems/scenes.md` for the UI composition detail
+> and ADR-0111.
+>
+> The scene feed markdown gap the audit also flagged (`EvenniaMessage` never
+> parsing `RichTextInput`'s markdown) is closed by the same restyle: the
+> structured feed renders `FormattedContent`, not raw `EvenniaMessage`.
 
-- **Rich text editor** — BUILT & WIRED (`RichTextInput`: toolbar, shortcuts, color picker,
-  `@name` autocomplete) — but `/game`'s feed (`EvenniaMessage`) never parses the markdown it
-  produces (#2156 fold-in bug)
-- **Smart input composer** — PARTIAL: `ModeSelector` (pose/say/emit/whisper/tabletalk) +
-  action attachment exist but mount only on the scene page; tabletalk is hardcoded off
-  (`isAtPlace={false}` TODO); no audience-scope hint in the bare `/game` composer (#2156)
-- **Conversation threading** — BUILT (`useThreading`/`ThreadSidebar`/`ThreadFilterModal`,
-  grouping by whisper-set/place/target) but only on `/scenes/:id`; per-thread unread is
-  stubbed to 0; the live `/game` view renders a flat log with a placeholder
-  `ConversationSidebar` (#2156)
+- **Rich text editor** — DONE. `RichTextInput` (toolbar, shortcuts, color picker,
+  `@name` autocomplete) composes into scenes on `/game`; the feed renders it via
+  `FormattedContent`, not the legacy raw `EvenniaMessage` log
+- **Smart input composer** — DONE. `ModeSelector` (pose/say/emit/whisper/tabletalk)
+  plus action attachment mount on `/game`'s composer, wired to the same
+  `useSceneInteractions` session the feed and toolset share; tabletalk is live
+  (no longer hardcoded off)
+- **Conversation threading** — DONE. `useThreading`/`ThreadSidebar`/`ThreadFilterModal`
+  (grouping by whisper-set/place/target) render on `/game` via `ConversationSidebar`;
+  per-thread unread counts are backed by session last-seen, not stubbed to 0
 - **~~Scene scheduling and discovery~~** — Split into separate concerns:
   - **Events system** (`world/events`) — scheduled RP gatherings with calendar, invitations, room modifications. See [Events roadmap](events.md) and `docs/plans/2026-03-27-events-system-design.md`
   - **Grid presence** — "who's where" on public rooms for organic RP, future graphical map. Separate feature, not part of scenes or events

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -668,6 +668,75 @@ informational note above, never to disable controls (#1476 cleared the old dange
 
 ---
 
+## UI Composition — `/game` One Play Surface (#2156)
+
+Before #2156, the scene toolset (threading, action attachment, places, consent,
+composer modes) was built but mounted only on the `/scenes/:id` record page; the
+live `/game` view rendered a flat monospace log with no threading. `/game` is now
+the one play surface — the full toolset composes there, and `/scenes/:id` remains
+the unchanged record/detail page (`SceneInteractionPanel`).
+
+**`GamePage`** (`frontend/src/game/GamePage.tsx`) is the composition root: it
+derives the active session's `sceneId`/`roomName`, calls `useSceneInteractions` +
+`useThreading` **once**, and threads the results down as props to
+`ConversationSidebar` (left column), `GameWindow` (center feed + composer), and the
+scene toolset (`ActionPanel`, `PlaceBar`, `ConsentPrompt`, `CharacterCardDrawer`) —
+no child re-fetches the same scene/roster data.
+
+**Feed presentation:** `PoseUnit` (`frontend/src/scenes/components/PoseUnit.tsx`)
+renders each interaction as a chat bubble — avatar thumbnail, author, timestamp,
+`FormattedContent`-rendered prose, and reactions — never monospace/terminal
+styling (ratified presentation bar; terminal-style rendering on the primary feed is
+a defect, not a variant). `GameWindow` renders this structured bubble feed plus
+`SystemLane` (muted, collapsible system/channel/error strip) whenever the active
+session has a scene; with no active scene it falls back to the legacy raw
+`ChatWindow` log (`frontend/src/game/components/ChatWindow.tsx`). This restyle also
+closes the markdown-rendering gap the #2155 audit flagged: the feed now renders
+`FormattedContent`, so `RichTextInput`'s markdown output actually displays as
+formatted prose instead of raw text.
+
+**Threading + per-thread unread:** `ConversationSidebar` renders `ThreadSidebar` +
+`ThreadFilterModal` from the `ThreadingState` `GamePage` composes, falling back to
+a static "Room" button with no active scene. Per-thread unread counts are backed by
+`Session.threadLastSeen` (per-thread last-seen timestamps, persisted in Redux via
+`markThreadSeen`) rather than stubbed to 0. A thread key with no last-seen entry —
+i.e. a thread that's new since the session started — falls back to
+`Session.sceneBaselineId`, a single scene-load baseline scalar set once via
+`setSceneBaseline`; this is what lets a brand-new mid-session thread badge
+correctly as unread from its first message, rather than needing its own baseline
+established retroactively. With neither a per-thread entry nor a baseline (e.g.
+`/scenes/:id`, which passes no threading options at all), unread is 0 — unchanged
+behavior for the record page.
+
+**Character-card drawer:** clicking a `PoseUnit` avatar opens `CharacterCardDrawer`
+(`frontend/src/game/components/CharacterCardDrawer.tsx`) in place (a `Sheet`
+drawer over the conversation, not a page navigation) with Friend/Whisper quick
+actions. **Privacy rule:** the persona payload carried by an `Interaction` has no
+roster-entry or character-sheet id — only id/name/thumbnail — deliberately, so a
+disguised or temporary persona can't be de-anonymized through the card. The drawer
+resolves identity **only** via the public `AllowAny` roster search
+(`useRosterEntryByNameQuery`, the same endpoint `RosterListPage` uses) and requires
+an exact name match; no match (disguise, temporary persona, unlisted character)
+renders name + avatar + a "not on the public roster" notice with no sheet data and
+no `FriendButton`. Never resolve through `receiver_persona_ids`, scene
+participation, or any other non-public linkage.
+
+**Backend — pose co-location + place presence:** `PoseSubmitSerializer.validate`
+(`interaction_serializers.py`) rejects (400) a pose submitted with a `scene_id`
+whose scene has a room (`scene.location` set) that doesn't match the actor
+character's current location — a wrong-room pose is now a validation error instead
+of silently recording under the wrong scene. A scene with no location (`location`
+is `None`) skips the check. `PlaceSerializer.viewer_is_present`
+(`place_views.py`) is a `SerializerMethodField` reporting whether one of the
+requesting account's owned personas has a `PlacePresence` row at that place;
+memoized per serializer instance so a places-list response shares one owned-persona
+lookup across all rows instead of re-querying per row. Scene poses submitted from
+`/game` take the REST `submit-pose` path keyed by `scene_id` (not the scene's
+room id) — the fold-in fix that had `/game`'s places query using the scene id
+instead of the scene's room id is also folded into this slate.
+
+---
+
 ## Permissions
 
 | Permission Class | Used For | Rule |

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -698,13 +698,18 @@ formatted prose instead of raw text.
 **Threading + per-thread unread:** `ConversationSidebar` renders `ThreadSidebar` +
 `ThreadFilterModal` from the `ThreadingState` `GamePage` composes, falling back to
 a static "Room" button with no active scene. Per-thread unread counts are backed by
-`Session.threadLastSeen` (per-thread last-seen timestamps, persisted in Redux via
-`markThreadSeen`) rather than stubbed to 0. A thread key with no last-seen entry —
-i.e. a thread that's new since the session started — falls back to
-`Session.sceneBaselineId`, a single scene-load baseline scalar set once via
+`Session.threadLastSeen` (per-thread last-seen **interaction ids**, persisted in
+Redux via `markThreadSeen`) rather than stubbed to 0. A thread key with no
+last-seen entry — i.e. a thread that's new since the session started — falls back
+to `Session.sceneBaselineId`, a single scene-load baseline scalar set once via
 `setSceneBaseline`; this is what lets a brand-new mid-session thread badge
 correctly as unread from its first message, rather than needing its own baseline
-established retroactively. With neither a per-thread entry nor a baseline (e.g.
+established retroactively. Both `GamePage`'s baseline-capture effect and its
+threading-filter/mute reset (`useThreading.resetForNewScene`) are keyed on
+`[active, sceneId]`, so a puppet switch or scene change never strands a stale
+filter/mute or wipes an already-baselined puppet's accumulated unread (the
+baseline gate reads the per-puppet Redux `sceneBaselineId` directly, not a
+single scalar ref). With neither a per-thread entry nor a baseline (e.g.
 `/scenes/:id`, which passes no threading options at all), unread is 0 — unchanged
 behavior for the record page.
 
@@ -731,9 +736,16 @@ is `None`) skips the check. `PlaceSerializer.viewer_is_present`
 requesting account's owned personas has a `PlacePresence` row at that place;
 memoized per serializer instance so a places-list response shares one owned-persona
 lookup across all rows instead of re-querying per row. Scene poses submitted from
-`/game` take the REST `submit-pose` path keyed by `scene_id` (not the scene's
-room id) — the fold-in fix that had `/game`'s places query using the scene id
-instead of the scene's room id is also folded into this slate.
+`/game` take the REST `submit-pose` path, keyed by `scene_id` — a pose belongs to
+a scene, not a room, so this is unrelated to room id.
+
+**Places query room-id vs scene-id (fold-in fix, unrelated to the above):**
+`PlaceBar`'s `sceneId` prop is actually used as the ROOM id by
+`fetchPlaces(?room=)` (confirmed by reading `PlaceBar.tsx` + `actionQueries.ts`)
+— so `/game` derives `placesRoomId`/`isAtPlace` from the scene's room
+(`roomData.id`), not the scene id. `SceneDetailPage` still passes the scene id
+there; that's a separate, pre-existing latent bug on that page, left untouched
+by this slate.
 
 ---
 

--- a/frontend/src/game/CLAUDE.md
+++ b/frontend/src/game/CLAUDE.md
@@ -6,18 +6,34 @@ Core game interface for real-time RPG interaction with WebSocket communication a
 
 ### Main Interface
 
-- **`GamePage.tsx`**: Main game interface, composes the three-column layout
-- **`GameWindow.tsx`**: Central communication hub with session tabs, chat, and command input
+- **`GamePage.tsx`**: Composition root for `/game` (#2156). Derives the active
+  session's `sceneId`/`roomName`, calls `useSceneInteractions` +
+  `useThreading` once, owns `composerMode` state, and feeds the result down
+  as props to `ConversationSidebar` (left) and `GameWindow` (center) — no
+  duplicate roster/scene-interaction queries in the children.
+- **`GameWindow.tsx`**: Central communication hub with session tabs and
+  command input. When the composition root passes a `sceneFeed` prop (an
+  active scene), the center renders the structured chat-bubble feed
+  (`SceneMessages` + `SystemLane`) instead of the legacy `ChatWindow`.
 
 ### Layout (`components/`)
 
 - **`GameLayout.tsx`**: Three-column responsive grid (left sidebar, center, right sidebar)
 - **`GameTopBar.tsx`**: Character avatars, connection status, character switching
-- **`ConversationSidebar.tsx`**: Left sidebar for conversation channels (placeholder)
+- **`ConversationSidebar.tsx`**: Left sidebar. Renders the scene's
+  `ThreadSidebar` (room/place/whisper/target threads) when `GamePage` passes
+  threading state for an active scene; otherwise falls back to a static
+  "Room" button. Also owns the per-thread `ThreadFilterModal` (participant
+  mute list), mirroring `SceneInteractionPanel`'s composition on `/scenes/:id`.
 
 ### Communication (`components/`)
 
-- **`ChatWindow.tsx`**: Message display with auto-scroll and message type coloring
+- **`ChatWindow.tsx`**: Legacy raw message log (monospace, black background) —
+  the fallback center feed when there's no active scene to structure into
+  chat bubbles.
+- **`SystemLane.tsx`**: Muted, collapsible strip for system/channel/error
+  chatter shown alongside the structured scene feed (#2156) — no
+  `bg-black`/`font-mono`, just a quiet compact strip that expands on click.
 - **`CommandInput.tsx`**: Textarea input with Enter to submit, Shift+Enter for newline, command history
 - **`EvenniaMessage.tsx`**: Game message display and formatting
 

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -41,6 +41,11 @@ vi.mock('@/roster/queries', () => ({
     isLoading: false,
     isError: false,
   })),
+  // The character-card drawer (#2156 Task 7) always mounts (persona is null
+  // unless an avatar was clicked) and calls these — stub them out since this
+  // test suite isn't exercising the drawer's own identity resolution.
+  useRosterEntryByNameQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useRosterEntryQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
 }));
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/react';
+import { screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, vi, beforeEach, afterEach, expect } from 'vitest';
 import { GamePage } from './GamePage';
@@ -181,6 +181,60 @@ describe('GamePage', () => {
       await user.click(within(sidebar).getByText('All'));
       expect(screen.getByText('stretches languidly.')).toBeInTheDocument();
       expect(screen.getByText('meet me by the fountain at midnight.')).toBeInTheDocument();
+    });
+
+    it('marks the selected thread seen as it grows, while other threads accumulate unread badges (#2156)', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      seedWhisperThread();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+
+      await screen.findByText('stretches languidly.');
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+
+      // Baseline: both threads existed at scene load, so neither shows unread yet.
+      const roomButton = () =>
+        within(sidebar).getByText('The Grand Ballroom').closest('button') as HTMLElement;
+      const whisperButton = () =>
+        within(sidebar)
+          .getByText(/whisper/i)
+          .closest('button') as HTMLElement;
+
+      await waitFor(() => {
+        expect(within(roomButton()).queryByText(/^[1-9]/)).not.toBeInTheDocument();
+        expect(within(whisperButton()).queryByText(/^[1-9]/)).not.toBeInTheDocument();
+      });
+
+      // Select the whisper thread — it's now the actively-viewed thread.
+      await user.click(whisperButton());
+
+      // A new pose arrives in the (unselected) room thread from someone else.
+      store.dispatch(
+        addSceneInteraction({
+          character: ACTIVE_NAME,
+          interaction: {
+            id: 3,
+            persona: { id: 99, name: 'Bystander', thumbnail_url: '' },
+            content: 'glances over curiously.',
+            mode: 'pose',
+            timestamp: '2026-01-01T00:02:00Z',
+            scene_id: 100,
+            place_id: null,
+            place_name: null,
+            receiver_persona_ids: [],
+            target_persona_ids: [],
+          },
+        })
+      );
+
+      // The room thread's badge increments; the selected whisper thread stays at 0.
+      await waitFor(() => {
+        expect(within(roomButton()).getByText('1')).toBeInTheDocument();
+      });
+      expect(within(whisperButton()).queryByText(/^[1-9]/)).not.toBeInTheDocument();
     });
 
     it('falls back to the plain ChatWindow with no thread sidebar when there is no active scene', () => {

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -237,6 +237,70 @@ describe('GamePage', () => {
       expect(within(whisperButton()).queryByText(/^[1-9]/)).not.toBeInTheDocument();
     });
 
+    it('badges a brand-new thread that appears mid-session from its very first message (#2156 review fix)', async () => {
+      // Regression for a reviewer-caught defect: the old per-thread-KEY
+      // baseline zeroed out a brand-new thread's unread count the instant it
+      // was first observed (it baselined to the thread's own first message
+      // id), so a first-ever whisper never showed a badge. The fix baselines
+      // the SCENE once at load instead, so a thread with no prior
+      // `threadLastSeen` entry falls back to that scene baseline and counts
+      // unread from message one.
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+
+      await screen.findByText('stretches languidly.');
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+      const roomButton = () =>
+        within(sidebar).getByText('The Grand Ballroom').closest('button') as HTMLElement;
+
+      // Pre-existing room thread: no unread at scene load (the baseline was
+      // captured, zeroing it out).
+      await waitFor(() => {
+        expect(within(roomButton()).queryByText(/^[1-9]/)).not.toBeInTheDocument();
+      });
+
+      // A brand-new whisper thread arrives mid-session — the very first
+      // message anyone has ever sent in it, from someone other than the
+      // viewer, while it's unselected.
+      store.dispatch(
+        addSceneInteraction({
+          character: ACTIVE_NAME,
+          interaction: {
+            id: 5,
+            persona: { id: 42, name: 'Mysterious Stranger', thumbnail_url: '' },
+            content: 'psst -- a word, in private.',
+            mode: 'whisper',
+            timestamp: '2026-01-01T00:05:00Z',
+            scene_id: 100,
+            place_id: null,
+            place_name: null,
+            receiver_persona_ids: [7],
+            target_persona_ids: [],
+          },
+        })
+      );
+
+      const whisperButton = () =>
+        within(sidebar)
+          .getByText(/whisper/i)
+          .closest('button') as HTMLElement;
+
+      // The new thread badges unread from its first message, not 0.
+      await waitFor(() => {
+        expect(within(whisperButton()).getByText('1')).toBeInTheDocument();
+      });
+
+      // Selecting it clears the badge.
+      await user.click(whisperButton());
+      await waitFor(() => {
+        expect(within(whisperButton()).queryByText(/^[1-9]/)).not.toBeInTheDocument();
+      });
+    });
+
     it('falls back to the plain ChatWindow with no thread sidebar when there is no active scene', () => {
       store.dispatch(setAccount(mockAccount));
       store.dispatch(startSession(ACTIVE_NAME));

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -8,6 +8,7 @@ import { setAccount } from '@/store/authSlice';
 import { mockAccount } from '@/test/mocks/account';
 import {
   startSession,
+  setActiveSession,
   setSessionRoom,
   setSessionScene,
   addSceneInteraction,
@@ -35,9 +36,21 @@ const rosterEntry: MyRosterEntry = {
   active_persona_id: 7,
 };
 
+// A second puppet (#2156 review fix — multi-puppet threading/baseline tests
+// below need a real second roster entry so `active` can validly switch to it).
+const SECOND_NAME = 'Bianca';
+const rosterEntry2: MyRosterEntry = {
+  id: 2,
+  name: SECOND_NAME,
+  character_id: 43,
+  profile_picture_url: null,
+  primary_persona_id: 8,
+  active_persona_id: 8,
+};
+
 vi.mock('@/roster/queries', () => ({
   useMyRosterEntriesQuery: vi.fn(() => ({
-    data: [rosterEntry],
+    data: [rosterEntry, rosterEntry2],
     isLoading: false,
     isError: false,
   })),
@@ -451,6 +464,147 @@ describe('GamePage', () => {
       // scene baseline survived the churn.
       await waitFor(() => {
         expect(within(whisperButton()).getByText('1')).toBeInTheDocument();
+      });
+    });
+
+    it('resets the thread filter when the active puppet moves into a new scene (#2156 review fix 4)', async () => {
+      // Regression: useThreading's selectedThreadKey/enabledThreadKeys are
+      // local component state that never reset on their own — GamePage is a
+      // single long-lived composition root (unlike SceneDetailPage, which
+      // remounts on route change). A thread filter picked in the OLD scene
+      // must not silently keep hiding interactions once the puppet moves
+      // into a brand-new scene.
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      seedWhisperThread();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      const sidebar = () => screen.getByLabelText('Thread sidebar');
+      const whisperButton = () =>
+        within(sidebar())
+          .getByText(/whisper/i)
+          .closest('button') as HTMLElement;
+
+      // Filter down to just the whisper thread — the room pose is hidden.
+      await user.click(whisperButton());
+      expect(screen.queryByText('stretches languidly.')).not.toBeInTheDocument();
+
+      // The puppet moves into an entirely new scene.
+      store.dispatch(
+        setSessionScene({
+          character: ACTIVE_NAME,
+          scene: {
+            id: 300,
+            name: 'The Garden',
+            description: '',
+            is_owner: false,
+            has_unseen_observer: false,
+          },
+        })
+      );
+      store.dispatch(
+        addSceneInteraction({
+          character: ACTIVE_NAME,
+          interaction: {
+            id: 10,
+            persona: { id: 7, name: ACTIVE_NAME, thumbnail_url: '' },
+            content: 'strolls among the roses.',
+            mode: 'pose',
+            timestamp: '2026-01-01T00:10:00Z',
+            scene_id: 300,
+            place_id: null,
+            place_name: null,
+            receiver_persona_ids: [],
+            target_persona_ids: [],
+          },
+        })
+      );
+
+      // The stale whisper-only filter from the OLD scene must not hide the
+      // new scene's room pose.
+      await waitFor(() => {
+        expect(screen.getByText('strolls among the roses.')).toBeInTheDocument();
+      });
+    });
+
+    it("preserves puppet A's accumulated unread badge across a round trip through puppet B's different scene (#2156 review fix 3)", async () => {
+      // Regression: the old baseline gate was a single ref keyed only on
+      // sceneId. Puppet A (scene 100, badge already accumulated) -> puppet B
+      // (scene 200) -> back to puppet A re-triggered the baseline effect
+      // (the ref now held "200") and wiped A's badge back to 0. Gating on the
+      // per-puppet Redux `sceneBaselineId == null` instead means A's own
+      // baseline, once set, survives any number of puppet round trips.
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      seedWhisperThread();
+      store.dispatch(startSession(SECOND_NAME));
+      store.dispatch(
+        setSessionScene({
+          character: SECOND_NAME,
+          scene: {
+            id: 200,
+            name: 'The Kitchen',
+            description: '',
+            is_owner: false,
+            has_unseen_observer: false,
+          },
+        })
+      );
+      // startSession(SECOND_NAME) above made Bianca active — switch back to
+      // Aria before rendering (this test starts with Aria in view).
+      store.dispatch(setActiveSession(ACTIVE_NAME));
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      const sidebar = () => screen.getByLabelText('Thread sidebar');
+      const roomButton = () =>
+        within(sidebar()).getByText('The Grand Ballroom').closest('button') as HTMLElement;
+      const whisperButton = () =>
+        within(sidebar())
+          .getByText(/whisper/i)
+          .closest('button') as HTMLElement;
+
+      await waitFor(() => {
+        expect(within(roomButton()).queryByText(/^[1-9]/)).not.toBeInTheDocument();
+      });
+
+      // Select the whisper thread so the (now unselected) room thread
+      // accumulates unread from a new arrival.
+      await user.click(whisperButton());
+      store.dispatch(
+        addSceneInteraction({
+          character: ACTIVE_NAME,
+          interaction: {
+            id: 3,
+            persona: { id: 99, name: 'Bystander', thumbnail_url: '' },
+            content: 'glances over curiously.',
+            mode: 'pose',
+            timestamp: '2026-01-01T00:02:00Z',
+            scene_id: 100,
+            place_id: null,
+            place_name: null,
+            receiver_persona_ids: [],
+            target_persona_ids: [],
+          },
+        })
+      );
+      await waitFor(() => {
+        expect(within(roomButton()).getByText('1')).toBeInTheDocument();
+      });
+
+      // Round-trip through puppet B, who is in a completely different scene.
+      store.dispatch(setActiveSession(SECOND_NAME));
+      store.dispatch(setActiveSession(ACTIVE_NAME));
+
+      // Puppet A's room-thread badge must still read 1 — not wiped by the
+      // round trip.
+      await waitFor(() => {
+        expect(within(roomButton()).getByText('1')).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -1,13 +1,106 @@
 import { screen } from '@testing-library/react';
+import { describe, it, vi, beforeEach, afterEach, expect } from 'vitest';
 import { GamePage } from './GamePage';
 import { renderWithProviders } from '@/test/utils/renderWithProviders';
 import { store } from '@/store/store';
 import { setAccount } from '@/store/authSlice';
 import { mockAccount } from '@/test/mocks/account';
+import { startSession, setSessionScene, addSceneInteraction, resetGame } from '@/store/gameSlice';
+import type { MyRosterEntry } from '@/roster/types';
+import type { InteractionWsPayload } from '@/hooks/types';
+
+const ACTIVE_NAME = 'Aria';
+
+// ---------------------------------------------------------------------------
+// Mock the roster query — GamePage now derives `personaId` from it directly
+// (lifted from GameWindow, #2156 review fold-in) and GameWindow/PoseUnit's
+// sub-components (ReactionStrip, PersonaContextMenu, EndorsementControl) all
+// call the same hook.
+// ---------------------------------------------------------------------------
+
+const rosterEntry: MyRosterEntry = {
+  id: 1,
+  name: ACTIVE_NAME,
+  character_id: 42,
+  profile_picture_url: null,
+  primary_persona_id: 7,
+  active_persona_id: 7,
+};
+
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: vi.fn(() => ({
+    data: [rosterEntry],
+    isLoading: false,
+    isError: false,
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the REST interaction backfill (useSceneInteractions calls this) so the
+// test doesn't hit the network — the WS-seeded interaction below is enough to
+// exercise the merged feed.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/scenes/queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/scenes/queries')>();
+  return {
+    ...actual,
+    fetchInteractions: vi.fn(() => Promise.resolve({ results: [], next: undefined })),
+    postInteractionReaction: vi.fn().mockResolvedValue(null),
+    fetchReactionEmojiCatalog: vi.fn().mockResolvedValue([]),
+  };
+});
+
+// PoseUnit → PersonaContextMenu pulls in combat/queries for the duel-challenge
+// affordance; mirrors PoseUnit.test.tsx's mock to keep it from firing real fetches.
+vi.mock('@/combat/queries', () => ({
+  useOutcomeDetails: vi.fn().mockReturnValue({ data: [], isLoading: false }),
+  useDispatchPlayerAction: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
+  combatKeys: { duelChallengesAll: () => ['combat', 'duel-challenges'] },
+}));
+
+// EndorsementControl mounts its own hook machinery per-pose (#1138); stubbed
+// here since this test is about feed/threading composition, not endorsements.
+vi.mock('@/scenes/components/EndorsementControl', () => ({
+  EndorsementControl: () => null,
+}));
+
+function seedActiveSceneWithPose() {
+  store.dispatch(startSession(ACTIVE_NAME));
+  store.dispatch(
+    setSessionScene({
+      character: ACTIVE_NAME,
+      scene: {
+        id: 100,
+        name: 'The Grand Ballroom',
+        description: '',
+        is_owner: false,
+        has_unseen_observer: false,
+      },
+    })
+  );
+  const interaction: InteractionWsPayload = {
+    id: 1,
+    persona: { id: 7, name: ACTIVE_NAME, thumbnail_url: '' },
+    content: 'stretches languidly.',
+    mode: 'pose',
+    timestamp: '2026-01-01T00:00:00Z',
+    scene_id: 100,
+    place_id: null,
+    place_name: null,
+    receiver_persona_ids: [],
+    target_persona_ids: [],
+  };
+  store.dispatch(addSceneInteraction({ character: ACTIVE_NAME, interaction }));
+}
 
 describe('GamePage', () => {
   beforeEach(() => {
     store.dispatch(setAccount(null));
+  });
+
+  afterEach(() => {
+    store.dispatch(resetGame());
   });
 
   it('prompts to log in when not authenticated', () => {
@@ -21,5 +114,32 @@ describe('GamePage', () => {
     store.dispatch(setAccount(mockAccount));
     renderWithProviders(<GamePage />);
     expect(screen.queryByText(/you must be logged in/i)).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Structured chat-bubble scene feed + threading sidebar (#2156)
+  // ---------------------------------------------------------------------------
+
+  describe('structured scene feed + threading sidebar', () => {
+    it('renders a pose-unit bubble and the thread sidebar when a scene is active', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+
+      renderWithProviders(<GamePage />);
+
+      expect(await screen.findByTestId('pose-unit')).toBeInTheDocument();
+      expect(screen.getByLabelText('Thread sidebar')).toBeInTheDocument();
+    });
+
+    it('falls back to the plain ChatWindow with no thread sidebar when there is no active scene', () => {
+      store.dispatch(setAccount(mockAccount));
+      store.dispatch(startSession(ACTIVE_NAME));
+
+      renderWithProviders(<GamePage />);
+
+      expect(screen.getByText(/no messages yet/i)).toBeInTheDocument();
+      expect(screen.queryByLabelText('Thread sidebar')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('pose-unit')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -6,7 +6,13 @@ import { renderWithProviders } from '@/test/utils/renderWithProviders';
 import { store } from '@/store/store';
 import { setAccount } from '@/store/authSlice';
 import { mockAccount } from '@/test/mocks/account';
-import { startSession, setSessionScene, addSceneInteraction, resetGame } from '@/store/gameSlice';
+import {
+  startSession,
+  setSessionScene,
+  addSceneInteraction,
+  clearSceneInteractions,
+  resetGame,
+} from '@/store/gameSlice';
 import type { MyRosterEntry } from '@/roster/types';
 import type { InteractionWsPayload } from '@/hooks/types';
 
@@ -298,6 +304,119 @@ describe('GamePage', () => {
       await user.click(whisperButton());
       await waitFor(() => {
         expect(within(whisperButton()).queryByText(/^[1-9]/)).not.toBeInTheDocument();
+      });
+    });
+
+    it('keeps the scene baseline across ordinary ROOM_STATE churn, so a first-ever whisper still badges (#2156 review fix 2)', async () => {
+      // Regression for a reviewer-caught defect: `clearSceneInteractions` used
+      // to null `sceneBaselineId` unconditionally, and
+      // `handleRoomStatePayload` dispatches it on EVERY ROOM_STATE broadcast —
+      // which the backend sends on ordinary room movement (anyone
+      // entering/leaving), not just scene changes. GamePage's one-shot
+      // baseline ref never re-fires for the same scene id, so the baseline
+      // stayed null for the rest of the scene and new-thread badging died.
+      // Fix: `clearSceneInteractions` no longer touches `sceneBaselineId` —
+      // only an actual scene-id change (via `setSessionScene`) resets it.
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+
+      renderWithProviders(<GamePage />);
+
+      await screen.findByText('stretches languidly.');
+
+      // Simulate room churn: someone enters/leaves, the backend broadcasts
+      // ROOM_STATE for the SAME scene, and handleRoomStatePayload dispatches
+      // clearSceneInteractions.
+      store.dispatch(clearSceneInteractions(ACTIVE_NAME));
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+
+      // A first-ever whisper arrives after the churn, from someone other than
+      // the viewer, while it's unselected.
+      store.dispatch(
+        addSceneInteraction({
+          character: ACTIVE_NAME,
+          interaction: {
+            id: 5,
+            persona: { id: 42, name: 'Mysterious Stranger', thumbnail_url: '' },
+            content: 'psst -- a word, in private.',
+            mode: 'whisper',
+            timestamp: '2026-01-01T00:05:00Z',
+            scene_id: 100,
+            place_id: null,
+            place_name: null,
+            receiver_persona_ids: [7],
+            target_persona_ids: [],
+          },
+        })
+      );
+
+      const whisperButton = () =>
+        within(sidebar)
+          .getByText(/whisper/i)
+          .closest('button') as HTMLElement;
+
+      // The new thread still badges unread from its first message — the
+      // scene baseline survived the churn.
+      await waitFor(() => {
+        expect(within(whisperButton()).getByText('1')).toBeInTheDocument();
+      });
+    });
+
+    it('badges the first message of a scene that had zero interactions at load (#2156 review fix 2)', async () => {
+      // Regression for a reviewer-caught defect: GamePage stored `null` as the
+      // baseline for a scene with zero interactions at load — indistinguishable
+      // from "the baseline effect hasn't run yet" — so `countUnread` fell
+      // through to its no-baseline branch (0 unread) and the scene's first
+      // message never badged. Fix: store `0` as the "baselined empty" sentinel
+      // (interaction ids are DB pks and never 0), and `countUnread` treats any
+      // number, including 0, as a live threshold.
+      store.dispatch(setAccount(mockAccount));
+      store.dispatch(startSession(ACTIVE_NAME));
+      store.dispatch(
+        setSessionScene({
+          character: ACTIVE_NAME,
+          scene: {
+            id: 200,
+            name: 'An Empty Hall',
+            description: '',
+            is_owner: false,
+            has_unseen_observer: false,
+          },
+        })
+      );
+      // No interactions seeded — the scene is empty at load.
+
+      renderWithProviders(<GamePage />);
+
+      await screen.findByLabelText('Thread sidebar');
+
+      store.dispatch(
+        addSceneInteraction({
+          character: ACTIVE_NAME,
+          interaction: {
+            id: 1,
+            persona: { id: 42, name: 'Mysterious Stranger', thumbnail_url: '' },
+            content: 'psst -- a word, in private.',
+            mode: 'whisper',
+            timestamp: '2026-01-01T00:00:01Z',
+            scene_id: 200,
+            place_id: null,
+            place_name: null,
+            receiver_persona_ids: [7],
+            target_persona_ids: [],
+          },
+        })
+      );
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+      const whisperButton = () =>
+        within(sidebar)
+          .getByText(/whisper/i)
+          .closest('button') as HTMLElement;
+
+      await waitFor(() => {
+        expect(within(whisperButton()).getByText('1')).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -1,4 +1,5 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, vi, beforeEach, afterEach, expect } from 'vitest';
 import { GamePage } from './GamePage';
 import { renderWithProviders } from '@/test/utils/renderWithProviders';
@@ -94,6 +95,25 @@ function seedActiveSceneWithPose() {
   store.dispatch(addSceneInteraction({ character: ACTIVE_NAME, interaction }));
 }
 
+// Seeds a second, distinct thread (a whisper to persona 9) alongside the room
+// pose from seedActiveSceneWithPose, so a test can click a thread and assert
+// the feed actually narrows to it (#2156 review fix).
+function seedWhisperThread() {
+  const interaction: InteractionWsPayload = {
+    id: 2,
+    persona: { id: 7, name: ACTIVE_NAME, thumbnail_url: '' },
+    content: 'meet me by the fountain at midnight.',
+    mode: 'whisper',
+    timestamp: '2026-01-01T00:01:00Z',
+    scene_id: 100,
+    place_id: null,
+    place_name: null,
+    receiver_persona_ids: [9],
+    target_persona_ids: [],
+  };
+  store.dispatch(addSceneInteraction({ character: ACTIVE_NAME, interaction }));
+}
+
 describe('GamePage', () => {
   beforeEach(() => {
     store.dispatch(setAccount(null));
@@ -129,6 +149,38 @@ describe('GamePage', () => {
 
       expect(await screen.findByTestId('pose-unit')).toBeInTheDocument();
       expect(screen.getByLabelText('Thread sidebar')).toBeInTheDocument();
+    });
+
+    it('clicking a thread in the sidebar actually filters the center feed (review fix)', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      seedWhisperThread();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+
+      // Both interactions show before any thread is selected.
+      expect(await screen.findByText('stretches languidly.')).toBeInTheDocument();
+      expect(screen.getByText('meet me by the fountain at midnight.')).toBeInTheDocument();
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+      const whisperButton = within(sidebar)
+        .getByText(/whisper/i)
+        .closest('button');
+      expect(whisperButton).not.toBeNull();
+      await user.click(whisperButton as HTMLElement);
+
+      // Clicking the whisper thread must narrow the feed to just that thread —
+      // the room pose disappears and the whisper stays (GamePage's
+      // handleThreadClick must call toggleThreadVisibility, not just
+      // setSelectedThread, or filteredInteractions never changes).
+      expect(screen.queryByText('stretches languidly.')).not.toBeInTheDocument();
+      expect(screen.getByText('meet me by the fountain at midnight.')).toBeInTheDocument();
+
+      // "All" restores both threads.
+      await user.click(within(sidebar).getByText('All'));
+      expect(screen.getByText('stretches languidly.')).toBeInTheDocument();
+      expect(screen.getByText('meet me by the fountain at midnight.')).toBeInTheDocument();
     });
 
     it('falls back to the plain ChatWindow with no thread sidebar when there is no active scene', () => {

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -93,7 +93,7 @@ vi.mock('@/scenes/components/PendingActionAttachments', () => ({
   ),
 }));
 
-const mockFetchPlaces = vi.fn(() =>
+const mockFetchPlaces = vi.fn((_sceneId: string) =>
   Promise.resolve({
     results: [] as Array<{
       id: number;

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -8,6 +8,7 @@ import { setAccount } from '@/store/authSlice';
 import { mockAccount } from '@/test/mocks/account';
 import {
   startSession,
+  setSessionRoom,
   setSessionScene,
   addSceneInteraction,
   clearSceneInteractions,
@@ -55,6 +56,54 @@ vi.mock('@/scenes/queries', async (importOriginal) => {
     fetchInteractions: vi.fn(() => Promise.resolve({ results: [], next: undefined })),
     postInteractionReaction: vi.fn().mockResolvedValue(null),
     fetchReactionEmojiCatalog: vi.fn().mockResolvedValue([]),
+    fetchPendingUnlinkedActions: vi.fn(() => Promise.resolve([])),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Scene toolset (#2156 Task 6): ConsentPrompt/ActionPanel/PendingActionAttachments
+// are self-fetching components with heavy internal query machinery unrelated to
+// this test's concern (toolset mounting + isAtPlace wiring) — stubbed out as
+// lightweight divs, mirroring SceneDetailPage.test.tsx's proven pattern. PlaceBar
+// is stubbed too: `isAtPlace` is derived by GamePage's OWN `['scene-places', ...]`
+// query (query-reuse, not a callback prop), so exercising it only requires
+// controlling `fetchPlaces` — it doesn't require PlaceBar's real render tree.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/scenes/components/ConsentPrompt', () => ({
+  ConsentPrompt: () => <div data-testid="consent-prompt">ConsentPrompt</div>,
+}));
+
+vi.mock('@/scenes/components/PlaceBar', () => ({
+  PlaceBar: () => <div data-testid="place-bar">PlaceBar</div>,
+}));
+
+vi.mock('@/scenes/components/ActionPanel', () => ({
+  ActionPanel: () => <div data-testid="action-panel">ActionPanel</div>,
+}));
+
+vi.mock('@/scenes/components/PendingActionAttachments', () => ({
+  PendingActionAttachments: () => (
+    <div data-testid="pending-action-attachments">PendingActionAttachments</div>
+  ),
+}));
+
+const mockFetchPlaces = vi.fn(() =>
+  Promise.resolve({
+    results: [] as Array<{
+      id: number;
+      name: string;
+      description: string;
+      viewer_is_present: boolean;
+    }>,
+  })
+);
+
+vi.mock('@/scenes/actionQueries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/scenes/actionQueries')>();
+  return {
+    ...actual,
+    fetchPlaces: (...args: Parameters<typeof actual.fetchPlaces>) => mockFetchPlaces(...args),
   };
 });
 
@@ -118,6 +167,43 @@ function seedWhisperThread() {
     target_persona_ids: [],
   };
   store.dispatch(addSceneInteraction({ character: ACTIVE_NAME, interaction }));
+}
+
+// Seeds both room AND scene (#2156 Task 6) — real ROOM_STATE broadcasts always
+// carry both together (see handleRoomStatePayload.ts), and GamePage derives the
+// Place-bar/isAtPlace room id from `session.room.id`, so the toolset needs a
+// seeded room to mount PlaceBar and derive `isAtPlace` at all.
+function seedActiveSceneWithRoom() {
+  store.dispatch(startSession(ACTIVE_NAME));
+  store.dispatch(
+    setSessionRoom({
+      character: ACTIVE_NAME,
+      room: {
+        id: 55,
+        name: 'The Grand Ballroom',
+        description: '',
+        thumbnail_url: null,
+        characters: [],
+        objects: [],
+        exits: [],
+        is_owner: false,
+        is_public: true,
+        hub: null,
+      },
+    })
+  );
+  store.dispatch(
+    setSessionScene({
+      character: ACTIVE_NAME,
+      scene: {
+        id: 100,
+        name: 'The Grand Ballroom',
+        description: '',
+        is_owner: false,
+        has_unseen_observer: false,
+      },
+    })
+  );
 }
 
 describe('GamePage', () => {
@@ -429,6 +515,73 @@ describe('GamePage', () => {
       expect(screen.getByText(/no messages yet/i)).toBeInTheDocument();
       expect(screen.queryByLabelText('Thread sidebar')).not.toBeInTheDocument();
       expect(screen.queryByTestId('pose-unit')).not.toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scene toolset on /game + live tabletalk (#2156 Task 6)
+  // ---------------------------------------------------------------------------
+
+  describe('scene toolset', () => {
+    beforeEach(() => {
+      mockFetchPlaces.mockClear();
+      mockFetchPlaces.mockResolvedValue({ results: [] });
+    });
+
+    it('renders ConsentPrompt/PlaceBar/ActionPanel/PendingActionAttachments when a scene is active', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithRoom();
+
+      renderWithProviders(<GamePage />);
+
+      expect(await screen.findByTestId('consent-prompt')).toBeInTheDocument();
+      expect(screen.getByTestId('place-bar')).toBeInTheDocument();
+      expect(screen.getByTestId('action-panel')).toBeInTheDocument();
+      expect(screen.getByTestId('pending-action-attachments')).toBeInTheDocument();
+    });
+
+    it('does not render the scene toolset when there is no active scene', () => {
+      store.dispatch(setAccount(mockAccount));
+      store.dispatch(startSession(ACTIVE_NAME));
+
+      renderWithProviders(<GamePage />);
+
+      expect(screen.queryByTestId('consent-prompt')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('place-bar')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('action-panel')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('pending-action-attachments')).not.toBeInTheDocument();
+    });
+
+    it('passes isAtPlace=true to ModeSelector, offering the tt mode, when a place has viewer_is_present:true', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithRoom();
+      mockFetchPlaces.mockResolvedValue({
+        results: [{ id: 9, name: 'The Fountain', description: '', viewer_is_present: true }],
+      });
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+
+      const trigger = await screen.findByRole('button', { name: 'Pose' });
+      await user.click(trigger);
+
+      expect(await screen.findByText('Tabletalk')).toBeInTheDocument();
+    });
+
+    it('does not offer the tt mode when the viewer is not present at any place', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithRoom();
+      mockFetchPlaces.mockResolvedValue({
+        results: [{ id: 9, name: 'The Fountain', description: '', viewer_is_present: false }],
+      });
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+
+      const trigger = await screen.findByRole('button', { name: 'Pose' });
+      await user.click(trigger);
+
+      expect(screen.queryByText('Tabletalk')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { GameLayout } from './components/GameLayout';
 import { GameTopBar } from './components/GameTopBar';
 import { GameWindow } from './components/GameWindow';
+import { CharacterCardDrawer } from './components/CharacterCardDrawer';
 import { ConversationSidebar } from './components/ConversationSidebar';
 import { FocusPanel } from './components/FocusPanel';
 import { SidebarTabPanel } from './components/SidebarTabPanel';
@@ -28,6 +29,7 @@ import { ActionPanel } from '@/scenes/components/ActionPanel';
 import { PendingActionAttachments } from '@/scenes/components/PendingActionAttachments';
 import { createActionRequest, fetchPlaces } from '@/scenes/actionQueries';
 import type { ActionAttachmentInfo } from '@/scenes/actionTypes';
+import type { PoseUnitAvatarClickPersona } from '@/scenes/components/PoseUnit';
 import type { ComposerMode } from './components/CommandInput';
 
 const DEFAULT_ROOM_ENTRY: FocusEntry = {
@@ -59,6 +61,9 @@ export function GamePage() {
   // Lifted from GameWindow (#2156 review fold-in) — dedupes the roster query
   // that both GamePage and GameWindow used to call independently.
   const personaId = activeEntry?.primary_persona_id ?? null;
+  // The active character's own RosterEntry id (#2156 Task 7) — the FriendButton's
+  // `viewerEntryId` inside the character-card drawer.
+  const viewerEntryId = activeEntry?.id ?? null;
 
   const activeSession = active ? sessions[active] : null;
   const roomData = activeSession?.room ?? null;
@@ -81,6 +86,16 @@ export function GamePage() {
     sceneBaselineId,
   });
   const [composerMode, setComposerMode] = useState<ComposerMode | undefined>();
+
+  // Character-card drawer (#2156 Task 7): the clicked bubble's persona identity,
+  // or null when the drawer is closed. GamePage owns this state (mirrored on
+  // SceneDetailPage) since the drawer opens "in place" over whichever surface
+  // the avatar was clicked on, not as a route navigation.
+  const [cardPersona, setCardPersona] = useState<PoseUnitAvatarClickPersona | null>(null);
+  const handleWhisper = useCallback((name: string) => {
+    setComposerMode({ command: 'whisper', targets: [name], label: `Whisper → ${name}` });
+    setCardPersona(null);
+  }, []);
 
   // Scene-load baseline (#2156 review fix): a single scalar snapshot, not a
   // per-thread-key one. The old per-key baseline one-shotted per KEY, so a
@@ -289,6 +304,7 @@ export function GamePage() {
               composerMode={composerMode}
               onModeChange={setComposerMode}
               personaId={personaId}
+              onAvatarClick={setCardPersona}
               onAddTarget={setPendingTarget}
               onAttachAction={handleActionAttach}
               targetToAppend={targetToAppend}
@@ -343,6 +359,12 @@ export function GamePage() {
             }
           />
         }
+      />
+      <CharacterCardDrawer
+        persona={cardPersona}
+        onClose={() => setCardPersona(null)}
+        viewerEntryId={viewerEntryId}
+        onWhisper={handleWhisper}
       />
       <Toaster />
     </>

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { GameLayout } from './components/GameLayout';
 import { GameTopBar } from './components/GameTopBar';
@@ -102,7 +102,7 @@ export function GamePage() {
   // brand-new thread appearing mid-session (e.g. a first whisper) got its own
   // key baselined to its first message's id the moment it was observed —
   // countUnread's strict `>` then suppressed the badge on that very first
-  // message. Instead: the first time this effect runs for a given `sceneId`,
+  // message. Instead: the first time this effect runs for a given puppet+scene,
   // capture the highest interaction id present at that moment as
   // `sceneBaselineId` and never touch it again for this scene.
   // `useThreading`'s `countUnread` falls back to this scalar only for thread
@@ -115,18 +115,44 @@ export function GamePage() {
   // indistinguishable from "baseline effect hasn't run yet", which would make
   // `countUnread` fall through to its no-baseline branch and stay silently
   // unbadged for that scene's first message.
-  const sceneBaselinedRef = useRef<string | undefined>(undefined);
+  //
+  // Gated on the per-puppet Redux `sceneBaselineId == null` (review fix 3),
+  // NOT a single scalar ref keyed only by sceneId: a ref keyed on sceneId
+  // alone has two bugs with multiple puppets — (1) puppet A (scene X,
+  // baselined) -> puppet B (scene Y) -> back to puppet A (still scene X)
+  // re-triggers the effect (the ref now holds "Y", not "X") and WIPES A's
+  // already-accumulated unread by re-baselining to the current max id; (2)
+  // puppet A and puppet B in the SAME scene X: A's switch already set the
+  // ref to "X", so B's own turn never runs the effect at all and B's
+  // Redux `sceneBaselineId` starves at its initial `null` forever. Reading
+  // the per-puppet Redux value directly sidesteps both — it's already keyed
+  // by character (`sessions[active]`), and `setSessionScene` nulls it out
+  // exactly when that puppet's own scene id changes (see gameSlice.ts).
   useEffect(() => {
     if (!sceneId || !active) return;
-    if (sceneBaselinedRef.current === sceneId) return;
-    sceneBaselinedRef.current = sceneId;
+    if (activeSession?.sceneBaselineId != null) return;
     let maxId: number | undefined;
     for (const interaction of allInteractions) {
       const id = Number(interaction.id);
       if (maxId === undefined || id > maxId) maxId = id;
     }
     dispatch(setSceneBaseline({ character: active, baselineId: maxId ?? 0 }));
-  }, [sceneId, active, allInteractions, dispatch]);
+  }, [sceneId, active, activeSession?.sceneBaselineId, allInteractions, dispatch]);
+
+  // Threading filter/mute reset on scene change or puppet switch (#2156 review
+  // fix): `useThreading`'s selectedThreadKey/enabledThreadKeys/hiddenPersonaIds
+  // are local component state that otherwise never resets across renders —
+  // GamePage is a single long-lived composition root, unlike SceneDetailPage
+  // (a route change there remounts the whole tree for free). Without this, a
+  // thread filter or muted participant picked in a PREVIOUS scene/puppet
+  // context silently keeps hiding interactions in a new one, especially when
+  // the new context happens to reuse an identical thread key (e.g. two
+  // puppets in the same room). Keyed on the same `[active, sceneId]` pair the
+  // baseline effect above uses.
+  const threadingResetForNewScene = threading.resetForNewScene;
+  useEffect(() => {
+    threadingResetForNewScene();
+  }, [active, sceneId, threadingResetForNewScene]);
 
   // Continuously mark the SELECTED thread seen as its interactions grow — this is
   // the thread the player is actively viewing, so it never accumulates unread.

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { GameLayout } from './components/GameLayout';
 import { GameTopBar } from './components/GameTopBar';
 import { GameWindow } from './components/GameWindow';
@@ -15,9 +15,10 @@ import { useFocusStack, type FocusEntry } from '@/inventory/hooks/useFocusStack'
 import { Toaster } from '@/components/ui/sonner';
 import { Link } from 'react-router-dom';
 import { useAccount } from '@/store/hooks';
-import { useAppSelector } from '@/store/hooks';
+import { useAppSelector, useAppDispatch } from '@/store/hooks';
+import { markThreadSeen } from '@/store/gameSlice';
 import { useSceneInteractions } from '@/scenes/hooks/useSceneInteractions';
-import { useThreading } from '@/scenes/hooks/useThreading';
+import { useThreading, getThreadKey } from '@/scenes/hooks/useThreading';
 import { threadToComposerMode } from '@/scenes/hooks/threadToComposerMode';
 import type { ComposerMode } from './components/CommandInput';
 
@@ -27,8 +28,13 @@ const DEFAULT_ROOM_ENTRY: FocusEntry = {
   sceneSummary: null,
 };
 
+// Stable empty-object reference so `useThreading`'s memo doesn't see a "changed"
+// lastSeenByThread on every render when there's no active session yet (#2156).
+const EMPTY_THREAD_LAST_SEEN: Record<string, number> = {};
+
 export function GamePage() {
   const account = useAccount();
+  const dispatch = useAppDispatch();
   const { data: characters = [] } = useMyRosterEntriesQuery();
   const { sessions, active } = useAppSelector((state) => state.game);
 
@@ -59,8 +65,60 @@ export function GamePage() {
   // undefined with no active scene, which both hooks handle without firing
   // network calls or producing threads.
   const { allInteractions, hasNextPage, fetchNextPage } = useSceneInteractions(sceneId);
-  const threading = useThreading(allInteractions, roomName);
+  const threadLastSeen = activeSession?.threadLastSeen ?? EMPTY_THREAD_LAST_SEEN;
+  const threading = useThreading(allInteractions, roomName, {
+    lastSeenByThread: threadLastSeen,
+    viewerPersonaId: personaId,
+  });
   const [composerMode, setComposerMode] = useState<ComposerMode | undefined>();
+
+  // Per-thread unread badges (#2156): "no entry -> 0 unread" (useThreading) means a
+  // brand-new session would otherwise show every existing thread as fully unread on
+  // login. Baseline every thread's current max interaction id once per scene load
+  // (guarded per thread key so it never re-baselines — and thereby erases — a
+  // legitimately-accumulated unread count once that key has been seen this scene).
+  const baselinedRef = useRef<{ sceneId: string | undefined; keys: Set<string> }>({
+    sceneId: undefined,
+    keys: new Set(),
+  });
+  useEffect(() => {
+    if (!sceneId || !active) return;
+    if (baselinedRef.current.sceneId !== sceneId) {
+      baselinedRef.current = { sceneId, keys: new Set() };
+    }
+    const maxByThread = new Map<string, number>();
+    for (const interaction of allInteractions) {
+      const key = getThreadKey(interaction);
+      const id = Number(interaction.id);
+      const current = maxByThread.get(key);
+      if (current === undefined || id > current) {
+        maxByThread.set(key, id);
+      }
+    }
+    for (const [threadKey, interactionId] of maxByThread) {
+      if (!baselinedRef.current.keys.has(threadKey)) {
+        baselinedRef.current.keys.add(threadKey);
+        dispatch(markThreadSeen({ character: active, threadKey, interactionId }));
+      }
+    }
+  }, [sceneId, active, allInteractions, dispatch]);
+
+  // Continuously mark the SELECTED thread seen as its interactions grow — this is
+  // the thread the player is actively viewing, so it never accumulates unread.
+  // Unselected threads are left alone and accumulate unread from the baseline above.
+  useEffect(() => {
+    if (!sceneId || !active) return;
+    const selectedKey = threading.selectedThreadKey;
+    let maxId: number | undefined;
+    for (const interaction of allInteractions) {
+      if (getThreadKey(interaction) !== selectedKey) continue;
+      const id = Number(interaction.id);
+      if (maxId === undefined || id > maxId) maxId = id;
+    }
+    if (maxId !== undefined) {
+      dispatch(markThreadSeen({ character: active, threadKey: selectedKey, interactionId: maxId }));
+    }
+  }, [sceneId, active, allInteractions, threading.selectedThreadKey, dispatch]);
 
   // Mirrors SceneInteractionPanel's handleThreadClick (#2156 review fix): a
   // thread click toggles that thread's inclusion in the enabled-thread set

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { GameLayout } from './components/GameLayout';
 import { GameTopBar } from './components/GameTopBar';
 import { GameWindow } from './components/GameWindow';
@@ -20,6 +21,13 @@ import { markThreadSeen, setSceneBaseline } from '@/store/gameSlice';
 import { useSceneInteractions } from '@/scenes/hooks/useSceneInteractions';
 import { useThreading, getThreadKey } from '@/scenes/hooks/useThreading';
 import { threadToComposerMode } from '@/scenes/hooks/threadToComposerMode';
+import { usePendingUnlinkedActions } from '@/scenes/hooks/usePendingUnlinkedActions';
+import { ConsentPrompt } from '@/scenes/components/ConsentPrompt';
+import { PlaceBar } from '@/scenes/components/PlaceBar';
+import { ActionPanel } from '@/scenes/components/ActionPanel';
+import { PendingActionAttachments } from '@/scenes/components/PendingActionAttachments';
+import { createActionRequest, fetchPlaces } from '@/scenes/actionQueries';
+import type { ActionAttachmentInfo } from '@/scenes/actionTypes';
 import type { ComposerMode } from './components/CommandInput';
 
 const DEFAULT_ROOM_ENTRY: FocusEntry = {
@@ -134,6 +142,87 @@ export function GamePage() {
     }
   };
 
+  // Scene toolset (#2156 Task 6) — GamePage is the composition root, so it
+  // owns the same handler state SceneDetailPage.tsx:120-178 owns, mirrored
+  // exactly: consent, places, pending action attachments, and the action
+  // panel. `PlaceBar`'s `sceneId` prop is actually used as the ROOM id in its
+  // `fetchPlaces(?room=)` query (confirmed by reading PlaceBar.tsx +
+  // actionQueries.ts) — so /game passes the real room id (`roomData.id`),
+  // not the scene id. (`SceneDetailPage` passes the scene id, which is a
+  // pre-existing latent bug in the places query on that page — left
+  // untouched here; see the task report.)
+  const placesRoomId = sceneId && roomData ? String(roomData.id) : undefined;
+
+  // `isAtPlace` (#2156): derived from the SAME `['scene-places', placesRoomId]`
+  // query key `PlaceBar` uses below, so React Query's cache dedupes the two
+  // fetches into one (query-reuse, chosen over a callback-prop approach per
+  // the task brief).
+  const { data: placesData } = useQuery({
+    queryKey: ['scene-places', placesRoomId],
+    queryFn: () => fetchPlaces(placesRoomId!),
+    enabled: !!placesRoomId,
+  });
+  const isAtPlace = placesData?.results?.some((place) => place.viewer_is_present) ?? false;
+
+  // Pending unlinked actions for the chip strip — only fetched once a scene
+  // is active (personaId gated to null otherwise disables the query).
+  const { data: pendingActions } = usePendingUnlinkedActions(
+    sceneId ?? '',
+    sceneId ? personaId : null
+  );
+  const pendingActionIds = useMemo(() => pendingActions.map((a) => a.id), [pendingActions]);
+
+  const [detachedActionIds, setDetachedActionIds] = useState<number[]>([]);
+  const handleDetach = useCallback((actionId: number) => {
+    setDetachedActionIds((prev) => (prev.includes(actionId) ? prev : [...prev, actionId]));
+  }, []);
+  const handleUndoDetach = useCallback((actionId: number) => {
+    setDetachedActionIds((prev) => prev.filter((id) => id !== actionId));
+  }, []);
+  const handlePoseSubmitted = useCallback(() => {
+    setDetachedActionIds([]);
+  }, []);
+
+  const [targetToAppend, setPendingTarget] = useState<string | null>(null);
+  const [actionAttachment, setActionAttachment] = useState<ActionAttachmentInfo | null>(null);
+  const queryClient = useQueryClient();
+
+  const submitAction = useMutation({
+    mutationFn: (action: ActionAttachmentInfo) =>
+      createActionRequest(sceneId ?? '', {
+        action_key: action.actionKey,
+        target_persona_id: action.targetPersonaId,
+        technique_id: action.techniqueId,
+      }),
+    onSuccess: () => {
+      setActionAttachment(null);
+      queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
+      queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
+    },
+    onError: () => {
+      // Keep the attachment so the user can retry.
+    },
+  });
+
+  const handleSubmitAction = useCallback(
+    (action: ActionAttachmentInfo) => {
+      submitAction.mutate(action);
+    },
+    [submitAction]
+  );
+
+  const handleTargetConsumed = useCallback(() => {
+    setPendingTarget(null);
+  }, []);
+
+  const handleActionAttach = useCallback((action: ActionAttachmentInfo) => {
+    setActionAttachment(action);
+  }, []);
+
+  const handleActionDetach = useCallback(() => {
+    setActionAttachment(null);
+  }, []);
+
   if (!account) {
     return (
       <div className="mx-auto max-w-sm text-center">
@@ -177,22 +266,56 @@ export function GamePage() {
           />
         }
         center={
-          <GameWindow
-            characters={characters}
-            sceneFeed={
-              sceneId
-                ? {
-                    sceneId,
-                    interactions: threading.filteredInteractions,
-                    hasNextPage,
-                    fetchNextPage,
-                  }
-                : undefined
-            }
-            composerMode={composerMode}
-            onModeChange={setComposerMode}
-            personaId={personaId}
-          />
+          <>
+            {/* Scene toolset (#2156 Task 6) — mirrors SceneDetailPage.tsx:120-178's
+                props exactly. Placement differs deliberately from the record page:
+                ConsentPrompt sits above the center feed here; PlaceBar sits directly
+                above the composer (passed into GameWindow, rendered just before
+                CommandInput); ActionPanel is a `fixed` floating panel, so its DOM
+                position doesn't matter. */}
+            {sceneId && <ConsentPrompt sceneId={sceneId} />}
+            <GameWindow
+              characters={characters}
+              sceneFeed={
+                sceneId
+                  ? {
+                      sceneId,
+                      interactions: threading.filteredInteractions,
+                      hasNextPage,
+                      fetchNextPage,
+                    }
+                  : undefined
+              }
+              composerMode={composerMode}
+              onModeChange={setComposerMode}
+              personaId={personaId}
+              onAddTarget={setPendingTarget}
+              onAttachAction={handleActionAttach}
+              targetToAppend={targetToAppend}
+              onTargetConsumed={handleTargetConsumed}
+              actionAttachment={actionAttachment}
+              onActionAttach={handleActionAttach}
+              onActionDetach={handleActionDetach}
+              onSubmitAction={handleSubmitAction}
+              pendingActionIds={pendingActionIds}
+              detachedActionIds={detachedActionIds}
+              onPoseSubmitted={handlePoseSubmitted}
+              isAtPlace={isAtPlace}
+              placeBar={placesRoomId ? <PlaceBar sceneId={placesRoomId} /> : undefined}
+              pendingAttachments={
+                sceneId ? (
+                  <PendingActionAttachments
+                    sceneId={sceneId}
+                    personaId={personaId}
+                    detachedIds={detachedActionIds}
+                    onDetach={handleDetach}
+                    onUndoDetach={handleUndoDetach}
+                  />
+                ) : undefined
+              }
+            />
+            {sceneId && <ActionPanel sceneId={sceneId} />}
+          </>
         }
         rightSidebar={
           <SidebarTabPanel

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -62,8 +62,12 @@ export function GamePage() {
   const threading = useThreading(allInteractions, roomName);
   const [composerMode, setComposerMode] = useState<ComposerMode | undefined>();
 
+  // Mirrors SceneInteractionPanel's handleThreadClick (#2156 review fix): a
+  // thread click toggles that thread's inclusion in the enabled-thread set
+  // (which is what useThreading.filteredInteractions actually narrows on),
+  // not just the "selected" highlight — otherwise the feed never changes.
   const handleThreadClick = (key: string) => {
-    threading.setSelectedThread(key);
+    threading.toggleThreadVisibility(key);
     const thread = threading.threads.find((t) => t.key === key);
     if (thread) {
       setComposerMode(threadToComposerMode(thread, roomName));

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -237,7 +237,10 @@ export function GamePage() {
       }),
     onSuccess: () => {
       setActionAttachment(null);
-      queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
+      // No 'scene-messages' invalidation here (#2156 review fix): nothing in
+      // this codebase ever queries that key — the scene feed here is
+      // `useSceneInteractions`, which merges the WS-pushed interaction with no
+      // React Query cache to invalidate. The stale call was dead on arrival.
       queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
     },
     onError: () => {

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -16,7 +16,7 @@ import { Toaster } from '@/components/ui/sonner';
 import { Link } from 'react-router-dom';
 import { useAccount } from '@/store/hooks';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
-import { markThreadSeen } from '@/store/gameSlice';
+import { markThreadSeen, setSceneBaseline } from '@/store/gameSlice';
 import { useSceneInteractions } from '@/scenes/hooks/useSceneInteractions';
 import { useThreading, getThreadKey } from '@/scenes/hooks/useThreading';
 import { threadToComposerMode } from '@/scenes/hooks/threadToComposerMode';
@@ -66,41 +66,37 @@ export function GamePage() {
   // network calls or producing threads.
   const { allInteractions, hasNextPage, fetchNextPage } = useSceneInteractions(sceneId);
   const threadLastSeen = activeSession?.threadLastSeen ?? EMPTY_THREAD_LAST_SEEN;
+  const sceneBaselineId = activeSession?.sceneBaselineId ?? null;
   const threading = useThreading(allInteractions, roomName, {
     lastSeenByThread: threadLastSeen,
     viewerPersonaId: personaId,
+    sceneBaselineId,
   });
   const [composerMode, setComposerMode] = useState<ComposerMode | undefined>();
 
-  // Per-thread unread badges (#2156): "no entry -> 0 unread" (useThreading) means a
-  // brand-new session would otherwise show every existing thread as fully unread on
-  // login. Baseline every thread's current max interaction id once per scene load
-  // (guarded per thread key so it never re-baselines — and thereby erases — a
-  // legitimately-accumulated unread count once that key has been seen this scene).
-  const baselinedRef = useRef<{ sceneId: string | undefined; keys: Set<string> }>({
-    sceneId: undefined,
-    keys: new Set(),
-  });
+  // Scene-load baseline (#2156 review fix): a single scalar snapshot, not a
+  // per-thread-key one. The old per-key baseline one-shotted per KEY, so a
+  // brand-new thread appearing mid-session (e.g. a first whisper) got its own
+  // key baselined to its first message's id the moment it was observed —
+  // countUnread's strict `>` then suppressed the badge on that very first
+  // message. Instead: the first time this effect runs for a given `sceneId`,
+  // capture the highest interaction id present at that moment as
+  // `sceneBaselineId` and never touch it again for this scene.
+  // `useThreading`'s `countUnread` falls back to this scalar only for thread
+  // keys with no `threadLastSeen` entry, so pre-existing threads (which get a
+  // `threadLastSeen` entry from the selected-thread effect below, or already
+  // had one) stay zeroed while a genuinely new thread badges from message one.
+  const sceneBaselinedRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (!sceneId || !active) return;
-    if (baselinedRef.current.sceneId !== sceneId) {
-      baselinedRef.current = { sceneId, keys: new Set() };
-    }
-    const maxByThread = new Map<string, number>();
+    if (sceneBaselinedRef.current === sceneId) return;
+    sceneBaselinedRef.current = sceneId;
+    let maxId: number | undefined;
     for (const interaction of allInteractions) {
-      const key = getThreadKey(interaction);
       const id = Number(interaction.id);
-      const current = maxByThread.get(key);
-      if (current === undefined || id > current) {
-        maxByThread.set(key, id);
-      }
+      if (maxId === undefined || id > maxId) maxId = id;
     }
-    for (const [threadKey, interactionId] of maxByThread) {
-      if (!baselinedRef.current.keys.has(threadKey)) {
-        baselinedRef.current.keys.add(threadKey);
-        dispatch(markThreadSeen({ character: active, threadKey, interactionId }));
-      }
-    }
+    dispatch(setSceneBaseline({ character: active, baselineId: maxId ?? null }));
   }, [sceneId, active, allInteractions, dispatch]);
 
   // Continuously mark the SELECTED thread seen as its interactions grow — this is

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -86,6 +86,12 @@ export function GamePage() {
   // keys with no `threadLastSeen` entry, so pre-existing threads (which get a
   // `threadLastSeen` entry from the selected-thread effect below, or already
   // had one) stay zeroed while a genuinely new thread badges from message one.
+  // `maxId ?? 0` (not `?? null`, review fix 2): a scene with ZERO interactions
+  // at load must still baseline to a real number — interaction ids are DB pks
+  // and never 0, so 0 is a safe "baselined empty" sentinel. `null` would be
+  // indistinguishable from "baseline effect hasn't run yet", which would make
+  // `countUnread` fall through to its no-baseline branch and stay silently
+  // unbadged for that scene's first message.
   const sceneBaselinedRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (!sceneId || !active) return;
@@ -96,7 +102,7 @@ export function GamePage() {
       const id = Number(interaction.id);
       if (maxId === undefined || id > maxId) maxId = id;
     }
-    dispatch(setSceneBaseline({ character: active, baselineId: maxId ?? null }));
+    dispatch(setSceneBaseline({ character: active, baselineId: maxId ?? 0 }));
   }, [sceneId, active, allInteractions, dispatch]);
 
   // Continuously mark the SELECTED thread seen as its interactions grow — this is

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { GameLayout } from './components/GameLayout';
 import { GameTopBar } from './components/GameTopBar';
 import { GameWindow } from './components/GameWindow';
@@ -16,6 +16,10 @@ import { Toaster } from '@/components/ui/sonner';
 import { Link } from 'react-router-dom';
 import { useAccount } from '@/store/hooks';
 import { useAppSelector } from '@/store/hooks';
+import { useSceneInteractions } from '@/scenes/hooks/useSceneInteractions';
+import { useThreading } from '@/scenes/hooks/useThreading';
+import { threadToComposerMode } from '@/scenes/hooks/threadToComposerMode';
+import type { ComposerMode } from './components/CommandInput';
 
 const DEFAULT_ROOM_ENTRY: FocusEntry = {
   kind: 'room',
@@ -38,6 +42,33 @@ export function GamePage() {
     [characters, active]
   );
   const activeCharacterId = activeEntry?.character_id ?? null;
+  // Lifted from GameWindow (#2156 review fold-in) — dedupes the roster query
+  // that both GamePage and GameWindow used to call independently.
+  const personaId = activeEntry?.primary_persona_id ?? null;
+
+  const activeSession = active ? sessions[active] : null;
+  const roomData = activeSession?.room ?? null;
+  const sceneData = activeSession?.scene ?? null;
+  const sceneId = sceneData ? String(sceneData.id) : undefined;
+  const roomName = sceneData?.name ?? roomData?.name ?? 'Room';
+
+  // GamePage is the composition root (#2156): it calls the scene-feed +
+  // threading hooks once for the active session's scene and feeds both the
+  // left column (ThreadSidebar via ConversationSidebar) and the center
+  // (SceneMessages + composer). Called unconditionally — sceneId is simply
+  // undefined with no active scene, which both hooks handle without firing
+  // network calls or producing threads.
+  const { allInteractions, hasNextPage, fetchNextPage } = useSceneInteractions(sceneId);
+  const threading = useThreading(allInteractions, roomName);
+  const [composerMode, setComposerMode] = useState<ComposerMode | undefined>();
+
+  const handleThreadClick = (key: string) => {
+    threading.setSelectedThread(key);
+    const thread = threading.threads.find((t) => t.key === key);
+    if (thread) {
+      setComposerMode(threadToComposerMode(thread, roomName));
+    }
+  };
 
   if (!account) {
     return (
@@ -54,10 +85,6 @@ export function GamePage() {
       </div>
     );
   }
-
-  const activeSession = active ? sessions[active] : null;
-  const roomData = activeSession?.room ?? null;
-  const sceneData = activeSession?.scene ?? null;
 
   // The tab label mirrors whatever is currently focused. While focused
   // on the room, fall back to the room name; defaults to "Room" when
@@ -79,8 +106,30 @@ export function GamePage() {
     <>
       <GameLayout
         topBar={<GameTopBar characters={characters} />}
-        leftSidebar={<ConversationSidebar />}
-        center={<GameWindow characters={characters} />}
+        leftSidebar={
+          <ConversationSidebar
+            threading={sceneId ? threading : undefined}
+            onThreadClick={handleThreadClick}
+          />
+        }
+        center={
+          <GameWindow
+            characters={characters}
+            sceneFeed={
+              sceneId
+                ? {
+                    sceneId,
+                    interactions: threading.filteredInteractions,
+                    hasNextPage,
+                    fetchNextPage,
+                  }
+                : undefined
+            }
+            composerMode={composerMode}
+            onModeChange={setComposerMode}
+            personaId={personaId}
+          />
+        }
         rightSidebar={
           <SidebarTabPanel
             roomTabLabel={roomTabLabel}

--- a/frontend/src/game/components/CharacterCardDrawer.test.tsx
+++ b/frontend/src/game/components/CharacterCardDrawer.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Character-card drawer (#2156, Task 7) — avatar click opens the clicked
+ * bubble's persona in-place over the conversation, with Friend/Whisper quick
+ * actions. Identity resolution is PUBLIC-roster-only (never outs a disguise):
+ * the persona payload carries no roster/character id, so the card must search
+ * by exact name and fall back to "not on the roster" for anything that
+ * doesn't match exactly — mirrors the leak-table rule in the task brief.
+ */
+import { fireEvent, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { CharacterCardDrawer } from './CharacterCardDrawer';
+import type { PoseUnitAvatarClickPersona } from '@/scenes/components/PoseUnit';
+import type { PaginatedResponse } from '@/shared/types';
+import type { RosterEntryData } from '@/roster/types';
+
+vi.mock('@/roster/queries', () => ({
+  useRosterEntryByNameQuery: vi.fn(),
+  useRosterEntryQuery: vi.fn(),
+}));
+vi.mock('@/friends/queries', () => ({
+  useAddFriendMutation: vi.fn(),
+}));
+
+import { useRosterEntryByNameQuery, useRosterEntryQuery } from '@/roster/queries';
+import { useAddFriendMutation } from '@/friends/queries';
+
+const mockSearchQuery = vi.mocked(useRosterEntryByNameQuery);
+const mockEntryQuery = vi.mocked(useRosterEntryQuery);
+const mockAddFriend = vi.mocked(useAddFriendMutation);
+
+const PERSONA: PoseUnitAvatarClickPersona = { id: 9, name: 'Alice', thumbnail_url: null };
+
+function emptySearch(isLoading = false): PaginatedResponse<RosterEntryData> | undefined {
+  return isLoading ? undefined : { count: 0, next: null, previous: null, results: [] };
+}
+
+function matchedEntry(): RosterEntryData {
+  return {
+    id: 42,
+    character: {
+      id: 100,
+      name: 'Alice',
+      background: 'Once upon a time in the Vale.',
+      age: 30,
+      galleries: [],
+    },
+    profile_picture: null,
+    tenures: [],
+    can_apply: false,
+    fullname: 'Alice',
+    quote: '',
+    description: '',
+    creation_provenance: 'player',
+    creation_provenance_display: 'Player-created',
+    created_for_table_name: null,
+  };
+}
+
+function mockNoSearchResult(isLoading = false) {
+  mockSearchQuery.mockReturnValue({
+    data: emptySearch(isLoading),
+    isLoading,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof useRosterEntryByNameQuery>);
+}
+
+function mockSearchMatch(entry: RosterEntryData) {
+  mockSearchQuery.mockReturnValue({
+    data: { count: 1, next: null, previous: null, results: [entry] },
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof useRosterEntryByNameQuery>);
+  mockEntryQuery.mockReturnValue({
+    data: entry,
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as unknown as UseQueryResult<RosterEntryData, Error>);
+}
+
+describe('CharacterCardDrawer', () => {
+  beforeEach(() => {
+    mockAddFriend.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as unknown as ReturnType<typeof useAddFriendMutation>);
+    mockEntryQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as unknown as UseQueryResult<RosterEntryData, Error>);
+  });
+
+  it('renders the persona name and avatar immediately, before the roster search resolves', () => {
+    mockNoSearchResult(true);
+    renderWithProviders(
+      <CharacterCardDrawer
+        persona={PERSONA}
+        onClose={vi.fn()}
+        viewerEntryId={7}
+        onWhisper={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('renders nothing (drawer closed) when persona is null', () => {
+    mockNoSearchResult(false);
+    renderWithProviders(
+      <CharacterCardDrawer persona={null} onClose={vi.fn()} viewerEntryId={7} onWhisper={vi.fn()} />
+    );
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+  });
+
+  describe('with a public roster match', () => {
+    beforeEach(() => {
+      mockSearchMatch(matchedEntry());
+    });
+
+    it('renders BackgroundSection/StatsSection content, the Full profile link, and FriendButton', () => {
+      renderWithProviders(
+        <CharacterCardDrawer
+          persona={PERSONA}
+          onClose={vi.fn()}
+          viewerEntryId={7}
+          onWhisper={vi.fn()}
+        />
+      );
+      expect(screen.getByText(/once upon a time in the vale/i)).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: /full profile/i });
+      expect(link).toHaveAttribute('href', '/characters/42');
+      expect(screen.getByRole('button', { name: /\+ friend alice/i })).toBeInTheDocument();
+    });
+
+    it('fires onWhisper with the persona name and closes the drawer', () => {
+      const onWhisper = vi.fn();
+      const onClose = vi.fn();
+      renderWithProviders(
+        <CharacterCardDrawer
+          persona={PERSONA}
+          onClose={onClose}
+          viewerEntryId={7}
+          onWhisper={onWhisper}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /whisper/i }));
+      expect(onWhisper).toHaveBeenCalledWith('Alice');
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('omits the FriendButton when there is no active viewer character', () => {
+      renderWithProviders(
+        <CharacterCardDrawer
+          persona={PERSONA}
+          onClose={vi.fn()}
+          viewerEntryId={null}
+          onWhisper={vi.fn()}
+        />
+      );
+      expect(screen.queryByRole('button', { name: /\+ friend/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with no public roster match (disguise / temporary / unlisted persona)', () => {
+    beforeEach(() => {
+      mockNoSearchResult(false);
+    });
+
+    it('renders the not-on-roster copy and no FriendButton or sheet data', () => {
+      renderWithProviders(
+        <CharacterCardDrawer
+          persona={PERSONA}
+          onClose={vi.fn()}
+          viewerEntryId={7}
+          onWhisper={vi.fn()}
+        />
+      );
+      expect(screen.getByText(/this face isn't on the public roster/i)).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /\+ friend/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /full profile/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('fires onClose when the drawer close control is activated', () => {
+    mockNoSearchResult(false);
+    const onClose = vi.fn();
+    renderWithProviders(
+      <CharacterCardDrawer
+        persona={PERSONA}
+        onClose={onClose}
+        viewerEntryId={7}
+        onWhisper={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/game/components/CharacterCardDrawer.tsx
+++ b/frontend/src/game/components/CharacterCardDrawer.tsx
@@ -1,0 +1,124 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { PersonaAvatar } from '@/components/PersonaAvatar';
+import { BackgroundSection, StatsSection, CharacterLink } from '@/components/character';
+import { FriendButton } from '@/friends/components/FriendButton';
+import { useRosterEntryByNameQuery, useRosterEntryQuery } from '@/roster/queries';
+import type { PoseUnitAvatarClickPersona } from '@/scenes/components/PoseUnit';
+
+export interface CharacterCardDrawerProps {
+  /** The clicked bubble's persona identity; `null` means the drawer is closed. */
+  persona: PoseUnitAvatarClickPersona | null;
+  onClose: () => void;
+  /** The viewer's active character's RosterEntry id, for the FriendButton. */
+  viewerEntryId: number | null;
+  /** Fired with the persona's name; caller sets composer mode + closes. */
+  onWhisper: (name: string) => void;
+}
+
+/**
+ * Avatar-click identity card (#2156) — opens in-place over the conversation
+ * (a `Sheet` drawer, not a page navigation) with quick Friend/Whisper actions.
+ *
+ * PRIVACY (never out alts / disguise integrity): the persona payload carried by
+ * an `Interaction` has no roster-entry or character-sheet id — only id/name/
+ * thumbnail. This is deliberate: resolving identity through anything other than
+ * the PUBLIC roster search would leak a disguised or temporary persona's real
+ * character. So this card resolves the profile ONLY via `useRosterEntryByNameQuery`
+ * (the same public, `AllowAny` `/api/roster/entries/?name=` search
+ * `RosterListPage` uses) and only accepts an EXACT name match (the filter itself
+ * is `icontains` server-side). No match — a disguise, a temporary persona, or an
+ * unlisted character — renders name + avatar + "This face isn't on the public
+ * roster." and no sheet data, no FriendButton. Never resolve through
+ * `receiver_persona_ids`, scene participation, or any other non-public linkage.
+ *
+ * Radix note: `SheetContent`'s `hideOverlay` only removes the dimming backdrop —
+ * the underlying Dialog is still `modal` (focus-trapped, outside pointer events
+ * disabled) unless `Sheet` itself is given `modal={false}`, which most of this
+ * repo's other `Sheet` usages don't do either. Making the conversation genuinely
+ * interactive behind the drawer needs `modal={false}` *and* suppressing the
+ * default dismiss-on-outside-interaction, which is more surface than this task's
+ * brief calls for — accepting the brief's own fallback: overlay + click-outside
+ * (or Esc, or the close button) to close.
+ */
+export function CharacterCardDrawer({
+  persona,
+  onClose,
+  viewerEntryId,
+  onWhisper,
+}: CharacterCardDrawerProps) {
+  const { data: searchResult, isLoading: searching } = useRosterEntryByNameQuery(persona?.name);
+  const match = searchResult?.results.find((entry) => entry.character.name === persona?.name);
+  const matchId = match?.id;
+  const { data: entry } = useRosterEntryQuery(matchId ?? 0);
+
+  const handleWhisper = () => {
+    if (!persona) return;
+    onWhisper(persona.name);
+    onClose();
+  };
+
+  return (
+    <Sheet
+      open={persona !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-md">
+        {persona && (
+          <>
+            <SheetHeader>
+              <div className="flex items-center gap-3">
+                <PersonaAvatar
+                  source={{ name: persona.name, thumbnailUrl: persona.thumbnail_url }}
+                  size="lg"
+                />
+                <SheetTitle>{persona.name}</SheetTitle>
+              </div>
+            </SheetHeader>
+
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              {matchId != null && (
+                <FriendButton
+                  viewerEntryId={viewerEntryId}
+                  targetEntryId={matchId}
+                  targetName={persona.name}
+                />
+              )}
+              <Button type="button" variant="outline" size="sm" onClick={handleWhisper}>
+                Whisper
+              </Button>
+            </div>
+
+            {searching ? (
+              <p className="mt-4 text-sm text-muted-foreground">Loading…</p>
+            ) : match && entry ? (
+              <div className="mt-4 space-y-4">
+                <BackgroundSection background={entry.character.background} />
+                <StatsSection
+                  age={entry.character.age}
+                  gender={entry.character.gender}
+                  race={entry.character.race}
+                  charClass={entry.character.char_class}
+                  level={entry.character.level}
+                  concept={entry.character.concept}
+                  family={entry.character.family}
+                  vocation={entry.character.vocation}
+                  socialRank={entry.character.social_rank}
+                />
+                <CharacterLink id={match.id} className="text-sm underline">
+                  Full profile →
+                </CharacterLink>
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-muted-foreground">
+                This face isn't on the public roster.
+              </p>
+            )}
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/game/components/CommandInput.test.tsx
+++ b/frontend/src/game/components/CommandInput.test.tsx
@@ -277,7 +277,7 @@ describe('CommandInput', () => {
     });
   });
 
-  it('pose without detachments uses WebSocket send and skips REST submitPose', () => {
+  it('pose without detachments still uses REST submitPose (scene poses always take REST)', () => {
     const mode: ComposerMode = { command: 'pose', targets: [], label: 'Pose' };
     render(
       <CommandInput
@@ -294,7 +294,54 @@ describe('CommandInput', () => {
     fireEvent.change(textarea, { target: { value: 'stands ready' } });
     fireEvent.keyDown(textarea, { key: 'Enter' });
 
-    expect(sendMock).toHaveBeenCalledWith('Alice', 'pose stands ready');
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(submitPoseMock).toHaveBeenCalledWith({
+      persona_id: 42,
+      scene_id: 1,
+      content: 'stands ready',
+    });
+  });
+
+  it('plain pose (no composerMode) with sceneId/personaId uses REST submitPose', () => {
+    render(<CommandInput character="Alice" sceneId="5" personaId={9} />);
+    const textarea = screen.getByRole('textbox');
+
+    fireEvent.change(textarea, { target: { value: 'looks around' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(submitPoseMock).toHaveBeenCalledWith({
+      persona_id: 9,
+      scene_id: 5,
+      content: 'looks around',
+    });
+  });
+
+  it('pose with no sceneId uses WebSocket send', () => {
+    const mode: ComposerMode = { command: 'pose', targets: [], label: 'Pose' };
+    render(<CommandInput character="Alice" composerMode={mode} personaId={9} />);
+    const textarea = screen.getByRole('textbox');
+
+    fireEvent.change(textarea, { target: { value: 'waves' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(sendMock).toHaveBeenCalledWith('Alice', 'pose waves');
+    expect(submitPoseMock).not.toHaveBeenCalled();
+  });
+
+  it('whisper composer mode with sceneId still uses WebSocket send (non-pose commands keep WS)', () => {
+    const mode: ComposerMode = {
+      command: 'whisper',
+      targets: ['Bob'],
+      label: 'Whisper → Bob',
+    };
+    render(<CommandInput character="Alice" composerMode={mode} sceneId="5" personaId={9} />);
+    const textarea = screen.getByRole('textbox');
+
+    fireEvent.change(textarea, { target: { value: 'secret message' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(sendMock).toHaveBeenCalledWith('Alice', 'whisper Bob=secret message');
     expect(submitPoseMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/game/components/CommandInput.test.tsx
+++ b/frontend/src/game/components/CommandInput.test.tsx
@@ -1,4 +1,4 @@
-import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
+import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { RenderOptions } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -19,9 +19,14 @@ function render(ui: ReactElement, options?: RenderOptions) {
 const sendMock = vi.fn();
 const submitPoseMock = vi.fn(() => Promise.resolve());
 const fetchSceneMock = vi.fn();
+const toastErrorMock = vi.fn();
 
 vi.mock('@/hooks/useGameSocket', () => ({
   useGameSocket: () => ({ send: sendMock }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: (...args: unknown[]) => toastErrorMock(...args), success: vi.fn() },
 }));
 
 vi.mock('@/scenes/queries', () => ({
@@ -76,7 +81,9 @@ describe('CommandInput', () => {
   beforeEach(() => {
     sendMock.mockClear();
     submitPoseMock.mockClear();
+    submitPoseMock.mockImplementation(() => Promise.resolve());
     fetchSceneMock.mockClear();
+    toastErrorMock.mockClear();
     queryClient.clear();
   });
 
@@ -343,6 +350,41 @@ describe('CommandInput', () => {
 
     expect(sendMock).toHaveBeenCalledWith('Alice', 'whisper Bob=secret message');
     expect(submitPoseMock).not.toHaveBeenCalled();
+  });
+
+  it('directed pose composer mode sends target_names on the REST path (#2156)', () => {
+    const mode: ComposerMode = { command: 'pose', targets: ['Bob'], label: 'Pose → Bob' };
+    render(<CommandInput character="Alice" composerMode={mode} sceneId="5" personaId={9} />);
+    const textarea = screen.getByRole('textbox');
+
+    fireEvent.change(textarea, { target: { value: 'confronts' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(submitPoseMock).toHaveBeenCalledWith({
+      persona_id: 9,
+      scene_id: 5,
+      content: 'confronts',
+      target_names: ['Bob'],
+    });
+  });
+
+  it('keeps the draft and surfaces an error toast when submitPose rejects (#2156)', async () => {
+    submitPoseMock.mockImplementation(() => Promise.reject(new Error('Not co-located.')));
+    const onPoseSubmitted = vi.fn();
+    render(
+      <CommandInput character="Alice" sceneId="5" personaId={9} onPoseSubmitted={onPoseSubmitted} />
+    );
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: 'looks around' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(submitPoseMock).toHaveBeenCalled();
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith('Not co-located.'));
+
+    // The draft survives the rejection — never silently eaten.
+    expect(textarea.value).toBe('looks around');
+    expect(onPoseSubmitted).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/game/components/CommandInput.tsx
+++ b/frontend/src/game/components/CommandInput.tsx
@@ -113,18 +113,16 @@ export function CommandInput({
       onSubmitAction(actionAttachment);
     }
 
-    // Determine submission path for scene poses.
-    // The REST path is used ONLY when the user has detached actions — this is
-    // the only case where we need an explicit action_link_ids override.
-    // For all other cases (no detachments, non-pose commands, outside a scene)
-    // the WebSocket path runs and server-side auto-link handles attachment.
+    // Determine submission path. The REST path (submit_pose) is now the
+    // canonical route for scene poses: it carries scene_id explicitly and the
+    // server enforces the co-location check (actor must be in the scene's
+    // room) that the WebSocket command protocol can't express. WS remains
+    // for non-pose commands (say, whisper, tt, ...) and for poses outside a
+    // scene (no sceneId/personaId — e.g. room-only poses with no active scene).
     const isPose = !composerMode || composerMode.command === 'pose';
     const detachedSet = new Set(detachedActionIds ?? []);
     const hasDetachments = detachedSet.size > 0;
-    // Entrance poses must take the REST path — pose_kind doesn't travel over
-    // the WebSocket command protocol.
-    const usesRestSubmit =
-      isPose && sceneId !== undefined && personaId != null && (hasDetachments || isEntrance);
+    const usesRestSubmit = isPose && sceneId !== undefined && personaId != null;
 
     if (usesRestSubmit) {
       // REST path: explicit action_link_ids override when the user has detached

--- a/frontend/src/game/components/CommandInput.tsx
+++ b/frontend/src/game/components/CommandInput.tsx
@@ -56,6 +56,14 @@ interface CommandInputProps {
   detachedActionIds?: number[];
   /** Called after a successful pose submit so the parent can clear detachedActionIds. */
   onPoseSubmitted?: () => void;
+  /**
+   * Whether the viewer's active persona is currently present at a Place in
+   * this scene (#2156) — gates the `tt` (tabletalk) mode in `ModeSelector`.
+   * Derived by the composition root (`GamePage`/`SceneDetailPage`) from the
+   * shared `['scene-places', id]` query so it dedupes with `PlaceBar`'s own
+   * fetch. Defaults to `false` when omitted.
+   */
+  isAtPlace?: boolean;
 }
 
 export function CommandInput({
@@ -73,6 +81,7 @@ export function CommandInput({
   pendingActionIds,
   detachedActionIds,
   onPoseSubmitted,
+  isAtPlace,
 }: CommandInputProps) {
   const [command, setCommand] = useState('');
   const [history, setHistory] = useState<string[]>([]);
@@ -253,8 +262,7 @@ export function CommandInput({
           <ModeSelector
             currentMode={composerMode?.command ?? 'pose'}
             onModeChange={handleModeChange}
-            // TODO: derive from PlacePresence when place system is integrated
-            isAtPlace={false}
+            isAtPlace={isAtPlace ?? false}
           />
         }
         rightSlot={

--- a/frontend/src/game/components/CommandInput.tsx
+++ b/frontend/src/game/components/CommandInput.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { useGameSocket } from '@/hooks/useGameSocket';
 import { RichTextInput } from '@/components/RichTextInput';
 import { ModeSelector } from '@/scenes/components/ModeSelector';
@@ -136,12 +137,18 @@ export function CommandInput({
     if (usesRestSubmit) {
       // REST path: explicit action_link_ids override when the user has detached
       // one or more pending actions. WebSocket send() is intentionally skipped
-      // to avoid creating two POSE Interactions for the same pose.
+      // to avoid creating two POSE Interactions for the same pose. The draft
+      // is only cleared on success (#2156 review fix) — a rejected request
+      // (e.g. the co-location 400) must not silently eat the player's text;
+      // the composer keeps it and the server's error surfaces via toast so a
+      // retry doesn't mean retyping the whole pose.
+      const composerTargets = composerMode?.targets ?? [];
       submitPose({
         persona_id: personaId,
         scene_id: Number(sceneId),
         content: trimmed,
         pose_kind: isEntrance ? 'entry' : undefined,
+        ...(composerTargets.length > 0 ? { target_names: composerTargets } : {}),
         ...(hasDetachments
           ? {
               action_link_ids: (pendingActionIds ?? []).filter((id) => !detachedSet.has(id)),
@@ -150,14 +157,24 @@ export function CommandInput({
       })
         .then(() => {
           onPoseSubmitted?.();
+          setHistory((prev) => [...prev, trimmed]);
+          setHistoryIndex(-1);
+          setCommand('');
+          setIsEntrance(false);
         })
-        .catch(() => {});
-      setIsEntrance(false);
-    } else {
-      // WebSocket path: existing behavior. Server-side auto-link will attach
-      // any pending ACTION interactions when the POSE is created.
-      send(character, fullCommand);
+        .catch((error: unknown) => {
+          const message = error instanceof Error ? error.message : 'Failed to submit pose.';
+          toast.error(message);
+        })
+        .finally(() => {
+          submittingRef.current = false;
+        });
+      return;
     }
+
+    // WebSocket path: existing behavior. Server-side auto-link will attach
+    // any pending ACTION interactions when the POSE is created.
+    send(character, fullCommand);
 
     setHistory((prev) => [...prev, trimmed]);
     setHistoryIndex(-1);

--- a/frontend/src/game/components/ConversationSidebar.tsx
+++ b/frontend/src/game/components/ConversationSidebar.tsx
@@ -1,17 +1,63 @@
+import { useState } from 'react';
 import { MessageSquare } from 'lucide-react';
+import { ThreadSidebar } from '@/scenes/components/ThreadSidebar';
+import { ThreadFilterModal } from '@/scenes/components/ThreadFilterModal';
+import type { ThreadingState } from '@/scenes/hooks/useThreading';
 
-export function ConversationSidebar() {
+interface ConversationSidebarProps {
+  /** The active scene's threading state, composed once by `GamePage` (#2156). Absent with no active scene. */
+  threading?: ThreadingState;
+  /** Fired with a thread's key when it's clicked — GamePage owns the composer-mode translation. */
+  onThreadClick: (key: string) => void;
+}
+
+export function ConversationSidebar({ threading, onThreadClick }: ConversationSidebarProps) {
+  const [filterThreadKey, setFilterThreadKey] = useState<string | null>(null);
+
+  if (!threading) {
+    return (
+      <div className="flex flex-col">
+        <div className="border-b px-3 py-2">
+          <h3 className="text-xs font-semibold uppercase text-muted-foreground">Conversations</h3>
+        </div>
+        <div className="flex-1">
+          <button className="flex w-full items-center gap-2 bg-accent px-3 py-2 text-sm">
+            <MessageSquare className="h-4 w-4" />
+            <span className="font-medium">Room</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const filterThread = filterThreadKey
+    ? threading.threads.find((t) => t.key === filterThreadKey)
+    : undefined;
+
   return (
     <div className="flex flex-col">
       <div className="border-b px-3 py-2">
         <h3 className="text-xs font-semibold uppercase text-muted-foreground">Conversations</h3>
       </div>
-      <div className="flex-1">
-        <button className="flex w-full items-center gap-2 bg-accent px-3 py-2 text-sm">
-          <MessageSquare className="h-4 w-4" />
-          <span className="font-medium">Room</span>
-        </button>
-      </div>
+      <ThreadSidebar
+        threads={threading.threads}
+        selectedThreadKey={threading.selectedThreadKey}
+        enabledThreadKeys={threading.enabledThreadKeys}
+        isUnfiltered={threading.enabledThreadKeys.size === 0}
+        onThreadClick={onThreadClick}
+        onShowAll={threading.showAll}
+        onOpenFilter={setFilterThreadKey}
+      />
+
+      {filterThread && filterThreadKey && (
+        <ThreadFilterModal
+          open={!!filterThreadKey}
+          onClose={() => setFilterThreadKey(null)}
+          thread={filterThread}
+          hiddenPersonaIds={threading.getHiddenPersonaIds(filterThreadKey)}
+          onTogglePersona={(id) => threading.togglePersonaHidden(filterThreadKey, id)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -1,8 +1,10 @@
+import { useMemo } from 'react';
 import { ChatWindow } from './ChatWindow';
 import { CommandInput } from './CommandInput';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setActiveSession } from '@/store/gameSlice';
 import { useGameSocket } from '@/hooks/useGameSocket';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { Link } from 'react-router-dom';
 import type { MyRosterEntry } from '@/roster/types';
 
@@ -14,6 +16,11 @@ export function GameWindow({ characters }: GameWindowProps) {
   const dispatch = useAppDispatch();
   const { connect } = useGameSocket();
   const { sessions, active } = useAppSelector((state) => state.game);
+  const { data: myEntries = [] } = useMyRosterEntriesQuery();
+  const personaId = useMemo(
+    () => myEntries.find((e) => e.name === active)?.primary_persona_id ?? null,
+    [myEntries, active]
+  );
 
   if (characters.length === 0) {
     return (
@@ -39,6 +46,7 @@ export function GameWindow({ characters }: GameWindowProps) {
 
   const session = sessions[active];
   const sessionNames = Object.keys(sessions);
+  const sceneId = session.scene ? String(session.scene.id) : undefined;
 
   const handleTabClick = (name: MyRosterEntry['name']) => {
     dispatch(setActiveSession(name));
@@ -68,7 +76,7 @@ export function GameWindow({ characters }: GameWindowProps) {
         </div>
       )}
       <ChatWindow messages={session.messages} />
-      <CommandInput character={active} />
+      <CommandInput character={active} sceneId={sceneId} personaId={personaId} />
     </div>
   );
 }

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { ChatWindow } from './ChatWindow';
 import { CommandInput } from './CommandInput';
 import type { ComposerMode } from './CommandInput';
@@ -5,6 +6,7 @@ import { SystemLane } from './SystemLane';
 import { SceneMessages } from '@/scenes/components/SceneMessages';
 import type { PoseUnitAvatarClickPersona } from '@/scenes/components/PoseUnit';
 import type { Interaction } from '@/scenes/types';
+import type { ActionAttachmentInfo } from '@/scenes/actionTypes';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setActiveSession } from '@/store/gameSlice';
 import { useGameSocket } from '@/hooks/useGameSocket';
@@ -29,6 +31,29 @@ interface GameWindowProps {
   personaId: number | null;
   /** Avatar identity-click affordance (#2156) — not wired up until the character-card task (Task 7). */
   onAvatarClick?: (persona: PoseUnitAvatarClickPersona) => void;
+  /**
+   * Scene toolset plumbing (#2156, Task 6) — GamePage is the composition root
+   * that owns this state (mirroring `SceneDetailPage`'s handler state); these
+   * are threaded straight through to `SceneMessages` and `CommandInput` since
+   * both live inside this component.
+   */
+  onAddTarget?: (personaName: string) => void;
+  onAttachAction?: (action: ActionAttachmentInfo) => void;
+  targetToAppend?: string | null;
+  onTargetConsumed?: () => void;
+  actionAttachment?: ActionAttachmentInfo | null;
+  onActionAttach?: (action: ActionAttachmentInfo) => void;
+  onActionDetach?: () => void;
+  onSubmitAction?: (action: ActionAttachmentInfo) => void;
+  pendingActionIds?: number[];
+  detachedActionIds?: number[];
+  onPoseSubmitted?: () => void;
+  /** Whether the viewer's persona is present at a Place in this scene (#2156) — gates `tt`. */
+  isAtPlace?: boolean;
+  /** `PlaceBar`, rendered directly above the composer (#2156). */
+  placeBar?: ReactNode;
+  /** `PendingActionAttachments`, rendered directly above the composer (#2156). */
+  pendingAttachments?: ReactNode;
 }
 
 export function GameWindow({
@@ -38,6 +63,20 @@ export function GameWindow({
   onModeChange,
   personaId,
   onAvatarClick,
+  onAddTarget,
+  onAttachAction,
+  targetToAppend,
+  onTargetConsumed,
+  actionAttachment,
+  onActionAttach,
+  onActionDetach,
+  onSubmitAction,
+  pendingActionIds,
+  detachedActionIds,
+  onPoseSubmitted,
+  isAtPlace,
+  placeBar,
+  pendingAttachments,
 }: GameWindowProps) {
   const dispatch = useAppDispatch();
   const { connect } = useGameSocket();
@@ -102,6 +141,8 @@ export function GameWindow({
               sceneId={sceneFeed.sceneId}
               filteredInteractions={sceneFeed.interactions}
               onAvatarClick={onAvatarClick}
+              onAddTarget={onAddTarget}
+              onAttachAction={onAttachAction}
             />
             {sceneFeed.hasNextPage && (
               <button onClick={() => sceneFeed.fetchNextPage()} className="mt-4 px-4">
@@ -114,12 +155,24 @@ export function GameWindow({
       ) : (
         <ChatWindow messages={session.messages} />
       )}
+      {placeBar}
+      {pendingAttachments}
       <CommandInput
         character={active}
         sceneId={sceneFeed?.sceneId}
         personaId={personaId}
         composerMode={composerMode}
         onModeChange={onModeChange}
+        targetToAppend={targetToAppend}
+        onTargetConsumed={onTargetConsumed}
+        actionAttachment={actionAttachment}
+        onActionAttach={onActionAttach}
+        onActionDetach={onActionDetach}
+        onSubmitAction={onSubmitAction}
+        pendingActionIds={pendingActionIds}
+        detachedActionIds={detachedActionIds}
+        onPoseSubmitted={onPoseSubmitted}
+        isAtPlace={isAtPlace}
       />
     </div>
   );

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -29,7 +29,7 @@ interface GameWindowProps {
   onModeChange: (mode: ComposerMode) => void;
   /** The active character's persona id — lifted to GamePage to dedupe the roster query (#2156). */
   personaId: number | null;
-  /** Avatar identity-click affordance (#2156) — not wired up until the character-card task (Task 7). */
+  /** Avatar identity-click affordance (#2156) — opens the character-card drawer (Task 7). */
   onAvatarClick?: (persona: PoseUnitAvatarClickPersona) => void;
   /**
    * Scene toolset plumbing (#2156, Task 6) — GamePage is the composition root

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -1,26 +1,47 @@
-import { useMemo } from 'react';
 import { ChatWindow } from './ChatWindow';
 import { CommandInput } from './CommandInput';
+import type { ComposerMode } from './CommandInput';
+import { SystemLane } from './SystemLane';
+import { SceneMessages } from '@/scenes/components/SceneMessages';
+import type { PoseUnitAvatarClickPersona } from '@/scenes/components/PoseUnit';
+import type { Interaction } from '@/scenes/types';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setActiveSession } from '@/store/gameSlice';
 import { useGameSocket } from '@/hooks/useGameSocket';
-import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { Link } from 'react-router-dom';
 import type { MyRosterEntry } from '@/roster/types';
 
-interface GameWindowProps {
-  characters: MyRosterEntry[];
+/** The active scene's live feed, composed once by `GamePage` (#2156). */
+export interface GameWindowSceneFeed {
+  sceneId: string;
+  interactions: Interaction[];
+  hasNextPage?: boolean;
+  fetchNextPage: () => void;
 }
 
-export function GameWindow({ characters }: GameWindowProps) {
+interface GameWindowProps {
+  characters: MyRosterEntry[];
+  /** When present, the center column renders the structured scene feed instead of ChatWindow. */
+  sceneFeed?: GameWindowSceneFeed;
+  composerMode?: ComposerMode;
+  onModeChange: (mode: ComposerMode) => void;
+  /** The active character's persona id — lifted to GamePage to dedupe the roster query (#2156). */
+  personaId: number | null;
+  /** Avatar identity-click affordance (#2156) — not wired up until the character-card task (Task 7). */
+  onAvatarClick?: (persona: PoseUnitAvatarClickPersona) => void;
+}
+
+export function GameWindow({
+  characters,
+  sceneFeed,
+  composerMode,
+  onModeChange,
+  personaId,
+  onAvatarClick,
+}: GameWindowProps) {
   const dispatch = useAppDispatch();
   const { connect } = useGameSocket();
   const { sessions, active } = useAppSelector((state) => state.game);
-  const { data: myEntries = [] } = useMyRosterEntriesQuery();
-  const personaId = useMemo(
-    () => myEntries.find((e) => e.name === active)?.primary_persona_id ?? null,
-    [myEntries, active]
-  );
 
   if (characters.length === 0) {
     return (
@@ -46,7 +67,6 @@ export function GameWindow({ characters }: GameWindowProps) {
 
   const session = sessions[active];
   const sessionNames = Object.keys(sessions);
-  const sceneId = session.scene ? String(session.scene.id) : undefined;
 
   const handleTabClick = (name: MyRosterEntry['name']) => {
     dispatch(setActiveSession(name));
@@ -75,8 +95,32 @@ export function GameWindow({ characters }: GameWindowProps) {
           ))}
         </div>
       )}
-      <ChatWindow messages={session.messages} />
-      <CommandInput character={active} sceneId={sceneId} personaId={personaId} />
+      {sceneFeed ? (
+        <>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <SceneMessages
+              sceneId={sceneFeed.sceneId}
+              filteredInteractions={sceneFeed.interactions}
+              onAvatarClick={onAvatarClick}
+            />
+            {sceneFeed.hasNextPage && (
+              <button onClick={() => sceneFeed.fetchNextPage()} className="mt-4 px-4">
+                Load More
+              </button>
+            )}
+          </div>
+          <SystemLane messages={session.messages} />
+        </>
+      ) : (
+        <ChatWindow messages={session.messages} />
+      )}
+      <CommandInput
+        character={active}
+        sceneId={sceneFeed?.sceneId}
+        personaId={personaId}
+        composerMode={composerMode}
+        onModeChange={onModeChange}
+      />
     </div>
   );
 }

--- a/frontend/src/game/components/SystemLane.test.tsx
+++ b/frontend/src/game/components/SystemLane.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SystemLane } from './SystemLane';
+import { GAME_MESSAGE_TYPE } from '@/hooks/types';
+import type { GameMessage } from '@/hooks/types';
+
+function makeMessage(id: string, content: string): GameMessage & { id: string } {
+  return {
+    id,
+    content,
+    timestamp: Date.parse('2026-01-01T00:00:00Z'),
+    type: GAME_MESSAGE_TYPE.SYSTEM,
+  };
+}
+
+describe('SystemLane', () => {
+  it('renders nothing when there are no messages', () => {
+    const { container } = render(<SystemLane messages={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('starts collapsed, showing a count badge and no message list', () => {
+    render(<SystemLane messages={[makeMessage('1', 'Server restarting soon.')]} />);
+
+    expect(screen.getByTestId('system-lane-count')).toHaveTextContent('1');
+    expect(screen.queryByTestId('system-lane-messages')).toBeNull();
+    expect(screen.queryByText('Server restarting soon.')).not.toBeInTheDocument();
+  });
+
+  it('expands to reveal messages on click, and hides the count badge', () => {
+    render(<SystemLane messages={[makeMessage('1', 'Server restarting soon.')]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /system/i }));
+
+    expect(screen.getByTestId('system-lane-messages')).toBeInTheDocument();
+    expect(screen.getByText('Server restarting soon.')).toBeInTheDocument();
+    expect(screen.queryByTestId('system-lane-count')).toBeNull();
+  });
+
+  it('collapses again on a second click', () => {
+    render(<SystemLane messages={[makeMessage('1', 'Server restarting soon.')]} />);
+    const toggle = screen.getByRole('button', { name: /system/i });
+
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('system-lane-messages')).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.queryByTestId('system-lane-messages')).toBeNull();
+    expect(screen.getByTestId('system-lane-count')).toHaveTextContent('1');
+  });
+
+  it('never applies terminal styling (no bg-black / font-mono) on the lane container', () => {
+    const { container } = render(
+      <SystemLane messages={[makeMessage('1', 'Server restarting soon.')]} />
+    );
+    const lane = container.firstElementChild as HTMLElement;
+    expect(lane.className).not.toMatch(/bg-black/);
+    expect(lane.className).not.toMatch(/font-mono/);
+    expect(lane.className).toMatch(/text-xs/);
+    expect(lane.className).toMatch(/text-muted-foreground/);
+  });
+});

--- a/frontend/src/game/components/SystemLane.tsx
+++ b/frontend/src/game/components/SystemLane.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { GameMessage } from '@/hooks/types';
+import { EvenniaMessage } from './EvenniaMessage';
+
+interface SystemLaneProps {
+  messages: Array<GameMessage & { id: string }>;
+}
+
+/**
+ * Muted, collapsible strip for system/channel/error chatter (#2156). Chat
+ * bubbles on the primary feed are the ratified presentation; this lane keeps
+ * the raw Evennia-style log line output around (still useful for debugging
+ * and out-of-narrative notices) without letting it read as a terminal —
+ * no `bg-black`/`font-mono` on the lane itself, just a quiet compact strip
+ * that expands on demand.
+ */
+export function SystemLane({ messages }: SystemLaneProps) {
+  const [collapsed, setCollapsed] = useState(true);
+
+  if (messages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="shrink-0 border-t px-3 py-1 text-xs text-muted-foreground">
+      <button
+        type="button"
+        onClick={() => setCollapsed((prev) => !prev)}
+        aria-expanded={!collapsed}
+        className="flex w-full items-center gap-1 py-1 text-left transition-colors hover:text-foreground"
+      >
+        {collapsed ? (
+          <ChevronRight className="h-3 w-3 shrink-0" />
+        ) : (
+          <ChevronDown className="h-3 w-3 shrink-0" />
+        )}
+        <span>System</span>
+        {collapsed && (
+          <span
+            data-testid="system-lane-count"
+            className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-muted px-1"
+          >
+            {messages.length}
+          </span>
+        )}
+      </button>
+      {!collapsed && (
+        <div
+          data-testid="system-lane-messages"
+          className="max-h-40 space-y-0.5 overflow-y-auto pb-1 pl-4"
+        >
+          {messages.map((message) => (
+            <div key={message.id} className="flex gap-2">
+              <span className="shrink-0 text-muted-foreground/70">
+                {new Date(message.timestamp).toLocaleTimeString()}
+              </span>
+              <EvenniaMessage content={message.content} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -28853,6 +28853,8 @@ export interface components {
       /** Format: date-time */
       readonly created_at: string;
       readonly presence_count: number;
+      /** @description Whether one of the requesting account's personas is present at this place (#2156). */
+      readonly viewer_is_present: boolean;
     };
     PlaceRequest: {
       name: string;

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -7669,11 +7669,18 @@ export interface paths {
     get?: never;
     put?: never;
     /**
-     * @description Create a POSE Interaction and auto-link prior ACTION Interactions.
+     * @description Create a POSE Interaction with full WS-pose-path parity (#2156).
      *
      *     Accepts ``action_link_ids`` for an explicit override:
      *     - Absent (key missing): auto-link is run.
      *     - Present as a list (even empty): exact links are created; auto-link skipped.
+     *
+     *     Mirrors ``actions.definitions.communication.PoseAction.execute``: broadcasts
+     *     the raw text via ``message_location`` (telnet visibility), records through the
+     *     shared ``record_interaction`` seam (ephemeral-scene gate, SceneParticipation +
+     *     covenant engagement), and flags blocked-contact attempts for any resolved
+     *     directed-pose targets. ``target_names`` (composer-mode ``@Name`` targets) are
+     *     resolved with the same semantics as the WS ``@Name``-prefix parser.
      */
     post: operations['interactions_submit_pose_create'];
     delete?: never;

--- a/frontend/src/roster/api.ts
+++ b/frontend/src/roster/api.ts
@@ -108,11 +108,15 @@ export async function updateTenureGallery(
 }
 
 export async function fetchRosterEntries(
-  rosterId: RosterData['id'],
+  rosterId: RosterData['id'] | undefined,
   page = 1,
   filters: Partial<Pick<CharacterData, 'name' | 'char_class' | 'gender'>> = {}
 ): Promise<PaginatedResponse<RosterEntryData>> {
-  const params = new URLSearchParams({ roster: String(rosterId), page: String(page) });
+  const params = new URLSearchParams({ page: String(page) });
+  // `roster` is optional server-side (world/roster/filters.py's RosterEntryFilterSet) —
+  // omitting it searches across every public roster, which the character-card drawer's
+  // identity resolution relies on (#2156): a persona name isn't scoped to a roster.
+  if (rosterId !== undefined) params.set('roster', String(rosterId));
   if (filters.name) params.set('name', filters.name);
   if (filters.char_class) params.set('char_class', filters.char_class);
   if (filters.gender) params.set('gender', filters.gender);

--- a/frontend/src/roster/queries.ts
+++ b/frontend/src/roster/queries.ts
@@ -73,6 +73,24 @@ export function useRosterEntriesQuery(
   });
 }
 
+/**
+ * Public roster search by exact persona name (#2156) — the character-card drawer's
+ * ONLY allowed identity-resolution path. Searches across every public roster (no
+ * `roster` scope) since a persona name isn't tied to one; the `name` filter is
+ * `icontains` server-side, so callers must still check for an exact
+ * `result.character.name === name` match before treating it as a hit — a
+ * disguised/temporary persona whose name doesn't exactly match a public roster
+ * entry must render as "not on the roster," never fall back to a substring match.
+ */
+export function useRosterEntryByNameQuery(name: string | undefined) {
+  return useQuery<PaginatedResponse<RosterEntryData>>({
+    queryKey: ['roster-entry-by-name', name],
+    queryFn: () => fetchRosterEntries(undefined, 1, { name }),
+    enabled: !!name,
+    throwOnError: true,
+  });
+}
+
 export function useSendRosterApplication(id: RosterEntryData['id']) {
   return useMutation({
     mutationFn: (message: string) => postRosterApplication(id, message),

--- a/frontend/src/scenes/actionTypes.ts
+++ b/frontend/src/scenes/actionTypes.ts
@@ -252,6 +252,13 @@ export interface Place {
   id: number;
   name: string;
   description: string;
+  /**
+   * Whether one of the viewer's own personas is currently present at this
+   * place (#2156). Served by `PlaceSerializer.viewer_is_present` — hand-typed
+   * here because the generated `api.d.ts` from Task 1 doesn't carry it yet
+   * (schema regen deferred to Task 8).
+   */
+  viewer_is_present: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/scenes/components/PoseUnit.test.tsx
+++ b/frontend/src/scenes/components/PoseUnit.test.tsx
@@ -385,6 +385,110 @@ describe('PoseUnit', () => {
 
     expect(screen.queryByTestId('standalone-action-expand')).toBeNull();
   });
+
+  // ---------------------------------------------------------------------------
+  // Chat-bubble restyle + avatar identity click (#2156)
+  // ---------------------------------------------------------------------------
+
+  it('clicking the avatar fires onAvatarClick with the interaction persona (POSE)', () => {
+    const onAvatarClick = vi.fn();
+    const interaction = makeInteraction({
+      mode: 'pose',
+      persona: { id: 10, name: 'Alice', thumbnail_url: '/alice.png' },
+    });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" onAvatarClick={onAvatarClick} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Alice' }));
+    expect(onAvatarClick).toHaveBeenCalledWith({
+      id: 10,
+      name: 'Alice',
+      thumbnail_url: '/alice.png',
+    });
+  });
+
+  it('clicking the avatar fires onAvatarClick on the standalone ACTION branch', () => {
+    const onAvatarClick = vi.fn();
+    const interaction = makeInteraction({
+      mode: 'action',
+      persona: { id: 10, name: 'Alice', thumbnail_url: null },
+      action_links: [],
+    });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" onAvatarClick={onAvatarClick} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Alice' }));
+    expect(onAvatarClick).toHaveBeenCalledWith({ id: 10, name: 'Alice', thumbnail_url: null });
+  });
+
+  it('avatar is not an interactive button when onAvatarClick is not provided', () => {
+    const interaction = makeInteraction({ mode: 'pose' });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    expect(screen.queryByRole('button', { name: 'View Alice' })).toBeNull();
+  });
+
+  it('POSE branch still exposes data-testid="pose-unit" as a chat bubble', () => {
+    const interaction = makeInteraction({ mode: 'pose' });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    const bubble = screen.getByTestId('pose-unit');
+    expect(bubble).toHaveClass('rounded-lg');
+    expect(bubble).toHaveClass('bg-muted/40');
+    expect(bubble).not.toHaveClass('border-b');
+  });
+
+  it('standalone ACTION branch also renders as a bubble', () => {
+    const interaction = makeInteraction({ mode: 'action', action_links: [] });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    const bubble = screen.getByTestId('pose-unit-action-standalone');
+    expect(bubble).toHaveClass('rounded-lg');
+    expect(bubble).toHaveClass('bg-muted/40');
+    expect(bubble).not.toHaveClass('border-b');
+  });
+
+  it('outcome branch keeps its muted-system-notice look with no border', () => {
+    const interaction = makeInteraction({
+      mode: 'outcome',
+      persona: { id: 99, name: 'Narrator', thumbnail_url: '' },
+      content: 'The dust settles.',
+    });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    const notice = screen.getByTestId('pose-unit-outcome');
+    expect(notice).toHaveClass('italic');
+    expect(notice).toHaveClass('text-muted-foreground');
+    expect(notice).not.toHaveClass('border-b');
+  });
 });
 
 describe('PoseUnit outcome mode', () => {

--- a/frontend/src/scenes/components/PoseUnit.test.tsx
+++ b/frontend/src/scenes/components/PoseUnit.test.tsx
@@ -415,7 +415,7 @@ describe('PoseUnit', () => {
     const onAvatarClick = vi.fn();
     const interaction = makeInteraction({
       mode: 'action',
-      persona: { id: 10, name: 'Alice', thumbnail_url: null },
+      persona: { id: 10, name: 'Alice', thumbnail_url: undefined },
       action_links: [],
     });
 

--- a/frontend/src/scenes/components/PoseUnit.tsx
+++ b/frontend/src/scenes/components/PoseUnit.tsx
@@ -54,6 +54,54 @@ function ActionChip({ link, onExpandRequest }: ActionChipProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Avatar identity affordance (#2156)
+// ---------------------------------------------------------------------------
+
+interface PoseUnitAvatarProps {
+  interaction: Interaction;
+  onAvatarClick?: (persona: PoseUnitAvatarClickPersona) => void;
+}
+
+/**
+ * Avatar thumbnail in the bubble header. Identity click surface (#2156) — the
+ * name stays the PersonaContextMenu action surface; the avatar itself opens
+ * the character card. Renders as a plain (non-interactive) avatar when
+ * `onAvatarClick` isn't provided.
+ */
+function PoseUnitAvatar({ interaction, onAvatarClick }: PoseUnitAvatarProps) {
+  const avatar = (
+    <PersonaAvatar
+      source={{
+        name: interaction.persona.name,
+        thumbnailUrl: interaction.persona.thumbnail_url,
+      }}
+      size="sm"
+    />
+  );
+
+  if (!onAvatarClick) {
+    return avatar;
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={`View ${interaction.persona.name}`}
+      className="rounded-full transition-opacity hover:opacity-80"
+      onClick={() =>
+        onAvatarClick({
+          id: interaction.persona.id,
+          name: interaction.persona.name,
+          thumbnail_url: interaction.persona.thumbnail_url ?? null,
+        })
+      }
+    >
+      {avatar}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Reactions footer (mirrors SceneMessages pattern)
 // ---------------------------------------------------------------------------
 
@@ -108,6 +156,13 @@ function ReactionsFooter({ interaction, sceneId }: ReactionsFooterProps) {
 // PoseUnit
 // ---------------------------------------------------------------------------
 
+/** Minimal persona identity payload forwarded by the avatar-click affordance (#2156). */
+export interface PoseUnitAvatarClickPersona {
+  id: number;
+  name: string;
+  thumbnail_url: string | null;
+}
+
 export interface PoseUnitProps {
   interaction: Interaction;
   sceneId: string;
@@ -115,6 +170,13 @@ export interface PoseUnitProps {
   onAttachAction?: (action: ActionAttachmentInfo) => void;
   /** When true, shows the "Tag dramatic moment" GM control (#1139). */
   canGm?: boolean;
+  /**
+   * Avatar-click identity affordance (#2156): fired with the interaction's
+   * persona when the avatar thumbnail is clicked. The avatar renders as a
+   * plain (non-interactive) image when this prop is absent — the name's
+   * PersonaContextMenu remains the action surface either way.
+   */
+  onAvatarClick?: (persona: PoseUnitAvatarClickPersona) => void;
 }
 
 export function PoseUnit({
@@ -123,6 +185,7 @@ export function PoseUnit({
   onAddTarget,
   onAttachAction,
   canGm = false,
+  onAvatarClick,
 }: PoseUnitProps) {
   const isAction = interaction.mode === 'action';
   const actionLinks = interaction.action_links ?? [];
@@ -141,15 +204,12 @@ export function PoseUnit({
   // -------------------------------------------------------------------------
   if (isAction) {
     return (
-      <div className="border-b py-2" data-testid="pose-unit-action-standalone">
+      <div
+        className="my-1.5 max-w-[85%] rounded-lg bg-muted/40 px-3 py-2"
+        data-testid="pose-unit-action-standalone"
+      >
         <div className="flex items-center gap-2">
-          <PersonaAvatar
-            source={{
-              name: interaction.persona.name,
-              thumbnailUrl: interaction.persona.thumbnail_url,
-            }}
-            size="sm"
-          />
+          <PoseUnitAvatar interaction={interaction} onAvatarClick={onAvatarClick} />
           <PersonaContextMenu
             personaId={interaction.persona.id}
             personaName={interaction.persona.name}
@@ -203,7 +263,7 @@ export function PoseUnit({
   if (interaction.mode === 'outcome') {
     return (
       <div
-        className="border-b py-1.5 pl-2 text-sm italic text-muted-foreground"
+        className="my-1 pl-2 text-sm italic text-muted-foreground"
         data-testid="pose-unit-outcome"
       >
         <FormattedContent content={interaction.content} />
@@ -215,16 +275,10 @@ export function PoseUnit({
   // State 1 + 2: POSE (with or without linked actions)
   // -------------------------------------------------------------------------
   return (
-    <div className="border-b py-2" data-testid="pose-unit">
+    <div className="my-1.5 max-w-[85%] rounded-lg bg-muted/40 px-3 py-2" data-testid="pose-unit">
       {/* Header: avatar + name + timestamp */}
       <div className="flex items-center gap-2">
-        <PersonaAvatar
-          source={{
-            name: interaction.persona.name,
-            thumbnailUrl: interaction.persona.thumbnail_url,
-          }}
-          size="sm"
-        />
+        <PoseUnitAvatar interaction={interaction} onAvatarClick={onAvatarClick} />
         <PersonaContextMenu
           personaId={interaction.persona.id}
           personaName={interaction.persona.name}

--- a/frontend/src/scenes/components/SceneInteractionPanel.tsx
+++ b/frontend/src/scenes/components/SceneInteractionPanel.tsx
@@ -5,6 +5,7 @@ import { threadToComposerMode } from '../hooks/threadToComposerMode';
 import { ThreadSidebar } from './ThreadSidebar';
 import { ThreadFilterModal } from './ThreadFilterModal';
 import { SceneMessages } from './SceneMessages';
+import type { PoseUnitAvatarClickPersona } from './PoseUnit';
 import type { ComposerMode } from '@/game/components/CommandInput';
 import type { ActionAttachmentInfo } from '../actionTypes';
 
@@ -16,6 +17,8 @@ interface SceneInteractionPanelProps {
   onAttachAction?: (action: ActionAttachmentInfo) => void;
   /** When true, shows the GM dramatic-moment tagging control on each pose (#1139). */
   canGm?: boolean;
+  /** Avatar identity-click affordance passthrough to SceneMessages/PoseUnit (#2156). */
+  onAvatarClick?: (persona: PoseUnitAvatarClickPersona) => void;
 }
 
 export function SceneInteractionPanel({
@@ -25,6 +28,7 @@ export function SceneInteractionPanel({
   onAddTarget,
   onAttachAction,
   canGm,
+  onAvatarClick,
 }: SceneInteractionPanelProps) {
   const { allInteractions, hasNextPage, fetchNextPage } = useSceneInteractions(sceneId);
   const {
@@ -86,6 +90,7 @@ export function SceneInteractionPanel({
           onAddTarget={onAddTarget}
           onAttachAction={onAttachAction}
           canGm={canGm}
+          onAvatarClick={onAvatarClick}
         />
         {hasNextPage && (
           <button onClick={() => fetchNextPage()} className="mt-4 px-4">

--- a/frontend/src/scenes/components/SceneInteractionPanel.tsx
+++ b/frontend/src/scenes/components/SceneInteractionPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useSceneInteractions } from '../hooks/useSceneInteractions';
 import { useThreading } from '../hooks/useThreading';
-import type { Thread } from '../hooks/useThreading';
+import { threadToComposerMode } from '../hooks/threadToComposerMode';
 import { ThreadSidebar } from './ThreadSidebar';
 import { ThreadFilterModal } from './ThreadFilterModal';
 import { SceneMessages } from './SceneMessages';
@@ -16,27 +16,6 @@ interface SceneInteractionPanelProps {
   onAttachAction?: (action: ActionAttachmentInfo) => void;
   /** When true, shows the GM dramatic-moment tagging control on each pose (#1139). */
   canGm?: boolean;
-}
-
-function threadToComposerMode(thread: Thread, roomName: string): ComposerMode {
-  switch (thread.type) {
-    case 'room':
-      return { command: 'pose', targets: [], label: `Pose \u2192 ${roomName}` };
-    case 'place':
-      return { command: 'tt', targets: [], label: `TT \u2192 ${thread.label}` };
-    case 'whisper':
-      return {
-        command: 'whisper',
-        targets: thread.participantPersonas.map((p) => p.name),
-        label: `Whisper \u2192 ${thread.label.replace('Whisper: ', '')}`,
-      };
-    case 'target':
-      return {
-        command: 'pose',
-        targets: thread.participantPersonas.map((p) => p.name),
-        label: `Pose \u2192 ${thread.label}`,
-      };
-  }
 }
 
 export function SceneInteractionPanel({

--- a/frontend/src/scenes/components/SceneMessages.tsx
+++ b/frontend/src/scenes/components/SceneMessages.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { PoseUnit } from './PoseUnit';
+import type { PoseUnitAvatarClickPersona } from './PoseUnit';
 import type { Interaction } from '../types';
 import type { ActionAttachmentInfo } from '../actionTypes';
 
@@ -10,6 +11,8 @@ interface Props {
   onAttachAction?: (action: ActionAttachmentInfo) => void;
   /** When true, shows the GM dramatic-moment tagging control on each pose (#1139). */
   canGm?: boolean;
+  /** Avatar identity-click affordance passthrough to PoseUnit (#2156). */
+  onAvatarClick?: (persona: PoseUnitAvatarClickPersona) => void;
 }
 
 /**
@@ -71,6 +74,7 @@ export function SceneMessages({
   onAddTarget,
   onAttachAction,
   canGm,
+  onAvatarClick,
 }: Props) {
   // Collect the set of ACTION interaction IDs that are already embedded inside
   // a POSE via action_links. These are rendered inside their parent PoseUnit
@@ -136,6 +140,7 @@ export function SceneMessages({
             onAddTarget={onAddTarget}
             onAttachAction={onAttachAction}
             canGm={canGm}
+            onAvatarClick={onAvatarClick}
           />
         );
       })}

--- a/frontend/src/scenes/hooks/__tests__/useThreading.test.ts
+++ b/frontend/src/scenes/hooks/__tests__/useThreading.test.ts
@@ -237,4 +237,71 @@ describe('useThreading', () => {
     const hidden = result.current.getHiddenPersonaIds('nonexistent');
     expect(hidden.size).toBe(0);
   });
+
+  describe('unread counts', () => {
+    it('defaults unreadCount to 0 when no opts are passed at all', () => {
+      const interactions = [makeInteraction({ id: 1 }), makeInteraction({ id: 2 })];
+      const { result } = renderHook(() => useThreading(interactions, 'Room'));
+      expect(result.current.threads[0].unreadCount).toBe(0);
+    });
+
+    it('defaults unreadCount to 0 when lastSeenByThread has no entry for the thread (no stale badge wall on login)', () => {
+      const interactions = [makeInteraction({ id: 1 }), makeInteraction({ id: 2 })];
+      const { result } = renderHook(() =>
+        useThreading(interactions, 'Room', { lastSeenByThread: {}, viewerPersonaId: 999 })
+      );
+      expect(result.current.threads[0].unreadCount).toBe(0);
+    });
+
+    it("counts interactions newer than lastSeenByThread for that key, excluding the viewer's own", () => {
+      const interactions = [
+        makeInteraction({
+          id: 10,
+          mode: 'whisper',
+          persona: { id: 1, name: 'Viewer' },
+          receiver_persona_ids: [2],
+        }),
+        makeInteraction({
+          id: 11,
+          mode: 'whisper',
+          persona: { id: 2, name: 'Other' },
+          receiver_persona_ids: [1],
+        }),
+        makeInteraction({
+          id: 12,
+          mode: 'whisper',
+          persona: { id: 1, name: 'Viewer' },
+          receiver_persona_ids: [2],
+        }),
+      ];
+
+      const { result } = renderHook(() =>
+        useThreading(interactions, 'Room', {
+          lastSeenByThread: { 'whisper:1,2': 10 },
+          viewerPersonaId: 1,
+        })
+      );
+
+      const whisperThread = result.current.threads.find((t) => t.type === 'whisper');
+      // id 11 (persona 2) counts; id 12 is the viewer's own interaction and never counts.
+      expect(whisperThread?.unreadCount).toBe(1);
+    });
+
+    it('counts multiple unread interactions above the baseline', () => {
+      const interactions = [
+        makeInteraction({ id: 1, persona: { id: 10, name: 'Alice' } }),
+        makeInteraction({ id: 2, persona: { id: 20, name: 'Bob' } }),
+        makeInteraction({ id: 3, persona: { id: 20, name: 'Bob' } }),
+      ];
+
+      const { result } = renderHook(() =>
+        useThreading(interactions, 'Room', {
+          lastSeenByThread: { room: 1 },
+          viewerPersonaId: 10,
+        })
+      );
+
+      expect(result.current.threads[0].unreadCount).toBe(2);
+    });
+  });
 });

--- a/frontend/src/scenes/hooks/threadToComposerMode.ts
+++ b/frontend/src/scenes/hooks/threadToComposerMode.ts
@@ -1,0 +1,33 @@
+import type { Thread } from './useThreading';
+import type { ComposerMode } from '@/game/components/CommandInput';
+
+/**
+ * Translates a scene thread into the CommandInput composer mode that targets
+ * it: room threads pose broadly, place threads use tabletalk, whisper threads
+ * address their private audience, and ad-hoc target threads @-mention the
+ * thread's participants.
+ *
+ * Extracted from `SceneInteractionPanel` (#2156) so `GamePage` — the new
+ * composition root for `/game` — can reuse the same thread→composer
+ * translation without duplicating it.
+ */
+export function threadToComposerMode(thread: Thread, roomName: string): ComposerMode {
+  switch (thread.type) {
+    case 'room':
+      return { command: 'pose', targets: [], label: `Pose → ${roomName}` };
+    case 'place':
+      return { command: 'tt', targets: [], label: `TT → ${thread.label}` };
+    case 'whisper':
+      return {
+        command: 'whisper',
+        targets: thread.participantPersonas.map((p) => p.name),
+        label: `Whisper → ${thread.label.replace('Whisper: ', '')}`,
+      };
+    case 'target':
+      return {
+        command: 'pose',
+        targets: thread.participantPersonas.map((p) => p.name),
+        label: `Pose → ${thread.label}`,
+      };
+  }
+}

--- a/frontend/src/scenes/hooks/useSceneInteractions.ts
+++ b/frontend/src/scenes/hooks/useSceneInteractions.ts
@@ -34,7 +34,15 @@ export function wsPayloadToInteraction(payload: InteractionWsPayload): Interacti
   };
 }
 
-export function useSceneInteractions(sceneId: string) {
+/**
+ * Backfills a scene's interactions via REST (paginated, cursor-based) and
+ * merges in any newer ones that have arrived over the WebSocket while the
+ * page was open. `sceneId` is optional so composition roots like `GamePage`
+ * (#2156) — which may render with no active scene — can call this hook
+ * unconditionally (satisfying the rules of hooks) without triggering a
+ * REST fetch or matching the WS selector against every session.
+ */
+export function useSceneInteractions(sceneId: string | undefined) {
   const activeCharacter = useAppSelector((state) => state.game.active);
 
   // Memoized selector: only recomputes when the sceneInteractions array reference changes,
@@ -44,9 +52,11 @@ export function useSceneInteractions(sceneId: string) {
       createSelector(
         (state: RootState) => state.game.sessions[activeCharacter ?? '']?.sceneInteractions,
         (interactions) =>
-          (interactions ?? []).filter(
-            (ws) => ws.scene_id !== null && ws.scene_id.toString() === sceneId
-          )
+          sceneId === undefined
+            ? []
+            : (interactions ?? []).filter(
+                (ws) => ws.scene_id !== null && ws.scene_id.toString() === sceneId
+              )
       ),
     [activeCharacter, sceneId]
   );
@@ -56,8 +66,9 @@ export function useSceneInteractions(sceneId: string) {
     results: Interaction[];
     next?: string;
   }>({
-    queryKey: ['scene-interactions', sceneId],
-    queryFn: ({ pageParam }) => fetchInteractions(sceneId, pageParam as string | undefined),
+    queryKey: ['scene-interactions', sceneId ?? 'none'],
+    queryFn: ({ pageParam }) =>
+      fetchInteractions(sceneId as string, pageParam as string | undefined),
     getNextPageParam: (lastPage) => {
       if (!lastPage.next) return undefined;
       try {
@@ -68,6 +79,7 @@ export function useSceneInteractions(sceneId: string) {
       }
     },
     initialPageParam: undefined as string | undefined,
+    enabled: sceneId !== undefined,
   });
 
   const allInteractions = useMemo(() => {

--- a/frontend/src/scenes/hooks/useThreading.ts
+++ b/frontend/src/scenes/hooks/useThreading.ts
@@ -15,6 +15,15 @@ export interface UseThreadingOpts {
   lastSeenByThread?: Record<string, number>;
   /** The viewing persona's id — its own interactions never count toward its own unread. */
   viewerPersonaId?: number | null;
+  /**
+   * Highest interaction id present at scene-load time (Redux
+   * `Session.sceneBaselineId`, #2156 review fix). Used as the unread
+   * threshold for any thread key with no `lastSeenByThread` entry — so a
+   * brand-new thread that appears mid-session (no baseline of its own yet)
+   * badges unread from its first message, rather than being silently marked
+   * seen the moment it's first observed.
+   */
+  sceneBaselineId?: number | null;
 }
 
 export interface ThreadingState {
@@ -82,22 +91,29 @@ function getThreadLabel(
   return formatPersonaNames(personas);
 }
 
-// No entry for a thread key means "0 unread" — ratified semantics (#2156):
-// on first load, before GamePage has baselined every thread, this avoids a
-// wall of stale unread badges. Once a baseline exists, count interactions
-// newer than it, excluding the viewer's own (an author never owes themself
-// an unread badge for their own words).
+// Ratified semantics (#2156, review-fixed): a thread key with a real
+// `lastSeenByThread` entry counts interactions newer than it, excluding the
+// viewer's own (an author never owes themself an unread badge for their own
+// words). A thread key with NO entry falls back to the scene-load baseline
+// scalar (`sceneBaselineId`) — this is what lets a brand-new thread that
+// appears mid-session (a first whisper, say) badge unread starting from its
+// very first message, instead of being silently marked "seen" the moment
+// it's first observed (the old per-thread-key baseline's bug). With no entry
+// AND no baseline (e.g. `/scenes/:id` passing no opts at all) unread is 0,
+// exactly as before.
 function countUnread(
   threadInteractions: Interaction[],
   threadKey: string,
   lastSeenByThread: Record<string, number> | undefined,
-  viewerPersonaId: number | null | undefined
+  viewerPersonaId: number | null | undefined,
+  sceneBaselineId: number | null | undefined
 ): number {
   const lastSeen = lastSeenByThread?.[threadKey];
-  if (lastSeen === undefined) return 0;
+  const threshold = lastSeen !== undefined ? lastSeen : sceneBaselineId;
+  if (threshold === undefined || threshold === null) return 0;
   return threadInteractions.filter((i) => {
     if (viewerPersonaId != null && i.persona.id === viewerPersonaId) return false;
-    return Number(i.id) > lastSeen;
+    return Number(i.id) > threshold;
   }).length;
 }
 
@@ -112,6 +128,7 @@ export function useThreading(
   const isUnfiltered = enabledThreadKeys.size === 0;
   const lastSeenByThread = opts?.lastSeenByThread;
   const viewerPersonaId = opts?.viewerPersonaId;
+  const sceneBaselineId = opts?.sceneBaselineId;
 
   const { threads, threadKeyMap } = useMemo(() => {
     const groups = new Map<string, Interaction[]>();
@@ -138,7 +155,13 @@ export function useThreading(
           label: getThreadLabel(key, type, threadInteractions, roomName),
           participantPersonas: getParticipantPersonas(threadInteractions),
           latestTimestamp: threadInteractions[threadInteractions.length - 1]?.timestamp ?? '',
-          unreadCount: countUnread(threadInteractions, key, lastSeenByThread, viewerPersonaId),
+          unreadCount: countUnread(
+            threadInteractions,
+            key,
+            lastSeenByThread,
+            viewerPersonaId,
+            sceneBaselineId
+          ),
         } as Thread;
       })
       .sort((a, b) => {
@@ -147,7 +170,7 @@ export function useThreading(
         return b.latestTimestamp.localeCompare(a.latestTimestamp);
       });
     return { threads: threadList, threadKeyMap: keyMap };
-  }, [interactions, roomName, lastSeenByThread, viewerPersonaId]);
+  }, [interactions, roomName, lastSeenByThread, viewerPersonaId, sceneBaselineId]);
 
   const filteredInteractions = useMemo(() => {
     // Fast path: no thread filter and no hidden personas — return interactions as-is (Fix #6)

--- a/frontend/src/scenes/hooks/useThreading.ts
+++ b/frontend/src/scenes/hooks/useThreading.ts
@@ -37,6 +37,16 @@ export interface ThreadingState {
   showAll: () => void;
   togglePersonaHidden: (threadKey: string, personaId: number) => void;
   getHiddenPersonaIds: (threadKey: string) => Set<number>;
+  /**
+   * Clears the thread filter (enabledThreadKeys), selection, and every
+   * per-thread hidden-persona mute (#2156 review fix). `showAll` alone only
+   * clears the first two — this is the full reset a scene change or puppet
+   * switch needs so a filter/mute picked in the PREVIOUS scene/puppet
+   * context doesn't silently strand-hide interactions in a new one that
+   * happens to reuse the same thread key (e.g. two puppets in the same
+   * room, or a room re-entering an old scene id).
+   */
+  resetForNewScene: () => void;
 }
 
 export function getThreadKey(interaction: Interaction): string {
@@ -217,6 +227,12 @@ export function useThreading(
     setSelectedThread('room');
   }, []);
 
+  const resetForNewScene = useCallback(() => {
+    setEnabledThreadKeys(new Set());
+    setSelectedThread('room');
+    setHiddenPersonaIds(new Map());
+  }, []);
+
   const togglePersonaHidden = useCallback((threadKey: string, personaId: number) => {
     setHiddenPersonaIds((prev) => {
       const next = new Map(prev);
@@ -249,5 +265,6 @@ export function useThreading(
     showAll,
     togglePersonaHidden,
     getHiddenPersonaIds,
+    resetForNewScene,
   };
 }

--- a/frontend/src/scenes/hooks/useThreading.ts
+++ b/frontend/src/scenes/hooks/useThreading.ts
@@ -10,6 +10,13 @@ export interface Thread {
   unreadCount: number;
 }
 
+export interface UseThreadingOpts {
+  /** Highest interaction id already seen per thread key (Redux `Session.threadLastSeen`). */
+  lastSeenByThread?: Record<string, number>;
+  /** The viewing persona's id — its own interactions never count toward its own unread. */
+  viewerPersonaId?: number | null;
+}
+
 export interface ThreadingState {
   threads: Thread[];
   filteredInteractions: Interaction[];
@@ -75,11 +82,36 @@ function getThreadLabel(
   return formatPersonaNames(personas);
 }
 
-export function useThreading(interactions: Interaction[], roomName: string): ThreadingState {
+// No entry for a thread key means "0 unread" — ratified semantics (#2156):
+// on first load, before GamePage has baselined every thread, this avoids a
+// wall of stale unread badges. Once a baseline exists, count interactions
+// newer than it, excluding the viewer's own (an author never owes themself
+// an unread badge for their own words).
+function countUnread(
+  threadInteractions: Interaction[],
+  threadKey: string,
+  lastSeenByThread: Record<string, number> | undefined,
+  viewerPersonaId: number | null | undefined
+): number {
+  const lastSeen = lastSeenByThread?.[threadKey];
+  if (lastSeen === undefined) return 0;
+  return threadInteractions.filter((i) => {
+    if (viewerPersonaId != null && i.persona.id === viewerPersonaId) return false;
+    return Number(i.id) > lastSeen;
+  }).length;
+}
+
+export function useThreading(
+  interactions: Interaction[],
+  roomName: string,
+  opts?: UseThreadingOpts
+): ThreadingState {
   const [selectedThreadKey, setSelectedThread] = useState('room');
   const [enabledThreadKeys, setEnabledThreadKeys] = useState<Set<string>>(new Set());
   const [hiddenPersonaIds, setHiddenPersonaIds] = useState<Map<string, Set<number>>>(new Map());
   const isUnfiltered = enabledThreadKeys.size === 0;
+  const lastSeenByThread = opts?.lastSeenByThread;
+  const viewerPersonaId = opts?.viewerPersonaId;
 
   const { threads, threadKeyMap } = useMemo(() => {
     const groups = new Map<string, Interaction[]>();
@@ -106,7 +138,7 @@ export function useThreading(interactions: Interaction[], roomName: string): Thr
           label: getThreadLabel(key, type, threadInteractions, roomName),
           participantPersonas: getParticipantPersonas(threadInteractions),
           latestTimestamp: threadInteractions[threadInteractions.length - 1]?.timestamp ?? '',
-          unreadCount: 0, // TODO: track per-thread unread count (needs last-viewed timestamp per thread)
+          unreadCount: countUnread(threadInteractions, key, lastSeenByThread, viewerPersonaId),
         } as Thread;
       })
       .sort((a, b) => {
@@ -115,7 +147,7 @@ export function useThreading(interactions: Interaction[], roomName: string): Thr
         return b.latestTimestamp.localeCompare(a.latestTimestamp);
       });
     return { threads: threadList, threadKeyMap: keyMap };
-  }, [interactions, roomName]);
+  }, [interactions, roomName, lastSeenByThread, viewerPersonaId]);
 
   const filteredInteractions = useMemo(() => {
     // Fast path: no thread filter and no hidden personas — return interactions as-is (Fix #6)

--- a/frontend/src/scenes/pages/SceneDetailPage.tsx
+++ b/frontend/src/scenes/pages/SceneDetailPage.tsx
@@ -16,6 +16,8 @@ import { SoulTetherRescuePrompt } from '@/magic/components/SoulTetherRescuePromp
 import { EntryFlourishOfferGate } from '@/magic/components/EntryFlourishOfferGate';
 import { CommandInput } from '@/game/components/CommandInput';
 import type { ComposerMode } from '@/game/components/CommandInput';
+import { CharacterCardDrawer } from '@/game/components/CharacterCardDrawer';
+import type { PoseUnitAvatarClickPersona } from '../components/PoseUnit';
 import type { ActionAttachmentInfo } from '../actionTypes';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
@@ -44,6 +46,12 @@ export function SceneDetailPage() {
   );
   const characterSheetId = useMemo(
     () => myRosterEntries.find((e) => e.name === activeCharacter)?.character_id ?? 0,
+    [myRosterEntries, activeCharacter]
+  );
+  // The active character's own RosterEntry id (#2156 Task 7) — the FriendButton's
+  // `viewerEntryId` inside the character-card drawer.
+  const viewerEntryId = useMemo(
+    () => myRosterEntries.find((e) => e.name === activeCharacter)?.id ?? null,
     [myRosterEntries, activeCharacter]
   );
 
@@ -117,6 +125,18 @@ export function SceneDetailPage() {
     setComposerMode(mode);
   }, []);
 
+  // Character-card drawer (#2156 Task 7): the clicked bubble's persona identity,
+  // or null when the drawer is closed. Mirrors GamePage's state — the drawer
+  // opens "in place" over this record page's feed, not as a route navigation.
+  const [cardPersona, setCardPersona] = useState<PoseUnitAvatarClickPersona | null>(null);
+  const handleWhisper = useCallback(
+    (name: string) => {
+      handleComposerModeChange({ command: 'whisper', targets: [name], label: `Whisper → ${name}` });
+      setCardPersona(null);
+    },
+    [handleComposerModeChange]
+  );
+
   // `isAtPlace` (#2156, Task 6): derived from the SAME `['scene-places',
   // placesRoomId]` query key `PlaceBar` uses below, so React Query dedupes the
   // two fetches into one (query-reuse, matching GamePage's approach).
@@ -154,6 +174,7 @@ export function SceneDetailPage() {
         onAddTarget={setPendingTarget}
         onAttachAction={handleActionAttach}
         canGm={scene?.viewer_can_gm}
+        onAvatarClick={setCardPersona}
       />
 
       {/* Composer + Action Panel */}
@@ -190,6 +211,12 @@ export function SceneDetailPage() {
           <ActionPanel sceneId={id} />
         </div>
       )}
+      <CharacterCardDrawer
+        persona={cardPersona}
+        onClose={() => setCardPersona(null)}
+        viewerEntryId={viewerEntryId}
+        onWhisper={handleWhisper}
+      />
     </div>
   );
 }

--- a/frontend/src/scenes/pages/SceneDetailPage.tsx
+++ b/frontend/src/scenes/pages/SceneDetailPage.tsx
@@ -117,18 +117,18 @@ export function SceneDetailPage() {
     setComposerMode(mode);
   }, []);
 
-  // `isAtPlace` (#2156, Task 6): derived from the SAME `['scene-places', id]`
-  // query key `PlaceBar` uses below, so React Query dedupes the two fetches
-  // into one (query-reuse, matching GamePage's approach). NOTE: `id` here is
-  // the *scene* id, not a room id — `fetchPlaces` treats its argument as the
-  // ROOM id in its `?room=` query param (confirmed by reading PlaceBar.tsx +
-  // actionQueries.ts). This mirrors `PlaceBar sceneId={id}` above unchanged
-  // (a pre-existing latent bug in this page's places query, not introduced or
-  // fixed by this task — see the task report), so `isAtPlace` will only ever
-  // be `true` here in the coincidental case scene id === room id.
+  // `isAtPlace` (#2156, Task 6): derived from the SAME `['scene-places',
+  // placesRoomId]` query key `PlaceBar` uses below, so React Query dedupes the
+  // two fetches into one (query-reuse, matching GamePage's approach).
+  // `fetchPlaces` filters `?room=<id>` — a ROOM id, not the scene id — so this
+  // derives the room id from `scene.location.id` (fold-in fix, #2156: the
+  // earlier version passed the *scene* id here and to `PlaceBar`, which only
+  // worked by coincidence when scene pk === room pk).
+  const placesRoomId = scene?.location?.id != null ? String(scene.location.id) : undefined;
   const { data: placesData } = useQuery({
-    queryKey: ['scene-places', id],
-    queryFn: () => fetchPlaces(id),
+    queryKey: ['scene-places', placesRoomId],
+    queryFn: () => fetchPlaces(placesRoomId!),
+    enabled: !!placesRoomId,
   });
   const isAtPlace = placesData?.results?.some((place) => place.viewer_is_present) ?? false;
 
@@ -141,7 +141,7 @@ export function SceneDetailPage() {
         {isActive && <SoulTetherRescuePrompt />}
         {isActive && <EntryFlourishOfferGate characterSheetId={characterSheetId} />}
         {scene && <SceneLinesAndVeilsCard sceneId={id} />}
-        <PlaceBar sceneId={id} />
+        {placesRoomId && <PlaceBar sceneId={placesRoomId} />}
         <RoomPositionsPanel sceneId={id} />
         <HighlightReel sceneId={id} canGm={scene?.viewer_can_gm} />
       </div>

--- a/frontend/src/scenes/pages/SceneDetailPage.tsx
+++ b/frontend/src/scenes/pages/SceneDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchScene, SceneDetail } from '../queries';
-import { createActionRequest } from '../actionQueries';
+import { createActionRequest, fetchPlaces } from '../actionQueries';
 import { SceneHeader } from '../components/SceneHeader';
 import { SceneInteractionPanel } from '../components/SceneInteractionPanel';
 import { ActionPanel } from '../components/ActionPanel';
@@ -117,6 +117,21 @@ export function SceneDetailPage() {
     setComposerMode(mode);
   }, []);
 
+  // `isAtPlace` (#2156, Task 6): derived from the SAME `['scene-places', id]`
+  // query key `PlaceBar` uses below, so React Query dedupes the two fetches
+  // into one (query-reuse, matching GamePage's approach). NOTE: `id` here is
+  // the *scene* id, not a room id — `fetchPlaces` treats its argument as the
+  // ROOM id in its `?room=` query param (confirmed by reading PlaceBar.tsx +
+  // actionQueries.ts). This mirrors `PlaceBar sceneId={id}` above unchanged
+  // (a pre-existing latent bug in this page's places query, not introduced or
+  // fixed by this task — see the task report), so `isAtPlace` will only ever
+  // be `true` here in the coincidental case scene id === room id.
+  const { data: placesData } = useQuery({
+    queryKey: ['scene-places', id],
+    queryFn: () => fetchPlaces(id),
+  });
+  const isAtPlace = placesData?.results?.some((place) => place.viewer_is_present) ?? false;
+
   return (
     <div className="flex h-full flex-col">
       <div className="shrink-0 px-4 pt-4">
@@ -168,6 +183,7 @@ export function SceneDetailPage() {
                 pendingActionIds={pendingActionIds}
                 detachedActionIds={detachedActionIds}
                 onPoseSubmitted={handlePoseSubmitted}
+                isAtPlace={isAtPlace}
               />
             </>
           )}

--- a/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
+++ b/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
@@ -16,25 +16,41 @@ import { Routes, Route } from 'react-router-dom';
 import { describe, it, vi, beforeEach, expect } from 'vitest';
 import { renderWithProviders } from '@/test/utils/renderWithProviders';
 import { SceneDetailPage } from '../SceneDetailPage';
+import { fetchPlaces } from '../../actionQueries';
 
 // ---------------------------------------------------------------------------
 // Mock scene queries
 // ---------------------------------------------------------------------------
 
+// Mutable so individual tests can override the scene detail payload (e.g. to
+// set `location`) while keeping the default shape for the other tests.
+let mockSceneData: Record<string, unknown> = {
+  id: '1',
+  name: 'Test Scene',
+  is_active: true,
+  description: '',
+};
+
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-query')>();
   return {
     ...actual,
-    useQuery: vi.fn(() => ({
-      data: {
-        id: '1',
-        name: 'Test Scene',
-        is_active: true,
-        description: '',
-      },
-      isLoading: false,
-      refetch: vi.fn(),
-    })),
+    // SceneDetailPage makes two direct useQuery calls: the scene detail query
+    // (queryKey ['scene', id]) and the places-room-id derived query (queryKey
+    // ['scene-places', placesRoomId]). Route by queryKey so the second call
+    // actually invokes its queryFn (calling the mocked fetchPlaces) instead of
+    // returning a fixed canned value regardless of arguments.
+    useQuery: vi.fn(
+      (config: { queryKey: readonly unknown[]; queryFn?: () => unknown; enabled?: boolean }) => {
+        if (config.queryKey[0] === 'scene') {
+          return { data: mockSceneData, isLoading: false, refetch: vi.fn() };
+        }
+        if (config.enabled !== false) {
+          config.queryFn?.();
+        }
+        return { data: undefined, isLoading: false, refetch: vi.fn() };
+      }
+    ),
     useMutation: vi.fn(() => ({
       mutate: vi.fn(),
       isPending: false,
@@ -56,6 +72,7 @@ vi.mock('../../actionQueries', () => ({
   createActionRequest: vi.fn(),
   respondToRequest: vi.fn(),
   fetchActionPanelData: vi.fn(() => Promise.resolve({ techniques: [], pending_requests: [] })),
+  fetchPlaces: vi.fn(() => Promise.resolve({ results: [] })),
 }));
 
 // ---------------------------------------------------------------------------
@@ -201,6 +218,12 @@ vi.mock('@/game/components/CommandInput', () => ({
 describe('SceneDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSceneData = {
+      id: '1',
+      name: 'Test Scene',
+      is_active: true,
+      description: '',
+    };
   });
 
   it('renders without crashing', () => {
@@ -236,5 +259,26 @@ describe('SceneDetailPage', () => {
 
     // If the hook was called, the rescue prompt is mounted
     expect(mockUsePendingStageAdvanceOffers).toHaveBeenCalled();
+  });
+
+  it('fetches places by the scene’s room id, not the scene id (fold-in fix, #2156)', () => {
+    // The route/scene id is '5', but the scene's location (room) is 777 —
+    // fetchPlaces filters ?room=<id>, so it must be called with the room id.
+    mockSceneData = {
+      id: '5',
+      name: 'Test Scene',
+      is_active: true,
+      description: '',
+      location: { id: 777, name: 'The Hall' },
+    };
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/scenes/:id" element={<SceneDetailPage />} />
+      </Routes>,
+      { initialEntries: ['/scenes/5'] }
+    );
+
+    expect(fetchPlaces).toHaveBeenCalledWith('777');
   });
 });

--- a/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
+++ b/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
@@ -88,6 +88,11 @@ vi.mock('@/roster/queries', () => ({
     isLoading: false,
     isError: false,
   })),
+  // The character-card drawer (#2156 Task 7) always mounts (persona is null
+  // unless an avatar was clicked) and calls these — stub them out since this
+  // test suite isn't exercising the drawer's own identity resolution.
+  useRosterEntryByNameQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useRosterEntryQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
 }));
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -166,6 +166,12 @@ export interface SubmitPoseBody {
   action_link_ids?: number[];
   /** PoseKind: 'entry' opens a Make-an-Entrance reaction window (#904). */
   pose_kind?: string;
+  /**
+   * Composer-mode @Name targets (#2156) — resolved server-side with the same
+   * semantics as the WS `@Name`-prefix parser (unresolvable names are silently
+   * skipped, not an error).
+   */
+  target_names?: string[];
 }
 
 export async function submitPose(body: SubmitPoseBody): Promise<void> {
@@ -173,7 +179,10 @@ export async function submitPose(body: SubmitPoseBody): Promise<void> {
     method: 'POST',
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error('Failed to submit pose');
+  if (!res.ok) {
+    const data = (await res.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(data?.detail || 'Failed to submit pose');
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/store/__tests__/gameSlice.test.ts
+++ b/frontend/src/store/__tests__/gameSlice.test.ts
@@ -219,6 +219,7 @@ describe('gameSlice', () => {
           scene: null,
           sceneInteractions: [],
           threadLastSeen: {},
+          sceneBaselineId: null,
         });
       });
 

--- a/frontend/src/store/__tests__/gameSlice.test.ts
+++ b/frontend/src/store/__tests__/gameSlice.test.ts
@@ -55,6 +55,7 @@ interface Session {
   scene: SceneSummary | null;
   sceneInteractions: InteractionWsPayload[];
   threadLastSeen: Record<string, number>;
+  sceneBaselineId: number | null;
 }
 
 interface GameState {
@@ -71,6 +72,7 @@ const createDefaultSession = (overrides: Partial<Session> = {}): Session => ({
   scene: null,
   sceneInteractions: [],
   threadLastSeen: {},
+  sceneBaselineId: null,
   ...overrides,
 });
 
@@ -1128,6 +1130,7 @@ describe('gameSlice', () => {
             scene: createSceneSummary(1, 'Battle', 'An epic battle', true),
             sceneInteractions: [],
             threadLastSeen: { room: 5 },
+            sceneBaselineId: null,
           },
         },
         active: 'Hero',

--- a/frontend/src/store/__tests__/gameSlice.test.ts
+++ b/frontend/src/store/__tests__/gameSlice.test.ts
@@ -16,6 +16,7 @@ import {
   setSessionCommands,
   setSessionRoom,
   setSessionScene,
+  markThreadSeen,
   resetGame,
 } from '../gameSlice';
 import type {
@@ -53,6 +54,7 @@ interface Session {
   room: RoomData | null;
   scene: SceneSummary | null;
   sceneInteractions: InteractionWsPayload[];
+  threadLastSeen: Record<string, number>;
 }
 
 interface GameState {
@@ -68,6 +70,7 @@ const createDefaultSession = (overrides: Partial<Session> = {}): Session => ({
   room: null,
   scene: null,
   sceneInteractions: [],
+  threadLastSeen: {},
   ...overrides,
 });
 
@@ -215,7 +218,16 @@ describe('gameSlice', () => {
           room: null,
           scene: null,
           sceneInteractions: [],
+          threadLastSeen: {},
         });
+      });
+
+      it('initializes threadLastSeen as an empty object', () => {
+        const initialState: GameState = { sessions: {}, active: null };
+
+        const result = reducer(initialState, startSession('TestCharacter'));
+
+        expect(result.sessions['TestCharacter'].threadLastSeen).toEqual({});
       });
 
       it('sets new session as active', () => {
@@ -975,6 +987,73 @@ describe('gameSlice', () => {
     });
   });
 
+  describe('markThreadSeen', () => {
+    it('sets the last-seen interaction id for a thread key on an existing session', () => {
+      const initialState = createStateWithSession('TestCharacter', { threadLastSeen: {} });
+
+      const result = reducer(
+        initialState,
+        markThreadSeen({ character: 'TestCharacter', threadKey: 'room', interactionId: 5 })
+      );
+
+      expect(result.sessions['TestCharacter'].threadLastSeen).toEqual({ room: 5 });
+    });
+
+    it('raises an existing value when the new interactionId is higher', () => {
+      const initialState = createStateWithSession('TestCharacter', {
+        threadLastSeen: { room: 5 },
+      });
+
+      const result = reducer(
+        initialState,
+        markThreadSeen({ character: 'TestCharacter', threadKey: 'room', interactionId: 10 })
+      );
+
+      expect(result.sessions['TestCharacter'].threadLastSeen.room).toBe(10);
+    });
+
+    it('is idempotent — never lowers an existing last-seen value', () => {
+      const initialState = createStateWithSession('TestCharacter', {
+        threadLastSeen: { room: 10 },
+      });
+
+      const result = reducer(
+        initialState,
+        markThreadSeen({ character: 'TestCharacter', threadKey: 'room', interactionId: 3 })
+      );
+
+      expect(result.sessions['TestCharacter'].threadLastSeen.room).toBe(10);
+    });
+
+    it('does not affect other thread keys on the same session', () => {
+      const initialState = createStateWithSession('TestCharacter', {
+        threadLastSeen: { room: 5, 'whisper:1,2': 20 },
+      });
+
+      const result = reducer(
+        initialState,
+        markThreadSeen({ character: 'TestCharacter', threadKey: 'room', interactionId: 8 })
+      );
+
+      expect(result.sessions['TestCharacter'].threadLastSeen).toEqual({
+        room: 8,
+        'whisper:1,2': 20,
+      });
+    });
+
+    it('does nothing if session does not exist', () => {
+      const initialState = createStateWithSession('ExistingCharacter', {});
+
+      const result = reducer(
+        initialState,
+        markThreadSeen({ character: 'NonExistent', threadKey: 'room', interactionId: 5 })
+      );
+
+      expect(result.sessions['NonExistent']).toBeUndefined();
+      expect(result).toEqual(initialState);
+    });
+  });
+
   describe('resetGame', () => {
     it('returns to initial state', () => {
       const initialState = createStateWithMultipleSessions(
@@ -1047,6 +1126,7 @@ describe('gameSlice', () => {
             ),
             scene: createSceneSummary(1, 'Battle', 'An epic battle', true),
             sceneInteractions: [],
+            threadLastSeen: { room: 5 },
           },
         },
         active: 'Hero',

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -167,11 +167,17 @@ export const gameSlice = createSlice({
         }
       }
     },
+    // Deliberately does NOT touch `sceneBaselineId` (#2156 review fix 2): this
+    // reducer is dispatched on every ROOM_STATE broadcast (handleRoomStatePayload),
+    // which fires on ordinary room churn (anyone entering/leaving) — not just
+    // scene changes. Nulling the baseline here made it stick at null for the
+    // rest of the scene, since GamePage's one-shot baseline ref never re-fires
+    // for the same scene id. The scene-CHANGE reset lives in `setSessionScene`
+    // (guarded on an actual scene-id change), which pairs correctly with that ref.
     clearSceneInteractions: (state, action: PayloadAction<MyRosterEntry['name']>) => {
       const session = state.sessions[action.payload];
       if (session) {
         session.sceneInteractions = [];
-        session.sceneBaselineId = null;
       }
     },
     // Scene-load baseline scalar (#2156 review fix): set once by GamePage's

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -33,6 +33,15 @@ interface Session {
   sceneInteractions: InteractionWsPayload[];
   /** Highest interaction id seen per thread key (#2156 per-thread unread badges). */
   threadLastSeen: Record<string, number>;
+  /**
+   * Highest interaction id present the moment the current scene's threading
+   * was baselined (#2156 review fix). `countUnread` falls back to this scalar
+   * for any thread key with no `threadLastSeen` entry, so a brand-new thread
+   * that appears mid-session (e.g. a first whisper) badges unread starting
+   * from its first message, while threads that already existed at scene load
+   * stay zeroed. `null` before the baseline effect has run for this scene.
+   */
+  sceneBaselineId: number | null;
 }
 
 interface GameState {
@@ -61,6 +70,7 @@ export const gameSlice = createSlice({
           scene: null,
           sceneInteractions: [],
           threadLastSeen: {},
+          sceneBaselineId: null,
         };
       }
       state.active = name;
@@ -129,6 +139,14 @@ export const gameSlice = createSlice({
       const { character, scene } = action.payload;
       const session = state.sessions[character];
       if (session) {
+        // A scene change (including a brand-new scene at the same room)
+        // invalidates any previous scene's baseline — the baseline effect
+        // must re-run for the new scene id (#2156 review fix).
+        const previousId = session.scene?.id ?? null;
+        const nextId = scene?.id ?? null;
+        if (previousId !== nextId) {
+          session.sceneBaselineId = null;
+        }
         session.scene = scene;
       }
     },
@@ -153,6 +171,22 @@ export const gameSlice = createSlice({
       const session = state.sessions[action.payload];
       if (session) {
         session.sceneInteractions = [];
+        session.sceneBaselineId = null;
+      }
+    },
+    // Scene-load baseline scalar (#2156 review fix): set once by GamePage's
+    // baseline effect the first time it runs for a given scene id. See the
+    // `sceneBaselineId` field doc for why this replaced the old per-thread-key
+    // baseline (it one-shotted per KEY, so a brand-new thread's first message
+    // got marked seen on arrival instead of badging unread).
+    setSceneBaseline: (
+      state,
+      action: PayloadAction<{ character: MyRosterEntry['name']; baselineId: number | null }>
+    ) => {
+      const { character, baselineId } = action.payload;
+      const session = state.sessions[character];
+      if (session) {
+        session.sceneBaselineId = baselineId;
       }
     },
     // Idempotent: never lowers an existing last-seen value for the thread key
@@ -191,5 +225,6 @@ export const {
   addSceneInteraction,
   clearSceneInteractions,
   markThreadSeen,
+  setSceneBaseline,
   resetGame,
 } = gameSlice.actions;

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -31,6 +31,8 @@ interface Session {
   room: RoomData | null;
   scene: SceneSummary | null;
   sceneInteractions: InteractionWsPayload[];
+  /** Highest interaction id seen per thread key (#2156 per-thread unread badges). */
+  threadLastSeen: Record<string, number>;
 }
 
 interface GameState {
@@ -58,6 +60,7 @@ export const gameSlice = createSlice({
           room: null,
           scene: null,
           sceneInteractions: [],
+          threadLastSeen: {},
         };
       }
       state.active = name;
@@ -152,6 +155,26 @@ export const gameSlice = createSlice({
         session.sceneInteractions = [];
       }
     },
+    // Idempotent: never lowers an existing last-seen value for the thread key
+    // (ratified unread semantics, #2156) — a stale/out-of-order dispatch must
+    // not resurrect already-read interactions as unread.
+    markThreadSeen: (
+      state,
+      action: PayloadAction<{
+        character: MyRosterEntry['name'];
+        threadKey: string;
+        interactionId: number;
+      }>
+    ) => {
+      const { character, threadKey, interactionId } = action.payload;
+      const session = state.sessions[character];
+      if (session) {
+        const current = session.threadLastSeen[threadKey];
+        if (current === undefined || interactionId > current) {
+          session.threadLastSeen[threadKey] = interactionId;
+        }
+      }
+    },
     resetGame: () => initialState,
   },
 });
@@ -167,5 +190,6 @@ export const {
   setSessionScene,
   addSceneInteraction,
   clearSceneInteractions,
+  markThreadSeen,
   resetGame,
 } = gameSlice.actions;

--- a/src/actions/definitions/communication.py
+++ b/src/actions/definitions/communication.py
@@ -32,18 +32,14 @@ def _characters_to_active_personas(characters: list[ObjectDB]) -> list[Persona] 
     """Resolve character objects to their active personas.
 
     Returns None if no characters could be resolved (callers treat None as
-    'no explicit targets').
+    'no explicit targets'). Thin alias over the shared
+    ``world.scenes.interaction_services.personas_for_characters`` helper — the
+    REST submit-pose path (#2156) resolves directed-pose targets through the
+    same function, so both surfaces derive InteractionTargetPersona rows identically.
     """
-    personas: list[Persona] = []
-    for character in characters:
-        try:
-            sheet = character.sheet_data
-            primary = sheet.primary_persona
-        except (AttributeError, ObjectDoesNotExist):
-            continue
-        if primary is not None:
-            personas.append(primary)
-    return personas or None
+    from world.scenes.interaction_services import personas_for_characters  # noqa: PLC0415
+
+    return personas_for_characters(characters)
 
 
 def _flag_blocked_contact_for_targets(

--- a/src/commands/parsing.py
+++ b/src/commands/parsing.py
@@ -57,14 +57,12 @@ def parse_targets_from_text(
         name.strip().lstrip("@") for name in target_part.split(",") if name.strip().startswith("@")
     ]
 
-    # Resolve names against room contents (case-insensitive)
-    targets: list[ObjectDB] = []
-    for name in target_names:
-        lower_name = name.lower()
-        for obj in location.contents:
-            if obj.db_key.lower() == lower_name:
-                targets.append(obj)
-                break
+    # Resolve names against room contents (case-insensitive) — shared with the REST
+    # submit-pose `target_names` field so a directed pose resolves identically
+    # regardless of which surface sent it (#2156).
+    from world.scenes.interaction_services import resolve_characters_by_name  # noqa: PLC0415
+
+    targets = resolve_characters_by_name(target_names, location)
 
     return remaining, targets
 

--- a/src/schema.json
+++ b/src/schema.json
@@ -51142,11 +51142,17 @@ components:
         presence_count:
           type: integer
           readOnly: true
+        viewer_is_present:
+          type: boolean
+          description: Whether one of the requesting account's personas is present
+            at this place (#2156).
+          readOnly: true
       required:
       - created_at
       - id
       - name
       - presence_count
+      - viewer_is_present
     PlaceRequest:
       type: object
       properties:

--- a/src/schema.json
+++ b/src/schema.json
@@ -12084,11 +12084,18 @@ paths:
     post:
       operationId: interactions_submit_pose_create
       description: |-
-        Create a POSE Interaction and auto-link prior ACTION Interactions.
+        Create a POSE Interaction with full WS-pose-path parity (#2156).
 
         Accepts ``action_link_ids`` for an explicit override:
         - Absent (key missing): auto-link is run.
         - Present as a list (even empty): exact links are created; auto-link skipped.
+
+        Mirrors ``actions.definitions.communication.PoseAction.execute``: broadcasts
+        the raw text via ``message_location`` (telnet visibility), records through the
+        shared ``record_interaction`` seam (ephemeral-scene gate, SceneParticipation +
+        covenant engagement), and flags blocked-contact attempts for any resolved
+        directed-pose targets. ``target_names`` (composer-mode ``@Name`` targets) are
+        resolved with the same semantics as the WS ``@Name``-prefix parser.
       tags:
       - interactions
       requestBody:

--- a/src/world/scenes/interaction_serializers.py
+++ b/src/world/scenes/interaction_serializers.py
@@ -537,30 +537,42 @@ class PoseSubmitSerializer(serializers.Serializer):
         return value
 
     def validate(self, attrs: dict) -> dict:
-        """Cross-field: persona must own the action_link_ids (same character)."""
+        """Cross-field: persona must own the action_link_ids (same character);
+
+        persona's character must be co-located with a located scene (#2156).
+        """
         action_link_ids = attrs.get("action_link_ids")
-        if not action_link_ids:
-            return attrs
-
         persona_id = attrs.get("persona_id")
-        if persona_id is None:
-            return attrs  # persona_id error will be surfaced by its own validator
 
-        try:
-            persona = Persona.objects.get(pk=persona_id)
-        except Persona.DoesNotExist:
-            return attrs  # surfaced by validate_persona_id
+        if action_link_ids and persona_id is not None:
+            try:
+                persona = Persona.objects.get(pk=persona_id)
+            except Persona.DoesNotExist:
+                persona = None  # surfaced by validate_persona_id
 
-        # All action interactions must belong to the same persona as this pose.
-        wrong_persona = Interaction.objects.filter(
-            pk__in=action_link_ids,
-        ).exclude(persona=persona)
-        if wrong_persona.exists():
-            raise serializers.ValidationError(
-                {
-                    "action_link_ids": (
-                        "All action_link_ids must belong to the same persona as the pose."
+            if persona is not None:
+                # All action interactions must belong to the same persona as this pose.
+                wrong_persona = Interaction.objects.filter(
+                    pk__in=action_link_ids,
+                ).exclude(persona=persona)
+                if wrong_persona.exists():
+                    raise serializers.ValidationError(
+                        {
+                            "action_link_ids": (
+                                "All action_link_ids must belong to the same persona as the pose."
+                            )
+                        }
                     )
-                }
-            )
+
+        scene_id = attrs.get("scene_id")
+        if scene_id is not None and persona_id is not None:
+            scene = Scene.objects.filter(pk=scene_id).first()
+            persona = Persona.objects.filter(pk=persona_id).first()
+            if scene is not None and persona is not None and scene.location is not None:
+                actor_room = persona.character_sheet.character.location
+                if actor_room is None or actor_room.pk != scene.location.pk:
+                    raise serializers.ValidationError(
+                        {"scene_id": "Your character is not present in this scene's room."}
+                    )
+
         return attrs

--- a/src/world/scenes/interaction_serializers.py
+++ b/src/world/scenes/interaction_serializers.py
@@ -566,9 +566,11 @@ class PoseSubmitSerializer(serializers.Serializer):
 
         scene_id = attrs.get("scene_id")
         if scene_id is not None and persona_id is not None:
-            scene = Scene.objects.filter(pk=scene_id).first()
-            persona = Persona.objects.filter(pk=persona_id).first()
-            if scene is not None and persona is not None and scene.location is not None:
+            # Field validators (validate_scene_id / validate_persona_id) already guarantee
+            # these rows exist by the time cross-field validation runs.
+            scene = Scene.objects.get(pk=scene_id)
+            persona = Persona.objects.get(pk=persona_id)
+            if scene.location is not None:
                 actor_room = persona.character_sheet.character.location
                 if actor_room is None or actor_room.pk != scene.location.pk:
                     raise serializers.ValidationError(

--- a/src/world/scenes/interaction_serializers.py
+++ b/src/world/scenes/interaction_serializers.py
@@ -478,6 +478,18 @@ class PoseSubmitSerializer(serializers.Serializer):
         ),
     )
 
+    target_names = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_empty=True,
+        help_text=(
+            "Optional composer-mode @Name targets (#2156). Resolved against the "
+            "writer's room with the same case-insensitive exact-match semantics as "
+            "the WS/telnet '@Name' prefix parser — an unresolvable name is silently "
+            "skipped, not an error."
+        ),
+    )
+
     def validate_persona_id(self, value: int) -> int:
         """Confirm the persona exists and belongs to the requesting user."""
         request = self.context.get("request")

--- a/src/world/scenes/interaction_services.py
+++ b/src/world/scenes/interaction_services.py
@@ -24,7 +24,7 @@ from world.scenes.place_models import InteractionReceiver, Place
 from world.scenes.types import InteractionPayload, PersonaPayload
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from evennia.objects.models import ObjectDB
 
@@ -626,6 +626,46 @@ def resolve_audience(character: ObjectDB) -> list[Persona]:
     )
 
 
+def resolve_characters_by_name(names: Iterable[str], location: ObjectDB) -> list[ObjectDB]:
+    """Resolve bare character names against a room's contents (case-insensitive exact match).
+
+    Shared target-resolution semantics for directed communication: the telnet/WS
+    ``@Name``-prefix parser (``commands.parsing.parse_targets_from_text``) and the
+    REST submit-pose ``target_names`` field both resolve through this helper, so a
+    directed pose behaves identically regardless of which surface sent it.
+    Unresolvable names are silently skipped (not an error).
+    """
+    targets: list[ObjectDB] = []
+    for name in names:
+        lower_name = name.lower()
+        for obj in location.contents:
+            if obj.db_key.lower() == lower_name:
+                targets.append(obj)
+                break
+    return targets
+
+
+def personas_for_characters(characters: Iterable[ObjectDB]) -> list[Persona] | None:
+    """Resolve each character to its primary persona, for communication targeting.
+
+    Shared by the WS/telnet communication actions
+    (``actions.definitions.communication._characters_to_active_personas``) and the
+    REST submit-pose path, so both derive ``InteractionTargetPersona`` rows the same
+    way. Returns ``None`` (not an empty list) when nothing resolves, matching
+    ``create_interaction``/``record_interaction``'s "no explicit targets" contract.
+    """
+    personas: list[Persona] = []
+    for character in characters:
+        try:
+            sheet = character.sheet_data
+            primary = sheet.primary_persona
+        except (AttributeError, ObjectDoesNotExist):
+            continue
+        if primary is not None:
+            personas.append(primary)
+    return personas or None
+
+
 def record_interaction(  # noqa: PLR0913 - all fields needed for interaction creation
     *,
     character: ObjectDB,
@@ -635,23 +675,37 @@ def record_interaction(  # noqa: PLR0913 - all fields needed for interaction cre
     place: Place | None = None,
     receivers: list[Persona] | None = None,
     target_personas: list[Persona] | None = None,
+    persona: Persona | None = None,
+    pose_kind: str = PoseKind.STANDARD,
+    on_created: Callable[[Interaction], None] | None = None,
 ) -> Interaction | None:
     """Record an IC interaction to the database.
 
-    Reads the character's primary persona from their CharacterSheet. Skips
-    recording if the character has no CharacterSheet or no primary persona.
+    Reads the character's primary persona from their CharacterSheet, unless an
+    explicit ``persona`` override is supplied (the REST pose path lets the writer
+    pose as any owned persona — established/mask alt included — not just primary).
+    Skips recording if no persona could be resolved either way.
 
     For public interactions (no place, no receivers), the interaction is
     created without receiver rows. For place-scoped or whispered interactions,
     receiver rows are created from the place presences or explicit list.
 
+    ``pose_kind`` classifies the interaction (Spec C; only meaningful for POSE mode).
+    ``on_created``, if given, runs after the row is created and scene participation is
+    recorded, but *before* the real-time push — the seam callers use to attach
+    side effects that must exist before clients can react to the pushed payload
+    (e.g. opening a reaction window, bulk-creating InteractionAction links).
+
     After persisting, pushes the interaction payload to all objects in the
-    room via WebSocket for real-time delivery.
+    room via WebSocket for real-time delivery. Ephemeral scenes never persist —
+    they push in real-time and return None; ``on_created`` is never called in that
+    branch (there is no row to attach anything to).
     """
-    try:
-        persona = character.sheet_data.primary_persona
-    except ObjectDoesNotExist:
-        return None
+    if persona is None:
+        try:
+            persona = character.sheet_data.primary_persona
+        except ObjectDoesNotExist:
+            return None
 
     if scene is None:
         scene = get_active_scene(character.location)
@@ -674,10 +728,14 @@ def record_interaction(  # noqa: PLR0913 - all fields needed for interaction cre
         place=place,
         receivers=receivers,
         target_personas=target_personas,
+        pose_kind=pose_kind,
     )
 
     if scene is not None:
         _ensure_scene_participation(scene, character)
+
+    if on_created is not None:
+        on_created(interaction)
 
     # Pass IDs we already know to avoid re-querying rows just created.
     # For receivers: if explicitly provided use those; if place-scoped,

--- a/src/world/scenes/interaction_views.py
+++ b/src/world/scenes/interaction_views.py
@@ -14,8 +14,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
+from flows.scene_data_manager import SceneDataManager
+from flows.service_functions.communication import message_location
 from world.magic.models import CharacterResonance, PoseEndorsement, SceneEntryEndorsement
-from world.scenes.block_services import hidden_persona_ids_for_viewer
+from world.scenes.block_services import flag_blocked_contact_attempt, hidden_persona_ids_for_viewer
 from world.scenes.constants import (
     InteractionMode,
     PersonaType,
@@ -43,10 +45,11 @@ from world.scenes.interaction_serializers import (
     ReactionEmojiSerializer,
 )
 from world.scenes.interaction_services import (
-    create_interaction,
     delete_interaction,
     mark_very_private,
-    push_interaction,
+    personas_for_characters,
+    record_interaction,
+    resolve_characters_by_name,
 )
 from world.scenes.models import (
     Interaction,
@@ -277,11 +280,18 @@ class InteractionViewSet(
 
     @action(detail=False, methods=[HTTPMethod.POST], url_path="submit-pose")
     def submit_pose(self, request: Request) -> Response:
-        """Create a POSE Interaction and auto-link prior ACTION Interactions.
+        """Create a POSE Interaction with full WS-pose-path parity (#2156).
 
         Accepts ``action_link_ids`` for an explicit override:
         - Absent (key missing): auto-link is run.
         - Present as a list (even empty): exact links are created; auto-link skipped.
+
+        Mirrors ``actions.definitions.communication.PoseAction.execute``: broadcasts
+        the raw text via ``message_location`` (telnet visibility), records through the
+        shared ``record_interaction`` seam (ephemeral-scene gate, SceneParticipation +
+        covenant engagement), and flags blocked-contact attempts for any resolved
+        directed-pose targets. ``target_names`` (composer-mode ``@Name`` targets) are
+        resolved with the same semantics as the WS ``@Name``-prefix parser.
         """
         serializer = PoseSubmitSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
@@ -291,29 +301,42 @@ class InteractionViewSet(
         scene: Scene | None = (
             Scene.objects.get(pk=data["scene_id"]) if data.get("scene_id") else None
         )
-
+        character = persona.character_sheet.character
         pose_kind = data.get("pose_kind", PoseKind.STANDARD)
-        with transaction.atomic():
-            interaction = create_interaction(
-                persona=persona,
-                content=data["content"],
-                mode=InteractionMode.POSE,
+        content = data["content"]
+
+        target_names: list[str] = data.get("target_names") or []
+        target_characters = (
+            resolve_characters_by_name(target_names, character.location)
+            if target_names and character.location is not None
+            else []
+        )
+        target_personas = personas_for_characters(target_characters) if target_characters else None
+
+        # #1278/#2088 — flag circumvention: a blocked player directing a pose at the
+        # blocker via another identity. Mirrors PoseAction.execute's directed-pose gate.
+        for target_persona in target_personas or []:
+            flag_blocked_contact_attempt(
+                initiator_persona=persona,
+                target_persona=target_persona,
                 scene=scene,
-                pose_kind=pose_kind,
             )
-            if pose_kind == PoseKind.ENTRY and scene is not None:
+
+        action_link_ids: list[int] | None = data.get("action_link_ids")
+
+        def _on_created(created: Interaction) -> None:
+            if pose_kind == PoseKind.ENTRY and created.scene_id is not None:
                 # #904 — an entrance is a reactable moment; the window stays
                 # open (and reactable) until the scene closes.
-                open_reaction_window(interaction=interaction, kind=ReactionWindowKind.ENTRANCE)
+                open_reaction_window(interaction=created, kind=ReactionWindowKind.ENTRANCE)
 
-            action_link_ids: list[int] | None = data.get("action_link_ids")
             if action_link_ids is not None:
                 # Explicit override: create exactly the supplied links in order,
                 # skipping auto-link entirely (empty list = caller opted out).
                 InteractionAction.objects.bulk_create(
                     [
                         InteractionAction(
-                            pose=interaction,
+                            pose=created,
                             action_interaction_id=aid,
                             ordering=i,
                         )
@@ -321,25 +344,40 @@ class InteractionViewSet(
                     ]
                 )
             else:
-                auto_link_pose_to_actions(interaction)
+                auto_link_pose_to_actions(created)
 
-        # Broadcast after commit so clients that refetch on receipt see committed state.
-        # A fresh REST pose has no receiver/target rows; passing empty lists here
-        # explicitly skips push_interaction's fallback DB queries (per its docstring).
-        push_interaction(
-            interaction,
-            receiver_persona_ids=[],
-            target_persona_ids=[],
-            receiver_characters=[],
-        )
+        # Broadcast raw text for telnet clients (WS parity — mirrors
+        # PoseAction.execute's message_location call, which fires unconditionally
+        # before persistence, ephemeral scenes included).
+        sdm = SceneDataManager()
+        caller_state = sdm.initialize_state_for_object(character)
+        message_location(caller_state, content)
+
+        with transaction.atomic():
+            interaction = record_interaction(
+                character=character,
+                content=content,
+                mode=InteractionMode.POSE,
+                scene=scene,
+                persona=persona,
+                pose_kind=pose_kind,
+                target_personas=target_personas,
+                on_created=_on_created,
+            )
+
+        if interaction is None:
+            # Ephemeral scene: record_interaction already pushed the real-time
+            # payload (push_ephemeral_interaction) and deliberately never persists
+            # an Interaction row — there is nothing to serialize as a resource.
+            return Response({"ephemeral": True}, status=status.HTTP_201_CREATED)
 
         # The freshly-created interaction has not been through get_queryset()'s
         # Prefetch pipeline, so the cached_* to_attr attributes used by
         # InteractionListSerializer do not exist yet. Set them to empty lists
         # to avoid AttributeError on serialization; a new pose has no receivers,
-        # target personas, favorites, or reactions.
+        # favorites, or reactions (target personas are whatever we just resolved).
         interaction.cached_receivers = []
-        interaction.cached_target_personas = []
+        interaction.cached_target_personas = target_personas or []
         interaction.cached_favorites = []
         interaction.cached_reactions = []
         interaction.cached_action_links = []

--- a/src/world/scenes/place_views.py
+++ b/src/world/scenes/place_views.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from http import HTTPMethod
+from typing import Any
 
 from django.db.models import QuerySet
 from django_filters.rest_framework import DjangoFilterBackend
@@ -37,18 +38,31 @@ class PlaceSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_at"]
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Memoized per serializer instance so a list page's N rows share one
+        # owned-persona lookup instead of re-running it per row (#2156 review fold-in).
+        self._owned_persona_ids_cache: set[int] | None = None
+
+    def _owned_persona_ids(self) -> set[int]:
+        """Return (and cache) the requesting account's owned persona ids."""
+        if self._owned_persona_ids_cache is None:
+            request = self.context.get("request")
+            if not (request and request.user and request.user.is_authenticated):
+                self._owned_persona_ids_cache = set()
+            else:
+                self._owned_persona_ids_cache = set(get_account_personas(request))
+        return self._owned_persona_ids_cache
+
     def get_presence_count(self, obj: Place) -> int:
         return PlacePresence.objects.filter(place=obj).count()
 
     def get_viewer_is_present(self, obj: Place) -> bool:
         """Whether one of the requesting account's personas is present at this place (#2156)."""
-        request = self.context.get("request")
-        if not (request and request.user and request.user.is_authenticated):
-            return False
-        owned = get_account_personas(request)
-        if not owned:
-            return False
-        return PlacePresence.objects.filter(place=obj, persona_id__in=owned).exists()
+        owned = self._owned_persona_ids()
+        return (
+            bool(owned) and PlacePresence.objects.filter(place=obj, persona_id__in=owned).exists()
+        )
 
 
 class PlacePresenceSerializer(serializers.ModelSerializer):

--- a/src/world/scenes/place_views.py
+++ b/src/world/scenes/place_views.py
@@ -21,6 +21,7 @@ from world.scenes.place_models import Place, PlacePresence
 
 class PlaceSerializer(serializers.ModelSerializer):
     presence_count = serializers.SerializerMethodField()
+    viewer_is_present = serializers.SerializerMethodField()
 
     class Meta:
         model = Place
@@ -32,11 +33,22 @@ class PlaceSerializer(serializers.ModelSerializer):
             "status",
             "created_at",
             "presence_count",
+            "viewer_is_present",
         ]
         read_only_fields = ["id", "created_at"]
 
     def get_presence_count(self, obj: Place) -> int:
         return PlacePresence.objects.filter(place=obj).count()
+
+    def get_viewer_is_present(self, obj: Place) -> bool:
+        """Whether one of the requesting account's personas is present at this place (#2156)."""
+        request = self.context.get("request")
+        if not (request and request.user and request.user.is_authenticated):
+            return False
+        owned = get_account_personas(request)
+        if not owned:
+            return False
+        return PlacePresence.objects.filter(place=obj, persona_id__in=owned).exists()
 
 
 class PlacePresenceSerializer(serializers.ModelSerializer):

--- a/src/world/scenes/tests/test_interaction_views.py
+++ b/src/world/scenes/tests/test_interaction_views.py
@@ -27,7 +27,13 @@ from world.scenes.factories import (
     PlaceFactory,
     SceneFactory,
 )
-from world.scenes.models import Interaction, InteractionAction, InteractionFavorite
+from world.scenes.models import (
+    Interaction,
+    InteractionAction,
+    InteractionFavorite,
+    InteractionTargetPersona,
+    SceneParticipation,
+)
 
 
 class InteractionViewSetTestCase(APITestCase):
@@ -641,6 +647,126 @@ class PoseSubmitViewTests(APITestCase):
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED
+
+    @patch("world.scenes.interaction_views.message_location")
+    def test_submit_pose_broadcasts_via_message_location(self, mock_message_location) -> None:
+        """REST poses reach telnet clients too (#2156) — the same message_location
+
+        call PoseAction.execute makes, so a room-wide raw-text broadcast fires
+        regardless of which surface (web/telnet) submitted the pose.
+        """
+        response = self.client.post(
+            self.url,
+            {"persona_id": self.persona.pk, "content": "waves at the room."},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert mock_message_location.call_count == 1
+        _caller_state, text = mock_message_location.call_args.args
+        assert text == "waves at the room."
+
+    def test_submit_pose_creates_scene_participation_for_latecomer(self) -> None:
+        """A web pose into a scene the poser has no SceneParticipation row in yet
+
+        enrolls them (#2156) — parity with the WS pose path's
+        ``_ensure_scene_participation`` call.
+        """
+        scene = SceneFactory()
+        assert not SceneParticipation.objects.filter(scene=scene, account=self.account).exists()
+
+        response = self.client.post(
+            self.url,
+            {"persona_id": self.persona.pk, "scene_id": scene.pk, "content": "arrives late."},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert SceneParticipation.objects.filter(scene=scene, account=self.account).exists()
+
+    @patch("world.scenes.interaction_services._broadcast_to_location")
+    def test_submit_pose_in_ephemeral_scene_is_not_persisted(self, mock_broadcast) -> None:
+        """EPHEMERAL scenes push in real-time but never persist a POSE row (#2156)."""
+        scene = SceneFactory(privacy_mode=ScenePrivacyMode.EPHEMERAL)
+
+        response = self.client.post(
+            self.url,
+            {
+                "persona_id": self.persona.pk,
+                "scene_id": scene.pk,
+                "content": "a pose that must not be written to the log.",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data == {"ephemeral": True}
+        assert not Interaction.objects.filter(scene=scene).exists()
+        assert mock_broadcast.call_count == 1
+
+    def test_submit_pose_with_target_names_creates_target_rows(self) -> None:
+        """target_names resolves co-located characters into InteractionTargetPersona
+
+        rows (#2156) — the REST equivalent of the WS ``@Name``-prefix parse.
+        """
+        target_character = CharacterFactory(db_key="Bob", location=self.room)
+        target_sheet = CharacterSheetFactory(character=target_character)
+        target_persona = target_sheet.primary_persona
+
+        response = self.client.post(
+            self.url,
+            {
+                "persona_id": self.persona.pk,
+                "content": "waves.",
+                "target_names": ["Bob"],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        pose_id = response.data["id"]
+        assert InteractionTargetPersona.objects.filter(
+            interaction_id=pose_id, persona=target_persona
+        ).exists()
+        assert response.data["target_persona_ids"] == [target_persona.pk]
+
+    @patch("world.scenes.interaction_views.flag_blocked_contact_attempt")
+    def test_submit_pose_with_target_names_flags_blocked_contact(self, mock_flag) -> None:
+        """Directed REST poses run the same blocked-contact flag as WS/telnet (#2156)."""
+        target_character = CharacterFactory(db_key="Carol", location=self.room)
+        target_sheet = CharacterSheetFactory(character=target_character)
+        target_persona = target_sheet.primary_persona
+
+        response = self.client.post(
+            self.url,
+            {
+                "persona_id": self.persona.pk,
+                "content": "confronts.",
+                "target_names": ["Carol"],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_flag.assert_called_once_with(
+            initiator_persona=self.persona,
+            target_persona=target_persona,
+            scene=None,
+        )
+
+    def test_submit_pose_with_unresolvable_target_name_is_not_an_error(self) -> None:
+        """An unresolvable target_names entry is silently skipped, not rejected (#2156)."""
+        response = self.client.post(
+            self.url,
+            {
+                "persona_id": self.persona.pk,
+                "content": "waves at nobody.",
+                "target_names": ["Nobody"],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["target_persona_ids"] == []
 
 
 class ActionLinksSerializerTests(APITestCase):

--- a/src/world/scenes/tests/test_interaction_views.py
+++ b/src/world/scenes/tests/test_interaction_views.py
@@ -436,6 +436,53 @@ class PoseSubmitViewTests(APITestCase):
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data["scene"] == scene.pk
 
+    def test_submit_pose_rejects_when_actor_not_in_scenes_room(self) -> None:
+        """A located scene rejects a pose from a persona whose character is elsewhere (#2156)."""
+        other_room = ObjectDBFactory(
+            db_key="Other Room",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        scene = SceneFactory(location=other_room)
+        response = self.client.post(
+            self.url,
+            {
+                "persona_id": self.persona.pk,
+                "scene_id": scene.pk,
+                "content": "A pose from the wrong room.",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "not present" in str(response.data["scene_id"][0])
+
+    def test_submit_pose_accepts_when_actor_in_scenes_room(self) -> None:
+        """A located scene accepts a pose when the actor's character is co-located (#2156)."""
+        scene = SceneFactory(location=self.room)
+        response = self.client.post(
+            self.url,
+            {
+                "persona_id": self.persona.pk,
+                "scene_id": scene.pk,
+                "content": "A pose from the right room.",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_submit_pose_skips_colocation_check_for_locationless_scene(self) -> None:
+        """A scene with no location (e.g. scene-less RP) never gates on co-location (#2156)."""
+        scene = SceneFactory(location=None)
+        response = self.client.post(
+            self.url,
+            {
+                "persona_id": self.persona.pk,
+                "scene_id": scene.pk,
+                "content": "A pose in a scene-less location.",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
     def test_submit_entry_pose_opens_reaction_window(self) -> None:
         """pose_kind=entry persists and opens a Make-an-Entrance window (#904)."""
         from world.scenes.constants import PoseKind, ReactionWindowKind

--- a/src/world/scenes/tests/test_place_views.py
+++ b/src/world/scenes/tests/test_place_views.py
@@ -1,0 +1,74 @@
+"""Tests for the PlaceSerializer's viewer_is_present field (#2156)."""
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
+from world.scenes.factories import PlaceFactory, PlacePresenceFactory
+
+
+class PlaceViewerIsPresentTests(APITestCase):
+    """GET /api/places/?room=<room.id> reports whether the viewer's persona is present."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from evennia.utils.idmapper import models as idmapper_models
+
+        idmapper_models.flush_cache()
+        cls.account = AccountFactory()
+        cls.character = CharacterFactory()
+        cls.roster_entry = RosterEntryFactory(character_sheet__character=cls.character)
+        cls.player_data = PlayerDataFactory(account=cls.account)
+        cls.tenure = RosterTenureFactory(
+            player_data=cls.player_data,
+            roster_entry=cls.roster_entry,
+        )
+        cls.identity = CharacterSheetFactory(character=cls.character)
+        cls.persona = cls.identity.primary_persona
+
+    def setUp(self) -> None:
+        from evennia.utils.idmapper import models as idmapper_models
+
+        idmapper_models.flush_cache()
+        self.room = ObjectDBFactory(
+            db_key="Tavern",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        self.character.location = self.room
+        self.client.force_authenticate(user=self.account)
+        self.url = reverse("place-list")
+
+    def test_viewer_is_present_true_when_persona_has_presence(self) -> None:
+        place = PlaceFactory(room=self.room, name="Bar")
+        PlacePresenceFactory(place=place, persona=self.persona)
+
+        response = self.client.get(self.url, {"room": self.room.pk})
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data["results"]
+        assert len(results) == 1
+        assert results[0]["viewer_is_present"] is True
+
+    def test_viewer_is_present_false_when_no_presence(self) -> None:
+        PlaceFactory(room=self.room, name="Corner")
+
+        response = self.client.get(self.url, {"room": self.room.pk})
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data["results"]
+        assert len(results) == 1
+        assert results[0]["viewer_is_present"] is False
+
+    def test_unauthenticated_request_is_rejected(self) -> None:
+        self.client.force_authenticate(user=None)
+        PlaceFactory(room=self.room, name="Bar")
+
+        response = self.client.get(self.url, {"room": self.room.pk})
+
+        assert response.status_code in {
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        }

--- a/src/world/scenes/tests/test_place_views.py
+++ b/src/world/scenes/tests/test_place_views.py
@@ -72,3 +72,33 @@ class PlaceViewerIsPresentTests(APITestCase):
             status.HTTP_401_UNAUTHORIZED,
             status.HTTP_403_FORBIDDEN,
         }
+
+    def test_list_page_reuses_owned_persona_lookup_across_rows(self) -> None:
+        """A list page's N rows share ONE owned-persona lookup, not N (#2156 review fold-in).
+
+        Pinned to 18 queries for GET /api/places/?room=<room.id> with 3 places on the
+        page (observed via assertNumQueries's captured-query dump; composition below —
+        renumber this comment if the count ever legitimately changes):
+        1. session lookup (`force_authenticate`/session auth)
+        2-4. SAVEPOINT / INSERT / RELEASE SAVEPOINT (session-creation bookkeeping)
+        5. Place COUNT (pagination)
+        6. Place list SELECT (filtered/ordered/paginated)
+        7. PlacePresence COUNT for place 1 (`get_presence_count`)
+        8-10. get_account_personas' PlayerData -> RosterEntry -> Persona chain — runs
+           ONCE for the whole page (memoized by `PlaceSerializer._owned_persona_ids`);
+           this is the exact N-per-row duplication this test guards against
+        11. PlacePresence.exists() for place 1 (`get_viewer_is_present`)
+        12. PlacePresence COUNT for place 2
+        13. PlacePresence.exists() for place 2 (persona ids reused from cache, no re-query)
+        14. PlacePresence COUNT for place 3
+        15. PlacePresence.exists() for place 3 (persona ids reused from cache, no re-query)
+        16-18. SAVEPOINT / session UPDATE / RELEASE SAVEPOINT (session-teardown bookkeeping)
+        """
+        for name in ("Bar", "Corner", "Hearth"):
+            PlaceFactory(room=self.room, name=name)
+
+        with self.assertNumQueries(18):
+            response = self.client.get(self.url, {"room": self.room.pk})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 3


### PR DESCRIPTION
Closes #2156

## Summary

/game becomes the one play surface (spec on #2156, approved): chat-bubble scene feed (PoseUnit avatar bubbles, FormattedContent markdown — no terminal styling), conversation threading with per-thread unread (session last-seen + scene-load baseline), the scene toolset (actions/places/consent/composer modes incl. live tabletalk via viewer_is_present), and the ratified character card drawer (avatar click → in-place public-roster profile with Friend/Whisper; disguises never resolve). /scenes/:id stays the record page.

Correctness folds: REST submit-pose is now the canonical scene-pose path WITH full WS-parity side-effects (room broadcast so telnet players see web poses, scene participation + covenant engagement, ephemeral never-persist gate, directed-pose target rows + blocked-contact flagging) plus a server-side co-location check (null-location scenes skip); markdown renders; places queries key off the room id (fixing a pre-existing scene-id coincidence bug); pose rejections surface a toast and preserve the draft.

Review trail: per-task reviews + whole-branch adversarial review caught and fixed 5 user-facing defects pre-CI (thread clicks not filtering, first-whisper unread suppression, baseline killed by room churn, the submit-pose side-effect gap, dropped composer targets). ADR-0111. Notes: the no-scene /game fallback still renders the legacy ChatWindow (bubble bar fully met in-scene; acceptable scope); #1035 must take the next free ADR number (0111 consumed here).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2156 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: rebased onto origin/main (015bd842f); one conflict in docs/roadmap/rp-scenes.md resolved by keeping this branch's superset status block; post-rebase world.scenes 986 OK + frontend typecheck clean

<!-- last-addressed-comment: 0 -->