### PR TITLE
Wind-as-mechanic: combat/technique consumer of the weather WIND axis (#1522 follow-up)

### DIFF
--- a/docs/adr/0129-wind-consumes-as-banded-scene-modifiers-on-missile-deliveries.md
+++ b/docs/adr/0129-wind-consumes-as-banded-scene-modifiers-on-missile-deliveries.md
@@ -1,0 +1,29 @@
+# Wind consumes as banded SCENE check modifiers on missile deliveries only
+
+The WIND exposure axis (`world.locations.services.felt_exposure`, `StatKey.WIND`, #1522)
+gets its first combat consumer (#1555): `wind_penalty(felt) -> int` maps felt WIND to one of
+four authored bands — CALM (<15) → 0, BREEZY (15-39) → -5, WINDY (40-69) → -10, GALE (70+) →
+-20 — and that value is injected as a `ModifierContribution(source_kind=SCENE,
+label="Wind", ...)` into `collect_check_modifiers`, exactly like every other check
+contribution (effort, pull, bond, charge). It only touches missile-classified attacks: on
+the PC offense side (`CombatTechniqueResolver._roll_check`), the penalty applies when the
+attacker's strongest equipped weapon (the same `_select_equipped_weapon` pick the damage
+path uses) has `gear_archetype` RANGED or THROWN — melee and lance attacks skip the
+`felt_exposure` lookup entirely. On the NPC side, the symmetric case ("the gale that ruins
+your shot ruins theirs") adds the same-magnitude *positive* contribution to the PC's
+defense roll when the attacking `ThreatPoolEntry.delivery` is MISSILE
+(`resolve_npc_attack`); flat `base_damage` entries with no defense check are structurally
+untouched, since the wind seam lives only inside the defense-roll path. Three alternatives
+were rejected: **per-point raw modifier** (felt WIND fed straight into the roll as a 1:1
+penalty) — illegible, since a player can't reason about "37 wind" the way they can about
+"windy"; **a hard gale inhibitor** (a boolean immunity/block on missile attacks above the
+GALE threshold) — rejected as a different pattern (hard gates belong to
+`hazard_is_covered`-style shelter checks, not a graded combat penalty) that would make gale
+weather swing missile combat from "harder" to "impossible," out of proportion to every other
+banded exposure effect; and **an anima surcharge** (folding wind into spell-cast anima cost
+instead of the check roll) — rejected because it punishes casters for weather they didn't
+choose and only reaches magical missile techniques, missing mundane bows/thrown weapons
+entirely.
+
+> Status: accepted · Source: issue #1555 · Related: ADR-0010 (FK/consumer direction), #1522
+> (WIND exposure axis provider)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -158,6 +158,7 @@ treat those names as hints to confirm, not gospel.
 - [0124 — Redirect destination is declared, not improvised](0124-redirect-destination-is-declared-not-improvised.md) (extends ADR-0032/0060; related ADR-0023)
 - [0125 — Rampart is a position-anchored entity, not per-bearer group conditions](0125-rampart-is-an-entity-not-group-conditions.md) (extends ADR-0109; epic #2040 decision 3)
 - [0126 — A mount is a companion plus a verb-gating condition; charge/joust ride the existing move/duel seams](0126-mounts-are-companions-with-a-verb-gating-condition.md) (extends ADR-0023/0060)
+- [0129 — Wind consumes as banded SCENE check modifiers on missile deliveries only](0129-wind-consumes-as-banded-scene-modifiers-on-missile-deliveries.md) (related #1522)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -160,6 +160,18 @@ outcome** (a closed issue or a "SHIPPED" line is not proof). See the ledger's go
   for why that's now PROVEN, not the reverse "onto the boss" direction). Scenario
   composed by `BossFightScenarioFactory` (`world/combat/factories.py`); journey test:
   `src/integration_tests/test_boss_fight_journey.py`.
+- **Wind-as-mechanic combat consumer (#1555, ADR-0129).** The WIND exposure axis
+  (`world.locations.services.felt_exposure`, `StatKey.WIND`, provider #1522) gets its combat
+  reader: `wind_penalty(felt) -> int` (`world/combat/constants.py`) bands felt WIND —
+  CALM (<15) → 0, BREEZY (15-39) → -5, WINDY (40-69) → -10, GALE (70+) → -20 — into a
+  SCENE-sourced "Wind" `ModifierContribution`. Missile-classified attacks only: PC offense
+  (`CombatTechniqueResolver._roll_check`) applies the penalty when the attacker's strongest
+  equipped weapon is RANGED/THROWN (the same `_select_equipped_weapon` pick the damage path
+  uses); melee/lance skip the `felt_exposure` lookup entirely. Symmetric NPC side
+  (`resolve_npc_attack`) adds the same-magnitude positive bonus to the PC's defense roll when
+  the attacking `ThreatPoolEntry.delivery` is MISSILE; flat `base_damage` entries with no
+  defense roll are untouched. See `docs/systems/INDEX.md`'s "Combat" section for the full
+  wiring.
 
 ## WIRED-UNPROVEN (treat as not-done — write the journey test, fix what it exposes)
 

--- a/docs/roadmap/rooms-and-estates.md
+++ b/docs/roadmap/rooms-and-estates.md
@@ -243,8 +243,10 @@ ledger in issue **#1514**; security/access half (windows-as-egress, guards/defen
   echoes are squelchable per-player (`narrative.UserCategoryMute`). The 7 types + 263 emits are
   seeded from the Arx-1 corpus. `FeastDay` forces special weather (Eclipse / Moon Madness)
   world-wide on recurring IC dates — the GM-lever automation.
+- **Wind-as-mechanic combat consumer (#1555, ADR-0129, done):** `wind_penalty(felt)` banded
+  SCENE check modifier (CALM/BREEZY/WINDY/GALE) on missile offense checks and the symmetric
+  PC defense bonus vs. a MISSILE NPC attack — see `docs/systems/INDEX.md`'s "Combat" section.
 - **Later slices:** comfort→**Conditions** ("Chilled/Soaked", Tehom-coordinated `comfort_penalty`),
-  the **wind-as-mechanic** combat consumer (**#1555**, Tehom — the WIND provider side is done),
   re-seed-as-upsert for edited emits, the web owner **build-HUD**, and inhabitant/owner surfacing.
 
 ## What's Needed for MVP

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -893,7 +893,7 @@ Mechanical regional climate + transient weather feeding the #1514 comfort substr
 - **Constants:** `MONTH_TEMPERATURE_SHIFT` (12-value seasonal curve), `WEATHER_FADE_DAYS`, `WEATHER_SOURCE_PREFIX` — PLACEHOLDER magnitudes
 - **Integrates with:** locations (exposure axes + comfort cascade), areas (`Area.climate`, `RegionWeatherState.area`), game_clock (IC season/phase/month), codex (lore), battles (read-only `get_effective_weather(area)` via `Battle.region` to seed ambient weather; `Battle.weather_override`/`BattlePlace.weather_override` are battle-owned casts, not writes into `world.weather`, #1715 — see the "Battles" section)
 - **Feast days:** `special_weather_for_today()` — on an `ic_month`/`ic_day` match the tick forces the feast's special `WeatherType` (Eclipse / Moon Madness) world-wide, overriding the climate-gated roll (the GM-lever automation)
-- **Not yet wired:** re-seed-as-upsert for edited emits (loaddata duplicates keyless emit rows); wind-as-mechanic combat consumer (#1555, Tehom). Madness *mechanical* effects on characters are out of scope (Tehom)
+- **Not yet wired:** re-seed-as-upsert for edited emits (loaddata duplicates keyless emit rows). Madness *mechanical* effects on characters are out of scope (Tehom)
 - **Source:** `src/world/weather/` — see `world/weather/CLAUDE.md`
 ### Societies
 Social structures, organizations, reputation, and legend tracking.
@@ -3445,13 +3445,26 @@ reactive maneuvers (COVER, INTERPOSE, DEFEND stance), and clash-of-wills.
   `Rampart`'s `integrity` — via the shared `damage_rampart` seam — at the top of both
   `apply_damage_to_participant` and `_resolve_opponent_pre_apply`, **before**
   `DAMAGE_PRE_APPLY` emits. Firing order: Rampart → personal reactive interceptors → Guardian
-  reactions. `ThreatPoolEntry.delivery` (`StrikeDelivery`: MELEE/MISSILE, shared with the
-  open wind-mechanic question #1555) plus `is_area` (`targeting_mode != SINGLE`) feed a Wind
+  reactions. `ThreatPoolEntry.delivery` (`StrikeDelivery`: MELEE/MISSILE — also the field the
+  wind-as-mechanic consumer below reads) plus `is_area` (`targeting_mode != SINGLE`) feed a Wind
   profile's `MISSILE_WARD` resist adjustment. `Clash.rampart` (nullable FK) binds a
   sustained-attack WARD clash to the covered position's Rampart; `_sync_rampart_progress`
   (`world/combat/clash.py`) mirrors each round's progress delta onto `rampart.integrity`
   through the same `damage_rampart` seam, so interception (paused while that clash is
   ACTIVE) and clash-progress never drift apart.
+- **Wind-as-mechanic (#1555, ADR-0129):** the combat consumer of the WIND exposure axis
+  (`world.locations.services.felt_exposure`, `StatKey.WIND`; provider is #1522).
+  `wind_penalty(felt: int) -> int` (`world/combat/constants.py`) bands felt WIND into a check
+  modifier — CALM (<15) → 0, BREEZY (15-39) → -5, WINDY (40-69) → -10, GALE (70+) → -20.
+  On the PC offense side, `CombatTechniqueResolver._roll_check` (`world/combat/services.py`)
+  appends a `ModifierContribution(source_kind=SCENE, label="Wind", ...)` when the attacker's
+  strongest equipped weapon (`_select_equipped_weapon`, the same pick the damage path uses)
+  has `gear_archetype` RANGED or THROWN and the encounter has a room; melee/lance attacks skip
+  the `felt_exposure` lookup entirely. On the NPC side, `resolve_npc_attack` adds the
+  same-magnitude *positive* contribution to the PC's defense roll when the attacking
+  `ThreatPoolEntry.delivery` is MISSILE — symmetric with the offense side ("the gale that
+  ruins your shot ruins theirs"); flat `base_damage` entries with no defense check
+  (`defense_check_type` unset) never reach this seam.
 - **Mounted combat (#1843):** a mount is a companion + a verb-gating condition, not a new
   typeclass or a blanket stat bonus (ADR-0126). `world.companions.services.mount_companion`/
   `dismount_companion` set/clear `Companion.ridden_by` (nullable unique FK →

--- a/docs/systems/areas.md
+++ b/docs/systems/areas.md
@@ -406,10 +406,11 @@ a WARD-Clash meter subject, faction-blind coverage matching ADR-0109) rather tha
   pipeline. A melee strike against a MELEE_RETALIATION (Fire) profile burns the NPC striker
   back for `signature_value`; GRASPING (Thorn) is handled at the forced-move landing seam
   instead (`force_move_to_position`), not here.
-- **Strike delivery** (`StrikeDelivery`: MELEE/MISSILE, `world/combat/constants.py`,
-  shared with the open wind-mechanic question #1555) and `is_area`
-  (`targeting_mode != SINGLE`) feed a Wind (MISSILE_WARD) profile's resist adjustment:
-  bonus against MISSILE, penalty against area strikes.
+- **Strike delivery** (`StrikeDelivery`: MELEE/MISSILE, `world/combat/constants.py` — also
+  the field the wind-as-mechanic combat consumer reads, #1555/ADR-0129, see
+  `docs/systems/INDEX.md`'s "Combat" section) and `is_area` (`targeting_mode != SINGLE`) feed
+  a Wind (MISSILE_WARD) profile's resist adjustment: bonus against MISSILE, penalty against
+  area strikes.
 - **WARD Clash meter sync.** `Clash.rampart` (nullable FK) binds a sustained-attack WARD
   clash to the covered position's `Rampart`; `world.combat.clash._sync_rampart_progress`
   mirrors each round's progress delta onto `rampart.integrity` via the same

--- a/src/world/combat/AGENT_GLOSSARY.md
+++ b/src/world/combat/AGENT_GLOSSARY.md
@@ -174,14 +174,26 @@ sustained attack (`is_sustained_attack`) against a covered position instead open
 meter — interception no-ops while that Clash is ACTIVE (the no-double-drain rule).
 _Avoid_: ward, barrier, bulwark, shield wall (all already claimed elsewhere)
 
-**Strike delivery** (`StrikeDelivery`, #2209, shared with the open wind-mechanic question
-#1555):
+**Strike delivery** (`StrikeDelivery`, #2209):
 How a strike reaches its target — `MELEE` or `MISSILE` — carried on `ThreatPoolEntry.delivery`
 (NPC threat-pool entries; default `MELEE`) and passed through to
 `apply_damage_to_participant`/`apply_rampart_interception` alongside `is_area`
 (`targeting_mode != SINGLE`). A Wind-element Rampart's `MISSILE_WARD` signature reads
 `delivery`/`is_area` directly: bonus resist against `MISSILE`, penalty against area strikes.
+Also the field the Wind band (below) keys its symmetric NPC-side bonus on.
 _Avoid_: attack type, damage delivery, hit type
+
+**Wind band** (#1555, ADR-0129):
+The banded reading of a room's felt WIND exposure (`world.locations.services.felt_exposure`,
+`StatKey.WIND`) that a missile check consumes: CALM (<15) → 0, BREEZY (15-39) → -5, WINDY
+(40-69) → -10, GALE (70+) → -20 (`wind_penalty`, `world/combat/constants.py`). Authored as
+bands, not a raw per-point scale, so a player can reason about "it's windy" rather than a bare
+number. Applies as a SCENE `ModifierContribution` labeled "Wind": negative on a PC's missile
+(RANGED/THROWN-equipped) offense check, and the same magnitude positive on a PC's defense
+check against a `StrikeDelivery.MISSILE` NPC attack — the gale punishes both sides' aim
+equally. Melee/lance attacks and flat (no defense-roll) NPC damage never consult it.
+_Avoid_: wind penalty (that's `wind_penalty`, the function — "wind band" is the concept),
+weather modifier (too broad — this is WIND specifically, not the general exposure cascade)
 
 **BondCombatBonus**:
 The relationship co-combat passive (#2021, ADR-0109). While a PC and a bonded character (relationship above `BondCombatConfig.min_developed_absolute_value`) are co-combatants and the ally is `ParticipantStatus.ACTIVE`, the PC gains `int(mechanical_bonus)` (cube root of developed absolute value) as a `ModifierContribution(RELATIONSHIP)` on every combat check. Soul-tethered pairs get `soul_tether_multiplier × mechanical_bonus`. Directed (one-sided): only the character who invested gets the bonus. Drops when the ally falls (handing off to #2013's grief spike). Also scales INTERPOSE/SUCCOR capability checks via `bond_bonus(actor, protected)` → `extra_modifiers`.

--- a/src/world/combat/constants.py
+++ b/src/world/combat/constants.py
@@ -543,3 +543,36 @@ DEFAULT_STAKES_REQUIREMENTS: dict[str, dict] = {
 SCALING_CONFIG_BASELINE_PARTY_SIZE: int = 4
 SCALING_CONFIG_PER_EXTRA_MEMBER_PCT: str = "0.15"
 SCALING_CONFIG_PER_AVG_LEVEL_PCT: str = "0.05"
+
+
+# ---------------------------------------------------------------------------
+# Wind-as-mechanic (#1555) — the combat consumer of the WIND exposure axis
+# (world.locations.services.felt_exposure, StatKey.WIND, #1522). Bands are
+# authored thresholds on felt WIND, not raw per-point scaling — raw scaling
+# was rejected as illegible (see ADR — docs/adr/).
+# ---------------------------------------------------------------------------
+
+WIND_BAND_BREEZY_THRESHOLD: int = 15
+WIND_BAND_WINDY_THRESHOLD: int = 40
+WIND_BAND_GALE_THRESHOLD: int = 70
+
+WIND_PENALTY_BREEZY: int = -5
+WIND_PENALTY_WINDY: int = -10
+WIND_PENALTY_GALE: int = -20
+
+
+def wind_penalty(felt: int) -> int:
+    """The missile check penalty for a room's felt WIND exposure (#1555).
+
+    Banded, not linear: CALM (<15) -> 0, BREEZY (15-39) -> -5, WINDY (40-69) -> -10,
+    GALE (70+) -> -20. Pure function of the already-resolved felt exposure value
+    (``world.locations.services.felt_exposure``) — no room/DB access here, so callers
+    control when the (enclosure-gated) exposure lookup happens.
+    """
+    if felt >= WIND_BAND_GALE_THRESHOLD:
+        return WIND_PENALTY_GALE
+    if felt >= WIND_BAND_WINDY_THRESHOLD:
+        return WIND_PENALTY_WINDY
+    if felt >= WIND_BAND_BREEZY_THRESHOLD:
+        return WIND_PENALTY_BREEZY
+    return 0

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -5216,6 +5216,29 @@ def resolve_npc_attack(
         participant.character_sheet,
         participant.encounter,
     )
+
+    # Wind-as-mechanic (#1555) symmetry: the same gale that ruins a PC's
+    # missile shot ruins an NPC's. Only MISSILE-delivered threat entries with
+    # a defense roll are affected — flat base_damage entries (no defense_check_type,
+    # never reaching this function) stay untouched.
+    if (
+        opponent_action.threat_entry.delivery == StrikeDelivery.MISSILE
+        and participant.encounter.room is not None
+    ):
+        from world.locations.constants import StatKey  # noqa: PLC0415
+        from world.locations.services import felt_exposure  # noqa: PLC0415
+
+        wind_mod = wind_penalty(felt_exposure(participant.encounter.room, stat_key=StatKey.WIND))
+        if wind_mod:
+            bond_contributions = [
+                *bond_contributions,
+                ModifierContribution(
+                    source_kind=ModifierSourceKind.SCENE,
+                    source_label="Wind",
+                    value=-wind_mod,
+                ),
+            ]
+
     breakdown = collect_check_modifiers(
         participant.character_sheet,
         check_type,

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -96,6 +96,7 @@ from world.combat.constants import (
     StrikeDelivery,
     TargetingMode,
     TargetSelection,
+    wind_penalty,
 )
 from world.combat.damage_source import classify_source
 from world.combat.models import (
@@ -389,6 +390,28 @@ class CombatTechniqueResolver:
                         source_kind=ModifierSourceKind.CHARACTER,
                         source_label="Unmounted Lance",
                         value=LANCE_UNMOUNTED_PENALTY,
+                    )
+                )
+
+        # Wind-as-mechanic (#1555): a banded SCENE penalty on missile attacks
+        # only. Guarded cheaply — skip the felt_exposure room lookup entirely
+        # for melee/lance attacks, which stay untouched.
+        if (
+            weapon_archetype in (GearArchetype.RANGED, GearArchetype.THROWN)
+            and self.participant.encounter.room is not None
+        ):
+            from world.locations.constants import StatKey  # noqa: PLC0415
+            from world.locations.services import felt_exposure  # noqa: PLC0415
+
+            wind_mod = wind_penalty(
+                felt_exposure(self.participant.encounter.room, stat_key=StatKey.WIND)
+            )
+            if wind_mod:
+                extra_contributions.append(
+                    ModifierContribution(
+                        source_kind=ModifierSourceKind.SCENE,
+                        source_label="Wind",
+                        value=wind_mod,
                     )
                 )
 

--- a/src/world/combat/tests/test_wind_modifier.py
+++ b/src/world/combat/tests/test_wind_modifier.py
@@ -1,0 +1,299 @@
+"""Wind-as-mechanic (#1555): banded WIND penalty/bonus on missile check rolls.
+
+The WIND exposure axis (world.locations.services.felt_exposure, StatKey.WIND,
+#1522) feeds a banded SCENE ModifierContribution ("Wind") into combat checks —
+negative on a PC's missile *offense* check (CombatTechniqueResolver._roll_check),
+positive (same magnitude) on a PC's *defense* check against a MISSILE-delivered
+NPC attack (resolve_npc_attack). Melee/lance attacks and flat (no defense-roll)
+NPC damage never consult felt_exposure at all.
+
+felt_exposure itself is patched at its import point (world.locations.services)
+rather than built from real weather/enclosure fixtures — the combat-side seam
+is a pure consumer of the return value, and the enclosure-gating/regional-
+climate machinery is already covered in world.locations tests.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from actions.constants import ActionCategory
+from evennia_extensions.factories import CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.constants import ModifierSourceKind
+from world.checks.factories import CheckTypeFactory
+from world.combat.constants import StrikeDelivery
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+    ThreatPoolEntryFactory,
+    ThreatPoolFactory,
+)
+from world.combat.models import CombatOpponentAction, CombatRoundAction
+from world.combat.services import (
+    CombatTechniqueResolver,
+    apply_damage_to_participant,
+    resolve_npc_attack,
+)
+from world.fatigue.constants import EffortLevel
+from world.items.constants import BodyRegion, EquipmentLayer, GearArchetype
+from world.items.factories import EquippedItemFactory, ItemInstanceFactory, ItemTemplateFactory
+from world.magic.factories import EffectTypeFactory, GiftFactory, TechniqueFactory
+from world.vitals.models import CharacterVitals
+
+_FELT_EXPOSURE_PATH = "world.locations.services.felt_exposure"
+
+
+def _equip_weapon(character, archetype: str) -> None:
+    """Equip a single weapon-archetype item on *character* — only gear_archetype and
+    effective_weapon_damage (>0) matter to ``_select_equipped_weapon``; slot legality
+    isn't the concern here."""
+    template = ItemTemplateFactory(
+        gear_archetype=archetype, base_weapon_damage=5, max_durability=30
+    )
+    inst = ItemInstanceFactory(template=template, durability=30)
+    EquippedItemFactory(
+        character=character,
+        item_instance=inst,
+        body_region=BodyRegion.TORSO,
+        equipment_layer=EquipmentLayer.BASE,
+    )
+    character.equipped_items.invalidate()
+
+
+class WindOffenseModifierTests(TestCase):
+    """CombatTechniqueResolver._roll_check: missile attacks pick up a banded
+    "Wind" SCENE contribution from the encounter room's felt WIND exposure."""
+
+    def setUp(self) -> None:
+        self.encounter = CombatEncounterFactory(round_number=1)
+        pool = ThreatPoolFactory()
+        ThreatPoolEntryFactory(pool=pool, base_damage=30)
+        self.opponent = CombatOpponentFactory(encounter=self.encounter, threat_pool=pool)
+        self.character = CharacterFactory(db_key="WindOffenseChar")
+        self.sheet = CharacterSheetFactory(character=self.character)
+        self.participant = CombatParticipantFactory(
+            encounter=self.encounter, character_sheet=self.sheet
+        )
+        self.technique = TechniqueFactory(
+            gift=GiftFactory(),
+            effect_type=EffectTypeFactory(name="Attack", base_power=20),
+        )
+
+    def _resolver(self) -> CombatTechniqueResolver:
+        action = CombatRoundAction.objects.create(
+            participant=self.participant,
+            round_number=1,
+            focused_category=ActionCategory.PHYSICAL,
+            focused_action=self.technique,
+            focused_opponent_target=self.opponent,
+            effort_level=EffortLevel.MEDIUM,
+        )
+        return CombatTechniqueResolver(
+            participant=self.participant,
+            action=action,
+            pull_flat_bonus=0,
+            fatigue_category=ActionCategory.PHYSICAL,
+            offense_check_type=CheckTypeFactory(),
+            offense_check_fn=None,
+        )
+
+    def _spy_extra_contributions(self):
+        captured: dict = {}
+        from world.checks import services as checks_services
+
+        real_collect = checks_services.collect_check_modifiers
+
+        def _spy(sheet, check_type, **kwargs):
+            captured["extra_contributions"] = kwargs.get("extra_contributions")
+            return real_collect(sheet, check_type, **kwargs)
+
+        return _spy, captured
+
+    def _wind_contributions(self, captured: dict) -> list:
+        return [c for c in captured["extra_contributions"] if c.source_label == "Wind"]
+
+    def test_calm_room_missile_attack_no_wind_contribution(self) -> None:
+        """felt WIND below the BREEZY threshold (CALM) contributes nothing."""
+        _equip_weapon(self.character, GearArchetype.RANGED)
+        resolver = self._resolver()
+        spy, captured = self._spy_extra_contributions()
+
+        with (
+            patch("world.combat.services.perform_check") as mock_perform,
+            patch("world.combat.services.collect_check_modifiers", side_effect=spy),
+            patch(_FELT_EXPOSURE_PATH, return_value=10),
+        ):
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolver._roll_check()
+
+        self.assertEqual(self._wind_contributions(captured), [])
+
+    def test_gale_room_missile_attack_minus_twenty(self) -> None:
+        """GALE-band felt WIND applies a -20 SCENE "Wind" penalty to a RANGED attack."""
+        _equip_weapon(self.character, GearArchetype.RANGED)
+        resolver = self._resolver()
+        spy, captured = self._spy_extra_contributions()
+
+        with (
+            patch("world.combat.services.perform_check") as mock_perform,
+            patch("world.combat.services.collect_check_modifiers", side_effect=spy),
+            patch(_FELT_EXPOSURE_PATH, return_value=70),
+        ):
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolver._roll_check()
+
+        wind_contribs = self._wind_contributions(captured)
+        self.assertEqual(len(wind_contribs), 1)
+        self.assertEqual(wind_contribs[0].value, -20)
+        self.assertEqual(wind_contribs[0].source_kind, ModifierSourceKind.SCENE)
+
+    def test_gale_room_thrown_attack_minus_twenty(self) -> None:
+        """THROWN is missile-classified too, not just RANGED."""
+        _equip_weapon(self.character, GearArchetype.THROWN)
+        resolver = self._resolver()
+        spy, captured = self._spy_extra_contributions()
+
+        with (
+            patch("world.combat.services.perform_check") as mock_perform,
+            patch("world.combat.services.collect_check_modifiers", side_effect=spy),
+            patch(_FELT_EXPOSURE_PATH, return_value=70),
+        ):
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolver._roll_check()
+
+        wind_contribs = self._wind_contributions(captured)
+        self.assertEqual(len(wind_contribs), 1)
+        self.assertEqual(wind_contribs[0].value, -20)
+
+    def test_gale_room_melee_attack_untouched(self) -> None:
+        """A melee attack never looks at felt WIND — the felt_exposure call is
+        skipped entirely, and no Wind contribution appears even in a GALE room."""
+        _equip_weapon(self.character, GearArchetype.MELEE_ONE_HAND)
+        resolver = self._resolver()
+        spy, captured = self._spy_extra_contributions()
+
+        with (
+            patch("world.combat.services.perform_check") as mock_perform,
+            patch("world.combat.services.collect_check_modifiers", side_effect=spy),
+            patch(_FELT_EXPOSURE_PATH) as mock_felt,
+        ):
+            mock_felt.return_value = 70
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolver._roll_check()
+
+        mock_felt.assert_not_called()
+        self.assertEqual(self._wind_contributions(captured), [])
+
+    def test_enclosed_room_missile_attack_no_contribution(self) -> None:
+        """A sheltered room's felt WIND is 0 (enclosure gate) -> no Wind
+        contribution even on a RANGED attack."""
+        _equip_weapon(self.character, GearArchetype.RANGED)
+        resolver = self._resolver()
+        spy, captured = self._spy_extra_contributions()
+
+        with (
+            patch("world.combat.services.perform_check") as mock_perform,
+            patch("world.combat.services.collect_check_modifiers", side_effect=spy),
+            patch(_FELT_EXPOSURE_PATH, return_value=0),
+        ):
+            mock_perform.return_value = MagicMock(success_level=2)
+            resolver._roll_check()
+
+        self.assertEqual(self._wind_contributions(captured), [])
+
+
+class WindDefenseModifierTests(TestCase):
+    """resolve_npc_attack: symmetric positive "Wind" SCENE contribution on the
+    PC's defense check when the NPC's threat entry is MISSILE-delivered.
+
+    Uses setUp (not setUpTestData) — CombatOpponentFactory creates a CombatNPC
+    ObjectDB at the encounter's room, and the SharedMemoryModel identity map makes
+    that room non-deepcopyable, breaking setUpTestData's per-test deepcopy
+    (mirrors world.combat.tests.test_defense.ResolveNpcAttackTests).
+    """
+
+    def setUp(self) -> None:
+        self.encounter = CombatEncounterFactory(round_number=1)
+        pool = ThreatPoolFactory()
+        self.missile_entry = ThreatPoolEntryFactory(
+            pool=pool, base_damage=100, delivery=StrikeDelivery.MISSILE
+        )
+        self.melee_entry = ThreatPoolEntryFactory(
+            pool=pool, base_damage=100, delivery=StrikeDelivery.MELEE
+        )
+        self.opponent = CombatOpponentFactory(encounter=self.encounter, threat_pool=pool)
+        self.sheet = CharacterSheetFactory()
+        self.participant = CombatParticipantFactory(
+            encounter=self.encounter, character_sheet=self.sheet
+        )
+        CharacterVitals.objects.create(character_sheet=self.sheet, health=200, max_health=200)
+        self.check_type = CheckTypeFactory()
+
+    def _action_for(self, entry) -> CombatOpponentAction:
+        action = CombatOpponentAction.objects.create(
+            opponent=self.opponent, round_number=1, threat_entry=entry
+        )
+        action.targets.add(self.participant)
+        return action
+
+    def _spy(self):
+        captured: dict = {}
+
+        def spy(character, check_type, *args, **kwargs):
+            captured["extra_modifiers"] = kwargs.get("extra_modifiers", 0)
+            result = MagicMock()
+            result.success_level = 2
+            return result
+
+        return spy, captured
+
+    def test_gale_missile_attack_plus_twenty_defense(self) -> None:
+        """GALE-band felt WIND applies a +20 SCENE "Wind" bonus to the PC's
+        defense roll against a MISSILE-delivered NPC attack."""
+        action = self._action_for(self.missile_entry)
+        spy, captured = self._spy()
+
+        with patch(_FELT_EXPOSURE_PATH, return_value=70):
+            resolve_npc_attack(action, self.participant, self.check_type, perform_check_fn=spy)
+
+        self.assertEqual(captured["extra_modifiers"], 20)
+
+    def test_calm_missile_attack_no_defense_bonus(self) -> None:
+        action = self._action_for(self.missile_entry)
+        spy, captured = self._spy()
+
+        with patch(_FELT_EXPOSURE_PATH, return_value=10):
+            resolve_npc_attack(action, self.participant, self.check_type, perform_check_fn=spy)
+
+        self.assertEqual(captured["extra_modifiers"], 0)
+
+    def test_gale_melee_attack_no_defense_bonus(self) -> None:
+        """MELEE delivery is untouched by wind even in a GALE room — felt_exposure
+        is never consulted."""
+        action = self._action_for(self.melee_entry)
+        spy, captured = self._spy()
+
+        with patch(_FELT_EXPOSURE_PATH) as mock_felt:
+            mock_felt.return_value = 70
+            resolve_npc_attack(action, self.participant, self.check_type, perform_check_fn=spy)
+
+        mock_felt.assert_not_called()
+        self.assertEqual(captured["extra_modifiers"], 0)
+
+    def test_flat_damage_entry_untouched_by_wind(self) -> None:
+        """A flat base_damage entry (no defense_check_type) is applied via
+        apply_damage_to_participant directly — the wind seam lives only inside
+        resolve_npc_attack's defense-check path, so felt_exposure is never
+        consulted and the authored flat damage lands untouched (#1555)."""
+        with patch(_FELT_EXPOSURE_PATH) as mock_felt:
+            result = apply_damage_to_participant(
+                self.participant,
+                self.missile_entry.base_damage,
+                damage_type=self.missile_entry.damage_type,
+                delivery=self.missile_entry.delivery,
+            )
+
+        mock_felt.assert_not_called()
+        self.assertEqual(result.damage_dealt, 100)


### PR DESCRIPTION
Closes #1555

## Summary

First combat consumer of the WIND exposure axis (#1522 provider): missile attacks (equipped RANGED/THROWN weapons) take a banded SCENE 'Wind' check penalty read live from felt_exposure(encounter.room, WIND) — CALM/BREEZY/WINDY/GALE bands of 0/-5/-10/-20 — and NPC MISSILE-delivery attacks (the StrikeDelivery field from #2209) grant the targeted PC the same magnitude as a defense bonus, so the gale is symmetric. Melee and lance attacks skip the exposure read entirely; enclosure gating means indoor fights feel nothing; flat-damage entries stay authored. No models, no provider work (gale techniques already write WIND through the generic cascade). ADR-0129 + fix-on-sight of three stale 'wind not yet wired' doc claims.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #1555 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: rebased onto main post-#2261 at implementation start (reuses StrikeDelivery); re-sync clean at PR time

<!-- last-addressed-comment: 0 -->