### PR TITLE
Wire collect_food to telnet + web: the crop/food loop can close in play (#2237)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2718,7 +2718,13 @@ prosperity.
   - `max_food_capacity(domain)` — sums `granary.level × capacity_per_level`
     across all active Granaries in the domain's area subtree.
 - **Action:** `CollectFoodAction` (key `"collect_food"`, category
-  `"agriculture"`) — the single commit seam for telnet + web.
+  `"agriculture"`) — the single commit seam for telnet + web. Resolves its Field
+  from a pre-resolved `field_instance`, a `field_instance_id` (web/REST — the REST
+  path does no ObjectDB resolution, so the action resolves it), or the active FIELD
+  feature in `actor.location` (telnet). **Surfaces (#2237):** telnet `harvest`
+  (`commands/agriculture.py` `CmdHarvest`) + web `POST /api/agriculture/collect/`
+  (`CollectFoodView`, body `{field_instance_id}`). Without a surface the loop
+  couldn't close — the pool filled but never drained.
 - **Events:** `FOOD_COLLECTED`, `FOOD_SHORTAGE` (in `flows/constants.py`).
 - **Cron tasks:** `agriculture.field_production` (daily 24h),
   `agriculture.domain_consumption` (weekly, via weekly rollover).

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -383,6 +383,29 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/agriculture/collect/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description Collect food from a Field into its domain's stockpile.
+     *
+     *     Web dispatch of ``CollectFoodAction``: the body names the Field feature by
+     *     ``field_instance_id``; the Action resolves it (the REST path does no
+     *     ObjectDB resolution) and lands the food. Mirrors ``fatigue.RestView``.
+     */
+    post: operations['agriculture_collect_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/areas/': {
     parameters: {
       query?: never;
@@ -34701,6 +34724,24 @@ export interface operations {
         content: {
           'application/json': components['schemas']['AggregateBeatContribution'];
         };
+      };
+    };
+  };
+  agriculture_collect_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/src/actions/definitions/collect_food.py
+++ b/src/actions/definitions/collect_food.py
@@ -11,6 +11,37 @@ from actions.types import ActionContext, ActionResult, TargetType
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
+    from world.room_features.models import RoomFeatureInstance
+
+
+def _resolve_field_instance(actor: ObjectDB, field_instance_id: Any) -> RoomFeatureInstance | None:
+    """Resolve the Field ``RoomFeatureInstance`` to collect from.
+
+    Web dispatch passes ``field_instance_id`` (a pk); telnet stands in the room
+    and we resolve that room's active FIELD feature. The REST dispatch path does
+    no ObjectDB/instance resolution (see ``actions/CLAUDE.md``), so we resolve
+    here — the same ``execute()`` works for a telnet ``.run()`` passing a
+    pre-resolved ``field_instance`` and a REST call passing a raw id.
+    """
+    from world.room_features.constants import RoomFeatureServiceStrategy  # noqa: PLC0415
+    from world.room_features.models import RoomFeatureInstance  # noqa: PLC0415
+
+    fields = RoomFeatureInstance.objects.active().filter(
+        feature_kind__service_strategy=RoomFeatureServiceStrategy.FIELD
+    )
+    if field_instance_id is not None:
+        return fields.filter(pk=field_instance_id).first()
+
+    location = getattr(actor, "location", None)  # noqa: GETATTR_LITERAL
+    if location is None:
+        return None
+    from evennia_extensions.models import RoomProfile  # noqa: PLC0415
+
+    room_profile = RoomProfile.objects.filter(objectdb=location).first()
+    if room_profile is None:
+        return None
+    return fields.filter(room_profile=room_profile).first()
+
 
 @dataclass
 class CollectFoodAction(Action):
@@ -21,8 +52,10 @@ class CollectFoodAction(Action):
     check, applies the band percentage, and lands food into the domain's
     ``FoodStockpile`` (capped at Granary capacity).
 
-    kwargs:
-        field_instance: RoomFeatureInstance — the Field to collect from.
+    kwargs (resolved in priority order):
+        field_instance: RoomFeatureInstance — a pre-resolved Field (telnet ``.run()``).
+        field_instance_id: int — a Field feature pk (web/REST dispatch).
+        (neither) — the active FIELD feature in ``actor.location`` (telnet ``harvest``).
     """
 
     key: str = "collect_food"
@@ -41,9 +74,11 @@ class CollectFoodAction(Action):
 
         field_instance = kwargs.get("field_instance")
         if field_instance is None:
+            field_instance = _resolve_field_instance(actor, kwargs.get("field_instance_id"))
+        if field_instance is None:
             return ActionResult(
                 success=False,
-                message="Which field? (collect food <field>)",
+                message="There's no field here to collect from.",
             )
 
         try:

--- a/src/commands/agriculture.py
+++ b/src/commands/agriculture.py
@@ -1,0 +1,30 @@
+"""Telnet face of food collection (#2237).
+
+Thin command: ``harvest`` delegates to the REGISTRY ``CollectFoodAction``,
+which resolves the Field in the caller's current room and lands its food into
+the domain stockpile. Same seam the web ``CollectFoodView`` dispatches through.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from actions.definitions.collect_food import CollectFoodAction
+from commands.command import ArxCommand
+
+
+class CmdHarvest(ArxCommand):
+    """Collect the food a field here has grown into your domain's stores.
+
+    Stand where a field is. Collection rolls a check — a bad roll loses some
+    (or all) of the haul, and a full granary caps what lands.
+
+    Usage:
+      harvest
+    """
+
+    key = "harvest"
+    aliases: ClassVar[list[str]] = []
+    locks = "cmd:all()"
+    help_category = "General"
+    action = CollectFoodAction()

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -20,6 +20,7 @@ from commands.account.account_info import CmdAccount, CmdRoster
 from commands.account.character_switching import CmdCharacters, CmdIC
 from commands.account.prompt_reply import CmdPromptReply
 from commands.account.sheet import CmdSheet
+from commands.agriculture import CmdHarvest
 from commands.alterations import CmdMageScar
 from commands.battle import CmdBattle
 from commands.canon_review import CmdCanonReview
@@ -283,6 +284,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdHide,
             # #1491 — telnet face of RestAction; spend AP to become Well-Rested.
             CmdRest,
+            # #2237 — telnet face of CollectFoodAction; harvest a field's food.
+            CmdHarvest,
             # #1866 — telnet face of SearchAction; search for clues in a room.
             CmdSearch,
             # #1450 — the staff push face: hand-authored gemits scoped by reach.

--- a/src/schema.json
+++ b/src/schema.json
@@ -573,6 +573,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/AggregateBeatContribution'
           description: ''
+  /api/agriculture/collect/:
+    post:
+      operationId: agriculture_collect_create
+      description: |-
+        Collect food from a Field into its domain's stockpile.
+
+        Web dispatch of ``CollectFoodAction``: the body names the Field feature by
+        ``field_instance_id``; the Action resolves it (the REST path does no
+        ObjectDB resolution) and lands the food. Mirrors ``fatigue.RestView``.
+      tags:
+      - agriculture
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          description: No response body
   /api/areas/:
     get:
       operationId: areas_list

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path("api/justice/", include("world.justice.urls")),
     path("api/clues/", include("world.clues.urls")),
     path("api/fatigue/", include("world.fatigue.urls")),
+    path("api/agriculture/", include("world.agriculture.urls")),
     path("api/vitals/", include("world.vitals.urls")),
     path("api/action-points/", include("world.action_points.urls")),
     path("api/areas/", include("world.areas.urls")),

--- a/src/world/agriculture/tests/test_action.py
+++ b/src/world/agriculture/tests/test_action.py
@@ -9,8 +9,9 @@ class CollectFoodActionTests(TestCase):
     def test_no_field_instance_returns_failure(self):
         from actions.definitions.collect_food import CollectFoodAction
 
+        # No explicit field and no field resolvable from the (locationless) actor → failure.
         action = CollectFoodAction()
-        result = action.execute(MagicMock(), field_instance=None)
+        result = action.execute(MagicMock(location=None), field_instance=None)
         self.assertFalse(result.success)
 
     def test_successful_collection(self):
@@ -62,4 +63,63 @@ class CollectFoodActionTests(TestCase):
         action = CollectFoodAction()
         result = action.execute(MagicMock(), field_instance=instance)
 
+        self.assertFalse(result.success)
+
+
+def _make_field(*, pool: int, name: str = "Field"):
+    """A Field RoomFeatureInstance with a crop and an uncollected pool."""
+    from world.agriculture.models import CropType, FieldDetails
+    from world.room_features.constants import (
+        RoomFeatureInstallMechanism,
+        RoomFeatureServiceStrategy,
+    )
+    from world.room_features.factories import RoomFeatureInstanceFactory
+    from world.room_features.models import RoomFeatureKind
+
+    kind = RoomFeatureKind.objects.create(
+        name=name,
+        max_level=5,
+        service_strategy=RoomFeatureServiceStrategy.FIELD,
+        install_mechanism=RoomFeatureInstallMechanism.PROJECT,
+    )
+    crop = CropType.objects.create(name=f"{name}Crop", base_production=10)
+    instance = RoomFeatureInstanceFactory(feature_kind=kind)
+    FieldDetails.objects.create(feature_instance=instance, crop_type=crop, uncollected_pool=pool)
+    return instance
+
+
+class CollectFoodResolutionTests(TestCase):
+    """#2237 — the action resolves its Field from a raw id (REST) or the actor's room (telnet)."""
+
+    def test_resolves_field_by_id_the_rest_dispatch_shape(self):
+        # The REST path passes a raw int field_instance_id with no upstream ObjectDB resolution.
+        from actions.definitions.collect_food import CollectFoodAction
+
+        instance = _make_field(pool=50, name="RestField")
+        result = CollectFoodAction().execute(MagicMock(), field_instance_id=instance.pk)
+        self.assertTrue(result.success)
+        self.assertIn("landed", result.data)
+
+    def test_resolves_field_in_the_actors_room_the_telnet_shape(self):
+        from actions.definitions.collect_food import CollectFoodAction
+
+        instance = _make_field(pool=50, name="RoomField")
+        actor = MagicMock()
+        actor.location = instance.room_profile.objectdb
+        result = CollectFoodAction().execute(actor)  # no field kwargs — resolve from the room
+        self.assertTrue(result.success)
+
+    def test_unknown_field_id_returns_failure(self):
+        from actions.definitions.collect_food import CollectFoodAction
+
+        result = CollectFoodAction().execute(MagicMock(), field_instance_id=999999)
+        self.assertFalse(result.success)
+        self.assertIn("field", result.message.lower())
+
+    def test_no_room_and_no_field_returns_failure(self):
+        from actions.definitions.collect_food import CollectFoodAction
+
+        actor = MagicMock()
+        actor.location = None
+        result = CollectFoodAction().execute(actor)
         self.assertFalse(result.success)

--- a/src/world/agriculture/urls.py
+++ b/src/world/agriculture/urls.py
@@ -1,0 +1,10 @@
+"""Agriculture URL configuration."""
+
+from django.urls import path
+
+from world.agriculture.views import CollectFoodView
+
+app_name = "agriculture"
+urlpatterns = [
+    path("collect/", CollectFoodView.as_view(), name="collect"),
+]

--- a/src/world/agriculture/views.py
+++ b/src/world/agriculture/views.py
@@ -1,0 +1,37 @@
+"""Agriculture API views — the web face of food collection (#2237)."""
+
+from __future__ import annotations
+
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from actions.definitions.collect_food import CollectFoodAction
+
+
+class CollectFoodView(APIView):
+    """Collect food from a Field into its domain's stockpile.
+
+    Web dispatch of ``CollectFoodAction``: the body names the Field feature by
+    ``field_instance_id``; the Action resolves it (the REST path does no
+    ObjectDB resolution) and lands the food. Mirrors ``fatigue.RestView``.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request) -> Response:
+        if not hasattr(request.user, "player_data"):
+            return Response({"detail": "No active character."}, status=status.HTTP_404_NOT_FOUND)
+        current_character = request.user.player_data.get_current_character()
+        if not current_character:
+            return Response({"detail": "No active character."}, status=status.HTTP_404_NOT_FOUND)
+
+        field_instance_id = request.data.get("field_instance_id")
+        result = CollectFoodAction().run(
+            actor=current_character, field_instance_id=field_instance_id
+        )
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({"detail": result.message, **result.data})


### PR DESCRIPTION
Closes #2237.

## The bug
`CollectFoodAction` (#2220/#1864) was **orphaned** — its docstring called it "the single commit seam where telnet and web converge," but neither existed: no telnet command, no web surface, and `execute()` did a bare `kwargs.get("field_instance")` with no id resolution, so the REST dispatcher (which passes raw kwargs, per `actions/CLAUDE.md`) couldn't drive it either. It was callable only from a test with a pre-resolved instance.

**Impact:** food never left the Field pool → `FoodStockpile` stayed empty → weekly consumption always read *shortage* → **every populated domain bled `unrest +5 / prosperity −5` weekly regardless of its Fields.** Owning farmland strictly harmed a domain.

## The fix
- **Action resolution:** `execute()` now resolves the Field from a pre-resolved `field_instance` (telnet `.run()`), a `field_instance_id` (web/REST), or the active FIELD feature in `actor.location` (telnet convenience) — mirroring the `_resolve_room` / `_resolve_active_lab_station` patterns.
- **Telnet:** `harvest` — a thin `CmdRest`-style shell (`commands/agriculture.py` `CmdHarvest`), registered in `default_cmdsets`.
- **Web:** `POST /api/agriculture/collect/` (`CollectFoodView`, body `{field_instance_id}`) — mirrors `fatigue.RestView`; `world/agriculture/urls.py` registered in `web/urls.py`.

## Tests
`world/agriculture/tests/test_action.py` — resolution by `field_instance_id` (the REST-dispatch shape the `actions/CLAUDE.md` note demands proving with a plain int), resolution from the actor's room (telnet), and the unknown-id / no-field failures. Full `world.agriculture` suite green (24).

## Notes / scope
- The web endpoint is the REST seam for the frontend; a React harvest control lands with the domain-management web panel (#2239) — there's no domain UI to hang it on yet.
- Left as-is (separate concern, noted on #2237): the Field install handler hard-picks `CropType.objects.first()` and silently skips `FieldDetails` if no crop is seeded — an edge case that doesn't affect a seeded game.
- First of the review punch-list (#2237–#2243); the showstopper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)