### PR TITLE
Journals and letters without leaving the scene (#2155)

### DIFF
--- a/AGENT_GLOSSARY_MAP.md
+++ b/AGENT_GLOSSARY_MAP.md
@@ -30,6 +30,7 @@ term is chosen and the rest are listed under `_Avoid_`.
 - [gm](src/world/gm/AGENT_GLOSSARY.md)
 - [roster / kinship](src/world/roster/AGENT_GLOSSARY.md)
 - [missions](src/world/missions/AGENT_GLOSSARY.md)
+- [journals](src/world/journals/AGENT_GLOSSARY.md)
 - [npc_services](src/world/npc_services/AGENT_GLOSSARY.md)
 - [tarot](src/world/tarot/AGENT_GLOSSARY.md)
 - [currency](src/world/currency/AGENT_GLOSSARY.md)

--- a/docs/adr/0116-playermail-is-the-letters-surface-at-mvp.md
+++ b/docs/adr/0116-playermail-is-the-letters-surface-at-mvp.md
@@ -1,0 +1,15 @@
+# PlayerMail is the letters surface at MVP; tenure-routed anonymity is the mechanism
+
+`world.roster.PlayerMail` (tenure-to-tenure, threaded via `in_reply_to`) is the whole letters
+system for #2160 — compose/inbox at `/profile/mail`, in-scene quick-compose from the character
+card (`SendLetterDialog` pre-filling `ComposeMailForm`), unread badge, and a `MAIL_ARRIVED`
+websocket push on send. Routing through `RosterTenure` (not `AccountDB`) is what already buys
+player anonymity: the recipient is addressed and displayed as "the current player of Character X,"
+never by account, and the arrival push payload carries only `mail_id`/`sender_display`/`subject`
+for the same reason. We deliberately did not build a separate in-fiction messenger/delivery layer
+(travel time for physical letters, courier interception, forgeable seals) — that is a real,
+interesting IC-mechanics question, but it is a distinct system from "can a player privately message
+another player's current character," which `PlayerMail` already solves. Left as an open design
+question, not filed as a follow-up (no separable spec exists yet).
+
+> Status: accepted · Source: #2160

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -145,6 +145,7 @@ treat those names as hints to confirm, not gospel.
 - [0113 — Consent defaults are a category tree, not per-category flags](0113-consent-defaults-are-a-category-tree.md) (extends ADR-0024)
 - [0114 — Player-authored accusations are weight-bearing secrets, gated by consent not the model](0114-accusations-are-weight-bearing-player-secrets.md) (extends ADR-0062/0113)
 - [0115 — Applause is three axes, not one economy: votes=popularity, kudos=graciousness, reactions=expression](0115-applause-three-axes.md)
+- [0116 — PlayerMail is the letters surface at MVP; tenure-routed anonymity is the mechanism](0116-playermail-is-the-letters-surface-at-mvp.md)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/audits/2026-07-10-webclient-rp-ux-audit.md
+++ b/docs/audits/2026-07-10-webclient-rp-ux-audit.md
@@ -101,11 +101,18 @@ Resolving this split is **#2156**, the structural core of the slate.
   (ADR-0115) rather than an accident: `WeeklyVote` is wired end-to-end — `VoteButton` on
   every `PoseUnit` and `VotesPanel` on `/xp-kudos` — and the highlight reel re-ranks on
   all-time vote count first (reaction count as tie-break), not reaction count alone.
-- **`world.journals` (diary/praise-retort, weekly XP) has zero web frontend**; telnet
-  (`journal write`) is complete. The `/journal` route is a decoy — it's the *missions*
-  ledger, an unrelated system sharing the name.
-- **No messenger concept exists**; `PlayerMail` compose/inbox is at `/profile/mail` with no
-  in-scene compose, no unread badge, no arrival push.
+- [FIXED #2160] `world.journals` (diary/praise-retort, weekly XP) **had zero web frontend**;
+  telnet (`journal write`) was complete but the `/journal` route was a decoy — it's the
+  *missions* ledger, an unrelated system sharing the name. The missions ledger moved to
+  `/missions/journal`, freeing `/journal`/`/journals` for a real composer/feed page plus an
+  in-scene sidebar `JournalTab` quick-compose — see `src/world/journals/AGENT_GLOSSARY.md` for
+  the now-disambiguated "journal" homonym across journals/missions/clues.
+- [FIXED #2160] **No messenger concept exists** remains true by design (see ADR-0116 — an
+  in-fiction delivery layer is a deliberately deferred, distinct system), but the *web*
+  `PlayerMail` gaps are closed: an in-scene quick-compose (`SendLetterDialog` pre-filling
+  `ComposeMailForm`) from the character card, an `UnreadMailBadge` + arrival toast in the
+  header driven by a new `MAIL_ARRIVED` websocket push, and mark-read-on-open. Compose/inbox
+  stays at `/profile/mail`.
 - Latent gotcha: `KudosTransaction.awarded_by` serializes raw `username`; all callers pass
   `None` by convention only — no structural guard (ADR-0033 risk if a future caller passes
   an account).

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -89,7 +89,7 @@ limits, IC-vs-UI placement, etc. — see [`design-tenets.md`](design-tenets.md).
 | [Stories & GM Tables](stories-gm.md) | in-progress | Story arcs, GM tables, trust tiers, time reconciliation |
 | [Codex & Knowledge](codex.md) | in-progress | Lore repository, character-scoped knowledge, research, secrets |
 | [Investigation & Discovery](investigation-discovery.md) | in-progress | Clue model, room search, passive triggers, collaborative research projects, gating, rescue-as-clue — core loop shipped; trigger sources + journal UI remain |
-| [Journals & Expression](journals.md) | in-progress | IC writing, praises/retorts, freeform tags, weekly XP rewards. Action-backed (#1350): web+telnet (`CmdJournal`/`CmdGoal`) converge on `action.run()` |
+| [Journals & Expression](journals.md) | in-progress | IC writing, praises/retorts, freeform tags, weekly XP rewards. Action-backed (#1350): web+telnet (`CmdJournal`/`CmdGoal`) converge on `action.run()`. Web frontend shipped (#2160): `/journals` page + in-scene sidebar tab |
 | [Societies & Organizations](societies.md) | in-progress | Societies, organizations, reputation, legend, alter egos |
 | [Achievements & Discoveries](achievements.md) | in-progress | Achievement tracking, first-to-discover, stat tracking, chains |
 | [OOC Social & Community](ooc-social.md) | in-progress | Kudos, friend tracking, visibility controls, engagement tools |

--- a/docs/roadmap/journals.md
+++ b/docs/roadmap/journals.md
@@ -33,6 +33,10 @@ IC writing by players — journals, praises, retorts, and weekly XP awards. Jour
 - **Thread linking** — `JournalEntry.related_threads` M2M to the new `magic.Thread` model
   (Spec A). Replaces the deleted `ThreadJournal` join table; entries can now tag any
   anchored thread (trait, technique, item, room, relationship track, relationship capstone)
+- **Frontend React components (#2160)** — `/journals` page (composer, public feed, own-entries
+  tab) plus a `JournalTab` quick-compose panel in the in-scene sidebar. The `/journal` route
+  (previously a decoy pointing at the unrelated missions ledger) now belongs to this app; the
+  missions ledger moved to `/missions/journal`.
 
 ## Deferred (depends on systems that don't exist yet)
 - **Relationship gating for retorts** — retorts should validate antagonistic relationship (needs relationships system)
@@ -43,7 +47,6 @@ IC writing by players — journals, praises, retorts, and weekly XP awards. Jour
 - **Account-level block integration** — respect account blocks in journal visibility
 - **Great Archive IC location gating** — IC access point for the journal archive (needs world building)
 - **GoalJournal removal** — remove old goal-specific journals once migrated (ThreadJournal already removed; see Thread linking above)
-- **Frontend React components** — journal reading, writing, and browsing UI
 
 ## Notes
 - Retorts award more XP to receiver (3) than giver (1) to incentivize dramatic conflict

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -877,8 +877,14 @@ Character journal entries (public/private), praises, retorts, freeform tags, wee
 - **Models:** `JournalEntry` (FK CharacterSheet author; self-FK parent for responses), `JournalTag`, `WeeklyJournalXP`
 - **Write services:** `create_journal_entry` / `create_journal_response` / `edit_journal_entry`; `JournalError` user-safe exception in `types.py`
 - **Action-backed (#1350, ADR-0001):** `create_journal_entry` / `respond_to_journal` / `edit_journal_entry` Actions wrap the services; web `JournalEntryViewSet` + telnet `CmdJournal` (`journal write|respond|edit`) converge on `action.run()`
+- **Web surface (#2160):** previously zero web frontend (telnet-only); now `/journals`
+  (composer, public feed, own-entries tab) plus a `JournalTab` quick-compose panel in the
+  in-scene sidebar. `/journal` (singular) was freed from the missions ledger, which moved to
+  `/missions/journal` in the same PR — see Missions below and `journals/AGENT_GLOSSARY.md`'s
+  disambiguation entry for the "journal" homonym across apps.
 - **Integrates with:** progression (weekly XP awards), achievements (`journals.total_written`/`total_public` stats), threads (`JournalEntry.related_threads` M2M)
-- **Source:** `src/world/journals/`
+- **Source:** `src/world/journals/` (no dedicated `docs/systems/journals.md`; see the app's
+  `CLAUDE.md` and `AGENT_GLOSSARY.md`)
 ### Action Points
 Time/effort resource economy with regeneration via cron. The most complete gate pattern in the codebase.
 
@@ -1242,6 +1248,15 @@ Character lifecycle management with web-first applications and player anonymity.
   hosts the shared `_send_email`/`_get_staff_emails` primitives; `RosterEmailService`
   extends it unchanged. `world.character_creation.email_service.CGEmailService`
   extends the same base — see Character Creation above.
+- **Letters web surface (#2160, ADR-0116):** `PlayerMailViewSet` gained two actions —
+  `POST /api/roster/mail/{id}/mark-read/` (idempotent, recipient-scoped via the queryset) and
+  `GET /api/roster/mail/unread-count/` (unread + unarchived, across the requester's tenures).
+  Sending mail fires `notify_mail_arrived` via `transaction.on_commit` (the
+  `notify_battle_state_changed` pattern), pushing a new `WebsocketMessageType.MAIL_ARRIVED`
+  (`src/web/webclient/message_types.py`) payload — `mail_id`/`sender_display`/`subject` only, no
+  account identifiers. Frontend: in-scene quick-compose (`SendLetterDialog` pre-filling
+  `ComposeMailForm`) from the character card, an `UnreadMailBadge` in the header, and a
+  mark-read-on-open flow in `ReceivedMailList`. No telnet mail command exists or is planned.
 - **Integrates with:** accounts, character_sheets, scenes
 - **Source:** `src/world/roster/`
 - **Details:** [roster.md](roster.md)

--- a/docs/systems/MODEL_MAP.md
+++ b/docs/systems/MODEL_MAP.md
@@ -1694,19 +1694,19 @@
 
 ### StablesDetails
 **Foreign Keys:**
-  - feature_instance -> room_features.RoomFeatureInstance [OneToOne, PK]
+  - feature_instance -> room_features.RoomFeatureInstance [OneToOne]
 
 ### Service Functions
 - `bind_companion(*, owner: 'CharacterSheet', archetype: 'CompanionArchetype', granting_gift: 'Gift', name: 'str') -> 'Companion' — Create a bonded Companion + its live CompanionObject in owner's current room.`
-- `companion_capacity(character_sheet: 'CharacterSheet', gift: 'Gift') -> 'int' — Total Companion Capacity character_sheet has via gift's Thread level + Stables bonus.`
+- `companion_capacity(character_sheet: 'CharacterSheet', gift: 'Gift') -> 'int' — Total Companion Capacity character_sheet has via gift's Thread level.`
 - `get_pull_effects_for_thread(thread: 'Thread', **filters: 'object') -> 'list[ThreadPullEffect]' — Return ThreadPullEffect rows for ``thread`` with gift-specific preference.`
-- `handle_stables_progression(project: 'Project', target_level: 'int', outcome_tier: 'CheckOutcome | None' = None) -> 'None' — STABLES strategy: install/level RoomFeatureInstance + create StablesDetails (#1863).`
+- `handle_stables_progression(project: 'Project', target_level: 'int', outcome_tier: 'CheckOutcome | None' = None) -> 'None' — STABLES strategy: row-only install/level + create StablesDetails (#1863).`
 - `materialize_companion_as_battle_vehicle(companion: 'Companion', battle: 'Battle', side: 'BattleSide') -> 'BattleVehicle' — Bridge a persistent Companion into a battle-scale BattleVehicle (#1873).`
 - `materialize_companion_as_combat_opponent(companion: 'Companion', encounter: 'CombatEncounter', *, threat_pool: 'ThreatPool | None' = None) -> 'CombatOpponent' — Bridge a persistent Companion into a duel-scale CombatOpponent (#1873).`
 - `order_companion(*, companion: 'Companion', order_kind: 'str', round_number: 'int', encounter: 'CombatEncounter | None' = None, battle: 'Battle | None' = None, target_opponent=None, target_unit=None, ability=None, defending_participant=None, target_ally=None) — Validate and upsert a CompanionOrder directive (#1921).`
 - `release_companion(companion: 'Companion') -> 'None' — Release a bonded companion: destroy its live object, keep the row.`
 - `resolve_companion_defeat(companion: 'Companion', risk_level: 'str') -> 'bool' — Resolve a bridged companion's defeat consequence (#1873).`
-- `stables_capacity_bonus_for_sheet(character_sheet: 'CharacterSheet') -> 'int' — Flat Companion Capacity bonus from all Stables the sheet has standing in (#1863).`
+- `stables_capacity_bonus_for_sheet(character_sheet: 'CharacterSheet') -> 'int' — Flat Companion Capacity bonus from all Stables the sheet has standing in.`
 - `used_companion_capacity(character_sheet: 'CharacterSheet', gift: 'Gift') -> 'int' — Companion Capacity currently consumed by character_sheet's active companions via gift.`
 
 
@@ -2364,6 +2364,7 @@
   - temporary_changes <- forms.TemporaryFormChange
   - persona_descriptors <- forms.PersonaTraitDescriptor
   - appearance_changes <- forms.AppearanceChangeLog
+  - item_template_effects <- items.ItemTemplateAppearanceEffect
 
 ### FormTraitOption
 **Foreign Keys:**
@@ -2373,6 +2374,7 @@
   - character_values <- forms.CharacterFormValue
   - natural_for_values <- forms.CharacterFormValue
   - temporary_changes <- forms.TemporaryFormChange
+  - item_template_effects <- items.ItemTemplateAppearanceEffect
 
 ### SpeciesFormTrait
 **Foreign Keys:**
@@ -2667,6 +2669,7 @@
   - slots <- items.TemplateSlot
   - instances <- items.ItemInstance
   - interaction_bindings <- items.TemplateInteraction
+  - appearance_effects <- items.ItemTemplateAppearanceEffect
   - check_modifiers <- items.ItemCheckModifier
   - garment_mitigations <- items.GarmentMitigation
   - stock_listings <- items.StockListing
@@ -2711,6 +2714,12 @@
 **Foreign Keys:**
   - template -> items.ItemTemplate [FK]
   - interaction_type -> items.InteractionType [FK]
+
+### ItemTemplateAppearanceEffect
+**Foreign Keys:**
+  - item_template -> items.ItemTemplate [FK]
+  - trait -> forms.FormTrait [FK]
+  - target_option -> forms.FormTraitOption [FK]
 
 ### EquippedItem
 **Foreign Keys:**

--- a/docs/systems/roster.md
+++ b/docs/systems/roster.md
@@ -213,9 +213,21 @@ RosterTenure.objects.for_player(player_data)                 # For specific play
 - `GET /api/roster/tenures/` - List tenures with search by character name
 - `GET /api/roster/tenures/mine/` - Current user's active tenures (for dropdown selection)
 
-### Mail (`/api/roster/mail/`)
+### Mail (`/api/roster/mail/`) — the letters surface (#2160, ADR-0116)
 - `GET /api/roster/mail/` - List received mail (newest first)
-- `POST /api/roster/mail/` - Send mail (validates sender_tenure ownership)
+- `POST /api/roster/mail/` - Send mail (validates sender_tenure ownership); fires
+  `notify_mail_arrived(recipient_tenure, mail)` via `transaction.on_commit`, pushing a
+  `WebsocketMessageType.MAIL_ARRIVED` payload (`mail_id`/`sender_display`/`subject` — no
+  account identifiers) to the recipient's account. Fail-soft: an offline recipient's
+  `account.msg` is a harmless no-op; a push failure never blocks the send.
+- `POST /api/roster/mail/{id}/mark-read/` - Mark this mail read (idempotent; recipient-only,
+  enforced by the scoped queryset in `get_object()`)
+- `GET /api/roster/mail/unread-count/` - Count of unread, unarchived mail across the
+  requester's tenures (`UnreadMailCountSerializer`)
+
+Web-only surface: compose at `/profile/mail` or in-scene via `SendLetterDialog` (pre-fills
+`ComposeMailForm` from the character card quick actions), unread badge in the header
+(`UnreadMailBadge`), mark-read-on-open in `ReceivedMailList`. No telnet mail command.
 
 ### Families (`/api/roster/families/`)
 - `GET /api/roster/families/` - List playable families

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -258,6 +258,15 @@ const MagicProgressionPage = lazy(() =>
 );
 
 // ---------------------------------------------------------------------------
+// Lazy-loaded journals page (#2160) — diary route, plural /journals. Distinct
+// from /missions/journal (the mission ledger, moved there in Task 1).
+// ---------------------------------------------------------------------------
+
+const JournalsPage = lazy(() =>
+  import('@/journals/pages/JournalsPage').then((m) => ({ default: m.JournalsPage }))
+);
+
+// ---------------------------------------------------------------------------
 // Suspense fallback — shown while lazy stories chunks load
 // ---------------------------------------------------------------------------
 
@@ -326,6 +335,16 @@ function App() {
         <Route path="/characters/create" element={<CharacterCreationPage />} />
         <Route path="/characters/:id" element={<CharacterSheetPage />} />
         <Route path="/missions/journal" element={<JournalPage />} />
+        <Route
+          path="/journals"
+          element={
+            <Suspense fallback={<PageLoadingFallback />}>
+              <ProtectedRoute>
+                <JournalsPage />
+              </ProtectedRoute>
+            </Suspense>
+          }
+        />
         <Route path="/tidings" element={<TidingsPage />} />
         <Route path="/scenes" element={<ScenesListPage />} />
         <Route path="/scenes/:id" element={<SceneDetailPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -325,7 +325,7 @@ function App() {
         <Route path="/roster" element={<RosterListPage />} />
         <Route path="/characters/create" element={<CharacterCreationPage />} />
         <Route path="/characters/:id" element={<CharacterSheetPage />} />
-        <Route path="/journal" element={<JournalPage />} />
+        <Route path="/missions/journal" element={<JournalPage />} />
         <Route path="/tidings" element={<TidingsPage />} />
         <Route path="/scenes" element={<ScenesListPage />} />
         <Route path="/scenes/:id" element={<SceneDetailPage />} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -11,6 +11,7 @@ import { navigationMenuTriggerStyle } from '@/components/ui/navigation-menu-trig
 import { useAppSelector } from '@/store/hooks';
 import { useOpenSubmissionCount } from '@/staff/queries';
 import { UnreadNarrativeBadge } from '@/narrative/components/UnreadNarrativeBadge';
+import { UnreadMailBadge } from '@/mail/components/UnreadMailBadge';
 import { useRitualSessionInbox } from '@/rituals/queries';
 
 const links = [
@@ -100,6 +101,9 @@ export function Header() {
               <UnreadNarrativeBadge />
             </NavigationMenuItem>
             <NavigationMenuItem>
+              <UnreadMailBadge />
+            </NavigationMenuItem>
+            <NavigationMenuItem>
               <UserNav />
             </NavigationMenuItem>
           </NavigationMenuList>
@@ -142,6 +146,7 @@ export function Header() {
                 )}
                 <ModeToggle />
                 <UnreadNarrativeBadge />
+                <UnreadMailBadge />
                 <UserNav />
               </nav>
             </SheetContent>

--- a/frontend/src/components/__tests__/Header.test.tsx
+++ b/frontend/src/components/__tests__/Header.test.tsx
@@ -24,6 +24,10 @@ vi.mock('@/narrative/components/UnreadNarrativeBadge', () => ({
   UnreadNarrativeBadge: () => <div data-testid="unread-badge" />,
 }));
 
+vi.mock('@/mail/queries', () => ({
+  useUnreadMailCount: () => 0,
+}));
+
 vi.mock('@/rituals/queries', () => ({
   useRitualSessionInbox: () => ({
     data: [],

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -12,6 +12,7 @@ import { EventsSidebarPanel } from '@/events/components/EventsSidebarPanel';
 import { useEncounterForScene } from '@/combat/queries';
 import { useBattleForSceneQuery } from '@/battles/queries';
 import { StoryTray } from '@/missions/components/StoryTray';
+import { JournalTab } from '@/journals/components/JournalTab';
 import { StatusPanel } from '@/status/components/StatusPanel';
 import { InventorySidebarPanel } from '@/inventory/components/InventorySidebarPanel';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
@@ -397,6 +398,7 @@ export function GamePage() {
                 <InventorySidebarPanel characterId={activeCharacterId} />
               ) : undefined
             }
+            journalPanel={<JournalTab />}
           />
         }
       />

--- a/frontend/src/game/components/CharacterCardDrawer.test.tsx
+++ b/frontend/src/game/components/CharacterCardDrawer.test.tsx
@@ -36,7 +36,7 @@ function emptySearch(isLoading = false): PaginatedResponse<RosterEntryData> | un
   return isLoading ? undefined : { count: 0, next: null, previous: null, results: [] };
 }
 
-function matchedEntry(): RosterEntryData {
+function matchedEntry(tenures: RosterEntryData['tenures'] = []): RosterEntryData {
   return {
     id: 42,
     character: {
@@ -47,7 +47,7 @@ function matchedEntry(): RosterEntryData {
       galleries: [],
     },
     profile_picture: null,
-    tenures: [],
+    tenures,
     can_apply: false,
     fullname: 'Alice',
     quote: '',
@@ -56,6 +56,25 @@ function matchedEntry(): RosterEntryData {
     creation_provenance_display: 'Player-created',
     created_for_table_name: null,
   };
+}
+
+function liveTenure(): RosterEntryData['tenures'][number] {
+  return {
+    id: 7,
+    player_number: 1,
+    start_date: '2026-01-01',
+    end_date: null,
+    applied_date: '2026-01-01',
+    approved_date: '2026-01-01',
+    approved_by: null,
+    tenure_notes: '',
+    photo_folder: '',
+    media: [],
+  };
+}
+
+function endedTenure(): RosterEntryData['tenures'][number] {
+  return { ...liveTenure(), id: 8, end_date: '2026-02-01' };
 }
 
 function mockNoSearchResult(isLoading = false) {
@@ -167,6 +186,34 @@ describe('CharacterCardDrawer', () => {
       );
       expect(screen.queryByRole('button', { name: /\+ friend/i })).not.toBeInTheDocument();
     });
+  });
+
+  // #2160 Task 4: quick actions.
+  it('renders both quick actions when entry+live tenure resolve; hides "Send a letter" with no live tenure', () => {
+    mockSearchMatch(matchedEntry([liveTenure()]));
+    const { unmount } = renderWithProviders(
+      <CharacterCardDrawer
+        persona={PERSONA}
+        onClose={vi.fn()}
+        viewerEntryId={7}
+        onWhisper={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /write a journal/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /send a letter/i })).toBeInTheDocument();
+    unmount();
+
+    mockSearchMatch(matchedEntry([endedTenure()]));
+    renderWithProviders(
+      <CharacterCardDrawer
+        persona={PERSONA}
+        onClose={vi.fn()}
+        viewerEntryId={7}
+        onWhisper={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /write a journal/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /send a letter/i })).not.toBeInTheDocument();
   });
 
   describe('with no public roster match (disguise / temporary / unlisted persona)', () => {

--- a/frontend/src/game/components/CharacterCardDrawer.tsx
+++ b/frontend/src/game/components/CharacterCardDrawer.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 import { PersonaAvatar } from '@/components/PersonaAvatar';
@@ -5,6 +6,8 @@ import { BackgroundSection, StatsSection, CharacterLink } from '@/components/cha
 import { FriendButton } from '@/friends/components/FriendButton';
 import { useRosterEntryByNameQuery, useRosterEntryQuery } from '@/roster/queries';
 import type { PoseUnitAvatarClickPersona } from '@/scenes/components/PoseUnit';
+import { JournalComposerDialog } from '@/journals/components/JournalComposerDialog';
+import { SendLetterDialog } from './SendLetterDialog';
 
 export interface CharacterCardDrawerProps {
   /** The clicked bubble's persona identity; `null` means the drawer is closed. */
@@ -32,6 +35,13 @@ export interface CharacterCardDrawerProps {
  * roster." and no sheet data, no FriendButton. Never resolve through
  * `receiver_persona_ids`, scene participation, or any other non-public linkage.
  *
+ * Quick actions (#2160): "Write a journal" opens `JournalComposerDialog`
+ * pre-tagged with the resolved character's name once `entry` resolves.
+ * "Send a letter" opens `SendLetterDialog` pre-addressed to the character's
+ * live tenure (`entry.tenures.find(t => t.end_date === null)`) — hidden when
+ * there's no live tenure, since a vacant character has no one to address
+ * (same gating philosophy as the FriendButton viewer-required gate below).
+ *
  * Radix note: `SheetContent`'s `hideOverlay` only removes the dimming backdrop —
  * the underlying Dialog is still `modal` (focus-trapped, outside pointer events
  * disabled) unless `Sheet` itself is given `modal={false}`, which most of this
@@ -51,6 +61,10 @@ export function CharacterCardDrawer({
   const match = searchResult?.results.find((entry) => entry.character.name === persona?.name);
   const matchId = match?.id;
   const { data: entry } = useRosterEntryQuery(matchId ?? 0);
+  const liveTenure = entry?.tenures.find((tenure) => tenure.end_date === null) ?? null;
+
+  const [journalOpen, setJournalOpen] = useState(false);
+  const [letterOpen, setLetterOpen] = useState(false);
 
   const handleWhisper = () => {
     if (!persona) return;
@@ -89,7 +103,43 @@ export function CharacterCardDrawer({
               <Button type="button" variant="outline" size="sm" onClick={handleWhisper}>
                 Whisper
               </Button>
+              {entry && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setJournalOpen(true)}
+                >
+                  Write a journal
+                </Button>
+              )}
+              {entry && liveTenure && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setLetterOpen(true)}
+                >
+                  Send a letter
+                </Button>
+              )}
             </div>
+
+            {entry && (
+              <JournalComposerDialog
+                open={journalOpen}
+                onClose={() => setJournalOpen(false)}
+                initialTags={[entry.character.name]}
+              />
+            )}
+            {entry && liveTenure && (
+              <SendLetterDialog
+                open={letterOpen}
+                onClose={() => setLetterOpen(false)}
+                recipientTenureId={liveTenure.id}
+                recipientDisplay={entry.character.name}
+              />
+            )}
 
             {searching ? (
               <p className="mt-4 text-sm text-muted-foreground">Loading…</p>

--- a/frontend/src/game/components/SendLetterDialog.tsx
+++ b/frontend/src/game/components/SendLetterDialog.tsx
@@ -1,0 +1,61 @@
+/**
+ * SendLetterDialog — thin Dialog wrapper around `ComposeMailForm`, pre-addressed
+ * to a character from the character-card "Send a letter" quick action (#2160).
+ *
+ * Externally controlled (`open`/`onClose`), matching `JournalComposerDialog`'s
+ * pattern rather than owning its own trigger — `CharacterCardDrawer` opens it
+ * from its own quick-action button.
+ *
+ * `recipientTenureId`/`recipientDisplay` come from the card's resolved live
+ * tenure (`entry.tenures.find(t => t.end_date === null)`) — the card only
+ * offers this action when a live tenure exists (a vacant character has no one
+ * to address), so both are always required here. `senderTenureId` is optional:
+ * only pass it when the viewer's own current tenure is unambiguous from
+ * context; otherwise omit it and `ComposeMailForm` falls back to
+ * `MyTenureSelect` so the player picks among their own tenures.
+ */
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { toast } from 'sonner';
+import { ComposeMailForm } from '@/mail/components/ComposeMailForm';
+
+interface SendLetterDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** The pre-addressed recipient's live `RosterTenure` id. */
+  recipientTenureId: number;
+  /** The pre-addressed recipient's display name, shown as "To: {name}". */
+  recipientDisplay: string;
+  /** The viewer's own tenure id, when unambiguous — hides `MyTenureSelect`. */
+  senderTenureId?: number;
+}
+
+export function SendLetterDialog({
+  open,
+  onClose,
+  recipientTenureId,
+  recipientDisplay,
+  senderTenureId,
+}: SendLetterDialogProps) {
+  function handleOpenChange(isOpen: boolean) {
+    if (!isOpen) onClose();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Send a Letter to {recipientDisplay}</DialogTitle>
+        </DialogHeader>
+        <ComposeMailForm
+          initialRecipientTenureId={recipientTenureId}
+          initialRecipientDisplay={recipientDisplay}
+          fixedSenderTenureId={senderTenureId}
+          onSent={() => {
+            toast.success(`Letter sent to ${recipientDisplay}.`);
+            onClose();
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/game/components/SidebarTabPanel.tsx
+++ b/frontend/src/game/components/SidebarTabPanel.tsx
@@ -1,5 +1,14 @@
 import { type ReactNode, useCallback, useState } from 'react';
-import { Activity, Backpack, BookOpen, Calendar, MapPin, Scroll, Users } from 'lucide-react';
+import {
+  Activity,
+  Backpack,
+  BookOpen,
+  Calendar,
+  MapPin,
+  PenLine,
+  Scroll,
+  Users,
+} from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 interface SidebarTabPanelProps {
@@ -14,6 +23,8 @@ interface SidebarTabPanelProps {
   statusPanel?: ReactNode;
   /** #1446 read-only carried-items tab — the sheet describes; the scene does. */
   inventoryPanel?: ReactNode;
+  /** #2160 journal tab — compose + the player's 5 most recent entries. */
+  journalPanel?: ReactNode;
   /**
    * Label for the room tab. Defaults to ``"Room"`` but the parent can
    * pass the currently-focused subject (a character or item name) so the
@@ -32,6 +43,7 @@ export function SidebarTabPanel({
   presencePanel,
   statusPanel,
   inventoryPanel,
+  journalPanel,
   roomTabLabel,
 }: SidebarTabPanelProps) {
   const [activeTab, setActiveTab] = useState('room');
@@ -51,7 +63,7 @@ export function SidebarTabPanel({
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} className="flex h-full flex-col">
-      <TabsList className="mx-2 mt-2 grid w-auto grid-cols-7">
+      <TabsList className="mx-2 mt-2 grid w-auto grid-cols-8">
         <TabsTrigger value="room" className="gap-1 text-xs" title={label}>
           <MapPin className="h-3 w-3 shrink-0" />
           <span className="inline-block max-w-[8rem] truncate">{label}</span>
@@ -79,6 +91,10 @@ export function SidebarTabPanel({
         <TabsTrigger value="inventory" className="gap-1 text-xs">
           <Backpack className="h-3 w-3" />
           Items
+        </TabsTrigger>
+        <TabsTrigger value="journal" className="gap-1 text-xs">
+          <PenLine className="h-3 w-3" />
+          Journal
         </TabsTrigger>
       </TabsList>
       <TabsContent value="room" className="mt-0 flex-1 overflow-y-auto">
@@ -114,6 +130,13 @@ export function SidebarTabPanel({
       <TabsContent value="inventory" className="mt-0 flex-1 overflow-y-auto p-3">
         {activatedTabs.has('inventory')
           ? (inventoryPanel ?? <p className="text-sm text-muted-foreground">Nothing carried.</p>)
+          : null}
+      </TabsContent>
+      <TabsContent value="journal" className="mt-0 flex-1 overflow-y-auto">
+        {activatedTabs.has('journal')
+          ? (journalPanel ?? (
+              <p className="p-3 text-sm text-muted-foreground">No journal to show.</p>
+            ))
           : null}
       </TabsContent>
     </Tabs>

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -14721,6 +14721,40 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/roster/mail/{id}/mark-read/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Mark this mail as read (idempotent). Recipient-only via the scoped queryset. */
+    post: operations['roster_mail_mark_read_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/roster/mail/unread-count/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Count of unread, unarchived mail across the requester's tenures. */
+    get: operations['roster_mail_unread_count_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/roster/media/': {
     parameters: {
       query?: never;
@@ -33627,6 +33661,10 @@ export interface components {
      * @enum {string}
      */
     UnlockTypeEnum: 'class_level' | 'thread_xp_lock' | 'skill_breakthrough';
+    /** @description Response shape for ``PlayerMailViewSet.unread_count`` -- schema only, never a model. */
+    UnreadMailCount: {
+      readonly count: number;
+    };
     /**
      * @description Input for PATCH /api/table-bulletin-posts/{id}/.
      *
@@ -54575,6 +54613,47 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['PlayerMail'];
+        };
+      };
+    };
+  };
+  roster_mail_mark_read_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this player mail. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PlayerMail'];
+        };
+      };
+    };
+  };
+  roster_mail_unread_count_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['UnreadMailCount'];
         };
       };
     };

--- a/frontend/src/hooks/__tests__/handleMailArrivedPayload.test.ts
+++ b/frontend/src/hooks/__tests__/handleMailArrivedPayload.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { toast } from 'sonner';
+import { handleMailArrivedPayload } from '../handleMailArrivedPayload';
+import { mailKeys } from '@/mail/queries';
+import { queryClient } from '@/queryClient';
+import type { MailArrivedPayload } from '../types';
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }),
+}));
+
+describe('handleMailArrivedPayload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a toast naming the sender and subject', () => {
+    const payload: MailArrivedPayload = {
+      mail_id: 42,
+      sender_display: '1st player of Ariel',
+      subject: 'Regarding the border dispute',
+    };
+
+    handleMailArrivedPayload(payload);
+
+    expect(toast).toHaveBeenCalledWith(
+      'A letter from 1st player of Ariel: Regarding the border dispute'
+    );
+  });
+
+  it('invalidates the unread mail-count query', () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+
+    const payload: MailArrivedPayload = {
+      mail_id: 7,
+      sender_display: 'Guardsman Rolf',
+      subject: 'Patrol report',
+    };
+
+    handleMailArrivedPayload(payload);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: mailKeys.unreadCount() });
+
+    invalidateSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/handleMailArrivedPayload.ts
+++ b/frontend/src/hooks/handleMailArrivedPayload.ts
@@ -1,0 +1,15 @@
+import { toast } from 'sonner';
+import type { MailArrivedPayload } from './types';
+import { mailKeys } from '@/mail/queries';
+import { queryClient } from '@/queryClient';
+
+/**
+ * A letter arrived for one of the recipient's tenures (#2160). The payload
+ * is a slim ping (no mail body — see `MailArrivedPayload`'s anonymity-boundary
+ * note); on receipt we surface a toast and invalidate the unread-count query
+ * so the header badge refreshes.
+ */
+export function handleMailArrivedPayload(payload: MailArrivedPayload) {
+  toast(`A letter from ${payload.sender_display}: ${payload.subject}`);
+  void queryClient.invalidateQueries({ queryKey: mailKeys.unreadCount() });
+}

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -31,6 +31,8 @@ export const WS_MESSAGE_TYPE = {
   EXECUTE_ACTION: 'execute_action',
   /** Inbound: someone applauded your content; anonymous. */
   KUDOS_RECEIVED: 'kudos_received',
+  /** Inbound: a new letter arrived for one of the recipient's tenures (#2160). */
+  MAIL_ARRIVED: 'mail_arrived',
 } as const;
 
 export type SocketMessageType = (typeof WS_MESSAGE_TYPE)[keyof typeof WS_MESSAGE_TYPE];
@@ -155,6 +157,15 @@ export interface KudosReceivedPayload {
   amount: number;
   source_category: string;
   description: string;
+ * Slim arrival ping for `mail_arrived` messages (#2160). Anonymity boundary:
+ * `sender_display` is the sender tenure's display name only, never an
+ * account id/username. Carries no mail body — clients refetch the mail list
+ * / unread count on receipt.
+ */
+export interface MailArrivedPayload {
+  mail_id: number;
+  sender_display: string;
+  subject: string;
 }
 
 export interface InteractionWsPayload {

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -157,6 +157,9 @@ export interface KudosReceivedPayload {
   amount: number;
   source_category: string;
   description: string;
+}
+
+/**
  * Slim arrival ping for `mail_arrived` messages (#2160). Anonymity boundary:
  * `sender_display` is the sender tenure's display name only, never an
  * account id/username. Carries no mail body — clients refetch the mail list

--- a/frontend/src/hooks/useGameSocket.ts
+++ b/frontend/src/hooks/useGameSocket.ts
@@ -12,6 +12,7 @@ import type {
   IncomingMessage,
   InteractionWsPayload,
   KudosReceivedPayload,
+  MailArrivedPayload,
   OutgoingMessage,
   RoomStatePayload,
   ScenePayload,
@@ -26,6 +27,7 @@ import type { RoulettePayload } from '@/components/roulette/types';
 import { handleBattleStatePayload } from './handleBattleStatePayload';
 import type { BattleStatePayload } from '@/battles/types';
 import { handleKudosReceivedPayload } from './handleKudosReceivedPayload';
+import { handleMailArrivedPayload } from './handleMailArrivedPayload';
 
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -153,6 +155,11 @@ export function useGameSocket() {
 
           if (msgType === WS_MESSAGE_TYPE.BATTLE_STATE) {
             handleBattleStatePayload(kwargs as unknown as BattleStatePayload);
+            return;
+          }
+
+          if (msgType === WS_MESSAGE_TYPE.MAIL_ARRIVED) {
+            handleMailArrivedPayload(kwargs as unknown as MailArrivedPayload);
             return;
           }
 

--- a/frontend/src/journals/__tests__/JournalComposerDialog.test.tsx
+++ b/frontend/src/journals/__tests__/JournalComposerDialog.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * JournalComposerDialog tests (#2160).
+ *
+ * Covers the create flow: the composer posts the exact payload the backend
+ * expects (title/body/is_public/tags) — including tags pre-seeded via
+ * `initialTags`, which Task 4's card action relies on — via a mocked
+ * `useCreateJournalEntry` mutation. No real network/api module involved.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { JournalComposerDialog } from '../components/JournalComposerDialog';
+
+vi.mock('../queries', () => ({
+  useCreateJournalEntry: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import * as queries from '../queries';
+import { toast } from 'sonner';
+
+function makeCreateMock() {
+  const mutateMock = vi.fn();
+  vi.mocked(queries.useCreateJournalEntry).mockReturnValue({
+    mutate: mutateMock,
+    isPending: false,
+  } as unknown as ReturnType<typeof queries.useCreateJournalEntry>);
+  return mutateMock;
+}
+
+describe('JournalComposerDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render when closed', () => {
+    makeCreateMock();
+    render(<JournalComposerDialog open={false} onClose={vi.fn()} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('pre-seeds the tag chip list from initialTags', () => {
+    makeCreateMock();
+    render(
+      <JournalComposerDialog open onClose={vi.fn()} initialTags={['grief', 'court intrigue']} />
+    );
+
+    const tagList = screen.getByTestId('journal-tag-list');
+    expect(tagList).toHaveTextContent('grief');
+    expect(tagList).toHaveTextContent('court intrigue');
+  });
+
+  it('posts the correct payload on submit, including pre-seeded tags — never comma-split', async () => {
+    const user = userEvent.setup();
+    const mutateMock = makeCreateMock();
+
+    render(<JournalComposerDialog open onClose={vi.fn()} initialTags={['grief', 'a, b']} />);
+
+    await user.type(screen.getByLabelText(/title/i), 'A Quiet Evening');
+    await user.type(screen.getByLabelText('Entry'), 'The rain fell softly on the manor roof.');
+
+    // Add one more tag via the chip input (typed then Enter — not comma-split).
+    const tagInput = screen.getByLabelText(/tags/i);
+    await user.type(tagInput, 'rain{Enter}');
+
+    await user.click(screen.getByRole('button', { name: /post entry/i }));
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      {
+        title: 'A Quiet Evening',
+        body: 'The rain fell softly on the manor roof.',
+        is_public: false,
+        tags: ['grief', 'a, b', 'rain'],
+      },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+    );
+  });
+
+  it('toggling public flips is_public in the submitted payload', async () => {
+    const user = userEvent.setup();
+    const mutateMock = makeCreateMock();
+
+    render(<JournalComposerDialog open onClose={vi.fn()} />);
+
+    await user.type(screen.getByLabelText(/title/i), 'Public Thoughts');
+    await user.type(screen.getByLabelText('Entry'), 'Body text here.');
+    await user.click(screen.getByLabelText(/public/i));
+
+    await user.click(screen.getByRole('button', { name: /post entry/i }));
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ is_public: true }),
+      expect.any(Object)
+    );
+  });
+
+  it('shows a success toast and closes on successful submit', async () => {
+    const user = userEvent.setup();
+    const mutateMock = makeCreateMock();
+    const onClose = vi.fn();
+    mutateMock.mockImplementation((_vars, callbacks) => {
+      callbacks?.onSuccess?.();
+    });
+
+    render(<JournalComposerDialog open onClose={onClose} />);
+
+    await user.type(screen.getByLabelText(/title/i), 'Title');
+    await user.type(screen.getByLabelText('Entry'), 'Body');
+    await user.click(screen.getByRole('button', { name: /post entry/i }));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Journal entry recorded.');
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('disables submit until both title and body are filled', async () => {
+    const user = userEvent.setup();
+    makeCreateMock();
+    render(<JournalComposerDialog open onClose={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /post entry/i })).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/title/i), 'Title only');
+    expect(screen.getByRole('button', { name: /post entry/i })).toBeDisabled();
+
+    await user.type(screen.getByLabelText('Entry'), 'Now with body text.');
+    expect(screen.getByRole('button', { name: /post entry/i })).not.toBeDisabled();
+  });
+});

--- a/frontend/src/journals/api.ts
+++ b/frontend/src/journals/api.ts
@@ -1,0 +1,174 @@
+/**
+ * Journals API functions (#2160).
+ *
+ * Thin `apiFetch` wrappers over `/api/journals/entries/`. Types are
+ * hand-authored (not sourced from `@/generated/api`) because
+ * `world.journals.views.JournalEntryViewSet` builds its responses from
+ * plain `serializers.Serializer`/`ModelSerializer` calls inside each method
+ * body rather than declaring `serializer_class` or `@extend_schema`
+ * annotations — `drf-spectacular` can't introspect the response shape, so
+ * every operation in `src/schema.json` for this app comes back "No response
+ * body". Mirrors the same precedent as `frontend/src/stories/types.ts`'s
+ * dashboard-endpoint types (see that app's CLAUDE.md "Common Gotchas").
+ *
+ * Keep these shapes in sync BY HAND with
+ * `src/world/journals/serializers.py` / `constants.py` if the backend
+ * changes.
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+import { readErrorDetail } from '@/lib/errors';
+
+const ENTRIES_URL = '/api/journals/entries';
+
+export type JournalResponseType = 'praise' | 'retort';
+
+export interface JournalTag {
+  id: number;
+  name: string;
+}
+
+/** Shape returned by the list/mine feeds (`JournalEntryListSerializer`). */
+export interface JournalEntrySummary {
+  id: number;
+  author: number;
+  author_name: string;
+  title: string;
+  is_public: boolean;
+  response_type: JournalResponseType | null;
+  parent: number | null;
+  created_at: string;
+  edited_at: string | null;
+  tags: JournalTag[];
+  response_count: number;
+}
+
+/** Shape returned by retrieve/create/respond (`JournalEntryDetailSerializer`). */
+export interface JournalEntryDetail {
+  id: number;
+  author: number;
+  author_name: string;
+  title: string;
+  body: string;
+  is_public: boolean;
+  response_type: JournalResponseType | null;
+  parent: number | null;
+  created_at: string;
+  edited_at: string | null;
+  tags: JournalTag[];
+  responses: JournalEntrySummary[];
+}
+
+export interface PaginatedJournalEntries {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: JournalEntrySummary[];
+}
+
+export interface JournalEntryListFilters {
+  /** CharacterSheet id — filter by author. */
+  author?: number;
+  /** Tag name — filter by tag. */
+  tag?: string;
+  page?: number;
+  page_size?: number;
+}
+
+export interface CreateJournalEntryRequest {
+  title: string;
+  body: string;
+  is_public: boolean;
+  /** Freeform chip tags — never comma-split; each entry is one tag. */
+  tags: string[];
+}
+
+export interface RespondToJournalRequest {
+  title: string;
+  body: string;
+  response_type: JournalResponseType;
+}
+
+function jsonHeaders(): HeadersInit {
+  return { 'Content-Type': 'application/json' };
+}
+
+function buildQuery(params: Record<string, string | number | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) search.set(key, String(value));
+  }
+  const qs = search.toString();
+  return qs ? `?${qs}` : '';
+}
+
+/**
+ * GET /api/journals/entries/
+ *
+ * Public feed. Supports `?author=` and `?tag=` filters, paginated
+ * (page_size default 20, per `JournalEntryPagination`).
+ */
+export async function listJournalEntries(
+  filters: JournalEntryListFilters = {}
+): Promise<PaginatedJournalEntries> {
+  const res = await apiFetch(`${ENTRIES_URL}/${buildQuery(filters)}`);
+  if (!res.ok) {
+    await readErrorDetail(res, 'Failed to load journal entries');
+  }
+  return res.json();
+}
+
+/**
+ * GET /api/journals/entries/mine/
+ *
+ * The requesting character's own entries, including private ones.
+ */
+export async function listMyJournalEntries(
+  params: { page?: number; page_size?: number } = {}
+): Promise<PaginatedJournalEntries> {
+  const res = await apiFetch(`${ENTRIES_URL}/mine/${buildQuery(params)}`);
+  if (!res.ok) {
+    await readErrorDetail(res, 'Failed to load your journal entries');
+  }
+  return res.json();
+}
+
+/** GET /api/journals/entries/{id}/ */
+export async function getJournalEntry(id: number): Promise<JournalEntryDetail> {
+  const res = await apiFetch(`${ENTRIES_URL}/${id}/`);
+  if (!res.ok) {
+    await readErrorDetail(res, 'Failed to load journal entry');
+  }
+  return res.json();
+}
+
+/** POST /api/journals/entries/ */
+export async function createJournalEntry(
+  body: CreateJournalEntryRequest
+): Promise<JournalEntryDetail> {
+  const res = await apiFetch(`${ENTRIES_URL}/`, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    await readErrorDetail(res, 'Failed to post journal entry');
+  }
+  return res.json();
+}
+
+/** POST /api/journals/entries/{id}/respond/ */
+export async function respondToJournal(
+  id: number,
+  body: RespondToJournalRequest
+): Promise<JournalEntryDetail> {
+  const res = await apiFetch(`${ENTRIES_URL}/${id}/respond/`, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    await readErrorDetail(res, 'Failed to respond to journal entry');
+  }
+  return res.json();
+}

--- a/frontend/src/journals/api.ts
+++ b/frontend/src/journals/api.ts
@@ -66,14 +66,17 @@ export interface PaginatedJournalEntries {
   results: JournalEntrySummary[];
 }
 
-export interface JournalEntryListFilters {
+// A `type` alias (not `interface`) so it structurally satisfies `buildQuery`'s
+// `Record<string, string | number | undefined>` parameter — TS only allows implicit
+// index-signature assignability for object type literals, not declared interfaces.
+export type JournalEntryListFilters = {
   /** CharacterSheet id — filter by author. */
   author?: number;
   /** Tag name — filter by tag. */
   tag?: string;
   page?: number;
   page_size?: number;
-}
+};
 
 export interface CreateJournalEntryRequest {
   title: string;

--- a/frontend/src/journals/components/JournalComposerDialog.tsx
+++ b/frontend/src/journals/components/JournalComposerDialog.tsx
@@ -1,0 +1,183 @@
+/**
+ * JournalComposerDialog — write a new journal entry (#2160).
+ *
+ * Externally controlled (`open`/`onClose`), following the
+ * `DramaticMomentTagDialog` pattern rather than owning its own trigger —
+ * both the sidebar `JournalTab` and `JournalsPage` open it from their own
+ * "Write" buttons. `initialTags` pre-seeds the chip list — Task 4's
+ * card-action "post about this" flow opens the composer with a tag already
+ * attached (e.g. a character or location name) so the entry gets tagged
+ * without the player re-typing it.
+ *
+ * Tags are a chip list, never a comma-split string — the backend's
+ * `tags` field is a `ListField` of exact strings
+ * (`JournalEntryCreateSerializer`), so splitting on commas would silently
+ * mangle any tag that legitimately contains one.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { useCreateJournalEntry } from '../queries';
+
+interface JournalComposerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Tags to pre-seed the chip list with when the dialog opens. */
+  initialTags?: string[];
+}
+
+export function JournalComposerDialog({ open, onClose, initialTags }: JournalComposerDialogProps) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagDraft, setTagDraft] = useState('');
+
+  const createEntry = useCreateJournalEntry();
+
+  // Reset (and re-seed tags) only on the closed->open transition, not on
+  // every render while the dialog stays open — otherwise a parent that
+  // passes a fresh `initialTags` array literal each render would keep
+  // wiping out whatever the player has already typed.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (open && !wasOpenRef.current) {
+      setTitle('');
+      setBody('');
+      setIsPublic(false);
+      setTags(initialTags ?? []);
+      setTagDraft('');
+    }
+    wasOpenRef.current = open;
+  }, [open, initialTags]);
+
+  function handleOpenChange(isOpen: boolean) {
+    if (!isOpen) onClose();
+  }
+
+  function addTagFromDraft() {
+    const value = tagDraft.trim();
+    if (!value) return;
+    setTags((prev) => (prev.includes(value) ? prev : [...prev, value]));
+    setTagDraft('');
+  }
+
+  function handleTagKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addTagFromDraft();
+    } else if (e.key === 'Backspace' && tagDraft === '' && tags.length > 0) {
+      setTags((prev) => prev.slice(0, -1));
+    }
+  }
+
+  function removeTag(tag: string) {
+    setTags((prev) => prev.filter((t) => t !== tag));
+  }
+
+  function handleSubmit() {
+    if (!title.trim() || !body.trim() || createEntry.isPending) return;
+    createEntry.mutate(
+      { title: title.trim(), body, is_public: isPublic, tags },
+      {
+        onSuccess: () => {
+          toast.success('Journal entry recorded.');
+          onClose();
+        },
+        onError: (err) => {
+          toast.error(err instanceof Error ? err.message : 'Failed to post journal entry');
+        },
+      }
+    );
+  }
+
+  const canSubmit = title.trim().length > 0 && body.trim().length > 0 && !createEntry.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Write a Journal Entry</DialogTitle>
+          <DialogDescription>
+            Private entries are visible only to you. Public entries can be read — and praised or
+            retorted — by anyone.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="journal-title">Title</Label>
+            <Input
+              id="journal-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="A title for this entry"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="journal-body">Entry</Label>
+            <Textarea
+              id="journal-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="What's on your mind…"
+              className="min-h-[160px]"
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="journal-public">Public</Label>
+            <Switch id="journal-public" checked={isPublic} onCheckedChange={setIsPublic} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="journal-tag-input">Tags</Label>
+            {tags.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5" data-testid="journal-tag-list">
+                {tags.map((tag) => (
+                  <Badge key={tag} variant="secondary" className="gap-1 pr-1">
+                    {tag}
+                    <button
+                      type="button"
+                      onClick={() => removeTag(tag)}
+                      aria-label={`Remove tag ${tag}`}
+                      className="rounded-full px-1 hover:bg-secondary-foreground/10"
+                    >
+                      ×
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+            <Input
+              id="journal-tag-input"
+              value={tagDraft}
+              onChange={(e) => setTagDraft(e.target.value)}
+              onKeyDown={handleTagKeyDown}
+              onBlur={addTagFromDraft}
+              placeholder="Type a tag and press Enter"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={createEntry.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>
+            {createEntry.isPending ? 'Posting…' : 'Post Entry'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/journals/components/JournalTab.tsx
+++ b/frontend/src/journals/components/JournalTab.tsx
@@ -1,0 +1,67 @@
+/**
+ * JournalTab — the sidebar "Journal" tab content (#2160).
+ *
+ * A compose button (opens `JournalComposerDialog`) plus the player's 5
+ * most recent entries (title + date, linking through to `/journals` for
+ * the full page). Responses-to-me isn't surfaced here — the `mine/` feed
+ * doesn't return a per-entry "who responded to this" count cheaply (only
+ * `response_count`, which includes the author's own follow-ups), so a real
+ * "responses to me" count would need a new backend shape; out of scope for
+ * this task per the brief (no backend changes).
+ */
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { PenLine } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useMyJournalEntries } from '../queries';
+import { JournalComposerDialog } from './JournalComposerDialog';
+
+export function JournalTab() {
+  const [composerOpen, setComposerOpen] = useState(false);
+  const { data, isLoading } = useMyJournalEntries();
+  const recent = (data?.results ?? []).slice(0, 5);
+
+  return (
+    <div className="space-y-3 p-3">
+      <Button
+        size="sm"
+        className="w-full gap-1.5"
+        onClick={() => setComposerOpen(true)}
+        data-testid="journal-tab-compose"
+      >
+        <PenLine className="h-3.5 w-3.5" />
+        Write an entry
+      </Button>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : recent.length === 0 ? (
+        <p className="text-sm text-muted-foreground" data-testid="journal-tab-empty">
+          You haven&apos;t written anything yet.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {recent.map((entry) => (
+            <li key={entry.id}>
+              <Link
+                to="/journals"
+                className="block rounded border px-2 py-1.5 text-sm hover:bg-accent"
+              >
+                <span className="block truncate font-medium">{entry.title}</span>
+                <span className="block text-xs text-muted-foreground">
+                  {new Date(entry.created_at).toLocaleDateString()}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Link to="/journals" className="block text-xs text-muted-foreground underline">
+        Full journal →
+      </Link>
+
+      <JournalComposerDialog open={composerOpen} onClose={() => setComposerOpen(false)} />
+    </div>
+  );
+}

--- a/frontend/src/journals/pages/JournalsPage.tsx
+++ b/frontend/src/journals/pages/JournalsPage.tsx
@@ -1,0 +1,317 @@
+/**
+ * JournalsPage — `/journals` (#2160).
+ *
+ * Two sections: "My Journal" (`mine/`, includes private entries, with a
+ * "Write" button opening `JournalComposerDialog`) and "Public Journals" (the
+ * public feed, filterable by author id / tag name, paginated). Rows expand
+ * in place to the full entry — body, tags, and (public entries) a
+ * Praise/Retort response form plus existing responses.
+ */
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { toast } from 'sonner';
+import type { JournalEntrySummary, JournalResponseType } from '../api';
+import {
+  useJournalEntries,
+  useJournalEntry,
+  useMyJournalEntries,
+  useRespondToJournal,
+} from '../queries';
+import { JournalComposerDialog } from '../components/JournalComposerDialog';
+
+export function JournalsPage() {
+  const [composerOpen, setComposerOpen] = useState(false);
+
+  return (
+    <div className="container mx-auto max-w-3xl space-y-8 px-4 py-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Journals</h1>
+        <Button onClick={() => setComposerOpen(true)}>Write</Button>
+      </div>
+
+      <MyJournalSection />
+      <PublicJournalsSection />
+
+      <JournalComposerDialog open={composerOpen} onClose={() => setComposerOpen(false)} />
+    </div>
+  );
+}
+
+function MyJournalSection() {
+  const [page, setPage] = useState(1);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const { data, isLoading } = useMyJournalEntries(page);
+  const entries = data?.results ?? [];
+
+  return (
+    <section className="space-y-3" data-testid="my-journal-section">
+      <h2 className="text-lg font-medium">My Journal</h2>
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : entries.length === 0 ? (
+        <p className="text-sm text-muted-foreground">You haven&apos;t written anything yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {entries.map((entry) => (
+            <EntryRow
+              key={entry.id}
+              entry={entry}
+              expanded={expandedId === entry.id}
+              onToggle={() => setExpandedId(expandedId === entry.id ? null : entry.id)}
+              showResponseForm={false}
+            />
+          ))}
+        </div>
+      )}
+      <PaginationControls
+        page={page}
+        onPrev={() => setPage((p) => Math.max(1, p - 1))}
+        onNext={() => setPage((p) => p + 1)}
+        hasNext={!!data?.next}
+        hasPrev={!!data?.previous}
+      />
+    </section>
+  );
+}
+
+function PublicJournalsSection() {
+  const [page, setPage] = useState(1);
+  const [authorFilter, setAuthorFilter] = useState('');
+  const [tagFilter, setTagFilter] = useState('');
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  const author = authorFilter.trim() ? Number(authorFilter.trim()) : undefined;
+  const tag = tagFilter.trim() || undefined;
+
+  const { data, isLoading } = useJournalEntries({ page, author, tag: tag || undefined });
+  const entries = data?.results ?? [];
+
+  return (
+    <section className="space-y-3" data-testid="public-journals-section">
+      <h2 className="text-lg font-medium">Public Journals</h2>
+      <div className="flex flex-wrap gap-2">
+        <div className="space-y-1">
+          <Label htmlFor="filter-author">Author (character id)</Label>
+          <Input
+            id="filter-author"
+            value={authorFilter}
+            onChange={(e) => {
+              setAuthorFilter(e.target.value);
+              setPage(1);
+            }}
+            placeholder="e.g. 42"
+            className="w-40"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="filter-tag">Tag</Label>
+          <Input
+            id="filter-tag"
+            value={tagFilter}
+            onChange={(e) => {
+              setTagFilter(e.target.value);
+              setPage(1);
+            }}
+            placeholder="e.g. grief"
+            className="w-40"
+          />
+        </div>
+      </div>
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : entries.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No public entries found.</p>
+      ) : (
+        <div className="space-y-2">
+          {entries.map((entry) => (
+            <EntryRow
+              key={entry.id}
+              entry={entry}
+              expanded={expandedId === entry.id}
+              onToggle={() => setExpandedId(expandedId === entry.id ? null : entry.id)}
+              showResponseForm
+            />
+          ))}
+        </div>
+      )}
+      <PaginationControls
+        page={page}
+        onPrev={() => setPage((p) => Math.max(1, p - 1))}
+        onNext={() => setPage((p) => p + 1)}
+        hasNext={!!data?.next}
+        hasPrev={!!data?.previous}
+      />
+    </section>
+  );
+}
+
+function PaginationControls({
+  page,
+  onPrev,
+  onNext,
+  hasPrev,
+  hasNext,
+}: {
+  page: number;
+  onPrev: () => void;
+  onNext: () => void;
+  hasPrev: boolean;
+  hasNext: boolean;
+}) {
+  if (!hasPrev && !hasNext) return null;
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="sm" onClick={onPrev} disabled={!hasPrev}>
+        Previous
+      </Button>
+      <span className="text-sm text-muted-foreground">Page {page}</span>
+      <Button variant="outline" size="sm" onClick={onNext} disabled={!hasNext}>
+        Next
+      </Button>
+    </div>
+  );
+}
+
+function EntryRow({
+  entry,
+  expanded,
+  onToggle,
+  showResponseForm,
+}: {
+  entry: JournalEntrySummary;
+  expanded: boolean;
+  onToggle: () => void;
+  showResponseForm: boolean;
+}) {
+  return (
+    <Card>
+      <button type="button" className="block w-full text-left" onClick={onToggle}>
+        <CardHeader className="p-4">
+          <div className="flex items-center justify-between gap-2">
+            <CardTitle className="text-base">{entry.title}</CardTitle>
+            {!entry.is_public ? <Badge variant="outline">Private</Badge> : null}
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+            <span>{entry.author_name}</span>
+            <span>·</span>
+            <span>{new Date(entry.created_at).toLocaleDateString()}</span>
+            {entry.response_count > 0 ? (
+              <>
+                <span>·</span>
+                <span>
+                  {entry.response_count} response{entry.response_count === 1 ? '' : 's'}
+                </span>
+              </>
+            ) : null}
+            {entry.tags.map((tag) => (
+              <Badge key={tag.id} variant="secondary">
+                {tag.name}
+              </Badge>
+            ))}
+          </div>
+        </CardHeader>
+      </button>
+      {expanded ? (
+        <CardContent className="p-4 pt-0">
+          <EntryDetail entryId={entry.id} showResponseForm={showResponseForm} />
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}
+
+function EntryDetail({
+  entryId,
+  showResponseForm,
+}: {
+  entryId: number;
+  showResponseForm: boolean;
+}) {
+  const { data: detail, isLoading } = useJournalEntry(entryId);
+
+  if (isLoading || !detail) {
+    return <p className="text-sm text-muted-foreground">Loading…</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="whitespace-pre-wrap text-sm">{detail.body}</p>
+
+      {detail.responses.length > 0 ? (
+        <div className="space-y-2 border-l-2 pl-3">
+          {detail.responses.map((response) => (
+            <div key={response.id} className="text-sm">
+              <span className="font-medium">{response.author_name}</span>{' '}
+              <Badge variant={response.response_type === 'praise' ? 'default' : 'destructive'}>
+                {response.response_type}
+              </Badge>
+              <p className="mt-0.5">{response.title}</p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {showResponseForm ? <RespondForm entryId={entryId} /> : null}
+    </div>
+  );
+}
+
+function RespondForm({ entryId }: { entryId: number }) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const respond = useRespondToJournal();
+
+  function submit(responseType: JournalResponseType) {
+    if (!title.trim() || !body.trim() || respond.isPending) return;
+    respond.mutate(
+      { entryId, body: { title: title.trim(), body, response_type: responseType } },
+      {
+        onSuccess: () => {
+          toast.success(responseType === 'praise' ? 'Praise sent.' : 'Retort sent.');
+          setTitle('');
+          setBody('');
+        },
+        onError: (err) => {
+          toast.error(err instanceof Error ? err.message : 'Failed to respond');
+        },
+      }
+    );
+  }
+
+  const canSubmit = title.trim().length > 0 && body.trim().length > 0 && !respond.isPending;
+
+  return (
+    <div className="space-y-2 border-t pt-3">
+      <Label htmlFor={`respond-title-${entryId}`}>Respond</Label>
+      <Input
+        id={`respond-title-${entryId}`}
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="A title for your response"
+      />
+      <Textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Praise or retort…"
+      />
+      <div className="flex gap-2">
+        <Button size="sm" disabled={!canSubmit} onClick={() => submit('praise')}>
+          Praise
+        </Button>
+        <Button
+          size="sm"
+          variant="destructive"
+          disabled={!canSubmit}
+          onClick={() => submit('retort')}
+        >
+          Retort
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/journals/queries.ts
+++ b/frontend/src/journals/queries.ts
@@ -1,0 +1,81 @@
+/**
+ * React Query hooks for the journals module (#2160).
+ *
+ * Follows the key-factory + hook shape used by `frontend/src/relationships/queries.ts`.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import * as api from './api';
+import type {
+  CreateJournalEntryRequest,
+  JournalEntryListFilters,
+  RespondToJournalRequest,
+} from './api';
+
+export const journalsKeys = {
+  all: ['journals'] as const,
+  lists: () => [...journalsKeys.all, 'list'] as const,
+  list: (filters: JournalEntryListFilters = {}) => [...journalsKeys.lists(), filters] as const,
+  mine: (page = 1) => [...journalsKeys.all, 'mine', page] as const,
+  detail: (id: number) => [...journalsKeys.all, 'detail', id] as const,
+};
+
+/** GET /api/journals/entries/ — public feed, optionally filtered by author/tag. */
+export function useJournalEntries(filters: JournalEntryListFilters = {}) {
+  return useQuery({
+    queryKey: journalsKeys.list(filters),
+    queryFn: () => api.listJournalEntries(filters),
+  });
+}
+
+/** GET /api/journals/entries/mine/ — the viewer's own entries, including private. */
+export function useMyJournalEntries(page = 1) {
+  return useQuery({
+    queryKey: journalsKeys.mine(page),
+    queryFn: () => api.listMyJournalEntries({ page }),
+  });
+}
+
+/** GET /api/journals/entries/{id}/ — a single entry with its responses. */
+export function useJournalEntry(id: number | null, enabled = true) {
+  return useQuery({
+    queryKey: journalsKeys.detail(id ?? -1),
+    queryFn: () => api.getJournalEntry(id as number),
+    enabled: enabled && id != null,
+  });
+}
+
+/**
+ * POST /api/journals/entries/ — write a new entry. Invalidates the public
+ * feed and "mine" lists so the new entry (and its weekly-XP-driven counters)
+ * show up without a manual refetch.
+ */
+export function useCreateJournalEntry() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateJournalEntryRequest) => api.createJournalEntry(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: journalsKeys.lists() }).catch(() => {});
+      queryClient.invalidateQueries({ queryKey: journalsKeys.all }).catch(() => {});
+    },
+  });
+}
+
+/**
+ * POST /api/journals/entries/{id}/respond/ — praise or retort a parent entry.
+ * Invalidates the parent's detail (its `responses` list grows) plus the
+ * public/mine feeds (`response_count` changes).
+ */
+export function useRespondToJournal() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ entryId, body }: { entryId: number; body: RespondToJournalRequest }) =>
+      api.respondToJournal(entryId, body),
+    onSuccess: (_data, { entryId }) => {
+      queryClient.invalidateQueries({ queryKey: journalsKeys.detail(entryId) }).catch(() => {});
+      queryClient.invalidateQueries({ queryKey: journalsKeys.lists() }).catch(() => {});
+      queryClient.invalidateQueries({ queryKey: journalsKeys.mine() }).catch(() => {});
+    },
+  });
+}

--- a/frontend/src/mail/api.ts
+++ b/frontend/src/mail/api.ts
@@ -27,3 +27,22 @@ export async function searchTenures(term: string): Promise<PaginatedResponse<Ros
   }
   return res.json();
 }
+
+/** Mark a received letter as read (idempotent; recipient-only via the scoped queryset). */
+export async function markMailRead(id: number): Promise<PlayerMail> {
+  const res = await apiFetch(`/api/roster/mail/${id}/mark-read/`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error('Failed to mark mail as read');
+  }
+  return res.json();
+}
+
+/** Count of unread, unarchived mail across the requester's tenures. */
+export async function fetchUnreadMailCount(): Promise<number> {
+  const res = await apiFetch('/api/roster/mail/unread-count/');
+  if (!res.ok) {
+    throw new Error('Failed to load unread mail count');
+  }
+  const data: { count: number } = await res.json();
+  return data.count;
+}

--- a/frontend/src/mail/components/ComposeMailForm.tsx
+++ b/frontend/src/mail/components/ComposeMailForm.tsx
@@ -11,11 +11,32 @@ import MyTenureSelect from '@/components/MyTenureSelect';
 interface Props {
   replyTo?: PlayerMail | null;
   onSent?: () => void;
+  /**
+   * Pre-fill props for a "compose to a specific character" quick action
+   * (#2160's character-card "Send a letter"). When `initialRecipientTenureId`
+   * is set, the recipient row renders a static "To: {initialRecipientDisplay}"
+   * label instead of `TenureSearch` — that component's display text is
+   * internal state we can't hand it from outside.
+   */
+  initialRecipientTenureId?: number;
+  initialRecipientDisplay?: string;
+  /**
+   * When set, hides `MyTenureSelect` and sends from this tenure — only pass
+   * this when the sender is unambiguous (a single active tenure resolvable
+   * from context); otherwise omit it and let the player pick among theirs.
+   */
+  fixedSenderTenureId?: number;
 }
 
-export function ComposeMailForm({ replyTo, onSent }: Props) {
-  const [recipient, setRecipient] = useState<number | null>(null);
-  const [senderTenure, setSenderTenure] = useState<number | null>(null);
+export function ComposeMailForm({
+  replyTo,
+  onSent,
+  initialRecipientTenureId,
+  initialRecipientDisplay,
+  fixedSenderTenureId,
+}: Props) {
+  const [recipient, setRecipient] = useState<number | null>(initialRecipientTenureId ?? null);
+  const [senderTenure, setSenderTenure] = useState<number | null>(fixedSenderTenureId ?? null);
   const [subject, setSubject] = useState('');
   const [message, setMessage] = useState('');
   const sendMail = useSendMail();
@@ -35,6 +56,21 @@ export function ComposeMailForm({ replyTo, onSent }: Props) {
     }
   }, [replyTo]);
 
+  // Syncs the pre-filled recipient/sender when a parent hands us a new one
+  // (e.g. the character-card "Send a letter" dialog is reused for a
+  // different character without remounting this form).
+  useEffect(() => {
+    if (initialRecipientTenureId != null) {
+      setRecipient(initialRecipientTenureId);
+    }
+  }, [initialRecipientTenureId]);
+
+  useEffect(() => {
+    if (fixedSenderTenureId != null) {
+      setSenderTenure(fixedSenderTenureId);
+    }
+  }, [fixedSenderTenureId]);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!recipient || !senderTenure) return;
@@ -49,8 +85,11 @@ export function ComposeMailForm({ replyTo, onSent }: Props) {
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ['mail'] });
-          setRecipient(null);
-          setSenderTenure(null);
+          // Restore to the fixed pre-fill (if any) rather than blanking it —
+          // a reused mounted form (dialog stays mounted while closed, see
+          // JournalComposerDialog) must stay valid to send again.
+          setRecipient(initialRecipientTenureId ?? null);
+          setSenderTenure(fixedSenderTenureId ?? null);
           setSubject('');
           setMessage('');
           onSent?.();
@@ -62,8 +101,16 @@ export function ComposeMailForm({ replyTo, onSent }: Props) {
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
       <div className="flex gap-2">
-        <TenureSearch value={recipient} onChange={(id) => setRecipient(id)} />
-        <MyTenureSelect value={senderTenure} onChange={setSenderTenure} />
+        {initialRecipientTenureId != null ? (
+          <div className="flex w-64 flex-col justify-end pb-1">
+            <span className="text-sm font-medium">To: {initialRecipientDisplay}</span>
+          </div>
+        ) : (
+          <TenureSearch value={recipient} onChange={(id) => setRecipient(id)} />
+        )}
+        {fixedSenderTenureId == null && (
+          <MyTenureSelect value={senderTenure} onChange={setSenderTenure} />
+        )}
       </div>
       <Input placeholder="Subject" value={subject} onChange={(e) => setSubject(e.target.value)} />
       <Textarea

--- a/frontend/src/mail/components/ReceivedMailList.tsx
+++ b/frontend/src/mail/components/ReceivedMailList.tsx
@@ -1,14 +1,66 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { useMailQuery } from '../queries';
+import { useMailQuery, useMarkMailRead } from '../queries';
 import type { PlayerMail } from '../types';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 
 interface Props {
   page: number;
   onPageChange: (page: number) => void;
   onReply: (mail: PlayerMail) => void;
+}
+
+interface MailRowProps {
+  mail: PlayerMail;
+  onReply: (mail: PlayerMail) => void;
+}
+
+function MailRow({ mail, onReply }: MailRowProps) {
+  const isUnread = mail.read_date === null;
+  const { mutate: markRead } = useMarkMailRead(mail.id);
+
+  return (
+    <AccordionItem value={String(mail.id)} className="border-none">
+      <Card className="p-4">
+        <AccordionTrigger
+          className="p-0 hover:no-underline"
+          onClick={() => {
+            if (isUnread) markRead();
+          }}
+        >
+          <span className="flex items-center gap-2 text-left">
+            {isUnread && (
+              <span className="h-2 w-2 shrink-0 rounded-full bg-red-500" aria-label="Unread" />
+            )}
+            <span className={cn(isUnread && 'font-medium')}>{mail.subject}</span>
+          </span>
+        </AccordionTrigger>
+        <AccordionContent className="p-0 pt-2">
+          <div className="mb-2 flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              From {mail.sender_display} on {new Date(mail.sent_date).toLocaleString()}
+            </p>
+            {mail.sender_tenure && (
+              <Button size="sm" onClick={() => onReply(mail)}>
+                Reply
+              </Button>
+            )}
+          </div>
+          <div className="prose mt-2 max-w-none text-sm">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{mail.message}</ReactMarkdown>
+          </div>
+        </AccordionContent>
+      </Card>
+    </AccordionItem>
+  );
 }
 
 export function ReceivedMailList({ page, onPageChange, onReply }: Props) {
@@ -24,26 +76,11 @@ export function ReceivedMailList({ page, onPageChange, onReply }: Props) {
 
   return (
     <div className="space-y-2">
-      {data?.results.map((mail) => (
-        <Card key={mail.id} className="p-4">
-          <CardHeader className="mb-2 flex items-center justify-between p-0">
-            <CardTitle>{mail.subject}</CardTitle>
-            {mail.sender_tenure && (
-              <Button size="sm" onClick={() => onReply(mail)}>
-                Reply
-              </Button>
-            )}
-          </CardHeader>
-          <CardContent className="p-0">
-            <p className="text-sm text-muted-foreground">
-              From {mail.sender_display} on {new Date(mail.sent_date).toLocaleString()}
-            </p>
-            <div className="prose mt-2 max-w-none text-sm">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{mail.message}</ReactMarkdown>
-            </div>
-          </CardContent>
-        </Card>
-      ))}
+      <Accordion type="multiple" className="space-y-2">
+        {data?.results.map((mail) => (
+          <MailRow key={mail.id} mail={mail} onReply={onReply} />
+        ))}
+      </Accordion>
       <div className="flex gap-2">
         <Button onClick={prevPage} disabled={!data?.previous}>
           Previous

--- a/frontend/src/mail/components/UnreadMailBadge.tsx
+++ b/frontend/src/mail/components/UnreadMailBadge.tsx
@@ -1,0 +1,30 @@
+/**
+ * Unread letter counter badge for the top-level navigation.
+ *
+ * Shows a red badge with the count of unread received mail across the
+ * player's tenures. Clicking navigates to the mail inbox. Mirrors
+ * `UnreadNarrativeBadge` (frontend/src/narrative/components/UnreadNarrativeBadge.tsx).
+ */
+
+import { Link } from 'react-router-dom';
+import { Badge } from '@/components/ui/badge';
+import { useUnreadMailCount } from '@/mail/queries';
+
+export function UnreadMailBadge() {
+  const count = useUnreadMailCount();
+
+  if (count === 0) return null;
+
+  return (
+    <Link
+      to="/profile/mail"
+      className="flex items-center gap-1.5"
+      aria-label={`Letters, ${count} unread ${count === 1 ? 'letter' : 'letters'}`}
+    >
+      Letters
+      <Badge variant="destructive" className="bg-red-600 hover:bg-red-700">
+        {count}
+      </Badge>
+    </Link>
+  );
+}

--- a/frontend/src/mail/queries.ts
+++ b/frontend/src/mail/queries.ts
@@ -1,11 +1,18 @@
-import { useQuery, useMutation } from '@tanstack/react-query';
-import { fetchMail, sendMail, searchTenures } from './api';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { fetchMail, sendMail, searchTenures, markMailRead, fetchUnreadMailCount } from './api';
 import type { PlayerMail, MailFormData, RosterTenureOption } from './types';
 import type { PaginatedResponse } from '@/shared/types';
+import { useAccount } from '@/store/hooks';
+
+export const mailKeys = {
+  all: ['mail'] as const,
+  list: (page: number) => [...mailKeys.all, page] as const,
+  unreadCount: () => [...mailKeys.all, 'unread-count'] as const,
+};
 
 export function useMailQuery(page: number) {
   return useQuery<PaginatedResponse<PlayerMail>>({
-    queryKey: ['mail', page],
+    queryKey: mailKeys.list(page),
     queryFn: () => fetchMail(page),
     throwOnError: true,
   });
@@ -24,4 +31,31 @@ export function useTenureSearch(term: string) {
     enabled: term.length > 1,
     throwOnError: true,
   });
+}
+
+/** Marks a single received letter read; invalidates the mail list + unread count on success. */
+export function useMarkMailRead(id: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => markMailRead(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: mailKeys.all }).catch(() => {});
+    },
+  });
+}
+
+/**
+ * Unread-letter count for the "Letters" header badge — mirrors
+ * `useUnreadNarrativeCount` (REST count query, guarded on auth so the query
+ * doesn't fire on unauthenticated page loads like the login page).
+ */
+export function useUnreadMailCount() {
+  const account = useAccount();
+  const { data } = useQuery({
+    queryKey: mailKeys.unreadCount(),
+    queryFn: fetchUnreadMailCount,
+    enabled: !!account,
+    throwOnError: true,
+  });
+  return data ?? 0;
 }

--- a/frontend/src/mail/queries.ts
+++ b/frontend/src/mail/queries.ts
@@ -55,7 +55,8 @@ export function useUnreadMailCount() {
     queryKey: mailKeys.unreadCount(),
     queryFn: fetchUnreadMailCount,
     enabled: !!account,
-    throwOnError: true,
+    // No throwOnError: a nav badge must fail silent (0 → hidden), never
+    // detonate the Header tree. Mirrors UnreadNarrativeBadge.
   });
   return data ?? 0;
 }

--- a/frontend/src/missions/components/StoryTray.tsx
+++ b/frontend/src/missions/components/StoryTray.tsx
@@ -34,7 +34,7 @@ export function StoryTray({ roomKey }: StoryTrayProps) {
     return (
       <div className="space-y-2 p-3 text-sm text-muted-foreground" data-testid="story-tray-empty">
         <p>No stories pull at you right now.</p>
-        <Link to="/journal" className="text-xs underline">
+        <Link to="/missions/journal" className="text-xs underline">
           Open your journal
         </Link>
       </div>
@@ -53,7 +53,7 @@ export function StoryTray({ roomKey }: StoryTrayProps) {
         />
       ))}
       <div className="px-1">
-        <Link to="/journal" className="text-xs text-muted-foreground underline">
+        <Link to="/missions/journal" className="text-xs text-muted-foreground underline">
           Full journal →
         </Link>
       </div>

--- a/src/schema.json
+++ b/src/schema.json
@@ -24150,6 +24150,44 @@ paths:
               schema:
                 $ref: '#/components/schemas/PlayerMail'
           description: ''
+  /api/roster/mail/{id}/mark-read/:
+    post:
+      operationId: roster_mail_mark_read_create
+      description: Mark this mail as read (idempotent). Recipient-only via the scoped
+        queryset.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this player mail.
+        required: true
+      tags:
+      - roster
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlayerMail'
+          description: ''
+  /api/roster/mail/unread-count/:
+    get:
+      operationId: roster_mail_unread_count_retrieve
+      description: Count of unread, unarchived mail across the requester's tenures.
+      tags:
+      - roster
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnreadMailCount'
+          description: ''
   /api/roster/media/:
     get:
       operationId: roster_media_list
@@ -60545,6 +60583,16 @@ components:
         * `class_level` - Class Level
         * `thread_xp_lock` - Thread XP Lock
         * `skill_breakthrough` - Skill Breakthrough
+    UnreadMailCount:
+      type: object
+      description: Response shape for ``PlayerMailViewSet.unread_count`` -- schema
+        only, never a model.
+      properties:
+        count:
+          type: integer
+          readOnly: true
+      required:
+      - count
     UpdateBulletinPostInput:
       type: object
       description: |-

--- a/src/web/webclient/message_types.py
+++ b/src/web/webclient/message_types.py
@@ -20,6 +20,7 @@ class WebsocketMessageType(str, Enum):
     ROULETTE_RESULT = "roulette_result"
     BATTLE_STATE = "battle_state"
     KUDOS_RECEIVED = "kudos_received"
+    MAIL_ARRIVED = "mail_arrived"
 
 
 @dataclass
@@ -146,3 +147,18 @@ class KudosReceivedPayload:
     amount: int
     source_category: str
     description: str
+
+
+@dataclass
+class MailArrivedPayload:
+    """Payload for ``mail_arrived`` messages.
+
+    Anonymity boundary (#2160): tenure-display-only. ``sender_display`` is the sender tenure's
+    display name (e.g. "1st player of Ariel"), never an account id or username -- carrying either
+    would let the recipient unmask the sender's real player. Clients refetch the mail list /
+    unread count on receipt; this is a slim arrival ping, not the mail body.
+    """
+
+    mail_id: int
+    sender_display: str
+    subject: str

--- a/src/world/journals/AGENT_GLOSSARY.md
+++ b/src/world/journals/AGENT_GLOSSARY.md
@@ -1,0 +1,36 @@
+# Journals glossary
+
+Domain-local vocabulary for `world.journals` (the diary/reflection system, #2160). Root terms
+live in `AGENT_GLOSSARY_MAP.md`.
+
+- **Journal Entry** — a `JournalEntry`: a character's own diary/reflection writing, public or
+  private, authored by their `CharacterSheet`. This is the canonical "journal" — free-text,
+  player-voiced, no mechanical parsing. Web surface: `/journals` (composer, feed, own-entries
+  tab) plus a `JournalTab` quick-compose in the in-scene sidebar; telnet: `journal
+  write|respond|edit`. _Avoid:_ **the journal** unqualified when another app's homonym is in
+  scope — see Disambiguation below.
+- **Praise** — a `JournalEntry` with `response_type=praise`, a self-FK response to another
+  entry (via `parent`). Affirms the parent entry; awards weekly XP to both the giver and the
+  receiver.
+- **Retort** — a `JournalEntry` with `response_type=retort`, the antagonistic counterpart to
+  Praise. Also a threaded response via `parent`; awards weekly XP asymmetrically (retort given
+  is worth less than retort received — see `journals/CLAUDE.md`'s XP schedule).
+- **Weekly Journal XP** — `WeeklyJournalXP`, a per-character rolling 7-day counter
+  (`posts_this_week`, praise/retort given/received flags) gating the diminishing per-post XP
+  award. Resets on a timestamp check, not a scheduled job — same pattern as `relationships`.
+
+## Disambiguation — "journal" is a homonym across apps
+
+Three unrelated systems use the word "journal." Always qualify which one is meant:
+
+- **This app's Journal Entry** (above) — a diary/reflection post.
+- **The missions ledger** — `world.missions` calls its per-run activity record "the journal"
+  (`/api/missions/journal/`, moved off the `/journal` web route in #2160 to free the namespace
+  for this app). Per `missions/AGENT_GLOSSARY.md`: "the journal is the ledger; the tale is the
+  narration" — the missions journal is a structured run ledger, not free-text reflection, and
+  its player-authored counterpart is the `MissionRunTale`, not a Journal Entry.
+  _Avoid:_ calling the missions ledger "a journal entry" — that phrase means this app's model.
+- **The held-clue journal** — `world.clues`' read surface
+  (`GET /api/clues/held/`, `HeldClueSerializer`) is informally called "the held-clue journal" in
+  `docs/systems/INDEX.md` — a scoped list of clues a character holds, not a writable diary and
+  not owned by this app.

--- a/src/world/roster/AGENT_GLOSSARY.md
+++ b/src/world/roster/AGENT_GLOSSARY.md
@@ -51,3 +51,14 @@ kinship graph). Root terms live in `AGENT_GLOSSARY_MAP.md`.
   end reasons (disowned / married-out / renounced / annulled), with dates.
   `Kinsperson.family` is only the surname denorm of the active primary
   claim. _Avoid:_ family as a container that owns people.
+- **Letter (PlayerMail)** — a `PlayerMail` row: private, tenure-to-tenure
+  correspondence (`sender_tenure` → `recipient_tenure`, threaded via
+  `in_reply_to`), routed by `RosterTenure` rather than `AccountDB` so it
+  preserves player-anonymity: the recipient is addressed and displayed as
+  the current player of a character, never by account (#2160,
+  ADR-0116). Web is the letters surface — compose/inbox at
+  `/profile/mail`, an in-scene quick-compose from the character card, an
+  unread badge, and a `MAIL_ARRIVED` websocket push on send; there is
+  deliberately no telnet mail command. _Avoid:_ "mail Ariel" as a telnet
+  verb (retired aspiration, never built); messenger/courier (a distinct,
+  not-yet-built in-fiction delivery layer — see ADR-0116).

--- a/src/world/roster/CLAUDE.md
+++ b/src/world/roster/CLAUDE.md
@@ -52,7 +52,10 @@ This file provides specific guidance for working with the roster system in Arx I
 
 ### Extended Models (evennia_extensions/models.py)
 - **PlayerData**: Extends AccountDB with player preferences and session tracking
-- **PlayerMail**: Mail system with tenure targeting ("mail Ariel" → routes to current player)
+- **PlayerMail**: Letters (mail) with tenure-to-tenure targeting, routed by `RosterTenure` so the
+  current player of a character receives it regardless of who that is. Web-only surface
+  (`/profile/mail` + in-scene quick-compose); no telnet mail command exists or is planned
+  (ADR-0116).
 - **PlayerAllowList/PlayerBlockList**: Social lists for player communication
 
 ## Command Implementation Guidelines
@@ -78,10 +81,15 @@ When implementing commands like `@ic`, `@characters`, `@apply`:
 - System updates PlayerData.current_character field
 - Must verify character is available via active RosterTenure
 
-### Mail System
-- Players send "mail Ariel" targeting character names
-- System routes to current player via RosterTenure.recipient_tenure
+### Mail System (Letters)
+- Web-only: players compose at `/profile/mail`, or quick-compose in-scene from a character's
+  card (pre-filled `ComposeMailForm` via `SendLetterDialog`, #2160) — no telnet mail command
+  exists; telnet parity is deliberately out of scope (ADR-0116).
+- Players target a character name; the system routes to that character's current player via
+  `RosterTenure.recipient_tenure`
 - Maintains character context while preserving player anonymity
+- Recipient gets a `MAIL_ARRIVED` websocket push (tenure-display-only payload) plus an unread
+  badge/count in the web header; `mark-read`/`unread-count` are `PlayerMailViewSet` actions
 
 ### Trust-Based Permissions
 - Approval permissions are tied to specific characters, stories, or domains

--- a/src/world/roster/serializers/__init__.py
+++ b/src/world/roster/serializers/__init__.py
@@ -29,7 +29,7 @@ from world.roster.serializers.families import (
     KinSlotPoolSerializer,
     KinSlotSerializer,
 )
-from world.roster.serializers.mail import PlayerMailSerializer
+from world.roster.serializers.mail import PlayerMailSerializer, UnreadMailCountSerializer
 from world.roster.serializers.media import (
     ArtistSerializer,
     PlayerMediaSerializer,
@@ -77,4 +77,5 @@ __all__ = [
     "RosterTenureSerializer",
     "TenureGallerySerializer",
     "TenureMediaSerializer",
+    "UnreadMailCountSerializer",
 ]

--- a/src/world/roster/serializers/mail.py
+++ b/src/world/roster/serializers/mail.py
@@ -50,3 +50,9 @@ class PlayerMailSerializer(serializers.ModelSerializer):
             "sender_display",
             "recipient_display",
         ]
+
+
+class UnreadMailCountSerializer(serializers.Serializer):
+    """Response shape for ``PlayerMailViewSet.unread_count`` -- schema only, never a model."""
+
+    count = serializers.IntegerField(read_only=True)

--- a/src/world/roster/services/mail_notifications.py
+++ b/src/world/roster/services/mail_notifications.py
@@ -1,0 +1,49 @@
+"""Arrival notification for ``PlayerMail`` (#2160).
+
+The web-first mail surface needs a live nudge when new mail lands instead of requiring a
+poll/refresh — the ``mail_arrived`` websocket push fills that gap, mirroring
+``world.battles.services.notify_battle_state_changed``'s slim-ping shape (clients that care
+refetch the REST list on receipt) and
+``world.scenes.friend_services.notify_friends_of_status``'s tenure->account traversal.
+
+Anonymity boundary: the payload is tenure-display-only. It must never carry an account id,
+username, or anything else that would let a recipient unmask the sender's real player.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+from evennia.utils.logger import log_err
+
+from web.webclient.message_types import MailArrivedPayload
+
+if TYPE_CHECKING:
+    from world.roster.models import PlayerMail, RosterTenure
+
+
+def notify_mail_arrived(recipient_tenure: RosterTenure, mail: PlayerMail) -> None:
+    """Push a ``mail_arrived`` ping to the recipient's account.
+
+    Best-effort: a notification failure must never break mail delivery (the mail row is already
+    committed by the time this runs -- see ``PlayerMailViewSet.perform_create``'s
+    ``transaction.on_commit`` wrapper). ``account.msg`` to an offline account is a harmless
+    no-op, so an offline recipient simply doesn't see it.
+    """
+    try:
+        account = recipient_tenure.player_data.account
+        if account is None:
+            return
+        sender_tenure = mail.sender_tenure
+        sender_display = sender_tenure.display_name if sender_tenure is not None else "Unknown"
+        payload = asdict(
+            MailArrivedPayload(
+                mail_id=mail.pk,
+                sender_display=sender_display,
+                subject=mail.subject,
+            )
+        )
+        account.msg(mail_arrived=((), payload))
+    except Exception:  # noqa: BLE001 — best-effort arrival ping; never break mail send (#2160)
+        log_err(f"mail arrival ping failed for mail={mail.pk}")

--- a/src/world/roster/tests/test_mail_viewset.py
+++ b/src/world/roster/tests/test_mail_viewset.py
@@ -1,6 +1,7 @@
 """Tests for PlayerMailViewSet API endpoints."""
 
 from datetime import timedelta
+from unittest import mock
 
 from django.test import TestCase
 from django.urls import reverse
@@ -79,3 +80,156 @@ class PlayerMailViewSetTestCase(TestCase):
         assert response.status_code == 201
         reply = PlayerMail.objects.get(subject="Re: Old")
         assert reply.in_reply_to == original
+
+
+class PlayerMailMarkReadTestCase(TestCase):
+    """Test the mark-read action is recipient-only and idempotent."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.recipient = PlayerDataFactory()
+        self.tenure = RosterTenureFactory(player_data=self.recipient)
+        self.sender_tenure = RosterTenureFactory()
+        self.mail = PlayerMailFactory(
+            recipient_tenure=self.tenure,
+            sender_tenure=self.sender_tenure,
+        )
+
+    def test_recipient_can_mark_read(self):
+        """The recipient marking their own mail read sets read_date and is idempotent."""
+        self.client.force_authenticate(user=self.recipient.account)
+        url = reverse("roster:mail-mark-read", args=[self.mail.pk])
+
+        response = self.client.post(url)
+        assert response.status_code == 200
+        self.mail.refresh_from_db()
+        assert self.mail.read_date is not None
+        first_read_date = self.mail.read_date
+
+        # Idempotent: a second call does not move read_date.
+        response = self.client.post(url)
+        assert response.status_code == 200
+        self.mail.refresh_from_db()
+        assert self.mail.read_date == first_read_date
+
+    def test_non_recipient_cannot_mark_read(self):
+        """A player who isn't the recipient gets 404 -- the mail is invisible to them."""
+        other = PlayerDataFactory()
+        self.client.force_authenticate(user=other.account)
+        url = reverse("roster:mail-mark-read", args=[self.mail.pk])
+
+        response = self.client.post(url)
+        assert response.status_code == 404
+        self.mail.refresh_from_db()
+        assert self.mail.read_date is None
+
+    def test_unauthenticated_cannot_mark_read(self):
+        """No auth -- 401/403, not a leak of the mail's existence via a 404."""
+        url = reverse("roster:mail-mark-read", args=[self.mail.pk])
+        response = self.client.post(url)
+        assert response.status_code in (401, 403)
+
+
+class PlayerMailUnreadCountTestCase(TestCase):
+    """Test the unread-count action is scoped to the requester's own tenures."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.recipient = PlayerDataFactory()
+        self.tenure = RosterTenureFactory(player_data=self.recipient)
+        self.sender_tenure = RosterTenureFactory()
+        self.client.force_authenticate(user=self.recipient.account)
+        self.url = reverse("roster:mail-unread-count")
+
+    def test_counts_unread_unarchived_mail_for_requester(self):
+        """Two unread + one read + one archived -- only the two unread/unarchived count."""
+        PlayerMailFactory(recipient_tenure=self.tenure, sender_tenure=self.sender_tenure)
+        PlayerMailFactory(recipient_tenure=self.tenure, sender_tenure=self.sender_tenure)
+        PlayerMailFactory(
+            recipient_tenure=self.tenure,
+            sender_tenure=self.sender_tenure,
+            read_date=timezone.now(),
+        )
+        PlayerMailFactory(
+            recipient_tenure=self.tenure,
+            sender_tenure=self.sender_tenure,
+            archived=True,
+        )
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.json() == {"count": 2}
+
+    def test_excludes_other_players_unread_mail(self):
+        """Another player's unread mail never bleeds into this requester's count."""
+        other_recipient = PlayerDataFactory()
+        other_tenure = RosterTenureFactory(player_data=other_recipient)
+        PlayerMailFactory(recipient_tenure=other_tenure, sender_tenure=self.sender_tenure)
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.json() == {"count": 0}
+
+
+class PlayerMailArrivalPushTestCase(TestCase):
+    """Test the MAIL_ARRIVED push fired on send: anonymity boundary + offline no-op."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.recipient = PlayerDataFactory()
+        self.tenure = RosterTenureFactory(player_data=self.recipient)
+        self.sender_player = PlayerDataFactory()
+        self.sender_account = self.sender_player.account
+        self.sender_tenure = RosterTenureFactory(player_data=self.sender_player)
+
+    def test_send_mail_pushes_arrival_ping_with_no_account_identifiers(self):
+        """Push fires post-commit, carries only tenure-display data -- no account id/username."""
+        self.client.force_authenticate(user=self.sender_account)
+        url = reverse("roster:mail-list")
+        payload = {
+            "recipient_tenure": self.tenure.id,
+            "sender_tenure": self.sender_tenure.id,
+            "subject": "Hello",
+            "message": "Test message",
+        }
+
+        with mock.patch.object(self.recipient.account, "msg") as mock_msg:
+            with self.captureOnCommitCallbacks() as callbacks:
+                response = self.client.post(url, payload, format="json")
+            assert response.status_code == 201
+            # Deferred via transaction.on_commit -- not fired mid-request.
+            mock_msg.assert_not_called()
+            assert len(callbacks) == 1
+            for callback in callbacks:
+                callback()
+
+        mock_msg.assert_called_once()
+        _, kwargs = mock_msg.call_args
+        _, mail_payload = kwargs["mail_arrived"]
+        mail = PlayerMail.objects.get(subject="Hello")
+        assert mail_payload == {
+            "mail_id": mail.pk,
+            "sender_display": self.sender_tenure.display_name,
+            "subject": "Hello",
+        }
+        assert "account" not in mail_payload
+        assert "username" not in mail_payload
+        assert str(self.sender_account.pk) not in str(mail_payload)
+        assert self.sender_account.username not in str(mail_payload.values())
+
+    def test_offline_recipient_is_a_no_op(self):
+        """An offline recipient's real account.msg is a harmless no-op -- send still succeeds."""
+        self.client.force_authenticate(user=self.sender_account)
+        url = reverse("roster:mail-list")
+        payload = {
+            "recipient_tenure": self.tenure.id,
+            "sender_tenure": self.sender_tenure.id,
+            "subject": "Offline Test",
+            "message": "Test message",
+        }
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(url, payload, format="json")
+
+        assert response.status_code == 201
+        assert PlayerMail.objects.filter(subject="Offline Test").exists()

--- a/src/world/roster/views/mail_views.py
+++ b/src/world/roster/views/mail_views.py
@@ -1,16 +1,23 @@
 """Views for player mail."""
 
+from http import HTTPMethod
 from typing import Any
 
+from django.db import transaction
 from django.db.models import QuerySet
+from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, viewsets
+from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
 from world.roster.models import PlayerMail
-from world.roster.serializers import PlayerMailSerializer
+from world.roster.serializers import PlayerMailSerializer, UnreadMailCountSerializer
+from world.roster.services.mail_notifications import notify_mail_arrived
 
 
 class PlayerMailPagination(PageNumberPagination):
@@ -47,7 +54,7 @@ class PlayerMailViewSet(
         )
 
     def perform_create(self, serializer: BaseSerializer[Any]) -> None:
-        """Validate sender tenure ownership before saving."""
+        """Validate sender tenure ownership before saving, then ping the recipient."""
         sender_tenure = serializer.validated_data["sender_tenure"]
         if (
             not self.request.user.is_staff
@@ -55,4 +62,27 @@ class PlayerMailViewSet(
         ):
             msg = "Cannot send mail as this character."
             raise PermissionDenied(msg)
-        serializer.save()
+        mail = serializer.save()
+        # Deferred via transaction.on_commit (the notify_battle_state_changed pattern,
+        # battles/services.py) so the ping never fires on a row a concurrent reader can't
+        # yet see -- fires correctly under autocommit even though this view has no
+        # explicit atomic block.
+        recipient_tenure = mail.recipient_tenure
+        transaction.on_commit(lambda: notify_mail_arrived(recipient_tenure, mail))
+
+    @extend_schema(request=None, responses=PlayerMailSerializer, tags=["roster"])
+    @action(detail=True, methods=[HTTPMethod.POST], url_path="mark-read")
+    def mark_read(self, request: Request, pk: int | None = None) -> Response:
+        """Mark this mail as read (idempotent). Recipient-only via the scoped queryset."""
+        mail = self.get_object()
+        mail.mark_read()
+        serializer = self.get_serializer(mail)
+        return Response(serializer.data)
+
+    @extend_schema(responses=UnreadMailCountSerializer, tags=["roster"])
+    @action(detail=False, methods=[HTTPMethod.GET], url_path="unread-count")
+    def unread_count(self, request: Request) -> Response:
+        """Count of unread, unarchived mail across the requester's tenures."""
+        count = self.get_queryset().filter(read_date__isnull=True, archived=False).count()
+        serializer = UnreadMailCountSerializer({"count": count})
+        return Response(serializer.data)


### PR DESCRIPTION
Closes #2160

## Summary

Journals and letters become playable from the scene per the approved spec + ruling on #2160. Journals: the fully-built world.journals backend (untouched here) finally gets a web surface — a /journals page (my journal incl. private, public browse with author/tag filters, praise/retort responses), a JournalComposerDialog with two entry points per the ruling (a new Journal tab in the /game sidebar, and a pre-tagged 'Write a journal' quick action on the character card — pre-linking = a freeform JournalTag, zero backend change), and the /journal route collision resolved frontend-only (mission ledger → /missions/journal). Letters: PlayerMail is ratified as the letters surface at MVP (ADR-0116; the in-fiction messenger layer is a deliberately deferred design question) — 'Send a letter' on the character card pre-addresses via new ComposeMailForm pre-fill props (live-tenure-gated like FriendButton), and the read loop closes with mark-read + unread-count viewset actions, a header Letters badge, unread styling with mark-read-on-open, and a MAIL_ARRIVED WS push (on-commit, tenure-display-only payload) driving an in-game arrival toast. Docs: journals AGENT_GLOSSARY disambiguating the three 'journal' homonyms, roster CLAUDE.md's aspirational 'mail Ariel' telnet claim corrected, audit §4 annotated. Note: the journals viewset (like /api/user/) has no OpenAPI schema, so its frontend types are hand-authored and verified field-by-field against the serializers — giving these views real schemas would make such drift CI-visible.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2160 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main twice; final rebase crossed the just-merged #2213 (applause) — union-resolved the expected sibling-feature conflicts (KUDOS_RECEIVED + MAIL_ARRIVED in the WS enums/payloads on both sides, ADR index 0115+0116, audit-doc annotations) and verified with ruff/tsc/eslint + pre-commit hooks post-resolution.

<!-- last-addressed-comment: 0 -->