### PR TITLE
Battle system: war-scale outcome → win-gated LegendEntry creation wiring (design question)

### DIFF
--- a/docs/adr/0122-battle-legend-is-win-gated-with-standout-exceptions.md
+++ b/docs/adr/0122-battle-legend-is-win-gated-with-standout-exceptions.md
@@ -1,0 +1,27 @@
+# Battle-earned Legend is win-gated at authored tier values, with a standout exception for both sides
+
+`world.battles.legend_wiring.apply_battle_legend_awards` (#2184), registered as a
+battle-conclusion hook, mints a shared `create_legend_event` **only for the winning
+side** — every `BattleParticipant` plus every `BattleUnit.commander` on
+`battle.outcome`'s winning `BattleSideRole`, at an authored flat tier value
+(`BATTLE_LEGEND_DECISIVE_VALUE = 25` / `BATTLE_LEGEND_MARGINAL_VALUE = 12`, mirroring
+`DECISIVE_MARGIN`'s existing decisive/marginal split). The losing side earns nothing
+from the event. Separately, a smaller **standout pass** (`BATTLE_LEGEND_STANDOUT_VALUE
+= 15`) scans every resolved `BattleActionDeclaration` on *either* side with
+`success_level >= STANDOUT_SUCCESS_LEVEL` (2, clearly above bare success) on a
+`DRAMATIC_KINDS` action (RESCUE/ROUT/BREACH) and awards its actor a solo deed via
+`create_solo_deed` — stacking with the victory event by design, since a losing-side
+rescue is still a story worth telling.
+
+Rejected: minting a deed for every participant regardless of outcome (or scaling
+value by battle size/duration). That reads as automatic legend inflation — every
+battle a PC merely shows up for would pad their legend total, diluting Legend as a
+"remarkable accomplishments" signal (see `docs/systems/societies.md`) and undercutting
+the curated, authored-consequence-pool design tenet the checks/consequence system
+already holds elsewhere in this codebase. Win-gating plus a narrow standout exception
+keeps the story-worthiness bar high while still rewarding a dramatic losing-side
+action on its own merits.
+
+> Status: accepted · Source: #2184 · Related: `docs/systems/battles.md` §Legend
+> Wiring, `docs/systems/societies.md` §Legend System, ADR-0010 (FK direction —
+> `battles` importing `societies` here, both being general/reusable systems)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -152,6 +152,7 @@ treat those names as hints to confirm, not gospel.
 - [0119 — The accusation→heat bridge lives justice-side, and its tier is emergent from the real deed underneath](0119-accusation-heat-bridge-tier-is-emergent-from-the-deed.md) (extends ADR-0114/0010)
 - [0120 — Cross-Area travel rides the exit graph; Area coordinates are parent-local rendering data](0120-cross-area-travel-rides-the-exit-graph.md) (extends ADR-0081/0085)
 - [0121 — Portal anchors are a stackable magic-app model, not a RoomFeatureKind](0121-portal-anchors-are-a-stackable-magic-model.md) (related ADR-0010)
+- [0122 — Battle-earned Legend is win-gated at authored tier values, with a standout exception for both sides](0122-battle-legend-is-win-gated-with-standout-exceptions.md) (related ADR-0010)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -144,7 +144,10 @@ outcome** (a closed issue or a "SHIPPED" line is not proof). See the ledger's go
   actions, `CmdBattle` telnet namespace, E2E `test_battle_telnet_e2e.py`. Peril/rescue +
   AFK override shipped (#1733). Resources/units/terrain/tactics + type-matchups shipped
   (#1711). Command hierarchy + the Champion shipped (#1710). Campaign-stakes propagation
-  + win-gated Legend shipped (#1785). Battle-flow actions (rout/rally/repel/hold, second
+  (battle outcome → Story beat resolution) shipped (#1785); win-gated Legend (battle
+  outcome → `societies.LegendEntry`, a separate `world.battles.legend_wiring` seam —
+  25/12 decisive/marginal victory event for the winning side, 15-value standout deeds
+  for either side) shipped (#2184, ADR-0122). Battle-flow actions (rout/rally/repel/hold, second
   BattleUnit.morale resource, BattlePlace.controlled_by objective) shipped (#1712). Siege
   warfare: Fortification objectives + BREACH/FORTIFY + persistent
   Building.fortification_level investment (#1713). Naval-ship vertical slice shipped

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -918,7 +918,7 @@ Social structures, organizations, reputation, and legend tracking.
 - **`Organization`/`Society` as `NpcRegard` target (#1717):** either can now be the *target* (not
   holder) of a notable NPC's external opinion — see the Regard bullet in the NPC Services
   section above.
-- **Integrates with:** realms (Society.realm FK), character_sheets (Persona for identity), magic (Audere Majora crossing deed via `AudereMajoraCrossing.legend_entry`), secrets (contained-scandal minting + exposure, #1464), justice (leaked crimes mint heat via the knowledge seam, #1765), actions (shared `action.run()` / `dispatch_player_action()` seam)
+- **Integrates with:** realms (Society.realm FK), character_sheets (Persona for identity), magic (Audere Majora crossing deed via `AudereMajoraCrossing.legend_entry`), secrets (contained-scandal minting + exposure, #1464), justice (leaked crimes mint heat via the knowledge seam, #1765), actions (shared `action.run()` / `dispatch_player_action()` seam), battles (consumer — `world.battles.legend_wiring` calls `create_legend_event`/`create_solo_deed` from a battle-conclusion hook, win-gated Legend, #2184; FK direction battles→societies, ADR-0010 — this app never imports `world.battles`)
 - **Source:** `src/world/societies/`
 - **Details:** [societies.md](societies.md)
 
@@ -3758,8 +3758,19 @@ through abstract round-based VP mechanics. `Battle` is a 1:1 extension of `scene
     breach or living-mount defeat)
   - Conclusion: `check_victory` (graded outcome: decisive if margin ≥ 50, else marginal),
     `conclude_battle` (sets outcome + ends scene; resolves any linked story beat's stakes
-    contract via `resolve_battle_beats`, #1785; still never calls `complete_story`),
+    contract via `resolve_battle_beats`, #1785; runs every registered
+    `battles.conclusion_hooks` hook, including win-gated Legend wiring below; still never
+    calls `complete_story`),
     `maybe_conclude_on_timer` (timeout: defender holds unless attacker met threshold)
+- **Legend wiring (`world.battles.legend_wiring`, #2184):** `apply_battle_legend_awards`
+  — a `battles.conclusion_hooks` hook (`battles` importing `societies`, the ratified
+  direction, both general/reusable systems). Win-gated `create_legend_event` ("Victory at
+  {battle.name}") for the winning `BattleSideRole`'s participants + unit commanders (25
+  decisive / 12 marginal, `BattleOutcome`-driven); a separate standout pass
+  (`create_solo_deed`, 15) fires for *either* side on a resolved RESCUE/ROUT/BREACH
+  declaration with `success_level >= 2` — stacks with the victory event. Idempotent via a
+  lazy `"Battle"` `LegendSourceType` existence check on `battle.scene`. See
+  [battles.md](battles.md#legend-wiring-2184), ADR-0122.
 - **Resolution (`world.battles.resolution`):** `resolve_battle_round(battle_round)` →
   `BattleRoundResult` — casts each declaration's `technique` via `resolve_battle_technique`
   (routes through the real `use_technique` magic envelope, not a generic shared check),
@@ -3952,8 +3963,12 @@ through abstract round-based VP mechanics. `Battle` is a 1:1 extension of `scene
   (`BattlePlace.combat_encounter` bridge, now wired for Champion duels, #1710, and
   siege-engine skirmishes, #1713; shared `RoundStatus` / `AbstractRound`), covenants
   (`BattleSide.covenant`; `CovenantRole.command_tier`/`.is_champion_role`, #1710), stories
-  (`campaign_story` FK, informational; `world.battles.beat_wiring` resolves linked beats via
-  campaign-stakes propagation, #1785), buildings (`Fortification.building` FK, nullable,
+  (`campaign_story` FK — beat-resolution linkage via `world.battles.beat_wiring`'s
+  campaign-stakes propagation, #1785; also read directly as the `story=` arg to the
+  win-gated `create_legend_event` call, #2184), societies (`world.battles.legend_wiring`
+  imports `societies.services.create_legend_event`/`create_solo_deed` +
+  `societies.models.LegendEntry`/`LegendSourceType` — a battle-conclusion hook, `battles`
+  importing `societies`, #2184), buildings (`Fortification.building` FK, nullable,
   #1713 — `create_fortification` reads `Building.fortification_level` once at creation;
   this app does not import `world.buildings` beyond that FK),
   actions (REGISTRY + `get_active_round_context` seam), gm (`world.gm.permissions.HasGMTrust`

--- a/docs/systems/battles.md
+++ b/docs/systems/battles.md
@@ -627,6 +627,37 @@ tier (one `Battle` grades as one outcome, applied uniformly — per-front
 independent grading is **#1760**'s job, not duplicated here). No `withdrawal`
 path: `BattleOutcome` has no FLED/ABANDONED-equivalent value.
 
+## Legend Wiring (#2184)
+
+`world.battles.legend_wiring` registers `apply_battle_legend_awards` as a
+**battle-conclusion hook** (`world.battles.conclusion_hooks`, the same registry
+`world.ships.battle_wiring` uses) — `battles` importing `societies` is the
+ratified direction here, both being general/reusable systems (unlike the
+ships case, where the FK-direction rule points the other way, ADR-0010).
+Registered in `BattlesConfig.ready()` (`world/battles/apps.py`).
+
+**Idempotency:** no-ops if any `LegendEntry` tagged with the lazily-created
+`"Battle"` `LegendSourceType` already exists for `battle.scene` — covers a
+second `conclude_battle`/hook run without a duplicate-check flag.
+
+**Win-gated victory event:** `battle.outcome` maps to a winning
+`BattleSideRole` (`ATTACKER_DECISIVE`/`ATTACKER_MARGINAL` → attacker,
+`DEFENDER_DECISIVE`/`DEFENDER_MARGINAL` → defender; `UNRESOLVED` mints
+nothing). Every winning-side `BattleParticipant.character_sheet` plus every
+winning-side `BattleUnit.commander` (deduped by sheet, resolved to
+`active_persona_for_sheet(sheet)`) shares one `create_legend_event` titled
+`"Victory at {battle.name}"`, `base_value` `BATTLE_LEGEND_DECISIVE_VALUE` (25)
+or `BATTLE_LEGEND_MARGINAL_VALUE` (12), scoped to `battle.scene` and
+`battle.campaign_story`. The losing side earns nothing from the event.
+
+**Standout deeds (both sides):** independent of who won, any resolved
+`BattleActionDeclaration` with `success_level >= STANDOUT_SUCCESS_LEVEL` (2 —
+clearly above bare success) on a `DRAMATIC_KINDS` action
+(RESCUE/ROUT/BREACH) earns its actor a `create_solo_deed` worth
+`BATTLE_LEGEND_STANDOUT_VALUE` (15), scoped to `battle.scene`. A losing-side
+rescue is still legend-worthy; standout deeds stack with the victory event by
+design — see **ADR-0122**.
+
 ## Services (`src/world/battles/services.py`)
 
 All public functions are the only permitted entry points for battle state mutations.
@@ -785,6 +816,13 @@ list-filtered on `kind`/`breached`; `place`/`defending_side`/`integrity`/`max_in
   mirrors `RALLY_MORALE_PER_LEVEL`'s scaling
 - `BREACH_VP_PER_LEVEL = 5` — BREACH's VP award per success level (#1713)
 - `FORTIFY_VP = 3` — FORTIFY's flat VP award (#1713)
+- `BATTLE_LEGEND_DECISIVE_VALUE = 25` / `BATTLE_LEGEND_MARGINAL_VALUE = 12` — win-gated
+  victory `LegendEvent` base value (#2184), decisive vs. marginal
+- `BATTLE_LEGEND_STANDOUT_VALUE = 15` — standout solo-deed base value (#2184), both sides
+- `STANDOUT_SUCCESS_LEVEL = 2` — success-level floor for a standout deed (#2184), clearly
+  above bare success (`success_level > 0`)
+- `DRAMATIC_KINDS` — tuple (#2184): the `BattleActionKind`s eligible for a standout deed —
+  RESCUE / ROUT / BREACH
 
 ## Exceptions (`src/world/battles/exceptions.py`)
 
@@ -838,9 +876,11 @@ metadata only, not used for beat resolution (see below). `conclude_battle` delib
 **does not** call `complete_story` — automatically closing the whole campaign story on
 one battle's conclusion would foreclose a war arc prematurely.
 
-Campaign-stakes propagation (battle outcome → Story + win-gated Legend) is wired via
+Campaign-stakes propagation (battle outcome → Story beat resolution) is wired via
 `world.battles.beat_wiring` (#1785) — see [Stakes / Beat Wiring](#stakes--beat-wiring-1785)
-below.
+below. Win-gated Legend propagation (battle outcome → `societies.LegendEntry`) is a
+separate seam, `world.battles.legend_wiring` (#2184) — see
+[Legend Wiring](#legend-wiring-2184) below.
 
 ## PR 1 Scope vs. Deferred
 
@@ -895,7 +935,7 @@ declaration. Telnet grammar for all four (`battle declare rout/rally/repel/hold 
 
 | What | Issue |
 |---|---|
-| Battle writeup / React page | **built** — the live strategic battle map (`/scenes/:id/battle`, [Web surface (#2009)](#web-surface-2009) below) shipped; post-conclusion narrative writeup page at `/battles/:id` reuses `BattleDetailSerializer`'s aggregate shape (#1735). `BattleDetailSerializer` was extended with `concluded_at`, `created_at`, `campaign_story_id`, `scene_id`, and `deeds` (a `SerializerMethodField` querying `LegendEntry` by the battle's scene). The deeds section is empty until battle→LegendEntry creation wiring is built (deferred — see follow-up). |
+| Battle writeup / React page | **built** — the live strategic battle map (`/scenes/:id/battle`, [Web surface (#2009)](#web-surface-2009) below) shipped; post-conclusion narrative writeup page at `/battles/:id` reuses `BattleDetailSerializer`'s aggregate shape (#1735). `BattleDetailSerializer` was extended with `concluded_at`, `created_at`, `campaign_story_id`, `scene_id`, and `deeds` (a `SerializerMethodField` querying `LegendEntry` by the battle's scene). The deeds section now populates — see [Legend Wiring (#2184)](#legend-wiring-2184) above. |
 | Naval / aerial variants | partially built (`BattleVehicle`, `BattleActionKind.REPOSITION` + vehicle-commander gating + movement resolution, hull-breach/living-mount-defeat ejection + drowning/falling hazard, see below; REPOSITION's telnet `CmdBattle` subcommand shipped with #2007); a player-facing embark action still deferred (#1714) |
 | Siege variants | **built, see [Sieges (#1713)](#sieges-1713) below** |
 

--- a/src/world/battles/apps.py
+++ b/src/world/battles/apps.py
@@ -7,3 +7,9 @@ class BattlesConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "world.battles"
     verbose_name = "Battles"
+
+    def ready(self) -> None:
+        from world.battles.conclusion_hooks import register_battle_conclusion_hook  # noqa: PLC0415
+        from world.battles.legend_wiring import apply_battle_legend_awards  # noqa: PLC0415
+
+        register_battle_conclusion_hook(apply_battle_legend_awards)

--- a/src/world/battles/constants.py
+++ b/src/world/battles/constants.py
@@ -221,3 +221,25 @@ SET_ENVIRONMENT_VP = 4
 # route through resolve_damage_type_resistance for immunity = high resistance.
 VEHICLE_HAZARD_UNIT_STRENGTH_PENALTY = 30
 VEHICLE_HAZARD_BASE_DAMAGE = 20
+
+# Win-gated LegendEntry wiring (#2184). Only the winning side mints a Victory
+# LegendEvent — DECISIVE outweighs MARGINAL, mirroring DECISIVE_MARGIN's own
+# distinction. Standout deeds are a separate, smaller-value pass available to
+# BOTH sides (a losing-side rescue is still legend-worthy) — see
+# world.battles.legend_wiring.apply_battle_legend_awards.
+BATTLE_LEGEND_DECISIVE_VALUE = 25
+BATTLE_LEGEND_MARGINAL_VALUE = 12
+BATTLE_LEGEND_STANDOUT_VALUE = 15
+
+# success_level > 0 is already "success" (BattleActionDeclaration.success_level
+# help_text); STANDOUT_SUCCESS_LEVEL is set clearly above bare success (1) so a
+# routine hit doesn't also mint legend — only a standout margin does.
+STANDOUT_SUCCESS_LEVEL = 2
+
+# The action kinds dramatic enough to be worth a standout deed on their own,
+# independent of who won the battle.
+DRAMATIC_KINDS = (
+    BattleActionKind.RESCUE,
+    BattleActionKind.ROUT,
+    BattleActionKind.BREACH,
+)

--- a/src/world/battles/legend_wiring.py
+++ b/src/world/battles/legend_wiring.py
@@ -1,0 +1,147 @@
+"""Battle-conclusion win-gated LegendEntry wiring (#2184).
+
+Registered as a ``world.battles.conclusion_hooks`` hook in
+``world.battles.apps.ready()`` — mirrors ``world.ships.battle_wiring``'s shape,
+but here ``battles`` importing ``societies`` is the ratified direction (both
+are general/reusable systems; societies' legend model has no reason to know
+about battles, so the dependency runs the other way).
+
+Only the winning side's participants + winning-side unit commanders earn a
+shared Victory ``LegendEvent`` (win-gated — a decisive win is worth more than a
+marginal one, and a loss earns nothing from the event itself). Separately, any
+resolved battle-round declaration with a standout success on a dramatic action
+kind (RESCUE/ROUT/BREACH) earns its actor a smaller solo deed, regardless of
+which side they were on — a losing-side rescue is still a story worth telling.
+Standout deeds stack with the victory event by design.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from world.battles.constants import (
+    BATTLE_LEGEND_DECISIVE_VALUE,
+    BATTLE_LEGEND_MARGINAL_VALUE,
+    BATTLE_LEGEND_STANDOUT_VALUE,
+    DRAMATIC_KINDS,
+    STANDOUT_SUCCESS_LEVEL,
+    BattleActionKind,
+    BattleOutcome,
+    BattleSideRole,
+)
+from world.battles.models import BattleActionDeclaration, BattleParticipant, BattleUnit
+from world.scenes.services import active_persona_for_sheet
+from world.societies.models import LegendEntry, LegendSourceType
+from world.societies.services import create_legend_event, create_solo_deed
+
+if TYPE_CHECKING:
+    from world.battles.models import Battle
+    from world.character_sheets.models import CharacterSheet
+    from world.scenes.models import Persona
+
+# Which side won, and whether it was decisive, per graded BattleOutcome.
+# UNRESOLVED has no entry — callers must check membership before indexing.
+_WINNING_SIDE_BY_OUTCOME: dict[str, tuple[str, bool]] = {
+    BattleOutcome.ATTACKER_DECISIVE: (BattleSideRole.ATTACKER, True),
+    BattleOutcome.ATTACKER_MARGINAL: (BattleSideRole.ATTACKER, False),
+    BattleOutcome.DEFENDER_DECISIVE: (BattleSideRole.DEFENDER, True),
+    BattleOutcome.DEFENDER_MARGINAL: (BattleSideRole.DEFENDER, False),
+}
+
+# Standout-deed title per dramatic action kind, formatted with the battle name.
+_STANDOUT_TITLES: dict[str, str] = {
+    BattleActionKind.RESCUE: "Daring rescue at {battle}",
+    BattleActionKind.ROUT: "Decisive rout at {battle}",
+    BattleActionKind.BREACH: "Breakthrough breach at {battle}",
+}
+
+
+def _battle_source_type() -> LegendSourceType:
+    """Lazy ``LegendSourceType`` row for battle-earned legend (#2184).
+
+    Mirrors the ``_theft_source_type``/``theft_category`` lazy-row idiom
+    (``flows/service_functions/inventory.py``) — ``LegendSourceType`` has no
+    fixed enum of members, so there's no committed "existing member" to grep;
+    rows are get-or-created on first use instead of fixture-seeded (fixtures
+    aren't in version control, ADR-0013 bans seed migrations).
+    """
+    source_type, _ = LegendSourceType.objects.get_or_create(
+        name="Battle",
+        defaults={"description": "War-scale battle victories and standout deeds."},
+    )
+    return source_type
+
+
+def _winning_personas(battle: Battle, winning_side_role: str) -> list[Persona]:
+    """Every winning-side participant + winning-side unit commander, deduped by sheet."""
+    sheets: dict[int, CharacterSheet] = {}
+
+    participants = BattleParticipant.objects.filter(
+        battle=battle, side__role=winning_side_role
+    ).select_related("character_sheet")
+    for participant in participants:
+        sheets[participant.character_sheet_id] = participant.character_sheet
+
+    commanded_units = BattleUnit.objects.filter(
+        battle=battle, side__role=winning_side_role, commander__isnull=False
+    ).select_related("commander")
+    for unit in commanded_units:
+        sheets[unit.commander_id] = unit.commander
+
+    return [active_persona_for_sheet(sheet) for sheet in sheets.values()]
+
+
+def _award_standout_deeds(battle: Battle, source_type: LegendSourceType) -> None:
+    """Solo deeds for standout dramatic actions, winners and losers alike."""
+    declarations = BattleActionDeclaration.objects.filter(
+        participant__battle=battle,
+        resolved=True,
+        success_level__gte=STANDOUT_SUCCESS_LEVEL,
+        action_kind__in=DRAMATIC_KINDS,
+    ).select_related("participant__character_sheet")
+    for declaration in declarations:
+        sheet = declaration.participant.character_sheet
+        persona = active_persona_for_sheet(sheet)
+        title_template = _STANDOUT_TITLES[declaration.action_kind]
+        create_solo_deed(
+            persona,
+            title_template.format(battle=battle.name),
+            source_type,
+            BATTLE_LEGEND_STANDOUT_VALUE,
+            scene=battle.scene,
+        )
+
+
+def apply_battle_legend_awards(battle: Battle) -> None:
+    """Mint the winning side's Victory legend event + any standout solo deeds.
+
+    Idempotent: no-ops if any ``LegendEntry`` with the Battle source type
+    already exists for ``battle.scene`` (covers a hook re-run, e.g. a second
+    ``conclude_battle`` call — which is itself idempotent, but the hook
+    registry has no idempotency of its own).
+
+    Args:
+        battle: A just-concluded ``Battle`` (``battle.outcome`` set).
+    """
+    source_type = _battle_source_type()
+    if LegendEntry.objects.filter(source_type=source_type, scene=battle.scene).exists():
+        return
+
+    mapping = _WINNING_SIDE_BY_OUTCOME.get(battle.outcome)
+    if mapping is None:
+        # UNRESOLVED (or any future non-graded outcome) — nothing to mint.
+        return
+    winning_side_role, decisive = mapping
+
+    personas = _winning_personas(battle, winning_side_role)
+    base_value = BATTLE_LEGEND_DECISIVE_VALUE if decisive else BATTLE_LEGEND_MARGINAL_VALUE
+    create_legend_event(
+        f"Victory at {battle.name}",
+        source_type,
+        base_value,
+        personas,
+        scene=battle.scene,
+        story=battle.campaign_story,
+    )
+
+    _award_standout_deeds(battle, source_type)

--- a/src/world/battles/legend_wiring.py
+++ b/src/world/battles/legend_wiring.py
@@ -134,14 +134,19 @@ def apply_battle_legend_awards(battle: Battle) -> None:
     winning_side_role, decisive = mapping
 
     personas = _winning_personas(battle, winning_side_role)
-    base_value = BATTLE_LEGEND_DECISIVE_VALUE if decisive else BATTLE_LEGEND_MARGINAL_VALUE
-    create_legend_event(
-        f"Victory at {battle.name}",
-        source_type,
-        base_value,
-        personas,
-        scene=battle.scene,
-        story=battle.campaign_story,
-    )
+    if personas:
+        # A PC-less winning side mints no Victory event: create_legend_event
+        # with an empty persona list would leave a dangling LegendEvent with
+        # zero entries, and the entry-based idempotency guard above would not
+        # see it — every re-conclude would mint another empty event.
+        base_value = BATTLE_LEGEND_DECISIVE_VALUE if decisive else BATTLE_LEGEND_MARGINAL_VALUE
+        create_legend_event(
+            f"Victory at {battle.name}",
+            source_type,
+            base_value,
+            personas,
+            scene=battle.scene,
+            story=battle.campaign_story,
+        )
 
     _award_standout_deeds(battle, source_type)

--- a/src/world/battles/tests/test_legend_wiring.py
+++ b/src/world/battles/tests/test_legend_wiring.py
@@ -1,0 +1,150 @@
+"""Tests for battle -> win-gated LegendEntry wiring (#2184).
+
+``apply_battle_legend_awards`` is registered as a battle-conclusion hook in
+``world.battles.apps.ready()``. Tests reset the registry to exactly this hook
+(avoiding duplicate firing or cross-test leakage from other suites' probe
+hooks / production hooks like the ship writeback or duel wiring), then
+snapshot and restore the pre-test contents on cleanup — clearing to empty
+(rather than restoring) would permanently drop the production registration
+for the rest of the test process (mirrors ``test_conclusion_hooks.py`` /
+``ships/tests/test_battle_writeback.py``).
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from world.battles import conclusion_hooks
+from world.battles.conclusion_hooks import (
+    clear_battle_conclusion_hooks,
+    register_battle_conclusion_hook,
+)
+from world.battles.constants import (
+    BATTLE_LEGEND_DECISIVE_VALUE,
+    BATTLE_LEGEND_MARGINAL_VALUE,
+    BATTLE_LEGEND_STANDOUT_VALUE,
+    STANDOUT_SUCCESS_LEVEL,
+    BattleActionKind,
+    BattleOutcome,
+    BattleSideRole,
+)
+from world.battles.factories import (
+    BattleActionDeclarationFactory,
+    BattleFactory,
+    BattleParticipantFactory,
+    BattleRoundFactory,
+    BattleSideFactory,
+    BattleUnitFactory,
+)
+from world.battles.legend_wiring import apply_battle_legend_awards
+from world.battles.services import conclude_battle
+from world.character_sheets.factories import CharacterSheetFactory
+from world.societies.models import LegendEntry, LegendEvent
+
+
+class ApplyBattleLegendAwardsTests(TestCase):
+    def setUp(self) -> None:
+        self._saved_hooks = list(conclusion_hooks._HOOKS)
+        self.addCleanup(self._restore_hooks)
+        clear_battle_conclusion_hooks()
+        register_battle_conclusion_hook(apply_battle_legend_awards)
+
+        self.battle = BattleFactory(name="Siege of the Salt Marsh")
+        self.attacker_side = BattleSideFactory(battle=self.battle, role=BattleSideRole.ATTACKER)
+        self.defender_side = BattleSideFactory(battle=self.battle, role=BattleSideRole.DEFENDER)
+
+    def _restore_hooks(self) -> None:
+        conclusion_hooks._HOOKS[:] = self._saved_hooks
+
+    def test_decisive_win_awards_event_to_participants_and_commander(self) -> None:
+        winner_sheet = CharacterSheetFactory()
+        BattleParticipantFactory(
+            battle=self.battle, side=self.attacker_side, character_sheet=winner_sheet
+        )
+        commander_sheet = CharacterSheetFactory()
+        BattleUnitFactory(battle=self.battle, side=self.attacker_side, commander=commander_sheet)
+        loser_sheet = CharacterSheetFactory()
+        BattleParticipantFactory(
+            battle=self.battle, side=self.defender_side, character_sheet=loser_sheet
+        )
+
+        conclude_battle(battle=self.battle, outcome=BattleOutcome.ATTACKER_DECISIVE)
+
+        event = LegendEvent.objects.get(scene=self.battle.scene)
+        self.assertEqual(event.title, f"Victory at {self.battle.name}")
+        self.assertEqual(event.base_value, BATTLE_LEGEND_DECISIVE_VALUE)
+
+        entries = LegendEntry.objects.filter(event=event)
+        winner_personas = {winner_sheet.primary_persona.pk, commander_sheet.primary_persona.pk}
+        self.assertEqual({e.persona_id for e in entries}, winner_personas)
+        self.assertFalse(LegendEntry.objects.filter(persona=loser_sheet.primary_persona).exists())
+
+    def test_marginal_win_uses_marginal_value(self) -> None:
+        winner_sheet = CharacterSheetFactory()
+        BattleParticipantFactory(
+            battle=self.battle, side=self.attacker_side, character_sheet=winner_sheet
+        )
+
+        conclude_battle(battle=self.battle, outcome=BattleOutcome.ATTACKER_MARGINAL)
+
+        event = LegendEvent.objects.get(scene=self.battle.scene)
+        self.assertEqual(event.base_value, BATTLE_LEGEND_MARGINAL_VALUE)
+
+    def test_losing_side_standout_rescue_earns_stacking_solo_deed(self) -> None:
+        winner_sheet = CharacterSheetFactory()
+        BattleParticipantFactory(
+            battle=self.battle, side=self.attacker_side, character_sheet=winner_sheet
+        )
+        rescuer_sheet = CharacterSheetFactory()
+        rescuer_participant = BattleParticipantFactory(
+            battle=self.battle, side=self.defender_side, character_sheet=rescuer_sheet
+        )
+        battle_round = BattleRoundFactory(battle=self.battle)
+        BattleActionDeclarationFactory(
+            battle_round=battle_round,
+            participant=rescuer_participant,
+            action_kind=BattleActionKind.RESCUE,
+            resolved=True,
+            success_level=STANDOUT_SUCCESS_LEVEL,
+        )
+
+        conclude_battle(battle=self.battle, outcome=BattleOutcome.ATTACKER_DECISIVE)
+
+        standout = LegendEntry.objects.get(
+            persona=rescuer_sheet.primary_persona, event__isnull=True
+        )
+        self.assertEqual(standout.title, f"Daring rescue at {self.battle.name}")
+        self.assertEqual(standout.base_value, BATTLE_LEGEND_STANDOUT_VALUE)
+        self.assertEqual(standout.scene, self.battle.scene)
+
+        # The victory event still fired for the winning side.
+        self.assertTrue(LegendEvent.objects.filter(scene=self.battle.scene).exists())
+
+    def test_unresolved_outcome_mints_nothing(self) -> None:
+        BattleParticipantFactory(
+            battle=self.battle,
+            side=self.attacker_side,
+            character_sheet=CharacterSheetFactory(),
+        )
+
+        conclude_battle(battle=self.battle, outcome=BattleOutcome.UNRESOLVED)
+
+        self.assertFalse(LegendEntry.objects.filter(scene=self.battle.scene).exists())
+        self.assertFalse(LegendEvent.objects.filter(scene=self.battle.scene).exists())
+
+    def test_second_call_does_not_duplicate(self) -> None:
+        winner_sheet = CharacterSheetFactory()
+        BattleParticipantFactory(
+            battle=self.battle, side=self.attacker_side, character_sheet=winner_sheet
+        )
+
+        conclude_battle(battle=self.battle, outcome=BattleOutcome.ATTACKER_DECISIVE)
+        entry_count = LegendEntry.objects.filter(scene=self.battle.scene).count()
+        event_count = LegendEvent.objects.filter(scene=self.battle.scene).count()
+
+        # conclude_battle itself is idempotent (is_concluded guard), so exercise
+        # the hook's own idempotency directly, as a second conclusion attempt would.
+        apply_battle_legend_awards(self.battle)
+
+        self.assertEqual(LegendEntry.objects.filter(scene=self.battle.scene).count(), entry_count)
+        self.assertEqual(LegendEvent.objects.filter(scene=self.battle.scene).count(), event_count)


### PR DESCRIPTION
Closes #2184

## Summary

Wires battle conclusion to the legend system: the winning side's PCs (participants + unit commanders) earn a shared Victory LegendEvent (decisive 25 / marginal 12), and standout dramatic actions (RESCUE/ROUT/BREACH at success_level >= 2) earn solo deeds (15) on either side. Registered as a battle conclusion hook (ships-app pattern); lazy 'Battle' LegendSourceType bucket; idempotent; UNRESOLVED battles mint nothing. Includes ADR-0122 and doc fix-on-sight (stale '#1785 shipped win-gated legend' claims corrected).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2184 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: branch created from feee68ebd (current main); sync-with-main clean, no conflicts

<!-- last-addressed-comment: 0 -->