### PR TITLE
BuildingKind catalog expansion (post-Plan 3 content authoring)

### DIFF
--- a/src/world/buildings/seeds.py
+++ b/src/world/buildings/seeds.py
@@ -58,6 +58,49 @@ def ensure_house_kind() -> BuildingKind:
     return kind
 
 
+# Urban core BuildingKind catalog rows. Each is a staff-authored catalog
+# entry with non-exclusive descriptive flags (see BuildingKind model docstring).
+# Authored here (not as a fixture) per repo discipline #683.
+URBAN_BUILDING_KINDS: tuple[tuple[str, dict[str, bool]], ...] = (
+    ("Cottage", {"is_residential": True}),
+    ("Tavern", {"is_residential": True, "is_commercial": True}),
+    ("Shop", {"is_commercial": True}),
+    ("Workshop", {"is_commercial": True}),
+    ("Guild Hall", {"is_commercial": True}),
+    ("Warehouse", {"is_commercial": True}),
+)
+
+URBAN_BUILDING_KIND_DESCRIPTIONS: dict[str, str] = {
+    "Cottage": "A small residential dwelling; the rural baseline.",
+    "Tavern": "A commercial establishment offering food, drink, and lodging.",
+    "Shop": "A commercial storefront for trade and craft.",
+    "Workshop": "A production space for manufacturing and fabrication.",
+    "Guild Hall": "A headquarters for a guild or organization's operations.",
+    "Warehouse": "A commercial storage building for goods and materials.",
+}
+
+
+def ensure_urban_building_kinds() -> None:
+    """Get-or-create the urban core BuildingKind rows (#694).
+
+    Six kinds that expand the Builders Guild Clerk's permit menu beyond
+    House: Cottage, Tavern, Shop, Workshop, Guild Hall, Warehouse. Each
+    carries only the descriptive flags appropriate to its kind — all
+    other flags default to False on the model.
+
+    Idempotent — safe to call from test setUp, app startup, or staff
+    tooling.
+    """
+    for name, flags in URBAN_BUILDING_KINDS:
+        BuildingKind.objects.get_or_create(
+            name=name,
+            defaults={
+                "description": URBAN_BUILDING_KIND_DESCRIPTIONS[name],
+                **flags,
+            },
+        )
+
+
 # PLACEHOLDER magnitudes (#670) — ratified super-linear curve (one big build ≈ 2× two
 # half-size builds); absolute values await the economy/tuning pass. Admin-editable rows.
 BUILDING_SIZE_TIERS: tuple[tuple[int, str, int], ...] = (
@@ -119,6 +162,7 @@ def ensure_plan_3_seeds() -> None:
     """
     ensure_building_permit_template()
     ensure_house_kind()
+    ensure_urban_building_kinds()
     ensure_default_kind_on_permit_offers()
     ensure_building_size_tiers()
     # Room-size ladder (#670) lives in evennia_extensions but construction depends

--- a/src/world/buildings/tests/test_building_kinds_viewset.py
+++ b/src/world/buildings/tests/test_building_kinds_viewset.py
@@ -84,3 +84,19 @@ class BuildingKindViewSetTests(APITestCase):
         results = response.json()["results"]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["name"], "Tavern")
+
+    def test_urban_seed_kinds_appear_in_catalog(self) -> None:
+        """Seed-authored urban kinds appear in the catalog endpoint."""
+        from world.buildings.seeds import ensure_urban_building_kinds
+
+        ensure_urban_building_kinds()
+        response = self._get()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = {row["name"] for row in response.json()["results"]}
+        # The 3 manually-created kinds + 6 seeded urban kinds
+        for expected in ("Cottage", "Tavern", "Shop", "Workshop", "Guild Hall", "Warehouse"):
+            self.assertIn(expected, names)
+
+        cottage = next(row for row in response.json()["results"] if row["name"] == "Cottage")
+        self.assertTrue(cottage["is_residential"])
+        self.assertFalse(cottage["is_commercial"])

--- a/src/world/buildings/tests/test_seeds.py
+++ b/src/world/buildings/tests/test_seeds.py
@@ -9,8 +9,18 @@ from world.buildings.seeds import (
     ensure_building_permit_template,
     ensure_house_kind,
     ensure_plan_3_seeds,
+    ensure_urban_building_kinds,
 )
 from world.items.models import ItemTemplate
+
+URBAN_KIND_FLAGS = {
+    "Cottage": {"is_residential": True, "is_commercial": False},
+    "Tavern": {"is_residential": True, "is_commercial": True},
+    "Shop": {"is_residential": False, "is_commercial": True},
+    "Workshop": {"is_residential": False, "is_commercial": True},
+    "Guild Hall": {"is_residential": False, "is_commercial": True},
+    "Warehouse": {"is_residential": False, "is_commercial": True},
+}
 
 
 class BuildingPermitTemplateSeedTests(TestCase):
@@ -57,3 +67,27 @@ class Plan3SeedsTests(TestCase):
         for offer in NPCServiceOffer.objects.filter(kind=OfferKind.PERMIT):
             self.assertIsNotNone(offer.permit_offer_details.building_kind_id)
             self.assertEqual(offer.permit_offer_details.building_kind.name, HOUSE_KIND_NAME)
+
+
+class UrbanBuildingKindsSeedTests(TestCase):
+    def test_creates_all_six_urban_kinds(self) -> None:
+        ensure_urban_building_kinds()
+        for name, flags in URBAN_KIND_FLAGS.items():
+            kind = BuildingKind.objects.get(name=name)
+            for flag_name, expected in flags.items():
+                self.assertEqual(
+                    getattr(kind, flag_name),
+                    expected,
+                    f"{name}.{flag_name} should be {expected}",
+                )
+
+    def test_idempotent(self) -> None:
+        ensure_urban_building_kinds()
+        ensure_urban_building_kinds()
+        for name in URBAN_KIND_FLAGS:
+            self.assertEqual(BuildingKind.objects.filter(name=name).count(), 1)
+
+    def test_seeded_via_plan_3_seeds(self) -> None:
+        ensure_plan_3_seeds()
+        for name in URBAN_KIND_FLAGS:
+            self.assertTrue(BuildingKind.objects.filter(name=name).exists())

--- a/src/world/buildings/tests/test_seeds.py
+++ b/src/world/buildings/tests/test_seeds.py
@@ -55,18 +55,35 @@ class Plan3SeedsTests(TestCase):
         self.assertTrue(ItemTemplate.objects.filter(name=BUILDING_PERMIT_TEMPLATE_NAME).exists())
         self.assertTrue(BuildingKind.objects.filter(name=HOUSE_KIND_NAME).exists())
 
-    def test_wires_clerk_offers_to_house_when_present(self) -> None:
+    def test_defaults_unwired_permit_offers_to_house(self) -> None:
         from world.npc_services.constants import OfferKind
-        from world.npc_services.models import NPCServiceOffer
+        from world.npc_services.factories import NPCRoleFactory
+        from world.npc_services.models import NPCServiceOffer, PermitOfferDetails
         from world.npc_services.seeds import ensure_builders_guild_clerk_role
 
-        # First seed npc_services (creates offers with no kind)
+        # Seed the clerk role (offers are explicitly wired to urban kinds)
         ensure_builders_guild_clerk_role()
-        # Then run Plan 3 seeds — should patch the clerk's PERMIT offers
+        # Then run Plan 3 seeds — ensure_default_kind_on_permit_offers
+        # should NOT overwrite the clerk's explicitly-wired kinds, but
+        # SHOULD default any unknown PERMIT offers to House.
         ensure_plan_3_seeds()
-        for offer in NPCServiceOffer.objects.filter(kind=OfferKind.PERMIT):
-            self.assertIsNotNone(offer.permit_offer_details.building_kind_id)
-            self.assertEqual(offer.permit_offer_details.building_kind.name, HOUSE_KIND_NAME)
+        # The clerk's Cottage offer should still point at Cottage
+        cottage_offer = NPCServiceOffer.objects.get(label="Apply for a Cottage permit")
+        self.assertEqual(cottage_offer.permit_offer_details.building_kind.name, "Cottage")
+        # An unwired offer (simulating a future role) gets defaulted to House
+        unwired_role = NPCRoleFactory(name="Future Role")
+        unwired_offer = NPCServiceOffer.objects.create(
+            role=unwired_role,
+            label="Some future permit",
+            kind=OfferKind.PERMIT,
+        )
+        PermitOfferDetails.objects.create(offer=unwired_offer)
+        ensure_plan_3_seeds()
+        unwired_offer.refresh_from_db()
+        self.assertEqual(
+            unwired_offer.permit_offer_details.building_kind.name,
+            HOUSE_KIND_NAME,
+        )
 
 
 class UrbanBuildingKindsSeedTests(TestCase):

--- a/src/world/npc_services/seeds.py
+++ b/src/world/npc_services/seeds.py
@@ -29,14 +29,38 @@ if TYPE_CHECKING:
 BUILDERS_GUILD_CLERK_ROLE_NAME = "Builders Guild Clerk"
 
 
+_CLERK_OFFER_LABELS: frozenset[str] = frozenset(
+    {
+        "Apply for a Cottage permit",
+        "Apply for a House permit",
+        "Apply for a Tavern permit",
+        "Apply for a Shop permit",
+        "Apply for a Workshop permit",
+        "Apply for a Guild Hall permit",
+        "Apply for a Warehouse permit",
+        "Negotiate a discount on permit fees",
+        "Request expedited processing",
+    }
+)
+
+
 def ensure_builders_guild_clerk_role() -> NPCRole:
     """Get-or-create the Builders Guild Clerk role + its permit offers.
 
     Idempotent. Safe to call from test setUp, app startup, or staff
-    tooling. Offers are created with empty ``eligibility_rule`` (Plan 3
-    fills in the real ward-permit predicate); each offer gets a
-    ``PermitOfferDetails`` row so the per-kind details model is wired.
+    tooling. Each PERMIT offer is explicitly wired to a BuildingKind
+    via ``PermitOfferDetails.building_kind``. Old-label offers from
+    prior seed versions are cleaned up on each invocation.
     """
+    from world.buildings.models import BuildingKind  # noqa: PLC0415
+    from world.buildings.seeds import (  # noqa: PLC0415
+        ensure_house_kind,
+        ensure_urban_building_kinds,
+    )
+
+    ensure_urban_building_kinds()
+    ensure_house_kind()
+
     role, _ = NPCRole.objects.get_or_create(
         name=BUILDERS_GUILD_CLERK_ROLE_NAME,
         defaults={
@@ -51,15 +75,53 @@ def ensure_builders_guild_clerk_role() -> NPCRole:
             "default_rapport_starting_value": 0,
         },
     )
+
+    # Idempotent cleanup: delete any offers on this role whose labels
+    # are not in the current expected set (handles migration from old
+    # seed labels like "Apply for a small residential permit").
+    NPCServiceOffer.objects.filter(role=role).exclude(label__in=_CLERK_OFFER_LABELS).delete()
+
     _ensure_offer(
         role=role,
-        label="Apply for a small residential permit",
-        rapport_requirement=0,
+        label="Apply for a Cottage permit",
+        building_kind=BuildingKind.objects.get(name="Cottage"),
+        max_target_size=2,
     )
     _ensure_offer(
         role=role,
-        label="Apply for a workshop permit",
-        rapport_requirement=0,
+        label="Apply for a House permit",
+        building_kind=BuildingKind.objects.get(name="House"),
+        max_target_size=3,
+    )
+    _ensure_offer(
+        role=role,
+        label="Apply for a Tavern permit",
+        building_kind=BuildingKind.objects.get(name="Tavern"),
+        max_target_size=5,
+    )
+    _ensure_offer(
+        role=role,
+        label="Apply for a Shop permit",
+        building_kind=BuildingKind.objects.get(name="Shop"),
+        max_target_size=4,
+    )
+    _ensure_offer(
+        role=role,
+        label="Apply for a Workshop permit",
+        building_kind=BuildingKind.objects.get(name="Workshop"),
+        max_target_size=4,
+    )
+    _ensure_offer(
+        role=role,
+        label="Apply for a Guild Hall permit",
+        building_kind=BuildingKind.objects.get(name="Guild Hall"),
+        max_target_size=6,
+    )
+    _ensure_offer(
+        role=role,
+        label="Apply for a Warehouse permit",
+        building_kind=BuildingKind.objects.get(name="Warehouse"),
+        max_target_size=5,
     )
     _ensure_offer(
         role=role,

--- a/src/world/npc_services/seeds.py
+++ b/src/world/npc_services/seeds.py
@@ -14,12 +14,17 @@ testable today.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from world.npc_services.constants import DrawMode, OfferKind
 from world.npc_services.models import (
     NPCRole,
     NPCServiceOffer,
     PermitOfferDetails,
 )
+
+if TYPE_CHECKING:
+    from world.buildings.models import BuildingKind
 
 BUILDERS_GUILD_CLERK_ROLE_NAME = "Builders Guild Clerk"
 
@@ -72,12 +77,23 @@ def ensure_builders_guild_clerk_role() -> NPCRole:
     return role
 
 
-def _ensure_offer(role: NPCRole, label: str, **overrides: object) -> NPCServiceOffer:
+def _ensure_offer(
+    role: NPCRole,
+    label: str,
+    *,
+    building_kind: BuildingKind | None = None,
+    max_target_size: int | None = None,
+    **overrides: object,
+) -> NPCServiceOffer:
     """Inner helper: idempotent (role, label)-keyed offer + details row.
 
     ``overrides`` accepts any NPCServiceOffer field (rapport_requirement,
     is_final, rapport_delta_success/failure, etc.). Defaults to a final
     PERMIT MENU offer with zero rapport requirement and zero deltas.
+
+    When ``building_kind`` is provided, it is set on the offer's
+    ``PermitOfferDetails`` row at creation time. When ``max_target_size``
+    is provided, it overrides the default (10) on the details row.
     """
     defaults: dict[str, object] = {
         "kind": OfferKind.PERMIT,
@@ -93,5 +109,10 @@ def _ensure_offer(role: NPCRole, label: str, **overrides: object) -> NPCServiceO
         role=role, label=label, defaults=defaults
     )
     if created:
-        PermitOfferDetails.objects.create(offer=offer)
+        details_defaults: dict[str, object] = {}
+        if building_kind is not None:
+            details_defaults["building_kind"] = building_kind
+        if max_target_size is not None:
+            details_defaults["default_max_target_size"] = max_target_size
+        PermitOfferDetails.objects.create(offer=offer, **details_defaults)
     return offer

--- a/src/world/npc_services/tests/test_seeds.py
+++ b/src/world/npc_services/tests/test_seeds.py
@@ -65,3 +65,68 @@ class EnsureOfferBuildingKindTests(TestCase):
         role = NPCRoleFactory(name="test-role-no-kind")
         offer = _ensure_offer(role=role, label="Test permit no kind")
         self.assertIsNone(offer.permit_offer_details.building_kind_id)
+
+
+class ClerkOfferWiringTests(TestCase):
+    def setUp(self) -> None:
+        from world.buildings.seeds import ensure_urban_building_kinds
+
+        ensure_urban_building_kinds()
+
+    def test_creates_seven_permit_offers_wired_to_kinds(self) -> None:
+        role = ensure_builders_guild_clerk_role()
+        permit_offers = NPCServiceOffer.objects.filter(role=role, kind=OfferKind.PERMIT)
+        # All 9 offers have kind=PERMIT; the 7 kind-specific ones have
+        # building_kind wired, the 2 negotiation/utility ones do not.
+        wired = [o for o in permit_offers if o.permit_offer_details.building_kind_id]
+        self.assertEqual(len(wired), 7)
+        for offer in wired:
+            self.assertIsNotNone(
+                offer.permit_offer_details.building_kind_id,
+                f"Offer {offer.label!r} has no building_kind wired",
+            )
+
+    def test_total_offer_count_is_nine(self) -> None:
+        role = ensure_builders_guild_clerk_role()
+        offers = NPCServiceOffer.objects.filter(role=role)
+        self.assertEqual(offers.count(), 9)
+
+    def test_cottage_offer_capped_at_size_2(self) -> None:
+        role = ensure_builders_guild_clerk_role()
+        offer = NPCServiceOffer.objects.get(role=role, label="Apply for a Cottage permit")
+        self.assertEqual(offer.permit_offer_details.default_max_target_size, 2)
+        self.assertEqual(offer.permit_offer_details.building_kind.name, "Cottage")
+
+    def test_guild_hall_offer_capped_at_size_6(self) -> None:
+        role = ensure_builders_guild_clerk_role()
+        offer = NPCServiceOffer.objects.get(role=role, label="Apply for a Guild Hall permit")
+        self.assertEqual(offer.permit_offer_details.default_max_target_size, 6)
+        self.assertEqual(offer.permit_offer_details.building_kind.name, "Guild Hall")
+
+    def test_old_label_offers_cleaned_up(self) -> None:
+        """Old-label offers from the previous seed are deleted on re-seed."""
+        role = ensure_builders_guild_clerk_role()
+        # Manually add an old-label offer to simulate pre-migration state
+        NPCServiceOffer.objects.create(
+            role=role,
+            label="Apply for a small residential permit",
+            kind=OfferKind.PERMIT,
+        )
+        # Re-seed — should clean up the old-label offer
+        ensure_builders_guild_clerk_role()
+        self.assertFalse(
+            NPCServiceOffer.objects.filter(
+                role=role, label="Apply for a small residential permit"
+            ).exists()
+        )
+
+    def test_non_permit_offers_preserved(self) -> None:
+        role = ensure_builders_guild_clerk_role()
+        for label in (
+            "Negotiate a discount on permit fees",
+            "Request expedited processing",
+        ):
+            self.assertTrue(
+                NPCServiceOffer.objects.filter(role=role, label=label).exists(),
+                f"Non-permit offer {label!r} should still exist",
+            )

--- a/src/world/npc_services/tests/test_seeds.py
+++ b/src/world/npc_services/tests/test_seeds.py
@@ -2,10 +2,13 @@
 
 from django.test import TestCase
 
+from world.buildings.factories import BuildingKindFactory
 from world.npc_services.constants import DrawMode, OfferKind
+from world.npc_services.factories import NPCRoleFactory
 from world.npc_services.models import NPCRole, NPCServiceOffer, PermitOfferDetails
 from world.npc_services.seeds import (
     BUILDERS_GUILD_CLERK_ROLE_NAME,
+    _ensure_offer,
     ensure_builders_guild_clerk_role,
 )
 
@@ -43,3 +46,22 @@ class EnsureBuildersGuildClerkRoleTests(TestCase):
             .values_list("label", flat=True)
         )
         self.assertEqual(offers_first_pass, offers_second_pass)
+
+
+class EnsureOfferBuildingKindTests(TestCase):
+    def test_building_kind_set_on_permit_details(self) -> None:
+        role = NPCRoleFactory(name="test-role-for-kind")
+        kind = BuildingKindFactory(name="test-kind-for-offer")
+        offer = _ensure_offer(
+            role=role,
+            label="Test permit",
+            building_kind=kind,
+            max_target_size=4,
+        )
+        self.assertEqual(offer.permit_offer_details.building_kind, kind)
+        self.assertEqual(offer.permit_offer_details.default_max_target_size, 4)
+
+    def test_building_kind_none_leaves_unset(self) -> None:
+        role = NPCRoleFactory(name="test-role-no-kind")
+        offer = _ensure_offer(role=role, label="Test permit no kind")
+        self.assertIsNone(offer.permit_offer_details.building_kind_id)


### PR DESCRIPTION
Closes #694

## Summary

Authors 6 new BuildingKind rows (Cottage, Tavern, Shop, Workshop, Guild Hall, Warehouse) via ensure_urban_building_kinds(). Restructures the Builders Guild Clerk's permit offers from 2 generic offers to 7 kind-specific offers, each explicitly wired to a BuildingKind via PermitOfferDetails. Resolves the three open design questions from #694 as binding precedent: zero-room buildings are valid, fortified holds are distinct kinds, ships are buildings (ADR-0086).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #694 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: clean rebase, no conflicts

<!-- last-addressed-comment: 0 -->