### PR TITLE
One applause economy: reconcile kudos/votes/reactions and surface top poses (#2155)

### DIFF
--- a/docs/adr/0115-applause-three-axes.md
+++ b/docs/adr/0115-applause-three-axes.md
@@ -1,0 +1,28 @@
+# Applause is three axes, not one economy
+
+Player-to-player positive feedback on a pose stays split across three independent
+mechanisms, each with a distinct purpose: `WeeklyVote` is **popularity** — a scarce,
+budgeted weekly resource that ranks poses (feeds the scene highlight reel's all-time
+ordering) and settles into `MEMORABLE_POSE` XP for the top-ranked poses each week.
+`award_kudos` is **graciousness** — an unlimited, GM/player-awarded "good sport"
+currency with its own audit trail (`KudosTransaction`), claimable for XP later, and
+now pushing a real-time `kudos_received` WS toast on every award (#2161). `emoji
+InteractionReaction` is **expression** — cosmetic by default, but a nonzero-valence
+emoji additionally fires an ambient relationship bump at the pose's author
+(`ReactionEmoji.valence`, #1699) — a lightweight relationship-building signal
+distinct from both. Endorsements (`world.relationships`) are a separate, fourth axis
+entirely — the resonance/relationship-depth economy — named here only to draw the
+boundary: it is not merged into any of the three above either.
+
+We rejected merging these into one unified "applause economy": the three signals
+answer different questions (was this popular vs. was this player gracious vs. how did
+this specific beat land emotionally) and already had independent storage, UI
+surfaces, and settlement timing before #2161 audited them. Collapsing them would have
+required picking one settlement cadence and one XP conversion rate for mechanically
+unrelated behaviors, and would have thrown away the weekly-budget scarcity that makes
+votes meaningful as a ranking signal. #2161's job was reconciliation of what was
+half-wired (the highlight reel wasn't ranking on votes at all; kudos had no
+real-time push; `VoteButton`/`VotesPanel` weren't mounted), not consolidation of the
+three into fewer mechanisms.
+
+> Status: accepted · Source: #2161, Tehom's ruling on 2026-07-10

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -144,6 +144,7 @@ treat those names as hints to confirm, not gospel.
 - [0112 — MOVE tracks in-progress position via personal transit coordinates, not a rounds-counter](0112-move-uses-transit-coordinates.md) (extends ADR-0085)
 - [0113 — Consent defaults are a category tree, not per-category flags](0113-consent-defaults-are-a-category-tree.md) (extends ADR-0024)
 - [0114 — Player-authored accusations are weight-bearing secrets, gated by consent not the model](0114-accusations-are-weight-bearing-player-secrets.md) (extends ADR-0062/0113)
+- [0115 — Applause is three axes, not one economy: votes=popularity, kudos=graciousness, reactions=expression](0115-applause-three-axes.md)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/audits/2026-07-10-webclient-rp-ux-audit.md
+++ b/docs/audits/2026-07-10-webclient-rp-ux-audit.md
@@ -90,10 +90,17 @@ Resolving this split is **#2156**, the structural core of the slate.
 
 - **Giving kudos is exemplary** — one-tap `ReactionStrip` on every pose, ADR-0033-respecting
   anonymized attribution. But *seeing why you got kudos* requires navigating to `/xp-kudos`.
+  **[FIXED #2161]** Kudos now surfaces in-context: `award_kudos` pushes a real-time
+  `kudos_received` WS toast to the recipient (`notify_kudos_received`) instead of requiring
+  a trip to `/xp-kudos`.
 - **Three parallel applause systems disagree**: kudos chip, emoji reactions (what
   `HighlightReel` "top poses" actually ranks by), and the fully-built-server-side
   `WeeklyVote` heart economy whose `VoteButton`/`VotesPanel` components are **imported
   nowhere**; no top-voted endpoint exists.
+  **[FIXED #2161]** The disagreement is now a deliberate, documented three-axes design
+  (ADR-0115) rather than an accident: `WeeklyVote` is wired end-to-end — `VoteButton` on
+  every `PoseUnit` and `VotesPanel` on `/xp-kudos` — and the highlight reel re-ranks on
+  all-time vote count first (reaction count as tie-break), not reaction count alone.
 - **`world.journals` (diary/praise-retort, weekly XP) has zero web frontend**; telnet
   (`journal write`) is complete. The `/journal` route is a decoy — it's the *missions*
   ledger, an unrelated system sharing the name.
@@ -102,6 +109,9 @@ Resolving this split is **#2156**, the structural core of the slate.
 - Latent gotcha: `KudosTransaction.awarded_by` serializes raw `username`; all callers pass
   `None` by convention only — no structural guard (ADR-0033 risk if a future caller passes
   an account).
+  **[FIXED #2161]** The guard is now structural, not conventional: `awarded_by`/
+  `awarded_by_name` was removed from `KudosTransactionSerializer` entirely — a future
+  caller passing a real `awarded_by` account can no longer leak it to the recipient.
 
 ### 5. Rituals, threads, relationships (#2159)
 

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1154,6 +1154,13 @@ XP, kudos, development points, and unlock system. Contains the most explicit pre
 - **Telnet Commands:** `progression unlocks`, `progression unlock class=<id>`, `progression unlock thread=<id> level=<n>` (in `commands/progression.py`);
   `kudos`, `vote`, `randomscene` (alias `rscene`), `pathintent` (in `commands/progression_rewards.py`, #1348);
   `durance [status|intent|convene]` (in `commands/durance.py`, #1700)
+- **`award_kudos` real-time push + privacy guard (#2161):** every `award_kudos` call
+  schedules `notify_kudos_received` via `transaction.on_commit`, pushing a `kudos_received`
+  WS frame (amount/source_category/description) to the recipient's connected sessions —
+  central to the service, not per-caller, so vote settlement, GM awards, writeup kudos, and
+  the social-engagement roll below all get the toast for free. `KudosTransactionSerializer`
+  no longer exposes `awarded_by`/`awarded_by_name` to the recipient (ADR-0033 structural
+  guard — the awarder's identity never leaks to the person they kudos'd).
 - **Good-sport kudos accrual:**
   - `accrue(account, initiator_account, points) -> WeeklySocialEngagement` (`services/engagement.py`) — adds points to the weekly pending ledger; tracks `WeeklyEngagementInitiator` rows for distinct-initiator anti-farm; resets stale ledgers lazily on the game-week boundary.
   - `grant_social_engagement_kudos() -> int` (`services/engagement.py`) — called at weekly rollover; for each ungranted ledger with `engagement_events > 0`, rolls the diminishing-chance curve once per event (`_roll_good_sport_points`, guaranteed first point, capped at `GOOD_SPORT_WEEKLY_CAP`) and awards kudos via `award_kudos` when the roll yields > 0; every ledger is marked `granted=True` regardless of the rolled amount. There is no distinct-initiator floor — `distinct_initiators` (from `WeeklyEngagementInitiator` rows) is tracked on the ledger but not read by this function. Requires the `"social_engagement"` `KudosSourceCategory` to exist (seeded by the "kudos" cluster, #2026) or it logs a warning and no-ops.
@@ -1522,10 +1529,15 @@ action consent flow, and a three-mode non-combat round framework.
     and `SceneViewSet.highlight_reel`.
   - **Do not inline this logic.** `SceneViewSet`, `ReadOnlyOrSceneParticipant`, the combat
     encounter read gate, and the interaction/reel read gates all consume these forms.
-- **Highlight reel (#1241):** `GET /api/scenes/{id}/highlight-reel/` — a fully-sealed featured
-  moment + ranked index (ids only), ranked by `InteractionReaction` counts (a queryset-level
-  `Count` annotation, no denormalized column), GM-tagged poses headline. Filtered through
-  `Interaction.objects.visible_to`. Frontend: `HighlightReel` (`frontend/src/scenes/components/`).
+- **Highlight reel (#1241; re-ranked #2161):** `GET /api/scenes/{id}/highlight-reel/` — a
+  fully-sealed featured moment + ranked index, carrying `vote_count`/`reaction_count` per pose.
+  Ranked by all-time `WeeklyVote` count first (survives weekly settlement, unlike the weekly
+  `Interaction.vote_count` counter), `InteractionReaction` count as tie-break, recency last;
+  GM-tagged poses headline. Filtered through `Interaction.objects.visible_to`. Frontend:
+  `HighlightReel` (`frontend/src/scenes/components/`) — direct-mounted (no extra Accordion
+  wrapper, it's already self-collapsing) in the `/game` right sidebar's Room tab via
+  `SceneHighlightsPanel` (`frontend/src/game/components/room-panel/`), in addition to its
+  original mount on `SceneDetailPage`.
 - **API Endpoints:** `GET/POST /api/action-requests/`, `POST /api/action-requests/{id}/respond/`,
   `GET /api/action-targets/` (read-only; filterable by `scene` + `status`; surfaces pending
   additional-target consent rows for the authenticated player's personas).

--- a/docs/systems/progression.md
+++ b/docs/systems/progression.md
@@ -287,6 +287,14 @@ result = award_kudos(
     character=character,  # optional: associate with specific character
 )
 # Returns AwardResult(points_data, transaction)
+#
+# Post-commit side effect (#2161): every award — regardless of caller (vote
+# settlement, GM award, writeup kudos, social-engagement roll, …) — schedules
+# `notify_kudos_received(account, amount=..., source_category=..., description=...)`
+# via `transaction.on_commit`, pushing a `kudos_received` WS frame to the recipient's
+# connected sessions so the toast surfaces in real time. `KudosTransactionSerializer`
+# never exposes `awarded_by` to the recipient (ADR-0033 structural guard) — the push
+# payload mirrors that: no awarder identity, only amount/source_category/description.
 
 # Claim kudos for conversion (atomic: updates balance + creates transaction)
 result = claim_kudos(

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -366,12 +366,14 @@ with `distinct_initiators >= MIN_ENGAGEMENT_BAR` (currently 2) are granted Kudos
 - `DELETE /api/scenes/{id}/` - Delete scene (owner/staff only)
 - `POST /api/scenes/{id}/finish/` - Finish an active scene (owner/GM/staff)
 - `GET /api/scenes/spotlight/` - Active scenes + recently finished (last 7 days)
-- `GET /api/scenes/{id}/highlight-reel/` - Highlight reel (#1241): one **fully sealed**
-  featured moment + a ranked index, ids only. Featured = highest-reacted GM-tagged pose
-  (headlines even at 0 reactions — curation primacy), else the single most-reacted pose;
-  index = remaining poses with ≥1 reaction, ranked by reaction count, capped at 10. Source
-  set is filtered through `Interaction.objects.visible_to`, so hidden poses never appear.
-  Reveal a pose via `GET /api/interactions/{id}/`.
+- `GET /api/scenes/{id}/highlight-reel/` - Highlight reel (#1241, re-ranked #2161): one
+  **fully sealed** featured moment + a ranked index, ids plus `vote_count`/`reaction_count`.
+  Featured = highest-ranked GM-tagged pose (headlines even at 0 votes/reactions — curation
+  primacy), else the single most-ranked pose; index = remaining poses with ≥1 vote or
+  reaction, ranked by all-time `WeeklyVote` count first (persists past weekly settlement —
+  a pose's standing outlives the week it was posed in), reaction count as tie-break, and
+  recency last, capped at 10. Source set is filtered through `Interaction.objects.visible_to`,
+  so hidden poses never appear. Reveal a pose via `GET /api/interactions/{id}/`.
 
 **Filters:** `is_active`, `is_public`, `location`, `participant`, `status` (active/completed/upcoming), `gm`, `player`
 

--- a/frontend/src/game/components/RoomPanel.tsx
+++ b/frontend/src/game/components/RoomPanel.tsx
@@ -19,6 +19,7 @@ import { ObjectsList } from './room-panel/ObjectsList';
 import { RoomEditorPanel } from './room-panel/RoomEditorPanel';
 import { HubTidingsPanel } from './room-panel/HubTidingsPanel';
 import { RoomAuraPicker } from './room-panel/RoomAuraPicker';
+import { SceneHighlightsPanel } from './room-panel/SceneHighlightsPanel';
 
 export interface RoomData {
   id: number;
@@ -195,6 +196,8 @@ export function RoomPanel({
       {room.description && <RoomDescription description={room.description} />}
 
       {room.hub && <HubTidingsPanel hub={room.hub} />}
+
+      {scene && <SceneHighlightsPanel sceneId={scene.id} />}
 
       <CharactersList characters={room.characters} onCharacterClick={onCharacterClick} />
       <ExitsList exits={room.exits} onExit={handleExit} />

--- a/frontend/src/game/components/room-panel/SceneHighlightsPanel.test.tsx
+++ b/frontend/src/game/components/room-panel/SceneHighlightsPanel.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -9,9 +8,10 @@ vi.mock('@/scenes/queries', () => ({
   sceneKeys: { detail: (id: number | string) => ['scene', String(id)] },
 }));
 
-// Stub HighlightReel: this test only cares that the section starts collapsed
-// and threads sceneId/canGm through once opened — HighlightReel's own
-// behavior is covered by its own test suite.
+// Stub HighlightReel: this test only cares that it's mounted directly (no
+// wrapping Accordion — HighlightReel already self-collapses) with the right
+// sceneId/canGm props. HighlightReel's own collapse behavior is covered by
+// its own test suite.
 vi.mock('@/scenes/components/HighlightReel', () => ({
   HighlightReel: ({ sceneId, canGm }: { sceneId: string; canGm?: boolean }) => (
     <div data-testid="highlight-reel">
@@ -38,16 +38,14 @@ describe('SceneHighlightsPanel', () => {
     vi.clearAllMocks();
   });
 
-  it('is collapsed by default and does not mount HighlightReel until opened', async () => {
+  it('mounts HighlightReel directly with sceneId/canGm — no wrapping accordion', async () => {
     mockFetchScene.mockResolvedValue({ viewer_can_gm: true });
     renderPanel();
 
-    const trigger = await screen.findByRole('button', { name: /Highlights/ });
-    expect(screen.queryByTestId('highlight-reel')).not.toBeInTheDocument();
-
-    await userEvent.click(trigger);
-
     expect(await screen.findByTestId('highlight-reel')).toHaveTextContent('reel 5 gm:true');
     expect(mockFetchScene).toHaveBeenCalledWith('5');
+
+    // No extra "Highlights" accordion trigger/chevron on top of HighlightReel's own.
+    expect(screen.queryByRole('button', { name: /Highlights/ })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/game/components/room-panel/SceneHighlightsPanel.test.tsx
+++ b/frontend/src/game/components/room-panel/SceneHighlightsPanel.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/scenes/queries', () => ({
+  fetchScene: vi.fn(),
+  sceneKeys: { detail: (id: number | string) => ['scene', String(id)] },
+}));
+
+// Stub HighlightReel: this test only cares that the section starts collapsed
+// and threads sceneId/canGm through once opened — HighlightReel's own
+// behavior is covered by its own test suite.
+vi.mock('@/scenes/components/HighlightReel', () => ({
+  HighlightReel: ({ sceneId, canGm }: { sceneId: string; canGm?: boolean }) => (
+    <div data-testid="highlight-reel">
+      reel {sceneId} gm:{String(canGm)}
+    </div>
+  ),
+}));
+
+import { SceneHighlightsPanel } from './SceneHighlightsPanel';
+import { fetchScene } from '@/scenes/queries';
+
+const mockFetchScene = vi.mocked(fetchScene);
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return render(<SceneHighlightsPanel sceneId={5} />, { wrapper });
+}
+
+describe('SceneHighlightsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is collapsed by default and does not mount HighlightReel until opened', async () => {
+    mockFetchScene.mockResolvedValue({ viewer_can_gm: true });
+    renderPanel();
+
+    const trigger = await screen.findByRole('button', { name: /Highlights/ });
+    expect(screen.queryByTestId('highlight-reel')).not.toBeInTheDocument();
+
+    await userEvent.click(trigger);
+
+    expect(await screen.findByTestId('highlight-reel')).toHaveTextContent('reel 5 gm:true');
+    expect(mockFetchScene).toHaveBeenCalledWith('5');
+  });
+});

--- a/frontend/src/game/components/room-panel/SceneHighlightsPanel.tsx
+++ b/frontend/src/game/components/room-panel/SceneHighlightsPanel.tsx
@@ -1,10 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
 import { HighlightReel } from '@/scenes/components/HighlightReel';
 import { fetchScene, sceneKeys } from '@/scenes/queries';
 import type { SceneDetail } from '@/scenes/queries';
@@ -14,11 +8,13 @@ interface SceneHighlightsPanelProps {
 }
 
 /**
- * Collapsed-by-default "Highlights" section for the /game right sidebar's
- * Room tab (#2161) — wraps the existing `HighlightReel` (previously mounted
- * only on `SceneDetailPage`) so scene applause surfaces in-context. Radix's
- * `AccordionContent` isn't rendered until expanded, so `HighlightReel`'s own
- * data fetch doesn't fire for players who never open the section.
+ * Mounts the existing `HighlightReel` (previously mounted only on
+ * `SceneDetailPage`) in the `/game` right sidebar's Room tab (#2161) so
+ * scene applause surfaces in-context. `HighlightReel` is already
+ * collapsed-by-default and self-collapsing (its own header/chevron), so
+ * this doesn't re-wrap it in another Accordion — a second stacked chevron
+ * would force players through two clicks to see one thing, and its data
+ * fetch already only fires once its own section is opened.
  *
  * The WS `SceneSummary` GamePage threads down doesn't carry `viewer_can_gm`
  * (staff | scene GM | scene owner — see `serializers.get_viewer_can_gm`), so
@@ -31,16 +27,5 @@ export function SceneHighlightsPanel({ sceneId }: SceneHighlightsPanelProps) {
     queryFn: () => fetchScene(String(sceneId)),
   });
 
-  return (
-    <Accordion type="single" collapsible className="border-b">
-      <AccordionItem value="highlights" className="border-b-0">
-        <AccordionTrigger className="px-3 py-2 text-xs font-semibold uppercase text-muted-foreground hover:no-underline">
-          Highlights
-        </AccordionTrigger>
-        <AccordionContent className="px-3">
-          <HighlightReel sceneId={String(sceneId)} canGm={sceneDetail?.viewer_can_gm} />
-        </AccordionContent>
-      </AccordionItem>
-    </Accordion>
-  );
+  return <HighlightReel sceneId={String(sceneId)} canGm={sceneDetail?.viewer_can_gm} />;
 }

--- a/frontend/src/game/components/room-panel/SceneHighlightsPanel.tsx
+++ b/frontend/src/game/components/room-panel/SceneHighlightsPanel.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { HighlightReel } from '@/scenes/components/HighlightReel';
+import { fetchScene, sceneKeys } from '@/scenes/queries';
+import type { SceneDetail } from '@/scenes/queries';
+
+interface SceneHighlightsPanelProps {
+  sceneId: number;
+}
+
+/**
+ * Collapsed-by-default "Highlights" section for the /game right sidebar's
+ * Room tab (#2161) — wraps the existing `HighlightReel` (previously mounted
+ * only on `SceneDetailPage`) so scene applause surfaces in-context. Radix's
+ * `AccordionContent` isn't rendered until expanded, so `HighlightReel`'s own
+ * data fetch doesn't fire for players who never open the section.
+ *
+ * The WS `SceneSummary` GamePage threads down doesn't carry `viewer_can_gm`
+ * (staff | scene GM | scene owner — see `serializers.get_viewer_can_gm`), so
+ * this fetches the same scene-detail resource `SceneDetailPage` uses, sharing
+ * its query cache via `sceneKeys.detail`.
+ */
+export function SceneHighlightsPanel({ sceneId }: SceneHighlightsPanelProps) {
+  const { data: sceneDetail } = useQuery<SceneDetail>({
+    queryKey: sceneKeys.detail(sceneId),
+    queryFn: () => fetchScene(String(sceneId)),
+  });
+
+  return (
+    <Accordion type="single" collapsible className="border-b">
+      <AccordionItem value="highlights" className="border-b-0">
+        <AccordionTrigger className="px-3 py-2 text-xs font-semibold uppercase text-muted-foreground hover:no-underline">
+          Highlights
+        </AccordionTrigger>
+        <AccordionContent className="px-3">
+          <HighlightReel sceneId={String(sceneId)} canGm={sceneDetail?.viewer_can_gm} />
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -14963,13 +14963,14 @@ export interface paths {
      *
      *     Featured = the highest-reacted GM-tagged pose; a tagged pose headlines even with
      *     zero reactions, because storyteller curation has primacy. When the scene has no
-     *     tags, this falls back to the single most-reacted pose. The index is the remaining
-     *     poses with at least one reaction, ranked by reaction count (ties -> most recent)
-     *     and capped at 10. Every pose is drawn through ``Interaction.visible_to`` so the
-     *     reel can never surface a pose the viewer cannot already see — not even as a sealed
-     *     slot. The payload carries only interaction ids (the featured card is fully sealed);
-     *     the frontend reveals a pose by fetching it through the existing interaction-detail
-     *     endpoint, which re-checks visibility.
+     *     tags, this falls back to the single most-voted (reactions tie-break) pose. The
+     *     index is the remaining poses with at least one vote or reaction, ranked by
+     *     all-time vote count first, reaction count as tie-break, and recency last —
+     *     capped at 10. Every pose is drawn through ``Interaction.visible_to`` so the reel
+     *     can never surface a pose the viewer cannot already see — not even as a sealed
+     *     slot. The payload carries interaction ids plus vote/reaction counts (the featured
+     *     card stays otherwise sealed); the frontend reveals a pose by fetching it through
+     *     the existing interaction-detail endpoint, which re-checks visibility.
      */
     get: operations['scenes_highlight_reel_retrieve'];
     put?: never;
@@ -22398,30 +22399,35 @@ export interface components {
       readonly found_at: string;
     };
     /**
-     * @description A scene's highlight reel: a sealed featured moment + a ranked index (#1241).
+     * @description A scene's highlight reel: a sealed featured moment + a ranked index (#1241, #2161).
      *
-     *     ``featured`` is null when the scene has no GM-tagged moments AND no reacted poses
-     *     (an empty reel — the frontend hides the collapsible section).
+     *     ``featured`` is null when the scene has no GM-tagged moments AND no voted-or-reacted
+     *     poses (an empty reel — the frontend hides the collapsible section).
      */
     HighlightReel: {
       featured: components['schemas']['HighlightReelFeatured'] | null;
       index: components['schemas']['HighlightReelEntry'][];
     };
-    /** @description One sealed entry in the ranked index below the featured moment (#1241). */
+    /** @description One sealed entry in the ranked index below the featured moment (#1241, #2161). */
     HighlightReelEntry: {
       interaction_id: number;
       rank: number;
+      vote_count: number;
+      reaction_count: number;
     };
     /**
-     * @description The single featured moment of a scene's highlight reel (#1241).
+     * @description The single featured moment of a scene's highlight reel (#1241, #2161).
      *
-     *     Intentionally IDs-only: the collapsed featured card is *fully sealed* — it shows no
-     *     pose content, type, participants, or reaction count until the viewer expands it, at
-     *     which point the frontend fetches the pose through the existing interaction-detail
-     *     endpoint (which re-checks visibility). Sending content here would defeat the seal.
+     *     The collapsed featured card is *fully sealed* — it shows no pose content, type, or
+     *     participants until the viewer expands it, at which point the frontend fetches the
+     *     pose through the existing interaction-detail endpoint (which re-checks visibility).
+     *     Sending pose content here would defeat the seal, but ``vote_count``/``reaction_count``
+     *     (#2161) are exposed so the frontend can badge the sealed card.
      */
     HighlightReelFeatured: {
       interaction_id: number;
+      vote_count: number;
+      reaction_count: number;
     };
     /** @description A required catalog choice on a template, with its active options (#2079). */
     HouseAspectDefinition: {

--- a/frontend/src/hooks/__tests__/handleKudosReceivedPayload.test.ts
+++ b/frontend/src/hooks/__tests__/handleKudosReceivedPayload.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { toastMock, invalidateQueriesMock } = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+  invalidateQueriesMock: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(toastMock, { error: vi.fn(), success: vi.fn() }),
+}));
+
+vi.mock('@/queryClient', () => ({
+  queryClient: { invalidateQueries: invalidateQueriesMock },
+}));
+
+import { handleKudosReceivedPayload } from '../handleKudosReceivedPayload';
+import type { KudosReceivedPayload } from '../types';
+
+describe('handleKudosReceivedPayload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fires a quiet toast (never toast.error) with the amount and description', () => {
+    const payload: KudosReceivedPayload = {
+      amount: 3,
+      source_category: 'writeup_commend',
+      description: 'A commend for your writeup',
+    };
+
+    handleKudosReceivedPayload(payload);
+
+    expect(toastMock).toHaveBeenCalledWith('+3 kudos — A commend for your writeup', {
+      description: 'writeup_commend',
+    });
+  });
+
+  it('invalidates the account-progression query', () => {
+    const payload: KudosReceivedPayload = {
+      amount: 1,
+      source_category: 'pose_chip',
+      description: 'Someone applauded your pose',
+    };
+
+    handleKudosReceivedPayload(payload);
+
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: ['account-progression'] });
+  });
+
+  it('tolerates an undefined payload (malformed frame) without throwing', () => {
+    expect(() => handleKudosReceivedPayload(undefined)).not.toThrow();
+    expect(toastMock).toHaveBeenCalledWith('+0 kudos — ', { description: '' });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: ['account-progression'] });
+  });
+});

--- a/frontend/src/hooks/handleKudosReceivedPayload.ts
+++ b/frontend/src/hooks/handleKudosReceivedPayload.ts
@@ -1,0 +1,26 @@
+import { toast } from 'sonner';
+import type { KudosReceivedPayload } from './types';
+import { queryClient } from '@/queryClient';
+
+/**
+ * kudos_received (#2161) — fired from `notify_kudos_received` on every kudos
+ * award (pose chip, writeup commend, weekly engagement, spread-assist), so
+ * applause surfaces in-context instead of requiring a trip to the progression
+ * page. Anonymous by design (ADR-0033): the payload carries no giver identity.
+ *
+ * A quiet toast (never `toast.error`) plus an `account-progression`
+ * invalidation so the recipient's kudos/XP totals refresh without a reload.
+ */
+export function handleKudosReceivedPayload(payload: KudosReceivedPayload | undefined) {
+  const {
+    amount,
+    source_category: sourceCategory,
+    description,
+  } = payload ?? {
+    amount: 0,
+    source_category: '',
+    description: '',
+  };
+  toast(`+${amount} kudos — ${description}`, { description: sourceCategory });
+  void queryClient.invalidateQueries({ queryKey: ['account-progression'] });
+}

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -29,6 +29,8 @@ export const WS_MESSAGE_TYPE = {
   ACTION_RESULT: 'action_result',
   /** Outbound: invoke a registered action by name with kwargs. */
   EXECUTE_ACTION: 'execute_action',
+  /** Inbound: someone applauded your content; anonymous. */
+  KUDOS_RECEIVED: 'kudos_received',
 } as const;
 
 export type SocketMessageType = (typeof WS_MESSAGE_TYPE)[keyof typeof WS_MESSAGE_TYPE];
@@ -141,6 +143,18 @@ export interface ScenePayload {
 export interface CommandErrorPayload {
   command: string;
   error: string;
+}
+
+/**
+ * Payload for `kudos_received` messages — anonymous by design (ADR-0033).
+ * Carries no giver identity: `description` is the audited, already-anonymized
+ * text from the KudosTransaction; `source_category` is the applause axis
+ * (pose chip, writeup commend, weekly engagement, spread-assist).
+ */
+export interface KudosReceivedPayload {
+  amount: number;
+  source_category: string;
+  description: string;
 }
 
 export interface InteractionWsPayload {

--- a/frontend/src/hooks/useGameSocket.ts
+++ b/frontend/src/hooks/useGameSocket.ts
@@ -11,6 +11,7 @@ import type {
   GameMessage,
   IncomingMessage,
   InteractionWsPayload,
+  KudosReceivedPayload,
   OutgoingMessage,
   RoomStatePayload,
   ScenePayload,
@@ -24,6 +25,7 @@ import { handleRoulettePayload } from './handleRoulettePayload';
 import type { RoulettePayload } from '@/components/roulette/types';
 import { handleBattleStatePayload } from './handleBattleStatePayload';
 import type { BattleStatePayload } from '@/battles/types';
+import { handleKudosReceivedPayload } from './handleKudosReceivedPayload';
 
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -122,6 +124,11 @@ export function useGameSocket() {
           if (msgType === WS_MESSAGE_TYPE.COMMAND_ERROR) {
             const { error, command } = (kwargs as unknown as CommandErrorPayload) ?? {};
             toast.error(error, { description: command });
+            return;
+          }
+
+          if (msgType === WS_MESSAGE_TYPE.KUDOS_RECEIVED) {
+            handleKudosReceivedPayload(kwargs as unknown as KudosReceivedPayload | undefined);
             return;
           }
 

--- a/frontend/src/progression/XpKudosPage.tsx
+++ b/frontend/src/progression/XpKudosPage.tsx
@@ -5,6 +5,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAccountProgressionQuery, useClaimKudosMutation } from './queries';
+import { VotesPanel } from './components/VotesPanel';
 import { usePendingAlterations } from '@/magic/queries';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -64,9 +65,6 @@ function KudosTransactionRow({ transaction }: { transaction: KudosTransaction })
       <div className="flex-1">
         <div className="font-medium">{categoryName}</div>
         <div className="text-sm text-muted-foreground">{transaction.description}</div>
-        {transaction.awarded_by_name && (
-          <div className="text-xs text-muted-foreground">From: {transaction.awarded_by_name}</div>
-        )}
         <div className="text-xs text-muted-foreground">
           {formatDate(transaction.transaction_date)}
         </div>
@@ -341,7 +339,7 @@ export function XpKudosPage() {
 
       <AlterationGateAlert />
 
-      <div className="mb-6 grid gap-4 md:grid-cols-2">
+      <div className="mb-6 grid gap-4 md:grid-cols-3">
         <BalanceCard
           title="Experience Points"
           available={xp?.current_available || 0}
@@ -363,6 +361,7 @@ export function XpKudosPage() {
             )
           }
         />
+        <VotesPanel />
       </div>
 
       <Card>

--- a/frontend/src/progression/types.ts
+++ b/frontend/src/progression/types.ts
@@ -29,7 +29,6 @@ export interface KudosTransaction {
   source_category_name: string | null;
   claim_category_name: string | null;
   description: string;
-  awarded_by_name: string | null;
   transaction_date: string;
 }
 

--- a/frontend/src/scenes/components/PoseUnit.tsx
+++ b/frontend/src/scenes/components/PoseUnit.tsx
@@ -9,13 +9,16 @@
  * Phase 9, Task 9.2.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
+import { useAppSelector } from '@/store/hooks';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { PersonaAvatar } from '@/components/PersonaAvatar';
 import { FormattedContent } from '@/components/FormattedContent';
 import { Badge } from '@/components/ui/badge';
+import { VoteButton } from '@/components/VoteButton';
 import { PersonaContextMenu } from './PersonaContextMenu';
 import { ActionResult } from './ActionResult';
 import { ReactionStrip } from './ReactionStrip';
@@ -199,6 +202,19 @@ export function PoseUnit({
   const actionInteractionIds = actionLinks.map((l) => l.action_interaction.id);
   const dramaticTags = interaction.dramatic_moment_tags ?? [];
 
+  // Resolve the viewer's active persona to detect self-pose — mirrors
+  // EndorsementControl's self-endorsement guard (same signal, same source).
+  // VoteButton has no self-guard of its own (the backend rejects self-votes;
+  // this gate is UX only), so PoseUnit computes it and decides whether to mount.
+  const activeCharacterName = useAppSelector((state) => state.game.active);
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
+  const viewerPersonaId = useMemo(
+    () => myRosterEntries.find((e) => e.name === activeCharacterName)?.primary_persona_id ?? null,
+    [myRosterEntries, activeCharacterName]
+  );
+  const isSelfPose = viewerPersonaId != null && interaction.persona.id === viewerPersonaId;
+  const canVote = Boolean(sceneId) && !isSelfPose;
+
   // -------------------------------------------------------------------------
   // State 3: standalone ACTION (not linked to any pose)
   // -------------------------------------------------------------------------
@@ -244,7 +260,10 @@ export function PoseUnit({
           details
         </button>
         {expanded && <PoseUnitDetailPanel actionInteractionIds={[interaction.id]} />}
-        <ReactionsFooter interaction={interaction} sceneId={sceneId} />
+        <div className="flex items-center gap-1">
+          <ReactionsFooter interaction={interaction} sceneId={sceneId} />
+          {canVote && <VoteButton targetType="interaction" targetId={interaction.id} />}
+        </div>
         {/* Standalone ACTION rows are authored content (claimed resonances) and
             are endorsable per spec — this is intentional, not a slip. */}
         <EndorsementControl interaction={interaction} sceneId={sceneId} kind="pose" />
@@ -360,7 +379,10 @@ export function PoseUnit({
         </div>
       )}
 
-      <ReactionsFooter interaction={interaction} sceneId={sceneId} />
+      <div className="flex items-center gap-1">
+        <ReactionsFooter interaction={interaction} sceneId={sceneId} />
+        {canVote && <VoteButton targetType="interaction" targetId={interaction.id} />}
+      </div>
       <EndorsementControl interaction={interaction} sceneId={sceneId} kind="pose" />
       {interaction.pose_kind === 'entry' && (
         <EndorsementControl interaction={interaction} sceneId={sceneId} kind="entry" />

--- a/frontend/src/scenes/components/__tests__/PoseUnit.voteButton.test.tsx
+++ b/frontend/src/scenes/components/__tests__/PoseUnit.voteButton.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Targeted test: VoteButton visibility gating in PoseUnit (#2161).
+ *
+ * PoseUnit mounts VoteButton beside ReactionsFooter (both the POSE and
+ * standalone-ACTION branches), but only when the pose does not belong to the
+ * viewer — VoteButton itself carries no self-guard (the backend rejects
+ * self-votes; this gate is UX only), so PoseUnit computes the same
+ * viewer-persona signal EndorsementControl uses and decides whether to mount.
+ *
+ * Scope: gating only. VoteButton's own budget-disabled behavior is its own
+ * concern and isn't retested here.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import type { Interaction } from '../../types';
+
+// Mock @/combat/queries — used by PersonaContextMenu's duel-challenge affordance (#1181).
+vi.mock('@/combat/queries', () => ({
+  useOutcomeDetails: vi.fn().mockReturnValue({ data: [], isLoading: false }),
+  useDispatchPlayerAction: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
+  combatKeys: { duelChallengesAll: () => ['combat', 'duel-challenges'] },
+}));
+
+// Stub PoseUnitDetailPanel — irrelevant to VoteButton gating.
+vi.mock('../PoseUnitDetailPanel', () => ({
+  PoseUnitDetailPanel: () => <div data-testid="pose-unit-detail-panel" />,
+}));
+
+// Stub EndorsementControl — irrelevant to VoteButton gating; covered by its own tests.
+vi.mock('../EndorsementControl', () => ({
+  EndorsementControl: () => null,
+}));
+
+// Mock the reaction-emoji catalog fetch (#1699) so ReactionsFooter's useQuery
+// doesn't hit the real network.
+vi.mock('../../queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../queries')>();
+  return {
+    ...actual,
+    postInteractionReaction: vi.fn().mockResolvedValue(null),
+    fetchReactionEmojiCatalog: vi.fn().mockResolvedValue([]),
+  };
+});
+
+// Viewer persona resolution — mirrors EndorsementControl.test.tsx's idiom.
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: vi.fn(() => ({
+    data: [
+      {
+        id: 1,
+        name: 'ViewerChar',
+        character_id: 42,
+        profile_picture_url: null,
+        primary_persona_id: 7,
+        active_persona_id: 7,
+      },
+    ],
+  })),
+}));
+
+vi.mock('@/store/hooks', () => ({
+  useAppSelector: vi.fn((selector: (state: unknown) => unknown) =>
+    selector({ game: { active: 'ViewerChar' }, auth: {} })
+  ),
+}));
+
+// Vote hooks — mocked so VoteButton renders without hitting the network.
+const mockCastVote = vi.fn();
+const mockRemoveVote = vi.fn();
+vi.mock('@/progression/voteQueries', () => ({
+  useMyVotesQuery: vi.fn(() => ({ data: [] })),
+  useVoteBudgetQuery: vi.fn(() => ({
+    data: { base_votes: 5, scene_bonus_votes: 0, votes_spent: 0, votes_remaining: 5 },
+  })),
+  useCastVoteMutation: vi.fn(() => ({ mutate: mockCastVote, isPending: false })),
+  useRemoveVoteMutation: vi.fn(() => ({ mutate: mockRemoveVote, isPending: false })),
+}));
+
+import { PoseUnit } from '../PoseUnit';
+
+function makeInteraction(overrides: Partial<Interaction> = {}): Interaction {
+  return {
+    id: 1,
+    persona: { id: 10, name: 'Alice' },
+    content: 'Hello world',
+    mode: 'pose',
+    visibility: 'default',
+    timestamp: '2026-01-01T00:00:00Z',
+    scene: 1,
+    reactions: [],
+    is_favorited: false,
+    place: null,
+    place_name: null,
+    receiver_persona_ids: [],
+    target_persona_ids: [],
+    action_links: [],
+    pose_kind: 'standard',
+    endorsee_sheet_id: 20,
+    endorsable_resonances: [],
+    pose_endorsers: [],
+    my_pose_endorsement: null,
+    entry_endorsers: [],
+    entry_endorsed_by_me: false,
+    ...overrides,
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe('PoseUnit — VoteButton gating (#2161)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders VoteButton on another persona's pose in a scene", () => {
+    // Alice (id 10) is not the viewer (primary_persona_id 7).
+    const interaction = makeInteraction({ mode: 'pose', persona: { id: 10, name: 'Alice' } });
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+    expect(screen.getByTitle(/vote/i)).toBeInTheDocument();
+  });
+
+  it("hides VoteButton on the viewer's own pose", () => {
+    // persona.id === 7 matches the mocked viewer's primary_persona_id.
+    const interaction = makeInteraction({
+      mode: 'pose',
+      persona: { id: 7, name: 'ViewerChar' },
+    });
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+    expect(screen.queryByTitle(/vote/i)).toBeNull();
+  });
+
+  it("renders VoteButton on another persona's standalone ACTION in a scene", () => {
+    const interaction = makeInteraction({
+      mode: 'action',
+      persona: { id: 10, name: 'Alice' },
+      action_links: [],
+    });
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+    expect(screen.getByTitle(/vote/i)).toBeInTheDocument();
+  });
+
+  it("hides VoteButton on the viewer's own standalone ACTION", () => {
+    const interaction = makeInteraction({
+      mode: 'action',
+      persona: { id: 7, name: 'ViewerChar' },
+      action_links: [],
+    });
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+    expect(screen.queryByTitle(/vote/i)).toBeNull();
+  });
+});

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -127,15 +127,6 @@ export async function fetchReactionEmojiCatalog(): Promise<ReactionEmojiEntry[]>
   return data.results;
 }
 
-export async function toggleInteractionFavorite(interactionId: number) {
-  const res = await apiFetch('/api/interaction-favorites/', {
-    method: 'POST',
-    body: JSON.stringify({ interaction: interactionId }),
-  });
-  if (!res.ok && res.status !== 204) throw new Error('Failed to toggle favorite');
-  return res.status;
-}
-
 export interface PendingUnlinkedActionRow {
   id: number;
   content: string;

--- a/src/schema.json
+++ b/src/schema.json
@@ -24648,13 +24648,14 @@ paths:
 
         Featured = the highest-reacted GM-tagged pose; a tagged pose headlines even with
         zero reactions, because storyteller curation has primacy. When the scene has no
-        tags, this falls back to the single most-reacted pose. The index is the remaining
-        poses with at least one reaction, ranked by reaction count (ties -> most recent)
-        and capped at 10. Every pose is drawn through ``Interaction.visible_to`` so the
-        reel can never surface a pose the viewer cannot already see — not even as a sealed
-        slot. The payload carries only interaction ids (the featured card is fully sealed);
-        the frontend reveals a pose by fetching it through the existing interaction-detail
-        endpoint, which re-checks visibility.
+        tags, this falls back to the single most-voted (reactions tie-break) pose. The
+        index is the remaining poses with at least one vote or reaction, ranked by
+        all-time vote count first, reaction count as tie-break, and recency last —
+        capped at 10. Every pose is drawn through ``Interaction.visible_to`` so the reel
+        can never surface a pose the viewer cannot already see — not even as a sealed
+        slot. The payload carries interaction ids plus vote/reaction counts (the featured
+        card stays otherwise sealed); the frontend reveals a pose by fetching it through
+        the existing interaction-detail endpoint, which re-checks visibility.
       parameters:
       - in: path
         name: id
@@ -39613,10 +39614,10 @@ components:
     HighlightReel:
       type: object
       description: |-
-        A scene's highlight reel: a sealed featured moment + a ranked index (#1241).
+        A scene's highlight reel: a sealed featured moment + a ranked index (#1241, #2161).
 
-        ``featured`` is null when the scene has no GM-tagged moments AND no reacted poses
-        (an empty reel — the frontend hides the collapsible section).
+        ``featured`` is null when the scene has no GM-tagged moments AND no voted-or-reacted
+        poses (an empty reel — the frontend hides the collapsible section).
       properties:
         featured:
           allOf:
@@ -39631,30 +39632,43 @@ components:
       - index
     HighlightReelEntry:
       type: object
-      description: One sealed entry in the ranked index below the featured moment
-        (#1241).
+      description: 'One sealed entry in the ranked index below the featured moment
+        (#1241, #2161).'
       properties:
         interaction_id:
           type: integer
         rank:
           type: integer
-      required:
-      - interaction_id
-      - rank
-    HighlightReelFeatured:
-      type: object
-      description: |-
-        The single featured moment of a scene's highlight reel (#1241).
-
-        Intentionally IDs-only: the collapsed featured card is *fully sealed* — it shows no
-        pose content, type, participants, or reaction count until the viewer expands it, at
-        which point the frontend fetches the pose through the existing interaction-detail
-        endpoint (which re-checks visibility). Sending content here would defeat the seal.
-      properties:
-        interaction_id:
+        vote_count:
+          type: integer
+        reaction_count:
           type: integer
       required:
       - interaction_id
+      - rank
+      - reaction_count
+      - vote_count
+    HighlightReelFeatured:
+      type: object
+      description: |-
+        The single featured moment of a scene's highlight reel (#1241, #2161).
+
+        The collapsed featured card is *fully sealed* — it shows no pose content, type, or
+        participants until the viewer expands it, at which point the frontend fetches the
+        pose through the existing interaction-detail endpoint (which re-checks visibility).
+        Sending pose content here would defeat the seal, but ``vote_count``/``reaction_count``
+        (#2161) are exposed so the frontend can badge the sealed card.
+      properties:
+        interaction_id:
+          type: integer
+        vote_count:
+          type: integer
+        reaction_count:
+          type: integer
+      required:
+      - interaction_id
+      - reaction_count
+      - vote_count
     HouseAspectDefinition:
       type: object
       description: A required catalog choice on a template, with its active options

--- a/src/web/webclient/message_types.py
+++ b/src/web/webclient/message_types.py
@@ -19,6 +19,7 @@ class WebsocketMessageType(str, Enum):
     INTERACTION = "interaction"
     ROULETTE_RESULT = "roulette_result"
     BATTLE_STATE = "battle_state"
+    KUDOS_RECEIVED = "kudos_received"
 
 
 @dataclass
@@ -132,3 +133,16 @@ class BattleStatePayload:
 
     battle_id: int
     round_number: int | None
+
+
+@dataclass
+class KudosReceivedPayload:
+    """Payload for ``kudos_received`` messages — anonymous by design (ADR-0033).
+
+    Carries no giver identity: the description string is the audited,
+    already-anonymized text from the KudosTransaction.
+    """
+
+    amount: int
+    source_category: str
+    description: str

--- a/src/world/progression/AGENT_GLOSSARY.md
+++ b/src/world/progression/AGENT_GLOSSARY.md
@@ -1,6 +1,9 @@
 # Progression glossary
 
-> Durance, XP, Kudos, and Development Points are cross-cutting terms — see the root `AGENT_GLOSSARY_MAP.md`.
+> Durance, XP, and Development Points are cross-cutting terms — see the root `AGENT_GLOSSARY_MAP.md`.
+> Kudos, Weekly Vote, Vote Budget, and Memorable Pose are defined below — they're the
+> applause-economy axes native to this app (see ADR-0115 for how they relate to
+> `InteractionReaction`, the sibling axis defined in `scenes/AGENT_GLOSSARY.md`).
 
 **Unlock**:
 An authored advancement target a character can spend XP to acquire — e.g. `ClassLevelUnlock` (a class level) or `TraitRatingUnlock` (a major trait threshold) — whose availability is governed by Requirements.
@@ -17,6 +20,43 @@ _Avoid_: level-up event, training record.
 **PathIntent**:
 A character's mutable declared intention for their next Path — one row per sheet, overwritten on re-declaration — which the Audere Majora offer pre-selects when it is among the eligible paths.
 _Avoid_: path receipt, path choice (it is an aspiration, not a committed record).
+
+**Kudos**:
+An unlimited, GM- or player-awarded "good sport" currency (`award_kudos`,
+`KudosTransaction`) recognizing graciousness — someone was a good sport, wrote a
+great post, played fair through a loss. Distinct from `WeeklyVote` (a scarce,
+budgeted popularity signal) and `InteractionReaction` (cosmetic/relationship
+expression) — see ADR-0115 for why all three stay separate axes. Every award pushes
+a real-time `kudos_received` WS toast to the recipient (`notify_kudos_received`,
+#2161); the awarder's identity is never exposed to the recipient
+(`KudosTransactionSerializer` drops `awarded_by`, ADR-0033).
+_Avoid_: applause, upvote, like (reserve those for `WeeklyVote`/`InteractionReaction`).
+
+**Weekly Vote**:
+A single cast of a player's weekly `WeeklyVote` on a piece of content (a pose,
+scene participation, or journal entry) — the popularity axis of applause. Toggleable
+(cast/uncast) until the weekly cron processes it; settles into `MEMORABLE_POSE` XP
+for top-ranked poses and ranks the scene highlight reel by all-time vote count
+(#2161, `SceneViewSet.highlight_reel`). Frontend surface: `VoteButton` on each
+`PoseUnit` and the `/xp-kudos` `VotesPanel`.
+_Avoid_: kudos, like, favorite (favoriting is the private, non-social
+`InteractionFavorite` bookmark, unrelated to this axis).
+
+**Vote Budget**:
+`WeeklyVoteBudget` — how many `WeeklyVote`s an account can cast in a given
+`GameWeek`: 7 base votes plus 1 bonus per scene attended that week
+(`scene_bonus_votes`), minus `votes_spent`. Resets every game week; not a
+carry-forward currency.
+_Avoid_: vote balance, vote allowance.
+
+**Memorable Pose**:
+The weekly settlement outcome for the top-3 vote-ranked poses (via
+`process_memorable_poses`): 1st/2nd/3rd place authors receive `MEMORABLE_POSE_XP`
+([3, 2, 1]) XP, capped per-account by `VOTE_XP_CAP`. This is where a `WeeklyVote`'s
+popularity signal cashes out into XP — kudos and reactions have their own,
+independent settlement/effects.
+_Avoid_: top pose, featured pose (that's the highlight reel's *featured* slot,
+which can headline a GM-tagged pose with zero votes — a different selection rule).
 
 **trainer-of-record**:
 The `CharacterSheet` stored on a `DuranceTrainingSite` as the room's designated officiant.

--- a/src/world/progression/reaction_kinds.py
+++ b/src/world/progression/reaction_kinds.py
@@ -7,12 +7,16 @@ first reaction (``lazy_open``), so no per-pose rows exist until someone
 actually reacts. One reaction per player per pose is enforced by the
 window primitive's uniqueness.
 
-Pose-voting deliberately did NOT become a kind: that capability is already
-built and wired end-to-end as ``WeeklyVote`` (``cast_vote`` →
-progression views → the frontend VoteButton/VotesPanel) with weekly XP
-settlement. A voting kind would be a parallel implementation. The emoji
-``InteractionReaction`` layer likewise stays, per the ruling on #911 —
-Discord-style OOC reactions beside the mechanical kudos chip.
+Pose-voting deliberately did NOT become a kind: that capability is its own
+axis, ``WeeklyVote`` (``cast_vote`` → progression views → the frontend
+``VoteButton``/``VotesPanel``), with weekly XP settlement. #2161 landed the
+frontend mounting end-to-end — ``VoteButton`` on each ``PoseUnit`` and
+``VotesPanel`` on ``/xp-kudos`` — and re-ranked the scene highlight reel on
+all-time vote counts. A voting kind would still be a parallel implementation
+of an already-wired axis. The emoji ``InteractionReaction`` layer likewise
+stays, per the ruling on #911 — Discord-style OOC reactions beside the
+mechanical kudos chip. See ADR-0115 for the three-axes ruling (votes vs.
+kudos vs. reactions) that keeps all three separate by design.
 
 Registered from ``ProgressionConfig.ready()`` so scenes never imports
 progression.

--- a/src/world/progression/serializers/__init__.py
+++ b/src/world/progression/serializers/__init__.py
@@ -58,11 +58,6 @@ class KudosTransactionSerializer(serializers.ModelSerializer):
         read_only=True,
         allow_null=True,
     )
-    awarded_by_name = serializers.CharField(
-        source="awarded_by.username",
-        read_only=True,
-        allow_null=True,
-    )
 
     class Meta:
         model = KudosTransaction
@@ -72,7 +67,6 @@ class KudosTransactionSerializer(serializers.ModelSerializer):
             "source_category_name",
             "claim_category_name",
             "description",
-            "awarded_by_name",
             "transaction_date",
         ]
 

--- a/src/world/progression/services/kudos.py
+++ b/src/world/progression/services/kudos.py
@@ -15,6 +15,7 @@ from world.progression.models import (
     KudosSourceCategory,
     KudosTransaction,
 )
+from world.progression.services.notifications import notify_kudos_received
 from world.progression.types import AwardResult, ClaimResult, KudosXPResult, ProgressionReason
 
 
@@ -68,6 +69,15 @@ def award_kudos(  # noqa: PLR0913
         description=description,
         awarded_by=awarded_by,
         character=character,
+    )
+
+    transaction.on_commit(
+        lambda: notify_kudos_received(
+            account,
+            amount=amount,
+            source_category=source_category.display_name,
+            description=description,
+        )
     )
 
     return AwardResult(points_data=points_data, transaction=kudos_transaction)

--- a/src/world/progression/services/notifications.py
+++ b/src/world/progression/services/notifications.py
@@ -1,0 +1,31 @@
+"""Live pushes for progression events (#2161).
+
+Central seam: called from ``award_kudos`` post-commit so EVERY kudos award
+(pose chip, writeup commend, weekly engagement, spread-assist) surfaces
+in-context. msg() to an offline account is a harmless no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from evennia.accounts.models import AccountDB
+
+logger = logging.getLogger(__name__)
+
+
+def notify_kudos_received(
+    account: AccountDB, *, amount: int, source_category: str, description: str
+) -> None:
+    """Push a kudos_received frame to the recipient's connected sessions."""
+    payload = {
+        "amount": amount,
+        "source_category": source_category,
+        "description": description,
+    }
+    try:
+        account.msg(kudos_received=((), payload))
+    except Exception:
+        logger.exception("kudos_received push failed for account %s", account.pk)

--- a/src/world/progression/tests/test_kudos.py
+++ b/src/world/progression/tests/test_kudos.py
@@ -3,6 +3,7 @@ Tests for kudos models and services.
 """
 
 from decimal import Decimal
+from unittest import mock
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
@@ -578,3 +579,92 @@ class KudosDifficultyWeightTest(TestCase):
         KudosDifficultyWeightFactory(difficulty_choice="hard", multiplier=Decimal("0.50"))
         with pytest.raises(IntegrityError):
             KudosDifficultyWeightFactory(difficulty_choice="hard", multiplier=Decimal("0.75"))
+
+
+class AwardKudosNotificationTest(TestCase):
+    """Test the kudos_received WS push registered by award_kudos (#2161)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.account = AccountDB.objects.create(
+            username="recipient",
+            email="recipient@test.com",
+        )
+        cls.awarder = AccountDB.objects.create(
+            username="awarder",
+            email="awarder@test.com",
+        )
+        cls.source_category = KudosSourceCategoryFactory(
+            name="player_vote", display_name="Player Vote"
+        )
+
+    def setUp(self):
+        # Flush SharedMemoryModel caches and clean up per-test state
+        KudosPointsData.flush_instance_cache()
+        KudosTransaction.flush_instance_cache()
+        KudosPointsData.objects.filter(account=self.account).delete()
+        KudosTransaction.objects.filter(account=self.account).delete()
+
+    def test_award_kudos_pushes_kudos_received_post_commit(self):
+        """award_kudos defers a kudos_received push to the recipient via on_commit."""
+        # create=True: raw AccountDB rows lack msg (it lives on the Account
+        # typeclass); production accounts are always typeclassed and carry it.
+        with mock.patch.object(self.account, "msg", create=True) as mock_msg:
+            with self.captureOnCommitCallbacks() as callbacks:
+                award_kudos(
+                    account=self.account,
+                    amount=5,
+                    source_category=self.source_category,
+                    description="Thanks for helping!",
+                    awarded_by=self.awarder,
+                )
+            # Not fired yet -- still inside the transaction.
+            mock_msg.assert_not_called()
+            self.assertEqual(len(callbacks), 1)
+
+            for callback in callbacks:
+                callback()
+
+        mock_msg.assert_called_once_with(
+            kudos_received=(
+                (),
+                {
+                    "amount": 5,
+                    "source_category": "Player Vote",
+                    "description": "Thanks for helping!",
+                },
+            )
+        )
+
+    def test_award_kudos_survives_msg_raising(self):
+        """A recipient whose msg() raises (e.g. offline) does not break the award."""
+        with mock.patch.object(
+            self.account, "msg", create=True, side_effect=RuntimeError("offline")
+        ):
+            with self.captureOnCommitCallbacks(execute=True):
+                result = award_kudos(
+                    account=self.account,
+                    amount=5,
+                    source_category=self.source_category,
+                    description="Thanks for helping!",
+                )
+
+        assert result.points_data.total_earned == 5
+        assert result.transaction.amount == 5
+
+    def test_kudos_received_payload_omits_giver_identity(self):
+        """The payload carries no key referencing the giver (ADR-0033)."""
+        with mock.patch.object(self.account, "msg", create=True) as mock_msg:
+            with self.captureOnCommitCallbacks(execute=True):
+                award_kudos(
+                    account=self.account,
+                    amount=5,
+                    source_category=self.source_category,
+                    description="Thanks for helping!",
+                    awarded_by=self.awarder,
+                )
+
+        _, kwargs = mock_msg.call_args
+        _, payload = kwargs["kudos_received"]
+        assert set(payload.keys()) == {"amount", "source_category", "description"}
+        assert self.awarder.username not in str(payload.values())

--- a/src/world/progression/tests/test_views.py
+++ b/src/world/progression/tests/test_views.py
@@ -10,6 +10,10 @@ from world.progression.factories import KudosClaimCategoryFactory, KudosSourceCa
 from world.progression.services import award_kudos
 from world.roster.factories import PlayerDataFactory, RosterTenureFactory
 
+# awarded_by must never reach the wire — recipients cannot see who awarded kudos
+# (ADR-0033 structural guard, #2161).
+AWARDED_BY_KEYS = {"awarded_by", "awarded_by_name"}
+
 
 class ProgressionViewTestCase(TestCase):
     """Base test case with authenticated API client."""
@@ -66,6 +70,30 @@ class AccountProgressionViewTests(ProgressionViewTestCase):
         self.client.force_authenticate(user=None)
         response = self.client.get("/api/progression/account/")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_kudos_transactions_omit_awarded_by(self):
+        """A staff-awarded transaction's payload carries no awarded_by identity."""
+        from evennia.accounts.models import AccountDB
+
+        awarder = AccountDB.objects.create_user(
+            username="awarder", email="awarder@test.com", password="testpass123"
+        )
+        source_category = KudosSourceCategoryFactory(name="staff_award")
+        award_kudos(
+            account=self.user,
+            amount=5,
+            source_category=source_category,
+            description="Staff award",
+            awarded_by=awarder,
+        )
+
+        response = self.client.get("/api/progression/account/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        kudos_transactions = response.data["kudos_transactions"]
+        self.assertTrue(kudos_transactions)
+        for transaction in kudos_transactions:
+            self.assertFalse(AWARDED_BY_KEYS & set(transaction.keys()))
 
 
 class ClaimKudosViewTests(ProgressionViewTestCase):

--- a/src/world/scenes/AGENT_GLOSSARY.md
+++ b/src/world/scenes/AGENT_GLOSSARY.md
@@ -34,7 +34,7 @@ The defender's authored plausibility band (`DifficultyChoice`: trivial / easy / 
 _Avoid_: difficulty rating, target number (for the player-facing choice)
 
 **Highlight reel**:
-A read-only curated digest of a scene: one fully-sealed featured moment (highest-reacted GM-tagged pose, else most-reacted pose) plus a ranked index of remaining reacted poses, capped at ten. Filtered through interaction read-visibility so it can never surface a pose the viewer cannot see.
+A read-only curated digest of a scene: one fully-sealed featured moment (highest-ranked GM-tagged pose, else most-ranked pose) plus a ranked index of remaining voted-or-reacted poses, capped at ten. Ranked by all-time `progression.WeeklyVote` count first (the popularity axis, persists past weekly XP settlement), `InteractionReaction` count as tie-break, recency last (#2161 — previously reaction-count-only). Filtered through interaction read-visibility so it can never surface a pose the viewer cannot see. Each pose carries a `VoteButton` (see `progression/AGENT_GLOSSARY.md`'s Weekly Vote entry) so applause and reel ranking are driven by the same click.
 _Avoid_: feed, recap, summary, spotlight
 
 **Co-owner**:

--- a/src/world/scenes/models.py
+++ b/src/world/scenes/models.py
@@ -1067,15 +1067,13 @@ class InteractionReaction(SharedMemoryModel):
 
     Originally intended as a temporary bridge model, but now fully integrated
     with the API layer (viewset, serializer, filters), frontend components,
-    admin, factories, and tests. When the proper kudos/voting system is
-    designed, migration will require:
-    - Data migration from InteractionReaction to the new model
-    - API endpoint update or versioning
-    - Frontend component update
-    - Partition SQL update for composite FK
-
-    For now, this model serves its purpose well. The migration path should be
-    designed when the kudos system is specced, not preemptively.
+    admin, factories, and tests. #2161 resolved the "will this get merged into
+    kudos/voting?" question raised in this docstring's earlier revisions:
+    reactions stay their own axis (see ADR-0115) — expression + an ambient
+    relationship bump (``ReactionEmoji.valence``) — distinct from kudos
+    (graciousness, ``award_kudos``) and votes (popularity/ranking,
+    ``WeeklyVote``). No migration is planned; this model is the permanent
+    home for emoji reactions, not a bridge.
     """
 
     interaction = models.ForeignKey(

--- a/src/world/scenes/serializers.py
+++ b/src/world/scenes/serializers.py
@@ -403,29 +403,34 @@ class ScenesSpotlightSerializer(serializers.Serializer):
 
 
 class HighlightReelFeaturedSerializer(serializers.Serializer):
-    """The single featured moment of a scene's highlight reel (#1241).
+    """The single featured moment of a scene's highlight reel (#1241, #2161).
 
-    Intentionally IDs-only: the collapsed featured card is *fully sealed* — it shows no
-    pose content, type, participants, or reaction count until the viewer expands it, at
-    which point the frontend fetches the pose through the existing interaction-detail
-    endpoint (which re-checks visibility). Sending content here would defeat the seal.
+    The collapsed featured card is *fully sealed* — it shows no pose content, type, or
+    participants until the viewer expands it, at which point the frontend fetches the
+    pose through the existing interaction-detail endpoint (which re-checks visibility).
+    Sending pose content here would defeat the seal, but ``vote_count``/``reaction_count``
+    (#2161) are exposed so the frontend can badge the sealed card.
     """
 
     interaction_id = serializers.IntegerField()
+    vote_count = serializers.IntegerField()
+    reaction_count = serializers.IntegerField()
 
 
 class HighlightReelEntrySerializer(serializers.Serializer):
-    """One sealed entry in the ranked index below the featured moment (#1241)."""
+    """One sealed entry in the ranked index below the featured moment (#1241, #2161)."""
 
     interaction_id = serializers.IntegerField()
     rank = serializers.IntegerField()
+    vote_count = serializers.IntegerField()
+    reaction_count = serializers.IntegerField()
 
 
 class HighlightReelSerializer(serializers.Serializer):
-    """A scene's highlight reel: a sealed featured moment + a ranked index (#1241).
+    """A scene's highlight reel: a sealed featured moment + a ranked index (#1241, #2161).
 
-    ``featured`` is null when the scene has no GM-tagged moments AND no reacted poses
-    (an empty reel — the frontend hides the collapsible section).
+    ``featured`` is null when the scene has no GM-tagged moments AND no voted-or-reacted
+    poses (an empty reel — the frontend hides the collapsible section).
     """
 
     featured = HighlightReelFeaturedSerializer(allow_null=True)

--- a/src/world/scenes/tests/test_highlight_reel.py
+++ b/src/world/scenes/tests/test_highlight_reel.py
@@ -1,15 +1,19 @@
-"""Tests for the scene highlight reel (#1241).
+"""Tests for the scene highlight reel (#1241, #2161).
 
 The reel features one sealed "top moment" + a ranked index of the rest:
-- Featured = the highest-reacted GM-tagged pose; a tagged pose headlines even with zero
-  reactions (storyteller curation has primacy). With no tags, falls back to the single
-  most-reacted pose.
-- Index = remaining poses with >= 1 reaction, ranked by reaction count (ties -> most
-  recent), capped at 10, with the featured pose excluded.
+- Featured = the highest-ranked GM-tagged pose; a tagged pose headlines even with zero
+  votes/reactions (storyteller curation has primacy). With no tags, falls back to the
+  single most-ranked pose.
+- Ranking (#2161) is all-time ``WeeklyVote`` count first (persistent rows, not the
+  weekly-reset ``Interaction.vote_count`` counter), reaction count as tie-break, and
+  recency last.
+- Index = remaining poses with >= 1 vote or reaction, ranked as above, capped at 10,
+  with the featured pose excluded.
 - Source set is filtered through ``Interaction.visible_to`` so a pose the viewer cannot
   see never appears — not even as a sealed slot.
-- Payload is ids-only (the featured card is fully sealed; the frontend reveals a pose via
-  the existing interaction-detail endpoint).
+- Payload carries interaction ids + ``vote_count``/``reaction_count`` (the featured card
+  stays otherwise sealed; the frontend reveals a pose via the existing
+  interaction-detail endpoint).
 """
 
 from django.urls import reverse
@@ -17,7 +21,10 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from evennia_extensions.factories import AccountFactory
+from world.game_clock.week_services import advance_game_week, get_current_game_week
 from world.magic.factories import DramaticMomentTagFactory
+from world.progression.constants import VoteTargetType
+from world.progression.models.voting import WeeklyVote
 from world.scenes.constants import InteractionVisibility, ScenePrivacyMode
 from world.scenes.factories import (
     InteractionFactory,
@@ -33,6 +40,17 @@ class HighlightReelTestMixin:
         """Give ``interaction`` ``n`` reactions from distinct accounts."""
         for _ in range(n):
             InteractionReactionFactory(interaction=interaction)
+
+    def _vote(self, interaction, game_week, *, processed=False):
+        """Cast one all-time ``WeeklyVote`` on ``interaction`` from a fresh voter."""
+        return WeeklyVote.objects.create(
+            voter=AccountFactory(),
+            game_week=game_week,
+            target_type=VoteTargetType.INTERACTION,
+            target_id=interaction.pk,
+            author_account=AccountFactory(),
+            processed=processed,
+        )
 
     def _tag(self, interaction):
         """GM-tag ``interaction`` (pose-anchored DramaticMomentTag)."""
@@ -177,3 +195,113 @@ class HighlightReelVisibilityTest(HighlightReelTestMixin, APITestCase):
         writer_data = self._reel(writer, self.scene)
         self.assertEqual(writer_data["featured"]["interaction_id"], hidden_pose.pk)
         self.assertEqual(self._index_ids(writer_data), [public_pose.pk])
+
+
+class HighlightReelVoteRankingTest(HighlightReelTestMixin, APITestCase):
+    """#2161 — all-time ``WeeklyVote`` counts dominate ranking; reactions tie-break.
+
+    ``WeeklyVote`` rows are the persistent, all-time signal (they survive as
+    ``processed=True`` after weekly settlement), unlike ``Interaction.vote_count``, a
+    weekly counter reset to 0 at settlement. The reel ranks on the persistent rows.
+    """
+
+    def setUp(self):
+        self.viewer = AccountFactory()
+        self.scene = SceneFactory()
+
+    def test_votes_across_weeks_outrank_higher_reaction_count(self):
+        week1 = get_current_game_week()
+        week2 = advance_game_week()
+
+        voted = InteractionFactory(scene=self.scene)
+        self._vote(voted, week1, processed=True)
+        self._vote(voted, week1, processed=True)
+        self._vote(voted, week2)
+        self._react(voted, 1)
+
+        loud = InteractionFactory(scene=self.scene)
+        self._react(loud, 5)
+
+        data = self._reel(self.viewer, self.scene)
+
+        # 3 all-time votes (spanning two weeks, two of them already processed) beat 5
+        # raw reactions on the untouched pose.
+        self.assertEqual(data["featured"]["interaction_id"], voted.pk)
+        self.assertEqual(data["featured"]["vote_count"], 3)
+        self.assertEqual(data["featured"]["reaction_count"], 1)
+        self.assertEqual(self._index_ids(data), [loud.pk])
+        self.assertEqual(data["index"][0]["vote_count"], 0)
+        self.assertEqual(data["index"][0]["reaction_count"], 5)
+
+    def test_reaction_count_breaks_vote_ties(self):
+        week = get_current_game_week()
+
+        higher_reacted = InteractionFactory(scene=self.scene)
+        self._vote(higher_reacted, week)
+        self._vote(higher_reacted, week)
+        self._react(higher_reacted, 4)
+
+        lower_reacted = InteractionFactory(scene=self.scene)
+        self._vote(lower_reacted, week)
+        self._vote(lower_reacted, week)
+        self._react(lower_reacted, 1)
+
+        data = self._reel(self.viewer, self.scene)
+
+        # Equal vote counts (2 each) -- reaction count breaks the tie.
+        self.assertEqual(data["featured"]["interaction_id"], higher_reacted.pk)
+        self.assertEqual(data["featured"]["vote_count"], 2)
+        self.assertEqual(self._index_ids(data), [lower_reacted.pk])
+
+    def test_zero_votes_keeps_reaction_ranked_fallback(self):
+        top = InteractionFactory(scene=self.scene)
+        self._react(top, 3)
+        second = InteractionFactory(scene=self.scene)
+        self._react(second, 1)
+
+        data = self._reel(self.viewer, self.scene)
+
+        # No WeeklyVote rows anywhere -- pre-feature reaction-ranked fallback holds.
+        self.assertEqual(data["featured"]["interaction_id"], top.pk)
+        self.assertEqual(data["featured"]["vote_count"], 0)
+        self.assertEqual(data["featured"]["reaction_count"], 3)
+        self.assertEqual(self._index_ids(data), [second.pk])
+        self.assertEqual(data["index"][0]["vote_count"], 0)
+        self.assertEqual(data["index"][0]["reaction_count"], 1)
+
+    def test_gm_tagged_featured_logic_unchanged_by_votes(self):
+        week = get_current_game_week()
+
+        tagged = InteractionFactory(scene=self.scene)  # 0 votes, 0 reactions
+        self._tag(tagged)
+        heavily_voted = InteractionFactory(scene=self.scene)
+        self._vote(heavily_voted, week)
+        self._vote(heavily_voted, week)
+        self._vote(heavily_voted, week)
+
+        data = self._reel(self.viewer, self.scene)
+
+        # Curation primacy holds even against a pose with real all-time votes.
+        self.assertEqual(data["featured"]["interaction_id"], tagged.pk)
+        self.assertEqual(self._index_ids(data), [heavily_voted.pk])
+
+    def test_reel_entries_expose_vote_and_reaction_counts(self):
+        week = get_current_game_week()
+
+        pose = InteractionFactory(scene=self.scene)
+        self._vote(pose, week)
+        self._vote(pose, week)
+        self._react(pose, 4)
+        other = InteractionFactory(scene=self.scene)
+        self._react(other, 1)
+
+        data = self._reel(self.viewer, self.scene)
+
+        self.assertIn("vote_count", data["featured"])
+        self.assertIn("reaction_count", data["featured"])
+        self.assertEqual(data["featured"]["vote_count"], 2)
+        self.assertEqual(data["featured"]["reaction_count"], 4)
+        entry = data["index"][0]
+        self.assertEqual(entry["interaction_id"], other.pk)
+        self.assertEqual(entry["vote_count"], 0)
+        self.assertEqual(entry["reaction_count"], 1)

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -335,15 +335,18 @@ class SceneViewSet(viewsets.ModelViewSet):
 
         Featured = the highest-reacted GM-tagged pose; a tagged pose headlines even with
         zero reactions, because storyteller curation has primacy. When the scene has no
-        tags, this falls back to the single most-reacted pose. The index is the remaining
-        poses with at least one reaction, ranked by reaction count (ties -> most recent)
-        and capped at 10. Every pose is drawn through ``Interaction.visible_to`` so the
-        reel can never surface a pose the viewer cannot already see — not even as a sealed
-        slot. The payload carries only interaction ids (the featured card is fully sealed);
-        the frontend reveals a pose by fetching it through the existing interaction-detail
-        endpoint, which re-checks visibility.
+        tags, this falls back to the single most-voted (reactions tie-break) pose. The
+        index is the remaining poses with at least one vote or reaction, ranked by
+        all-time vote count first, reaction count as tie-break, and recency last —
+        capped at 10. Every pose is drawn through ``Interaction.visible_to`` so the reel
+        can never surface a pose the viewer cannot already see — not even as a sealed
+        slot. The payload carries interaction ids plus vote/reaction counts (the featured
+        card stays otherwise sealed); the frontend reveals a pose by fetching it through
+        the existing interaction-detail endpoint, which re-checks visibility.
         """
         from world.magic.models.dramatic_moment import DramaticMomentTag  # noqa: PLC0415
+        from world.progression.constants import VoteTargetType  # noqa: PLC0415
+        from world.progression.models.voting import WeeklyVote  # noqa: PLC0415
 
         scene = self.get_object()
         user = request.user
@@ -373,32 +376,67 @@ class SceneViewSet(viewsets.ModelViewSet):
                 "interaction_id", flat=True
             )
         )
+        # All-time votes are the persistent signal: WeeklyVote rows survive (as
+        # processed=True) after weekly settlement, unlike Interaction.vote_count, which
+        # is a weekly counter reset to 0 at settlement. Ranking on the persistent rows is
+        # the whole point of #2161 — a pose's standing outlives the week it was posed in.
+        vote_counts = dict(
+            WeeklyVote.objects.filter(
+                target_type=VoteTargetType.INTERACTION, target_id__in=pose_ids
+            )
+            .values("target_id")
+            .annotate(count=Count("id"))
+            .values_list("target_id", "count")
+        )
+
+        def votes_for(pose_id: int) -> int:
+            return vote_counts.get(pose_id, 0)
 
         def reactions_for(pose_id: int) -> int:
             return reaction_counts.get(pose_id, 0)
 
-        # Reaction count desc, then most-recent first.
+        # Vote count desc, reaction count tie-break, then most-recent first.
         ranked = sorted(
             pose_ids,
-            key=lambda pose_id: (reactions_for(pose_id), pose_timestamps[pose_id]),
+            key=lambda pose_id: (
+                votes_for(pose_id),
+                reactions_for(pose_id),
+                pose_timestamps[pose_id],
+            ),
             reverse=True,
         )
 
         featured_pk = None
         if tagged_ids:
-            # Highest-reacted tagged pose (ranked is already sorted); headlines even at 0.
+            # Highest-ranked tagged pose (ranked is already sorted); headlines even at 0.
             featured_pk = next((pose_id for pose_id in ranked if pose_id in tagged_ids), None)
-        elif ranked and reactions_for(ranked[0]) >= 1:
+        elif ranked and (votes_for(ranked[0]) + reactions_for(ranked[0])) >= 1:
             featured_pk = ranked[0]
 
         index = [
-            pose_id for pose_id in ranked if reactions_for(pose_id) >= 1 and pose_id != featured_pk
+            pose_id
+            for pose_id in ranked
+            if (votes_for(pose_id) + reactions_for(pose_id)) >= 1 and pose_id != featured_pk
         ][:10]
 
         payload = {
-            "featured": {"interaction_id": featured_pk} if featured_pk else None,
+            "featured": (
+                {
+                    "interaction_id": featured_pk,
+                    "vote_count": votes_for(featured_pk),
+                    "reaction_count": reactions_for(featured_pk),
+                }
+                if featured_pk
+                else None
+            ),
             "index": [
-                {"interaction_id": pose_id, "rank": i + 1} for i, pose_id in enumerate(index)
+                {
+                    "interaction_id": pose_id,
+                    "rank": i + 1,
+                    "vote_count": votes_for(pose_id),
+                    "reaction_count": reactions_for(pose_id),
+                }
+                for i, pose_id in enumerate(index)
             ],
         }
         return Response(HighlightReelSerializer(payload).data)


### PR DESCRIPTION
Closes #2161

## Summary

Implements Tehom's ratified three-axes applause ruling on #2161 — nothing merged, nothing deleted, all three wired with distinct purposes. Votes (popularity): the fully-built WeeklyVote economy finally reaches players — VoteButton on every eligible pose bubble (both /game and /scenes/:id via PoseUnit), VotesPanel on /xp-kudos, and the highlight reel now ranks by all-time WeeklyVote counts (persistent rows — the weekly-reset Interaction.vote_count is deliberately never used) with reaction-count tie-break; reel entries expose vote_count/reaction_count. Kudos (graciousness): now lands in-context via a new kudos_received WS push fired centrally from award_kudos post-commit (covers all four award paths), showing a quiet anonymous toast in /game; plus the ADR-0033 guard goes structural — awarded_by_name is removed from the player-facing serializer entirely (provably always-null; model column stays for staff audit). Reactions (expression): untouched, still the relationship bump. HighlightReel also mounts inside /game's Room tab. Fold-ins: stale 'votes wired end-to-end' comment fixed, InteractionReaction docstring migration note resolved, dead toggleInteractionFavorite removed, ADR-0115 + glossary entries added.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2161 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main twice (pre-implementation, pre-PR); final rebase over 5 commits (incl. #2203) was conflict-free; post-rebase typecheck clean.

<!-- last-addressed-comment: 0 -->