### PR TITLE
The game answers back: live feedback for social and magical outcomes (#2155)

### DIFF
--- a/frontend/src/scenes/actionTypes.ts
+++ b/frontend/src/scenes/actionTypes.ts
@@ -231,6 +231,8 @@ export interface ActionResultData {
   applied_effects: AppliedEffectData[];
   /** Present when an anima ritual resolves; absent for all other action types. */
   anima_recovery?: AnimaRecoveryData;
+  /** Set when this action moved a persona-bearing NPC's affection (#2158). */
+  disposition_message?: string | null;
 }
 
 export interface ActionRequestResponse {

--- a/frontend/src/scenes/components/ActionPanel.test.tsx
+++ b/frontend/src/scenes/components/ActionPanel.test.tsx
@@ -1377,4 +1377,59 @@ describe('ActionPanel', () => {
       );
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Anima/resonance freshness on cast/pull (#2158)
+  // -------------------------------------------------------------------------
+
+  describe('ActionPanel anima/resonance freshness (#2158)', () => {
+    it('invalidates anima and resonance queries after a successful cast', async () => {
+      vi.mocked(castTechnique).mockResolvedValue({ id: 99, status: 'pending' });
+      vi.mocked(fetchAvailableActions).mockResolvedValue(MOCK_ACTIONS);
+      mockEmberTouchCastables();
+      await mockRosterWithPersona();
+
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+      const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+      const user = userEvent.setup();
+
+      render(<ActionPanel sceneId="42" />, {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      });
+
+      // Open panel → Cast → select technique → commit (mirrors openCastDialogWithEmberTouch)
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Cast')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Cast'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Ember Touch')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Ember Touch'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /cast ember touch/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /cast ember touch/i }));
+
+      await waitFor(() => {
+        expect(invalidateSpy).toHaveBeenCalledWith({
+          queryKey: ['magic', 'character-anima', 42],
+        });
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['magic', 'character-resonances', 'list'],
+      });
+    });
+  });
 });

--- a/frontend/src/scenes/components/ActionPanel.tsx
+++ b/frontend/src/scenes/components/ActionPanel.tsx
@@ -25,6 +25,7 @@ import { useCastPullSelection } from '../hooks/useCastPullSelection';
 import { extractErrorMessage } from '@/lib/errors';
 import { toast } from 'sonner';
 import { useNavigate } from 'react-router-dom';
+import { magicKeys } from '@/magic/queries';
 import type {
   PlayerAction,
   AvailableEnhancement,
@@ -137,6 +138,10 @@ export function ActionPanel({ sceneId }: Props) {
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
       queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
+      if (characterId !== null) {
+        queryClient.invalidateQueries({ queryKey: magicKeys.characterAnima(characterId) });
+        queryClient.invalidateQueries({ queryKey: magicKeys.characterResonanceList() });
+      }
       setSelectedTechnique(null);
       setCastTargetPersonaId(null);
       setCastTargetPersonaIds([]);
@@ -173,6 +178,10 @@ export function ActionPanel({ sceneId }: Props) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
       queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
+      if (characterId !== null) {
+        queryClient.invalidateQueries({ queryKey: magicKeys.characterAnima(characterId) });
+        queryClient.invalidateQueries({ queryKey: magicKeys.characterResonanceList() });
+      }
       setOpen(false);
       setTargetingAction(null);
       setStrainByAction({});

--- a/frontend/src/scenes/components/ActionPanel.tsx
+++ b/frontend/src/scenes/components/ActionPanel.tsx
@@ -85,6 +85,18 @@ export function ActionPanel({ sceneId }: Props) {
 
   const queryClient = useQueryClient();
 
+  // Shared by performCast and performAction's onSuccess — a cast or dispatched
+  // action may have spent anima/resonance, so both invalidate the same set
+  // of caches (#2158).
+  function invalidateActionOutcomeQueries() {
+    queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
+    queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
+    if (characterId !== null) {
+      queryClient.invalidateQueries({ queryKey: magicKeys.characterAnima(characterId) });
+      queryClient.invalidateQueries({ queryKey: magicKeys.characterResonanceList() });
+    }
+  }
+
   // Resolve the active character name to its numeric ObjectDB pk and primary persona.
   const activeCharacterName = useAppSelector((state) => state.game.active);
   const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
@@ -136,12 +148,7 @@ export function ActionPanel({ sceneId }: Props) {
         ...params,
       }),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
-      queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
-      if (characterId !== null) {
-        queryClient.invalidateQueries({ queryKey: magicKeys.characterAnima(characterId) });
-        queryClient.invalidateQueries({ queryKey: magicKeys.characterResonanceList() });
-      }
+      invalidateActionOutcomeQueries();
       setSelectedTechnique(null);
       setCastTargetPersonaId(null);
       setCastTargetPersonaIds([]);
@@ -176,12 +183,7 @@ export function ActionPanel({ sceneId }: Props) {
       effort_level?: string;
     }) => createActionRequest(sceneId, params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
-      queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
-      if (characterId !== null) {
-        queryClient.invalidateQueries({ queryKey: magicKeys.characterAnima(characterId) });
-        queryClient.invalidateQueries({ queryKey: magicKeys.characterResonanceList() });
-      }
+      invalidateActionOutcomeQueries();
       setOpen(false);
       setTargetingAction(null);
       setStrainByAction({});

--- a/frontend/src/scenes/components/ConsentPrompt.test.tsx
+++ b/frontend/src/scenes/components/ConsentPrompt.test.tsx
@@ -40,9 +40,17 @@ vi.mock('../actionQueries', () => ({
   respondToRequest: vi.fn(),
 }));
 
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 import { fetchPendingRequests, fetchPendingTargets, respondToRequest } from '../actionQueries';
 import type { PendingActionTarget } from '../actionTypes';
 import { ConsentPrompt } from './ConsentPrompt';
+import { toast } from 'sonner';
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -590,5 +598,79 @@ describe('ConsentPrompt', () => {
         target_persona_id: 99,
       })
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // NPC disposition toast (#2158)
+  // ---------------------------------------------------------------------------
+
+  it('toasts the disposition message when the response includes one (#2158)', async () => {
+    vi.mocked(fetchPendingRequests).mockResolvedValue({ results: [MOCK_REQUEST] });
+    vi.mocked(respondToRequest).mockResolvedValue({
+      status: 'resolved',
+      result: {
+        interaction_id: 1,
+        action_key: 'persuade',
+        action_resolution: {
+          current_phase: 'resolved',
+          main_result: { step_label: 'Roll', check_outcome: 'Success', consequence_id: null },
+          gate_results: [],
+        },
+        technique_result: null,
+        technique_name: null,
+        check_result: null,
+        selected_consequence: null,
+        applied_effects: [],
+        disposition_message: "Mara's regard for you warms noticeably.",
+      },
+    });
+    const user = userEvent.setup();
+
+    render(<ConsentPrompt sceneId="42" />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Accept').length).toBeGreaterThan(0);
+    });
+
+    await user.click(screen.getAllByText('Accept')[0]);
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Mara's regard for you warms noticeably.");
+    });
+  });
+
+  it('does not toast when disposition_message is absent', async () => {
+    vi.mocked(fetchPendingRequests).mockResolvedValue({ results: [MOCK_REQUEST] });
+    vi.mocked(respondToRequest).mockResolvedValue({
+      status: 'resolved',
+      result: {
+        interaction_id: 1,
+        action_key: 'intimidate',
+        action_resolution: {
+          current_phase: 'resolved',
+          main_result: { step_label: 'Roll', check_outcome: 'Success', consequence_id: null },
+          gate_results: [],
+        },
+        technique_result: null,
+        technique_name: null,
+        check_result: null,
+        selected_consequence: null,
+        applied_effects: [],
+      },
+    });
+    const user = userEvent.setup();
+
+    render(<ConsentPrompt sceneId="42" />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Accept').length).toBeGreaterThan(0);
+    });
+
+    await user.click(screen.getAllByText('Accept')[0]);
+
+    await waitFor(() => {
+      expect(respondToRequest).toHaveBeenCalled();
+    });
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/scenes/components/ConsentPrompt.tsx
+++ b/frontend/src/scenes/components/ConsentPrompt.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ShieldAlert, Check, X } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -194,7 +195,10 @@ export function ConsentPrompt({ sceneId }: Props) {
       blacklist_actor?: boolean;
     }) =>
       respondToRequest(sceneId, requestId, { accept, difficulty, resist_effort, blacklist_actor }),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      if (data.result?.disposition_message) {
+        toast.success(data.result.disposition_message);
+      }
       queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
       queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
     },
@@ -229,7 +233,10 @@ export function ConsentPrompt({ sceneId }: Props) {
         blacklist_actor,
         target_persona_id: targetPersonaId,
       }),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      if (data.result?.disposition_message) {
+        toast.success(data.result.disposition_message);
+      }
       queryClient.invalidateQueries({ queryKey: ['pending-targets', sceneId] });
       queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
     },

--- a/frontend/src/scenes/components/ConsentPrompt.tsx
+++ b/frontend/src/scenes/components/ConsentPrompt.tsx
@@ -11,10 +11,23 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { fetchPendingRequests, fetchPendingTargets, respondToRequest } from '../actionQueries';
-import type { ActionRequest, PendingActionTarget, StakesSummary } from '../actionTypes';
+import type {
+  ActionRequest,
+  ActionRequestResponse,
+  PendingActionTarget,
+  StakesSummary,
+} from '../actionTypes';
 
 interface Props {
   sceneId: string;
+}
+
+// Shared by respond and respondTarget's onSuccess — an NPC disposition shift
+// (#2158) may follow either the primary or an additional-target accept.
+function toastDispositionMessage(data: ActionRequestResponse) {
+  if (data.result?.disposition_message) {
+    toast.success(data.result.disposition_message);
+  }
 }
 
 /**
@@ -196,9 +209,7 @@ export function ConsentPrompt({ sceneId }: Props) {
     }) =>
       respondToRequest(sceneId, requestId, { accept, difficulty, resist_effort, blacklist_actor }),
     onSuccess: (data) => {
-      if (data.result?.disposition_message) {
-        toast.success(data.result.disposition_message);
-      }
+      toastDispositionMessage(data);
       queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
       queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
     },
@@ -234,9 +245,7 @@ export function ConsentPrompt({ sceneId }: Props) {
         target_persona_id: targetPersonaId,
       }),
     onSuccess: (data) => {
-      if (data.result?.disposition_message) {
-        toast.success(data.result.disposition_message);
-      }
+      toastDispositionMessage(data);
       queryClient.invalidateQueries({ queryKey: ['pending-targets', sceneId] });
       queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
     },

--- a/frontend/src/scenes/components/PersonaContextMenu.test.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.test.tsx
@@ -43,7 +43,7 @@ vi.mock('@/combat/queries', () => ({
 }));
 
 import { PersonaContextMenu } from './PersonaContextMenu';
-import { createActionRequest } from '../actionQueries';
+import { createActionRequest, fetchAvailableActions } from '../actionQueries';
 import { useDispatchPlayerAction } from '@/combat/queries';
 
 function makeAction(
@@ -360,5 +360,77 @@ describe('PersonaContextMenu', () => {
     });
 
     expect(screen.queryByText('Attach to Pose')).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Consistency with ActionPanel (#2158)
+  // ---------------------------------------------------------------------------
+
+  it('shows an unmet-prerequisite action disabled with its reason, not omitted (#2158)', async () => {
+    const user = userEvent.setup();
+    // Same action-object shape ActionPanel.test.tsx's disabled-tooltip test exercises.
+    const actionsWithUnmet: PlayerActionsResponse = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [
+        makeAction({
+          display_name: 'Intimidate',
+          prerequisite_met: false,
+          prerequisite_reasons: ['Must be in combat'],
+          ref: {
+            backend: 'registry',
+            challenge_instance_id: null,
+            approach_id: null,
+            technique_id: null,
+            registry_key: 'intimidate',
+          },
+        }),
+      ],
+    };
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    queryClient.setQueryData(['available-actions', 42], actionsWithUnmet);
+
+    render(
+      <PersonaContextMenu personaId={10} personaName="Alice" sceneId="1">
+        <span>Alice</span>
+      </PersonaContextMenu>,
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        ),
+      }
+    );
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Intimidate')).toBeInTheDocument();
+    });
+    const item = screen.getByText('Intimidate').closest('[role="menuitem"], button');
+    expect(item).toHaveAttribute('title', expect.stringContaining('Must be in combat'));
+    expect(item).toBeDisabled();
+  });
+
+  it('fetches available actions itself, not only from a pre-populated cache (#2158)', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetchAvailableActions).mockResolvedValue(MOCK_ACTIONS);
+
+    render(
+      <PersonaContextMenu personaId={10} personaName="Alice" sceneId="1">
+        <span>Alice</span>
+      </PersonaContextMenu>,
+      // No pre-populated cache — the opposite of every other test in this file.
+      { wrapper: createWrapper(false) }
+    );
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Intimidate')).toBeInTheDocument();
+    });
+    // Proves the component's own fetch populated the menu, not a
+    // pre-existing cache entry.
+    expect(fetchAvailableActions).toHaveBeenCalledWith(42);
   });
 });

--- a/frontend/src/scenes/components/PersonaContextMenu.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useMemo, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,8 +26,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useCreateBlock, useCreateMute } from '@/social/queries';
-import { createActionRequest } from '../actionQueries';
-import type { ActionAttachmentInfo, PlayerActionsResponse, PlayerAction } from '../actionTypes';
+import { createActionRequest, fetchAvailableActions } from '../actionQueries';
+import type { ActionAttachmentInfo, PlayerAction } from '../actionTypes';
 import type { SceneDetail } from '../types';
 import { WhisperReceiverPicker } from './WhisperReceiverPicker';
 import { TreatActionPanel } from '@/conditions/components/TreatActionPanel';
@@ -65,9 +65,14 @@ export function PersonaContextMenu({
     [myRosterEntries, activeCharacterName]
   );
 
-  // Read from React Query cache instead of triggering a fetch.
-  // The ActionAttachment component populates this cache when opened.
-  const data = queryClient.getQueryData<PlayerActionsResponse>(['available-actions', characterId]);
+  // Fetch directly (mirrors ActionPanel.tsx) rather than reading the cache
+  // opportunistically — the menu must populate even if ActionPanel/ActionAttachment
+  // hasn't been opened yet this session (#2158).
+  const { data } = useQuery({
+    queryKey: ['available-actions', characterId],
+    queryFn: () => fetchAvailableActions(characterId!),
+    enabled: characterId !== null,
+  });
 
   // #907: present scene personas (excluding the target) are the extra-listener
   // pool. Read from the already-loaded scene cache; empty if not yet present.
@@ -147,8 +152,9 @@ export function PersonaContextMenu({
     },
   });
 
-  // Show all prerequisite-met actions as potential targeted actions.
-  const targetedActions: PlayerAction[] = (data?.results ?? []).filter((a) => a.prerequisite_met);
+  // Show every targeted action, including unmet-prerequisite ones — rendered
+  // disabled with their reason below, not silently omitted (mirrors ActionPanel, #2158).
+  const targetedActions: PlayerAction[] = data?.results ?? [];
 
   // Treat affordance (#1486): available for any non-self target once the viewer's
   // character is resolved.  The discovery endpoint gates candidates server-side,
@@ -198,6 +204,24 @@ export function PersonaContextMenu({
             picks the audience (#903); the plain "Default" entry sends NO delivery
             so the backend's template default stays the single fallback authority. */}
           {targetedActions.map((action) => {
+            const stableKey = `${action.ref.backend}-${action.ref.challenge_instance_id ?? ''}-${action.ref.approach_id ?? ''}-${action.ref.registry_key ?? ''}`;
+            if (!action.prerequisite_met) {
+              // Unmet prerequisite: shown disabled with its reason instead of
+              // omitted (mirrors ActionPanel.tsx's disabled-button pattern, #2158).
+              // No delivery submenu — the action can't be fired regardless.
+              return (
+                <button
+                  key={stableKey}
+                  type="button"
+                  disabled
+                  title={action.prerequisite_reasons.join('; ')}
+                  className="flex w-full cursor-not-allowed select-none items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm opacity-50 outline-none"
+                >
+                  <Zap className="mr-2 h-4 w-4" />
+                  {action.display_name}
+                </button>
+              );
+            }
             const techniqueId = action.ref.technique_id ?? undefined;
             const actionKey =
               action.ref.registry_key ??
@@ -212,9 +236,7 @@ export function PersonaContextMenu({
               });
             const defaultDelivery = action.action_template?.default_delivery ?? 'pose';
             return (
-              <DropdownMenuSub
-                key={`${action.ref.backend}-${action.ref.challenge_instance_id ?? ''}-${action.ref.approach_id ?? ''}-${action.ref.registry_key ?? ''}`}
-              >
+              <DropdownMenuSub key={stableKey}>
                 <DropdownMenuSubTrigger disabled={performAction.isPending}>
                   <Zap className="mr-2 h-4 w-4" />
                   {action.display_name}
@@ -257,6 +279,23 @@ export function PersonaContextMenu({
               <DropdownMenuSeparator />
               <DropdownMenuLabel className="text-xs">Attach to Pose</DropdownMenuLabel>
               {targetedActions.map((action) => {
+                const stableKey = `attach-${action.ref.backend}-${action.ref.challenge_instance_id ?? ''}-${action.ref.approach_id ?? ''}-${action.ref.registry_key ?? ''}`;
+                if (!action.prerequisite_met) {
+                  // Unmet prerequisite: shown disabled with its reason instead of
+                  // omitted (mirrors ActionPanel.tsx's disabled-button pattern, #2158).
+                  return (
+                    <button
+                      key={stableKey}
+                      type="button"
+                      disabled
+                      title={action.prerequisite_reasons.join('; ')}
+                      className="flex w-full cursor-not-allowed select-none items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm opacity-50 outline-none"
+                    >
+                      <Zap className="mr-2 h-4 w-4" />
+                      {action.display_name}
+                    </button>
+                  );
+                }
                 const techniqueId = action.ref.technique_id ?? undefined;
                 const actionKey =
                   action.ref.registry_key ??
@@ -264,7 +303,7 @@ export function PersonaContextMenu({
                   action.display_name.toLowerCase();
                 return (
                   <DropdownMenuItem
-                    key={`attach-${action.ref.backend}-${action.ref.challenge_instance_id ?? ''}-${action.ref.approach_id ?? ''}-${action.ref.registry_key ?? ''}`}
+                    key={stableKey}
                     onClick={() =>
                       onAttachAction({
                         actionKey,

--- a/frontend/src/scenes/components/PersonaContextMenu.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.tsx
@@ -39,6 +39,25 @@ interface PendingWhisper {
   techniqueId?: number;
 }
 
+// Unmet prerequisite: shown disabled with its reason instead of omitted
+// (mirrors ActionPanel.tsx's disabled-button pattern, #2158). No delivery
+// submenu — the action can't be fired regardless. Shared by both the direct-
+// execute list and the "Attach to Pose" list below.
+function disabledActionItem(action: PlayerAction, key: string) {
+  return (
+    <button
+      key={key}
+      type="button"
+      disabled
+      title={action.prerequisite_reasons.join('; ')}
+      className="flex w-full cursor-not-allowed select-none items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm opacity-50 outline-none"
+    >
+      <Zap className="mr-2 h-4 w-4" />
+      {action.display_name}
+    </button>
+  );
+}
+
 interface Props {
   personaId: number;
   personaName: string;
@@ -206,21 +225,7 @@ export function PersonaContextMenu({
           {targetedActions.map((action) => {
             const stableKey = `${action.ref.backend}-${action.ref.challenge_instance_id ?? ''}-${action.ref.approach_id ?? ''}-${action.ref.registry_key ?? ''}`;
             if (!action.prerequisite_met) {
-              // Unmet prerequisite: shown disabled with its reason instead of
-              // omitted (mirrors ActionPanel.tsx's disabled-button pattern, #2158).
-              // No delivery submenu — the action can't be fired regardless.
-              return (
-                <button
-                  key={stableKey}
-                  type="button"
-                  disabled
-                  title={action.prerequisite_reasons.join('; ')}
-                  className="flex w-full cursor-not-allowed select-none items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm opacity-50 outline-none"
-                >
-                  <Zap className="mr-2 h-4 w-4" />
-                  {action.display_name}
-                </button>
-              );
+              return disabledActionItem(action, stableKey);
             }
             const techniqueId = action.ref.technique_id ?? undefined;
             const actionKey =
@@ -281,20 +286,7 @@ export function PersonaContextMenu({
               {targetedActions.map((action) => {
                 const stableKey = `attach-${action.ref.backend}-${action.ref.challenge_instance_id ?? ''}-${action.ref.approach_id ?? ''}-${action.ref.registry_key ?? ''}`;
                 if (!action.prerequisite_met) {
-                  // Unmet prerequisite: shown disabled with its reason instead of
-                  // omitted (mirrors ActionPanel.tsx's disabled-button pattern, #2158).
-                  return (
-                    <button
-                      key={stableKey}
-                      type="button"
-                      disabled
-                      title={action.prerequisite_reasons.join('; ')}
-                      className="flex w-full cursor-not-allowed select-none items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm opacity-50 outline-none"
-                    >
-                      <Zap className="mr-2 h-4 w-4" />
-                      {action.display_name}
-                    </button>
-                  );
+                  return disabledActionItem(action, stableKey);
                 }
                 const techniqueId = action.ref.technique_id ?? undefined;
                 const actionKey =

--- a/frontend/src/scenes/components/PoseUnit.test.tsx
+++ b/frontend/src/scenes/components/PoseUnit.test.tsx
@@ -3,13 +3,20 @@
  * Phase 9, Task 9.2.
  */
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { Provider } from 'react-redux';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { store } from '@/store/store';
 import { PoseUnit } from './PoseUnit';
 import type { Interaction } from '../types';
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 
 // Mock @/combat/queries — used by PoseUnitDetailPanel; prevents real fetches.
 // PoseUnit also renders PersonaContextMenu, which reads useDispatchPlayerAction
@@ -41,6 +48,9 @@ vi.mock('../queries', async (importOriginal) => {
       .mockResolvedValue([{ emoji: '\u{1F44D}', valence: 0, sort_order: 0 }]),
   };
 });
+
+import { postInteractionReaction } from '../queries';
+import { toast } from 'sonner';
 
 // Stub EndorsementControl so PoseUnit mount tests can assert presence/absence
 // without pulling in endorsement hook machinery. The stub renders data-* attributes
@@ -637,5 +647,36 @@ describe('PoseUnit endorsement control mounting', () => {
 
     const control = screen.getByTestId('endorsement-control-pose');
     expect(control).toHaveAttribute('data-visibility', 'very_private');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regard-bump confirmation toast (#2158)
+// ---------------------------------------------------------------------------
+
+describe('PoseUnit reaction regard-bump toast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('toasts the bump message on a successful regard bump (#2158)', async () => {
+    vi.mocked(postInteractionReaction).mockResolvedValue({
+      bump_applied: true,
+      bump_message: 'Your regard for Elena warms.',
+    });
+    const interaction = makeInteraction({ mode: 'pose' });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    const emojiButton = await screen.findByText('\u{1F44D}');
+    fireEvent.click(emojiButton);
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Your regard for Elena warms.');
+    });
   });
 });

--- a/frontend/src/scenes/components/PoseUnit.test.tsx
+++ b/frontend/src/scenes/components/PoseUnit.test.tsx
@@ -679,4 +679,27 @@ describe('PoseUnit reaction regard-bump toast', () => {
       expect(toast.success).toHaveBeenCalledWith('Your regard for Elena warms.');
     });
   });
+
+  it('does not toast when the reaction resolves with no bump message (#2158)', async () => {
+    vi.mocked(postInteractionReaction).mockResolvedValue({
+      bump_applied: false,
+      bump_message: null,
+    });
+    const interaction = makeInteraction({ mode: 'pose' });
+
+    render(
+      <Wrapper>
+        <PoseUnit interaction={interaction} sceneId="1" />
+      </Wrapper>
+    );
+
+    const emojiButton = await screen.findByText('\u{1F44D}');
+    fireEvent.click(emojiButton);
+
+    await waitFor(() => {
+      expect(postInteractionReaction).toHaveBeenCalled();
+    });
+
+    expect(toast.success).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/scenes/components/PoseUnit.tsx
+++ b/frontend/src/scenes/components/PoseUnit.tsx
@@ -12,6 +12,7 @@
 import { useMemo, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
@@ -117,7 +118,12 @@ function ReactionsFooter({ interaction, sceneId }: ReactionsFooterProps) {
   const queryClient = useQueryClient();
   const reactionMutation = useMutation({
     mutationFn: (emoji: string) => postInteractionReaction(interaction.id, emoji),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] }),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] });
+      if (data?.bump_message) {
+        toast.success(data.bump_message);
+      }
+    },
   });
   // Staff-editable catalog (#1699); valenced entries also nudge the author's regard.
   const { data: catalog } = useQuery({

--- a/frontend/src/scenes/components/SceneHeader.test.tsx
+++ b/frontend/src/scenes/components/SceneHeader.test.tsx
@@ -53,3 +53,49 @@ describe('SceneHeader combat badge', () => {
     expect(screen.queryByTestId('scene-header-combat-badge')).not.toBeInTheDocument();
   });
 });
+
+const BASE_SCENE: SceneDetail = {
+  id: 1,
+  name: 'S',
+  description: '',
+  date_started: '',
+  participants: [],
+  is_active: true,
+  is_owner: false,
+  viewer_can_gm: false,
+  positions: [],
+  position_adjacency: [],
+  persona_positions: [],
+  active_round: null,
+} as unknown as SceneDetail;
+
+describe('SceneHeader round-state badge (#2158)', () => {
+  it('shows round number and status to every viewer, not just the GM', () => {
+    mockUseEncounterForScene.mockReturnValue({ data: null, isLoading: false, isError: false });
+
+    renderWrapped({
+      ...BASE_SCENE,
+      is_active: true,
+      viewer_can_gm: false,
+      active_round: {
+        mode: 'strict',
+        advance_quorum_pct: 100,
+        max_actions_per_round: 1,
+        per_target_repeat_lock: false,
+        status: 'declaring',
+        round_number: 3,
+        is_danger: false,
+      },
+    });
+
+    expect(screen.getByText(/round 3/i)).toBeInTheDocument();
+    expect(screen.getByText(/declaring/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when there is no active round', () => {
+    mockUseEncounterForScene.mockReturnValue({ data: null, isLoading: false, isError: false });
+
+    renderWrapped({ ...BASE_SCENE, active_round: null });
+    expect(screen.queryByText(/round/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/scenes/components/SceneHeader.test.tsx
+++ b/frontend/src/scenes/components/SceneHeader.test.tsx
@@ -20,6 +20,7 @@ const SCENE = {
   is_active: true,
   is_owner: false,
   participants: [],
+  active_round: null,
 } as unknown as SceneDetail;
 
 function renderWrapped(scene: SceneDetail = SCENE) {

--- a/frontend/src/scenes/components/SceneHeader.tsx
+++ b/frontend/src/scenes/components/SceneHeader.tsx
@@ -7,6 +7,7 @@ import { useDispatchPlayerAction } from '@/combat/queries';
 import { SceneDetail, updateScene, finishScene } from '../queries';
 import { fetchAvailableActions } from '../actionQueries';
 import type { PlayerAction } from '../actionTypes';
+import type { SceneRoundState } from '../types';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -85,6 +86,22 @@ function GrantSceneGMControl() {
       </div>
       {feedback && <p className="mt-1 text-xs text-muted-foreground">{feedback}</p>}
     </div>
+  );
+}
+
+/**
+ * Round-state badge (#2158) — read-only round number and status, visible to
+ * every scene participant, not just the GM. Mirrors the round state
+ * `RoundSettingsDialog` lets the GM edit, but is rendered unconditionally.
+ */
+function RoundStateBadge({ activeRound }: { activeRound: SceneRoundState | null }) {
+  if (activeRound === null) {
+    return null;
+  }
+  return (
+    <span className="rounded bg-muted px-2 py-1 text-xs text-muted-foreground">
+      Round {activeRound.round_number} · {activeRound.status}
+    </span>
   );
 }
 
@@ -179,6 +196,7 @@ export function SceneHeader({ scene, onRefresh }: Props) {
               Refresh
             </Button>
           )}
+          <RoundStateBadge activeRound={scene.active_round} />
           <RoundSettingsDialog scene={scene} />
         </div>
       )}

--- a/frontend/src/scenes/components/SceneHeader.tsx
+++ b/frontend/src/scenes/components/SceneHeader.tsx
@@ -94,13 +94,20 @@ function GrantSceneGMControl() {
  * every scene participant, not just the GM. Mirrors the round state
  * `RoundSettingsDialog` lets the GM edit, but is rendered unconditionally.
  */
+function formatRoundStatus(status: string): string {
+  return status
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 function RoundStateBadge({ activeRound }: { activeRound: SceneRoundState | null }) {
   if (activeRound === null) {
     return null;
   }
   return (
     <span className="rounded bg-muted px-2 py-1 text-xs text-muted-foreground">
-      Round {activeRound.round_number} · {activeRound.status}
+      Round {activeRound.round_number} · {formatRoundStatus(activeRound.status)}
     </span>
   );
 }

--- a/frontend/src/scenes/queries.ts
+++ b/frontend/src/scenes/queries.ts
@@ -109,7 +109,15 @@ export async function fetchHighlightReel(sceneId: string): Promise<HighlightReel
   return res.json();
 }
 
-export async function postInteractionReaction(interactionId: number, emoji: string) {
+export interface InteractionReactionResponse {
+  bump_applied: boolean;
+  bump_message: string | null;
+}
+
+export async function postInteractionReaction(
+  interactionId: number,
+  emoji: string
+): Promise<InteractionReactionResponse | null> {
   const res = await apiFetch('/api/interaction-reactions/', {
     method: 'POST',
     body: JSON.stringify({ interaction: interactionId, emoji }),

--- a/src/world/npc_services/social_disposition.py
+++ b/src/world/npc_services/social_disposition.py
@@ -8,14 +8,34 @@ from __future__ import annotations
 # <=0 = no positive movement. Thresholds: >=5 critical, >=3 strong, >=1 marginal.
 _TIER_DELTA = {5: 5, 3: 3, 1: 1}
 
+# Qualitative band per tier delta (#2158) — this path is warming-only (no
+# negative deltas exist in _TIER_DELTA), so the band never needs a "cools"
+# branch.
+_SHIFT_BAND = {1: "slightly", 3: "noticeably", 5: "considerably"}
 
-def apply_social_disposition_delta(actor, target_persona_id, result) -> None:
+
+def disposition_shift_band(delta: int) -> str:
+    """The qualitative magnitude word for a disposition delta (#2158).
+
+    Mirrors this codebase's established per-domain qualitative-band pattern
+    (``world.locations.character_comfort._band_for``) — never a raw number in
+    player-facing text.
+    """
+    return _SHIFT_BAND.get(delta, "slightly")
+
+
+def apply_social_disposition_delta(actor, target_persona_id, result) -> str | None:
     """Apply a tiered disposition delta after a social action resolves.
 
     Persona-bearing NPCs (``target_persona_id`` resolves to a ``Persona``)
     move durable ``NPCStanding.affection``. The persona-less mook path is
     deferred — ``execute()`` has no session-scoped ephemeral store in scope,
     so Task 7's promotion seam will wire that path.
+
+    Returns a ready-to-display message (e.g. "Their regard for you warms
+    noticeably.") when a delta was applied, or None when nothing moved —
+    callers (#2158) surface this directly as a toast; no caller should
+    reconstruct wording from a raw delta.
     """
     from world.npc_services.services import adjust_npc_affection  # noqa: PLC0415
     from world.scenes.services import (  # noqa: PLC0415
@@ -26,23 +46,25 @@ def apply_social_disposition_delta(actor, target_persona_id, result) -> None:
     success_level = _success_level(result)
     delta = _delta_for_tier(success_level)
     if delta == 0 or target_persona_id is None:
-        return
+        return None
 
     from world.scenes.action_services import _persona_is_npc  # noqa: PLC0415
     from world.scenes.models import Persona  # noqa: PLC0415
 
     target_persona = Persona.objects.filter(pk=target_persona_id).first()
     if target_persona is None or not _persona_is_npc(target_persona):
-        return
+        return None
 
     # Persona-bearing NPC → durable NPCStanding.
     try:
         pc_persona = persona_for_character(actor)
     except MissingPrimaryPersonaError:
         # A half-set-up actor should not crash the action.
-        return
+        return None
 
     adjust_npc_affection(pc_persona, target_persona, delta=delta)
+    target_name = target_persona.character_sheet.character.db_key
+    return f"{target_name}'s regard for you warms {disposition_shift_band(delta)}."
 
 
 def _success_level(result) -> int:

--- a/src/world/npc_services/tests/test_social_affection_delta.py
+++ b/src/world/npc_services/tests/test_social_affection_delta.py
@@ -155,3 +155,32 @@ class SocialAffectionDeltaTest(TestCase):
                 npc_persona=pc_target_persona,
             ).exists()
         )
+
+    def test_success_returns_qualitative_message(self) -> None:
+        """A successful check returns a ready-to-display warm message, not None."""
+        from world.npc_services.social_disposition import apply_social_disposition_delta
+
+        success = CheckOutcomeFactory(name="Social Success", success_level=5)
+        with force_check_outcome(success):
+            result = PersuadeAction().run(
+                self.pc_character,
+                target_persona_id=self.npc_persona.pk,
+            )
+        resolution = result.data["resolution"]
+        message = apply_social_disposition_delta(self.pc_character, self.npc_persona.pk, resolution)
+        self.assertIsNotNone(message)
+        self.assertIn("warms considerably", message)
+
+    def test_no_movement_returns_none(self) -> None:
+        """A failed check (no delta) returns None, not an empty message."""
+        from world.npc_services.social_disposition import apply_social_disposition_delta
+
+        failure = CheckOutcomeFactory(name="Social Failure", success_level=0)
+        with force_check_outcome(failure):
+            result = PersuadeAction().run(
+                self.pc_character,
+                target_persona_id=self.npc_persona.pk,
+            )
+        resolution = result.data["resolution"]
+        message = apply_social_disposition_delta(self.pc_character, self.npc_persona.pk, resolution)
+        self.assertIsNone(message)

--- a/src/world/scenes/action_serializers.py
+++ b/src/world/scenes/action_serializers.py
@@ -591,6 +591,7 @@ class EnhancedSceneActionResultSerializer(serializers.Serializer):
     anima_recovery = serializers.SerializerMethodField()
     power_ledger = serializers.SerializerMethodField()
     fizzle_note = serializers.CharField(allow_null=True, required=False)
+    disposition_message = serializers.CharField(allow_null=True, required=False)
 
     @extend_schema_field(PowerLedgerSerializer)
     def get_power_ledger(self, obj: object) -> dict | None:

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -785,6 +785,9 @@ def _resolve_action_against_persona(
     from world.checks.services import collect_check_modifiers  # noqa: PLC0415
     from world.fatigue.constants import EFFORT_CHECK_MODIFIER  # noqa: PLC0415
     from world.fatigue.services import apply_fatigue  # noqa: PLC0415
+    from world.npc_services.social_disposition import (  # noqa: PLC0415
+        apply_social_disposition_delta,
+    )
     from world.relationships.services import relationship_gated_contributions  # noqa: PLC0415
 
     if difficulty_override is not None:
@@ -878,6 +881,10 @@ def _resolve_action_against_persona(
     # Berserk condition). The check chain above resolves the action; this is where
     # data-driven condition effects reach the live player path (#1172).
     _dispatch_action_effects(action_request, character, target_character)
+
+    result.disposition_message = apply_social_disposition_delta(
+        character, target_persona.pk, result.action_resolution
+    )
 
     result_interaction = _create_result_interaction(
         action_request=action_request,

--- a/src/world/scenes/interaction_views.py
+++ b/src/world/scenes/interaction_views.py
@@ -475,25 +475,31 @@ class InteractionReactionViewSet(viewsets.ModelViewSet):
         )
         if not created:
             return Response(status=status.HTTP_204_NO_CONTENT)
-        bump_applied = self._maybe_apply_bump(request, interaction, emoji)
+        bump_applied, bump_message = self._maybe_apply_bump(request, interaction, emoji)
         return Response(
-            {**InteractionReactionSerializer(reaction).data, "bump_applied": bump_applied},
+            {
+                **InteractionReactionSerializer(reaction).data,
+                "bump_applied": bump_applied,
+                "bump_message": bump_message,
+            },
             status=status.HTTP_201_CREATED,
         )
 
-    def _maybe_apply_bump(self, request: Request, interaction: Any, emoji: str) -> bool:
+    def _maybe_apply_bump(
+        self, request: Request, interaction: Any, emoji: str
+    ) -> tuple[bool, str | None]:
         """Fire the relationship bump for a valenced catalog emoji; never raise."""
         from actions.definitions.relationships import RelationshipBumpAction  # noqa: PLC0415
 
         catalog_entry = ReactionEmoji.objects.filter(emoji=emoji, is_active=True).first()
         if catalog_entry is None or catalog_entry.valence == 0:
-            return False
+            return False, None
         actor = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
         if actor is None:
-            return False
+            return False, None
         author_persona = interaction.persona
         if author_persona is None or author_persona.character_sheet is None:
-            return False
+            return False, None
         result = RelationshipBumpAction().run(
             actor=actor,
             target_sheet=author_persona.character_sheet,
@@ -501,7 +507,7 @@ class InteractionReactionViewSet(viewsets.ModelViewSet):
             interaction=interaction,
             source_emoji=catalog_entry,
         )
-        return result.success
+        return result.success, (result.message if result.success else None)
 
 
 class ReactionEmojiViewSet(viewsets.ReadOnlyModelViewSet):

--- a/src/world/scenes/tests/test_reaction_emoji_bumps.py
+++ b/src/world/scenes/tests/test_reaction_emoji_bumps.py
@@ -32,7 +32,9 @@ class ValencedReactionBumpTests(TestCase):
         RelationshipTrackFactory(
             name="Friction", sign=TrackSign.NEGATIVE, system_key=TrackSystemKey.FRICTION
         )
-        ReactionEmoji.objects.create(emoji="❤️", valence=ReactionValence.POSITIVE, sort_order=1)
+        self.warm_emoji = ReactionEmoji.objects.create(
+            emoji="❤️", valence=ReactionValence.POSITIVE, sort_order=1
+        )
         ReactionEmoji.objects.create(
             emoji="\U0001f44d", valence=ReactionValence.NEUTRAL, sort_order=0
         )
@@ -100,6 +102,13 @@ class ValencedReactionBumpTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertFalse(response.data["bump_applied"])
         self.assertEqual(RelationshipBump.objects.count(), 0)
+
+    def test_bump_message_reaches_response(self) -> None:
+        """A successful valenced-emoji bump's response includes bump_message."""
+        response = self._post_reaction(emoji=self.warm_emoji.emoji)
+        self.assertTrue(response.data["bump_applied"])
+        self.assertIsNotNone(response.data["bump_message"])
+        self.assertIn("warms", response.data["bump_message"])
 
 
 class ReactionEmojiCatalogTests(TestCase):

--- a/src/world/scenes/tests/test_reaction_emoji_bumps.py
+++ b/src/world/scenes/tests/test_reaction_emoji_bumps.py
@@ -87,6 +87,7 @@ class ValencedReactionBumpTests(TestCase):
         response = self._post_reaction("\U0001f44d")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertFalse(response.data["bump_applied"])
+        self.assertIsNone(response.data["bump_message"])
         self.assertEqual(RelationshipBump.objects.count(), 0)
         self.assertTrue(InteractionReaction.objects.exists())
 
@@ -94,6 +95,7 @@ class ValencedReactionBumpTests(TestCase):
         response = self._post_reaction("\U0001f9c4")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertFalse(response.data["bump_applied"])
+        self.assertIsNone(response.data["bump_message"])
         self.assertEqual(RelationshipBump.objects.count(), 0)
 
     def test_self_reaction_never_bumps(self) -> None:
@@ -101,6 +103,7 @@ class ValencedReactionBumpTests(TestCase):
         response = self._post_reaction("❤️", interaction=own_pose)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertFalse(response.data["bump_applied"])
+        self.assertIsNone(response.data["bump_message"])
         self.assertEqual(RelationshipBump.objects.count(), 0)
 
     def test_bump_message_reaches_response(self) -> None:

--- a/src/world/scenes/tests/test_scene_action_integration.py
+++ b/src/world/scenes/tests/test_scene_action_integration.py
@@ -142,6 +142,31 @@ class TestSceneActionIntegration(_BaseActionIntegrationTest):
         request.refresh_from_db()
         assert request.resolved_difficulty == 60  # HARD = 60
 
+    def test_accept_resolves_with_disposition_message_for_npc_target(self) -> None:
+        """Accepting against a persona-bearing NPC target sets disposition_message."""
+        request = create_action_request(
+            scene=self.scene,
+            initiator_persona=self.initiator,
+            target_persona=self.target,  # confirm/adjust NPC-ness per Step 1's note above
+            action_key="persuade",
+        )
+        request.action_template = self.persuade_template
+        request.save(update_fields=["action_template"])
+
+        result = respond_to_action_request(
+            action_request=request,
+            decision=ConsentDecision.ACCEPT,
+        )
+
+        assert result is not None
+        # Whether disposition_message is set depends on the real check's
+        # success tier (this test uses real traits, not a forced outcome) —
+        # assert the field EXISTS on the result (attribute access doesn't
+        # raise) as the minimum bar; a stronger assertion needs a forced
+        # check outcome, following test_social_affection_delta.py's
+        # force_check_outcome pattern if this test proves flaky on success tier.
+        assert hasattr(result, "disposition_message")
+
     def test_request_without_template_raises(self) -> None:
         """A request whose action_key resolves no ActionTemplate still raises ValueError.
 

--- a/src/world/scenes/tests/test_scene_action_integration.py
+++ b/src/world/scenes/tests/test_scene_action_integration.py
@@ -10,11 +10,13 @@ from django.test import TestCase
 
 from actions.models import ActionEnhancement
 from world.checks.factories import create_social_action_templates
+from world.checks.test_helpers import force_check_outcome
 from world.magic.factories import (
     CharacterAnimaFactory,
     CharacterTechniqueFactory,
     TechniqueFactory,
 )
+from world.npc_services.models import NPCStanding
 from world.scenes.action_constants import (
     ActionRequestStatus,
     ConsentDecision,
@@ -23,7 +25,7 @@ from world.scenes.action_constants import (
 from world.scenes.action_services import create_action_request, respond_to_action_request
 from world.scenes.factories import PersonaFactory, SceneFactory
 from world.scenes.place_models import InteractionReceiver
-from world.traits.factories import CheckSystemSetupFactory
+from world.traits.factories import CheckOutcomeFactory, CheckSystemSetupFactory
 from world.traits.models import CharacterTraitValue, Trait
 
 
@@ -143,29 +145,44 @@ class TestSceneActionIntegration(_BaseActionIntegrationTest):
         assert request.resolved_difficulty == 60  # HARD = 60
 
     def test_accept_resolves_with_disposition_message_for_npc_target(self) -> None:
-        """Accepting against a persona-bearing NPC target sets disposition_message."""
+        """Accepting against a persona-bearing NPC target moves real disposition.
+
+        Forces the check outcome to a deterministic success_level=5 (mirroring
+        ``SocialAffectionDeltaTest.test_persuade_success_moves_durable_affection``
+        in ``world/npc_services/tests/test_social_affection_delta.py``) so the
+        assertions below are genuinely load-bearing on the #2158 wiring
+        (``_resolve_action_against_persona`` actually calling
+        ``apply_social_disposition_delta``) — unlike a bare ``hasattr`` check,
+        which would pass identically even if that wiring were deleted, since
+        ``disposition_message`` is a dataclass field with ``default=None``.
+        """
         request = create_action_request(
             scene=self.scene,
             initiator_persona=self.initiator,
-            target_persona=self.target,  # confirm/adjust NPC-ness per Step 1's note above
+            target_persona=self.target,  # PersonaFactory default has no account -> NPC
             action_key="persuade",
         )
         request.action_template = self.persuade_template
         request.save(update_fields=["action_template"])
 
-        result = respond_to_action_request(
-            action_request=request,
-            decision=ConsentDecision.ACCEPT,
+        pc_persona = self.initiator.character_sheet.primary_persona
+        self.assertFalse(
+            NPCStanding.objects.filter(persona=pc_persona, npc_persona=self.target).exists()
         )
 
+        success = CheckOutcomeFactory(name="Social Success", success_level=5)
+        with force_check_outcome(success):
+            result = respond_to_action_request(
+                action_request=request,
+                decision=ConsentDecision.ACCEPT,
+            )
+
         assert result is not None
-        # Whether disposition_message is set depends on the real check's
-        # success tier (this test uses real traits, not a forced outcome) —
-        # assert the field EXISTS on the result (attribute access doesn't
-        # raise) as the minimum bar; a stronger assertion needs a forced
-        # check outcome, following test_social_affection_delta.py's
-        # force_check_outcome pattern if this test proves flaky on success tier.
-        assert hasattr(result, "disposition_message")
+        assert result.disposition_message is not None
+        assert "warms considerably" in result.disposition_message
+
+        standing = NPCStanding.objects.get(persona=pc_persona, npc_persona=self.target)
+        assert standing.affection == 5
 
     def test_request_without_template_raises(self) -> None:
         """A request whose action_key resolves no ActionTemplate still raises ValueError.

--- a/src/world/scenes/types.py
+++ b/src/world/scenes/types.py
@@ -61,6 +61,10 @@ class EnhancedSceneActionResult:
     """When a thread pull was declared but failed at charge time (#1919), this
     carries the player-facing explanation so the OUTCOME pose can note the
     fizzle. ``None`` when no pull was declared or the pull succeeded."""
+    disposition_message: str | None = None
+    """Set when this action's resolution moved a persona-bearing NPC's
+    NPCStanding.affection (#1591) — a ready-to-toast qualitative message
+    (#2158). None when no NPC-affection movement occurred."""
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Closes #2158

## Summary

Five independent freshness/feedback fixes from the #2155 webclient RP UX audit, so the game visibly answers back when a social or magical action lands:

- **Anima/resonance freshness**: cast and pull mutations in `ActionPanel` now invalidate `magicKeys.characterAnima`/`characterResonanceList` on success, so the character's magic status reflects the just-spent cost instead of a stale cache.
- **Regard-bump confirmation**: the one-click emoji regard bump (`RelationshipBumpAction` via `interaction_views.py`) now returns its message and toasts it client-side instead of firing silently.
- **NPC disposition visibility**: `apply_social_disposition_delta` now returns a qualitative shift message ("X's regard for you warms slightly/noticeably/considerably"), threaded through `EnhancedSceneActionResult.disposition_message` and surfaced as a toast on accept in `ConsentPrompt`. Wired end-to-end (backend → serializer → frontend type → toast) on the real web consent-request path (`action_services.py`'s `_resolve_action_against_persona`), not the telnet-only `_SocialTemplateAction` path.
- **Round-state visibility for non-GMs**: a new read-only `RoundStateBadge` in `SceneHeader` shows the active round number/status to every participant, not just the GM-gated `RoundSettingsDialog`.
- **PersonaContextMenu consistency**: unmet-prerequisite actions now render disabled with their reason (matching `ActionPanel`) instead of being silently omitted, and the menu fetches its own `available-actions` data instead of reading a cache that may not be populated yet.

**Known pre-existing gap (not introduced by this PR, filed separately):** the NPC-disposition toast's wiring is correct end-to-end but is currently unreachable via the common single-target case — `create_action_request` only auto-resolves NPC targets when `additional_target_personas` is non-empty (multi-target), leaving single-target NPC-primary requests stuck PENDING forever with no web path to resolve them. Independently verified against source during final review. Filed as #2214 (needs-design) rather than expanding this PR's scope.

## Follow-ups filed

- #2214

## Notes

- Spec: reviewed & approved on #2158 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch was local-only (never pushed before this sync), so synced via rebase onto origin/main (9 commits of drift, mostly #2155 sibling PRs). Two conflicts, both from sibling PRs touching the same files: (1) ActionPanel.tsx — import-block conflict between this branch's toast/useNavigate imports and a sibling's magicKeys import; resolved by keeping both. (2) SceneHeader.test.tsx — add/add conflict between this branch's round-badge test suite and a sibling's new combat-badge test suite (same filename, both newly created); resolved by merging both describe blocks into one file, which surfaced a real bug in the merge (SCENE fixture missing active_round, crashing RoundStateBadge's === null check on undefined) — fixed in a follow-up commit with tests re-verified (33/33 passing).

<!-- last-addressed-comment: 0 -->