### PR TITLE
devcontainer: forward web ports + allowlist Playwright CDN

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -80,8 +80,20 @@ services:
     # Windows browser reaches the in-container server. The skill's
     # start-server.sh defaults to binding 127.0.0.1; pass --host 0.0.0.0
     # --url-host localhost so it actually listens on the forwarded interface.
+    #
+    # Web ports for manual browser testing of the game from the Windows host:
+    #   3000 — Vite dev server (frontend with hot reload); proxies /api → :4001
+    #   4001 — Django/Evennia web server (REST API, admin, static assets)
+    #   4002 — Evennia portal (game websocket — the browser connects directly)
+    # All three are needed: the browser loads the page from :3000, makes API
+    # calls through Vite's proxy to :4001, and opens a websocket to :4002.
+    # Use `arx serve` (which serves the built frontend from Django) if you
+    # only want to forward 4001+4002 and skip Vite.
     ports:
       - "49200:49200"
+      - "3000:3000"
+      - "4001:4001"
+      - "4002:4002"
     command: sleep infinity
     # Cap container logs at 150 MB (50 MB × 3 rotated files). Docker's
     # default json-file driver has no rotation — a crash-looping process

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -161,6 +161,11 @@ resolve_and_add "pypi.org"
 # (eu-west-3); dig-resolved like the other small/stable hosts above.
 resolve_and_add "api.code.umans.ai"
 
+# Playwright downloads Chromium binaries from its own CDN (cdn.playwright.dev),
+# needed for headless browser E2E testing from inside the container. Resolved
+# via dig like the other small/stable hosts above.
+resolve_and_add "cdn.playwright.dev"
+
 # ---- b) GitHub meta API (git + api + web + packages CIDRs) ----
 echo "Fetching GitHub IP ranges via meta API..."
 GITHUB_META=$(curl -sf --connect-timeout 15 --max-time 30 https://api.github.com/meta)


### PR DESCRIPTION
## Summary

Enables manual browser testing of the game from the Windows host when using the devcontainer.

### Changes

**Port forwarding** ():
- Forward ports 3000 (Vite), 4001 (Django/Evennia API), and 4002 (game websocket) to the host
- Previously only port 49200 (brainstorm server) was forwarded — no web ports were accessible from a Windows browser
- All three are needed: the browser loads the page from `:3000`, makes API calls through Vite's proxy to `:4001`, and opens a websocket to `:4002`

**Firewall allowlist** ():
- Add `cdn.playwright.dev` to the egress allowlist so Playwright can download Chromium binaries for headless browser E2E testing
- The devcontainer's default-deny firewall was blocking the download (`EHOSTUNREACH`)

### Usage

After `just dc-up`, open `http://localhost:3000` in any Windows browser to reach the game. Run the game stack inside the container:
```bash
just start    # Django :4001, websocket :4002
just fe-dev   # Vite :3000
```

### Testing
- [x] `docker-compose.yml` parses (compose file read at runtime by `just dc-up`)
- [x] Firewall script syntax valid (bash)
- [ ] Verify ports reachable from Windows browser after container recreate
- [ ] Verify Playwright browser download succeeds after `just dc-build`