### PR TITLE
WAR_FUNDING: ContributionMethod seeds — which check-based contribution methods to author

### DIFF
--- a/src/world/battles/seeds.py
+++ b/src/world/battles/seeds.py
@@ -1,0 +1,66 @@
+"""Seed ContributionMethod rows for the WAR_FUNDING project kind (#2382).
+
+Three check-based contribution methods, each reusing an existing CheckType:
+"Drill Troops" (Household Command), "Scout Enemy Positions" (Stealth),
+"Fortify Defenses" (Search). AP cost / progress magnitudes are PLACEHOLDER
+(tuning ledger §6), mirroring the BUILDING_PREPARATION seed's values.
+"""
+
+from __future__ import annotations
+
+
+def seed_war_funding_contribution_methods() -> None:
+    """Seed three ContributionMethod rows for WAR_FUNDING (#2382).
+
+    Idempotent — uses ``update_or_create`` on (kind, name), so re-runs
+    update existing rows and staff edits survive a re-seed. Each method
+    references an already-seeded CheckType; the relevant seed function is
+    called if the CheckType is missing (mirroring ``buildings/seeds.py``).
+    """
+    from world.checks.models import CheckType  # noqa: PLC0415
+    from world.projects.constants import ProjectKind  # noqa: PLC0415
+    from world.projects.models import ContributionMethod  # noqa: PLC0415
+    from world.seeds.governance_checks import seed_governance_check_content  # noqa: PLC0415
+    from world.seeds.investigation_checks import seed_investigation_check_content  # noqa: PLC0415
+    from world.seeds.stealth_checks import seed_stealth_check_content  # noqa: PLC0415
+
+    def _get_check_type(name: str, seeder: object) -> CheckType:
+        ct = CheckType.objects.filter(name=name).first()
+        if ct is None:
+            seeder()
+            ct = CheckType.objects.get(name=name)
+        return ct
+
+    methods = [
+        (
+            "Drill Troops",
+            "Household Command",
+            seed_governance_check_content,
+            "PLACEHOLDER — rally and drill troops to improve military readiness.",
+        ),
+        (
+            "Scout Enemy Positions",
+            "Stealth",
+            seed_stealth_check_content,
+            "PLACEHOLDER — scout enemy positions to gather intelligence for the war effort.",
+        ),
+        (
+            "Fortify Defenses",
+            "Search",
+            seed_investigation_check_content,
+            "PLACEHOLDER — survey and fortify defensive positions.",
+        ),
+    ]
+
+    for method_name, check_type_name, seeder, description in methods:
+        check_type = _get_check_type(check_type_name, seeder)
+        ContributionMethod.objects.update_or_create(
+            kind=ProjectKind.WAR_FUNDING,
+            name=method_name,
+            defaults={
+                "description": description,
+                "check_type": check_type,
+                "ap_cost": 5,
+                "progress_on_success": 10,
+            },
+        )

--- a/src/world/battles/tests/test_war_funding_seeds.py
+++ b/src/world/battles/tests/test_war_funding_seeds.py
@@ -1,0 +1,45 @@
+"""Tests for the WAR_FUNDING ContributionMethod seed (#2382).
+
+Mirrors ``test_seed_staging_catalog.py``'s shape: proves the seed creates
+three ContributionMethod rows with the correct CheckType references and
+placeholder values, plus idempotency (re-running is a no-op).
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from world.projects.constants import ProjectKind
+from world.projects.models import ContributionMethod
+from world.seeds.database import seed_dev_database
+
+
+class SeedWarFundingContributionMethodsTests(TestCase):
+    """The WAR_FUNDING ContributionMethod seed row shape and idempotency."""
+
+    def test_seeds_three_methods(self) -> None:
+        seed_dev_database()
+
+        methods = ContributionMethod.objects.filter(kind=ProjectKind.WAR_FUNDING).order_by("name")
+        self.assertEqual(methods.count(), 3)
+
+        expected = {
+            "Drill Troops": "Household Command",
+            "Fortify Defenses": "Search",
+            "Scout Enemy Positions": "Stealth",
+        }
+        for method in methods:
+            self.assertIn(method.name, expected)
+            self.assertEqual(method.check_type.name, expected[method.name])
+            self.assertEqual(method.ap_cost, 5)
+            self.assertEqual(method.progress_on_success, 10)
+            self.assertTrue(method.is_active)
+
+    def test_seed_is_idempotent(self) -> None:
+        seed_dev_database()
+        seed_dev_database()
+
+        self.assertEqual(
+            ContributionMethod.objects.filter(kind=ProjectKind.WAR_FUNDING).count(),
+            3,
+        )

--- a/src/world/seeds/clusters.py
+++ b/src/world/seeds/clusters.py
@@ -36,6 +36,9 @@ def _seed_combat() -> None:
 
 
 def _seed_battles() -> None:
+    from world.battles.seeds import (  # noqa: PLC0415
+        seed_war_funding_contribution_methods,
+    )
     from world.seeds.game_content.battles import (  # noqa: PLC0415
         seed_battle_staging_catalog,
         seed_champion_duel_outcome_wiring,
@@ -49,6 +52,8 @@ def _seed_battles() -> None:
     # Property/CapabilityType rows by name), no ordering dependency on another
     # cluster.
     seed_battle_staging_catalog()
+    # WAR_FUNDING check-based contribution methods (#2382).
+    seed_war_funding_contribution_methods()
 
 
 def _seed_checks() -> None:


### PR DESCRIPTION
Closes #2382

## Summary

Seed three ContributionMethod rows for the WAR_FUNDING project kind, reusing existing CheckTypes (Household Command, Stealth, Search) with uniform placeholder values (ap_cost=5, progress_on_success=10).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2382 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto latest main; no conflicts.

<!-- last-addressed-comment: 0 -->