### PR TITLE
Attraction loop remainders: surprise-attack semantics, social fatigue, rank-delta intrigue easing (#1695 audit)

### DIFF
--- a/src/world/scenes/AGENT_GLOSSARY.md
+++ b/src/world/scenes/AGENT_GLOSSARY.md
@@ -26,7 +26,7 @@ A single IC contribution recorded within a scene — the atomic unit of RP (pose
 _Avoid_: message, post, line, Interaction (at player surfaces)
 
 **Effort Level**:
-The initiator's declared exertion on a social action (`EffortLevel`: very low / low / medium / high / extreme), forwarded at dispatch. It is a check-roll modifier and charges the initiator social fatigue — orthogonal to a technique's power levers.
+The initiator's declared exertion on a social action (`EffortLevel`: very low / low / medium / high / extreme), forwarded at dispatch. It is a check-roll modifier and charges the initiator social fatigue — orthogonal to a technique's power levers. Accumulated social fatigue feeds back as a penalty on subsequent social check rolls (#2241): a character who has flirted several times in a scene sees their composure fatigue rise, penalizing later rolls.
 _Avoid_: intensity, difficulty (effort is the initiator's input, not the target's)
 
 **Difficulty Choice**:

--- a/src/world/scenes/action_services.py
+++ b/src/world/scenes/action_services.py
@@ -829,7 +829,7 @@ def _resolve_action_against_persona(
     from actions.constants import ActionCategory  # noqa: PLC0415
     from world.checks.services import collect_check_modifiers  # noqa: PLC0415
     from world.fatigue.constants import EFFORT_CHECK_MODIFIER  # noqa: PLC0415
-    from world.fatigue.services import apply_fatigue  # noqa: PLC0415
+    from world.fatigue.services import apply_fatigue, get_fatigue_penalty  # noqa: PLC0415
     from world.npc_services.social_disposition import (  # noqa: PLC0415
         apply_social_disposition_delta,
     )
@@ -855,6 +855,16 @@ def _resolve_action_against_persona(
     # technique's anima/intensity/fury levers, which scale cast power; the effort
     # cost axis is charged separately by apply_fatigue below.
     check_modifiers = EFFORT_CHECK_MODIFIER.get(action_request.effort_level, 0)
+    # Read the initiator's accumulated social fatigue penalty back into the check
+    # roll (#2241). Combat already does this (combat/services.py:323-329); social
+    # actions charged fatigue but never read it back, so repeated flirting had no
+    # diminishing-returns teeth. The penalty is 0 when FRESH, −1 through −4 as
+    # fatigue accumulates — the "getting tired of this" effect.
+    fatigue_penalty = get_fatigue_penalty(
+        action_request.initiator_persona.character_sheet,
+        ActionCategory.SOCIAL,
+    )
+    check_modifiers += fatigue_penalty
     if action_request.technique is not None:
         result = _resolve_enhanced_action(
             character=character,

--- a/src/world/scenes/social_difficulty.py
+++ b/src/world/scenes/social_difficulty.py
@@ -114,10 +114,25 @@ def resolved_base_difficulty(
 
     For a social action it is ``affection_base + (difficulty_choice relative to NORMAL) +
     difficulty_tier_modifier`` in tier space, clamped. Callers add the resist-effort increment.
+
+    For a non-social targeted action, only ``exploitable_tiers`` easing applies (a
+    Smitten target is easier to exploit in ALL ways, not just socially) — the
+    affection-derived base and ``difficulty_tier_modifier`` remain social-only.
     """
     template = action_request.action_template
-    if template is None or template.category != _SOCIAL_CATEGORY:
+    if template is None:
         return DIFFICULTY_VALUES[difficulty_choice]
+    if template.category != _SOCIAL_CATEGORY:
+        # Non-social: apply only exploitable easing (a Smitten target is easier to
+        # exploit in ALL ways), not affection base or tier modifier (#2241).
+        if target_sheet is None:
+            return DIFFICULTY_VALUES[difficulty_choice]
+        easing = _exploitable_easing(target_sheet)
+        if easing == 0:
+            return DIFFICULTY_VALUES[difficulty_choice]
+        choice_index = _TIER_ORDER.index(DifficultyChoice(difficulty_choice))
+        eased_index = max(0, choice_index - easing)
+        return DIFFICULTY_VALUES[_TIER_ORDER[eased_index]]
 
     affection = 0
     exploitable_easing = 0

--- a/src/world/scenes/tests/test_action_services.py
+++ b/src/world/scenes/tests/test_action_services.py
@@ -1053,6 +1053,56 @@ class TestEffortAndFatigueOnTargetedResolution(TestCase):
         )
         self.assertEqual(difficulty, DIFFICULTY_VALUES[DifficultyChoice.NORMAL])
 
+    @patch("world.scenes.action_services.start_action_resolution")
+    def test_social_fatigue_penalty_applied_to_check_roll(self, mock_resolve: MagicMock) -> None:
+        """#2241: accumulated social fatigue penalizes the initiator's check roll."""
+        from world.fatigue.services import get_or_create_fatigue_pool
+        from world.scenes.action_services import _resolve_action_against_persona
+
+        mock_resolve.return_value = _make_pending_resolution(success=True)
+        request = self._make_request(effort_level="medium")
+
+        # Accumulate enough social fatigue to enter a penalized zone.
+        # We add a large amount directly to guarantee we're past TIRED.
+        sheet = self.initiator.character_sheet
+        pool = get_or_create_fatigue_pool(sheet)
+        pool.social_current = 1000
+        pool.save(update_fields=["social_current"])
+
+        _resolve_action_against_persona(request, self.target, difficulty_override=None)
+
+        # The mock's call kwargs should include extra_modifiers with a negative
+        # fatigue penalty folded in. EFFORT_CHECK_MODIFIER[MEDIUM] = 0, so the
+        # only non-zero contribution to check_modifiers is the fatigue penalty.
+        call_kwargs = mock_resolve.call_args.kwargs
+        extra_modifiers = call_kwargs.get("extra_modifiers", 0)
+        # The fatigue penalty is negative (−2 for TIRED, −3 for OVEREXERTED, etc.).
+        self.assertLess(extra_modifiers, 0)
+
+    @patch("world.scenes.action_services.start_action_resolution")
+    def test_no_fatigue_penalty_when_fresh(self, mock_resolve: MagicMock) -> None:
+        """#2241: FRESH fatigue zone → zero penalty, check_modifiers unaffected."""
+        from world.fatigue.services import get_or_create_fatigue_pool
+        from world.scenes.action_services import _resolve_action_against_persona
+
+        mock_resolve.return_value = _make_pending_resolution(success=True)
+        request = self._make_request(effort_level="medium")
+
+        # Ensure the pool exists and is at 0 (FRESH).
+        pool = get_or_create_fatigue_pool(self.initiator.character_sheet)
+        pool.social_current = 0
+        pool.save(update_fields=["social_current"])
+
+        _resolve_action_against_persona(request, self.target, difficulty_override=None)
+
+        # MEDIUM effort modifier = 0, FRESH fatigue penalty = 0, so extra_modifiers
+        # should be 0 (plus any breakdown contributions, which are 0 for a bare
+        # test character with no conditions/modifiers).
+        call_kwargs = mock_resolve.call_args.kwargs
+        extra_modifiers = call_kwargs.get("extra_modifiers", 0)
+        # Allow for breakdown.total being 0 in a bare test setup.
+        self.assertEqual(extra_modifiers, 0)
+
 
 class TestDefenderSetsPlausibilityBandAtConsent(TestCase):
     """Task 4 (A4): defender supplies difficulty at consent; diverges per-target.

--- a/src/world/scenes/tests/test_social_difficulty.py
+++ b/src/world/scenes/tests/test_social_difficulty.py
@@ -134,3 +134,109 @@ class AffectionTierLadderTests(TestCase):
         apply_condition(self.target_sheet.character, smitten, severity=1)
         # Neutral base (Normal) − 2 exploitable tiers → Trivial.
         self.assertEqual(self._value(), DIFFICULTY_VALUES[DifficultyChoice.TRIVIAL])
+
+
+class NonSocialExploitableEasingTests(TestCase):
+    """#2241: exploitable_tiers easing extends beyond social-category checks."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        from world.seeds.relationship_scale import seed_relationship_scale_content
+
+        seed_relationship_scale_content()
+
+    def setUp(self) -> None:
+        from evennia.utils.idmapper.models import flush_cache
+
+        from world.character_sheets.factories import CharacterSheetFactory
+
+        flush_cache()
+        self.actor_sheet = CharacterSheetFactory()
+        self.target_sheet = CharacterSheetFactory()
+
+    def _non_social_request(self):
+        template = SimpleNamespace(category="items", difficulty_tier_modifier=0)
+        persona = SimpleNamespace(character_sheet=self.actor_sheet)
+        return SimpleNamespace(action_template=template, initiator_persona=persona)
+
+    def test_non_social_no_target_uses_absolute_choice(self) -> None:
+        """Non-social with no target → raw difficulty choice (no easing)."""
+        req = self._non_social_request()
+        value = resolved_base_difficulty(
+            action_request=req,
+            difficulty_choice=DifficultyChoice.HARD,
+            target_sheet=None,
+        )
+        self.assertEqual(value, DIFFICULTY_VALUES[DifficultyChoice.HARD])
+
+    def test_non_social_no_exploitable_condition_is_unaffected(self) -> None:
+        """Non-social with a target but no exploitable condition → raw difficulty."""
+        req = self._non_social_request()
+        value = resolved_base_difficulty(
+            action_request=req,
+            difficulty_choice=DifficultyChoice.HARD,
+            target_sheet=self.target_sheet,
+        )
+        self.assertEqual(value, DIFFICULTY_VALUES[DifficultyChoice.HARD])
+
+    def test_non_social_with_exploitable_condition_eases_tiers(self) -> None:
+        """Non-social with a Smitten target → eased by exploitable_tiers."""
+        from world.conditions.services import apply_condition
+        from world.seeds.social_actions import ensure_smitten_condition
+
+        smitten = ensure_smitten_condition()
+        apply_condition(self.target_sheet.character, smitten, severity=1)
+        req = self._non_social_request()
+        # HARD (index 3) − 2 exploitable tiers → EASY (index 1).
+        value = resolved_base_difficulty(
+            action_request=req,
+            difficulty_choice=DifficultyChoice.HARD,
+            target_sheet=self.target_sheet,
+        )
+        self.assertEqual(value, DIFFICULTY_VALUES[DifficultyChoice.EASY])
+
+    def test_non_social_exploitable_easing_clamps_at_trivial(self) -> None:
+        """Easing clamps at the bottom of the tier ladder (Trivial)."""
+        from world.conditions.services import apply_condition
+        from world.seeds.social_actions import ensure_smitten_condition
+
+        smitten = ensure_smitten_condition()
+        apply_condition(self.target_sheet.character, smitten, severity=1)
+        req = self._non_social_request()
+        # NORMAL (index 2) − 2 exploitable tiers → TRIVIAL (index 0).
+        value = resolved_base_difficulty(
+            action_request=req,
+            difficulty_choice=DifficultyChoice.NORMAL,
+            target_sheet=self.target_sheet,
+        )
+        self.assertEqual(value, DIFFICULTY_VALUES[DifficultyChoice.TRIVIAL])
+
+    def test_non_social_exploitable_easing_no_affection_base(self) -> None:
+        """Non-social easing does NOT apply affection-derived base (social-only)."""
+        from world.relationships.constants import TrackSystemKey
+        from world.relationships.models import (
+            CharacterRelationship,
+            RelationshipTrack,
+            RelationshipTrackProgress,
+        )
+
+        # Give the target high affection for the actor — should NOT ease a
+        # non-social check (affection base is social-only).
+        track = RelationshipTrack.objects.get(system_key=TrackSystemKey.REGARD)
+        relationship, _ = CharacterRelationship.objects.get_or_create(
+            source=self.target_sheet, target=self.actor_sheet
+        )
+        RelationshipTrackProgress.objects.create(
+            relationship=relationship,
+            track=track,
+            capacity=2000,
+            developed_points=2000,
+        )
+        req = self._non_social_request()
+        value = resolved_base_difficulty(
+            action_request=req,
+            difficulty_choice=DifficultyChoice.NORMAL,
+            target_sheet=self.target_sheet,
+        )
+        # No exploitable condition → raw difficulty, despite high affection.
+        self.assertEqual(value, DIFFICULTY_VALUES[DifficultyChoice.NORMAL])

--- a/src/world/seeds/social_actions.py
+++ b/src/world/seeds/social_actions.py
@@ -186,9 +186,11 @@ def ensure_smitten_condition():
     - A ``ConditionCheckModifier`` penalizing the bearer's Melee Defense — they
       defend worse while captivated.
     - A ``ConditionDamageInteraction`` boosting Force damage against the bearer
-      (rides the #2018 wiring). PLACEHOLDER: keyed to Force until a generic
-      physical DamageType exists; full surprise-attack semantics are a combat
-      design question (TehomCD), deliberately not built here.
+      (rides the #2018 wiring), keyed to Force (the physical damage type).
+
+    The condition-scoped modifier package (defense penalty + damage amplification
+    + tier easing) IS the surprise-attack mechanic — no separate combat primitive
+    is needed. Ratified in #2241: the shipped shape is the final shape.
 
     Applied by Seduce, not Flirt. Field updates are explicit writes / upserts so
     re-seeding applies edits (#946).


### PR DESCRIPTION
Closes #2241

## Summary

Resolves all three design questions from #2241 (epic #1695 audit remainders): surprise-attack semantics (condition-scoped, docstring settled), social fatigue penalty (wired into check roll), rank-delta easing (extended beyond social-category).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2241 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: up to date, no conflicts

<!-- last-addressed-comment: 0 -->