### PR TITLE
From 'that scene looks fun' to standing in it: discovery→presence bridge (#2155)

### DIFF
--- a/docs/roadmap/ooc-social.md
+++ b/docs/roadmap/ooc-social.md
@@ -165,8 +165,15 @@ Details: `docs/systems/character_creation.md`'s "Email Notifications (#2162)" se
   `JournalPage`/`BeatCard`. The web registration→application funnel polish — ✅ **shipped
   (#2162)**, see "Built — Web Registration → Application Funnel" above.
 - Anti-harassment tools — blocking, muting, reporting
-- Scene discovery — finding active public scenes to join; the discovery→presence bridge
-  is #2163
+- Scene discovery — finding active public scenes to join. ~~The discovery→presence
+  bridge~~ — SHIPPED (#2163): `where` rows and the scene browser (`ScenesListPage`)
+  both grew "Go there" buttons dispatching the `travel_to` REGISTRY action
+  (`TravelAction`/`StopTravelAction`, `actions/definitions/movement.py`), which
+  auto-walks a same-Area, public-rooms-only route computed by `find_route()`
+  (`world/areas/positioning/travel.py`, frontier-batched BFS); telnet parity via
+  `CmdTravel` (`travel <name>` / `travel stop`). See `docs/systems/areas.md`'s
+  "Presence & Travel" section. Still open: no dedicated search/filter UI for
+  browsing scenes beyond the plain list, and cross-Area routing.
 - Social feed — what's happening in the game right now (new achievements, notable events, active scenes)
 
 See `docs/audits/2026-07-10-webclient-rp-ux-audit.md` (epic #2155) for the full

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -641,6 +641,14 @@ Spatial hierarchy for organizing rooms into regions, districts, and neighborhood
 - **Models:** `Area`, `AreaClosure` (unmanaged, materialized view)
 - **Enums:** `AreaLevel` (Region, District, Neighborhood)
 - **Key Functions:** `get_ancestry()`, `get_descendant_areas()`, `get_rooms_in_area()`, `reparent_area()`
+- **Presence & Travel (#1463 + #2163):** `where_listing()` — public presence directory,
+  returns `WhereEntry(persona_name, room_path, room_id)` per online character in a
+  publicly-listed room; `find_route(origin_room, destination_room) -> list[ObjectDB] | None`
+  (`world.areas.positioning.travel`) — frontier-batched BFS pathfinder, same-Area +
+  public-rooms-only, capped at `settings.TRAVEL_MAX_HOPS`. `TravelAction`/`StopTravelAction`
+  (`registry_key`s `travel_to`/`stop_travel`) auto-walk a computed route one hop at a time;
+  shared by telnet `CmdTravel` and "Go there" buttons on the scene browser + presence panel.
+  See [areas.md](areas.md) "Presence & Travel" section.
 - **Pattern:** Postgres materialized view with recursive CTE for hierarchy queries
 - **Integrates with:** realms (Area.realm FK), evennia_extensions (RoomProfile.area FK)
 - **Source:** `src/world/areas/`

--- a/docs/systems/areas.md
+++ b/docs/systems/areas.md
@@ -111,6 +111,77 @@ refresh_area_closure()
 
 ---
 
+## Presence & Travel (`where` / `travel`, #1463 + #2163)
+
+Room-to-room navigation layered on the Area hierarchy: a public presence directory
+(`where`) listing every character currently in a publicly-listed room, and a
+pathfinder + auto-walk pair (`travel`) that lets a player "go there" to any of them.
+
+### `where_listing` (`src/world/areas/services.py`, #1463)
+
+```python
+from world.areas.services import WhereEntry, where_listing
+
+# One entry per online, non-concealed, non-hidden character in a publicly-listed
+# room, sorted by persona name.
+entries = where_listing(viewer_account=account)
+# WhereEntry(persona_name: str, room_path: str, room_id: int)
+```
+
+`room_path` is the coloured `Area` ancestry path (`colored_area_path()`, see
+above). `room_id` (#2163 addition) is the destination room's pk — added so a
+`where` row can dispatch a `travel_to` Action directly without re-resolving the
+room by name.
+
+### `find_route()` (`src/world/areas/positioning/travel.py`, #2163)
+
+```python
+from world.areas.positioning.travel import find_route
+
+route = find_route(origin_room, destination_room)
+# -> list[ObjectDB] (an ordered list of Exit objects) | None
+```
+
+Frontier-batched BFS: each level fetches every outbound exit for the *entire*
+current frontier in one query (mirroring `area_subtree_pks`'s
+`parent_id__in=[...]` batching over the Area tree above), rather than one room
+at a time — the fix for the per-room-query blowup that breaks naive BFS at
+scale. Scoped to same-Area travel only — cross-Area routing needs
+Area-to-Area connectivity data this codebase doesn't have yet — and to
+publicly-listed rooms only (`room_is_publicly_listed`), matching the `where`
+privacy invariant (#1287): a route never passes through, or reveals, a private
+room. Capped at `settings.TRAVEL_MAX_HOPS` (default 50). Returns `None` when
+unreachable, off-Area, the destination isn't public, or the route would exceed
+the hop cap; returns `[]` when already at the destination.
+
+### `TravelAction` / `StopTravelAction` (`src/actions/definitions/movement.py`, #2163)
+
+REGISTRY actions (keys `"travel_to"` / `"stop_travel"`) — a server-paced,
+cancellable auto-walk. `TravelAction` computes a route via `find_route()` and
+schedules one hop per `hop_delay_seconds` (1.5s) via `evennia.utils.delay()`,
+reusing the same `check_exit_traversal`/`traverse_exit` primitives a manual
+`TraverseExitAction` hop uses, so room-state broadcasts happen exactly as they
+do for a manual walk. A per-caller `.ndb.active_travel_token` makes
+cancellation/re-dispatch safe: every scheduled hop callback checks its token
+against the caller's *current* active token before acting, so a stale callback
+from a superseded or stopped walk silently no-ops instead of moving the player
+unexpectedly. `StopTravelAction` cancels the pending `.ndb.active_travel_task`
+and clears the token.
+
+### Telnet (`src/commands/travel.py`, #2163)
+
+`CmdTravel` (`travel <character name>` / `travel stop`) resolves the named
+character's current room and dispatches `TravelAction`/`StopTravelAction`.
+
+### Frontend (#2163)
+
+"Go there" buttons on the scene browser (`ScenesListPage`,
+`frontend/src/scenes/pages/`) and the presence panel (`PresencePanel`,
+`frontend/src/game/components/`) dispatch the `travel_to` REGISTRY action with
+the row's room id (the scene's room, or `WhereEntry.room_id`).
+
+---
+
 ## Positioning Submodule (`src/world/areas/positioning/`)
 
 Room-anchored spatial graph: named position nodes, traversable edges, per-object occupancy, capability-gated movement, and GM terrain blueprints for non-combat scene staging.

--- a/frontend/src/game/components/PresencePanel.test.tsx
+++ b/frontend/src/game/components/PresencePanel.test.tsx
@@ -1,4 +1,5 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
 import { renderWithProviders } from '@/test/utils/renderWithProviders';
@@ -6,6 +7,39 @@ import { getPresence } from '@/presence/api';
 import { PresencePanel } from './PresencePanel';
 
 vi.mock('@/presence/api', () => ({ getPresence: vi.fn() }));
+
+// Mock the roster query — component resolves active character → characterId (#2163)
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: vi.fn(() => ({
+    data: [
+      {
+        id: 1,
+        name: 'TestChar',
+        character_id: 42,
+        profile_picture_url: null,
+        primary_persona_id: null,
+        active_persona_id: null,
+      },
+    ],
+  })),
+}));
+
+// Mock the Redux selector — return the active character name used above
+vi.mock('@/store/hooks', () => ({
+  useAppSelector: vi.fn((selector: (state: unknown) => unknown) =>
+    selector({ game: { active: 'TestChar' }, auth: {} })
+  ),
+}));
+
+// Mock the combat dispatch hook (Go there travel affordance, #2163)
+vi.mock('@/combat/queries', () => ({
+  useDispatchPlayerAction: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+import { useDispatchPlayerAction } from '@/combat/queries';
 
 describe('PresencePanel', () => {
   it('renders the online roster with a coarse idle marker', async () => {
@@ -21,9 +55,54 @@ describe('PresencePanel', () => {
   it('renders where entries with their location', async () => {
     vi.mocked(getPresence).mockResolvedValue({
       who: [],
-      where: [{ persona_name: 'Captain Vale', room_path: 'Umbros - Sable Hold' }],
+      where: [{ persona_name: 'Captain Vale', room_path: 'Umbros - Sable Hold', room_id: 501 }],
     });
     renderWithProviders(<PresencePanel />);
     expect(await screen.findByText('Captain Vale')).toBeInTheDocument();
+  });
+});
+
+describe('PresencePanel — Go there button (#2163)', () => {
+  beforeEach(() => {
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+  });
+
+  it('renders a Go there control for each where row', async () => {
+    vi.mocked(getPresence).mockResolvedValue({
+      who: [],
+      where: [{ persona_name: 'Captain Vale', room_path: 'Umbros - Sable Hold', room_id: 501 }],
+    });
+
+    renderWithProviders(<PresencePanel />);
+
+    expect(await screen.findByTestId('go-there-where-0')).toBeInTheDocument();
+  });
+
+  it('dispatches the travel_to registry action with the target room id on click', async () => {
+    const user = userEvent.setup();
+    const mockMutate = vi.fn();
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+    vi.mocked(getPresence).mockResolvedValue({
+      who: [],
+      where: [{ persona_name: 'Captain Vale', room_path: 'Umbros - Sable Hold', room_id: 501 }],
+    });
+
+    renderWithProviders(<PresencePanel />);
+
+    const button = await screen.findByTestId('go-there-where-0');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledWith({
+        ref: { backend: 'registry', registry_key: 'travel_to' },
+        kwargs: { target: 501 },
+      });
+    });
   });
 });

--- a/frontend/src/game/components/PresencePanel.tsx
+++ b/frontend/src/game/components/PresencePanel.tsx
@@ -1,5 +1,9 @@
+import { useMemo } from 'react';
 import { FormattedContent } from '@/components/FormattedContent';
 import { usePresence } from '@/presence/queries';
+import { useAppSelector } from '@/store/hooks';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+import { useDispatchPlayerAction } from '@/combat/queries';
 
 /**
  * Right-sidebar "Who" tab (#1463): online presence for the web game view.
@@ -7,10 +11,26 @@ import { usePresence } from '@/presence/queries';
  * - **Online** — every online character by active persona, with a *coarse* idle marker
  *   (active / idle / away; never exact, so identical idle times can't out alts).
  * - **Where** — characters in public rooms with their coloured area path (rendered through
- *   `FormattedContent`, which parses the Evennia colour codes the backend emits).
+ *   `FormattedContent`, which parses the Evennia colour codes the backend emits), plus a
+ *   "Go there" affordance (#2163) that dispatches the `travel_to` registry action.
  */
 export function PresencePanel() {
   const { data, isLoading, isError } = usePresence();
+
+  const activeCharacterName = useAppSelector((state) => state.game.active);
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
+  const characterId = useMemo(
+    () => myRosterEntries.find((e) => e.name === activeCharacterName)?.character_id ?? null,
+    [myRosterEntries, activeCharacterName]
+  );
+  const { mutate, isPending } = useDispatchPlayerAction(characterId ?? 0);
+
+  const dispatchTravel = (roomId: number) => {
+    mutate({
+      ref: { backend: 'registry', registry_key: 'travel_to' },
+      kwargs: { target: roomId },
+    });
+  };
 
   if (isLoading) {
     return <div className="p-3 text-sm text-muted-foreground">Loading…</div>;
@@ -48,6 +68,15 @@ export function PresencePanel() {
                 <span className="font-medium">{entry.persona_name}</span>{' '}
                 <span className="text-muted-foreground">— </span>
                 <FormattedContent content={entry.room_path} />
+                <button
+                  type="button"
+                  className="ml-2 text-xs text-blue-600 hover:underline"
+                  onClick={() => dispatchTravel(entry.room_id)}
+                  disabled={isPending}
+                  data-testid={`go-there-where-${i}`}
+                >
+                  Go there
+                </button>
               </li>
             ))}
           </ul>

--- a/frontend/src/presence/api.ts
+++ b/frontend/src/presence/api.ts
@@ -11,6 +11,7 @@ export interface WhoEntry {
 export interface WhereEntry {
   persona_name: string;
   room_path: string;
+  room_id: number;
 }
 
 export interface PresencePayload {

--- a/frontend/src/scenes/pages/ScenesListPage.tsx
+++ b/frontend/src/scenes/pages/ScenesListPage.tsx
@@ -1,7 +1,10 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { CharacterLink } from '@/components/character';
+import { useAppSelector } from '@/store/hooks';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+import { useDispatchPlayerAction } from '@/combat/queries';
 import { fetchScenes, SceneListItem } from '../queries';
 
 export function ScenesListPage() {
@@ -10,6 +13,21 @@ export function ScenesListPage() {
     queryKey: ['scenes', status],
     queryFn: () => fetchScenes(`status=${status}`),
   });
+
+  const activeCharacterName = useAppSelector((state) => state.game.active);
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
+  const characterId = useMemo(
+    () => myRosterEntries.find((e) => e.name === activeCharacterName)?.character_id ?? null,
+    [myRosterEntries, activeCharacterName]
+  );
+  const { mutate: dispatchTravel, isPending } = useDispatchPlayerAction(characterId ?? 0);
+
+  const goThere = (roomId: number) => {
+    dispatchTravel({
+      ref: { backend: 'registry', registry_key: 'travel_to' },
+      kwargs: { target: roomId },
+    });
+  };
 
   return (
     <div className="container mx-auto p-4">
@@ -47,7 +65,20 @@ export function ScenesListPage() {
               </td>
               <td className="border p-2">{scene.description}</td>
               <td className="border p-2">{new Date(scene.date_started).toLocaleDateString()}</td>
-              <td className="border p-2">{scene.location?.name || ''}</td>
+              <td className="border p-2">
+                {scene.location?.name || ''}
+                {scene.location && (
+                  <button
+                    type="button"
+                    className="ml-2 text-xs text-blue-600 hover:underline"
+                    onClick={() => goThere(scene.location!.id)}
+                    disabled={isPending}
+                    data-testid={`go-there-${scene.id}`}
+                  >
+                    Go there
+                  </button>
+                )}
+              </td>
               <td className="border p-2">
                 {scene.participants.map((p, idx) => (
                   <span key={p.id}>

--- a/frontend/src/scenes/pages/__tests__/ScenesListPage.test.tsx
+++ b/frontend/src/scenes/pages/__tests__/ScenesListPage.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import type { SceneListItem } from '../../types';
+
+// Mock the roster query — component resolves active character → characterId
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: vi.fn(() => ({
+    data: [
+      {
+        id: 1,
+        name: 'TestChar',
+        character_id: 42,
+        profile_picture_url: null,
+        primary_persona_id: null,
+        active_persona_id: null,
+      },
+    ],
+  })),
+}));
+
+// Mock the Redux selector — return the active character name used above
+vi.mock('@/store/hooks', () => ({
+  useAppSelector: vi.fn((selector: (state: unknown) => unknown) =>
+    selector({ game: { active: 'TestChar' }, auth: {} })
+  ),
+}));
+
+// Mock the combat dispatch hook (Go there travel affordance, #2163)
+vi.mock('@/combat/queries', () => ({
+  useDispatchPlayerAction: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+vi.mock('../../queries', async () => {
+  const actual = await vi.importActual<typeof import('../../queries')>('../../queries');
+  return {
+    ...actual,
+    fetchScenes: vi.fn(),
+  };
+});
+
+import { ScenesListPage } from '../ScenesListPage';
+import { fetchScenes } from '../../queries';
+import { useDispatchPlayerAction } from '@/combat/queries';
+
+function makeScene(overrides: Partial<SceneListItem> = {}): SceneListItem {
+  return {
+    id: 1,
+    name: 'Test Scene',
+    description: '',
+    date_started: '2026-01-01T00:00:00Z',
+    location: { id: 501, name: 'The Bar' },
+    participants: [],
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('ScenesListPage — Go there button (#2163)', () => {
+  beforeEach(() => {
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+  });
+
+  it('renders a Go there button for a scene row with a non-null location', async () => {
+    vi.mocked(fetchScenes).mockResolvedValue({ results: [makeScene()] });
+
+    render(<ScenesListPage />, { wrapper: createWrapper() });
+
+    expect(await screen.findByTestId('go-there-1')).toBeInTheDocument();
+  });
+
+  it('does not render a Go there button when location is null', async () => {
+    vi.mocked(fetchScenes).mockResolvedValue({
+      results: [makeScene({ location: null })],
+    });
+
+    render(<ScenesListPage />, { wrapper: createWrapper() });
+
+    await screen.findByText('Test Scene');
+    expect(screen.queryByTestId('go-there-1')).not.toBeInTheDocument();
+  });
+
+  it('dispatches the travel_to registry action with the target room id on click', async () => {
+    const user = userEvent.setup();
+    const mockMutate = vi.fn();
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+    vi.mocked(fetchScenes).mockResolvedValue({ results: [makeScene()] });
+
+    render(<ScenesListPage />, { wrapper: createWrapper() });
+
+    const button = await screen.findByTestId('go-there-1');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledWith({
+        ref: { backend: 'registry', registry_key: 'travel_to' },
+        kwargs: { target: 501 },
+      });
+    });
+  });
+});

--- a/src/actions/CLAUDE.md
+++ b/src/actions/CLAUDE.md
@@ -416,6 +416,28 @@ on sync-with-main. Resolution is mechanical: keep **both** sides' appends
 one breaks the exact-match test. Verify post-merge with `just test-fast
 actions`; a failure there means a key was dropped or duplicated.
 
+**`objectdb_target_kwargs` does NOT auto-resolve on the REST dispatch path** (#2163,
+a real bug that shipped past all per-task tests because they mocked the dispatch
+hook). `objectdb_target_kwargs: ClassVar[frozenset[str]]` (declared on e.g.
+`TraverseExitAction`, `items.py`'s several actions) is consumed **only** by the
+websocket `execute_action` inputfunc's `_resolve_registry_kwargs`
+(`server/conf/inputfuncs.py`) — and even there, only for kwargs whose wire key ends
+in `_id` (`key.endswith("_id") and key[:-3] in objectdb_targets`), so the kwarg must
+be named `<field>_id` (e.g. `target_id`), not the bare field name. The REST dispatch
+path (`dispatch_player_action` → `_dispatch_registry`,
+`actions/player_interface.py`) does **no** ObjectDB resolution at all — it passes
+raw kwargs straight to `action_obj.run()`. If your action takes an ObjectDB-typed
+kwarg and is dispatched from the web via `useDispatchPlayerAction`/`postDispatchAction`
+(REST, not the websocket), **resolve the id yourself inside `execute()`** — see
+`_resolve_room()` in `definitions/locations.py:92-100` for the established pattern
+(`ObjectDB.objects.filter(pk=kwargs.get("foo")).first()` when the value is an int,
+falling through unchanged when it's already an ObjectDB, so the same `execute()`
+works for both a telnet `.run()` call passing a resolved object and a REST dispatch
+passing a raw id). Declaring `objectdb_target_kwargs` is harmless but does nothing
+for a REST-only action — don't rely on it as your only correctness guarantee, and
+write at least one test that calls `.run()` with a plain int in that kwarg (not a
+mock, not a pre-resolved object) to prove the REST shape actually works.
+
 ## Enhancement System
 
 ### ActionEnhancement Model

--- a/src/actions/CLAUDE.md
+++ b/src/actions/CLAUDE.md
@@ -272,7 +272,20 @@ They do not use the command system, dispatchers, or handlers.
   commands in `src/commands/currency.py`: `CmdDeposit` (`deposit <item>`),
   `CmdSteal` (`steal <item>` / `steal <item> from <container>`, mirrors
   `CmdGet`'s two grammars but always dispatches `StealAction`), `CmdSecure`
-  (`secure <container>=<open|friends|owner_only>`).)
+  (`secure <container>=<open|friends|owner_only>`).
+  `movement.py` (#2163) — alongside the existing `GetAction`/`DropAction`/`GiveAction`/
+  `TraverseExitAction`/`HomeAction`, the "go there" auto-walk pair: `TravelAction`
+  (key `"travel_to"`, `target_type=SINGLE`) computes a route via
+  `world.areas.positioning.travel.find_route()` (same-Area, public-rooms-only
+  frontier-batched BFS) and paces one hop per `hop_delay_seconds` via
+  `evennia.utils.delay()`, reusing `check_exit_traversal`/`traverse_exit` per hop
+  so room-state broadcasts match a manual walk; a per-caller
+  `.ndb.active_travel_token` makes re-dispatch/cancellation safe — a stale
+  scheduled callback no-ops instead of moving the player unexpectedly.
+  `StopTravelAction` (`"stop_travel"`, `target_type=SELF`) cancels the pending
+  `.ndb.active_travel_task` and clears the token. Shared by telnet `CmdTravel`
+  (`travel <name>` / `travel stop`, `src/commands/travel.py`) and the web "Go
+  there" buttons on the scene browser + presence panel.)
 
   **Dissolution is a soft-delete**: `perform_dissolution` sets `RoomFeatureInstance.dissolved_at`
   (nullable DateTimeField) rather than deleting the row. The `.active()` queryset manager

--- a/src/actions/definitions/movement.py
+++ b/src/actions/definitions/movement.py
@@ -4,18 +4,23 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, ClassVar
+import uuid
 
 from evennia.objects.models import ObjectDB
+from evennia.utils import delay
 
 from actions.base import Action
 from actions.constants import ActionCategory
 from actions.definitions.item_helpers import resolve_item_instance
 from actions.types import ActionContext, ActionResult, TargetType
+from commands.exceptions import CommandError
+from evennia_extensions.models import room_is_publicly_listed
 from flows.object_states.item_state import ItemState
 from flows.scene_data_manager import SceneDataManager
 from flows.service_functions.communication import message_location, send_room_state
 from flows.service_functions.inventory import drop, give, pick_up
 from flows.service_functions.movement import check_exit_traversal, move_object, traverse_exit
+from world.areas.positioning.travel import find_route
 from world.items.exceptions import InventoryError
 from world.mechanics.constants import ChallengeType
 from world.mechanics.models import ChallengeInstance
@@ -235,6 +240,147 @@ class TraverseExitAction(Action):
         send_room_state(caller_state)
 
         return ActionResult(success=True)
+
+
+@dataclass
+class TravelAction(Action):
+    """Walk a computed route to a destination room, one hop per tick.
+
+    Server-paced via evennia.utils.delay() — each scheduled hop reuses the
+    same check_exit_traversal/traverse_exit primitives TraverseExitAction
+    uses, so room-state broadcasts happen exactly as they do for a manual
+    walk. A per-caller `.ndb.active_travel_token` makes cancellation and
+    re-dispatch safe: every scheduled callback checks its token against the
+    caller's *current* active token before acting, so a stale callback from
+    a superseded or stopped walk silently no-ops instead of moving the
+    player unexpectedly (#2163).
+    """
+
+    key: str = "travel_to"
+    name: str = "Travel"
+    icon: str = "route"
+    category: str = "movement"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SINGLE
+
+    # Tells the dispatch layer to resolve kwargs["target"] from a raw id
+    # into an ObjectDB before execute() runs — same declaration
+    # TraverseExitAction uses (actions/definitions/movement.py existing
+    # code). Without this, a web dispatch's kwargs={"target": <room_id>}
+    # would arrive at execute() as a bare int, not a Room ObjectDB.
+    objectdb_target_kwargs: ClassVar[frozenset[str]] = frozenset({"target"})
+
+    # Seconds paused between each hop of the auto-walk.
+    hop_delay_seconds: ClassVar[float] = 1.5
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        destination = kwargs.get("target")
+        if destination is None:
+            return ActionResult(success=False, message="Travel where?")
+
+        origin = actor.location
+        if origin is None:
+            return ActionResult(success=False, message="You have no location to travel from.")
+
+        route = find_route(origin, destination)
+        if route is None:
+            return ActionResult(success=False, message="There's no clear public path there.")
+        if not route:
+            return ActionResult(success=False, message="You're already there.")
+
+        token = uuid.uuid4()
+        actor.ndb.active_travel_token = token
+        task = delay(
+            self.hop_delay_seconds,
+            self._do_hop,
+            actor,
+            route,
+            0,
+            token,
+        )
+        actor.ndb.active_travel_task = task
+
+        return ActionResult(success=True, message="You set off.")
+
+    @staticmethod
+    def _do_hop(actor: ObjectDB, route: list[ObjectDB], hop_index: int, token: uuid.UUID) -> None:
+        """Execute one hop of a scheduled walk, or no-op if superseded/stopped."""
+        if actor.ndb.active_travel_token != token:
+            return  # Superseded by a re-dispatch, or stopped — stale callback.
+
+        exit_obj = route[hop_index]
+        sdm = SceneDataManager()
+        try:
+            caller_state = sdm.initialize_state_for_object(actor)
+            exit_state = sdm.initialize_state_for_object(exit_obj)
+            check_exit_traversal(caller_state, exit_state)
+
+            destination_room = exit_obj.destination
+            if destination_room is None or not room_is_publicly_listed(destination_room):
+                closed_msg = "That path is no longer open."
+                raise CommandError(closed_msg)
+
+            dest_state = sdm.initialize_state_for_object(destination_room)
+            traverse_exit(caller_state, exit_state, dest_state)
+
+            caller_state = sdm.initialize_state_for_object(actor)
+            send_room_state(caller_state)
+        except CommandError as err:
+            actor.ndb.active_travel_token = None
+            actor.ndb.active_travel_task = None
+            actor.msg(f"Your route stops here: {err}")
+            return
+
+        next_index = hop_index + 1
+        if next_index >= len(route):
+            actor.ndb.active_travel_token = None
+            actor.ndb.active_travel_task = None
+            actor.msg("You arrive.")
+            return
+
+        task = delay(
+            TravelAction.hop_delay_seconds,
+            TravelAction._do_hop,
+            actor,
+            route,
+            next_index,
+            token,
+        )
+        actor.ndb.active_travel_task = task
+
+
+@dataclass
+class StopTravelAction(Action):
+    """Stop an in-progress travel_to walk, if one is active."""
+
+    key: str = "stop_travel"
+    name: str = "Stop Traveling"
+    icon: str = "stop"
+    category: str = "movement"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        if actor.ndb.active_travel_token is None:
+            return ActionResult(success=False, message="You aren't traveling anywhere.")
+
+        task = actor.ndb.active_travel_task
+        if task is not None:
+            task.cancel()
+
+        actor.ndb.active_travel_token = None
+        actor.ndb.active_travel_task = None
+        return ActionResult(success=True, message="You stop where you are.")
 
 
 @dataclass

--- a/src/actions/definitions/movement.py
+++ b/src/actions/definitions/movement.py
@@ -280,6 +280,8 @@ class TravelAction(Action):
         **kwargs: Any,
     ) -> ActionResult:
         destination = kwargs.get("target")
+        if isinstance(destination, int):
+            destination = ObjectDB.objects.filter(pk=destination).first()
         if destination is None:
             return ActionResult(success=False, message="Travel where?")
 
@@ -335,6 +337,10 @@ class TravelAction(Action):
             actor.ndb.active_travel_task = None
             actor.msg(f"Your route stops here: {err}")
             return
+        except Exception:
+            actor.ndb.active_travel_token = None
+            actor.ndb.active_travel_task = None
+            raise
 
         next_index = hop_index + 1
         if next_index >= len(route):

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -200,6 +200,8 @@ from actions.definitions.movement import (
     GetAction,
     GiveAction,
     HomeAction,
+    StopTravelAction,
+    TravelAction,
     TraverseExitAction,
 )
 from actions.definitions.npc_services import (
@@ -405,6 +407,8 @@ _ALL_ACTIONS: list[Action] = [
     SceneEntryEndorseAction(),
     StylePresentationEndorseAction(),
     TraverseExitAction(),
+    TravelAction(),
+    StopTravelAction(),
     HomeAction(),
     MoveToPositionAction(),
     TakePositionAction(),

--- a/src/actions/tests/test_actions.py
+++ b/src/actions/tests/test_actions.py
@@ -709,6 +709,62 @@ class TravelActionTests(TestCase):
         # The stale callback did NOT move the actor — token mismatch caught it.
         assert actor.location == rooms[0]
 
+    @tag("postgres")  # a successful hop calls send_room_state -> get_ancestry,
+    # which walks the areas_areaclosure materialized view (PG-only).
+    def test_travel_resolves_int_target_like_a_rest_dispatch_would(self):
+        """Regression test for the web dispatch path (#2163 final-review Critical
+        finding): REST dispatch (`_dispatch_registry`) does NOT resolve
+        objectdb_target_kwargs — it passes kwargs straight to execute(). This test
+        calls TravelAction exactly as the REST path does: target as a raw int, not
+        a pre-resolved ObjectDB, mirroring what `dispatch_player_action` /
+        `_dispatch_registry` actually does (see `src/actions/player_interface.py`).
+        """
+        rooms, _exits = self._make_route(2)
+        actor = ObjectDBFactory(
+            db_key="RestTraveler",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=rooms[0],
+        )
+        action = TravelAction()
+
+        with patch.object(actor, "msg"), patch("actions.definitions.movement.delay") as mock_delay:
+
+            def run_immediately(_seconds, callback, *args, **kwargs):
+                callback(*args, **kwargs)
+
+            mock_delay.side_effect = run_immediately
+            # target is a plain int, exactly as it arrives from a REST dispatch's
+            # raw JSON kwargs — NOT rooms[-1] (the ObjectDB), which is what a
+            # telnet .run() call would pass.
+            result = action.run(actor, target=rooms[-1].id)
+
+        assert result.success is True
+        actor.refresh_from_db()
+        assert actor.location == rooms[-1]
+
+    def test_travel_int_target_that_does_not_exist_fails_gracefully(self):
+        area = AreaFactory()
+        room_a = ObjectDBFactory(db_key="OnlyRoom", db_typeclass_path="typeclasses.rooms.Room")
+        # typeclasses.rooms.Room.at_object_creation() already auto-creates a bare
+        # RoomProfile via get_or_create — update_or_create (not create) applies
+        # our area/is_public onto that existing row instead of colliding with it
+        # (same gotcha documented in _make_route above).
+        RoomProfile.objects.update_or_create(
+            objectdb=room_a, defaults={"area": area, "is_public": True}
+        )
+        actor = ObjectDBFactory(
+            db_key="LostTraveler",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room_a,
+        )
+        action = TravelAction()
+
+        result = action.run(actor, target=999999999)
+
+        assert result.success is False
+        actor.refresh_from_db()
+        assert actor.location == room_a
+
 
 class TraverseExitWithChallengesTest(TestCase):
     """Test that INHIBITOR challenges block exit traversal."""

--- a/src/actions/tests/test_actions.py
+++ b/src/actions/tests/test_actions.py
@@ -2,12 +2,21 @@
 
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from actions.definitions.communication import PoseAction, SayAction, WhisperAction
-from actions.definitions.movement import DropAction, GetAction, GiveAction, TraverseExitAction
+from actions.definitions.movement import (
+    DropAction,
+    GetAction,
+    GiveAction,
+    StopTravelAction,
+    TravelAction,
+    TraverseExitAction,
+)
 from actions.definitions.perception import InventoryAction, LookAction
 from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
+from evennia_extensions.models import RoomProfile
+from world.areas.factories import AreaFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.conditions.factories import (
     ConditionCategoryFactory,
@@ -523,6 +532,182 @@ class TraverseExitActionTests(TestCase):
         assert result.success is True
         actor.refresh_from_db()
         assert actor.location == room2
+
+
+class TravelActionTests(TestCase):
+    def _make_route(self, hop_count):
+        """origin -> room_1 -> ... -> room_N, each room public, same Area."""
+        area = AreaFactory()
+        rooms = []
+        for i in range(hop_count + 1):
+            room = ObjectDBFactory(
+                db_key=f"TravelRoom{i}",
+                db_typeclass_path="typeclasses.rooms.Room",
+            )
+            # typeclasses.rooms.Room.at_object_creation() already auto-creates a
+            # bare RoomProfile via get_or_create — update_or_create (not create)
+            # applies our area/is_public onto that existing row instead of
+            # colliding with it (same gotcha documented in Task 1's
+            # world/areas/positioning/tests/test_travel.py:make_room).
+            RoomProfile.objects.update_or_create(
+                objectdb=room, defaults={"area": area, "is_public": True}
+            )
+            rooms.append(room)
+        exits = [
+            ObjectDBFactory(
+                db_key=f"exit{i}",
+                db_typeclass_path="typeclasses.exits.Exit",
+                location=rooms[i],
+                destination=rooms[i + 1],
+            )
+            for i in range(hop_count)
+        ]
+        return rooms, exits
+
+    @tag("postgres")  # a successful hop calls send_room_state -> get_ancestry,
+    # which walks the areas_areaclosure materialized view (PG-only).
+    def test_travel_walks_full_route_and_arrives(self):
+        rooms, _exits = self._make_route(3)
+        actor = ObjectDBFactory(
+            db_key="Traveler",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=rooms[0],
+        )
+        action = TravelAction()
+
+        with patch.object(actor, "msg"), patch("actions.definitions.movement.delay") as mock_delay:
+            # Capture-and-run: TravelAction schedules its next hop via
+            # evennia.utils.delay(seconds, callback, ...) — since this test
+            # runs synchronously (no real reactor), replace delay with an
+            # immediate call to the callback so the whole route walks in
+            # one test tick. This exercises the exact same callback logic
+            # the real delayed path uses, just without the real pause.
+            def run_immediately(_seconds, callback, *args, **kwargs):
+                callback(*args, **kwargs)
+
+            mock_delay.side_effect = run_immediately
+            result = action.run(actor, target=rooms[-1])
+
+        assert result.success is True
+        actor.refresh_from_db()
+        assert actor.location == rooms[-1]
+        assert actor.ndb.active_travel_token is None
+
+    def test_travel_no_route_fails_immediately(self):
+        area = AreaFactory()
+        room_a = ObjectDBFactory(db_key="A", db_typeclass_path="typeclasses.rooms.Room")
+        room_b = ObjectDBFactory(db_key="B", db_typeclass_path="typeclasses.rooms.Room")
+        RoomProfile.objects.update_or_create(
+            objectdb=room_a, defaults={"area": area, "is_public": True}
+        )
+        RoomProfile.objects.update_or_create(
+            objectdb=room_b, defaults={"area": area, "is_public": True}
+        )
+        # No exit connects them.
+        actor = ObjectDBFactory(
+            db_key="Stuck",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=room_a,
+        )
+        action = TravelAction()
+
+        result = action.run(actor, target=room_b)
+
+        assert result.success is False
+        assert actor.location == room_a
+
+    @tag("postgres")  # hop 1 succeeds and calls send_room_state -> get_ancestry,
+    # which walks the areas_areaclosure materialized view (PG-only).
+    def test_travel_stops_early_when_a_waypoint_goes_private_mid_walk(self):
+        rooms, _exits = self._make_route(2)
+        actor = ObjectDBFactory(
+            db_key="Traveler2",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=rooms[0],
+        )
+        action = TravelAction()
+
+        hop_count = {"n": 0}
+
+        def run_and_flip_privacy(_seconds, callback, *args, **kwargs):
+            hop_count["n"] += 1
+            if hop_count["n"] == 2:
+                # Simulate a GM flipping the final waypoint private between
+                # dispatch and this hop's execution.
+                rooms[2].room_profile.is_public = False
+                rooms[2].room_profile.save()
+            callback(*args, **kwargs)
+
+        with (
+            patch.object(actor, "msg"),
+            patch("actions.definitions.movement.delay", side_effect=run_and_flip_privacy),
+        ):
+            action.run(actor, target=rooms[-1])
+
+        actor.refresh_from_db()
+        # Stopped at the last successfully-reached room, never entered the
+        # now-private room 2.
+        assert actor.location == rooms[1]
+        assert actor.ndb.active_travel_token is None
+
+    def test_stop_travel_clears_active_token(self):
+        rooms, _exits = self._make_route(3)
+        actor = ObjectDBFactory(
+            db_key="Traveler3",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=rooms[0],
+        )
+        with patch.object(actor, "msg"), patch("actions.definitions.movement.delay") as mock_delay:
+            # Don't run the callback — leave the walk "in flight".
+            mock_delay.return_value = None
+            TravelAction().run(actor, target=rooms[-1])
+
+        assert actor.ndb.active_travel_token is not None
+
+        with patch.object(actor, "msg"):
+            result = StopTravelAction().run(actor)
+
+        assert result.success is True
+        assert actor.ndb.active_travel_token is None
+        # Actor never actually moved past the origin (walk was stopped
+        # before any hop callback fired).
+        actor.refresh_from_db()
+        assert actor.location == rooms[0]
+
+    def test_redispatch_supersedes_prior_walk_no_orphaned_movement(self):
+        rooms, _exits = self._make_route(3)
+        actor = ObjectDBFactory(
+            db_key="Traveler4",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=rooms[0],
+        )
+        stale_callbacks = []
+
+        def capture_but_dont_run(_seconds, callback, *args, **kwargs):
+            stale_callbacks.append((callback, args, kwargs))
+
+        with (
+            patch.object(actor, "msg"),
+            patch("actions.definitions.movement.delay", side_effect=capture_but_dont_run),
+        ):
+            TravelAction().run(actor, target=rooms[-1])
+            first_token = actor.ndb.active_travel_token
+
+            # Re-dispatch mid-walk — supersedes the first walk.
+            TravelAction().run(actor, target=rooms[1])
+            second_token = actor.ndb.active_travel_token
+
+        assert first_token != second_token
+
+        # Now fire the STALE callback from the first walk (as if its delay
+        # had actually elapsed after being superseded) — it must no-op.
+        stale_callback, stale_args, stale_kwargs = stale_callbacks[0]
+        with patch.object(actor, "msg"):
+            stale_callback(*stale_args, **stale_kwargs)
+
+        actor.refresh_from_db()
+        # The stale callback did NOT move the actor — token mismatch caught it.
+        assert actor.location == rooms[0]
 
 
 class TraverseExitWithChallengesTest(TestCase):

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -198,6 +198,8 @@ class ActionRegistryTests(TestCase):
             "present_outfit",
             "judge_presentation",
             "traverse_exit",
+            "travel_to",
+            "stop_travel",
             "home",
             "activate_permit",
             "use_item",

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -551,6 +551,15 @@ actions, backends, and service functions.
   each with their coloured area-hierarchy path (`colored_area_path` walks `AreaClosure`,
   colouring each segment by `Area.color` with cascade-down inheritance). Private rooms /
   private RP never appear (the #1287 invariant). Colours are author-set flavour (PLACEHOLDER).
+- **`travel.py`**: `CmdTravel` (`travel`, #2163) — telnet face of the "go there" auto-walk.
+  `travel <character name>` resolves the target's current room and dispatches
+  `TravelAction` (key `travel_to`, `actions/definitions/movement.py`); `travel stop`
+  dispatches `StopTravelAction` (key `stop_travel`). Mirrors `CmdWhere`'s public-only
+  scope — `find_route()` (`world.areas.positioning.travel`) only routes through
+  same-Area, publicly-listed rooms. Overrides `func()` directly (like `CmdPosition`)
+  rather than the base `ArxCommand._execute()` single-action recipe, since resolving
+  the destination argument needs custom logic before dispatch. No business logic in
+  the command.
 - **`who.py`**: `CmdWho` (`who`, #1463) — the online roster. Thin read over
   `world.scenes.presence.who_listing`: online characters by **active** persona with a **coarse**
   idle marker (active / idle / away — never exact, so identical idle times can't out an account's

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -132,6 +132,7 @@ from commands.social.tidings import CmdTidings
 from commands.story import CmdStory
 from commands.technique import CmdTechnique
 from commands.threads import CmdThreads
+from commands.travel import CmdTravel  # #2163
 from commands.weather import CmdTime
 from commands.weave import CmdWeaveThread
 from commands.where import CmdWhere
@@ -369,6 +370,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdPlaces,
             # #2005 — tactical position graph: list/take/move telnet namespace.
             CmdPosition,
+            # #2163 — "go there" travel: auto-walk to a character's location.
+            CmdTravel,
             # #1234 — Lab crafting station install/upgrade/repair namespace.
             CmdLabStation,
             CmdMarket,

--- a/src/commands/tests/test_travel_command.py
+++ b/src/commands/tests/test_travel_command.py
@@ -1,0 +1,70 @@
+"""Tests for CmdTravel (#2163)."""
+
+from django.test import TestCase
+
+from commands.travel import CmdTravel
+from evennia_extensions.factories import ObjectDBFactory, RoomProfileFactory
+from world.areas.factories import AreaFactory
+
+
+class CmdTravelTests(TestCase):
+    def setUp(self):
+        self.area = AreaFactory()
+        self.room_a = ObjectDBFactory(db_key="RoomA", db_typeclass_path="typeclasses.rooms.Room")
+        self.room_b = ObjectDBFactory(db_key="RoomB", db_typeclass_path="typeclasses.rooms.Room")
+        # Room.at_object_creation() already auto-creates a bare RoomProfile
+        # (typeclasses/rooms.py) — RoomProfileFactory (rather than
+        # RoomProfile.objects.create()) is the established fix for the
+        # resulting UNIQUE-constraint collision (see its docstring).
+        RoomProfileFactory(objectdb=self.room_a, area=self.area, is_public=True)
+        RoomProfileFactory(objectdb=self.room_b, area=self.area, is_public=True)
+        ObjectDBFactory(
+            db_key="east",
+            db_typeclass_path="typeclasses.exits.Exit",
+            location=self.room_a,
+            destination=self.room_b,
+        )
+        self.caller = ObjectDBFactory(
+            db_key="Wanderer",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room_a,
+        )
+        self.target_char = ObjectDBFactory(
+            db_key="Friend",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room_b,
+        )
+
+    def _make_cmd(self, args):
+        cmd = CmdTravel()
+        cmd.caller = self.caller
+        cmd.args = args
+        cmd.raw_string = f"travel {args}"
+        return cmd
+
+    def test_travel_to_character_resolves_and_dispatches(self):
+        from unittest.mock import patch
+
+        cmd = self._make_cmd("Friend")
+        with patch.object(self.caller, "msg"), patch("actions.definitions.movement.delay"):
+            cmd.func()
+        # No CommandError raised means the action dispatched successfully —
+        # TravelAction's own tests (Task 2) cover the walk mechanics; this
+        # test covers only name resolution and dispatch wiring.
+
+    def test_travel_unknown_name_raises_command_error_message(self):
+        from unittest.mock import patch
+
+        cmd = self._make_cmd("NobodyHere")
+        with patch.object(self.caller, "msg") as mock_msg:
+            cmd.func()
+        assert mock_msg.called
+
+    def test_travel_stop_dispatches_stop_travel_action(self):
+        from unittest.mock import patch
+
+        self.caller.ndb.active_travel_token = "some-token"  # noqa: S105
+        cmd = self._make_cmd("stop")
+        with patch.object(self.caller, "msg"):
+            cmd.func()
+        assert self.caller.ndb.active_travel_token is None

--- a/src/commands/travel.py
+++ b/src/commands/travel.py
@@ -1,0 +1,58 @@
+"""Telnet `travel` command (#2163) — dispatches TravelAction/StopTravelAction.
+
+Modeled on CmdPosition (commands/positions.py): overrides func() directly
+(rather than the base ArxCommand._execute() single-action-dispatch recipe)
+since resolving the destination argument needs custom logic before dispatch.
+"""
+
+from actions.definitions.movement import StopTravelAction, TravelAction
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+_STOP_TOKEN = "stop"  # noqa: S105
+
+
+class CmdTravel(ArxCommand):
+    """Auto-walk to a character's location, or stop an in-progress walk.
+
+    Usage:
+      travel <character name>
+      travel stop
+    """
+
+    key = "travel"
+    locks = "cmd:all()"
+
+    def func(self) -> None:
+        raw = (self.args or "").strip()
+        if not raw:
+            self.msg("Travel to whom? (Usage: travel <character name> | travel stop)")
+            return
+
+        if raw.lower() == _STOP_TOKEN:
+            self._do_stop()
+            return
+
+        try:
+            self._do_travel(raw)
+        except CommandError as err:
+            self.msg(str(err))
+
+    def _do_travel(self, name: str) -> None:
+        target_char = self.caller.search(name, global_search=True)
+        if target_char is None:
+            # caller.search() already messaged the caller on no-match.
+            return
+        destination = target_char.location
+        if destination is None:
+            msg = f"{target_char.name} has no location to travel to."
+            raise CommandError(msg)
+
+        result = TravelAction().run(self.caller, target=destination)
+        if result.message:
+            self.msg(result.message)
+
+    def _do_stop(self) -> None:
+        result = StopTravelAction().run(self.caller)
+        if result.message:
+            self.msg(result.message)

--- a/src/server/conf/settings.py
+++ b/src/server/conf/settings.py
@@ -210,6 +210,11 @@ FALL_IMPACT_PER_LEVEL = env.int("FALL_IMPACT_PER_LEVEL", default=5)
 # TEMPORARY masks are not capped here (throwaway). PLACEHOLDER magnitude.
 MAX_ESTABLISHED_PERSONAS_PER_SHEET = env.int("MAX_ESTABLISHED_PERSONAS_PER_SHEET", default=5)
 
+# Max number of exits a single travel_to dispatch will traverse in one go (#2163).
+# Backstop against a pathological/disconnected-but-still-searched graph; same-Area
+# scoping already bounds most realistic routes well under this.
+TRAVEL_MAX_HOPS = env.int("TRAVEL_MAX_HOPS", default=50)
+
 # Web frontend base URL — the React app's origin. Referenced by allauth's
 # headless redirect config below, CSRF_TRUSTED_ORIGINS, and telnet-side
 # signposts (connection screen, characterless post-login message; #2122)

--- a/src/world/areas/positioning/tests/test_travel.py
+++ b/src/world/areas/positioning/tests/test_travel.py
@@ -1,0 +1,128 @@
+"""Tests for find_route (#2163) — frontier-batched BFS over the room/exit graph."""
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from evennia_extensions.factories import ObjectDBFactory
+from evennia_extensions.models import RoomProfile
+from world.areas.factories import AreaFactory
+from world.areas.positioning.travel import find_route
+
+
+def make_room(area, key="Room"):
+    # typeclasses.rooms.Room.at_object_creation() already auto-creates a bare
+    # RoomProfile via get_or_create — update_or_create (not create) applies our
+    # area/is_public onto that existing row instead of colliding with it.
+    room = ObjectDBFactory(db_key=key, db_typeclass_path="typeclasses.rooms.Room")
+    RoomProfile.objects.update_or_create(objectdb=room, defaults={"area": area, "is_public": True})
+    return room
+
+
+def make_exit(location, destination, key="exit"):
+    return ObjectDBFactory(
+        db_key=key,
+        db_typeclass_path="typeclasses.exits.Exit",
+        location=location,
+        destination=destination,
+    )
+
+
+class FindRouteTests(TestCase):
+    def setUp(self):
+        self.area = AreaFactory()
+        self.other_area = AreaFactory()
+
+    def test_direct_route_one_hop(self):
+        room_a = make_room(self.area, "A")
+        room_b = make_room(self.area, "B")
+        exit_ab = make_exit(room_a, room_b, "east")
+
+        route = find_route(room_a, room_b)
+
+        assert route == [exit_ab]
+
+    def test_multi_hop_route(self):
+        room_a = make_room(self.area, "A")
+        room_b = make_room(self.area, "B")
+        room_c = make_room(self.area, "C")
+        exit_ab = make_exit(room_a, room_b, "east")
+        exit_bc = make_exit(room_b, room_c, "east")
+
+        route = find_route(room_a, room_c)
+
+        assert route == [exit_ab, exit_bc]
+
+    def test_no_route_returns_none(self):
+        room_a = make_room(self.area, "A")
+        room_b = make_room(self.area, "B")
+        # No exit connects them.
+
+        assert find_route(room_a, room_b) is None
+
+    def test_different_area_returns_none(self):
+        room_a = make_room(self.area, "A")
+        room_b = make_room(self.other_area, "B")
+        make_exit(room_a, room_b, "east")
+
+        assert find_route(room_a, room_b) is None
+
+    def test_destination_not_public_returns_none(self):
+        room_a = make_room(self.area, "A")
+        room_b = ObjectDBFactory(db_key="Private", db_typeclass_path="typeclasses.rooms.Room")
+        RoomProfile.objects.update_or_create(
+            objectdb=room_b, defaults={"area": self.area, "is_public": False}
+        )
+        make_exit(room_a, room_b, "east")
+
+        assert find_route(room_a, room_b) is None
+
+    def test_private_room_not_used_as_waypoint(self):
+        room_a = make_room(self.area, "A")
+        room_private = ObjectDBFactory(db_key="Private", db_typeclass_path="typeclasses.rooms.Room")
+        RoomProfile.objects.update_or_create(
+            objectdb=room_private, defaults={"area": self.area, "is_public": False}
+        )
+        room_c = make_room(self.area, "C")
+        make_exit(room_a, room_private, "east")
+        make_exit(room_private, room_c, "east")
+        # No public path from A to C exists — the only path runs through a private room.
+
+        assert find_route(room_a, room_c) is None
+
+    def test_hop_cap_exceeded_returns_none(self):
+        from django.test import override_settings
+
+        rooms = [make_room(self.area, f"R{i}") for i in range(5)]
+        for i in range(4):
+            make_exit(rooms[i], rooms[i + 1], "east")
+
+        with override_settings(TRAVEL_MAX_HOPS=2):
+            assert find_route(rooms[0], rooms[4]) is None
+
+    def test_query_count_scales_with_depth_not_room_count(self):
+        """Load-bearing test for the query-cost constraint (#2163 Decision 7).
+
+        A naive per-room BFS issues one query per room visited. This test builds
+        a wide-but-shallow graph (many rooms, few hops) and asserts the query
+        count stays bounded by hop depth, not room count — proving the frontier
+        batching is real, not accidental.
+        """
+        room_a = make_room(self.area, "A")
+        # 20 rooms all directly reachable from A in one hop each (wide frontier).
+        leaves = [make_room(self.area, f"Leaf{i}") for i in range(20)]
+        for leaf in leaves:
+            make_exit(room_a, leaf, "path")
+        target = leaves[-1]
+
+        with CaptureQueriesContext(connection) as ctx:
+            route = find_route(room_a, target)
+
+        assert route is not None
+        # One level of BFS (frontier={A}) should issue O(1) queries, not
+        # O(20) — a naive per-room implementation would issue ~20 queries
+        # for the 20-room frontier fetched here; batching keeps this small.
+        assert len(ctx.captured_queries) <= 5, (
+            f"expected a small, depth-bounded query count, got "
+            f"{len(ctx.captured_queries)}: {[q['sql'] for q in ctx.captured_queries]}"
+        )

--- a/src/world/areas/positioning/tests/test_travel.py
+++ b/src/world/areas/positioning/tests/test_travel.py
@@ -126,3 +126,49 @@ class FindRouteTests(TestCase):
             f"expected a small, depth-bounded query count, got "
             f"{len(ctx.captured_queries)}: {[q['sql'] for q in ctx.captured_queries]}"
         )
+
+    def test_query_count_stays_low_with_genuinely_multi_room_frontier(self):
+        """Companion to test_query_count_scales_with_depth_not_room_count —
+        that test's frontier is only ever 1 room wide at each level actually
+        processed (all 20 leaves are direct children of the single origin),
+        so it can't distinguish batched-per-level querying from a naive
+        per-room-loop implementation for this exact graph shape. This test
+        builds a genuinely multi-room frontier (5 rooms wide) at level 2, so
+        the bulk `db_location_id__in=frontier` query is exercised against a
+        real multi-room `frontier` set — a naive per-room-loop implementation
+        would issue ~5 queries at level 2 where the batched one issues 1.
+        """
+        room_a = make_room(self.area, "A")
+        # Level 1: 5 rooms, all direct children of A (frontier size 5 at level 2).
+        level1 = [make_room(self.area, f"L1-{i}") for i in range(5)]
+        for room in level1:
+            make_exit(room_a, room, "path")
+        # Level 2: each level-1 room has 4 children — frontier at level 2
+        # processing is genuinely {L1-0, L1-1, L1-2, L1-3, L1-4}, 5 rooms.
+        level2_target = None
+        for room in level1:
+            for i in range(4):
+                leaf = make_room(self.area, f"L2-{room.db_key}-{i}")
+                make_exit(room, leaf, "path")
+                if level2_target is None:
+                    level2_target = leaf
+        # Force the target to be reached only after level 2 is processed —
+        # pick the LAST leaf created under the LAST level-1 room, so BFS must
+        # fully expand the 5-room level-1 frontier before finding it.
+        last_room = level1[-1]
+        final_leaf = make_room(self.area, "FinalTarget")
+        make_exit(last_room, final_leaf, "path")
+
+        with CaptureQueriesContext(connection) as ctx:
+            route = find_route(room_a, final_leaf)
+
+        assert route is not None
+        assert len(route) == 2
+        # Two BFS levels processed (level 1: frontier={A}, level 2:
+        # frontier={5 level-1 rooms}) should still issue a small, level-bounded
+        # query count — not one query per room in the 5-room frontier.
+        assert len(ctx.captured_queries) <= 6, (
+            f"expected query count bounded by BFS depth (2 levels), not frontier "
+            f"width (5 rooms at level 2), got {len(ctx.captured_queries)}: "
+            f"{[q['sql'] for q in ctx.captured_queries]}"
+        )

--- a/src/world/areas/positioning/travel.py
+++ b/src/world/areas/positioning/travel.py
@@ -1,0 +1,123 @@
+"""Room-to-room travel pathfinding (#2163) — the room-level sibling of this
+package's intra-room `position_graph`/`reachable_positions` (services.py).
+
+Frontier-batched BFS: each level fetches every outbound exit for the entire
+current frontier in one query (mirroring `world.areas.services.area_subtree_pks`'s
+`parent_id__in=[...]` batching over the Area tree), never one room at a time.
+This is the fix for the exact failure mode that broke naive per-room BFS at
+scale in a prior project — the per-room query cost itself is cheap (Evennia's
+`.exits`/`.contents` is a single cached query per room instance), but an
+unbounded frontier fan-out without batching still costs one query per room
+visited. Batching collapses that to one query per BFS *level*.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from evennia.objects.models import ObjectDB
+
+from evennia_extensions.models import room_is_publicly_listed
+
+
+def _area_id(room: ObjectDB) -> int | None:
+    """The room's Area pk, or None if it has no RoomProfile / no Area set."""
+    try:
+        return room.room_profile.area_id
+    except ObjectDoesNotExist:
+        return None
+
+
+def _is_usable_waypoint(dest: ObjectDB, visited: set[int], area_id: int | None) -> bool:
+    """Whether `dest` is a not-yet-visited, publicly-listed room in the target Area.
+
+    Shared gate for both intermediate waypoints and the destination room itself —
+    keeping this a single predicate is what pulls find_route's per-exit branching
+    under the complexity threshold without changing any of the batching logic.
+    """
+    if dest is None or dest.id in visited:
+        return False
+    if not room_is_publicly_listed(dest):
+        return False
+    return _area_id(dest) == area_id
+
+
+def find_route(origin_room: ObjectDB, destination_room: ObjectDB) -> list[ObjectDB] | None:
+    """Find a public-room-only walking route from origin to destination.
+
+    Scoped to same-Area travel only (#2163 Decision 6) — cross-Area routing
+    needs Area-to-Area connectivity data this codebase doesn't have yet.
+
+    Returns an ordered list of Exit ObjectDB instances forming the route, or
+    None if unreachable, the destination isn't publicly listed, the rooms are
+    in different Areas, or the route would exceed TRAVEL_MAX_HOPS.
+    """
+    if origin_room.id == destination_room.id:
+        return []
+
+    origin_area_id = _area_id(origin_room)
+    dest_area_id = _area_id(destination_room)
+    if origin_area_id is None or origin_area_id != dest_area_id:
+        return None
+
+    if not room_is_publicly_listed(destination_room):
+        return None
+
+    max_hops = settings.TRAVEL_MAX_HOPS
+
+    # predecessor[room_id] = (exit_objectdb, previous_room_id)
+    predecessor: dict[int, tuple[ObjectDB, int]] = {}
+    visited: set[int] = {origin_room.id}
+    frontier: set[int] = {origin_room.id}
+
+    for _hop in range(max_hops):
+        if not frontier:
+            return None
+
+        # One bulk query for the entire frontier's outbound exits — the
+        # load-bearing batching step (#2163 Decision 7). select_related
+        # walks both the destination room AND its RoomProfile (a reverse
+        # OneToOne, select_related-able) in the SAME query — without the
+        # room_profile leg, every room_is_publicly_listed()/_area_id() call
+        # below would issue its own query per candidate room, silently
+        # reintroducing the exact per-room N+1 this function exists to avoid.
+        exits = list(
+            ObjectDB.objects.filter(
+                db_location_id__in=frontier,
+                db_destination__isnull=False,
+            ).select_related("db_destination__room_profile")
+        )
+
+        next_frontier: set[int] = set()
+        for exit_obj in exits:
+            dest = exit_obj.db_destination
+            if not _is_usable_waypoint(dest, visited, origin_area_id):
+                continue
+
+            predecessor[dest.id] = (exit_obj, exit_obj.db_location_id)
+            visited.add(dest.id)
+
+            if dest.id == destination_room.id:
+                return _reconstruct_path(predecessor, origin_room.id, destination_room.id)
+
+            next_frontier.add(dest.id)
+
+        frontier = next_frontier
+
+    return None
+
+
+def _reconstruct_path(
+    predecessor: dict[int, tuple[ObjectDB, int]],
+    origin_id: int,
+    destination_id: int,
+) -> list[ObjectDB]:
+    """Walk the predecessor chain backward from destination to origin, then reverse."""
+    path: list[ObjectDB] = []
+    current_id = destination_id
+    while current_id != origin_id:
+        exit_obj, prev_id = predecessor[current_id]
+        path.append(exit_obj)
+        current_id = prev_id
+    path.reverse()
+    return path

--- a/src/world/areas/serializers.py
+++ b/src/world/areas/serializers.py
@@ -8,6 +8,7 @@ class WhereEntrySerializer(serializers.Serializer):
 
     persona_name = serializers.CharField(read_only=True)
     room_path = serializers.CharField(read_only=True)
+    room_id = serializers.IntegerField(read_only=True)
 
 
 class WhoEntrySerializer(serializers.Serializer):

--- a/src/world/areas/services.py
+++ b/src/world/areas/services.py
@@ -54,6 +54,7 @@ class WhereEntry:
 
     persona_name: str
     room_path: str
+    room_id: int
 
 
 def _room_display_name(room: ObjectDB) -> str:
@@ -129,7 +130,13 @@ def where_listing(viewer_account: object | None = None) -> list[WhereEntry]:
         except (AttributeError, ObjectDoesNotExist):
             continue
         persona = active_persona_for_sheet(sheet)
-        entries.append(WhereEntry(persona_name=persona.name, room_path=colored_area_path(room)))
+        entries.append(
+            WhereEntry(
+                persona_name=persona.name,
+                room_path=colored_area_path(room),
+                room_id=room.id,
+            )
+        )
     entries.sort(key=lambda entry: entry.persona_name.lower())
     return entries
 

--- a/src/world/areas/test_where.py
+++ b/src/world/areas/test_where.py
@@ -95,3 +95,9 @@ class WhereListingConcealmentTests(TestCase):
             entries = where_listing()
         names = [entry.persona_name for entry in entries]
         assert self.visible_sheet.primary_persona.name in names
+
+    def test_where_entry_includes_room_id(self) -> None:
+        with patch("evennia.SESSION_HANDLER") as handler:
+            handler.get_sessions.return_value = [self._session(self.visible)]
+            entries = where_listing()
+        assert any(entry.room_id == self.room.id for entry in entries)


### PR DESCRIPTION
Closes #2163

## Summary

Builds the walking-directions half of #2163's ratified travel fiction (2026-07-10, Tehom): a frontier-batched, hop-capped find_route() pathfinder over the room/exit graph (same-Area, public-rooms-only), a paced/cancellable TravelAction+StopTravelAction (server-side auto-walk via evennia.utils.delay, one hop per 1.5s, reusing the existing single-hop traversal primitives), telnet CmdTravel (travel <name> / travel stop), WhereEntry.room_id for presence-panel parity, and Go there buttons on the scene browser + presence panel.

The central engineering constraint was query cost: the user flagged from direct prior-project experience that naive per-room BFS eventually has to be abandoned at scale. Verified the actual risk is unbounded room-visit count without batching (not per-room query cost, which Evennia's .exits/.contents already makes O(1)/room) — fixed by reusing an existing frontier-batching pattern (area_subtree_pks's parent_id__in=[...] BFS over the Area tree) applied to the room/exit graph for the first time, proven by two query-count tests against both a wide-shallow graph and a genuinely multi-room BFS frontier.

7 SDD tasks + 2 fix waves. Final whole-branch review (Opus) caught one real Critical: the web Go there buttons dispatched via REST, which never auto-resolves objectdb_target_kwargs (that resolution only exists on a different, websocket-only code path, and even there requires a target_id-suffixed key, not target) — so TravelAction received a raw int and find_route crashed. Fixed: TravelAction.execute() resolves a raw int target itself (mirrors the established _resolve_room() REST-safe pattern already used elsewhere), with a genuine non-mocked regression test proving the fix. Re-review: Ready to merge, Yes, no remaining Critical/Important.

Deferred, filed as follow-ups: portal/transport-gift travel (#2222 — the other ratified-fiction half, needs a new Minor Gift + room-fixture kind), and cross-Area travel + a proposed nested Area/Building coordinate system (#2223 — raised mid-design by the user; verified coordinates alone don't solve routing since no Area-to-Area connectivity data exists, so this is a design question, not asserted work).

## Follow-ups filed

- #2222
- #2223

## Notes

- Spec: reviewed & approved on #2163 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (8561d6dbc, clean, no conflicts) once at pickup and again just before opening this PR (origin/main had moved further); full per-task fast-tier test evidence preserved across the rebase since it was a clean fast-forward with no manual resolution.

<!-- last-addressed-comment: 0 -->