### PR TITLE
Content pipeline Phase 2: NPC roles + item/building/decoration prose domains (Apostate path, #2266)

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -118,7 +118,13 @@ limits, IC-vs-UI placement, etc. — see [`design-tenets.md`](design-tenets.md).
     (`tech_health.py`: idmapper RAM, process RSS/CPU, open system errors, deploy SHA).
   - Superuser-only external content-repo load surface (`web/admin/content_load_views.py`,
     `CONTENT_REPO_PATH` env var) upserting into the DB via `core_management.content_fixtures`;
-    linked from the Game Setup hub alongside both new dashboards.
+    linked from the Game Setup hub alongside both new dashboards. Phase 2 (#2266, complete):
+    extended past `stats`/`skills` to `npc_roles`, `items`, `building_kinds`,
+    `decoration_kinds`; fixed `DecorationKind`/`ArchitecturalStyle` seeder rows that carried
+    `PLACEHOLDER` in the *name* (silently orphaning the seeded row instead of being
+    superseded by content); rooms/areas remain deferred (no natural key today). Game Setup
+    inventory now also tracks `Trait` (the #944 Phase-1 domain had none) and
+    `BuildingKind`/`DecorationKind`.
   - Built on the existing `ArxAdminSite` with `django-htmx` + vendored `htmx.min.js`, not
     `django-unfold` (deviation from the original #1221 spec — see ADR-0093, which narrows
     ADR-0022's admin-hosted-not-React decision). Details: [tuning.md](../systems/tuning.md).

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -4336,7 +4336,11 @@ Admin-hosted, superuser-only HTMX dashboards for difficulty tuning/simulation an
 - **Content-repo load:** `web/admin/content_load_views.py` — superuser upsert of the
   maintainers' private content repository (`CONTENT_REPO_PATH` env var) via
   `core_management.content_fixtures.build_all` + `load_entries`; linked from the Game
-  Setup hub.
+  Setup hub. Domains (`DOMAIN_BUILDERS`, `core_management/content_fixtures.py`): `stats`/
+  `skills` → `traits.Trait` (#944); `npc_roles` → `npc_services.NPCRole`, `items` →
+  `items.ItemTemplate`, `building_kinds` → `buildings.BuildingKind`, `decoration_kinds` →
+  `buildings.DecorationKind` (#2266) — every domain upserts by a DB-unique `name`; rooms/
+  areas are deferred (no natural key on `Area`/`RoomProfile` today).
 - **Permissions:** every view superuser-only (`web.admin.tuning.views.superuser_required`,
   mirroring `game_setup_views.py`'s gate).
 - **Source:** `src/web/admin/tuning/`, `src/web/admin/content_load_views.py`,

--- a/src/commands/tests/test_manageroom_command.py
+++ b/src/commands/tests/test_manageroom_command.py
@@ -91,10 +91,10 @@ class RoomCommandParseTests(TestCase):
         assert (key, kwargs) == ("set_building_style", {"style": "Antique Imperial"})
 
     def test_fixture_switches_route(self) -> None:
-        key, kwargs = self._dispatch(["fixture"], "Great Hearth PLACEHOLDER")
-        assert (key, kwargs) == ("place_room_fixture", {"kind": "Great Hearth PLACEHOLDER"})
-        key, kwargs = self._dispatch(["removefixture"], "Great Hearth PLACEHOLDER")
-        assert (key, kwargs) == ("remove_room_fixture", {"kind": "Great Hearth PLACEHOLDER"})
+        key, kwargs = self._dispatch(["fixture"], "Great Hearth")
+        assert (key, kwargs) == ("place_room_fixture", {"kind": "Great Hearth"})
+        key, kwargs = self._dispatch(["removefixture"], "Great Hearth")
+        assert (key, kwargs) == ("remove_room_fixture", {"kind": "Great Hearth"})
 
     def test_extend_routes_added_budget(self) -> None:
         key, kwargs = self._dispatch(["extend"], "50")

--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -1,4 +1,4 @@
-"""Content pipeline core (#944): private authored content → fixture JSON.
+"""Content pipeline core (#944, #2266): private authored content → fixture JSON.
 
 The maintainers' content repository (never named in this repo — located via
 the ``CONTENT_REPO_PATH`` env var) holds one file per entry: YAML
@@ -8,17 +8,53 @@ keys, so ``loaddata`` upserts by identity — idempotent across database
 wipes, pk churn, and migration rebuilds.
 
 Import-safe without Django configured (the tools wrapper and tests use it
-standalone); only fixture WRITING touches the filesystem and nothing here
-touches the database.
+standalone). ``build_all()`` stays DB-free for every domain EXCEPT
+``npc_roles/``'s optional ``faction_affiliation`` field: resolving an
+org-by-name reference requires a live database, so that one builder does a
+deferred Django import and touches the DB — only when a file actually sets
+the key — to raise ``ContentError`` (naming the file + the missing org) at
+validate time, mirroring how a bad ``category`` is caught today. Every other
+builder (including the same domain's other fields) stays pure. Only
+``load_entries`` performs the actual upsert I/O.
 
-Phase 1 domains: ``stats/`` and ``skills/`` → ``traits.Trait`` rows
-(name, type, category, description). Wrapper models without natural keys
-(e.g. ``skills.Skill``) onboard in later phases once they grow them.
+Optional-field update semantics (#2266 Q1): a builder OMITS an optional key
+from the returned ``fields`` dict entirely when the frontmatter doesn't set
+it — it never fills in `None`/0/"" as a stand-in. This is deliberate:
+``load_entries`` upserts via ``update_or_create(name=..., defaults=fields)``,
+and Django only touches the fields present in ``defaults`` — on CREATE, an
+absent key falls through to the model field's own default; on UPDATE, an
+absent key leaves the existing row's value untouched. So "key omitted from
+frontmatter" already means "don't touch this field" for free, with no extra
+mechanism needed. This is the convention every optional field in this module
+follows (``default_rapport_starting_value``, ``default_description_template``,
+``faction_affiliation``, ``value``, ``weight``) — keep it when adding more.
+
+FK-by-name fields (``faction_affiliation``) are emitted in the fixture using
+Django's own natural-key fixture convention — a one-element list
+(``["Org Name"]``) — rather than a resolved pk or model instance, so the
+generated JSON stays plain-JSON-serializable (``write_fixtures`` just calls
+``json.dumps``) and also stays loadable by a real ``loaddata`` against a
+fresh DB, since ``Organization`` already carries ``NaturalKeyMixin``
+(``world/societies/models.py``) — no new natural-key infrastructure needed.
+``load_entries`` resolves that list back into a real instance immediately
+before the write.
+
+Domains: ``stats``/``skills`` → ``traits.Trait`` rows (name, type, category,
+description); ``npc_roles`` → ``npc_services.NPCRole`` (name, description,
+optional faction/rapport/flavor-template); ``items`` →
+``items.ItemTemplate`` (name, description, optional value/weight);
+``building_kinds`` → ``buildings.BuildingKind`` and ``decoration_kinds`` →
+``buildings.DecorationKind`` (name, description only — mechanical flags stay
+admin/seeder-authored). Every domain's model has a DB-unique ``name``, so
+``load_entries``'s natural key stays a bare ``name`` for all of them; a
+future domain without one (e.g. Area — see #2266) needs a configurable
+natural-key field list before it can onboard.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from functools import partial
 import json
 from pathlib import Path
 
@@ -44,6 +80,15 @@ TRAIT_CATEGORIES = {
     "war",
     "other",
 }
+
+# Optional frontmatter field names, factored out to module constants so a
+# repeated ``key in entry.meta`` membership check doesn't trip the
+# bare-string-literal-as-identifier lint (tools/lint_string_literal.py).
+FIELD_FACTION_AFFILIATION = "faction_affiliation"
+FIELD_DEFAULT_RAPPORT_STARTING_VALUE = "default_rapport_starting_value"
+FIELD_DEFAULT_DESCRIPTION_TEMPLATE = "default_description_template"
+FIELD_VALUE = "value"
+FIELD_WEIGHT = "weight"
 
 
 class ContentError(Exception):
@@ -73,6 +118,9 @@ class BuildResult:
     fixtures: dict[str, list[dict]] = field(default_factory=dict)  # output path -> objects
     entries: list[ContentEntry] = field(default_factory=list)
     placeholder_counts: dict[str, int] = field(default_factory=dict)  # domain -> count
+    # output path -> source file per object, same order as fixtures[output].
+    # Lets load_entries name the originating file in a resolution error.
+    source_paths: dict[str, list[Path]] = field(default_factory=dict)
 
 
 def parse_content_file(path: Path, domain: str) -> ContentEntry:
@@ -101,22 +149,33 @@ def parse_content_file(path: Path, domain: str) -> ContentEntry:
     return ContentEntry(path=path, domain=domain, meta=meta, body=body)
 
 
+def _require_name_and_body(entry: ContentEntry) -> str:
+    """Validate the two fields every domain requires; return ``name``.
+
+    Shared by every per-domain builder below — one non-empty string
+    ``name`` and one non-empty markdown body (PLACEHOLDER text satisfies
+    the body requirement, same as today).
+    """
+    name = entry.meta.get("name")
+    if not name or not isinstance(name, str):
+        msg = f"{entry.path}: 'name' (string) is required."
+        raise ContentError(msg)
+    if not entry.body:
+        msg = f"{entry.path}: description body is required (PLACEHOLDER is fine)."
+        raise ContentError(msg)
+    return name
+
+
 def _build_trait_fixture(entry: ContentEntry, *, trait_type: str) -> dict:
     """Map a stats/ or skills/ entry to a traits.Trait fixture object.
 
     No "pk" key: with NaturalKeyManager.get_by_natural_key on the model,
     loaddata resolves existing rows by name and UPDATES them.
     """
-    name = entry.meta.get("name")
-    if not name or not isinstance(name, str):
-        msg = f"{entry.path}: 'name' (string) is required."
-        raise ContentError(msg)
+    name = _require_name_and_body(entry)
     category = entry.meta.get("category")
     if category not in TRAIT_CATEGORIES:
         msg = f"{entry.path}: 'category' must be one of {sorted(TRAIT_CATEGORIES)}."
-        raise ContentError(msg)
-    if not entry.body:
-        msg = f"{entry.path}: description body is required (PLACEHOLDER is fine)."
         raise ContentError(msg)
     return {
         "model": "traits.trait",
@@ -129,10 +188,133 @@ def _build_trait_fixture(entry: ContentEntry, *, trait_type: str) -> dict:
     }
 
 
-# domain dir -> (builder callable kwargs, output fixture path relative to src/)
+def _build_npc_role_fixture(entry: ContentEntry) -> dict:
+    """Map an npc_roles/ entry to an npc_services.NPCRole fixture object.
+
+    Required: ``name``. Optional: ``faction_affiliation`` (an Organization
+    name, resolved eagerly below — raises ContentError if not found, same
+    error-collection shape as a bad ``category``), ``default_rapport_starting_value``
+    (int), ``default_description_template`` (string; the class-1 nameless-NPC
+    flavor line, distinct from ``description`` — ratified Q1: a second
+    optional key on the same file, body stays the full ``description``).
+    """
+    name = _require_name_and_body(entry)
+    fields: dict = {"name": name, "description": entry.body}
+
+    faction = entry.meta.get(FIELD_FACTION_AFFILIATION)
+    if faction:
+        if not isinstance(faction, str):
+            msg = f"{entry.path}: 'faction_affiliation' must be a string (org name)."
+            raise ContentError(msg)
+        from world.societies.models import Organization  # noqa: PLC0415
+
+        try:
+            Organization.objects.get_by_natural_key(faction)
+        except Organization.DoesNotExist:
+            msg = f"{entry.path}: 'faction_affiliation' organization {faction!r} not found."
+            raise ContentError(msg) from None
+        # Django's own natural-key fixture convention (a 1-element list) —
+        # keeps this JSON-serializable; load_entries resolves it back to an
+        # instance right before the write.
+        fields[FIELD_FACTION_AFFILIATION] = [faction]
+
+    if FIELD_DEFAULT_RAPPORT_STARTING_VALUE in entry.meta:
+        value = entry.meta[FIELD_DEFAULT_RAPPORT_STARTING_VALUE]
+        if not isinstance(value, int) or isinstance(value, bool):
+            msg = f"{entry.path}: 'default_rapport_starting_value' must be an int."
+            raise ContentError(msg)
+        fields[FIELD_DEFAULT_RAPPORT_STARTING_VALUE] = value
+
+    if FIELD_DEFAULT_DESCRIPTION_TEMPLATE in entry.meta:
+        template = entry.meta[FIELD_DEFAULT_DESCRIPTION_TEMPLATE]
+        if not isinstance(template, str):
+            msg = f"{entry.path}: 'default_description_template' must be a string."
+            raise ContentError(msg)
+        fields[FIELD_DEFAULT_DESCRIPTION_TEMPLATE] = template
+
+    return {"model": "npc_services.npcrole", "fields": fields}
+
+
+def _build_item_template_fixture(entry: ContentEntry) -> dict:
+    """Map an items/ entry to an items.ItemTemplate fixture object.
+
+    Required: ``name``. Optional: ``value`` (int), ``weight`` (decimal).
+    Mechanical/balance flags (is_consumable, container sizing, etc.) stay
+    admin/seeder-authored — this pipeline is for prose + identity, not
+    tuning (matches the stats/skills precedent).
+    """
+    name = _require_name_and_body(entry)
+    fields: dict = {"name": name, "description": entry.body}
+
+    if FIELD_VALUE in entry.meta:
+        value = entry.meta[FIELD_VALUE]
+        if not isinstance(value, int) or isinstance(value, bool):
+            msg = f"{entry.path}: 'value' must be an int."
+            raise ContentError(msg)
+        fields[FIELD_VALUE] = value
+
+    if FIELD_WEIGHT in entry.meta:
+        weight = entry.meta[FIELD_WEIGHT]
+        if not isinstance(weight, int | float) or isinstance(weight, bool):
+            msg = f"{entry.path}: 'weight' must be a number."
+            raise ContentError(msg)
+        fields[FIELD_WEIGHT] = str(weight)
+
+    return {"model": "items.itemtemplate", "fields": fields}
+
+
+def _build_building_kind_fixture(entry: ContentEntry) -> dict:
+    """Map a building_kinds/ entry to a buildings.BuildingKind fixture object.
+
+    Required: ``name``. Body → ``description``. Descriptive flags
+    (is_residential, is_commercial, ...) stay admin/seeder-authored.
+    """
+    name = _require_name_and_body(entry)
+    return {
+        "model": "buildings.buildingkind",
+        "fields": {"name": name, "description": entry.body},
+    }
+
+
+def _build_decoration_kind_fixture(entry: ContentEntry) -> dict:
+    """Map a decoration_kinds/ entry to a buildings.DecorationKind fixture object.
+
+    Required: ``name``. Body → ``description``. ``amenity``/affinity
+    magnitudes stay admin/seeder-authored.
+    """
+    name = _require_name_and_body(entry)
+    return {
+        "model": "buildings.decorationkind",
+        "fields": {"name": name, "description": entry.body},
+    }
+
+
+# domain dir -> {builder callable, output fixture path relative to src/}
 DOMAIN_BUILDERS = {
-    "stats": {"trait_type": "stat", "output": "world/traits/fixtures/content_stats.json"},
-    "skills": {"trait_type": "skill", "output": "world/traits/fixtures/content_skills.json"},
+    "stats": {
+        "builder": partial(_build_trait_fixture, trait_type="stat"),
+        "output": "world/traits/fixtures/content_stats.json",
+    },
+    "skills": {
+        "builder": partial(_build_trait_fixture, trait_type="skill"),
+        "output": "world/traits/fixtures/content_skills.json",
+    },
+    "npc_roles": {
+        "builder": _build_npc_role_fixture,
+        "output": "world/npc_services/fixtures/content_npc_roles.json",
+    },
+    "items": {
+        "builder": _build_item_template_fixture,
+        "output": "world/items/fixtures/content_items.json",
+    },
+    "building_kinds": {
+        "builder": _build_building_kind_fixture,
+        "output": "world/buildings/fixtures/content_building_kinds.json",
+    },
+    "decoration_kinds": {
+        "builder": _build_decoration_kind_fixture,
+        "output": "world/buildings/fixtures/content_decoration_kinds.json",
+    },
 }
 
 
@@ -149,10 +331,12 @@ def build_all(content_root: Path) -> BuildResult:
         if not domain_dir.is_dir():
             continue
         objects: list[dict] = []
+        paths: list[Path] = []
         for path in sorted(domain_dir.rglob("*.md")):
             try:
                 entry = parse_content_file(path, domain)
-                objects.append(_build_trait_fixture(entry, trait_type=config["trait_type"]))
+                objects.append(config["builder"](entry))
+                paths.append(entry.path)
                 result.entries.append(entry)
                 if entry.has_placeholder:
                     result.placeholder_counts[domain] = result.placeholder_counts.get(domain, 0) + 1
@@ -160,10 +344,36 @@ def build_all(content_root: Path) -> BuildResult:
                 errors.append(str(exc))
         if objects:
             result.fixtures[config["output"]] = objects
+            result.source_paths[config["output"]] = paths
     if errors:
         msg = "Content validation failed:\n" + "\n".join(errors)
         raise ContentError(msg)
     return result
+
+
+def _resolve_natural_key_fields(model, fields: dict, source_path: Path | None) -> None:
+    """Swap any natural-key-list field values in *fields* for real instances.
+
+    A builder emits an FK-by-name value as a 1-element list (Django's own
+    fixture natural-key convention — see the module docstring); this
+    resolves it back into the related model's instance immediately before
+    the upsert, using that related model's own ``get_by_natural_key``
+    (``NaturalKeyMixin`` — no bespoke lookup table here). Raises
+    ContentError, naming the source file, if the target no longer exists
+    (build-time validation already checked this once; re-checking here is
+    the only way to guarantee correctness against a DB that may have
+    changed between build and load).
+    """
+    for field_name, value in list(fields.items()):
+        if not isinstance(value, list):
+            continue
+        related_model = model._meta.get_field(field_name).related_model  # noqa: SLF001
+        try:
+            fields[field_name] = related_model.objects.get_by_natural_key(*value)
+        except related_model.DoesNotExist:
+            location = source_path if source_path is not None else model._meta.label  # noqa: SLF001
+            msg = f"{location}: {field_name!r} {related_model.__name__} {value!r} not found."
+            raise ContentError(msg) from None
 
 
 def load_entries(result: BuildResult) -> tuple[int, int]:
@@ -184,12 +394,14 @@ def load_entries(result: BuildResult) -> tuple[int, int]:
 
     created_count = 0
     updated_count = 0
-    for objects in result.fixtures.values():
-        for obj in objects:
+    for output_path, objects in result.fixtures.items():
+        paths = result.source_paths.get(output_path, [])
+        for obj, source_path in zip(objects, paths, strict=False):
             app_label, model_name = obj["model"].split(".")
             model = apps.get_model(app_label, model_name)
             fields = dict(obj["fields"])
             name = fields.pop("name")
+            _resolve_natural_key_fields(model, fields, source_path)
             _, created = model.objects.update_or_create(name=name, defaults=fields)
             if created:
                 created_count += 1

--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -4,8 +4,25 @@ The maintainers' content repository (never named in this repo — located via
 the ``CONTENT_REPO_PATH`` env var) holds one file per entry: YAML
 frontmatter for mechanical keys, markdown body for prose. This module
 parses, validates, and emits Django fixture JSON serialized with natural
-keys, so ``loaddata`` upserts by identity — idempotent across database
-wipes, pk churn, and migration rebuilds.
+keys (no "pk" key), identity-stable across database wipes, pk churn, and
+migration rebuilds.
+
+Honest ``loaddata`` semantics (#946, #2266 review fix): every domain's model
+now carries ``NaturalKeyMixin``, so ``loaddata`` on the emitted JSON
+correctly *resolves* an existing same-name row rather than raising
+``IntegrityError`` on a blind INSERT — but on a `SharedMemoryModel`,
+``loaddata`` still cannot **update** that resolved row. The identity map
+returns the cached instance, `loaddata` writes the incoming field values
+onto it, then Django's `save(force_insert=False)` path re-fetches from the
+cache and the new values never land in the DB (verified cross-process,
+#946). So the emitted fixture JSON is **fresh-DB / insert-or-resolve only**
+— safe to `loaddata` against an empty table or a table whose rows it
+already matches, but never a reliable way to push edited content onto rows
+that already exist with different values. ``load_entries`` (below), which
+drives both ``tools/build_content_fixtures.py --load`` and the admin "Load
+private content repo" button, calls ``update_or_create`` directly against
+the live model manager instead of going through ``loaddata`` — that is the
+**only** update-safe path for re-authored content.
 
 Import-safe without Django configured (the tools wrapper and tests use it
 standalone). ``build_all()`` stays DB-free for every domain EXCEPT
@@ -25,19 +42,36 @@ and Django only touches the fields present in ``defaults`` — on CREATE, an
 absent key falls through to the model field's own default; on UPDATE, an
 absent key leaves the existing row's value untouched. So "key omitted from
 frontmatter" already means "don't touch this field" for free, with no extra
-mechanism needed. This is the convention every optional field in this module
-follows (``default_rapport_starting_value``, ``default_description_template``,
-``faction_affiliation``, ``value``, ``weight``) — keep it when adding more.
+mechanism needed. This is the convention every scalar optional field in this
+module follows (``default_rapport_starting_value``,
+``default_description_template``, ``value``, ``weight``) — keep it when
+adding more.
 
-FK-by-name fields (``faction_affiliation``) are emitted in the fixture using
-Django's own natural-key fixture convention — a one-element list
-(``["Org Name"]``) — rather than a resolved pk or model instance, so the
-generated JSON stays plain-JSON-serializable (``write_fixtures`` just calls
-``json.dumps``) and also stays loadable by a real ``loaddata`` against a
-fresh DB, since ``Organization`` already carries ``NaturalKeyMixin``
-(``world/societies/models.py``) — no new natural-key infrastructure needed.
-``load_entries`` resolves that list back into a real instance immediately
-before the write.
+Three-state convention for clearable FK-by-name fields (``faction_affiliation``,
+#2266 review fix): a scalar field has only "omit" vs "set"; a nullable FK-by-name
+field genuinely needs a third state — "clear the existing value" — that "omit"
+can't express (omit already means "leave it alone"). So ``faction_affiliation``
+is handled distinctly from the scalar fields above:
+
+- key ABSENT from frontmatter → omitted from ``fields`` → untouched on UPDATE
+  (same as every scalar field).
+- key PRESENT but null/empty (``faction_affiliation:`` or ``faction_affiliation:
+  null``) → emitted as ``fields["faction_affiliation"] = None`` → UPDATE sets the
+  FK to null, clearing it. Requires the target field to be nullable
+  (``NPCRole.faction_affiliation`` is, per spec); a future clearable FK-by-name
+  field that ISN'T nullable must raise ``ContentError`` for the explicit-null
+  case instead of emitting ``None``.
+- key PRESENT with a non-empty string → resolved/validated as an Organization
+  name and emitted using Django's own natural-key fixture convention — a
+  one-element list (``["Org Name"]``) — rather than a resolved pk or model
+  instance, so the generated JSON stays plain-JSON-serializable
+  (``write_fixtures`` just calls ``json.dumps``) and also stays loadable by a
+  real ``loaddata`` against a fresh DB, since ``Organization`` already carries
+  ``NaturalKeyMixin`` (``world/societies/models.py``) — no new natural-key
+  infrastructure needed. ``_resolve_natural_key_fields`` (used by
+  ``load_entries``) resolves that list back into a real instance immediately
+  before the write; a bare ``None`` passes through untouched (not a list, so
+  the resolver skips it and ``update_or_create`` receives the null directly).
 
 Domains: ``stats``/``skills`` → ``traits.Trait`` rows (name, type, category,
 description); ``npc_roles`` → ``npc_services.NPCRole`` (name, description,
@@ -197,26 +231,40 @@ def _build_npc_role_fixture(entry: ContentEntry) -> dict:
     (int), ``default_description_template`` (string; the class-1 nameless-NPC
     flavor line, distinct from ``description`` — ratified Q1: a second
     optional key on the same file, body stays the full ``description``).
+
+    ``faction_affiliation`` is three-state (#2266 review fix; see the module
+    docstring): key ABSENT from frontmatter omits the field (UPDATE leaves the
+    existing value untouched); key PRESENT but null/empty emits ``None``
+    (UPDATE clears it — ``NPCRole.faction_affiliation`` is nullable); key
+    PRESENT with a non-empty string resolves/validates it as an Organization
+    name. Without this, a builder that only checked truthiness would make the
+    field one-way-sticky — content could set it but never clear it back out.
     """
     name = _require_name_and_body(entry)
     fields: dict = {"name": name, "description": entry.body}
 
-    faction = entry.meta.get(FIELD_FACTION_AFFILIATION)
-    if faction:
-        if not isinstance(faction, str):
+    if FIELD_FACTION_AFFILIATION in entry.meta:
+        faction = entry.meta[FIELD_FACTION_AFFILIATION]
+        if not faction:
+            # Explicit null/empty: clear the FK on UPDATE. NPCRole.faction_affiliation
+            # is nullable (null=True, blank=True), so a bare None is a valid
+            # update_or_create default.
+            fields[FIELD_FACTION_AFFILIATION] = None
+        elif not isinstance(faction, str):
             msg = f"{entry.path}: 'faction_affiliation' must be a string (org name)."
             raise ContentError(msg)
-        from world.societies.models import Organization  # noqa: PLC0415
+        else:
+            from world.societies.models import Organization  # noqa: PLC0415
 
-        try:
-            Organization.objects.get_by_natural_key(faction)
-        except Organization.DoesNotExist:
-            msg = f"{entry.path}: 'faction_affiliation' organization {faction!r} not found."
-            raise ContentError(msg) from None
-        # Django's own natural-key fixture convention (a 1-element list) —
-        # keeps this JSON-serializable; load_entries resolves it back to an
-        # instance right before the write.
-        fields[FIELD_FACTION_AFFILIATION] = [faction]
+            try:
+                Organization.objects.get_by_natural_key(faction)
+            except Organization.DoesNotExist:
+                msg = f"{entry.path}: 'faction_affiliation' organization {faction!r} not found."
+                raise ContentError(msg) from None
+            # Django's own natural-key fixture convention (a 1-element list) —
+            # keeps this JSON-serializable; load_entries resolves it back to an
+            # instance right before the write.
+            fields[FIELD_FACTION_AFFILIATION] = [faction]
 
     if FIELD_DEFAULT_RAPPORT_STARTING_VALUE in entry.meta:
         value = entry.meta[FIELD_DEFAULT_RAPPORT_STARTING_VALUE]
@@ -363,15 +411,34 @@ def _resolve_natural_key_fields(model, fields: dict, source_path: Path | None) -
     (build-time validation already checked this once; re-checking here is
     the only way to guarantee correctness against a DB that may have
     changed between build and load).
+
+    Guard (#2266 review fix): ``isinstance(value, list)`` alone only tells us
+    a builder emitted a list; it says nothing about whether the *field* is
+    relational. A plain (non-FK) model field that happened to be list-valued
+    would fall through to ``get_field(...).related_model`` and raise a bare
+    ``AttributeError`` (regular ``Field`` has no ``related_model`` attribute
+    — only relation fields do), crashing ``load_entries`` mid-batch instead
+    of failing cleanly. So this checks ``field.is_relation`` first and raises
+    a normal ``ContentError`` naming the field (and the source file, when
+    known) for a non-relational list value, matching every other validation
+    failure's error style in this module.
     """
     for field_name, value in list(fields.items()):
         if not isinstance(value, list):
             continue
-        related_model = model._meta.get_field(field_name).related_model  # noqa: SLF001
+        field = model._meta.get_field(field_name)  # noqa: SLF001
+        location = source_path if source_path is not None else model._meta.label  # noqa: SLF001
+        if not field.is_relation:
+            msg = (
+                f"{location}: {field_name!r} on {model._meta.label} is a list-valued "  # noqa: SLF001
+                "field but not a relational one — natural-key resolution only "
+                "supports FK-by-name values (a 1-element list)."
+            )
+            raise ContentError(msg)
+        related_model = field.related_model
         try:
             fields[field_name] = related_model.objects.get_by_natural_key(*value)
         except related_model.DoesNotExist:
-            location = source_path if source_path is not None else model._meta.label  # noqa: SLF001
             msg = f"{location}: {field_name!r} {related_model.__name__} {value!r} not found."
             raise ContentError(msg) from None
 

--- a/src/core_management/tests/test_content_fixtures.py
+++ b/src/core_management/tests/test_content_fixtures.py
@@ -15,6 +15,11 @@ from core_management.content_fixtures import (
     parse_content_file,
     write_fixtures,
 )
+from world.buildings.models import BuildingKind, DecorationKind
+from world.buildings.seeds import ensure_decoration_kinds
+from world.items.models import ItemTemplate
+from world.npc_services.models import NPCRole
+from world.societies.factories import OrganizationFactory
 from world.traits.models import Trait, TraitCategory, TraitType
 
 
@@ -30,6 +35,35 @@ name: Performance
 category: social
 ---
 PLACEHOLDER Captivating an audience through music, oration, or storytelling.
+"""
+
+GOOD_NPC_ROLE = """---
+name: Builders Guild Clerk
+faction_affiliation: Builders Guild
+default_rapport_starting_value: 5
+default_description_template: A harried clerk, stamp in hand.
+---
+Issues building permits on behalf of the Builders Guild.
+"""
+
+GOOD_ITEM = """---
+name: Iron Longsword
+value: 40
+weight: 3.5
+---
+A well-balanced blade, plain but serviceable.
+"""
+
+GOOD_BUILDING_KIND = """---
+name: Watchtower
+---
+PLACEHOLDER — a fortified lookout post.
+"""
+
+GOOD_DECORATION_KIND = """---
+name: Great Hearth
+---
+A roaring stone hearth that drives out the worst of the cold.
 """
 
 
@@ -80,6 +114,59 @@ class ParseAndValidateTests(TestCase):
             build_all(self.root)
 
 
+class NewDomainParseAndValidateTests(TestCase):
+    """#2266: npc_roles/items/building_kinds/decoration_kinds shape validation."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        OrganizationFactory(name="Builders Guild")
+
+    def test_good_files_parse_for_every_new_domain(self) -> None:
+        _write(self.root, "npc_roles/clerk.md", GOOD_NPC_ROLE)
+        _write(self.root, "items/longsword.md", GOOD_ITEM)
+        _write(self.root, "building_kinds/watchtower.md", GOOD_BUILDING_KIND)
+        _write(self.root, "decoration_kinds/hearth.md", GOOD_DECORATION_KIND)
+        result = build_all(self.root)
+        outputs = set(result.fixtures)
+        assert "world/npc_services/fixtures/content_npc_roles.json" in outputs
+        assert "world/items/fixtures/content_items.json" in outputs
+        assert "world/buildings/fixtures/content_building_kinds.json" in outputs
+        assert "world/buildings/fixtures/content_decoration_kinds.json" in outputs
+
+        npc_fields = result.fixtures["world/npc_services/fixtures/content_npc_roles.json"][0][
+            "fields"
+        ]
+        assert npc_fields["faction_affiliation"] == ["Builders Guild"]
+        assert npc_fields["default_rapport_starting_value"] == 5
+        assert npc_fields["default_description_template"] == "A harried clerk, stamp in hand."
+
+        item_fields = result.fixtures["world/items/fixtures/content_items.json"][0]["fields"]
+        assert item_fields["value"] == 40
+        assert item_fields["weight"] == "3.5"
+
+    def test_missing_name_collects_error_for_every_new_domain(self) -> None:
+        _write(self.root, "npc_roles/bad.md", "---\ndescription: nope\n---\nbody\n")
+        _write(self.root, "items/bad.md", "---\nvalue: 1\n---\nbody\n")
+        _write(self.root, "building_kinds/bad.md", "---\n{}\n---\nbody\n")
+        _write(self.root, "decoration_kinds/bad.md", "---\n{}\n---\nbody\n")
+        with self.assertRaises(ContentError) as ctx:
+            build_all(self.root)
+        message = str(ctx.exception)
+        assert message.count("'name' (string) is required") == 4
+
+    def test_npc_role_bad_faction_affiliation_collects_error(self) -> None:
+        _write(
+            self.root,
+            "npc_roles/ghost.md",
+            "---\nname: Ghost Clerk\nfaction_affiliation: Nonexistent Guild\n---\nbody\n",
+        )
+        with self.assertRaises(ContentError) as ctx:
+            build_all(self.root)
+        assert "Nonexistent Guild" in str(ctx.exception)
+
+
 class ContentLoadTests(TestCase):
     """End-to-end: build → load_entries twice → idempotent upsert.
 
@@ -121,3 +208,99 @@ class ContentLoadTests(TestCase):
         written = write_fixtures(build_all(self.root), Path(out.name))
         call_command("loaddata", str(written[0]), verbosity=0)
         assert Trait.objects.filter(name="Performance").exists()
+
+
+class NewDomainContentLoadTests(TestCase):
+    """#2266: create-then-update idempotency by natural key, per new domain."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        OrganizationFactory(name="Builders Guild")
+
+    def test_npc_role_load_creates_then_updates(self) -> None:
+        _write(self.root, "npc_roles/clerk.md", GOOD_NPC_ROLE)
+        created, updated = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+        role = NPCRole.objects.get(name="Builders Guild Clerk")
+        assert role.faction_affiliation.name == "Builders Guild"
+        assert role.default_rapport_starting_value == 5
+
+        _write(
+            self.root,
+            "npc_roles/clerk.md",
+            GOOD_NPC_ROLE.replace(
+                "Issues building permits on behalf of the Builders Guild.",
+                "Rewritten flavor text.",
+            ),
+        )
+        created, updated = load_entries(build_all(self.root))
+        assert (created, updated) == (0, 1)
+        assert NPCRole.objects.filter(name="Builders Guild Clerk").count() == 1
+        role.refresh_from_db()
+        assert role.description == "Rewritten flavor text."
+
+    def test_npc_role_omitted_optional_key_leaves_existing_value_on_update(self) -> None:
+        """#2266 Q1: an omitted optional key doesn't clobber the row on UPDATE."""
+        _write(self.root, "npc_roles/clerk.md", GOOD_NPC_ROLE)
+        load_entries(build_all(self.root))
+        role = NPCRole.objects.get(name="Builders Guild Clerk")
+        assert role.default_rapport_starting_value == 5
+
+        # Re-author without default_rapport_starting_value or faction_affiliation.
+        _write(
+            self.root,
+            "npc_roles/clerk.md",
+            "---\nname: Builders Guild Clerk\n---\nRewritten flavor text.\n",
+        )
+        load_entries(build_all(self.root))
+        role.refresh_from_db()
+        assert role.description == "Rewritten flavor text."
+        assert role.default_rapport_starting_value == 5
+        assert role.faction_affiliation.name == "Builders Guild"
+
+    def test_item_template_load_creates_then_updates(self) -> None:
+        _write(self.root, "items/longsword.md", GOOD_ITEM)
+        created, updated = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+        item = ItemTemplate.objects.get(name="Iron Longsword")
+        assert item.value == 40
+
+        _write(self.root, "items/longsword.md", GOOD_ITEM.replace("well-balanced", "battered"))
+        created, updated = load_entries(build_all(self.root))
+        assert (created, updated) == (0, 1)
+        assert ItemTemplate.objects.filter(name="Iron Longsword").count() == 1
+
+    def test_building_kind_load_creates_then_updates(self) -> None:
+        _write(self.root, "building_kinds/watchtower.md", GOOD_BUILDING_KIND)
+        created, updated = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+        assert BuildingKind.objects.filter(name="Watchtower").count() == 1
+
+        _write(
+            self.root,
+            "building_kinds/watchtower.md",
+            GOOD_BUILDING_KIND.replace("fortified lookout post", "watchpost"),
+        )
+        created, updated = load_entries(build_all(self.root))
+        assert (created, updated) == (0, 1)
+        assert BuildingKind.objects.filter(name="Watchtower").count() == 1
+
+    def test_decoration_kind_seeder_row_superseded_by_content(self) -> None:
+        """The seeder-name-mismatch bug this issue fixes stays fixed.
+
+        Seeds the real DecorationKind row (post-rename), then loads authored
+        content for the same name — must UPDATE that row, never create a
+        second orphaned one.
+        """
+        ensure_decoration_kinds()
+        assert DecorationKind.objects.filter(name="Great Hearth").count() == 1
+
+        _write(self.root, "decoration_kinds/hearth.md", GOOD_DECORATION_KIND)
+        created, updated = load_entries(build_all(self.root))
+        assert (created, updated) == (0, 1)
+
+        assert DecorationKind.objects.filter(name="Great Hearth").count() == 1
+        kind = DecorationKind.objects.get(name="Great Hearth")
+        assert kind.description == "A roaring stone hearth that drives out the worst of the cold."

--- a/src/core_management/tests/test_content_fixtures.py
+++ b/src/core_management/tests/test_content_fixtures.py
@@ -10,6 +10,7 @@ from core_management.content_fixtures import (
     TRAIT_CATEGORIES,
     TRAIT_TYPES,
     ContentError,
+    _resolve_natural_key_fields,
     build_all,
     load_entries,
     parse_content_file,
@@ -209,6 +210,35 @@ class ContentLoadTests(TestCase):
         call_command("loaddata", str(written[0]), verbosity=0)
         assert Trait.objects.filter(name="Performance").exists()
 
+    def test_fresh_db_loaddata_resolves_but_does_not_update_seeded_row(self) -> None:
+        """#946/#2266: NaturalKeyMixin makes ``loaddata`` resolve-not-duplicate a
+        pre-existing same-name row (no IntegrityError) — but it still can't UPDATE
+        it. ``DecorationKind`` is a SharedMemoryModel; the identity map returns the
+        already-cached seeded instance, so the content-authored description is
+        silently dropped. This is the honest, documented no-op — ``load_entries``
+        (covered by ``NewDomainContentLoadTests``) is the only update-safe path.
+        """
+        ensure_decoration_kinds()
+        seeded = DecorationKind.objects.get(name="Great Hearth")
+        seeded_description = seeded.description
+
+        _write(self.root, "decoration_kinds/hearth.md", GOOD_DECORATION_KIND)
+        out = tempfile.TemporaryDirectory()
+        self.addCleanup(out.cleanup)
+        written = write_fixtures(build_all(self.root), Path(out.name))
+        decoration_fixture = next(p for p in written if p.name == "content_decoration_kinds.json")
+
+        # No IntegrityError on the unique `name` constraint: NaturalKeyMixin lets
+        # loaddata resolve the existing row instead of blind-INSERTing a dupe.
+        call_command("loaddata", str(decoration_fixture), verbosity=0)
+
+        assert DecorationKind.objects.filter(name="Great Hearth").count() == 1
+        seeded.refresh_from_db()
+        # The content body ("A roaring stone hearth...") never lands — loaddata
+        # on an idmapper model cannot UPDATE (#946). Still the seeded PLACEHOLDER.
+        assert seeded.description == seeded_description
+        assert "roaring stone hearth" not in seeded.description
+
 
 class NewDomainContentLoadTests(TestCase):
     """#2266: create-then-update idempotency by natural key, per new domain."""
@@ -242,7 +272,11 @@ class NewDomainContentLoadTests(TestCase):
         assert role.description == "Rewritten flavor text."
 
     def test_npc_role_omitted_optional_key_leaves_existing_value_on_update(self) -> None:
-        """#2266 Q1: an omitted optional key doesn't clobber the row on UPDATE."""
+        """#2266 Q1/review fix: three-state convention, "absent" branch — an omitted
+        optional key (including ``faction_affiliation``) doesn't clobber the row on
+        UPDATE. Contrast with the "explicit null" branch covered by
+        ``test_npc_role_explicit_null_faction_clears_it_on_update`` below.
+        """
         _write(self.root, "npc_roles/clerk.md", GOOD_NPC_ROLE)
         load_entries(build_all(self.root))
         role = NPCRole.objects.get(name="Builders Guild Clerk")
@@ -259,6 +293,28 @@ class NewDomainContentLoadTests(TestCase):
         assert role.description == "Rewritten flavor text."
         assert role.default_rapport_starting_value == 5
         assert role.faction_affiliation.name == "Builders Guild"
+
+    def test_npc_role_explicit_null_faction_clears_it_on_update(self) -> None:
+        """#2266 review fix: three-state convention, "explicit null" branch — a
+        frontmatter key PRESENT but null/empty clears the FK, distinct from the
+        "absent" branch above which leaves it untouched. Without this distinction,
+        faction_affiliation would be one-way-sticky (content could set it but never
+        un-set it).
+        """
+        _write(self.root, "npc_roles/clerk.md", GOOD_NPC_ROLE)
+        load_entries(build_all(self.root))
+        role = NPCRole.objects.get(name="Builders Guild Clerk")
+        assert role.faction_affiliation.name == "Builders Guild"
+
+        _write(
+            self.root,
+            "npc_roles/clerk.md",
+            "---\nname: Builders Guild Clerk\nfaction_affiliation:\n---\nRewritten flavor text.\n",
+        )
+        load_entries(build_all(self.root))
+        role.refresh_from_db()
+        assert role.faction_affiliation is None
+        assert role.description == "Rewritten flavor text."
 
     def test_item_template_load_creates_then_updates(self) -> None:
         _write(self.root, "items/longsword.md", GOOD_ITEM)
@@ -304,3 +360,24 @@ class NewDomainContentLoadTests(TestCase):
         assert DecorationKind.objects.filter(name="Great Hearth").count() == 1
         kind = DecorationKind.objects.get(name="Great Hearth")
         assert kind.description == "A roaring stone hearth that drives out the worst of the cold."
+
+
+class ResolveNaturalKeyFieldsGuardTests(TestCase):
+    """#2266 review fix: ``_resolve_natural_key_fields`` must not crash on a
+    list-valued value for a NON-relational field — it should raise a clean
+    ContentError instead of a bare AttributeError from ``related_model``.
+    """
+
+    def test_non_relational_list_field_raises_content_error(self) -> None:
+        # NPCRole.description is a plain TextField (not a relation); a list
+        # value there can only mean a future bug, not a legitimate FK-by-name.
+        with self.assertRaises(ContentError) as ctx:
+            _resolve_natural_key_fields(NPCRole, {"description": ["oops"]}, None)
+        assert "description" in str(ctx.exception)
+
+    def test_relational_list_field_still_resolves(self) -> None:
+        # Sanity check the guard doesn't break the legitimate FK-by-name path.
+        OrganizationFactory(name="Builders Guild")
+        fields = {"faction_affiliation": ["Builders Guild"]}
+        _resolve_natural_key_fields(NPCRole, fields, None)
+        assert fields["faction_affiliation"].name == "Builders Guild"

--- a/src/web/admin/content_load_views.py
+++ b/src/web/admin/content_load_views.py
@@ -72,11 +72,10 @@ def content_load_run(request: HttpRequest) -> HttpResponse:
 
     try:
         result = build_all(content_root)
+        created, updated = load_entries(result)
     except ContentError as exc:
         messages.error(request, str(exc))
         return HttpResponseRedirect(reverse("admin_game_setup"))
-
-    created, updated = load_entries(result)
     placeholders = sum(result.placeholder_counts.values())
     messages.success(
         request,

--- a/src/web/admin/content_load_views.py
+++ b/src/web/admin/content_load_views.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.exceptions import PermissionDenied
+from django.db import Error as DjangoDbError
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
@@ -75,6 +76,20 @@ def content_load_run(request: HttpRequest) -> HttpResponse:
         created, updated = load_entries(result)
     except ContentError as exc:
         messages.error(request, str(exc))
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+    except DjangoDbError as exc:
+        # Unlike the tools/build_content_fixtures.py CLI wrapper, this view
+        # never needs to catch ImproperlyConfigured — an admin request only
+        # reaches here with Django already fully configured. An unmigrated
+        # or unreachable DB (e.g. the npc_roles/ faction_affiliation lookup,
+        # or load_entries' update_or_create) is the one environmental
+        # failure mode left; surface it the same clean way as ContentError
+        # instead of a raw 500.
+        messages.error(
+            request,
+            f"Database error while loading content: {exc} "
+            "(hint: run `arx manage migrate` to bring the dev DB schema up to date).",
+        )
         return HttpResponseRedirect(reverse("admin_game_setup"))
     placeholders = sum(result.placeholder_counts.values())
     messages.success(

--- a/src/web/admin/tests/test_content_load_views.py
+++ b/src/web/admin/tests/test_content_load_views.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from django.urls import reverse
 from evennia.accounts.models import AccountDB
 
+from world.buildings.models import DecorationKind
 from world.traits.models import Trait
 
 GOOD_SKILL = """---
@@ -16,6 +17,12 @@ name: Performance
 category: social
 ---
 PLACEHOLDER Captivating an audience through music, oration, or storytelling.
+"""
+
+GOOD_DECORATION_KIND = """---
+name: Great Hearth
+---
+A roaring stone hearth that drives out the worst of the cold.
 """
 
 
@@ -85,6 +92,7 @@ class TestContentLoadConfigured(TestCase):
         self.addCleanup(self.content.cleanup)
         self.root = Path(self.content.name)
         _write(self.root, "skills/performance.md", GOOD_SKILL)
+        _write(self.root, "decoration_kinds/hearth.md", GOOD_DECORATION_KIND)
 
     def test_game_setup_reports_configured(self) -> None:
         self.client.force_login(self.super)
@@ -93,6 +101,7 @@ class TestContentLoadConfigured(TestCase):
         self.assertTrue(resp.context["content_repo_configured"])
 
     def test_run_loads_content_and_flashes_success(self) -> None:
+        """One run across two domains (#2266) — the flashed count covers both."""
         self.client.force_login(self.super)
         with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
             resp = self.client.post(reverse("admin_content_load_run"))
@@ -100,8 +109,9 @@ class TestContentLoadConfigured(TestCase):
         self.assertEqual(resp.url, reverse("admin_game_setup"))
         trait = Trait.objects.get(name="Performance")
         self.assertIn("PLACEHOLDER", trait.description)
+        self.assertTrue(DecorationKind.objects.filter(name="Great Hearth").exists())
         messages = list(resp.wsgi_request._messages)
-        self.assertTrue(any("1 created" in str(m) for m in messages))
+        self.assertTrue(any("2 created" in str(m) for m in messages))
         self.assertTrue(any("1 placeholder" in str(m) for m in messages))
 
     def test_run_with_missing_dir_redirects_with_error(self) -> None:

--- a/src/world/buildings/models.py
+++ b/src/world/buildings/models.py
@@ -28,6 +28,7 @@ from django.db import models
 from django.utils import timezone
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.buildings import room_constants
 from world.buildings.constants import ConditionTier
 from world.locations.constants import StatKey
@@ -44,7 +45,7 @@ _ARCHITECTURAL_STYLE_FK = "buildings.ArchitecturalStyle"
 _ROOM_PROFILE_FK = "evennia_extensions.RoomProfile"
 
 
-class BuildingKind(SharedMemoryModel):
+class BuildingKind(NaturalKeyMixin, SharedMemoryModel):
     """An authorable category of building.
 
     Open catalog — rows authored by staff, not an enum. Each row carries
@@ -54,6 +55,16 @@ class BuildingKind(SharedMemoryModel):
     Per the brainstorm, the flag set is NOT a taxonomy. Flags are
     sort/filter axes used by authoring NPCs to decide what they issue
     permits for. Multiple flags can be true on one row.
+
+    Carries `NaturalKeyMixin` (#2266 review fix) so the content pipeline's
+    emitted fixture JSON (natural-key format, no "pk" key) resolves an
+    existing same-name row on `loaddata` instead of blind-INSERTing into it
+    and raising `IntegrityError` on the unique `name` constraint. Per #946,
+    `loaddata` on a `SharedMemoryModel` can INSERT via a natural key but
+    cannot UPDATE — the identity map returns the cached instance before the
+    new field values land. `core_management.content_fixtures.load_entries`
+    (`update_or_create`) remains the only update-safe path; the emitted
+    fixture JSON is fresh-DB/insert-or-resolve only.
     """
 
     name = models.CharField(max_length=100, unique=True)
@@ -71,6 +82,11 @@ class BuildingKind(SharedMemoryModel):
     is_aerial = models.BooleanField(default=False)
     is_subterranean = models.BooleanField(default=False)
     is_secret = models.BooleanField(default=False)
+
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["name"]
 
     def __str__(self) -> str:
         return self.name
@@ -1244,7 +1260,7 @@ class StyleAffinity(SharedMemoryModel):
         return f"{self.style.name}: {self.stat_key} {self.value:+d}"
 
 
-class DecorationKind(SharedMemoryModel):
+class DecorationKind(NaturalKeyMixin, SharedMemoryModel):
     """A catalog decoration/furnishing that passively mods a room's comfort by presence (#1514).
 
     Lightweight + **stackable** — distinct from `RoomFeatureKind` (an *exclusive* capability you
@@ -1253,6 +1269,18 @@ class DecorationKind(SharedMemoryModel):
     via `DecorationAffinity`) and adds only a **small** `amenity`; luxury pieces are mostly
     amenity. Placement is cosmetic/instant (owner-gated, money/material cost). Magnitudes are a
     PLACEHOLDER author pass.
+
+    Carries `NaturalKeyMixin` (#2266 review fix) so the content pipeline's
+    emitted fixture JSON (natural-key format, no "pk" key) resolves an
+    existing same-name row on `loaddata` instead of blind-INSERTing into it
+    and raising `IntegrityError` on the unique `name` constraint — the exact
+    collision hit when content re-authors a decoration whose name a seeder
+    (`ensure_decoration_kinds()`) already created (e.g. "Great Hearth"). Per
+    #946, `loaddata` on a `SharedMemoryModel` can INSERT via a natural key
+    but cannot UPDATE — the identity map returns the cached instance before
+    the new field values land. `core_management.content_fixtures.load_entries`
+    (`update_or_create`) remains the only update-safe path; the emitted
+    fixture JSON is fresh-DB/insert-or-resolve only.
     """
 
     name = models.CharField(max_length=100, unique=True)
@@ -1267,6 +1295,11 @@ class DecorationKind(SharedMemoryModel):
             "pieces (a hearth is mostly mitigation); large for luxury/magical comfort."
         ),
     )
+
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["name"]
 
     class Meta:
         ordering = ["name"]

--- a/src/world/buildings/seeds.py
+++ b/src/world/buildings/seeds.py
@@ -186,7 +186,7 @@ def ensure_architectural_styles() -> None:
     from world.clues.models import Clue  # noqa: PLC0415
     from world.codex.models import CodexCategory, CodexEntry, CodexSubject  # noqa: PLC0415
 
-    for name in ("Vernacular Timberframe PLACEHOLDER", "Harborstone Classical PLACEHOLDER"):
+    for name in ("Vernacular Timberframe", "Harborstone Classical"):
         ArchitecturalStyle.objects.update_or_create(
             name=name,
             defaults={"is_default": True, "prestige_bonus": 0, "cost_multiplier": 1},
@@ -197,8 +197,8 @@ def ensure_architectural_styles() -> None:
         defaults={"description": "PLACEHOLDER — the built world's styles and lost arts."},
     )
     throwbacks = (
-        ("Antique Imperial PLACEHOLDER", 50, "1.500"),
-        ("Drowned Dynasty PLACEHOLDER", 80, "2.000"),
+        ("Antique Imperial", 50, "1.500"),
+        ("Drowned Dynasty", 80, "2.000"),
     )
     for style_name, prestige_bonus, cost_multiplier in throwbacks:
         subject, _ = CodexSubject.objects.get_or_create(
@@ -251,9 +251,9 @@ def ensure_decoration_kinds() -> None:
     from world.locations.constants import StatKey  # noqa: PLC0415
 
     kinds = (
-        ("Great Hearth PLACEHOLDER", 1, ((StatKey.COLD, -4),)),
-        ("Oiled Awning PLACEHOLDER", 0, ((StatKey.WET, -3),)),
-        ("Shade Colonnade PLACEHOLDER", 0, ((StatKey.HEAT, -3),)),
+        ("Great Hearth", 1, ((StatKey.COLD, -4),)),
+        ("Oiled Awning", 0, ((StatKey.WET, -3),)),
+        ("Shade Colonnade", 0, ((StatKey.HEAT, -3),)),
     )
     for name, amenity, affinities in kinds:
         kind, _ = DecorationKind.objects.update_or_create(

--- a/src/world/buildings/tests/test_architectural_styles_viewset.py
+++ b/src/world/buildings/tests/test_architectural_styles_viewset.py
@@ -18,8 +18,8 @@ from world.codex.constants import CodexKnowledgeStatus
 from world.codex.models import CharacterCodexKnowledge
 from world.roster.factories import PlayerDataFactory, RosterEntryFactory, RosterTenureFactory
 
-DEFAULT_STYLE = "Vernacular Timberframe PLACEHOLDER"
-THROWBACK = "Antique Imperial PLACEHOLDER"
+DEFAULT_STYLE = "Vernacular Timberframe"
+THROWBACK = "Antique Imperial"
 
 
 @tag("sqlite_safe")

--- a/src/world/buildings/tests/test_comfort_hud.py
+++ b/src/world/buildings/tests/test_comfort_hud.py
@@ -30,7 +30,7 @@ from world.roster.factories import (
     RosterTenureFactory,
 )
 
-HEARTH = "Great Hearth PLACEHOLDER"
+HEARTH = "Great Hearth"
 
 
 def _room_in(area, *, name="A Room", enclosure=RoomEnclosure.WALLED):
@@ -136,7 +136,7 @@ class FixtureActionTests(ComfortHudBase):
     def test_unknown_kind_lists_options(self) -> None:
         result = get_action("place_room_fixture").run(actor=self.actor, kind="Nonsense")
         self.assertFalse(result.success)
-        self.assertIn("PLACEHOLDER", result.message)
+        self.assertIn(HEARTH, result.message)
 
     def test_non_owner_cannot_place(self) -> None:
         stranger = CharacterFactory()

--- a/src/world/buildings/tests/test_style_discovery.py
+++ b/src/world/buildings/tests/test_style_discovery.py
@@ -30,8 +30,8 @@ from world.locations.services import assign_room_tenant, set_primary_home
 from world.roster.factories import RosterEntryFactory
 from world.traits.factories import CheckOutcomeFactory
 
-THROWBACK = "Antique Imperial PLACEHOLDER"
-DEFAULT_STYLE = "Vernacular Timberframe PLACEHOLDER"
+THROWBACK = "Antique Imperial"
+DEFAULT_STYLE = "Vernacular Timberframe"
 
 
 def _room_in(area, *, name="A Room"):
@@ -79,7 +79,7 @@ class StyleDiscoveryBase(TestCase):
 class SeedTests(StyleDiscoveryBase):
     def test_seed_is_idempotent_and_wires_the_pipeline(self) -> None:
         ensure_architectural_styles()  # second call — no dupes
-        self.assertEqual(ArchitecturalStyle.objects.filter(name__endswith="PLACEHOLDER").count(), 4)
+        self.assertEqual(ArchitecturalStyle.objects.count(), 4)
         self.assertFalse(self.throwback.is_default)
         self.assertIsNotNone(self.throwback.codex_subject)
         self.assertGreater(self.throwback.prestige_bonus, 0)

--- a/src/world/items/models.py
+++ b/src/world/items/models.py
@@ -130,13 +130,23 @@ class InteractionType(SharedMemoryModel):
         return self.label
 
 
-class ItemTemplate(SharedMemoryModel):
+class ItemTemplate(NaturalKeyMixin, SharedMemoryModel):
     """
     Archetype definition for an item type (e.g., "iron longsword", "silk shirt").
 
     Templates define shared base properties. Individual items in the world are
     ItemInstance records that reference their template for defaults, with
     per-instance overrides for customization (custom names, descriptions, etc.).
+
+    Carries `NaturalKeyMixin` (#2266 review fix) so the content pipeline's
+    emitted fixture JSON (natural-key format, no "pk" key) resolves an
+    existing same-name row on `loaddata` instead of blind-INSERTing into it
+    and raising `IntegrityError` on the unique `name` constraint. Per #946,
+    `loaddata` on a `SharedMemoryModel` can INSERT via a natural key but
+    cannot UPDATE — the identity map returns the cached instance before the
+    new field values land. `core_management.content_fixtures.load_entries`
+    (`update_or_create`) remains the only update-safe path; the emitted
+    fixture JSON is fresh-DB/insert-or-resolve only.
     """
 
     name = models.CharField(max_length=200, unique=True)
@@ -342,6 +352,11 @@ class ItemTemplate(SharedMemoryModel):
             "polish_value is ignored (item is functional, not decorative)."
         ),
     )
+
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["name"]
 
     class Meta:
         constraints = [

--- a/src/world/npc_services/models.py
+++ b/src/world/npc_services/models.py
@@ -23,6 +23,7 @@ from evennia.utils.idmapper.models import SharedMemoryModel
 
 from core.managers import ArxSharedMemoryManager
 from core.mixins import DiscriminatorMixin
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.npc_services.constants import (
     DrawMode,
     NpcRegardEventReason,
@@ -129,13 +130,23 @@ class NPCStanding(SharedMemoryModel):
         return f"{self.persona} ↔ {self.npc_persona} (affection={self.affection})"
 
 
-class NPCRole(SharedMemoryModel):
+class NPCRole(NaturalKeyMixin, SharedMemoryModel):
     """A kind of NPC role — a bundle of `NPCServiceOffer` rows.
 
     One role can be instantiated across the world as multiple class-1 NPCs
     (every Builders Guild Clerk in every guild hall) or attached to a
     specific class-2+ named NPC. Offers are authored on the role; per-NPC
     overrides are a follow-up.
+
+    Carries `NaturalKeyMixin` (#2266 review fix) so the content pipeline's
+    emitted fixture JSON (natural-key format, no "pk" key) resolves an
+    existing same-name row on `loaddata` instead of blind-INSERTing into it
+    and raising `IntegrityError` on the unique `name` constraint. Per #946,
+    `loaddata` on a `SharedMemoryModel` can INSERT via a natural key but
+    cannot UPDATE — the identity map returns the cached instance before the
+    new field values land. `core_management.content_fixtures.load_entries`
+    (`update_or_create`) remains the only update-safe path; the emitted
+    fixture JSON is fresh-DB/insert-or-resolve only.
     """
 
     name = models.CharField(
@@ -182,6 +193,11 @@ class NPCRole(SharedMemoryModel):
             "migrated value from the legacy `MissionGiver.is_active`."
         ),
     )
+
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["name"]
 
     def __str__(self) -> str:
         return self.name

--- a/src/world/seeds/clusters.py
+++ b/src/world/seeds/clusters.py
@@ -265,6 +265,20 @@ def _seed_project_resonance() -> None:
     ensure_project_kind_resonance_awards()
 
 
+def _seed_traits() -> None:
+    """No-op cluster (#2266): Trait rows are created by other clusters already —
+
+    ``character_creation`` seeds the 12 core stat Traits; the checks-family
+    clusters (``combat_checks``/``social``/``investigation``/``governance``/
+    ``stealth``/``security``) seed skill Traits alongside their CheckTypes.
+    Registered purely so the Game Setup inventory can show a Trait row count:
+    the #944 Phase-1 content-pipeline domain (``stats/``/``skills/`` via
+    ``core_management.content_fixtures``) had no inventory visibility at all
+    until this cluster existed, even though the rows themselves were always
+    seeded.
+    """
+
+
 CLUSTER_SEEDERS: dict[str, Callable[[], None]] = {
     # The checks spine owns the global resolution charts/outcomes; seed it first
     # so the canonical rows exist before the other clusters run. (Idempotency
@@ -387,6 +401,10 @@ CLUSTER_SEEDERS: dict[str, Callable[[], None]] = {
     # PROJECT_CONTRIBUTION GainSource (#2038 — "projects to add gifts to
     # organizations"). No dependencies on any other cluster.
     "project_resonance": _seed_project_resonance,
+    # Traits: no-op — see _seed_traits docstring. Registered so the Game Setup
+    # inventory can show a Trait row count for the #944 content-pipeline domain,
+    # which had zero inventory visibility before #2266.
+    "traits": _seed_traits,
 }
 
 
@@ -429,6 +447,7 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
     from actions.models import ActionTemplate  # noqa: PLC0415
     from world.agriculture.models import CropType  # noqa: PLC0415
     from world.battles.models import BattleMapBlueprint, BattleUnitTemplate  # noqa: PLC0415
+    from world.buildings.models import BuildingKind, DecorationKind  # noqa: PLC0415
     from world.character_creation.models import (  # noqa: PLC0415
         Beginnings,
         CGExplanation,
@@ -462,7 +481,7 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
     from world.societies.houses.models import Title  # noqa: PLC0415
     from world.societies.models import PropagandaCampaignTier  # noqa: PLC0415
     from world.species.models import Species  # noqa: PLC0415
-    from world.traits.models import ResultChart  # noqa: PLC0415
+    from world.traits.models import ResultChart, Trait  # noqa: PLC0415
 
     return {
         "checks": [CheckType, ResultChart],
@@ -493,8 +512,11 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
         # covenant-lifecycle content landed after the Big Button run.
         "magic": [Affinity, Resonance, Ritual],
         # Style also carries the seeded aesthetic vocabulary spread across the four
-        # audacity tiers (#2029).
-        "items": [ItemTemplate, Style],
+        # audacity tiers (#2029). BuildingKind/DecorationKind (#2266) — no cluster
+        # seeds these via the Big Button today (they're staff/content authored,
+        # e.g. `world.buildings.seeds.ensure_urban_building_kinds`); tracked here
+        # so a content load against them is inventory-visible.
+        "items": [ItemTemplate, Style, BuildingKind, DecorationKind],
         # Combat seeds check-types used by the resolution spine, not standalone
         # content rows; it still appears in the inventory as a seeded cluster.
         "combat": [],
@@ -564,4 +586,7 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
         "project_resonance": [ProjectKindResonanceAward],
         # Agriculture: Field + Granary RoomFeatureKinds + starter CropTypes (#1864).
         "agriculture": [CropType, RoomFeatureKind],
+        # Traits: no-op seeder — see _seed_traits (#2266). Row count for the #944
+        # content-pipeline domain (stats/skills), previously invisible in this hub.
+        "traits": [Trait],
     }

--- a/src/world/seeds/tests/test_clusters.py
+++ b/src/world/seeds/tests/test_clusters.py
@@ -45,6 +45,7 @@ class TestClusterRegistry(TestCase):
                 "skills",
                 "project_resonance",
                 "agriculture",
+                "traits",
             },
         )
 

--- a/tools/build_content_fixtures.py
+++ b/tools/build_content_fixtures.py
@@ -71,6 +71,16 @@ def main() -> int:
         print(f"Content path does not exist: {content_root}", file=sys.stderr)
         return 2
 
+    # Django env needed even for --check (#2266): npc_roles/'s optional
+    # faction_affiliation field is validated by an eager DB lookup, same as
+    # every other domain's shape validation. Settings resolve .env relative
+    # to src/. Harmless for domains that don't touch the DB.
+    import django  # noqa: PLC0415
+
+    os.chdir(SRC_ROOT)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+    django.setup()
+
     try:
         result = build_all(content_root)
     except ContentError as exc:
@@ -90,16 +100,14 @@ def main() -> int:
     print(f"OK: {total} content files -> {len(written)} fixture file(s).")
 
     if args.load:
-        # Upsert path (NOT loaddata — see load_entries docstring). Needs the
-        # Django env; settings resolve .env relative to src/.
-        import django  # noqa: PLC0415
-
-        os.chdir(SRC_ROOT)
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
-        django.setup()
+        # Upsert path (NOT loaddata — see load_entries docstring).
         from core_management.content_fixtures import load_entries  # noqa: PLC0415
 
-        created, updated = load_entries(result)
+        try:
+            created, updated = load_entries(result)
+        except ContentError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
         print(f"loaded: {created} created, {updated} updated.")
     return 0
 

--- a/tools/build_content_fixtures.py
+++ b/tools/build_content_fixtures.py
@@ -23,10 +23,27 @@ SRC_ROOT = REPO_ROOT / "src"
 sys.path.insert(0, str(SRC_ROOT))
 
 from core_management.content_fixtures import (  # noqa: E402
+    BuildResult,
     ContentError,
     build_all,
     write_fixtures,
 )
+
+
+class _ExitEarly(Exception):
+    """Internal control-flow signal carrying an exit code.
+
+    Lets each validation/setup step below print its own clean stderr message
+    and bail out via a single ``raise``, instead of every caller up the chain
+    needing its own ``if error: return code`` branch — that branching is what
+    pushed ``main()`` over ruff's return-count/complexity limits (#2266
+    review fix) once environmental-error handling was added alongside the
+    original content-shape errors.
+    """
+
+    def __init__(self, code: int) -> None:
+        self.code = code
+        super().__init__(code)
 
 
 def _load_dotenv_path() -> str | None:
@@ -41,6 +58,112 @@ def _load_dotenv_path() -> str | None:
             if stripped.startswith("CONTENT_REPO_PATH="):
                 return stripped.split("=", 1)[1].strip().strip('"').strip("'")
     return None
+
+
+def _require_content_root(args: argparse.Namespace) -> Path:
+    """Resolve + validate the content checkout path, or raise ``_ExitEarly(2)``."""
+    content_path = args.content_path or _load_dotenv_path()
+    if not content_path:
+        print(
+            "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
+            "local checkout of the private content repository.",
+            file=sys.stderr,
+        )
+        raise _ExitEarly(2)
+    content_root = Path(content_path).expanduser()
+    if not content_root.is_dir():
+        print(f"Content path does not exist: {content_root}", file=sys.stderr)
+        raise _ExitEarly(2)
+    return content_root
+
+
+def _configure_django() -> None:
+    """Import + configure Django, or raise ``_ExitEarly(2)`` with a clean hint.
+
+    Needed even for --check (#2266): npc_roles/'s optional faction_affiliation
+    field is validated by an eager DB lookup, same as every other domain's
+    shape validation. Settings resolve .env relative to src/. Harmless for
+    domains that don't touch the DB.
+    """
+    import django  # noqa: PLC0415
+    from django.core.exceptions import ImproperlyConfigured  # noqa: PLC0415
+
+    os.chdir(SRC_ROOT)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+    try:
+        django.setup()
+    except ImproperlyConfigured as exc:
+        print(
+            f"Django is not configured: {exc}\n"
+            "Hint: a content-only author still needs src/.env with SECRET_KEY/"
+            "DATABASE_URL set — the npc_roles/ domain's faction_affiliation "
+            "field validates by querying the dev DB, so Django must be able "
+            "to start even for --check.",
+            file=sys.stderr,
+        )
+        raise _ExitEarly(2) from exc
+
+
+def _build_content(content_root: Path) -> BuildResult:
+    """Run ``build_all``, or raise ``_ExitEarly`` with a clean stderr message."""
+    from django.db import Error as DjangoDbError  # noqa: PLC0415
+
+    try:
+        return build_all(content_root)
+    except ContentError as exc:
+        print(str(exc), file=sys.stderr)
+        raise _ExitEarly(1) from exc
+    except DjangoDbError as exc:
+        print(
+            f"Database error while validating content: {exc}\n"
+            "Hint: run `arx manage migrate` to bring the dev DB schema up to date.",
+            file=sys.stderr,
+        )
+        raise _ExitEarly(2) from exc
+
+
+def _load_content(result) -> tuple[int, int]:
+    """Run ``load_entries``, or raise ``_ExitEarly`` with a clean stderr message."""
+    from django.db import Error as DjangoDbError  # noqa: PLC0415
+
+    from core_management.content_fixtures import load_entries  # noqa: PLC0415
+
+    try:
+        return load_entries(result)
+    except ContentError as exc:
+        print(str(exc), file=sys.stderr)
+        raise _ExitEarly(1) from exc
+    except DjangoDbError as exc:
+        print(
+            f"Database error while loading content: {exc}\n"
+            "Hint: run `arx manage migrate` to bring the dev DB schema up to date.",
+            file=sys.stderr,
+        )
+        raise _ExitEarly(2) from exc
+
+
+def _run(args: argparse.Namespace) -> int:
+    content_root = _require_content_root(args)
+    _configure_django()
+    result = _build_content(content_root)
+
+    total = len(result.entries)
+    for domain, count in sorted(result.placeholder_counts.items()):
+        print(f"PLACEHOLDER remaining in {domain}/: {count}")
+    if args.check:
+        print(f"OK: {total} content files validated; nothing written (--check).")
+        return 0
+
+    written = write_fixtures(result, SRC_ROOT)
+    for path in written:
+        print(f"wrote {path.relative_to(REPO_ROOT)}")
+    print(f"OK: {total} content files -> {len(written)} fixture file(s).")
+
+    if args.load:
+        # Upsert path (NOT loaddata — see load_entries docstring).
+        created, updated = _load_content(result)
+        print(f"loaded: {created} created, {updated} updated.")
+    return 0
 
 
 def main() -> int:
@@ -58,58 +181,10 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    content_path = args.content_path or _load_dotenv_path()
-    if not content_path:
-        print(
-            "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
-            "local checkout of the private content repository.",
-            file=sys.stderr,
-        )
-        return 2
-    content_root = Path(content_path).expanduser()
-    if not content_root.is_dir():
-        print(f"Content path does not exist: {content_root}", file=sys.stderr)
-        return 2
-
-    # Django env needed even for --check (#2266): npc_roles/'s optional
-    # faction_affiliation field is validated by an eager DB lookup, same as
-    # every other domain's shape validation. Settings resolve .env relative
-    # to src/. Harmless for domains that don't touch the DB.
-    import django  # noqa: PLC0415
-
-    os.chdir(SRC_ROOT)
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
-    django.setup()
-
     try:
-        result = build_all(content_root)
-    except ContentError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
-
-    total = len(result.entries)
-    for domain, count in sorted(result.placeholder_counts.items()):
-        print(f"PLACEHOLDER remaining in {domain}/: {count}")
-    if args.check:
-        print(f"OK: {total} content files validated; nothing written (--check).")
-        return 0
-
-    written = write_fixtures(result, SRC_ROOT)
-    for path in written:
-        print(f"wrote {path.relative_to(REPO_ROOT)}")
-    print(f"OK: {total} content files -> {len(written)} fixture file(s).")
-
-    if args.load:
-        # Upsert path (NOT loaddata — see load_entries docstring).
-        from core_management.content_fixtures import load_entries  # noqa: PLC0415
-
-        try:
-            created, updated = load_entries(result)
-        except ContentError as exc:
-            print(str(exc), file=sys.stderr)
-            return 1
-        print(f"loaded: {created} created, {updated} updated.")
-    return 0
+        return _run(args)
+    except _ExitEarly as exc:
+        return exc.code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2266 (spec approved on the issue; rulings recorded in its comments). Part of #2236 Phase 4 — the Apostate path.

## What this adds

Four new authored-content domains in the frontmatter+markdown pipeline, all reusing the existing `DOMAIN_BUILDERS` registry and `load_entries` upsert (no parallel loaders, natural key = the models' existing unique `name`):

- `npc_roles/` → `NPCRole` — body = description; optional `faction_affiliation:` (resolved to an Organization by name, eagerly validated with the pipeline's collect-all-errors behavior), optional `default_rapport_starting_value:`, optional `default_description_template:` (Q1 ruling). Three-state field convention: key absent = untouched on update; key explicitly null/empty = cleared; value = set.
- `items/` → `ItemTemplate` — body = description; optional `value:`/`weight:`; mechanical flags stay admin/seeder-authored (prose-not-balance rule from the spec).
- `building_kinds/` → `BuildingKind`, `decoration_kinds/` → `DecorationKind` — name + prose.

**Seeder supersession made safe (Q3 ruling folded in):** `DecorationKind` and `ArchitecturalStyle` seeder rows had `PLACEHOLDER` baked into the *name itself* ("Great Hearth PLACEHOLDER"), so authoring the real name would have created a duplicate instead of superseding. Renamed to real names (marker stays in descriptions only), all referencing tests updated, plus a regression test proving seed → author → exactly one row.

**Game Setup inventory:** `BuildingKind`/`DecorationKind` now tracked under the items cluster, and the never-tracked Phase-1 `Trait` domain gets an inventory row — the "content gaps go green as domains load" story is now true for every pipeline domain.

**Review hardening (2-angle + verified):** the four models gained `NaturalKeyMixin` (manager-level, zero migrations) so their emitted fixtures resolve instead of `IntegrityError`-ing against seeded rows on fresh-DB `loaddata`; the module docstring now states the honest #946 semantics (`loaddata` resolves but never updates idmapper rows — `load_entries` is the only update-safe path, with a test documenting exactly that); `--check` without a configured `src/.env`/migrated DB exits with actionable hints instead of raw tracebacks; and `_resolve_natural_key_fields` fails cleanly on a future non-relational list field instead of `AttributeError`.

**Deferred by ruling (Q2):** rooms/areas — `Area` has no natural key and room identity lives on Evennia ObjectDB; both need their own schema/design pass before onboarding.

## Validation

`just test-fast` across core_management + npc_services + items + buildings/seeds + clusters + admin content-load: 1011 tests OK; Postgres parity tier on the touched modules OK; `makemigrations --check` clean for all touched apps (mixin is manager-level only); ruff + pre-commit hooks clean; end-to-end smoke of `--check`/`--load` against a synthetic content dir including the FK-error path. The private lore repo itself is not in CI by design — synthetic-fixture tests mirror its format exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)