### PR TITLE
Accusation counter-play — slice 1: light-smear enablement (#1825)

### DIFF
--- a/src/world/secrets/services.py
+++ b/src/world/secrets/services.py
@@ -168,7 +168,7 @@ def mint_accusation(  # noqa: PLR0913 — keyword-only; each arg is a distinct s
     if level > ACCUSATION_MAX_LEVEL:
         msg = "That accusation is too grave to mint without evidence."
         raise SecretError(msg, user_message=msg)
-    return author_secret(
+    secret = author_secret(
         subject_sheet=subject_sheet,
         provenance=SecretProvenance.ACCUSATION,
         level=level,
@@ -179,6 +179,17 @@ def mint_accusation(  # noqa: PLR0913 — keyword-only; each arg is a distinct s
         mission_deed=mission_deed,
         scene=scene,
     )
+    # The author knows their own accusation — so a Level-1 smear is immediately gossipable by
+    # its framer (`gossip plant`, #1572), the light-tier spread of the counter-play (#1825).
+    # Best-effort: an author with no roster entry (an edge case) simply gets no knowledge row.
+    from world.roster.models import RosterEntry  # noqa: PLC0415
+
+    author_entry = RosterEntry.objects.filter(
+        character_sheet=accuser_persona.character_sheet
+    ).first()
+    if author_entry is not None:
+        grant_secret_knowledge(roster_entry=author_entry, secret=secret)
+    return secret
 
 
 def accusation_permitted(*, framer_sheet: CharacterSheet, target_sheet: CharacterSheet) -> bool:

--- a/src/world/secrets/tests/test_secrets.py
+++ b/src/world/secrets/tests/test_secrets.py
@@ -163,6 +163,18 @@ class MintAccusationServiceTests(TestCase):
                 level=SecretLevel.DANGEROUS,
             )
 
+    def test_author_holds_knowledge_of_their_own_accusation(self) -> None:
+        # #1825 counter-play (light smear): the framer knows what they minted, so a Level-1
+        # accusation is immediately gossipable by them (`gossip plant`).
+        author_entry = RosterEntryFactory()
+        secret = mint_accusation(
+            accuser_persona=author_entry.character_sheet.primary_persona,
+            subject_sheet=self.target,
+            content="They cheat at cards.",
+            level=SecretLevel.UNCOMMON_KNOWLEDGE,
+        )
+        assert secret_known_to(secret, author_entry) is True
+
 
 class AccusationPermittedTests(TestCase):
     """The frame-job consent gate (#1825) — the target's ``hostile`` category decides."""


### PR DESCRIPTION
## What

First slice of the frame-job **counter-play** (the expanded #1825 spec). Connects two already-shipped systems into the **light-tier offense**: a Level-1 smear is now immediately spreadable.

`mint_accusation` (shipped in #2200) now grants the **author** `SecretKnowledge` of the accusation they just minted. Because `gossip plant` (#1572) requires you to hold a Level-1 secret, this is the one missing link that lets a framer `accuse <target> = <claim>` (mint L1) → `gossip plant <#>` (spread it through the rumor mill), raising its regional heat and pushing the reputation hit — the cheap, easy-to-trace smear tier.

## How

- One behavioural change in `mint_accusation`: after authoring, `grant_secret_knowledge(roster_entry=author, secret)`. Best-effort — an author with no roster entry (edge case) simply gets no knowledge row. Semantically correct on its own: you know the claim you made.
- No consent hole: consent is enforced at mint (`accusation_permitted`), so spreading an already-minted accusation is just ordinary gossip.
- The L1 gate on `plant_gossip` is exactly the tier boundary from the spec — heavy (L2–L3) frames escalate through the justice route, not the rumor mill.

## Tests

`world.secrets.tests.test_secrets` — the author holds knowledge of their own Level-1 accusation (28 green).

## Scope

Part of #1825's counter-play epic (does **not** close it). The full design — the heavy frame `Project`, the accusation→heat bridge, the investigate-to-nullify + author-unmask, the symmetric refute-at-hub, the framer backfire, the lethal-consent gating, and the frame-an-NPC achievement — is specced on #1825, with the favor/authority clearing mapped to #1826 and NPC accusers to a future content issue. Subsequent slices extend this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)