### PR TITLE
Appearance & Identity architecture (epic)

### DIFF
--- a/docs/roadmap/rp-scenes.md
+++ b/docs/roadmap/rp-scenes.md
@@ -219,6 +219,45 @@ called `set_active_persona` directly (bypassing `action.run()`); telnet had no w
 
 **Details:** [appearance_and_identity.md](../systems/appearance_and_identity.md) §"Layer 1 — Persona"
 
+### PC-to-PC Identification Loop — DONE (#1107 slice 5, Apostate's 2026-07-03 ruling)
+
+The mask fiction's missing other half: a viewer can now *try to find out* who's
+really under a masked/disguised character, instead of a mask being an unbreakable
+lock.
+
+- **Seed:** a dedicated **Identification** `CheckType` (intellect + Investigation) —
+  `ensure_identification_check` in `world/seeds/investigation_checks.py`, distinct
+  from `Search` (perception + Investigation).
+- **Service (`world/forms/services/identification.py`):**
+  `identification_difficulty(viewer_sheet, target_character)` — baseline from the
+  target's active fake overlay (`DisguiseKind` × `ConcealmentLevel`) or the bare
+  "mask floor" for a name-only fake persona with no overlay, eased by an active
+  `CharacterRelationship` and the target's true-persona `fame_tier` (both stack —
+  PLACEHOLDER additive combine rule, contrast `social_difficulty.py`'s `max()`
+  precedent). `attempt_identification(viewer, target, guess_name=None)` rolls
+  `perform_check` against that difficulty (a correct named guess eases it, but never
+  rescues the auto-fail band), writes a `PersonaDiscovery` row on success via the
+  same writer the GM `PERSONA_LINK` clue uses (#2120 — second in-game producer), and
+  fake-IDs a random active `Functionary` (new `random_active_functionary()` picker,
+  `world/npc_services/functionaries.py`) on a botch — **never a real PC**. Failure
+  and auto-fail share the identical player-facing message (the oracle rule).
+- **Action + telnet + web:** `IdentifyAction` (registry key `identify`,
+  `actions/definitions/identification.py`) — a plain registry action (not
+  `ActionTemplate`-backed, unlike Deceive/Persuade), since identify's bespoke
+  check pipeline and roller-only messaging don't fit the consequence-pool template
+  shape. Telnet `CmdIdentify` (`identify <target>[=<guess>]`,
+  `commands/identification.py`). Web reachability is a dedicated "Identify" item on
+  `PersonaContextMenu.tsx` dispatching REGISTRY REST directly
+  (`useDispatchPlayerAction`) — deliberately **not** listed by
+  `get_player_actions`/`ActionPanel.tsx`, since every generic-panel consumer
+  dispatches through the CONSENT pipeline (`createActionRequest`), which a
+  no-consent private perception roll (ADR-0024) must never enter.
+- **Follow-up:** crafted disguise kits (kit quality as a pierce-resistance modifier
+  on the baseline) are DEFERRED per the ruling — draft child-issue body at
+  `.superpowers/sdd/disguise-kit-issue-draft.md` (not yet filed).
+
+**Details:** [appearance_and_identity.md](../systems/appearance_and_identity.md) §"Identification loop (slice 5)"
+
 ### Positioning in Scenes — DONE (#1017, spatial map #2006)
 - **Scene API extension:** `SceneDetailSerializer` exposes `positions`, `position_adjacency`, `persona_positions`, and (#2006) `position_nodes`/`position_edges` — the full tactical-map graph — for the scene's room.
 - **Frontend:** `SceneTacticalMap` component (`frontend/src/scenes/components/`) renders the position graph as a spatial `@xyflow/react` map — occupant avatars per node, edges styled by passability/gating, click-to-move, and a staff "Set the stage" control — replacing the earlier `RoomPositionsPanel` text-list UI (#2006). `MovementActions` extracted as a shared component (`frontend/src/combat/components/`).

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -624,10 +624,14 @@ shapeshift lifecycle.
 - **Enums:** `TraitType` (color/style), `FormType` (TRUE/ALTERNATE/DISGUISE), `DurationType`
 - **Key Services:** `assume_alternate_self(sheet, alt)`, `revert_alternate_self(sheet)`,
   `switch_form(character, target_form)`, `revert_to_true_form(character)`,
-  `get_presented_appearance(character)`, `trigger_transformation(sheet, alt, *, cause, instance_value=1.0)` (the seam both non-command cause-paths call; #1604)
+  `get_presented_appearance(character)`, `trigger_transformation(sheet, alt, *, cause, instance_value=1.0)` (the seam both non-command cause-paths call; #1604),
+  `identification_difficulty(viewer_sheet, target_character)` / `attempt_identification(viewer, target, guess_name=None)` (`world/forms/services/identification.py`, #1107 slice 5 — the PC-to-PC "who's really under this mask" check; second `PersonaDiscovery` producer, see [appearance_and_identity.md](appearance_and_identity.md) §"Identification loop (slice 5)")
 - **Key Exceptions:** `RevertBlockedError`, `AlternateSelfActiveError`, `FormOwnershipError`
-- **Integrates with:** character_sheets (appearance, character anchor), scenes (Persona),
-  mechanics (ModifierSource / CharacterModifier), magic (CharacterTechnique)
+- **Integrates with:** character_sheets (appearance, character anchor), scenes (Persona,
+  `PersonaDiscovery`, `CharacterRelationship`-adjacent familiarity), mechanics
+  (ModifierSource / CharacterModifier), magic (CharacterTechnique), npc_services
+  (`random_active_functionary` botch picker), actions (`IdentifyAction`, registry key
+  `identify`)
 - **Source:** `src/world/forms/`
 - **Details:** [forms.md](forms.md)
 ### Appearance & Identity (architecture)
@@ -635,10 +639,15 @@ How Persona (identity), Form (real body), disguise/illusion (fake overlay), and 
 true-form/natural baseline compose into what a viewer sees — plus the per-persona
 descriptor overlay, cosmetic editing, and shapeshift slots.
 
-- **Spans:** forms (body), scenes (Persona), character_sheets (anchor)
+- **Spans:** forms (body), scenes (Persona), character_sheets (anchor), npc_services
+  (Functionary botch picker), actions (`IdentifyAction`)
 - **Key ideas:** four-question model; `(Persona × FormTrait)` descriptor; single
-  render composition (viewer-gated); real-vs-fake truth ledger; cosmetic vs disguise
-- **Status:** design (slices); depends on #1044
+  render composition (viewer-gated); real-vs-fake truth ledger; cosmetic vs disguise;
+  PC-to-PC identification loop (familiarity-staged intellect+Investigation check vs.
+  the illusion-piercing contest, kept distinct)
+- **Status:** design (slices 1-4); **slice 5 (PC-to-PC identification loop) BUILT,
+  #1107** — `identify` registry action + telnet `CmdIdentify` + `PersonaContextMenu`
+  web dispatch; depends on #1044
 - **Details:** [appearance_and_identity.md](appearance_and_identity.md)
 ### Classes (Paths)
 Character paths with evolution hierarchy through stages of power; also owns the

--- a/docs/systems/appearance_and_identity.md
+++ b/docs/systems/appearance_and_identity.md
@@ -293,7 +293,7 @@ path copies a descriptor from a sibling persona.
 | Surface | Verdict | Evidence |
 |---|---|---|
 | `Persona` + `active_persona` resolution | **BUILT & WIRED** | `world/scenes/models.py`; `active_persona_for_sheet` (#1044); set-active wired via `SetActivePersonaAction` (web + telnet, #1347) |
-| `PersonaDiscovery` | **BUILT & WIRED** | `world/scenes`; in-game producer: `PERSONA_LINK` clue kind (`world/clues`, #2120) |
+| `PersonaDiscovery` | **BUILT & WIRED — two producers** | `world/scenes`; GM-authored producer: `PERSONA_LINK` clue kind (`world/clues`, #2120); player-rolled producer: `attempt_identification` (`world/forms/services/identification.py`, #1107 slice 5) — same writer (`world.scenes.services.record_persona_discovery`), so pair-normalization isn't duplicated |
 | `CharacterForm` / `FormType` (TRUE/ALTERNATE/DISGUISE) / `CharacterFormState` / `switch_form` / `get_apparent_form` | **BUILT, partly wired** | `world/forms/models.py:202-302`, `services.py:18-64`; wired to a forms API endpoint, **not** to character-appearance rendering (`_build_appearance` reads the TRUE form) |
 | `DurationType` + `TemporaryFormChange` | **BUILT** | `world/forms/models.py:215-318` — covers shapeshift/overlay durations |
 | Legacy `Characteristic` skin/eye/hair | **BUILT & WIRED (to retire)** | `character_sheets/factories.py:280-393`; read by telnet `item_data` — **duplicates** the FormTrait definitions |
@@ -316,8 +316,15 @@ so `FormTrait` is the single home (kills the telnet-vs-web duplication).
   `revert_gate`, in-control flag).
 - **Magic / combat / conditions / scars (senior dev's domain):** illusion casting &
   dispel, shapeshift spells & triggers, the **berserker-rage condition + calm-down
-  contest**, perception-vs-disguise contests, scars/aging, and the **combat profiles**
-  of forms. The substrate exposes slots; those systems fill them.
+  contest**, the **illusion-piercing contest** (perception vs. a MAGICAL overlay —
+  "can this fake even be seen through at all," still future work), scars/aging, and
+  the **combat profiles** of forms. The substrate exposes slots; those systems fill
+  them.
+- **PC-to-PC identification (ours, built — slice 5, #1107):** a separate question
+  from illusion-piercing above — not "can this disguise be seen through" but "*who*
+  is really underneath, once you're looking." An Identification check (intellect +
+  Investigation) staged by familiarity, rolled against the target's presentation
+  baseline. See "Identification loop (slice 5)" below.
 
 ## Decomposition (slices)
 
@@ -339,6 +346,116 @@ so `FormTrait` is the single home (kills the telnet-vs-web duplication).
 4. **Slice 4 — shapeshift (mostly senior dev).** Voluntary alternate forms first (Lily
    controlled, near-free from `ALTERNATE`); then involuntary/rage as a
    conditions-driven state; durations; combat profiles.
+5. **Slice 5 — PC-to-PC identification loop (ours, built, #1107).** "Who's really
+   under this mask" gets its missing other half: a viewer-rolled Identification
+   check, staged by familiarity, that pierces a mask/disguise for that viewer via
+   `PersonaDiscovery`. Distinct from the illusion-piercing contest above (still
+   deferred to the senior dev). See "Identification loop (slice 5)" below.
+
+## Identification loop (slice 5)
+
+**Status:** built, #1107 (Apostate's 2026-07-03 ruling on the epic comment). A player
+who suspects the masked stranger at the bar can *try to find out* — wearing a mask is
+now a bet, not a lock.
+
+**Check composition.** A dedicated **Identification** `CheckType` — **intellect +
+Investigation** — seeded idempotently in `world/seeds/investigation_checks.py`
+(`ensure_identification_check`). Deliberately *not* the existing `Search` CheckType
+(perception + Investigation): recognizing a face is an intellect act, not a perception
+act, per the ruling. The baseline difficulty comes from what the target is actively
+presenting, checked in order (`world/forms/services/identification.py`,
+`identification_difficulty`): an active fake overlay (`DisguiseKind` ×
+`ConcealmentLevel`, MAGICAL/FULL deliberately sits *above* the hardest authored tier —
+unbeatable by this check alone without heavy familiarity ease, matching the
+illusion-piercing boundary above); failing that, a name-only TEMPORARY mask persona
+with no overlay at all (the flat "mask floor" — a familiar glance can still catch a
+bare fake name); failing both, `IdentificationOdds(applicable=False, ...)` — nothing to
+identify.
+
+**Familiarity staging.** Two eases apply against the baseline: an active
+`CharacterRelationship` the viewer holds toward the sheet under the mask ("I know this
+person," a large flat ease), and the `fame_tier` of the target's TRUE persona (a
+famous face is recognized regardless of which persona is currently worn). **Both
+eases stack additively.** This combine rule is a **PLACEHOLDER**, not a spec mandate —
+an implementer choice pending playtest tuning. It is called out because it cuts
+against a nearby precedent: `world/scenes/social_difficulty.py::_exploitable_easing`
+deliberately takes `max()` across its easing sources ("two exploitable conditions
+never stack"). Additive stacking here means "I personally know the famous person under
+the mask" eases *more* than either fact alone — plausible, but unreviewed; revisit
+alongside the module's other PLACEHOLDER magnitudes.
+
+**Guess semantics.** `identify <target>[=<guess>]` accepts an optional named guess
+(Decision 3). A guess that case-insensitively names the target's TRUE persona eases
+the target difficulty (`_target_difficulty` in `identification.py`); a wrong guess is
+just a failure, same as no guess at all. Critically, **a correct guess only eases a
+still-rollable check — it never rescues the auto-fail band** (ratified this run):
+`identification_difficulty` computes `auto_fail` from familiarity alone, *before* any
+guess is known, and `attempt_identification` checks `odds.auto_fail` before ever
+computing the guess-eased difficulty. A player cannot out-guess an unrollable illusion.
+
+**No-PC red herrings.** A botch (`success_level <= -2`, the repo's shared
+critical-failure threshold) never fingers a real PC. It fake-IDs a random active
+`Functionary` NPC instead, via the new `random_active_functionary()` picker
+(`world/npc_services/functionaries.py`) — `order_by("?")` over active functionaries,
+acceptable at this scale. A botch with no Functionary in the world degrades to a plain
+FAILURE (same message — see the oracle rule below) rather than crash or reach for a
+PC.
+
+**`PersonaDiscovery` as the sink.** Success writes a `PersonaDiscovery` row via the
+same `world.scenes.services.record_persona_discovery` writer the GM-authored
+`PERSONA_LINK` clue kind uses (#2120) — `attempt_identification` is the second
+in-game producer, not a parallel write path. The row is per-viewer: the viewer now
+sees through that mask everywhere, not just in this scene. A repeat `identify` against
+an already-linked pair short-circuits to `ALREADY_KNOWN` before rolling.
+
+**Oracle rules.** Three structural guarantees keep this check from leaking more than
+the fiction allows: (1) **roller-only** — `IdentifyAction.execute` returns
+`result.player_message` to the actor alone; the attempt itself lands as a generic,
+outcome-blind scene `Interaction` (`_log_identify_attempt`) so *that* someone made an
+attempt is visible (containing "silent stalking") without narrating *at what* or *with
+what result*. (2) **`FAILURE` == `AUTO_FAIL`** — both share the literal same
+player-facing string (`_FAILURE_MESSAGE`), so a player can never distinguish "you
+rolled and missed" from "this was never rollable," which would otherwise oracle "there
+IS someone/something identifiable here, you just aren't strong enough" vs. "there's
+truly nothing to find." (3) **the prerequisite reveals nothing new** —
+`IdentifiableTargetPrerequisite` (gating whether `identify` is even offered) only
+confirms the target is co-located and presenting a fake-name persona; per the "named
+faces are public; concealment is opt-in" tenet, an anonymous/masked persona already
+renders visibly as such via sdesc (it's the *identity*, not the *fact of concealment*,
+that's hidden) — so the prerequisite adds no oracle beyond what the sdesc render
+already shows.
+
+**The mask-vs-overlay boundary.** Identification targets a **fake-name persona** —
+either a TEMPORARY mask on its own, or a fake overlay (`active_fake_overlay`) layered
+under one. An **overlay-only** disguise that never swaps the active persona (i.e.
+`apply_disguise` was called without ever minting/wearing a fake-name persona, so
+`active_persona_for_sheet` still resolves to the TRUE persona) has nothing to
+*identify* in the persona sense — there's no fake name to unmask, only an illusion to
+pierce, which is the still-deferred illusion-piercing contest above. Guarded twice,
+defense-in-depth: `IdentifiableTargetPrerequisite` gates it at the action seam (Task 3
+ruling 1a), and `attempt_identification` degrades the degenerate presented==true pair
+to a plain `FAILURE` if a caller ever reaches the service directly (Task 3 review
+ruling 1b) — checked *after* the `AUTO_FAIL` check so an overlay-only target that's
+*also* past the auto-fail band still reports indistinguishable `AUTO_FAIL`, not a
+reclassified `FAILURE`.
+
+**Deferred: crafted disguise kits.** Apostate's ruling explicitly marks kit-crafting
+"(not yet in scope)" — the baseline above derives purely from the existing overlay
+data (`DisguiseKind` + `ConcealmentLevel`); kit *quality* as a pierce-resistance
+modifier is a later slot-in, not built here. Draft child-issue body:
+`.superpowers/sdd/disguise-kit-issue-draft.md`.
+
+**Built surfaces:** `world/forms/services/identification.py` (`identification_difficulty`,
+`attempt_identification`); `world/forms/types.py` (`IdentificationOdds`,
+`IdentificationResult`, `IdentificationOutcome`); `world/npc_services/functionaries.py`
+(`random_active_functionary`); `actions/definitions/identification.py` (`IdentifyAction`,
+registry key `identify`); `commands/identification.py` (`CmdIdentify`, telnet
+`identify <target>[=<guess>]`); web reachability via a dedicated "Identify" item on
+`PersonaContextMenu.tsx` dispatching REGISTRY REST directly (`useDispatchPlayerAction`)
+— deliberately **not** surfaced through `get_player_actions`/`ActionPanel.tsx`'s
+consent (`createActionRequest`) pipeline, since identify is a no-consent private
+perception roll (ADR-0024) with no `ActionTemplate` to resolve a consent accept
+against.
 
 ## Open decisions (resolve at spec time)
 

--- a/frontend/src/scenes/components/PersonaContextMenu.test.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.test.tsx
@@ -33,13 +33,20 @@ vi.mock('@/store/hooks', () => ({
   ),
 }));
 
-// Mock the combat dispatch hook (challenge affordance, #1181)
+// Mock the combat dispatch hook (challenge affordance, #1181; identify affordance, #1107)
 vi.mock('@/combat/queries', () => ({
   useDispatchPlayerAction: vi.fn(() => ({
     mutateAsync: vi.fn(() => Promise.resolve()),
     isPending: false,
   })),
   combatKeys: { duelChallengesAll: () => ['combat', 'duel-challenges'] },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 import { PersonaContextMenu } from './PersonaContextMenu';
@@ -339,6 +346,72 @@ describe('PersonaContextMenu', () => {
     await user.click(screen.getByRole('button'));
     await screen.findByText('Intimidate');
     expect(screen.queryByTestId('challenge-to-duel-item')).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Identify affordance (#1107 Task 3 review — Critical finding: identify must
+  // dispatch via the registry REST path, never the createActionRequest consent
+  // pipeline the targetedActions submenu below uses).
+  // ---------------------------------------------------------------------------
+
+  it('dispatches the identify action via the registry dispatch hook with the target persona id', async () => {
+    const user = userEvent.setup();
+    const mockMutateAsync = vi.fn(() =>
+      Promise.resolve({ backend: 'registry', deferred: false, success: true, message: 'ok' })
+    );
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+
+    render(
+      <PersonaContextMenu personaId={10} personaName="Alice" sceneId="1">
+        <span>Alice</span>
+      </PersonaContextMenu>,
+      { wrapper: createWrapperWithScene([{ id: 10, name: 'Alice', character_sheet: 99 }]) }
+    );
+
+    await user.click(screen.getByRole('button'));
+    const identifyItem = await screen.findByTestId('identify-persona-item');
+    await user.click(identifyItem);
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      ref: { backend: 'registry', registry_key: 'identify' },
+      kwargs: { target: 10 },
+    });
+  });
+
+  it('shows the identify item even when the target has opted out of social targeting', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PersonaContextMenu personaId={10} personaName="Alice" sceneId="1">
+        <span>Alice</span>
+      </PersonaContextMenu>,
+      {
+        wrapper: createWrapperWithScene([
+          { id: 10, name: 'Alice', character_sheet: 99, allow_social_actions: false },
+        ]),
+      }
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(await screen.findByTestId('identify-persona-item')).toBeInTheDocument();
+  });
+
+  it('hides the identify item for the viewer’s own persona (no self-identify)', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PersonaContextMenu personaId={10} personaName="TestChar" sceneId="1">
+        <span>TestChar</span>
+      </PersonaContextMenu>,
+      { wrapper: createWrapperWithScene([{ id: 10, name: 'TestChar', character_sheet: 42 }]) }
+    );
+
+    await user.click(screen.getByRole('button'));
+    await screen.findByText('Intimidate');
+    expect(screen.queryByTestId('identify-persona-item')).not.toBeInTheDocument();
   });
 
   it('does not show "Attach to Pose" section when onAttachAction is not provided', async () => {

--- a/frontend/src/scenes/components/PersonaContextMenu.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Ban, HeartPulse, Swords, VolumeX, Zap, ScrollText } from 'lucide-react';
+import { Ban, HeartPulse, Swords, VolumeX, Zap, ScrollText, Eye } from 'lucide-react';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useDispatchPlayerAction, combatKeys } from '@/combat/queries';
@@ -26,6 +26,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useCreateBlock, useCreateMute } from '@/social/queries';
+import { toast } from 'sonner';
 import { createActionRequest, fetchAvailableActions } from '../actionQueries';
 import type { ActionAttachmentInfo, PlayerAction } from '../actionTypes';
 import type { SceneDetail } from '../types';
@@ -123,6 +124,21 @@ export function PersonaContextMenu({
     characterId ?? 0
   );
 
+  // #1107 Task 3 review (Critical finding): Identify dispatches via the same registry
+  // path as Challenge — it MUST NOT flow through the generic targetedActions/
+  // createActionRequest consent pipeline below. Identify is a no-consent private
+  // perception roll (ADR-0024) with no ActionTemplate and no custom consent resolver;
+  // routing it through createActionRequest would both hand the masked target a veto
+  // they shouldn't have and crash on accept. It is deliberately not surfaced by the
+  // backend's get_player_actions listing (see actions/player_interface.py's module
+  // docstring) — this menu item is its only web entry point.
+  const { mutateAsync: dispatchIdentify, isPending: isIdentifyPending } = useDispatchPlayerAction(
+    characterId ?? 0
+  );
+  // No allow_social_actions gate (unlike canChallenge): identify doesn't check the
+  // target's social-consent preference, only presence + self-exclusion.
+  const canIdentify = characterId !== null && targetPersona !== null && !isSelfTarget;
+
   const [pendingWhisper, setPendingWhisper] = useState<PendingWhisper | null>(null);
 
   // #1278 — block/mute. The viewer's own face in this scene is the blocker persona; a block needs
@@ -181,9 +197,9 @@ export function PersonaContextMenu({
   // list renders an inline "No treatable conditions." message in the dialog.
   const canTreat = characterId !== null && !isSelfTarget;
 
-  // The menu is worth showing if there are targeted actions, a challenge, treat,
-  // or block/mute.
-  if (targetedActions.length === 0 && !canChallenge && !canTreat && !canModerate) {
+  // The menu is worth showing if there are targeted actions, a challenge, identify,
+  // treat, or block/mute.
+  if (targetedActions.length === 0 && !canChallenge && !canIdentify && !canTreat && !canModerate) {
     return <>{children}</>;
   }
 
@@ -193,6 +209,26 @@ export function PersonaContextMenu({
       kwargs: { target: personaId },
     })
       .then(() => queryClient.invalidateQueries({ queryKey: combatKeys.duelChallengesAll() }))
+      .catch(() => {});
+  }
+
+  // The outcome message is the entire payoff of an Identify attempt (the oracle rule
+  // keeps FAILURE/AUTO_FAIL indistinguishable in that message's text itself — the
+  // toast styling success/non-success split is fine, since result.success already
+  // distinguishes SUCCESS from everything else for the roller).
+  function handleIdentify() {
+    dispatchIdentify({
+      ref: { backend: 'registry', registry_key: 'identify' },
+      kwargs: { target: personaId },
+    })
+      .then((result) => {
+        if (!result.message) return;
+        if (result.success) {
+          toast.success(result.message);
+        } else {
+          toast.error(result.message);
+        }
+      })
       .catch(() => {});
   }
 
@@ -214,6 +250,19 @@ export function PersonaContextMenu({
               >
                 <Swords className="mr-2 h-4 w-4" />
                 Challenge to a duel
+              </DropdownMenuItem>
+              {(canIdentify || targetedActions.length > 0) && <DropdownMenuSeparator />}
+            </>
+          )}
+          {canIdentify && (
+            <>
+              <DropdownMenuItem
+                disabled={isIdentifyPending}
+                data-testid="identify-persona-item"
+                onClick={handleIdentify}
+              >
+                <Eye className="mr-2 h-4 w-4" />
+                Identify
               </DropdownMenuItem>
               {targetedActions.length > 0 && <DropdownMenuSeparator />}
             </>

--- a/src/actions/definitions/identification.py
+++ b/src/actions/definitions/identification.py
@@ -18,9 +18,18 @@ ActionTemplate involved).
 
 Not auto-surfaced to the web dynamic action panel like the ActionTemplate-backed social
 actions are (``_scene_actions`` in ``actions/player_interface.py`` only picks up
-``ActionTemplate`` rows) — a REGISTRY action with no ActionTemplate backing needs its own
-adapter, per the #2005/#2010 battle-staging precedent (``_positioning_actions``/
-``_battle_staging_actions``); see ``_identification_actions`` in ``player_interface.py``.
+``ActionTemplate`` rows) — and deliberately NOT given a bespoke web-panel adapter either,
+unlike the #2005/#2010 battle-staging precedent (``_positioning_actions``/
+``_battle_staging_actions``). Every consumer of ``get_player_actions`` (``ActionPanel.tsx``,
+``PersonaContextMenu.tsx``) dispatches its listed entries through the CONSENT pipeline
+(``createActionRequest``), which identify — a no-consent private perception roll, ADR-0024 —
+must never enter (#1107 Task 3 review, Critical finding: it would both hand the masked
+target a veto it shouldn't have and crash on accept, no ``ActionTemplate``/
+``CUSTOM_ACTION_RESOLVERS`` entry to resolve against). Its only web path is a dedicated
+"Identify" item in ``PersonaContextMenu`` that dispatches REGISTRY REST directly
+(``useDispatchPlayerAction`` -> ``_dispatch_registry`` -> ``.run()``), mirroring that menu's
+pre-existing ``challenge`` dispatch; telnet reaches it via ``CmdIdentify``
+(``commands/identification.py``).
 """
 
 from __future__ import annotations
@@ -44,31 +53,48 @@ _NOT_PRESENT_MESSAGE = "They aren't here."
 _NOTHING_TO_SEE_MESSAGE = "Their face is their own — there is no mask to see through."
 
 
-def _resolve_identify_target(kwargs: dict[str, Any]) -> ObjectDB | None:
-    """Resolve the identify target from either dispatch shape (#1107 Task 3, the #2163 gotcha).
-
-    Telnet passes an already-resolved ``target`` ``ObjectDB`` directly. The web REGISTRY
-    dispatch path for a PERSONA-kind target instead sends ``target_persona_id`` (a ``Persona``
-    pk, per the frontend's ``ActionPanel`` dispatch convention) — REST dispatch
-    (``dispatch_player_action`` -> ``_dispatch_registry``) does no ``ObjectDB`` resolution of
-    its own; ``objectdb_target_kwargs`` only helps the *websocket* inputfunc, and only for wire
-    keys it's told about. Resolve defensively here so both dispatch shapes work, shared by the
-    prerequisite gate and ``execute()``.
-    """
-    target = kwargs.get("target")
-    if target is not None:
-        return target
-
-    persona_id = kwargs.get("target_persona_id")
-    if persona_id is None:
-        return None
-
+def _resolve_persona_pk_to_character(persona_id: Any) -> ObjectDB | None:
+    """Resolve a ``Persona`` pk to its owning character ``ObjectDB``, or ``None``."""
     from world.scenes.models import Persona  # noqa: PLC0415
 
     persona = Persona.objects.filter(pk=persona_id).select_related("character_sheet").first()
     if persona is None:
         return None
     return persona.character_sheet.character
+
+
+def _resolve_identify_target(kwargs: dict[str, Any]) -> ObjectDB | None:
+    """Resolve the identify target from any dispatch shape (#1107 Task 3, the #2163 gotcha;
+    hardened in the Task 3 review's Minor finding 1).
+
+    Three shapes are accepted, all keyed off ``target``/``target_persona_id``:
+
+    - Telnet passes an already-resolved ``target`` ``ObjectDB`` directly.
+    - The ``PersonaContextMenu`` "Identify" item (web) sends a raw ``target`` kwarg holding a
+      ``Persona`` pk (an ``int``) — mirroring ``ChallengeAction``'s
+      ``_resolve_challenge_target`` (``actions/definitions/duels.py``), the established
+      precedent for a context-menu-dispatched persona-pk ``target`` kwarg.
+    - The generic web REGISTRY dispatch convention instead sends ``target_persona_id`` (a
+      ``Persona`` pk) — kept for back-compat with the #2163 REST-dispatch gotcha this
+      resolver was originally written to cover.
+
+    REST dispatch (``dispatch_player_action`` -> ``_dispatch_registry``) does no ``ObjectDB``
+    resolution of its own; ``objectdb_target_kwargs`` only helps the *websocket* inputfunc, and
+    only for wire keys it's told about. Resolve defensively here so every dispatch shape works,
+    shared by the prerequisite gate and ``execute()``.
+    """
+    from evennia.objects.models import ObjectDB  # noqa: PLC0415
+
+    target = kwargs.get("target")
+    if isinstance(target, ObjectDB):
+        return target
+    if target is not None:
+        return _resolve_persona_pk_to_character(target)
+
+    persona_id = kwargs.get("target_persona_id")
+    if persona_id is None:
+        return None
+    return _resolve_persona_pk_to_character(persona_id)
 
 
 def _presented_fake_persona(target_obj: ObjectDB) -> Persona | None:
@@ -216,6 +242,3 @@ class IdentifyAction(Action):
         result = attempt_identification(actor, target, guess_name=guess_name)
         success = result.outcome == IdentificationOutcome.SUCCESS
         return ActionResult(success=success, message=result.player_message)
-
-
-identify = IdentifyAction()

--- a/src/actions/definitions/identification.py
+++ b/src/actions/definitions/identification.py
@@ -1,0 +1,221 @@
+"""IdentifyAction — see through a mask or disguise to who's really underneath (#1107 slice 5).
+
+**Not** an ActionTemplate-driven ``_SocialTemplateAction`` like Deceive/Persuade/Seduce
+(``actions/definitions/social.py``): ``attempt_identification``
+(``world.forms.services.identification``) already owns its own bespoke check pipeline — a
+custom difficulty table (familiarity/fame eases, a named-guess ease), a direct
+``perform_check`` roll against that computed difficulty, and its own outcome branching
+(SUCCESS/FAILURE/BOTCH_FAKE_ID/ALREADY_KNOWN/AUTO_FAIL) with a ``PersonaDiscovery`` write on
+success. None of that fits the ActionTemplate/ConsequencePool pipeline
+``start_action_resolution`` drives (fixed ``target_difficulty=0``, gate/consequence-pool
+resolution, NPC disposition delta) — and identification's outcome message must stay
+roller-only (the spec's oracle rule: FAILURE and AUTO_FAIL are player-indistinguishable, and
+a BOTCH must never name a real PC), unlike social template actions whose consequences are
+narrated into the scene. A plain registry action thinly wrapping the service directly is the
+repo's other established idiom for this shape (``battles.py``, ``sanctum.py``,
+``relationships.py`` — ``Action`` subclasses calling a service function with no
+ActionTemplate involved).
+
+Not auto-surfaced to the web dynamic action panel like the ActionTemplate-backed social
+actions are (``_scene_actions`` in ``actions/player_interface.py`` only picks up
+``ActionTemplate`` rows) — a REGISTRY action with no ActionTemplate backing needs its own
+adapter, per the #2005/#2010 battle-staging precedent (``_positioning_actions``/
+``_battle_staging_actions``); see ``_identification_actions`` in ``player_interface.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from actions.base import Action
+from actions.constants import ActionCategory, TargetKind
+from actions.prerequisites import Prerequisite, resolve_actor_sheet
+from actions.types import ActionResult, TargetFilters, TargetType
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from actions.types import ActionContext
+    from world.scenes.models import Persona
+
+_NO_TARGET_MESSAGE = "Identify whom?"
+_NOT_PRESENT_MESSAGE = "They aren't here."
+_NOTHING_TO_SEE_MESSAGE = "Their face is their own — there is no mask to see through."
+
+
+def _resolve_identify_target(kwargs: dict[str, Any]) -> ObjectDB | None:
+    """Resolve the identify target from either dispatch shape (#1107 Task 3, the #2163 gotcha).
+
+    Telnet passes an already-resolved ``target`` ``ObjectDB`` directly. The web REGISTRY
+    dispatch path for a PERSONA-kind target instead sends ``target_persona_id`` (a ``Persona``
+    pk, per the frontend's ``ActionPanel`` dispatch convention) — REST dispatch
+    (``dispatch_player_action`` -> ``_dispatch_registry``) does no ``ObjectDB`` resolution of
+    its own; ``objectdb_target_kwargs`` only helps the *websocket* inputfunc, and only for wire
+    keys it's told about. Resolve defensively here so both dispatch shapes work, shared by the
+    prerequisite gate and ``execute()``.
+    """
+    target = kwargs.get("target")
+    if target is not None:
+        return target
+
+    persona_id = kwargs.get("target_persona_id")
+    if persona_id is None:
+        return None
+
+    from world.scenes.models import Persona  # noqa: PLC0415
+
+    persona = Persona.objects.filter(pk=persona_id).select_related("character_sheet").first()
+    if persona is None:
+        return None
+    return persona.character_sheet.character
+
+
+def _presented_fake_persona(target_obj: ObjectDB) -> Persona | None:
+    """The target's active persona iff it is a fake-name mask, else ``None``."""
+    from world.scenes.models import Persona  # noqa: PLC0415
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+    target_sheet = resolve_actor_sheet(target_obj)
+    if target_sheet is None:
+        return None
+    try:
+        presented = active_persona_for_sheet(target_sheet)
+    except Persona.DoesNotExist:
+        return None
+    return presented if presented.is_fake_name else None
+
+
+def _is_viewers_own_persona(actor: ObjectDB, presented: Persona) -> bool:
+    """Whether ``presented`` is the persona the viewer themself is currently wearing."""
+    from world.scenes.models import Persona  # noqa: PLC0415
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+    actor_sheet = resolve_actor_sheet(actor)
+    if actor_sheet is None:
+        return False
+    try:
+        viewer_persona = active_persona_for_sheet(actor_sheet)
+    except Persona.DoesNotExist:
+        return False
+    return viewer_persona.pk == presented.pk
+
+
+@dataclass
+class IdentifiableTargetPrerequisite(Prerequisite):
+    """The target must be present and currently presenting a fake-name persona (#1107 Task 3).
+
+    Ruling 1a from Task 2's review (closing the overlay-only degenerate-SUCCESS hole): an
+    overlay-only disguise (no persona swap — ``apply_disguise`` alone doesn't change
+    ``active_persona_for_sheet``, see the Task 2 report's concern) or an undisguised target
+    has nothing to identify and must fail here with a clean message, before
+    ``attempt_identification`` is ever reached. (``attempt_identification``'s own
+    presented-vs-true guard, ruling 1b, is defense-in-depth for a caller that skips this gate
+    — e.g. a future non-Action caller of the service.)
+    """
+
+    def is_met(
+        self,
+        actor: ObjectDB,
+        target: ObjectDB | None = None,
+        context: dict | None = None,
+    ) -> tuple[bool, str]:
+        del target  # resolved from kwargs below — see _resolve_identify_target's docstring
+        kwargs = (context or {}).get("kwargs", {})
+        target_obj = _resolve_identify_target(kwargs)
+        if target_obj is None:
+            return False, _NO_TARGET_MESSAGE
+        if target_obj.location != actor.location:
+            return False, _NOT_PRESENT_MESSAGE
+
+        presented = _presented_fake_persona(target_obj)
+        if presented is None or _is_viewers_own_persona(actor, presented):
+            return False, _NOTHING_TO_SEE_MESSAGE
+        return True, ""
+
+
+def _log_identify_attempt(actor: ObjectDB) -> None:
+    """Log the attempt as a normal, outcome-blind scene Interaction (spec: "attempt is a scene
+    action, normal Interaction visibility" — contains "silent stalking", per the issue #1107
+    slice-5 leak-analysis table).
+
+    Deliberately generic content — never names who was targeted, guessed, or revealed; the
+    outcome stays roller-only via the returned ``ActionResult.message``. No-ops quietly when
+    there's no active scene or persona to attribute it to (a defensive, non-fatal skip — the
+    roll itself still proceeds either way).
+    """
+    from world.scenes.interaction_services import (  # noqa: PLC0415
+        create_action_interaction_core,
+        get_active_scene,
+    )
+    from world.scenes.models import Persona  # noqa: PLC0415
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+    sheet = resolve_actor_sheet(actor)
+    if sheet is None:
+        return
+    scene = get_active_scene(actor.location)
+    if scene is None:
+        return
+    try:
+        persona = active_persona_for_sheet(sheet)
+    except Persona.DoesNotExist:
+        return
+    create_action_interaction_core(
+        persona=persona,
+        scene=scene,
+        summary_label="studies someone closely, trying to place who they really are.",
+    )
+
+
+@dataclass
+class IdentifyAction(Action):
+    """Try to see through a mask or disguise to who's really underneath (#1107 slice 5).
+
+    Thin wrapper over ``attempt_identification`` (``world.forms.services.identification``),
+    which owns the full check pipeline: difficulty, the roll, and the ``PersonaDiscovery``
+    write. Result messaging is roller-only (never broadcast) — the oracle rule keeps FAILURE
+    and AUTO_FAIL indistinguishable, and a BOTCH never reveals a real PC's name (it fake-IDs a
+    random active ``Functionary`` instead).
+    """
+
+    key: str = "identify"
+    name: str = "Identify"
+    icon: str = "eye"
+    category: str = "investigation"
+    target_type: TargetType = TargetType.SINGLE
+    target_kind: TargetKind | None = TargetKind.PERSONA
+    target_filters: TargetFilters | None = field(
+        default_factory=lambda: TargetFilters(in_same_scene=True, exclude_self=True)
+    )
+    action_category: ActionCategory | None = ActionCategory.MENTAL
+    costs_turn: bool = True
+
+    def get_prerequisites(self) -> list[Prerequisite]:
+        return [IdentifiableTargetPrerequisite()]
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.forms.services.identification import attempt_identification  # noqa: PLC0415
+        from world.forms.types import IdentificationOutcome  # noqa: PLC0415
+
+        target = _resolve_identify_target(kwargs)
+        if target is None:
+            return ActionResult(success=False, message=_NO_TARGET_MESSAGE)
+
+        guess = kwargs.get("guess")
+        guess_name = str(guess).strip() if guess else None
+        guess_name = guess_name or None
+
+        _log_identify_attempt(actor)
+
+        result = attempt_identification(actor, target, guess_name=guess_name)
+        success = result.outcome == IdentificationOutcome.SUCCESS
+        return ActionResult(success=success, message=result.player_message)
+
+
+identify = IdentifyAction()

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -23,7 +23,7 @@ Backend resolution:
   ``FOCUSED`` slot and one ``PASSIVE`` slot per clash, per the design spec (§4 —
   every PC in the encounter sees every active clash; POV-filter is post-positioning).
 - REGISTRY    -- ``get_actions_for_target_type`` returns registry ``Action`` singletons;
-  these have no ``ActionTemplate`` / ``check_type`` so ALL current registry actions are
+  these have no ``ActionTemplate`` / ``check_type`` so by default registry actions are
   excluded from ``get_player_actions``.  ``dispatch_player_action`` still handles REGISTRY
   refs for immediate execution (no declaration gating needed for utility actions).
 
@@ -33,7 +33,11 @@ Registry exclusion note:
   requires a resolved ``CheckType`` instance (the unifying resolution anchor), which
   cannot be provided for registry actions until they are backed by ``ActionTemplate``
   rows.  They are excluded rather than emitted with a placeholder to avoid confusing the
-  dispatch layer.
+  dispatch layer -- UNLESS a small per-action adapter hand-builds the ``PlayerAction``
+  itself with ``check_type=None``, the pattern ``_positioning_actions``/
+  ``_set_the_stage_actions``/``_battle_staging_actions``/``_identification_actions``
+  use for REGISTRY actions that need web-panel visibility but aren't (and don't want to
+  become) ActionTemplate-backed.
 """
 
 from __future__ import annotations
@@ -396,9 +400,11 @@ def get_player_actions(character: ObjectDB) -> list[PlayerAction]:
     actions.extend(_positioning_actions(character))
     actions.extend(_set_the_stage_actions(character))
     actions.extend(_battle_staging_actions(character))
-    # Registry backend: all current actions excluded (no ActionTemplate / check_type)
-    # — see module docstring.  When registry actions gain ActionTemplate backing,
-    # uncomment and implement _registry_actions(character).
+    actions.extend(_identification_actions(character))
+    # Registry backend: all remaining registry actions excluded (no ActionTemplate /
+    # check_type) — see module docstring.  When a registry action gains ActionTemplate
+    # backing, or needs web-panel visibility without one, add it to an adapter above
+    # (or a new one) rather than uncommenting a blanket _registry_actions(character).
 
     # Single batched pass: attach enhancements/target_spec/strain to each
     # PlayerAction. All queries happen once for the whole character.
@@ -1109,6 +1115,39 @@ def _battle_staging_actions(character: ObjectDB) -> list[PlayerAction]:
             action_category=ActionCategory.PHYSICAL,
         )
         for key, display_name in staging_keys
+    ]
+
+
+def _identification_actions(character: ObjectDB) -> list[PlayerAction]:
+    """Surface the ``identify`` REGISTRY action to the web (#1107 slice 5, Task 3).
+
+    ``IdentifyAction`` (``actions/definitions/identification.py``) is deliberately NOT
+    ActionTemplate-backed (see that module's docstring), so it doesn't reach the web via
+    ``_scene_actions`` the way Deceive/Persuade/Seduce do — it needs its own bespoke
+    adapter, mirroring ``_positioning_actions``/``_set_the_stage_actions``/
+    ``_battle_staging_actions``.
+
+    Offers one ``Identify`` entry whenever the character has a sheet and a location —
+    the only two things identifying anyone at all requires (target_kind=PERSONA is
+    resolved generically by ``_target_spec_for_action``'s hand-coded-Action branch,
+    reading ``IdentifyAction.target_kind``/``target_filters`` directly — no per-target
+    enumeration needed, same as the social ActionTemplate actions). Target validity
+    (co-located + presenting a fake-name persona) is deliberately NOT filtered here —
+    that's ``IdentifiableTargetPrerequisite``'s job at dispatch time. Filtering the
+    *picker* on "someone masked is present" would also be an oracle leak: the button's
+    mere appearance would become a free, actionless mask detector, whereas a targeted
+    attempt at least lands as a visible scene interaction (the spec's leak-analysis
+    table).
+    """
+    if _get_character_sheet(character) is None or character.location is None:
+        return []
+    return [
+        PlayerAction(
+            backend=ActionBackend.REGISTRY,
+            display_name="Identify",
+            ref=ActionRef(backend=ActionBackend.REGISTRY, registry_key="identify"),
+            description="Try to see through a mask or disguise to who's really underneath.",
+        )
     ]
 
 

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -35,9 +35,23 @@ Registry exclusion note:
   rows.  They are excluded rather than emitted with a placeholder to avoid confusing the
   dispatch layer -- UNLESS a small per-action adapter hand-builds the ``PlayerAction``
   itself with ``check_type=None``, the pattern ``_positioning_actions``/
-  ``_set_the_stage_actions``/``_battle_staging_actions``/``_identification_actions``
-  use for REGISTRY actions that need web-panel visibility but aren't (and don't want to
-  become) ActionTemplate-backed.
+  ``_set_the_stage_actions``/``_battle_staging_actions`` use for REGISTRY actions that
+  need web-panel visibility but aren't (and don't want to become) ActionTemplate-backed.
+
+  ``identify`` (``actions/definitions/identification.py``) deliberately does NOT get one
+  of these adapters (#1107 Task 3 review, Critical finding): every generic-panel consumer
+  of ``get_player_actions`` (``ActionPanel.tsx``, ``PersonaContextMenu.tsx``) dispatches
+  its listed entries through ``createActionRequest`` -- the CONSENT pipeline
+  (``world.scenes.action_services.create_action_request`` /
+  ``_resolve_accepted_action_request``). Identify is a no-consent private perception roll
+  (ADR-0024 -- it doesn't act on the target's behavior) with no ``ActionTemplate`` and no
+  ``CUSTOM_ACTION_RESOLVERS`` entry, so a consent-pipeline dispatch would both hand the
+  masked target a veto it shouldn't have and crash on accept (``ValueError`` in
+  ``_resolve_standard_action``, no template/resolver to resolve against). Its only
+  correct web path is direct REGISTRY REST dispatch (``useDispatchPlayerAction`` ->
+  ``_dispatch_registry`` -> ``.run()``) from a dedicated ``PersonaContextMenu`` "Identify"
+  item (mirroring that menu's pre-existing ``challenge`` dispatch), never from a listing a
+  generic panel would render+fire through ``createActionRequest``.
 """
 
 from __future__ import annotations
@@ -400,11 +414,16 @@ def get_player_actions(character: ObjectDB) -> list[PlayerAction]:
     actions.extend(_positioning_actions(character))
     actions.extend(_set_the_stage_actions(character))
     actions.extend(_battle_staging_actions(character))
-    actions.extend(_identification_actions(character))
     # Registry backend: all remaining registry actions excluded (no ActionTemplate /
     # check_type) — see module docstring.  When a registry action gains ActionTemplate
     # backing, or needs web-panel visibility without one, add it to an adapter above
     # (or a new one) rather than uncommenting a blanket _registry_actions(character).
+    # ``identify`` is deliberately NOT listed here (#1107 Task 3 review, Critical
+    # finding) — every consumer of this list dispatches through the CONSENT pipeline
+    # (createActionRequest), which identify must never enter. See the module docstring's
+    # "identify" paragraph. It's reached instead by a dedicated PersonaContextMenu
+    # "Identify" item that dispatches REGISTRY REST directly (useDispatchPlayerAction),
+    # plus telnet (CmdIdentify).
 
     # Single batched pass: attach enhancements/target_spec/strain to each
     # PlayerAction. All queries happen once for the whole character.
@@ -1118,37 +1137,9 @@ def _battle_staging_actions(character: ObjectDB) -> list[PlayerAction]:
     ]
 
 
-def _identification_actions(character: ObjectDB) -> list[PlayerAction]:
-    """Surface the ``identify`` REGISTRY action to the web (#1107 slice 5, Task 3).
-
-    ``IdentifyAction`` (``actions/definitions/identification.py``) is deliberately NOT
-    ActionTemplate-backed (see that module's docstring), so it doesn't reach the web via
-    ``_scene_actions`` the way Deceive/Persuade/Seduce do — it needs its own bespoke
-    adapter, mirroring ``_positioning_actions``/``_set_the_stage_actions``/
-    ``_battle_staging_actions``.
-
-    Offers one ``Identify`` entry whenever the character has a sheet and a location —
-    the only two things identifying anyone at all requires (target_kind=PERSONA is
-    resolved generically by ``_target_spec_for_action``'s hand-coded-Action branch,
-    reading ``IdentifyAction.target_kind``/``target_filters`` directly — no per-target
-    enumeration needed, same as the social ActionTemplate actions). Target validity
-    (co-located + presenting a fake-name persona) is deliberately NOT filtered here —
-    that's ``IdentifiableTargetPrerequisite``'s job at dispatch time. Filtering the
-    *picker* on "someone masked is present" would also be an oracle leak: the button's
-    mere appearance would become a free, actionless mask detector, whereas a targeted
-    attempt at least lands as a visible scene interaction (the spec's leak-analysis
-    table).
-    """
-    if _get_character_sheet(character) is None or character.location is None:
-        return []
-    return [
-        PlayerAction(
-            backend=ActionBackend.REGISTRY,
-            display_name="Identify",
-            ref=ActionRef(backend=ActionBackend.REGISTRY, registry_key="identify"),
-            description="Try to see through a mask or disguise to who's really underneath.",
-        )
-    ]
+# ``identify`` deliberately has no web-panel adapter here — see the module docstring's
+# "identify" paragraph (#1107 Task 3 review, Critical finding) and
+# ``PersonaContextMenu.tsx``'s dedicated "Identify" menu item.
 
 
 # ---------------------------------------------------------------------------

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -145,6 +145,7 @@ from actions.definitions.gm_stories import (
     WithdrawGroupStoryRequestAction,
 )
 from actions.definitions.goals import LogGoalProgressAction, SetCharacterGoalsAction
+from actions.definitions.identification import IdentifyAction
 from actions.definitions.imbue import ImbueAction
 from actions.definitions.investigation import SearchAction
 from actions.definitions.items import (
@@ -332,6 +333,7 @@ _ALL_ACTIONS: list[Action] = [
     LookAtItemAction(),
     InventoryAction(),
     SearchAction(),
+    IdentifyAction(),
     SayAction(),
     PoseAction(),
     EmitAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -143,6 +143,7 @@ class ActionRegistryTests(TestCase):
             "look_at_item",
             "inventory",
             "search",
+            "identify",
             "say",
             "pose",
             "emit",

--- a/src/actions/tests/test_identification.py
+++ b/src/actions/tests/test_identification.py
@@ -1,0 +1,208 @@
+"""IdentifyAction (#1107 slice 5, Task 3) — the identify command's wrapper over
+``attempt_identification``.
+
+Action-seam journeys: success/botch/failure result messaging (roller-only), the
+prerequisite gate (co-located + presenting a fake-name persona), guess parsing, and the
+REST-dispatch ``target_persona_id`` resolution shape (the #2163 gotcha).
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from actions.constants import TargetKind
+from actions.definitions.identification import IdentifyAction
+from actions.registry import get_action
+from evennia_extensions.factories import RoomProfileFactory
+from world.checks.test_helpers import force_check_outcome
+from world.npc_services.factories import FunctionaryFactory, NPCRoleFactory
+from world.roster.factories import RosterEntryFactory
+from world.scenes.factories import SceneFactory
+from world.scenes.interaction_services import get_active_scene
+from world.scenes.models import Interaction, PersonaDiscovery
+from world.scenes.services import create_mask
+from world.seeds.checks import seed_check_resolution_tables
+from world.seeds.investigation_checks import seed_investigation_check_content
+from world.traits.factories import CheckOutcomeFactory
+
+
+class IdentifyActionTestCase(TestCase):
+    def setUp(self) -> None:
+        seed_check_resolution_tables()
+        seed_investigation_check_content()
+
+        room_profile = RoomProfileFactory()
+        self.room = room_profile.objectdb
+
+        viewer_roster = RosterEntryFactory()
+        self.viewer = viewer_roster.character_sheet.character
+        self.viewer.move_to(self.room, quiet=True)
+
+        target_roster = RosterEntryFactory()
+        self.target = target_roster.character_sheet.character
+        self.target_sheet = target_roster.character_sheet
+        self.target.move_to(self.room, quiet=True)
+        self.mask = create_mask(self.target_sheet, name="Nobody in Particular")
+
+        self.action = IdentifyAction()
+
+
+class RegistrationTests(IdentifyActionTestCase):
+    def test_registered_with_persona_target_kind(self) -> None:
+        action = get_action("identify")
+        assert isinstance(action, IdentifyAction)
+        assert action.target_kind == TargetKind.PERSONA
+
+    def test_web_panel_surfaces_identify_for_a_placed_character(self) -> None:
+        # The _identification_actions adapter (player_interface.py) — registry actions are
+        # NOT auto-surfaced to the web panel; this adapter is the wire that makes identify
+        # reachable from the dynamic action panel (#2010's registry-adapter lesson).
+        from actions.constants import ActionBackend
+        from actions.player_interface import get_player_actions
+
+        actions = get_player_actions(self.viewer)
+        identify_entries = [
+            a
+            for a in actions
+            if a.backend == ActionBackend.REGISTRY and a.ref.registry_key == "identify"
+        ]
+        self.assertEqual(len(identify_entries), 1)
+        spec = identify_entries[0].target_spec
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.kind, TargetKind.PERSONA)
+
+
+class PrerequisiteTests(IdentifyActionTestCase):
+    def test_undisguised_target_fails_prerequisite_cleanly(self) -> None:
+        stranger_roster = RosterEntryFactory()
+        stranger = stranger_roster.character_sheet.character
+        stranger.move_to(self.room, quiet=True)
+
+        result = self.action.run(actor=self.viewer, target=stranger)
+
+        self.assertFalse(result.success)
+        self.assertIn("no mask to see through", result.message)
+        self.assertFalse(PersonaDiscovery.objects.exists())
+
+    def test_target_not_present_fails_prerequisite(self) -> None:
+        other_room = RoomProfileFactory().objectdb
+        self.target.move_to(other_room, quiet=True)
+
+        result = self.action.run(actor=self.viewer, target=self.target)
+
+        self.assertFalse(result.success)
+        self.assertIn("aren't here", result.message)
+
+    def test_no_target_fails_prerequisite(self) -> None:
+        result = self.action.run(actor=self.viewer)
+
+        self.assertFalse(result.success)
+        self.assertIn("Identify whom", result.message)
+
+
+class OutcomeMessagingTests(IdentifyActionTestCase):
+    def test_success_writes_discovery_and_messages_roller_only(self) -> None:
+        success = CheckOutcomeFactory(name="IdentifyAction Success", success_level=2)
+        with force_check_outcome(success):
+            result = self.action.run(actor=self.viewer, target=self.target)
+
+        self.assertTrue(result.success)
+        self.assertIn(self.target_sheet.primary_persona.name, result.message)
+        self.assertEqual(PersonaDiscovery.objects.count(), 1)
+
+    def test_botch_reveals_a_functionary_never_a_pc(self) -> None:
+        role = NPCRoleFactory(name="Gate Clerk")
+        functionary = FunctionaryFactory(role=role, name_override="Old Marta")
+        botch = CheckOutcomeFactory(name="IdentifyAction Botch", success_level=-2)
+
+        with force_check_outcome(botch):
+            result = self.action.run(actor=self.viewer, target=self.target)
+
+        self.assertFalse(result.success)
+        self.assertIn(functionary.display_name, result.message)
+        self.assertNotIn(self.target_sheet.primary_persona.name, result.message)
+        self.assertNotIn(self.mask.name, result.message)
+        self.assertFalse(PersonaDiscovery.objects.exists())
+
+    def test_failure_and_no_functionary_botch_share_the_same_message(self) -> None:
+        # Oracle rule, echoed at the action seam: a plain failure and a botch-with-no-NPC-to-
+        # blame both degrade to the identical FAILURE/AUTO_FAIL player_message.
+        failure = CheckOutcomeFactory(name="IdentifyAction Failure", success_level=-1)
+        with force_check_outcome(failure):
+            failure_result = self.action.run(actor=self.viewer, target=self.target)
+
+        self.assertFalse(failure_result.success)
+        self.assertTrue(failure_result.message)
+
+
+class GuessParsingTests(IdentifyActionTestCase):
+    def test_guess_kwarg_reaches_the_service(self) -> None:
+        failure = CheckOutcomeFactory(name="IdentifyAction Guess", success_level=-1)
+        with force_check_outcome(failure) as capture:
+            self.action.run(
+                actor=self.viewer,
+                target=self.target,
+                guess=self.target_sheet.primary_persona.name,
+            )
+        # A correct guess eases target_difficulty below the unguessed baseline.
+        with force_check_outcome(failure) as capture_unguessed:
+            self.action.run(actor=self.viewer, target=self.target)
+
+        self.assertLess(capture.target_difficulty, capture_unguessed.target_difficulty)
+
+    def test_blank_guess_is_treated_as_no_guess(self) -> None:
+        failure = CheckOutcomeFactory(name="IdentifyAction Blank Guess", success_level=-1)
+        with force_check_outcome(failure) as capture_blank:
+            self.action.run(actor=self.viewer, target=self.target, guess="   ")
+        with force_check_outcome(failure) as capture_unguessed:
+            self.action.run(actor=self.viewer, target=self.target)
+
+        self.assertEqual(capture_blank.target_difficulty, capture_unguessed.target_difficulty)
+
+
+class RestDispatchTargetResolutionTests(IdentifyActionTestCase):
+    """The #2163 gotcha: REST dispatch sends ``target_persona_id`` (an int), not a resolved
+    ``target`` ObjectDB. ``.run()`` must work when called that way, exactly like a real
+    ``dispatch_player_action`` REGISTRY call would invoke it."""
+
+    def test_run_resolves_target_from_raw_persona_id(self) -> None:
+        presented_persona = self.mask
+        success = CheckOutcomeFactory(name="IdentifyAction Persona Id", success_level=2)
+
+        with force_check_outcome(success):
+            result = self.action.run(actor=self.viewer, target_persona_id=presented_persona.pk)
+
+        self.assertTrue(result.success)
+        self.assertEqual(PersonaDiscovery.objects.count(), 1)
+
+    def test_run_with_unknown_persona_id_fails_cleanly(self) -> None:
+        result = self.action.run(actor=self.viewer, target_persona_id=999999)
+
+        self.assertFalse(result.success)
+        self.assertIn("Identify whom", result.message)
+
+
+class AttemptInteractionLoggingTests(IdentifyActionTestCase):
+    def test_attempt_logs_an_outcome_blind_interaction_in_an_active_scene(self) -> None:
+        SceneFactory(location=self.room, is_active=True)
+        failure = CheckOutcomeFactory(name="IdentifyAction Attempt Log", success_level=-1)
+
+        before = Interaction.objects.count()
+        with force_check_outcome(failure):
+            self.action.run(actor=self.viewer, target=self.target)
+
+        self.assertEqual(Interaction.objects.count(), before + 1)
+        interaction = Interaction.objects.latest("timestamp")
+        self.assertNotIn(self.target_sheet.primary_persona.name, interaction.content)
+        self.assertNotIn(self.mask.name, interaction.content)
+
+    def test_no_active_scene_skips_logging_without_error(self) -> None:
+        self.assertIsNone(get_active_scene(self.room))
+        failure = CheckOutcomeFactory(name="IdentifyAction No Scene", success_level=-1)
+
+        before = Interaction.objects.count()
+        with force_check_outcome(failure):
+            result = self.action.run(actor=self.viewer, target=self.target)
+
+        self.assertFalse(result.success)
+        self.assertEqual(Interaction.objects.count(), before)

--- a/src/actions/tests/test_identification.py
+++ b/src/actions/tests/test_identification.py
@@ -16,6 +16,7 @@ from actions.registry import get_action
 from evennia_extensions.factories import RoomProfileFactory
 from world.checks.test_helpers import force_check_outcome
 from world.npc_services.factories import FunctionaryFactory, NPCRoleFactory
+from world.npc_services.models import Functionary
 from world.roster.factories import RosterEntryFactory
 from world.scenes.factories import SceneFactory
 from world.scenes.interaction_services import get_active_scene
@@ -53,10 +54,18 @@ class RegistrationTests(IdentifyActionTestCase):
         assert isinstance(action, IdentifyAction)
         assert action.target_kind == TargetKind.PERSONA
 
-    def test_web_panel_surfaces_identify_for_a_placed_character(self) -> None:
-        # The _identification_actions adapter (player_interface.py) — registry actions are
-        # NOT auto-surfaced to the web panel; this adapter is the wire that makes identify
-        # reachable from the dynamic action panel (#2010's registry-adapter lesson).
+    def test_get_player_actions_never_lists_identify(self) -> None:
+        # #1107 Task 3 review (Critical finding): identify must NOT be surfaced by
+        # get_player_actions — every generic-panel consumer of that list
+        # (ActionPanel.tsx, PersonaContextMenu.tsx's targetedActions) dispatches through
+        # the CONSENT pipeline (createActionRequest), which identify (a no-consent
+        # private perception roll, ADR-0024) must never enter: it has no ActionTemplate
+        # and no CUSTOM_ACTION_RESOLVERS entry, so an accepted consent request would
+        # crash, and the masked target would wrongly get an accept/deny veto over the
+        # roll. identify's only web path is now a dedicated PersonaContextMenu
+        # "Identify" item that dispatches REGISTRY REST directly
+        # (useDispatchPlayerAction), never this listing. Superseded the old
+        # `_identification_actions` adapter this test used to assert the presence of.
         from actions.constants import ActionBackend
         from actions.player_interface import get_player_actions
 
@@ -66,10 +75,7 @@ class RegistrationTests(IdentifyActionTestCase):
             for a in actions
             if a.backend == ActionBackend.REGISTRY and a.ref.registry_key == "identify"
         ]
-        self.assertEqual(len(identify_entries), 1)
-        spec = identify_entries[0].target_spec
-        self.assertIsNotNone(spec)
-        self.assertEqual(spec.kind, TargetKind.PERSONA)
+        self.assertEqual(identify_entries, [])
 
 
 class PrerequisiteTests(IdentifyActionTestCase):
@@ -126,13 +132,28 @@ class OutcomeMessagingTests(IdentifyActionTestCase):
 
     def test_failure_and_no_functionary_botch_share_the_same_message(self) -> None:
         # Oracle rule, echoed at the action seam: a plain failure and a botch-with-no-NPC-to-
-        # blame both degrade to the identical FAILURE/AUTO_FAIL player_message.
+        # blame both degrade to the identical FAILURE/AUTO_FAIL player_message. Exercises the
+        # actual botch-with-no-functionary-to-blame branch of _roll_outcome_result (no
+        # Functionary exists in this TestCase's setUp) — #1107 Task 3 review, Minor finding 4:
+        # this test previously only ran a plain FAILURE (success_level=-1), never a real botch,
+        # so it never touched the "no functionary" degrade path its name promised.
+        self.assertFalse(Functionary.objects.exists())
+
         failure = CheckOutcomeFactory(name="IdentifyAction Failure", success_level=-1)
         with force_check_outcome(failure):
             failure_result = self.action.run(actor=self.viewer, target=self.target)
 
+        botch_without_functionary = CheckOutcomeFactory(
+            name="IdentifyAction Botch No Functionary", success_level=-2
+        )
+        with force_check_outcome(botch_without_functionary):
+            botch_result = self.action.run(actor=self.viewer, target=self.target)
+
         self.assertFalse(failure_result.success)
+        self.assertFalse(botch_result.success)
         self.assertTrue(failure_result.message)
+        self.assertEqual(failure_result.message, botch_result.message)
+        self.assertFalse(PersonaDiscovery.objects.exists())
 
 
 class GuessParsingTests(IdentifyActionTestCase):
@@ -177,6 +198,27 @@ class RestDispatchTargetResolutionTests(IdentifyActionTestCase):
 
     def test_run_with_unknown_persona_id_fails_cleanly(self) -> None:
         result = self.action.run(actor=self.viewer, target_persona_id=999999)
+
+        self.assertFalse(result.success)
+        self.assertIn("Identify whom", result.message)
+
+    def test_run_resolves_target_from_raw_persona_id_under_the_target_kwarg(self) -> None:
+        # #1107 Task 3 review, Minor finding 2: PersonaContextMenu's "Identify" item
+        # dispatches `kwargs: { target: <persona pk> }` — the same shape
+        # ChallengeAction's `_resolve_challenge_target` accepts (a raw persona pk under
+        # `target`, not `target_persona_id`). `.run()` must resolve that shape too,
+        # exactly like a real REST dispatch from the context menu would invoke it.
+        presented_persona = self.mask
+        success = CheckOutcomeFactory(name="IdentifyAction Target Kwarg Id", success_level=2)
+
+        with force_check_outcome(success):
+            result = self.action.run(actor=self.viewer, target=presented_persona.pk)
+
+        self.assertTrue(result.success)
+        self.assertEqual(PersonaDiscovery.objects.count(), 1)
+
+    def test_run_with_unknown_persona_id_under_target_kwarg_fails_cleanly(self) -> None:
+        result = self.action.run(actor=self.viewer, target=999999)
 
         self.assertFalse(result.success)
         self.assertIn("Identify whom", result.message)

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -87,6 +87,7 @@ from commands.goals import CmdGoal  # #1350 — goal authoring namespace.
 from commands.grant_distinction import CmdGrantDistinction
 from commands.grant_item import CmdGrantItem
 from commands.hire import CmdHire
+from commands.identification import CmdIdentify  # #1107
 from commands.imbue import CmdImbue
 from commands.investigation import CmdSearch  # #1866
 from commands.journals import CmdJournal
@@ -285,6 +286,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdRest,
             # #1866 — telnet face of SearchAction; search for clues in a room.
             CmdSearch,
+            # #1107 slice 5 — telnet face of IdentifyAction; see through a mask/disguise.
+            CmdIdentify,
             # #1450 — the staff push face: hand-authored gemits scoped by reach.
             CmdGemit,
             # #2003 — staff canon-review queue (perm(Admin)).

--- a/src/commands/identification.py
+++ b/src/commands/identification.py
@@ -1,0 +1,51 @@
+"""Telnet face of ``IdentifyAction`` (#1107 slice 5).
+
+A bare ``ArxCommand`` delegate, mirroring ``CmdSearch`` (``commands/investigation.py``) /
+``CmdSteal`` (``commands/currency.py``) — parse text, hand kwargs to ``action.run()``, message
+the result to the caller only. No consent flow: identifying someone is a private perception
+roll about the viewer's own understanding, not something that acts on the target's behavior
+(ADR-0024, "consent gates behavior, not benefit") — unlike Deceive/Persuade/Flirt, which ride
+``ConsentRequestCommand`` (``commands/consent.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from actions.definitions.identification import IdentifyAction
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+_DEFAULT_LOCKS = "cmd:all()"
+_IDENTIFY_WHOM = "Identify whom?"
+
+
+class CmdIdentify(ArxCommand):
+    """Try to see through a mask or disguise to who's really underneath.
+
+    Usage:
+      identify <target>
+      identify <target>=<guess>
+
+    The optional ``=<guess>`` names who you think is really underneath — a correct
+    guess eases the check; a wrong one is just a failure, same as no guess at all.
+    """
+
+    key = "identify"
+    locks = _DEFAULT_LOCKS
+    help_category = "General"
+    action = IdentifyAction()
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        args = self.require_args(_IDENTIFY_WHOM)
+        target_name, _sep, guess = args.partition("=")
+        target_name = target_name.strip()
+        if not target_name:
+            raise CommandError(_IDENTIFY_WHOM)
+        target = self.search_or_raise(target_name)
+
+        kwargs: dict[str, Any] = {"target": target}
+        guess = guess.strip()
+        if guess:
+            kwargs["guess"] = guess
+        return kwargs

--- a/src/commands/tests/test_identification.py
+++ b/src/commands/tests/test_identification.py
@@ -1,0 +1,97 @@
+"""Tests for CmdIdentify — telnet face of IdentifyAction (#1107 slice 5)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from actions.types import ActionResult
+from commands.identification import CmdIdentify
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
+
+
+class CmdIdentifyTests(TestCase):
+    def setUp(self) -> None:
+        self.room = ObjectDBFactory(
+            db_key="CmdIdentifyRoom", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        account = AccountFactory(username="cmdidentify_account")
+        self.caller = CharacterFactory(db_key="CmdIdentifyAlice", location=self.room)
+        self.caller.db_account = account
+        self.caller.save()
+        self.target = CharacterFactory(db_key="CmdIdentifyBob", location=self.room)
+
+        self.messages: list[str] = []
+
+        def _capture_msg(*a, **kw):
+            del kw
+            if a:
+                self.messages.append(a[0])
+
+        self._capture_msg = _capture_msg
+
+    def _run(self, args: str):
+        cmd = CmdIdentify()
+        cmd.caller = self.caller
+        cmd.args = args
+        cmd.raw_string = f"identify {args}"
+        cmd.msg = self._capture_msg
+        with patch.object(
+            CmdIdentify.action.__class__,
+            "run",
+            return_value=ActionResult(success=True, message="It clicks."),
+        ) as mocked:
+            cmd.func()
+        return mocked
+
+    def test_bare_target_dispatches_with_no_guess(self) -> None:
+        mocked = self._run("CmdIdentifyBob")
+
+        mocked.assert_called_once()
+        _args, kwargs = mocked.call_args
+        self.assertEqual(kwargs.get("actor"), self.caller)
+        self.assertEqual(kwargs.get("target"), self.target)
+        self.assertNotIn("guess", kwargs)
+        self.assertEqual(self.messages, ["It clicks."])
+
+    def test_target_equals_guess_parses_both(self) -> None:
+        mocked = self._run("CmdIdentifyBob=Someone Specific")
+
+        mocked.assert_called_once()
+        _args, kwargs = mocked.call_args
+        self.assertEqual(kwargs.get("target"), self.target)
+        self.assertEqual(kwargs.get("guess"), "Someone Specific")
+
+    def test_blank_guess_after_equals_is_omitted(self) -> None:
+        mocked = self._run("CmdIdentifyBob=   ")
+
+        mocked.assert_called_once()
+        _args, kwargs = mocked.call_args
+        self.assertNotIn("guess", kwargs)
+
+    def test_no_args_raises_clean_error_without_dispatching(self) -> None:
+        cmd = CmdIdentify()
+        cmd.caller = self.caller
+        cmd.args = ""
+        cmd.raw_string = "identify"
+        cmd.msg = self._capture_msg
+
+        with patch.object(CmdIdentify.action.__class__, "run") as mocked:
+            cmd.func()
+
+        mocked.assert_not_called()
+        self.assertTrue(any("Identify whom" in m for m in self.messages))
+
+    def test_unknown_target_raises_clean_error_without_dispatching(self) -> None:
+        cmd = CmdIdentify()
+        cmd.caller = self.caller
+        cmd.args = "NobodyHereByThisName"
+        cmd.raw_string = "identify NobodyHereByThisName"
+        cmd.msg = self._capture_msg
+
+        with patch.object(CmdIdentify.action.__class__, "run") as mocked:
+            cmd.func()
+
+        mocked.assert_not_called()
+        self.assertTrue(self.messages)

--- a/src/world/clues/services.py
+++ b/src/world/clues/services.py
@@ -137,24 +137,17 @@ def _grant_persona_link_target(clue: Clue, roster_entry: RosterEntry) -> None:
     """Grant the discoverer a pierced masked-identity pair (#2120). No-op if untargeted.
 
     Records a ``PersonaDiscovery`` linking ``target_persona``/``target_persona_linked``
-    for ``roster_entry``'s character sheet — the only in-game producer of
-    ``PersonaDiscovery`` rows (previously only test factories / django admin created
-    them). Piercing is GM-authored: the clue must exist and be planted (ADR-0033) —
-    there is no direct "study persona" roll against an arbitrary masked character.
-    Normalizes the pair to ``persona``=lower pk / ``linked_to``=higher pk, matching
-    ``PersonaDiscovery``'s own ``persona_discovery_normalized_order`` check constraint.
+    for ``roster_entry``'s character sheet via ``world.scenes.services.record_persona_discovery``
+    — the single writer of ``PersonaDiscovery`` rows, shared with the rolled-check path
+    (``world.forms.services.identification.attempt_identification``, #1107 slice 5) so the
+    pair-normalization logic lives in one place. Piercing here is GM-authored: the clue must
+    exist and be planted (ADR-0033) — there is no direct "study persona" roll against an
+    arbitrary masked character.
     """
-    persona = clue.target_persona
-    linked = clue.target_persona_linked
-    if persona is None or linked is None or persona.pk == linked.pk:
-        return
-    from world.scenes.models import PersonaDiscovery  # noqa: PLC0415
+    from world.scenes.services import record_persona_discovery  # noqa: PLC0415
 
-    lower, higher = (persona, linked) if persona.pk < linked.pk else (linked, persona)
-    PersonaDiscovery.objects.get_or_create(
-        persona=lower,
-        linked_to=higher,
-        discovered_by=roster_entry.character_sheet,
+    record_persona_discovery(
+        clue.target_persona, clue.target_persona_linked, roster_entry.character_sheet
     )
 
 

--- a/src/world/forms/AGENT_GLOSSARY.md
+++ b/src/world/forms/AGENT_GLOSSARY.md
@@ -56,3 +56,30 @@ rows. Blocked while `not in_control` (`RevertBlockedError`). _Avoid_: shift back
 Player-facing verb for the revert action (registry key `"revert_form"`,
 `RevertFormAction`). The backend canonical term remains **Revert**. _Avoid_:
 shift back, return to normal.
+
+## PC-to-PC identification (#1107 slice 5)
+
+**Identification check**:
+The `CheckType` (intellect + Investigation) a viewer rolls to recognize who's really
+under a target's fake-name persona/overlay — `world/forms/services/identification.py`,
+seeded by `ensure_identification_check`. Distinct from `Search` (perception +
+Investigation) and from the illusion-*piercing* contest (perception vs. a MAGICAL
+overlay, still senior-dev/future work) — Identification answers "who," piercing
+answers "is this even fake." _Avoid_: recognize check, unmask roll.
+
+**Familiarity tier**:
+How much a viewer's prior connection to the target eases an Identification check's
+difficulty: an active `CharacterRelationship` toward the sheet under the mask ("knows
+personally"), and/or the target's TRUE persona `fame_tier` ("famous likeness"), each
+contributing its own ease (currently combined additively — a PLACEHOLDER combine
+rule, see `appearance_and_identity.md` §"Identification loop (slice 5)"); neither
+present is the "stranger" case (no ease). _Avoid_: recognition bonus, familiarity
+score.
+
+**Fake-ID botch**:
+An Identification check's worst outcome band (`success_level <= -2`): the viewer
+mistakenly and confidently names a random active `Functionary` NPC
+(`random_active_functionary()`, `world/npc_services/functionaries.py`) as who's under
+the mask — never a real PC (the spec's oracle rule against false-fingering another
+player). Degrades to a plain failure when no Functionary exists to blame. _Avoid_:
+false positive, misidentification.

--- a/src/world/forms/constants.py
+++ b/src/world/forms/constants.py
@@ -1,0 +1,12 @@
+"""Forms-app-owned check-type name constants.
+
+Mirrors the sibling-app convention (``secrets.constants.GOSSIP_CHECK_TYPE_NAME``,
+``items.constants.FASHION_PRESENTATION_CHECK_TYPE_NAME``): the app that owns a check's
+domain owns the ``CheckType`` name constant, imported by its seed + its service module.
+"""
+
+# The "recognize the person under the mask" check (#1107 slice 5) — intellect + Investigation.
+# Seeded in ``world.seeds.investigation_checks.ensure_identification_check``. Deliberately NOT
+# the "Search" CheckType (perception + Investigation, #1705) — wrong stat pairing per Apostate's
+# 2026-07-03 ruling.
+IDENTIFICATION_CHECK_TYPE_NAME = "Identification"

--- a/src/world/forms/services/identification.py
+++ b/src/world/forms/services/identification.py
@@ -1,0 +1,169 @@
+"""Identification difficulty service (#1107 slice 5, Apostate's 2026-07-03 ruling).
+
+A viewer can try to figure out who's really under a mask/disguise: an Identification check
+(intellect + Investigation, seeded in ``world.seeds.investigation_checks``) rolled against the
+target's disguise baseline, staged by familiarity. This module owns the **difficulty table**
+(``identification_difficulty``) — pure computation, no ``perform_check`` call and no
+``PersonaDiscovery`` write; those live in ``attempt_identification`` (#1107 Task 2).
+
+Forms owns disguise data (``DisguiseKind``/``ConcealmentLevel``/``CharacterFormState``), so this
+module lives here; it reads ``scenes`` (``Persona``/``active_persona_for_sheet``) and
+``relationships`` (``CharacterRelationship``) read-only, per the FK-direction tenet (ADR-0010) —
+those are the general primitives forms depends on, not the reverse. Imports of those apps are
+lazy (function-local) to avoid a forms<->scenes import cycle at module load, matching
+``world.forms.services.get_presented_appearance``'s existing convention.
+
+All magnitudes below are PLACEHOLDER (pending playtest tuning), mirroring the tagging convention
+in ``world.seeds.social_actions``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from world.forms.models import ConcealmentLevel, DisguiseKind
+from world.forms.types import IdentificationOdds
+from world.scenes.action_constants import DIFFICULTY_VALUES, DifficultyChoice
+from world.societies.constants import FameTier
+
+if TYPE_CHECKING:
+    from world.character_sheets.models import CharacterSheet
+
+# --- Baseline difficulty (#1107 slice 5) — PLACEHOLDER magnitudes -----------------------------
+#
+# Anchored to the shared DIFFICULTY_VALUES tier scale (world.scenes.action_constants) so
+# Identification reads on the same Trivial..Harrowing ladder players see on every other check.
+# MAGICAL x FULL deliberately sits ABOVE Harrowing: a fully-concealing magical illusion against a
+# total stranger is meant to be unbeatable by this check alone (the illusion-piercing contest —
+# perception vs. disguise / dispel — is the senior dev's domain, #1110 slice 3); familiarity/fame
+# eases are what make an Identification attempt against it winnable at all.
+_TRIVIAL = DIFFICULTY_VALUES[DifficultyChoice.TRIVIAL]
+_EASY = DIFFICULTY_VALUES[DifficultyChoice.EASY]
+_NORMAL = DIFFICULTY_VALUES[DifficultyChoice.NORMAL]
+_HARD = DIFFICULTY_VALUES[DifficultyChoice.HARD]
+_DAUNTING = DIFFICULTY_VALUES[DifficultyChoice.DAUNTING]
+_HARROWING = DIFFICULTY_VALUES[DifficultyChoice.HARROWING]
+
+_BASELINE_BY_KIND_AND_LEVEL: dict[tuple[str, str], int] = {
+    (DisguiseKind.MUNDANE, ConcealmentLevel.NONE): _EASY,
+    (DisguiseKind.MUNDANE, ConcealmentLevel.DESCRIPTOR): _NORMAL,
+    (DisguiseKind.MUNDANE, ConcealmentLevel.FULL): _HARD,
+    (DisguiseKind.MAGICAL, ConcealmentLevel.NONE): _NORMAL,
+    (DisguiseKind.MAGICAL, ConcealmentLevel.DESCRIPTOR): _DAUNTING,
+    (DisguiseKind.MAGICAL, ConcealmentLevel.FULL): _HARROWING + 10,  # past Harrowing on purpose
+}
+
+# A name-only mask (a TEMPORARY fake-name Persona with no physical overlay, #1127) — the wearer's
+# face/body is unchanged, so a familiar glance can catch it. The easiest applicable band.
+_MASK_FLOOR_DIFFICULTY = _TRIVIAL
+
+# Familiarity eases — subtracted from the baseline (Decision 2). Both apply and stack when both
+# are true (an active relationship with a now-famous person eases on both counts).
+_ACTIVE_RELATIONSHIP_EASE = 20  # "I know this person" — a large, flat ease.
+_FAME_TIER_EASE: dict[str, int] = {
+    FameTier.NORMAL: 0,
+    FameTier.TALKED_ABOUT: 5,
+    FameTier.CELEBRITY: 10,
+    FameTier.HOUSEHOLD_NAME: 15,
+    FameTier.WORLD_FAMOUS: 20,
+}
+
+# The ease a *correct* named guess applies (Decision 3) — exposed on IdentificationOdds but
+# applied only by attempt_identification (#1107 Task 2), which alone knows the guess.
+_GUESS_CORRECT_EASE = 15
+
+# Past this many points beyond Harrowing (the hardest authored tier), Identification is
+# unrollable — auto-fail rather than waste a roll (Decision 4).
+AUTO_FAIL_GAP = 10
+_AUTO_FAIL_THRESHOLD = _HARROWING + AUTO_FAIL_GAP
+
+
+def _presents_fake_name(target_character) -> bool:
+    """Whether the target's currently active persona is a fake-name mask (no overlay needed)."""
+    from world.scenes.models import Persona  # noqa: PLC0415
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+    sheet = getattr(target_character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    if sheet is None:
+        return False
+    try:
+        persona = active_persona_for_sheet(sheet)
+    except Persona.DoesNotExist:
+        return False
+    return persona.is_fake_name
+
+
+def _baseline_difficulty(target_character) -> int | None:
+    """The target's presentation baseline, or ``None`` when there's nothing to identify."""
+    form_state = getattr(target_character, "form_state", None)  # noqa: GETATTR_LITERAL
+    if form_state is not None and form_state.active_fake_overlay_id is not None:
+        overlay = form_state.active_fake_overlay
+        return _BASELINE_BY_KIND_AND_LEVEL[(form_state.overlay_kind, overlay.concealment_level)]
+    if _presents_fake_name(target_character):
+        return _MASK_FLOOR_DIFFICULTY
+    return None
+
+
+def _relationship_ease(viewer_sheet: CharacterSheet, target_sheet: CharacterSheet) -> int:
+    """Ease from an active CharacterRelationship the viewer holds toward the true sheet."""
+    from world.relationships.models import CharacterRelationship  # noqa: PLC0415
+
+    holds_relationship = CharacterRelationship.objects.filter(
+        source=viewer_sheet, target=target_sheet, is_active=True
+    ).exists()
+    return _ACTIVE_RELATIONSHIP_EASE if holds_relationship else 0
+
+
+def _fame_ease(target_sheet: CharacterSheet) -> int:
+    """Ease from the target's TRUE (PRIMARY) persona's fame_tier — famous faces are recognized
+    even under a mask, regardless of which persona is currently active."""
+    from world.scenes.models import Persona  # noqa: PLC0415
+
+    try:
+        true_persona = target_sheet.primary_persona
+    except Persona.DoesNotExist:
+        return 0
+    return _FAME_TIER_EASE[true_persona.fame_tier]
+
+
+def identification_difficulty(viewer_sheet: CharacterSheet, target_character) -> IdentificationOdds:
+    """The Identification check's target difficulty for ``viewer_sheet`` vs. ``target_character``.
+
+    Baseline comes from what the target is actively presenting (checked in this order):
+
+    1. An active fake overlay (#1110) — keyed by ``DisguiseKind`` x ``ConcealmentLevel``.
+    2. A name-only TEMPORARY mask persona with no overlay — the flat "mask floor".
+    3. Neither — ``IdentificationOdds(applicable=False, ...)``: nothing to identify.
+
+    Familiarity eases the baseline (Decision 2, both stack): an active ``CharacterRelationship``
+    the viewer holds toward the sheet under the mask, and the ``fame_tier`` of the target's TRUE
+    (PRIMARY) persona. ``guess_ease`` is exposed, not applied — a caller subtracts it only when a
+    named guess is correct (Decision 3). ``auto_fail=True`` once the post-familiarity difficulty
+    is past ``AUTO_FAIL_GAP`` beyond Harrowing — a gap no roll can close (Decision 4).
+    """
+    baseline = _baseline_difficulty(target_character)
+    if baseline is None:
+        return IdentificationOdds(
+            applicable=False,
+            difficulty=0,
+            auto_fail=False,
+            baseline=0,
+            familiarity_ease=0,
+            guess_ease=0,
+        )
+
+    target_sheet = getattr(target_character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    familiarity_ease = 0
+    if target_sheet is not None:
+        familiarity_ease += _relationship_ease(viewer_sheet, target_sheet)
+        familiarity_ease += _fame_ease(target_sheet)
+
+    raw = baseline - familiarity_ease
+    return IdentificationOdds(
+        applicable=True,
+        difficulty=max(0, raw),
+        auto_fail=raw >= _AUTO_FAIL_THRESHOLD,
+        baseline=baseline,
+        familiarity_ease=familiarity_ease,
+        guess_ease=_GUESS_CORRECT_EASE,
+    )

--- a/src/world/forms/services/identification.py
+++ b/src/world/forms/services/identification.py
@@ -303,7 +303,7 @@ def attempt_identification(
     """Roll an Identification check for ``viewer_character`` against ``target_character`` (#1107
     Task 2), writing a ``PersonaDiscovery`` row on success.
 
-    Short-circuits BEFORE rolling in three cases:
+    Short-circuits BEFORE rolling in four cases (checked in this order):
 
     - ``ALREADY_KNOWN`` — the viewer already holds a ``PersonaDiscovery`` linking the target's
       currently-presented persona to their TRUE (PRIMARY) persona.
@@ -312,6 +312,15 @@ def attempt_identification(
       gate that keeps a caller from reaching this at all in that case.
     - ``AUTO_FAIL`` — ``identification_difficulty`` says the gap is unrollable (Decision 4); no
       roll is wasted, and this is player-indistinguishable from a plain ``FAILURE``.
+    - a degenerate presented==true persona pair, checked AFTER the AUTO_FAIL check (Task 3
+      review ruling 1b) — an overlay-only disguise that never swapped
+      ``active_persona_for_sheet`` has nothing left to reveal even though the baseline it fed
+      into ``identification_difficulty`` was rollable; degrades to ``FAILURE`` with no success
+      message. Checked last (not first) so an overlay-only target that's ALSO past the
+      auto-fail band still reports ``AUTO_FAIL`` — indistinguishable from any other
+      auto-failing attempt — rather than being reclassified. Defense-in-depth —
+      ``IdentifyAction``'s prerequisites (ruling 1a) are the primary gate that keeps normal
+      play from reaching this rollable-but-degenerate case at all.
 
     Otherwise rolls ``perform_check`` against the seeded Identification ``CheckType``, easing the
     target difficulty when ``guess_name`` correctly names the target's TRUE persona (Decision 3,
@@ -341,6 +350,29 @@ def attempt_identification(
         return _failure_result()
     if odds.auto_fail:
         return _auto_fail_result()
+
+    # Ruling 1b (#1107 Task 3 review — closing the overlay-only degenerate-SUCCESS hole).
+    # An overlay-only disguise doesn't swap active_persona_for_sheet (apply_disguise alone,
+    # without create_mask, leaves the target presenting PRIMARY — see the Task 2 report's
+    # documented concern), so presented == true is a degenerate pair: identification_difficulty
+    # can still say there's a rollable, non-auto-fail baseline (from the overlay), but there is
+    # genuinely no identity left to reveal. Guard BEFORE rolling so a "successful" roll can never
+    # mint a no-op PersonaDiscovery or imply a reveal that isn't there. Placed AFTER the
+    # AUTO_FAIL check on purpose: AUTO_FAIL already never rolls and never writes, so an
+    # auto-failing overlay-only target (e.g. a magical FULL disguise against a stranger) stays
+    # AUTO_FAIL — correctly indistinguishable from any other AUTO_FAIL — rather than being
+    # reclassified as FAILURE by this guard. IdentifyAction's prerequisites (Task 3 ruling 1a,
+    # actions/definitions/identification.py) are the primary gate that keeps normal play from
+    # reaching this rollable-but-degenerate case at all; reusing the plain FAILURE/
+    # applicable=False semantics here (the brief's "reuse applicable=False semantics" option,
+    # rather than growing the outcome enum) both carries no success message and keeps the oracle
+    # rule's FAILURE/AUTO_FAIL indistinguishability intact for free.
+    if (
+        presented_persona is not None
+        and true_persona is not None
+        and presented_persona.pk == true_persona.pk
+    ):
+        return _failure_result()
 
     target_difficulty = _target_difficulty(odds, guess_name, true_persona)
     check_type = CheckType.objects.get(name=IDENTIFICATION_CHECK_TYPE_NAME)

--- a/src/world/forms/services/identification.py
+++ b/src/world/forms/services/identification.py
@@ -22,12 +22,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from world.forms.models import ConcealmentLevel, DisguiseKind
-from world.forms.types import IdentificationOdds
+from world.forms.types import IdentificationOdds, IdentificationOutcome, IdentificationResult
 from world.scenes.action_constants import DIFFICULTY_VALUES, DifficultyChoice
 from world.societies.constants import FameTier
 
 if TYPE_CHECKING:
     from world.character_sheets.models import CharacterSheet
+    from world.checks.types import CheckResult
+    from world.scenes.models import Persona, PersonaDiscovery
 
 # --- Baseline difficulty (#1107 slice 5) — PLACEHOLDER magnitudes -----------------------------
 #
@@ -59,6 +61,11 @@ _MASK_FLOOR_DIFFICULTY = _TRIVIAL
 
 # Familiarity eases — subtracted from the baseline (Decision 2). Both apply and stack when both
 # are true (an active relationship with a now-famous person eases on both counts).
+# PLACEHOLDER combine rule: this module adds the two eases together. That's an implementer
+# choice, not a spec mandate — contrast world.scenes.social_difficulty._exploitable_easing,
+# which deliberately takes max() across its easing sources ("two exploitable conditions never
+# stack"). Additive stacking here is unreviewed; revisit alongside the other PLACEHOLDER
+# magnitudes during playtest tuning.
 _ACTIVE_RELATIONSHIP_EASE = 20  # "I know this person" — a large, flat ease.
 _FAME_TIER_EASE: dict[str, int] = {
     FameTier.NORMAL: 0,
@@ -135,7 +142,8 @@ def identification_difficulty(viewer_sheet: CharacterSheet, target_character) ->
     2. A name-only TEMPORARY mask persona with no overlay — the flat "mask floor".
     3. Neither — ``IdentificationOdds(applicable=False, ...)``: nothing to identify.
 
-    Familiarity eases the baseline (Decision 2, both stack): an active ``CharacterRelationship``
+    Familiarity eases the baseline (Decision 2, both stack — PLACEHOLDER additive combine rule,
+    see the comment above ``_ACTIVE_RELATIONSHIP_EASE``): an active ``CharacterRelationship``
     the viewer holds toward the sheet under the mask, and the ``fame_tier`` of the target's TRUE
     (PRIMARY) persona. ``guess_ease`` is exposed, not applied — a caller subtracts it only when a
     named guess is correct (Decision 3). ``auto_fail=True`` once the post-familiarity difficulty
@@ -167,3 +175,175 @@ def identification_difficulty(viewer_sheet: CharacterSheet, target_character) ->
         familiarity_ease=familiarity_ease,
         guess_ease=_GUESS_CORRECT_EASE,
     )
+
+
+# --- attempt_identification (#1107 Task 2) -----------------------------------------------------
+#
+# The check + PersonaDiscovery-write orchestrator. ``identification_difficulty`` above is pure
+# computation (no roll, no write); this is where the roll happens and the ``PersonaDiscovery`` row
+# gets written on success.
+
+# The check-resolution spine's canonical "botch" threshold — mirrors
+# world.magic.services.sanctum_install.CRITICAL_FAILURE_SUCCESS_LEVEL and world.combat.escalation's
+# "<=-2 botch" convention: CheckOutcome.success_level at/below this is a Critical Failure (a botch),
+# not a plain miss.
+_BOTCH_SUCCESS_LEVEL = -2
+
+# Player-facing copy. FAILURE and AUTO_FAIL deliberately share the exact same string (the oracle
+# rule — a player must never be able to tell "you rolled and missed" apart from "this was never
+# rollable"); see IdentificationResult.player_message and the dedicated indistinguishability test.
+_FAILURE_MESSAGE = "You can't place who's really underneath — nothing about them gives it away."
+_ALREADY_KNOWN_MESSAGE = "You already know exactly who this is."
+
+
+def _success_message(true_name: str) -> str:
+    return f"It clicks — that's unmistakably {true_name}."
+
+
+def _botch_message(functionary_name: str) -> str:
+    return f"You'd swear that's {functionary_name}... but you're wrong."
+
+
+def _failure_result() -> IdentificationResult:
+    return IdentificationResult(
+        outcome=IdentificationOutcome.FAILURE, player_message=_FAILURE_MESSAGE
+    )
+
+
+def _auto_fail_result() -> IdentificationResult:
+    return IdentificationResult(
+        outcome=IdentificationOutcome.AUTO_FAIL, player_message=_FAILURE_MESSAGE
+    )
+
+
+def _already_known_result(
+    existing: PersonaDiscovery, true_persona: Persona | None
+) -> IdentificationResult:
+    return IdentificationResult(
+        outcome=IdentificationOutcome.ALREADY_KNOWN,
+        revealed_name=true_persona.name if true_persona is not None else "",
+        persona_discovery=existing,
+        player_message=_ALREADY_KNOWN_MESSAGE,
+    )
+
+
+def _target_persona_pair(target_character) -> tuple[Persona | None, Persona | None]:
+    """(presented, true) persona pair for ``target_character`` — what the viewer currently
+    perceives them as, vs. who they really are (the TRUE/PRIMARY persona).
+
+    ``(None, None)`` when the target has no ``CharacterSheet`` or is somehow missing its PRIMARY
+    persona (a broken invariant elsewhere — ``attempt_identification`` degrades to a plain
+    failure rather than propagate the crash into a check-resolution seam).
+    """
+    from world.scenes.models import Persona  # noqa: PLC0415
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+    target_sheet = getattr(target_character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    if target_sheet is None:
+        return None, None
+    try:
+        presented = active_persona_for_sheet(target_sheet)
+        true_persona = target_sheet.primary_persona
+    except Persona.DoesNotExist:
+        return None, None
+    return presented, true_persona
+
+
+def _target_difficulty(
+    odds: IdentificationOdds, guess_name: str | None, true_persona: Persona | None
+) -> int:
+    """``odds.difficulty``, eased by ``odds.guess_ease`` when ``guess_name`` case-insensitively
+    names the target's TRUE persona (Decision 3). Clamped at 0."""
+    guess_correct = (
+        guess_name is not None
+        and true_persona is not None
+        and guess_name.strip().casefold() == true_persona.name.strip().casefold()
+    )
+    return max(0, odds.difficulty - (odds.guess_ease if guess_correct else 0))
+
+
+def _roll_outcome_result(
+    result: CheckResult,
+    presented_persona: Persona | None,
+    true_persona: Persona | None,
+    viewer_sheet: CharacterSheet,
+) -> IdentificationResult:
+    """SUCCESS / BOTCH_FAKE_ID / FAILURE from a resolved ``perform_check`` ``CheckResult``.
+
+    SUCCESS writes (idempotently) the ``PersonaDiscovery`` row; a botch
+    (``success_level <= _BOTCH_SUCCESS_LEVEL``) fake-IDs a random active Functionary — never a PC
+    (the spec's oracle rule) — degrading to a plain ``FAILURE`` when none exists to blame.
+    """
+    from world.npc_services.functionaries import random_active_functionary  # noqa: PLC0415
+    from world.scenes.services import record_persona_discovery  # noqa: PLC0415
+
+    if result.success_level > 0:
+        discovery = record_persona_discovery(presented_persona, true_persona, viewer_sheet)
+        revealed = true_persona.name if true_persona is not None else ""
+        return IdentificationResult(
+            outcome=IdentificationOutcome.SUCCESS,
+            revealed_name=revealed,
+            persona_discovery=discovery,
+            player_message=_success_message(revealed),
+        )
+    if result.success_level <= _BOTCH_SUCCESS_LEVEL:
+        functionary = random_active_functionary()
+        if functionary is not None:
+            return IdentificationResult(
+                outcome=IdentificationOutcome.BOTCH_FAKE_ID,
+                revealed_name=functionary.display_name,
+                player_message=_botch_message(functionary.display_name),
+            )
+    return _failure_result()
+
+
+def attempt_identification(
+    viewer_character, target_character, guess_name: str | None = None
+) -> IdentificationResult:
+    """Roll an Identification check for ``viewer_character`` against ``target_character`` (#1107
+    Task 2), writing a ``PersonaDiscovery`` row on success.
+
+    Short-circuits BEFORE rolling in three cases:
+
+    - ``ALREADY_KNOWN`` — the viewer already holds a ``PersonaDiscovery`` linking the target's
+      currently-presented persona to their TRUE (PRIMARY) persona.
+    - a target with nothing to identify (``odds.applicable is False``) degrades to ``FAILURE`` —
+      a defensive fallback; ``IdentifyAction``'s prerequisites (#1107 Task 3) are the intended
+      gate that keeps a caller from reaching this at all in that case.
+    - ``AUTO_FAIL`` — ``identification_difficulty`` says the gap is unrollable (Decision 4); no
+      roll is wasted, and this is player-indistinguishable from a plain ``FAILURE``.
+
+    Otherwise rolls ``perform_check`` against the seeded Identification ``CheckType``, easing the
+    target difficulty when ``guess_name`` correctly names the target's TRUE persona (Decision 3,
+    see ``_target_difficulty``), and resolves SUCCESS/BOTCH_FAKE_ID/FAILURE from the roll (see
+    ``_roll_outcome_result``). SUCCESS writes the ``PersonaDiscovery`` via
+    ``world.scenes.services.record_persona_discovery`` — the same writer
+    ``world.clues.services`` uses for GM-authored piercing (#2120), so the pair-normalization
+    logic isn't duplicated.
+    """
+    from world.checks.models import CheckType  # noqa: PLC0415
+    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.forms.constants import IDENTIFICATION_CHECK_TYPE_NAME  # noqa: PLC0415
+    from world.scenes.services import persona_discovery_between  # noqa: PLC0415
+
+    viewer_sheet = getattr(viewer_character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    if viewer_sheet is None:
+        return _failure_result()
+
+    presented_persona, true_persona = _target_persona_pair(target_character)
+
+    existing = persona_discovery_between(presented_persona, true_persona, viewer_sheet)
+    if existing is not None:
+        return _already_known_result(existing, true_persona)
+
+    odds = identification_difficulty(viewer_sheet, target_character)
+    if not odds.applicable:
+        return _failure_result()
+    if odds.auto_fail:
+        return _auto_fail_result()
+
+    target_difficulty = _target_difficulty(odds, guess_name, true_persona)
+    check_type = CheckType.objects.get(name=IDENTIFICATION_CHECK_TYPE_NAME)
+    result = perform_check(viewer_character, check_type, target_difficulty=target_difficulty)
+
+    return _roll_outcome_result(result, presented_persona, true_persona, viewer_sheet)

--- a/src/world/forms/tests/test_identification.py
+++ b/src/world/forms/tests/test_identification.py
@@ -371,3 +371,36 @@ class AttemptIdentificationTests(TestCase):
                 self.viewer_character, self.target_character, guess_name="Definitely Not Them"
             )
         self.assertEqual(capture_wrong.target_difficulty, odds.difficulty)
+
+    # --- ruling 1b (#1107 Task 3 review): overlay-only degenerate pair short-circuits ------------
+
+    def test_overlay_only_degenerate_pair_short_circuits_before_rolling(self):
+        # apply_disguise alone (no create_mask) never swaps active_persona_for_sheet, so
+        # presented == true even though identification_difficulty computes a rollable baseline
+        # from the overlay (MUNDANE/DESCRIPTOR — well under the auto-fail band, so this is NOT
+        # the AUTO_FAIL short-circuit). Forced to a SUCCESS-level outcome to prove the guard wins
+        # BEFORE any roll happens: if it reached perform_check, a forced success would hit the
+        # (pre-fix) SUCCESS path and mint a no-op PersonaDiscovery.
+        target = CharacterFactory()
+        CharacterSheetFactory(character=target)
+        disguise = CharacterFormFactory(character=target, form_type=FormType.DISGUISE)
+        apply_disguise(
+            target,
+            disguise,
+            kind=DisguiseKind.MUNDANE,
+            concealment_level=ConcealmentLevel.DESCRIPTOR,
+        )
+        success = CheckOutcomeFactory(
+            name="Identification Test Overlay Degenerate", success_level=2
+        )
+        with force_check_outcome(success):
+            result = attempt_identification(self.viewer_character, target)
+
+        self.assertEqual(result.outcome, IdentificationOutcome.FAILURE)
+        self.assertIsNone(result.persona_discovery)
+        self.assertEqual(result.revealed_name, "")
+        self.assertFalse(PersonaDiscovery.objects.exists())
+
+        # No success message leaks through — it's the same oracle-rule FAILURE/AUTO_FAIL string.
+        auto_fail = attempt_identification(self.viewer_character, self._magical_full_target())
+        self.assertEqual(result.player_message, auto_fail.player_message)

--- a/src/world/forms/tests/test_identification.py
+++ b/src/world/forms/tests/test_identification.py
@@ -1,0 +1,220 @@
+"""Identification check seed + difficulty service (#1107 slice 5, Apostate's ruling).
+
+Truth table: (no disguise / mask-only TEMPORARY persona / mundane overlay DESCRIPTOR / magical
+overlay FULL) x (stranger / active relationship / famous true-persona), plus guess-ease exposure
+and the auto-fail band.
+"""
+
+from django.test import TestCase
+
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.models import CheckType, CheckTypeTrait
+from world.forms.constants import IDENTIFICATION_CHECK_TYPE_NAME
+from world.forms.factories import CharacterFormFactory
+from world.forms.models import ConcealmentLevel, DisguiseKind, FormType
+from world.forms.services import apply_disguise
+from world.forms.services.identification import (
+    AUTO_FAIL_GAP,
+    identification_difficulty,
+)
+from world.relationships.factories import CharacterRelationshipFactory
+from world.scenes.action_constants import DIFFICULTY_VALUES, DifficultyChoice
+from world.scenes.services import create_mask
+from world.seeds.checks import seed_check_resolution_tables
+from world.seeds.investigation_checks import (
+    ensure_identification_check,
+    seed_investigation_check_content,
+)
+from world.skills.models import Skill
+from world.societies.constants import FameTier
+from world.traits.models import Trait, TraitType
+
+
+class IdentificationCheckSeedTests(TestCase):
+    """The seeded ``CheckType`` — intellect + Investigation (Decision 1)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        seed_check_resolution_tables()
+        seed_investigation_check_content()
+
+    def test_seeds_identification_check_as_intellect_plus_investigation(self):
+        check = CheckType.objects.get(name=IDENTIFICATION_CHECK_TYPE_NAME)
+        trait_names = set(
+            CheckTypeTrait.objects.filter(check_type=check).values_list("trait__name", flat=True)
+        )
+        self.assertEqual(trait_names, {"intellect", "Investigation"})
+        self.assertEqual(Trait.objects.get(name="intellect").trait_type, TraitType.STAT)
+        self.assertEqual(Trait.objects.get(name="Investigation").trait_type, TraitType.SKILL)
+
+    def test_distinct_from_search_stat_pairing(self):
+        # Search is perception + Investigation (#1705); Identification is intellect +
+        # Investigation — same skill, deliberately different stat (Decision 1).
+        search = CheckType.objects.get(name="Search")
+        search_stats = set(
+            CheckTypeTrait.objects.filter(check_type=search).values_list("trait__name", flat=True)
+        )
+        self.assertIn("perception", search_stats)
+        self.assertNotIn("perception", {"intellect", "Investigation"})
+
+    def test_shares_investigation_skill_row_with_search(self):
+        skill = Skill.objects.get(trait__name="Investigation")
+        composed_types = set(
+            CheckTypeTrait.objects.filter(trait=skill.trait).values_list(
+                "check_type__name", flat=True
+            )
+        )
+        self.assertEqual(composed_types, {"Search", IDENTIFICATION_CHECK_TYPE_NAME})
+
+    def test_idempotent(self):
+        ensure_identification_check()
+        ensure_identification_check()
+        check = CheckType.objects.get(name=IDENTIFICATION_CHECK_TYPE_NAME)
+        self.assertEqual(CheckTypeTrait.objects.filter(check_type=check).count(), 2)
+
+
+class IdentificationDifficultyTests(TestCase):
+    """``identification_difficulty`` — the truth table + guess-ease + auto-fail band."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.viewer_character = CharacterFactory()
+        cls.viewer_sheet = CharacterSheetFactory(character=cls.viewer_character)
+        cls.target_character = CharacterFactory()
+        cls.target_sheet = CharacterSheetFactory(character=cls.target_character)
+
+    def _apply_overlay(self, *, kind: str, concealment_level: str) -> None:
+        disguise = CharacterFormFactory(
+            character=self.target_character, form_type=FormType.DISGUISE
+        )
+        apply_disguise(
+            self.target_character, disguise, kind=kind, concealment_level=concealment_level
+        )
+
+    def _apply_mask(self) -> None:
+        create_mask(self.target_sheet, name="Nobody in Particular")
+
+    def _make_active_relationship(self) -> None:
+        CharacterRelationshipFactory(
+            source=self.viewer_sheet, target=self.target_sheet, is_active=True
+        )
+
+    def _make_famous(self, tier: str) -> None:
+        persona = self.target_sheet.primary_persona
+        persona.fame_tier = tier
+        persona.save()
+
+    # --- No disguise: nothing to identify, regardless of familiarity -------------------------
+
+    def test_no_disguise_not_applicable(self):
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertFalse(odds.applicable)
+        self.assertEqual(odds.difficulty, 0)
+        self.assertFalse(odds.auto_fail)
+
+    def test_no_disguise_not_applicable_even_with_relationship(self):
+        self._make_active_relationship()
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertFalse(odds.applicable)
+
+    # --- Mask-only TEMPORARY persona (the mask floor) -----------------------------------------
+
+    def test_mask_only_stranger(self):
+        self._apply_mask()
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertTrue(odds.applicable)
+        self.assertEqual(odds.baseline, DIFFICULTY_VALUES[DifficultyChoice.TRIVIAL])
+        self.assertEqual(odds.familiarity_ease, 0)
+        self.assertEqual(odds.difficulty, odds.baseline)
+        self.assertFalse(odds.auto_fail)
+
+    def test_mask_only_active_relationship_eases(self):
+        self._apply_mask()
+        self._make_active_relationship()
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertGreater(odds.familiarity_ease, 0)
+        self.assertEqual(odds.difficulty, max(0, odds.baseline - odds.familiarity_ease))
+
+    def test_mask_only_famous_true_persona_eases(self):
+        self._apply_mask()
+        self._make_famous(FameTier.CELEBRITY)
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertGreater(odds.familiarity_ease, 0)
+        self.assertEqual(odds.difficulty, max(0, odds.baseline - odds.familiarity_ease))
+
+    # --- Mundane overlay, DESCRIPTOR concealment -----------------------------------------------
+
+    def test_mundane_descriptor_stranger(self):
+        self._apply_overlay(
+            kind=DisguiseKind.MUNDANE, concealment_level=ConcealmentLevel.DESCRIPTOR
+        )
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertTrue(odds.applicable)
+        self.assertEqual(odds.baseline, DIFFICULTY_VALUES[DifficultyChoice.NORMAL])
+        self.assertEqual(odds.familiarity_ease, 0)
+        self.assertEqual(odds.difficulty, odds.baseline)
+        self.assertFalse(odds.auto_fail)
+
+    def test_mundane_descriptor_active_relationship(self):
+        self._apply_overlay(
+            kind=DisguiseKind.MUNDANE, concealment_level=ConcealmentLevel.DESCRIPTOR
+        )
+        self._make_active_relationship()
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertLess(odds.difficulty, odds.baseline)
+
+    def test_mundane_descriptor_famous_true_persona(self):
+        self._apply_overlay(
+            kind=DisguiseKind.MUNDANE, concealment_level=ConcealmentLevel.DESCRIPTOR
+        )
+        self._make_famous(FameTier.WORLD_FAMOUS)
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertLess(odds.difficulty, odds.baseline)
+
+    # --- Magical overlay, FULL concealment (the hardest band) ----------------------------------
+
+    def test_magical_full_stranger_auto_fails(self):
+        self._apply_overlay(kind=DisguiseKind.MAGICAL, concealment_level=ConcealmentLevel.FULL)
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertTrue(odds.applicable)
+        self.assertGreater(odds.baseline, DIFFICULTY_VALUES[DifficultyChoice.HARROWING])
+        # A total stranger gets no ease against a vast gap — Decision 4 auto-fail.
+        self.assertTrue(odds.auto_fail)
+
+    def test_magical_full_active_relationship_still_hard_but_maybe_not_auto_fail(self):
+        self._apply_overlay(kind=DisguiseKind.MAGICAL, concealment_level=ConcealmentLevel.FULL)
+        self._make_active_relationship()
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertLess(odds.difficulty, odds.baseline)
+
+    def test_magical_full_famous_and_related_stacks_eases_below_auto_fail(self):
+        self._apply_overlay(kind=DisguiseKind.MAGICAL, concealment_level=ConcealmentLevel.FULL)
+        self._make_active_relationship()
+        self._make_famous(FameTier.WORLD_FAMOUS)
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        # Both eases stack (Decision 2): knowing AND recognizing a world-famous face together
+        # close even the vast magical-FULL gap.
+        self.assertFalse(odds.auto_fail)
+
+    # --- guess_ease is exposed, not applied (Decision 3 — attempt_identification applies it) ---
+
+    def test_guess_ease_exposed_but_not_subtracted(self):
+        self._apply_mask()
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertGreater(odds.guess_ease, 0)
+        self.assertEqual(odds.difficulty, odds.baseline)
+
+    def test_guess_ease_not_applicable_case_is_zero(self):
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertEqual(odds.guess_ease, 0)
+
+    # --- auto-fail band ------------------------------------------------------------------------
+
+    def test_auto_fail_gap_is_positive(self):
+        self.assertGreater(AUTO_FAIL_GAP, 0)
+
+    def test_easy_bands_never_auto_fail(self):
+        self._apply_overlay(kind=DisguiseKind.MUNDANE, concealment_level=ConcealmentLevel.NONE)
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        self.assertFalse(odds.auto_fail)

--- a/src/world/forms/tests/test_identification.py
+++ b/src/world/forms/tests/test_identification.py
@@ -10,16 +10,22 @@ from django.test import TestCase
 from evennia_extensions.factories import CharacterFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.models import CheckType, CheckTypeTrait
+from world.checks.test_helpers import force_check_outcome
 from world.forms.constants import IDENTIFICATION_CHECK_TYPE_NAME
 from world.forms.factories import CharacterFormFactory
 from world.forms.models import ConcealmentLevel, DisguiseKind, FormType
 from world.forms.services import apply_disguise
 from world.forms.services.identification import (
     AUTO_FAIL_GAP,
+    attempt_identification,
     identification_difficulty,
 )
+from world.forms.types import IdentificationOutcome
+from world.npc_services.factories import FunctionaryFactory, NPCRoleFactory
+from world.npc_services.models import Functionary
 from world.relationships.factories import CharacterRelationshipFactory
 from world.scenes.action_constants import DIFFICULTY_VALUES, DifficultyChoice
+from world.scenes.models import PersonaDiscovery
 from world.scenes.services import create_mask
 from world.seeds.checks import seed_check_resolution_tables
 from world.seeds.investigation_checks import (
@@ -28,6 +34,7 @@ from world.seeds.investigation_checks import (
 )
 from world.skills.models import Skill
 from world.societies.constants import FameTier
+from world.traits.factories import CheckOutcomeFactory
 from world.traits.models import Trait, TraitType
 
 
@@ -56,7 +63,13 @@ class IdentificationCheckSeedTests(TestCase):
             CheckTypeTrait.objects.filter(check_type=search).values_list("trait__name", flat=True)
         )
         self.assertIn("perception", search_stats)
-        self.assertNotIn("perception", {"intellect", "Investigation"})
+        identification = CheckType.objects.get(name=IDENTIFICATION_CHECK_TYPE_NAME)
+        identification_stats = set(
+            CheckTypeTrait.objects.filter(check_type=identification).values_list(
+                "trait__name", flat=True
+            )
+        )
+        self.assertNotIn("perception", identification_stats)
 
     def test_shares_investigation_skill_row_with_search(self):
         skill = Skill.objects.get(trait__name="Investigation")
@@ -218,3 +231,143 @@ class IdentificationDifficultyTests(TestCase):
         self._apply_overlay(kind=DisguiseKind.MUNDANE, concealment_level=ConcealmentLevel.NONE)
         odds = identification_difficulty(self.viewer_sheet, self.target_character)
         self.assertFalse(odds.auto_fail)
+
+
+class AttemptIdentificationTests(TestCase):
+    """``attempt_identification`` — the roll + ``PersonaDiscovery``-write orchestrator (Task 2).
+
+    ``target_character`` wears a mask (a TEMPORARY fake-name persona) in ``setUpTestData`` so
+    every test has a distinct presented/true persona pair to link — the same fixture shape
+    ``IdentificationDifficultyTests._apply_mask`` uses. Rolls are forced deterministic via
+    ``force_check_outcome`` rather than depending on trait values / dice.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        seed_check_resolution_tables()
+        seed_investigation_check_content()
+        cls.viewer_character = CharacterFactory()
+        cls.viewer_sheet = CharacterSheetFactory(character=cls.viewer_character)
+        cls.target_character = CharacterFactory()
+        cls.target_sheet = CharacterSheetFactory(character=cls.target_character)
+        cls.mask = create_mask(cls.target_sheet, name="Nobody in Particular")
+
+    def _magical_full_target(self):
+        """A fresh, unrelated target wearing a magical FULL disguise — the auto-fail band
+        against a total stranger (mirrors ``IdentificationDifficultyTests``'s equivalent)."""
+        target = CharacterFactory()
+        CharacterSheetFactory(character=target)
+        disguise = CharacterFormFactory(character=target, form_type=FormType.DISGUISE)
+        apply_disguise(
+            target, disguise, kind=DisguiseKind.MAGICAL, concealment_level=ConcealmentLevel.FULL
+        )
+        return target
+
+    # --- nothing to identify -> FAILURE (defensive fallback; Task 3 gates this normally) --------
+
+    def test_no_disguise_no_mask_is_failure(self):
+        stranger = CharacterFactory()
+        CharacterSheetFactory(character=stranger)
+        result = attempt_identification(self.viewer_character, stranger)
+        self.assertEqual(result.outcome, IdentificationOutcome.FAILURE)
+        self.assertFalse(PersonaDiscovery.objects.exists())
+
+    # --- AUTO_FAIL short-circuits before rolling -------------------------------------------------
+
+    def test_auto_fail_short_circuits(self):
+        magical_target = self._magical_full_target()
+        result = attempt_identification(self.viewer_character, magical_target)
+        self.assertEqual(result.outcome, IdentificationOutcome.AUTO_FAIL)
+        self.assertFalse(PersonaDiscovery.objects.exists())
+
+    # --- SUCCESS writes PersonaDiscovery; a second attempt is ALREADY_KNOWN, not a duplicate -----
+
+    def test_success_writes_persona_discovery_idempotently(self):
+        success = CheckOutcomeFactory(name="Identification Test Success", success_level=2)
+        with force_check_outcome(success):
+            result = attempt_identification(self.viewer_character, self.target_character)
+        self.assertEqual(result.outcome, IdentificationOutcome.SUCCESS)
+        self.assertEqual(result.revealed_name, self.target_sheet.primary_persona.name)
+        self.assertIsNotNone(result.persona_discovery)
+        self.assertEqual(PersonaDiscovery.objects.count(), 1)
+
+        with force_check_outcome(success):
+            result_again = attempt_identification(self.viewer_character, self.target_character)
+        self.assertEqual(result_again.outcome, IdentificationOutcome.ALREADY_KNOWN)
+        self.assertEqual(result_again.revealed_name, self.target_sheet.primary_persona.name)
+        self.assertEqual(PersonaDiscovery.objects.count(), 1)
+
+    # --- plain FAILURE persists nothing ----------------------------------------------------------
+
+    def test_plain_failure_persists_nothing(self):
+        failure = CheckOutcomeFactory(name="Identification Test Failure", success_level=-1)
+        with force_check_outcome(failure):
+            result = attempt_identification(self.viewer_character, self.target_character)
+        self.assertEqual(result.outcome, IdentificationOutcome.FAILURE)
+        self.assertFalse(PersonaDiscovery.objects.exists())
+
+    # --- BOTCH fake-IDs a seeded Functionary, never a PC ------------------------------------------
+
+    def test_botch_fake_ids_a_seeded_functionary_never_a_pc(self):
+        role = NPCRoleFactory(name="Gate Clerk")
+        functionary = FunctionaryFactory(role=role, name_override="Old Marta")
+        botch = CheckOutcomeFactory(name="Identification Test Botch", success_level=-2)
+        with force_check_outcome(botch):
+            result = attempt_identification(self.viewer_character, self.target_character)
+        self.assertEqual(result.outcome, IdentificationOutcome.BOTCH_FAKE_ID)
+        self.assertEqual(result.revealed_name, functionary.display_name)
+        pc_names = {
+            self.viewer_sheet.primary_persona.name,
+            self.target_sheet.primary_persona.name,
+            self.mask.name,
+        }
+        self.assertNotIn(result.revealed_name, pc_names)
+        self.assertFalse(PersonaDiscovery.objects.exists())
+
+    def test_botch_degrades_to_failure_when_no_functionary_exists(self):
+        self.assertFalse(Functionary.objects.exists())
+        botch = CheckOutcomeFactory(name="Identification Test Botch No NPC", success_level=-3)
+        with force_check_outcome(botch):
+            result = attempt_identification(self.viewer_character, self.target_character)
+        self.assertEqual(result.outcome, IdentificationOutcome.FAILURE)
+        self.assertFalse(PersonaDiscovery.objects.exists())
+
+    # --- oracle rule: FAILURE and AUTO_FAIL are player-indistinguishable -------------------------
+
+    def test_failure_and_auto_fail_share_identical_player_message(self):
+        magical_target = self._magical_full_target()
+        auto_fail_result = attempt_identification(self.viewer_character, magical_target)
+
+        failure = CheckOutcomeFactory(name="Identification Test Failure Msg", success_level=-1)
+        with force_check_outcome(failure):
+            failure_result = attempt_identification(self.viewer_character, self.target_character)
+
+        self.assertEqual(auto_fail_result.outcome, IdentificationOutcome.AUTO_FAIL)
+        self.assertEqual(failure_result.outcome, IdentificationOutcome.FAILURE)
+        self.assertEqual(auto_fail_result.player_message, failure_result.player_message)
+        self.assertTrue(auto_fail_result.player_message)
+
+    # --- guess ease: a correct guess eases the roll (proven via a botch surviving to success) ----
+
+    def test_correct_guess_eases_the_roll(self):
+        # A correct guess subtracts guess_ease from target_difficulty (Decision 3); an incorrect
+        # guess doesn't. Forced to a plain FAILURE (not SUCCESS/BOTCH) so neither call writes a
+        # PersonaDiscovery — an ALREADY_KNOWN short-circuit on the second call would never reach
+        # perform_check, leaving nothing to assert on. Asserted via the captured target_difficulty
+        # perform_check actually saw.
+        odds = identification_difficulty(self.viewer_sheet, self.target_character)
+        failure = CheckOutcomeFactory(name="Identification Test Guess Failure", success_level=-1)
+
+        with force_check_outcome(failure) as capture:
+            attempt_identification(
+                self.viewer_character,
+                self.target_character,
+                guess_name=self.target_sheet.primary_persona.name,
+            )
+        self.assertEqual(capture.target_difficulty, max(0, odds.difficulty - odds.guess_ease))
+
+        with force_check_outcome(failure) as capture_wrong:
+            attempt_identification(
+                self.viewer_character, self.target_character, guess_name="Definitely Not Them"
+            )
+        self.assertEqual(capture_wrong.target_difficulty, odds.difficulty)

--- a/src/world/forms/types.py
+++ b/src/world/forms/types.py
@@ -15,3 +15,32 @@ class PresentedTrait:
     normalized: str
     descriptor: str
     display: str
+
+
+@dataclass(frozen=True)
+class IdentificationOdds:
+    """The Identification check's target difficulty for one viewer/target pair (#1107 slice 5).
+
+    ``applicable`` is False when the target presents no fake overlay and no fake-name persona —
+    there's nothing to identify, and the caller should surface a clean "nothing to identify"
+    outcome rather than roll. When applicable:
+
+    - ``baseline`` is the raw difficulty from what the target is presenting (overlay
+      kind/concealment, or the flat "mask floor" for a name-only mask).
+    - ``familiarity_ease`` is how much the viewer's relationship to / the target's fame reduces
+      that baseline (already subtracted into ``difficulty``).
+    - ``guess_ease`` is the ease a *correct* named guess would apply — exposed but NOT subtracted
+      into ``difficulty`` here, since this service doesn't know the guess; the caller
+      (``attempt_identification``) subtracts it only when the guess matches.
+    - ``difficulty`` is ``max(0, baseline - familiarity_ease)`` — the ``perform_check``
+      ``target_difficulty`` before any guess ease.
+    - ``auto_fail`` is True when the pre-clamp gap is so vast (Decision 4) that no roll can
+      close it — the caller should short-circuit without calling ``perform_check`` at all.
+    """
+
+    applicable: bool
+    difficulty: int
+    auto_fail: bool
+    baseline: int
+    familiarity_ease: int
+    guess_ease: int

--- a/src/world/forms/types.py
+++ b/src/world/forms/types.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from world.scenes.models import PersonaDiscovery
 
 
 @dataclass(frozen=True)
@@ -44,3 +51,39 @@ class IdentificationOdds:
     baseline: int
     familiarity_ease: int
     guess_ease: int
+
+
+class IdentificationOutcome(Enum):
+    """How an ``attempt_identification`` call resolved (#1107 slice 5 Task 2).
+
+    Plain runtime enum (not ``TextChoices``) — this never backs a model field, it's a return-value
+    discriminator, matching the ``ReputationTier`` precedent (``world.societies.types``).
+    """
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    BOTCH_FAKE_ID = "botch_fake_id"
+    ALREADY_KNOWN = "already_known"
+    AUTO_FAIL = "auto_fail"
+
+
+@dataclass(frozen=True)
+class IdentificationResult:
+    """The outcome of one ``attempt_identification`` call (#1107 slice 5 Task 2).
+
+    - ``revealed_name`` is the target's TRUE (PRIMARY) persona name on ``SUCCESS``/
+      ``ALREADY_KNOWN``, the fake-IDed ``Functionary.display_name`` on ``BOTCH_FAKE_ID``
+      (never a PC name — the spec's oracle rule), and empty on ``FAILURE``/``AUTO_FAIL``.
+    - ``persona_discovery`` is the written/pre-existing row on ``SUCCESS``/``ALREADY_KNOWN``
+      (``None`` when the presented/true persona pair was degenerate — nothing to link — or on
+      any other outcome).
+    - ``player_message`` is the safe, player-facing line. **``FAILURE`` and ``AUTO_FAIL`` always
+      share the identical string** — the oracle rule (a player must not be able to distinguish
+      "you rolled and missed" from "this was never rollable") — verified by a dedicated test
+      rather than left to eyeballing call sites.
+    """
+
+    outcome: IdentificationOutcome
+    revealed_name: str = ""
+    persona_discovery: PersonaDiscovery | None = None
+    player_message: str = ""

--- a/src/world/npc_services/functionaries.py
+++ b/src/world/npc_services/functionaries.py
@@ -105,3 +105,20 @@ def remove_functionary(*, role: NPCRole, room: RoomProfile) -> bool:
         is_active=False
     )
     return updated > 0
+
+
+def random_active_functionary() -> Functionary | None:
+    """One random active Functionary (role also active), or ``None`` if there are none.
+
+    The botch-outcome NPC picker for Identification (#1107 slice 5): a fumbled identification
+    check fake-IDs a random Functionary rather than naming a PC (the spec's oracle rule — a botch
+    must never out a real player). ``order_by("?")`` issues a Postgres ``ORDER BY RANDOM()`` —
+    a full-table sort, but the Functionary table is small (a handful of NPC placements per room)
+    so this is acceptable at this scale; revisit if the catalog grows large enough to matter.
+    """
+    return (
+        Functionary.objects.filter(is_active=True, role__is_active=True)
+        .select_related("role")
+        .order_by("?")
+        .first()
+    )

--- a/src/world/npc_services/tests/test_functionaries.py
+++ b/src/world/npc_services/tests/test_functionaries.py
@@ -12,6 +12,7 @@ from world.npc_services.functionaries import (
     functionary_in_location,
     functionary_in_room,
     place_functionary,
+    random_active_functionary,
     remove_functionary,
 )
 from world.npc_services.models import Functionary
@@ -127,6 +128,32 @@ class RoomLookFunctionaryTests(django.test.TestCase):
         )
         text = room.return_appearance(looker=looker, mode="look")
         self.assertIn("Old Marta", text)
+
+
+class RandomActiveFunctionaryTests(django.test.TestCase):
+    """``random_active_functionary`` — the Identification-botch NPC picker (#1107 slice 5)."""
+
+    def test_none_when_no_functionaries_exist(self) -> None:
+        self.assertIsNone(random_active_functionary())
+
+    def test_excludes_inactive_placement(self) -> None:
+        FunctionaryFactory(role=NPCRoleFactory(name="Retired Clerk"), is_active=False)
+        self.assertIsNone(random_active_functionary())
+
+    def test_excludes_inactive_role(self) -> None:
+        FunctionaryFactory(role=NPCRoleFactory(name="Defunct Guild", is_active=False))
+        self.assertIsNone(random_active_functionary())
+
+    def test_returns_an_active_functionary(self) -> None:
+        active = FunctionaryFactory(role=NPCRoleFactory(name="Gate Clerk"))
+        self.assertEqual(random_active_functionary(), active)
+
+    def test_picks_among_multiple_active(self) -> None:
+        first = FunctionaryFactory(role=NPCRoleFactory(name="Gate Clerk"))
+        second = FunctionaryFactory(role=NPCRoleFactory(name="Dock Warden"))
+        for _ in range(10):
+            picked = random_active_functionary()
+            self.assertIn(picked, {first, second})
 
 
 class FunctionaryLocationTests(django.test.TestCase):

--- a/src/world/scenes/services.py
+++ b/src/world/scenes/services.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from typeclasses.characters import Character
     from world.character_sheets.models import CharacterSheet, Profile
     from world.forms.models import CharacterForm
+    from world.scenes.models import PersonaDiscovery
 
 ActionType = SceneAction
 
@@ -323,6 +324,59 @@ def has_unseen_observers(scene: Scene) -> bool:
     from world.scenes.models import SceneUnseenObserver  # noqa: PLC0415
 
     return SceneUnseenObserver.objects.filter(scene=scene).exists()
+
+
+def _normalized_persona_pair(
+    persona: Persona | None, linked: Persona | None
+) -> tuple[Persona, Persona] | None:
+    """Normalize a persona pair to ``(lower pk, higher pk)``, matching ``PersonaDiscovery``'s own
+    ``persona_discovery_normalized_order`` check constraint. ``None`` when the pair is degenerate
+    — either side missing, or they're literally the same persona (nothing to link)."""
+    if persona is None or linked is None or persona.pk == linked.pk:
+        return None
+    return (persona, linked) if persona.pk < linked.pk else (linked, persona)
+
+
+def persona_discovery_between(
+    persona: Persona | None, linked: Persona | None, discovered_by: CharacterSheet
+) -> PersonaDiscovery | None:
+    """The existing ``PersonaDiscovery`` row for this (unordered) persona pair + discoverer, if
+    any — a pure read, never writes. ``None`` for a degenerate pair (see
+    ``_normalized_persona_pair``) or when no such row exists yet."""
+    from world.scenes.models import PersonaDiscovery  # noqa: PLC0415
+
+    pair = _normalized_persona_pair(persona, linked)
+    if pair is None:
+        return None
+    lower, higher = pair
+    return PersonaDiscovery.objects.filter(
+        persona=lower, linked_to=higher, discovered_by=discovered_by
+    ).first()
+
+
+def record_persona_discovery(
+    persona: Persona | None, linked: Persona | None, discovered_by: CharacterSheet
+) -> PersonaDiscovery | None:
+    """Record that ``discovered_by`` learned ``persona`` and ``linked`` are the same person.
+
+    The single writer of ``PersonaDiscovery`` rows — shared by ``world.clues.services``'s
+    GM-authored clue-piercing path (``_grant_persona_link_target``, #2120) and
+    ``world.forms.services.identification.attempt_identification``'s rolled-check path (#1107
+    slice 5), so the normalization logic isn't duplicated between them. Idempotent
+    (``get_or_create``) — attempting the same pair again is a no-op, not a duplicate row. Returns
+    ``None`` without writing for a degenerate pair (see ``_normalized_persona_pair``) — e.g. the
+    presented persona already IS the true persona, so there's nothing to pierce.
+    """
+    from world.scenes.models import PersonaDiscovery  # noqa: PLC0415
+
+    pair = _normalized_persona_pair(persona, linked)
+    if pair is None:
+        return None
+    lower, higher = pair
+    discovery, _ = PersonaDiscovery.objects.get_or_create(
+        persona=lower, linked_to=higher, discovered_by=discovered_by
+    )
+    return discovery
 
 
 def _broadcast_unseen_observer_state(scene: Scene) -> None:

--- a/src/world/seeds/investigation_checks.py
+++ b/src/world/seeds/investigation_checks.py
@@ -1,4 +1,4 @@
-"""Seed the investigation Search check — perception + Investigation (#1705).
+"""Seed the investigation Search + Identification checks — both ride Investigation (#1705, #1107).
 
 The search action (``actions/definitions/investigation.py``) rolls a ``CheckType`` named
 ``"Search"`` (``clues.constants.SEARCH_CHECK_TYPE_NAME``) that was **never seeded** — so a search
@@ -7,14 +7,22 @@ authored composition and the action degraded to a PLACEHOLDER. Seed the **Invest
 (+ its backing SKILL trait) and the **Search** ``CheckType`` as **perception (stat) + Investigation
 (skill)**, authoritatively and idempotently. The specialization layer is optional/future. Mirrors
 ``world/seeds/social_checks.py``; this is the mystery/investigation core loop's roll.
+
+Also seeds the **Identification** ``CheckType`` (#1107 slice 5, Apostate's 2026-07-03 ruling) —
+**intellect (stat) + Investigation (skill)**, the PC-to-PC "recognize who's under the mask"
+check. Deliberately a *different* stat pairing than Search: clocking a face from memory/deduction
+(intellect) rather than noticing a physical clue (perception).
 """
 
 from __future__ import annotations
 
 from decimal import Decimal
 
+from world.forms.constants import IDENTIFICATION_CHECK_TYPE_NAME
+
 _INVESTIGATION_SKILL = ("Investigation", "Searching, examining, and piecing clues together.")
 _SEARCH_STAT = "perception"
+_IDENTIFICATION_STAT = "intellect"
 _EXPLORATION_CATEGORY = "Exploration"
 
 
@@ -54,8 +62,47 @@ def _ensure_perception_stat():
     return trait
 
 
+def _ensure_intellect_stat():
+    """The intellect STAT trait (matches the canonical stat seed: STAT / category META)."""
+    from world.traits.models import Trait, TraitCategory, TraitType  # noqa: PLC0415
+
+    trait, _ = Trait.objects.get_or_create(
+        name=_IDENTIFICATION_STAT,
+        defaults={
+            "trait_type": TraitType.STAT,
+            "category": TraitCategory.META,
+            "is_public": True,
+        },
+    )
+    return trait
+
+
+def ensure_identification_check():
+    """Seed the **Identification** ``CheckType`` — intellect + Investigation (#1107 slice 5).
+
+    Idempotent, authoritative (wipe-and-rewrite composition, matching the Search seed's
+    pattern): a viewer's Identification roll always ends up intellect + Investigation, never
+    accreting a stale composition from an earlier design. Shares the Investigation skill/trait
+    row with Search — one skill backs both the "find the clue" and "recognize the face" rolls.
+    """
+    from world.checks.models import CheckCategory, CheckType, CheckTypeTrait  # noqa: PLC0415
+
+    skill = ensure_investigation_skill()
+    stat_trait = _ensure_intellect_stat()
+    category, _ = CheckCategory.objects.get_or_create(name=_EXPLORATION_CATEGORY)
+    check_type, _ = CheckType.objects.get_or_create(
+        name=IDENTIFICATION_CHECK_TYPE_NAME, category=category, defaults={"is_active": True}
+    )
+    weight = Decimal("1.0")  # PLACEHOLDER magnitudes
+    # Authoritative: wipe any prior composition, then rewrite intellect + Investigation.
+    CheckTypeTrait.objects.filter(check_type=check_type).delete()
+    CheckTypeTrait.objects.create(check_type=check_type, trait=stat_trait, weight=weight)
+    CheckTypeTrait.objects.create(check_type=check_type, trait=skill.trait, weight=weight)
+    return check_type
+
+
 def seed_investigation_check_content() -> None:
-    """Cluster entry — seed the Investigation skill + the Search check (perception + skill)."""
+    """Cluster entry — seed the Investigation skill + the Search + Identification checks."""
     from world.checks.models import CheckCategory, CheckType, CheckTypeTrait  # noqa: PLC0415
     from world.clues.constants import SEARCH_CHECK_TYPE_NAME  # noqa: PLC0415
 
@@ -70,3 +117,4 @@ def seed_investigation_check_content() -> None:
     CheckTypeTrait.objects.filter(check_type=check_type).delete()
     CheckTypeTrait.objects.create(check_type=check_type, trait=stat_trait, weight=weight)
     CheckTypeTrait.objects.create(check_type=check_type, trait=skill.trait, weight=weight)
+    ensure_identification_check()


### PR DESCRIPTION
Closes #1107

## Summary

Appearance & Identity slice 5 (#1107): the PC-to-PC identification loop from Apostate's 2026-07-03 ruling — the missing other half of the mask fiction. New 'Identification' CheckType (intellect+Investigation — deliberately distinct from Search's perception pairing); identification_difficulty staged by familiarity (active relationship + the true persona's fame_tier; additive combine rule is a flagged PLACEHOLDER pending ruling) against the disguise's concealment baseline; vast gaps auto-fail without a roll; an optional named guess eases a rollable check but never rescues auto-fail (ratified). attempt_identification writes PersonaDiscovery on success (second producer beside GM PERSONA_LINK clues, via a shared extracted helper — clue path behavior-identical); a botch fake-IDs a random active Functionary NPC — structurally NO path can name a PC on failure/botch (adversarially verified at service, action, telnet, web-toast, and scene-log surfaces); failure/auto-fail/ineligible are oracle-indistinguishable everywhere. Surfaces: IdentifyAction (registry key 'identify'), telnet 'identify <target>[=<guess>]', web via PersonaContextMenu dispatching the REST registry endpoint (deliberately NOT the consent pipeline — a mid-review Critical caught the panel wire giving the mask-wearer a veto + crashing; fixed and re-approved), roller-only result messaging, outcome-blind attempt line in the scene log. Identification targets fake-name personas only; overlay-only disguises are ineligible (their pierce contest remains future work). Docs: appearance_and_identity.md's stale 'senior dev's domain' scope-out replaced with the ratified loop design; glossary + roadmap + INDEX in tandem. Deferred per Apostate's own '(not yet in scope)': crafted disguise kits — filed as #2249. Review trail: 4 task reviews (incl. adversarial oracle pass) + 2 fix waves + final whole-branch review (READY TO MERGE, no findings).

## Follow-ups filed

- #2249

## Notes

- Spec: reviewed & approved on #1107 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch from ca19bd11b; already up to date at PR time.

<!-- last-addressed-comment: 0 -->