### PR TITLE
Telnet parity question: direct GM dramatic-moment tagging (moment tag <char>=<type>)

### DIFF
--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -876,7 +876,7 @@ actions, backends, and service functions.
   wrapper resolving a pending entry-flourish offer via `ResolveFlourishOfferAction`.
 
 ### Magic-Adjacent Commands (`commands/`)
-- **`dramatic_moments.py`** (#2183): `CmdMoment` (`moment`) — the GM-facing
+- **`dramatic_moments.py`** (#2183, #2227): `CmdMoment` (`moment`) — the GM-facing
   Dramatic Moment Suggestion inbox surfaced by technique entrances. `moment suggestions`
   lists PENDING suggestions for the active scene here; `moment confirm <id>` / `moment
   dismiss <id>` resolve one. Account-authorized (mirrors `CmdEvent`'s host-lifecycle
@@ -884,7 +884,12 @@ actions, backends, and service functions.
   `ConfirmDramaticMomentSuggestionAction` / `DismissDramaticMomentSuggestionAction`
   (`actions/definitions/dramatic_moments.py`) — the same seam the web
   `DramaticMomentSuggestionViewSet` uses. GM-gated (scene GM, owner, or staff) entirely in
-  the Actions; no business logic in the command.
+  the Actions; no business logic in the command. `moment tag <character>=<type>` (#2227)
+  is the direct-tagging telnet parity for the web `DramaticMomentTagDialog` — a thin
+  command calling `create_dramatic_moment_tag` directly (the same service the web
+  serializer calls, not via an Action). `moment tag list` browses the authored
+  `DramaticMomentType` catalog. Both GM-gated via `_account_can_gm_scene` on the caller's
+  active scene.
 
 ### Frontend Integration
 - **`frontend.py`**: `FrontendMetadataMixin` — for non-action commands (builder, page)

--- a/src/commands/dramatic_moments.py
+++ b/src/commands/dramatic_moments.py
@@ -23,23 +23,30 @@ from commands.command import ArxCommand
 from commands.exceptions import CommandError
 
 if TYPE_CHECKING:
+    from evennia.accounts.models import AccountDB
+
     from world.scenes.models import Scene
 
 _SUBVERB_SUGGESTIONS = "suggestions"
 _SUBVERB_CONFIRM = "confirm"
 _SUBVERB_DISMISS = "dismiss"
-_USAGE = "Usage: moment suggestions|confirm <id>|dismiss <id>"
+_SUBVERB_TAG = "tag"
+_TAG_LIST_ARG = "list"
+_USAGE = "Usage: moment suggestions|confirm <id>|dismiss <id>|tag <character>=<type>|tag list"
 
 
 class CmdMoment(ArxCommand):
-    """List and resolve dramatic-moment suggestions surfaced by technique entrances.
+    """List and resolve dramatic-moment suggestions; tag dramatic moments.
 
     Usage:
         moment suggestions   — list PENDING suggestions for the active scene here
         moment confirm <id>  — confirm a suggestion (mints the dramatic-moment tag)
         moment dismiss <id>  — dismiss a suggestion
+        moment tag <char>=<type> — tag a character's dramatic moment (GM)
+        moment tag list      — list available dramatic-moment types (GM)
 
-    GM-gated: only the active scene's GM, owner, or staff may list, confirm, or dismiss.
+    GM-gated: only the active scene's GM, owner, or staff may list, confirm,
+    dismiss, or tag.
     """
 
     key = "moment"
@@ -66,6 +73,8 @@ class CmdMoment(ArxCommand):
             self._resolve(rest, confirm=True)
         elif subverb == _SUBVERB_DISMISS:
             self._resolve(rest, confirm=False)
+        elif subverb == _SUBVERB_TAG:
+            self._handle_tag(rest)
         else:
             raise CommandError(_USAGE)
 
@@ -80,7 +89,7 @@ class CmdMoment(ArxCommand):
             raise CommandError(msg)
         return scene
 
-    def _account(self) -> object:
+    def _account(self) -> AccountDB:
         """The caller's account (confirm/dismiss are account-authorized)."""
         account = self.caller.account
         if account is None:
@@ -140,3 +149,87 @@ class CmdMoment(ArxCommand):
         result = action_cls().run(actor=None, account=account, suggestion_id=suggestion_id)
         if result.message:
             self.msg(result.message)
+
+    # -- tag subverb -----------------------------------------------------------
+
+    def _handle_tag(self, rest: str) -> None:
+        """``moment tag <character>=<type label>`` or ``moment tag list``."""
+        if not rest:
+            raise CommandError(_USAGE)
+        if rest.lower() == _TAG_LIST_ARG:
+            self._handle_tag_list()
+            return
+        if "=" not in rest:
+            raise CommandError(_USAGE)
+        name, type_label = (part.strip() for part in rest.split("=", 1))
+        if not name or not type_label:
+            raise CommandError(_USAGE)
+
+        scene = self._active_scene()
+        account = self._account()
+        from actions.definitions.dramatic_moments import _account_can_gm_scene  # noqa: PLC0415
+
+        if not _account_can_gm_scene(account, scene):
+            msg = "Only the scene's GM, owner, or staff may tag dramatic moments."
+            raise CommandError(msg)
+
+        target = self.caller.search(name, global_search=True)
+        if target is None:
+            return
+
+        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL, STRING_LITERAL
+        if sheet is None:
+            self.msg("That is not a character.")
+            return
+
+        from world.magic.models.dramatic_moment import DramaticMomentType  # noqa: PLC0415
+        from world.magic.services.gain import create_dramatic_moment_tag  # noqa: PLC0415
+
+        moment_type = DramaticMomentType.objects.filter(label__iexact=type_label).first()
+        if moment_type is None:
+            available = ", ".join(
+                str(m.label) for m in DramaticMomentType.objects.order_by("label")
+            )
+            self.msg(f"No dramatic-moment type named '{type_label}'. Available: {available}")
+            return
+
+        from world.magic.exceptions import (  # noqa: PLC0415
+            DramaticMomentCapExceeded,
+            EndorsementValidationError,
+        )
+
+        try:
+            create_dramatic_moment_tag(
+                character_sheet=sheet,
+                moment_type=moment_type,
+                tagged_by=account,
+                scene=scene,
+            )
+        except (EndorsementValidationError, DramaticMomentCapExceeded) as exc:
+            self.msg(exc.user_message)
+            return
+
+        self.msg(
+            f"You tagged {target.db_key} with '{moment_type.label}'. Resonance and renown awarded."
+        )
+
+    def _handle_tag_list(self) -> None:
+        """``moment tag list`` — show available DramaticMomentType rows."""
+        scene = self._active_scene()
+        account = self._account()
+        from actions.definitions.dramatic_moments import _account_can_gm_scene  # noqa: PLC0415
+
+        if not _account_can_gm_scene(account, scene):
+            msg = "Only the scene's GM, owner, or staff may list dramatic-moment types."
+            raise CommandError(msg)
+
+        from world.magic.models.dramatic_moment import DramaticMomentType  # noqa: PLC0415
+
+        types = list(DramaticMomentType.objects.select_related("resonance").order_by("label"))
+        if not types:
+            self.msg("No dramatic-moment types are defined.")
+            return
+        lines = ["|wAvailable dramatic-moment types:|n"]
+        lines.extend(f"  {mt.label} — {mt.resonance.name} ({mt.resonance_amount})" for mt in types)
+        lines.append("\nUse: moment tag <character>=<type>")
+        self.msg("\n".join(lines))

--- a/src/commands/tests/test_moment_command.py
+++ b/src/commands/tests/test_moment_command.py
@@ -170,3 +170,127 @@ class MomentTelnetE2ETest(TestCase):
         )
         msg = self.gm_character.msg.call_args[0][0]
         self.assertIn("already", msg.lower())
+
+    # ------------------------------------------------------------------
+    # tag list
+    # ------------------------------------------------------------------
+
+    def test_tag_list_shows_types_for_gm(self) -> None:
+        _run(self.gm_character, "tag list")
+
+        self.gm_character.msg.assert_called()
+        msg = self.gm_character.msg.call_args[0][0]
+        self.assertIn(self.moment_type.label, msg)
+
+    def test_non_gm_tag_list_refused(self) -> None:
+        _run(self.outsider_character, "tag list")
+
+        self.outsider_character.msg.assert_called()
+        msg = self.outsider_character.msg.call_args[0][0]
+        self.assertIn("gm", msg.lower())
+
+    # ------------------------------------------------------------------
+    # tag <character>=<type>
+    # ------------------------------------------------------------------
+
+    def test_gm_tag_creates_tag_and_grants_resonance(self) -> None:
+        """GM tags a character — tag row created, resonance granted."""
+        from world.magic.models import CharacterResonance
+
+        target_sheet = CharacterSheetFactory()
+        target_char = target_sheet.character
+        CharacterResonanceFactory(
+            character_sheet=target_sheet,
+            resonance=self.moment_type.resonance,
+        )
+
+        _run(self.gm_character, f"tag {target_char.db_key}={self.moment_type.label}")
+
+        from world.magic.models.dramatic_moment import DramaticMomentTag
+
+        tag = DramaticMomentTag.objects.get(
+            character_sheet=target_sheet, moment_type=self.moment_type
+        )
+        self.assertEqual(tag.tagged_by, self.gm_account)
+        self.assertEqual(tag.scene, self.scene)
+        cr = CharacterResonance.objects.get(
+            character_sheet=target_sheet, resonance=self.moment_type.resonance
+        )
+        self.assertEqual(cr.balance, self.moment_type.resonance_amount)
+        self.gm_character.msg.assert_called()
+        msg = self.gm_character.msg.call_args[0][0]
+        self.assertIn("tagged", msg.lower())
+
+    def test_non_gm_tag_refused(self) -> None:
+        target_sheet = CharacterSheetFactory()
+        target_char = target_sheet.character
+        CharacterResonanceFactory(
+            character_sheet=target_sheet,
+            resonance=self.moment_type.resonance,
+        )
+
+        _run(self.outsider_character, f"tag {target_char.db_key}={self.moment_type.label}")
+
+        from world.magic.models.dramatic_moment import DramaticMomentTag
+
+        self.assertFalse(DramaticMomentTag.objects.filter(moment_type=self.moment_type).exists())
+        self.outsider_character.msg.assert_called()
+        msg = self.outsider_character.msg.call_args[0][0]
+        self.assertIn("gm", msg.lower())
+
+    def test_tag_unknown_type_lists_available(self) -> None:
+        target_sheet = CharacterSheetFactory()
+        target_char = target_sheet.character
+        CharacterResonanceFactory(
+            character_sheet=target_sheet,
+            resonance=self.moment_type.resonance,
+        )
+
+        _run(self.gm_character, f"tag {target_char.db_key}=NonexistentType")
+
+        self.gm_character.msg.assert_called()
+        msg = self.gm_character.msg.call_args[0][0]
+        self.assertIn(self.moment_type.label, msg)
+
+    def test_tag_unclaimed_resonance_surfaces_error(self) -> None:
+        """Target hasn't claimed the type's resonance → EndorsementValidationError."""
+        target_sheet = CharacterSheetFactory()
+        target_char = target_sheet.character
+        # No CharacterResonance for this resonance on target_sheet
+
+        _run(self.gm_character, f"tag {target_char.db_key}={self.moment_type.label}")
+
+        self.gm_character.msg.assert_called()
+        msg = self.gm_character.msg.call_args[0][0]
+        self.assertIn("not claimed", msg.lower())
+
+    def test_tag_per_scene_cap_surfaces_error(self) -> None:
+        """Cap already reached → DramaticMomentCapExceeded surfaces."""
+        from world.magic.services.gain import create_dramatic_moment_tag
+
+        target_sheet = CharacterSheetFactory()
+        target_char = target_sheet.character
+        CharacterResonanceFactory(
+            character_sheet=target_sheet,
+            resonance=self.moment_type.resonance,
+        )
+        # moment_type has per_scene_cap=1 — tag once directly via the service
+        create_dramatic_moment_tag(
+            character_sheet=target_sheet,
+            moment_type=self.moment_type,
+            tagged_by=self.gm_account,
+            scene=self.scene,
+        )
+
+        _run(self.gm_character, f"tag {target_char.db_key}={self.moment_type.label}")
+
+        self.gm_character.msg.assert_called()
+        msg = self.gm_character.msg.call_args[0][0]
+        self.assertIn("maximum", msg.lower())
+
+    def test_tag_missing_equals_is_usage_error(self) -> None:
+        _run(self.gm_character, "tag SomeCharWithoutEquals")
+
+        self.gm_character.msg.assert_called()
+        msg = self.gm_character.msg.call_args_list[0][0][0]
+        self.assertIn("usage", msg.lower())

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -1103,6 +1103,15 @@ Raises `EndorsementValidationError` (unclaimed resonance) or `DramaticMomentCapE
 - `GET /api/magic/dramatic-moment-tags/` — list tags; filterable by `character_sheet`
   and `scene`; paginated.
 
+**Telnet (#2227):**
+
+- `moment tag <character>=<type>` — direct GM tagging from telnet; thin command
+  calling `create_dramatic_moment_tag` directly (the same service the web serializer
+  calls). Target resolved by name (`caller.search(global_search=True)`), type by
+  `label__iexact`. GM-gated via `_account_can_gm_scene` on the caller's active scene.
+- `moment tag list` — lists available `DramaticMomentType` rows (label + resonance +
+  amount), same GM gate.
+
 **Django admin (`admin.py`):**
 
 - `DramaticMomentTypeAdmin` — full CRUD for the authored catalog. Fields:


### PR DESCRIPTION
Closes #2227

## Summary

Extends CmdMoment with `moment tag <character>=<type>` and `moment tag list` subverbs, giving telnet GMs parity with the web DramaticMomentTagDialog. Calls the existing `create_dramatic_moment_tag` service directly (the same seam the web serializer uses); no new Action, model, service, or migration.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2227 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: clean rebase, no conflicts

<!-- last-addressed-comment: 0 -->