### PR TITLE
Servant fetch — intercept NotReachable when a servant is assigned

### DIFF
--- a/docs/roadmap/rooms-and-estates.md
+++ b/docs/roadmap/rooms-and-estates.md
@@ -95,6 +95,28 @@
   inhabitant surfacing shipped as #1522's REST widgets + weather echo);
   Chilled/Soaked threshold conditions (Tehom's integration, per the spec).
 
+## Built (2026-07-12, #2276 — servant fetch)
+
+- **Servant fetch service** (`world.npc_services.servant_fetch`): when a
+  player with owner/tenant standing attempts to retrieve an item or outfit
+  in another room within their estate, and an active SERVANT `NPCAssignment`
+  exists, the `NotReachable` failure is intercepted at the action layer
+  (`GetAction`, `TakeOutAction`, `ApplyOutfitAction`). A servant NPC
+  "fetches" the item with a delayed completion (`evennia.utils.delay`) and
+  room echoes (departure + arrival).
+- **Estate-scoped:** servant lookup walks the `AreaClosure` chain (same as
+  `is_owner`/`is_tenant`).
+- **Cancellation:** `.ndb.active_fetch_token` (mirrors `TravelAction`); if
+  the actor moves before the fetch completes, the stale callback no-ops.
+  `cancel_servant_fetch` is called from `Character.at_post_move`.
+- **Outfit retrieval:** servant brings individual pieces to the actor and
+  equips them via the existing `equip()` service. Wardrobe stays in place.
+- **Only different-room `NotReachable` qualifies** — closed-container-in-
+  same-room does not trigger servant fetch.
+- **Servant assignment actions deferred** — `assign_servant` / `unassign_servant`
+  / `list_servant_assignments` (mirroring the #2178 guard pattern) are a
+  follow-up issue.
+
 ## Built (2026-07-12, #2178 — guard assignment + detection)
 
 - **`NPCAssignment` model** (`world.npc_services`): a join model with

--- a/src/actions/definitions/items.py
+++ b/src/actions/definitions/items.py
@@ -32,7 +32,7 @@ from flows.service_functions.inventory import (
 )
 from world.gm.constants import GMLevel
 from world.items.constants import ContainerAccessPolicy
-from world.items.exceptions import InventoryError, ItemError
+from world.items.exceptions import InventoryError, ItemError, NotReachable
 from world.items.services.usage import use_item
 
 
@@ -225,6 +225,18 @@ class TakeOutAction(Action):
 
         try:
             take_out(actor_state, item_state)
+        except NotReachable:
+            from world.npc_services.servant_fetch import (  # noqa: PLC0415
+                can_servant_fetch,
+                servant_fetch_item,
+            )
+
+            if can_servant_fetch(actor=actor, item_instance=item_instance):
+                servant_fetch_item(actor=actor, item_instance=item_instance)
+                return ActionResult(
+                    success=True, message="A servant bows and departs to fetch that."
+                )
+            return ActionResult(success=False, message=NotReachable.user_message)
         except InventoryError as exc:
             return ActionResult(success=False, message=exc.user_message)
 

--- a/src/actions/definitions/movement.py
+++ b/src/actions/definitions/movement.py
@@ -21,7 +21,7 @@ from flows.service_functions.communication import message_location, send_room_st
 from flows.service_functions.inventory import drop, give, pick_up
 from flows.service_functions.movement import check_exit_traversal, move_object, traverse_exit
 from world.areas.positioning.travel import find_route
-from world.items.exceptions import InventoryError
+from world.items.exceptions import InventoryError, NotReachable
 from world.mechanics.constants import ChallengeType
 from world.mechanics.models import ChallengeInstance
 
@@ -62,6 +62,18 @@ class GetAction(Action):
 
         try:
             pick_up(actor_state, item_state)
+        except NotReachable:
+            from world.npc_services.servant_fetch import (  # noqa: PLC0415
+                can_servant_fetch,
+                servant_fetch_item,
+            )
+
+            if can_servant_fetch(actor=actor, item_instance=item_instance):
+                servant_fetch_item(actor=actor, item_instance=item_instance)
+                return ActionResult(
+                    success=True, message="A servant bows and departs to fetch that."
+                )
+            return ActionResult(success=False, message=NotReachable.user_message)
         except InventoryError as exc:
             return ActionResult(success=False, message=exc.user_message)
 

--- a/src/actions/definitions/outfits.py
+++ b/src/actions/definitions/outfits.py
@@ -21,7 +21,7 @@ from flows.service_functions.outfits import (
     save_outfit as save_outfit_service,
     undress as undress_service,
 )
-from world.items.exceptions import InventoryError, ItemError
+from world.items.exceptions import InventoryError, ItemError, NotReachable
 from world.items.models import Outfit
 
 if TYPE_CHECKING:
@@ -64,6 +64,20 @@ class ApplyOutfitAction(Action):
 
         try:
             apply_outfit_service(actor_state, outfit_state)
+        except NotReachable:
+            from world.npc_services.servant_fetch import (  # noqa: PLC0415
+                can_servant_fetch,
+                servant_fetch_outfit,
+            )
+
+            # The wardrobe is the unreachable item — check eligibility with it.
+            if can_servant_fetch(actor=actor, item_instance=outfit.wardrobe):
+                servant_fetch_outfit(actor=actor, outfit=outfit)
+                return ActionResult(
+                    success=True,
+                    message="A servant bows and departs to fetch your outfit.",
+                )
+            return ActionResult(success=False, message=NotReachable.user_message)
         except InventoryError as exc:
             return ActionResult(success=False, message=exc.user_message)
 

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -435,6 +435,18 @@ class Character(ObjectParent, DefaultCharacter):
                 actor=self,
             )
 
+            # Cancel any in-progress servant fetch (#2276) — the servant
+            # can't deliver to an empty room.
+            from world.npc_services.servant_fetch import (
+                cancel_servant_fetch,
+            )
+
+            run_safely(
+                "cancel_servant_fetch_on_move",
+                lambda: cancel_servant_fetch(self),
+                actor=self,
+            )
+
     def at_attacked(self, attacker, weapon, damage_result, action) -> None:
         """Called by combat after damage calc, before damage apply.
 

--- a/src/world/npc_services/servant_fetch.py
+++ b/src/world/npc_services/servant_fetch.py
@@ -1,0 +1,381 @@
+"""Servant fetch service (#2276).
+
+Intercepts the ``NotReachable`` path for item/outfit retrieval when an
+active SERVANT ``NPCAssignment`` exists in the actor's estate. The servant
+queues a delayed fetch with room echoes: a departure echo, a delay, then
+the item appears and an arrival echo fires.
+
+The interception happens at the **action layer** (``GetAction``,
+``TakeOutAction``, ``ApplyOutfitAction``), not the service layer — the
+service functions (``pick_up``, ``take_out``, ``apply_outfit``) raise
+``NotReachable`` unchanged. Only the action's ``execute()`` catches it
+and delegates here.
+
+Cancellation mirrors ``TravelAction``: a ``.ndb.active_fetch_token``
+makes stale callbacks no-op when the actor moves before the delay fires.
+``cancel_servant_fetch`` is called from ``Character.at_post_move``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+import uuid
+
+from django.db import transaction
+from evennia.utils import delay
+
+from world.areas.services import get_room_profile
+from world.npc_services.models import AssignmentRole, NPCAssignment
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from world.items.models import ItemInstance, Outfit
+
+
+#: Default delay (seconds) before a servant fetch completes.
+DEFAULT_FETCH_DELAY_SECONDS: float = 5.0
+
+
+def find_servant(room: ObjectDB) -> NPCAssignment | None:
+    """Return the active SERVANT NPCAssignment in the room's area-closure chain, or None.
+
+    Walks the same ``AreaClosure`` chain as ``is_owner``/``is_tenant``.
+    Queries ``NPCAssignment`` for SERVANT role across all rooms whose
+    ``RoomProfile.area`` is an ancestor of (or equal to) the actor's room's
+    area. One servant per estate is the expected common case; if multiple
+    exist, the most recently assigned wins (``ordering = ["-assigned_at"]``).
+    """
+    from world.areas.models import AreaClosure  # noqa: PLC0415
+
+    profile = get_room_profile(room)
+    if profile is None or profile.area is None:
+        return None
+
+    ancestor_ids = list(
+        AreaClosure.objects.filter(descendant_id=profile.area.pk).values_list(
+            "ancestor_id", flat=True
+        )
+    )
+    if not ancestor_ids:
+        return None
+
+    return (
+        NPCAssignment.objects.filter(
+            room__area_id__in=ancestor_ids,
+            assignment_role=AssignmentRole.SERVANT,
+            is_active=True,
+        )
+        .select_related("functionary", "npc_asset")
+        .first()
+    )
+
+
+def can_servant_fetch(*, actor: ObjectDB, item_instance: ItemInstance) -> bool:  # noqa: PLR0911
+    """Eligibility check: may a servant fetch this item for this actor?
+
+    Returns True only when ALL of:
+        1. The actor has an active persona with owner or tenant standing
+           at their current location (``is_owner`` or ``is_tenant``).
+        2. An active SERVANT ``NPCAssignment`` exists in the estate
+           (area-closure chain of the actor's room).
+        3. The item has a ``game_object``.
+        4. The item's topmost container's location is in a DIFFERENT room
+           than the actor — a closed container in the same room does not
+           qualify (the servant cannot open containers).
+
+    Does NOT raise — returns False if any step fails.
+    """
+    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+    from world.locations.services import is_owner, is_tenant  # noqa: PLC0415
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+    # Resolve the actor's active persona.
+    try:
+        sheet = actor.sheet_data
+    except (AttributeError, ObjectDoesNotExist):
+        return False
+    persona = active_persona_for_sheet(sheet)
+    if persona is None:
+        return False
+
+    # Check owner/tenant standing.
+    if actor.location is None:
+        return False
+    if not (is_owner(persona, actor.location) or is_tenant(persona, actor.location)):
+        return False
+
+    # Check servant exists in the estate.
+    if find_servant(actor.location) is None:
+        return False
+
+    # Check the item has a game_object.
+    if item_instance.game_object is None:
+        return False
+
+    # Walk contained_in to the topmost item.
+    topmost = item_instance
+    while topmost.contained_in is not None:
+        topmost = topmost.contained_in
+
+    # The item must be in a DIFFERENT room (not a same-room closed container).
+    if topmost.game_object is None:
+        return False
+    if topmost.game_object.location == actor.location:
+        return False
+
+    return True
+
+
+def servant_fetch_item(
+    *,
+    actor: ObjectDB,
+    item_instance: ItemInstance,
+    delay_seconds: float = DEFAULT_FETCH_DELAY_SECONDS,
+) -> bool:
+    """Queue a delayed item fetch with room echoes.
+
+    Emits a departure echo to the actor's room, schedules a delayed
+    callback via ``evennia.utils.delay()``, and stores the cancellation
+    token on ``actor.ndb``. The callback is ``@transaction.atomic`` and:
+
+    1. Checks the token (stale → no-op, actor moved).
+    2. Moves the item's ``game_object`` to the actor (into inventory).
+    3. Clears ``contained_in`` if set.
+    4. Sets ``holder_character_sheet`` if the item was unowned.
+    5. Invalidates the actor's ``carried_items`` cache.
+    6. Emits an arrival echo.
+
+    Args:
+        actor: The character requesting the fetch.
+        item_instance: The item to fetch.
+        delay_seconds: Seconds before the fetch completes.
+
+    Returns:
+        True if the fetch was queued.
+    """
+    from flows.scene_data_manager import SceneDataManager  # noqa: PLC0415
+    from flows.service_functions.communication import (  # noqa: PLC0415
+        message_location,
+    )
+
+    servant = find_servant(actor.location)
+    servant_name = servant.get_active_target_name() if servant else "A servant"
+
+    # Departure echo.
+    sdm = SceneDataManager()
+    actor_state = sdm.initialize_state_for_object(actor)
+    item_name = item_instance.display_name
+    message_location(
+        actor_state,
+        f"{servant_name} bows and departs to fetch {item_name}.",
+    )
+
+    # Cancellation token.
+    token = uuid.uuid4()
+    actor.ndb.active_fetch_token = token
+    task = delay(
+        delay_seconds,
+        _complete_item_fetch,
+        actor,
+        item_instance,
+        token,
+        servant_name,
+    )
+    actor.ndb.active_fetch_task = task
+    return True
+
+
+@transaction.atomic
+def _complete_item_fetch(
+    actor: ObjectDB,
+    item_instance: ItemInstance,
+    token: uuid.UUID,
+    servant_name: str,
+) -> None:
+    """Delayed completion: move the item to the actor and emit arrival echo.
+
+    Wrapped in ``@transaction.atomic`` so partial failures (move succeeds
+    but holder save fails) roll back — mirroring the ``pick_up`` / ``take_out``
+    service functions' own atomicity.
+    """
+    # Stale callback — actor moved or a new fetch superseded this one.
+    current_token = actor.ndb.active_fetch_token
+    if current_token != token:
+        return
+
+    if item_instance.game_object is None:
+        return
+
+    # Clear container nesting if any.
+    if item_instance.contained_in is not None:
+        item_instance.contained_in = None
+        item_instance.save(update_fields=["contained_in"])
+
+    # Move to the actor (into inventory, not just the room).
+    if not item_instance.game_object.move_to(actor, quiet=True):
+        return
+
+    # Set holder if unowned (same logic as pick_up).
+    taker_sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    if item_instance.holder_character_sheet_id is None and taker_sheet is not None:
+        item_instance.holder_character_sheet = taker_sheet
+        item_instance.save(update_fields=["holder_character_sheet"])
+
+    # Invalidate carried-items cache.
+    if hasattr(actor, "carried_items"):
+        actor.carried_items.invalidate()
+
+    # Arrival echo.
+    from flows.scene_data_manager import SceneDataManager  # noqa: PLC0415
+    from flows.service_functions.communication import (  # noqa: PLC0415
+        message_location,
+    )
+
+    sdm = SceneDataManager()
+    actor_state = sdm.initialize_state_for_object(actor)
+    item_name = item_instance.display_name
+    message_location(
+        actor_state,
+        f"{servant_name} returns with {item_name} and hands it to $You().",
+    )
+
+    # Clear token.
+    actor.ndb.active_fetch_token = None
+    actor.ndb.active_fetch_task = None
+
+
+def servant_fetch_outfit(
+    *,
+    actor: ObjectDB,
+    outfit: Outfit,
+    delay_seconds: float = DEFAULT_FETCH_DELAY_SECONDS,
+) -> bool:
+    """Queue a delayed outfit fetch with room echoes.
+
+    The servant brings individual outfit pieces to the actor and equips
+    them via the existing ``equip()`` service. The wardrobe stays in place
+    — narratively correct (a servant brings clothes, not the armoire).
+
+    The completion callback is ``@transaction.atomic`` and:
+    1. Checks the token (stale → no-op).
+    2. For each outfit slot: moves the piece's ``game_object`` to the
+       actor (NOT to the room — ``equip()``'s ``can_equip`` checks
+       ``is_in_possession``, which requires ``game_object.location == actor``).
+       Clears ``contained_in``, then calls ``equip()``.
+    3. Emits an arrival echo.
+    4. Clears the token.
+
+    Args:
+        actor: The character requesting the outfit.
+        outfit: The ``Outfit`` to fetch and equip.
+        delay_seconds: Seconds before the fetch completes.
+
+    Returns:
+        True if the fetch was queued.
+    """
+    from flows.scene_data_manager import SceneDataManager  # noqa: PLC0415
+    from flows.service_functions.communication import (  # noqa: PLC0415
+        message_location,
+    )
+
+    servant = find_servant(actor.location)
+    servant_name = servant.get_active_target_name() if servant else "A servant"
+
+    # Departure echo.
+    sdm = SceneDataManager()
+    actor_state = sdm.initialize_state_for_object(actor)
+    message_location(
+        actor_state,
+        f"{servant_name} bows and departs to fetch your {outfit.name}.",
+    )
+
+    # Cancellation token.
+    token = uuid.uuid4()
+    actor.ndb.active_fetch_token = token
+    task = delay(
+        delay_seconds,
+        _complete_outfit_fetch,
+        actor,
+        outfit,
+        token,
+        servant_name,
+    )
+    actor.ndb.active_fetch_task = task
+    return True
+
+
+@transaction.atomic
+def _complete_outfit_fetch(
+    actor: ObjectDB,
+    outfit: Outfit,
+    token: uuid.UUID,
+    servant_name: str,
+) -> None:
+    """Delayed completion: bring outfit pieces and equip them.
+
+    Wrapped in ``@transaction.atomic`` so partial failures roll back.
+    """
+    # Stale callback.
+    current_token = actor.ndb.active_fetch_token
+    if current_token != token:
+        return
+
+    from flows.object_states.item_state import ItemState  # noqa: PLC0415
+    from flows.scene_data_manager import SceneDataManager  # noqa: PLC0415
+    from flows.service_functions.communication import (  # noqa: PLC0415
+        message_location,
+    )
+    from flows.service_functions.inventory import equip  # noqa: PLC0415
+    from world.items.exceptions import InventoryError  # noqa: PLC0415
+
+    sdm = SceneDataManager()
+    actor_state = sdm.initialize_state_for_object(actor)
+
+    for slot in outfit.slots.all():
+        piece = slot.item_instance
+        if piece.game_object is None:
+            continue
+        # Clear container nesting.
+        if piece.contained_in is not None:
+            piece.contained_in = None
+            piece.save(update_fields=["contained_in"])
+        # Move to the actor (NOT the room — equip() requires possession).
+        if not piece.game_object.move_to(actor, quiet=True):
+            continue
+        # Equip the piece.
+        item_state = ItemState(piece, context=sdm)
+        try:
+            equip(actor_state, item_state)
+        except InventoryError:
+            # If a piece can't be equipped (slot conflict, etc.), skip it.
+            # The transaction will still commit the moves that succeeded.
+            continue
+
+    # Arrival echo.
+    message_location(
+        actor_state,
+        f"{servant_name} returns with your {outfit.name} and helps you change.",
+    )
+
+    # Clear token.
+    actor.ndb.active_fetch_token = None
+    actor.ndb.active_fetch_task = None
+
+
+def cancel_servant_fetch(actor: ObjectDB) -> None:
+    """Cancel an in-progress servant fetch, if any.
+
+    Called from ``Character.at_post_move`` when the actor leaves the room.
+    Cancels the pending delay task and clears the token so the stale
+    callback no-ops.
+    """
+    token = actor.ndb.active_fetch_token
+    if token is None:
+        return
+    task = actor.ndb.active_fetch_task
+    if task is not None:
+        task.cancel()
+    actor.ndb.active_fetch_token = None
+    actor.ndb.active_fetch_task = None

--- a/src/world/npc_services/tests/test_servant_fetch.py
+++ b/src/world/npc_services/tests/test_servant_fetch.py
@@ -1,0 +1,479 @@
+"""Tests for the servant-fetch service (#2276).
+
+The AreaClosure materialized view is Postgres-only, so tests that would
+hit the closure chain mock ``is_owner``/``is_tenant``/``find_servant``
+at the service boundary rather than relying on real closure data.
+"""
+
+from unittest.mock import patch
+import uuid
+
+from django.test import TestCase
+
+from evennia_extensions.factories import (
+    CharacterFactory,
+    ObjectDBFactory,
+    RoomProfileFactory,
+)
+from world.areas.factories import AreaFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.items.factories import (
+    ItemInstanceFactory,
+    OutfitFactory,
+    OutfitSlotFactory,
+)
+from world.npc_services.factories import FunctionaryFactory
+from world.npc_services.models import (
+    AssignmentRole,
+    NPCAssignment,
+    NPCSourceType,
+)
+from world.npc_services.servant_fetch import (
+    can_servant_fetch,
+    cancel_servant_fetch,
+    find_servant,
+    servant_fetch_item,
+    servant_fetch_outfit,
+)
+from world.scenes.factories import PersonaFactory
+
+
+def _make_item_in_room(room):
+    """Create an ItemInstance with a game_object placed in ``room``."""
+    obj = ObjectDBFactory(db_key="item-obj")
+    obj.location = room
+    obj.save()
+    return ItemInstanceFactory(game_object=obj)
+
+
+class FindServantTests(TestCase):
+    """Tests for find_servant.
+
+    The AreaClosure materialized view is Postgres-only, so we mock the
+    closure query and test the NPCAssignment filtering logic directly.
+    """
+
+    def setUp(self) -> None:
+        self.area = AreaFactory()
+        self.room_profile = RoomProfileFactory(area=self.area)
+        self.room = self.room_profile.objectdb
+
+    def _create_servant(self, room_profile=None):
+        """Create an active SERVANT NPCAssignment in a room."""
+        func = FunctionaryFactory(room=room_profile or self.room_profile)
+        persona = PersonaFactory()
+        return NPCAssignment.objects.create(
+            source_type=NPCSourceType.FUNCTIONARY,
+            functionary=func,
+            room=room_profile or self.room_profile,
+            assignment_role=AssignmentRole.SERVANT,
+            assigned_by=persona,
+        )
+
+    def test_no_servant_returns_none(self):
+        """Room with no SERVANT assignment → None."""
+        with patch(
+            "world.areas.models.AreaClosure",
+        ) as mock_closure:
+            mock_closure.objects.filter.return_value.values_list.return_value = [self.area.pk]
+            self.assertIsNone(find_servant(self.room))
+
+    def test_servant_in_same_room_found(self):
+        """SERVANT assigned to the actor's room → found."""
+        self._create_servant()
+        # Patch AreaClosure to return the area's own pk (self at depth 0).
+        with patch(
+            "world.areas.models.AreaClosure",
+        ) as mock_closure:
+            mock_closure.objects.filter.return_value.values_list.return_value = [self.area.pk]
+            result = find_servant(self.room)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.assignment_role, AssignmentRole.SERVANT)
+
+    def test_inactive_servant_not_found(self):
+        """Retired SERVANT → not found."""
+        assignment = self._create_servant()
+        assignment.is_active = False
+        assignment.save()
+        with patch(
+            "world.areas.models.AreaClosure",
+        ) as mock_closure:
+            mock_closure.objects.filter.return_value.values_list.return_value = [self.area.pk]
+            result = find_servant(self.room)
+        self.assertIsNone(result)
+
+    def test_guard_not_treated_as_servant(self):
+        """A GUARD assignment does not satisfy find_servant."""
+        func = FunctionaryFactory(room=self.room_profile)
+        NPCAssignment.objects.create(
+            source_type=NPCSourceType.FUNCTIONARY,
+            functionary=func,
+            room=self.room_profile,
+            assignment_role=AssignmentRole.GUARD,
+            assigned_by=PersonaFactory(),
+        )
+        with patch(
+            "world.areas.models.AreaClosure",
+        ) as mock_closure:
+            mock_closure.objects.filter.return_value.values_list.return_value = [self.area.pk]
+            result = find_servant(self.room)
+        self.assertIsNone(result)
+
+    def test_no_profile_returns_none(self):
+        """Room with no RoomProfile → None."""
+        from evennia.objects.models import ObjectDB
+
+        bare_room = ObjectDB.objects.create(db_key="bare-room")
+        self.assertIsNone(find_servant(bare_room))
+
+
+class CanServantFetchTests(TestCase):
+    """Tests for can_servant_fetch.
+
+    Mocks ``is_owner``/``is_tenant``/``find_servant`` since they hit
+    the Postgres-only AreaClosure view.
+    """
+
+    def setUp(self) -> None:
+        self.area = AreaFactory()
+        self.room_profile = RoomProfileFactory(area=self.area)
+        self.room = self.room_profile.objectdb
+        self.other_room_profile = RoomProfileFactory(area=self.area)
+        self.other_room = self.other_room_profile.objectdb
+        self.owner_persona = PersonaFactory()
+        self.char = CharacterFactory(db_key="owner")
+        CharacterSheetFactory(character=self.char)
+        self.char.location = self.room
+        self.char.save()
+        # Item in the other room.
+        self.item_instance = _make_item_in_room(self.other_room)
+        # Servant assignment (for find_servant to return).
+        func = FunctionaryFactory(room=self.room_profile)
+        self.servant = NPCAssignment.objects.create(
+            source_type=NPCSourceType.FUNCTIONARY,
+            functionary=func,
+            room=self.room_profile,
+            assignment_role=AssignmentRole.SERVANT,
+            assigned_by=self.owner_persona,
+        )
+
+    def test_eligible_when_owner_with_servant_and_item_in_other_room(self):
+        """Owner + servant + item in another room → True."""
+        with (
+            patch("world.locations.services.is_owner", return_value=True),
+            patch("world.locations.services.is_tenant", return_value=False),
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=self.servant,
+            ),
+            patch(
+                "world.scenes.services.active_persona_for_sheet",
+                return_value=self.owner_persona,
+            ),
+        ):
+            self.assertTrue(can_servant_fetch(actor=self.char, item_instance=self.item_instance))
+
+    def test_no_servant_returns_false(self):
+        """Owner but no servant → False."""
+        with (
+            patch("world.locations.services.is_owner", return_value=True),
+            patch("world.locations.services.is_tenant", return_value=False),
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=None,
+            ),
+            patch(
+                "world.scenes.services.active_persona_for_sheet",
+                return_value=self.owner_persona,
+            ),
+        ):
+            self.assertFalse(can_servant_fetch(actor=self.char, item_instance=self.item_instance))
+
+    def test_same_room_item_returns_false(self):
+        """Item in the same room (closed container case) → False."""
+        # Move item to the actor's room (same room).
+        self.item_instance.game_object.location = self.room
+        self.item_instance.game_object.save()
+        with (
+            patch("world.locations.services.is_owner", return_value=True),
+            patch("world.locations.services.is_tenant", return_value=False),
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=self.servant,
+            ),
+            patch(
+                "world.scenes.services.active_persona_for_sheet",
+                return_value=self.owner_persona,
+            ),
+        ):
+            self.assertFalse(can_servant_fetch(actor=self.char, item_instance=self.item_instance))
+
+    def test_no_standing_returns_false(self):
+        """Actor without owner/tenant standing → False."""
+        with (
+            patch("world.locations.services.is_owner", return_value=False),
+            patch("world.locations.services.is_tenant", return_value=False),
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=self.servant,
+            ),
+            patch(
+                "world.scenes.services.active_persona_for_sheet",
+                return_value=self.owner_persona,
+            ),
+        ):
+            self.assertFalse(can_servant_fetch(actor=self.char, item_instance=self.item_instance))
+
+    def test_no_game_object_returns_false(self):
+        """Item with no game_object → False."""
+        no_game_obj = ItemInstanceFactory()
+        with (
+            patch("world.locations.services.is_owner", return_value=True),
+            patch("world.locations.services.is_tenant", return_value=False),
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=self.servant,
+            ),
+            patch(
+                "world.scenes.services.active_persona_for_sheet",
+                return_value=self.owner_persona,
+            ),
+        ):
+            self.assertFalse(can_servant_fetch(actor=self.char, item_instance=no_game_obj))
+
+    def test_no_persona_returns_false(self):
+        """Actor with no active persona → False."""
+        with patch(
+            "world.scenes.services.active_persona_for_sheet",
+            return_value=None,
+        ):
+            self.assertFalse(can_servant_fetch(actor=self.char, item_instance=self.item_instance))
+
+
+class ServantFetchItemTests(TestCase):
+    """Tests for servant_fetch_item and _complete_item_fetch."""
+
+    def setUp(self) -> None:
+        self.area = AreaFactory()
+        self.room_profile = RoomProfileFactory(area=self.area)
+        self.room = self.room_profile.objectdb
+        self.other_room_profile = RoomProfileFactory(area=self.area)
+        self.other_room = self.other_room_profile.objectdb
+        self.owner_persona = PersonaFactory()
+        self.char = CharacterFactory(db_key="fetcher")
+        CharacterSheetFactory(character=self.char)
+        self.char.location = self.room
+        self.char.save()
+        # Item in the other room.
+        self.item_instance = _make_item_in_room(self.other_room)
+        # Servant.
+        func = FunctionaryFactory(room=self.room_profile)
+        self.servant = NPCAssignment.objects.create(
+            source_type=NPCSourceType.FUNCTIONARY,
+            functionary=func,
+            room=self.room_profile,
+            assignment_role=AssignmentRole.SERVANT,
+            assigned_by=self.owner_persona,
+        )
+
+    def test_fetch_moves_item_to_actor(self):
+        """After the delay fires, item is in actor's possession."""
+        with (
+            patch("world.npc_services.servant_fetch.delay") as mock_delay,
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=self.servant,
+            ),
+        ):
+            mock_delay.side_effect = lambda _seconds, callback, *args: callback(*args)
+            result = servant_fetch_item(
+                actor=self.char, item_instance=self.item_instance, delay_seconds=0
+            )
+        self.assertTrue(result)
+        self.item_instance.refresh_from_db()
+        self.assertEqual(self.item_instance.game_object.location, self.char)
+
+    def test_fetch_sets_holder_character_sheet(self):
+        """Unowned item gets holder set to the actor's sheet."""
+        self.item_instance.holder_character_sheet = None
+        self.item_instance.save()
+        with (
+            patch("world.npc_services.servant_fetch.delay") as mock_delay,
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=self.servant,
+            ),
+        ):
+            mock_delay.side_effect = lambda _seconds, callback, *args: callback(*args)
+            servant_fetch_item(actor=self.char, item_instance=self.item_instance, delay_seconds=0)
+        self.item_instance.refresh_from_db()
+        self.assertEqual(self.item_instance.holder_character_sheet, self.char.sheet_data)
+
+    def test_fetch_clears_contained_in(self):
+        """Item in a container has contained_in cleared."""
+        container = _make_item_in_room(self.other_room)
+        self.item_instance.contained_in = container
+        self.item_instance.save()
+        with (
+            patch("world.npc_services.servant_fetch.delay") as mock_delay,
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=self.servant,
+            ),
+        ):
+            mock_delay.side_effect = lambda _seconds, callback, *args: callback(*args)
+            servant_fetch_item(actor=self.char, item_instance=self.item_instance, delay_seconds=0)
+        self.item_instance.refresh_from_db()
+        self.assertIsNone(self.item_instance.contained_in)
+
+    def test_fetch_sets_ndb_token(self):
+        """Fetch sets the cancellation token on the actor."""
+        with (
+            patch("world.npc_services.servant_fetch.delay"),
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=self.servant,
+            ),
+        ):
+            servant_fetch_item(actor=self.char, item_instance=self.item_instance, delay_seconds=5.0)
+        self.assertIsNotNone(self.char.ndb.active_fetch_token)
+
+    def test_stale_callback_no_ops(self):
+        """A stale token (actor moved) → no item delivery."""
+        with (
+            patch("world.npc_services.servant_fetch.delay") as mock_delay,
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=self.servant,
+            ),
+        ):
+            captured = []
+            mock_delay.side_effect = lambda _seconds, callback, *args: captured.append(
+                (callback, args)
+            )
+            servant_fetch_item(actor=self.char, item_instance=self.item_instance, delay_seconds=5.0)
+            # Simulate the actor moving (token invalidated).
+            self.char.ndb.active_fetch_token = uuid.uuid4()
+            # Now fire the stale callback.
+            callback, args = captured[0]
+            callback(*args)
+
+        # Item should NOT have moved.
+        self.item_instance.refresh_from_db()
+        self.assertEqual(self.item_instance.game_object.location, self.other_room)
+
+
+class CancelServantFetchTests(TestCase):
+    def test_cancel_clears_token_and_task(self):
+        from unittest.mock import Mock
+
+        char = CharacterFactory(db_key="mover")
+        char.ndb.active_fetch_token = uuid.uuid4()
+        mock_task = Mock()
+        char.ndb.active_fetch_task = mock_task
+        cancel_servant_fetch(char)
+        mock_task.cancel.assert_called_once()
+        self.assertIsNone(char.ndb.active_fetch_token)
+        self.assertIsNone(char.ndb.active_fetch_task)
+
+    def test_cancel_noop_when_no_fetch(self):
+        char = CharacterFactory(db_key="idle")
+        # Should not raise.
+        cancel_servant_fetch(char)
+        self.assertIsNone(char.ndb.active_fetch_token)
+
+
+class ServantFetchOutfitTests(TestCase):
+    """Tests for servant_fetch_outfit and _complete_outfit_fetch."""
+
+    def setUp(self) -> None:
+        self.area = AreaFactory()
+        self.room_profile = RoomProfileFactory(area=self.area)
+        self.room = self.room_profile.objectdb
+        self.other_room_profile = RoomProfileFactory(area=self.area)
+        self.other_room = self.other_room_profile.objectdb
+        self.owner_persona = PersonaFactory()
+        self.char = CharacterFactory(db_key="noble")
+        self.sheet = CharacterSheetFactory(character=self.char)
+        self.char.location = self.room
+        self.char.save()
+        # Wardrobe in the other room.
+        self.wardrobe = _make_item_in_room(self.other_room)
+        # Outfit piece in the other room (owned by the sheet).
+        self.piece = _make_item_in_room(self.other_room)
+        self.piece.holder_character_sheet = self.sheet
+        self.piece.save()
+        # Give the piece's template an equipment slot so equip() can equip it.
+        from world.items.factories import TemplateSlotFactory
+
+        TemplateSlotFactory(template=self.piece.template)
+        # Outfit referencing the wardrobe + piece.
+        self.outfit = OutfitFactory(
+            character_sheet=self.sheet, wardrobe=self.wardrobe, name="Court Attire"
+        )
+        OutfitSlotFactory(
+            outfit=self.outfit,
+            item_instance=self.piece,
+        )
+        # Servant.
+        func = FunctionaryFactory(room=self.room_profile)
+        NPCAssignment.objects.create(
+            source_type=NPCSourceType.FUNCTIONARY,
+            functionary=func,
+            room=self.room_profile,
+            assignment_role=AssignmentRole.SERVANT,
+            assigned_by=self.owner_persona,
+        )
+
+    def test_outfit_fetch_equips_pieces(self):
+        """After delay, outfit pieces are moved to actor and equipped."""
+        from world.items.models import EquippedItem
+
+        with (
+            patch("world.npc_services.servant_fetch.delay") as mock_delay,
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=NPCAssignment.objects.filter(
+                    assignment_role=AssignmentRole.SERVANT, is_active=True
+                ).first(),
+            ),
+        ):
+            mock_delay.side_effect = lambda _seconds, callback, *args: callback(*args)
+            result = servant_fetch_outfit(actor=self.char, outfit=self.outfit, delay_seconds=0)
+        self.assertTrue(result)
+        # The piece should now be on the actor.
+        self.piece.refresh_from_db()
+        self.assertEqual(self.piece.game_object.location, self.char)
+        # And should have an equipped row.
+        self.assertTrue(
+            EquippedItem.objects.filter(character=self.char, item_instance=self.piece).exists()
+        )
+
+    def test_outfit_fetch_stale_callback_no_ops(self):
+        """Stale token → no equip, pieces stay in other room."""
+        from world.items.models import EquippedItem
+
+        with (
+            patch("world.npc_services.servant_fetch.delay") as mock_delay,
+            patch(
+                "world.npc_services.servant_fetch.find_servant",
+                return_value=NPCAssignment.objects.filter(
+                    assignment_role=AssignmentRole.SERVANT, is_active=True
+                ).first(),
+            ),
+        ):
+            captured = []
+            mock_delay.side_effect = lambda _seconds, callback, *args: captured.append(
+                (callback, args)
+            )
+            servant_fetch_outfit(actor=self.char, outfit=self.outfit, delay_seconds=5.0)
+            # Simulate actor moving.
+            self.char.ndb.active_fetch_token = uuid.uuid4()
+            callback, args = captured[0]
+            callback(*args)
+
+        self.piece.refresh_from_db()
+        self.assertEqual(self.piece.game_object.location, self.other_room)
+        self.assertFalse(
+            EquippedItem.objects.filter(character=self.char, item_instance=self.piece).exists()
+        )


### PR DESCRIPTION
Closes #2276

## Summary

Servant fetch — intercept NotReachable at the action layer for item/outfit retrieval when a SERVANT NPCAssignment exists in the actor's estate

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2276 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: clean sync

<!-- last-addressed-comment: 0 -->