### PR TITLE
Frontend CG resonance picker for the magic stage (design)

### DIFF
--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -763,8 +763,9 @@ ceremony-direct testing. (`world/covenants/discovery.py` re-exports it as
   (`world/magic/specialization/services.py`) creates the level-0 GIFT thread at
   character-creation finalization, idempotent on `(owner, gift)` and write-once on resonance.
   Wires from `finalize_magic_data` after `CharacterGift` creation, reading the chosen
-  `selected_gift_resonance_id` from `draft.draft_data` (frontend picker is a deferred
-  needs-design follow-up; falls back to `gift.resonances.first()`).
+  `selected_gift_resonance_id` from `draft.draft_data` (frontend picker is built #1620;
+  the `CantripSelector` component writes the key; `compute_magic_errors` requires it.
+  Legacy/absent draft data falls back to `gift.resonances.first()`).
 - **Weaving commits resonance** — `weave_thread(target_kind=GIFT)` commits/chooses a
   resonance onto the existing latent thread rather than creating a new one (validates the
   resonance is in the gift's supported set, else raises `UnsupportedGiftResonanceError`,
@@ -779,8 +780,7 @@ ceremony-direct testing. (`world/covenants/discovery.py` re-exports it as
 **GIFT anchor cap (#1580):** `compute_anchor_cap` now handles `TargetKind.GIFT`:
 `_current_path_stage(thread.owner) × ANCHOR_CAP_GIFT_PER_STAGE` (=10,
 `world/magic/services/threads.py`). GIFT threads are always in-action (intrinsic species
-gift — added to `_ALWAYS_IN_ACTION_KINDS`). The frontend CG resonance picker remains a
-needs-design follow-up.
+gift — added to `_ALWAYS_IN_ACTION_KINDS`). The frontend CG resonance picker is built (#1620).
 
 Proven end-to-end by `world/magic/tests/integration/test_gift_specialization_e2e.py` (#1578):
 CG provisioning → base resolve at level 0 → `gift_resonances_for` reads the thread's

--- a/frontend/src/character-creation/__tests__/components/CantripSelector.test.tsx
+++ b/frontend/src/character-creation/__tests__/components/CantripSelector.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * CantripSelector Component Tests
+ *
+ * Tests cantrip card selection, facet dropdown, consequence-pool dropdown,
+ * and the resonance dropdown (#1620).
+ */
+
+import { screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { CantripSelector } from '../../components/magic/CantripSelector';
+import { mockResonances } from '../fixtures';
+import {
+  renderWithCharacterCreationProviders,
+  seedQueryData,
+  createTestQueryClient,
+} from '../testUtils';
+import { characterCreationKeys } from '../../queries';
+import type { Cantrip, CharacterDraft } from '../../types';
+
+// Mock the API module
+vi.mock('../../api', () => ({
+  getResonances: vi.fn(),
+  getConsequencePoolCatalog: vi.fn(),
+  updateDraft: vi.fn(),
+}));
+
+const mockCantrip: Cantrip = {
+  id: 10,
+  name: 'Danger Sense',
+  description: 'Sense nearby threats.',
+  archetype: 'utility',
+  requires_facet: false,
+  facet_prompt: '',
+  allowed_facets: [],
+  sort_order: 0,
+  style_id: 1,
+};
+
+const mockConsequencePools = [{ id: 1, name: 'Volatile', description: 'High risk, high reward.' }];
+
+function makeDraft(selectedCantripId?: number): CharacterDraft {
+  return {
+    id: 1,
+    current_stage: 7 as never,
+    selected_area: null,
+    selected_beginnings: null,
+    selected_species: null,
+    selected_gender: null,
+    age: null,
+    family: null,
+    claimed_kin_slot: null,
+    claimed_kin_pool: null,
+    defer_parents: false,
+    height_band: null,
+    height_inches: null,
+    build: null,
+    selected_path: null,
+    selected_tradition: null,
+    cg_points_spent: 0,
+    cg_points_remaining: 100,
+    stat_bonuses: {},
+    draft_data: selectedCantripId ? { selected_cantrip_id: selectedCantripId } : {},
+    stage_completion: {} as never,
+    has_existing_characters: false,
+    stage_errors: {},
+    stats_points_remaining: 5,
+    stats_budget: 5,
+  };
+}
+
+function renderSelector(draft: CharacterDraft, cantrips: Cantrip[]) {
+  const queryClient = createTestQueryClient();
+  seedQueryData(queryClient, characterCreationKeys.resonances(), mockResonances);
+  seedQueryData(queryClient, characterCreationKeys.consequencePoolCatalog(), mockConsequencePools);
+
+  return renderWithCharacterCreationProviders(
+    <CantripSelector draft={draft} cantrips={cantrips} />,
+    { queryClient }
+  );
+}
+
+describe('CantripSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the resonance dropdown when a cantrip is selected', () => {
+    const draft = makeDraft(10);
+    renderSelector(draft, [mockCantrip]);
+
+    expect(screen.getByText('Gift Resonance')).toBeInTheDocument();
+  });
+
+  it('does not render the resonance dropdown when no cantrip is selected', () => {
+    const draft = makeDraft();
+    renderSelector(draft, [mockCantrip]);
+
+    expect(screen.queryByText('Gift Resonance')).not.toBeInTheDocument();
+  });
+
+  it('renders the resonance options from the resonances query', () => {
+    const draft = makeDraft(10);
+    renderSelector(draft, [mockCantrip]);
+
+    // The dropdown trigger should be present with a placeholder
+    expect(screen.getByText('Gift Resonance')).toBeInTheDocument();
+    expect(screen.getByText('Select a resonance')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/character-creation/components/magic/CantripSelector.tsx
+++ b/frontend/src/character-creation/components/magic/CantripSelector.tsx
@@ -15,7 +15,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
-import { useConsequencePoolCatalog, useUpdateDraft } from '../../queries';
+import { useConsequencePoolCatalog, useResonances, useUpdateDraft } from '../../queries';
 import type { Cantrip, CharacterDraft } from '../../types';
 
 const ARCHETYPE_LABELS: Record<Cantrip['archetype'], string> = {
@@ -42,6 +42,9 @@ export function CantripSelector({ draft, cantrips }: CantripSelectorProps) {
 
   const { data: consequencePools = [] } = useConsequencePoolCatalog();
   const selectedPoolId = draft.draft_data.selected_consequence_pool_id ?? null;
+
+  const { data: resonances = [] } = useResonances();
+  const selectedResonanceId = draft.draft_data.selected_gift_resonance_id ?? null;
 
   // Group cantrips by archetype
   const grouped = ARCHETYPE_ORDER.map((archetype) => ({
@@ -84,6 +87,18 @@ export function CantripSelector({ draft, cantrips }: CantripSelectorProps) {
         draft_data: {
           ...draft.draft_data,
           selected_consequence_pool_id: poolId === 'standard' ? null : parseInt(poolId, 10),
+        },
+      },
+    });
+  };
+
+  const handleSelectResonance = (resonanceId: string) => {
+    updateDraft.mutate({
+      draftId: draft.id,
+      data: {
+        draft_data: {
+          ...draft.draft_data,
+          selected_gift_resonance_id: parseInt(resonanceId, 10),
         },
       },
     });
@@ -155,6 +170,28 @@ export function CantripSelector({ draft, cantrips }: CantripSelectorProps) {
               {consequencePools.map((p) => (
                 <SelectItem key={p.id} value={String(p.id)}>
                   {p.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Gift resonance selector — anchors the latent GIFT thread (#1620) */}
+      {selectedCantrip && (
+        <div className="max-w-xs space-y-2">
+          <Label>Gift Resonance</Label>
+          <Select
+            value={selectedResonanceId?.toString() ?? ''}
+            onValueChange={handleSelectResonance}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select a resonance" />
+            </SelectTrigger>
+            <SelectContent>
+              {resonances.map((r) => (
+                <SelectItem key={r.id} value={r.id.toString()}>
+                  {r.name}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/frontend/src/character-creation/types.ts
+++ b/frontend/src/character-creation/types.ts
@@ -678,6 +678,8 @@ export interface DraftData {
   motif_description?: string;
   // The Glimpse story
   glimpse_story?: string;
+  // Magic fields - Gift resonance (anchors the latent GIFT thread at CG finalization, #1620)
+  selected_gift_resonance_id?: number | null;
   magic_complete?: boolean;
   // Tarot card selection for familyless characters
   tarot_card_name?: string;

--- a/src/world/character_creation/CLAUDE.md
+++ b/src/world/character_creation/CLAUDE.md
@@ -63,16 +63,17 @@ latent GIFT thread (#1578, ADR-0055):
   thread (the specialization substrate), idempotent on `(owner, gift)` and write-once on
   resonance. One active GIFT thread per gift.
 - The resonance is read from `draft.draft_data["selected_gift_resonance_id"]`. The
-  frontend CG resonance picker is a deferred needs-design follow-up; until it lands,
-  that draft key is never written in production or tests (the E2E test calls
-  `provision_latent_gift_thread(..., resonance=...)` directly). When unset, the
-  provisioning falls back to `gift.resonances.first()` with a warning, and skips
-  entirely if the gift supports no resonances.
+  frontend CG resonance picker is built (#1620): the `CantripSelector` component
+  renders a resonance dropdown (via `useResonances()`) that writes this key, and
+  `compute_magic_errors` requires it — submission is blocked until a resonance is
+  selected. When unset (legacy drafts), the provisioning falls back to
+  `gift.resonances.first()` with a warning, and skips entirely if the gift
+  supports no resonances.
 - The cantrip's starting technique may also carry a chosen consequence-pool "flavor"
   (#1320): `draft.draft_data["selected_consequence_pool_id"]` is read and resolved via
   `world.magic.services.technique_builder.resolve_cast_action_template()` to pick the
-  `Technique.action_template`. Unlike the resonance picker, the frontend picker (CG
-  magic stage's `CantripSelector`) is built and writes this key. An unset key resolves
+  `Technique.action_template`. The frontend picker (CG magic stage's
+  `CantripSelector`) is built and writes this key. An unset key resolves
   to the shared default template (`resolve_cast_action_template(None)`); a stale/invalid
   id raises `InvalidConsequencePoolChoice`, which finalize catches, logs a warning, and
   falls back to the shared default template — finalize never fails on a bad pool id.

--- a/src/world/character_creation/tests/test_application_services.py
+++ b/src/world/character_creation/tests/test_application_services.py
@@ -707,11 +707,12 @@ class ApproveApplicationIntegrationTests(TestCase):
         self.account = AccountFactory()
 
     def _create_complete_magic(self, draft):
-        """Helper to create complete magic data for a draft (cantrip in draft_data)."""
+        """Helper to create complete magic data for a draft (cantrip + resonance in draft_data)."""
         from world.magic.factories import CantripFactory
 
         cantrip = CantripFactory(requires_facet=False)
         draft.draft_data["selected_cantrip_id"] = cantrip.id
+        draft.draft_data["selected_gift_resonance_id"] = self.resonance.id
         draft.save(update_fields=["draft_data"])
 
     def _create_approved_application(self):

--- a/src/world/character_creation/tests/test_magic_stage.py
+++ b/src/world/character_creation/tests/test_magic_stage.py
@@ -10,7 +10,7 @@ from world.character_creation.validators import compute_magic_errors
 from world.character_sheets.factories import CharacterSheetFactory
 from world.classes.factories import PathFactory
 from world.fatigue.models import FatiguePool
-from world.magic.factories import CantripFactory, FacetFactory
+from world.magic.factories import CantripFactory, FacetFactory, ResonanceFactory
 from world.magic.models import CharacterAnima, Technique
 from world.narrative.constants import NarrativeCategory
 from world.narrative.models import NarrativeMessageDelivery
@@ -51,6 +51,7 @@ class MagicStageValidationTest(TestCase):
         cls.manifested_cantrip.allowed_facets.add(fire, ice)
         cls.fire = fire
         cls.unrelated_facet = FacetFactory(name="Wolf")
+        cls.resonance = ResonanceFactory()
 
     def test_no_cantrip_selected_returns_error(self):
         draft = CharacterDraftFactory()
@@ -59,7 +60,10 @@ class MagicStageValidationTest(TestCase):
 
     def test_innate_cantrip_selected_passes(self):
         draft = CharacterDraftFactory(
-            draft_data={"selected_cantrip_id": self.innate_cantrip.id},
+            draft_data={
+                "selected_cantrip_id": self.innate_cantrip.id,
+                "selected_gift_resonance_id": self.resonance.id,
+            },
         )
         errors = compute_magic_errors(draft)
         assert errors == []
@@ -78,6 +82,7 @@ class MagicStageValidationTest(TestCase):
             draft_data={
                 "selected_cantrip_id": self.manifested_cantrip.id,
                 "selected_facet_id": self.fire.id,
+                "selected_gift_resonance_id": self.resonance.id,
             },
         )
         errors = compute_magic_errors(draft)
@@ -100,6 +105,25 @@ class MagicStageValidationTest(TestCase):
         )
         errors = compute_magic_errors(draft)
         assert len(errors) > 0
+
+    def test_cantrip_without_resonance_fails(self):
+        """Resonance is required — anchors the latent GIFT thread (#1620)."""
+        draft = CharacterDraftFactory(
+            draft_data={"selected_cantrip_id": self.innate_cantrip.id},
+        )
+        errors = compute_magic_errors(draft)
+        assert "Select a gift resonance" in errors
+
+    def test_cantrip_with_resonance_passes(self):
+        """Valid cantrip + facet + resonance produces no errors."""
+        draft = CharacterDraftFactory(
+            draft_data={
+                "selected_cantrip_id": self.innate_cantrip.id,
+                "selected_gift_resonance_id": self.resonance.id,
+            },
+        )
+        errors = compute_magic_errors(draft)
+        assert errors == []
 
 
 class MagicFinalizationCGSeedingTest(TestCase):

--- a/src/world/character_creation/tests/test_services.py
+++ b/src/world/character_creation/tests/test_services.py
@@ -122,11 +122,12 @@ class FinalizationTestMixin:
         target.tradition = TraditionFactory()
 
     def _create_complete_magic(self, draft: CharacterDraft) -> None:
-        """Create complete magic data for a draft (cantrip in draft_data)."""
+        """Create complete magic data for a draft (cantrip + resonance in draft_data)."""
         from world.magic.factories import CantripFactory
 
         cantrip = CantripFactory(requires_facet=False)
         draft.draft_data["selected_cantrip_id"] = cantrip.id
+        draft.draft_data["selected_gift_resonance_id"] = self.resonance.id
         draft.save(update_fields=["draft_data"])
 
     def _create_base_draft(
@@ -1088,9 +1089,10 @@ class FinalizeMagicDataCantripTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        from world.magic.factories import CantripFactory, TraditionFactory
+        from world.magic.factories import CantripFactory, ResonanceFactory, TraditionFactory
 
         cls.cantrip = CantripFactory(name="Danger Sense", requires_facet=False)
+        cls.resonance = ResonanceFactory()
         cls.tradition = TraditionFactory()
 
     def test_gift_created_from_cantrip(self) -> None:
@@ -1335,6 +1337,7 @@ class FinalizeMagicDataCantripTests(TestCase):
         draft_data: dict = {}
         if cantrip is not None:
             draft_data["selected_cantrip_id"] = cantrip.id
+            draft_data["selected_gift_resonance_id"] = self.resonance.id
         if custom_gift_name:
             draft_data["custom_gift_name"] = custom_gift_name
         if custom_gift_description:

--- a/src/world/character_creation/validators.py
+++ b/src/world/character_creation/validators.py
@@ -190,6 +190,7 @@ def compute_magic_errors(draft: CharacterDraft) -> list[str]:
     Cantrip-based validation:
     - Must have selected_cantrip_id in draft_data
     - If cantrip requires_facet, must have selected_facet_id that is in allowed_facets
+    - Must have selected_gift_resonance_id (anchors the latent GIFT thread, #1620)
     """
     from world.magic.models import Cantrip  # noqa: PLC0415
 
@@ -209,5 +210,10 @@ def compute_magic_errors(draft: CharacterDraft) -> list[str]:
             return [prompt]
         if not cantrip.allowed_facets.filter(pk=facet_id).exists():
             return ["Selected option is not valid for this cantrip"]
+
+    # Resonance is required — anchors the latent GIFT thread (#1620)
+    resonance_id = draft.draft_data.get("selected_gift_resonance_id")
+    if not resonance_id:
+        return ["Select a gift resonance"]
 
     return []

--- a/src/world/magic/tests/test_character_cast_check.py
+++ b/src/world/magic/tests/test_character_cast_check.py
@@ -132,6 +132,7 @@ class ProvisionUsesPerCharacterCheckTests(TestCase):
         TechniqueStyleFactory()
         EffectTypeFactory()
         ResonanceFactory()
+        cls.resonance = ResonanceFactory()
         tradition = TraditionFactory()
 
         # Skill needed so provision_player_anima_ritual doesn't log + skip.
@@ -180,6 +181,7 @@ class ProvisionUsesPerCharacterCheckTests(TestCase):
                 "tarot_reversed": False,
                 "traits_complete": True,
                 "selected_cantrip_id": self.cantrip.id,
+                "selected_gift_resonance_id": self.resonance.id,
                 "skills": {str(self.skill.pk): 20},
             },
         )
@@ -260,6 +262,7 @@ class GetCharacterCastCheckTests(TestCase):
         TechniqueStyleFactory()
         EffectTypeFactory()
         ResonanceFactory()
+        cls.resonance = ResonanceFactory()
         tradition = TraditionFactory()
         cls.skill = SkillFactory(trait__name="CCProvisionMelee")
         cantrip = CantripFactory(requires_facet=False)
@@ -312,6 +315,7 @@ class GetCharacterCastCheckTests(TestCase):
                 "tarot_reversed": False,
                 "traits_complete": True,
                 "selected_cantrip_id": self.cantrip.id,
+                "selected_gift_resonance_id": self.resonance.id,
                 "skills": {str(self.skill.pk): 20},
             },
         )

--- a/src/world/scenes/tests/test_cast_per_character_check.py
+++ b/src/world/scenes/tests/test_cast_per_character_check.py
@@ -130,6 +130,7 @@ class CastUsesPerCharacterCheckTests(TestCase):
         TechniqueStyleFactory()
         EffectTypeFactory()
         ResonanceFactory()
+        cls.resonance = ResonanceFactory()
         cls.tradition = TraditionFactory()
         # Skill so provision_player_anima_ritual finds a default and doesn't skip.
         cls.skill = SkillFactory(trait__name="CastPCRitualism")
@@ -169,6 +170,7 @@ class CastUsesPerCharacterCheckTests(TestCase):
                 "tarot_reversed": False,
                 "traits_complete": True,
                 "selected_cantrip_id": self.cantrip.id,
+                "selected_gift_resonance_id": self.resonance.id,
                 "skills": {str(self.skill.pk): 20},
             },
         )

--- a/src/world/seeds/tests/test_playable_slice.py
+++ b/src/world/seeds/tests/test_playable_slice.py
@@ -85,7 +85,7 @@ class TestSeededCharacterCreation(TestCase):
         from world.character_creation.models import CharacterDraft
         from world.character_creation.services import finalize_character
         from world.character_sheets.models import CharacterSheet
-        from world.magic.models import Cantrip
+        from world.magic.models import Cantrip, Resonance
         from world.seeds.character_creation import DEFAULT_STAT_NAMES
         from world.tarot.models import TarotCard
 
@@ -117,6 +117,8 @@ class TestSeededCharacterCreation(TestCase):
         # The seeded magic cluster provides a selectable cantrip.
         cantrip = Cantrip.objects.first()
         self.assertIsNotNone(cantrip, "magic cluster must seed a selectable cantrip")
+        resonance = Resonance.objects.first()
+        self.assertIsNotNone(resonance, "magic cluster must seed a resonance")
 
         account = AccountDB.objects.create(username="seeded_cg_player")
         draft_data = {
@@ -128,6 +130,7 @@ class TestSeededCharacterCreation(TestCase):
             "tarot_reversed": False,
             "traits_complete": True,
             "selected_cantrip_id": cantrip.id,
+            "selected_gift_resonance_id": resonance.id,
         }
         # selected_tradition may be nullable; leave it unset unless finalize needs it.
 


### PR DESCRIPTION
Closes #1620

## Summary

Add a resonance dropdown to the CG MagicStage's CantripSelector so players can choose which magical resonance anchors their gift's latent GIFT thread (#1578). The backend already reads selected_gift_resonance_id at finalization but nothing on the frontend ever wrote it — the fallback (gift.resonances.first()) is always None for CG-created gifts, so the latent thread was silently skipped in production.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1620 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean rebase onto main, no conflicts

<!-- last-addressed-comment: 0 -->