### PR TITLE
Allow AWS CloudFront egress so agents can reach SonarCloud's own API

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -10,7 +10,7 @@
 #   https://raw.githubusercontent.com/anthropics/claude-code/main/.devcontainer/init-firewall.sh
 # Structure preserved; allowlist replaced; IP-range gathering uses the same
 # "fetch published ranges before lockdown" philosophy as the upstream reference,
-# extended to cover all five logical destination groups.
+# extended to cover all six logical destination groups.
 
 set -euo pipefail
 IFS=$'\n\t'
@@ -107,7 +107,17 @@ iptables -A OUTPUT -d 172.16.0.0/12 -j ACCEPT
 #      published Storage-service IP ranges instead — scoped to the Storage tag,
 #      not all of Azure.
 #
-# Sources b–e use -exist so duplicate CIDRs across ranges don't error.
+#   f) AWS CloudFront published ranges — covers sonarcloud.io and
+#      api.sonarcloud.io, both served from CloudFront (confirmed via
+#      api.sonarcloud.io's CNAME to a *.cloudfront.net distribution).
+#      SonarCloud used to be in group (a) as a single dig-resolved IP, which
+#      is exactly the wrong approach for a CDN-fronted host (same failure
+#      mode as (e)'s Azure blob storage) — a one-shot dig only catches
+#      whichever edge node answered that query, so it silently goes stale
+#      and CI-failure diagnosis via the SonarCloud API stops working. Fixed
+#      by allowing AWS's published CLOUDFRONT service-tag ranges instead.
+#
+# Sources b–f use -exist so duplicate CIDRs across ranges don't error.
 # ---------------------------------------------------------------------------
 ipset create allowed-domains hash:net
 
@@ -145,8 +155,6 @@ resolve_and_add "sentry.io"
 # endpoint that Claude Code reaches.
 resolve_and_add "statsig.com"
 resolve_and_add "pypi.org"
-# SonarCloud — public-project API for fetching code-quality findings on PRs.
-resolve_and_add "sonarcloud.io"
 # Umans Code — Anthropic-compatible model endpoint (https://api.code.umans.ai).
 # Backs two harnesses: Claude Code via its ANTHROPIC_BASE_URL override, and
 # polytoken's custom Anthropic-compatible provider. Two stable AWS EIPs
@@ -248,6 +256,26 @@ if [ "$AZURE_COUNT" -lt 50 ]; then
 fi
 echo "  Added ${AZURE_COUNT} Azure Storage CIDRs."
 
+# ---- f) AWS CloudFront published ranges (sonarcloud.io, api.sonarcloud.io) ----
+echo "Fetching AWS CloudFront IP ranges..."
+AWS_RANGES=$(curl -sf --connect-timeout 15 --max-time 30 https://ip-ranges.amazonaws.com/ip-ranges.json)
+if [ -z "$AWS_RANGES" ]; then
+    echo "ERROR: Failed to fetch https://ip-ranges.amazonaws.com/ip-ranges.json" >&2
+    exit 1
+fi
+CLOUDFRONT_COUNT=0
+while read -r cidr; do
+    if is_valid_ipv4_cidr "$cidr"; then
+        ipset add allowed-domains "$cidr" -exist
+        CLOUDFRONT_COUNT=$((CLOUDFRONT_COUNT + 1))
+    fi
+done < <(echo "$AWS_RANGES" | jq -r '.prefixes[] | select(.service == "CLOUDFRONT") | .ip_prefix')
+if [ "$CLOUDFRONT_COUNT" -lt 50 ]; then
+    echo "ERROR: AWS CloudFront ranges returned only ${CLOUDFRONT_COUNT} IPv4 CIDRs (minimum 50); aborting" >&2
+    exit 1
+fi
+echo "  Added ${CLOUDFRONT_COUNT} AWS CloudFront CIDRs."
+
 # ---------------------------------------------------------------------------
 # 4. Default-deny policies and final ACCEPT/REJECT rules.
 #
@@ -293,7 +321,8 @@ echo "Verifying firewall rules..."
 # (a) Blocked host must be unreachable. Use www.google.com — Google's own
 # IPs (142.250.0.0/15, 142.251.0.0/16) are not in any of our allowlist
 # sources (Anthropic, Sentry, Statsig, PyPI, GitHub meta, Fastly,
-# Cloudflare, Azure Storage), so reachability here means a firewall miss. Avoid
+# Cloudflare, Azure Storage, AWS CloudFront), so reachability here means a
+# firewall miss. Avoid
 # example.com / example.org as test targets: both now resolve to
 # Cloudflare IPs (104.20.x.x, 172.66.x.x) that are legitimately in our
 # allowlist because Cloudflare fronts the npm registry.

--- a/docs/dev-commands.md
+++ b/docs/dev-commands.md
@@ -115,6 +115,24 @@ Automatic-Analysis-specific behaviors that differ from a configured scanner:
   extracting a shared helper. Sonar's mechanical duplication check doesn't
   grade semantic justification, so even duplication a human reviewer calls
   "reasonable" still fails the gate.
+- **The duplication gate is an aggregate percentage, not a per-file
+  annotation** — the Checks API only tells you the failing metric name and
+  its value, not which lines are duplicated against which. To find the exact
+  duplicate blocks, call SonarCloud's own API directly (`SONAR_TOKEN` is
+  already in the devcontainer env; anonymous calls return empty bodies, so
+  basic-auth with the token and no password):
+  ```bash
+  # Find offending files on this PR/branch:
+  curl -su "$SONAR_TOKEN:" "https://sonarcloud.io/api/measures/component_tree?component=Arx-Game_arxii&metricKeys=new_duplicated_lines_density&pullRequest=<PR#>&ps=500"
+  # Exact duplicate block locations for one file (component key from above):
+  curl -su "$SONAR_TOKEN:" "https://sonarcloud.io/api/duplications/show?key=<file-component-key>"
+  # Full issue list with rule + message (also works for non-duplication findings):
+  curl -su "$SONAR_TOKEN:" "https://sonarcloud.io/api/issues/search?componentKeys=Arx-Game_arxii&pullRequest=<PR#>&resolved=false"
+  ```
+  This needs `sonarcloud.io`/`api.sonarcloud.io` reachable from the
+  devcontainer — see the SonarCloud row in `docs/devcontainer-setup.md`'s
+  egress table if these calls fail with a connection error rather than an
+  HTTP error.
 - **A backend-only model retype (e.g. int→enum) can trip both the duplication
   gate indirectly and, separately, the frontend `api-types-drift`/build gates**
   (see "Generated API Schema" in `django_notes.md`) — regenerating the

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -227,6 +227,7 @@ published IP-range data so CDN edge nodes are covered:
 | GitHub CDN / PyPI files | `objects.githubusercontent.com`, `files.pythonhosted.org` | Fastly published ranges (`api.fastly.com/public-ip-list`) |
 | npm registry | `registry.npmjs.org` | Cloudflare published ranges (`cloudflare.com/ips-v4`) |
 | GitHub Actions log downloads | `productionresultssaN.blob.core.windows.net` (N unbounded, no fixed IPs — each shard is a different Azure region behind Traffic Manager) | Azure's global `Storage` service tag (Microsoft's `ServiceTags_Public_*.json`) |
+| SonarCloud | `sonarcloud.io`, `api.sonarcloud.io` (both CloudFront-fronted, rotating edge IPs) | AWS's published `CLOUDFRONT` service tag (`ip-ranges.amazonaws.com/ip-ranges.json`) |
 
 If any required fetch fails during initialization the script exits 1 **before**
 applying the default-deny policy, so the container retains open egress rather than


### PR DESCRIPTION
## Summary
- Confirmed live from inside the devcontainer: `sonarcloud.io` currently fails to connect (`curl: (7) Failed to connect ... Couldn't connect to server`), same symptom class as the GitHub-Actions-log issue fixed in #2233.
- Root cause: both `sonarcloud.io` and `api.sonarcloud.io` are served via AWS CloudFront (`api.sonarcloud.io` CNAMEs to a `*.cloudfront.net` distribution; `sonarcloud.io`'s apex resolves to rotating `52.222.177.x`-style edge IPs). The firewall's existing entry treated it as a "small/stable host" — a single `dig`-resolved snapshot IP — which is exactly the wrong strategy for a CDN-fronted host: it goes stale as soon as DNS round-robins to a different edge node.
- Removes the flawed `resolve_and_add "sonarcloud.io"` line and adds a 6th fetch group allowing AWS's published `CLOUDFRONT` service-tag ranges (`ip-ranges.amazonaws.com/ip-ranges.json`), the same "trust the vendor's published ranges" pattern already used for Fastly/Cloudflare/Azure Storage.
- Updates `docs/devcontainer-setup.md`'s allowed-destinations table.
- Adds a new bullet to `docs/dev-commands.md`'s SonarCloud section documenting the actual API calls (with `SONAR_TOKEN`, already present in the devcontainer env) needed to drill into *which lines* triggered a duplication-gate failure — the Checks API annotation only gives the aggregate percentage, not file/line detail. This recipe previously only existed in an agent's memory from a past PR, not in the repo, which is why agents didn't know how to investigate a duplication failure even once network access works.

## Why this matters
Per the user: agents currently hit a SonarCloud duplication-gate failure and "have no idea how to get to it." Two separate gaps, both closed here:
1. Network: `sonarcloud.io`/`api.sonarcloud.io` weren't reliably reachable (this PR).
2. Knowledge: even when reachable, the specific SONAR_TOKEN + endpoint recipe to get from "3.5% duplication" to "these exact lines" wasn't written down anywhere agents would find it (`docs/dev-commands.md` update, this PR).

## Verification
- `bash -n` and `shellcheck` pass clean.
- Dry-ran the `jq` CLOUDFRONT-service filter against a synthetic fixture matching AWS's real `ip-ranges.json` schema (IPv4 CLOUDFRONT entries, a non-CLOUDFRONT EC2 entry, and a garbage string) — confirms only CloudFront IPv4 CIDRs are picked up.
- **Not yet verified end-to-end** for the same reason as #2233: this script only takes effect after a devcontainer rebuild (`just dc-build`), which I didn't trigger since it tears down the running container.

## Test plan
- [ ] After merge + rebuild, confirm firewall init completes without errors
- [ ] Confirm `curl -su "$SONAR_TOKEN:" "https://sonarcloud.io/api/issues/search?componentKeys=Arx-Game_arxii&pullRequest=<any open PR>&resolved=false"` succeeds
- [ ] Confirm the existing firewall verification step (blocked: google.com, allowed: api.github.com) still passes