### PR TITLE
Playing multiple characters simultaneously, sanely (#2155)

### DIFF
--- a/docs/roadmap/rp-scenes.md
+++ b/docs/roadmap/rp-scenes.md
@@ -328,6 +328,19 @@ resolving on accept).
 > The scene feed markdown gap the audit also flagged (`EvenniaMessage` never
 > parsing `RichTextInput`'s markdown) is closed by the same restyle: the
 > structured feed renders `FormattedContent`, not raw `EvenniaMessage`.
+>
+> **#2166 multi-character attention — DONE.** A player running several PCs at
+> once gets background-character attention routing, entirely client-side and
+> per-PC scoped: `GameTopBar`/`GameWindow` badge each alt character by tier
+> (`sessionAttention` — red numeric for a direct whisper/@-target, muted dot
+> for ambient activity, active character excluded); an unseen background
+> whisper fires a switch-through toast; duel challenges and scene action
+> (consent) requests addressed to ANY played character surface account-wide
+> and act/respond **as the addressed character**, not whichever PC happens to
+> be active (`DuelChallengeNotifier` fix + new `ConsentAttentionNotifier`,
+> backed by a new `role=incoming` filter on `/api/action-requests/`); and
+> every composer carries a standing "speaking as" identity chip. See
+> `docs/systems/scenes.md`'s "#2166 multi-character attention" subsection.
 
 - **Rich text editor** — DONE. `RichTextInput` (toolbar, shortcuts, color picker,
   `@name` autocomplete) composes into scenes on `/game`; the feed renders it via

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -408,7 +408,16 @@ with `distinct_initiators >= MIN_ENGAGEMENT_BAR` (currently 2) are granted Kudos
 - `POST /api/action-requests/` - Dispatch a new action request (single- or multi-target)
 - `POST /api/action-requests/{id}/respond/` - Accept or deny a primary-target request; also handles additional-target consent when `target_persona_id` is included in the payload
 
-**Filters:** `scene`, `status`, `initiator`, `target`
+**Filters:** `scene`, `status`, `initiator`, `target`, `role` (#2166 — `incoming`/
+`outgoing`, mirroring `world.combat.filters.DuelChallengeFilter.role` verbatim;
+narrows the queryset's already-account-scoped `Q(initiator_persona_id__in=...) |
+Q(target_persona_id__in=...)` — every persona across every character the
+account has ever played, via `get_account_personas` — down to just the
+`target_persona_id__in=...` side for `incoming`). `GET
+/api/action-requests/?status=pending&role=incoming` is what
+`ConsentAttentionNotifier` polls for an account-wide "pending requests
+addressed to any of my played characters" view; no `scene` param needed, and
+it never surfaces another account's requests.
 
 ### Action Targets (`/api/action-targets/`)
 
@@ -766,6 +775,64 @@ never message content) via `threadTabsStorage.ts`'s `localStorage` helpers, and
 `gameSlice` resets both tab fields whenever the session's scene id actually
 changes, since a tab pointing at a previous scene's thread set is unsafe to keep
 open.
+
+### #2166 multi-character attention
+
+Cross-character attention routing so a player running several PCs at once
+doesn't have to poll every tab for background activity — all of it client-side
+and per-PC scoped, no new server data or write path.
+
+**Two-tier attention derivation:** `sessionAttention(session, personaId)`
+(`frontend/src/game/attention.ts`) is a pure, selector-side function reusing
+#2165's `getThreadKey`/`countUnread` grouping against
+`threadLastSeen`/`sceneBaselineId` — the same threshold rule the tab strip's
+own unread badges already use, just re-run per background session instead of
+per open tab. `direct` = unread on `whisper:*` threads plus `target:*` threads
+that include that session's `personaId` (an @-target, duel challenge, or
+consent request aimed at that persona specifically); `ambient` = any other
+thread unread, or the legacy `session.unread` scalar. `GameTopBar`'s alt
+avatars and `GameWindow`'s puppet tab bar both render the tier as a red
+numeric badge (direct) or a muted dot (ambient) — the **active** character is
+always excluded (its own attention already lives in `ConversationTabStrip`'s
+per-tab badges), so nothing double-counts.
+
+**Whisper toasts:** `handleInteractionPayload.ts` (`frontend/src/hooks/`)
+fires one toast when a whisper lands on a session that isn't the active one
+and wasn't authored by that session's own persona, deduped per
+`character:interactionId` (a shared whisper delivered to two of the player's
+own characters toasts once per character, not once total). Clicking the toast
+switches the active session, opens the whisper's thread tab, and navigates to
+`/game` — the same switch-through a player would do by hand.
+
+**Right-character prompt dispatch:** duel challenges and scene action
+(consent) requests addressed to a background character surface and act **as
+that character**, not the currently-active one. `DuelChallengeNotifier`
+(`frontend/src/combat/`) already polled account-wide; the fix was resolving
+each challenge's `challenged` CharacterSheet id against the account's roster
+and binding `useDispatchPlayerAction` to that character per-toast, so Accept/
+Decline dispatch under the addressed character's id even while a different PC
+is active. `ConsentAttentionNotifier` (`frontend/src/scenes/components/`) is
+the same shape for scene action requests: it polls
+`GET /api/action-requests/?status=pending&role=incoming` (see the `role`
+filter under Action Requests below), resolves the request's `target_persona`
+against the roster's `primary_persona_id`/`active_persona_id`, and toasts
+"Consent request for `<Character>`: `<action>` from `<initiator>`" with no
+accept/deny in the toast itself — clicking only switches to (or starts a
+session for) the addressed character and navigates to `/game`, where the
+existing per-scene `ConsentPrompt` owns the graded response.
+
+**Speaking-as chip:** every composer (`CommandInput.tsx`, on both `/game` and
+`/scenes/:id`) renders a standing avatar+name chip naming whichever character
+is about to speak, even for single-character players — a permanent answer to
+"who am I talking as right now" independent of the attention badges above.
+
+**Per-PC scoping ("Never out alts", `docs/roadmap/design-tenets.md`):** all of
+the above is derived client-side from data the account already legitimately
+holds (its own sessions' cached interactions, its own roster's persona ids,
+requests already scoped server-side to `get_account_personas`) — no new
+account-wide field is added to any payload another player can see, and
+nothing here merges or unions what two of an account's characters can
+perceive.
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,6 +96,7 @@ import { StaffGMApplicationDetailPage } from './staff/pages/StaffGMApplicationDe
 import { RouletteModal } from './components/roulette/RouletteModal';
 import { Toaster } from './components/ui/sonner';
 import { DuelChallengeNotifier } from './combat/DuelChallengeNotifier';
+import { ConsentAttentionNotifier } from './scenes/components/ConsentAttentionNotifier';
 
 // ---------------------------------------------------------------------------
 // Lazy-loaded stories pages (React.lazy for route-level code splitting)
@@ -976,6 +977,7 @@ function App() {
       <RouletteModal />
       <Toaster />
       <DuelChallengeNotifier />
+      <ConsentAttentionNotifier />
     </Layout>
   );
 }

--- a/frontend/src/combat/DuelChallengeNotifier.tsx
+++ b/frontend/src/combat/DuelChallengeNotifier.tsx
@@ -14,31 +14,56 @@
  * dispatch is never silently lost (the id was already added to toastedIds when the
  * toast first fired, so a dismissed-on-error toast would otherwise never resurface).
  *
+ * Right-character dispatch (#2166): `useDuelChallengeInbox` is already account-wide
+ * (server-scoped to `request.user.played_character_sheet_ids`, not the active
+ * character), so a challenge addressed to a *background* character can appear
+ * while a different character is active. Each toast resolves the challenged
+ * character's own roster entry (`challenge.challenged.id` is the CharacterSheet
+ * pk, matching `MyRosterEntry.character_id`) and dispatches Accept/Decline as
+ * THAT character — never the active one. Resolution + the `useDispatchPlayerAction`
+ * call both live in `DuelChallengeToastBody` (one component instance per toast, its
+ * own hook call bound to the resolved character id) rather than the notifier's
+ * top level, because a single top-level hook call can only bind one fixed
+ * character and multiple background challenges may target different characters
+ * concurrently. The dispatch is plain REST by character id
+ * (`POST /api/actions/characters/{characterId}/dispatch/`) — it works whether or
+ * not that character has a live session/tab open.
+ *
  * Renders nothing itself — `null` always, purely a side-effect component.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
+import type { MyRosterEntry } from '@/roster/types';
 import { useDuelChallengeInbox, useDispatchPlayerAction } from './queries';
+import type { DuelChallenge } from './api';
 import { registryRef } from './duels/DuelChallengeControls';
 
 interface ToastBodyProps {
-  challengerName: string;
-  onAccept: () => Promise<void>;
-  onDecline: () => Promise<void>;
+  toastId: string | number;
+  challenge: DuelChallenge;
+  /** The challenged character's own sheet id — dispatch always uses this, never the active character. */
+  characterId: number;
+  characterName: string;
 }
 
-function DuelChallengeToastBody({ challengerName, onAccept, onDecline }: ToastBodyProps) {
+function DuelChallengeToastBody({
+  toastId,
+  challenge,
+  characterId,
+  characterName,
+}: ToastBodyProps) {
+  const { mutateAsync } = useDispatchPlayerAction(characterId);
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function handle(action: () => Promise<void>) {
+  async function handle(action: 'accept' | 'decline') {
     setIsPending(true);
     setError(null);
     try {
-      await action();
+      await mutateAsync(registryRef(action, { challenge_id: challenge.id }));
+      toast.dismiss(toastId);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to respond to the challenge');
     } finally {
@@ -52,14 +77,18 @@ function DuelChallengeToastBody({ challengerName, onAccept, onDecline }: ToastBo
       data-testid="duel-challenge-toast"
     >
       <p className="text-sm text-foreground">
-        <span className="font-semibold">{challengerName}</span> has challenged you to a duel.
+        <span className="font-semibold">{challenge.challenger.name}</span> has challenged{' '}
+        <span className="font-semibold">{characterName}</span> to a duel.
+      </p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Responding as <span className="font-semibold">{characterName}</span>.
       </p>
       <div className="mt-2 flex gap-2">
         <button
           type="button"
           disabled={isPending}
           onClick={() => {
-            handle(onAccept).catch(() => {});
+            handle('accept').catch(() => {});
           }}
           data-testid="duel-toast-accept-btn"
           className="rounded border border-emerald-500/60 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
@@ -70,7 +99,7 @@ function DuelChallengeToastBody({ challengerName, onAccept, onDecline }: ToastBo
           type="button"
           disabled={isPending}
           onClick={() => {
-            handle(onDecline).catch(() => {});
+            handle('decline').catch(() => {});
           }}
           data-testid="duel-toast-decline-btn"
           className="rounded border border-destructive/60 bg-destructive/10 px-3 py-1 text-xs font-semibold text-destructive disabled:cursor-not-allowed disabled:opacity-50"
@@ -87,20 +116,25 @@ function DuelChallengeToastBody({ challengerName, onAccept, onDecline }: ToastBo
   );
 }
 
+/** Resolve the roster entry (if any) for the CharacterSheet id the challenge is addressed to. */
+function resolveChallenged(
+  challenge: DuelChallenge,
+  myRosterEntries: MyRosterEntry[]
+): { characterId: number; characterName: string } {
+  const entry = myRosterEntries.find((e) => e.character_id === challenge.challenged.id);
+  return {
+    characterId: entry?.character_id ?? challenge.challenged.id,
+    characterName: entry?.name ?? challenge.challenged.name,
+  };
+}
+
 export function DuelChallengeNotifier() {
-  const activeCharacter = useAppSelector((state) => state.game.active);
   const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
-  const activeEntry = useMemo(
-    () => myRosterEntries.find((e) => e.name === activeCharacter) ?? null,
-    [myRosterEntries, activeCharacter]
-  );
-  const characterId = activeEntry?.character_id ?? 0;
 
   const { data: incomingChallenges = [] } = useDuelChallengeInbox({
-    enabled: characterId > 0,
+    enabled: myRosterEntries.length > 0,
     role: 'incoming',
   });
-  const { mutateAsync } = useDispatchPlayerAction(characterId);
 
   const toastedIds = useRef<Set<number>>(new Set());
 
@@ -109,21 +143,18 @@ export function DuelChallengeNotifier() {
       if (toastedIds.current.has(challenge.id)) continue;
       toastedIds.current.add(challenge.id);
 
+      const { characterId, characterName } = resolveChallenged(challenge, myRosterEntries);
+
       toast.custom((toastId) => (
         <DuelChallengeToastBody
-          challengerName={challenge.challenger.name}
-          onAccept={async () => {
-            await mutateAsync(registryRef('accept', { challenge_id: challenge.id }));
-            toast.dismiss(toastId);
-          }}
-          onDecline={async () => {
-            await mutateAsync(registryRef('decline', { challenge_id: challenge.id }));
-            toast.dismiss(toastId);
-          }}
+          toastId={toastId}
+          challenge={challenge}
+          characterId={characterId}
+          characterName={characterName}
         />
       ));
     }
-  }, [incomingChallenges, mutateAsync]);
+  }, [incomingChallenges, myRosterEntries]);
 
   return null;
 }

--- a/frontend/src/combat/__tests__/DuelChallengeNotifier.test.tsx
+++ b/frontend/src/combat/__tests__/DuelChallengeNotifier.test.tsx
@@ -4,21 +4,21 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { DuelChallengeNotifier } from '../DuelChallengeNotifier';
 
 const mockUseDuelChallengeInbox = vi.fn();
+const mockUseDispatchPlayerAction = vi.fn();
 const mockMutateAsync = vi.fn();
 vi.mock('@/combat/queries', () => ({
   useDuelChallengeInbox: (...args: unknown[]) => mockUseDuelChallengeInbox(...args),
-  useDispatchPlayerAction: () => ({ mutateAsync: mockMutateAsync, isPending: false }),
+  useDispatchPlayerAction: (characterId: number) => {
+    mockUseDispatchPlayerAction(characterId);
+    return { mutateAsync: mockMutateAsync, isPending: false };
+  },
 }));
 
+let mockRosterEntries: unknown[] = [
+  { id: 1, name: 'TestChar', character_id: 42, primary_persona_id: 77 },
+];
 vi.mock('@/roster/queries', () => ({
-  useMyRosterEntriesQuery: () => ({
-    data: [{ id: 1, name: 'TestChar', character_id: 42, primary_persona_id: 77 }],
-  }),
-}));
-
-vi.mock('@/store/hooks', () => ({
-  useAppSelector: (selector: (state: unknown) => unknown) =>
-    selector({ game: { active: 'TestChar' } }),
+  useMyRosterEntriesQuery: () => ({ data: mockRosterEntries }),
 }));
 
 const toastCustomMock = vi.fn();
@@ -46,6 +46,7 @@ describe('DuelChallengeNotifier', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseDuelChallengeInbox.mockReturnValue({ data: [], isLoading: false });
+    mockRosterEntries = [{ id: 1, name: 'TestChar', character_id: 42, primary_persona_id: 77 }];
   });
 
   it('fires a custom toast the first time a new incoming challenge appears', () => {
@@ -116,6 +117,47 @@ describe('DuelChallengeNotifier', () => {
     });
     await waitFor(() => {
       expect(toastDismissMock).toHaveBeenCalledWith('toast-1');
+    });
+  });
+
+  it('dispatches as the challenged (background) character, not the active one', async () => {
+    mockRosterEntries = [
+      { id: 1, name: 'CharA', character_id: 42, primary_persona_id: 77 },
+      { id: 2, name: 'CharB', character_id: 99, primary_persona_id: 88 },
+    ];
+    mockUseDuelChallengeInbox.mockReturnValue({
+      data: [
+        {
+          id: 7,
+          challenger: { id: 900, name: 'Rivalis' },
+          challenged: { id: 99, name: 'CharB' },
+          status: 'pending' as const,
+          created_at: '2026-07-11T00:00:00Z',
+          resolved_at: null,
+          resulting_encounter: null,
+        },
+      ],
+      isLoading: false,
+    });
+    mockMutateAsync.mockResolvedValue({});
+
+    render(<DuelChallengeNotifier />);
+
+    const renderFn = toastCustomMock.mock.calls[0][0] as (id: string | number) => JSX.Element;
+    const { getByTestId, getByText } = render(renderFn('toast-1'));
+
+    // Resolved against B's roster entry, never the active character (A, id 42).
+    expect(mockUseDispatchPlayerAction).toHaveBeenCalledWith(99);
+    expect(mockUseDispatchPlayerAction).not.toHaveBeenCalledWith(42);
+    expect(getByText(/Responding as/)).toHaveTextContent('Responding as CharB.');
+
+    fireEvent.click(getByTestId('duel-toast-accept-btn'));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        ref: { backend: 'registry', registry_key: 'accept' },
+        kwargs: { challenge_id: 7 },
+      });
     });
   });
 

--- a/frontend/src/combat/pages/CombatScenePage.tsx
+++ b/frontend/src/combat/pages/CombatScenePage.tsx
@@ -265,6 +265,11 @@ export function CombatScenePage() {
               />
               <CommandInput
                 character={activeCharacter}
+                speakingAs={
+                  activeEntry
+                    ? { name: activeEntry.name, thumbnailUrl: activeEntry.profile_picture_url }
+                    : undefined
+                }
                 composerMode={composerMode}
                 onModeChange={handleComposerModeChange}
                 targetToAppend={targetToAppend}

--- a/frontend/src/game/CLAUDE.md
+++ b/frontend/src/game/CLAUDE.md
@@ -26,7 +26,14 @@ Core game interface for real-time RPG interaction with WebSocket communication a
   `ConversationTabStrip` above the feed when `conversationTabs` is passed
   (#2165), and remembers each conversation tab's scroll offset (`Map<threadKey,
 scrollTop>`), restoring it on tab switch and re-pinning to the bottom only
-  when the reader was already at the bottom for that tab.
+  when the reader was already at the bottom for that tab. The multi-puppet
+  session tab bar carries the same direct/ambient `AttentionBadge` as
+  `GameTopBar` (#2166), keyed per session name via each character's
+  `primary_persona_id` — with one guard `GameTopBar` doesn't need: the
+  **active** puppet's own tab never badges (`name !== active`), since its
+  attention already surfaces via `ConversationTabStrip`; badging it too would
+  double-count the active character's own unseen activity on its own
+  already-highlighted tab.
 - **`threadTabsStorage.ts`**: `loadThreadTabs`/`saveThreadTabs` (#2165) —
   client-local persistence of the open-tab layout (thread **keys** only, never
   message content) in `localStorage`, keyed per character+scene
@@ -34,11 +41,29 @@ scrollTop>`), restoring it on tab switch and re-pinning to the bottom only
   scene's entry, older entries for the same character are pruned on save.
   Best-effort: any storage error (unavailable, unparsable) is swallowed and
   treated as "nothing stored."
+- **`attention.ts`**: `sessionAttention(session, personaId)` (#2166) — pure,
+  selector-side two-tier attention derivation for one character's session, no
+  new Redux write path. Reuses `getThreadKey`/`countUnread` (exported from
+  `useThreading.ts`) against `threadLastSeen`/`sceneBaselineId`, the same
+  grouping #2165's tab strip badges use. `direct` = unread on `whisper:*`
+  threads plus `target:*` threads that include `personaId` (an @-target,
+  duel challenge, or consent request aimed at that persona specifically);
+  `ambient` = any other thread unread, or the legacy `session.unread` scalar.
+  Requires a resolved `personaId` to route to `direct` at all — before the
+  roster loads, whisper/target unread routes to `ambient` instead, so a
+  session's own echoed whisper never misreads as direct pre-roster-load.
 
 ### Layout (`components/`)
 
 - **`GameLayout.tsx`**: Three-column responsive grid (left sidebar, center, right sidebar)
-- **`GameTopBar.tsx`**: Character avatars, connection status, character switching
+- **`GameTopBar.tsx`**: Character avatars, connection status, character
+  switching. Each alt character's avatar carries a two-tier attention
+  indicator (#2166, `sessionAttention` from `attention.ts`): a red numeric
+  badge for _direct_ attention (an unseen whisper or @-target aimed at that
+  character), else a muted dot for _ambient_ (any other unseen activity in
+  that session), else nothing. The active character is structurally excluded
+  (this bar only ever renders alts) — its own attention lives in
+  `ConversationTabStrip`'s per-tab badges, not here.
 - **`ConversationSidebar.tsx`**: Left sidebar. Renders the scene's
   `ThreadSidebar` (room/place/whisper/target threads) when `GamePage` passes
   threading state for an active scene; otherwise falls back to a static
@@ -66,7 +91,16 @@ scrollTop>`), restoring it on tab switch and re-pinning to the bottom only
 - **`SystemLane.tsx`**: Muted, collapsible strip for system/channel/error
   chatter shown alongside the structured scene feed (#2156) — no
   `bg-black`/`font-mono`, just a quiet compact strip that expands on click.
-- **`CommandInput.tsx`**: Textarea input with Enter to submit, Shift+Enter for newline, command history
+- **`CommandInput.tsx`**: Textarea input with Enter to submit, Shift+Enter for
+  newline, command history. Optional `speakingAs?: { name, thumbnailUrl }`
+  prop (#2166) renders a compact `PersonaAvatar` + name chip at the start of
+  `leftSlot`, before `ModeSelector` — a standing "who am I talking as right
+  now" identity marker on the composer, shown even for single-character
+  players. Always renders when supplied; renders nothing when omitted
+  (legacy callers unaffected). `GamePage` supplies it from `activeEntry`;
+  `SceneDetailPage`'s record-page composer supplies the same shape from its
+  own roster lookup. `CombatScenePage`'s composer does not yet thread this
+  prop (out of scope for #2166).
 - **`EvenniaMessage.tsx`**: Game message display and formatting
 
 ### Room Panel (`components/room-panel/`)
@@ -105,6 +139,19 @@ scrollTop>`), restoring it on tab switch and re-pinning to the bottom only
 - **Conversation tabs (#2165)**: Keep several threads (room + place/whisper/target)
   open at once per session; the composer's audience locks to whichever tab is
   active
+- **Cross-character attention (#2166)**: Background characters badge
+  distinctly by tier (`attention.ts`) — direct (whisper/@-target/prompt, red
+  numeric) vs ambient (any other activity, muted dot) — on `GameTopBar` and
+  `GameWindow`'s puppet tabs. A background whisper also fires a switch-through
+  toast (`handleInteractionPayload.ts`, in `frontend/src/hooks/`) that jumps
+  to the right character and thread on click. Duel challenges and consent
+  requests addressed to ANY played character surface account-wide
+  (`DuelChallengeNotifier`, `ConsentAttentionNotifier`) and act/respond **as**
+  the addressed character, not the currently-active one. Every composer
+  carries a "speaking as" identity chip (see `CommandInput.tsx` below). All
+  routing is derived client-side from data already scoped to the account's own
+  personas — no new account-wide payload is rendered to other players ("Never
+  out alts").
 - **Dynamic commands**: Commands discovered from server with generated forms
 - **Real-time updates**: WebSocket integration for live game state
 - **Context menus**: Right-click actions on game entities

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -13,6 +13,8 @@ import {
   setSessionRoom,
   setSessionScene,
   addSceneInteraction,
+  addSessionMessage,
+  setSceneBaseline,
   clearSceneInteractions,
   resetGame,
 } from '@/store/gameSlice';
@@ -692,6 +694,88 @@ describe('GamePage', () => {
       expect(screen.getByText(/no messages yet/i)).toBeInTheDocument();
       expect(screen.queryByLabelText('Thread sidebar')).not.toBeInTheDocument();
       expect(screen.queryByTestId('pose-unit')).not.toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Puppet session tab bar attention badge (#2166) — GameWindow's multi-puppet
+  // tab strip (rendered when 2+ sessions are open) badges the SAME two-tier
+  // `sessionAttention` result as GameTopBar's alt-character avatars.
+  // ---------------------------------------------------------------------------
+
+  describe('puppet tab bar attention badge (#2166)', () => {
+    it('badges a background puppet tab with a numeric direct count on an unseen whisper', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      store.dispatch(startSession(SECOND_NAME));
+      store.dispatch(setSceneBaseline({ character: SECOND_NAME, baselineId: 0 }));
+      store.dispatch(
+        addSceneInteraction({
+          character: SECOND_NAME,
+          interaction: {
+            id: 1,
+            persona: { id: 99, name: 'Other', thumbnail_url: '' },
+            content: 'psst.',
+            mode: 'whisper',
+            timestamp: '2026-01-01T00:00:00Z',
+            scene_id: 200,
+            place_id: null,
+            place_name: null,
+            receiver_persona_ids: [8],
+            target_persona_ids: [],
+          },
+        })
+      );
+      // Back to Aria active; Bianca stays a background session.
+      store.dispatch(setActiveSession(ACTIVE_NAME));
+
+      const { container } = renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      // Scope to the puppet session tab bar itself (GameWindow.tsx) — "Aria"
+      // and "Bianca" also appear as persona names elsewhere in the feed.
+      const tabBar = container.querySelector('.mb-2.flex.gap-2.border-b') as HTMLElement;
+      const biancaTab = within(tabBar).getByText(SECOND_NAME).closest('button') as HTMLElement;
+      expect(within(biancaTab).getByText('1')).toBeInTheDocument();
+    });
+
+    it('shows a muted ambient dot on a background puppet tab with unread but no direct attention', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      store.dispatch(startSession(SECOND_NAME));
+      // Switch back to Aria BEFORE the message arrives, so addSessionMessage
+      // sees an inactive Bianca session and increments her unread scalar.
+      store.dispatch(setActiveSession(ACTIVE_NAME));
+      store.dispatch(
+        addSessionMessage({
+          character: SECOND_NAME,
+          message: { content: 'The kitchen stirs.', timestamp: Date.now(), type: 'text' },
+        })
+      );
+
+      const { container } = renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      const tabBar = container.querySelector('.mb-2.flex.gap-2.border-b') as HTMLElement;
+      const biancaTab = within(tabBar).getByText(SECOND_NAME).closest('button') as HTMLElement;
+      expect(within(biancaTab).queryByText(/[0-9]/)).not.toBeInTheDocument();
+      expect(biancaTab.querySelector('.bg-muted-foreground\\/60')).not.toBeNull();
+    });
+
+    it('renders no badge on the active puppet tab', async () => {
+      store.dispatch(setAccount(mockAccount));
+      seedActiveSceneWithPose();
+      store.dispatch(startSession(SECOND_NAME));
+      store.dispatch(setActiveSession(ACTIVE_NAME));
+
+      const { container } = renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      const tabBar = container.querySelector('.mb-2.flex.gap-2.border-b') as HTMLElement;
+      const ariaTab = within(tabBar).getByText(ACTIVE_NAME).closest('button') as HTMLElement;
+      expect(within(ariaTab).queryByText(/[0-9]/)).not.toBeInTheDocument();
+      expect(ariaTab.querySelector('.bg-muted-foreground\\/60')).toBeNull();
+      expect(ariaTab.querySelector('.bg-red-500')).toBeNull();
     });
   });
 

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -777,6 +777,66 @@ describe('GamePage', () => {
       expect(ariaTab.querySelector('.bg-muted-foreground\\/60')).toBeNull();
       expect(ariaTab.querySelector('.bg-red-500')).toBeNull();
     });
+
+    it('never badges the active puppet tab for its own unseen whisper on a non-selected thread, while a background character with the same shape does badge (#2166 review fold-in)', async () => {
+      store.dispatch(setAccount(mockAccount));
+      // Aria (active) has an unseen whisper on a thread she hasn't opened —
+      // her own attention belongs to ConversationTabStrip, not her puppet tab.
+      seedActiveSceneWithPose();
+      store.dispatch(setSceneBaseline({ character: ACTIVE_NAME, baselineId: 0 }));
+      store.dispatch(
+        addSceneInteraction({
+          character: ACTIVE_NAME,
+          interaction: {
+            id: 2,
+            persona: { id: 99, name: 'Other', thumbnail_url: '' },
+            content: 'psst, over here.',
+            mode: 'whisper',
+            timestamp: '2026-01-01T00:00:01Z',
+            scene_id: 100,
+            place_id: null,
+            place_name: null,
+            receiver_persona_ids: [7],
+            target_persona_ids: [],
+          },
+        })
+      );
+
+      // Bianca (background) gets an unseen whisper of the identical shape —
+      // she still should badge, since #2166's routing is for background puppets.
+      store.dispatch(startSession(SECOND_NAME));
+      store.dispatch(setSceneBaseline({ character: SECOND_NAME, baselineId: 0 }));
+      store.dispatch(
+        addSceneInteraction({
+          character: SECOND_NAME,
+          interaction: {
+            id: 1,
+            persona: { id: 99, name: 'Other', thumbnail_url: '' },
+            content: 'psst.',
+            mode: 'whisper',
+            timestamp: '2026-01-01T00:00:00Z',
+            scene_id: 200,
+            place_id: null,
+            place_name: null,
+            receiver_persona_ids: [8],
+            target_persona_ids: [],
+          },
+        })
+      );
+      store.dispatch(setActiveSession(ACTIVE_NAME));
+
+      const { container } = renderWithProviders(<GamePage />);
+      await screen.findByText('stretches languidly.');
+
+      const tabBar = container.querySelector('.mb-2.flex.gap-2.border-b') as HTMLElement;
+      const ariaTab = within(tabBar).getByText(ACTIVE_NAME).closest('button') as HTMLElement;
+      expect(within(ariaTab).queryByText(/[0-9]/)).not.toBeInTheDocument();
+      expect(ariaTab.querySelector('.bg-muted-foreground\\/60')).toBeNull();
+      expect(ariaTab.querySelector('.bg-red-500')).toBeNull();
+
+      const biancaTab = within(tabBar).getByText(SECOND_NAME).closest('button') as HTMLElement;
+      expect(within(biancaTab).getByText('1')).toBeInTheDocument();
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/frontend/src/game/GamePage.test.tsx
+++ b/frontend/src/game/GamePage.test.tsx
@@ -698,6 +698,21 @@ describe('GamePage', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Speaking-as identity chip (#2166) — the composer always shows the active
+  // character's identity, so a pose can never be mis-attributed.
+  // ---------------------------------------------------------------------------
+
+  it('shows the active character on the speaking-as composer chip', async () => {
+    store.dispatch(setAccount(mockAccount));
+    seedActiveSceneWithPose();
+
+    renderWithProviders(<GamePage />);
+
+    await screen.findByText('stretches languidly.');
+    expect(screen.getByTestId('speaking-as-chip')).toHaveTextContent(ACTIVE_NAME);
+  });
+
+  // ---------------------------------------------------------------------------
   // Puppet session tab bar attention badge (#2166) — GameWindow's multi-puppet
   // tab strip (rendered when 2+ sessions are open) badges the SAME two-tier
   // `sessionAttention` result as GameTopBar's alt-character avatars.

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -481,6 +481,11 @@ export function GamePage() {
               onPoseSubmitted={handlePoseSubmitted}
               isAtPlace={isAtPlace}
               conversationTabs={conversationTabs}
+              speakingAs={
+                activeEntry
+                  ? { name: activeEntry.name, thumbnailUrl: activeEntry.profile_picture_url }
+                  : undefined
+              }
               placeBar={placesRoomId ? <PlaceBar sceneId={placesRoomId} /> : undefined}
               pendingAttachments={
                 sceneId ? (

--- a/frontend/src/game/attention.test.ts
+++ b/frontend/src/game/attention.test.ts
@@ -144,7 +144,7 @@ describe('sessionAttention', () => {
     expect(result).toEqual({ direct: 0, ambient: true });
   });
 
-  it('handles a null personaId (no active persona known) without throwing', () => {
+  it('routes a whisper to ambient (not direct) when personaId is null (pre-roster-load flicker guard)', () => {
     const session = makeSession({
       sceneInteractions: [
         makeInteraction({
@@ -158,6 +158,6 @@ describe('sessionAttention', () => {
 
     const result = sessionAttention(session, null);
 
-    expect(result).toEqual({ direct: 1, ambient: false });
+    expect(result).toEqual({ direct: 0, ambient: true });
   });
 });

--- a/frontend/src/game/attention.test.ts
+++ b/frontend/src/game/attention.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { sessionAttention } from './attention';
+import type { Session } from '@/store/gameSlice';
+import type { InteractionWsPayload } from '@/hooks/types';
+
+const VIEWER_PERSONA_ID = 10;
+
+function makeInteraction(overrides: Partial<InteractionWsPayload> = {}): InteractionWsPayload {
+  return {
+    id: 1,
+    persona: { id: 99, name: 'Other', thumbnail_url: '' },
+    content: 'Hello',
+    mode: 'say',
+    timestamp: '2026-01-01T00:00:00Z',
+    scene_id: 1,
+    place_id: null,
+    place_name: null,
+    receiver_persona_ids: [],
+    target_persona_ids: [],
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    isConnected: true,
+    messages: [],
+    unread: 0,
+    commands: [],
+    room: null,
+    scene: null,
+    sceneInteractions: [],
+    threadLastSeen: {},
+    sceneBaselineId: 0,
+    openThreadTabs: [],
+    activeThreadTab: null,
+    ...overrides,
+  };
+}
+
+describe('sessionAttention', () => {
+  it('counts a whisper to me as direct', () => {
+    const session = makeSession({
+      sceneInteractions: [
+        makeInteraction({
+          id: 5,
+          mode: 'whisper',
+          persona: { id: 99, name: 'Other', thumbnail_url: '' },
+          receiver_persona_ids: [VIEWER_PERSONA_ID],
+        }),
+      ],
+    });
+
+    const result = sessionAttention(session, VIEWER_PERSONA_ID);
+
+    expect(result).toEqual({ direct: 1, ambient: false });
+  });
+
+  it('counts room scroll as ambient, not direct', () => {
+    const session = makeSession({
+      sceneInteractions: [makeInteraction({ id: 5, mode: 'say' })],
+    });
+
+    const result = sessionAttention(session, VIEWER_PERSONA_ID);
+
+    expect(result).toEqual({ direct: 0, ambient: true });
+  });
+
+  it('counts an own-authored whisper as neither direct nor ambient', () => {
+    const session = makeSession({
+      sceneInteractions: [
+        makeInteraction({
+          id: 5,
+          mode: 'whisper',
+          persona: { id: VIEWER_PERSONA_ID, name: 'Me', thumbnail_url: '' },
+          receiver_persona_ids: [99],
+        }),
+      ],
+    });
+
+    const result = sessionAttention(session, VIEWER_PERSONA_ID);
+
+    expect(result).toEqual({ direct: 0, ambient: false });
+  });
+
+  it('counts a target thread that includes me as direct', () => {
+    const session = makeSession({
+      sceneInteractions: [
+        makeInteraction({
+          id: 5,
+          mode: 'say',
+          persona: { id: 99, name: 'Other', thumbnail_url: '' },
+          target_persona_ids: [VIEWER_PERSONA_ID, 42],
+        }),
+      ],
+    });
+
+    const result = sessionAttention(session, VIEWER_PERSONA_ID);
+
+    expect(result).toEqual({ direct: 1, ambient: false });
+  });
+
+  it('clears direct once threadLastSeen marks the whisper thread read', () => {
+    const interaction = makeInteraction({
+      id: 5,
+      mode: 'whisper',
+      persona: { id: 99, name: 'Other', thumbnail_url: '' },
+      receiver_persona_ids: [VIEWER_PERSONA_ID],
+    });
+    const sortedIds = [interaction.persona.id, VIEWER_PERSONA_ID].sort((a, b) => a - b);
+    const threadKey = `whisper:${sortedIds.join(',')}`;
+    const session = makeSession({
+      sceneInteractions: [interaction],
+      threadLastSeen: { [threadKey]: 5 },
+    });
+
+    const result = sessionAttention(session, VIEWER_PERSONA_ID);
+
+    expect(result).toEqual({ direct: 0, ambient: false });
+  });
+
+  it('a target thread NOT aimed at me is ambient, not direct', () => {
+    const session = makeSession({
+      sceneInteractions: [
+        makeInteraction({
+          id: 5,
+          mode: 'say',
+          persona: { id: 99, name: 'Other', thumbnail_url: '' },
+          target_persona_ids: [42, 43],
+        }),
+      ],
+    });
+
+    const result = sessionAttention(session, VIEWER_PERSONA_ID);
+
+    expect(result).toEqual({ direct: 0, ambient: true });
+  });
+
+  it('falls back to the legacy unread scalar for ambient', () => {
+    const session = makeSession({ unread: 3 });
+
+    const result = sessionAttention(session, VIEWER_PERSONA_ID);
+
+    expect(result).toEqual({ direct: 0, ambient: true });
+  });
+
+  it('handles a null personaId (no active persona known) without throwing', () => {
+    const session = makeSession({
+      sceneInteractions: [
+        makeInteraction({
+          id: 5,
+          mode: 'whisper',
+          persona: { id: 99, name: 'Other', thumbnail_url: '' },
+          receiver_persona_ids: [1],
+        }),
+      ],
+    });
+
+    const result = sessionAttention(session, null);
+
+    expect(result).toEqual({ direct: 1, ambient: false });
+  });
+});

--- a/frontend/src/game/attention.ts
+++ b/frontend/src/game/attention.ts
@@ -22,7 +22,11 @@ export interface SessionAttention {
  * `personaId` (an @-target/duel-challenge/consent-request aimed at this
  * persona specifically). `countUnread` already excludes the viewer's own
  * authored interactions, so a thread containing only this persona's own poses
- * contributes to neither tier.
+ * contributes to neither tier. Both require `personaId != null` — until the
+ * roster resolves it, `countUnread` can't exclude the session's own authored
+ * messages, so whisper/target unread routes to `ambient` instead (avoids a
+ * pre-roster-load flicker where a session's own echoed whisper reads as
+ * direct).
  *
  * `ambient` = true when any other thread (room/place scroll, or a `target:*`
  * thread NOT aimed at this persona) has unread, or the legacy `session.unread`
@@ -56,7 +60,12 @@ export function sessionAttention(session: Session, personaId: number | null): Se
 
     const isWhisper = key.startsWith('whisper:');
     const isTargetedAtMe = key.startsWith('target:') && targetIncludes(key, personaId);
-    if (isWhisper || isTargetedAtMe) {
+    // Guard on personaId != null (#2166 review fold-in): countUnread can't
+    // exclude the viewer's own authored interactions without a personaId, so
+    // before the roster loads (personaId still null) a session's own echoed
+    // whisper would otherwise count as unread and get misattributed to
+    // direct. Route it to ambient instead until personaId resolves.
+    if (personaId != null && (isWhisper || isTargetedAtMe)) {
       direct += unread;
     } else {
       ambient = true;

--- a/frontend/src/game/attention.ts
+++ b/frontend/src/game/attention.ts
@@ -1,0 +1,73 @@
+import type { Session } from '@/store/gameSlice';
+import type { Interaction } from '@/scenes/types';
+import { getThreadKey, countUnread } from '@/scenes/hooks/useThreading';
+import { wsPayloadToInteraction } from '@/scenes/hooks/useSceneInteractions';
+
+export interface SessionAttention {
+  /** Total unread across whisper threads + target threads aimed at `personaId`. */
+  direct: number;
+  /** True when any other thread has unread, or the legacy `session.unread` counter is set. */
+  ambient: boolean;
+}
+
+/**
+ * Two-tier attention derivation for one character's session (#2166 Decisions
+ * 4a/4b). Pure and selector-side — no new Redux write path; reuses #2156/#2165's
+ * `getThreadKey`/`countUnread` grouping and threshold rule against
+ * `threadLastSeen`/`sceneBaselineId`.
+ *
+ * `direct` = total unread on `whisper:*` threads (a session only ever receives
+ * whispers addressed to its own persona, so every whisper thread here already
+ * targets this character) plus `target:*` threads whose key includes
+ * `personaId` (an @-target/duel-challenge/consent-request aimed at this
+ * persona specifically). `countUnread` already excludes the viewer's own
+ * authored interactions, so a thread containing only this persona's own poses
+ * contributes to neither tier.
+ *
+ * `ambient` = true when any other thread (room/place scroll, or a `target:*`
+ * thread NOT aimed at this persona) has unread, or the legacy `session.unread`
+ * scalar (pre-#2156 sessions / non-interaction game messages) is nonzero.
+ */
+export function sessionAttention(session: Session, personaId: number | null): SessionAttention {
+  const interactions: Interaction[] = session.sceneInteractions.map(wsPayloadToInteraction);
+  const byThread = new Map<string, Interaction[]>();
+  for (const interaction of interactions) {
+    const key = getThreadKey(interaction);
+    const bucket = byThread.get(key);
+    if (bucket) {
+      bucket.push(interaction);
+    } else {
+      byThread.set(key, [interaction]);
+    }
+  }
+
+  let direct = 0;
+  let ambient = session.unread > 0;
+
+  for (const [key, threadInteractions] of byThread) {
+    const unread = countUnread(
+      threadInteractions,
+      key,
+      session.threadLastSeen,
+      personaId,
+      session.sceneBaselineId
+    );
+    if (unread === 0) continue;
+
+    const isWhisper = key.startsWith('whisper:');
+    const isTargetedAtMe = key.startsWith('target:') && targetIncludes(key, personaId);
+    if (isWhisper || isTargetedAtMe) {
+      direct += unread;
+    } else {
+      ambient = true;
+    }
+  }
+
+  return { direct, ambient };
+}
+
+function targetIncludes(threadKey: string, personaId: number | null): boolean {
+  if (personaId == null) return false;
+  const ids = threadKey.slice('target:'.length).split(',').map(Number);
+  return ids.includes(personaId);
+}

--- a/frontend/src/game/components/CommandInput.test.tsx
+++ b/frontend/src/game/components/CommandInput.test.tsx
@@ -519,6 +519,37 @@ describe('CommandInput', () => {
     expect(createActionRequestMock).not.toHaveBeenCalled();
   });
 
+  // ---------------------------------------------------------------------------
+  // Speaking-as identity chip (#2166)
+  // ---------------------------------------------------------------------------
+
+  it('renders the speaking-as chip with name and avatar when provided', () => {
+    render(
+      <CommandInput
+        character="Alice"
+        speakingAs={{ name: 'Alice', thumbnailUrl: 'https://example.com/alice.png' }}
+      />
+    );
+
+    const chip = screen.getByTestId('speaking-as-chip');
+    expect(chip).toHaveTextContent('Alice');
+    const img = chip.querySelector('img');
+    expect(img).toHaveAttribute('src', 'https://example.com/alice.png');
+  });
+
+  it('renders the speaking-as chip with initial-letter avatar when thumbnailUrl is null', () => {
+    render(<CommandInput character="Alice" speakingAs={{ name: 'Bianca', thumbnailUrl: null }} />);
+
+    const chip = screen.getByTestId('speaking-as-chip');
+    expect(chip).toHaveTextContent('Bianca');
+    expect(chip.querySelector('img')).toBeNull();
+  });
+
+  it('does not render the speaking-as chip when the prop is omitted (legacy callers)', () => {
+    render(<CommandInput character="Alice" />);
+    expect(screen.queryByTestId('speaking-as-chip')).toBeNull();
+  });
+
   it('a plain (non-entrance) pose sends no action request — byte-identical regression', async () => {
     submitPoseMock.mockImplementation(() => Promise.resolve({ id: 789 }));
 

--- a/frontend/src/game/components/CommandInput.tsx
+++ b/frontend/src/game/components/CommandInput.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useGameSocket } from '@/hooks/useGameSocket';
 import { RichTextInput } from '@/components/RichTextInput';
+import { PersonaAvatar } from '@/components/PersonaAvatar';
 import { ModeSelector } from '@/scenes/components/ModeSelector';
 import { ActionAttachment } from '@/scenes/components/ActionAttachment';
 import {
@@ -73,6 +74,15 @@ interface CommandInputProps {
    * fetch. Defaults to `false` when omitted.
    */
   isAtPlace?: boolean;
+  /**
+   * The "speaking as" identity chip (#2166 Decision 3) — the character whose
+   * voice this composer speaks in. Rendered at the START of `leftSlot`,
+   * before `ModeSelector`, whenever provided; absent for legacy callers that
+   * haven't been threaded yet. Mis-attributed poses are the multi-character
+   * equivalent of the wrong-scene-pose bug, so this is always-on (not gated
+   * behind having more than one character) once the caller supplies it.
+   */
+  speakingAs?: { name: string; thumbnailUrl: string | null };
 }
 
 export function CommandInput({
@@ -91,6 +101,7 @@ export function CommandInput({
   detachedActionIds,
   onPoseSubmitted,
   isAtPlace,
+  speakingAs,
 }: CommandInputProps) {
   const [command, setCommand] = useState('');
   const [history, setHistory] = useState<string[]>([]);
@@ -321,12 +332,27 @@ export function CommandInput({
         onKeyDown={handleKeyDown}
         rows={2}
         leftSlot={
-          <ModeSelector
-            currentMode={composerMode?.command ?? 'pose'}
-            onModeChange={handleModeChange}
-            isAtPlace={isAtPlace ?? false}
-            locked={composerMode?.locked ?? false}
-          />
+          <div className="flex items-center gap-1">
+            {speakingAs && (
+              <span
+                className="flex items-center gap-1 rounded-full bg-accent/50 py-0.5 pl-0.5 pr-2 text-xs font-medium"
+                title={`Speaking as ${speakingAs.name}`}
+                data-testid="speaking-as-chip"
+              >
+                <PersonaAvatar
+                  source={{ name: speakingAs.name, thumbnailUrl: speakingAs.thumbnailUrl }}
+                  size="sm"
+                />
+                <span>{speakingAs.name}</span>
+              </span>
+            )}
+            <ModeSelector
+              currentMode={composerMode?.command ?? 'pose'}
+              onModeChange={handleModeChange}
+              isAtPlace={isAtPlace ?? false}
+              locked={composerMode?.locked ?? false}
+            />
+          </div>
         }
         rightSlot={
           sceneId ? (

--- a/frontend/src/game/components/GameTopBar.test.tsx
+++ b/frontend/src/game/components/GameTopBar.test.tsx
@@ -1,11 +1,18 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 
 import { GameTopBar } from './GameTopBar';
 import { renderWithProviders } from '@/test/utils/renderWithProviders';
 import { store } from '@/store/store';
-import { resetGame } from '@/store/gameSlice';
+import {
+  resetGame,
+  startSession,
+  addSceneInteraction,
+  addSessionMessage,
+  setSceneBaseline,
+} from '@/store/gameSlice';
 import type { MyRosterEntry } from '@/roster/types';
+import type { InteractionWsPayload } from '@/hooks/types';
 
 // GameTopBar reads `sessions`/`active` from Redux (via useAppSelector) and calls
 // useGameSocket() — both are safe to exercise for real here, mirroring
@@ -22,6 +29,35 @@ const rosterEntry: MyRosterEntry = {
   primary_persona_id: 7,
   active_persona_id: 7,
 };
+
+// A second, background puppet (#2166) — Aria stays active; Bianca's session
+// carries whatever attention state each test sets up.
+const rosterEntry2: MyRosterEntry = {
+  id: 2,
+  name: 'Bianca',
+  character_id: 43,
+  profile_picture_url: null,
+  primary_persona_id: 8,
+  active_persona_id: 8,
+};
+
+function makeWhisperInteraction(
+  overrides: Partial<InteractionWsPayload> = {}
+): InteractionWsPayload {
+  return {
+    id: 1,
+    persona: { id: 99, name: 'Other', thumbnail_url: '' },
+    content: 'psst.',
+    mode: 'whisper',
+    timestamp: '2026-01-01T00:00:00Z',
+    scene_id: 100,
+    place_id: null,
+    place_name: null,
+    receiver_persona_ids: [8],
+    target_persona_ids: [],
+    ...overrides,
+  };
+}
 
 describe('GameTopBar', () => {
   afterEach(() => {
@@ -46,5 +82,55 @@ describe('GameTopBar', () => {
     renderWithProviders(<GameTopBar characters={[rosterEntry]} />);
 
     expect(screen.queryByText(/no characters yet/i)).not.toBeInTheDocument();
+  });
+
+  describe('background-session attention badge (#2166)', () => {
+    function seedBackgroundBianca() {
+      // Bianca's session is created first, then Aria's — startSession makes
+      // the most-recently-started character active, so this leaves Aria
+      // active and Bianca as a background alt session.
+      store.dispatch(startSession('Bianca'));
+      store.dispatch(startSession('Aria'));
+    }
+
+    it('badges a background session with an unseen whisper as a numeric direct count', () => {
+      seedBackgroundBianca();
+      store.dispatch(setSceneBaseline({ character: 'Bianca', baselineId: 0 }));
+      store.dispatch(
+        addSceneInteraction({ character: 'Bianca', interaction: makeWhisperInteraction() })
+      );
+
+      renderWithProviders(<GameTopBar characters={[rosterEntry, rosterEntry2]} />);
+
+      const biancaButton = screen.getByTitle('Switch to Bianca');
+      expect(within(biancaButton).getByText('1')).toBeInTheDocument();
+    });
+
+    it('shows a muted ambient dot for a background session with unread but no direct attention', () => {
+      seedBackgroundBianca();
+      store.dispatch(
+        addSessionMessage({
+          character: 'Bianca',
+          message: { content: 'The room stirs.', timestamp: Date.now(), type: 'text' },
+        })
+      );
+
+      renderWithProviders(<GameTopBar characters={[rosterEntry, rosterEntry2]} />);
+
+      const biancaButton = screen.getByTitle('Switch to Bianca');
+      expect(within(biancaButton).queryByText(/[0-9]/)).not.toBeInTheDocument();
+      expect(biancaButton.querySelector('.bg-muted-foreground\\/60')).not.toBeNull();
+    });
+
+    it('renders no badge for a background session with no unread attention', () => {
+      seedBackgroundBianca();
+
+      renderWithProviders(<GameTopBar characters={[rosterEntry, rosterEntry2]} />);
+
+      const biancaButton = screen.getByTitle('Switch to Bianca');
+      expect(within(biancaButton).queryByText(/[0-9]/)).not.toBeInTheDocument();
+      expect(biancaButton.querySelector('.bg-muted-foreground\\/60')).toBeNull();
+      expect(biancaButton.querySelector('.bg-red-500')).toBeNull();
+    });
   });
 });

--- a/frontend/src/game/components/GameTopBar.tsx
+++ b/frontend/src/game/components/GameTopBar.tsx
@@ -7,12 +7,35 @@ import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import type { MyRosterEntry } from '@/roster/types';
 import { WeatherWidget } from '@/weather/components/WeatherWidget';
 import { ComfortWidget } from '@/comfort/components/ComfortWidget';
+import { sessionAttention } from '@/game/attention';
 
 import { FormSwitcher } from './FormSwitcher';
 import { PersonaSwitcher } from './PersonaSwitcher';
 
 interface GameTopBarProps {
   characters: MyRosterEntry[];
+}
+
+/**
+ * Two-tier attention indicator (#2166 Decision 4a) — direct (unseen
+ * whisper/@-target aimed at this character) badges a small red numeric
+ * count, mirroring `ConversationTabStrip`'s `UnreadBadge`; ambient (any
+ * other unread) shows a muted dot; neither renders nothing.
+ */
+function AttentionBadge({ direct, ambient }: { direct: number; ambient: boolean }) {
+  if (direct > 0) {
+    return (
+      <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-medium text-white">
+        {direct}
+      </span>
+    );
+  }
+  if (ambient) {
+    return (
+      <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-muted-foreground/60" />
+    );
+  }
+  return null;
 }
 
 function getInitials(name: string): string {
@@ -82,22 +105,23 @@ export function GameTopBar({ characters }: GameTopBarProps) {
         </div>
       ) : null}
 
-      {altCharacters.map((char) => (
-        <button
-          key={char.id}
-          onClick={() => handleSelectCharacter(char.name)}
-          className="relative opacity-60 transition-opacity hover:opacity-100"
-          title={`Switch to ${char.name}`}
-        >
-          <Avatar className="h-7 w-7">
-            <AvatarImage src={char.profile_picture_url ?? undefined} alt={char.name} />
-            <AvatarFallback className="text-xs">{getInitials(char.name)}</AvatarFallback>
-          </Avatar>
-          {sessions[char.name]?.unread > 0 && (
-            <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-red-500" />
-          )}
-        </button>
-      ))}
+      {altCharacters.map((char) => {
+        const attention = sessionAttention(sessions[char.name], char.primary_persona_id);
+        return (
+          <button
+            key={char.id}
+            onClick={() => handleSelectCharacter(char.name)}
+            className="relative opacity-60 transition-opacity hover:opacity-100"
+            title={`Switch to ${char.name}`}
+          >
+            <Avatar className="h-7 w-7">
+              <AvatarImage src={char.profile_picture_url ?? undefined} alt={char.name} />
+              <AvatarFallback className="text-xs">{getInitials(char.name)}</AvatarFallback>
+            </Avatar>
+            <AttentionBadge direct={attention.direct} ambient={attention.ambient} />
+          </button>
+        );
+      })}
 
       {!active &&
         characters.map((char) => (

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -14,6 +14,29 @@ import { setActiveSession } from '@/store/gameSlice';
 import { useGameSocket } from '@/hooks/useGameSocket';
 import { Link } from 'react-router-dom';
 import type { MyRosterEntry } from '@/roster/types';
+import { sessionAttention } from '@/game/attention';
+
+/**
+ * Two-tier attention indicator (#2166 Decision 4a) on a puppet session tab —
+ * direct (unseen whisper/@-target aimed at that character) badges a small
+ * red numeric count, mirroring `ConversationTabStrip`'s `UnreadBadge`;
+ * ambient (any other unread) shows a muted dot; neither renders nothing.
+ */
+function AttentionBadge({ direct, ambient }: { direct: number; ambient: boolean }) {
+  if (direct > 0) {
+    return (
+      <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-medium text-white">
+        {direct}
+      </span>
+    );
+  }
+  if (ambient) {
+    return (
+      <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-muted-foreground/60" />
+    );
+  }
+  return null;
+}
 
 /** The active scene's live feed, composed once by `GamePage` (#2156). */
 export interface GameWindowSceneFeed {
@@ -165,20 +188,22 @@ export function GameWindow({
     <div className="flex min-h-0 flex-1 flex-col">
       {sessionNames.length >= 2 && (
         <div className="mb-2 flex gap-2 border-b">
-          {sessionNames.map((name) => (
-            <button
-              key={name}
-              onClick={() => handleTabClick(name)}
-              className={`relative rounded-t px-2 py-1 text-sm ${
-                active === name ? 'border-b-2 border-primary' : ''
-              }`}
-            >
-              {name}
-              {sessions[name].unread > 0 && (
-                <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-red-500" />
-              )}
-            </button>
-          ))}
+          {sessionNames.map((name) => {
+            const personaId = characters.find((c) => c.name === name)?.primary_persona_id ?? null;
+            const attention = sessionAttention(sessions[name], personaId);
+            return (
+              <button
+                key={name}
+                onClick={() => handleTabClick(name)}
+                className={`relative rounded-t px-2 py-1 text-sm ${
+                  active === name ? 'border-b-2 border-primary' : ''
+                }`}
+              >
+                {name}
+                <AttentionBadge direct={attention.direct} ambient={attention.ambient} />
+              </button>
+            );
+          })}
         </div>
       )}
       {sceneFeed && conversationTabs && <ConversationTabStrip {...conversationTabs} />}

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -81,6 +81,8 @@ interface GameWindowProps {
   pendingAttachments?: ReactNode;
   /** Open conversation tabs (#2165); absent = no strip, plain feed. */
   conversationTabs?: ConversationTabStripProps;
+  /** "Speaking as" identity chip (#2166 Decision 3) — threaded straight to `CommandInput`. */
+  speakingAs?: { name: string; thumbnailUrl: string | null };
 }
 
 export function GameWindow({
@@ -105,6 +107,7 @@ export function GameWindow({
   placeBar,
   pendingAttachments,
   conversationTabs,
+  speakingAs,
 }: GameWindowProps) {
   const dispatch = useAppDispatch();
   const { connect } = useGameSocket();
@@ -255,6 +258,7 @@ export function GameWindow({
         detachedActionIds={detachedActionIds}
         onPoseSubmitted={onPoseSubmitted}
         isAtPlace={isAtPlace}
+        speakingAs={speakingAs}
       />
     </div>
   );

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -200,7 +200,12 @@ export function GameWindow({
                 }`}
               >
                 {name}
-                <AttentionBadge direct={attention.direct} ambient={attention.ambient} />
+                {/* The active character's own attention already lives in
+                    ConversationTabStrip's badges (#2166 review fold-in) — badging
+                    its own already-highlighted puppet tab too is redundant/wrong. */}
+                {name !== active && (
+                  <AttentionBadge direct={attention.direct} ambient={attention.ambient} />
+                )}
               </button>
             );
           })}

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -34499,6 +34499,13 @@ export interface operations {
         initiator?: number;
         /** @description A page number within the paginated result set. */
         page?: number;
+        /**
+         * @description Request direction relative to the requesting account's played characters.
+         *
+         *     * `incoming` - Incoming
+         *     * `outgoing` - Outgoing
+         */
+        role?: 'incoming' | 'outgoing';
         scene?: number;
         status?: string;
         target?: number;
@@ -34619,6 +34626,13 @@ export interface operations {
         initiator?: number;
         /** @description Persona id (owned by the requester) to list castable techniques for. */
         initiator_persona: number;
+        /**
+         * @description Request direction relative to the requesting account's played characters.
+         *
+         *     * `incoming` - Incoming
+         *     * `outgoing` - Outgoing
+         */
+        role?: 'incoming' | 'outgoing';
         scene?: number;
         status?: string;
         target?: number;

--- a/frontend/src/hooks/__tests__/handleInteractionPayload.test.ts
+++ b/frontend/src/hooks/__tests__/handleInteractionPayload.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for handleInteractionPayload's background-whisper attention toast
+ * (#2166 Task 3). The scene-interaction dispatch itself is covered
+ * incidentally; the focus here is the toast-fire/dedupe/own-persona/click
+ * behavior layered on top.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { toastMock, getStateMock, getQueryDataMock } = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+  getStateMock: vi.fn(),
+  getQueryDataMock: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(toastMock, { error: vi.fn(), success: vi.fn() }),
+}));
+
+vi.mock('@/store/store', () => ({
+  store: { getState: getStateMock },
+}));
+
+vi.mock('@/queryClient', () => ({
+  queryClient: { getQueryData: getQueryDataMock },
+}));
+
+import { handleInteractionPayload } from '../handleInteractionPayload';
+import { addSceneInteraction, openThreadTab, setActiveSession } from '@/store/gameSlice';
+import type { InteractionWsPayload } from '../types';
+import type { MyRosterEntry } from '@/roster/types';
+import type { NavigateFunction } from 'react-router-dom';
+
+function makeRosterEntries(): MyRosterEntry[] {
+  return [
+    {
+      id: 1,
+      name: 'Alice',
+      character_id: 101,
+      profile_picture_url: null,
+      primary_persona_id: 11,
+      active_persona_id: 11,
+    },
+    {
+      id: 2,
+      name: 'Bob',
+      character_id: 102,
+      profile_picture_url: null,
+      primary_persona_id: 22,
+      active_persona_id: 22,
+    },
+  ];
+}
+
+function makeWhisperPayload(overrides: Partial<InteractionWsPayload> = {}): InteractionWsPayload {
+  return {
+    id: 500,
+    persona: { id: 11, name: 'Alice-Persona', thumbnail_url: '' },
+    content: 'psst',
+    mode: 'whisper',
+    timestamp: '2026-07-12T00:00:00Z',
+    scene_id: 9,
+    place_id: null,
+    place_name: null,
+    receiver_persona_ids: [22],
+    target_persona_ids: [],
+    ...overrides,
+  };
+}
+
+describe('handleInteractionPayload', () => {
+  let dispatch: ReturnType<typeof vi.fn>;
+  let navigate: NavigateFunction;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dispatch = vi.fn();
+    navigate = vi.fn() as unknown as NavigateFunction;
+    getStateMock.mockReturnValue({ game: { active: 'Alice' } });
+    getQueryDataMock.mockReturnValue(makeRosterEntries());
+  });
+
+  it('always dispatches addSceneInteraction regardless of toast outcome', () => {
+    const payload = makeWhisperPayload({ id: 490 });
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      addSceneInteraction({ character: 'Bob', interaction: payload })
+    );
+  });
+
+  it('fires a toast for a whisper delivered to a background session', () => {
+    const payload = makeWhisperPayload({ id: 491 });
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+    expect(toastMock).toHaveBeenCalledWith(
+      'Whisper to Bob from Alice-Persona',
+      expect.objectContaining({ action: expect.objectContaining({ label: 'Switch' }) })
+    );
+  });
+
+  it('dedupes on a repeat interaction id', () => {
+    const payload = makeWhisperPayload({ id: 492 });
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not toast when the receiving session is the active session', () => {
+    getStateMock.mockReturnValue({ game: { active: 'Bob' } });
+    const payload = makeWhisperPayload({ id: 502 });
+
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it('does not toast for a non-whisper interaction', () => {
+    const payload = makeWhisperPayload({ id: 503, mode: 'pose' });
+
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it('does not toast a whisper echoed back to its own author session', () => {
+    // Bob's own persona (22) whispering out — Bob's own socket sees the echo.
+    const payload = makeWhisperPayload({
+      id: 504,
+      persona: { id: 22, name: 'Bob-Persona', thumbnail_url: '' },
+      receiver_persona_ids: [11],
+    });
+
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it('still toasts when the roster cache has not resolved own-persona (MVP fallback)', () => {
+    getQueryDataMock.mockReturnValue(undefined);
+    const payload = makeWhisperPayload({ id: 505 });
+
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('click dispatches setActiveSession + openThreadTab and navigates to /game', () => {
+    const payload = makeWhisperPayload({ id: 506 });
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+
+    const [, options] = toastMock.mock.calls[0];
+    options.action.onClick();
+
+    expect(dispatch).toHaveBeenCalledWith(setActiveSession('Bob'));
+    expect(dispatch).toHaveBeenCalledWith(
+      openThreadTab({ character: 'Bob', threadKey: 'whisper:11,22' })
+    );
+    expect(navigate).toHaveBeenCalledWith('/game');
+  });
+
+  it('click does not navigate again when already on /game', () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, pathname: '/game' },
+    });
+
+    const payload = makeWhisperPayload({ id: 507 });
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+
+    const [, options] = toastMock.mock.calls[0];
+    options.action.onClick();
+
+    expect(navigate).not.toHaveBeenCalled();
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/handleInteractionPayload.test.ts
+++ b/frontend/src/hooks/__tests__/handleInteractionPayload.test.ts
@@ -30,6 +30,7 @@ import { addSceneInteraction, openThreadTab, setActiveSession } from '@/store/ga
 import type { InteractionWsPayload } from '../types';
 import type { MyRosterEntry } from '@/roster/types';
 import type { NavigateFunction } from 'react-router-dom';
+import type { AppDispatch } from '@/store/store';
 
 function makeRosterEntries(): MyRosterEntry[] {
   return [
@@ -69,12 +70,12 @@ function makeWhisperPayload(overrides: Partial<InteractionWsPayload> = {}): Inte
 }
 
 describe('handleInteractionPayload', () => {
-  let dispatch: ReturnType<typeof vi.fn>;
+  let dispatch: AppDispatch;
   let navigate: NavigateFunction;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    dispatch = vi.fn();
+    dispatch = vi.fn() as unknown as AppDispatch;
     navigate = vi.fn() as unknown as NavigateFunction;
     getStateMock.mockReturnValue({ game: { active: 'Alice' } });
     getQueryDataMock.mockReturnValue(makeRosterEntries());

--- a/frontend/src/hooks/__tests__/handleInteractionPayload.test.ts
+++ b/frontend/src/hooks/__tests__/handleInteractionPayload.test.ts
@@ -108,6 +108,33 @@ describe('handleInteractionPayload', () => {
     expect(toastMock).toHaveBeenCalledTimes(1);
   });
 
+  it('toasts for BOTH characters when the same payload id is delivered to two background sessions', () => {
+    // A whisper addressed to two of the player's characters arrives on two
+    // separate sockets, each processing the same payload.id — the dedupe
+    // key must be scoped per receiving character or the second toast is
+    // silently dropped (#2166 review fix).
+    getStateMock.mockReturnValue({ game: { active: 'Dave' } });
+    const payload = makeWhisperPayload({
+      id: 493,
+      receiver_persona_ids: [22, 33],
+    });
+
+    handleInteractionPayload('Bob', payload, dispatch, navigate);
+    handleInteractionPayload('Carol', payload, dispatch, navigate);
+
+    expect(toastMock).toHaveBeenCalledTimes(2);
+    expect(toastMock).toHaveBeenNthCalledWith(
+      1,
+      'Whisper to Bob from Alice-Persona',
+      expect.objectContaining({ action: expect.objectContaining({ label: 'Switch' }) })
+    );
+    expect(toastMock).toHaveBeenNthCalledWith(
+      2,
+      'Whisper to Carol from Alice-Persona',
+      expect.objectContaining({ action: expect.objectContaining({ label: 'Switch' }) })
+    );
+  });
+
   it('does not toast when the receiving session is the active session', () => {
     getStateMock.mockReturnValue({ game: { active: 'Bob' } });
     const payload = makeWhisperPayload({ id: 502 });

--- a/frontend/src/hooks/handleInteractionPayload.ts
+++ b/frontend/src/hooks/handleInteractionPayload.ts
@@ -1,12 +1,83 @@
+import { toast } from 'sonner';
+import type { NavigateFunction } from 'react-router-dom';
 import type { InteractionWsPayload } from './types';
 import type { AppDispatch } from '@/store/store';
-import { addSceneInteraction } from '@/store/gameSlice';
+import { store } from '@/store/store';
+import { addSceneInteraction, openThreadTab, setActiveSession } from '@/store/gameSlice';
 import type { MyRosterEntry } from '@/roster/types';
+import { queryClient } from '@/queryClient';
+import { getThreadKey } from '@/scenes/hooks/useThreading';
+import { wsPayloadToInteraction } from '@/scenes/hooks/useSceneInteractions';
 
 export function handleInteractionPayload(
   character: MyRosterEntry['name'],
   payload: InteractionWsPayload,
-  dispatch: AppDispatch
+  dispatch: AppDispatch,
+  navigate: NavigateFunction
 ) {
   dispatch(addSceneInteraction({ character, interaction: payload }));
+  maybeToastWhisperAttention(character, payload, dispatch, navigate);
+}
+
+/**
+ * Interaction ids already toasted (#2166) — mirrors DuelChallengeNotifier's
+ * `toastedIds` dedupe idiom, but module-level rather than a ref: this file has
+ * no component instance, and `useGameSocket` opens one socket per character
+ * (a fresh mount doesn't replay past frames), so a plain module `Set` is safe.
+ */
+const toastedWhisperIds = new Set<number>();
+
+/**
+ * Own-persona detection (#2166 Task 3 decision, documented per the plan's
+ * framework): a session's own persona id is NOT in Redux (only the roster
+ * query has it), so this reads `primary_persona_id` for the RECEIVING
+ * character straight out of the React Query cache via `queryClient
+ * .getQueryData(['my-roster-entries'])` — the same cache
+ * `useMyRosterEntriesQuery` populates, and the same field (`primary_persona_id`)
+ * Task 2's `sessionAttention` call sites already use as "this session's
+ * persona" for thread-key grouping, so the definition of "my persona" stays
+ * consistent across the badge and the toast. By the time any socket message
+ * arrives the roster has always already been fetched (a session can't exist
+ * without the roster resolving the character first), so the cache is expected
+ * to be warm; if it is ever empty (`ownPersonaId` stays `null`) this
+ * deliberately does NOT suppress the toast — per the plan's documented MVP
+ * fallback, a false-positive toast on a rare self-echo is preferable to
+ * silently dropping a real cross-character whisper.
+ */
+function ownPersonaId(character: MyRosterEntry['name']): number | null {
+  const rosterEntries = queryClient.getQueryData<MyRosterEntry[]>(['my-roster-entries']);
+  return rosterEntries?.find((entry) => entry.name === character)?.primary_persona_id ?? null;
+}
+
+function maybeToastWhisperAttention(
+  character: MyRosterEntry['name'],
+  payload: InteractionWsPayload,
+  dispatch: AppDispatch,
+  navigate: NavigateFunction
+) {
+  if (payload.mode !== 'whisper') return;
+
+  const activeCharacter = store.getState().game.active;
+  if (character === activeCharacter) return;
+
+  const myPersonaId = ownPersonaId(character);
+  if (myPersonaId != null && payload.persona.id === myPersonaId) return;
+
+  if (toastedWhisperIds.has(payload.id)) return;
+  toastedWhisperIds.add(payload.id);
+
+  const threadKey = getThreadKey(wsPayloadToInteraction(payload));
+
+  toast(`Whisper to ${character} from ${payload.persona.name}`, {
+    action: {
+      label: 'Switch',
+      onClick: () => {
+        dispatch(setActiveSession(character));
+        dispatch(openThreadTab({ character, threadKey }));
+        if (window.location.pathname !== '/game') {
+          navigate('/game');
+        }
+      },
+    },
+  });
 }

--- a/frontend/src/hooks/handleInteractionPayload.ts
+++ b/frontend/src/hooks/handleInteractionPayload.ts
@@ -24,8 +24,17 @@ export function handleInteractionPayload(
  * `toastedIds` dedupe idiom, but module-level rather than a ref: this file has
  * no component instance, and `useGameSocket` opens one socket per character
  * (a fresh mount doesn't replay past frames), so a plain module `Set` is safe.
+ *
+ * Keyed by `${character}:${payload.id}` rather than bare `payload.id` — the
+ * same whisper is delivered once per receiving character's own socket (e.g.
+ * two of the player's characters both on the receiver list), and a bare-id
+ * key would let whichever character's frame processes first swallow the
+ * other's legitimate attention toast. A cap bounds unbounded growth for a
+ * long-lived session; this Set is best-effort spam protection, not a
+ * correctness-critical cache, so a blunt full clear at the cap is fine.
  */
-const toastedWhisperIds = new Set<number>();
+const toastedWhisperIds = new Set<string>();
+const MAX_TOASTED_WHISPER_IDS = 500;
 
 /**
  * Own-persona detection (#2166 Task 3 decision, documented per the plan's
@@ -63,8 +72,10 @@ function maybeToastWhisperAttention(
   const myPersonaId = ownPersonaId(character);
   if (myPersonaId != null && payload.persona.id === myPersonaId) return;
 
-  if (toastedWhisperIds.has(payload.id)) return;
-  toastedWhisperIds.add(payload.id);
+  const toastKey = `${character}:${payload.id}`;
+  if (toastedWhisperIds.has(toastKey)) return;
+  if (toastedWhisperIds.size > MAX_TOASTED_WHISPER_IDS) toastedWhisperIds.clear();
+  toastedWhisperIds.add(toastKey);
 
   const threadKey = getThreadKey(wsPayloadToInteraction(payload));
 

--- a/frontend/src/hooks/useGameSocket.ts
+++ b/frontend/src/hooks/useGameSocket.ts
@@ -167,7 +167,8 @@ export function useGameSocket() {
             handleInteractionPayload(
               character,
               kwargs as unknown as InteractionWsPayload,
-              dispatch
+              dispatch,
+              navigate
             );
             return;
           }

--- a/frontend/src/scenes/actionQueries.ts
+++ b/frontend/src/scenes/actionQueries.ts
@@ -5,6 +5,7 @@ import type {
   PlayerActionsResponse,
   ActionRequest,
   ActionRequestResponse,
+  IncomingConsentRequest,
   Place,
   CastableTechnique,
   CastPullRequestBody,
@@ -129,6 +130,22 @@ export async function createActionRequest(
 export async function fetchPendingRequests(sceneId: string): Promise<{ results: ActionRequest[] }> {
   const res = await apiFetch(`/api/action-requests/?scene=${sceneId}&status=pending`);
   if (!res.ok) throw new Error('Failed to load pending requests');
+  return res.json();
+}
+
+/**
+ * Account-wide pending-consent inbox (#2166) — the `ConsentAttentionNotifier`
+ * counterpart to `fetchPendingRequests` above, but WITHOUT a `scene` filter:
+ * `role=incoming` (SceneActionRequestFilter, #2166) narrows to requests
+ * addressed to ANY of the requesting account's played characters, across
+ * every scene. Server-side scoping (`get_account_personas`) means this never
+ * returns another player's requests.
+ */
+export async function fetchIncomingConsentRequests(): Promise<{
+  results: IncomingConsentRequest[];
+}> {
+  const res = await apiFetch('/api/action-requests/?status=pending&role=incoming');
+  if (!res.ok) throw new Error('Failed to load incoming consent requests');
   return res.json();
 }
 

--- a/frontend/src/scenes/actionTypes.ts
+++ b/frontend/src/scenes/actionTypes.ts
@@ -192,6 +192,28 @@ export interface ActionRequest {
   created_at: string;
 }
 
+/**
+ * One row in the account-wide consent-request inbox
+ * (`GET /api/action-requests/?status=pending&role=incoming`, #2166).
+ *
+ * A narrower slice of SceneActionRequestSerializer's FLAT payload than
+ * `ActionRequest` above — this is used OUTSIDE a scene context (the
+ * app-root `ConsentAttentionNotifier`), so unlike `ActionRequest` it needs
+ * `scene` (to route navigation) and `target_persona`/`target_name` (the
+ * scene-scoped ConsentPrompt already knows the target is "me").
+ */
+export interface IncomingConsentRequest {
+  id: number;
+  scene: number;
+  /** Persona pk being addressed. Null only for area actions/standalone casts (never PENDING+targeted). */
+  target_persona: number | null;
+  target_name: string;
+  initiator_name: string;
+  action_key: string;
+  technique_name: string | null;
+  created_at: string;
+}
+
 export interface CheckResultData {
   outcome: string;
   success_level: number;

--- a/frontend/src/scenes/components/ConsentAttentionNotifier.test.tsx
+++ b/frontend/src/scenes/components/ConsentAttentionNotifier.test.tsx
@@ -1,0 +1,192 @@
+import type { ReactNode } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { setActiveSession, startSession } from '@/store/gameSlice';
+import type { IncomingConsentRequest } from '../actionTypes';
+
+const {
+  mockDispatch,
+  mockConnect,
+  mockNavigate,
+  mockFetchIncomingConsentRequests,
+  toastMock,
+  sessionsRef,
+  rosterEntriesRef,
+} = vi.hoisted(() => ({
+  mockDispatch: vi.fn(),
+  mockConnect: vi.fn(),
+  mockNavigate: vi.fn(),
+  mockFetchIncomingConsentRequests: vi.fn(),
+  toastMock: vi.fn(),
+  sessionsRef: { current: {} as Record<string, { isConnected: boolean }> },
+  rosterEntriesRef: { current: [] as unknown[] },
+}));
+
+vi.mock('@/store/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: (selector: (state: unknown) => unknown) =>
+    selector({ game: { sessions: sessionsRef.current } }),
+}));
+
+vi.mock('@/hooks/useGameSocket', () => ({
+  useGameSocket: () => ({ connect: mockConnect }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: () => ({ data: rosterEntriesRef.current }),
+}));
+
+vi.mock('../actionQueries', () => ({
+  fetchIncomingConsentRequests: (...args: unknown[]) => mockFetchIncomingConsentRequests(...args),
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(toastMock, { error: vi.fn(), success: vi.fn() }),
+}));
+
+import { ConsentAttentionNotifier } from './ConsentAttentionNotifier';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function request(overrides: Partial<IncomingConsentRequest> = {}): IncomingConsentRequest {
+  return {
+    id: 1,
+    scene: 55,
+    target_persona: 22,
+    target_name: 'CharB',
+    initiator_name: 'Rivalis',
+    action_key: 'intimidate',
+    technique_name: null,
+    created_at: '2026-07-11T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ConsentAttentionNotifier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionsRef.current = {};
+    rosterEntriesRef.current = [
+      { id: 1, name: 'CharA', character_id: 1, primary_persona_id: 11, active_persona_id: 11 },
+      { id: 2, name: 'CharB', character_id: 2, primary_persona_id: 22, active_persona_id: 22 },
+    ];
+    mockFetchIncomingConsentRequests.mockResolvedValue({ results: [] });
+  });
+
+  it('fires a toast naming the resolved (background) character, action, and initiator', async () => {
+    mockFetchIncomingConsentRequests.mockResolvedValue({ results: [request()] });
+
+    render(<ConsentAttentionNotifier />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        'Consent request for CharB: intimidate from Rivalis',
+        expect.objectContaining({ action: expect.objectContaining({ label: 'View' }) })
+      );
+    });
+  });
+
+  it('prefers technique_name over action_key when present', async () => {
+    mockFetchIncomingConsentRequests.mockResolvedValue({
+      results: [request({ id: 2, technique_name: 'Mind Whisper' })],
+    });
+
+    render(<ConsentAttentionNotifier />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        'Consent request for CharB: Mind Whisper from Rivalis',
+        expect.anything()
+      );
+    });
+  });
+
+  it('resolves the target via active_persona_id when it does not match primary_persona_id', async () => {
+    // CharB is currently wearing a mask (active_persona_id=99) that differs
+    // from their primary (22) — the request is addressed to the worn mask.
+    rosterEntriesRef.current = [
+      { id: 2, name: 'CharB', character_id: 2, primary_persona_id: 22, active_persona_id: 99 },
+    ];
+    mockFetchIncomingConsentRequests.mockResolvedValue({
+      results: [request({ id: 6, target_persona: 99 })],
+    });
+
+    render(<ConsentAttentionNotifier />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        'Consent request for CharB: intimidate from Rivalis',
+        expect.anything()
+      );
+    });
+  });
+
+  it('falls back to the raw target_name when no roster entry matches', async () => {
+    rosterEntriesRef.current = [
+      { id: 1, name: 'CharA', character_id: 1, primary_persona_id: 11, active_persona_id: 11 },
+    ];
+    mockFetchIncomingConsentRequests.mockResolvedValue({
+      results: [request({ id: 7, target_persona: 999, target_name: 'Mystery Mask' })],
+    });
+
+    render(<ConsentAttentionNotifier />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        'Consent request for Mystery Mask: intimidate from Rivalis',
+        expect.anything()
+      );
+    });
+  });
+
+  it('does not re-fire for a request id already toasted', async () => {
+    mockFetchIncomingConsentRequests.mockResolvedValue({ results: [request({ id: 3 })] });
+
+    const { rerender } = render(<ConsentAttentionNotifier />, { wrapper: createWrapper() });
+    await waitFor(() => expect(toastMock).toHaveBeenCalledTimes(1));
+
+    rerender(<ConsentAttentionNotifier />);
+    await waitFor(() => expect(toastMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('clicking the toast action starts a session for a not-yet-live character and navigates to /game', async () => {
+    mockFetchIncomingConsentRequests.mockResolvedValue({ results: [request({ id: 4 })] });
+
+    render(<ConsentAttentionNotifier />, { wrapper: createWrapper() });
+    await waitFor(() => expect(toastMock).toHaveBeenCalledTimes(1));
+
+    const [, options] = toastMock.mock.calls[0] as [string, { action: { onClick: () => void } }];
+    options.action.onClick();
+
+    expect(mockDispatch).toHaveBeenCalledWith(startSession('CharB'));
+    expect(mockConnect).toHaveBeenCalledWith('CharB');
+    expect(mockNavigate).toHaveBeenCalledWith('/game');
+  });
+
+  it('clicking the toast action switches an already-live character without restarting it', async () => {
+    sessionsRef.current = { CharB: { isConnected: true } };
+    mockFetchIncomingConsentRequests.mockResolvedValue({ results: [request({ id: 5 })] });
+
+    render(<ConsentAttentionNotifier />, { wrapper: createWrapper() });
+    await waitFor(() => expect(toastMock).toHaveBeenCalledTimes(1));
+
+    const [, options] = toastMock.mock.calls[0] as [string, { action: { onClick: () => void } }];
+    options.action.onClick();
+
+    expect(mockDispatch).toHaveBeenCalledWith(setActiveSession('CharB'));
+    expect(mockDispatch).not.toHaveBeenCalledWith(startSession('CharB'));
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/scenes/components/ConsentAttentionNotifier.tsx
+++ b/frontend/src/scenes/components/ConsentAttentionNotifier.tsx
@@ -1,0 +1,121 @@
+/**
+ * ConsentAttentionNotifier — site-wide alert for a pending consent/action
+ * request addressed to ANY of the account's played characters (#2166).
+ *
+ * Mirrors `DuelChallengeNotifier` (#2157): mounted once at the app root
+ * (`App.tsx`, beside it), polls ACCOUNT-WIDE rather than per-scene
+ * (`GET /api/action-requests/?status=pending&role=incoming` —
+ * `SceneActionRequestFilter.role`, added for this task; the underlying
+ * queryset was already scoped to the caller's own personas via
+ * `get_account_personas`, so `role=incoming` only narrows *which side* —
+ * target, not initiator — of that already-owned set to keep; it never leaks
+ * another player's requests), and fires one toast per newly-seen pending
+ * request id.
+ *
+ * Dedupe uses a module-level `Set` with the 500-cap idiom from
+ * `handleInteractionPayload.ts` (#2166 Task 3) rather than a component ref —
+ * the poll (not a per-character socket) is this component's data source, and
+ * a `Set` survives remounts the same way that file's does.
+ *
+ * NO accept/deny here — the in-scene `ConsentPrompt` owns the graded response
+ * (plausibility band, resist effort, blacklist-actor). Clicking the toast
+ * only switches to the addressed character — starting a session first if
+ * none is live yet, mirroring `GameTopBar.handleSelectCharacter` — and
+ * navigates to `/game`, where `ConsentPrompt`'s own per-scene poll picks the
+ * request up from there.
+ *
+ * Character resolution (#2166, documented per the plan's decision framework):
+ * `target_persona` is a Persona pk, not a CharacterSheet id, so unlike
+ * `DuelChallengeNotifier` (whose `challenged.id` IS the CharacterSheet pk and
+ * matches `MyRosterEntry.character_id` directly) this can't be resolved with
+ * a single equality check. It is matched against each roster entry's own
+ * `primary_persona_id` first — the same "this session's own persona"
+ * definition Task 2's `sessionAttention` call sites and Task 3's
+ * `ownPersonaId` (`handleInteractionPayload.ts`) already use, kept consistent
+ * here rather than introducing a third definition — then against
+ * `active_persona_id` (the currently-worn face), which additionally covers
+ * the common case of a request addressed to a mask while it's still worn. A
+ * request addressed to a mask the player has since put away is a rare edge
+ * this toast still fires for (falls back to the raw `target_name` label with
+ * no session-switch on click, rather than being silently dropped).
+ *
+ * Renders nothing itself — `null` always, purely a side-effect component.
+ */
+
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useNavigate } from 'react-router-dom';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { setActiveSession, startSession } from '@/store/gameSlice';
+import { useGameSocket } from '@/hooks/useGameSocket';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+import type { MyRosterEntry } from '@/roster/types';
+import { fetchIncomingConsentRequests } from '../actionQueries';
+import type { IncomingConsentRequest } from '../actionTypes';
+
+const toastedRequestIds = new Set<number>();
+const MAX_TOASTED_REQUEST_IDS = 500;
+
+function resolveTargetCharacter(
+  request: IncomingConsentRequest,
+  myRosterEntries: MyRosterEntry[]
+): MyRosterEntry | null {
+  return (
+    myRosterEntries.find((e) => e.primary_persona_id === request.target_persona) ??
+    myRosterEntries.find((e) => e.active_persona_id === request.target_persona) ??
+    null
+  );
+}
+
+export function ConsentAttentionNotifier() {
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const { connect } = useGameSocket();
+  const sessions = useAppSelector((state) => state.game.sessions);
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
+
+  const { data } = useQuery({
+    queryKey: ['incoming-consent-requests'],
+    queryFn: fetchIncomingConsentRequests,
+    enabled: myRosterEntries.length > 0,
+    refetchInterval: 15_000,
+    staleTime: 10_000,
+  });
+  useEffect(() => {
+    const pendingRequests = data?.results ?? [];
+    for (const request of pendingRequests) {
+      if (toastedRequestIds.has(request.id)) continue;
+      if (toastedRequestIds.size > MAX_TOASTED_REQUEST_IDS) toastedRequestIds.clear();
+      toastedRequestIds.add(request.id);
+
+      const targetEntry = resolveTargetCharacter(request, myRosterEntries);
+      const characterName = targetEntry?.name ?? request.target_name;
+      const actionLabel = request.technique_name ?? request.action_key;
+
+      toast(`Consent request for ${characterName}: ${actionLabel} from ${request.initiator_name}`, {
+        action: {
+          label: 'View',
+          onClick: () => {
+            if (targetEntry) {
+              if (sessions[targetEntry.name]) {
+                dispatch(setActiveSession(targetEntry.name));
+                if (!sessions[targetEntry.name].isConnected) {
+                  connect(targetEntry.name);
+                }
+              } else {
+                dispatch(startSession(targetEntry.name));
+                connect(targetEntry.name);
+              }
+            }
+            if (window.location.pathname !== '/game') {
+              navigate('/game');
+            }
+          },
+        },
+      });
+    }
+  }, [data, myRosterEntries, sessions, dispatch, navigate, connect]);
+
+  return null;
+}

--- a/frontend/src/scenes/hooks/useThreading.ts
+++ b/frontend/src/scenes/hooks/useThreading.ts
@@ -116,7 +116,9 @@ function getThreadLabel(
 // it's first observed (the old per-thread-key baseline's bug). With no entry
 // AND no baseline (e.g. `/scenes/:id` passing no opts at all) unread is 0,
 // exactly as before.
-function countUnread(
+// Exported (#2166) so `game/attention.ts`'s `sessionAttention` can reuse the
+// exact same threshold rule per thread key instead of duplicating it.
+export function countUnread(
   threadInteractions: Interaction[],
   threadKey: string,
   lastSeenByThread: Record<string, number> | undefined,

--- a/frontend/src/scenes/pages/SceneDetailPage.tsx
+++ b/frontend/src/scenes/pages/SceneDetailPage.tsx
@@ -43,20 +43,15 @@ export function SceneDetailPage() {
   // Also derives characterSheetId: CharacterSheet uses OneToOneField(primary_key=True)
   // to ObjectDB, so character_id === character_sheet pk.
   const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
-  const personaId = useMemo(
-    () => myRosterEntries.find((e) => e.name === activeCharacter)?.primary_persona_id ?? null,
+  const activeEntry = useMemo(
+    () => myRosterEntries.find((e) => e.name === activeCharacter) ?? null,
     [myRosterEntries, activeCharacter]
   );
-  const characterSheetId = useMemo(
-    () => myRosterEntries.find((e) => e.name === activeCharacter)?.character_id ?? 0,
-    [myRosterEntries, activeCharacter]
-  );
+  const personaId = activeEntry?.primary_persona_id ?? null;
+  const characterSheetId = activeEntry?.character_id ?? 0;
   // The active character's own RosterEntry id (#2156 Task 7) — the FriendButton's
   // `viewerEntryId` inside the character-card drawer.
-  const viewerEntryId = useMemo(
-    () => myRosterEntries.find((e) => e.name === activeCharacter)?.id ?? null,
-    [myRosterEntries, activeCharacter]
-  );
+  const viewerEntryId = activeEntry?.id ?? null;
 
   // Track IDs the user has detached from the auto-attach chip strip.
   const [detachedActionIds, setDetachedActionIds] = useState<number[]>([]);
@@ -227,6 +222,11 @@ export function SceneDetailPage() {
                 detachedActionIds={detachedActionIds}
                 onPoseSubmitted={handlePoseSubmitted}
                 isAtPlace={isAtPlace}
+                speakingAs={
+                  activeEntry
+                    ? { name: activeEntry.name, thumbnailUrl: activeEntry.profile_picture_url }
+                    : undefined
+                }
               />
             </>
           )}

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -23,7 +23,11 @@ interface RoomData {
   hub: HubTidings | null;
 }
 
-interface Session {
+/**
+ * Exported (#2166) so selector-side derivations (e.g. `game/attention.ts`'s
+ * `sessionAttention`) can type against a session without duplicating its shape.
+ */
+export interface Session {
   isConnected: boolean;
   messages: Array<GameMessage & { id: string }>;
   unread: number;

--- a/src/schema.json
+++ b/src/schema.json
@@ -202,6 +202,18 @@ paths:
         schema:
           type: integer
       - in: query
+        name: role
+        schema:
+          type: string
+          enum:
+          - incoming
+          - outgoing
+        description: |-
+          Request direction relative to the requesting account's played characters.
+
+          * `incoming` - Incoming
+          * `outgoing` - Outgoing
+      - in: query
         name: scene
         schema:
           type: number
@@ -350,6 +362,18 @@ paths:
         description: Persona id (owned by the requester) to list castable techniques
           for.
         required: true
+      - in: query
+        name: role
+        schema:
+          type: string
+          enum:
+          - incoming
+          - outgoing
+        description: |-
+          Request direction relative to the requesting account's played characters.
+
+          * `incoming` - Incoming
+          * `outgoing` - Outgoing
       - in: query
         name: scene
         schema:

--- a/src/world/scenes/action_filters.py
+++ b/src/world/scenes/action_filters.py
@@ -1,8 +1,15 @@
 """Filters for scene action requests."""
 
+from django.db.models import QuerySet
 import django_filters
 
 from world.scenes.action_models import SceneActionRequest, SceneActionTarget
+from world.scenes.interaction_permissions import get_account_personas
+
+# Direction values for SceneActionRequestFilter.role (#2166 — mirrors
+# world.combat.filters.DuelChallengeFilter's role=incoming|outgoing).
+_ROLE_INCOMING = "incoming"
+_ROLE_OUTGOING = "outgoing"
 
 
 class SceneActionRequestFilter(django_filters.FilterSet):
@@ -10,10 +17,37 @@ class SceneActionRequestFilter(django_filters.FilterSet):
     status = django_filters.CharFilter(field_name="status")
     initiator = django_filters.NumberFilter(field_name="initiator_persona_id")
     target = django_filters.NumberFilter(field_name="target_persona_id")
+    # #2166 — ConsentAttentionNotifier's account-wide poll: narrow to requests
+    # addressed to (role=incoming) or issued by (role=outgoing) ANY of the
+    # requesting account's played characters, not just one persona.
+    # SceneActionRequestViewSet.get_queryset already scopes the base queryset to
+    # the account's own personas (never leaks another player's requests) — this
+    # filter only narrows *which side* of that already-owned queryset to keep.
+    role = django_filters.ChoiceFilter(
+        choices=[(_ROLE_INCOMING, "Incoming"), (_ROLE_OUTGOING, "Outgoing")],
+        method="filter_role",
+        label="Request direction relative to the requesting account's played characters.",
+    )
 
     class Meta:
         model = SceneActionRequest
-        fields = ["scene", "status", "initiator", "target"]
+        fields = ["scene", "status", "initiator", "target", "role"]
+
+    def filter_role(
+        self,
+        queryset: QuerySet[SceneActionRequest],
+        name: str,  # noqa: ARG002 — django-filter's method-filter signature requires it.
+        value: str,
+    ) -> QuerySet[SceneActionRequest]:
+        request = self.request
+        if request is None:
+            return queryset.none()
+        persona_ids = get_account_personas(request)
+        if value == _ROLE_INCOMING:
+            return queryset.filter(target_persona_id__in=persona_ids)
+        if value == _ROLE_OUTGOING:
+            return queryset.filter(initiator_persona_id__in=persona_ids)
+        return queryset
 
 
 class SceneActionTargetFilter(django_filters.FilterSet):

--- a/src/world/scenes/tests/test_action_views.py
+++ b/src/world/scenes/tests/test_action_views.py
@@ -123,6 +123,50 @@ class SceneActionRequestViewSetTestCase(APITestCase):
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data["results"]) == 1
 
+    def test_role_incoming_scopes_across_all_played_characters(self) -> None:
+        """#2166 — ConsentAttentionNotifier's account-wide poll: role=incoming must
+        return pending requests addressed to ANY of the account's played
+        characters (not just one persona), exclude the account's own outgoing
+        requests, and never leak another account's requests.
+        """
+        # A second character played by the SAME account (multi-character play) —
+        # the request below is addressed to this background character, not
+        # `self.persona`, so a single-persona filter would miss it.
+        second_character = CharacterFactory()
+        second_roster_entry = RosterEntryFactory(character_sheet__character=second_character)
+        RosterTenureFactory(player_data=self.player_data, roster_entry=second_roster_entry)
+        second_persona = CharacterSheetFactory(character=second_character).primary_persona
+
+        incoming_to_background_char = SceneActionRequestFactory(
+            scene=self.scene,
+            initiator_persona=self.target_persona,
+            target_persona=second_persona,
+        )
+        # Outgoing (the account's own character initiated it) — must be excluded.
+        SceneActionRequestFactory(
+            scene=self.scene,
+            initiator_persona=self.persona,
+            target_persona=self.target_persona,
+        )
+        # Involves neither of the account's personas at all — must never leak.
+        other_account = AccountFactory()
+        other_character = CharacterFactory()
+        other_roster_entry = RosterEntryFactory(character_sheet__character=other_character)
+        other_player_data = PlayerDataFactory(account=other_account)
+        RosterTenureFactory(player_data=other_player_data, roster_entry=other_roster_entry)
+        other_persona = CharacterSheetFactory(character=other_character).primary_persona
+        SceneActionRequestFactory(
+            scene=self.scene,
+            initiator_persona=self.target_persona,
+            target_persona=other_persona,
+        )
+
+        url = reverse("sceneactionrequest-list")
+        response = self.client.get(url, {"status": ActionRequestStatus.PENDING, "role": "incoming"})
+        assert response.status_code == status.HTTP_200_OK
+        ids = {row["id"] for row in response.data["results"]}
+        assert ids == {incoming_to_background_char.pk}
+
 
 def _make_area_action_mock() -> MagicMock:
     """Return a mock action object with target_type = AREA."""


### PR DESCRIPTION
Closes #2166

## Summary

Multi-character play, sanely (#2166) — the last epic:scenes-rp slice. Attention now routes across a player's characters: (1) two-tier badges on the character tabs/avatars — a whisper or @-target to a background character shows a red numeric DIRECT badge, ambient room scroll a muted dot, derived client-side per session from the existing per-thread unread machinery (no new server data; active character excluded — its attention lives in the #2165 conversation-tab badges); (2) background-whisper toasts with one-click switch-through (switches character AND opens that whisper's conversation tab; per-character dedupe so a group whisper to two of your alts toasts for both); (3) prompts act as the RIGHT character — DuelChallengeNotifier now resolves the challenged character and responds as them (was: dispatched as whichever character was active), and a new ConsentAttentionNotifier polls pending action-requests account-wide (new role=incoming DRF filter that only NARROWS the already-account-scoped queryset; negative-leak test included) and routes you to the asked character; (4) a speaking-as identity chip (avatar+name) on every composer — /game, /scenes/:id, and the combat page — so mis-attributed poses are impossible. All routing is client-local per the Never-out-alts tenet; nothing account-linked renders to other players. Ratified scope cuts: ritual invites/mission summonses/teaching offers stay out (no arrival semantics exist today); unified-inbox layout rejected in favor of the ratified tab composition. Built stacked on #2165 and rebased onto main after its merge (clean, zero conflicts). Review trail: 6 task reviews + 3 fix waves + final whole-branch review (READY WITH NITS — the combat-composer chip folded in).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2166 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch developed stacked on feature-2165 (merged as PR #2245), then rebased --onto origin/main cleanly; final base = current main.

<!-- last-addressed-comment: 0 -->