### PR TITLE
Combat announces itself: seamless scene→combat→scene transitions (#2155)

### DIFF
--- a/frontend/e2e/battle-map.spec.ts
+++ b/frontend/e2e/battle-map.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Battle map smoke tests', () => {
+  test('battle map route mounts without errors', async ({ page }) => {
+    // Use a non-existent scene id; the page should render its empty/loading state
+    // without crashing — that's the smoke contract (mirrors combat.spec.ts).
+    const errors: string[] = [];
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    await page.goto('/scenes/999999/battle');
+    await page.waitForLoadState('networkidle');
+
+    const root = page.locator('#root');
+    await expect(root).not.toBeEmpty();
+
+    const unexpectedErrors = consoleErrors.filter(
+      (e) => !e.includes('Failed to load resource') && !e.includes('favicon')
+    );
+    expect(errors).toEqual([]);
+    expect(unexpectedErrors).toEqual([]);
+  });
+
+  test('battle map route does not load a blank page', async ({ page }) => {
+    await page.goto('/scenes/1/battle');
+    const root = page.locator('#root');
+    await expect(root).not.toBeEmpty();
+  });
+
+  test('no uncaught JS exceptions on the battle map route', async ({ page }) => {
+    const exceptions: string[] = [];
+    page.on('pageerror', (err) => {
+      exceptions.push(err.message);
+    });
+
+    await page.goto('/scenes/999999/battle');
+    await page.waitForLoadState('networkidle');
+
+    expect(exceptions).toEqual([]);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -93,6 +93,7 @@ import { StaffAccountHistoryPage } from './staff/pages/StaffAccountHistoryPage';
 import { StaffGMApplicationsPage } from './staff/pages/StaffGMApplicationsPage';
 import { StaffGMApplicationDetailPage } from './staff/pages/StaffGMApplicationDetailPage';
 import { RouletteModal } from './components/roulette/RouletteModal';
+import { Toaster } from './components/ui/sonner';
 
 // ---------------------------------------------------------------------------
 // Lazy-loaded stories pages (React.lazy for route-level code splitting)
@@ -951,6 +952,7 @@ function App() {
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
       <RouletteModal />
+      <Toaster />
     </Layout>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -94,6 +94,7 @@ import { StaffGMApplicationsPage } from './staff/pages/StaffGMApplicationsPage';
 import { StaffGMApplicationDetailPage } from './staff/pages/StaffGMApplicationDetailPage';
 import { RouletteModal } from './components/roulette/RouletteModal';
 import { Toaster } from './components/ui/sonner';
+import { DuelChallengeNotifier } from './combat/DuelChallengeNotifier';
 
 // ---------------------------------------------------------------------------
 // Lazy-loaded stories pages (React.lazy for route-level code splitting)
@@ -953,6 +954,7 @@ function App() {
       </Routes>
       <RouletteModal />
       <Toaster />
+      <DuelChallengeNotifier />
     </Layout>
   );
 }

--- a/frontend/src/combat/CombatTurnPanel.tsx
+++ b/frontend/src/combat/CombatTurnPanel.tsx
@@ -147,7 +147,7 @@ export function CombatTurnPanel({
             Encounter Concluded — Round {encounter.round_number ?? 0}
           </h2>
         </div>
-        <EncounterOutcomeBanner outcome={outcome} />
+        <EncounterOutcomeBanner outcome={outcome} sceneId={encounter.scene} />
       </div>
     );
   }

--- a/frontend/src/combat/DuelChallengeNotifier.tsx
+++ b/frontend/src/combat/DuelChallengeNotifier.tsx
@@ -1,0 +1,101 @@
+/**
+ * DuelChallengeNotifier — site-wide alert for an incoming duel challenge (#2157).
+ *
+ * `useDuelChallengeInbox` was previously polled only inside `CombatScenePage`,
+ * so a player who never navigated there never saw an incoming challenge. This
+ * component is mounted once at the app root (alongside `<Toaster/>` and
+ * `<RouletteModal/>` in App.tsx) and fires a toast — with inline Accept/Decline
+ * buttons — the first time a new challenge id appears in the poll. A `Set` of
+ * already-toasted ids prevents the 15s poll from re-firing the same toast.
+ *
+ * Renders nothing itself — `null` always, purely a side-effect component.
+ */
+
+import { useEffect, useMemo, useRef } from 'react';
+import { toast } from 'sonner';
+import { useAppSelector } from '@/store/hooks';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+import { useDuelChallengeInbox, useDispatchPlayerAction } from './queries';
+import { registryRef } from './duels/DuelChallengeControls';
+
+interface ToastBodyProps {
+  toastId: string | number;
+  challengerName: string;
+  challengeId: number;
+  onAccept: () => void;
+  onDecline: () => void;
+}
+
+function DuelChallengeToastBody({ challengerName, onAccept, onDecline }: ToastBodyProps) {
+  return (
+    <div
+      className="rounded-md border border-amber-500/50 bg-amber-500/10 p-3 shadow-sm"
+      data-testid="duel-challenge-toast"
+    >
+      <p className="text-sm text-foreground">
+        <span className="font-semibold">{challengerName}</span> has challenged you to a duel.
+      </p>
+      <div className="mt-2 flex gap-2">
+        <button
+          type="button"
+          onClick={onAccept}
+          data-testid="duel-toast-accept-btn"
+          className="rounded border border-emerald-500/60 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-300"
+        >
+          Accept
+        </button>
+        <button
+          type="button"
+          onClick={onDecline}
+          data-testid="duel-toast-decline-btn"
+          className="rounded border border-destructive/60 bg-destructive/10 px-3 py-1 text-xs font-semibold text-destructive"
+        >
+          Decline
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function DuelChallengeNotifier() {
+  const activeCharacter = useAppSelector((state) => state.game.active);
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
+  const activeEntry = useMemo(
+    () => myRosterEntries.find((e) => e.name === activeCharacter) ?? null,
+    [myRosterEntries, activeCharacter]
+  );
+  const characterId = activeEntry?.character_id ?? 0;
+
+  const { data: incomingChallenges = [] } = useDuelChallengeInbox({
+    enabled: characterId > 0,
+    role: 'incoming',
+  });
+  const { mutate } = useDispatchPlayerAction(characterId);
+
+  const toastedIds = useRef<Set<number>>(new Set());
+
+  useEffect(() => {
+    for (const challenge of incomingChallenges) {
+      if (toastedIds.current.has(challenge.id)) continue;
+      toastedIds.current.add(challenge.id);
+
+      toast.custom((toastId) => (
+        <DuelChallengeToastBody
+          toastId={toastId}
+          challengerName={challenge.challenger.name}
+          challengeId={challenge.id}
+          onAccept={() => {
+            mutate(registryRef('accept', { challenge_id: challenge.id }));
+            toast.dismiss(toastId);
+          }}
+          onDecline={() => {
+            mutate(registryRef('decline', { challenge_id: challenge.id }));
+            toast.dismiss(toastId);
+          }}
+        />
+      ));
+    }
+  }, [incomingChallenges, mutate]);
+
+  return null;
+}

--- a/frontend/src/combat/DuelChallengeNotifier.tsx
+++ b/frontend/src/combat/DuelChallengeNotifier.tsx
@@ -8,10 +8,16 @@
  * buttons — the first time a new challenge id appears in the poll. A `Set` of
  * already-toasted ids prevents the 15s poll from re-firing the same toast.
  *
+ * Accept/Decline await the dispatch (mirroring DuelChallengeControls' mutateAsync
+ * + try/catch pattern) — the toast only dismisses on success; on failure it stays
+ * open with an inline error and the buttons remain clickable to retry, so a failed
+ * dispatch is never silently lost (the id was already added to toastedIds when the
+ * toast first fired, so a dismissed-on-error toast would otherwise never resurface).
+ *
  * Renders nothing itself — `null` always, purely a side-effect component.
  */
 
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
@@ -19,14 +25,27 @@ import { useDuelChallengeInbox, useDispatchPlayerAction } from './queries';
 import { registryRef } from './duels/DuelChallengeControls';
 
 interface ToastBodyProps {
-  toastId: string | number;
   challengerName: string;
-  challengeId: number;
-  onAccept: () => void;
-  onDecline: () => void;
+  onAccept: () => Promise<void>;
+  onDecline: () => Promise<void>;
 }
 
 function DuelChallengeToastBody({ challengerName, onAccept, onDecline }: ToastBodyProps) {
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handle(action: () => Promise<void>) {
+    setIsPending(true);
+    setError(null);
+    try {
+      await action();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to respond to the challenge');
+    } finally {
+      setIsPending(false);
+    }
+  }
+
   return (
     <div
       className="rounded-md border border-amber-500/50 bg-amber-500/10 p-3 shadow-sm"
@@ -38,21 +57,32 @@ function DuelChallengeToastBody({ challengerName, onAccept, onDecline }: ToastBo
       <div className="mt-2 flex gap-2">
         <button
           type="button"
-          onClick={onAccept}
+          disabled={isPending}
+          onClick={() => {
+            handle(onAccept).catch(() => {});
+          }}
           data-testid="duel-toast-accept-btn"
-          className="rounded border border-emerald-500/60 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-300"
+          className="rounded border border-emerald-500/60 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          Accept
+          {isPending ? 'Dispatching…' : 'Accept'}
         </button>
         <button
           type="button"
-          onClick={onDecline}
+          disabled={isPending}
+          onClick={() => {
+            handle(onDecline).catch(() => {});
+          }}
           data-testid="duel-toast-decline-btn"
-          className="rounded border border-destructive/60 bg-destructive/10 px-3 py-1 text-xs font-semibold text-destructive"
+          className="rounded border border-destructive/60 bg-destructive/10 px-3 py-1 text-xs font-semibold text-destructive disabled:cursor-not-allowed disabled:opacity-50"
         >
-          Decline
+          {isPending ? 'Dispatching…' : 'Decline'}
         </button>
       </div>
+      {error !== null && (
+        <p role="alert" className="mt-2 text-xs text-destructive" data-testid="duel-toast-error">
+          {error}
+        </p>
+      )}
     </div>
   );
 }
@@ -70,7 +100,7 @@ export function DuelChallengeNotifier() {
     enabled: characterId > 0,
     role: 'incoming',
   });
-  const { mutate } = useDispatchPlayerAction(characterId);
+  const { mutateAsync } = useDispatchPlayerAction(characterId);
 
   const toastedIds = useRef<Set<number>>(new Set());
 
@@ -81,21 +111,19 @@ export function DuelChallengeNotifier() {
 
       toast.custom((toastId) => (
         <DuelChallengeToastBody
-          toastId={toastId}
           challengerName={challenge.challenger.name}
-          challengeId={challenge.id}
-          onAccept={() => {
-            mutate(registryRef('accept', { challenge_id: challenge.id }));
+          onAccept={async () => {
+            await mutateAsync(registryRef('accept', { challenge_id: challenge.id }));
             toast.dismiss(toastId);
           }}
-          onDecline={() => {
-            mutate(registryRef('decline', { challenge_id: challenge.id }));
+          onDecline={async () => {
+            await mutateAsync(registryRef('decline', { challenge_id: challenge.id }));
             toast.dismiss(toastId);
           }}
         />
       ));
     }
-  }, [incomingChallenges, mutate]);
+  }, [incomingChallenges, mutateAsync]);
 
   return null;
 }

--- a/frontend/src/combat/__tests__/CombatTurnPanel.test.tsx
+++ b/frontend/src/combat/__tests__/CombatTurnPanel.test.tsx
@@ -17,6 +17,7 @@ import { render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 
 // ---------------------------------------------------------------------------
 // Module mocks — hoisted before imports
@@ -120,7 +121,11 @@ function createWrapper() {
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
   return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
   };
 }
 
@@ -464,6 +469,7 @@ describe('CombatTurnPanel — encounter outcome banner (#876)', () => {
       status: 'completed',
       outcome: 'victory',
       completed_at: '2026-06-12T00:00:00Z',
+      scene: 8,
     });
 
     render(<CombatTurnPanel encounterId={1} characterId={10} characterSheetId={100} />, {
@@ -472,6 +478,8 @@ describe('CombatTurnPanel — encounter outcome banner (#876)', () => {
 
     const banner = screen.getByRole('status');
     expect(banner).toHaveTextContent('Victory');
+    const returnLink = screen.getByRole('link', { name: /return to scene/i });
+    expect(returnLink).toHaveAttribute('href', '/scenes/8');
     // Live sections are replaced by the banner.
     expect(screen.queryByTestId('your-turn-stub')).not.toBeInTheDocument();
     expect(screen.queryByTestId('round-flow-section')).not.toBeInTheDocument();

--- a/frontend/src/combat/__tests__/DuelChallengeNotifier.test.tsx
+++ b/frontend/src/combat/__tests__/DuelChallengeNotifier.test.tsx
@@ -1,13 +1,13 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { DuelChallengeNotifier } from '../DuelChallengeNotifier';
 
 const mockUseDuelChallengeInbox = vi.fn();
-const mockMutate = vi.fn();
+const mockMutateAsync = vi.fn();
 vi.mock('@/combat/queries', () => ({
   useDuelChallengeInbox: (...args: unknown[]) => mockUseDuelChallengeInbox(...args),
-  useDispatchPlayerAction: () => ({ mutate: mockMutate, isPending: false }),
+  useDispatchPlayerAction: () => ({ mutateAsync: mockMutateAsync, isPending: false }),
 }));
 
 vi.mock('@/roster/queries', () => ({
@@ -62,7 +62,6 @@ describe('DuelChallengeNotifier', () => {
     const { rerender } = render(<DuelChallengeNotifier />);
     expect(toastCustomMock).toHaveBeenCalledTimes(1);
 
-    // Same data on a re-render (e.g. the 15s poll ticking with no change).
     rerender(<DuelChallengeNotifier />);
     expect(toastCustomMock).toHaveBeenCalledTimes(1);
   });
@@ -80,33 +79,59 @@ describe('DuelChallengeNotifier', () => {
     expect(toastCustomMock).toHaveBeenCalledTimes(2);
   });
 
-  it('Accept button dispatches the accept registry action with the challenge id', () => {
+  it('Accept button dispatches the accept registry action and dismisses on success', async () => {
     mockUseDuelChallengeInbox.mockReturnValue({ data: [challenge(5)], isLoading: false });
+    mockMutateAsync.mockResolvedValue({});
     render(<DuelChallengeNotifier />);
 
     const renderFn = toastCustomMock.mock.calls[0][0] as (id: string | number) => JSX.Element;
     const { getByTestId } = render(renderFn('toast-1'));
     fireEvent.click(getByTestId('duel-toast-accept-btn'));
 
-    expect(mockMutate).toHaveBeenCalledWith({
-      ref: { backend: 'registry', registry_key: 'accept' },
-      kwargs: { challenge_id: 5 },
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        ref: { backend: 'registry', registry_key: 'accept' },
+        kwargs: { challenge_id: 5 },
+      });
     });
-    expect(toastDismissMock).toHaveBeenCalledWith('toast-1');
+    await waitFor(() => {
+      expect(toastDismissMock).toHaveBeenCalledWith('toast-1');
+    });
   });
 
-  it('Decline button dispatches the decline registry action with the challenge id', () => {
+  it('Decline button dispatches the decline registry action and dismisses on success', async () => {
     mockUseDuelChallengeInbox.mockReturnValue({ data: [challenge(5)], isLoading: false });
+    mockMutateAsync.mockResolvedValue({});
     render(<DuelChallengeNotifier />);
 
     const renderFn = toastCustomMock.mock.calls[0][0] as (id: string | number) => JSX.Element;
     const { getByTestId } = render(renderFn('toast-1'));
     fireEvent.click(getByTestId('duel-toast-decline-btn'));
 
-    expect(mockMutate).toHaveBeenCalledWith({
-      ref: { backend: 'registry', registry_key: 'decline' },
-      kwargs: { challenge_id: 5 },
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        ref: { backend: 'registry', registry_key: 'decline' },
+        kwargs: { challenge_id: 5 },
+      });
     });
-    expect(toastDismissMock).toHaveBeenCalledWith('toast-1');
+    await waitFor(() => {
+      expect(toastDismissMock).toHaveBeenCalledWith('toast-1');
+    });
+  });
+
+  it('shows an inline error and does not dismiss the toast when the dispatch fails', async () => {
+    mockUseDuelChallengeInbox.mockReturnValue({ data: [challenge(5)], isLoading: false });
+    mockMutateAsync.mockRejectedValue(new Error('Network error'));
+    render(<DuelChallengeNotifier />);
+
+    const renderFn = toastCustomMock.mock.calls[0][0] as (id: string | number) => JSX.Element;
+    const { getByTestId } = render(renderFn('toast-1'));
+    fireEvent.click(getByTestId('duel-toast-accept-btn'));
+
+    await waitFor(() => {
+      expect(getByTestId('duel-toast-error')).toHaveTextContent('Network error');
+    });
+    expect(toastDismissMock).not.toHaveBeenCalled();
+    expect(getByTestId('duel-toast-accept-btn')).not.toBeDisabled();
   });
 });

--- a/frontend/src/combat/__tests__/DuelChallengeNotifier.test.tsx
+++ b/frontend/src/combat/__tests__/DuelChallengeNotifier.test.tsx
@@ -1,0 +1,112 @@
+import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { DuelChallengeNotifier } from '../DuelChallengeNotifier';
+
+const mockUseDuelChallengeInbox = vi.fn();
+const mockMutate = vi.fn();
+vi.mock('@/combat/queries', () => ({
+  useDuelChallengeInbox: (...args: unknown[]) => mockUseDuelChallengeInbox(...args),
+  useDispatchPlayerAction: () => ({ mutate: mockMutate, isPending: false }),
+}));
+
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: () => ({
+    data: [{ id: 1, name: 'TestChar', character_id: 42, primary_persona_id: 77 }],
+  }),
+}));
+
+vi.mock('@/store/hooks', () => ({
+  useAppSelector: (selector: (state: unknown) => unknown) =>
+    selector({ game: { active: 'TestChar' } }),
+}));
+
+const toastCustomMock = vi.fn();
+const toastDismissMock = vi.fn();
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    custom: (...args: unknown[]) => toastCustomMock(...args),
+    dismiss: (...args: unknown[]) => toastDismissMock(...args),
+  }),
+}));
+
+function challenge(id: number, challengerName = 'Rivalis') {
+  return {
+    id,
+    challenger: { id: 900 + id, name: challengerName },
+    challenged: { id: 42, name: 'TestChar' },
+    status: 'pending' as const,
+    created_at: '2026-07-11T00:00:00Z',
+    resolved_at: null,
+    resulting_encounter: null,
+  };
+}
+
+describe('DuelChallengeNotifier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDuelChallengeInbox.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it('fires a custom toast the first time a new incoming challenge appears', () => {
+    mockUseDuelChallengeInbox.mockReturnValue({ data: [challenge(1)], isLoading: false });
+
+    render(<DuelChallengeNotifier />);
+
+    expect(toastCustomMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-fire for a challenge id already toasted', () => {
+    mockUseDuelChallengeInbox.mockReturnValue({ data: [challenge(1)], isLoading: false });
+
+    const { rerender } = render(<DuelChallengeNotifier />);
+    expect(toastCustomMock).toHaveBeenCalledTimes(1);
+
+    // Same data on a re-render (e.g. the 15s poll ticking with no change).
+    rerender(<DuelChallengeNotifier />);
+    expect(toastCustomMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires a second toast for a genuinely new second challenge id', () => {
+    mockUseDuelChallengeInbox.mockReturnValue({ data: [challenge(1)], isLoading: false });
+    const { rerender } = render(<DuelChallengeNotifier />);
+    expect(toastCustomMock).toHaveBeenCalledTimes(1);
+
+    mockUseDuelChallengeInbox.mockReturnValue({
+      data: [challenge(1), challenge(2)],
+      isLoading: false,
+    });
+    rerender(<DuelChallengeNotifier />);
+    expect(toastCustomMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('Accept button dispatches the accept registry action with the challenge id', () => {
+    mockUseDuelChallengeInbox.mockReturnValue({ data: [challenge(5)], isLoading: false });
+    render(<DuelChallengeNotifier />);
+
+    const renderFn = toastCustomMock.mock.calls[0][0] as (id: string | number) => JSX.Element;
+    const { getByTestId } = render(renderFn('toast-1'));
+    fireEvent.click(getByTestId('duel-toast-accept-btn'));
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      ref: { backend: 'registry', registry_key: 'accept' },
+      kwargs: { challenge_id: 5 },
+    });
+    expect(toastDismissMock).toHaveBeenCalledWith('toast-1');
+  });
+
+  it('Decline button dispatches the decline registry action with the challenge id', () => {
+    mockUseDuelChallengeInbox.mockReturnValue({ data: [challenge(5)], isLoading: false });
+    render(<DuelChallengeNotifier />);
+
+    const renderFn = toastCustomMock.mock.calls[0][0] as (id: string | number) => JSX.Element;
+    const { getByTestId } = render(renderFn('toast-1'));
+    fireEvent.click(getByTestId('duel-toast-decline-btn'));
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      ref: { backend: 'registry', registry_key: 'decline' },
+      kwargs: { challenge_id: 5 },
+    });
+    expect(toastDismissMock).toHaveBeenCalledWith('toast-1');
+  });
+});

--- a/frontend/src/combat/__tests__/YourTurn.test.tsx
+++ b/frontend/src/combat/__tests__/YourTurn.test.tsx
@@ -1538,3 +1538,82 @@ describe('YourTurn — soulfray and fury declaration wiring (issue-1543)', () =>
     mockActionDeclarationCard.mockImplementation(defaultCardImpl);
   });
 });
+
+// ---------------------------------------------------------------------------
+// YourTurn — first-timer wayfinding tooltips (#2157)
+// ---------------------------------------------------------------------------
+
+describe('YourTurn — first-timer wayfinding tooltips (#2157)', () => {
+  it('labels the Focused Action section for a first-timer', () => {
+    setupMocks();
+
+    render(<YourTurn {...defaultProps()} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Focused Action')).toHaveAttribute(
+      'title',
+      "Your primary declared action this round — the technique or maneuver you're committing to."
+    );
+  });
+
+  it('labels the Clash Contributions section for a first-timer', () => {
+    setupMocks();
+    const clashAction = makePlayerAction(42, 'The Great Clash');
+
+    render(<YourTurn {...defaultProps({ availableActions: [clashAction] })} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText('Clash Contributions')).toHaveAttribute(
+      'title',
+      'Add strain to an ongoing team Clash instead of acting alone this round.'
+    );
+  });
+
+  it('labels the Passive Actions section for a first-timer', () => {
+    setupMocks();
+
+    render(<YourTurn {...defaultProps()} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Passive Actions')).toHaveAttribute(
+      'title',
+      "Secondary declarations in categories your Focused Action doesn't use — they resolve alongside it."
+    );
+  });
+
+  it('labels the Combo Upgrades section for a first-timer', () => {
+    setupMocks({
+      combos: [{ combo_id: 1, combo_name: 'Tidewall', known_by_participant: true, slot_count: 2 }],
+    });
+
+    render(<YourTurn {...defaultProps()} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Combo Upgrades')).toHaveAttribute(
+      'title',
+      'Upgrade your Focused Action into a known multi-slot combo, if you qualify this round.'
+    );
+  });
+
+  it('labels the Thread Pull row for a first-timer', () => {
+    setupMocks();
+
+    render(<YourTurn {...defaultProps()} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('✦ Thread Pull')).toHaveAttribute(
+      'title',
+      "Draw on a bonded Thread to empower this round's action."
+    );
+  });
+
+  it('labels the Maneuvers section for a first-timer', () => {
+    setupMocks();
+
+    render(<YourTurn {...defaultProps({ encounter: makeEncounter() })} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText('Maneuvers')).toHaveAttribute(
+      'title',
+      'Flee the encounter, or Cover an ally, instead of declaring an offensive or defensive action.'
+    );
+  });
+});

--- a/frontend/src/combat/components/EncounterOutcomeBanner.tsx
+++ b/frontend/src/combat/components/EncounterOutcomeBanner.tsx
@@ -3,9 +3,12 @@
  *
  * Rendered by CombatTurnPanel in place of the live rail sections once the
  * encounter status is "completed" (#876). The Narrator OUTCOME line in the
- * pose log carries the prose; this banner is the at-a-glance verdict.
+ * pose log carries the prose; this banner is the at-a-glance verdict, plus
+ * an explicit way back to the scene (#2157) — combat stays a separate page,
+ * so without this link a player is stranded on the combat URL.
  */
 
+import { Link } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 
 const OUTCOME_STYLES: Record<string, { label: string; className: string }> = {
@@ -23,19 +26,29 @@ const OUTCOME_STYLES: Record<string, { label: string; className: string }> = {
 
 export interface EncounterOutcomeBannerProps {
   outcome: string;
+  /** The encounter's backing scene id (`EncounterDetail.scene`) — the return-CTA target. */
+  sceneId: number;
 }
 
-export function EncounterOutcomeBanner({ outcome }: EncounterOutcomeBannerProps) {
+export function EncounterOutcomeBanner({ outcome, sceneId }: EncounterOutcomeBannerProps) {
   const style = OUTCOME_STYLES[outcome] ?? OUTCOME_STYLES.abandoned;
   return (
-    <div
-      role="status"
-      className={cn(
-        'rounded-md border px-4 py-3 text-center text-lg font-semibold tracking-wide',
-        style.className
-      )}
-    >
-      {style.label}
+    <div className="flex flex-col items-center gap-3">
+      <div
+        role="status"
+        className={cn(
+          'w-full rounded-md border px-4 py-3 text-center text-lg font-semibold tracking-wide',
+          style.className
+        )}
+      >
+        {style.label}
+      </div>
+      <Link
+        to={`/scenes/${sceneId}`}
+        className="rounded-md border border-primary/40 bg-primary/5 px-4 py-1.5 text-sm font-medium text-primary hover:bg-primary/10"
+      >
+        Return to Scene
+      </Link>
     </div>
   );
 }

--- a/frontend/src/combat/components/__tests__/EncounterOutcomeBanner.test.tsx
+++ b/frontend/src/combat/components/__tests__/EncounterOutcomeBanner.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { EncounterOutcomeBanner } from '../EncounterOutcomeBanner';
+
+describe('EncounterOutcomeBanner', () => {
+  it('renders the outcome label', () => {
+    render(
+      <MemoryRouter>
+        <EncounterOutcomeBanner outcome="victory" sceneId={12} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Victory');
+  });
+
+  it('renders a Return to Scene link to the given sceneId', () => {
+    render(
+      <MemoryRouter>
+        <EncounterOutcomeBanner outcome="defeat" sceneId={12} />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole('link', { name: /return to scene/i });
+    expect(link).toHaveAttribute('href', '/scenes/12');
+  });
+});

--- a/frontend/src/combat/duels/DuelChallengeControls.tsx
+++ b/frontend/src/combat/duels/DuelChallengeControls.tsx
@@ -34,7 +34,7 @@ import { useDispatchPlayerAction } from '@/combat/queries';
 // Dispatch helper — registry-backend action with no extra kwargs
 // ---------------------------------------------------------------------------
 
-function registryRef(key: string, kwargs: Record<string, unknown> = {}) {
+export function registryRef(key: string, kwargs: Record<string, unknown> = {}) {
   return {
     ref: {
       backend: 'registry' as const,

--- a/frontend/src/combat/sections/YourTurn.tsx
+++ b/frontend/src/combat/sections/YourTurn.tsx
@@ -694,7 +694,10 @@ export function YourTurn({
 
       {/* Focused slot */}
       <div>
-        <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        <p
+          className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          title="Your primary declared action this round — the technique or maneuver you're committing to."
+        >
           Focused Action
         </p>
         <ActionDeclarationCard
@@ -737,7 +740,10 @@ export function YourTurn({
       {/* Clash contribution subsection — shown when clash actions are available */}
       {clashActions.length > 0 && (
         <div className="space-y-2" data-testid="clash-contributions-section">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <p
+            className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            title="Add strain to an ongoing team Clash instead of acting alone this round."
+          >
             Clash Contributions
           </p>
           {clashActions.map((action) => {
@@ -775,7 +781,10 @@ export function YourTurn({
       {/* Passive slots — only non-focused-category slots */}
       {visiblePassiveSlots.length > 0 && (
         <div className="space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <p
+            className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            title="Secondary declarations in categories your Focused Action doesn't use — they resolve alongside it."
+          >
             Passive Actions
           </p>
           {visiblePassiveSlots.map((slot) => (
@@ -797,7 +806,10 @@ export function YourTurn({
       {/* Combo upgrade row — shown when combos are available */}
       {availableCombos !== undefined && availableCombos.length > 0 && (
         <div className="space-y-2" data-testid="combo-upgrade-section">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <p
+            className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            title="Upgrade your Focused Action into a known multi-slot combo, if you qualify this round."
+          >
             Combo Upgrades
           </p>
           {availableCombos.map((combo) => (
@@ -817,7 +829,12 @@ export function YourTurn({
         data-testid="thread-pull-row"
       >
         <div className="flex items-center justify-between">
-          <span className="text-xs font-semibold text-primary/80">✦ Thread Pull</span>
+          <span
+            className="text-xs font-semibold text-primary/80"
+            title="Draw on a bonded Thread to empower this round's action."
+          >
+            ✦ Thread Pull
+          </span>
           <div className="flex gap-2">
             {selectedPull !== null && (
               <button
@@ -862,7 +879,10 @@ export function YourTurn({
       {/* Flee / Cover declaration cluster — always rendered when encounter is non-null; controls disabled outside the declaring phase */}
       {encounter != null && (
         <div className="space-y-2" data-testid="maneuver-declaration-section">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <p
+            className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            title="Flee the encounter, or Cover an ally, instead of declaring an offensive or defensive action."
+          >
             Maneuvers
           </p>
 

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -130,7 +130,12 @@ vi.mock('@/scenes/actionQueries', async (importOriginal) => {
 vi.mock('@/combat/queries', () => ({
   useOutcomeDetails: vi.fn().mockReturnValue({ data: [], isLoading: false }),
   useDispatchPlayerAction: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
+  useEncounterForScene: vi.fn().mockReturnValue({ data: null, isLoading: false, isError: false }),
   combatKeys: { duelChallengesAll: () => ['combat', 'duel-challenges'] },
+}));
+
+vi.mock('@/battles/queries', () => ({
+  useBattleForSceneQuery: vi.fn().mockReturnValue({ data: null, isLoading: false, isError: false }),
 }));
 
 // EndorsementControl mounts its own hook machinery per-pose (#1138); stubbed

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -14,7 +14,6 @@ import { StatusPanel } from '@/status/components/StatusPanel';
 import { InventorySidebarPanel } from '@/inventory/components/InventorySidebarPanel';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useFocusStack, type FocusEntry } from '@/inventory/hooks/useFocusStack';
-import { Toaster } from '@/components/ui/sonner';
 import { Link } from 'react-router-dom';
 import { useAccount } from '@/store/hooks';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
@@ -395,7 +394,6 @@ export function GamePage() {
         viewerEntryId={viewerEntryId}
         onWhisper={handleWhisper}
       />
-      <Toaster />
     </>
   );
 }

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -9,6 +9,8 @@ import { FocusPanel } from './components/FocusPanel';
 import { SidebarTabPanel } from './components/SidebarTabPanel';
 import { PresencePanel } from './components/PresencePanel';
 import { EventsSidebarPanel } from '@/events/components/EventsSidebarPanel';
+import { useEncounterForScene } from '@/combat/queries';
+import { useBattleForSceneQuery } from '@/battles/queries';
 import { StoryTray } from '@/missions/components/StoryTray';
 import { StatusPanel } from '@/status/components/StatusPanel';
 import { InventorySidebarPanel } from '@/inventory/components/InventorySidebarPanel';
@@ -69,6 +71,14 @@ export function GamePage() {
   const sceneData = activeSession?.scene ?? null;
   const sceneId = sceneData ? String(sceneData.id) : undefined;
   const roomName = sceneData?.name ?? roomData?.name ?? 'Room';
+
+  // RoomHeader combat/battle badges (#2157) — GamePage is the composition root,
+  // so it calls both hooks once here and threads the derived booleans down
+  // through FocusPanel -> RoomPanel -> RoomHeader.
+  const { data: activeEncounter } = useEncounterForScene(sceneData?.id ?? 0);
+  const { data: activeBattle } = useBattleForSceneQuery(sceneData?.id ?? null);
+  const hasActiveEncounter = activeEncounter != null;
+  const hasActiveBattle = activeBattle != null && activeBattle.outcome === 'unresolved';
 
   // GamePage is the composition root (#2156): it calls the scene-feed +
   // threading hooks once for the active session's scene and feeds both the
@@ -370,6 +380,8 @@ export function GamePage() {
                 roomCharacter={active}
                 roomData={roomData}
                 sceneData={sceneData}
+                hasActiveEncounter={hasActiveEncounter}
+                hasActiveBattle={hasActiveBattle}
               />
             }
             storiesPanel={<StoryTray roomKey={roomData?.name ?? 'nowhere'} />}

--- a/frontend/src/game/components/FocusPanel.tsx
+++ b/frontend/src/game/components/FocusPanel.tsx
@@ -37,9 +37,20 @@ interface FocusPanelProps {
   roomCharacter: string | null;
   roomData: RoomData | null;
   sceneData: SceneSummary | null;
+  /** True when the scene's room has an active CombatEncounter (#2157). */
+  hasActiveEncounter?: boolean;
+  /** True when the scene's room has an active Battle (#2157). */
+  hasActiveBattle?: boolean;
 }
 
-export function FocusPanel({ focus, roomCharacter, roomData, sceneData }: FocusPanelProps) {
+export function FocusPanel({
+  focus,
+  roomCharacter,
+  roomData,
+  sceneData,
+  hasActiveEncounter = false,
+  hasActiveBattle = false,
+}: FocusPanelProps) {
   // Resolve the active puppet name to a numeric character id. The
   // visible-worn endpoints require an ``observer`` query parameter, and
   // the room-state ``active`` key is just the character's name. The
@@ -108,6 +119,8 @@ export function FocusPanel({ focus, roomCharacter, roomData, sceneData }: FocusP
           room={roomData}
           scene={sceneData}
           onCharacterClick={onCharacterClickFromRoom}
+          hasActiveEncounter={hasActiveEncounter}
+          hasActiveBattle={hasActiveBattle}
         />
       );
       break;

--- a/frontend/src/game/components/RoomPanel.tsx
+++ b/frontend/src/game/components/RoomPanel.tsx
@@ -40,6 +40,10 @@ interface RoomPanelProps {
   room: RoomData | null;
   scene: SceneSummary | null;
   onCharacterClick?: (character: RoomStateObject) => void;
+  /** True when the scene's room has an active CombatEncounter (#2157). */
+  hasActiveEncounter?: boolean;
+  /** True when the scene's room has an active Battle (#2157). */
+  hasActiveBattle?: boolean;
 }
 
 export function RoomPanel({
@@ -48,6 +52,8 @@ export function RoomPanel({
   room,
   scene,
   onCharacterClick,
+  hasActiveEncounter = false,
+  hasActiveBattle = false,
 }: RoomPanelProps) {
   const { send } = useGameSocket();
   const dispatch = useAppDispatch();
@@ -119,6 +125,8 @@ export function RoomPanel({
         isEndPending={end.isPending}
         canEdit={Boolean(room.is_owner) && characterId != null}
         onEditRoom={() => setEditOpen(true)}
+        hasActiveEncounter={hasActiveEncounter}
+        hasActiveBattle={hasActiveBattle}
       />
 
       {room.is_owner && characterId != null && (

--- a/frontend/src/game/components/room-panel/RoomHeader.test.tsx
+++ b/frontend/src/game/components/room-panel/RoomHeader.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { RoomHeader } from './RoomHeader';
+
+const SCENE = {
+  id: 7,
+  name: 'The Hall',
+  description: '',
+  is_owner: false,
+  has_unseen_observer: false,
+};
+
+function renderHeader(props: { hasActiveEncounter?: boolean; hasActiveBattle?: boolean } = {}) {
+  return render(
+    <MemoryRouter>
+      <RoomHeader
+        name="The Hall"
+        scene={SCENE}
+        onStartScene={vi.fn()}
+        onEndScene={vi.fn()}
+        isStartPending={false}
+        isEndPending={false}
+        {...props}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('RoomHeader combat/battle badges', () => {
+  it('shows an In Combat badge linking to the combat route when hasActiveEncounter is true', () => {
+    renderHeader({ hasActiveEncounter: true });
+
+    const badge = screen.getByTestId('room-header-combat-badge');
+    expect(badge).toHaveTextContent('In Combat');
+    expect(badge.closest('a')).toHaveAttribute('href', '/scenes/7/combat');
+  });
+
+  it('shows a Battle badge linking to the battle map when hasActiveBattle is true', () => {
+    renderHeader({ hasActiveBattle: true });
+
+    const badge = screen.getByTestId('room-header-battle-badge');
+    expect(badge).toHaveTextContent('Battle');
+    expect(badge.closest('a')).toHaveAttribute('href', '/scenes/7/battle');
+  });
+
+  it('shows both badges together when both are active', () => {
+    renderHeader({ hasActiveEncounter: true, hasActiveBattle: true });
+
+    expect(screen.getByTestId('room-header-combat-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('room-header-battle-badge')).toBeInTheDocument();
+  });
+
+  it('shows neither badge by default', () => {
+    renderHeader();
+
+    expect(screen.queryByTestId('room-header-combat-badge')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('room-header-battle-badge')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/game/components/room-panel/RoomHeader.tsx
+++ b/frontend/src/game/components/room-panel/RoomHeader.tsx
@@ -13,6 +13,10 @@ interface RoomHeaderProps {
   /** Show the "Edit" affordance — true only when the viewer owns this room (#1470). */
   canEdit?: boolean;
   onEditRoom?: () => void;
+  /** True when the scene's room has an active (non-completed) CombatEncounter (#2157). */
+  hasActiveEncounter?: boolean;
+  /** True when the scene's room has an active (unresolved) Battle (#2157). */
+  hasActiveBattle?: boolean;
 }
 
 export function RoomHeader({
@@ -24,6 +28,8 @@ export function RoomHeader({
   isEndPending,
   canEdit = false,
   onEditRoom,
+  hasActiveEncounter = false,
+  hasActiveBattle = false,
 }: RoomHeaderProps) {
   return (
     <div className="border-b px-3 py-2">
@@ -36,12 +42,34 @@ export function RoomHeader({
         )}
       </div>
       {scene ? (
-        <div className="mt-1 flex items-center gap-2">
+        <div className="mt-1 flex flex-wrap items-center gap-2">
           <Link to={`/scenes/${scene.id}`}>
             <Badge variant="secondary" className="text-xs">
               Scene: {scene.name}
             </Badge>
           </Link>
+          {hasActiveEncounter && (
+            <Link to={`/scenes/${scene.id}/combat`}>
+              <Badge
+                variant="destructive"
+                className="text-xs"
+                data-testid="room-header-combat-badge"
+              >
+                In Combat
+              </Badge>
+            </Link>
+          )}
+          {hasActiveBattle && (
+            <Link to={`/scenes/${scene.id}/battle`}>
+              <Badge
+                variant="destructive"
+                className="text-xs"
+                data-testid="room-header-battle-badge"
+              >
+                Battle
+              </Badge>
+            </Link>
+          )}
           {scene.has_unseen_observer && (
             <Badge variant="destructive" className="text-xs">
               ⚠ OOC: an unseen observer is present

--- a/frontend/src/scenes/actionTypes.ts
+++ b/frontend/src/scenes/actionTypes.ts
@@ -327,6 +327,11 @@ export interface CastResponse {
    * read `result.power_ledger` instead.
    */
   action_interaction?: number | null;
+  /**
+   * Present when this cast seeded or joined a CombatEncounter
+   * (`action_views.py:601-605`). Absent for casts that don't touch combat.
+   */
+  encounter?: { id: number; status: string };
 }
 
 // Mirrors SceneActionTargetSerializer (#1177). Kept in sync with the backend.

--- a/frontend/src/scenes/components/ActionPanel.test.tsx
+++ b/frontend/src/scenes/components/ActionPanel.test.tsx
@@ -87,6 +87,17 @@ vi.mock('@/magic/components/threads/ThreadPullPicker', () => ({
   ),
 }));
 
+const toastSuccessMock = vi.fn();
+vi.mock('sonner', () => ({
+  toast: { success: (...args: unknown[]) => toastSuccessMock(...args), error: vi.fn() },
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
 import {
   fetchAvailableActions,
   createActionRequest,
@@ -642,6 +653,58 @@ describe('ActionPanel', () => {
       expect(screen.queryByTestId('cast-ledger-result')).not.toBeInTheDocument();
     });
     expect(document.getElementById('cast-section')).toBeNull();
+  });
+
+  it('fires a "Combat has begun" toast with a Join Combat action when the cast seeds an encounter', async () => {
+    vi.mocked(castTechnique).mockResolvedValue({
+      id: 3,
+      status: 'pending',
+      encounter: { id: 55, status: 'declaring' },
+    });
+    const user = userEvent.setup();
+
+    await openCastDialogWithEmberTouch(user);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /cast ember touch/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /cast ember touch/i }));
+
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        'Combat has begun',
+        expect.objectContaining({
+          action: expect.objectContaining({
+            label: 'Join Combat',
+          }),
+        })
+      );
+    });
+
+    // Clicking the toast action navigates to the combat route for this scene.
+    const call = toastSuccessMock.mock.calls[0];
+    const options = call[1] as { action: { onClick: () => void } };
+    options.action.onClick();
+    expect(mockNavigate).toHaveBeenCalledWith('/scenes/42/combat');
+  });
+
+  it('does not fire a combat-start toast when the cast has no encounter', async () => {
+    vi.mocked(castTechnique).mockResolvedValue({ id: 4, status: 'pending' });
+    const user = userEvent.setup();
+
+    await openCastDialogWithEmberTouch(user);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /cast ember touch/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /cast ember touch/i }));
+
+    await waitFor(() => {
+      expect(castTechnique).toHaveBeenCalled();
+    });
+    expect(toastSuccessMock).not.toHaveBeenCalled();
   });
 
   it('closes the panel normally after a benign (pending) cast', async () => {

--- a/frontend/src/scenes/components/ActionPanel.tsx
+++ b/frontend/src/scenes/components/ActionPanel.tsx
@@ -23,6 +23,8 @@ import { PowerLedgerPanel } from '@/magic/components/PowerLedgerPanel';
 import { ThreadPullPicker } from '@/magic/components/threads/ThreadPullPicker';
 import { useCastPullSelection } from '../hooks/useCastPullSelection';
 import { extractErrorMessage } from '@/lib/errors';
+import { toast } from 'sonner';
+import { useNavigate } from 'react-router-dom';
 import type {
   PlayerAction,
   AvailableEnhancement,
@@ -61,6 +63,7 @@ const DEFAULT_EFFORT = 'medium';
  * and target picker — all sourced from inline fields on the action.
  */
 export function ActionPanel({ sceneId }: Props) {
+  const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const [expandedAction, setExpandedAction] = useState<string | null>(null);
   const [pendingWarning, setPendingWarning] = useState<PendingWarning | null>(null);
@@ -139,6 +142,14 @@ export function ActionPanel({ sceneId }: Props) {
       setCastTargetPersonaIds([]);
       setCastPickingTarget(false);
       pull.reset();
+      if (data.encounter) {
+        toast.success('Combat has begun', {
+          action: {
+            label: 'Join Combat',
+            onClick: () => navigate(`/scenes/${sceneId}/combat`),
+          },
+        });
+      }
       if (data.result?.power_ledger) {
         // Immediate cast: keep the panel open showing the ledger (#859).
         setCastLedgerResult(data);

--- a/frontend/src/scenes/components/SceneHeader.test.tsx
+++ b/frontend/src/scenes/components/SceneHeader.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { SceneHeader } from './SceneHeader';
+import type { SceneDetail } from '../types';
+
+const mockUseEncounterForScene = vi.fn();
+vi.mock('@/combat/queries', () => ({
+  useEncounterForScene: () => mockUseEncounterForScene(),
+}));
+
+// Only the fields SceneHeader actually reads are filled in — cast covers the
+// rest of SceneDetail's shape, which this test doesn't exercise.
+const SCENE = {
+  id: 9,
+  name: 'Test Scene',
+  description: '',
+  is_active: true,
+  is_owner: false,
+  participants: [],
+} as unknown as SceneDetail;
+
+function renderWrapped(scene: SceneDetail = SCENE) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+  return render(<SceneHeader scene={scene} />, { wrapper: Wrapper });
+}
+
+describe('SceneHeader combat badge', () => {
+  it('shows an In Combat badge when the scene has an active encounter', () => {
+    mockUseEncounterForScene.mockReturnValue({ data: { id: 1 }, isLoading: false, isError: false });
+
+    renderWrapped();
+
+    const badge = screen.getByTestId('scene-header-combat-badge');
+    expect(badge).toHaveTextContent('In Combat');
+    expect(badge.closest('a')).toHaveAttribute('href', '/scenes/9/combat');
+  });
+
+  it('does not show the badge when there is no active encounter', () => {
+    mockUseEncounterForScene.mockReturnValue({ data: null, isLoading: false, isError: false });
+
+    renderWrapped();
+
+    expect(screen.queryByTestId('scene-header-combat-badge')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/scenes/components/SceneHeader.tsx
+++ b/frontend/src/scenes/components/SceneHeader.tsx
@@ -12,6 +12,9 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { SubmitButton } from '@/components/SubmitButton';
 import { RoundSettingsDialog } from './RoundSettingsDialog';
+import { Link } from 'react-router-dom';
+import { Badge } from '@/components/ui/badge';
+import { useEncounterForScene } from '@/combat/queries';
 
 interface Props {
   scene?: SceneDetail;
@@ -94,6 +97,7 @@ export function SceneHeader({ scene, onRefresh }: Props) {
   useEffect(() => {
     reset({ name: scene?.name ?? '', description: scene?.description ?? '' });
   }, [scene, reset]);
+  const { data: activeEncounter } = useEncounterForScene(scene?.id ?? 0);
   const save = useMutation({
     mutationFn: (values: { name: string; description: string }) =>
       updateScene(String(scene?.id), values),
@@ -142,6 +146,13 @@ export function SceneHeader({ scene, onRefresh }: Props) {
   return (
     <div>
       <h1 className="mb-2 text-xl font-bold">{scene.name}</h1>
+      {activeEncounter != null && (
+        <Link to={`/scenes/${scene.id}/combat`} className="mb-2 inline-block">
+          <Badge variant="destructive" className="text-xs" data-testid="scene-header-combat-badge">
+            In Combat
+          </Badge>
+        </Link>
+      )}
       <p className="mb-4">{scene.description}</p>
       {(scene.is_owner || scene.is_active) && (
         <div className="mb-2 flex gap-2">

--- a/frontend/src/scenes/pages/SceneDetailPage.tsx
+++ b/frontend/src/scenes/pages/SceneDetailPage.tsx
@@ -158,7 +158,16 @@ export function SceneDetailPage() {
     <div className="flex h-full flex-col">
       <div className="shrink-0 px-4 pt-4">
         <SceneHeader scene={scene} onRefresh={() => refetch()} />
-        {battle && (
+        {battle && battle.outcome === 'unresolved' && (
+          <Link
+            to={`/scenes/${id}/battle`}
+            className="mt-1 inline-block text-sm text-blue-600 hover:underline"
+            data-testid="scene-battle-map-link"
+          >
+            Battle Map
+          </Link>
+        )}
+        {battle && battle.outcome !== 'unresolved' && (
           <Link
             to={`/battles/${battle.id}`}
             className="mt-1 inline-block text-sm text-blue-600 hover:underline"

--- a/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
+++ b/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
@@ -102,7 +102,7 @@ vi.mock('@/roster/queries', () => ({
 
 const mockUseBattleForSceneQuery = vi.fn(
   (): {
-    data: { id: number } | null;
+    data: { id: number; outcome: string } | null;
     isLoading: boolean;
     isError: boolean;
   } => ({
@@ -314,9 +314,9 @@ describe('SceneDetailPage', () => {
     expect(fetchPlaces).toHaveBeenCalledWith('777');
   });
 
-  it('shows a Battle Writeup link when a battle exists for the scene (#1735)', () => {
+  it('shows a Battle Writeup link when a concluded battle exists for the scene (#1735)', () => {
     mockUseBattleForSceneQuery.mockReturnValue({
-      data: { id: 42 },
+      data: { id: 42, outcome: 'attacker_decisive' },
       isLoading: false,
       isError: false,
     });
@@ -330,6 +330,7 @@ describe('SceneDetailPage', () => {
 
     const link = getByTestId('scene-battle-writeup-link');
     expect(link).toHaveAttribute('href', '/battles/42');
+    expect(link).toHaveTextContent('Battle Writeup');
   });
 
   it('does not show a Battle Writeup link when no battle exists (#1735)', () => {
@@ -340,6 +341,26 @@ describe('SceneDetailPage', () => {
       { initialEntries: ['/scenes/1'] }
     );
 
+    expect(queryByTestId('scene-battle-writeup-link')).not.toBeInTheDocument();
+  });
+
+  it('links to the live battle map, not the writeup, while the battle is unresolved (#2157)', () => {
+    mockUseBattleForSceneQuery.mockReturnValue({
+      data: { id: 42, outcome: 'unresolved' },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { getByTestId, queryByTestId } = renderWithProviders(
+      <Routes>
+        <Route path="/scenes/:id" element={<SceneDetailPage />} />
+      </Routes>,
+      { initialEntries: ['/scenes/1'] }
+    );
+
+    const link = getByTestId('scene-battle-map-link');
+    expect(link).toHaveAttribute('href', '/scenes/1/battle');
+    expect(link).toHaveTextContent('Battle Map');
     expect(queryByTestId('scene-battle-writeup-link')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #2157

## Summary

Wires already-built combat/battle/duel-challenge signals into visible UI (frontend-only, no backend changes): cast_result.encounter now surfaces as a 'Combat has begun' toast with a Join Combat action; the room chip badges 'In Combat'/'Battle' via useEncounterForScene/useBattleForSceneQuery; SceneHeader gets the same combat badge and SceneDetailPage's mis-linked 'Battle Writeup' link (pointed at the writeup page even mid-battle) now gates on outcome; a new global DuelChallengeNotifier surfaces incoming duel challenges from anywhere in the app; EncounterOutcomeBanner gets a Return to Scene CTA; YourTurn's section labels get first-timer tooltips; and a battle-map e2e smoke test mirrors the existing combat.spec.ts pattern.

7 SDD tasks + 1 mid-task fix wave (DuelChallengeNotifier's Accept/Decline originally swallowed dispatch failures and permanently marked the challenge un-retoastable — fixed to match DuelChallengeControls' existing mutateAsync+try/catch+inline-error pattern). Final whole-branch review (Opus): Ready to merge, no Critical/Important findings.

Note: frontend/e2e/battle-map.spec.ts could not be executed in this devcontainer session — Playwright's Chromium binary install is blocked by the firewall (cdn.playwright.dev isn't allowlisted). Confirmed this is a pre-existing, environment-wide limitation shared by the already-merged combat.spec.ts (fails identically), not specific to this file; no CI workflow runs pnpm test:e2e. Content is verbatim-correct against the working combat.spec.ts pattern.

## Follow-ups filed

- #2197

## Notes

- Spec: reviewed & approved on #2157 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (a46636e37, clean, no conflicts); full frontend typecheck + all 142 tests across every touched file re-verified green post-rebase.

<!-- last-addressed-comment: 0 -->