### PR TITLE
Recurring intel feed: rotating clue pool for asset intel tasks

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2623,13 +2623,35 @@ ADR-0091.
   than inventing new Trait rows — framework-proving only. The #1907 variants
   gate on Persuasion (GUARD, FAN) and Scholarship (MINOR_ALLY), rolling
   Intimidation/Gossip/Domain Investment checks respectively.
+- **Intel tasking** (#1905, #2293): `ASSET_TASK_INTEL` `OfferKind` +
+  `run_asset_intel_task` effect handler. The PC directs an owned asset to
+  gather intel — a `perform_check` gates success (failure = "nothing useful
+  to report"), and on success a `Clue` is drawn from a weighted `CluePool`
+  (#2293: replaced the single fixed `clue` FK with a `clue_pool` FK on
+  `AssetTaskIntelDetails`). The draw excludes clues the promoter's
+  `RosterEntry` already holds (via `CharacterClue`), and when the pool is
+  exhausted (all clues held) the offer becomes ineligible — hidden from
+  `available_offers` via `_intel_pool_has_unheld_clues` in
+  `world.npc_services.services`. Per-(offer, persona) `OfferCooldown` still
+  gates recurrence. The asset itself can be lost (`AssetStatus.COMPROMISED`/
+  `LOST`/`DISMISSED`), removing the intel source entirely. This embodies
+  ADR-0081: no dependable, entirely passive generation — the pool is finite,
+  the check can fail, the cooldown gates recurrence, and the asset can be
+  lost. Staff must add new clues to replenish an exhausted pool.
+  - **`CluePool`** (`world.assets.models`): named, reusable collection of
+    clues with weighted `CluePoolEntry` rows (default weight 1, min 1).
+    Mirrors `ConsequencePool`'s shape but purpose-built for clues — no
+    inheritance/exclusion machinery.
+  - **`CluePoolEntry`**: links a `Clue` to a `CluePool` with a draw weight.
+    Unique per (pool, clue). Drawn via the shared `select_weighted` utility
+    (`world.checks.outcome_utils`).
 - **REST API:** `world.assets.views.NPCAssetViewSet` — read-only, mounted
   at `/api/assets/`, scoped to the requesting user's own promoted assets.
 - **Source:** `src/world/assets/`
 
 Deferred follow-ups: distinction-granted starting assets (`needs-design`),
-asset gameplay loops (tasking/intel/income), compromise/loss lifecycle,
-voluntary asset sharing.
+money streams (asset-generated income — ADR-0081 constrains to active
+collection), voluntary asset sharing.
 
 ### Room Features (Plan 4 framework — Subsystem E)
 Plan 4 (#669, shipped via #703). Generic per-room enhancement framework — a

--- a/src/world/assets/admin.py
+++ b/src/world/assets/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from world.assets.models import DistinctionAssetGrant, NPCAsset
+from world.assets.models import CluePool, CluePoolEntry, DistinctionAssetGrant, NPCAsset
 
 
 @admin.register(NPCAsset)
@@ -36,3 +36,16 @@ class DistinctionAssetGrantAdmin(admin.ModelAdmin):
     # for NPCRole in world.npc_services, and autocomplete_fields requires the
     # target model's admin to declare search_fields (admin.E039).
     autocomplete_fields = ["distinction"]
+
+
+class CluePoolEntryInline(admin.TabularInline):
+    model = CluePoolEntry
+    extra = 1
+    autocomplete_fields = ["clue"]
+
+
+@admin.register(CluePool)
+class CluePoolAdmin(admin.ModelAdmin):
+    list_display = ["name", "description"]
+    search_fields = ["name"]
+    inlines = [CluePoolEntryInline]

--- a/src/world/assets/effects.py
+++ b/src/world/assets/effects.py
@@ -16,7 +16,10 @@ from world.assets.constants import AssetRoleContext
 from world.npc_services.effects import EffectResult
 
 if TYPE_CHECKING:
+    from world.assets.models import CluePool
+    from world.clues.models import Clue
     from world.npc_services.models import NPCServiceOffer
+    from world.roster.models import RosterEntry
     from world.scenes.models import Persona
 
 _FUNCTIONARY_GONE_MESSAGE = "They're no longer here."
@@ -133,22 +136,45 @@ def promote_as_minor_ally(offer: NPCServiceOffer, persona: Persona) -> EffectRes
     return _promote_functionary(offer, persona, role_context=AssetRoleContext.MINOR_ALLY)
 
 
+def _draw_clue_from_pool(pool: CluePool, roster_entry: RosterEntry) -> Clue | None:
+    """Draw a weighted random clue from the pool, excluding held clues (#2293).
+
+    Returns the drawn Clue, or None if the promoter holds every clue in
+    the pool (pool exhausted for this persona).
+    """
+    from world.checks.outcome_utils import select_weighted  # noqa: PLC0415
+    from world.clues.models import CharacterClue  # noqa: PLC0415
+
+    held_clue_ids = set(
+        CharacterClue.objects.filter(roster_entry=roster_entry).values_list("clue_id", flat=True)
+    )
+    available_entries = [
+        e for e in pool.entries.select_related("clue") if e.clue_id not in held_clue_ids
+    ]
+    if not available_entries:
+        return None
+    drawn = select_weighted(available_entries)
+    return drawn.clue
+
+
 @transaction.atomic
 def run_asset_intel_task(offer: NPCServiceOffer, persona: Persona) -> EffectResult:
-    """ASSET_TASK_INTEL effect handler (#1905).
+    """ASSET_TASK_INTEL effect handler (#1905, #2293).
 
     Resolves the active NPCAsset owned by the interacting persona, rolls
-    the offer's check, and on success grants a CharacterClue to the
-    promoter's roster entry. The PC rolls the check (they're directing the
-    task; the check models how well they've cultivated the asset's cooperation).
+    the offer's check, and on success draws a clue from the pool (excluding
+    clues the promoter already holds) and grants a CharacterClue. The PC
+    rolls the check (they're directing the task; the check models how well
+    they've cultivated the asset's cooperation).
 
     Requires the offer to have an AssetTaskIntelDetails row pointing at the
-    Clue to grant. Returns a failure EffectResult if the asset is not ACTIVE,
-    the check fails, or the details row is missing.
+    CluePool to draw from. Returns a failure EffectResult if the asset is
+    not ACTIVE, the check fails, the details row is missing, or the pool
+    is exhausted (all clues already held).
     """
     from world.assets.constants import AssetStatus  # noqa: PLC0415
 
-    # Resolve the details row (the clue to grant).
+    # Resolve the details row (the clue pool to draw from).
     from world.assets.models import (  # noqa: PLC0415
         AssetTaskIntelDetails,
         NPCAsset,
@@ -190,7 +216,7 @@ def run_asset_intel_task(offer: NPCServiceOffer, persona: Persona) -> EffectResu
                 message="Your asset has nothing useful to report this time.",
             )
 
-    # Grant the clue to the promoter's roster entry.
+    # Resolve the promoter's roster entry for the clue grant.
     roster_entry = RosterEntry.objects.filter(character_sheet=persona.character_sheet).first()
     if roster_entry is None:
         return EffectResult(
@@ -198,15 +224,23 @@ def run_asset_intel_task(offer: NPCServiceOffer, persona: Persona) -> EffectResu
             message="Your asset brings back word, but there's nowhere to record it.",
         )
 
+    # Draw a clue from the pool, excluding clues the promoter already holds.
+    drawn_clue = _draw_clue_from_pool(details.clue_pool, roster_entry)
+    if drawn_clue is None:
+        return EffectResult(
+            kind=offer.kind,
+            message="Your asset has nothing new to report. They've told you everything they know.",
+        )
+
     CharacterClue.objects.get_or_create(
         roster_entry=roster_entry,
-        clue=details.clue,
+        clue=drawn_clue,
     )
 
     return EffectResult(
         kind=offer.kind,
-        object_pk=details.clue.pk,
-        object_label=details.clue.name,
-        message=f"Your asset brings back word: {details.clue.name}.",
-        payload={"clue_pk": details.clue.pk, "asset_pk": asset.pk},
+        object_pk=drawn_clue.pk,
+        object_label=drawn_clue.name,
+        message=f"Your asset brings back word: {drawn_clue.name}.",
+        payload={"clue_pk": drawn_clue.pk, "asset_pk": asset.pk},
     )

--- a/src/world/assets/factories.py
+++ b/src/world/assets/factories.py
@@ -6,7 +6,7 @@ import factory
 from factory.django import DjangoModelFactory
 
 from world.assets.constants import AssetRoleContext
-from world.assets.models import NPCAsset
+from world.assets.models import CluePool, CluePoolEntry, NPCAsset
 
 _PERSONA_FACTORY = "world.scenes.factories.PersonaFactory"
 
@@ -19,3 +19,20 @@ class NPCAssetFactory(DjangoModelFactory):
     asset_persona = factory.SubFactory(_PERSONA_FACTORY)
     role_context = AssetRoleContext.INFORMANT
     source_functionary = factory.SubFactory("world.npc_services.factories.FunctionaryFactory")
+
+
+class CluePoolFactory(DjangoModelFactory):
+    class Meta:
+        model = CluePool
+
+    name = factory.Sequence(lambda n: f"Clue Pool {n}")
+    description = "A pool of clues for intel tasks."
+
+
+class CluePoolEntryFactory(DjangoModelFactory):
+    class Meta:
+        model = CluePoolEntry
+
+    pool = factory.SubFactory(CluePoolFactory)
+    clue = factory.SubFactory("world.clues.factories.ClueFactory")
+    weight = 1

--- a/src/world/assets/migrations/0008_clue_pool.py
+++ b/src/world/assets/migrations/0008_clue_pool.py
@@ -1,0 +1,116 @@
+"""Add CluePool + CluePoolEntry; swap AssetTaskIntelDetails.clue → clue_pool (#2293)."""
+
+from django.core.validators import MinValueValidator
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("assets", "0007_asset_task_intel_details"),
+        ("clues", "0009_clue_target_persona_clue_target_persona_linked_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CluePool",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "name",
+                    models.CharField(
+                        help_text="Human-readable pool name (e.g., 'Rumors of Arx').",
+                        max_length=100,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "description",
+                    models.TextField(
+                        blank=True,
+                        help_text="GM authoring context for this pool.",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Clue Pool",
+                "verbose_name_plural": "Clue Pools",
+            },
+        ),
+        migrations.CreateModel(
+            name="CluePoolEntry",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "weight",
+                    models.PositiveIntegerField(
+                        default=1,
+                        help_text=(
+                            "Draw weight. Higher = more likely to be drawn. "
+                            "Default 1 = uniform. Minimum 1."
+                        ),
+                        validators=[MinValueValidator(1)],
+                    ),
+                ),
+                (
+                    "pool",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="entries",
+                        to="assets.cluepool",
+                    ),
+                ),
+                (
+                    "clue",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="pool_entries",
+                        to="clues.clue",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Clue Pool Entry",
+                "verbose_name_plural": "Clue Pool Entries",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="cluepoolentry",
+            constraint=models.UniqueConstraint(
+                fields=["pool", "clue"],
+                name="unique_clue_pool_entry",
+            ),
+        ),
+        # Remove the old single-clue FK and add the new clue_pool FK.
+        # No data migration — there is no existing production data.
+        migrations.RemoveField(
+            model_name="assettaskinteldetails",
+            name="clue",
+        ),
+        migrations.AddField(
+            model_name="assettaskinteldetails",
+            name="clue_pool",
+            field=models.ForeignKey(
+                help_text="The pool of clues this intel task draws from.",
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="intel_task_offers",
+                to="assets.cluepool",
+            ),
+        ),
+    ]

--- a/src/world/assets/migrations/max_migration.txt
+++ b/src/world/assets/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0007_asset_task_intel_details
+0008_clue_pool

--- a/src/world/assets/models.py
+++ b/src/world/assets/models.py
@@ -7,6 +7,7 @@ check or room placement required.
 
 from __future__ import annotations
 
+from django.core.validators import MinValueValidator
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
@@ -173,12 +174,14 @@ class DistinctionAssetGrant(SharedMemoryModel):
 
 
 class AssetTaskIntelDetails(SharedMemoryModel):
-    """Per-kind details for ASSET_TASK_INTEL offers (#1905).
+    """Per-kind details for ASSET_TASK_INTEL offers (#1905, #2293).
 
     Mirrors the existing per-kind details pattern (PermitOfferDetails,
     LoanOfferDetails, CourtGrantOfferDetails) — a 1:1 reverse from
     NPCServiceOffer carrying the kind-specific parameters. For intel tasks,
-    the parameter is the Clue granted on a successful check.
+    the parameter is the CluePool the task draws from (#2293: replaced the
+    single ``clue`` FK with a ``clue_pool`` FK so repeated tasking yields
+    different intel over time).
     """
 
     offer = models.OneToOneField(
@@ -186,11 +189,11 @@ class AssetTaskIntelDetails(SharedMemoryModel):
         on_delete=models.CASCADE,
         related_name="asset_task_intel_details",
     )
-    clue = models.ForeignKey(
-        "clues.Clue",
+    clue_pool = models.ForeignKey(
+        "assets.CluePool",
         on_delete=models.PROTECT,
-        related_name="asset_task_offers",
-        help_text="The clue granted on a successful intel task.",
+        related_name="intel_task_offers",
+        help_text="The pool of clues this intel task draws from.",
     )
 
     class Meta:
@@ -198,4 +201,73 @@ class AssetTaskIntelDetails(SharedMemoryModel):
         verbose_name_plural = "Asset Task Intel Details"
 
     def __str__(self) -> str:
-        return f"Intel task: {self.clue.name}"
+        return f"Intel task: {self.clue_pool.name}"
+
+
+class CluePool(SharedMemoryModel):
+    """Named, reusable collection of clues for asset intel task draws (#2293).
+
+    Staff-authored pool of clues that an ASSET_TASK_INTEL offer draws from.
+    Each draw selects a weighted random clue, excluding clues the promoter's
+    roster entry already holds. When all clues are held, the offer becomes
+    ineligible (hidden from the interaction menu) until staff adds new clues.
+
+    Mirrors ConsequencePool's shape (named pool + weighted entries) but is
+    purpose-built for clues — no inheritance, no exclusions, no consequence-
+    specific fields.
+    """
+
+    name = models.CharField(
+        max_length=100,
+        unique=True,
+        help_text="Human-readable pool name (e.g., 'Rumors of Arx').",
+    )
+    description = models.TextField(
+        blank=True,
+        help_text="GM authoring context for this pool.",
+    )
+
+    class Meta:
+        verbose_name = "Clue Pool"
+        verbose_name_plural = "Clue Pools"
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class CluePoolEntry(SharedMemoryModel):
+    """Links a Clue to a CluePool with a draw weight (#2293).
+
+    Mirrors ConsequencePoolEntry's shape but with a non-nullable weight
+    (default 1, minimum 1) instead of an optional weight_override — clues
+    have no natural default weight to fall back to.
+    """
+
+    pool = models.ForeignKey(
+        CluePool,
+        on_delete=models.CASCADE,
+        related_name="entries",
+    )
+    clue = models.ForeignKey(
+        "clues.Clue",
+        on_delete=models.PROTECT,
+        related_name="pool_entries",
+    )
+    weight = models.PositiveIntegerField(
+        default=1,
+        validators=[MinValueValidator(1)],
+        help_text="Draw weight. Higher = more likely to be drawn. Default 1 = uniform. Minimum 1.",
+    )
+
+    class Meta:
+        verbose_name = "Clue Pool Entry"
+        verbose_name_plural = "Clue Pool Entries"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["pool", "clue"],
+                name="unique_clue_pool_entry",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.pool.name}: {self.clue.name} (weight {self.weight})"

--- a/src/world/assets/tests/test_asset_tasking.py
+++ b/src/world/assets/tests/test_asset_tasking.py
@@ -1,27 +1,35 @@
-"""E2E tests for ASSET_TASK_INTEL offer (#1905).
+"""E2E tests for ASSET_TASK_INTEL offer (#1905, #2293).
 
 Tests the full resolve_offer → dispatch_offer_effect → run_asset_intel_task
 pipeline: PC interacts with their asset, selects the intel task offer, check
-is rolled, and a CharacterClue is granted on success.
+is rolled, and a CharacterClue is drawn from the pool and granted on success.
+
+#2293: the single fixed clue is replaced with a CluePool. Tests cover pool
+draw, exclusion of already-held clues, pool-exhaustion hiding, and weighted
+distribution.
 """
 
 from __future__ import annotations
 
+from collections import Counter
+
 from evennia.utils.test_resources import EvenniaTestCase
 
 from world.assets.constants import AssetStatus
-from world.assets.factories import NPCAssetFactory
+from world.assets.factories import CluePoolEntryFactory, CluePoolFactory, NPCAssetFactory
 from world.assets.models import AssetTaskIntelDetails
 from world.clues.factories import ClueFactory
+from world.clues.models import CharacterClue
 from world.npc_services.constants import OfferKind
 from world.npc_services.effects import dispatch_offer_effect, reset_offer_effect_handlers
 from world.npc_services.factories import NPCRoleFactory
 from world.npc_services.models import NPCServiceOffer
+from world.npc_services.services import available_offers, start_interaction
 from world.roster.factories import RosterEntryFactory
 
 
 class AssetTaskIntelHandlerTests(EvenniaTestCase):
-    """Tests for the ASSET_TASK_INTEL offer effect handler (#1905)."""
+    """Tests for the ASSET_TASK_INTEL offer effect handler (#1905, #2293)."""
 
     def setUp(self) -> None:
         super().setUp()
@@ -37,8 +45,14 @@ class AssetTaskIntelHandlerTests(EvenniaTestCase):
         # Build an active asset owned by the promoter.
         self.asset = NPCAssetFactory(promoter_persona=self.promoter)
 
-        # Build a Clue for the intel task to grant.
-        self.clue = ClueFactory()
+        # Build a CluePool with 3 clues for the intel task to draw from.
+        self.pool = CluePoolFactory()
+        self.clue_a = ClueFactory()
+        self.clue_b = ClueFactory()
+        self.clue_c = ClueFactory()
+        CluePoolEntryFactory(pool=self.pool, clue=self.clue_a, weight=1)
+        CluePoolEntryFactory(pool=self.pool, clue=self.clue_b, weight=1)
+        CluePoolEntryFactory(pool=self.pool, clue=self.clue_c, weight=1)
 
         # Build an NPCRole + an ASSET_TASK_INTEL offer + details.
         self.role = NPCRoleFactory()
@@ -50,26 +64,27 @@ class AssetTaskIntelHandlerTests(EvenniaTestCase):
         )
         AssetTaskIntelDetails.objects.create(
             offer=self.offer,
-            clue=self.clue,
+            clue_pool=self.pool,
         )
 
     def tearDown(self) -> None:
         reset_offer_effect_handlers()
         super().tearDown()
 
-    def test_successful_intel_task_grants_clue(self) -> None:
-        """A successful intel task grants a CharacterClue to the promoter."""
+    def test_successful_intel_task_grants_clue_from_pool(self) -> None:
+        """A successful intel task grants a CharacterClue drawn from the pool."""
         result = dispatch_offer_effect(self.offer, self.promoter)
 
         self.assertTrue(result.message.startswith("Your asset brings back word"))
-        self.assertEqual(result.object_label, self.clue.name)
-        # CharacterClue should be created for the promoter's roster entry.
-        from world.clues.models import CharacterClue
-
-        clue_held = CharacterClue.objects.filter(
-            roster_entry=self.roster_entry, clue=self.clue
-        ).exists()
-        self.assertTrue(clue_held)
+        # The granted clue must be one of the pool's clues.
+        granted_clue_ids = set(
+            CharacterClue.objects.filter(roster_entry=self.roster_entry).values_list(
+                "clue_id", flat=True
+            )
+        )
+        pool_clue_ids = {self.clue_a.pk, self.clue_b.pk, self.clue_c.pk}
+        self.assertTrue(granted_clue_ids.issubset(pool_clue_ids))
+        self.assertEqual(len(granted_clue_ids), 1)
 
     def test_no_active_asset_returns_failure(self) -> None:
         """When the promoter has no active asset, the handler returns a failure."""
@@ -93,3 +108,91 @@ class AssetTaskIntelHandlerTests(EvenniaTestCase):
         result = dispatch_offer_effect(offer_without_details, self.promoter)
 
         self.assertIn("Authoring error", result.message)
+
+    def test_pool_excludes_already_held_clues(self) -> None:
+        """Already-held clues are never drawn from the pool."""
+        # Pre-grant clue_a to the promoter.
+        CharacterClue.objects.create(
+            roster_entry=self.roster_entry,
+            clue=self.clue_a,
+        )
+
+        # Draw multiple times — should never return clue_a.
+        for _ in range(10):
+            result = dispatch_offer_effect(self.offer, self.promoter)
+            self.assertNotEqual(result.object_label, self.clue_a.name)
+
+    def test_pool_exhaustion_returns_nothing_new(self) -> None:
+        """When all clues are held, the handler returns 'nothing new to report'."""
+        # Grant all three clues.
+        CharacterClue.objects.create(roster_entry=self.roster_entry, clue=self.clue_a)
+        CharacterClue.objects.create(roster_entry=self.roster_entry, clue=self.clue_b)
+        CharacterClue.objects.create(roster_entry=self.roster_entry, clue=self.clue_c)
+
+        result = dispatch_offer_effect(self.offer, self.promoter)
+
+        self.assertIn("nothing new to report", result.message.lower())
+
+    def test_pool_exhaustion_hides_offer(self) -> None:
+        """When all clues are held, the offer is ineligible (hidden from available_offers)."""
+        # Grant all three clues.
+        CharacterClue.objects.create(roster_entry=self.roster_entry, clue=self.clue_a)
+        CharacterClue.objects.create(roster_entry=self.roster_entry, clue=self.clue_b)
+        CharacterClue.objects.create(roster_entry=self.roster_entry, clue=self.clue_c)
+
+        session = start_interaction(
+            role=self.role,
+            persona=self.promoter,
+            character=self.character,
+        )
+        offers = available_offers(session)
+        self.assertNotIn(self.offer, offers)
+
+    def test_pool_not_exhausted_shows_offer(self) -> None:
+        """When some clues remain unheld, the offer is still eligible."""
+        # Grant only one clue — two remain.
+        CharacterClue.objects.create(roster_entry=self.roster_entry, clue=self.clue_a)
+
+        session = start_interaction(
+            role=self.role,
+            persona=self.promoter,
+            character=self.character,
+        )
+        offers = available_offers(session)
+        self.assertIn(self.offer, offers)
+
+    def test_weighted_draw_distribution(self) -> None:
+        """Weighted clues appear at roughly the expected frequency."""
+        # Rebuild the pool with weights 3:1.
+        weighted_pool = CluePoolFactory()
+        clue_common = ClueFactory()
+        clue_rare = ClueFactory()
+        CluePoolEntryFactory(pool=weighted_pool, clue=clue_common, weight=3)
+        CluePoolEntryFactory(pool=weighted_pool, clue=clue_rare, weight=1)
+
+        weighted_offer = NPCServiceOffer.objects.create(
+            role=self.role,
+            kind=OfferKind.ASSET_TASK_INTEL,
+            label="Weighted Intel",
+            is_final=True,
+        )
+        AssetTaskIntelDetails.objects.create(
+            offer=weighted_offer,
+            clue_pool=weighted_pool,
+        )
+
+        # Draw 40 times (resetting the held clue each time so the pool
+        # doesn't exhaust). With weight 3:1, we expect ~30 common / ~10 rare.
+        # Use a loose assertion: common should appear more than half the time.
+        results: list[str] = []
+        for _ in range(40):
+            result = dispatch_offer_effect(weighted_offer, self.promoter)
+            results.append(result.object_label)
+            # Clear the granted clue so the next draw is from the full pool.
+            CharacterClue.objects.filter(
+                roster_entry=self.roster_entry,
+                clue__in=[clue_common, clue_rare],
+            ).delete()
+
+        counts = Counter(results)
+        self.assertGreater(counts[clue_common.name], counts[clue_rare.name])

--- a/src/world/npc_services/services.py
+++ b/src/world/npc_services/services.py
@@ -217,7 +217,7 @@ def _build_eligibility_cache(
     )
 
 
-def _is_offer_eligible(  # noqa: PLR0913
+def _is_offer_eligible(  # noqa: PLR0911, PLR0913
     offer: NPCServiceOffer,
     *,
     persona: Persona,
@@ -274,8 +274,38 @@ def _is_offer_eligible(  # noqa: PLR0913
         offer=offer, persona=persona, character=character, cache=cache
     ):
         return False
+    if offer.kind == OfferKind.ASSET_TASK_INTEL.value and not _intel_pool_has_unheld_clues(
+        offer=offer, persona=persona
+    ):
+        return False
     ctx = CharacterPredicateContext(character, presented_persona=persona)
     return evaluate(offer.eligibility_rule or {}, ctx)
+
+
+def _intel_pool_has_unheld_clues(*, offer: NPCServiceOffer, persona: Persona) -> bool:
+    """Check whether the offer's clue pool has at least one unheld clue (#2293).
+
+    Returns False (offer ineligible) when the persona's roster entry already
+    holds every clue in the pool — the intel source is exhausted. Also returns
+    False on authoring errors (missing details row, missing roster entry) to
+    fail closed, consistent with ``_mission_gates_pass``.
+    """
+    from world.assets.models import AssetTaskIntelDetails  # noqa: PLC0415
+    from world.clues.models import CharacterClue  # noqa: PLC0415
+    from world.roster.models import RosterEntry  # noqa: PLC0415
+
+    try:
+        details = offer.asset_task_intel_details
+    except AssetTaskIntelDetails.DoesNotExist:
+        return False
+    roster_entry = RosterEntry.objects.filter(character_sheet=persona.character_sheet).first()
+    if roster_entry is None:
+        return False
+    held_clue_ids = set(
+        CharacterClue.objects.filter(roster_entry=roster_entry).values_list("clue_id", flat=True)
+    )
+    pool_clue_ids = set(details.clue_pool.entries.values_list("clue_id", flat=True))
+    return bool(pool_clue_ids - held_clue_ids)
 
 
 def _mission_gates_pass(  # noqa: PLR0911


### PR DESCRIPTION
Closes #2293

## Summary

Replace the single fixed Clue FK on AssetTaskIntelDetails with a weighted CluePool + CluePoolEntry model pair. The intel task handler now draws a weighted random clue from the pool, excluding clues the promoter already holds. When the pool is exhausted (all clues collected), the offer becomes ineligible and disappears from the interaction menu. This embodies ADR-0081: no dependable, entirely passive generation of wealth.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2293 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Already up to date with main (no conflicts).

<!-- last-addressed-comment: 0 -->