### PR TITLE
Food collection mini-game — needs-design

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2838,6 +2838,16 @@ a character actively collects it via a lossy check-based dispatch (mirrors
 population consumes food weekly with shortage raising unrest and lowering
 prosperity.
 
+**Food collection mini-game (#2218):** Collection is a two-event reactive flow.
+Before the pool is zeroed, `FOOD_PRE_COLLECT` fires with a mutable
+`FoodPreCollectPayload` — reactive flows may inspect the pool size, adjust the
+`difficulty_modifier` (intimidation, persuasion, bribery), or cancel the
+collection entirely (pool stays intact). After the outcome resolves,
+`FOOD_COLLECTED` fires with a frozen `FoodCollectedPayload` for post-hoc
+reactions (spawn a bandit ambush on catastrophe, etc.). Pool size scales
+difficulty: pools above `FoodConfig.pool_difficulty_threshold` add +1 difficulty
+per `pool_difficulty_step`, capped at `pool_difficulty_max_bonus`.
+
 - **Models** (`world.agriculture.models`):
   - `CropType` — staff-authored catalog (name, base_production, description).
   - `FieldDetails` — OneToOne to `RoomFeatureInstance`; carries `crop_type` FK
@@ -2848,15 +2858,19 @@ prosperity.
   - `FoodStockpile` — OneToOne to `Domain`; `stored` balance + `last_collected_at`.
     Lazily created via `get_or_create` in `collect_field_food`.
   - `FoodConfig` — singleton (pk=1) tuning knobs: production rate, consumption
-    per capita, shortage penalties, granary capacity per level.
+    per capita, shortage penalties, granary capacity per level, and pool-size
+    difficulty scaling (`pool_difficulty_threshold` / `pool_difficulty_step` /
+    `pool_difficulty_max_bonus`, #2218).
 - **Services** (`world.agriculture.services`):
   - `field_production_tick()` — daily cron; accrues `base_production × level ×
     multiplier` into each active Field's `uncollected_pool`.
   - `collect_field_food(character, field_instance)` — active collection dispatch;
-    zeroes pool, rolls a Food Collection check, applies `COLLECTION_BAND_PCTS`
-    (reused from currency), then **unrest skims the haul** (`_apply_unrest_skim`,
-    #2238), lands food into domain's `FoodStockpile` (capped at Granary capacity;
-    excess is overflow/lost).
+    emits `FOOD_PRE_COLLECT` (cancellable, #2218), zeroes pool, rolls a Food
+    Collection check at effective difficulty (base + pool bonus + reactive
+    modifier), applies `COLLECTION_BAND_PCTS` (reused from currency), then
+    **unrest skims the haul** (`_apply_unrest_skim`, #2238), lands food into
+    domain's `FoodStockpile` (capped at Granary capacity; excess is
+    overflow/lost), emits `FOOD_COLLECTED`.
   - `domain_consumption_tick()` — weekly cron (part of weekly rollover); the
     domain **civ-stat update**: population consumes food; shortage raises unrest +
     lowers prosperity; a **well-fed** week instead relaxes unrest + recovers
@@ -2867,15 +2881,22 @@ prosperity.
     `AreaClosure` ancestor chain to find the `Domain`.
   - `max_food_capacity(domain)` — sums `granary.level × capacity_per_level`
     across all active Granaries in the domain's area subtree.
+- **Flow service functions** (`flows.service_functions.agriculture`):
+  - `food_collection_difficulty` — flow-callable wrapper that computes the
+    pool-size difficulty bonus for a collection attempt (#2218).
 - **Action:** `CollectFoodAction` (key `"collect_food"`, category
   `"agriculture"`) — the single commit seam for telnet + web. Resolves its Field
   from a pre-resolved `field_instance`, a `field_instance_id` (web/REST — the REST
   path does no ObjectDB resolution, so the action resolves it), or the active FIELD
-  feature in `actor.location` (telnet). **Surfaces (#2237):** telnet `harvest`
+  feature in `actor.location` (telnet). Handles cancelled results (returns
+  failure with `cancelled: True`). **Surfaces (#2237):** telnet `harvest`
   (`commands/agriculture.py` `CmdHarvest`) + web `POST /api/agriculture/collect/`
   (`CollectFoodView`, body `{field_instance_id}`). Without a surface the loop
   couldn't close — the pool filled but never drained.
-- **Events:** `FOOD_COLLECTED`, `FOOD_SHORTAGE` (in `flows/constants.py`).
+- **Events:** `FOOD_PRE_COLLECT` (cancellable pre-collect, #2218),
+  `FOOD_COLLECTED` (post-collect outcome), `FOOD_SHORTAGE` (in
+  `flows/constants.py`). Payloads: `FoodPreCollectPayload` (mutable),
+  `FoodCollectedPayload` (frozen) in `flows/events/payloads.py`.
 - **Cron tasks:** `agriculture.field_production` (daily 24h),
   `agriculture.domain_consumption` (weekly, via weekly rollover).
 - **Seeds:** `ensure_field_granary_kinds()` + `ensure_starter_crop_types()`

--- a/src/actions/definitions/collect_food.py
+++ b/src/actions/definitions/collect_food.py
@@ -86,6 +86,18 @@ class CollectFoodAction(Action):
         except ValueError as exc:
             return ActionResult(success=False, message=str(exc))
 
+        if result.cancelled:
+            return ActionResult(
+                success=False,
+                message="Your collection attempt was thwarted — the food remains in the field.",
+                data={
+                    "gathered": result.gathered,
+                    "landed": result.landed,
+                    "overflow": result.overflow,
+                    "cancelled": True,
+                },
+            )
+
         if result.catastrophe:
             return ActionResult(
                 success=True,

--- a/src/flows/constants.py
+++ b/src/flows/constants.py
@@ -62,6 +62,7 @@ class EventName(models.TextChoices):
     ENGAGEMENT_LOCK_FORMED = "engagement_lock_formed", "Engagement Lock Formed"
     ENGAGEMENT_LOCK_BROKEN = "engagement_lock_broken", "Engagement Lock Broken"
     # Agriculture (crop/food system, #1864)
+    FOOD_PRE_COLLECT = "food_pre_collect", "Food Pre-Collect"
     FOOD_COLLECTED = "food_collected", "Food Collected"
     FOOD_SHORTAGE = "food_shortage", "Food Shortage"
     # Asset lifecycle (#1905) — emitted post-transition by transition_asset_status().

--- a/src/flows/events/payloads.py
+++ b/src/flows/events/payloads.py
@@ -272,6 +272,49 @@ class AssetStatusPayload:
     reason: str
 
 
+# ---- Agriculture (#1864, #2218) ----
+
+
+@dataclass
+class FoodPreCollectPayload:
+    """Cancellable pre-collection payload for the food collection mini-game (#2218).
+
+    Emitted by ``collect_field_food`` *before* the pool is zeroed and the
+    check is rolled. Reactive flows may inspect the pool size and mutate
+    ``difficulty_modifier`` (e.g. intimidation increases difficulty for a
+    larger haul) or cancel the collection entirely (e.g. an NPC refuses
+    to hand over the food and the encounter must be resolved by other means).
+
+    The ``pool_difficulty_bonus`` is pre-computed from the pool size by the
+    service function — the base difficulty plus this bonus yields the
+    effective difficulty passed to the check. Reactive flows may further
+    adjust ``difficulty_modifier`` on top.
+    """
+
+    character: Character
+    field_instance: object
+    domain: object | None
+    gathered: int
+    pool_difficulty_bonus: int
+    difficulty_modifier: int = 0
+
+
+@dataclass(frozen=True)
+class FoodCollectedPayload:
+    """Post-collection outcome payload (#1864, #2218).
+
+    Emitted after food has landed (or been lost) in the stockpile. Read-only
+    — reactive flows cannot rewrite history.
+    """
+
+    character: Character
+    domain: object | None
+    gathered: int
+    landed: int
+    overflow: int
+    catastrophe: bool
+
+
 PAYLOAD_FOR_EVENT: dict[str, type] = {
     "attack_pre_resolve": AttackPreResolvePayload,
     "attack_landed": AttackLandedPayload,
@@ -297,4 +340,6 @@ PAYLOAD_FOR_EVENT: dict[str, type] = {
     "asset_compromised": AssetStatusPayload,
     "asset_lost": AssetStatusPayload,
     "asset_dismissed": AssetStatusPayload,
+    "food_pre_collect": FoodPreCollectPayload,
+    "food_collected": FoodCollectedPayload,
 }

--- a/src/flows/migrations/0010_alter_triggerdefinition_event_name.py
+++ b/src/flows/migrations/0010_alter_triggerdefinition_event_name.py
@@ -1,0 +1,71 @@
+# Generated for #2218 — adds food_pre_collect to TriggerDefinition.event_name choices.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("flows", "0009_alter_triggerdefinition_event_name"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="triggerdefinition",
+            name="event_name",
+            field=models.CharField(
+                choices=[
+                    ("attack_pre_resolve", "Attack Pre-Resolve"),
+                    ("attack_landed", "Attack Landed"),
+                    ("attack_missed", "Attack Missed"),
+                    ("damage_pre_apply", "Damage Pre-Apply"),
+                    ("damage_applied", "Damage Applied"),
+                    ("character_incapacitated", "Character Incapacitated"),
+                    ("character_killed", "Character Killed"),
+                    ("move_pre_depart", "Move: Pre-Depart"),
+                    ("moved", "Moved"),
+                    ("examine_pre", "Examine Pre"),
+                    ("examined", "Examined"),
+                    ("condition_pre_apply", "Condition Pre-Apply"),
+                    ("condition_applied", "Condition Applied"),
+                    ("condition_stage_changed", "Condition Stage Changed"),
+                    ("condition_removed", "Condition Removed"),
+                    ("technique_pre_cast", "Technique Pre-Cast"),
+                    ("technique_cast", "Technique Cast"),
+                    ("technique_affected", "Technique Affected"),
+                    ("corruption_accruing", "Corruption accruing (pre-mutation)"),
+                    ("corruption_accrued", "Corruption accrued (post-mutation)"),
+                    ("corruption_warning", "Corruption warning (stage 3-4)"),
+                    ("corruption_reduced", "Corruption reduced"),
+                    ("protagonism_locked", "Protagonism locked (stage 5 entry)"),
+                    ("protagonism_restored", "Protagonism restored (stage 5 exit)"),
+                    (
+                        "condition_stage_advance_check_about_to_fire",
+                        "Condition stage advance resist check about to fire",
+                    ),
+                    ("soul_tether_formed", "Soul Tether formed"),
+                    ("soul_tether_dissolved", "Soul Tether dissolved"),
+                    ("before_apply_outfit", "Before Apply Outfit"),
+                    ("apply_outfit", "Apply Outfit"),
+                    ("before_undress", "Before Undress"),
+                    ("undress", "Undress"),
+                    ("before_present_outfit", "Before Present Outfit"),
+                    ("present_outfit", "Present Outfit"),
+                    ("before_judge_presentation", "Before Judge Presentation"),
+                    ("judge_presentation", "Judge Presentation"),
+                    ("encounter_completed", "Encounter Completed"),
+                    ("fell", "Fell"),
+                    ("combat_round_starting", "Combat Round Starting"),
+                    ("engagement_lock_formed", "Engagement Lock Formed"),
+                    ("engagement_lock_broken", "Engagement Lock Broken"),
+                    ("food_pre_collect", "Food Pre-Collect"),
+                    ("food_collected", "Food Collected"),
+                    ("food_shortage", "Food Shortage"),
+                    ("asset_compromised", "Asset Compromised"),
+                    ("asset_lost", "Asset Lost"),
+                    ("asset_dismissed", "Asset Dismissed"),
+                ],
+                help_text="The event name this trigger listens for.",
+                max_length=64,
+            ),
+        ),
+    ]

--- a/src/flows/migrations/max_migration.txt
+++ b/src/flows/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0009_alter_triggerdefinition_event_name
+0010_alter_triggerdefinition_event_name

--- a/src/flows/service_functions/__init__.py
+++ b/src/flows/service_functions/__init__.py
@@ -6,6 +6,7 @@ import importlib
 from flows.helpers.hooks import get_package_hooks
 
 SERVICE_MODULES = [
+    "flows.service_functions.agriculture",
     "flows.service_functions.communication",
     "flows.service_functions.forms",
     "flows.service_functions.movement",

--- a/src/flows/service_functions/agriculture.py
+++ b/src/flows/service_functions/agriculture.py
@@ -1,0 +1,75 @@
+"""Flow-callable service functions for the agriculture system (#2218).
+
+Thin wrappers that accept string-name lookups so FlowStepDefinition
+parameters can reference agriculture concepts by name.  These exist to
+bridge the flow parameter-resolution layer (which resolves ``@variable``
+references and passes raw values through) with production services.
+
+Registered in ``flows.service_functions.__init__.SERVICE_MODULES`` so the
+``hooks`` dict below is auto-discovered by the service function registry.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+
+def _unwrap_objectdb(obj: ObjectDB) -> ObjectDB:
+    """Unwrap a BaseState wrapper to its underlying ObjectDB.
+
+    The flow execution layer may pass a ``BaseState`` (e.g., ``CharacterState``)
+    rather than a raw ``ObjectDB`` when the parameter is resolved via
+    ``_resolve_service_param``.  ``BaseState`` exposes the raw object on its
+    ``.obj`` attribute; raw ``ObjectDB`` instances have no such attribute.
+
+    Args:
+        obj: A raw ``ObjectDB`` or a ``BaseState`` wrapping one.
+
+    Returns:
+        The underlying ``ObjectDB``.
+    """
+    return getattr(obj, "obj", obj)  # noqa: GETATTR_LITERAL
+
+
+def flow_food_collection_difficulty(
+    *,
+    character: ObjectDB,
+    field_instance: ObjectDB,
+) -> dict[str, int | str]:
+    """Compute the pool-size difficulty bonus for a food collection attempt.
+
+    Flow-callable wrapper around the pool-difficulty calculation in
+    ``world.agriculture.services.collection``.  Returns a dict with:
+
+    - ``pool_difficulty_bonus``: the computed bonus (capped).
+    - ``difficulty_name``: the ``DifficultyChoice`` label for the
+      effective difficulty, suitable for display or further flow logic.
+
+    Args:
+        character: The collecting character (ObjectDB or BaseState).
+        field_instance: The Field RoomFeatureInstance (or its pk).
+
+    Returns:
+        Dict with ``pool_difficulty_bonus`` (int) and ``difficulty_name`` (str).
+    """
+    from world.agriculture.services.collection import (  # noqa: PLC0415
+        _pool_difficulty_bonus,
+    )
+
+    raw_character = _unwrap_objectdb(character)
+    # field_instance may arrive as a BaseState, a RoomFeatureInstance, or a pk.
+    raw_field = getattr(field_instance, "obj", field_instance)  # noqa: GETATTR_LITERAL
+
+    bonus = _pool_difficulty_bonus(raw_field, raw_character)
+    return {
+        "pool_difficulty_bonus": bonus,
+        "difficulty_name": "Normal",  # base; reactive flows can escalate
+    }
+
+
+hooks = {
+    "food_collection_difficulty": flow_food_collection_difficulty,
+}

--- a/src/flows/tests/test_event_names.py
+++ b/src/flows/tests/test_event_names.py
@@ -51,6 +51,7 @@ class EventNameTests(TestCase):
             "combat_round_starting",
             "engagement_lock_formed",
             "engagement_lock_broken",
+            "food_pre_collect",
             "food_collected",
             "food_shortage",
             "asset_compromised",

--- a/src/world/agriculture/constants.py
+++ b/src/world/agriculture/constants.py
@@ -2,6 +2,10 @@
 
 FOOD_COLLECTION_CHECK_NAME = "Food Collection"
 
+#: Base difficulty label for food collection checks (#2218). Pool size and
+#: reactive triggers may escalate this. PLACEHOLDER — tune via admin or data.
+FOOD_COLLECTION_BASE_DIFFICULTY = "normal"
+
 #: Max level for the Field RoomFeatureKind.
 FIELD_MAX_LEVEL = 5
 

--- a/src/world/agriculture/migrations/0003_foodconfig_pool_difficulty_fields.py
+++ b/src/world/agriculture/migrations/0003_foodconfig_pool_difficulty_fields.py
@@ -1,0 +1,42 @@
+# Generated for #2218 — pool-size difficulty scaling for the food collection mini-game.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("agriculture", "0002_foodconfig_prosperity_equilibrium_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="foodconfig",
+            name="pool_difficulty_threshold",
+            field=models.PositiveIntegerField(
+                default=50,
+                help_text=(
+                    "Pool size above which difficulty begins to ramp "
+                    "(the first 'step' boundary). PLACEHOLDER."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="foodconfig",
+            name="pool_difficulty_step",
+            field=models.PositiveIntegerField(
+                default=50,
+                help_text=(
+                    "Each full step of pool size above the threshold adds one "
+                    "difficulty point. PLACEHOLDER."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="foodconfig",
+            name="pool_difficulty_max_bonus",
+            field=models.PositiveSmallIntegerField(
+                default=30,
+                help_text="Cap on the total difficulty bonus from pool size. PLACEHOLDER.",
+            ),
+        ),
+    ]

--- a/src/world/agriculture/migrations/max_migration.txt
+++ b/src/world/agriculture/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0002_foodconfig_prosperity_equilibrium_and_more
+0003_foodconfig_pool_difficulty_fields

--- a/src/world/agriculture/models.py
+++ b/src/world/agriculture/models.py
@@ -145,6 +145,27 @@ class FoodConfig(SharedMemoryModel):
         default=100,
         help_text="Max stored food per Granary level.",
     )
+    # Pool-size difficulty scaling (#2218): a larger accumulated pool is harder
+    # to collect — more food means more laborers, carts, and attention drawn.
+    # All PLACEHOLDER — tune via admin.
+    pool_difficulty_threshold = models.PositiveIntegerField(
+        default=50,
+        help_text=(
+            "Pool size above which difficulty begins to ramp "
+            "(the first 'step' boundary). PLACEHOLDER."
+        ),
+    )
+    pool_difficulty_step = models.PositiveIntegerField(
+        default=50,
+        help_text=(
+            "Each full step of pool size above the threshold adds one "
+            "difficulty point. PLACEHOLDER."
+        ),
+    )
+    pool_difficulty_max_bonus = models.PositiveSmallIntegerField(
+        default=30,
+        help_text=("Cap on the total difficulty bonus from pool size. PLACEHOLDER."),
+    )
 
     class Meta:
         verbose_name = "Food Config"

--- a/src/world/agriculture/services/collection.py
+++ b/src/world/agriculture/services/collection.py
@@ -40,6 +40,37 @@ def _apply_unrest_skim(landed: int, unrest: int) -> int:
     return landed * (100 - skim_pct) // 100
 
 
+def _pool_difficulty_bonus(field_instance, _character=None) -> int:
+    """Compute the difficulty bonus from accumulated pool size (#2218).
+
+    A larger uncollected pool is harder to collect — more laborers, carts,
+    and attention drawn.  Reads ``FoodConfig.pool_difficulty_*`` knobs:
+
+    - No bonus while pool ≤ ``pool_difficulty_threshold``.
+    - Each full ``pool_difficulty_step`` above the threshold adds +1 difficulty.
+    - Capped at ``pool_difficulty_max_bonus``.
+
+    The ``_character`` parameter is accepted for API symmetry with future
+    character-based difficulty modifiers but is not currently used.
+
+    Returns 0 if the Field has no ``FieldDetails`` (shouldn't happen here —
+    the caller already validated it, but defensive).
+    """
+    from world.agriculture.services.production import get_food_config  # noqa: PLC0415
+
+    try:
+        pool = field_instance.field_details.uncollected_pool
+    except Exception:  # noqa: BLE001
+        return 0
+
+    config = get_food_config()
+    threshold = config.pool_difficulty_threshold
+    step = config.pool_difficulty_step or 1  # avoid div-by-zero
+    excess = max(0, pool - threshold)
+    bonus = excess // step
+    return min(bonus, config.pool_difficulty_max_bonus)
+
+
 @transaction.atomic
 def collect_field_food(character, field_instance) -> FoodCollectionResult:
     """One active collection dispatch from a Field's uncollected pool.
@@ -50,24 +81,35 @@ def collect_field_food(character, field_instance) -> FoodCollectionResult:
     ``FoodStockpile`` (capped at max capacity from Granaries). Excess
     above capacity is lost (overflow).
 
+    **Mini-game event flow (#2218):**
+
+    1. ``FOOD_PRE_COLLECT`` — emitted *before* the pool is zeroed. The
+       payload (``FoodPreCollectPayload``) is mutable and cancellable.
+       Reactive flows may inspect the pool size and pre-computed
+       ``pool_difficulty_bonus``, adjust ``difficulty_modifier`` (e.g.
+       intimidation, bribery, persuasion), or cancel the collection
+       entirely (the pool is left untouched).
+    2. If cancelled, returns early with ``cancelled=True`` — pool intact.
+    3. The check is rolled at the effective difficulty (base + pool bonus
+       + modifier from the reactive payload).
+    4. ``FOOD_COLLECTED`` — emitted *after* the outcome is resolved.
+       Read-only; reactive flows may react to the result (e.g. spawn a
+       bandit ambush on a catastrophe).
+
     Args:
         character: The collecting character (ObjectDB).
         field_instance: The ``RoomFeatureInstance`` for the Field.
 
     Returns:
-        ``FoodCollectionResult`` with gathered, landed, overflow, and
-        catastrophe details.
+        ``FoodCollectionResult`` with gathered, landed, overflow,
+        catastrophe, and cancelled details.
 
     Raises:
         ValueError: If the pool is empty (nothing to collect).
     """
-    from world.agriculture.constants import FOOD_COLLECTION_CHECK_NAME  # noqa: PLC0415
-    from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
-    from world.scenes.action_constants import (  # noqa: PLC0415
-        DIFFICULTY_VALUES,
-        DifficultyChoice,
-    )
+    from flows.constants import EventName  # noqa: PLC0415
+    from flows.emit import emit_event  # noqa: PLC0415
+    from flows.events.payloads import FoodPreCollectPayload  # noqa: PLC0415
 
     try:
         details = field_instance.field_details
@@ -80,48 +122,122 @@ def collect_field_food(character, field_instance) -> FoodCollectionResult:
         msg = "There is nothing waiting to be collected."
         raise ValueError(msg)
 
+    # Resolve the domain early — the pre-collect payload carries it so
+    # reactive flows can inspect domain state (unrest, etc.).
+    domain = resolve_domain_for_feature(field_instance)
+
+    # --- Pool-size difficulty scaling (#2218) ---
+    pool_bonus = _pool_difficulty_bonus(field_instance, character)
+
+    # --- Pre-collect event (cancellable, mutable) ---
+    location = getattr(character, "location", None)  # noqa: GETATTR_LITERAL
+    pre_payload = FoodPreCollectPayload(
+        character=character,
+        field_instance=field_instance,
+        domain=domain,
+        gathered=gathered,
+        pool_difficulty_bonus=pool_bonus,
+        difficulty_modifier=0,
+    )
+
+    cancelled = False
+    if location is not None:
+        stack = emit_event(
+            EventName.FOOD_PRE_COLLECT,
+            pre_payload,
+            location,
+        )
+        cancelled = stack.was_cancelled()
+
+    if cancelled:
+        # The collection was cancelled before the pool was zeroed — the
+        # food stays in the field.  The reactive flow is responsible for
+        # narrating why (NPC refusal, ambush, etc.).
+        return FoodCollectionResult(
+            gathered=gathered,
+            landed=0,
+            overflow=0,
+            success_level=0,
+            cancelled=True,
+        )
+
     # Zero the pool — food left with the collector regardless of outcome.
     details.uncollected_pool = 0
     details.save(update_fields=["uncollected_pool"])
 
-    # Roll the check.
-    check_type = CheckType.objects.filter(name__iexact=FOOD_COLLECTION_CHECK_NAME).first()
-    success_level = 0  # unseeded world: unremarkable partial
-    if check_type is not None:
-        result = perform_check(
-            character,
-            check_type,
-            target_difficulty=DIFFICULTY_VALUES[DifficultyChoice.NORMAL],
-        )
-        success_level = result.success_level
+    # Roll the check at the effective difficulty.
+    success_level = _roll_collection_check(character, pool_bonus, pre_payload.difficulty_modifier)
 
     pct = _collection_band_pct(success_level)
     if pct is None:
         # Catastrophe: the collector never made it back with the food.
-        return FoodCollectionResult(
+        result = FoodCollectionResult(
             gathered=gathered,
             landed=0,
             overflow=0,
             success_level=success_level,
             catastrophe=True,
         )
+        _emit_food_collected(location, character, domain, result)
+        return result
 
     landed = gathered * pct // 100
 
-    # Land into the domain's stockpile, capped at max capacity.
-    domain = resolve_domain_for_feature(field_instance)
     if domain is None:
         # No domain — food is collected but has nowhere to go.
-        return FoodCollectionResult(
+        result = FoodCollectionResult(
             gathered=gathered,
             landed=0,
             overflow=landed,
             success_level=success_level,
         )
+        _emit_food_collected(location, character, domain, result)
+        return result
 
-    # Unrest skims the haul (#2238): a domain in chaos loses food on the way in.
+    # Unrest skims the haul (#2238), then land into the stockpile (capped).
     landed = _apply_unrest_skim(landed, domain.unrest)
+    result = _land_food(domain, gathered, landed, success_level)
+    _emit_food_collected(location, character, domain, result)
+    return result
 
+
+def _roll_collection_check(character, pool_bonus: int, difficulty_modifier: int) -> int:
+    """Roll the Food Collection check at the effective difficulty (#2218).
+
+    Effective difficulty = base (NORMAL) + pool bonus + reactive modifier,
+    clamped to the [TRIVIAL, HARROWING] range.  Returns ``success_level``.
+    """
+    from world.agriculture.constants import FOOD_COLLECTION_CHECK_NAME  # noqa: PLC0415
+    from world.checks.models import CheckType  # noqa: PLC0415
+    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.scenes.action_constants import (  # noqa: PLC0415
+        DIFFICULTY_VALUES,
+        DifficultyChoice,
+    )
+
+    check_type = CheckType.objects.filter(name__iexact=FOOD_COLLECTION_CHECK_NAME).first()
+    if check_type is None:
+        return 0  # unseeded world: unremarkable partial
+
+    effective_difficulty = (
+        DIFFICULTY_VALUES[DifficultyChoice.NORMAL] + pool_bonus + difficulty_modifier
+    )
+    effective_difficulty = min(effective_difficulty, DIFFICULTY_VALUES[DifficultyChoice.HARROWING])
+    effective_difficulty = max(effective_difficulty, DIFFICULTY_VALUES[DifficultyChoice.TRIVIAL])
+    result = perform_check(
+        character,
+        check_type,
+        target_difficulty=effective_difficulty,
+    )
+    return result.success_level
+
+
+def _land_food(domain, gathered: int, landed: int, success_level: int) -> FoodCollectionResult:
+    """Land food into the domain's stockpile, capped at Granary capacity.
+
+    Excess above capacity is lost (overflow).  Returns the final
+    ``FoodCollectionResult``.
+    """
     stockpile, _ = FoodStockpile.objects.get_or_create(domain=domain)
     capacity = max_food_capacity(domain)
     headroom = max(0, capacity - stockpile.stored)
@@ -137,4 +253,33 @@ def collect_field_food(character, field_instance) -> FoodCollectionResult:
         landed=actual_landed,
         overflow=overflow,
         success_level=success_level,
+    )
+
+
+def _emit_food_collected(location, character, domain, result: FoodCollectionResult) -> None:
+    """Emit the post-collection ``FOOD_COLLECTED`` event (#2218).
+
+    Read-only — reactive flows cannot modify the outcome.  They may react
+    to it (e.g. spawn a bandit ambush on a catastrophe, reward the collector
+    on a critical success).
+    """
+    from flows.constants import EventName  # noqa: PLC0415
+    from flows.emit import emit_event  # noqa: PLC0415
+    from flows.events.payloads import FoodCollectedPayload  # noqa: PLC0415
+
+    if location is None:
+        return
+
+    payload = FoodCollectedPayload(
+        character=character,
+        domain=domain,
+        gathered=result.gathered,
+        landed=result.landed,
+        overflow=result.overflow,
+        catastrophe=result.catastrophe,
+    )
+    emit_event(
+        EventName.FOOD_COLLECTED,
+        payload,
+        location,
     )

--- a/src/world/agriculture/tests/test_action.py
+++ b/src/world/agriculture/tests/test_action.py
@@ -35,7 +35,7 @@ class CollectFoodActionTests(TestCase):
         FieldDetails.objects.create(feature_instance=instance, crop_type=crop, uncollected_pool=50)
 
         action = CollectFoodAction()
-        result = action.execute(MagicMock(), field_instance=instance)
+        result = action.execute(MagicMock(location=None), field_instance=instance)
 
         self.assertTrue(result.success)
         self.assertIn("landed", result.data)
@@ -61,7 +61,7 @@ class CollectFoodActionTests(TestCase):
         FieldDetails.objects.create(feature_instance=instance, crop_type=crop, uncollected_pool=0)
 
         action = CollectFoodAction()
-        result = action.execute(MagicMock(), field_instance=instance)
+        result = action.execute(MagicMock(location=None), field_instance=instance)
 
         self.assertFalse(result.success)
 
@@ -96,7 +96,9 @@ class CollectFoodResolutionTests(TestCase):
         from actions.definitions.collect_food import CollectFoodAction
 
         instance = _make_field(pool=50, name="RestField")
-        result = CollectFoodAction().execute(MagicMock(), field_instance_id=instance.pk)
+        result = CollectFoodAction().execute(
+            MagicMock(location=None), field_instance_id=instance.pk
+        )
         self.assertTrue(result.success)
         self.assertIn("landed", result.data)
 
@@ -112,7 +114,7 @@ class CollectFoodResolutionTests(TestCase):
     def test_unknown_field_id_returns_failure(self):
         from actions.definitions.collect_food import CollectFoodAction
 
-        result = CollectFoodAction().execute(MagicMock(), field_instance_id=999999)
+        result = CollectFoodAction().execute(MagicMock(location=None), field_instance_id=999999)
         self.assertFalse(result.success)
         self.assertIn("field", result.message.lower())
 

--- a/src/world/agriculture/tests/test_collection.py
+++ b/src/world/agriculture/tests/test_collection.py
@@ -44,8 +44,8 @@ class CollectFieldFoodTests(TestCase):
         instance = _make_field(pool=100)
 
         # No check type seeded → success_level defaults to 0 → 85% band
-        # No domain → all overflow
-        result = collect_field_food(MagicMock(), instance)
+        # No domain → all overflow.  location=None so no emit_event dispatch.
+        result = collect_field_food(MagicMock(location=None), instance)
         self.assertIsInstance(result, FoodCollectionResult)
         self.assertEqual(result.gathered, 100)
         self.assertFalse(result.catastrophe)

--- a/src/world/agriculture/tests/test_collection_events.py
+++ b/src/world/agriculture/tests/test_collection_events.py
@@ -1,0 +1,231 @@
+"""Tests for the food collection mini-game event flow (#2218).
+
+Tests the pre/post event emission, cancellation, difficulty modification,
+and pool-size difficulty scaling.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from world.agriculture.types import FoodCollectionResult
+
+
+def _make_field(pool=100, name="Field"):
+    """Helper: create a Field instance with a crop and uncollected pool."""
+    from world.agriculture.models import CropType, FieldDetails
+    from world.room_features.constants import (
+        RoomFeatureInstallMechanism,
+        RoomFeatureServiceStrategy,
+    )
+    from world.room_features.factories import RoomFeatureInstanceFactory
+    from world.room_features.models import RoomFeatureKind
+
+    kind = RoomFeatureKind.objects.create(
+        name=name,
+        max_level=5,
+        service_strategy=RoomFeatureServiceStrategy.FIELD,
+        install_mechanism=RoomFeatureInstallMechanism.PROJECT,
+    )
+    crop = CropType.objects.create(name=f"{name}Crop", base_production=10)
+    instance = RoomFeatureInstanceFactory(feature_kind=kind)
+    FieldDetails.objects.create(feature_instance=instance, crop_type=crop, uncollected_pool=pool)
+    return instance
+
+
+def _mock_location():
+    """A mock location with no triggers so emit_event returns an uncancelled stack."""
+    room = MagicMock()
+    room.contents = []
+    room.trigger_handler = None
+    return room
+
+
+def _seed_check_type():
+    """Create the Food Collection CheckType so perform_check is actually called."""
+    from world.checks.factories import CheckTypeFactory
+
+    return CheckTypeFactory(name="Food Collection")
+
+
+def _uncancelled_stack(*args, **kwargs):
+    """Return a FlowStack that was not cancelled (the normal case)."""
+    from flows.flow_stack import FlowStack
+
+    return FlowStack(owner=None)
+
+
+def _cancelled_stack(*args, **kwargs):
+    """Return a FlowStack that was cancelled."""
+    from flows.flow_stack import FlowStack
+
+    stack = FlowStack(owner=None)
+    stack.mark_cancelled()
+    return stack
+
+
+class PoolDifficultyBonusTests(TestCase):
+    """The pool-size difficulty scaling helper (#2218)."""
+
+    def test_small_pool_no_bonus(self):
+        """Pool at or below the threshold produces zero bonus."""
+        from world.agriculture.services.collection import _pool_difficulty_bonus
+
+        instance = _make_field(pool=50, name="SmallPool")
+        bonus = _pool_difficulty_bonus(instance, MagicMock())
+        self.assertEqual(bonus, 0)
+
+    def test_pool_above_threshold_gives_bonus(self):
+        """Pool above the threshold produces a stepped bonus."""
+        from world.agriculture.services.collection import _pool_difficulty_bonus
+
+        # threshold=50, step=50: pool=150 → excess=100 → bonus=2
+        instance = _make_field(pool=150, name="LargePool")
+        bonus = _pool_difficulty_bonus(instance, MagicMock())
+        self.assertEqual(bonus, 2)
+
+    def test_bonus_is_capped(self):
+        """Pool far above the threshold is capped at max_bonus."""
+        from world.agriculture.services.collection import _pool_difficulty_bonus
+
+        # threshold=50, step=50, max_bonus=30: pool=5000 → excess=4950 → 99, capped at 30
+        instance = _make_field(pool=5000, name="HugePool")
+        bonus = _pool_difficulty_bonus(instance, MagicMock())
+        self.assertEqual(bonus, 30)
+
+
+class FoodPreCollectEventTests(TestCase):
+    """The FOOD_PRE_COLLECT event is emitted before the pool is zeroed."""
+
+    def test_pre_collect_event_emitted(self):
+        """The FOOD_PRE_COLLECT event fires before the pool is zeroed."""
+        from world.agriculture.services import collect_field_food
+
+        instance = _make_field(pool=100, name="PreCollect")
+        actor = MagicMock(location=_mock_location())
+
+        with patch("flows.emit.emit_event", side_effect=_uncancelled_stack) as mock_emit:
+            collect_field_food(actor, instance)
+
+            # emit_event should have been called with food_pre_collect
+            self.assertTrue(mock_emit.called)
+            first_call = mock_emit.call_args_list[0]
+            self.assertEqual(first_call.args[0], "food_pre_collect")
+
+    def test_cancellation_preserves_pool(self):
+        """A cancelled pre-collect event leaves the pool intact."""
+        from world.agriculture.models import FieldDetails
+        from world.agriculture.services import collect_field_food
+
+        instance = _make_field(pool=100, name="Cancelled")
+        actor = MagicMock(location=_mock_location())
+
+        with patch("flows.emit.emit_event", side_effect=_cancelled_stack):
+            result = collect_field_food(actor, instance)
+
+            self.assertTrue(result.cancelled)
+            self.assertEqual(result.gathered, 100)
+            self.assertEqual(result.landed, 0)
+
+            # Pool was NOT zeroed
+            details = FieldDetails.objects.get(feature_instance=instance)
+            self.assertEqual(details.uncollected_pool, 100)
+
+    def test_difficulty_modifier_carried_into_check(self):
+        """A reactive flow that mutates difficulty_modifier affects the check difficulty."""
+        from world.agriculture.services import collect_field_food
+
+        _seed_check_type()
+        instance = _make_field(pool=100, name="ModDifficulty")
+        actor = MagicMock(location=_mock_location())
+
+        def emit_side_effect(event_name, payload, location, **kwargs):
+            if event_name == "food_pre_collect":
+                payload.difficulty_modifier = 10
+            from flows.flow_stack import FlowStack
+
+            return FlowStack(owner=None)
+
+        with (
+            patch("flows.emit.emit_event", side_effect=emit_side_effect),
+            patch("world.checks.services.perform_check") as mock_check,
+        ):
+            mock_check.return_value = MagicMock(success_level=0)
+
+            collect_field_food(actor, instance)
+
+            # The check should have been called with the modified difficulty
+            check_call = mock_check.call_args
+            # Base NORMAL=45 + pool_bonus(1 for pool=100: (100-50)/50=1) + modifier(10) = 56
+            self.assertEqual(check_call.kwargs["target_difficulty"], 56)
+
+
+class FoodCollectedEventTests(TestCase):
+    """The FOOD_COLLECTED event is emitted after the outcome is resolved."""
+
+    def test_post_collect_event_emitted(self):
+        """The FOOD_COLLECTED event fires after collection completes."""
+        from world.agriculture.services import collect_field_food
+
+        instance = _make_field(pool=100, name="PostCollect")
+        actor = MagicMock(location=_mock_location())
+
+        with patch("flows.emit.emit_event", side_effect=_uncancelled_stack) as mock_emit:
+            collect_field_food(actor, instance)
+
+            # Two emit calls: pre-collect and post-collect
+            self.assertEqual(mock_emit.call_count, 2)
+            post_call = mock_emit.call_args_list[1]
+            self.assertEqual(post_call.args[0], "food_collected")
+
+    def test_catastrophe_emits_post_event(self):
+        """A catastrophe still emits the post-collect event with catastrophe=True."""
+        from world.agriculture.services import collect_field_food
+
+        _seed_check_type()
+        instance = _make_field(pool=100, name="Catastrophe")
+        actor = MagicMock(location=_mock_location())
+
+        with (
+            patch("flows.emit.emit_event", side_effect=_uncancelled_stack) as mock_emit,
+            patch("world.checks.services.perform_check") as mock_check,
+        ):
+            # success_level=-2 → below the last band floor (-1) → catastrophe
+            mock_check.return_value = MagicMock(success_level=-2)
+
+            result = collect_field_food(actor, instance)
+
+            self.assertTrue(result.catastrophe)
+            # Post-collect event was still emitted
+            self.assertEqual(mock_emit.call_count, 2)
+            post_call = mock_emit.call_args_list[1]
+            self.assertEqual(post_call.args[0], "food_collected")
+            # The payload should have catastrophe=True
+            payload = post_call.args[1]
+            self.assertTrue(payload.catastrophe)
+
+
+class FoodCollectionResultCancelledTests(TestCase):
+    """The FoodCollectionResult.cancelled field (#2218)."""
+
+    def test_cancelled_result_has_cancelled_flag(self):
+        """A cancelled result has cancelled=True and zeroes for landed/overflow."""
+        result = FoodCollectionResult(
+            gathered=100,
+            landed=0,
+            overflow=0,
+            success_level=0,
+            cancelled=True,
+        )
+        self.assertTrue(result.cancelled)
+        self.assertFalse(result.catastrophe)
+
+    def test_normal_result_cancelled_defaults_false(self):
+        """A normal result has cancelled=False by default."""
+        result = FoodCollectionResult(
+            gathered=100,
+            landed=85,
+            overflow=0,
+            success_level=0,
+        )
+        self.assertFalse(result.cancelled)

--- a/src/world/agriculture/types.py
+++ b/src/world/agriculture/types.py
@@ -13,7 +13,9 @@ class FoodCollectionResult:
     the attempt); ``landed`` is what reached the stockpile after the
     outcome band; ``overflow`` is what was lost above the Granary's
     capacity; ``success_level`` is the check band that decided it.
-    ``catastrophe`` marks the nothing-lands case.
+    ``catastrophe`` marks the nothing-lands case.  ``cancelled`` marks
+    a pre-collect reactive cancellation (#2218): a trigger cancelled the
+    collection before the check was rolled — the pool was *not* zeroed.
     """
 
     gathered: int
@@ -21,3 +23,4 @@ class FoodCollectionResult:
     overflow: int
     success_level: int
     catastrophe: bool = False
+    cancelled: bool = False


### PR DESCRIPTION
Closes #2218

## Summary

Implements the food collection mini-game (#2218) as a data-driven reactive flow.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2218 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: Rebased on main, no conflicts.

<!-- last-addressed-comment: 0 -->