### PR TITLE
Enable e2e user journey testing in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -73,6 +73,12 @@ RUN cd /tmp/mise && ~/.local/bin/mise trust \
 USER root
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
  && apt-get install -y --no-install-recommends gh shellcheck \
+      # Playwright Chromium runtime dependencies (not the browser itself —
+      # that's downloaded at runtime via `npx playwright install chromium`).
+      # Without these libs, Chromium launches but crashes on first navigation.
+      libnss3 libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 \
+      libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+      libgbm1 libpango-1.0-0 libcairo2 libasound2t64 \
  && rm -rf /var/lib/apt/lists/*
 USER vscode
 

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -162,9 +162,12 @@ resolve_and_add "pypi.org"
 resolve_and_add "api.code.umans.ai"
 
 # Playwright downloads Chromium binaries from its own CDN (cdn.playwright.dev),
-# needed for headless browser E2E testing from inside the container. Resolved
-# via dig like the other small/stable hosts above.
-resolve_and_add "cdn.playwright.dev"
+# which is fronted by Azure Front Door. Azure Front Door rotates IPs across a
+# large pool, so a single dig only catches whichever edge node answered — the
+# next request may hit a different IP and be blocked. Instead, we allowlist the
+# full AzureFrontDoor.Frontend service-tag range from the Azure JSON fetched in
+# step (e) below. The single dig was the root cause of Chromium install failures
+# (EHOSTUNREACH / No route to host) after the firewall took effect.
 
 # ---- b) GitHub meta API (git + api + web + packages CIDRs) ----
 echo "Fetching GitHub IP ranges via meta API..."
@@ -260,6 +263,25 @@ if [ "$AZURE_COUNT" -lt 50 ]; then
     exit 1
 fi
 echo "  Added ${AZURE_COUNT} Azure Storage CIDRs."
+
+# ---- e2) Azure Front Door published ranges (cdn.playwright.dev) ----
+# Playwright's CDN is fronted by Azure Front Door, which rotates IPs across a
+# large pool. The service tag "AzureFrontDoor.Frontend" publishes the full set.
+# Without this, the single dig in step (a) only catches one edge node and the
+# Chromium binary download fails with EHOSTUNREACH once the firewall takes
+# effect. Same AZURE_JSON as (e), different service-tag selector.
+AZURE_FD_COUNT=0
+while read -r cidr; do
+    if is_valid_ipv4_cidr "$cidr"; then
+        ipset add allowed-domains "$cidr" -exist
+        AZURE_FD_COUNT=$((AZURE_FD_COUNT + 1))
+    fi
+done < <(echo "$AZURE_JSON" | jq -r '.values[] | select(.name == "AzureFrontDoor.Frontend") | .properties.addressPrefixes[]')
+if [ "$AZURE_FD_COUNT" -lt 10 ]; then
+    echo "ERROR: Azure Front Door service tag returned only ${AZURE_FD_COUNT} IPv4 CIDRs (minimum 10); aborting" >&2
+    exit 1
+fi
+echo "  Added ${AZURE_FD_COUNT} Azure Front Door CIDRs."
 
 # ---- f) AWS CloudFront published ranges (sonarcloud.io, api.sonarcloud.io) ----
 echo "Fetching AWS CloudFront IP ranges..."

--- a/frontend/e2e.backend.config.ts
+++ b/frontend/e2e.backend.config.ts
@@ -1,0 +1,31 @@
+/**
+ * Playwright config for running e2e tests against the Django-served frontend
+ * (production build served by Evennia's TwistedWeb on :4001).
+ *
+ * Unlike the default playwright.config.ts (which starts `vite preview` with no
+ * backend), this config expects the Evennia server to already be running
+ * (`just start` from the repo root). The tests hit real API endpoints:
+ * allauth signup, CSRF, /api/status/, /api/user/, etc.
+ *
+ * Usage:  just fe-e2e  (or: cd frontend && npx playwright test --config e2e.backend.config.ts)
+ */
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:4001',
+    headless: true,
+  },
+  // No webServer block — the Django/Evennia server must be started manually
+  // via `just start`. This prevents Playwright from trying to spin up a
+  // Vite preview server that would shadow the real backend.
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/frontend/e2e/user-journey.spec.ts
+++ b/frontend/e2e/user-journey.spec.ts
@@ -1,0 +1,324 @@
+/**
+ * User journey e2e tests — registration, email verification, login, and the
+ * authenticated home page.
+ *
+ * Unlike the existing smoke tests (which run against `vite preview` with no
+ * backend), these tests run against the Django-served frontend at :4001 with
+ * a live Evennia backend. They exercise the real API stack: allauth signup,
+ * CSRF, email verification, session cookies, and the account payload.
+ *
+ * Prerequisites:
+ *   - Evennia server running on :4001 (`arx start` from the repo root)
+ *   - DEBUG=True in src/.env (so email goes to console, not Resend SMTP)
+ *   - Chromium installed (`cd frontend && npx playwright install chromium`)
+ *
+ * The email verification step is mocked via page.route() because extracting
+ * the HMAC key from the server log is not feasible from inside a browser test.
+ * The mock intercepts the POST to /api/auth/browser/v1/auth/email/verify and
+ * returns success — but the account is NOT actually verified in the DB. For
+ * a full verification test, see the Python integration tests.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+const BASE_URL = 'http://localhost:4001';
+
+/** Unique suffix so parallel runs / repeated runs don't collide on usernames. */
+function uniqueSuffix(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Suppress expected API-failure console noise — same filter as the smoke tests,
+ * extended to cover the social-providers fetch that may fail if providers
+ * aren't configured.
+ */
+function filterApiNoise(msg: string): boolean {
+  return (
+    msg.includes('Failed to load resource') ||
+    msg.includes('favicon') ||
+    msg.includes('NetworkError') ||
+    msg.includes('Load failed') ||
+    msg.includes('404')
+  );
+}
+
+/** Set up console error capture on a page. Returns a getter for the errors array. */
+function captureConsoleErrors(page: Page): () => string[] {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && !filterApiNoise(msg.text())) {
+      errors.push(msg.text());
+    }
+  });
+  page.on('pageerror', (err) => {
+    errors.push(err.message);
+  });
+  return () => errors;
+}
+
+// ---------------------------------------------------------------------------
+// Homepage — what a visitor sees first
+// ---------------------------------------------------------------------------
+
+test.describe('Visitor homepage', () => {
+  test('homepage renders with hero, status, and navigation', async ({ page }) => {
+    const getErrors = captureConsoleErrors(page);
+    await page.goto(BASE_URL);
+    await page.waitForLoadState('networkidle');
+
+    // Hero section
+    await expect(page.locator('h1').first()).toContainText('Welcome to Arx II');
+    await expect(page.getByText('Play in the browser')).toBeVisible();
+
+    // Status block should be present (even if stats are 0)
+    // The StatusBlock renders server stats from /api/status/
+    const root = page.locator('#root');
+    await expect(root).not.toBeEmpty();
+
+    expect(getErrors()).toEqual([]);
+  });
+
+  test('homepage shows game stats from live API', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await page.waitForLoadState('networkidle');
+
+    // The StatsCard should show numbers (accounts, characters, rooms)
+    // These come from /api/status/ — if the API is down, the card shows
+    // loading skeletons instead of numbers.
+    const statsText = await page.locator('#root').textContent();
+    // At minimum the page should not show a crash or error boundary
+    expect(statsText).not.toContain('Something went wrong');
+  });
+
+  test('navigation links work from homepage', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await page.waitForLoadState('networkidle');
+
+    // The "Play in the browser" button links to /game
+    const playButton = page.getByRole('link', { name: /play in the browser/i });
+    await expect(playButton).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registration — the full signup form journey
+// ---------------------------------------------------------------------------
+
+test.describe('Registration flow', () => {
+  test('register page renders with all fields', async ({ page }) => {
+    await page.goto(`${BASE_URL}/register`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('h1')).toContainText('Register for Arx II');
+
+    // All four fields should be present
+    await expect(page.locator('#username')).toBeVisible();
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.locator('#password1')).toBeVisible();
+    await expect(page.locator('#password2')).toBeVisible();
+
+    // Submit button
+    await expect(page.getByRole('button', { name: /register/i })).toBeVisible();
+  });
+
+  test('password confirmation validation works', async ({ page }) => {
+    await page.goto(`${BASE_URL}/register`);
+    await page.waitForLoadState('networkidle');
+
+    // Fill in mismatched passwords
+    await page.locator('#username').fill(`mismatch-${uniqueSuffix()}`);
+    await page.locator('#email').fill(`mismatch-${uniqueSuffix()}@test.com`);
+    await page.locator('#password1').fill('TestPass123!');
+    await page.locator('#password2').fill('DifferentPass456!');
+
+    // Blur the confirm field to trigger validation
+    await page.locator('#password2').blur();
+
+    await expect(page.getByText('Passwords must match')).toBeVisible();
+  });
+
+  test('successful registration redirects to email verification page', async ({ page }) => {
+    const suffix = uniqueSuffix();
+    const username = `e2e-${suffix}`;
+    const email = `e2e-${suffix}@test.com`;
+
+    await page.goto(`${BASE_URL}/register`);
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('#username').fill(username);
+    await page.locator('#email').fill(email);
+    await page.locator('#password1').fill('TestPass123!');
+    await page.locator('#password2').fill('TestPass123!');
+
+    // Blur fields to trigger async validation (username/email availability)
+    await page.locator('#email').blur();
+
+    // Submit the form
+    await page.getByRole('button', { name: /register/i }).click();
+
+    // Should navigate to the email verification pending page
+    await page.waitForURL('**/register/verify-email', { timeout: 10000 });
+    await expect(page.locator('h1')).toContainText('Check Your Email');
+  });
+
+  test('duplicate username is rejected', async ({ page }) => {
+    // First registration
+    const suffix = uniqueSuffix();
+    const username = `dup-${suffix}`;
+    const email = `dup-${suffix}@test.com`;
+
+    await page.goto(`${BASE_URL}/register`);
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('#username').fill(username);
+    await page.locator('#email').fill(email);
+    await page.locator('#password1').fill('TestPass123!');
+    await page.locator('#password2').fill('TestPass123!');
+    await page.locator('#email').blur();
+    await page.getByRole('button', { name: /register/i }).click();
+
+    await page.waitForURL('**/register/verify-email', { timeout: 10000 });
+
+    // Now try the same username again
+    await page.goto(`${BASE_URL}/register`);
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('#username').fill(username);
+    // Blur to trigger availability check
+    await page.locator('#username').blur();
+
+    await expect(page.getByText('Username already taken')).toBeVisible({ timeout: 10000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Login — the authenticated entry point
+// ---------------------------------------------------------------------------
+
+test.describe('Login flow', () => {
+  test('login page renders with username/password and register link', async ({ page }) => {
+    await page.goto(`${BASE_URL}/login`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('h1')).toContainText('Login to Arx II');
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+    await expect(page.getByRole('link', { name: /register/i })).toBeVisible();
+  });
+
+  test('login with wrong password shows error', async ({ page }) => {
+    const suffix = uniqueSuffix();
+
+    await page.goto(`${BASE_URL}/login`);
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('input[type="text"]').fill(`nonexistent-${suffix}`);
+    await page.locator('input[type="password"]').fill('WrongPassword123!');
+    await page.getByRole('button', { name: /log in/i }).click();
+
+    // Should show an error message (not crash)
+    await expect(page.getByText(/login failed/i)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('full journey: register → verify → login → see authenticated home', async ({ page }) => {
+    const suffix = uniqueSuffix();
+    const username = `journey-${suffix}`;
+    const email = `journey-${suffix}@test.com`;
+    const password = 'TestPass123!';
+
+    // Step 1: Register
+    await page.goto(`${BASE_URL}/register`);
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('#username').fill(username);
+    await page.locator('#email').fill(email);
+    await page.locator('#password1').fill(password);
+    await page.locator('#password2').fill(password);
+    await page.locator('#email').blur();
+
+    await page.getByRole('button', { name: /register/i }).click();
+    await page.waitForURL('**/register/verify-email', { timeout: 10000 });
+
+    // Step 2: Mock the email verification API call.
+    // In DEBUG mode the verification key is printed to the server console
+    // log, which we can't read from a browser test. We intercept the verify
+    // endpoint and return success, then proceed to login. The account is
+    // not actually verified in the DB — for a true verification test, use
+    // the Python integration test suite which can call Django's signing
+    // module directly to generate a valid key.
+    await page.route('**/api/auth/browser/v1/auth/email/verify', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Email successfully verified' }),
+      });
+    });
+
+    // Navigate to the verify page with a dummy key — the mock makes it succeed
+    await page.goto(`${BASE_URL}/verify-email/dummy-key-for-e2e`);
+    await expect(page.locator('h1')).toContainText('Email Verified', { timeout: 10000 });
+
+    // Step 3: Login
+    // The mock verification didn't actually verify the account in the DB,
+    // so login will redirect to the unverified page. That's the expected
+    // behavior — the test verifies the UI flow, not the DB state.
+    await page.goto(`${BASE_URL}/login`);
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('input[type="text"]').fill(username);
+    await page.locator('input[type="password"]').fill(password);
+    await page.getByRole('button', { name: /log in/i }).click();
+
+    // The user is either redirected to / (if verified) or /account/unverified
+    // (if not verified). Both are valid outcomes — the test verifies login
+    // succeeds (no crash, no error message).
+    await page.waitForURL('**/', { timeout: 10000 }).catch(() => {
+      // May redirect to /account/unverified — that's fine
+    });
+    await page.waitForURL('**/account/unverified', { timeout: 10000 }).catch(() => {
+      // May redirect to / — that's fine
+    });
+
+    // Either way, we should not be on the login page anymore
+    expect(page.url()).not.toContain('/login');
+    await expect(page.locator('#root')).not.toBeEmpty();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authenticated homepage — what a logged-in user sees
+// ---------------------------------------------------------------------------
+
+test.describe('Authenticated user experience', () => {
+  test('login redirect for protected routes works', async ({ page }) => {
+    // Visiting a protected route while logged out should redirect to /login
+    await page.goto(`${BASE_URL}/journals`);
+    await page.waitForLoadState('networkidle');
+
+    // Should be redirected to login
+    await page.waitForURL('**/login', { timeout: 10000 }).catch(() => {
+      // Some routes may redirect differently — just verify we're not on /journals
+    });
+
+    // Should not be on the protected route
+    expect(page.url()).not.toContain('/journals');
+  });
+
+  test('roster page is accessible without login', async ({ page }) => {
+    const getErrors = captureConsoleErrors(page);
+    await page.goto(`${BASE_URL}/roster`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('#root')).not.toBeEmpty();
+    expect(getErrors()).toEqual([]);
+  });
+
+  test('scenes page is accessible without login', async ({ page }) => {
+    const getErrors = captureConsoleErrors(page);
+    await page.goto(`${BASE_URL}/scenes`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('#root')).not.toBeEmpty();
+    expect(getErrors()).toEqual([]);
+  });
+});

--- a/justfile
+++ b/justfile
@@ -320,6 +320,28 @@ fe-lint *args:
 fe-test *args:
     cd frontend && pnpm test --run {{args}}
 
+# Run Playwright e2e tests against the Django-served frontend (production
+# build). Requires the Evennia server to be running on :4001 (just start).
+# The smoke tests (frontend/e2e/smoke.spec.ts etc.) can also run against
+# `vite preview` with no backend — use `fe-e2e-frontend` for that mode.
+#   just fe-e2e                      # all e2e tests against Django backend
+#   just fe-e2e user-journey          # specific spec file
+fe-e2e *args:
+    cd frontend && npx playwright test --config e2e.backend.config.ts {{args}}
+
+# Run Playwright e2e tests against the Vite preview build (no backend).
+# This is the original smoke-test mode — pages render but all API calls fail.
+#   just fe-e2e-frontend
+#   just fe-e2e-frontend smoke
+fe-e2e-frontend *args:
+    cd frontend && npx playwright test {{args}}
+
+# Install Playwright's Chromium browser binary. Must be run once before e2e
+# tests work. Requires the devcontainer firewall to allowlist cdn.playwright.dev
+# (already configured in init-firewall.sh via Azure Front Door ranges).
+fe-e2e-install:
+    cd frontend && npx playwright install chromium
+
 # --- Cache / scratch ---------------------------------------------------------
 
 # Delete all Python bytecode caches under src/.

--- a/src/server/conf/settings.py
+++ b/src/server/conf/settings.py
@@ -184,8 +184,12 @@ cloudinary.config(
 )
 
 # Email configuration
-if env("RESEND_API_KEY", default=""):
-    # Use Resend for email delivery
+if env("RESEND_API_KEY", default="") and not DEBUG:
+    # Use Resend for email delivery in production only.
+    # In DEBUG mode, always use the console backend so registration / email
+    # verification flows work without outbound SMTP (e.g. in the devcontainer,
+    # which blocks smtp.resend.com:587). The verification key prints to the
+    # server log, where it can be extracted for manual or automated testing.
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
     EMAIL_HOST = "smtp.resend.com"
     EMAIL_PORT = 587


### PR DESCRIPTION
## What this does

Four changes to make the full user journey (homepage → register → verify → login) testable from the devcontainer before committing to standing up production infra.

### 1. Email backend: console in DEBUG mode (`src/server/conf/settings.py`)
When `DEBUG=True` and `RESEND_API_KEY` is set, the email backend now falls back to `console.EmailBackend` instead of SMTP. The devcontainer firewall blocks outbound SMTP (`smtp.resend.com:587`), so registration was 500ing with `[Errno 113] No route to host`. With console backend, verification keys print to the server log for manual or automated extraction. Production (`DEBUG=False`) is unaffected — still uses Resend SMTP.

### 2. Firewall + Dockerfile: fix Playwright Chromium download (`.devcontainer/`)
- **`init-firewall.sh`**: `cdn.playwright.dev` is fronted by Azure Front Door, which rotates IPs across a large pool. The previous single `dig` only caught one edge node, so Chromium downloads failed with `EHOSTUNREACH` after the firewall took effect. Added the `AzureFrontDoor.Frontend` service-tag range extraction (same pattern as the existing Azure Storage fetch, reusing the same JSON).
- **`Dockerfile`**: Added Playwright Chromium runtime dependencies (`libnss3`, `libatk1.0-0t64`, `libgbm1`, etc.) so the browser launches without crashing after download.

### 3. New e2e spec: `frontend/e2e/user-journey.spec.ts`
Tests covering the real user journey against the Django-served frontend at `:4001`:
- Homepage renders (hero, status block, navigation)
- Registration form validation (password mismatch, duplicate username)
- Full signup flow → email verification pending page
- Email verification UI (mocked API — can't extract HMAC key from server logs in a browser test)
- Login with wrong password → error
- Login after registration → authenticated home or unverified page
- Protected route redirect to login
- Public pages (roster, scenes) accessible without login

### 4. Justfile + Playwright config
- `just fe-e2e` — runs e2e tests against the Django backend (`:4001`)
- `just fe-e2e-frontend` — runs against vite preview (original smoke-test mode, no backend)
- `just fe-e2e-install` — installs Chromium binary
- New `frontend/e2e.backend.config.ts` — Playwright config that expects the Evennia server to already be running (no `webServer` block)

## What this does NOT do
- Does not test social auth (Facebook/Google/Discord) — those require outbound OAuth redirects blocked by the firewall. The existing `arx ngrok` + `arx integration-test` commands handle manual social auth testing.
- Does not test email verification end-to-end through the DB — the e2e spec mocks the verify API. True verification testing belongs in the Python integration test suite.
- The firewall and Dockerfile changes require a container rebuild (`just dc-build`) to take effect.

## Testing
- [x] `just test-fast web` — 179 tests pass (SQLite tier)
- [x] `just test-fast web.api.tests.test_email_verification` — 11 tests pass
- [x] `pnpm typecheck` — passes
- [x] Pre-commit hooks (ESLint, Prettier, TypeScript check) — all pass
- [ ] e2e tests — require container rebuild for Chromium install (firewall fix)