### PR TITLE
Conversation tabs: keep several conversations straight at once (#2155)

### DIFF
--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -749,6 +749,24 @@ a scene, not a room, so this is unrelated to room id.
 there; that's a separate, pre-existing latent bug on that page, left untouched
 by this slate.
 
+**#2165 conversation tabs:** `/game` can keep several conversations open at once
+— the room feed as a permanent anchor plus a closable tab per broken-out
+place/whisper/target thread (`ConversationTabStrip.tsx`, rendered above the feed
+in `GameWindow`). Tab state (`openThreadTabs`/`activeThreadTab`) lives in
+`gameSlice`'s per-character `Session`, one tab set per session. The
+`ConversationSidebar` is the **open-a-tab surface**: clicking a thread row opens
+or focuses its tab; clicking the room row or "All" re-anchors the strip back to
+the room feed. The composer's audience is **derived from the active tab and
+locked**, never stored independently — `tabKeyToComposerMode` (in
+`threadToComposerMode.ts`) translates the active tab's key into a locked
+`ComposerMode` every render, which is the mis-send guard (a stale composer
+audience surviving a tab switch is the failure mode this closes). The open-tab
+layout is persisted client-locally per character+scene (thread **keys** only,
+never message content) via `threadTabsStorage.ts`'s `localStorage` helpers, and
+`gameSlice` resets both tab fields whenever the session's scene id actually
+changes, since a tab pointing at a previous scene's thread set is unsafe to keep
+open.
+
 ---
 
 ## Permissions

--- a/frontend/src/game/CLAUDE.md
+++ b/frontend/src/game/CLAUDE.md
@@ -10,11 +10,30 @@ Core game interface for real-time RPG interaction with WebSocket communication a
   session's `sceneId`/`roomName`, calls `useSceneInteractions` +
   `useThreading` once, owns `composerMode` state, and feeds the result down
   as props to `ConversationSidebar` (left) and `GameWindow` (center) — no
-  duplicate roster/scene-interaction queries in the children.
+  duplicate roster/scene-interaction queries in the children. Also owns the
+  **conversation-tab session state** (#2165): `openThreadTabs`/`activeThreadTab`
+  live in `gameSlice` per session, and `GamePage` derives the tab strip's props,
+  the tab-narrowed feed (`tabInteractions`), and the tab-locked composer mode
+  (`effectiveComposerMode`, via `tabKeyToComposerMode`) from that state every
+  render — the composer's audience is never stored, only derived, which is the
+  mis-send guard. It also hydrates/persists the open-tab layout from
+  `threadTabsStorage.ts` and resets tabs on scene change (see `gameSlice.ts`'s
+  `setSessionScene`).
 - **`GameWindow.tsx`**: Central communication hub with session tabs and
   command input. When the composition root passes a `sceneFeed` prop (an
   active scene), the center renders the structured chat-bubble feed
-  (`SceneMessages` + `SystemLane`) instead of the legacy `ChatWindow`.
+  (`SceneMessages` + `SystemLane`) instead of the legacy `ChatWindow`. Renders
+  `ConversationTabStrip` above the feed when `conversationTabs` is passed
+  (#2165), and remembers each conversation tab's scroll offset (`Map<threadKey,
+scrollTop>`), restoring it on tab switch and re-pinning to the bottom only
+  when the reader was already at the bottom for that tab.
+- **`threadTabsStorage.ts`**: `loadThreadTabs`/`saveThreadTabs` (#2165) —
+  client-local persistence of the open-tab layout (thread **keys** only, never
+  message content) in `localStorage`, keyed per character+scene
+  (`arx:threadTabs:<character>:<sceneId>`); a character keeps at most one
+  scene's entry, older entries for the same character are pruned on save.
+  Best-effort: any storage error (unavailable, unparsable) is swallowed and
+  treated as "nothing stored."
 
 ### Layout (`components/`)
 
@@ -25,6 +44,19 @@ Core game interface for real-time RPG interaction with WebSocket communication a
   threading state for an active scene; otherwise falls back to a static
   "Room" button. Also owns the per-thread `ThreadFilterModal` (participant
   mute list), mirroring `SceneInteractionPanel`'s composition on `/scenes/:id`.
+  **Open-a-tab surface (#2165):** clicking a non-room thread row calls
+  `onThreadClick`, which `GamePage` wires to open (or focus, if already open) a
+  conversation tab — the sidebar itself never narrows the feed. Clicking the
+  room row, or the "All" button, re-anchors the tab strip back to the room and
+  resets the composer; `onShowAll` is `GamePage`'s override of
+  `threading.showAll` for exactly that reason (the bare `showAll` only resets
+  the filter/mute state, not the active tab).
+- **`ConversationTabStrip.tsx`**: The open-conversations tab strip rendered
+  above the feed in `GameWindow` (#2165) — the room feed as a permanent,
+  unclosable anchor tab plus one closable tab per broken-out thread
+  (place/whisper/target), each with an unread badge. Selecting a tab dispatches
+  `setActiveThreadTab`; closing one dispatches `closeThreadTab`. Renders
+  nothing when no conversation tab is open (room-only sessions see no strip).
 
 ### Communication (`components/`)
 
@@ -67,6 +99,9 @@ Core game interface for real-time RPG interaction with WebSocket communication a
 - **Three-column layout**: Conversation sidebar, communication hub, room panel
 - **Responsive**: Sidebars hidden below lg breakpoint, center content fills screen
 - **Multi-character sessions**: Multiple character tabs open simultaneously
+- **Conversation tabs (#2165)**: Keep several threads (room + place/whisper/target)
+  open at once per session; the composer's audience locks to whichever tab is
+  active
 - **Dynamic commands**: Commands discovered from server with generated forms
 - **Real-time updates**: WebSocket integration for live game state
 - **Context menus**: Right-click actions on game entities

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -765,7 +765,7 @@ describe('GamePage', () => {
   // ---------------------------------------------------------------------------
 
   describe('conversation tabs (#2165)', () => {
-    it('clicking a whisper thread in the sidebar opens a tab, narrows the feed, and locks the composer to its audience', async () => {
+    it('sidebar whisper click opens a tab, narrows feed, locks composer to it', async () => {
       store.dispatch(setAccount(mockAccount));
       seedActiveSceneWithPose();
       seedWhisperThread();
@@ -805,7 +805,7 @@ describe('GamePage', () => {
       expect(screen.queryByRole('button', { name: 'Pose' })).not.toBeInTheDocument();
     });
 
-    it('clicking the room anchor tab restores the full feed and re-enables the mode dropdown', async () => {
+    it('clicking room anchor tab restores full feed, re-enables mode dropdown', async () => {
       store.dispatch(setAccount(mockAccount));
       seedActiveSceneWithPose();
       seedWhisperThread();
@@ -843,7 +843,7 @@ describe('GamePage', () => {
       expect(roomTab).toHaveAttribute('aria-selected', 'true');
     });
 
-    it('badges the whisper tab with unread while the room anchor is active, and clears it on switch', async () => {
+    it('badges whisper tab unread while room anchor active, clears on switch', async () => {
       store.dispatch(setAccount(mockAccount));
       seedActiveSceneWithPose();
       seedWhisperThread();
@@ -903,7 +903,7 @@ describe('GamePage', () => {
       });
     });
 
-    it('closing the active tab falls back to the room anchor and the tab strip disappears; the sidebar reopens it', async () => {
+    it('closing the active tab falls back to room anchor; sidebar reopens it', async () => {
       store.dispatch(setAccount(mockAccount));
       seedActiveSceneWithPose();
       seedWhisperThread();
@@ -967,6 +967,77 @@ describe('GamePage', () => {
       await waitFor(() => {
         expect(screen.queryByRole('tablist', { name: 'Conversations' })).not.toBeInTheDocument();
       });
+    });
+
+    it('sidebar All button restores the room feed while a whisper tab is active', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      seedWhisperThread();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+      const whisperRow = within(sidebar)
+        .getByText(/whisper/i)
+        .closest('button') as HTMLElement;
+      await user.click(whisperRow);
+      await screen.findByRole('tablist', { name: 'Conversations' });
+
+      // Feed is narrowed to the whisper thread only.
+      expect(screen.queryByText('stretches languidly.')).not.toBeInTheDocument();
+
+      // Clicking the sidebar's "All" button (#2165 review fix) must restore
+      // the room feed AND re-anchor the tab strip to the room tab —
+      // `threading.showAll()` alone only resets the filter/mute state, not
+      // the active conversation tab.
+      const allButton = within(sidebar).getByRole('button', { name: 'All' });
+      await user.click(allButton);
+
+      expect(await screen.findByText('stretches languidly.')).toBeInTheDocument();
+      expect(screen.getByText('meet me by the fountain at midnight.')).toBeInTheDocument();
+
+      const tablist = screen.getByRole('tablist', { name: 'Conversations' });
+      const roomTab = within(tablist)
+        .getByText('The Grand Ballroom')
+        .closest('[role="tab"]') as HTMLElement;
+      expect(roomTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('room tab click resets a stale composer mode left by a drawer whisper', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      // Drawer-whisper (#2156): clicking the pose's avatar opens the
+      // character card; "Whisper" sets an UNLOCKED composer mode targeting
+      // the persona, before any conversation tab exists.
+      await user.click(screen.getByRole('button', { name: `View ${ACTIVE_NAME}` }));
+      await user.click(await screen.findByRole('button', { name: 'Whisper' }));
+      expect(screen.getByText(`Whisper → ${ACTIVE_NAME}`)).toBeInTheDocument();
+
+      // Open and activate a real conversation tab.
+      seedWhisperThread();
+      const sidebar = screen.getByLabelText('Thread sidebar');
+      const whisperRow = await within(sidebar).findByText(/whisper/i);
+      await user.click(whisperRow.closest('button') as HTMLElement);
+      const tablist = await screen.findByRole('tablist', { name: 'Conversations' });
+
+      // Clicking the strip's room tab (#2165 review fix) must reset the
+      // composer to the room pose mode — not leave the stale drawer-whisper
+      // mode that predates any tab.
+      const roomTab = within(tablist)
+        .getByText('The Grand Ballroom')
+        .closest('[role="tab"]') as HTMLElement;
+      await user.click(roomTab);
+
+      expect(await screen.findByRole('button', { name: 'Pose' })).toBeInTheDocument();
+      expect(screen.getByText('Pose → The Grand Ballroom')).toBeInTheDocument();
+      expect(screen.queryByText(`Whisper → ${ACTIVE_NAME}`)).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -267,6 +267,16 @@ describe('GamePage', () => {
     });
 
     it('clicking a thread in the sidebar actually filters the center feed (review fix)', async () => {
+      // #2165 update: clicking a non-room thread row now OPENS A TAB
+      // (GamePage's handleThreadClick dispatches openThreadTab) rather than
+      // toggling useThreading's local enabledThreadKeys filter — that old
+      // narrowing mechanism is retired for the /game room feed (it still
+      // backs /scenes/:id's SceneInteractionPanel, untouched here). The feed
+      // narrows because the active TAB drives `tabInteractions` now, and the
+      // way back to the full feed is the room row, not "All" (clicking "All"
+      // only clears the retired enabledThreadKeys filter, which no longer
+      // drives what's on screen once a tab is active — see the "conversation
+      // tabs (#2165)" describe block below for that contract's own coverage).
       store.dispatch(setAccount(mockAccount));
       seedActiveSceneWithPose();
       seedWhisperThread();
@@ -285,15 +295,14 @@ describe('GamePage', () => {
       expect(whisperButton).not.toBeNull();
       await user.click(whisperButton as HTMLElement);
 
-      // Clicking the whisper thread must narrow the feed to just that thread —
-      // the room pose disappears and the whisper stays (GamePage's
-      // handleThreadClick must call toggleThreadVisibility, not just
-      // setSelectedThread, or filteredInteractions never changes).
+      // Clicking the whisper thread opens its tab and narrows the feed to
+      // just that thread — the room pose disappears and the whisper stays.
       expect(screen.queryByText('stretches languidly.')).not.toBeInTheDocument();
       expect(screen.getByText('meet me by the fountain at midnight.')).toBeInTheDocument();
 
-      // "All" restores both threads.
-      await user.click(within(sidebar).getByText('All'));
+      // The room row restores the full feed (the room anchor).
+      const roomButton = within(sidebar).getByText('The Grand Ballroom').closest('button');
+      await user.click(roomButton as HTMLElement);
       expect(screen.getByText('stretches languidly.')).toBeInTheDocument();
       expect(screen.getByText('meet me by the fountain at midnight.')).toBeInTheDocument();
     });
@@ -746,6 +755,218 @@ describe('GamePage', () => {
       await user.click(trigger);
 
       expect(screen.queryByText('Tabletalk')).not.toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Conversation tabs (#2165): sidebar-click opens/focuses a tab; the tab
+  // strip narrows the feed + locks the composer; close falls back to the
+  // room anchor; a scene change clears every open tab.
+  // ---------------------------------------------------------------------------
+
+  describe('conversation tabs (#2165)', () => {
+    it('clicking a whisper thread in the sidebar opens a tab, narrows the feed, and locks the composer to its audience', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      seedWhisperThread();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+
+      await screen.findByText('stretches languidly.');
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+      const whisperRow = within(sidebar)
+        .getByText(/whisper/i)
+        .closest('button') as HTMLElement;
+      await user.click(whisperRow);
+
+      // A tablist appears with the room anchor + the whisper tab, the
+      // whisper tab selected.
+      const tablist = await screen.findByRole('tablist', { name: 'Conversations' });
+      const tabs = within(tablist).getAllByRole('tab');
+      expect(tabs).toHaveLength(2);
+      const whisperTab = within(tablist)
+        .getByText(/whisper/i)
+        .closest('[role="tab"]') as HTMLElement;
+      expect(whisperTab).toHaveAttribute('aria-selected', 'true');
+      const roomTab = within(tablist)
+        .getByText('The Grand Ballroom')
+        .closest('[role="tab"]') as HTMLElement;
+      expect(roomTab).toHaveAttribute('aria-selected', 'false');
+
+      // The feed narrows to ONLY the whisper thread's interactions.
+      expect(screen.queryByText('stretches languidly.')).not.toBeInTheDocument();
+      expect(screen.getByText('meet me by the fountain at midnight.')).toBeInTheDocument();
+
+      // The composer is locked to the whisper audience.
+      const lockedMode = screen.getByTitle('Audience is locked to this conversation tab');
+      expect(lockedMode).toHaveTextContent(/whisper/i);
+      expect(screen.queryByRole('button', { name: 'Pose' })).not.toBeInTheDocument();
+    });
+
+    it('clicking the room anchor tab restores the full feed and re-enables the mode dropdown', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      seedWhisperThread();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+
+      await screen.findByText('stretches languidly.');
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+      const whisperRow = within(sidebar)
+        .getByText(/whisper/i)
+        .closest('button') as HTMLElement;
+      await user.click(whisperRow);
+
+      const tablist = await screen.findByRole('tablist', { name: 'Conversations' });
+      const roomTab = within(tablist)
+        .getByText('The Grand Ballroom')
+        .closest('[role="tab"]') as HTMLElement;
+      await user.click(roomTab);
+
+      // Full feed is back.
+      expect(await screen.findByText('stretches languidly.')).toBeInTheDocument();
+      expect(screen.getByText('meet me by the fountain at midnight.')).toBeInTheDocument();
+
+      // The mode dropdown is re-enabled (unlocked) — the trigger button
+      // renders instead of the locked static label.
+      expect(await screen.findByRole('button', { name: 'Pose' })).toBeInTheDocument();
+      expect(
+        screen.queryByTitle('Audience is locked to this conversation tab')
+      ).not.toBeInTheDocument();
+
+      // The tab strip still shows both tabs — closing wasn't involved — with
+      // the room anchor now selected.
+      expect(roomTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('badges the whisper tab with unread while the room anchor is active, and clears it on switch', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      seedWhisperThread();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+      const whisperRow = () =>
+        within(sidebar)
+          .getByText(/whisper/i)
+          .closest('button') as HTMLElement;
+      const roomRow = () =>
+        within(sidebar).getByText('The Grand Ballroom').closest('button') as HTMLElement;
+
+      // Open the whisper tab, then focus back on the room anchor — the tab
+      // stays open (only closing removes it from openThreadTabs).
+      await user.click(whisperRow());
+      await screen.findByRole('tablist', { name: 'Conversations' });
+      await user.click(roomRow());
+
+      // A new whisper arrives, in the same thread, from someone else, while
+      // the room anchor is active.
+      store.dispatch(
+        addSceneInteraction({
+          character: ACTIVE_NAME,
+          interaction: {
+            id: 3,
+            persona: { id: 9, name: 'Bystander', thumbnail_url: '' },
+            content: 'psst, did you hear?',
+            mode: 'whisper',
+            timestamp: '2026-01-01T00:02:00Z',
+            scene_id: 100,
+            place_id: null,
+            place_name: null,
+            receiver_persona_ids: [7],
+            target_persona_ids: [],
+          },
+        })
+      );
+
+      const tablist = screen.getByRole('tablist', { name: 'Conversations' });
+      const whisperTab = () =>
+        within(tablist)
+          .getByText(/whisper/i)
+          .closest('[role="tab"]') as HTMLElement;
+
+      await waitFor(() => {
+        expect(within(whisperTab()).getByText('1')).toBeInTheDocument();
+      });
+
+      // Switching to the whisper tab clears its badge.
+      await user.click(whisperTab());
+      await waitFor(() => {
+        expect(within(whisperTab()).queryByText(/^[1-9]/)).not.toBeInTheDocument();
+      });
+    });
+
+    it('closing the active tab falls back to the room anchor and the tab strip disappears; the sidebar reopens it', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      seedWhisperThread();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+      const whisperRow = () =>
+        within(sidebar)
+          .getByText(/whisper/i)
+          .closest('button') as HTMLElement;
+
+      await user.click(whisperRow());
+      const tablist = await screen.findByRole('tablist', { name: 'Conversations' });
+      const closeButton = within(tablist).getByRole('button', { name: /close whisper/i });
+      await user.click(closeButton);
+
+      // The strip disappears entirely (no open tabs left).
+      expect(screen.queryByRole('tablist', { name: 'Conversations' })).not.toBeInTheDocument();
+
+      // The room anchor is active again — full feed is back.
+      expect(screen.getByText('stretches languidly.')).toBeInTheDocument();
+      expect(screen.getByText('meet me by the fountain at midnight.')).toBeInTheDocument();
+
+      // Clicking the sidebar thread again reopens the tab.
+      await user.click(whisperRow());
+      expect(await screen.findByRole('tablist', { name: 'Conversations' })).toBeInTheDocument();
+    });
+
+    it('clears the tab strip when the active puppet moves into a new scene', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      seedWhisperThread();
+
+      const user = userEvent.setup();
+      renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      const sidebar = screen.getByLabelText('Thread sidebar');
+      const whisperRow = within(sidebar)
+        .getByText(/whisper/i)
+        .closest('button') as HTMLElement;
+      await user.click(whisperRow);
+      await screen.findByRole('tablist', { name: 'Conversations' });
+
+      store.dispatch(
+        setSessionScene({
+          character: ACTIVE_NAME,
+          scene: {
+            id: 300,
+            name: 'The Garden',
+            description: '',
+            is_owner: false,
+            has_unseen_observer: false,
+          },
+        })
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByRole('tablist', { name: 'Conversations' })).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -807,6 +807,18 @@ describe('GamePage', () => {
       const lockedMode = screen.getByTitle('Audience is locked to this conversation tab');
       expect(lockedMode).toHaveTextContent(/whisper/i);
       expect(screen.queryByRole('button', { name: 'Pose' })).not.toBeInTheDocument();
+
+      // #2165 fold-in fix: the sidebar's OWN row selection must track the
+      // active tab too, not stay pinned to the room. Without the fix,
+      // `threading.selectedThreadKey` never changes once tab wiring takes
+      // over, so the room row stays permanently marked selected
+      // (`font-semibold`, per ThreadSidebar.tsx) and the whisper row never
+      // is, even while its tab is the one showing.
+      expect(whisperRow).toHaveClass('font-semibold');
+      const roomRow = within(sidebar)
+        .getByText('The Grand Ballroom')
+        .closest('button') as HTMLElement;
+      expect(roomRow).not.toHaveClass('font-semibold');
     });
 
     it('clicking room anchor tab restores full feed, re-enables mode dropdown', async () => {

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -2,7 +2,7 @@ import { screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, vi, beforeEach, afterEach, expect } from 'vitest';
 import { GamePage } from './GamePage';
-import { saveThreadTabs } from './threadTabsStorage';
+import { saveThreadTabs, loadThreadTabs } from './threadTabsStorage';
 import { renderWithProviders } from '@/test/utils/renderWithProviders';
 import { store } from '@/store/store';
 import { setAccount } from '@/store/authSlice';
@@ -1067,6 +1067,79 @@ describe('GamePage', () => {
         .getByText('Whisper')
         .closest('[role="tab"]') as HTMLElement;
       expect(whisperTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('does not clobber a restored tab layout in storage on mount (review race fix)', async () => {
+      // Regression for a task-review finding on 408e8f8c1: the hydrate effect
+      // used to set a ref synchronously and dispatch `hydrateThreadTabs`, but
+      // the save effect ran in the SAME commit right after — its closure
+      // still held the pre-hydration `openThreadTabs: []`, so it wrote (and
+      // pruned) an empty layout over the entry this test just seeded. Assert
+      // on STORAGE, not just the DOM: the DOM self-heals on the corrective
+      // re-render, but a durable empty write underneath would go unnoticed.
+      store.dispatch(setAccount(mockAccount));
+      saveThreadTabs(ACTIVE_NAME, '100', {
+        openThreadTabs: ['whisper:9'],
+        activeThreadTab: 'whisper:9',
+      });
+
+      seedActiveSceneWithPose();
+      renderWithProviders(<GamePage />);
+
+      const tablist = await screen.findByRole('tablist', { name: 'Conversations' });
+      await within(tablist).findByText('Whisper');
+
+      expect(localStorage.getItem(`arx:threadTabs:${ACTIVE_NAME}:100`)).not.toBeNull();
+      expect(loadThreadTabs(ACTIVE_NAME, '100')).toEqual({
+        openThreadTabs: ['whisper:9'],
+        activeThreadTab: 'whisper:9',
+      });
+    });
+
+    it("keeps puppet A's persisted tab layout intact after a round trip through puppet B (A->B->A, review race fix)", async () => {
+      // Same review finding as above, in the shape the reviewer specifically
+      // flagged: a ref-based hydration guard doesn't re-run once set, so a
+      // character/scene round trip (A->B->A) re-triggers the hydrate effect
+      // for A a second time with no self-heal render to fall back on if
+      // anything raced. Assert A's storage survives the round trip untouched.
+      store.dispatch(setAccount(mockAccount));
+      saveThreadTabs(ACTIVE_NAME, '100', {
+        openThreadTabs: ['whisper:9'],
+        activeThreadTab: 'whisper:9',
+      });
+
+      seedActiveSceneWithPose();
+      store.dispatch(startSession(SECOND_NAME));
+      store.dispatch(
+        setSessionScene({
+          character: SECOND_NAME,
+          scene: {
+            id: 200,
+            name: 'The Kitchen',
+            description: '',
+            is_owner: false,
+            has_unseen_observer: false,
+          },
+        })
+      );
+      // startSession(SECOND_NAME) above made Bianca active — switch back to
+      // Aria before rendering (this test starts with Aria in view).
+      store.dispatch(setActiveSession(ACTIVE_NAME));
+
+      renderWithProviders(<GamePage />);
+      const tablist = await screen.findByRole('tablist', { name: 'Conversations' });
+      await within(tablist).findByText('Whisper');
+
+      // Round-trip through puppet B, then back to A.
+      store.dispatch(setActiveSession(SECOND_NAME));
+      store.dispatch(setActiveSession(ACTIVE_NAME));
+
+      await waitFor(() => {
+        expect(loadThreadTabs(ACTIVE_NAME, '100')).toEqual({
+          openThreadTabs: ['whisper:9'],
+          activeThreadTab: 'whisper:9',
+        });
+      });
     });
   });
 });

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -2,6 +2,7 @@ import { screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, vi, beforeEach, afterEach, expect } from 'vitest';
 import { GamePage } from './GamePage';
+import { saveThreadTabs } from './threadTabsStorage';
 import { renderWithProviders } from '@/test/utils/renderWithProviders';
 import { store } from '@/store/store';
 import { setAccount } from '@/store/authSlice';
@@ -232,6 +233,9 @@ function seedActiveSceneWithRoom() {
 describe('GamePage', () => {
   beforeEach(() => {
     store.dispatch(setAccount(null));
+    // #2165: the save effect now writes real localStorage during render, so
+    // clear between tests to keep them isolated from each other.
+    localStorage.clear();
   });
 
   afterEach(() => {
@@ -1038,6 +1042,31 @@ describe('GamePage', () => {
       expect(await screen.findByRole('button', { name: 'Pose' })).toBeInTheDocument();
       expect(screen.getByText('Pose → The Grand Ballroom')).toBeInTheDocument();
       expect(screen.queryByText(`Whisper → ${ACTIVE_NAME}`)).not.toBeInTheDocument();
+    });
+
+    it('restores a persisted tab layout on mount (#2165 localStorage persistence)', async () => {
+      store.dispatch(setAccount(mockAccount));
+      // Pre-seed localStorage for the fixture character+scene BEFORE the
+      // scene/session exists in Redux — the hydration effect reads this on
+      // first render once `active`+`sceneId` are both set.
+      saveThreadTabs(ACTIVE_NAME, '100', {
+        openThreadTabs: ['whisper:9'],
+        activeThreadTab: 'whisper:9',
+      });
+
+      seedActiveSceneWithPose();
+
+      renderWithProviders(<GamePage />);
+
+      // The restored tab is active on mount, narrowing the feed to the
+      // (currently empty) whisper thread — the room pose is NOT visible.
+      // No interaction has arrived for this thread yet, so the strip falls
+      // back to the generic 'Whisper' label until real messages backfill it.
+      const tablist = await screen.findByRole('tablist', { name: 'Conversations' });
+      const whisperTab = within(tablist)
+        .getByText('Whisper')
+        .closest('[role="tab"]') as HTMLElement;
+      expect(whisperTab).toHaveAttribute('aria-selected', 'true');
     });
   });
 });

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -145,8 +145,21 @@ export function GamePage() {
         };
       }),
       activeKey: activeThreadTab,
-      onSelect: (key: string | null) =>
-        dispatch(setActiveThreadTab({ character: active, threadKey: key })),
+      onSelect: (key: string | null) => {
+        dispatch(setActiveThreadTab({ character: active, threadKey: key }));
+        // #2165 review fix: the strip's room-anchor tab must reset the
+        // composer the same way the sidebar's room row does (handleThreadClick
+        // below) — otherwise a stale locked mode (e.g. a whisper) survives the
+        // switch back to the room anchor.
+        if (key === null) {
+          const roomThread = threading.threads.find((t) => t.key === 'room');
+          setComposerMode(
+            roomThread
+              ? threadToComposerMode(roomThread, roomName)
+              : { command: 'pose', targets: [], label: `Pose → ${roomName}` }
+          );
+        }
+      },
       onClose: (key: string) => dispatch(closeThreadTab({ character: active, threadKey: key })),
     };
   }, [sceneId, active, openThreadTabs, threading.threads, roomName, activeThreadTab, dispatch]);
@@ -255,6 +268,17 @@ export function GamePage() {
     }
     dispatch(openThreadTab({ character: active, threadKey: key }));
   };
+
+  // #2165 review fix: the sidebar's "All" button must restore the room feed,
+  // not just reset the filter/mute state. `threading.showAll` alone clears
+  // `enabledThreadKeys`/`hiddenPersonaIds` but leaves an active conversation
+  // TAB in place — without also re-anchoring the tab, the tab strip keeps a
+  // whisper tab selected and the "All" click appears to do nothing.
+  const threadingShowAll = threading.showAll;
+  const handleShowAll = useCallback(() => {
+    threadingShowAll();
+    if (active) dispatch(setActiveThreadTab({ character: active, threadKey: null }));
+  }, [threadingShowAll, active, dispatch]);
 
   // Scene toolset (#2156 Task 6) — GamePage is the composition root, so it
   // owns the same handler state SceneDetailPage.tsx:120-178 owns, mirrored
@@ -380,6 +404,7 @@ export function GamePage() {
           <ConversationSidebar
             threading={sceneId ? threading : undefined}
             onThreadClick={handleThreadClick}
+            onShowAll={handleShowAll}
           />
         }
         center={

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { GameLayout } from './components/GameLayout';
 import { GameTopBar } from './components/GameTopBar';
@@ -117,29 +117,37 @@ export function GamePage() {
       : null;
 
   // #2165 tab-layout persistence (spec decision 5a). Hydrate once per
-  // character+scene, BEFORE the save effect below may write — the ref
-  // handshake prevents a fresh mount's empty state from clobbering a stored
-  // layout it hasn't restored yet.
-  const tabsHydratedForRef = useRef<string | null>(null);
+  // character+scene, BEFORE the save effect below may write. This used to be
+  // a ref handshake, but a ref is set synchronously the instant hydration is
+  // *attempted* — the save effect runs in the same commit right after, while
+  // its closure still holds the pre-hydration `openThreadTabs: []`, so it
+  // wrote (and pruned) an empty layout over the entry just loaded. That
+  // self-healed on the next render UNLESS the user switched character/scene
+  // first (A->B->A), leaving the empty write durable (review fold-in). Using
+  // React state instead means `setTabsReadyFor` and the `hydrateThreadTabs`
+  // dispatch land in the same batched re-render, so the save effect's first
+  // run for a key is the POST-hydration commit, with hydrated values in the
+  // closure — the save is gated on hydration having LANDED, not attempted.
+  const [tabsReadyFor, setTabsReadyFor] = useState<string | null>(null);
   useEffect(() => {
     if (!active || !sceneId) return;
     const hydrationKey = `${active}:${sceneId}`;
-    if (tabsHydratedForRef.current === hydrationKey) return;
-    tabsHydratedForRef.current = hydrationKey;
+    if (tabsReadyFor === hydrationKey) return;
     const stored = loadThreadTabs(active, sceneId);
     if (stored && stored.openThreadTabs.length > 0) {
       dispatch(hydrateThreadTabs({ character: active, ...stored }));
     }
-  }, [active, sceneId, dispatch]);
+    setTabsReadyFor(hydrationKey);
+  }, [active, sceneId, dispatch, tabsReadyFor]);
 
   useEffect(() => {
     if (!active || !sceneId) return;
-    if (tabsHydratedForRef.current !== `${active}:${sceneId}`) return;
+    if (tabsReadyFor !== `${active}:${sceneId}`) return;
     saveThreadTabs(active, sceneId, {
       openThreadTabs,
       activeThreadTab: activeThreadTabRaw,
     });
-  }, [active, sceneId, openThreadTabs, activeThreadTabRaw]);
+  }, [active, sceneId, openThreadTabs, activeThreadTabRaw, tabsReadyFor]);
 
   const [composerMode, setComposerMode] = useState<ComposerMode | undefined>();
 

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -440,6 +440,7 @@ export function GamePage() {
             threading={sceneId ? threading : undefined}
             onThreadClick={handleThreadClick}
             onShowAll={handleShowAll}
+            selectedThreadKey={activeThreadTab ?? 'room'}
           />
         }
         center={

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -20,10 +20,16 @@ import { useFocusStack, type FocusEntry } from '@/inventory/hooks/useFocusStack'
 import { Link } from 'react-router-dom';
 import { useAccount } from '@/store/hooks';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
-import { markThreadSeen, setSceneBaseline } from '@/store/gameSlice';
+import {
+  markThreadSeen,
+  setSceneBaseline,
+  openThreadTab,
+  closeThreadTab,
+  setActiveThreadTab,
+} from '@/store/gameSlice';
 import { useSceneInteractions } from '@/scenes/hooks/useSceneInteractions';
 import { useThreading, getThreadKey } from '@/scenes/hooks/useThreading';
-import { threadToComposerMode } from '@/scenes/hooks/threadToComposerMode';
+import { threadToComposerMode, tabKeyToComposerMode } from '@/scenes/hooks/threadToComposerMode';
 import { usePendingUnlinkedActions } from '@/scenes/hooks/usePendingUnlinkedActions';
 import { ConsentPrompt } from '@/scenes/components/ConsentPrompt';
 import { PlaceBar } from '@/scenes/components/PlaceBar';
@@ -33,6 +39,7 @@ import { createActionRequest, fetchPlaces } from '@/scenes/actionQueries';
 import type { ActionAttachmentInfo } from '@/scenes/actionTypes';
 import type { PoseUnitAvatarClickPersona } from '@/scenes/components/PoseUnit';
 import type { ComposerMode } from './components/CommandInput';
+import type { ConversationTabStripProps } from './components/ConversationTabStrip';
 
 const DEFAULT_ROOM_ENTRY: FocusEntry = {
   kind: 'room',
@@ -43,6 +50,8 @@ const DEFAULT_ROOM_ENTRY: FocusEntry = {
 // Stable empty-object reference so `useThreading`'s memo doesn't see a "changed"
 // lastSeenByThread on every render when there's no active session yet (#2156).
 const EMPTY_THREAD_LAST_SEEN: Record<string, number> = {};
+// Stable empty-array reference (#2165) — same reasoning as EMPTY_THREAD_LAST_SEEN.
+const EMPTY_OPEN_TABS: string[] = [];
 
 export function GamePage() {
   const account = useAccount();
@@ -95,17 +104,66 @@ export function GamePage() {
     viewerPersonaId: personaId,
     sceneBaselineId,
   });
+
+  const openThreadTabs = activeSession?.openThreadTabs ?? EMPTY_OPEN_TABS;
+  const activeThreadTabRaw = activeSession?.activeThreadTab ?? null;
+  // Guard against a stale active pointer (e.g. hydration races): only an
+  // OPEN tab may be active; anything else is the room anchor.
+  const activeThreadTab =
+    activeThreadTabRaw !== null && openThreadTabs.includes(activeThreadTabRaw)
+      ? activeThreadTabRaw
+      : null;
+
   const [composerMode, setComposerMode] = useState<ComposerMode | undefined>();
+
+  // #2165: the active conversation tab narrows the feed to its thread; the
+  // room anchor keeps the existing filtered feed. The composer's audience is
+  // DERIVED from the active tab every render (never stored) — that derivation
+  // is the mis-send guard.
+  const tabInteractions = useMemo(() => {
+    if (activeThreadTab === null) return threading.filteredInteractions;
+    return threading.interactionsByThread.get(activeThreadTab) ?? [];
+  }, [activeThreadTab, threading.filteredInteractions, threading.interactionsByThread]);
+
+  const effectiveComposerMode = useMemo(() => {
+    if (activeThreadTab === null) return composerMode;
+    return tabKeyToComposerMode(activeThreadTab, threading.threads, roomName);
+  }, [activeThreadTab, threading.threads, roomName, composerMode]);
+
+  const conversationTabs = useMemo<ConversationTabStripProps | undefined>(() => {
+    if (!sceneId || !active || openThreadTabs.length === 0) return undefined;
+    const roomThread = threading.threads.find((t) => t.key === 'room');
+    return {
+      roomLabel: roomName,
+      roomUnreadCount: roomThread?.unreadCount ?? 0,
+      tabs: openThreadTabs.map((key) => {
+        const thread = threading.threads.find((t) => t.key === key);
+        return {
+          key,
+          label: thread?.label ?? (key.startsWith('place:') ? 'Place' : 'Whisper'),
+          unreadCount: thread?.unreadCount ?? 0,
+        };
+      }),
+      activeKey: activeThreadTab,
+      onSelect: (key: string | null) =>
+        dispatch(setActiveThreadTab({ character: active, threadKey: key })),
+      onClose: (key: string) => dispatch(closeThreadTab({ character: active, threadKey: key })),
+    };
+  }, [sceneId, active, openThreadTabs, threading.threads, roomName, activeThreadTab, dispatch]);
 
   // Character-card drawer (#2156 Task 7): the clicked bubble's persona identity,
   // or null when the drawer is closed. GamePage owns this state (mirrored on
   // SceneDetailPage) since the drawer opens "in place" over whichever surface
   // the avatar was clicked on, not as a route navigation.
   const [cardPersona, setCardPersona] = useState<PoseUnitAvatarClickPersona | null>(null);
-  const handleWhisper = useCallback((name: string) => {
-    setComposerMode({ command: 'whisper', targets: [name], label: `Whisper → ${name}` });
-    setCardPersona(null);
-  }, []);
+  const handleWhisper = useCallback(
+    (name: string) => {
+      if (active) dispatch(setActiveThreadTab({ character: active, threadKey: null }));
+      setComposerMode({ command: 'whisper', targets: [name], label: `Whisper → ${name}` });
+      setCardPersona(null);
+    },
+    [active, dispatch]
+  );
 
   // Scene-load baseline (#2156 review fix): a single scalar snapshot, not a
   // per-thread-key one. The old per-key baseline one-shotted per KEY, so a
@@ -164,33 +222,38 @@ export function GamePage() {
     threadingResetForNewScene();
   }, [active, sceneId, threadingResetForNewScene]);
 
-  // Continuously mark the SELECTED thread seen as its interactions grow — this is
-  // the thread the player is actively viewing, so it never accumulates unread.
-  // Unselected threads are left alone and accumulate unread from the baseline above.
+  // Continuously mark the ACTIVE TAB's thread seen as its interactions grow —
+  // this is the thread the player is actively viewing (the room anchor when
+  // no tab is active), so it never accumulates unread. Unselected threads are
+  // left alone and accumulate unread from the baseline above (#2165: was
+  // keyed on threading.selectedThreadKey before conversation tabs existed).
   useEffect(() => {
     if (!sceneId || !active) return;
-    const selectedKey = threading.selectedThreadKey;
+    const seenKey = activeThreadTab ?? 'room';
     let maxId: number | undefined;
     for (const interaction of allInteractions) {
-      if (getThreadKey(interaction) !== selectedKey) continue;
+      if (getThreadKey(interaction) !== seenKey) continue;
       const id = Number(interaction.id);
       if (maxId === undefined || id > maxId) maxId = id;
     }
     if (maxId !== undefined) {
-      dispatch(markThreadSeen({ character: active, threadKey: selectedKey, interactionId: maxId }));
+      dispatch(markThreadSeen({ character: active, threadKey: seenKey, interactionId: maxId }));
     }
-  }, [sceneId, active, allInteractions, threading.selectedThreadKey, dispatch]);
+  }, [sceneId, active, allInteractions, activeThreadTab, dispatch]);
 
-  // Mirrors SceneInteractionPanel's handleThreadClick (#2156 review fix): a
-  // thread click toggles that thread's inclusion in the enabled-thread set
-  // (which is what useThreading.filteredInteractions actually narrows on),
-  // not just the "selected" highlight — otherwise the feed never changes.
+  // #2165: the sidebar is the open-a-tab surface. A conversation row opens or
+  // focuses its tab; the room row focuses the anchor. The old
+  // toggleThreadVisibility narrowing is retired for the room feed — the
+  // per-participant mute (ThreadFilterModal) still applies to the anchor.
   const handleThreadClick = (key: string) => {
-    threading.toggleThreadVisibility(key);
-    const thread = threading.threads.find((t) => t.key === key);
-    if (thread) {
-      setComposerMode(threadToComposerMode(thread, roomName));
+    if (!active) return;
+    if (key === 'room') {
+      dispatch(setActiveThreadTab({ character: active, threadKey: null }));
+      const roomThread = threading.threads.find((t) => t.key === 'room');
+      if (roomThread) setComposerMode(threadToComposerMode(roomThread, roomName));
+      return;
     }
+    dispatch(openThreadTab({ character: active, threadKey: key }));
   };
 
   // Scene toolset (#2156 Task 6) — GamePage is the composition root, so it
@@ -334,13 +397,13 @@ export function GamePage() {
                 sceneId
                   ? {
                       sceneId,
-                      interactions: threading.filteredInteractions,
+                      interactions: tabInteractions,
                       hasNextPage,
                       fetchNextPage,
                     }
                   : undefined
               }
-              composerMode={composerMode}
+              composerMode={effectiveComposerMode}
               onModeChange={setComposerMode}
               personaId={personaId}
               onAvatarClick={setCardPersona}
@@ -356,6 +419,7 @@ export function GamePage() {
               detachedActionIds={detachedActionIds}
               onPoseSubmitted={handlePoseSubmitted}
               isAtPlace={isAtPlace}
+              conversationTabs={conversationTabs}
               placeBar={placesRoomId ? <PlaceBar sceneId={placesRoomId} /> : undefined}
               pendingAttachments={
                 sceneId ? (

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { GameLayout } from './components/GameLayout';
 import { GameTopBar } from './components/GameTopBar';
@@ -26,7 +26,9 @@ import {
   openThreadTab,
   closeThreadTab,
   setActiveThreadTab,
+  hydrateThreadTabs,
 } from '@/store/gameSlice';
+import { loadThreadTabs, saveThreadTabs } from './threadTabsStorage';
 import { useSceneInteractions } from '@/scenes/hooks/useSceneInteractions';
 import { useThreading, getThreadKey } from '@/scenes/hooks/useThreading';
 import { threadToComposerMode, tabKeyToComposerMode } from '@/scenes/hooks/threadToComposerMode';
@@ -113,6 +115,31 @@ export function GamePage() {
     activeThreadTabRaw !== null && openThreadTabs.includes(activeThreadTabRaw)
       ? activeThreadTabRaw
       : null;
+
+  // #2165 tab-layout persistence (spec decision 5a). Hydrate once per
+  // character+scene, BEFORE the save effect below may write — the ref
+  // handshake prevents a fresh mount's empty state from clobbering a stored
+  // layout it hasn't restored yet.
+  const tabsHydratedForRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!active || !sceneId) return;
+    const hydrationKey = `${active}:${sceneId}`;
+    if (tabsHydratedForRef.current === hydrationKey) return;
+    tabsHydratedForRef.current = hydrationKey;
+    const stored = loadThreadTabs(active, sceneId);
+    if (stored && stored.openThreadTabs.length > 0) {
+      dispatch(hydrateThreadTabs({ character: active, ...stored }));
+    }
+  }, [active, sceneId, dispatch]);
+
+  useEffect(() => {
+    if (!active || !sceneId) return;
+    if (tabsHydratedForRef.current !== `${active}:${sceneId}`) return;
+    saveThreadTabs(active, sceneId, {
+      openThreadTabs,
+      activeThreadTab: activeThreadTabRaw,
+    });
+  }, [active, sceneId, openThreadTabs, activeThreadTabRaw]);
 
   const [composerMode, setComposerMode] = useState<ComposerMode | undefined>();
 

--- a/frontend/src/game/components/CommandInput.test.tsx
+++ b/frontend/src/game/components/CommandInput.test.tsx
@@ -295,6 +295,19 @@ describe('CommandInput', () => {
     expect(screen.getByTestId('action-attachment')).toBeInTheDocument();
   });
 
+  it('renders the locked mode label with no dropdown trigger when locked (#2165)', () => {
+    const mode: ComposerMode = {
+      command: 'whisper',
+      targets: ['Alise'],
+      label: 'Whisper → Alise',
+      locked: true,
+    };
+    render(<CommandInput character="Alice" composerMode={mode} />);
+
+    expect(screen.getByTitle('Audience is locked to this conversation tab')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /whisper/i })).not.toBeInTheDocument();
+  });
+
   it('pose with detachments uses REST submitPose and skips WebSocket send', async () => {
     const mode: ComposerMode = { command: 'pose', targets: [], label: 'Pose' };
     render(

--- a/frontend/src/game/components/CommandInput.tsx
+++ b/frontend/src/game/components/CommandInput.tsx
@@ -21,6 +21,8 @@ export interface ComposerMode {
   command: string; // "pose" | "say" | "tt" | "whisper"
   targets: string[]; // persona names for @targeting
   label: string; // "Pose -> The Grand Ballroom"
+  /** #2165: audience is fixed by the active conversation tab — mode switching disabled. */
+  locked?: boolean;
 }
 
 const KNOWN_COMMANDS = ['pose', 'say', 'emit', 'emote', 'whisper', 'tt', 'tabletalk'];
@@ -248,14 +250,13 @@ export function CommandInput({
 
   const handleModeChange = useCallback(
     (mode: string) => {
-      if (onModeChange && composerMode) {
-        const label = mode.charAt(0).toUpperCase() + mode.slice(1);
-        onModeChange({
-          command: mode,
-          targets: composerMode.targets,
-          label,
-        });
-      }
+      if (!onModeChange || !composerMode || composerMode.locked) return;
+      const label = mode.charAt(0).toUpperCase() + mode.slice(1);
+      onModeChange({
+        command: mode,
+        targets: composerMode.targets,
+        label,
+      });
     },
     [onModeChange, composerMode]
   );
@@ -324,6 +325,7 @@ export function CommandInput({
             currentMode={composerMode?.command ?? 'pose'}
             onModeChange={handleModeChange}
             isAtPlace={isAtPlace ?? false}
+            locked={composerMode?.locked ?? false}
           />
         }
         rightSlot={

--- a/frontend/src/game/components/ConversationSidebar.tsx
+++ b/frontend/src/game/components/ConversationSidebar.tsx
@@ -9,9 +9,20 @@ interface ConversationSidebarProps {
   threading?: ThreadingState;
   /** Fired with a thread's key when it's clicked — GamePage owns the composer-mode translation. */
   onThreadClick: (key: string) => void;
+  /**
+   * Fired when the "All" button is clicked. Defaults to `threading.showAll`
+   * (the filter/mute reset); GamePage overrides it (#2165 review fix) to ALSO
+   * re-anchor the active conversation tab back to the room, since `showAll`
+   * alone doesn't touch tab state.
+   */
+  onShowAll?: () => void;
 }
 
-export function ConversationSidebar({ threading, onThreadClick }: ConversationSidebarProps) {
+export function ConversationSidebar({
+  threading,
+  onThreadClick,
+  onShowAll,
+}: ConversationSidebarProps) {
   const [filterThreadKey, setFilterThreadKey] = useState<string | null>(null);
 
   if (!threading) {
@@ -45,7 +56,7 @@ export function ConversationSidebar({ threading, onThreadClick }: ConversationSi
         enabledThreadKeys={threading.enabledThreadKeys}
         isUnfiltered={threading.enabledThreadKeys.size === 0}
         onThreadClick={onThreadClick}
-        onShowAll={threading.showAll}
+        onShowAll={onShowAll ?? threading.showAll}
         onOpenFilter={setFilterThreadKey}
       />
 

--- a/frontend/src/game/components/ConversationSidebar.tsx
+++ b/frontend/src/game/components/ConversationSidebar.tsx
@@ -16,12 +16,22 @@ interface ConversationSidebarProps {
    * alone doesn't touch tab state.
    */
   onShowAll?: () => void;
+  /**
+   * Which row renders selected. Defaults to `threading.selectedThreadKey`;
+   * GamePage overrides it (#2165 fold-in fix) to the active conversation TAB
+   * instead — `threading.selectedThreadKey` is pinned to `'room'` forever on
+   * /game since the tab wiring stopped calling `setSelectedThread`, which was
+   * leaving the room row permanently highlighted and no thread row ever
+   * marking the active conversation.
+   */
+  selectedThreadKey?: string;
 }
 
 export function ConversationSidebar({
   threading,
   onThreadClick,
   onShowAll,
+  selectedThreadKey,
 }: ConversationSidebarProps) {
   const [filterThreadKey, setFilterThreadKey] = useState<string | null>(null);
 
@@ -52,7 +62,7 @@ export function ConversationSidebar({
       </div>
       <ThreadSidebar
         threads={threading.threads}
-        selectedThreadKey={threading.selectedThreadKey}
+        selectedThreadKey={selectedThreadKey ?? threading.selectedThreadKey}
         enabledThreadKeys={threading.enabledThreadKeys}
         isUnfiltered={threading.enabledThreadKeys.size === 0}
         onThreadClick={onThreadClick}

--- a/frontend/src/game/components/ConversationTabStrip.test.tsx
+++ b/frontend/src/game/components/ConversationTabStrip.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConversationTabStrip } from './ConversationTabStrip';
+import type { ConversationTabMeta } from './ConversationTabStrip';
+
+const WHISPER_TAB: ConversationTabMeta = {
+  key: 'whisper-1',
+  label: 'Whisper: Alise, Ben',
+  unreadCount: 0,
+};
+
+describe('ConversationTabStrip', () => {
+  it('renders nothing when tabs is empty', () => {
+    const { container } = render(
+      <ConversationTabStrip
+        roomLabel="Room"
+        roomUnreadCount={0}
+        tabs={[]}
+        activeKey={null}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the room anchor tab plus a labeled tab per open conversation', () => {
+    render(
+      <ConversationTabStrip
+        roomLabel="Room"
+        roomUnreadCount={0}
+        tabs={[WHISPER_TAB]}
+        activeKey={null}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('tab', { name: 'Room' })).toBeInTheDocument();
+    expect(screen.getByText('Whisper: Alise, Ben')).toBeInTheDocument();
+  });
+
+  it('shows a numeric unread badge when unreadCount is greater than zero', () => {
+    render(
+      <ConversationTabStrip
+        roomLabel="Room"
+        roomUnreadCount={3}
+        tabs={[{ ...WHISPER_TAB, unreadCount: 2 }]}
+        activeKey={null}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('renders no badge when unreadCount is zero', () => {
+    render(
+      <ConversationTabStrip
+        roomLabel="Room"
+        roomUnreadCount={0}
+        tabs={[WHISPER_TAB]}
+        activeKey={null}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('calls onSelect with the tab key when a conversation tab is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <ConversationTabStrip
+        roomLabel="Room"
+        roomUnreadCount={0}
+        tabs={[WHISPER_TAB]}
+        activeKey={null}
+        onSelect={onSelect}
+        onClose={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Whisper: Alise, Ben/ }));
+
+    expect(onSelect).toHaveBeenCalledWith('whisper-1');
+  });
+
+  it('calls onSelect with null when the room anchor tab is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <ConversationTabStrip
+        roomLabel="Room"
+        roomUnreadCount={0}
+        tabs={[WHISPER_TAB]}
+        activeKey="whisper-1"
+        onSelect={onSelect}
+        onClose={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Room' }));
+
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('calls onClose (not onSelect) when the close button is clicked', () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <ConversationTabStrip
+        roomLabel="Room"
+        roomUnreadCount={0}
+        tabs={[WHISPER_TAB]}
+        activeKey={null}
+        onSelect={onSelect}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close Whisper: Alise, Ben' }));
+
+    expect(onClose).toHaveBeenCalledWith('whisper-1');
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/game/components/ConversationTabStrip.tsx
+++ b/frontend/src/game/components/ConversationTabStrip.tsx
@@ -1,0 +1,85 @@
+import { X } from 'lucide-react';
+
+export interface ConversationTabMeta {
+  key: string;
+  label: string;
+  unreadCount: number;
+}
+
+export interface ConversationTabStripProps {
+  roomLabel: string;
+  roomUnreadCount: number;
+  tabs: ConversationTabMeta[];
+  /** Active conversation tab key; null = the room anchor tab. */
+  activeKey: string | null;
+  onSelect: (key: string | null) => void;
+  onClose: (key: string) => void;
+}
+
+function UnreadBadge({ count }: { count: number }) {
+  if (count <= 0) return null;
+  return (
+    <span className="ml-1 rounded-full bg-primary px-1.5 text-xs text-primary-foreground">
+      {count}
+    </span>
+  );
+}
+
+/**
+ * Tab strip of open conversations (#2165) — the room feed as the anchor tab
+ * plus one closable tab per broken-out thread. Mirrors the multi-puppet
+ * session tab bar directly above it (GameWindow.tsx); renders nothing until
+ * at least one conversation tab is open.
+ */
+export function ConversationTabStrip({
+  roomLabel,
+  roomUnreadCount,
+  tabs,
+  activeKey,
+  onSelect,
+  onClose,
+}: ConversationTabStripProps) {
+  if (tabs.length === 0) return null;
+  const tabClass = (isActive: boolean) =>
+    `flex items-center whitespace-nowrap rounded-t px-2 py-1 text-sm ${
+      isActive ? 'border-b-2 border-primary font-medium' : 'text-muted-foreground'
+    }`;
+  return (
+    <div
+      role="tablist"
+      aria-label="Conversations"
+      className="mb-2 flex gap-1 overflow-x-auto border-b"
+    >
+      <button
+        role="tab"
+        aria-selected={activeKey === null}
+        onClick={() => onSelect(null)}
+        className={tabClass(activeKey === null)}
+      >
+        {roomLabel}
+        <UnreadBadge count={roomUnreadCount} />
+      </button>
+      {tabs.map((tab) => (
+        <span key={tab.key} className="flex items-center">
+          <button
+            role="tab"
+            aria-selected={activeKey === tab.key}
+            onClick={() => onSelect(tab.key)}
+            className={tabClass(activeKey === tab.key)}
+          >
+            {tab.label}
+            <UnreadBadge count={tab.unreadCount} />
+          </button>
+          <button
+            type="button"
+            aria-label={`Close ${tab.label}`}
+            onClick={() => onClose(tab.key)}
+            className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/game/components/ConversationTabStrip.tsx
+++ b/frontend/src/game/components/ConversationTabStrip.tsx
@@ -51,6 +51,7 @@ export function ConversationTabStrip({
       className="mb-2 flex gap-1 overflow-x-auto border-b"
     >
       <button
+        type="button"
         role="tab"
         aria-selected={activeKey === null}
         onClick={() => onSelect(null)}
@@ -62,6 +63,7 @@ export function ConversationTabStrip({
       {tabs.map((tab) => (
         <span key={tab.key} className="flex items-center">
           <button
+            type="button"
             role="tab"
             aria-selected={activeKey === tab.key}
             onClick={() => onSelect(tab.key)}

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -1,7 +1,9 @@
 import type { ReactNode } from 'react';
+import { useEffect, useRef } from 'react';
 import { ChatWindow } from './ChatWindow';
 import { CommandInput } from './CommandInput';
 import type { ComposerMode } from './CommandInput';
+import { ConversationTabStrip, type ConversationTabStripProps } from './ConversationTabStrip';
 import { SystemLane } from './SystemLane';
 import { SceneMessages } from '@/scenes/components/SceneMessages';
 import type { PoseUnitAvatarClickPersona } from '@/scenes/components/PoseUnit';
@@ -54,6 +56,8 @@ interface GameWindowProps {
   placeBar?: ReactNode;
   /** `PendingActionAttachments`, rendered directly above the composer (#2156). */
   pendingAttachments?: ReactNode;
+  /** Open conversation tabs (#2165); absent = no strip, plain feed. */
+  conversationTabs?: ConversationTabStripProps;
 }
 
 export function GameWindow({
@@ -77,10 +81,47 @@ export function GameWindow({
   isAtPlace,
   placeBar,
   pendingAttachments,
+  conversationTabs,
 }: GameWindowProps) {
   const dispatch = useAppDispatch();
   const { connect } = useGameSocket();
   const { sessions, active } = useAppSelector((state) => state.game);
+
+  // #2165 per-tab scroll: remember each tab's scroll offset, restore on
+  // switch, and stick to bottom while the reader is already at the bottom
+  // (adapted from ChatWindow's autoScroll pattern).
+  const feedScrollRef = useRef<HTMLDivElement>(null);
+  const scrollPositionsRef = useRef(new Map<string, number>());
+  const pinnedRef = useRef(true);
+  const activeConvKey = conversationTabs?.activeKey ?? 'room';
+  const interactionCount = sceneFeed?.interactions.length ?? 0;
+
+  useEffect(() => {
+    const el = feedScrollRef.current;
+    if (!el) return;
+    const saved = scrollPositionsRef.current.get(activeConvKey);
+    if (saved !== undefined) {
+      el.scrollTop = saved;
+      pinnedRef.current = el.scrollHeight - saved - el.clientHeight < 8;
+    } else {
+      el.scrollTop = el.scrollHeight;
+      pinnedRef.current = true;
+    }
+  }, [activeConvKey]);
+
+  useEffect(() => {
+    const el = feedScrollRef.current;
+    if (el && pinnedRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [interactionCount, activeConvKey]);
+
+  const handleFeedScroll = () => {
+    const el = feedScrollRef.current;
+    if (!el) return;
+    scrollPositionsRef.current.set(activeConvKey, el.scrollTop);
+    pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 8;
+  };
 
   if (characters.length === 0) {
     return (
@@ -134,9 +175,14 @@ export function GameWindow({
           ))}
         </div>
       )}
+      {sceneFeed && conversationTabs && <ConversationTabStrip {...conversationTabs} />}
       {sceneFeed ? (
         <>
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          <div
+            className="min-h-0 flex-1 overflow-y-auto"
+            ref={feedScrollRef}
+            onScroll={handleFeedScroll}
+          >
             <SceneMessages
               sceneId={sceneFeed.sceneId}
               filteredInteractions={sceneFeed.interactions}

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -107,7 +107,13 @@ export function GameWindow({
       el.scrollTop = el.scrollHeight;
       pinnedRef.current = true;
     }
-  }, [activeConvKey]);
+    // Prune scroll offsets for tabs that are no longer open (#2165 review
+    // fold-in) — otherwise a closed tab's entry lingers in the map forever.
+    const liveKeys = new Set(['room', ...(conversationTabs?.tabs.map((t) => t.key) ?? [])]);
+    for (const key of scrollPositionsRef.current.keys()) {
+      if (!liveKeys.has(key)) scrollPositionsRef.current.delete(key);
+    }
+  }, [activeConvKey, conversationTabs?.tabs]);
 
   useEffect(() => {
     const el = feedScrollRef.current;

--- a/frontend/src/game/threadTabsStorage.test.ts
+++ b/frontend/src/game/threadTabsStorage.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadThreadTabs, saveThreadTabs, type StoredThreadTabs } from './threadTabsStorage';
+
+describe('threadTabsStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('round-trips a value', () => {
+    const value: StoredThreadTabs = {
+      openThreadTabs: ['whisper:9', 'place:3'],
+      activeThreadTab: 'whisper:9',
+    };
+    saveThreadTabs('Aria', '100', value);
+    expect(loadThreadTabs('Aria', '100')).toEqual(value);
+  });
+
+  it('returns null when nothing is stored', () => {
+    expect(loadThreadTabs('Aria', '100')).toBeNull();
+  });
+
+  it('returns null for garbage JSON', () => {
+    localStorage.setItem('arx:threadTabs:Aria:100', 'not json{{{');
+    expect(loadThreadTabs('Aria', '100')).toBeNull();
+  });
+
+  it('returns null when openThreadTabs is not an array', () => {
+    localStorage.setItem(
+      'arx:threadTabs:Aria:100',
+      JSON.stringify({ openThreadTabs: 'whisper:9', activeThreadTab: null })
+    );
+    expect(loadThreadTabs('Aria', '100')).toBeNull();
+  });
+
+  it('prunes other scene keys for the same character, but leaves other characters alone', () => {
+    saveThreadTabs('Aria', '100', { openThreadTabs: ['whisper:9'], activeThreadTab: 'whisper:9' });
+    saveThreadTabs('Bianca', '200', {
+      openThreadTabs: ['whisper:4'],
+      activeThreadTab: 'whisper:4',
+    });
+
+    // Aria moves to a new scene — her old scene-100 entry should be pruned.
+    saveThreadTabs('Aria', '300', { openThreadTabs: ['place:1'], activeThreadTab: null });
+
+    expect(loadThreadTabs('Aria', '100')).toBeNull();
+    expect(loadThreadTabs('Aria', '300')).toEqual({
+      openThreadTabs: ['place:1'],
+      activeThreadTab: null,
+    });
+    // Bianca's entry, a different character, is untouched.
+    expect(loadThreadTabs('Bianca', '200')).toEqual({
+      openThreadTabs: ['whisper:4'],
+      activeThreadTab: 'whisper:4',
+    });
+  });
+});

--- a/frontend/src/game/threadTabsStorage.ts
+++ b/frontend/src/game/threadTabsStorage.ts
@@ -1,0 +1,48 @@
+/**
+ * Client-local persistence for the conversation-tab layout (#2165, spec
+ * decision 5a): thread KEYS only — never message content. Keyed per
+ * character+scene; a character keeps at most one scene's entry.
+ */
+const STORAGE_PREFIX = 'arx:threadTabs:';
+
+export interface StoredThreadTabs {
+  openThreadTabs: string[];
+  activeThreadTab: string | null;
+}
+
+function storageKey(character: string, sceneId: string): string {
+  return `${STORAGE_PREFIX}${character}:${sceneId}`;
+}
+
+export function loadThreadTabs(character: string, sceneId: string): StoredThreadTabs | null {
+  try {
+    const raw = localStorage.getItem(storageKey(character, sceneId));
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const candidate = parsed as Partial<StoredThreadTabs>;
+    if (!Array.isArray(candidate.openThreadTabs)) return null;
+    return {
+      openThreadTabs: candidate.openThreadTabs.filter((k): k is string => typeof k === 'string'),
+      activeThreadTab:
+        typeof candidate.activeThreadTab === 'string' ? candidate.activeThreadTab : null,
+    };
+  } catch {
+    return null; // localStorage unavailable or unparsable — best-effort feature.
+  }
+}
+
+export function saveThreadTabs(character: string, sceneId: string, value: StoredThreadTabs): void {
+  try {
+    const keep = storageKey(character, sceneId);
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(`${STORAGE_PREFIX}${character}:`) && key !== keep) {
+        localStorage.removeItem(key);
+      }
+    }
+    localStorage.setItem(keep, JSON.stringify(value));
+  } catch {
+    // localStorage unavailable — persistence is best-effort.
+  }
+}

--- a/frontend/src/scenes/components/ModeSelector.test.tsx
+++ b/frontend/src/scenes/components/ModeSelector.test.tsx
@@ -55,4 +55,13 @@ describe('ModeSelector', () => {
     render(<ModeSelector currentMode="whisper" onModeChange={vi.fn()} isAtPlace={false} />);
     expect(screen.getByRole('button', { name: /whisper/i })).toBeInTheDocument();
   });
+
+  it('renders a locked, non-interactive label with no dropdown trigger when locked (#2165)', () => {
+    render(<ModeSelector currentMode="whisper" onModeChange={vi.fn()} isAtPlace={false} locked />);
+
+    const lockedLabel = screen.getByTitle('Audience is locked to this conversation tab');
+    expect(lockedLabel.tagName).toBe('SPAN');
+    expect(lockedLabel).toHaveTextContent(/whisper/i);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/scenes/components/ModeSelector.tsx
+++ b/frontend/src/scenes/components/ModeSelector.tsx
@@ -4,12 +4,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Lock } from 'lucide-react';
 
 interface ModeSelectorProps {
   currentMode: string;
   onModeChange: (mode: string) => void;
   isAtPlace: boolean;
+  /** #2165: audience is fixed by the active conversation tab — renders a static label, no dropdown. */
+  locked?: boolean;
 }
 
 const COMMUNICATION_MODES = [
@@ -21,12 +23,24 @@ const COMMUNICATION_MODES = [
   { key: 'tt', label: 'Tabletalk' },
 ] as const;
 
-export function ModeSelector({ currentMode, onModeChange, isAtPlace }: ModeSelectorProps) {
+export function ModeSelector({ currentMode, onModeChange, isAtPlace, locked }: ModeSelectorProps) {
   const currentLabel = COMMUNICATION_MODES.find((m) => m.key === currentMode)?.label ?? currentMode;
 
   const visibleModes = isAtPlace
     ? COMMUNICATION_MODES
     : COMMUNICATION_MODES.filter((m) => m.key !== 'tt');
+
+  if (locked) {
+    return (
+      <span
+        title="Audience is locked to this conversation tab"
+        className="flex items-center gap-0.5 whitespace-nowrap rounded-sm px-2 py-0.5 text-xs font-medium text-muted-foreground"
+      >
+        <Lock className="h-3 w-3" />
+        {currentLabel}
+      </span>
+    );
+  }
 
   return (
     <DropdownMenu>

--- a/frontend/src/scenes/components/ModeSelector.tsx
+++ b/frontend/src/scenes/components/ModeSelector.tsx
@@ -10,7 +10,10 @@ interface ModeSelectorProps {
   currentMode: string;
   onModeChange: (mode: string) => void;
   isAtPlace: boolean;
-  /** #2165: audience is fixed by the active conversation tab — renders a static label, no dropdown. */
+  /**
+   * #2165: audience is fixed by the active conversation tab — renders a
+   * static label, no dropdown.
+   */
   locked?: boolean;
 }
 

--- a/frontend/src/scenes/hooks/__tests__/threadToComposerMode.test.ts
+++ b/frontend/src/scenes/hooks/__tests__/threadToComposerMode.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { tabKeyToComposerMode } from '../threadToComposerMode';
+import type { Thread } from '../useThreading';
+
+const whisperThread: Thread = {
+  key: 'whisper:1,2',
+  type: 'whisper',
+  label: 'Whisper: Alise, Ben',
+  participantPersonas: [
+    { id: 1, name: 'Alise' },
+    { id: 2, name: 'Ben' },
+  ],
+  latestTimestamp: '2026-07-11T00:00:00Z',
+  unreadCount: 0,
+};
+
+describe('tabKeyToComposerMode (#2165)', () => {
+  it('derives a locked whisper mode from a resolved thread', () => {
+    const mode = tabKeyToComposerMode('whisper:1,2', [whisperThread], 'The Grand Ballroom');
+    expect(mode.command).toBe('whisper');
+    expect(mode.targets).toEqual(['Alise', 'Ben']);
+    expect(mode.locked).toBe(true);
+  });
+
+  it('falls back to a target-less locked whisper for an unresolved whisper key', () => {
+    const mode = tabKeyToComposerMode('whisper:3,4', [], 'The Grand Ballroom');
+    expect(mode.command).toBe('whisper');
+    expect(mode.targets).toEqual([]);
+    expect(mode.locked).toBe(true);
+  });
+
+  it('falls back to locked tabletalk for an unresolved place key', () => {
+    const mode = tabKeyToComposerMode('place:7', [], 'The Grand Ballroom');
+    expect(mode.command).toBe('tt');
+    expect(mode.locked).toBe(true);
+  });
+});

--- a/frontend/src/scenes/hooks/__tests__/useThreading.test.ts
+++ b/frontend/src/scenes/hooks/__tests__/useThreading.test.ts
@@ -238,6 +238,33 @@ describe('useThreading', () => {
     expect(hidden.size).toBe(0);
   });
 
+  it('interactionsByThread groups interactions per thread key (#2165)', () => {
+    const interactions = [
+      makeInteraction({
+        id: 1,
+        mode: 'whisper',
+        persona: { id: 1, name: 'Alice' },
+        receiver_persona_ids: [2],
+      }),
+      makeInteraction({
+        id: 2,
+        mode: 'whisper',
+        persona: { id: 2, name: 'Bob' },
+        receiver_persona_ids: [1],
+      }),
+      makeInteraction({ id: 3 }),
+      makeInteraction({ id: 4 }),
+    ];
+
+    const { result } = renderHook(() => useThreading(interactions, 'Room'));
+
+    const whisperInteractions = result.current.interactionsByThread.get('whisper:1,2');
+    expect(whisperInteractions?.map((i) => i.id)).toEqual([1, 2]);
+
+    const roomInteractions = result.current.interactionsByThread.get('room');
+    expect(roomInteractions?.map((i) => i.id)).toEqual([3, 4]);
+  });
+
   describe('unread counts', () => {
     it('defaults unreadCount to 0 when no opts are passed at all', () => {
       const interactions = [makeInteraction({ id: 1 }), makeInteraction({ id: 2 })];

--- a/frontend/src/scenes/hooks/threadToComposerMode.ts
+++ b/frontend/src/scenes/hooks/threadToComposerMode.ts
@@ -31,3 +31,26 @@ export function threadToComposerMode(thread: Thread, roomName: string): Composer
       };
   }
 }
+
+/**
+ * Composer mode for an open conversation TAB (#2165) — always `locked`.
+ * Prefers the resolved thread; a restored tab whose thread hasn't backfilled
+ * yet derives a safe audience from the key shape alone. An unresolved whisper
+ * key yields `targets: []`, which CommandInput's whisper guard refuses to
+ * send — fail-closed beats mis-sending to the room.
+ */
+export function tabKeyToComposerMode(
+  key: string,
+  threads: Thread[],
+  roomName: string
+): ComposerMode {
+  const thread = threads.find((t) => t.key === key);
+  if (thread) return { ...threadToComposerMode(thread, roomName), locked: true };
+  if (key.startsWith('place:')) {
+    return { command: 'tt', targets: [], label: 'Tabletalk', locked: true };
+  }
+  if (key.startsWith('whisper:')) {
+    return { command: 'whisper', targets: [], label: 'Whisper', locked: true };
+  }
+  return { command: 'pose', targets: [], label: `Pose → ${roomName}`, locked: true };
+}

--- a/frontend/src/scenes/hooks/useThreading.ts
+++ b/frontend/src/scenes/hooks/useThreading.ts
@@ -28,7 +28,10 @@ export interface UseThreadingOpts {
 
 export interface ThreadingState {
   threads: Thread[];
-  /** Interactions grouped by thread key (#2165 per-tab feeds) — same grouping the threads list is built from. */
+  /**
+   * Interactions grouped by thread key (#2165 per-tab feeds) — same
+   * grouping the threads list is built from.
+   */
   interactionsByThread: Map<string, Interaction[]>;
   filteredInteractions: Interaction[];
   selectedThreadKey: string;

--- a/frontend/src/scenes/hooks/useThreading.ts
+++ b/frontend/src/scenes/hooks/useThreading.ts
@@ -28,6 +28,8 @@ export interface UseThreadingOpts {
 
 export interface ThreadingState {
   threads: Thread[];
+  /** Interactions grouped by thread key (#2165 per-tab feeds) — same grouping the threads list is built from. */
+  interactionsByThread: Map<string, Interaction[]>;
   filteredInteractions: Interaction[];
   selectedThreadKey: string;
   enabledThreadKeys: Set<string>;
@@ -140,7 +142,7 @@ export function useThreading(
   const viewerPersonaId = opts?.viewerPersonaId;
   const sceneBaselineId = opts?.sceneBaselineId;
 
-  const { threads, threadKeyMap } = useMemo(() => {
+  const { threads, threadKeyMap, interactionsByThread } = useMemo(() => {
     const groups = new Map<string, Interaction[]>();
     const keyMap = new Map<number, string>();
     for (const interaction of interactions) {
@@ -179,7 +181,7 @@ export function useThreading(
         if (b.type === 'room') return 1;
         return b.latestTimestamp.localeCompare(a.latestTimestamp);
       });
-    return { threads: threadList, threadKeyMap: keyMap };
+    return { threads: threadList, threadKeyMap: keyMap, interactionsByThread: groups };
   }, [interactions, roomName, lastSeenByThread, viewerPersonaId, sceneBaselineId]);
 
   const filteredInteractions = useMemo(() => {
@@ -256,6 +258,7 @@ export function useThreading(
 
   return {
     threads,
+    interactionsByThread,
     filteredInteractions,
     selectedThreadKey,
     enabledThreadKeys,

--- a/frontend/src/store/CLAUDE.md
+++ b/frontend/src/store/CLAUDE.md
@@ -12,7 +12,19 @@ Redux Toolkit store for global client state management. Minimal use of Redux - o
 ### State Slices
 
 - **`authSlice.ts`**: User authentication state management
-- **`gameSlice.ts`**: Game session management (messages, connections, character sessions)
+- **`gameSlice.ts`**: Game session management (messages, connections, character sessions).
+  Each per-character `Session` also carries the **conversation-tab state** (#2165):
+  `openThreadTabs` (ordered thread keys with an open tab; never contains `'room'`,
+  which is always the anchor) and `activeThreadTab` (the focused tab's key, or
+  `null` for the room anchor). Reducers: `openThreadTab` (opens or focuses a tab),
+  `closeThreadTab` (drops a tab, falling back to the room anchor if it was
+  active), `setActiveThreadTab` (guards against activating a key that isn't in
+  `openThreadTabs`), and `hydrateThreadTabs` (seeds tab state from
+  `frontend/src/game/threadTabsStorage.ts`'s `localStorage` snapshot — only when
+  the session hasn't already opened tabs, so a live session always wins over a
+  stale snapshot). `setSessionScene` resets both fields to empty/`null` whenever
+  the session's scene id actually changes — a tab pointing at a previous scene's
+  thread set is a mis-send vector, not just stale UI.
 
 ## Key Features
 

--- a/frontend/src/store/__tests__/gameSlice.test.ts
+++ b/frontend/src/store/__tests__/gameSlice.test.ts
@@ -1141,6 +1141,8 @@ describe('gameSlice', () => {
             sceneInteractions: [],
             threadLastSeen: { room: 5 },
             sceneBaselineId: null,
+            openThreadTabs: ['whisper:1'],
+            activeThreadTab: 'whisper:1',
           },
         },
         active: 'Hero',

--- a/frontend/src/store/__tests__/gameSlice.test.ts
+++ b/frontend/src/store/__tests__/gameSlice.test.ts
@@ -17,6 +17,10 @@ import {
   setSessionRoom,
   setSessionScene,
   markThreadSeen,
+  openThreadTab,
+  closeThreadTab,
+  setActiveThreadTab,
+  hydrateThreadTabs,
   resetGame,
 } from '../gameSlice';
 import type {
@@ -56,6 +60,8 @@ interface Session {
   sceneInteractions: InteractionWsPayload[];
   threadLastSeen: Record<string, number>;
   sceneBaselineId: number | null;
+  openThreadTabs: string[];
+  activeThreadTab: string | null;
 }
 
 interface GameState {
@@ -73,6 +79,8 @@ const createDefaultSession = (overrides: Partial<Session> = {}): Session => ({
   sceneInteractions: [],
   threadLastSeen: {},
   sceneBaselineId: null,
+  openThreadTabs: [],
+  activeThreadTab: null,
   ...overrides,
 });
 
@@ -222,6 +230,8 @@ describe('gameSlice', () => {
           sceneInteractions: [],
           threadLastSeen: {},
           sceneBaselineId: null,
+          openThreadTabs: [],
+          activeThreadTab: null,
         });
       });
 
@@ -1242,5 +1252,146 @@ describe('gameSlice', () => {
       expect(state.sessions['NewHero'].messages).toEqual([]);
       expect(state.sessions['Hero']).toBeUndefined();
     });
+  });
+});
+
+describe('conversation tabs (#2165)', () => {
+  const character = 'Alise';
+  function withSession(): ReturnType<typeof reducer> {
+    return reducer(undefined, startSession(character));
+  }
+
+  it('openThreadTab appends once and activates', () => {
+    let state = withSession();
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    expect(state.sessions[character].openThreadTabs).toEqual(['whisper:1,2']);
+    expect(state.sessions[character].activeThreadTab).toBe('whisper:1,2');
+  });
+
+  it('openThreadTab with room activates the anchor without appending', () => {
+    let state = withSession();
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(state, openThreadTab({ character, threadKey: 'room' }));
+    expect(state.sessions[character].openThreadTabs).toEqual(['whisper:1,2']);
+    expect(state.sessions[character].activeThreadTab).toBeNull();
+  });
+
+  it('closeThreadTab removes the tab and clears active when it was the active tab', () => {
+    let state = withSession();
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(state, closeThreadTab({ character, threadKey: 'whisper:1,2' }));
+    expect(state.sessions[character].openThreadTabs).toEqual([]);
+    expect(state.sessions[character].activeThreadTab).toBeNull();
+  });
+
+  it('closeThreadTab removes an inactive tab and leaves active untouched', () => {
+    let state = withSession();
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:3,4' }));
+    state = reducer(state, setActiveThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(state, closeThreadTab({ character, threadKey: 'whisper:3,4' }));
+    expect(state.sessions[character].openThreadTabs).toEqual(['whisper:1,2']);
+    expect(state.sessions[character].activeThreadTab).toBe('whisper:1,2');
+  });
+
+  it('setActiveThreadTab activates an open tab', () => {
+    let state = withSession();
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:3,4' }));
+    state = reducer(state, setActiveThreadTab({ character, threadKey: 'whisper:1,2' }));
+    expect(state.sessions[character].activeThreadTab).toBe('whisper:1,2');
+  });
+
+  it('setActiveThreadTab activates null (the room anchor)', () => {
+    let state = withSession();
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(state, setActiveThreadTab({ character, threadKey: null }));
+    expect(state.sessions[character].activeThreadTab).toBeNull();
+  });
+
+  it('setActiveThreadTab ignores a key not in openThreadTabs', () => {
+    let state = withSession();
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(state, setActiveThreadTab({ character, threadKey: 'whisper:9,9' }));
+    expect(state.sessions[character].activeThreadTab).toBe('whisper:1,2');
+  });
+
+  it('hydrateThreadTabs seeds both fields when openThreadTabs is empty', () => {
+    let state = withSession();
+    state = reducer(
+      state,
+      hydrateThreadTabs({
+        character,
+        openThreadTabs: ['whisper:1,2', 'table:5'],
+        activeThreadTab: 'table:5',
+      })
+    );
+    expect(state.sessions[character].openThreadTabs).toEqual(['whisper:1,2', 'table:5']);
+    expect(state.sessions[character].activeThreadTab).toBe('table:5');
+  });
+
+  it('hydrateThreadTabs does nothing when openThreadTabs is already occupied', () => {
+    let state = withSession();
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(
+      state,
+      hydrateThreadTabs({
+        character,
+        openThreadTabs: ['table:5'],
+        activeThreadTab: 'table:5',
+      })
+    );
+    expect(state.sessions[character].openThreadTabs).toEqual(['whisper:1,2']);
+    expect(state.sessions[character].activeThreadTab).toBe('whisper:1,2');
+  });
+
+  it('hydrateThreadTabs filters room out of the incoming open list', () => {
+    let state = withSession();
+    state = reducer(
+      state,
+      hydrateThreadTabs({
+        character,
+        openThreadTabs: ['room', 'whisper:1,2'],
+        activeThreadTab: 'whisper:1,2',
+      })
+    );
+    expect(state.sessions[character].openThreadTabs).toEqual(['whisper:1,2']);
+    expect(state.sessions[character].activeThreadTab).toBe('whisper:1,2');
+  });
+
+  it('hydrateThreadTabs drops an activeThreadTab not present in the hydrated open list', () => {
+    let state = withSession();
+    state = reducer(
+      state,
+      hydrateThreadTabs({
+        character,
+        openThreadTabs: ['whisper:1,2'],
+        activeThreadTab: 'table:5',
+      })
+    );
+    expect(state.sessions[character].openThreadTabs).toEqual(['whisper:1,2']);
+    expect(state.sessions[character].activeThreadTab).toBeNull();
+  });
+
+  it('setSessionScene with a different scene id clears openThreadTabs and activeThreadTab', () => {
+    const sceneOne = createSceneSummary(1, 'Scene One');
+    const sceneTwo = createSceneSummary(2, 'Scene Two');
+    let state = withSession();
+    state = reducer(state, setSessionScene({ character, scene: sceneOne }));
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(state, setSessionScene({ character, scene: sceneTwo }));
+    expect(state.sessions[character].openThreadTabs).toEqual([]);
+    expect(state.sessions[character].activeThreadTab).toBeNull();
+  });
+
+  it('setSessionScene with the same scene id leaves tabs alone', () => {
+    const scene = createSceneSummary(1, 'Scene One');
+    let state = withSession();
+    state = reducer(state, setSessionScene({ character, scene }));
+    state = reducer(state, openThreadTab({ character, threadKey: 'whisper:1,2' }));
+    state = reducer(state, setSessionScene({ character, scene: { ...scene } }));
+    expect(state.sessions[character].openThreadTabs).toEqual(['whisper:1,2']);
+    expect(state.sessions[character].activeThreadTab).toBe('whisper:1,2');
   });
 });

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -42,6 +42,10 @@ interface Session {
    * stay zeroed. `null` before the baseline effect has run for this scene.
    */
   sceneBaselineId: number | null;
+  /** Ordered thread keys with an open conversation tab (#2165). Never contains 'room'. */
+  openThreadTabs: string[];
+  /** Active conversation tab's thread key; null = the room anchor tab (#2165). */
+  activeThreadTab: string | null;
 }
 
 interface GameState {
@@ -71,6 +75,8 @@ export const gameSlice = createSlice({
           sceneInteractions: [],
           threadLastSeen: {},
           sceneBaselineId: null,
+          openThreadTabs: [],
+          activeThreadTab: null,
         };
       }
       state.active = name;
@@ -146,6 +152,10 @@ export const gameSlice = createSlice({
         const nextId = scene?.id ?? null;
         if (previousId !== nextId) {
           session.sceneBaselineId = null;
+          // Tabs are scene-contextual (#2165): a stale tab pointing at last
+          // scene's table/whisper set is a mis-send vector.
+          session.openThreadTabs = [];
+          session.activeThreadTab = null;
         }
         session.scene = scene;
       }
@@ -215,6 +225,61 @@ export const gameSlice = createSlice({
         }
       }
     },
+    openThreadTab: (
+      state,
+      action: PayloadAction<{ character: MyRosterEntry['name']; threadKey: string }>
+    ) => {
+      const { character, threadKey } = action.payload;
+      const session = state.sessions[character];
+      if (session) {
+        if (threadKey !== 'room' && !session.openThreadTabs.includes(threadKey)) {
+          session.openThreadTabs.push(threadKey);
+        }
+        session.activeThreadTab = threadKey === 'room' ? null : threadKey;
+      }
+    },
+    closeThreadTab: (
+      state,
+      action: PayloadAction<{ character: MyRosterEntry['name']; threadKey: string }>
+    ) => {
+      const { character, threadKey } = action.payload;
+      const session = state.sessions[character];
+      if (session) {
+        session.openThreadTabs = session.openThreadTabs.filter((k) => k !== threadKey);
+        if (session.activeThreadTab === threadKey) {
+          session.activeThreadTab = null;
+        }
+      }
+    },
+    setActiveThreadTab: (
+      state,
+      action: PayloadAction<{ character: MyRosterEntry['name']; threadKey: string | null }>
+    ) => {
+      const { character, threadKey } = action.payload;
+      const session = state.sessions[character];
+      if (session && (threadKey === null || session.openThreadTabs.includes(threadKey))) {
+        session.activeThreadTab = threadKey;
+      }
+    },
+    // localStorage restore (#2165): only seeds a session that hasn't opened
+    // tabs yet — a live session's state always wins over a stale snapshot.
+    hydrateThreadTabs: (
+      state,
+      action: PayloadAction<{
+        character: MyRosterEntry['name'];
+        openThreadTabs: string[];
+        activeThreadTab: string | null;
+      }>
+    ) => {
+      const { character, openThreadTabs, activeThreadTab } = action.payload;
+      const session = state.sessions[character];
+      if (session && session.openThreadTabs.length === 0) {
+        const open = openThreadTabs.filter((k) => k !== 'room');
+        session.openThreadTabs = open;
+        session.activeThreadTab =
+          activeThreadTab !== null && open.includes(activeThreadTab) ? activeThreadTab : null;
+      }
+    },
     resetGame: () => initialState,
   },
 });
@@ -232,5 +297,9 @@ export const {
   clearSceneInteractions,
   markThreadSeen,
   setSceneBaseline,
+  openThreadTab,
+  closeThreadTab,
+  setActiveThreadTab,
+  hydrateThreadTabs,
   resetGame,
 } = gameSlice.actions;


### PR DESCRIPTION
Closes #2165

## Summary

Conversation tabs on the /game play surface (#2165): a tab strip above the scene feed — room feed as the permanent anchor tab plus a closable tab per broken-out conversation (whisper/place/target thread). Each tab has its own thread-narrowed feed, preserved scroll position (stick-to-bottom aware), numeric unread badge riding #2156's per-thread unread, and a composer whose audience is DERIVED from the active tab and locked (the mis-send guard — a whisper-tab send can never land in the room; unresolved whisper tabs fail closed). The thread sidebar becomes the open-a-tab surface (row click opens/focuses; All re-anchors; row selection tracks the active tab). Tab layout persists client-locally per character+scene (thread keys only, localStorage, hydration-race-guarded) and resets on scene change. Frontend-only; 562 vitest cases green incl. new reducer/integration/storage suites; pnpm build verified. Review trail: per-task reviews + 3 fix waves + final whole-branch review (READY WITH NITS, nit folded in). Deliberately dropped (pre-existing from #2156, noted by the final review): whisper composer uses targets[0]/author-derived participants — fail-closed, never room-bound; composer draft persists across tab switches (audience label always visible).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2165 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main (local-only branch, clean, no conflicts).

<!-- last-addressed-comment: 0 -->