### PR TITLE
Silent-fail audit, tranche 1: retire the getattr accessor traps (+1 dormant bug)

### DIFF
--- a/src/actions/definitions/consent_preferences.py
+++ b/src/actions/definitions/consent_preferences.py
@@ -45,7 +45,7 @@ def _display_mode(mode: str | None) -> str | None:
 
 
 def _resolve_owner_tenure(actor: ObjectDB, tenure_id: int | None):
-    sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = actor.character_sheet
     if sheet is None:
         return None, _MSG_NO_IDENTITY
     try:

--- a/src/actions/definitions/distinctions.py
+++ b/src/actions/definitions/distinctions.py
@@ -97,7 +97,7 @@ class GMAwardDistinctionAction(Action):
             # search() already messaged the actor with a not-found/ambiguous notice.
             return ActionResult(success=False)
 
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = target.character_sheet
         if sheet is None:
             return ActionResult(success=False, message="That is not a character.")
 

--- a/src/actions/definitions/gm_adjudication.py
+++ b/src/actions/definitions/gm_adjudication.py
@@ -309,7 +309,7 @@ class GMAwardAction(Action):
         from world.progression.types import DevelopmentSource, ProgressionReason  # noqa: PLC0415
         from world.traits.models import Trait  # noqa: PLC0415
 
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = target.character_sheet
         if sheet is None:
             return ActionResult(success=False, message=f"{target.key} has no character sheet.")
 

--- a/src/actions/definitions/investigation.py
+++ b/src/actions/definitions/investigation.py
@@ -90,7 +90,7 @@ class SearchAction(Action):
             register_detection,
         )
 
-        actor_sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        actor_sheet = actor.character_sheet
         if actor_sheet is None or actor.location is None:
             return
         detected_any = False
@@ -213,7 +213,7 @@ class StartInvestigationAction(Action):
         from world.clues.models import CharacterClue, Clue  # noqa: PLC0415
         from world.clues.services import acquire_clue  # noqa: PLC0415
 
-        entry = getattr(sheet, "roster_entry", None)  # noqa: GETATTR_LITERAL
+        entry = sheet.roster_entry_or_none
         if entry is None:
             return ActionResult(success=False, message="You have no roster identity.")
 

--- a/src/actions/definitions/items.py
+++ b/src/actions/definitions/items.py
@@ -591,7 +591,7 @@ class GrantItemAction(Action):
             # search() already messaged the actor with a not-found/ambiguous notice.
             return ActionResult(success=False)
 
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = target.character_sheet
         if sheet is None:
             return ActionResult(success=False, message="That is not a character.")
 

--- a/src/actions/definitions/market.py
+++ b/src/actions/definitions/market.py
@@ -25,7 +25,7 @@ _MSG_NO_PERSONA = "You have no active character."
 def _active_persona(actor: ObjectDB):
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-    sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL — puppet may be sheetless
+    sheet = actor.character_sheet
     if sheet is None:
         return None
     return active_persona_for_sheet(sheet)

--- a/src/actions/definitions/progression_rewards.py
+++ b/src/actions/definitions/progression_rewards.py
@@ -287,7 +287,7 @@ class SelectPathAction(Action):
         from world.progression.exceptions import PathAlreadySelectedError  # noqa: PLC0415
         from world.progression.services.advancement import select_initial_path  # noqa: PLC0415
 
-        if getattr(actor, "sheet_data", None) is None:  # noqa: GETATTR_LITERAL
+        if actor.character_sheet is None:
             return ActionResult(success=False, message="No active character.")
         path = Path.objects.filter(
             pk=kwargs.get("path_id"), is_active=True, stage=PathStage.PROSPECT

--- a/src/actions/definitions/scene_reactions.py
+++ b/src/actions/definitions/scene_reactions.py
@@ -44,8 +44,8 @@ class ToggleFavoriteAction(Action):
         )
 
         interaction = kwargs.get("interaction")
-        sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
-        roster_entry = getattr(sheet, "roster_entry", None)  # noqa: GETATTR_LITERAL
+        sheet = actor.character_sheet
+        roster_entry = sheet.roster_entry_or_none
         if sheet is None or roster_entry is None:
             return ActionResult(success=False, message="You have no roster entry to favorite with.")
         created, _favorite = toggle_interaction_favorite(
@@ -122,7 +122,7 @@ class ReactToWindowAction(Action):
         interaction = kwargs.get("interaction")
         kind = kwargs.get("kind")
         choice = kwargs.get("choice")
-        sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = actor.character_sheet
         persona = getattr(sheet, "primary_persona", None)  # noqa: GETATTR_LITERAL
         if persona is None:
             return ActionResult(success=False, message="You have no persona to react with.")

--- a/src/commands/account/sheet_sections.py
+++ b/src/commands/account/sheet_sections.py
@@ -467,7 +467,7 @@ def _render_family_section(command: object) -> list[str]:
     distinctly (the Arx 1 in-law ambiguity is gone by construction).
     """
     character = command.caller
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL — puppet may be sheetless
+    sheet = character.character_sheet
     if sheet is None:
         return ["No character sheet."]
     from world.roster.models import Kinsperson, RosterEntry  # noqa: PLC0415
@@ -525,7 +525,7 @@ def _render_family_section(command: object) -> list[str]:
 def _render_house_section(command: object) -> list[str]:
     """``sheet/house`` (#1884) — the character's house: fealty, titles, tidings."""
     character = command.caller
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL — puppet may be sheetless
+    sheet = character.character_sheet
     if sheet is None:
         return ["No character sheet."]
     from world.roster.models import Kinsperson  # noqa: PLC0415

--- a/src/commands/battle.py
+++ b/src/commands/battle.py
@@ -248,7 +248,7 @@ class CmdBattle(ArxCommand):
     # Resolution helpers
 
     def _actor_sheet(self) -> object:
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             msg = "You have no character sheet."
             raise CommandError(msg)

--- a/src/commands/captivity.py
+++ b/src/commands/captivity.py
@@ -67,7 +67,7 @@ class CmdDemandRansom(ArxCommand):
         if target is None:
             return  # search() already messaged the caller.
 
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = target.character_sheet
         if sheet is None:
             msg = "That is not a character."
             raise CommandError(msg)

--- a/src/commands/companion.py
+++ b/src/commands/companion.py
@@ -125,7 +125,7 @@ class CmdCompanion(DispatchCommand):
 
     def _sheet(self) -> Any:
         """Return the caller's CharacterSheet, or raise CommandError if none."""
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             msg = "You have no character sheet."
             raise CommandError(msg)
@@ -321,7 +321,7 @@ class CmdCompanion(DispatchCommand):
         """List the caller's active companions + remaining capacity per gift."""
         lines = ["|wCompanion actions|n: bind, release, fight, deploy, order, mount, dismount"]
 
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             self.msg("\n".join(lines))
             return

--- a/src/commands/consent.py
+++ b/src/commands/consent.py
@@ -122,7 +122,7 @@ class ConsentRequestCommand(PullParsingMixin, ArxCommand):
 
     def _persona_for(self, character: object, missing_msg: str) -> Persona:
         """Active persona for ``character``; ``CommandError(missing_msg)`` on miss."""
-        sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = character.character_sheet
         if sheet is None:
             raise CommandError(missing_msg)
         try:
@@ -286,7 +286,7 @@ class _RespondCommand(ArxCommand):
         ``self.args`` is a digit, looks up by pk (still constrained to the
         caller as target). Returns None when nothing matches.
         """
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             return None
         try:
@@ -325,13 +325,13 @@ class CmdAccept(_RespondCommand):
             super()._execute()
 
     def _has_registry_pending(self) -> bool:
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             return False
         return bool(get_all_pending(sheet))
 
     def _dispatch_registry(self, args: str) -> str:
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         keyword, _, rest = args.partition(" ")
         if not keyword:
             return format_pending_listing(get_all_pending(sheet) if sheet is not None else [])

--- a/src/commands/consent_preferences.py
+++ b/src/commands/consent_preferences.py
@@ -200,7 +200,7 @@ class CmdConsent(DispatchCommand):
         from world.roster.models import RosterTenure  # noqa: PLC0415
 
         target = self.search_or_raise(name)
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = target.character_sheet
         if sheet is None:
             _no_identity_msg = f"{target} has no character identity."
             raise CommandError(_no_identity_msg)
@@ -217,7 +217,7 @@ class CmdConsent(DispatchCommand):
         """Return the caller's active RosterTenure."""
         from world.roster.models import RosterTenure  # noqa: PLC0415
 
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             _no_identity_msg = "You have no character identity."
             raise CommandError(_no_identity_msg)

--- a/src/commands/covenant.py
+++ b/src/commands/covenant.py
@@ -89,7 +89,7 @@ class CmdCovenant(ArxCommand):
     # Resolution helpers
 
     def _actor_sheet(self) -> Any:
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             msg = "You have no character sheet."
             raise CommandError(msg)
@@ -129,7 +129,7 @@ class CmdCovenant(ArxCommand):
         if not target:
             msg = f"Could not find '{char_name}'."
             raise CommandError(msg)
-        target_sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        target_sheet = target.character_sheet
         if target_sheet is None:
             msg = f"'{char_name}' has no character sheet."
             raise CommandError(msg)

--- a/src/commands/domains.py
+++ b/src/commands/domains.py
@@ -99,7 +99,7 @@ class CmdDomain(ArxCommand):
     def _active_persona(self) -> Any:
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             msg = "You have no character sheet."
             raise CommandError(msg)
@@ -245,7 +245,7 @@ class CmdDomain(ArxCommand):
         if not target:
             msg = f"Could not find '{char_name}'."
             raise CommandError(msg)
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = target.character_sheet
         if sheet is None:
             msg = f"'{char_name}' has no character sheet."
             raise CommandError(msg)

--- a/src/commands/dramatic_moments.py
+++ b/src/commands/dramatic_moments.py
@@ -177,7 +177,7 @@ class CmdMoment(ArxCommand):
         if target is None:
             return
 
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL, STRING_LITERAL
+        sheet = target.character_sheet
         if sheet is None:
             self.msg("That is not a character.")
             return

--- a/src/commands/durance.py
+++ b/src/commands/durance.py
@@ -84,7 +84,7 @@ class CmdDurance(ArxCommand):
         from world.magic.audere_majora import AudereMajoraThreshold  # noqa: PLC0415
         from world.progression.selectors import eligible_advanced_paths_for  # noqa: PLC0415
 
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             msg = "You have no character sheet."
             raise CommandError(msg)
@@ -246,7 +246,7 @@ class CmdDurance(ArxCommand):
         from world.progression.exceptions import ClassLevelAdvancementError  # noqa: PLC0415
         from world.progression.services.advancement import convene_durance_at_site  # noqa: PLC0415
 
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             msg = "You have no character sheet."
             raise CommandError(msg)

--- a/src/commands/endorse.py
+++ b/src/commands/endorse.py
@@ -52,12 +52,12 @@ class CmdPoses(ArxCommand):
             char_name,
             not_found_msg=f"No character named '{char_name}' here.",
         )
-        endorsee_sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        endorsee_sheet = target.character_sheet
         if endorsee_sheet is None:
             msg = f"'{char_name}' has no character sheet."
             raise CommandError(msg)
 
-        endorser_sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        endorser_sheet = self.caller.character_sheet
         if endorser_sheet is None:
             msg = "You have no character sheet."
             raise CommandError(msg)
@@ -169,7 +169,7 @@ class CmdEndorse(ArxCommand):
             char_name,
             not_found_msg=f"No character named '{char_name}' here.",
         )
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = target.character_sheet
         if sheet is None:
             msg = f"'{char_name}' has no character sheet."
             raise CommandError(msg)
@@ -223,7 +223,7 @@ class CmdEndorse(ArxCommand):
             raise CommandError(msg)
 
         endorsee_sheet = self._resolve_endorsee(char_name)
-        endorser_sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        endorser_sheet = self.caller.character_sheet
         if endorser_sheet is None:
             msg = "You have no character sheet."
             raise CommandError(msg)

--- a/src/commands/gift_learning.py
+++ b/src/commands/gift_learning.py
@@ -90,7 +90,7 @@ class CmdLearn(DispatchCommand):
         """List open GiftUnlocks (XP cost + status) and open teaching offers."""
         lines = ["|wLearn actions|n: gift <id>, technique <id>, thread <id>"]
 
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         lines.extend(self._gift_unlock_lines(sheet))
         lines.extend(self._technique_offer_lines())
         lines.extend(self._thread_offer_lines())

--- a/src/commands/locations.py
+++ b/src/commands/locations.py
@@ -233,7 +233,7 @@ class CmdRoom(ArxCommand):
         if not target:
             msg = f"Could not find '{char_name}'."
             raise CommandError(msg)
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = target.character_sheet
         if sheet is None:
             msg = f"'{char_name}' has no character sheet."
             raise CommandError(msg)

--- a/src/commands/offer_response.py
+++ b/src/commands/offer_response.py
@@ -18,7 +18,7 @@ class CmdDecline(ArxCommand):
     action = None
 
     def _execute(self) -> None:
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         args = (self.args or "").strip()
         if not args:
             self.msg(format_pending_listing(get_all_pending(sheet) if sheet is not None else []))

--- a/src/commands/outfit.py
+++ b/src/commands/outfit.py
@@ -98,7 +98,7 @@ class CmdOutfit(ArxCommand):
     def _show_hub(self) -> None:
         from world.items.models import Outfit  # noqa: PLC0415
 
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             self.msg("You have no character sheet.")
             return

--- a/src/commands/places.py
+++ b/src/commands/places.py
@@ -85,7 +85,7 @@ class CmdPlaces(ArxCommand):
         from world.scenes.place_models import PlacePresence  # noqa: PLC0415
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             msg = "No active character."
             raise CommandError(msg)

--- a/src/commands/react.py
+++ b/src/commands/react.py
@@ -77,7 +77,7 @@ class CmdReact(ArxCommand):
     # Shared resolution
 
     def _actor_sheet(self) -> Any:
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             msg = "You have no character sheet."
             raise CommandError(msg)
@@ -99,7 +99,7 @@ class CmdReact(ArxCommand):
         target = self.search_or_raise(
             char_name, not_found_msg=f"No character named '{char_name}' here."
         )
-        endorsee_sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        endorsee_sheet = target.character_sheet
         if endorsee_sheet is None:
             msg = f"'{char_name}' has no character sheet."
             raise CommandError(msg)

--- a/src/commands/resonance.py
+++ b/src/commands/resonance.py
@@ -70,7 +70,7 @@ class CmdResonance(ArxCommand):
 
     def _viewer_sheet(self) -> CharacterSheet:
         """The caller's own sheet. Raises ``CommandError`` if the caller has none."""
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             raise CommandError(_NO_IDENTITY)
         return sheet

--- a/src/commands/ritual.py
+++ b/src/commands/ritual.py
@@ -215,7 +215,7 @@ class CmdRitual(ArxCommand):
             if target is None:
                 msg = f"Cannot find '{invite_name}'."
                 raise CommandError(msg)
-            invitee_sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+            invitee_sheet = target.character_sheet
             if invitee_sheet is None:
                 msg = f"'{invite_name}' has no character sheet."
                 raise CommandError(msg)

--- a/src/commands/ritual_adapters.py
+++ b/src/commands/ritual_adapters.py
@@ -264,7 +264,7 @@ class DuranceAdapter(RitualDraftAdapter):
             participant_kwargs["testament"] = testament
         path_token = kwargs.get("path", "").strip()
         if path_token:
-            sheet = getattr(caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+            sheet = caller.character_sheet
             path = resolve_advanced_path_by_name(sheet, path_token) if sheet else None
             if path is None:
                 from world.progression.selectors import eligible_advanced_paths_for  # noqa: PLC0415

--- a/src/commands/sanctum.py
+++ b/src/commands/sanctum.py
@@ -307,7 +307,7 @@ class CmdSanctum(DispatchCommand):
         ]
 
         # getattr avoids AttributeError on objects that don't carry a sheet.
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is not None:
             lines.extend(self._standing_sanctum_lines(sheet))
 

--- a/src/commands/signature.py
+++ b/src/commands/signature.py
@@ -133,7 +133,7 @@ class CmdSignature(DispatchCommand):
         from world.magic.constants import TargetKind  # noqa: PLC0415
         from world.magic.models import CharacterTechnique  # noqa: PLC0415
 
-        sheet = getattr(self.caller, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.caller.character_sheet
         if sheet is None:
             msg = "No active character."
             raise CommandError(msg)

--- a/src/commands/social/soul_tether.py
+++ b/src/commands/social/soul_tether.py
@@ -73,7 +73,7 @@ def _parse_kwargs(args: str) -> dict[str, str]:
 
 def _get_sheet(character: Any) -> Any:
     """Return the CharacterSheet for *character* or raise ``CommandError``."""
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is None:
         msg = f"{character} has no character sheet."
         raise CommandError(msg)

--- a/src/commands/story.py
+++ b/src/commands/story.py
@@ -1460,7 +1460,7 @@ class CmdStory(ArxNamespaceCommand):
             msg = f"Multiple characters match '{name}'."
             raise CommandError(msg)
         target = matches[0]
-        sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = target.character_sheet
         if sheet is None:
             msg = f"'{name}' is not a character with a sheet."
             raise CommandError(msg)

--- a/src/commands/tests/test_sineater_dispatch.py
+++ b/src/commands/tests/test_sineater_dispatch.py
@@ -30,9 +30,8 @@ class SineaterDispatchTests(TestCase):
     def test_pleas_no_sheet_sends_error(self):
         cmd = CmdSineater()
         cmd.caller = MagicMock()
-        cmd.caller.sheet_data = None
-        del cmd.caller.sheet_data
-        type(cmd.caller).sheet_data = None
+        # Simulate "no sheet": the command reads the character_sheet property (audit).
+        type(cmd.caller).character_sheet = None
         cmd.args = "pleas"
         cmd.caller.search.return_value = None
         cmd.func()

--- a/src/evennia_extensions/observability/idmapper_gauge.py
+++ b/src/evennia_extensions/observability/idmapper_gauge.py
@@ -12,9 +12,12 @@ and it never raises—errors on individual classes are caught and skipped.
 from __future__ import annotations
 
 from collections.abc import Iterator
+import logging
 
 from evennia.utils.idmapper.models import SharedMemoryModel
 from pympler.asizeof import asizeof as _asizeof
+
+logger = logging.getLogger(__name__)
 
 
 def _iter_subclasses() -> Iterator[type]:
@@ -96,6 +99,7 @@ def snapshot() -> dict[str, tuple[int, int]]:
             seen_cache_ids.add(cid)
             approx_bytes = _asizeof(cache)
             result[_label(cls)] = (count, int(approx_bytes))
-        except Exception:  # noqa: BLE001,S112
+        except Exception:  # noqa: BLE001
+            logger.debug("idmapper gauge skipped a cache class (audit: was silent)", exc_info=True)
             continue
     return result

--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -50,11 +50,16 @@ class BaseState:
         self.name_prefix_map: dict[int, str] = {}
         self.name_suffix_map: dict[int, str] = {}
         self.packages: list[BehaviorPackageInstance] = []
+        # Generic seam: ``obj`` may be any stateable object — a typeclassed game
+        # object (which carries the ``character_sheet`` property) or a plain model
+        # (ItemInstance in some flows). Explicit type dispatch, not getattr-default.
+        from evennia.objects.models import ObjectDB  # noqa: PLC0415
+
         from world.conditions.thumbnail_services import resolve_thumbnail  # noqa: PLC0415
         from world.scenes.models import Persona  # noqa: PLC0415
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        sheet = getattr(self.obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.obj.character_sheet if isinstance(self.obj, ObjectDB) else None
         if sheet is not None:
             try:
                 persona = active_persona_for_sheet(sheet)

--- a/src/flows/object_states/character_state.py
+++ b/src/flows/object_states/character_state.py
@@ -48,7 +48,7 @@ class CharacterState(BaseState):
         from world.scenes.persona_display import resolve_display_for_viewer  # noqa: PLC0415
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        sheet = getattr(self.obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.obj.character_sheet
         if sheet is None:
             return None
         try:

--- a/src/flows/object_states/exit_state.py
+++ b/src/flows/object_states/exit_state.py
@@ -37,7 +37,7 @@ class ExitState(BaseState):
         from world.locations.services import is_owner, is_tenant  # noqa: PLC0415
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        sheet = getattr(actor.obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = actor.obj.character_sheet
         if sheet is None:
             return True
         persona = active_persona_for_sheet(sheet)

--- a/src/flows/service_functions/inventory.py
+++ b/src/flows/service_functions/inventory.py
@@ -67,7 +67,7 @@ def _require_hot_goods_consent(recipient: CharacterState, item_instance: ItemIns
     the item's provenance from the refusal. NPC recipients (no live tenure)
     are unaffected — consent is a player-protection surface.
     """
-    recipient_sheet = getattr(recipient.obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    recipient_sheet = recipient.obj.character_sheet
     if recipient_sheet is None:
         return
     recipient_tenure = _active_tenure_for_sheet(recipient_sheet)
@@ -271,7 +271,7 @@ def pick_up(character: CharacterState, item: ItemState) -> None:
     """
     if not item.can_take(taker=character):
         raise NotReachable
-    taker_sheet = getattr(character.obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    taker_sheet = character.obj.character_sheet
     denial = _take_denial(taker_sheet, item.instance)
     if denial is not None:
         raise denial
@@ -502,7 +502,7 @@ def take_out(character: CharacterState, item: ItemState) -> None:
         raise NotReachable
     if item.instance.contained_in is None:
         raise NotInContainer
-    taker_sheet = getattr(character.obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    taker_sheet = character.obj.character_sheet
     denial = _take_denial(taker_sheet, item.instance)
     if denial is not None:
         raise denial
@@ -637,7 +637,7 @@ def steal(character: CharacterState, item: ItemState) -> None:
     # None rather than raise DoesNotExist — steal_permitted then delegates to
     # take_requires_steal, which returns False for a None sheet, so a
     # sheet-less actor always ends up refused here (they free-take instead).
-    taker_sheet = getattr(character.obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    taker_sheet = character.obj.character_sheet
     if not steal_permitted(taker_sheet, item.instance):
         raise TheftNotPermitted
     previous_holder_sheet = item.instance.holder_character_sheet
@@ -673,7 +673,7 @@ def set_container_policy(character: CharacterState, container: ItemState, policy
     owner = container.instance.holder_character_sheet
     # getattr, not direct access: a sheet-less actor owns nothing, so it can
     # never be the container's owner — refuse rather than raise DoesNotExist.
-    actor_sheet = getattr(character.obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    actor_sheet = character.obj.character_sheet
     if owner is None or actor_sheet is None or owner.pk != actor_sheet.pk:
         raise NotInPossession
     container.instance.access_policy = ContainerAccessPolicy(policy)

--- a/src/flows/service_functions/movement.py
+++ b/src/flows/service_functions/movement.py
@@ -45,7 +45,7 @@ def move_object(
         raise CommandError(msg)
 
     # Auto-engage Durance covenant if co-present with members (Slice B §4.10)
-    sheet = getattr(obj.obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = obj.obj.character_sheet
     if sheet is not None and obj.obj.location is not None:
         from world.covenants.services import (  # noqa: PLC0415
             evaluate_scene_engagement,
@@ -65,7 +65,7 @@ def move_object(
         from world.covenants.services import revalidate_engagements  # noqa: PLC0415
 
         for remaining in origin.contents:
-            remaining_sheet = getattr(remaining, "sheet_data", None)  # noqa: GETATTR_LITERAL
+            remaining_sheet = remaining.character_sheet
             if remaining_sheet is None:
                 continue
             roles = remaining_sheet.character.covenant_roles

--- a/src/typeclasses/mixins.py
+++ b/src/typeclasses/mixins.py
@@ -64,7 +64,7 @@ class ObjectParent:
     def character_sheet(self: Union[Self, "DefaultObject"]) -> "CharacterSheet | None":
         """This object's CharacterSheet, or None for anything that isn't a character.
 
-        The safe, explicit replacement for ``getattr(obj, "sheet_data", None)``:
+        The safe, explicit replacement for ``obj.character_sheet``:
         ``sheet_data`` is the reverse OneToOne from ``CharacterSheet.character`` and
         raises on sheetless objects — the getattr idiom only "worked" because Django's
         RelatedObjectDoesNotExist subclasses AttributeError, which also swallowed

--- a/src/web/admin/views.py
+++ b/src/web/admin/views.py
@@ -1,6 +1,7 @@
 """Admin customization views."""
 
 from datetime import UTC, datetime
+import logging
 
 from django.apps import apps
 from django.contrib.admin.views.decorators import staff_member_required
@@ -11,6 +12,8 @@ from django.views.decorators.http import require_POST
 
 from web.admin.models import AdminExcludedModel, AdminPinnedModel
 from web.admin.services import HARDCODED_EXCLUDED_APPS, analyze_fixture, execute_import
+
+logger = logging.getLogger(__name__)
 
 
 @require_POST
@@ -75,7 +78,8 @@ def export_data(request):
             model = apps.get_model(app_label, model_name)
             objects = list(model.objects.all())
             all_objects.extend(objects)
-        except Exception:  # noqa: BLE001, S112
+        except Exception:
+            logger.exception("admin export loop skipped a model (audit: was silent)")
             continue
 
     # Serialize with natural keys
@@ -157,7 +161,8 @@ def export_preview(request):
         # Get record count
         try:
             count = model.objects.count()
-        except Exception:  # noqa: BLE001, S112
+        except Exception:
+            logger.exception("admin export loop skipped a model (audit: was silent)")
             continue
 
         has_natural_key = issubclass(model, NaturalKeyMixin) or hasattr(model, "natural_key")

--- a/src/world/areas/positioning/plummet.py
+++ b/src/world/areas/positioning/plummet.py
@@ -175,7 +175,7 @@ def _apply_fall_impact(target: ObjectDB, instance: ConditionInstance) -> None:  
     from world.conditions.models import DamageType  # noqa: PLC0415
     from world.vitals.services import process_damage_consequences  # noqa: PLC0415
 
-    sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = target.character_sheet
     damage = instance.severity * settings.FALL_IMPACT_PER_LEVEL
     fall_type = DamageType.objects.filter(name=FALL_DAMAGE_TYPE_NAME).first()
 

--- a/src/world/boundaries/services.py
+++ b/src/world/boundaries/services.py
@@ -66,7 +66,7 @@ def _sheet_player_and_tenure_ids(sheets: list[CharacterSheet]) -> tuple[set[int]
     player_ids: set[int] = set()
     tenure_ids: set[int] = set()
     for sheet in sheets:
-        entry = getattr(sheet, "roster_entry", None)  # noqa: GETATTR_LITERAL — OneToOne reverse may not exist
+        entry = sheet.roster_entry_or_none
         tenure = entry.current_tenure if entry else None
         if tenure is not None:
             player_ids.add(tenure.player_data_id)

--- a/src/world/character_sheets/models.py
+++ b/src/world/character_sheets/models.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from world.items.handlers import CharacterSheetOutfitsHandler
     from world.magic.models.affinity import Resonance
     from world.mechanics.models import Property
+    from world.roster.models import RosterEntry
     from world.scenes.models import Persona
 
 from django.core.exceptions import ValidationError
@@ -625,7 +626,7 @@ class CharacterSheet(SharedMemoryModel):
         available signal (so consumers can still read decay_tier even when
         the cron won't auto-flip activity_state).
         """
-        entry = getattr(self, "roster_entry", None)  # noqa: GETATTR_LITERAL — OneToOne reverse may not exist
+        entry = self.roster_entry_or_none
         if entry is None:
             return self.created_by.last_login if self.created_by_id else None
 
@@ -648,6 +649,22 @@ class CharacterSheet(SharedMemoryModel):
         from world.achievements.handlers import StatHandler  # noqa: PLC0415
 
         return StatHandler(self)
+
+    @property
+    def roster_entry_or_none(self) -> RosterEntry | None:
+        """This sheet's RosterEntry, or None (test/NPC sheets outside the roster flow).
+
+        The safe, explicit replacement for ``sheet.roster_entry_or_none``:
+        the reverse OneToOne raises RelatedObjectDoesNotExist (an AttributeError
+        subclass), so the getattr default silently swallowed genuine attribute bugs
+        along with the expected miss. Mirrors ``ObjectParent.character_sheet``.
+        """
+        from world.roster.models import RosterEntry  # noqa: PLC0415
+
+        try:
+            return self.roster_entry
+        except RosterEntry.DoesNotExist:
+            return None
 
     @cached_property
     def primary_persona(self) -> Persona:

--- a/src/world/character_sheets/tests/test_roster_entry_accessor.py
+++ b/src/world/character_sheets/tests/test_roster_entry_accessor.py
@@ -1,0 +1,21 @@
+"""CharacterSheet.roster_entry_or_none — the safe reverse-OneToOne accessor (audit).
+
+Replaces the ``getattr(sheet, "roster_entry", None)`` idiom: the reverse OneToOne
+raises RelatedObjectDoesNotExist (an AttributeError subclass), so getattr-with-default
+silently swallowed real attribute bugs along with the expected miss.
+"""
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import RosterEntryFactory
+
+
+class RosterEntryOrNoneTests(TestCase):
+    def test_sheet_with_entry_returns_it(self):
+        entry = RosterEntryFactory()
+        assert entry.character_sheet.roster_entry_or_none == entry
+
+    def test_sheet_without_entry_returns_none(self):
+        sheet = CharacterSheetFactory()
+        assert sheet.roster_entry_or_none is None

--- a/src/world/combat/escalation.py
+++ b/src/world/combat/escalation.py
@@ -356,7 +356,7 @@ def apply_relationship_escalation_spike(
     from world.relationships.models import CharacterRelationship  # noqa: PLC0415
     from world.scenes.constants import RoundStatus  # noqa: PLC0415
 
-    fallen_sheet = getattr(fallen_character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    fallen_sheet = fallen_character.character_sheet
     if fallen_sheet is None:
         return
 
@@ -427,7 +427,7 @@ def apply_peril_escalation_spike(
     from world.relationships.models import CharacterRelationship  # noqa: PLC0415
     from world.scenes.constants import RoundStatus  # noqa: PLC0415
 
-    victim_sheet = getattr(victim_character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    victim_sheet = victim_character.character_sheet
     if victim_sheet is None:
         return
 

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -2288,7 +2288,7 @@ def _enforce_opponent_custody_gate(
     """
     if is_ephemeral or acting_account is None:
         return
-    sheet = getattr(objectdb, "sheet_data", None)  # noqa: GETATTR_LITERAL — OneToOne reverse may not exist
+    sheet = objectdb.character_sheet
     if sheet is None:
         return
 
@@ -8887,7 +8887,7 @@ def _resonant_armor_soak(character: Character) -> int:
         get_modifier_breakdown,
     )
 
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL — OneToOne reverse may not exist
+    sheet = character.character_sheet
     if sheet is None:
         return 0
     try:

--- a/src/world/companions/handlers.py
+++ b/src/world/companions/handlers.py
@@ -24,11 +24,11 @@ class CharacterCompanionHandler:
         """This character's currently-bonded (unreleased) companions.
 
         Returns [] gracefully when the character has no sheet_data (mirrors
-        the existing getattr(self, "sheet_data", None) guard pattern used
+        the existing self.character_sheet guard pattern used
         throughout typeclasses/characters.py) — e.g. a CompanionObject or a
         GM/Staff character has no companions of its own.
         """
-        sheet = getattr(self.character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = self.character.character_sheet
         if sheet is None:
             return []
         return list(

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -277,7 +277,7 @@ def can_perceive(actor: "ObjectDB", target: "ObjectDB") -> bool:  # noqa: OBJECT
     concealments = active_concealments(target)
     if not concealments.exists():
         return True
-    actor_sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    actor_sheet = actor.character_sheet
     if actor_sheet is None:
         return False
     return not concealments.exclude(detected_by=actor_sheet).exists()

--- a/src/world/conditions/views.py
+++ b/src/world/conditions/views.py
@@ -477,7 +477,7 @@ class TreatmentCandidateViewSet(CharacterContextMixin, viewsets.ViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        helper_sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        helper_sheet = character.character_sheet
         if helper_sheet is None:
             return Response(
                 {"detail": "No character sheet found."},

--- a/src/world/covenants/court_missions.py
+++ b/src/world/covenants/court_missions.py
@@ -68,7 +68,7 @@ def has_regarded_target_present(*, character_sheet: CharacterSheet, covenant: Co
         return False
 
     for obj in location.contents:
-        sheet = getattr(obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = obj.character_sheet
         if sheet is None or sheet == character_sheet:
             continue
         target_persona = active_persona_for_sheet(sheet)

--- a/src/world/covenants/handlers.py
+++ b/src/world/covenants/handlers.py
@@ -223,7 +223,7 @@ def can_engage_membership(membership: CharacterCovenantRole) -> bool:
     self_sheet = membership.character_sheet
     target_covenant = membership.covenant
     for obj in location.contents:
-        sheet = getattr(obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = obj.character_sheet
         if sheet is None or sheet == self_sheet:
             continue
         if sheet.character.covenant_roles.currently_held_role_in(target_covenant) is not None:

--- a/src/world/covenants/services.py
+++ b/src/world/covenants/services.py
@@ -1669,7 +1669,7 @@ def _co_present_member_count(
     target = membership.covenant
     n = 0
     for obj in room.contents:
-        sheet = getattr(obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = obj.character_sheet
         if sheet is None or sheet == self_sheet:
             continue
         if sheet.character.covenant_roles.currently_held_role_in(target) is not None:
@@ -1691,7 +1691,7 @@ def covenant_members_present(*, covenant: Covenant, room: ObjectDB) -> list[Char
     )
     present: list[CharacterSheet] = []
     for obj in room.contents:
-        sheet = getattr(obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = obj.character_sheet
         if sheet is not None and sheet.pk in active_sheet_ids:
             present.append(sheet)
     return present

--- a/src/world/currency/views.py
+++ b/src/world/currency/views.py
@@ -187,7 +187,7 @@ def _viewer_persona(request: Request):
         return None
     if puppet is None:
         return None
-    sheet = getattr(puppet, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = puppet.character_sheet
     if sheet is None:
         return None
     try:

--- a/src/world/forms/serializers.py
+++ b/src/world/forms/serializers.py
@@ -130,7 +130,7 @@ class AlternateSelfSerializer(serializers.ModelSerializer):
             request = self.context.get("request")
             user = getattr(request, "user", None)  # noqa: GETATTR_LITERAL
             puppet = getattr(user, "puppet", None)  # noqa: GETATTR_LITERAL
-            sheet = getattr(puppet, "sheet_data", None)  # noqa: GETATTR_LITERAL
+            sheet = puppet.character_sheet
             active = (
                 getattr(sheet, "active_alternate_self", None)  # noqa: GETATTR_LITERAL
                 if sheet is not None

--- a/src/world/forms/services/__init__.py
+++ b/src/world/forms/services/__init__.py
@@ -742,7 +742,7 @@ def get_presented_appearance(character, *, pierced: bool = False) -> list[Presen
     )
 
     descriptors: dict[int, str] = {}
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is not None and not hide_descriptors:
         try:
             persona = active_persona_for_sheet(sheet)

--- a/src/world/forms/services/identification.py
+++ b/src/world/forms/services/identification.py
@@ -102,7 +102,7 @@ def _presents_fake_name(target_character) -> bool:
     from world.scenes.models import Persona  # noqa: PLC0415
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-    sheet = getattr(target_character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = target_character.character_sheet
     if sheet is None:
         return False
     try:
@@ -194,7 +194,7 @@ def identification_difficulty(viewer_sheet: CharacterSheet, target_character) ->
             kit_quality_bonus=0,
         )
 
-    target_sheet = getattr(target_character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    target_sheet = target_character.character_sheet
     familiarity_ease = 0
     if target_sheet is not None:
         familiarity_ease += _relationship_ease(viewer_sheet, target_sheet)
@@ -274,7 +274,7 @@ def _target_persona_pair(target_character) -> tuple[Persona | None, Persona | No
     from world.scenes.models import Persona  # noqa: PLC0415
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-    target_sheet = getattr(target_character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    target_sheet = target_character.character_sheet
     if target_sheet is None:
         return None, None
     try:
@@ -371,7 +371,7 @@ def attempt_identification(
     from world.forms.constants import IDENTIFICATION_CHECK_TYPE_NAME  # noqa: PLC0415
     from world.scenes.services import persona_discovery_between  # noqa: PLC0415
 
-    viewer_sheet = getattr(viewer_character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    viewer_sheet = viewer_character.character_sheet
     if viewer_sheet is None:
         return _failure_result()
 

--- a/src/world/forms/views.py
+++ b/src/world/forms/views.py
@@ -132,7 +132,7 @@ class AlternateSelfViewSet(
     def get_queryset(self):
         """Filter to alternate selves belonging to the played character's sheet."""
         user = self.request.user
-        sheet = getattr(getattr(user, "puppet", None), "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = getattr(user, "puppet", None).character_sheet  # noqa: GETATTR_LITERAL
         queryset = AlternateSelf.objects.select_related(
             "persona", "form", "combat_profile"
         ).prefetch_related("techniques")  # noqa: PREFETCH_STRING
@@ -156,7 +156,7 @@ class AlternateSelfViewSet(
         body = ShiftFormRequestSerializer(data=request.data)
         body.is_valid(raise_exception=True)
         puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        sheet = getattr(puppet, "sheet_data", None) if puppet is not None else None  # noqa: GETATTR_LITERAL
+        sheet = puppet.character_sheet if puppet is not None else None
         if puppet is None or sheet is None:
             msg = "You must be playing a character to shift forms."
             raise serializers.ValidationError(msg)
@@ -187,7 +187,7 @@ class AlternateSelfViewSet(
     def revert(self, request: Request) -> Response:
         """#1111 — revert the active alternate self (blocked while not in control)."""
         puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        sheet = getattr(puppet, "sheet_data", None) if puppet is not None else None  # noqa: GETATTR_LITERAL
+        sheet = puppet.character_sheet if puppet is not None else None
         if puppet is None or sheet is None:
             msg = "You must be playing a character to revert forms."
             raise serializers.ValidationError(msg)

--- a/src/world/forms/views.py
+++ b/src/world/forms/views.py
@@ -32,6 +32,7 @@ from world.forms.serializers import (
     ShiftFormRequestSerializer,
 )
 from world.forms.services import get_apparent_form, get_cg_builds, get_cg_height_bands
+from world.roster.selectors import puppeted_sheet_for
 
 
 class FormTraitViewSet(viewsets.ReadOnlyModelViewSet):
@@ -132,7 +133,7 @@ class AlternateSelfViewSet(
     def get_queryset(self):
         """Filter to alternate selves belonging to the played character's sheet."""
         user = self.request.user
-        sheet = getattr(user, "puppet", None).character_sheet  # noqa: GETATTR_LITERAL
+        sheet = puppeted_sheet_for(user)
         queryset = AlternateSelf.objects.select_related(
             "persona", "form", "combat_profile"
         ).prefetch_related("techniques")  # noqa: PREFETCH_STRING
@@ -156,7 +157,7 @@ class AlternateSelfViewSet(
         body = ShiftFormRequestSerializer(data=request.data)
         body.is_valid(raise_exception=True)
         puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        sheet = puppet.character_sheet if puppet is not None else None
+        sheet = puppeted_sheet_for(request.user)
         if puppet is None or sheet is None:
             msg = "You must be playing a character to shift forms."
             raise serializers.ValidationError(msg)
@@ -187,7 +188,7 @@ class AlternateSelfViewSet(
     def revert(self, request: Request) -> Response:
         """#1111 — revert the active alternate self (blocked while not in control)."""
         puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        sheet = puppet.character_sheet if puppet is not None else None
+        sheet = puppeted_sheet_for(request.user)
         if puppet is None or sheet is None:
             msg = "You must be playing a character to revert forms."
             raise serializers.ValidationError(msg)

--- a/src/world/items/services/mantle.py
+++ b/src/world/items/services/mantle.py
@@ -44,7 +44,7 @@ def _codex_entry_learned(sheet: CharacterSheet, entry_id: int) -> bool:
     """
     from world.codex.models import CharacterCodexKnowledge  # noqa: PLC0415
 
-    roster_entry = getattr(sheet, "roster_entry", None)  # noqa: GETATTR_LITERAL — reverse OneToOne may not exist
+    roster_entry = sheet.roster_entry_or_none
     if roster_entry is None:
         return False
     return CharacterCodexKnowledge.objects.filter(

--- a/src/world/items/services/usage.py
+++ b/src/world/items/services/usage.py
@@ -211,7 +211,7 @@ def _apply_appearance_effects(
     from world.forms.services import NonCosmeticTraitError, change_appearance  # noqa: PLC0415
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-    sheet = getattr(user, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = user.character_sheet
     if sheet is None:
         return []
 
@@ -253,7 +253,7 @@ def _apply_disguise_kit_effects(
     from world.forms.models import CharacterForm, CharacterFormState, FormType  # noqa: PLC0415
     from world.forms.services import apply_disguise  # noqa: PLC0415
 
-    sheet = getattr(user, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = user.character_sheet
     if sheet is None:
         return None
 

--- a/src/world/items/views.py
+++ b/src/world/items/views.py
@@ -1291,7 +1291,7 @@ class VisibleItemDetailViewSet(viewsets.ViewSet):
         observer = _fetch_owned_observer(request, user)
         if observer is None:
             return None
-        return getattr(observer, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        return observer.character_sheet
 
     def _user_can_view(self, user: AccountDB, item: ItemInstance, request: Request) -> bool:
         """Permission check for ``item`` against ``user`` and the observer."""

--- a/src/world/justice/display.py
+++ b/src/world/justice/display.py
@@ -41,7 +41,7 @@ def heat_reading_for_character(character: ObjectDB, room: ObjectDB | None) -> He
 
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is None or room is None:
         return None
     try:

--- a/src/world/locations/character_comfort.py
+++ b/src/world/locations/character_comfort.py
@@ -89,7 +89,7 @@ def comfort_mitigation(character: DefaultObject) -> dict[StatKey, int]:
     targets). The aggregate the room's exposure is measured against.
     """
     mitigation = _worn_garment_mitigation(character)
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is not None:
         _add_modifier_mitigation(sheet, mitigation)
     return mitigation
@@ -97,7 +97,7 @@ def comfort_mitigation(character: DefaultObject) -> dict[StatKey, int]:
 
 def injury_discomfort(character: DefaultObject) -> int:
     """Extra discomfort from injury — scales with how far below full health the character is."""
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is None:
         return 0
     try:

--- a/src/world/magic/crossing/ceremony.py
+++ b/src/world/magic/crossing/ceremony.py
@@ -136,7 +136,7 @@ def _unlock_codex(sheet: CharacterSheet, codex_entry: CodexEntry) -> None:
     """
     # CharacterCodexKnowledge is keyed on RosterEntry, not CharacterSheet.
     # sheet.roster_entry is a OneToOne reverse — may not exist.
-    roster_entry = getattr(sheet, "roster_entry", None)  # noqa: GETATTR_LITERAL
+    roster_entry = sheet.roster_entry_or_none
     if roster_entry is None:
         return
 

--- a/src/world/magic/services/gain.py
+++ b/src/world/magic/services/gain.py
@@ -59,6 +59,7 @@ Accessor reference (verified 2026-04-23 during implementation):
 from __future__ import annotations
 
 from decimal import Decimal
+import logging
 import math
 from typing import TYPE_CHECKING
 
@@ -97,6 +98,8 @@ from world.magic.types import (
 from world.scenes.constants import InteractionMode, InteractionVisibility, ScenePrivacyMode
 from world.scenes.models import Interaction, Persona, Scene, SceneParticipation
 from world.scenes.place_models import InteractionReceiver
+
+logger = logging.getLogger(__name__)
 
 
 def account_for_sheet(sheet: CharacterSheet) -> AccountDB | None:
@@ -1009,8 +1012,8 @@ def residence_trickle_tick() -> ResonanceDailyTickSummary:
                         room_profile=rp,
                     )
                     grants_issued += 1
-            except Exception:  # noqa: BLE001, S112
-                # TODO: structured log via Evennia logger.
+            except Exception:
+                logger.exception("resonance trickle skipped a sheet (audit: was silent)")
                 continue
 
     return ResonanceDailyTickSummary(
@@ -1129,7 +1132,8 @@ def resonance_weekly_settlement_tick() -> ResonanceWeeklySettlementSummary:
         sheet = CharacterSheet.objects.get(pk=sheet_id)
         try:
             result = settle_weekly_pot(sheet)
-        except Exception:  # noqa: BLE001, S112
+        except Exception:
+            logger.exception("resonance grant loop skipped an entry (audit: was silent)")
             continue
         if result.endorsements_settled:
             endorsers_settled += 1

--- a/src/world/magic/services/portal_travel.py
+++ b/src/world/magic/services/portal_travel.py
@@ -73,7 +73,7 @@ def _active_persona_for(character: ObjectDB) -> Persona | None:
 
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is None:
         return None
     try:
@@ -89,7 +89,7 @@ def _known_travel_technique_map(character: ObjectDB) -> dict[int, Technique]:
     character who knows several techniques bound to the same anchor kind
     still only needs one to travel through it.
     """
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is None:
         return {}
 

--- a/src/world/magic/services/progression_dashboard.py
+++ b/src/world/magic/services/progression_dashboard.py
@@ -233,7 +233,7 @@ def build_progression_dashboard(sheet: CharacterSheet) -> list[StageView]:
 
     No queries run inside the per-stage / per-milestone loops.
     """
-    roster_entry = getattr(sheet, "roster_entry", None)  # noqa: GETATTR_LITERAL
+    roster_entry = sheet.roster_entry_or_none
     current_stage = _current_path_stage(sheet)
 
     # Load all milestones in a single query.

--- a/src/world/magic/services/pull_modulation_court.py
+++ b/src/world/magic/services/pull_modulation_court.py
@@ -58,7 +58,7 @@ def court_regard_modulation(
     leader_persona = _resolve_court_leader_persona(thread)
     if leader_persona is None:
         return base_scaled
-    target_sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    target_sheet = target.character_sheet
     if target_sheet is None:
         return base_scaled
     regard = get_regard(leader_persona, active_persona_for_sheet(target_sheet))

--- a/src/world/magic/services/pull_modulation_relationship.py
+++ b/src/world/magic/services/pull_modulation_relationship.py
@@ -118,7 +118,7 @@ def relationship_bond_modulation(
     from world.magic.services.threads import _soft_cap  # noqa: PLC0415
     from world.relationships.models import CharacterRelationship  # noqa: PLC0415
 
-    x_sheet = getattr(target, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    x_sheet = target.character_sheet
     if x_sheet is None:
         return base_scaled
 

--- a/src/world/missions/integrations/crime_watch.py
+++ b/src/world/missions/integrations/crime_watch.py
@@ -37,7 +37,7 @@ def _deed_time_persona(line: MissionDeedRewardLine) -> Persona | None:
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
     actor = line.deed.actor
-    sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = actor.character_sheet
     accepted = line.deed.instance.accepted_as_persona
     if accepted is not None and sheet is not None and accepted.character_sheet_id == sheet.pk:
         return accepted

--- a/src/world/missions/services/external_acts.py
+++ b/src/world/missions/services/external_acts.py
@@ -173,7 +173,7 @@ def fast_forward_external_acts(instance: MissionInstance, node: MissionNode) -> 
     holder = instance.participants.filter(is_contract_holder=True).first()
     if holder is None:
         return
-    sheet = getattr(holder.character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = holder.character.character_sheet
     if sheet is None:
         return
     option = node.options.filter(

--- a/src/world/missions/services/multiplayer.py
+++ b/src/world/missions/services/multiplayer.py
@@ -223,7 +223,7 @@ def _emit_group_resolution_narrative(
             continue
         story_text = _story_text_for(presented_opt, deed, template_name)
         actor = deed.actor
-        sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = actor.character_sheet
         if sheet is not None:
             send_narrative_message(
                 recipients=[sheet],

--- a/src/world/missions/services/offer_handler.py
+++ b/src/world/missions/services/offer_handler.py
@@ -148,7 +148,7 @@ def _is_solo_without_vow(persona: Persona) -> bool:
         for obj in location.contents:
             if obj == character:
                 continue
-            if getattr(obj, "sheet_data", None) is not None:  # noqa: GETATTR_LITERAL
+            if obj.character_sheet is not None:
                 return False
     return True
 

--- a/src/world/missions/services/play.py
+++ b/src/world/missions/services/play.py
@@ -210,7 +210,7 @@ def _seed_legend_stories(
     from world.societies.models import LegendDeedStory, LegendEntry  # noqa: PLC0415
     from world.societies.spread_services import save_deed_story  # noqa: PLC0415
 
-    sheet = getattr(participant.character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = participant.character.character_sheet
     if sheet is None:
         return
     if participant.is_contract_holder and instance.accepted_as_persona_id is not None:
@@ -317,7 +317,7 @@ def resolve_beat_option(
     # an activation is open — safe to call on every action.
     from world.missions.services.beat import activate_stakes_for_instance  # noqa: PLC0415
 
-    stake_sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    stake_sheet = character.character_sheet
     if stake_sheet is not None:
         activate_stakes_for_instance(instance, [stake_sheet])
 
@@ -325,7 +325,7 @@ def resolve_beat_option(
     story_text = _story_text_for(presented, deed, instance.template.name)
     is_terminal = instance.current_node_id is None
 
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is not None:
         send_narrative_message(
             recipients=[sheet],

--- a/src/world/missions/services/report.py
+++ b/src/world/missions/services/report.py
@@ -213,7 +213,7 @@ def _apply_masked_deed_association(
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
     mask = instance.accepted_as_persona
-    sheet = getattr(reporter, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = reporter.character_sheet
     if mask is None or sheet is None or mask.character_sheet_id != sheet.pk:
         return
     reporting_persona = active_persona_for_sheet(sheet)
@@ -242,7 +242,7 @@ def _apply_masked_deed_association(
 def _deliver_bonus_money(reporter: ObjectDB, amount: int) -> None:
     from world.currency.services import deliver_mission_money  # noqa: PLC0415
 
-    sheet = getattr(reporter, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = reporter.character_sheet
     if sheet is not None and amount > 0:
         deliver_mission_money(recipient_sheet=sheet, amount=amount, ref="mission-embellish-bonus")
 
@@ -253,7 +253,7 @@ def _apply_fame_prestige(reporter: ObjectDB, delta: int) -> None:
     from world.scenes.constants import PersonaType  # noqa: PLC0415
     from world.societies.renown import award_deed_prestige, set_persona_fame  # noqa: PLC0415
 
-    sheet = getattr(reporter, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = reporter.character_sheet
     if sheet is None:
         return
     persona = sheet.personas.filter(persona_type=PersonaType.PRIMARY).first()
@@ -267,7 +267,7 @@ def _grant_style_resonance(reporter: ObjectDB, style: str) -> None:
     name = _STYLE_RESONANCE.get(style)
     if name is None:
         return
-    sheet = getattr(reporter, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = reporter.character_sheet
     if sheet is None:
         return
     from world.magic.constants import GainSource  # noqa: PLC0415

--- a/src/world/narrative/services.py
+++ b/src/world/narrative/services.py
@@ -365,7 +365,7 @@ def emit_ambient_room_stir(room: ObjectDB, *, exclude: ObjectDB | None = None) -
     for obj in room.contents:
         if exclude is not None and obj.pk == exclude.pk:
             continue
-        sheet = getattr(obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = obj.character_sheet
         if sheet is not None:
             recipients.append(sheet)
     if not recipients:

--- a/src/world/npc_services/servant_fetch.py
+++ b/src/world/npc_services/servant_fetch.py
@@ -218,7 +218,7 @@ def _complete_item_fetch(
         return
 
     # Set holder if unowned (same logic as pick_up).
-    taker_sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    taker_sheet = actor.character_sheet
     if item_instance.holder_character_sheet_id is None and taker_sheet is not None:
         item_instance.holder_character_sheet = taker_sheet
         item_instance.save(update_fields=["holder_character_sheet"])

--- a/src/world/npc_services/services.py
+++ b/src/world/npc_services/services.py
@@ -194,7 +194,7 @@ def _build_eligibility_cache(
     role_cooldown_active = NPCRoleCooldown.objects.filter(
         role_id=role.pk, persona=persona, available_at__gt=now
     ).exists()
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is None:
         pc_at_npc_cap = True
     else:
@@ -359,7 +359,7 @@ def _mission_gates_pass(  # noqa: PLR0911
         return False
     if not template_visible_to(template, character, persona=persona):
         return False
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is None:
         # No sheet → no level → can't satisfy the level-band gate. Fail closed
         # consistently with the PC-cap gate above (cache.pc_at_npc_cap is True

--- a/src/world/npc_services/views.py
+++ b/src/world/npc_services/views.py
@@ -368,7 +368,7 @@ class OfferSummonsViewSet(viewsets.ModelViewSet):
         puppet = getattr(user, "puppet", None)  # noqa: GETATTR_LITERAL
         if puppet is None:
             return qs.none()
-        sheet_data = getattr(puppet, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet_data = puppet.character_sheet
         persona = getattr(sheet_data, "primary_persona", None) if sheet_data is not None else None  # noqa: GETATTR_LITERAL
         if persona is None:
             return qs.none()

--- a/src/world/npc_services/views.py
+++ b/src/world/npc_services/views.py
@@ -365,8 +365,12 @@ class OfferSummonsViewSet(viewsets.ModelViewSet):
         except GMProfile.DoesNotExist:
             pass
         # Non-staff: scope to the caller's active persona.
+        from evennia.objects.models import ObjectDB  # noqa: PLC0415
+
+        # Account.puppet is not None for sessionless accounts — it can be a
+        # non-character object. Explicit type dispatch (audit), not getattr-default.
         puppet = getattr(user, "puppet", None)  # noqa: GETATTR_LITERAL
-        if puppet is None:
+        if not isinstance(puppet, ObjectDB):
             return qs.none()
         sheet_data = puppet.character_sheet
         persona = getattr(sheet_data, "primary_persona", None) if sheet_data is not None else None  # noqa: GETATTR_LITERAL

--- a/src/world/progression/views.py
+++ b/src/world/progression/views.py
@@ -77,6 +77,7 @@ from world.progression.services.voting import (
     get_votes_by_voter,
 )
 from world.roster.models import RosterEntry
+from world.roster.selectors import puppeted_sheet_for
 from world.skills.services import skills_at_boundary
 from world.stories.pagination import StandardResultsSetPagination
 
@@ -551,7 +552,7 @@ class SelectPathViewSet(CharacterContextMixin, viewsets.ViewSet):
 def _resolve_puppet_sheet(request: Request) -> tuple[Any, CharacterSheet]:
     """Return the played character and its sheet, or raise ValidationError."""
     puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-    sheet = puppet.character_sheet if puppet is not None else None
+    sheet = puppeted_sheet_for(request.user)
     if puppet is None or sheet is None:
         msg = "You must be playing a character to view or purchase unlocks."
         raise serializers.ValidationError(msg)

--- a/src/world/progression/views.py
+++ b/src/world/progression/views.py
@@ -434,7 +434,7 @@ class PathIntentViewSet(CharacterContextMixin, viewsets.ViewSet):
         if character is None:
             return None
         # Reverse OneToOne may be absent for sheet-less characters.
-        return getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        return character.character_sheet
 
     def list(self, request: Request) -> Response:
         """GET — return current intent or {"intent": null}."""
@@ -551,7 +551,7 @@ class SelectPathViewSet(CharacterContextMixin, viewsets.ViewSet):
 def _resolve_puppet_sheet(request: Request) -> tuple[Any, CharacterSheet]:
     """Return the played character and its sheet, or raise ValidationError."""
     puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-    sheet = getattr(puppet, "sheet_data", None) if puppet is not None else None  # noqa: GETATTR_LITERAL
+    sheet = puppet.character_sheet if puppet is not None else None
     if puppet is None or sheet is None:
         msg = "You must be playing a character to view or purchase unlocks."
         raise serializers.ValidationError(msg)

--- a/src/world/relationships/helpers.py
+++ b/src/world/relationships/helpers.py
@@ -22,8 +22,8 @@ def get_relationship_tier(character_a: ObjectDB, character_b: ObjectDB) -> int:
     Returns:
         Relationship tier as an integer (0 = no/new relationship).
     """
-    sheet_a = getattr(character_a, "sheet_data", None)  # noqa: GETATTR_LITERAL
-    sheet_b = getattr(character_b, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet_a = character_a.character_sheet
+    sheet_b = character_b.character_sheet
     if sheet_a is None or sheet_b is None:
         return 0
     rel = CharacterRelationship.objects.filter(source=sheet_a, target=sheet_b).first()

--- a/src/world/relationships/services.py
+++ b/src/world/relationships/services.py
@@ -873,8 +873,8 @@ def bond_bonus(actor: ObjectDB, protected: ObjectDB) -> int:
     Looks up the directed relationship actor→protected and returns
     ``int(mechanical_bonus)`` if above the config floor, else 0.
     """
-    actor_sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
-    protected_sheet = getattr(protected, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    actor_sheet = actor.character_sheet
+    protected_sheet = protected.character_sheet
     if actor_sheet is None or protected_sheet is None:
         return 0
 

--- a/src/world/relationships/tests/test_combat_bonds.py
+++ b/src/world/relationships/tests/test_combat_bonds.py
@@ -148,9 +148,9 @@ class BondBonusTests(TestCase):
         sheet = CharacterSheetFactory()
         ally = CharacterSheetFactory()
         actor = MagicMock()
-        actor.sheet_data = sheet
+        actor.character_sheet = sheet
         protected = MagicMock()
-        protected.sheet_data = ally
+        protected.character_sheet = ally
         self.assertEqual(bond_bonus(actor, protected), 0)
 
     def test_bond_above_floor_returns_bonus(self):
@@ -159,9 +159,9 @@ class BondBonusTests(TestCase):
 
         sheet, ally, _ = _make_bonded_pair(CharacterSheetFactory, developed_points=27)
         actor = MagicMock()
-        actor.sheet_data = sheet
+        actor.character_sheet = sheet
         protected = MagicMock()
-        protected.sheet_data = ally
+        protected.character_sheet = ally
         self.assertEqual(bond_bonus(actor, protected), 3)
 
     def test_bond_below_floor_returns_zero(self):
@@ -170,17 +170,17 @@ class BondBonusTests(TestCase):
 
         sheet, ally, _ = _make_bonded_pair(CharacterSheetFactory, developed_points=5)
         actor = MagicMock()
-        actor.sheet_data = sheet
+        actor.character_sheet = sheet
         protected = MagicMock()
-        protected.sheet_data = ally
+        protected.character_sheet = ally
         self.assertEqual(bond_bonus(actor, protected), 0)
 
     def test_no_sheet_data_returns_zero(self):
         """Actor/protected with no sheet_data → 0."""
         actor = MagicMock()
-        actor.sheet_data = None
+        actor.character_sheet = None
         protected = MagicMock()
-        protected.sheet_data = None
+        protected.character_sheet = None
         self.assertEqual(bond_bonus(actor, protected), 0)
 
 

--- a/src/world/room_features/services.py
+++ b/src/world/room_features/services.py
@@ -590,7 +590,7 @@ def react_to_unauthorized_entry(actor, room) -> None:
     from world.locations.services import is_owner, is_tenant  # noqa: PLC0415
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-    sheet = getattr(actor, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = actor.character_sheet
     if sheet is None:
         return
     persona = active_persona_for_sheet(sheet)

--- a/src/world/roster/selectors.py
+++ b/src/world/roster/selectors.py
@@ -54,3 +54,17 @@ def active_player_character_sheets() -> list[CharacterSheet]:
         .select_related("roster_entry")
         .distinct()
     )
+
+
+def puppeted_sheet_for(user: object) -> CharacterSheet | None:
+    """The CharacterSheet of the character ``user`` is currently puppeting, or None.
+
+    The canonical user→puppet→sheet resolver (silent-fail audit): ``Account.puppet``
+    can be a truthy non-character object for sessionless accounts, and AnonymousUser
+    has no puppet attribute at all — inline ``puppet.character_sheet`` dances 500'd
+    the summons list and silently degraded drf-spectacular's queryset inference.
+    """
+    puppet = getattr(user, "puppet", None)  # noqa: GETATTR_LITERAL — AnonymousUser has none
+    if not isinstance(puppet, ObjectDB):
+        return None
+    return puppet.character_sheet

--- a/src/world/roster/tests/test_puppeted_sheet_selector.py
+++ b/src/world/roster/tests/test_puppeted_sheet_selector.py
@@ -1,0 +1,30 @@
+"""puppeted_sheet_for — the canonical user→puppet→sheet resolver (silent-fail audit).
+
+Seven view sites did this dance inline as ``puppet.character_sheet if puppet is not
+None else None`` — but ``Account.puppet`` can be a truthy non-character object for
+sessionless accounts (and AnonymousUser has no puppet at all), which 500'd the summons
+list and silently degraded drf-spectacular's schema inference. One guarded accessor.
+"""
+
+from types import SimpleNamespace
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.selectors import puppeted_sheet_for
+
+
+class PuppetedSheetForTests(TestCase):
+    def test_character_puppet_resolves_its_sheet(self):
+        sheet = CharacterSheetFactory()
+        user = SimpleNamespace(puppet=sheet.character)
+        assert puppeted_sheet_for(user) == sheet
+
+    def test_no_puppet_attribute_returns_none(self):
+        assert puppeted_sheet_for(SimpleNamespace()) is None
+
+    def test_none_puppet_returns_none(self):
+        assert puppeted_sheet_for(SimpleNamespace(puppet=None)) is None
+
+    def test_non_character_puppet_returns_none(self):
+        assert puppeted_sheet_for(SimpleNamespace(puppet=object())) is None

--- a/src/world/roster/views/settings_views.py
+++ b/src/world/roster/views/settings_views.py
@@ -16,6 +16,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from world.roster.selectors import puppeted_sheet_for
 from world.roster.serializers.settings import VisibilitySettingsSerializer
 from world.roster.services.display import set_appear_offline
 
@@ -40,8 +41,7 @@ class VisibilitySettingsView(APIView):
 
     def _current_tenure(self, request: Request) -> RosterTenure:
         """The played character's current tenure, or raise a uniform validation error."""
-        puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        sheet = puppet.character_sheet if puppet is not None else None
+        sheet = puppeted_sheet_for(request.user)
         entry = sheet.roster_entry_or_none if sheet is not None else None
         tenure = entry.current_tenure if entry is not None else None
         if tenure is None:

--- a/src/world/roster/views/settings_views.py
+++ b/src/world/roster/views/settings_views.py
@@ -41,8 +41,8 @@ class VisibilitySettingsView(APIView):
     def _current_tenure(self, request: Request) -> RosterTenure:
         """The played character's current tenure, or raise a uniform validation error."""
         puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        sheet = getattr(puppet, "sheet_data", None) if puppet is not None else None  # noqa: GETATTR_LITERAL
-        entry = getattr(sheet, "roster_entry", None) if sheet is not None else None  # noqa: GETATTR_LITERAL
+        sheet = puppet.character_sheet if puppet is not None else None
+        entry = sheet.roster_entry_or_none if sheet is not None else None
         tenure = entry.current_tenure if entry is not None else None
         if tenure is None:
             msg = "You must be playing a character to change its visibility."

--- a/src/world/scenes/interaction_services.py
+++ b/src/world/scenes/interaction_services.py
@@ -550,7 +550,7 @@ def _ensure_scene_participation(scene: Scene, character: ObjectDB) -> None:
 
     # Auto-engage covenant for the participant (Slice B §4.10). Fires even when
     # the character has no account yet, matching prior behavior.
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is not None and scene.location is not None:
         from world.covenants.services import evaluate_scene_engagement  # noqa: PLC0415
 

--- a/src/world/scenes/place_services.py
+++ b/src/world/scenes/place_services.py
@@ -57,7 +57,7 @@ def ensure_scene_for_location(
     from world.covenants.services import evaluate_scene_engagement  # noqa: PLC0415
 
     for obj in room.contents:
-        sheet = getattr(obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = obj.character_sheet
         if sheet is not None:
             evaluate_scene_engagement(character_sheet=sheet, room=room)
 

--- a/src/world/scenes/scene_admin_services.py
+++ b/src/world/scenes/scene_admin_services.py
@@ -205,7 +205,7 @@ def finish_scene_full(scene: Scene, by_account: AccountDB | None = None) -> None
         invalidate_active_scene_cache(scene.location)
 
         for obj in scene.location.contents:
-            sheet = getattr(obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+            sheet = obj.character_sheet
             if sheet is None:
                 continue
             roles = sheet.character.covenant_roles

--- a/src/world/scenes/serializers.py
+++ b/src/world/scenes/serializers.py
@@ -462,7 +462,7 @@ class SceneSummaryRevisionSerializer(serializers.ModelSerializer):
             request = self.context.get("request")
             if request and request.user.is_authenticated:
                 # Check the requesting user owns the character behind this persona
-                roster_entry = getattr(persona.character_sheet, "roster_entry", None)  # noqa: GETATTR_LITERAL
+                roster_entry = persona.character_sheet.roster_entry_or_none
                 if roster_entry is None:
                     raise serializers.ValidationError(
                         {"persona": "Persona's character has no roster entry."}
@@ -483,7 +483,10 @@ class SceneSummaryRevisionSerializer(serializers.ModelSerializer):
             # Check that persona's character's account is a scene participant
             from world.roster.models import RosterTenure  # noqa: PLC0415
 
-            roster_entry = getattr(persona.character_sheet.character, "roster_entry", None)  # noqa: GETATTR_LITERAL
+            # Audit fix (was getattr(...character, "roster_entry", None)): the reverse
+            # OneToOne lives on the SHEET — the old receiver was the ObjectDB character,
+            # so this always resolved None and the participant check silently never ran.
+            roster_entry = persona.character_sheet.roster_entry_or_none
             if roster_entry:
                 active_tenure = (
                     RosterTenure.objects.filter(

--- a/src/world/scenes/services.py
+++ b/src/world/scenes/services.py
@@ -48,7 +48,7 @@ def persona_for_character(character: Character) -> Persona:
     than silently bypassing any gate that needs the persona (cooldown,
     standing, item ownership, etc.).
     """
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is None:
         raise MissingPrimaryPersonaError(character)
     try:

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -14,6 +14,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
+from world.roster.selectors import puppeted_sheet_for
 from world.scenes.constants import SceneAction, ScenePrivacyMode
 from world.scenes.filters import (
     PersonaFilter,
@@ -499,7 +500,7 @@ class PersonaViewSet(
         body = SetActivePersonaRequestSerializer(data=request.data)
         body.is_valid(raise_exception=True)
         puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        sheet = puppet.character_sheet if puppet is not None else None
+        sheet = puppeted_sheet_for(request.user)
         if puppet is None or sheet is None:
             msg = "You must be playing a character to switch identities."
             raise serializers.ValidationError(msg)
@@ -522,9 +523,8 @@ class PersonaViewSet(
 
     def _played_sheet(self, request: Request) -> "CharacterSheet":
         """The played character's sheet, or raise a uniform validation error (#1127)."""
-        puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        sheet = puppet.character_sheet if puppet is not None else None
-        if puppet is None or sheet is None:
+        sheet = puppeted_sheet_for(request.user)
+        if sheet is None:
             msg = "You must be playing a character to create an identity."
             raise serializers.ValidationError(msg)
         return sheet

--- a/src/world/scenes/views.py
+++ b/src/world/scenes/views.py
@@ -499,7 +499,7 @@ class PersonaViewSet(
         body = SetActivePersonaRequestSerializer(data=request.data)
         body.is_valid(raise_exception=True)
         puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        sheet = getattr(puppet, "sheet_data", None) if puppet is not None else None  # noqa: GETATTR_LITERAL
+        sheet = puppet.character_sheet if puppet is not None else None
         if puppet is None or sheet is None:
             msg = "You must be playing a character to switch identities."
             raise serializers.ValidationError(msg)
@@ -523,7 +523,7 @@ class PersonaViewSet(
     def _played_sheet(self, request: Request) -> "CharacterSheet":
         """The played character's sheet, or raise a uniform validation error (#1127)."""
         puppet = getattr(request.user, "puppet", None)  # noqa: GETATTR_LITERAL
-        sheet = getattr(puppet, "sheet_data", None) if puppet is not None else None  # noqa: GETATTR_LITERAL
+        sheet = puppet.character_sheet if puppet is not None else None
         if puppet is None or sheet is None:
             msg = "You must be playing a character to create an identity."
             raise serializers.ValidationError(msg)

--- a/src/world/societies/fame_reactions.py
+++ b/src/world/societies/fame_reactions.py
@@ -89,7 +89,7 @@ def _active_persona(character: ObjectDB) -> Persona | None:
     """
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is None:
         return None
     try:
@@ -119,7 +119,7 @@ def _deliver(line: FameReactionLine, character: ObjectDB, room: ObjectDB) -> Non
         for obj in room.contents:
             if obj.pk == character.pk:
                 continue
-            sheet = getattr(obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+            sheet = obj.character_sheet
             if sheet is not None:
                 bystander_sheets.append(sheet)
         if bystander_sheets:
@@ -130,7 +130,7 @@ def _deliver(line: FameReactionLine, character: ObjectDB, room: ObjectDB) -> Non
                 ooc_note="Fame reaction (bystander register, #881).",
             )
     if line.arriver_body:
-        arriver_sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        arriver_sheet = character.character_sheet
         if arriver_sheet is not None:
             send_narrative_message(
                 recipients=[arriver_sheet],

--- a/src/world/societies/ranking_views.py
+++ b/src/world/societies/ranking_views.py
@@ -86,7 +86,7 @@ def _viewer_persona(request: Request):
         return None
     if puppet is None:
         return None
-    sheet = getattr(puppet, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = puppet.character_sheet
     if sheet is None:
         return None
     try:

--- a/src/world/societies/tests/test_house_aspects.py
+++ b/src/world/societies/tests/test_house_aspects.py
@@ -235,7 +235,7 @@ class DisplaySurfaceTests(AspectTestData):
 
         from commands.account.sheet_sections import _render_house_section
 
-        command = SimpleNamespace(caller=SimpleNamespace(sheet_data=self.sheet))
+        command = SimpleNamespace(caller=SimpleNamespace(character_sheet=self.sheet))
         lines = "\n".join(_render_house_section(command))
         self.assertIn("The Fens Endure", lines)
         self.assertIn("russet and bog-iron grey", lines)

--- a/src/world/species/services.py
+++ b/src/world/species/services.py
@@ -39,7 +39,7 @@ def reconcile_sunlight_exposure(character, room) -> None:
     from world.species.factories import ensure_sunlight_exposure_content  # noqa: PLC0415
 
     template = ensure_sunlight_exposure_content()
-    sheet = getattr(character, "sheet_data", None)  # noqa: GETATTR_LITERAL
+    sheet = character.character_sheet
     if sheet is None or not _has_sunlight_drawback(sheet):
         return
     outdoor = _room_is_outdoor(room) and not _character_shelters_radiant(character, room)

--- a/src/world/species/tests/test_sunlight_exposure.py
+++ b/src/world/species/tests/test_sunlight_exposure.py
@@ -26,9 +26,13 @@ class ReconcileSunlightExposureTest(TestCase):
         cls.template = ensure_sunlight_exposure_content()
 
     def test_no_sheet_is_noop(self):
-        """A character without sheet_data (NPC/non-puppet) is a no-op."""
+        """A character without a CharacterSheet (NPC/non-puppet) is a no-op."""
         char = MagicMock()
-        del char.sheet_data  # getattr returns MagicMock by default; force AttributeError
+        # Sheetless objects surface as character_sheet=None (the property maps
+        # RelatedObjectDoesNotExist to None); a bare MagicMock would instead
+        # fabricate an attribute chain and _species_and_ancestors would walk
+        # mock.parent forever.
+        char.character_sheet = None
         with patch("world.species.services.apply_condition") as ac:
             reconcile_sunlight_exposure(char, room=None)
         ac.assert_not_called()

--- a/src/world/stories/serializers.py
+++ b/src/world/stories/serializers.py
@@ -291,7 +291,7 @@ class StoryDetailSerializer(serializers.ModelSerializer):
         if sheet is None:
             return None
         # OneToOne reverse accessor may not exist.
-        entry = getattr(sheet, "roster_entry", None)  # noqa: GETATTR_LITERAL
+        entry = sheet.roster_entry_or_none
         tenure = entry.current_tenure if entry else None
         return tenure.pk if tenure else None
 

--- a/src/world/stories/services/boundaries.py
+++ b/src/world/stories/services/boundaries.py
@@ -177,7 +177,7 @@ def _resolve_sheet_identity(
     sheet_player: dict[int, int] = {}
     sheet_tenure: dict[int, int] = {}
     for sheet in sheets:
-        entry = getattr(sheet, "roster_entry", None)  # noqa: GETATTR_LITERAL — OneToOne reverse may not exist
+        entry = sheet.roster_entry_or_none
         cur = entry.current_tenure if entry else None
         if cur is not None:
             sheet_player[sheet.pk] = cur.player_data_id

--- a/src/world/weather/tasks.py
+++ b/src/world/weather/tasks.py
@@ -35,7 +35,7 @@ def _online_recipients(room: DefaultObject) -> list[CharacterSheet]:
     for obj in room.contents:
         if not obj.sessions.count():
             continue
-        sheet = getattr(obj, "sheet_data", None)  # noqa: GETATTR_LITERAL
+        sheet = obj.character_sheet
         if sheet is not None:
             recipients.append(sheet)
     return recipients


### PR DESCRIPTION
## What

The silent-fail audit you asked for after the `sheet_data` discovery, executed as fixes rather than a document. Inventory: **433 `getattr`-literal escape hatches** and **127 real broad-`except` sites** in non-test code, classified and worked highest-risk first.

## Fixed in this PR

**1. The `getattr(x, "sheet_data", None)` idiom — retired (126 sites, 83 files).** All now use `ObjectParent.character_sheet` (the property from #2384). One generic seam needed honest type dispatch instead: `flows/object_states/base_state.py` wraps heterogeneous objects including plain `ItemInstance` models, so it now does an explicit `isinstance(obj, ObjectDB)` check — the one place the old getattr was doing real polymorphic work.

**2. The `getattr(sheet, "roster_entry", None)` twin — retired (13 sites, 11 files).** Same disease (`RelatedObjectDoesNotExist` subclasses `AttributeError`); new scaffolding `CharacterSheet.roster_entry_or_none`, mirroring `character_sheet`.

**3. 🐛 One real dormant bug found and fixed.** `world/scenes/serializers.py` was calling `getattr(persona.character_sheet.character, "roster_entry", None)` — the reverse OneToOne lives on the *sheet*, so the receiver was wrong and the expression **always returned None: the scene-participant validation on revision submissions silently never ran.** Exactly the failure mode that motivated this audit.

**4. Six unlogged loop-skips now log** (`magic/services/gain.py` ×3, `observability/idmapper_gauge.py`, `web/admin/views.py` ×2) — `except Exception: continue` with zero trace, two of which carried their own "TODO: log" comments.

## Classified, deliberately not changed

- **60 log-and-continue sites** — accepted interim per the standing #1164 decision (destination: Sentry-like service); inventoried, healthy.
- **24 translate/re-raise + 12 boundary sites** (CLI, email, Cloudinary, the central `report_error` catch-all) — correct as-is.

## The next tranche (needs your ratification per family)

- **~20 remaining SWALLOW sites** where a broad catch stands in for a missing accessor, clustered on five attributes: `primary_persona`/`active_persona_for_sheet` (proposal: an `active_persona_or_none(sheet)` seam beside the loud one, then narrow every catch to it), `check_config` (3 serializer/service sites), `room_profile` (2), `class_level`/`trait_value` (3). Each is a small typed-accessor + catch-narrowing change; I stopped here so you can veto any family.
- **~290 remaining getattr-literal sites** in the long tail: `location` (37), `puppet` (17), `is_authenticated`/`is_staff` (32), `trigger_handler` (16), `user_message` (15) and smaller. The `user_message` family wants real scaffolding — a shared `UserFacingError` base class replacing ~8 duplicate per-app `XError(user_message=...)` classes — which is a design call worth its own commit. The rest are mostly receiver-type paranoia convertible to direct access with per-site checks.
- Two `agriculture/services/domain.py` SQLite-fallback catches that mask genuine DB errors behind bare `except Exception` — want narrowing to `OperationalError`.

## Tests

TDD on the new accessors; the touched high-traffic suites (actions, commands, scenes, items, flows, secrets, character_sheets, magic, web) green on the fast tier; CI carries the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
