### PR TITLE
Telnet parity: CmdSeduce mirrors CmdFlirt (#1695 audit fold-in)

### DIFF
--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -129,7 +129,7 @@ actions, backends, and service functions.
   `_actor_may_gm_encounter` (staff or `encounter.scene.is_gm(account)`) in the Action layer —
   reads the same `SceneParticipation.is_gm` flag `enroll_present_table_gms`/
   `GrantSceneGMAction`/`_enroll_lead_gm_on_scene` write (#2113). No business logic in the command.
-- **`consent.py`**: `ConsentRequestCommand` (base), `CmdIntimidate`, `CmdPersuade`, `CmdDeceive`, `CmdFlirt`, `CmdPerform`, `CmdEntrance`, `CmdRestoreSense` — telnet shells for social consent-flow actions (#1337/#1338); `CmdAccept` (extended to check offer registry first; consent
+- **`consent.py`**: `ConsentRequestCommand` (base), `CmdIntimidate`, `CmdPersuade`, `CmdDeceive`, `CmdFlirt`, `CmdSeduce`, `CmdPerform`, `CmdEntrance`, `CmdRestoreSense` — telnet shells for social consent-flow actions (#1337/#1338/#1695); `CmdAccept` (extended to check offer registry first; consent
   fall-through unchanged), `CmdDeny` — target responses. All call `create_action_request` / `respond_to_action_request` — the same service the web viewset calls.
 - **`social/grievance.py`**: `CmdGrievance` (`+grievance`, #1429) — the telnet face of the secret-victim grievance prompt; thin over `world.secrets.services.register_secret_grievance` (the same service the web `/api/secrets/grievance/` endpoint calls). A wronged character picks a `GrievanceOption` for a secret they've learned; it applies a one-sided relationship swing toward the perpetrator.
 - **`ritual.py`**: `CmdRitual` (alias `perform`) — telnet face of

--- a/src/commands/consent.py
+++ b/src/commands/consent.py
@@ -175,6 +175,17 @@ class CmdFlirt(ConsentRequestCommand):
     action_key = "flirt"
 
 
+class CmdSeduce(ConsentRequestCommand):
+    """Seduce another character (they must accept or deny).
+
+    Usage:
+        seduce <character>
+    """
+
+    key = "seduce"
+    action_key = "seduce"
+
+
 class CmdPerform(ConsentRequestCommand):
     """Captivate another character through music, oration, or storytelling.
 

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -39,6 +39,7 @@ from commands.consent import (
     CmdPerform,
     CmdPersuade,
     CmdRestoreSense,
+    CmdSeduce,
 )
 from commands.consent_preferences import CmdConsent
 from commands.covenant import CmdCovenant
@@ -239,6 +240,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdPersuade,
             CmdDeceive,
             CmdFlirt,
+            CmdSeduce,
             CmdPerform,
             CmdEntrance,
             CmdRestoreSense,

--- a/src/commands/tests/test_consent_commands.py
+++ b/src/commands/tests/test_consent_commands.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
-from commands.consent import CmdAccept, CmdDeny, CmdIntimidate, ConsentRequestCommand
+from commands.consent import CmdAccept, CmdDeny, CmdIntimidate, CmdSeduce, ConsentRequestCommand
 from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.scenes.action_constants import ActionRequestStatus, ConsentDecision
@@ -107,6 +107,62 @@ class CmdIntimidateTests(TestCase):
         """The base reads ``action_key`` from the subclass — no hardcoding."""
         self.assertEqual(CmdIntimidate.action_key, "intimidate")
         self.assertTrue(issubclass(CmdIntimidate, ConsentRequestCommand))
+
+
+class CmdSeduceTests(TestCase):
+    """Initiator runs ``seduce <target>``; a PENDING request is created (#1695).
+
+    Mirrors ``CmdIntimidateTests`` — ``CmdSeduce`` is the same thin
+    ``ConsentRequestCommand`` shell as ``CmdFlirt``, just with
+    ``action_key = "seduce"``.
+    """
+
+    def setUp(self) -> None:
+        # DbHolder trap: Evennia ObjectDB fixtures must be built in setUp.
+        self.room = ObjectDBFactory(
+            db_key="Hall",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        self.initiator_char = ObjectDBFactory(
+            db_key="Alice",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+        self.target_char = ObjectDBFactory(
+            db_key="Bob",
+            db_typeclass_path="typeclasses.characters.Character",
+            location=self.room,
+        )
+        self.initiator_sheet = CharacterSheetFactory(character=self.initiator_char)
+        self.target_sheet = CharacterSheetFactory(character=self.target_char)
+        self.initiator_persona = self.initiator_sheet.primary_persona
+        self.target_persona = self.target_sheet.primary_persona
+        self.scene = SceneFactory(is_active=True, location=self.room)
+        if hasattr(self.room, "_active_scene_cache"):
+            del self.room._active_scene_cache
+
+    def _run(self, caller: object, args: str) -> CmdSeduce:
+        cmd = CmdSeduce()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.raw_string = f"seduce {args}"
+        caller.msg = MagicMock()
+        cmd.func()
+        return cmd
+
+    def test_seduce_creates_pending_request(self) -> None:
+        cmd = self._run(self.initiator_char, self.target_char.key)
+
+        req = SceneActionRequest.objects.get(initiator_persona=self.initiator_persona)
+        self.assertEqual(req.status, ActionRequestStatus.PENDING)
+        self.assertEqual(req.target_persona, self.target_persona)
+        self.assertEqual(req.action_key, "seduce")
+        self.assertEqual(req.scene, self.scene)
+        cmd.caller.msg.assert_called()
+
+    def test_action_key_class_attr_drives_request(self) -> None:
+        self.assertEqual(CmdSeduce.action_key, "seduce")
+        self.assertTrue(issubclass(CmdSeduce, ConsentRequestCommand))
 
 
 class RespondCommandTests(TestCase):
@@ -254,6 +310,7 @@ class AllSocialCommandsRegisteredTests(TestCase):
             "persuade": CmdPersuade,
             "deceive": CmdDeceive,
             "flirt": CmdFlirt,
+            "seduce": CmdSeduce,
             "perform": CmdPerform,
             "entrance": CmdEntrance,
             "restore_sense": CmdRestoreSense,


### PR DESCRIPTION
## Summary
- Adds `CmdSeduce` — the telnet shell for the `seduce` social consent action — mirroring `CmdFlirt` exactly (same `ConsentRequestCommand` base, `action_key="seduce"`, registered in `CharacterCmdSet`).
- Gap found by the code-verified completion audit on epic #1695: Seduce was web-reachable via the dynamic action panel but had no telnet command (telnet-parity policy: same issue, not a follow-up).
- Tests: `CmdSeduceTests` (pending-request creation + registration) added to `test_consent_commands.py`; `AllSocialCommandsRegisteredTests` extended. `just test-fast commands`: 1069 tests OK.
- Docs in tandem: `src/commands/CLAUDE.md` consent.py listing updated.

Refs #1695 (audit comment there has the full stream-by-stream verification).

## Notes
- Design pass: skipped (parity fold-in from the epic audit; no new design surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)