### PR TITLE
Break/pick locked exits

### DIFF
--- a/src/actions/definitions/doors.py
+++ b/src/actions/definitions/doors.py
@@ -1,9 +1,14 @@
-"""Door lock/unlock Actions (#1866).
+"""Door lock/unlock Actions (#1866) and pick/break Actions (#2176).
 
 Lock state is a plain Evennia attribute on the Exit object (``db.locked``)
 — no new Django model, no migration. Room-owner/tenant gated, not
 key-item gated (user decision, spec #1866): the simplest option reusing the
 existing room-ownership substrate.
+
+``PickLockAction`` and ``BreakExitAction`` (#2176) are the intruder path past
+those locks: pick is quiet and check-gated (Wits + Larceny), break is loud
+and always succeeds but damages building condition. Both leave crime-tagged
+Legend deeds.
 """
 
 from __future__ import annotations
@@ -12,13 +17,17 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from actions.base import Action
-from actions.prerequisites import IsExitRoomOwnerPrerequisite, Prerequisite
-from actions.types import ActionResult, TargetType
+from actions.prerequisites import (
+    HasCharacterSheetPrerequisite,
+    IsExitRoomOwnerPrerequisite,
+    Prerequisite,
+)
+from actions.types import ActionContext, ActionResult, TargetType
+from flows.scene_data_manager import SceneDataManager
+from flows.service_functions.communication import message_location
 
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
-
-    from actions.types import ActionContext
 
 
 @dataclass
@@ -71,3 +80,221 @@ class UnlockAction(Action):
             return ActionResult(success=False, message="Unlock which exit?")
         exit_obj.db.locked = False
         return ActionResult(success=True, message=f"You unlock {exit_obj.key}.")
+
+
+# ---------------------------------------------------------------------------
+# Intruder Actions (#2176)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_exit_obj(actor: ObjectDB, kwargs: dict) -> ObjectDB | None:
+    """Resolve an exit from kwargs — ObjectDB (telnet) or exit_id int (web).
+
+    Follows the same dual-path pattern as ``_resolve_room`` in
+    ``definitions/locations.py``: accept a resolved ObjectDB from telnet or
+    a raw int pk from web dispatch.
+    """
+    exit_obj = kwargs.get("exit")
+    if exit_obj is not None and hasattr(exit_obj, "pk"):
+        return exit_obj
+    exit_id = kwargs.get("exit_id")
+    if exit_id is not None:
+        from evennia.objects.models import ObjectDB as _ObjectDB  # noqa: PLC0415
+
+        return _ObjectDB.objects.filter(pk=exit_id, db_location=actor.location).first()
+    return None
+
+
+def _burglary_crime_kind():
+    """Lazy CrimeKind row for break-ins (mirrors _theft_crime_kind idiom)."""
+    from world.justice.models import CrimeKind  # noqa: PLC0415
+
+    kind, _ = CrimeKind.objects.get_or_create(
+        slug="burglary",
+        defaults={
+            "name": "Burglary",
+            "description": "Breaking in to take — walls breached, locks forced.",
+        },
+    )
+    return kind
+
+
+def _crime_source_type():
+    """Lazy LegendSourceType row (mirrors _theft_source_type idiom)."""
+    from world.societies.models import LegendSourceType  # noqa: PLC0415
+
+    source_type, _ = LegendSourceType.objects.get_or_create(
+        name="Crime",
+        defaults={"description": "Personal antagonistic acts against another persona."},
+    )
+    return source_type
+
+
+def _record_breakin_deed(
+    actor: ObjectDB,
+    exit_obj: ObjectDB,
+    *,
+    title_prefix: str,
+    concealed: bool,
+    base_value: int,
+) -> None:
+    """Create a crime-tagged Legend deed for a pick/break attempt.
+
+    Mirrors ``_record_theft_deed`` in ``flows/service_functions/inventory.py``:
+    resolve persona + scene from the actor, then call ``create_solo_deed``
+    with ``crime_kinds=[burglary]`` and the requested concealment.
+    """
+    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+    from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+    from world.societies.services import create_solo_deed  # noqa: PLC0415
+
+    try:
+        sheet = actor.sheet_data
+    except (AttributeError, ObjectDoesNotExist):
+        return
+
+    persona = active_persona_for_sheet(sheet)
+    scene = get_active_scene(actor.location)
+    create_solo_deed(
+        persona,
+        f"{title_prefix} at {exit_obj.key}",
+        _crime_source_type(),
+        base_value,
+        scene=scene,
+        crime_kinds=[_burglary_crime_kind()],
+        concealed=concealed,
+    )
+
+
+@dataclass
+class PickLockAction(Action):
+    """Pick a locked exit — quiet, check-gated (Wits + Larceny).
+
+    On success, unlocks the exit (``db.locked = False``). Either way,
+    creates a concealed Legend deed tagged with the ``burglary`` CrimeKind
+    so the justice/heat system tracks the attempt.
+    """
+
+    key: str = "pick_lock"
+    name: str = "Pick Lock"
+    icon: str = "key"
+    category: str = "locations"
+    target_type: TargetType = TargetType.SELF
+
+    intent_event: str | None = "before_pick_lock"
+    result_event: str | None = "pick_lock"
+
+    def get_prerequisites(self) -> list[Prerequisite]:
+        return [HasCharacterSheetPrerequisite()]
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        exit_obj = _resolve_exit_obj(actor, kwargs)
+        if exit_obj is None:
+            return ActionResult(success=False, message="Pick which exit?")
+
+        if not exit_obj.db.locked:
+            return ActionResult(success=False, message="That exit isn't locked.")
+
+        from world.checks.models import CheckType  # noqa: PLC0415
+        from world.checks.services import perform_check  # noqa: PLC0415
+
+        check_type = CheckType.objects.filter(name="Lockpicking", is_active=True).first()
+        if check_type is None:
+            return ActionResult(success=False, message="Lockpicking isn't available right now.")
+
+        check_result = perform_check(actor, check_type, target_difficulty=0)
+
+        sdm = context.scene_data if context else SceneDataManager()
+        actor_state = sdm.initialize_state_for_object(actor)
+
+        if check_result.outcome and check_result.outcome.success_level > 0:
+            exit_obj.db.locked = False
+            message_location(
+                actor_state,
+                "$You() $conj(pick) the lock on {target}.",
+                mapping={"target": exit_obj},
+            )
+            success = True
+            message = f"You pick the lock on {exit_obj.key}."
+        else:
+            message_location(
+                actor_state,
+                "$You() $conj(fumble) with the lock on {target}.",
+                mapping={"target": exit_obj},
+            )
+            success = False
+            message = f"You fail to pick the lock on {exit_obj.key}."
+
+        _record_breakin_deed(
+            actor, exit_obj, title_prefix="Lockpicking", concealed=True, base_value=5
+        )
+
+        return ActionResult(success=success, message=message)
+
+
+@dataclass
+class BreakExitAction(Action):
+    """Break through a locked exit — loud, always succeeds.
+
+    Unlocks the exit (``db.locked = False``), damages the building's
+    condition tier by 1 (floored at DECAYED), emits a loud room echo,
+    and creates a non-concealed Legend deed tagged with ``burglary``.
+    """
+
+    key: str = "break_exit"
+    name: str = "Break Exit"
+    icon: str = "hammer"
+    category: str = "locations"
+    target_type: TargetType = TargetType.SELF
+
+    intent_event: str | None = "before_break_exit"
+    result_event: str | None = "break_exit"
+
+    def get_prerequisites(self) -> list[Prerequisite]:
+        return [HasCharacterSheetPrerequisite()]
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        exit_obj = _resolve_exit_obj(actor, kwargs)
+        if exit_obj is None:
+            return ActionResult(success=False, message="Break which exit?")
+
+        if not exit_obj.db.locked:
+            return ActionResult(success=False, message="That exit isn't locked.")
+
+        exit_obj.db.locked = False
+
+        from world.buildings.constants import ConditionTier  # noqa: PLC0415
+        from world.buildings.room_services import building_for_room  # noqa: PLC0415
+        from world.buildings.upkeep_services import set_condition_tier  # noqa: PLC0415
+
+        building = building_for_room(exit_obj.location)
+        if building is not None:
+            new_tier = max(ConditionTier.DECAYED, building.condition_tier - 1)
+            set_condition_tier(building, new_tier)
+
+        sdm = context.scene_data if context else SceneDataManager()
+        actor_state = sdm.initialize_state_for_object(actor)
+        message_location(
+            actor_state,
+            "$You() $conj(break) through the lock on {target}!"
+            " A loud crack echoes through the area.",
+            mapping={"target": exit_obj},
+        )
+
+        _record_breakin_deed(
+            actor, exit_obj, title_prefix="Break-in", concealed=False, base_value=10
+        )
+
+        return ActionResult(success=True, message=f"You break through the lock on {exit_obj.key}!")

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -83,7 +83,7 @@ from actions.definitions.crossing import resolve_crossing_offer
 from actions.definitions.currency import DepositCoinsAction, GiveCoinsAction, WithdrawCoinsAction
 from actions.definitions.deeds import SaveDeedStoryAction, SpreadTaleAction
 from actions.definitions.distinctions import GMAwardDistinctionAction
-from actions.definitions.doors import LockAction, UnlockAction
+from actions.definitions.doors import BreakExitAction, LockAction, PickLockAction, UnlockAction
 from actions.definitions.dramatic_moments import (
     ConfirmDramaticMomentSuggestionAction,
     DismissDramaticMomentSuggestionAction,
@@ -591,6 +591,8 @@ _ALL_ACTIONS: list[Action] = [
     # #1866 — door lock/unlock telnet coverage.
     LockAction(),
     UnlockAction(),
+    PickLockAction(),
+    BreakExitAction(),
     OpenWindowAction(),
     CloseWindowAction(),
     # #2116 — gift/technique/thread-weaving acquisition surface.

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -392,6 +392,8 @@ class ActionRegistryTests(TestCase):
             "order_companion",
             "lock_exit",
             "unlock_exit",
+            "pick_lock",
+            "break_exit",
             "open_window",
             "close_window",
             # #2116 — gift/technique/thread-weaving acquisition surface.

--- a/src/actions/tests/test_door_actions.py
+++ b/src/actions/tests/test_door_actions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django.test import TestCase
 
-from actions.definitions.doors import LockAction, UnlockAction
+from actions.definitions.doors import BreakExitAction, LockAction, PickLockAction, UnlockAction
 from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.locations.services import transfer_ownership
@@ -69,3 +69,185 @@ class UnlockActionTests(TestCase):
         result = UnlockAction().run(actor=actor, exit=exit_obj)
         assert result.success
         assert exit_obj.db.locked is False
+
+
+class PickLockActionTests(TestCase):
+    """Tests for PickLockAction (#2176) — quiet, check-gated lockpicking."""
+
+    def _actor_and_locked_exit(self):
+        room = ObjectDBFactory(db_key="PickLockRoom", db_typeclass_path="typeclasses.rooms.Room")
+        destination = ObjectDBFactory(
+            db_key="PickLockDest", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        account = AccountFactory(username="pick_lock_account")
+        actor = CharacterFactory(db_key="PickLockAlice", location=room)
+        actor.db_account = account
+        actor.save()
+        sheet = CharacterSheetFactory(character=actor)
+        persona = PersonaFactory(character_sheet=sheet)
+        sheet.active_persona = persona
+        sheet.save(update_fields=["active_persona"])
+        exit_obj = ObjectDBFactory(db_key="north", db_typeclass_path="typeclasses.exits.Exit")
+        exit_obj.location = room
+        exit_obj.destination = destination
+        exit_obj.db.locked = True
+        exit_obj.save()
+        return actor, exit_obj, room
+
+    def test_pick_lock_success_unlocks_exit(self):
+        from world.checks.test_helpers import force_check_outcome
+        from world.seeds.checks import seed_check_resolution_tables
+        from world.seeds.investigation_checks import ensure_lockpicking_check
+        from world.traits.models import CheckOutcome
+
+        seed_check_resolution_tables()
+        ensure_lockpicking_check()
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+
+        success_outcome = CheckOutcome.objects.filter(success_level__gt=0).first()
+        with force_check_outcome(success_outcome):
+            result = PickLockAction().run(actor=actor, exit=exit_obj)
+
+        assert result.success
+        assert exit_obj.db.locked is False
+
+    def test_pick_lock_failure_keeps_exit_locked(self):
+        from world.checks.test_helpers import force_check_outcome
+        from world.seeds.checks import seed_check_resolution_tables
+        from world.seeds.investigation_checks import ensure_lockpicking_check
+        from world.traits.models import CheckOutcome
+
+        seed_check_resolution_tables()
+        ensure_lockpicking_check()
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+
+        fail_outcome = CheckOutcome.objects.filter(success_level=0).first()
+        with force_check_outcome(fail_outcome):
+            result = PickLockAction().run(actor=actor, exit=exit_obj)
+
+        assert not result.success
+        assert exit_obj.db.locked is True
+
+    def test_pick_lock_on_unlocked_exit_fails(self):
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+        exit_obj.db.locked = False
+        result = PickLockAction().run(actor=actor, exit=exit_obj)
+        assert not result.success
+
+    def test_pick_lock_creates_concealed_deed(self):
+        from world.checks.test_helpers import force_check_outcome
+        from world.seeds.checks import seed_check_resolution_tables
+        from world.seeds.investigation_checks import ensure_lockpicking_check
+        from world.societies.models import LegendEntry
+        from world.traits.models import CheckOutcome
+
+        seed_check_resolution_tables()
+        ensure_lockpicking_check()
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+
+        success_outcome = CheckOutcome.objects.filter(success_level__gt=0).first()
+        with force_check_outcome(success_outcome):
+            PickLockAction().run(actor=actor, exit=exit_obj)
+
+        deeds = LegendEntry.objects.filter(persona=actor.sheet_data.active_persona)
+        assert deeds.exists()
+        deed = deeds.first()
+        assert deed.title.startswith("Lockpicking")
+
+    def test_pick_lock_no_check_type_seeded_fails_gracefully(self):
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+        result = PickLockAction().run(actor=actor, exit=exit_obj)
+        assert not result.success
+        assert "available" in result.message.lower()
+
+
+class BreakExitActionTests(TestCase):
+    """Tests for BreakExitAction (#2176) — loud, always-succeeds lock breaking."""
+
+    def _actor_and_locked_exit(self):
+        room = ObjectDBFactory(db_key="BreakExitRoom", db_typeclass_path="typeclasses.rooms.Room")
+        destination = ObjectDBFactory(
+            db_key="BreakExitDest", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        account = AccountFactory(username="break_exit_account")
+        actor = CharacterFactory(db_key="BreakExitBob", location=room)
+        actor.db_account = account
+        actor.save()
+        sheet = CharacterSheetFactory(character=actor)
+        persona = PersonaFactory(character_sheet=sheet)
+        sheet.active_persona = persona
+        sheet.save(update_fields=["active_persona"])
+        exit_obj = ObjectDBFactory(db_key="east", db_typeclass_path="typeclasses.exits.Exit")
+        exit_obj.location = room
+        exit_obj.destination = destination
+        exit_obj.db.locked = True
+        exit_obj.save()
+        return actor, exit_obj, room
+
+    def test_break_exit_unlocks_exit(self):
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+        result = BreakExitAction().run(actor=actor, exit=exit_obj)
+        assert result.success
+        assert exit_obj.db.locked is False
+
+    def test_break_exit_on_unlocked_exit_fails(self):
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+        exit_obj.db.locked = False
+        result = BreakExitAction().run(actor=actor, exit=exit_obj)
+        assert not result.success
+
+    def test_break_exit_creates_non_concealed_deed(self):
+        from world.societies.models import LegendEntry
+
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+        BreakExitAction().run(actor=actor, exit=exit_obj)
+
+        deeds = LegendEntry.objects.filter(persona=actor.sheet_data.active_persona)
+        assert deeds.exists()
+        deed = deeds.first()
+        assert deed.title.startswith("Break-in")
+
+    def test_break_exit_damages_building_condition(self):
+        from evennia_extensions.models import RoomProfile
+        from world.areas.factories import AreaFactory
+        from world.buildings.constants import ConditionTier
+        from world.buildings.factories import BuildingFactory
+
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+        area = AreaFactory(level=10)
+        profile = RoomProfile.objects.filter(objectdb=room).first()
+        if profile is None:
+            profile = RoomProfile.objects.create(objectdb=room, area=area)
+        else:
+            profile.area = area
+            profile.save(update_fields=["area"])
+        building = BuildingFactory(area=area, condition_tier=ConditionTier.EXCELLENT)
+
+        BreakExitAction().run(actor=actor, exit=exit_obj)
+        building.refresh_from_db()
+        assert building.condition_tier == ConditionTier.GOOD
+
+    def test_break_exit_condition_floors_at_decayed(self):
+        from evennia_extensions.models import RoomProfile
+        from world.areas.factories import AreaFactory
+        from world.buildings.constants import ConditionTier
+        from world.buildings.factories import BuildingFactory
+
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+        area = AreaFactory(level=10)
+        profile = RoomProfile.objects.filter(objectdb=room).first()
+        if profile is None:
+            profile = RoomProfile.objects.create(objectdb=room, area=area)
+        else:
+            profile.area = area
+            profile.save(update_fields=["area"])
+        building = BuildingFactory(area=area, condition_tier=ConditionTier.DECAYED)
+
+        BreakExitAction().run(actor=actor, exit=exit_obj)
+        building.refresh_from_db()
+        assert building.condition_tier == ConditionTier.DECAYED
+
+    def test_break_exit_no_building_succeeds_without_damage(self):
+        actor, exit_obj, _room = self._actor_and_locked_exit()
+        result = BreakExitAction().run(actor=actor, exit=exit_obj)
+        assert result.success

--- a/src/actions/tests/test_door_actions.py
+++ b/src/actions/tests/test_door_actions.py
@@ -213,7 +213,7 @@ class BreakExitActionTests(TestCase):
         from world.buildings.constants import ConditionTier
         from world.buildings.factories import BuildingFactory
 
-        actor, exit_obj, _room = self._actor_and_locked_exit()
+        actor, exit_obj, room = self._actor_and_locked_exit()
         area = AreaFactory(level=10)
         profile = RoomProfile.objects.filter(objectdb=room).first()
         if profile is None:
@@ -233,7 +233,7 @@ class BreakExitActionTests(TestCase):
         from world.buildings.constants import ConditionTier
         from world.buildings.factories import BuildingFactory
 
-        actor, exit_obj, _room = self._actor_and_locked_exit()
+        actor, exit_obj, room = self._actor_and_locked_exit()
         area = AreaFactory(level=10)
         profile = RoomProfile.objects.filter(objectdb=room).first()
         if profile is None:

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -107,7 +107,12 @@ actions, backends, and service functions.
   `UnlockAction` (`actions/definitions/doors.py`). Room-owner/tenant gated via the
   Actions' prerequisite, not in the command; no key-item system — lock state is a
   plain `db.locked` Evennia attribute on the Exit, checked by
-  `ExitState.can_traverse`.
+  `ExitState.can_traverse`. `CmdPick`/`CmdBreak` (`pick`/`break`, #2176) —
+  the intruder path: `pick` dispatches `PickLockAction` (key `"pick_lock"`,
+  check-gated Wits + Larceny, concealed deed); `break` dispatches
+  `BreakExitAction` (key `"break_exit"`, always succeeds, damages building
+  condition tier by 1, non-concealed deed). Both gated only on
+  `HasCharacterSheetPrerequisite` — no owner/tenant standing required.
 - **`offer_registry.py`**: `OfferHandler` protocol, `_REGISTRY`, `register_offer_handler`,
   `get_all_pending`, `find_handler` — pure-Python in-process registry; no DB model.
 - **`offer_response.py`**: `CmdDecline` (`decline`) — registry-offer decline; see also

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -48,7 +48,7 @@ from commands.crafting import CmdCraft
 from commands.crafting_station import CmdLabStation
 from commands.currency import CmdDeposit, CmdSecure, CmdSteal
 from commands.deeds import CmdDeed
-from commands.door import CmdLock, CmdUnlock
+from commands.door import CmdBreak, CmdLock, CmdPick, CmdUnlock
 from commands.dramatic_moments import CmdMoment
 from commands.duels import CmdDuel
 from commands.durance import CmdDurance
@@ -207,6 +207,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdTabletalk,
             CmdLock,
             CmdUnlock,
+            CmdPick,
+            CmdBreak,
             CmdOpenWindow,
             CmdCloseWindow,
             CmdRitual,

--- a/src/commands/door.py
+++ b/src/commands/door.py
@@ -1,15 +1,17 @@
-"""Door lock/unlock telnet commands (#1866).
+"""Door lock/unlock/pick/break telnet commands (#1866, #2176).
 
 Real implementation replacing the former stubs — dispatches to
-LockAction/UnlockAction (actions/definitions/doors.py). Room-owner/tenant
-gated (enforced by the Action's prerequisite, not here).
+LockAction/UnlockAction/PickLockAction/BreakExitAction
+(actions/definitions/doors.py). Room-owner/tenant gated (enforced by the
+Action's prerequisite, not here) for lock/unlock; pick/break are the
+intruder path gated only on having a character sheet.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from actions.definitions.doors import LockAction, UnlockAction
+from actions.definitions.doors import BreakExitAction, LockAction, PickLockAction, UnlockAction
 from commands.command import ArxCommand
 
 
@@ -47,6 +49,48 @@ class CmdUnlock(ArxCommand):
 
     def resolve_action_args(self) -> dict[str, Any]:
         name = self.require_args("Unlock which exit?")
+        exit_obj = self.search_or_raise(
+            name,
+            location=self.caller.location,
+            not_found_msg=f"Could not find an exit called '{name}'.",
+        )
+        return {"exit": exit_obj}
+
+
+class CmdPick(ArxCommand):
+    """Pick the lock on an exit in your current room.
+
+    Usage:
+      pick <exit name>
+    """
+
+    key = "pick"
+    locks = "cmd:all()"
+    action = PickLockAction()
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        name = self.require_args("Pick which exit?")
+        exit_obj = self.search_or_raise(
+            name,
+            location=self.caller.location,
+            not_found_msg=f"Could not find an exit called '{name}'.",
+        )
+        return {"exit": exit_obj}
+
+
+class CmdBreak(ArxCommand):
+    """Break through the lock on an exit in your current room.
+
+    Usage:
+      break <exit name>
+    """
+
+    key = "break"
+    locks = "cmd:all()"
+    action = BreakExitAction()
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        name = self.require_args("Break which exit?")
         exit_obj = self.search_or_raise(
             name,
             location=self.caller.location,

--- a/src/commands/tests/test_door.py
+++ b/src/commands/tests/test_door.py
@@ -1,4 +1,4 @@
-"""Tests for the real CmdLock/CmdUnlock (#1866, replacing the stubs)."""
+"""Tests for CmdLock/CmdUnlock (#1866) and CmdPick/CmdBreak (#2176)."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from actions.types import ActionResult
-from commands.door import CmdLock, CmdUnlock
+from commands.door import CmdBreak, CmdLock, CmdPick, CmdUnlock
 from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 
 
@@ -73,3 +73,39 @@ class CmdLockTests(TestCase):
         payload = kwargs_calls[0]["command_error"]
         assert "find" in payload["error"].lower() or "such" in payload["error"].lower()
         assert payload["command"] == "lock nowhere"
+
+
+class CmdPickTests(CmdLockTests):
+    """Tests for CmdPick (#2176) — telnet face of PickLockAction."""
+
+    def test_pick_dispatches_pick_lock_action(self):
+        caller, exit_obj = self._caller_and_exit()
+        with patch("commands.door.PickLockAction.run") as mocked:
+            mocked.return_value = ActionResult(success=True, message="Picked.")
+            self._run(CmdPick, caller, "gate")
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs["exit"] == exit_obj
+
+    def test_pick_no_such_exit(self):
+        caller, _ = self._caller_and_exit()
+        kwargs_calls: list[dict] = []
+        messages = self._run(CmdPick, caller, "nowhere", kwargs_out=kwargs_calls)
+        assert any("find" in m.lower() or "such" in m.lower() for m in messages)
+
+
+class CmdBreakTests(CmdLockTests):
+    """Tests for CmdBreak (#2176) — telnet face of BreakExitAction."""
+
+    def test_break_dispatches_break_exit_action(self):
+        caller, exit_obj = self._caller_and_exit()
+        with patch("commands.door.BreakExitAction.run") as mocked:
+            mocked.return_value = ActionResult(success=True, message="Broken.")
+            self._run(CmdBreak, caller, "gate")
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs["exit"] == exit_obj
+
+    def test_break_no_such_exit(self):
+        caller, _ = self._caller_and_exit()
+        kwargs_calls: list[dict] = []
+        messages = self._run(CmdBreak, caller, "nowhere", kwargs_out=kwargs_calls)
+        assert any("find" in m.lower() or "such" in m.lower() for m in messages)

--- a/src/world/seeds/investigation_checks.py
+++ b/src/world/seeds/investigation_checks.py
@@ -25,6 +25,10 @@ _SEARCH_STAT = "perception"
 _IDENTIFICATION_STAT = "intellect"
 _EXPLORATION_CATEGORY = "Exploration"
 
+_LOCKPICKING_CHECK_TYPE_NAME = "Lockpicking"
+_LARCENY_SKILL = ("Larceny", "Picking locks, pockets, and sleight of hand.")
+_WITS_STAT = "wits"
+
 
 def ensure_investigation_skill():
     """Seed the Investigation ``Skill`` (+ its backing SKILL ``Trait``)."""
@@ -101,6 +105,63 @@ def ensure_identification_check():
     return check_type
 
 
+def _ensure_wits_stat():
+    """The wits STAT trait (matches the canonical stat seed: STAT / category META)."""
+    from world.traits.models import Trait, TraitCategory, TraitType  # noqa: PLC0415
+
+    trait, _ = Trait.objects.get_or_create(
+        name=_WITS_STAT,
+        defaults={
+            "trait_type": TraitType.STAT,
+            "category": TraitCategory.META,
+            "is_public": True,
+        },
+    )
+    return trait
+
+
+def ensure_larceny_skill():
+    """Seed the Larceny ``Skill`` (+ its backing SKILL ``Trait``)."""
+    from world.skills.models import Skill  # noqa: PLC0415
+    from world.traits.models import Trait, TraitCategory, TraitType  # noqa: PLC0415
+
+    name, tooltip = _LARCENY_SKILL
+    trait, _ = Trait.objects.get_or_create(
+        name=name,
+        defaults={
+            "trait_type": TraitType.SKILL,
+            "category": TraitCategory.GENERAL,
+            "is_public": True,
+        },
+    )
+    skill, _ = Skill.objects.get_or_create(
+        trait=trait,
+        defaults={"tooltip": tooltip, "display_order": 0, "is_active": True},
+    )
+    return skill
+
+
+def ensure_lockpicking_check():
+    """Seed the **Lockpicking** ``CheckType`` — wits + Larceny (#2176).
+
+    Idempotent, authoritative (wipe-and-rewrite composition): a lockpicking
+    roll always ends up wits + Larceny, never accreting a stale composition.
+    """
+    from world.checks.models import CheckCategory, CheckType, CheckTypeTrait  # noqa: PLC0415
+
+    skill = ensure_larceny_skill()
+    stat_trait = _ensure_wits_stat()
+    category, _ = CheckCategory.objects.get_or_create(name=_EXPLORATION_CATEGORY)
+    check_type, _ = CheckType.objects.get_or_create(
+        name=_LOCKPICKING_CHECK_TYPE_NAME, category=category, defaults={"is_active": True}
+    )
+    weight = Decimal("1.0")  # PLACEHOLDER magnitudes
+    CheckTypeTrait.objects.filter(check_type=check_type).delete()
+    CheckTypeTrait.objects.create(check_type=check_type, trait=stat_trait, weight=weight)
+    CheckTypeTrait.objects.create(check_type=check_type, trait=skill.trait, weight=weight)
+    return check_type
+
+
 def seed_investigation_check_content() -> None:
     """Cluster entry — seed the Investigation skill + the Search + Identification checks."""
     from world.checks.models import CheckCategory, CheckType, CheckTypeTrait  # noqa: PLC0415
@@ -118,3 +179,4 @@ def seed_investigation_check_content() -> None:
     CheckTypeTrait.objects.create(check_type=check_type, trait=stat_trait, weight=weight)
     CheckTypeTrait.objects.create(check_type=check_type, trait=skill.trait, weight=weight)
     ensure_identification_check()
+    ensure_lockpicking_check()

--- a/src/world/seeds/tests/test_investigation_checks.py
+++ b/src/world/seeds/tests/test_investigation_checks.py
@@ -36,3 +36,35 @@ class InvestigationCheckSeedTests(TestCase):
         search = CheckType.objects.get(name=SEARCH_CHECK_TYPE_NAME)
         # Authoritative re-seed leaves exactly the two composition rows (no duplicates).
         self.assertEqual(CheckTypeTrait.objects.filter(check_type=search).count(), 2)
+
+
+class LockpickingCheckSeedTests(TestCase):
+    """Lockpicking CheckType seed — wits + Larceny (#2176)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        seed_check_resolution_tables()
+        seed_investigation_check_content()
+
+    def test_ensure_lockpicking_check_creates_check_type(self) -> None:
+        from world.seeds.investigation_checks import ensure_lockpicking_check
+
+        check_type = ensure_lockpicking_check()
+        self.assertEqual(check_type.name, "Lockpicking")
+        self.assertTrue(check_type.is_active)
+        trait_names = set(
+            CheckTypeTrait.objects.filter(check_type=check_type).values_list(
+                "trait__name", flat=True
+            )
+        )
+        self.assertEqual(trait_names, {"wits", "Larceny"})
+        self.assertEqual(Trait.objects.get(name="Larceny").trait_type, TraitType.SKILL)
+        self.assertEqual(Trait.objects.get(name="wits").trait_type, TraitType.STAT)
+
+    def test_ensure_lockpicking_check_is_idempotent(self) -> None:
+        from world.seeds.investigation_checks import ensure_lockpicking_check
+
+        first = ensure_lockpicking_check()
+        second = ensure_lockpicking_check()
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(CheckTypeTrait.objects.filter(check_type=first).count(), 2)


### PR DESCRIPTION
Closes #2176

## Summary

Add PickLockAction and BreakExitAction — the intruder path past #1866 door locks. Pick is quiet and check-gated (Wits + Larceny); break is loud, always succeeds, and damages building condition. Both leave crime-tagged Legend deeds. Includes CmdPick/CmdBreak telnet commands and a seeded Lockpicking CheckType.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2176 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean rebase, no conflicts.

<!-- last-addressed-comment: 0 -->