### PR TITLE
E2E test: 3-PC party vs factory boss (boss anatomy)

### DIFF
--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -112,10 +112,27 @@ outcome** (a closed issue or a "SHIPPED" line is not proof). See the ledger's go
   still has no position picker (telnet-only there). See
   [magic.md](../systems/magic.md) (Effect Palette) and [INDEX.md](../systems/INDEX.md)
   (Combat § "Cast-position targeting") for the full wiring.
+- **3-PC party vs. a factory boss — the full break-bar/phase/enrage journey (#2095).**
+  One `resolve_round`-driven test proves the whole boss-anatomy chain (#2016, ADR-0102)
+  in order: solo attacks fully soaked while the guard is unbroken → a landed combo chips
+  the break bar to 0 and opens a vulnerability window (soak bypassed) → crossing a
+  phase's health trigger while still in that window transitions the boss and spawns its
+  authored reinforcements → a later phase transition stamps an enraged
+  `damage_multiplier` (proven via a real before/after NPC-damage comparison, not just a
+  field read) → the break bar re-breaks in the final phase, opening a second window →
+  the party finishes the boss off with `vulnerability_rounds_remaining > 0` still true at
+  the kill. Also proves enemy-NPC condition application (`ThreatPoolEntry
+  .conditions_applied` landing on the attacked PC — see the WIRED-UNPROVEN entry below
+  for why that's now PROVEN, not the reverse "onto the boss" direction). Scenario
+  composed by `BossFightScenarioFactory` (`world/combat/factories.py`); journey test:
+  `src/integration_tests/test_boss_fight_journey.py`.
 
 ## WIRED-UNPROVEN (treat as not-done — write the journey test, fix what it exposes)
 
-- Enemy-NPC condition application · thread-pull final outcome. (Combo full journey proven in #2017.)
+- Thread-pull final outcome in combat. (Combo full journey proven in #2017; enemy-NPC
+  condition application — the other half of this bullet's old wording — is now proven
+  by the #2095 boss-fight journey above: `ThreatPoolEntry.conditions_applied` lands the
+  condition on the attacked PC, never on the attacking NPC/boss itself.)
 - **Guardian-reaction surfaces beyond the two #2207 journey tests above.** Wired but
   not journey-proven: the technique-guardian BLINK flavor's clean-success ward
   relocation (`force_move_to_position` to the guardian's own position —

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -3666,6 +3666,13 @@ reactive maneuvers (COVER, INTERPOSE, DEFEND stance), and clash-of-wills.
   action for DEFEND; reactive-defense handlers in `world/magic/services/effect_handlers.py`),
   covenants (speed_rank resolution order, `apply_equipped_armor_soak`),
   magic (technique use pipeline, `CombatPull`, effect palette — summon/reactive handlers)
+- **Test composition helper:** `BossFightScenarioFactory` (`world/combat/factories.py`,
+  #2095) composes a full 3-PC-vs-boss encounter (distinct-EffectType techniques, a
+  learned PC1/PC2 combo, a BOSS opponent with 3 authored `BossPhase` rows — break bar +
+  phase-2 reinforcement + phase-3 enrage — and a threat pool carrying both a flat-damage
+  entry and a `conditions_applied` entry) in one call, mirroring
+  `PlayableCombatScenarioFactory`'s style; use it instead of hand-rolling boss-fight
+  fixtures. Driven end-to-end by `src/integration_tests/test_boss_fight_journey.py`.
 - **Source:** `src/world/combat/`
 - **Details:** `docs/roadmap/combat.md` · architecture:
   `docs/architecture/combat-magic-integration.md`,

--- a/src/integration_tests/test_boss_fight_journey.py
+++ b/src/integration_tests/test_boss_fight_journey.py
@@ -1,0 +1,307 @@
+"""E2E journey test: 3-PC party vs a factory-composed boss (#2095).
+
+Walks the full DoD beat sequence via ``resolve_round`` against a
+``BossFightScenarioFactory``-built encounter: solo-spam mitigation -> combo
+break-bar break -> vulnerability window -> phase 2 transition (reinforcement
+adds) -> phase 3 transition (enrage) -> a break-bar re-break -> the party
+finishing the boss off while still inside the reopened vulnerability window.
+
+Round-by-round numeric derivation (all authored, not tuned by trial and
+error — see ``BossFightScenarioFactory`` in ``world/combat/factories.py``
+for the underlying config):
+
+- Phase 1: ``soak_value=15``, ``break_bar_threshold=6``. Each PC's technique
+  deals ``base_damage=10`` (``EffectType.base_power=10``, no intensity/SL
+  scaling, ``DamageSuccessLevelMultiplier`` seeded at ``min_success_level=1``
+  -> ``1.00``). ``apply_damage_to_opponent``'s
+  ``damage_through = max(0, raw - soak - resistance)`` -> ``10 - 15 = 0`` for
+  a solo hit: fully soaked while the guard is unbroken.
+- Round 1: 3 PCs solo-attack (no combo) -> 0 damage through each -> boss
+  health unchanged (100). ``assess_break_bar``'s distinct-PC/distinct-effect
+  chip path still fires (3 distinct PCs, 3 distinct effect types all
+  "damaged" the boss per ``_outcome_damaged_boss``, which only checks that a
+  result references the boss, not that damage_through > 0) -> break bar
+  6 -> 5. Also two NPC attacks are resolved directly via
+  ``_resolve_npc_action`` (proven pattern — see
+  ``test_defense_sourcing.DefenseCheckSourcingTests``) against a fixed
+  ``defense_check_fn`` (``success_level=0`` -> ``DEFENSE_FULL_MULTIPLIER``
+  1.0, isolating ``opponent.damage_multiplier`` as the only variable): the
+  flat entry (``base_damage=12``) establishes the pre-enrage damage baseline
+  (``12``), and the ``conditions_applied`` entry (``base_damage=8``) proves
+  enemy-NPC condition application onto a PC (see the DoD-wording-discrepancy
+  note below).
+- Round 2: PC1+PC2 upgrade to the learned combo (``bonus_damage=10``,
+  ``bypass_soak=True``); PC3 solo. Combo riders bypass soak entirely
+  (``2 x 10 = 20`` damage through); each PC's own technique is still soaked
+  to 0. Health 100 -> 80. ``assess_break_bar``'s combo path adds
+  ``combo.bonus_damage`` (10) and the distinct-chip path adds 1 more (still
+  3 distinct PCs/effect types) -> ``bar_damage=11`` against
+  ``break_bar_current=5`` -> clamped to 0 -> ``vulnerability_rounds_remaining
+  = vulnerability_rounds = 2``. No phase transition yet (80% > phase 2's 70%
+  trigger), so this vulnerability write survives past round 2 untouched —
+  the DoD's "vulnerability window opens" beat is asserted right here.
+- Round 3: vulnerability decremented 2 -> 1 at the top of the round (still
+  active for this round's own actions) -> soak is fully bypassed
+  (``_effective_soak_for_opponent`` returns 0 when vulnerable) -> 3 PCs solo
+  now deal their full ``10`` raw damage each -> 30 through. Health 80 -> 50
+  (50%), crossing phase 2's ``health_trigger_percentage=0.70`` ->
+  ``check_and_advance_boss_phase`` transitions 1 -> 2 at the end of this same
+  round: reinforcements spawn (``reinforcement_count=2``) and the break bar
+  is re-stamped from phase 2's config (``threshold=1``) — which, per
+  ``_stamp_break_bar``, *always* resets ``vulnerability_rounds_remaining`` to
+  0 regardless of branch. That reset happens only after round 3's own damage
+  was already applied, so it doesn't retroactively undo anything asserted at
+  round 2.
+- Round 4: PC1+PC2 combo again (``2 x 10 = 20`` bypass-soak damage; PC3 solo
+  vs phase 2's ``soak_value=20`` -> 0). Health 50 -> 30 (30%), crossing phase
+  3's ``health_trigger_percentage=0.30`` -> transition 2 -> 3: enrage
+  (``damage_multiplier=2.50``) is stamped, and the break bar resets again
+  (phase 3's own ``threshold=1``).
+- Round 5: no combo — the distinct-chip path alone (3 PCs, 3 effect types)
+  chips phase 3's tiny bar from 1 -> 0 -> ``vulnerability_rounds_remaining =
+  2`` (a *second* window, opened in the final phase — nothing will transition
+  again to reset it, since phase 3 is the last authored phase). A second
+  direct ``_resolve_npc_action`` call with the same flat entry now applies
+  ``int(12 * 2.50) = 30`` damage — 2.5x the round-1 baseline of 12,
+  demonstrating the enrage delta via a real damage comparison, not just a
+  field read.
+- Round 6: vulnerability decremented 2 -> 1 (still active this round) -> 3
+  PCs solo-attack unsoaked (phase 3's ``soak_value=10`` is bypassed) ->
+  ``3 x 10 = 30`` damage through, exactly zeroing the boss's remaining 30
+  health -> ``OpponentStatus.DEFEATED``. Because the boss dies mid
+  action-resolution, ``assess_break_bar``/``_check_boss_transitions`` (which
+  both filter ``status=ACTIVE``) never run again for it that round, so
+  ``vulnerability_rounds_remaining`` is left exactly as the top-of-round
+  decrement set it: 1 (> 0) — proving the kill landed *inside* the
+  vulnerability window, not merely after a health check happened to cross 0.
+
+DoD-wording discrepancy (documented per the task instructions rather than
+forced into a wrong assertion): the issue's beat 5 says "condition applied to
+the boss (enemy-NPC condition application proof via
+``ThreatPoolEntry.conditions_applied``)". Reading the resolution path
+(``_resolve_npc_action_on_target`` in ``world/combat/services.py``) shows
+``conditions_applied`` conditions from an NPC's threat entry land on the *PC*
+target of that NPC's attack, never on the NPC/boss itself — there is no code
+path that lets a PC's incoming damage apply a threat-entry condition back
+onto the attacking boss. Task 1's own spec text is accurate here ("enemy-NPC
+condition application is provable via the resolution path"); only beat 5's
+"to the boss" phrasing is imprecise. This test proves the mechanism as it
+actually works: an NPC (boss) attack with ``conditions_applied`` lands that
+condition on the targeted PC.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from world.combat.constants import OpponentStatus, OpponentTier
+from world.combat.factories import BossFightScenarioFactory
+from world.combat.models import CombatOpponentAction, CombatRoundAction
+from world.combat.services import _resolve_npc_action, resolve_round, upgrade_action_to_combo
+from world.conditions.factories import DamageSuccessLevelMultiplierFactory
+from world.conditions.models import ConditionInstance
+from world.scenes.constants import RoundStatus
+from world.vitals.models import CharacterVitals
+
+
+def _offense_check_fn(*args: object, **kwargs: object) -> MagicMock:
+    """Fixed success_level=1 -> DamageSuccessLevelMultiplier's 1.00 row."""
+    return MagicMock(success_level=1)
+
+
+def _defense_check_fn(*args: object, **kwargs: object) -> MagicMock:
+    """Fixed success_level=0 -> DEFENSE_FULL_MULTIPLIER (1.0), isolating enrage."""
+    return MagicMock(success_level=0)
+
+
+class BossFightJourneyTest(TestCase):
+    """3-PC party vs a factory-composed boss: the full break-bar/phase/enrage journey."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        DamageSuccessLevelMultiplierFactory(
+            min_success_level=1, multiplier=Decimal("1.00"), label="Full"
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.scenario = BossFightScenarioFactory.create(num_pcs=3)
+        self.encounter = self.scenario.encounter
+        self.opponent = self.scenario.opponent
+        self.participants = self.scenario.participants
+        self.techniques = self.scenario.techniques
+        self.combo = self.scenario.combo
+
+    def _declare_round(
+        self, round_number: int, *, combo_pcs: tuple[int, ...] = ()
+    ) -> list[CombatRoundAction]:
+        """Declare one solo/combo focused action per PC for the given round.
+
+        ``resolve_round`` always transitions the encounter to BETWEEN_ROUNDS
+        (or COMPLETED) on return, so every round after the first must reopen
+        DECLARING before actions can be resolved again.
+        """
+        if round_number > 1:
+            self.encounter.refresh_from_db()
+            self.encounter.round_number = round_number
+            self.encounter.status = RoundStatus.DECLARING
+            self.encounter.save(update_fields=["round_number", "status"])
+        actions = []
+        for i, (participant, technique) in enumerate(
+            zip(self.participants, self.techniques, strict=True)
+        ):
+            action = CombatRoundAction.objects.create(
+                participant=participant,
+                round_number=round_number,
+                focused_category=technique.action_category,
+                focused_action=technique,
+                focused_opponent_target=self.opponent,
+            )
+            if i in combo_pcs:
+                upgrade_action_to_combo(action, self.combo)
+            actions.append(action)
+        return actions
+
+    def _resolve(self) -> object:
+        return resolve_round(
+            self.encounter,
+            offense_check_fn=_offense_check_fn,
+        )
+
+    def test_boss_fight_journey(self) -> None:  # noqa: PLR0915 - one linear journey walk
+        """Walk every DoD beat in order: mitigation -> break -> vuln -> phase 2 ->
+        phase 3 (enrage) -> re-break -> win inside the reopened vulnerability window.
+        """
+        # --- Round 1: solo spam. Damage fully soaked while the guard is unbroken. ---
+        self._declare_round(1)
+        self._resolve()
+
+        self.opponent.refresh_from_db()
+        self.assertEqual(self.opponent.health, 100, "phase-1 soak should fully mitigate solo hits")
+        self.assertEqual(self.opponent.current_phase, 1)
+
+        # Baseline enrage measurement (opponent.damage_multiplier is still 1.0):
+        # a direct NPC attack via the flat threat entry, forced to a fixed
+        # success_level=0 defense roll so only the enrage multiplier varies.
+        baseline_action = CombatOpponentAction.objects.create(
+            opponent=self.opponent,
+            round_number=1,
+            threat_entry=self.scenario.flat_entry,
+        )
+        baseline_action.targets.add(self.participants[2])
+        _resolve_npc_action(
+            self.opponent,
+            baseline_action,
+            defense_check_type=None,
+            defense_check_fn=_defense_check_fn,
+        )
+        pc3_sheet = self.participants[2].character_sheet
+        pc3_vitals = CharacterVitals.objects.get(character_sheet=pc3_sheet)
+        baseline_damage = 100 - pc3_vitals.health
+        self.assertEqual(baseline_damage, 12, "pre-enrage NPC hit should be flat base_damage")
+
+        # Enemy-NPC condition application: the boss's Venom Bite entry
+        # (conditions_applied=[condition_template]) landing on a PC target.
+        condition_action = CombatOpponentAction.objects.create(
+            opponent=self.opponent,
+            round_number=1,
+            threat_entry=self.scenario.condition_entry,
+        )
+        condition_action.targets.add(self.participants[0])
+        _resolve_npc_action(
+            self.opponent,
+            condition_action,
+            defense_check_type=None,
+            defense_check_fn=_defense_check_fn,
+        )
+
+        # --- Round 2: combo lands. Break bar hits 0; vulnerability window opens. ---
+        self._declare_round(2, combo_pcs=(0, 1))
+        self._resolve()
+
+        self.opponent.refresh_from_db()
+        self.assertEqual(self.opponent.break_bar_current, 0)
+        self.assertGreater(self.opponent.vulnerability_rounds_remaining, 0)
+        self.assertEqual(self.opponent.health, 80)
+        self.assertEqual(self.opponent.current_phase, 1, "phase-2 trigger not yet crossed")
+
+        # --- Round 3: vulnerable — soak bypassed. Phase 2 transition: adds spawn. ---
+        self._declare_round(3)
+        self._resolve()
+
+        self.opponent.refresh_from_db()
+        self.assertEqual(self.opponent.health, 50)
+        self.assertEqual(self.opponent.current_phase, 2)
+        reinforcement_count = self.opponent.encounter.opponents.filter(
+            tier=OpponentTier.MOOK,
+            name=self.scenario.reinforcement_template.name,
+        ).count()
+        self.assertEqual(reinforcement_count, 2, "phase-2 transition should spawn its adds")
+
+        # --- Round 4: combo again crosses phase 3's trigger. Enrage stamped. ---
+        self._declare_round(4, combo_pcs=(0, 1))
+        self._resolve()
+
+        self.opponent.refresh_from_db()
+        self.assertEqual(self.opponent.health, 30)
+        self.assertEqual(self.opponent.current_phase, 3)
+        self.assertEqual(self.opponent.damage_multiplier, Decimal("2.50"))
+
+        # Enrage proof via a real damage comparison against the round-1 baseline.
+        enrage_action = CombatOpponentAction.objects.create(
+            opponent=self.opponent,
+            round_number=4,
+            threat_entry=self.scenario.flat_entry,
+        )
+        enrage_action.targets.add(self.participants[2])
+        _resolve_npc_action(
+            self.opponent,
+            enrage_action,
+            defense_check_type=None,
+            defense_check_fn=_defense_check_fn,
+        )
+        pc3_vitals.refresh_from_db()
+        enraged_damage = (100 - baseline_damage) - pc3_vitals.health
+        self.assertEqual(enraged_damage, 30, "enraged hit should be 2.50x the base_damage")
+        expected_enraged = int(self.scenario.flat_entry.base_damage * Decimal("2.50"))
+        self.assertEqual(enraged_damage, expected_enraged)
+
+        # Enemy-NPC condition application (round 1's Venom Bite hit PC1 — see the
+        # module docstring's DoD-wording-discrepancy note: conditions_applied
+        # flows NPC-attack -> PC target, never PC/boss-ward, so this proves the
+        # mechanism as it actually works rather than forcing the issue's literal
+        # "to the boss" phrasing).
+        pc1_character = self.participants[0].character_sheet.character
+        self.assertTrue(
+            ConditionInstance.objects.filter(
+                target=pc1_character,
+                condition=self.scenario.condition_template,
+            ).exists(),
+            "the boss's conditions_applied threat entry should land its condition on the PC target",
+        )
+
+        # --- Round 5: re-break phase 3's bar via the distinct-chip path (no combo
+        # needed) -> a second, final vulnerability window opens. ---
+        self._declare_round(5)
+        self._resolve()
+
+        self.opponent.refresh_from_db()
+        self.assertEqual(self.opponent.break_bar_current, 0)
+        self.assertEqual(self.opponent.vulnerability_rounds_remaining, 2)
+        self.assertEqual(self.opponent.current_phase, 3, "no further phase to transition into")
+
+        # --- Round 6: vulnerable again — the party finishes the boss off. ---
+        self._declare_round(6)
+        self._resolve()
+
+        self.opponent.refresh_from_db()
+        self.assertEqual(self.opponent.health, 0)
+        self.assertEqual(self.opponent.status, OpponentStatus.DEFEATED)
+        self.assertGreater(
+            self.opponent.vulnerability_rounds_remaining,
+            0,
+            "the killing blow should have landed while still inside the vulnerability window",
+        )

--- a/src/world/combat/factories.py
+++ b/src/world/combat/factories.py
@@ -744,6 +744,244 @@ class PlayableCombatScenarioFactory:
         )
 
 
+# =============================================================================
+# Boss fight scenario — composition helper, not a DjangoModelFactory (#2095).
+# =============================================================================
+
+
+@dataclass
+class BossFightScenario:
+    """A fully-composed 3-PC-vs-boss encounter for the break-bar / vulnerability-
+    window / phase-transition / enrage journey test.
+
+    Built by ``BossFightScenarioFactory.create()``. The boss carries 3
+    ``BossPhase`` rows, each with its own break bar (phase 1's config is also
+    stamped directly onto the ``opponent``, mirroring what a real
+    ``add_opponent``-driven spawn does for phase 1): phase 2 authors
+    ``reinforcement_template``/``reinforcement_count`` (adds spawn on 1→2), and
+    phase 3 authors an enraged ``damage_multiplier`` (stamped on 2→3). PCs 1-2
+    share a learned combo (``ComboLearning`` already exists — the combo is
+    known going in) whose ``bonus_damage`` both chips the break bar
+    (``assess_break_bar``) and, bypassing soak, deals real HP damage. The
+    threat pool's ``flat_entry`` carries a ``defense_check_type`` (required for
+    ``opponent.damage_multiplier`` to apply — see ``resolve_npc_attack``) so
+    the enrage delta is provable via a direct before/after damage comparison;
+    ``condition_entry`` carries ``conditions_applied`` so an enemy-NPC attack
+    landing a condition on a PC is provable via the resolution path.
+    """
+
+    scene: object
+    encounter: CombatEncounter
+    participants: list[CombatParticipant]
+    techniques: list[object]
+    opponent: CombatOpponent
+    phases: list[BossPhase]
+    combo: ComboDefinition
+    threat_pool: ThreatPool
+    flat_entry: ThreatPoolEntry
+    condition_entry: ThreatPoolEntry
+    condition_template: object
+    reinforcement_template: CreatureTemplate
+    defense_check_type: object
+
+
+class BossFightScenarioFactory:
+    """Compose a full 3-PC-vs-boss scenario in one call (#2095).
+
+    Wires a Scene + CombatEncounter (DECLARING status) + ``num_pcs`` PC
+    ``CombatParticipant``s (character sheet, vitals, anima, fatigue,
+    engagement, one technique each of a distinct ``EffectType``) + a
+    BOSS-tier ``CombatOpponent`` with 3 authored ``BossPhase`` rows (break
+    bar / reinforcement / enrage) + a learned 2-PC combo + a threat pool
+    carrying both a flat-damage entry and a condition-applying entry.
+
+    Used by the boss-fight journey test (``test_boss_fight_journey.py``) as
+    its scenario builder — mirrors ``PlayableCombatScenarioFactory``'s
+    composition style.
+
+    Authored numbers are deterministic by design (not tuned by trial and
+    error) — see the journey test's module docstring for the full derivation.
+    """
+
+    @classmethod
+    def create(cls, *, num_pcs: int = 3) -> BossFightScenario:
+        from actions.factories import ActionTemplateFactory
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.checks.factories import CheckTypeFactory
+        from world.combat.constants import ComboLearningMethod
+        from world.conditions.factories import ConditionTemplateFactory
+        from world.fatigue.models import FatiguePool
+        from world.magic.factories import (
+            CharacterAnimaFactory,
+            CharacterTechniqueFactory,
+            EffectTypeFactory,
+            GiftFactory,
+            TechniqueFactory,
+        )
+        from world.mechanics.factories import CharacterEngagementFactory
+        from world.scenes.constants import RoundStatus
+        from world.scenes.factories import SceneFactory
+        from world.vitals.models import CharacterVitals
+
+        scene = SceneFactory()
+        encounter = CombatEncounterFactory(
+            scene=scene,
+            status=RoundStatus.DECLARING,
+            round_number=1,
+        )
+
+        # --- Threat pool: a flat-damage entry (defense_check_type set so the
+        # enrage damage_multiplier applies — see resolve_npc_attack) and a
+        # conditions_applied entry (enemy-NPC condition application). ---
+        threat_pool = ThreatPoolFactory(name="Boss Threat Pool")
+        defense_check_type = CheckTypeFactory(name="Boss Attack Defense")
+        # Long duration so the condition survives the multi-round journey rather
+        # than decaying away (default ConditionTemplate duration is 3 rounds)
+        # before the journey test gets to assert it landed.
+        condition_template = ConditionTemplateFactory(
+            name="Scorched (Boss Fight)", default_duration_value=50
+        )
+        flat_entry = ThreatPoolEntryFactory(
+            pool=threat_pool,
+            name="Claw Swipe",
+            base_damage=12,
+            defense_check_type=defense_check_type,
+        )
+        condition_entry = ThreatPoolEntryFactory(
+            pool=threat_pool,
+            name="Venom Bite",
+            base_damage=8,
+            defense_check_type=defense_check_type,
+        )
+        condition_entry.conditions_applied.add(condition_template)
+
+        # --- Boss opponent: phase 1's break bar stamped directly (mirrors what
+        # a real spawn does for phase 1 — see _stamp_phase_break_bar_config). ---
+        opponent = BossOpponentFactory(
+            encounter=encounter,
+            name="Factory Boss",
+            health=100,
+            max_health=100,
+            soak_value=15,
+            threat_pool=threat_pool,
+            current_phase=1,
+            break_bar_threshold=6,
+            break_bar_current=6,
+            vulnerability_rounds=2,
+            vulnerability_intensity_bonus=2,
+        )
+
+        pool_p2 = ThreatPoolFactory(name="Boss Threat Pool — Phase 2+")
+        add_template = CreatureTemplate.objects.create(
+            name="Boss Fight Add",
+            tier=OpponentTier.MOOK,
+            threat_pool=pool_p2,
+        )
+        phase1 = BossPhaseFactory(
+            opponent=opponent,
+            phase_number=1,
+            threat_pool=threat_pool,
+            soak_value=15,
+            break_bar_threshold=6,
+            vulnerability_rounds=2,
+            vulnerability_intensity_bonus=2,
+            damage_multiplier=Decimal("1.0"),
+        )
+        phase2 = BossPhaseFactory(
+            opponent=opponent,
+            phase_number=2,
+            threat_pool=pool_p2,
+            soak_value=20,
+            health_trigger_percentage=0.70,
+            break_bar_threshold=1,
+            vulnerability_rounds=2,
+            vulnerability_intensity_bonus=2,
+            damage_multiplier=Decimal("1.0"),
+            reinforcement_template=add_template,
+            reinforcement_count=2,
+        )
+        phase3 = BossPhaseFactory(
+            opponent=opponent,
+            phase_number=3,
+            threat_pool=pool_p2,
+            soak_value=10,
+            health_trigger_percentage=0.30,
+            break_bar_threshold=1,
+            vulnerability_rounds=2,
+            vulnerability_intensity_bonus=2,
+            damage_multiplier=Decimal("2.50"),
+        )
+
+        # --- PCs: one technique each of a distinct EffectType. ---
+        gift = GiftFactory()
+        participants: list[CombatParticipant] = []
+        techniques: list[object] = []
+        for i in range(num_pcs):
+            sheet = CharacterSheetFactory()
+            CharacterVitals.objects.create(
+                character_sheet=sheet,
+                health=100,
+                max_health=100,
+                base_max_health=100,
+            )
+            CharacterAnimaFactory(character=sheet.character, current=50, maximum=50)
+            FatiguePool.objects.create(character_sheet=sheet)
+            CharacterEngagementFactory(character=sheet.character)
+            effect_type = EffectTypeFactory(name=f"Boss Fight Effect {i}", base_power=10)
+            technique = TechniqueFactory(
+                gift=gift,
+                effect_type=effect_type,
+                action_template=ActionTemplateFactory(check_type=CheckTypeFactory()),
+            )
+            CharacterTechniqueFactory(character=sheet, technique=technique)
+            participant = CombatParticipantFactory(encounter=encounter, character_sheet=sheet)
+            participants.append(participant)
+            techniques.append(technique)
+
+        # --- Learned combo between PCs 1-2 (already known — no discovery needed). ---
+        combo = ComboDefinitionFactory(
+            name="Boss Fight Combo",
+            bonus_damage=10,
+            bypass_soak=True,
+        )
+        ComboSlotFactory(
+            combo=combo,
+            slot_number=1,
+            required_action_type=techniques[0].effect_type,
+        )
+        ComboSlotFactory(
+            combo=combo,
+            slot_number=2,
+            required_action_type=techniques[1].effect_type,
+        )
+        ComboLearningFactory(
+            combo=combo,
+            character_sheet=participants[0].character_sheet,
+            learned_via=ComboLearningMethod.TRAINING,
+        )
+        ComboLearningFactory(
+            combo=combo,
+            character_sheet=participants[1].character_sheet,
+            learned_via=ComboLearningMethod.TRAINING,
+        )
+
+        return BossFightScenario(
+            scene=scene,
+            encounter=encounter,
+            participants=participants,
+            techniques=techniques,
+            opponent=opponent,
+            phases=[phase1, phase2, phase3],
+            combo=combo,
+            threat_pool=threat_pool,
+            flat_entry=flat_entry,
+            condition_entry=condition_entry,
+            condition_template=condition_template,
+            reinforcement_template=add_template,
+            defense_check_type=defense_check_type,
+        )
+
+
 def wire_penetration_check_type():
     """Seed the 'penetration' CheckType for the ward contest (#639, #767, #1706).
 


### PR DESCRIPTION
Closes #2095

## Summary

Ships the deferred boss-anatomy E2E (#2016 follow-through): a BossFightScenarioFactory composing 3 PCs (distinct effect types), a BOSS opponent with 3 authored phases (break bars, phase-2 reinforcements, phase-3 enrage), a learned PC1/PC2 combo, and condition-applying threat entries — plus one resolve_round-driven journey test proving all seven DoD beats in sequence (mitigation stall, combo breaks the bar, vulnerability window, adds spawn, enrage raises output 12->30, condition application, kill inside the window). All numbers derived from the actual formulas; module docstring documents the derivation and the engine's window-resets-on-phase-transition constraint. Note: ThreatPoolEntry.conditions_applied provably applies NPC->PC (the DoD's 'to the boss' phrasing was imprecise); the test and roadmap document the mechanism as it actually works.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2095 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: rebased onto origin/main, clean

<!-- last-addressed-comment: 0 -->