### PR TITLE
Should any protective cast at an embattled ally pull the caster into the fight? (generalize #2183's benign-intervention join)

### DIFF
--- a/docs/adr/0119-protective-casts-seat-caster-in-combat.md
+++ b/docs/adr/0119-protective-casts-seat-caster-in-combat.md
@@ -1,0 +1,79 @@
+# ADR-0119: Protective casts at embattled allies seat the caster in combat
+
+**Date:** 2026-07-12
+**Status:** Accepted
+**Context:** #2226
+
+## Context
+
+Before #2226, the only paths by which a cast seated a non-participant in a live
+`CombatEncounter` were:
+
+1. **Hostile cast** → `seed_or_feed_encounter_from_cast` (pre-existing).
+2. **Technique entrance** (#2183) → `seed_or_feed_encounter_from_benign_intervention`,
+   called only from the entrance path.
+
+An ordinary (non-entrance) protective cast at an embattled ally resolved via
+`_route_immediate_cast` — it applied its effect but touched no combat state. The
+caster was not seated in the encounter, not made targetable, and acknowledged no
+risk. This let a caster support from total safety: casting a shield onto someone
+mid-melee without any combat consequence.
+
+The mechanical seam (`seed_or_feed_encounter_from_benign_intervention`) already
+existed and was trivially callable from the general benign-cast path. The
+question was whether to generalize it.
+
+## Decision
+
+Generalize benign-intervention combat seating to **all** protective casts. Any
+benign (non-hostile) technique cast that affects an ACTIVE combatant seats the
+caster in that combatant's encounter — regardless of targeting mode (SINGLE, AREA,
+FILTERED_GROUP) or consent path (immediate or consent-requiring).
+
+The cast's effect still applies normally. The seating is a post-resolution
+side-effect, not a pre-cast gate. The caster is seated once per cast, even if
+the technique touched multiple embattled allies.
+
+Risk acknowledgement is automatic (`acknowledge_encounter_risk`), not a consent
+gate. The caster chose to cast at someone in a fight; the risk acknowledgement
+records that choice.
+
+## Rejected alternatives
+
+- **Opt-in only (the status quo):** Total safety from support casting is an
+  exploit of the benign/behavioral consent distinction (ADR-0024 gates consent
+  on behavior-alteration, not benign-vs-hostile). A protective shield is
+  benign, so it resolves consent-free — but letting it affect combat without
+  consequence is an oversight, not a design.
+- **Offer-to-join prompt:** Preserves the deliberate-act principle but leaves
+  the safe-distance gap open if the caster declines. The caster already chose
+  to cast at a fighter; a second prompt is redundant friction.
+
+## Relationship to existing ADRs
+
+- **ADR-0024 (consent gates behavior-altering effects):** Benign casts remain
+  consent-free for the *target* (no behavioral agency lost). The combat
+  consequence falls on the *caster* via automatic risk acknowledgement, not a
+  consent gate — deliberate, because the caster chose to cast at someone in a
+  fight.
+- **ADR-0023 (PvP is structurally non-lethal):** Seating makes the caster
+  targetable, but PvP remains non-lethal. The caster risks defeat/yield, not
+  death.
+- **ADR-0113 (entrance carries the cast):** #2183's entrance-path seating is
+  now a special case of the generalized rule. The entrance path's other hooks
+  (flourish, disposition, suggestion) remain entrance-only; only the seating
+  generalized.
+
+## Consequences
+
+- The `seat_caster_for_benign_intervention` wrapper (in `cast_seed.py`) iterates
+  target sheets and calls the existing `seed_or_feed_encounter_from_benign_intervention`
+  for each until one returns non-None. It excludes the caster's own sheet
+  (self-cast is not intervention).
+- `_route_immediate_cast` calls `_maybe_seat_caster_after_benign_cast` after the
+  cast resolves. `CastResult.combat_seated` signals whether seating occurred.
+- `resolve_accepted_cast` calls `_maybe_seat_after_consent_accept` after the
+  benign consent-accept resolution. Both paths guard on `success_level > 0`.
+- The entrance-path seating calls in `_run_entrance_benign_accept_hooks` and
+  `EntranceAction._resolve_inline_entrance_result` are removed — the generalized
+  calls supersede them.

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -3392,10 +3392,14 @@ reactive maneuvers (COVER, INTERPOSE, DEFEND stance), and clash-of-wills.
   (the entrance's own recognition hooks fired flourish-only at declaration time — the
   suggestion was deferred). `world.combat.cast_seed
   .seed_or_feed_encounter_from_benign_intervention(*, caster_sheet, target_sheet, scene)`
-  is the benign sibling: seats a non-combatant whose protective (non-hostile) entrance
-  cast landed on an already-embattled ally into the fight — no opponent row, no stakes
+  is the benign sibling: seats a non-combatant whose protective (non-hostile) cast
+  landed on an already-embattled ally into the fight — no opponent row, no stakes
   lock, no FOCUSED declaration (the cast already resolved standalone); no-ops when there
-  is no feedable encounter or the target isn't embattled in it.
+  is no feedable encounter or the target isn't embattled in it. #2226 (ADR-0119)
+  generalized this to **all** benign casts via the `seat_caster_for_benign_intervention`
+  wrapper (`cast_seed.py`), called post-resolution from `_route_immediate_cast` and
+  `resolve_accepted_cast`; the entrance path's own seating calls were removed (the
+  generalized calls supersede them).
 - **Effect-palette / summon / allegiance additions (#1584):**
   - `CombatOpponent.allegiance` (`CombatAllegiance`: ENEMY default / ALLY) — mutable
     side-field; ALLY opponents fight *for* the party (summons, and future charm/

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -255,6 +255,10 @@ Lives on `world/conditions/models.py:ConditionCategory`.
 - Hostile → `seed_or_feed_encounter_from_cast` (combat).
 - Benign + behavior-altering → PENDING `SceneActionRequest` (consent required).
 - Benign + capability/stat → resolves immediately, including on other PCs.
+- **Any benign cast that affects an ACTIVE combatant** seats the caster in
+  that combatant's encounter (#2226, ADR-0119) — via
+  `seat_caster_for_benign_intervention`, called post-resolution on both the
+  immediate and consent-accept paths. Risk acknowledgement is automatic.
 
 **Shared condition application** (`world/magic/services/condition_application.py`):
 `apply_technique_conditions(*, technique, success_level, eff_intensity, targets_by_kind, source_character, applied_condition_rows=None)`
@@ -1082,7 +1086,7 @@ time:
 
 | Branch | What happens |
 |--------|--------------|
-| Resolved inline (self/room/no-target, or a benign no-consent cast at another PC) | Full hooks fire immediately once the success level clears 0: entry-flourish offer, disposition delta (non-hostile only), the `Dramatic Moment Suggestion` check, and — when the target is another sheet's ACTIVE combatant — a **benign-intervention combat join** (`seed_or_feed_encounter_from_benign_intervention`, see combat.md). |
+| Resolved inline (self/room/no-target, or a benign no-consent cast at another PC) | Full hooks fire immediately once the success level clears 0: entry-flourish offer, disposition delta (non-hostile only), the `Dramatic Moment Suggestion` check. A **benign-intervention combat join** (`seat_caster_for_benign_intervention`, #2226/ADR-0119) fires for *any* benign cast (not just entrances) that affects an ACTIVE combatant — see the consent-routing note above. |
 | Hostile cast at another PC | Seeds/feeds a combat encounter (`seed_or_feed_encounter_from_cast(..., from_entrance=True)`) — flourish only; the success level isn't known until the declared cast resolves at round resolution (see combat.md's `_maybe_suggest_entrance_dramatic_moment`). |
 | PENDING (benign consent-gated, or hostile #777 risk-gated) | No hooks at declaration; `SceneActionRequest.originated_as_entrance` marks the request so `resolve_accepted_cast` fires the deferred hooks at accept-time resolution instead. |
 | Soulfray gate not confirmed | Registers a `PendingCast` (mirrors `cast.py`) carrying an `"entrance": True` marker in its kwargs; `SoulfrayPendingHandler`'s `accept soulfray` re-dispatch reads the marker and re-enters through the `"entrance"` REGISTRY action (not `"cast_technique"`) so the flourish/suggestion/intervention hooks stay reachable — see `world/magic/offer_handlers.py`. |

--- a/src/actions/definitions/cast.py
+++ b/src/actions/definitions/cast.py
@@ -146,7 +146,12 @@ class CastTechniqueAction(Action):
                 ),
             )
 
-        return ActionResult(success=True, message="Your technique resolves.")
+        message = "Your technique resolves."
+        if cast.combat_seated:
+            message = (
+                f"{message}\nYour cast reaches an embattled ally — you are drawn into the fight."
+            )
+        return ActionResult(success=True, message=message)
 
     def round_declaration(
         self,

--- a/src/actions/definitions/social.py
+++ b/src/actions/definitions/social.py
@@ -559,9 +559,9 @@ class EntranceAction(_SocialTemplateAction):
     def _resolve_inline_entrance_result(  # noqa: PLR0913 - cohesive resolved-inline outcome params
         actor: ObjectDB,
         scene: Scene,
-        actor_sheet: CharacterSheet | None,
+        _actor_sheet: CharacterSheet | None,  # #2226: was used for seating, now generalized
         technique: Technique,
-        target: Persona | None,
+        _target: Persona | None,  # #2226: was used for seating, now generalized
         target_persona_id: int | None,
         entry_interaction: Interaction | None,
         cast: CastResult,
@@ -573,9 +573,6 @@ class EntranceAction(_SocialTemplateAction):
         combat-seed/PENDING branches in ``_dispatch_entrance_cast``.)
         """
         from actions.types import ActionResult as _ActionResult  # noqa: PLC0415
-        from world.combat.cast_seed import (  # noqa: PLC0415
-            seed_or_feed_encounter_from_benign_intervention,
-        )
         from world.magic.services.hostility import is_technique_hostile  # noqa: PLC0415
         from world.npc_services.social_disposition import (  # noqa: PLC0415
             apply_social_disposition_delta,
@@ -606,17 +603,9 @@ class EntranceAction(_SocialTemplateAction):
         if prompt:
             message = f"{message}\n{prompt}"
 
-        if (
-            target is not None
-            and actor_sheet is not None
-            and target.character_sheet_id != actor_sheet.pk
-        ):
-            seed_or_feed_encounter_from_benign_intervention(
-                caster_sheet=actor_sheet,
-                target_sheet=target.character_sheet,
-                scene=scene,
-            )
-
+        # #2226: combat seating for benign casts is now handled by
+        # _route_immediate_cast's generalized seating call — no need to
+        # duplicate it here.
         return _ActionResult(success=True, message=message)
 
     @staticmethod

--- a/src/world/combat/cast_seed.py
+++ b/src/world/combat/cast_seed.py
@@ -196,6 +196,36 @@ def seed_or_feed_encounter_from_benign_intervention(
     return participant
 
 
+def seat_caster_for_benign_intervention(
+    *,
+    caster_sheet: CharacterSheet,
+    target_sheets: list[CharacterSheet],
+    scene: Scene,
+) -> CombatParticipant | None:
+    """Seat the caster in the first encounter found among embattled targets.
+
+    Iterates target sheets, calling ``seed_or_feed_encounter_from_benign_intervention``
+    for each until one returns non-None (caster seated). Returns None when no
+    target is embattled in any feedable encounter.
+
+    Excludes the caster's own sheet from the target list — a self-cast is not
+    an intervention at another PC, and ``seed_or_feed_encounter_from_benign_intervention``
+    has no self-cast guard (it checks only whether the target is embattled, not
+    whether the target is the caster).
+    """
+    for target_sheet in target_sheets:
+        if target_sheet.pk == caster_sheet.pk:
+            continue
+        participant = seed_or_feed_encounter_from_benign_intervention(
+            caster_sheet=caster_sheet,
+            target_sheet=target_sheet,
+            scene=scene,
+        )
+        if participant is not None:
+            return participant
+    return None
+
+
 @transaction.atomic
 def seed_or_feed_encounter_from_cast(  # noqa: PLR0913 - cast context + entrance marker flag
     *,

--- a/src/world/combat/tests/test_benign_cast_seating.py
+++ b/src/world/combat/tests/test_benign_cast_seating.py
@@ -1,0 +1,377 @@
+"""Tests for generalized benign-intervention combat seating (#2226).
+
+Any benign (non-hostile) cast that affects an ACTIVE combatant seats the caster
+in that combatant's encounter — regardless of targeting mode (SINGLE, AREA,
+FILTERED_GROUP) or consent path (immediate or consent-requiring). The cast's
+effect still applies normally; the seating is a post-resolution side-effect.
+
+These tests exercise ``seat_caster_for_benign_intervention`` (the multi-target
+wrapper) and the ``_maybe_seat_caster_after_benign_cast`` hook in
+``_route_immediate_cast``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from evennia.utils.test_resources import EvenniaTestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.constants import (
+    CombatAllegiance,
+    EncounterType,
+    OpponentStatus,
+    ParticipantStatus,
+    RiskLevel,
+)
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+)
+from world.combat.models import (
+    CombatParticipant,
+    EncounterRiskAcknowledgement,
+)
+from world.scenes.constants import RoundStatus
+from world.scenes.factories import SceneFactory
+from world.vitals.models import CharacterVitals
+
+
+class SeatCasterForBenignInterventionTests(EvenniaTestCase):
+    """Tests for the ``seat_caster_for_benign_intervention`` wrapper."""
+
+    @staticmethod
+    def _make_sheets(n=2):
+        sheets = []
+        for _ in range(n):
+            sheet = CharacterSheetFactory()
+            CharacterVitals.objects.create(
+                character_sheet=sheet,
+                health=50,
+                max_health=50,
+                base_max_health=50,
+            )
+            sheets.append(sheet)
+        return sheets
+
+    @staticmethod
+    def _make_declaring_encounter():
+        return CombatEncounterFactory(
+            status=RoundStatus.DECLARING,
+            risk_level=RiskLevel.MODERATE,
+            encounter_type=EncounterType.PARTY_COMBAT,
+            round_number=1,
+        )
+
+    def test_single_target_seats_caster(self):
+        """A single embattled ally seats the caster."""
+        from world.combat.cast_seed import seat_caster_for_benign_intervention
+
+        caster, target = self._make_sheets()
+        encounter = self._make_declaring_encounter()
+        CombatParticipantFactory(
+            encounter=encounter,
+            character_sheet=target,
+            status=ParticipantStatus.ACTIVE,
+        )
+
+        participant = seat_caster_for_benign_intervention(
+            caster_sheet=caster,
+            target_sheets=[target],
+            scene=encounter.scene,
+        )
+
+        self.assertIsNotNone(participant)
+        self.assertEqual(participant.character_sheet, caster)
+        self.assertTrue(
+            EncounterRiskAcknowledgement.objects.filter(
+                encounter=encounter,
+                character_sheet=caster,
+            ).exists()
+        )
+
+    def test_multiple_targets_seats_once(self):
+        """Multiple embattled allies seat the caster once (first encounter wins)."""
+        from world.combat.cast_seed import seat_caster_for_benign_intervention
+
+        caster, target1, target2 = self._make_sheets(3)
+        encounter = self._make_declaring_encounter()
+        for t in (target1, target2):
+            CombatParticipantFactory(
+                encounter=encounter,
+                character_sheet=t,
+                status=ParticipantStatus.ACTIVE,
+            )
+
+        participant = seat_caster_for_benign_intervention(
+            caster_sheet=caster,
+            target_sheets=[target1, target2],
+            scene=encounter.scene,
+        )
+
+        self.assertIsNotNone(participant)
+        # Caster is seated exactly once — one participant row.
+        self.assertEqual(
+            CombatParticipant.objects.filter(
+                encounter=encounter,
+                character_sheet=caster,
+                status=ParticipantStatus.ACTIVE,
+            ).count(),
+            1,
+        )
+
+    def test_self_cast_excluded(self):
+        """The caster's own sheet is excluded from the target list."""
+        from world.combat.cast_seed import seat_caster_for_benign_intervention
+
+        caster, _target = self._make_sheets()
+        encounter = self._make_declaring_encounter()
+        # The caster is themselves an embattled combatant.
+        CombatParticipantFactory(
+            encounter=encounter,
+            character_sheet=caster,
+            status=ParticipantStatus.ACTIVE,
+        )
+
+        # Only the caster's sheet is in the list — should not seat (no other
+        # target to intervene on).
+        participant = seat_caster_for_benign_intervention(
+            caster_sheet=caster,
+            target_sheets=[caster],
+            scene=encounter.scene,
+        )
+
+        self.assertIsNone(participant)
+
+    def test_no_embattled_target_returns_none(self):
+        """A target that is not in any encounter returns None."""
+        from world.combat.cast_seed import seat_caster_for_benign_intervention
+
+        caster, target = self._make_sheets()
+        scene = SceneFactory()
+
+        participant = seat_caster_for_benign_intervention(
+            caster_sheet=caster,
+            target_sheets=[target],
+            scene=scene,
+        )
+
+        self.assertIsNone(participant)
+
+    def test_already_in_encounter_no_double_seating(self):
+        """A caster already in the encounter is not double-seated."""
+        from world.combat.cast_seed import seat_caster_for_benign_intervention
+
+        caster, target = self._make_sheets()
+        encounter = self._make_declaring_encounter()
+        CombatParticipantFactory(
+            encounter=encounter,
+            character_sheet=target,
+            status=ParticipantStatus.ACTIVE,
+        )
+        CombatParticipantFactory(
+            encounter=encounter,
+            character_sheet=caster,
+            status=ParticipantStatus.ACTIVE,
+        )
+
+        participant = seat_caster_for_benign_intervention(
+            caster_sheet=caster,
+            target_sheets=[target],
+            scene=encounter.scene,
+        )
+
+        # Returns non-None (the existing participant), but only one row.
+        self.assertIsNotNone(participant)
+        self.assertEqual(
+            CombatParticipant.objects.filter(
+                encounter=encounter,
+                character_sheet=caster,
+                status=ParticipantStatus.ACTIVE,
+            ).count(),
+            1,
+        )
+
+    def test_ally_opponent_seats_caster(self):
+        """A target that is an ALLY opponent (not a participant) also seats."""
+        from world.combat.cast_seed import seat_caster_for_benign_intervention
+
+        caster, target = self._make_sheets()
+        encounter = self._make_declaring_encounter()
+        CombatOpponentFactory(
+            encounter=encounter,
+            objectdb_id=target.character.pk,
+            allegiance=CombatAllegiance.ALLY,
+            status=OpponentStatus.ACTIVE,
+        )
+
+        participant = seat_caster_for_benign_intervention(
+            caster_sheet=caster,
+            target_sheets=[target],
+            scene=encounter.scene,
+        )
+
+        self.assertIsNotNone(participant)
+        self.assertEqual(participant.character_sheet, caster)
+
+
+class MaybeSeatCasterAfterBenignCastTests(EvenniaTestCase):
+    """Tests for the ``_maybe_seat_caster_after_benign_cast`` immediate-path hook."""
+
+    @staticmethod
+    def _make_sheet():
+        sheet = CharacterSheetFactory()
+        CharacterVitals.objects.create(
+            character_sheet=sheet,
+            health=50,
+            max_health=50,
+            base_max_health=50,
+        )
+        return sheet
+
+    def _make_mock_result(self, success_level=3):
+        """Build a mock EnhancedSceneActionResult with the given success level."""
+        result = MagicMock()
+        result.action_resolution.main_result.check_result.success_level = success_level
+        return result
+
+    def test_failed_cast_does_not_seat(self):
+        """A cast with success_level <= 0 does not seat the caster."""
+        from world.scenes.cast_services import _maybe_seat_caster_after_benign_cast
+
+        caster = self._make_sheet()
+        target = self._make_sheet()
+        encounter = CombatEncounterFactory(
+            status=RoundStatus.DECLARING,
+            risk_level=RiskLevel.MODERATE,
+            encounter_type=EncounterType.PARTY_COMBAT,
+            round_number=1,
+        )
+        CombatParticipantFactory(
+            encounter=encounter,
+            character_sheet=target,
+            status=ParticipantStatus.ACTIVE,
+        )
+
+        from world.scenes.factories import PersonaFactory
+
+        caster_persona = PersonaFactory(character_sheet=caster)
+        target_persona = PersonaFactory(character_sheet=target)
+        technique = MagicMock()
+        technique.target_type = "SINGLE"
+
+        with patch(
+            "world.scenes.cast_services.is_technique_hostile",
+            return_value=False,
+        ):
+            seated = _maybe_seat_caster_after_benign_cast(
+                scene=encounter.scene,
+                initiator_persona=caster_persona,
+                target_persona=target_persona,
+                technique=technique,
+                supplied_personas=None,
+                result=self._make_mock_result(success_level=0),
+            )
+
+        self.assertFalse(seated)
+        self.assertFalse(
+            CombatParticipant.objects.filter(
+                encounter=encounter,
+                character_sheet=caster,
+            ).exists()
+        )
+
+    def test_hostile_cast_does_not_seat(self):
+        """A hostile cast does not seat via the benign path (handled by _route_hostile_cast)."""
+        from world.scenes.cast_services import _maybe_seat_caster_after_benign_cast
+
+        caster = self._make_sheet()
+        target = self._make_sheet()
+        encounter = CombatEncounterFactory(
+            status=RoundStatus.DECLARING,
+            risk_level=RiskLevel.MODERATE,
+            encounter_type=EncounterType.PARTY_COMBAT,
+            round_number=1,
+        )
+        CombatParticipantFactory(
+            encounter=encounter,
+            character_sheet=target,
+            status=ParticipantStatus.ACTIVE,
+        )
+
+        from world.scenes.factories import PersonaFactory
+
+        caster_persona = PersonaFactory(character_sheet=caster)
+        target_persona = PersonaFactory(character_sheet=target)
+        technique = MagicMock()
+
+        with patch(
+            "world.scenes.cast_services.is_technique_hostile",
+            return_value=True,
+        ):
+            seated = _maybe_seat_caster_after_benign_cast(
+                scene=encounter.scene,
+                initiator_persona=caster_persona,
+                target_persona=target_persona,
+                technique=technique,
+                supplied_personas=None,
+                result=self._make_mock_result(success_level=3),
+            )
+
+        self.assertFalse(seated)
+
+    def test_non_combatant_target_does_not_seat(self):
+        """A benign cast at a non-combatant does not seat the caster."""
+        from world.scenes.cast_services import _maybe_seat_caster_after_benign_cast
+
+        caster = self._make_sheet()
+        target = self._make_sheet()
+        scene = SceneFactory()
+
+        from world.scenes.factories import PersonaFactory
+
+        caster_persona = PersonaFactory(character_sheet=caster)
+        target_persona = PersonaFactory(character_sheet=target)
+        technique = MagicMock()
+
+        with patch(
+            "world.scenes.cast_services.is_technique_hostile",
+            return_value=False,
+        ):
+            seated = _maybe_seat_caster_after_benign_cast(
+                scene=scene,
+                initiator_persona=caster_persona,
+                target_persona=target_persona,
+                technique=technique,
+                supplied_personas=None,
+                result=self._make_mock_result(success_level=3),
+            )
+
+        self.assertFalse(seated)
+
+    def test_none_result_does_not_seat(self):
+        """A None result (e.g. soulfray-halted cast) does not seat."""
+        from world.scenes.cast_services import _maybe_seat_caster_after_benign_cast
+
+        caster = self._make_sheet()
+        target = self._make_sheet()
+
+        from world.scenes.factories import PersonaFactory
+
+        caster_persona = PersonaFactory(character_sheet=caster)
+        target_persona = PersonaFactory(character_sheet=target)
+        technique = MagicMock()
+
+        with patch(
+            "world.scenes.cast_services.is_technique_hostile",
+            return_value=False,
+        ):
+            seated = _maybe_seat_caster_after_benign_cast(
+                scene=SceneFactory(),
+                initiator_persona=caster_persona,
+                target_persona=target_persona,
+                technique=technique,
+                supplied_personas=None,
+                result=None,
+            )
+
+        self.assertFalse(seated)

--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -669,6 +669,9 @@ class SceneActionRequestViewSet(PuppetActorMixin, viewsets.ModelViewSet):
         if cast_result.outcome_interaction is not None:
             response_data["outcome_interaction"] = cast_result.outcome_interaction.pk
 
+        if cast_result.combat_seated:
+            response_data["combat_seated"] = True
+
         return Response(response_data, status=status.HTTP_201_CREATED)
 
     @extend_schema(

--- a/src/world/scenes/cast_services.py
+++ b/src/world/scenes/cast_services.py
@@ -28,6 +28,7 @@ from actions.services import start_action_resolution
 from world.checks.types import ResolutionContext
 from world.combat.cast_seed import (
     encounter_requiring_risk_acknowledgement,
+    seat_caster_for_benign_intervention,
     seed_or_feed_encounter_from_cast,
 )
 from world.combat.services import acknowledge_encounter_risk
@@ -543,7 +544,52 @@ def resolve_accepted_cast(
     if action_request.originated_as_entrance and result is not None:
         _run_entrance_benign_accept_hooks(action_request, initiator, target, technique, result)
 
+    # #2226: Generalized benign-intervention seating — any benign cast accepted
+    # by the target seats the caster if the target is an embattled ally. This
+    # supersedes the entrance-only seating that used to live inside
+    # _run_entrance_benign_accept_hooks; entrance casts still get their hooks
+    # (flourish/disposition/suggestion) from the block above, but seating is
+    # now handled here for all benign casts.
+    if result is not None and not is_technique_hostile(technique):
+        _maybe_seat_after_consent_accept(
+            scene=action_request.scene,
+            initiator_persona=initiator,
+            target_persona=target,
+            result=result,
+        )
+
     return result  # result.power_ledger is already set from _resolve_cast
+
+
+def _maybe_seat_after_consent_accept(
+    *,
+    scene: Scene,
+    initiator_persona: Persona,
+    target_persona: Persona | None,
+    result: EnhancedSceneActionResult,
+) -> None:
+    """Seat the caster in combat when a benign consent-accept cast touched an
+    embattled ally (#2226).
+
+    The consent-accept benign path is always SINGLE-target (``_route_benign_cast``
+    creates requests with a single ``target_persona``; AREA/FILTERED_GROUP
+    behavior-altering casts raise ``InvalidCastTarget``), so the target sheet is
+    simply ``target_persona.character_sheet``.
+
+    Guarded by ``success_level > 0`` — a resolved-but-fizzled cast does not seat.
+    """
+    main = result.action_resolution.main_result
+    success_level = main.check_result.success_level if main is not None else 0
+    if success_level <= 0:
+        return
+    if target_persona is None:
+        return
+
+    seat_caster_for_benign_intervention(
+        caster_sheet=initiator_persona.character_sheet,
+        target_sheets=[target_persona.character_sheet],
+        scene=scene,
+    )
 
 
 def _run_entrance_benign_accept_hooks(
@@ -558,13 +604,13 @@ def _run_entrance_benign_accept_hooks(
     Mirrors ``EntranceAction._resolve_inline_entrance_result`` (the resolved-inline
     branch), but at accept-time resolution instead of request-time: disposition
     (non-hostile + target present, raw resolution), flourish + suggestion when the
-    resolved success level clears 0, and a benign-intervention combat join when the
-    target is another sheet's ACTIVE combatant.
+    resolved success level clears 0.
+
+    Combat seating (#2226) is no longer handled here — the generalized
+    ``_maybe_seat_after_consent_accept`` call in ``resolve_accepted_cast``
+    handles it for all benign casts (entrance and non-entrance alike).
     """
     from actions.definitions.social import run_entrance_success_hooks  # noqa: PLC0415
-    from world.combat.cast_seed import (  # noqa: PLC0415
-        seed_or_feed_encounter_from_benign_intervention,
-    )
     from world.npc_services.social_disposition import (  # noqa: PLC0415
         apply_social_disposition_delta,
     )
@@ -586,13 +632,6 @@ def _run_entrance_benign_accept_hooks(
         target_persona_id=target.pk if target is not None else None,
         technique=technique,
     )
-
-    if target is not None and target.character_sheet_id != initiator.character_sheet_id:
-        seed_or_feed_encounter_from_benign_intervention(
-            caster_sheet=initiator.character_sheet,
-            target_sheet=target.character_sheet,
-            scene=action_request.scene,
-        )
 
 
 def _guard_area_consent(technique: Technique, *, caster: ObjectDB) -> None:  # noqa: OBJECTDB_PARAM
@@ -973,6 +1012,66 @@ def _route_benign_cast(  # noqa: PLR0913 - cohesive benign-cast routing params
     return CastResult(request=request)
 
 
+def _maybe_seat_caster_after_benign_cast(  # noqa: PLR0913 - cohesive seating params
+    *,
+    scene: Scene,
+    initiator_persona: Persona,
+    target_persona: Persona | None,
+    technique: Technique,
+    supplied_personas: list[Persona] | None,
+    result: EnhancedSceneActionResult | None,
+) -> bool:
+    """Seat the caster in combat when a benign cast touched an embattled ally (#2226).
+
+    Returns True if the caster was seated (newly or already). The cast must
+    have succeeded (success_level > 0) and the technique must be non-hostile
+    (hostile casts seed encounters via ``_route_hostile_cast``).
+
+    Enumerates the target sheets by targeting mode:
+    - SINGLE: the single ``target_persona``.
+    - FILTERED_GROUP: the ``supplied_personas`` list.
+    - AREA: ``resolve_targets`` (a pure query) to enumerate affected scene personas.
+    """
+    if result is None:
+        return False
+    main = result.action_resolution.main_result
+    success_level = main.check_result.success_level if main is not None else 0
+    if success_level <= 0:
+        return False
+    if is_technique_hostile(technique):
+        return False
+
+    caster_sheet = initiator_persona.character_sheet
+    target_sheets: list[CharacterSheet] = []
+
+    if supplied_personas is not None:
+        target_sheets = [p.character_sheet for p in supplied_personas]
+    elif target_persona is not None:
+        target_sheets = [target_persona.character_sheet]
+    else:
+        # AREA cast: enumerate affected personas via the pure query.
+        from actions.constants import ActionTargetType  # noqa: PLC0415
+
+        if technique.target_type == ActionTargetType.AREA:
+            resolved = resolve_targets(
+                technique=technique,
+                initiator_persona=initiator_persona,
+                scene=scene,
+                supplied_personas=[],
+            )
+            target_sheets = [p.character_sheet for p in resolved]
+
+    if not target_sheets:
+        return False
+
+    participant = seat_caster_for_benign_intervention(
+        caster_sheet=caster_sheet,
+        target_sheets=target_sheets,
+        scene=scene,
+    )
+    return participant is not None
+
+
 def _route_immediate_cast(  # noqa: PLR0913 - cohesive immediate-cast routing params
     *,
     scene: Scene,
@@ -1036,4 +1135,12 @@ def _route_immediate_cast(  # noqa: PLR0913 - cohesive immediate-cast routing pa
         result=result,
         outcome_interaction=pose,
         power_ledger=power_ledger,
+        combat_seated=_maybe_seat_caster_after_benign_cast(
+            scene=scene,
+            initiator_persona=initiator_persona,
+            target_persona=target_persona,
+            technique=technique,
+            supplied_personas=supplied_personas,
+            result=result,
+        ),
     )

--- a/src/world/scenes/tests/test_entrance_cast_threading.py
+++ b/src/world/scenes/tests/test_entrance_cast_threading.py
@@ -147,7 +147,9 @@ class TestAcceptedEntranceCastHooks(CastScenarioMixin):
         )
 
     def test_accepted_non_entrance_cast_no_hooks(self) -> None:
-        """Regression pin: a non-entrance accepted cast fires none of the #2183 hooks."""
+        """A non-entrance accepted cast fires none of the #2183 entrance hooks (flourish,
+        suggestion), but DOES seat the caster in combat per #2226's generalized
+        benign-intervention seating."""
         self._make_embattled_encounter()
 
         technique = make_benign_castable_technique()
@@ -165,6 +167,7 @@ class TestAcceptedEntranceCastHooks(CastScenarioMixin):
         with patch("actions.services.perform_check", return_value=_make_check_mock(3)):
             resolve_accepted_cast(cast.request)
 
+        # Entrance-only hooks: flourish and suggestion do NOT fire for non-entrance casts.
         self.assertFalse(
             PendingEntryFlourishOffer.objects.filter(
                 character_sheet=self.caster.character_sheet
@@ -175,7 +178,9 @@ class TestAcceptedEntranceCastHooks(CastScenarioMixin):
                 character_sheet=self.caster.character_sheet
             ).exists()
         )
-        self.assertFalse(
+        # #2226: combat seating IS generalized — a non-entrance benign accepted cast
+        # at an embattled ally seats the caster.
+        self.assertTrue(
             CombatParticipant.objects.filter(
                 character_sheet=self.caster.character_sheet,
             ).exists()

--- a/src/world/scenes/types.py
+++ b/src/world/scenes/types.py
@@ -83,6 +83,10 @@ class CastResult:
     ``soulfray_warning`` is set when ``use_technique`` returned ``confirmed=False``
     (the cast was halted for soulfray consent). The caller should prompt the actor
     to confirm or decline before re-dispatching with ``confirm_soulfray_risk=True``.
+
+    ``combat_seated`` is True when a benign cast at an embattled ally seated the
+    caster in that ally's encounter (#2226). Callers append a notification when
+    True so the caster knows they've been drawn into the fight.
     """
 
     request: SceneActionRequest | None = None
@@ -91,3 +95,4 @@ class CastResult:
     outcome_interaction: Interaction | None = None
     power_ledger: PowerLedger | None = None
     soulfray_warning: SoulfrayWarning | None = None
+    combat_seated: bool = False


### PR DESCRIPTION
Closes #2226

## Summary

Generalizes benign-intervention combat seating to all protective casts. Any benign (non-hostile) technique cast that affects an ACTIVE combatant now seats the caster in that encounter — all targeting modes (SINGLE, AREA, FILTERED_GROUP), both consent paths (immediate and consent-accept). The existing `seed_or_feed_encounter_from_benign_intervention` function is reused unchanged; new work is a multi-target wrapper, two post-resolution hooks, a CastResult flag, and caster notification. The entrance-path seating calls (#2183) are removed — the generalized calls supersede them.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2226 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean rebase, no conflicts.

<!-- last-addressed-comment: 0 -->