### PR TITLE
Silent-fail audit tranche 3: long-tail triage + fixture sweep — 61 justified suppressions remain, bare-ObjectDB tests eliminated

### DIFF
--- a/src/actions/definitions/consent_preferences.py
+++ b/src/actions/definitions/consent_preferences.py
@@ -224,7 +224,7 @@ class AddSocialConsentWhitelistAction(Action):
         if error is not None:
             return error
         tenure, category, allowed_tenure = targets
-        preference = getattr(tenure, "social_consent_preference", None)  # noqa: GETATTR_LITERAL
+        preference = tenure.social_consent_preference_or_none
         if preference is None:
             set_social_consent_preference(tenure, True)
         add_social_consent_whitelist(tenure, allowed_tenure, category)
@@ -300,7 +300,7 @@ class AddSocialConsentBlacklistAction(Action):
         if error is not None:
             return error
         tenure, category, blocked_tenure = targets
-        preference = getattr(tenure, "social_consent_preference", None)  # noqa: GETATTR_LITERAL
+        preference = tenure.social_consent_preference_or_none
         if preference is None:
             set_social_consent_preference(tenure, True)
         add_social_consent_blacklist(tenure, blocked_tenure, category)

--- a/src/actions/definitions/items.py
+++ b/src/actions/definitions/items.py
@@ -409,7 +409,7 @@ class ActivatePermitAction(Action):
         item_instance = resolve_item_instance(target)
         if item_instance is None:
             return ActionResult(success=False, message="That can't be activated.")
-        permit_details = getattr(item_instance, "building_permit_details", None)  # noqa: GETATTR_LITERAL
+        permit_details = item_instance.building_permit_details_or_none
         if permit_details is None:
             return ActionResult(success=False, message="That's not a building permit.")
 
@@ -602,7 +602,7 @@ class GrantItemAction(Action):
                 message=f"No item template found named '{template_name}'.",
             )
 
-        granted_by = getattr(actor, "account", None)  # noqa: GETATTR_LITERAL
+        granted_by = actor.account
         grant_touchstone_item_to_character(
             character_sheet=sheet, template=template, granted_by=granted_by
         )

--- a/src/actions/definitions/motif_style.py
+++ b/src/actions/definitions/motif_style.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
 
 _BIND_EXCEPTIONS = (StyleResonanceUnclaimed, StyleBindingCapExceeded)
 _MSG_NO_ACTIVE_CHARACTER = "No active character."
-_MSG_OPERATION_FAILED = "Operation failed."
 
 
 @dataclass
@@ -70,7 +69,7 @@ class BindMotifStyleAction(MotifStyleActionBase):
         try:
             binding = bind_motif_style(sheet, style, resonance)
         except _BIND_EXCEPTIONS as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         return ActionResult(
             success=True,
             message=f"'{style.name}' is now bound to your {resonance.name} resonance.",
@@ -96,7 +95,7 @@ class UnbindMotifStyleAction(MotifStyleActionBase):
         try:
             unbind_motif_style(sheet, style)
         except StyleNotBound as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         return ActionResult(
             success=True,
             message=f"'{style.name}' is no longer bound.",

--- a/src/actions/definitions/sanctum.py
+++ b/src/actions/definitions/sanctum.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
 
 
 _MSG_NO_ACTIVE_CHARACTER = "No active character."
-_MSG_OPERATION_FAILED = "Operation failed."
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +187,7 @@ class SanctumInstallAction(SanctumActionBase):
         except RitualComponentError as exc:
             return self._fail(exc.user_message)
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         if result.fizzled:
             return ActionResult(
                 success=True,
@@ -232,7 +231,7 @@ class SanctumHomecomingAction(SanctumActionBase):
                 narrative_text=kwargs.get("narrative_text", ""),
             )
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         return ActionResult(
             success=True,
             message="The Homecoming ritual is complete.",
@@ -267,7 +266,7 @@ class SanctumPurgingAction(SanctumActionBase):
                 kwargs["resonance_sacrificed"],
             )
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         return ActionResult(
             success=True,
             message="The Purging ritual is complete.",
@@ -298,7 +297,7 @@ class SanctumWeaveAction(SanctumActionBase):
                 kwargs["sanctum"], persona.character_sheet, kwargs["slot_kind"]
             )
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         return ActionResult(
             success=True,
             message="You weave a thread into the Sanctum.",
@@ -321,7 +320,7 @@ class SanctumDissolveAction(SanctumActionBase):
         try:
             result = perform_dissolution(kwargs["sanctum"], persona)
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         return ActionResult(
             success=True,
             message="The Sanctum is dissolved.",
@@ -350,7 +349,7 @@ class SanctumAbsorbAction(SanctumActionBase):
         try:
             result = absorb_sanctum_pool(kwargs["sanctum"], persona)
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         return ActionResult(
             success=True,
             message="You absorb the Sanctum's resonance pool.",
@@ -378,7 +377,7 @@ class SanctumSeverAction(SanctumActionBase):
         try:
             sever_sanctum_thread(kwargs["thread"])
         except SANCTUM_EXC as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         return ActionResult(
             success=True,
             message="You sever the thread.",

--- a/src/actions/definitions/signature.py
+++ b/src/actions/definitions/signature.py
@@ -43,7 +43,6 @@ _SIGNATURE_SET_EXCEPTIONS = (
     TechniqueNotOwned,
 )
 _MSG_NO_ACTIVE_CHARACTER = "No active character."
-_MSG_OPERATION_FAILED = "Operation failed."
 
 
 @dataclass
@@ -93,7 +92,7 @@ class SignatureSetAction(SignatureActionBase):
         try:
             set_signature_bonus(thread, bonus)
         except _SIGNATURE_SET_EXCEPTIONS as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         return ActionResult(
             success=True,
             message=f"Signature bonus '{bonus.name}' set on {thread.name}.",
@@ -122,7 +121,7 @@ class SignatureClearAction(SignatureActionBase):
         try:
             clear_signature_bonus(thread)
         except _SIGNATURE_SET_EXCEPTIONS as exc:
-            return self._fail(getattr(exc, "user_message", _MSG_OPERATION_FAILED))  # noqa: GETATTR_LITERAL
+            return self._fail(exc.user_message)
         return ActionResult(
             success=True,
             message=f"Signature bonus cleared from {thread.name}.",

--- a/src/actions/tests/test_condition_actions.py
+++ b/src/actions/tests/test_condition_actions.py
@@ -6,10 +6,9 @@ walks the ``AreaClosure`` materialized view. Setup mirrors
 """
 
 from django.test import TestCase, tag
-from evennia.objects.models import ObjectDB
 
 from actions.registry import get_action
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from evennia_extensions.models import RoomProfile
 from world.areas.constants import AreaLevel
 from world.areas.factories import AreaFactory
@@ -25,7 +24,7 @@ from world.locations.models import LocationOwnership
 
 
 def _room_in(area, *, name="A Room"):
-    room = ObjectDB.objects.create(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+    room = ObjectDBFactory(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
     RoomProfile.objects.update_or_create(objectdb=room, defaults={"area": area})
     return room
 

--- a/src/actions/tests/test_dispatch_scene_tick.py
+++ b/src/actions/tests/test_dispatch_scene_tick.py
@@ -16,6 +16,7 @@ from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
 from actions.constants import ActionBackend
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.conditions.constants import DurationType
 from world.conditions.factories import ConditionInstanceFactory, ConditionTemplateFactory
@@ -95,7 +96,7 @@ class TestChallengeDispatchTicksSceneRound(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.room = ObjectDB.objects.create(db_key="SceneTickRoom")
+        cls.room = ObjectDBFactory(db_key="SceneTickRoom")
         cls.sheet = CharacterSheetFactory()
         cls.character = _set_character_location(cls.sheet.character, cls.room)
 
@@ -156,7 +157,7 @@ class TestRegistryDispatchDoesNotTickSceneRound(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.room = ObjectDB.objects.create(db_key="RegistryTickRoom")
+        cls.room = ObjectDBFactory(db_key="RegistryTickRoom")
         cls.sheet = CharacterSheetFactory()
         cls.character = _set_character_location(cls.sheet.character, cls.room)
 

--- a/src/actions/tests/test_endorsement_actions.py
+++ b/src/actions/tests/test_endorsement_actions.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from evennia.utils.idmapper import models as idmapper_models
 
 from actions.definitions.endorsements import PoseEndorseAction
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.factories import CharacterResonanceFactory, ResonanceFactory
 from world.roster.factories import RosterEntryFactory, RosterTenureFactory
@@ -25,9 +25,7 @@ def _char_with_account():
 class PoseEndorseActionTests(TestCase):
     def setUp(self):
         idmapper_models.flush_cache()
-        self.room = __import__(
-            "evennia.objects.models", fromlist=["ObjectDB"]
-        ).ObjectDB.objects.create(
+        self.room = ObjectDBFactory(
             db_key="TestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/actions/tests/test_introduce_asset_action.py
+++ b/src/actions/tests/test_introduce_asset_action.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from django.test import TestCase
 
 from actions.registry import get_action
+from evennia_extensions.factories import ObjectDBFactory
 from world.assets.constants import AssetAcquisitionSource, AssetRoleContext
 from world.assets.factories import NPCAssetFactory
 from world.assets.models import NPCAsset
@@ -22,7 +23,6 @@ class IntroduceAssetActionTests(TestCase):
 
     def test_successful_introduction_via_action_run(self) -> None:
         """action.run() creates a co-owner NPCAsset for the ally."""
-        from evennia.objects.models import ObjectDB
 
         from world.character_sheets.factories import CharacterSheetFactory
 
@@ -40,7 +40,7 @@ class IntroduceAssetActionTests(TestCase):
         )
 
         # Place introducer and ally in the same room.
-        room = ObjectDB.objects.create(db_key="Intro Room")
+        room = ObjectDBFactory(db_key="Intro Room")
         introducer_char = introducer_sheet.character
         introducer_char.db_location = room
         introducer_char.save()

--- a/src/actions/tests/test_player_action_api.py
+++ b/src/actions/tests/test_player_action_api.py
@@ -20,7 +20,7 @@ from evennia.objects.models import ObjectDB
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from evennia_extensions.factories import AccountFactory
+from evennia_extensions.factories import AccountFactory, ObjectDBFactory
 from world.checks.factories import CheckTypeFactory, ConsequenceFactory
 from world.mechanics.constants import DifficultyIndicator
 from world.mechanics.factories import (
@@ -119,7 +119,7 @@ class AvailableActionsViewOwnerTests(TestCase):
             end_date=None,
         )
 
-        cls.room = ObjectDB.objects.create(db_key="AvailActionsRoom")
+        cls.room = ObjectDBFactory(db_key="AvailActionsRoom")
         cls.other_account = AccountFactory()
         cls.staff_account = AccountFactory(is_staff=True)
 
@@ -272,7 +272,7 @@ class AvailableActionsViewChallengeShapeTests(TestCase):
             end_date=None,
         )
 
-        cls.room = ObjectDB.objects.create(db_key="ChallengeShapeRoom")
+        cls.room = ObjectDBFactory(db_key="ChallengeShapeRoom")
 
         cls.challenge_instance, cls.approach, cls.capability, cls.check_type, _, _ = (
             _make_challenge_setup(cls.sheet, cls.room)
@@ -387,7 +387,7 @@ class DispatchActionViewPermissionTests(TestCase):
             end_date=None,
         )
 
-        cls.room = ObjectDB.objects.create(db_key="DispatchPermRoom")
+        cls.room = ObjectDBFactory(db_key="DispatchPermRoom")
         cls.other_account = AccountFactory()
         cls.staff_account = AccountFactory(is_staff=True)
 
@@ -453,7 +453,7 @@ class DispatchActionViewChallengeTests(TestCase):
             end_date=None,
         )
 
-        cls.room = ObjectDB.objects.create(db_key="DispatchChallengeRoom")
+        cls.room = ObjectDBFactory(db_key="DispatchChallengeRoom")
 
         (
             cls.challenge_instance,
@@ -750,7 +750,7 @@ class DispatchActionViewSuccessFieldTests(TestCase):
             end_date=None,
         )
 
-        cls.room = ObjectDB.objects.create(db_key="DispatchSuccessFieldRoom")
+        cls.room = ObjectDBFactory(db_key="DispatchSuccessFieldRoom")
 
     def setUp(self) -> None:
         self.client = APIClient()

--- a/src/actions/tests/test_player_interface.py
+++ b/src/actions/tests/test_player_interface.py
@@ -21,6 +21,7 @@ from evennia.objects.models import ObjectDB
 
 from actions.constants import ActionBackend
 from actions.errors import ActionDispatchError
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.combat.constants import ParticipantStatus
@@ -122,7 +123,7 @@ class TestGetPlayerActionsChallengeBackend(django.test.TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.room = ObjectDB.objects.create(db_key="ChallengeRoom")
+        cls.room = ObjectDBFactory(db_key="ChallengeRoom")
         cls.sheet = CharacterSheetFactory()
         # Set character location (bypasses Evennia's at_db_location_postsave hook).
         cls.character = _set_character_location(cls.sheet.character, cls.room)
@@ -441,7 +442,7 @@ class TestGetPlayerActionsRecomputedEachCall(django.test.TestCase):
             TechniqueFactory,
         )
 
-        cls.room = ObjectDB.objects.create(db_key="RecomputeRoom")
+        cls.room = ObjectDBFactory(db_key="RecomputeRoom")
         cls.sheet = CharacterSheetFactory()
         cls.character = _set_character_location(cls.sheet.character, cls.room)
 
@@ -527,7 +528,7 @@ class TestGetPlayerActionsNoCharacterSheet(django.test.TestCase):
         from actions.player_interface import get_player_actions
 
         # Create a bare ObjectDB with no CharacterSheet attached.
-        character = ObjectDB.objects.create(db_key="SheetlessCharacter")
+        character = ObjectDBFactory(db_key="SheetlessCharacter")
         try:
             actions = get_player_actions(character)
             self.assertEqual(
@@ -555,7 +556,7 @@ class TestDispatchPlayerActionChallengeImmediate(django.test.TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.room = ObjectDB.objects.create(db_key="DispatchChallengeRoom")
+        cls.room = ObjectDBFactory(db_key="DispatchChallengeRoom")
         cls.sheet = CharacterSheetFactory()
         cls.character = _set_character_location(cls.sheet.character, cls.room)
 
@@ -775,7 +776,7 @@ class TestDispatchPlayerActionChallengeDeferred(django.test.TestCase):
         )
 
         # Put the character in the room with the challenge
-        cls.room = ObjectDB.objects.create(db_key="DeferredChallengeRoom")
+        cls.room = ObjectDBFactory(db_key="DeferredChallengeRoom")
         _set_character_location(cls.character, cls.room)
 
         cls.challenge_instance, cls.approach, cls.capability, cls.check_type = (
@@ -832,7 +833,7 @@ class TestDispatchPlayerActionUnknownRef(django.test.TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.room = ObjectDB.objects.create(db_key="StaleRefRoom")
+        cls.room = ObjectDBFactory(db_key="StaleRefRoom")
         cls.sheet = CharacterSheetFactory()
         cls.character = _set_character_location(cls.sheet.character, cls.room)
 

--- a/src/actions/tests/test_relationship_bump.py
+++ b/src/actions/tests/test_relationship_bump.py
@@ -1,11 +1,10 @@
 """Tests for RelationshipBumpAction (#1699): backfill anchoring + both doors' kwargs."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper import models as idmapper_models
 
 from actions.definitions.relationships import RelationshipBumpAction
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.relationships.constants import BumpValence, TrackSign, TrackSystemKey
 from world.relationships.factories import RelationshipTrackFactory
@@ -40,9 +39,7 @@ class RelationshipBumpActionTests(TestCase):
         RelationshipTrackFactory(
             name="Friction", sign=TrackSign.NEGATIVE, system_key=TrackSystemKey.FRICTION
         )
-        self.room = ObjectDB.objects.create(
-            db_key="TestRoom", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        self.room = ObjectDBFactory(db_key="TestRoom", db_typeclass_path="typeclasses.rooms.Room")
         self.scene = SceneFactory(location=self.room, is_active=True)
         self.actor, self.actor_sheet, self.actor_account = _char_with_account(self.room)
         self.target, self.target_sheet, self.target_account = _char_with_account(self.room)

--- a/src/actions/tests/test_renovation_action.py
+++ b/src/actions/tests/test_renovation_action.py
@@ -6,10 +6,9 @@ and wrong-name paths return before the service call and run on SQLite too.
 """
 
 from django.test import TestCase, tag
-from evennia.objects.models import ObjectDB
 
 from actions.registry import get_action
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from evennia_extensions.models import RoomProfile
 from world.areas.constants import AreaLevel
 from world.areas.factories import AreaFactory
@@ -21,7 +20,7 @@ from world.projects.constants import ProjectKind
 
 
 def _room_in(area, *, name="A Room"):
-    room = ObjectDB.objects.create(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+    room = ObjectDBFactory(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
     RoomProfile.objects.update_or_create(objectdb=room, defaults={"area": area})
     return room
 
@@ -81,9 +80,7 @@ class RenovationCommissionTests(TestCase):
         # The actor owns a *non-building* room — the owner prerequisite passes,
         # but the room isn't part of any building, so the action reports that.
         area = AreaFactory()
-        bare_room = ObjectDB.objects.create(
-            db_key="Void", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        bare_room = ObjectDBFactory(db_key="Void", db_typeclass_path="typeclasses.rooms.Room")
         RoomProfile.objects.update_or_create(objectdb=bare_room, defaults={"area": area})
         persona = self.actor.sheet_data.primary_persona
         LocationOwnership.objects.create(

--- a/src/actions/tests/test_room_builder_web_kwargs.py
+++ b/src/actions/tests/test_room_builder_web_kwargs.py
@@ -10,7 +10,7 @@ from django.test import TestCase, tag
 from evennia.objects.models import ObjectDB
 
 from actions.registry import get_action
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from evennia_extensions.models import RoomProfile, RoomSizeTier
 from evennia_extensions.seeds import ensure_room_size_tiers
 from world.areas.constants import AreaLevel
@@ -22,7 +22,7 @@ from world.locations.models import LocationOwnership
 
 
 def _room_in(area, *, size=None, grid=(None, None, 0), name="A Room"):
-    room = ObjectDB.objects.create(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+    room = ObjectDBFactory(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
     RoomProfile.objects.update_or_create(
         objectdb=room,
         defaults={

--- a/src/actions/tests/test_scene_reactions.py
+++ b/src/actions/tests/test_scene_reactions.py
@@ -11,7 +11,7 @@ from actions.definitions.scene_reactions import (
     ToggleFavoriteAction,
     ToggleReactionAction,
 )
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.factories import CharacterResonanceFactory, ResonanceFactory
 from world.roster.factories import RosterEntryFactory, RosterTenureFactory
@@ -50,9 +50,7 @@ def _wire_account(sheet):
 class ToggleFavoriteActionTests(TestCase):
     def setUp(self) -> None:
         idmapper_models.flush_cache()
-        self.room = ObjectDB.objects.create(
-            db_key="FavRoom", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        self.room = ObjectDBFactory(db_key="FavRoom", db_typeclass_path="typeclasses.rooms.Room")
         self.scene = SceneFactory(location=self.room, is_active=True)
         self.actor_char = _make_char_in_room(self.room)
         self.actor_sheet = CharacterSheetFactory(character=self.actor_char)
@@ -102,9 +100,7 @@ class ToggleFavoriteActionTests(TestCase):
 class ToggleReactionActionTests(TestCase):
     def setUp(self) -> None:
         idmapper_models.flush_cache()
-        self.room = ObjectDB.objects.create(
-            db_key="RxnRoom", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        self.room = ObjectDBFactory(db_key="RxnRoom", db_typeclass_path="typeclasses.rooms.Room")
         self.scene = SceneFactory(location=self.room, is_active=True)
         self.actor_char = _make_char_in_room(self.room)
         self.actor_sheet = CharacterSheetFactory(character=self.actor_char)
@@ -138,9 +134,7 @@ class ToggleReactionActionTests(TestCase):
 class ReactToWindowActionTests(TestCase):
     def setUp(self) -> None:
         idmapper_models.flush_cache()
-        self.room = ObjectDB.objects.create(
-            db_key="WinRoom", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        self.room = ObjectDBFactory(db_key="WinRoom", db_typeclass_path="typeclasses.rooms.Room")
         self.scene = SceneFactory(location=self.room, is_active=True)
         self.actor_char = _make_char_in_room(self.room)
         self.actor_sheet = CharacterSheetFactory(character=self.actor_char)

--- a/src/actions/tests/test_social_consent_enforcement.py
+++ b/src/actions/tests/test_social_consent_enforcement.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import django.test
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.consent.constants import ConsentMode
 from world.consent.factories import (
     SocialConsentBlacklistFactory,
@@ -246,7 +247,7 @@ class SocialConsentExclusionsIntegrationTest(django.test.TestCase):
             SceneParticipationFactory,
         )
 
-        self.room = ObjectDB.objects.create(db_key="ConsentTestRoom")
+        self.room = ObjectDBFactory(db_key="ConsentTestRoom")
 
         # Actor character (has a RosterTenure so actor_tenure is resolved)
         self.actor_sheet = CharacterSheetFactory()
@@ -327,7 +328,7 @@ class SocialConsentExclusionsQueryBudgetTest(django.test.TestCase):
         from world.roster.factories import RosterEntryFactory, RosterTenureFactory
         from world.scenes.factories import SceneFactory, SceneParticipationFactory
 
-        room = ObjectDB.objects.create(db_key=f"BudgetRoom{num_targets}")
+        room = ObjectDBFactory(db_key=f"BudgetRoom{num_targets}")
 
         actor_sheet = CharacterSheetFactory()
         actor_char = actor_sheet.character

--- a/src/actions/tests/test_unified_player_actions.py
+++ b/src/actions/tests/test_unified_player_actions.py
@@ -17,13 +17,12 @@ from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
-from evennia.objects.models import ObjectDB
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from actions.factories import ActionTemplateFactory
 from actions.models import ActionEnhancement
-from evennia_extensions.factories import AccountFactory
+from evennia_extensions.factories import AccountFactory, ObjectDBFactory
 from world.magic.factories import (
     CharacterAnimaFactory,
     CharacterTechniqueFactory,
@@ -59,7 +58,7 @@ class UnifiedPlayerActionsEndpointShapeTests(TestCase):
             end_date=None,
         )
 
-        cls.room = ObjectDB.objects.create(db_key="UnifiedActionsShapeRoom")
+        cls.room = ObjectDBFactory(db_key="UnifiedActionsShapeRoom")
 
         # Seed a social template with a matching enhancement so an action surfaces.
         _make_social_template("Intimidate")
@@ -134,7 +133,7 @@ class UnifiedPlayerActionsQueryBudgetTests(TestCase):
             end_date=None,
         )
 
-        cls.room = ObjectDB.objects.create(db_key="UnifiedActionsBudgetRoom")
+        cls.room = ObjectDBFactory(db_key="UnifiedActionsBudgetRoom")
 
         # Three social templates (the action_keys that the enhancements link to).
         for action_key in ("intimidate", "persuade", "flirt"):

--- a/src/commands/account/sheet_sections.py
+++ b/src/commands/account/sheet_sections.py
@@ -437,7 +437,7 @@ def _render_status_section(command: Command) -> list[str]:
     )
     lines.append(f"  Fatigue: {zones}")
 
-    anima = getattr(character, "anima", None)  # noqa: GETATTR_LITERAL
+    anima = character.anima_or_none
     if anima is not None:
         lines.append(f"  Anima: {anima_band_for(anima.current, anima.maximum)}")
 

--- a/src/commands/consent.py
+++ b/src/commands/consent.py
@@ -261,6 +261,7 @@ class _RespondCommand(ArxCommand):
         if request is None:
             self.msg(_NO_PENDING_MSG)
             return
+        # Suppression justified: Evennia cmdhandler sets .switches at parse time.
         switches = getattr(self, "switches", None) or []  # noqa: GETATTR_LITERAL
         difficulty = next((sw for sw in switches if sw in _DIFFICULTY_SWITCHES), None)
         blacklist_actor = self.decision == ConsentDecision.DENY and bool(

--- a/src/commands/evennia_overrides/communication.py
+++ b/src/commands/evennia_overrides/communication.py
@@ -172,6 +172,7 @@ class CmdPage(FrontendMetadataMixin, Command):  # ty: ignore[invalid-base]
             character_appears_offline,
         )
 
+        # Suppression justified: Evennia cmdhandler sets .session at runtime.
         session = getattr(self, "session", None)  # noqa: GETATTR_LITERAL
         sender_char = session.puppet if session is not None else None
         # (a) A hidden character can only page people on their own allowlist — so they never

--- a/src/commands/evennia_overrides/movement.py
+++ b/src/commands/evennia_overrides/movement.py
@@ -111,6 +111,7 @@ class CmdHome(ArxCommand):
     def _execute(self) -> None:
         # ``switches`` is populated by the cmdhandler at parse time; a directly-constructed
         # command (unit tests) may not have it, so default to empty.
+        # Suppression justified: Evennia cmdhandler attr; absent on direct construction.
         switches = getattr(self, "switches", None) or ()  # noqa: GETATTR_LITERAL
         if self.SET_SWITCH in switches:
             self._set_home()

--- a/src/commands/hire.py
+++ b/src/commands/hire.py
@@ -79,7 +79,11 @@ class CmdHire(ArxCommand):
             self.msg(str(err))
 
     def _session(self) -> Any | None:
-        """Return the in-flight InteractionSession, if any."""
+        """Return the in-flight InteractionSession, if any.
+
+        ndb returns None natively for a missing attribute; the dynamic
+        attribute name is why this is getattr at all.
+        """
         return getattr(self.caller.session.ndb, self._SESSION_KEY, None)
 
     def _set_session(self, session: Any) -> None:

--- a/src/commands/ritual.py
+++ b/src/commands/ritual.py
@@ -38,11 +38,16 @@ _SESSION_SUBCMDS = frozenset({"sessions", "draft", "join", "decline", "fire", "c
 
 
 def _advancement_error_message(exc: Exception) -> str:
-    """Return a caller-safe error string from a ``ClassLevelAdvancementError``."""
-    failed = getattr(exc, "failed", None)  # noqa: GETATTR_LITERAL
-    if failed:
-        return "; ".join(failed)
-    return getattr(exc, "user_message", "This advancement could not be completed.")  # noqa: GETATTR_LITERAL
+    """Return a caller-safe error string from a ``ClassLevelAdvancementError``.
+
+    Only ``AdvancementRequirementsNotMet`` carries the per-requirement
+    ``failed`` list — explicit dispatch, not a getattr default (#2386).
+    """
+    from world.progression.exceptions import AdvancementRequirementsNotMet  # noqa: PLC0415
+
+    if isinstance(exc, AdvancementRequirementsNotMet) and exc.failed:
+        return "; ".join(exc.failed)
+    return exc.user_message
 
 
 def _tokenize_draft_args(rest: str) -> tuple[str, list[str], dict[str, str]]:
@@ -474,7 +479,7 @@ class CmdRitual(ArxCommand):
         """Collect ItemInstance rows for the caller's carried items."""
         components = []
         for obj in self.caller.contents:
-            instance = getattr(obj, "item_instance", None)  # noqa: GETATTR_LITERAL
+            instance = obj.item_instance_or_none
             if instance is not None:
                 components.append(instance)
         return components

--- a/src/commands/sanctum.py
+++ b/src/commands/sanctum.py
@@ -215,7 +215,7 @@ class CmdSanctum(DispatchCommand):
         """
         components = []
         for obj in self.caller.contents:
-            instance = getattr(obj, "item_instance", None)  # noqa: GETATTR_LITERAL
+            instance = obj.item_instance_or_none
             if instance is not None:
                 components.append(instance)
         return components

--- a/src/commands/tests/test_consent_commands.py
+++ b/src/commands/tests/test_consent_commands.py
@@ -323,7 +323,7 @@ class AllSocialCommandsRegisteredTests(TestCase):
     def test_ritual_command_has_no_perform_alias(self) -> None:
         from commands.ritual import CmdRitual
 
-        self.assertNotIn("perform", getattr(CmdRitual, "aliases", []))  # noqa: GETATTR_LITERAL
+        self.assertNotIn("perform", CmdRitual.aliases)
 
 
 class PullParsingOnConsentCommandsTests(TestCase):

--- a/src/commands/tests/test_react_command.py
+++ b/src/commands/tests/test_react_command.py
@@ -15,7 +15,7 @@ from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper import models as idmapper_models
 
 from commands.react import CmdReact
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.factories import CharacterResonanceFactory, ResonanceFactory
 from world.roster.factories import RosterEntryFactory, RosterTenureFactory
@@ -48,9 +48,7 @@ def _wire_account(sheet):
 class CmdReactTests(TestCase):
     def setUp(self) -> None:
         idmapper_models.flush_cache()
-        self.room = ObjectDB.objects.create(
-            db_key="ReactRoom", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        self.room = ObjectDBFactory(db_key="ReactRoom", db_typeclass_path="typeclasses.rooms.Room")
         self.scene = SceneFactory(location=self.room, is_active=True)
         # Actor
         self.actor = _make_char_in_room(self.room)

--- a/src/commands/tests/test_relationships_command.py
+++ b/src/commands/tests/test_relationships_command.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 
 from commands.relationships import CmdRelationship, _parse_name_and_kwargs
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.relationships.constants import TrackSign, UpdateVisibility
 from world.relationships.factories import (
@@ -491,7 +491,6 @@ class CmdRelationshipBumpTests(TestCase):
     """``relationship plus|neg <name>`` (+ switch form) runs the bump Action (#1699)."""
 
     def setUp(self) -> None:
-        from evennia.objects.models import ObjectDB
         from evennia.utils.idmapper.models import flush_cache
 
         from world.relationships.constants import TrackSystemKey
@@ -504,9 +503,7 @@ class CmdRelationshipBumpTests(TestCase):
         RelationshipTrackFactory(
             name="Friction", sign=TrackSign.NEGATIVE, system_key=TrackSystemKey.FRICTION
         )
-        self.room = ObjectDB.objects.create(
-            db_key="BumpRoom", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        self.room = ObjectDBFactory(db_key="BumpRoom", db_typeclass_path="typeclasses.rooms.Room")
         self.scene = SceneFactory(location=self.room, is_active=True)
         self.caller = CharacterFactory()
         self.caller.location = self.room

--- a/src/core/testing.py
+++ b/src/core/testing.py
@@ -85,6 +85,8 @@ def _flush_sharedmemorymodel_caches() -> None:
         # Abstract subclasses or those without a concrete ``__dbclass__``
         # may not implement ``flush_instance_cache`` cleanly; skip them
         # rather than fail the entire teardown.
+        # Suppression justified: duck-typed SharedMemoryModel subclass-tree walk; abstract classes
+        # lack it.
         flusher = getattr(cls, "flush_instance_cache", None)  # noqa: GETATTR_LITERAL
         if flusher is not None:
             with contextlib.suppress(AttributeError, TypeError):
@@ -126,6 +128,8 @@ def _flush_arx_manager_caches() -> None:
         if cls in seen:
             continue
         seen.add(cls)
+        # Suppression justified: duck-typed SharedMemoryModel subclass-tree walk; abstract classes
+        # lack it.
         mgr = getattr(cls, "objects", None)  # noqa: GETATTR_LITERAL
         if isinstance(mgr, CachedAllMixin):
             mgr.flush_all_cache()

--- a/src/evennia_extensions/observability/settings.py
+++ b/src/evennia_extensions/observability/settings.py
@@ -31,6 +31,8 @@ def observability_config() -> ObservabilityConfig:
             or safe defaults (disabled, port 9109).
     """
     return ObservabilityConfig(
+        # Suppression justified: Django optional-setting read.
         enabled=bool(getattr(settings, "OBSERVABILITY_ENABLED", False)),  # noqa: GETATTR_LITERAL
+        # Suppression justified: Django optional-setting read.
         port=int(getattr(settings, "OBSERVABILITY_PORT", 9109)),  # noqa: GETATTR_LITERAL
     )

--- a/src/flows/emit.py
+++ b/src/flows/emit.py
@@ -65,7 +65,7 @@ def _gather_triggers(event_name: str, location: Any) -> list[Any]:
         # room to gather triggers from — the old getattr-default hid this case.
         return []
     owners: list[Any] = [location]
-    contents = getattr(location, "contents", None) or []  # noqa: GETATTR_LITERAL
+    contents = location.contents or []
     owners.extend(contents)
 
     gathered: list[Any] = []

--- a/src/flows/filters/evaluator.py
+++ b/src/flows/filters/evaluator.py
@@ -127,6 +127,7 @@ def _walk_dotted(obj: Any, dotted: str) -> Any:
             # None propagates (optional-chaining semantics): None.anything → None.
             # The subsequent comparison (e.g. None == "Celestial") evaluates False.
             return None
+        # Suppression justified: dynamic DSL path segment; SENTINEL default raises loudly.
         result = getattr(current, part, SENTINEL)  # noqa: GETATTR_LITERAL
         if result is SENTINEL:
             msg = f"Cannot resolve '{part}' on {type(current).__name__} (full path: {dotted})"

--- a/src/flows/models/flows.py
+++ b/src/flows/models/flows.py
@@ -31,7 +31,7 @@ def _resolve_emit_location(flow_execution: "FlowExecution") -> Any:
     character is in). Returns ``None`` when no dispatchable location can
     be resolved — callers should skip the emit in that case.
     """
-    owner = getattr(flow_execution.flow_stack, "owner", None)  # noqa: GETATTR_LITERAL
+    owner = flow_execution.flow_stack.owner
     if owner is None:
         return None
     from evennia.objects.objects import DefaultRoom  # noqa: PLC0415
@@ -537,6 +537,7 @@ class FlowStepDefinition(SharedMemoryModel):
         op = params["op"]
         value = params["value"]
 
+        # Suppression justified: dynamic field name from step params; no default, loud on typo.
         current = getattr(payload, field)  # noqa: GETATTR_LITERAL
         if op == "set":  # noqa: STRING_LITERAL
             new_value = value
@@ -551,6 +552,7 @@ class FlowStepDefinition(SharedMemoryModel):
         else:
             msg = f"Unknown modify_payload op: {op}"
             raise ValueError(msg)
+        # Suppression justified: dynamic field name from step params; no default, loud on typo.
         setattr(payload, field, new_value)  # noqa: GETATTR_LITERAL
         return flow_execution.get_next_child(self)
 

--- a/src/flows/object_states/base_state.py
+++ b/src/flows/object_states/base_state.py
@@ -17,6 +17,17 @@ if TYPE_CHECKING:
     from world.scenes.models import Scene
 
 
+def unwrap_objectdb(obj: "BaseState | ObjectDB") -> "ObjectDB":
+    """Unwrap a BaseState wrapper to its underlying ObjectDB.
+
+    The flow execution layer may pass a ``BaseState`` (e.g. ``CharacterState``)
+    rather than a raw ``ObjectDB`` when a parameter is resolved via
+    ``_resolve_service_param``. Explicit isinstance dispatch — a getattr
+    default here would silently swallow genuine attribute bugs (#2386).
+    """
+    return obj.obj if isinstance(obj, BaseState) else obj
+
+
 class BaseState:
     """Ephemeral wrapper around an Evennia object.
 

--- a/src/flows/object_states/character_state.py
+++ b/src/flows/object_states/character_state.py
@@ -79,6 +79,7 @@ class CharacterState(BaseState):
         Cached on the state so listing a room's occupants resolves the looker's context once, not
         once per occupant.
         """
+        # Suppression justified: lazy memoization slot, absent until first compute.
         if getattr(self, "_viewer_persona_ctx", None) is None:  # noqa: GETATTR_LITERAL
             from world.scenes.persona_display import viewer_context_for_account  # noqa: PLC0415
 

--- a/src/flows/service_functions/agriculture.py
+++ b/src/flows/service_functions/agriculture.py
@@ -13,25 +13,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from flows.object_states.base_state import unwrap_objectdb
+
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
-
-
-def _unwrap_objectdb(obj: ObjectDB) -> ObjectDB:
-    """Unwrap a BaseState wrapper to its underlying ObjectDB.
-
-    The flow execution layer may pass a ``BaseState`` (e.g., ``CharacterState``)
-    rather than a raw ``ObjectDB`` when the parameter is resolved via
-    ``_resolve_service_param``.  ``BaseState`` exposes the raw object on its
-    ``.obj`` attribute; raw ``ObjectDB`` instances have no such attribute.
-
-    Args:
-        obj: A raw ``ObjectDB`` or a ``BaseState`` wrapping one.
-
-    Returns:
-        The underlying ``ObjectDB``.
-    """
-    return getattr(obj, "obj", obj)  # noqa: GETATTR_LITERAL
 
 
 def flow_food_collection_difficulty(
@@ -59,9 +44,9 @@ def flow_food_collection_difficulty(
         _pool_difficulty_bonus,
     )
 
-    raw_character = _unwrap_objectdb(character)
+    raw_character = unwrap_objectdb(character)
     # field_instance may arrive as a BaseState, a RoomFeatureInstance, or a pk.
-    raw_field = getattr(field_instance, "obj", field_instance)  # noqa: GETATTR_LITERAL
+    raw_field = unwrap_objectdb(field_instance)
 
     bonus = _pool_difficulty_bonus(raw_field, raw_character)
     return {

--- a/src/flows/service_functions/conditions.py
+++ b/src/flows/service_functions/conditions.py
@@ -12,25 +12,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from flows.object_states.base_state import unwrap_objectdb
+
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
-
-
-def _unwrap_objectdb(obj: ObjectDB) -> ObjectDB:
-    """Unwrap a BaseState wrapper to its underlying ObjectDB.
-
-    The flow execution layer may pass a ``BaseState`` (e.g., ``CharacterState``)
-    rather than a raw ``ObjectDB`` when the parameter is resolved via
-    ``_resolve_service_param``.  ``BaseState`` exposes the raw object on its
-    ``.obj`` attribute; raw ``ObjectDB`` instances have no such attribute.
-
-    Args:
-        obj: A raw ``ObjectDB`` or a ``BaseState`` wrapping one.
-
-    Returns:
-        The underlying ``ObjectDB``.
-    """
-    return getattr(obj, "obj", obj)  # noqa: GETATTR_LITERAL
 
 
 def flow_apply_condition(
@@ -51,7 +36,7 @@ def flow_apply_condition(
     from world.conditions.models import ConditionTemplate  # noqa: PLC0415
     from world.conditions.services import apply_condition  # noqa: PLC0415
 
-    raw_target = _unwrap_objectdb(target)
+    raw_target = unwrap_objectdb(target)
     condition = ConditionTemplate.get_by_name(condition_name)
     apply_condition(target=raw_target, condition=condition)
 
@@ -76,7 +61,7 @@ def flow_perform_check(
     from world.checks.models import CheckType  # noqa: PLC0415
     from world.checks.services import perform_check  # noqa: PLC0415
 
-    raw_character = _unwrap_objectdb(character)
+    raw_character = unwrap_objectdb(character)
     check_type = CheckType.objects.get(name=check_type_name)
     result = perform_check(
         character=raw_character,

--- a/src/flows/service_functions/forms.py
+++ b/src/flows/service_functions/forms.py
@@ -12,25 +12,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from flows.object_states.base_state import unwrap_objectdb
+
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
-
-
-def _unwrap_objectdb(obj: ObjectDB) -> ObjectDB:
-    """Unwrap a BaseState wrapper to its underlying ObjectDB.
-
-    The flow execution layer may pass a ``BaseState`` (e.g., ``CharacterState``)
-    rather than a raw ``ObjectDB`` when the parameter is resolved via
-    ``_resolve_service_param``.  ``BaseState`` exposes the raw object on its
-    ``.obj`` attribute; raw ``ObjectDB`` instances have no such attribute.
-
-    Args:
-        obj: A raw ``ObjectDB`` or a ``BaseState`` wrapping one.
-
-    Returns:
-        The underlying ``ObjectDB``.
-    """
-    return getattr(obj, "obj", obj)  # noqa: GETATTR_LITERAL
 
 
 def flow_trigger_transformation(
@@ -62,7 +47,7 @@ def flow_trigger_transformation(
     from world.forms.models import AlternateSelf, CharacterForm  # noqa: PLC0415
     from world.forms.services.transformation import trigger_transformation  # noqa: PLC0415
 
-    raw_character = _unwrap_objectdb(character)
+    raw_character = unwrap_objectdb(character)
     sheet = raw_character.sheet_data
     form = CharacterForm.objects.get(name=form_name)
     alt = AlternateSelf.objects.get(character=sheet, form=form)

--- a/src/flows/service_functions/serializers/room_state.py
+++ b/src/flows/service_functions/serializers/room_state.py
@@ -53,7 +53,7 @@ class ObjectStateSerializer(serializers.Serializer):
         viewer_can_see_hidden = looker is not None and looker.obj == instance.obj
         return resolve_thumbnail(
             instance.obj,
-            persona=getattr(instance, "_resolved_persona", None),  # noqa: GETATTR_LITERAL
+            persona=instance._resolved_persona,  # noqa: SLF001 — BaseState seam, set in __init__
             viewer_can_see_hidden=viewer_can_see_hidden,
         )
 

--- a/src/flows/tests/test_flow_steps/test_cancel_event.py
+++ b/src/flows/tests/test_flow_steps/test_cancel_event.py
@@ -3,7 +3,7 @@
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.emit import emit_event
@@ -13,7 +13,7 @@ from world.conditions.factories import ReactiveConditionFactory
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/flows/tests/test_flow_steps/test_modify_payload.py
+++ b/src/flows/tests/test_flow_steps/test_modify_payload.py
@@ -5,7 +5,7 @@ import dataclasses
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.emit import emit_event
@@ -19,7 +19,7 @@ from world.conditions.factories import ReactiveConditionFactory
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/flows/tests/test_reactive_integration.py
+++ b/src/flows/tests/test_reactive_integration.py
@@ -23,7 +23,7 @@ from types import SimpleNamespace
 from django.test import TestCase, tag
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.emit import emit_event
@@ -58,7 +58,7 @@ NOT_SELF_FILTER = {"path": "target", "op": "!=", "value": "self"}
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/flows/tests/test_trigger_handler/test_dispatch.py
+++ b/src/flows/tests/test_trigger_handler/test_dispatch.py
@@ -3,7 +3,7 @@
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.emit import emit_event
@@ -13,7 +13,7 @@ from world.conditions.factories import ReactiveConditionFactory
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/flows/tests/test_typeclass_hooks/test_at_examined.py
+++ b/src/flows/tests/test_typeclass_hooks/test_at_examined.py
@@ -8,7 +8,7 @@ targeting is expressed via ``SELF_FILTER`` rather than a scope kwarg.
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.events.payloads import ExaminedPayload, ExaminePrePayload
@@ -25,7 +25,7 @@ SELF_FILTER = {"path": "target", "op": "==", "value": "self"}
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
     """Create a Room typeclass instance suitable for trigger dispatch."""
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )
@@ -33,7 +33,7 @@ def _create_room(key: str = "TestRoom") -> ObjectDB:
 
 def _create_object(key: str = "TestObj", location=None) -> ObjectDB:
     """Create a plain Object typeclass instance."""
-    obj = ObjectDB.objects.create(
+    obj = ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.objects.Object",
     )

--- a/src/flows/tests/test_typeclass_hooks/test_character_hooks.py
+++ b/src/flows/tests/test_typeclass_hooks/test_character_hooks.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.events.payloads import AttackLandedPayload, MovePreDepartPayload
@@ -29,7 +29,7 @@ CHAR_SELF_FILTER = {"path": "character", "op": "==", "value": "self"}
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
     """Create a Room typeclass instance suitable for trigger dispatch."""
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/integration_tests/pipeline/test_challenge_dispatch_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_challenge_dispatch_telnet_e2e.py
@@ -27,6 +27,7 @@ from evennia.utils.idmapper import models as idmapper_models
 from actions.constants import ActionBackend
 from actions.types import ActionRef
 from commands.command import DispatchCommand
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.conditions.factories import CapabilityTypeFactory
@@ -93,7 +94,7 @@ class ChallengeTelnetDispatchE2ETests(TestCase):
     def setUp(self) -> None:
         idmapper_models.flush_cache()
 
-        self.room = ObjectDB.objects.create(db_key="ChallengeTelnetTestRoom")
+        self.room = ObjectDBFactory(db_key="ChallengeTelnetTestRoom")
         self.sheet = CharacterSheetFactory()
         self.character = _set_character_location(self.sheet.character, self.room)
 

--- a/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_combat_cast_telnet_e2e.py
@@ -31,6 +31,7 @@ from evennia.utils.idmapper import models as idmapper_models
 
 from commands.combat import CmdDeclareTechnique
 from commands.combat_maneuvers import CmdCombat
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.constants import (
     ActionCategory,
@@ -153,7 +154,7 @@ class CombatCastTelnetE2ETests(TestCase):
         CharacterEngagementFactory(character=self.character)
 
         # Place the character in a room so location-dependent queries don't fail.
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/integration_tests/pipeline/test_combat_clash_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_combat_clash_telnet_e2e.py
@@ -27,6 +27,7 @@ from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper import models as idmapper_models
 
 from commands.combat import CmdClashCommit
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.constants import (
     ActionCategory,
@@ -141,7 +142,7 @@ class CombatClashTelnetE2ETests(TestCase):
         CharacterEngagementFactory(character=self.character)
 
         # Place the character in a room so location-dependent queries don't fail.
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/integration_tests/pipeline/test_consent_telnet_e2e.py
+++ b/src/integration_tests/pipeline/test_consent_telnet_e2e.py
@@ -33,7 +33,7 @@ from actions.constants import ResolutionPhase
 from actions.factories import ActionTemplateFactory
 from actions.types import PendingActionResolution, StepResult
 from commands.consent import CmdAccept, CmdIntimidate
-from evennia_extensions.factories import AccountFactory, CharacterFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.scenes.action_constants import ActionRequestStatus
 from world.scenes.action_models import SceneActionRequest
@@ -97,7 +97,7 @@ class ConsentTelnetE2ETests(TestCase):
 
         # Room both characters share; the scene is located here so the telnet
         # command's get_active_scene(location) finds it.
-        self.room = ObjectDB.objects.create(
+        self.room = ObjectDBFactory(
             db_key="TestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/integration_tests/pipeline/test_corruption_per_cast_pipeline.py
+++ b/src/integration_tests/pipeline/test_corruption_per_cast_pipeline.py
@@ -42,6 +42,8 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from evennia_extensions.factories import ObjectDBFactory
+
 
 class TestCorruptionPerCastPipeline(TestCase):
     """Per-cast corruption hook pipeline — Audere, multi-resonance, stacked multipliers.
@@ -388,7 +390,6 @@ class TestCorruptionPerCastPipeline(TestCase):
         Uses a single Abyssal resonance with intensity=5, level=1.
         Expected: 1 CORRUPTION_ACCRUING + 1 CORRUPTION_ACCRUED emitted.
         """
-        from evennia.objects.models import ObjectDB
 
         from flows.constants import EventName
         from world.character_sheets.factories import CharacterSheetFactory
@@ -405,7 +406,7 @@ class TestCorruptionPerCastPipeline(TestCase):
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
 
         # Give the character a location so emit_event fires (skipped when location is None).
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="CorruptionPipelineTestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/integration_tests/pipeline/test_endorsement_journey_e2e.py
+++ b/src/integration_tests/pipeline/test_endorsement_journey_e2e.py
@@ -23,7 +23,7 @@ from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper import models as idmapper_models
 
 from commands.endorse import CmdEndorse, CmdPoses
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.factories import CharacterResonanceFactory, ResonanceFactory
 from world.magic.models import PoseEndorsement, SceneEntryEndorsement
@@ -63,7 +63,7 @@ class EndorsementJourneyE2ETests(TestCase):
     def setUp(self) -> None:
         idmapper_models.flush_cache()
 
-        self.room = ObjectDB.objects.create(
+        self.room = ObjectDBFactory(
             db_key="EndorseTestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -189,7 +189,7 @@ class EndorsementJourneyE2ETests(TestCase):
         """``poses`` outside an active scene sends a CommandError message."""
         # Move both characters to a room with no active scene so search succeeds
         # but get_active_scene returns None.
-        empty_room = ObjectDB.objects.create(
+        empty_room = ObjectDBFactory(
             db_key="EmptyRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/integration_tests/pipeline/test_pull_outcome_cross_context_e2e.py
+++ b/src/integration_tests/pipeline/test_pull_outcome_cross_context_e2e.py
@@ -28,10 +28,10 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, tag
-from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper import models as idmapper_models
 
 from commands.combat import CmdClashCommit, CmdDeclareTechnique
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.constants import (
     ActionCategory,
@@ -115,7 +115,7 @@ class NoncombatCastPullChangesCheckModifierE2ETests(TestCase):
 
         self.action_template = ensure_technique_cast_content()
 
-        self.room = ObjectDB.objects.create(
+        self.room = ObjectDBFactory(
             db_key="PullOutcomeTestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -319,7 +319,7 @@ class CombatCastPullFlatBonusReadPathE2ETests(TestCase):
         )
 
         # Place the character in a room so location-dependent queries don't fail.
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="CombatCastPullRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -470,7 +470,7 @@ class CombatClashPullIntensityReadPathE2ETests(TestCase):
             character_sheet=self.sheet, health=100, max_health=100, base_max_health=100
         )
 
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="ClashPullRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -583,7 +583,7 @@ class RefuseWithoutChargeE2ETests(TestCase):
 
         self.action_template = ensure_technique_cast_content()
 
-        self.room = ObjectDB.objects.create(
+        self.room = ObjectDBFactory(
             db_key="RefuseTestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/integration_tests/pipeline/test_reaction_journey_e2e.py
+++ b/src/integration_tests/pipeline/test_reaction_journey_e2e.py
@@ -16,7 +16,7 @@ from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper import models as idmapper_models
 
 from commands.react import CmdReact
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.roster.factories import RosterEntryFactory, RosterTenureFactory
 from world.scenes.constants import InteractionMode, InteractionVisibility
@@ -46,7 +46,7 @@ class ReactionJourneyE2ETests(TestCase):
 
     def setUp(self) -> None:
         idmapper_models.flush_cache()
-        self.room = ObjectDB.objects.create(
+        self.room = ObjectDBFactory(
             db_key="ReactionE2ERoom", db_typeclass_path="typeclasses.rooms.Room"
         )
         self.scene = SceneFactory(location=self.room, is_active=True)
@@ -102,7 +102,7 @@ class ReactionJourneyE2ETests(TestCase):
         self.assertEqual(WindowReaction.objects.count(), 1)
 
     def test_react_no_active_scene_shows_error(self) -> None:
-        empty_room = ObjectDB.objects.create(
+        empty_room = ObjectDBFactory(
             db_key="EmptyRoom2", db_typeclass_path="typeclasses.rooms.Room"
         )
         self.reactor_char.location = empty_room

--- a/src/integration_tests/pipeline/test_weave_imbue_pull_journey_e2e.py
+++ b/src/integration_tests/pipeline/test_weave_imbue_pull_journey_e2e.py
@@ -30,13 +30,13 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper import models as idmapper_models
 
 from commands.combat import CmdDeclareTechnique
 from commands.imbue import CmdImbue
 from commands.ritual import CmdRitual
 from commands.weave import CmdWeaveThread
+from evennia_extensions.factories import ObjectDBFactory
 from integration_tests.game_content.magic import seed_thread_pull_catalog
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.constants import EffectKind, TargetKind
@@ -178,7 +178,7 @@ class WeaveImbulePullJourneyE2ETests(TestCase):
         CheckSystemSetupFactory.create()
 
         # Room + scene for the non-combat cast path.
-        self.room = ObjectDB.objects.create(
+        self.room = ObjectDBFactory(
             db_key="JourneyPullTestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/typeclasses/characters.py
+++ b/src/typeclasses/characters.py
@@ -67,6 +67,9 @@ class Character(ObjectParent, DefaultCharacter):
     #: on ObjectParent (CharacterFormState.character is limited to Characters).
     form_state_or_none = ReverseOneToOneOrNone("form_state")
 
+    #: Reverse-OneToOne safe accessor (#2386): the CharacterAnima row, or None.
+    anima_or_none = ReverseOneToOneOrNone("anima")
+
     # Example typeclass defaults for item_data fallbacks
     # These provide sensible defaults when data objects don't exist
     default_height_inches = 70  # 5'10" default height

--- a/src/typeclasses/mixins.py
+++ b/src/typeclasses/mixins.py
@@ -84,6 +84,7 @@ class ObjectParent:
     # missing row is a hard bug; use world.areas.services.get_room_profile when
     # you want get-or-create.
     room_profile_or_none = ReverseOneToOneOrNone("room_profile")
+    item_instance_or_none = ReverseOneToOneOrNone("item_instance")
 
     @cached_property
     def positions_cached(self: Union[Self, "DefaultObject"]) -> list:
@@ -223,6 +224,7 @@ class ObjectParent:
         if looker is not None and not self.at_examined(looker):
             return ""
         base = super().return_appearance(looker, **kwargs)  # type: ignore[misc]
+        # Suppression justified: set only by the at_examined hook (reset-on-entry contract).
         sections: list[str] = getattr(self, "_examine_sections", [])  # noqa: GETATTR_LITERAL
         ranking = _maybe_render_ranking_display(self, looker)
         if ranking is not None:

--- a/src/typeclasses/rooms.py
+++ b/src/typeclasses/rooms.py
@@ -80,11 +80,12 @@ class Room(ObjectParent, DefaultRoom):
 
     @property
     def active_scene(self) -> Scene | None:
-        """Scene currently running in this room."""
-        try:
-            return self.ndb.active_scene
-        except AttributeError:
-            return None
+        """Scene currently running in this room.
+
+        Evennia's ndb holder returns None natively for a missing attribute —
+        no defensive guard needed (silent-fail audit, holder hunt).
+        """
+        return self.ndb.active_scene
 
     @active_scene.setter
     def active_scene(self, value: Scene | None) -> None:

--- a/src/web/tests/test_api.py
+++ b/src/web/tests/test_api.py
@@ -5,7 +5,6 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from evennia.accounts.models import AccountDB
-from evennia.objects.models import ObjectDB
 
 from evennia_extensions.factories import (
     CharacterFactory,
@@ -48,11 +47,12 @@ class WebAPITests(TestCase):
     @patch("web.api.views.general_views.SESSION_HANDLER")
     def test_status_api_returns_counts(self, mock_session_handler):
         mock_session_handler.account_count.return_value = 2
-        character = ObjectDB.objects.create(
+        character = ObjectDBFactory(
             db_key="Char",
             db_typeclass_path="typeclasses.characters.Character",
-            db_account=self.account,
         )
+        character.db_account = self.account
+        character.save()
         from world.character_sheets.models import CharacterSheet
 
         sheet, _ = CharacterSheet.objects.get_or_create(character=character)
@@ -62,7 +62,7 @@ class WebAPITests(TestCase):
         )
         entry.last_puppeted = timezone.now()
         entry.save()
-        ObjectDB.objects.create(
+        ObjectDBFactory(
             db_key="Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -134,7 +134,7 @@ class WebAPITests(TestCase):
         assert data["email"]
 
     def test_roster_detail_api_returns_data(self):
-        character = ObjectDB.objects.create(
+        character = ObjectDBFactory(
             db_key="Hero",
             db_typeclass_path="typeclasses.characters.Character",
         )
@@ -161,7 +161,7 @@ class WebAPITests(TestCase):
         self.client.logout()
 
     def test_roster_application_api_accepts_message(self):
-        character = ObjectDB.objects.create(
+        character = ObjectDBFactory(
             db_key="Hero",
             db_typeclass_path="typeclasses.characters.Character",
         )
@@ -199,8 +199,9 @@ class WebAPITests(TestCase):
             db_key="Alice",
             db_typeclass_path="typeclasses.characters.Character",
             location=room,
-            db_account=self.account,
         )
+        caller.db_account = self.account
+        caller.save()
         target = ObjectDBFactory(
             db_key="Bob",
             db_typeclass_path="typeclasses.characters.Character",

--- a/src/world/achievements/discovery.py
+++ b/src/world/achievements/discovery.py
@@ -46,7 +46,7 @@ def announce_achievement(
 
 def _names(items):
     """Return a comma-separated display string of item names."""
-    return ", ".join(getattr(i, "name", str(i)) for i in items)  # noqa: GETATTR_LITERAL
+    return ", ".join(i.name for i in items)
 
 
 def announce_access_change(character_sheet, *, gained, lost, source):
@@ -74,7 +74,11 @@ def announce_access_change(character_sheet, *, gained, lost, source):
             sender_account=None,
         )
     for item in gained:
-        ach = getattr(item, "discovery_achievement", None)  # noqa: GETATTR_LITERAL
+        # Only DiscoverableContent subclasses carry discovery_achievement;
+        # CapabilityType grants never do.
+        from world.achievements.models import DiscoverableContent  # noqa: PLC0415
+
+        ach = item.discovery_achievement if isinstance(item, DiscoverableContent) else None
         if ach is None:
             continue
         from world.achievements.models import CharacterAchievement  # noqa: PLC0415
@@ -85,7 +89,7 @@ def announce_access_change(character_sheet, *, gained, lost, source):
             continue
         is_first = not CharacterAchievement.objects.filter(achievement=ach).exists()
         grant_achievement(ach, [character_sheet])
-        name = getattr(item, "name", str(item))  # noqa: GETATTR_LITERAL
+        name = item.name
         announce_achievement(
             [character_sheet],
             is_first=is_first,

--- a/src/world/agriculture/services/production.py
+++ b/src/world/agriculture/services/production.py
@@ -46,7 +46,7 @@ def field_production_tick() -> dict[str, int]:
     food_accrued = 0
 
     for instance in instances:
-        field_details = getattr(instance, "field_details", None)  # noqa: GETATTR_LITERAL
+        field_details = instance.field_details_or_none
         if field_details is None:
             continue
         try:

--- a/src/world/areas/positioning/factories.py
+++ b/src/world/areas/positioning/factories.py
@@ -28,7 +28,7 @@ class PositionFactory(factory.django.DjangoModelFactory):
     By default creates a fresh Room for each position. For tests that need two
     positions in the same room, pass ``room=some_room`` explicitly:
 
-        room = ObjectDB.objects.create(...)
+        room = ObjectDBFactory(...)
         a = PositionFactory(room=room, name="ground")
         b = PositionFactory(room=room, name="balcony")
     """

--- a/src/world/areas/positioning/tests/test_obstacle_lifecycle.py
+++ b/src/world/areas/positioning/tests/test_obstacle_lifecycle.py
@@ -1,8 +1,8 @@
 """Tests for conjured obstacle lifecycle (#2019)."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.areas.positioning.factories import PositionFactory
 from world.areas.positioning.models import PositionEdge
 from world.areas.positioning.services import (
@@ -17,7 +17,7 @@ class ObstacleLifecycleTest(TestCase):
     """Conjured obstacles get duration, owner, and restore-on-teardown (#2019)."""
 
     def setUp(self) -> None:
-        self.room = ObjectDB.objects.create(db_key="test_room")
+        self.room = ObjectDBFactory(db_key="test_room")
         self.pos_a = PositionFactory(room=self.room, name="alpha")
         self.pos_b = PositionFactory(room=self.room, name="bravo")
         self.sheet = CharacterSheetFactory()

--- a/src/world/areas/positioning/tests/test_ramparts.py
+++ b/src/world/areas/positioning/tests/test_ramparts.py
@@ -1,8 +1,8 @@
 """Tests for living-barrier ramparts (#2209)."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.areas.positioning.constants import RampartCrackState, RampartSignature
 from world.areas.positioning.factories import (
     PositionFactory,
@@ -25,7 +25,7 @@ class RaiseRampartTest(TestCase):
     """raise_rampart creates a Rampart row and (for SEAL_EDGES) seals adjacent edges."""
 
     def setUp(self) -> None:
-        self.room = ObjectDB.objects.create(db_key="test_room")
+        self.room = ObjectDBFactory(db_key="test_room")
         self.pos = PositionFactory(room=self.room, name="courtyard")
         self.neighbor = PositionFactory(room=self.room, name="gate")
         self.edge = connect_positions(self.pos, self.neighbor, is_passable=True)
@@ -133,7 +133,7 @@ class ExpireTeardownTest(TestCase):
     """expire_rampart_rounds / teardown_ramparts restore/remove ramparts in a room."""
 
     def setUp(self) -> None:
-        self.room = ObjectDB.objects.create(db_key="test_room")
+        self.room = ObjectDBFactory(db_key="test_room")
         self.pos = PositionFactory(room=self.room, name="courtyard")
 
     def test_expire_decrements_and_deletes_at_zero(self) -> None:

--- a/src/world/areas/positioning/tests/test_round_tick_expiry.py
+++ b/src/world/areas/positioning/tests/test_round_tick_expiry.py
@@ -1,8 +1,8 @@
 """Tests for round-tick expiry of conjured obstacles (#2019)."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.areas.positioning.factories import PositionFactory
 from world.areas.positioning.models import PositionEdge
 from world.areas.positioning.services import create_conjured_obstacle, expire_obstacle_rounds
@@ -13,7 +13,7 @@ class RoundTickExpiryTest(TestCase):
     """expire_obstacle_rounds decrements duration and restores at 0 (#2019)."""
 
     def setUp(self) -> None:
-        self.room = ObjectDB.objects.create(db_key="room")
+        self.room = ObjectDBFactory(db_key="room")
         self.pos_a = PositionFactory(room=self.room, name="alpha")
         self.pos_b = PositionFactory(room=self.room, name="bravo")
         self.sheet = CharacterSheetFactory()

--- a/src/world/areas/tests/test_existing.py
+++ b/src/world/areas/tests/test_existing.py
@@ -3,9 +3,8 @@ from unittest.mock import MagicMock
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from evennia_extensions.models import RoomProfile
 from flows.service_functions.serializers.room_state import RoomStatePayloadSerializer
 from world.areas.constants import AreaLevel
@@ -262,7 +261,7 @@ class RoomProfileTests(TestCase):
     def setUpTestData(cls):
         cls.city = AreaFactory(name="Arx", level=AreaLevel.CITY)
         cls.building = AreaFactory(name="Tavern", level=AreaLevel.BUILDING, parent=cls.city)
-        cls.room_obj = ObjectDB.objects.create(
+        cls.room_obj = ObjectDBFactory(
             db_key="Main Hall",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -329,19 +328,19 @@ class SubtreeQueryTests(TestCase):
             name="Dockside Pub", level=AreaLevel.BUILDING, parent=cls.other_ward
         )
 
-        cls.room1 = ObjectDB.objects.create(
+        cls.room1 = ObjectDBFactory(
             db_key="Tavern Hall",
             db_typeclass_path="typeclasses.rooms.Room",
         )
-        cls.room2 = ObjectDB.objects.create(
+        cls.room2 = ObjectDBFactory(
             db_key="Tavern Kitchen",
             db_typeclass_path="typeclasses.rooms.Room",
         )
-        cls.room3 = ObjectDB.objects.create(
+        cls.room3 = ObjectDBFactory(
             db_key="Dock Bar",
             db_typeclass_path="typeclasses.rooms.Room",
         )
-        cls.room_no_area = ObjectDB.objects.create(
+        cls.room_no_area = ObjectDBFactory(
             db_key="Wilderness",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -445,7 +444,7 @@ class RoomStateAncestryTests(TestCase):
         )
         cls.city = AreaFactory(name="Arx", level=AreaLevel.CITY, parent=cls.kingdom)
         cls.building = AreaFactory(name="The Stag", level=AreaLevel.BUILDING, parent=cls.city)
-        cls.room_obj = ObjectDB.objects.create(
+        cls.room_obj = ObjectDBFactory(
             db_key="Main Hall",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -474,7 +473,7 @@ class RoomStateAncestryTests(TestCase):
 class GetRoomProfileTests(TestCase):
     def test_get_room_profile_creates_if_missing(self):
         """get_room_profile creates a RoomProfile for non-Room ObjectDB instances."""
-        room_obj = ObjectDB.objects.create(
+        room_obj = ObjectDBFactory(
             db_key="New Room",
             db_typeclass_path="typeclasses.objects.Object",
         )
@@ -485,7 +484,7 @@ class GetRoomProfileTests(TestCase):
 
     def test_get_room_profile_returns_existing(self):
         building = AreaFactory(name="Building", level=AreaLevel.BUILDING)
-        room_obj = ObjectDB.objects.create(
+        room_obj = ObjectDBFactory(
             db_key="Existing Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -504,7 +503,7 @@ class PayloadIntegrationTests(TestCase):
         cls.realm = Realm.objects.create(name="Arx", theme="arx")
         cls.kingdom = AreaFactory(name="Compact", level=AreaLevel.KINGDOM, realm=cls.realm)
         cls.city = AreaFactory(name="Arx", level=AreaLevel.CITY, parent=cls.kingdom)
-        cls.room_obj = ObjectDB.objects.create(
+        cls.room_obj = ObjectDBFactory(
             db_key="Hall",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -530,7 +529,7 @@ class PayloadIntegrationTests(TestCase):
 
 def _make_room_in_area(area):
     """Create a room ObjectDB and point its RoomProfile at the given area."""
-    room_obj = ObjectDB.objects.create(
+    room_obj = ObjectDBFactory(
         db_key="Test Room",
         db_typeclass_path="typeclasses.rooms.Room",
     )
@@ -612,7 +611,7 @@ class SocietiesForSceneTests(TestCase):
         assert result == [self.society_b]
 
     def test_no_area_returns_empty(self):
-        room_obj = ObjectDB.objects.create(
+        room_obj = ObjectDBFactory(
             db_key="Placeless Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -647,11 +646,11 @@ class SocietiesForSceneTests(TestCase):
 
 class PositionModelTests(TestCase):
     def setUp(self):
-        self.room = ObjectDB.objects.create(
+        self.room = ObjectDBFactory(
             db_key="Plaza",
             db_typeclass_path="typeclasses.rooms.Room",
         )
-        self.room2 = ObjectDB.objects.create(
+        self.room2 = ObjectDBFactory(
             db_key="Alley",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -668,10 +667,10 @@ class PositionModelTests(TestCase):
 
     def test_object_position_is_one_to_one(self):
         a = Position.objects.create(room=self.room, name="a_oto", kind=PositionKind.FEATURE)
-        obj = ObjectDB.objects.create(
+        obj = ObjectDBFactory(
             db_key="Pat",
             db_typeclass_path="typeclasses.characters.Character",
-            db_location=self.room,
+            location=self.room,
         )
         ObjectPosition.objects.create(objectdb=obj, position=a)
         b = Position.objects.create(room=self.room, name="b_oto", kind=PositionKind.FEATURE)

--- a/src/world/assets/tests/test_e2e_introduction_journey.py
+++ b/src/world/assets/tests/test_e2e_introduction_journey.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from django.test import TestCase
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.assets.constants import (
     AssetAcquisitionSource,
     AssetRoleContext,
@@ -27,9 +28,7 @@ class IntroductionJourneyTests(TestCase):
     """Full-journey E2E for #2295 co-ownership."""
 
     def setUp(self) -> None:
-        from evennia.objects.models import ObjectDB
-
-        self.room = ObjectDB.objects.create(db_key="Journey Room")
+        self.room = ObjectDBFactory(db_key="Journey Room")
         self.promoter_sheet = CharacterSheetFactory()
         self.promoter = self.promoter_sheet.primary_persona
         self.ally_sheet = CharacterSheetFactory()

--- a/src/world/assets/tests/test_introduction.py
+++ b/src/world/assets/tests/test_introduction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from django.test import TestCase
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.assets.constants import (
     AssetAcquisitionSource,
     AssetRoleContext,
@@ -102,9 +103,8 @@ class IntroduceAssetTests(TestCase):
 
     def _place_in_same_room(self, *personas: Persona) -> None:
         """Place the characters for the given personas in the same room."""
-        from evennia.objects.models import ObjectDB
 
-        room = ObjectDB.objects.create(db_key="Test Room")
+        room = ObjectDBFactory(db_key="Test Room")
         for persona in personas:
             character = persona.character_sheet.character
             character.location = room

--- a/src/world/battles/models.py
+++ b/src/world/battles/models.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.descriptors import ReverseOneToOneOrNone
 from core.managers import ArxSharedMemoryManager
 from world.battles.constants import (
     DEFAULT_MORALE,
@@ -222,6 +223,9 @@ class BattleSide(SharedMemoryModel):
 class BattlePlace(SharedMemoryModel):
     """A named front or zone within a battle (e.g. 'The Main Gates')."""
 
+    # Reverse-OneToOne safe accessor (#2386): missing row -> None.
+    vehicle_or_none = ReverseOneToOneOrNone("vehicle")
+
     battle = models.ForeignKey(
         Battle,
         on_delete=models.CASCADE,
@@ -369,6 +373,9 @@ class Fortification(SharedMemoryModel):
 
 class BattleUnit(SharedMemoryModel):
     """An abstract typed force (enemy or friendly) at a particular front."""
+
+    # Reverse-OneToOne safe accessor (#2386): missing row -> None.
+    vehicle_or_none = ReverseOneToOneOrNone("vehicle")
 
     battle = models.ForeignKey(
         Battle,

--- a/src/world/battles/resolution.py
+++ b/src/world/battles/resolution.py
@@ -797,7 +797,7 @@ def _resolve_reposition_success(
     from world.conditions.models import CapabilityType  # noqa: PLC0415
 
     place = declaration.target_place
-    vehicle = getattr(place, "vehicle", None)  # noqa: GETATTR_LITERAL
+    vehicle = place.vehicle_or_none
     if vehicle is None:
         return
     dx = declaration.reposition_dx or 0

--- a/src/world/battles/serializers.py
+++ b/src/world/battles/serializers.py
@@ -209,6 +209,8 @@ class BattleParticipantSerializer(serializers.ModelSerializer):
         # #2196: use prefetched conditions if available (battles view prefetches
         # them on the character to avoid per-participant N+1).
         cached_conditions = (
+            # Suppression justified: mutating condition set on identity-mapped ObjectDB; (#2401)
+            # context-over-cache.
             getattr(character, "cached_active_conditions", None)  # noqa: GETATTR_LITERAL
             if character is not None
             else None

--- a/src/world/battles/services.py
+++ b/src/world/battles/services.py
@@ -871,7 +871,7 @@ def _validate_unit_place_overlap(
     vehicle's own unit is gated the same as a BREACH against its hull.
     """
     target_unit_place = target_unit.place
-    if target_unit_place is None and hasattr(target_unit, "vehicle"):  # noqa: GETATTR_LITERAL
+    if target_unit_place is None and target_unit.vehicle_or_none is not None:
         target_unit_place = target_unit.vehicle.place
     if (
         target_unit_place is not None
@@ -891,7 +891,7 @@ def _validate_fortification_place_overlap(
     if (
         action_kind == BattleActionKind.BREACH
         and target_fortification is not None
-        and hasattr(target_fortification.place, "vehicle")  # noqa: GETATTR_LITERAL
+        and target_fortification.place.vehicle_or_none is not None
         and participant.place_id is not None
         and target_fortification.place_id != participant.place_id
         and not places_overlap(target_fortification.place, participant.place)
@@ -941,7 +941,7 @@ def _validate_vehicle_command(
     """
     if target_place is None:
         raise MissingScopeTargetError
-    vehicle = getattr(target_place, "vehicle", None)  # noqa: GETATTR_LITERAL
+    vehicle = target_place.vehicle_or_none
     if vehicle is None or vehicle.unit.military_unit.commander_id != participant.character_sheet_id:
         raise NotVehicleCommanderError
 

--- a/src/world/buildings/services.py
+++ b/src/world/buildings/services.py
@@ -129,7 +129,7 @@ def issue_permit(offer: NPCServiceOffer, persona: Persona) -> EffectResult:
     from world.items.models import ItemInstance, ItemTemplate, OwnershipEvent  # noqa: PLC0415
     from world.npc_services.effects import EffectResult  # noqa: PLC0415
 
-    details = getattr(offer, "permit_offer_details", None)  # noqa: GETATTR_LITERAL
+    details = offer.permit_offer_details_or_none
     if details is None:
         msg = f"NPCServiceOffer {offer.pk} (kind=PERMIT) has no PermitOfferDetails row."
         raise PermitIssuanceError(msg)
@@ -156,8 +156,7 @@ def issue_permit(offer: NPCServiceOffer, persona: Persona) -> EffectResult:
         crafter_persona_display=persona,
         charges=1,
     )
-    persona_name = getattr(persona, "display_ic", None)  # noqa: GETATTR_LITERAL
-    holder_persona_name = persona_name() if callable(persona_name) else str(persona)
+    holder_persona_name = persona.display_ic()
     permit = BuildingPermitDetails.objects.create(
         item_instance=instance,
         holder_persona_name=holder_persona_name,
@@ -235,7 +234,7 @@ def validate_permit_site(
 
     room_profile = site_room.room_profile_or_none
     if room_profile is None:
-        msg = f"Site {getattr(site_room, 'pk', '?')} has no RoomProfile (not a room)."  # noqa: GETATTR_LITERAL
+        msg = f"Site {site_room.pk} has no RoomProfile (not a room)."
         raise PermitSiteNotOutdoorError(msg)
     if not room_profile.is_outdoor:
         msg = f"Site {site_room.pk} is not an outdoor room."

--- a/src/world/buildings/tests/test_comfort_hud.py
+++ b/src/world/buildings/tests/test_comfort_hud.py
@@ -7,13 +7,12 @@ objects can't survive Django's per-test deepcopy).
 """
 
 from django.test import tag
-from evennia.objects.models import ObjectDB
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from actions.registry import get_action
 from evennia_extensions.constants import RoomEnclosure
-from evennia_extensions.factories import AccountFactory, CharacterFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 from evennia_extensions.models import RoomProfile
 from world.areas.constants import AreaLevel
 from world.areas.factories import AreaFactory
@@ -34,7 +33,7 @@ HEARTH = "Great Hearth"
 
 
 def _room_in(area, *, name="A Room", enclosure=RoomEnclosure.WALLED):
-    room = ObjectDB.objects.create(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+    room = ObjectDBFactory(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
     RoomProfile.objects.update_or_create(
         objectdb=room, defaults={"area": area, "enclosure": enclosure}
     )

--- a/src/world/buildings/tests/test_manager_api.py
+++ b/src/world/buildings/tests/test_manager_api.py
@@ -6,11 +6,10 @@ for-room resolver the RoomPanel button uses, and the two public catalogs
 """
 
 from django.test import tag
-from evennia.objects.models import ObjectDB
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from evennia_extensions.factories import AccountFactory
+from evennia_extensions.factories import AccountFactory, ObjectDBFactory
 from evennia_extensions.models import RoomProfile, RoomSizeTier
 from evennia_extensions.seeds import ensure_room_size_tiers
 from world.areas.constants import AreaLevel
@@ -34,7 +33,7 @@ from world.roster.factories import (
 
 
 def _room_in(area, *, size=None, grid=(None, None, 0), name="A Room"):
-    room = ObjectDB.objects.create(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+    room = ObjectDBFactory(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
     RoomProfile.objects.update_or_create(
         objectdb=room,
         defaults={
@@ -87,17 +86,17 @@ class ManagerApiBase(APITestCase):
         self.attic = _room_in(area, size=self.snug, grid=(0, 0, 1), name="Attic")
 
         # One exit pair entry <-> study.
-        self.exit_out = ObjectDB.objects.create(
+        self.exit_out = ObjectDBFactory(
             db_key="east",
             db_typeclass_path="typeclasses.exits.Exit",
-            db_location=self.entry,
-            db_destination=self.study,
+            location=self.entry,
+            destination=self.study,
         )
-        self.exit_back = ObjectDB.objects.create(
+        self.exit_back = ObjectDBFactory(
             db_key="west",
             db_typeclass_path="typeclasses.exits.Exit",
-            db_location=self.study,
-            db_destination=self.entry,
+            location=self.study,
+            destination=self.entry,
         )
 
         # A tenant with a primary home in the study.

--- a/src/world/buildings/tests/test_room_services.py
+++ b/src/world/buildings/tests/test_room_services.py
@@ -2,6 +2,7 @@
 
 from django.test import TestCase
 
+from evennia_extensions.factories import ObjectDBFactory
 from evennia_extensions.models import ObjectDisplayData, RoomProfile, RoomSizeTier
 from evennia_extensions.seeds import ensure_room_size_tiers
 from world.areas.constants import AreaLevel
@@ -19,9 +20,7 @@ from world.scenes.factories import PersonaFactory
 
 
 def _room_in(area, *, size=None, grid=(None, None, 0), name="A Room"):
-    from evennia.objects.models import ObjectDB
-
-    room = ObjectDB.objects.create(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+    room = ObjectDBFactory(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
     profile, _ = RoomProfile.objects.update_or_create(
         objectdb=room,
         defaults={

--- a/src/world/buildings/tests/test_style_discovery.py
+++ b/src/world/buildings/tests/test_style_discovery.py
@@ -7,10 +7,9 @@ Evennia objects can't survive Django's per-test deepcopy).
 """
 
 from django.test import TestCase, tag
-from evennia.objects.models import ObjectDB
 
 from actions.registry import get_action
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from evennia_extensions.models import RoomProfile
 from world.areas.constants import AreaLevel
 from world.areas.factories import AreaFactory
@@ -35,7 +34,7 @@ DEFAULT_STYLE = "Vernacular Timberframe"
 
 
 def _room_in(area, *, name="A Room"):
-    room = ObjectDB.objects.create(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
+    room = ObjectDBFactory(db_key=name, db_typeclass_path="typeclasses.rooms.Room")
     RoomProfile.objects.update_or_create(objectdb=room, defaults={"area": area})
     return room
 

--- a/src/world/captivity/tests/test_services.py
+++ b/src/world/captivity/tests/test_services.py
@@ -3,6 +3,7 @@
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.captivity.constants import CaptivityStatus
 from world.captivity.exceptions import AlreadyCapturedError, NotHeldError
 from world.captivity.models import Captivity, CaptivityConfig
@@ -25,7 +26,7 @@ from world.scenes.factories import SceneFactory
 class CaptureCharacterTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.return_room = ObjectDB.objects.create(
+        cls.return_room = ObjectDBFactory(
             db_key="Capture Site",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -114,7 +115,7 @@ class CaptureGroupKeyTests(TestCase):
 class ResolveCaptivityTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.return_room = ObjectDB.objects.create(
+        cls.return_room = ObjectDBFactory(
             db_key="Home Square",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -301,11 +302,11 @@ class BrigHoldingRoomCaptureTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.brig_room = ObjectDB.objects.create(
+        cls.brig_room = ObjectDBFactory(
             db_key="Ship Brig",
             db_typeclass_path="typeclasses.rooms.Room",
         )
-        cls.return_room = ObjectDB.objects.create(
+        cls.return_room = ObjectDBFactory(
             db_key="Capture Site",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/character_creation/serializers.py
+++ b/src/world/character_creation/serializers.py
@@ -212,14 +212,9 @@ class TraditionSerializer(serializers.ModelSerializer):
         every caller (no per-request filter), so attaching to the shared
         Tradition instance is safe.
         """
-        cached = getattr(obj, "cached_codex_grants", None)  # noqa: GETATTR_LITERAL
-        if cached is not None:
-            return [grant.entry_id for grant in cached]
-        from world.codex.models import TraditionCodexGrant  # noqa: PLC0415
-
-        return list(
-            TraditionCodexGrant.objects.filter(tradition=obj).values_list("entry_id", flat=True)
-        )
+        # cached_codex_grants is a cached_property (never None) — the shared
+        # Prefetch/query interface, #2386.
+        return [grant.entry_id for grant in obj.cached_codex_grants]
 
     def get_required_distinction_id(self, obj) -> int | None:
         """Get the required distinction ID from the BeginningTradition context.

--- a/src/world/character_creation/views.py
+++ b/src/world/character_creation/views.py
@@ -261,6 +261,7 @@ class TraditionViewSet(viewsets.ReadOnlyModelViewSet):
         ``query_params`` returns the id as a string, but Evennia's identity
         map keys instances by int pk; cast explicitly so the cache hits.
         """
+        # Suppression justified: DRF .request absent during drf-spectacular schema generation.
         request = getattr(self, "request", None)  # noqa: GETATTR_LITERAL
         raw = (
             request.query_params.get("beginning_id")  # noqa: USE_FILTERSET

--- a/src/world/character_sheets/models.py
+++ b/src/world/character_sheets/models.py
@@ -658,6 +658,8 @@ class CharacterSheet(SharedMemoryModel):
     roster_entry_or_none = ReverseOneToOneOrNone("roster_entry")
     vitals_or_none = ReverseOneToOneOrNone("vitals")
     fatigue_or_none = ReverseOneToOneOrNone("fatigue")
+    active_alternate_self_or_none = ReverseOneToOneOrNone("active_alternate_self")
+    path_intent_or_none = ReverseOneToOneOrNone("path_intent")
 
     @cached_property
     def primary_persona(self) -> Persona:

--- a/src/world/character_sheets/serializers.py
+++ b/src/world/character_sheets/serializers.py
@@ -687,6 +687,8 @@ def _build_magic_anima_ritual(sheet: CharacterSheet) -> AnimaRitualSection | Non
 
     rituals: list[Ritual] = getattr(
         account,
+        # Suppression justified: mutating prefetch on identity-mapped parent; context-over-cache
+        # (#2401).
         "cached_scene_action_rituals",  # noqa: GETATTR_LITERAL
         None,
     )
@@ -893,6 +895,8 @@ def _build_personas(
     """
     if privileged:
         # #2196: use prefetched conditions from the character (avoids N+1 per persona).
+        # Suppression justified: mutating prefetch on identity-mapped parent; context-over-cache
+        # (#2401).
         cached_conditions = getattr(sheet.character, "cached_active_conditions", None)  # noqa: GETATTR_LITERAL
         return [
             PersonaEntry(

--- a/src/world/checks/test_helpers.py
+++ b/src/world/checks/test_helpers.py
@@ -33,6 +33,7 @@ class CheckCapture:
 
 def _consume_forced_outcome() -> CheckOutcome | None:
     """Read and clear the thread-local outcome override. Returns None if none active."""
+    # Suppression justified: threading.local attr absent until a force context sets it.
     outcome = getattr(_local, "forced_outcome", None)  # noqa: GETATTR_LITERAL
     _local.forced_outcome = None
     return outcome
@@ -40,6 +41,7 @@ def _consume_forced_outcome() -> CheckOutcome | None:
 
 def _record_capture(*, check_type: CheckType, target_difficulty: int | None) -> None:
     """Write into the active CheckCapture, if any. No-op outside a force context."""
+    # Suppression justified: threading.local attr absent until a force context sets it.
     capture: CheckCapture | None = getattr(_local, "capture", None)  # noqa: GETATTR_LITERAL
     if capture is not None:
         capture.check_type = check_type

--- a/src/world/checks/tests/test_apply_pool_deterministically.py
+++ b/src/world/checks/tests/test_apply_pool_deterministically.py
@@ -1,10 +1,10 @@
 """Tests for apply_pool_deterministically() consequence resolution."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
 from actions.factories import ConsequencePoolEntryFactory, ConsequencePoolFactory
 from actions.models import ConsequencePoolEntry
+from evennia_extensions.factories import ObjectDBFactory
 from world.checks.consequence_resolution import apply_pool_deterministically
 from world.checks.factories import ConsequenceFactory
 from world.checks.types import ResolutionContext
@@ -16,7 +16,7 @@ class ApplyPoolDeterministicallyTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="DeterministicChar")
+        cls.character = ObjectDBFactory(db_key="DeterministicChar")
 
     def _make_context(self) -> ResolutionContext:
         return ResolutionContext(character=self.character)

--- a/src/world/checks/tests/test_collect_check_modifiers.py
+++ b/src/world/checks/tests/test_collect_check_modifiers.py
@@ -15,8 +15,8 @@ ConditionCheckModifier) live in setUpTestData for speed.
 """
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.constants import ModifierSourceKind
 from world.checks.factories import CheckTypeFactory
@@ -44,7 +44,7 @@ class CollectCheckModifiersTest(TestCase):
 
     def setUp(self):
         # Mutable per-test: fresh ObjectDB + CharacterSheet (rollmod=0 default).
-        self.target = ObjectDB.objects.create(db_key="CollectModTarget")
+        self.target = ObjectDBFactory(db_key="CollectModTarget")
         self.sheet = CharacterSheetFactory(character=self.target)
 
     def test_condition_and_rollmod_combined_total(self):
@@ -147,7 +147,7 @@ class CollectCheckModifiersMockCheckTypeTest(TestCase):
     """
 
     def setUp(self):
-        self.target = ObjectDB.objects.create(db_key="MockCheckTypeTarget")
+        self.target = ObjectDBFactory(db_key="MockCheckTypeTarget")
         self.sheet = CharacterSheetFactory(character=self.target)
 
     def test_mock_check_type_does_not_raise(self):
@@ -181,7 +181,6 @@ class CharacterSourceTests(TestCase):
 
     def setUp(self):
         # Mutable per-test: fresh ObjectDB + CharacterSheet (matches the module's pattern).
-        from evennia.objects.models import ObjectDB
 
         from world.character_sheets.factories import CharacterSheetFactory
         from world.checks.factories import CheckTypeFactory
@@ -197,7 +196,7 @@ class CharacterSourceTests(TestCase):
             ModifierTargetFactory,
         )
 
-        self.target_obj = ObjectDB.objects.create(db_key="CharacterSourceTarget")
+        self.target_obj = ObjectDBFactory(db_key="CharacterSourceTarget")
         self.sheet = CharacterSheetFactory(character=self.target_obj)
         self.check_type = CheckTypeFactory(name="Warded Strike")
         self.scoped_target = ModifierTargetFactory(

--- a/src/world/checks/tests/test_equipment_walk_in_checks.py
+++ b/src/world/checks/tests/test_equipment_walk_in_checks.py
@@ -28,6 +28,7 @@ from decimal import Decimal
 
 from django.test import TestCase
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.checks.constants import ModifierSourceKind
 
 
@@ -36,9 +37,7 @@ class EquipmentWalkInChecksTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:  # noqa: PLR0915 - end-to-end fixture spans many rows
-        from evennia.objects.models import ObjectDB
-
-        from evennia_extensions.factories import CharacterFactory
+        from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
         from world.areas.constants import AreaLevel
         from world.areas.factories import AreaFactory
         from world.character_sheets.factories import CharacterSheetFactory
@@ -206,7 +205,7 @@ class EquipmentWalkInChecksTests(TestCase):
             realm=cls.realm,
             dominant_society=cls.society,
         )
-        cls.room_obj = ObjectDB.objects.create(
+        cls.room_obj = ObjectDBFactory(
             db_key="EquipWalkChecksRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -265,11 +264,9 @@ class EquipmentWalkMockCheckTypeTests(TestCase):
     """A MagicMock check_type must not hit the DB (mirrors combat-resolver tests)."""
 
     def setUp(self) -> None:
-        from evennia.objects.models import ObjectDB
-
         from world.character_sheets.factories import CharacterSheetFactory
 
-        self.target = ObjectDB.objects.create(db_key="EquipWalkMockTarget")
+        self.target = ObjectDBFactory(db_key="EquipWalkMockTarget")
         self.sheet = CharacterSheetFactory(character=self.target)
 
     def test_mock_check_type_does_not_raise_and_no_equipment(self) -> None:

--- a/src/world/checks/tests/test_legend_award_handler.py
+++ b/src/world/checks/tests/test_legend_award_handler.py
@@ -3,8 +3,8 @@
 from unittest.mock import MagicMock
 
 from django.test import TestCase, tag
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.checks.constants import EffectType
 from world.checks.factories import ConsequenceEffectFactory, ConsequenceFactory
 from world.checks.types import ResolutionContext
@@ -35,7 +35,7 @@ class LegendAwardHandlerCreateEventTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="HandlerTestChar")
+        cls.character = ObjectDBFactory(db_key="HandlerTestChar")
         cls.source_type = LegendSourceTypeFactory()
         cls.persona_a = PersonaFactory()
         cls.persona_b = PersonaFactory()
@@ -117,7 +117,7 @@ class LegendAwardHandlerParticipantMissingTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="MissingParticipantChar")
+        cls.character = ObjectDBFactory(db_key="MissingParticipantChar")
         cls.source_type = LegendSourceTypeFactory()
 
     def test_none_participants_raises_error(self) -> None:
@@ -144,7 +144,7 @@ class LegendAwardDescriptionFallbackTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="DescFallbackChar")
+        cls.character = ObjectDBFactory(db_key="DescFallbackChar")
         cls.source_type = LegendSourceTypeFactory()
         cls.persona = PersonaFactory()
 
@@ -228,7 +228,7 @@ class LegendAwardHandlerCovenantFanOutTests(TestCase):
         # PersonaFactory defaults to ESTABLISHED, which is valid for legend.
         persona = PersonaFactory(character_sheet=sheet)
 
-        character = ObjectDB.objects.create(db_key="FanOutChar")
+        character = ObjectDBFactory(db_key="FanOutChar")
         source_type = LegendSourceTypeFactory()
         consequence = ConsequenceFactory()
         effect = _make_legend_effect(consequence, source_type, template="Fan-out deed.")
@@ -256,7 +256,7 @@ class LegendAwardRiskTierScalingTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         """Shared character/source_type/persona fixtures for all scaling scenarios."""
-        cls.character = ObjectDB.objects.create(db_key="RiskTierScalingChar")
+        cls.character = ObjectDBFactory(db_key="RiskTierScalingChar")
         cls.source_type = LegendSourceTypeFactory()
         cls.persona = PersonaFactory()
 

--- a/src/world/checks/tests/test_resolution_context.py
+++ b/src/world/checks/tests/test_resolution_context.py
@@ -1,8 +1,8 @@
 """Tests for ResolutionContext's outcome_tier field."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.checks.types import ResolutionContext
 from world.traits.factories import CheckOutcomeFactory
 
@@ -12,13 +12,13 @@ class ResolutionContextOutcomeTierTests(TestCase):
 
     def test_outcome_tier_defaults_to_none(self) -> None:
         """outcome_tier should default to None."""
-        character = ObjectDB.objects.create(db_key="ResolutionContextTestChar")
+        character = ObjectDBFactory(db_key="ResolutionContextTestChar")
         context = ResolutionContext(character=character)
         assert context.outcome_tier is None
 
     def test_outcome_tier_can_be_set(self) -> None:
         """outcome_tier should be settable on initialization."""
-        character = ObjectDB.objects.create(db_key="ResolutionContextTestChar2")
+        character = ObjectDBFactory(db_key="ResolutionContextTestChar2")
         tier = CheckOutcomeFactory(name="Overwhelming Victory", success_level=9)
         context = ResolutionContext(character=character, outcome_tier=tier)
         assert context.outcome_tier == tier

--- a/src/world/combat/interaction_services.py
+++ b/src/world/combat/interaction_services.py
@@ -262,8 +262,13 @@ def render_action_outcome_narration(  # noqa: PLR0913 - all params describe one 
         "Kira’s Frost Bolt misses the Pyromancer — the ward turns it aside."
         "Garruk uses Guard Stance."
     """
+    from world.combat.types import OpponentDamageResult  # noqa: PLC0415
+
     total_damage = sum(dr.damage_dealt for dr in outcome.damage_results)
-    defeated = any(getattr(dr, "defeated", False) for dr in outcome.damage_results)  # noqa: GETATTR_LITERAL
+    # Only opponent results carry `defeated`; participant results never do.
+    defeated = any(
+        isinstance(dr, OpponentDamageResult) and dr.defeated for dr in outcome.damage_results
+    )
     knocked_out = any(c.knocked_out for c in outcome.damage_consequences)
     dying = any(c.dying for c in outcome.damage_consequences)
     wounds = [ct.name for c in outcome.damage_consequences for ct in c.wounds_applied]

--- a/src/world/combat/models.py
+++ b/src/world/combat/models.py
@@ -183,6 +183,8 @@ class CombatEncounter(AbstractRound):
         flee. Cache-aware: uses prefetched ``opponents_cached`` when present
         so the detail serializer adds no query.
         """
+        # Suppression justified: live combat state on identity-mapped encounter; (#2401)
+        # context-over-cache.
         cached = getattr(self, "opponents_cached", None)  # noqa: GETATTR_LITERAL
         if cached is not None:
             return any(

--- a/src/world/combat/permissions.py
+++ b/src/world/combat/permissions.py
@@ -16,10 +16,9 @@ def can_view_encounter_effects(user: object, encounter: CombatEncounter) -> bool
     spectating the scene.
     """
 
-    # Suppression justified: user is deliberately duck-typed (object) — tests
-    # exercise this with bare non-user objects, and absence of the attribute
-    # is the "not authenticated" signal itself.
-    if not getattr(user, "is_authenticated", False):  # noqa: GETATTR_LITERAL
+    # Every Django user-like (User AND AnonymousUser) defines is_authenticated;
+    # a non-user object failing loudly here is correct (#2386 tranche 3).
+    if not user.is_authenticated:
         return False
     if user.is_staff:
         return True

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -79,6 +79,8 @@ def _serialize_active_conditions(
     Falls back to ``get_active_conditions`` for callers that build the
     serializer directly (e.g. unit tests).
     """
+    # Suppression justified: live/time-derived set on identity-mapped parent; context-over-cache —
+    # (#2401) never a cached_property.
     cached = getattr(target, ACTIVE_CONDITIONS_CACHE_ATTR, None)  # noqa: GETATTR_LITERAL
     if cached is not None:
         instances = [
@@ -205,6 +207,8 @@ class OpponentSerializer(serializers.ModelSerializer):
                 character = None
             target = character or obj.objectdb
             # #2196: use prefetched conditions from the view (on objectdb)
+            # Suppression justified: live/time-derived set on identity-mapped parent; (#2401) — a
+            # context-over-cache never cached_property.
             cached_conditions = getattr(obj.objectdb, "active_condition_instances", None)  # noqa: GETATTR_LITERAL
             return resolve_thumbnail(
                 target,
@@ -486,6 +490,8 @@ class ParticipantSerializer(serializers.ModelSerializer):
             return None
         # #2196: use the view's prefetched conditions (ACTIVE_CONDITIONS_CACHE_ATTR)
         # to avoid N+1 when serializing multiple participants.
+        # Suppression justified: live/time-derived set on identity-mapped parent; (#2401) — never
+        # context-over-cache a cached_property.
         cached_conditions = getattr(character, "active_condition_instances", None)  # noqa: GETATTR_LITERAL
         return resolve_thumbnail(character, persona=persona, cached_conditions=cached_conditions)
 
@@ -1041,6 +1047,8 @@ class EncounterDetailSerializer(serializers.ModelSerializer):
         Falls back to a direct filter for callers that don't use the viewset
         (e.g. unit tests that call the serializer directly).
         """
+        # Suppression justified: live/time-derived set on identity-mapped parent; (#2401) — never
+        # context-over-cache a cached_property.
         clashes = getattr(obj, "clashes_cached", None)  # noqa: GETATTR_LITERAL
         if clashes is None:
             clashes = (
@@ -1064,6 +1072,8 @@ class EncounterDetailSerializer(serializers.ModelSerializer):
         serialization. Falls back to a direct filter for callers that don't
         use the viewset (e.g. unit tests that call the serializer directly).
         """
+        # Suppression justified: live/time-derived set on identity-mapped parent; (#2401) — never
+        # context-over-cache a cached_property.
         locks = getattr(obj, "engagement_locks_cached", None)  # noqa: GETATTR_LITERAL
         if locks is None:
             from world.combat.constants import EngagementLockStatus  # noqa: PLC0415

--- a/src/world/combat/tests/test_agency_integration.py
+++ b/src/world/combat/tests/test_agency_integration.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from django.test import TestCase, tag
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.checks.test_helpers import force_check_outcome
@@ -252,10 +253,8 @@ class BleedOutProgressionTests(TestCase):
         cls.resist_check = CheckTypeFactory(name="bleed-resist")
 
     def setUp(self) -> None:
-        from evennia.objects.models import ObjectDB
-
         # A bare ObjectDB has db_account=None → classified as NPC → death_is_permitted True.
-        self.npc = ObjectDB.objects.create(db_key="BleedOutTestNPC")
+        self.npc = ObjectDBFactory(db_key="BleedOutTestNPC")
 
     def _build_terminal_bleed_out(self) -> world.conditions.models.ConditionTemplate:  # type: ignore[name-defined]
         """Create a Bleeding-Out template with exactly one stage (terminal by definition)."""

--- a/src/world/combat/tests/test_combat_magic_integration.py
+++ b/src/world/combat/tests/test_combat_magic_integration.py
@@ -9,9 +9,9 @@ rather than internal call patterns.
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
 from actions.constants import ActionTargetType
+from evennia_extensions.factories import ObjectDBFactory
 from flows.constants import EventName
 from flows.events.payloads import TechniqueCastPayload, TechniquePreCastPayload
 from world.character_sheets.factories import CharacterSheetFactory
@@ -79,7 +79,7 @@ def _setup_pc_attacking_mook(
     )
     anima = CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
     CharacterEngagementFactory(character=sheet.character)
-    room = ObjectDB.objects.create(
+    room = ObjectDBFactory(
         db_key="TestRoom",
         db_typeclass_path="typeclasses.rooms.Room",
     )
@@ -686,9 +686,7 @@ class CombatAoETargetPrerequisitesPreFlightTest(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
-            db_key="TestRoom", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        room = ObjectDBFactory(db_key="TestRoom", db_typeclass_path="typeclasses.rooms.Room")
         sheet.character.location = room
         sheet.character.save()
 

--- a/src/world/combat/tests/test_combat_magic_non_attack_integration.py
+++ b/src/world/combat/tests/test_combat_magic_non_attack_integration.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from evennia.objects.models import ObjectDB
 from evennia.utils.test_resources import EvenniaTestCase
 
+from evennia_extensions.factories import ObjectDBFactory
 from flows.constants import EventName
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.constants import (
@@ -38,7 +39,7 @@ from world.vitals.models import CharacterVitals
 
 
 def _create_room() -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key="TestRoom",
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/combat/tests/test_combat_power_ledger_persist.py
+++ b/src/world/combat/tests/test_combat_power_ledger_persist.py
@@ -13,9 +13,9 @@ from decimal import Decimal
 from unittest.mock import MagicMock
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
 from actions.factories import ActionTemplateFactory
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.combat.constants import (
@@ -81,7 +81,7 @@ class CombatPowerLedgerPersistTests(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoomLedger",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/combat/tests/test_damage.py
+++ b/src/world/combat/tests/test_damage.py
@@ -9,6 +9,7 @@ from actions.factories import (
     ConsequencePoolEntryFactory,
     ConsequencePoolFactory,
 )
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.constants import EffectType
 from world.checks.factories import CheckTypeFactory, ConsequenceEffectFactory, ConsequenceFactory
@@ -224,7 +225,7 @@ class KnockoutDeathProcessingTest(TestCase):
         )
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoomKO",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -321,7 +322,7 @@ class KnockoutDeathProcessingTest(TestCase):
         )
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoomDying",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -529,7 +530,7 @@ class NpcActionInteractionLazyCreationTests(TestCase):
         )
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key=f"LazyNPCRoom-{pc_health}-{npc_damage}",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/combat/tests/test_declare_reach_gate.py
+++ b/src/world/combat/tests/test_declare_reach_gate.py
@@ -15,7 +15,7 @@ from rest_framework import status as http_status
 from rest_framework.test import APIClient
 
 from actions.errors import ActionDispatchError
-from evennia_extensions.factories import AccountFactory
+from evennia_extensions.factories import AccountFactory, ObjectDBFactory
 from world.areas.positioning.services import (
     connect_positions,
     create_position,
@@ -266,10 +266,8 @@ class DispatchOutOfReachReturns400Tests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        from evennia.objects.models import ObjectDB
-
         cls.account = AccountFactory()
-        cls.character = ObjectDB.objects.create(db_key="ReachDispatchChar")
+        cls.character = ObjectDBFactory(db_key="ReachDispatchChar")
         cls.tenure = RosterTenureFactory(
             roster_entry__character_sheet__character=cls.character,
             player_data__account=cls.account,

--- a/src/world/combat/tests/test_defense.py
+++ b/src/world/combat/tests/test_defense.py
@@ -166,9 +166,7 @@ class DefensiveFashionWiringTests(TestCase):
     """
 
     def setUp(self) -> None:
-        from evennia.objects.models import ObjectDB
-
-        from evennia_extensions.factories import CharacterFactory
+        from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
         from evennia_extensions.models import RoomProfile
         from world.areas.constants import AreaLevel
         from world.areas.factories import AreaFactory
@@ -232,7 +230,7 @@ class DefensiveFashionWiringTests(TestCase):
             realm=realm,
             dominant_society=self.society,
         )
-        area_room = ObjectDB.objects.create(
+        area_room = ObjectDBFactory(
             db_key="Defense Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/combat/tests/test_encounter_aftermath.py
+++ b/src/world/combat/tests/test_encounter_aftermath.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 
 from django.db import IntegrityError, transaction
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 from rest_framework import status as http_status
 from rest_framework.test import APIClient
 
@@ -13,7 +12,7 @@ from actions.factories import (
     ConsequencePoolEntryFactory,
     ConsequencePoolFactory,
 )
-from evennia_extensions.factories import AccountFactory, CharacterFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from world.achievements.models import StatDefinition
 from world.character_sheets.factories import CharacterSheetFactory
@@ -464,7 +463,7 @@ class ResolveRoundCompletionTests(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="AftermathCompletionRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/combat/tests/test_entrance_seeding.py
+++ b/src/world/combat/tests/test_entrance_seeding.py
@@ -15,10 +15,10 @@
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 from evennia.utils.test_resources import EvenniaTestCase
 
 from actions.factories import ActionTemplateFactory
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.combat.constants import ActionCategory, OpponentTier
@@ -280,7 +280,7 @@ class EntranceDeclarationSuggestsOnResolutionTests(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="EntranceSuggestionRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/combat/tests/test_outcome_broadcast.py
+++ b/src/world/combat/tests/test_outcome_broadcast.py
@@ -11,9 +11,9 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
 from actions.factories import ActionTemplateFactory
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.combat.constants import (
@@ -84,7 +84,7 @@ class OutcomeBroadcastTest(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="OutcomeBroadcastRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/combat/tests/test_outcome_details_visibility.py
+++ b/src/world/combat/tests/test_outcome_details_visibility.py
@@ -68,13 +68,12 @@ class CanViewEncounterEffectsHelperTest(TestCase):
         self.assertFalse(can_view_encounter_effects(self.outsider, self.encounter))
 
     def test_unauthenticated_cannot_view(self) -> None:
-        """An anonymous-user-like object with no is_authenticated attribute returns False."""
+        """AnonymousUser (is_authenticated False) returns False."""
+        from django.contrib.auth.models import AnonymousUser
+
         from world.combat.permissions import can_view_encounter_effects
 
-        class _Anon:
-            pass
-
-        self.assertFalse(can_view_encounter_effects(_Anon(), self.encounter))
+        self.assertFalse(can_view_encounter_effects(AnonymousUser(), self.encounter))
 
 
 class OutcomeEndpointNonViewerDegradationTest(APITestCase):

--- a/src/world/combat/tests/test_reactive_integration.py
+++ b/src/world/combat/tests/test_reactive_integration.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.events.payloads import (
@@ -60,7 +60,7 @@ SELF_FILTER = {"path": "target", "op": "==", "value": "self"}
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/combat/tests/test_resolve_combat_technique_fury.py
+++ b/src/world/combat/tests/test_resolve_combat_technique_fury.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.constants import ActionCategory, OpponentTier
 from world.combat.factories import (
@@ -77,7 +77,7 @@ def _setup_combat_scenario():
     CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
     anima = CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
     CharacterEngagementFactory(character=sheet.character)
-    room = ObjectDB.objects.create(
+    room = ObjectDBFactory(
         db_key="TestRoom",
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/combat/tests/test_round_orchestrator.py
+++ b/src/world/combat/tests/test_round_orchestrator.py
@@ -3,9 +3,9 @@
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
 from actions.factories import ActionTemplateFactory
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.combat.constants import (
@@ -100,7 +100,7 @@ class ResolveRoundBasicTests(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -225,7 +225,7 @@ class ResolveRoundBasicTests(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoomComplete",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -363,7 +363,7 @@ class ResolveRoundDefenseCheckTests(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=200, max_health=200)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoomDefense",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -462,7 +462,7 @@ class ResolveRoundBossPhaseTests(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=500, max_health=500)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoomBoss",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -537,7 +537,7 @@ class ResolveRoundOffenseCheckTests(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoomOffense",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -917,7 +917,7 @@ class ResolveDeclaredChallengesTests(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet_combat, health=100, max_health=100)
         CharacterAnimaFactory(character=sheet_combat.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet_combat.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoomChalPost",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -1154,7 +1154,7 @@ class OffenseCheckSourceTests(TestCase):
         CharacterVitals.objects.create(character_sheet=sheet, health=100, max_health=100)
         CharacterAnimaFactory(character=sheet.character, current=20, maximum=20)
         CharacterEngagementFactory(character=sheet.character)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoomOffenseCheckSource",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/combat/tests/test_views.py
+++ b/src/world/combat/tests/test_views.py
@@ -3,14 +3,13 @@
 from decimal import Decimal
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 from rest_framework import status as http_status
 from rest_framework.test import APIClient
 
 from actions.constants import ActionBackend
 from actions.errors import ActionDispatchError
 from actions.factories import ActionTemplateFactory
-from evennia_extensions.factories import AccountFactory, CharacterFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.checks.test_helpers import force_check_outcome
@@ -760,7 +759,7 @@ class DeclareAndResolveE2ETest(TestCase):
         CharacterEngagementFactory(character=self.player_character)
 
         # Room location for the caster character (required by use_technique)
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="E2ETestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/conditions/tests/test_can_perceive.py
+++ b/src/world/conditions/tests/test_can_perceive.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.conditions.factories import (
     ConditionCategoryFactory,
     ConditionInstanceFactory,
@@ -11,7 +12,7 @@ from world.roster.factories import RosterEntryFactory
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/conditions/tests/test_check_modifier_contributions.py
+++ b/src/world/conditions/tests/test_check_modifier_contributions.py
@@ -9,8 +9,8 @@ reimplementing get_check_modifier's logic.
 from decimal import Decimal
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.constants import ModifierSourceKind
 from world.checks.factories import CheckTypeFactory
@@ -28,7 +28,7 @@ class ConditionContributionsTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.target = ObjectDB.objects.create(db_key="ContribTarget")
+        cls.target = ObjectDBFactory(db_key="ContribTarget")
         CharacterSheetFactory(character=cls.target)
         cls.combat_attack = CheckTypeFactory(name="combat-attack-contrib")
 
@@ -104,7 +104,7 @@ class ConditionContributionsWithStageTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.target = ObjectDB.objects.create(db_key="StageContribTarget")
+        cls.target = ObjectDBFactory(db_key="StageContribTarget")
         CharacterSheetFactory(character=cls.target)
         cls.combat_attack = CheckTypeFactory(name="combat-attack-stage-contrib")
 

--- a/src/world/conditions/tests/test_decay_severity.py
+++ b/src/world/conditions/tests/test_decay_severity.py
@@ -8,7 +8,7 @@ and emits CONDITION_STAGE_CHANGED only on actual stage change.
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.events.payloads import ConditionStageChangedPayload
 from world.conditions.factories import (
@@ -23,7 +23,7 @@ from world.conditions.services import (
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/conditions/tests/test_decay_tick.py
+++ b/src/world/conditions/tests/test_decay_tick.py
@@ -6,8 +6,8 @@ passive_decay_blocked_in_engagement and passive_decay_max_severity.
 """
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.conditions.factories import (
     ConditionInstanceFactory,
     ConditionStageFactory,
@@ -122,7 +122,7 @@ class DecayAllConditionsTickTests(TestCase):
         )
         stage = ConditionStageFactory(condition=template, severity_threshold=1)
 
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="AnchorRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/conditions/tests/test_position_fields.py
+++ b/src/world/conditions/tests/test_position_fields.py
@@ -1,8 +1,8 @@
 """Tests for cast-time position FK fields on ConditionInstance (#2019)."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.areas.positioning.factories import PositionFactory
 from world.conditions.factories import ConditionTemplateFactory
 from world.conditions.models import ConditionInstance
@@ -14,7 +14,7 @@ class ConditionInstancePositionFieldsTest(TestCase):
     """
 
     def setUp(self) -> None:
-        self.target = ObjectDB.objects.create(db_key="test_char")
+        self.target = ObjectDBFactory(db_key="test_char")
         self.template = ConditionTemplateFactory()
         self.pos = PositionFactory()
 

--- a/src/world/conditions/tests/test_reactive_integration.py
+++ b/src/world/conditions/tests/test_reactive_integration.py
@@ -21,7 +21,7 @@ Tests verify:
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.events.payloads import (
@@ -56,7 +56,7 @@ NOT_SELF_FILTER = {"path": "target", "op": "!=", "value": "self"}
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/conditions/tests/test_round_tick_shared.py
+++ b/src/world/conditions/tests/test_round_tick_shared.py
@@ -1,8 +1,8 @@
 """Tests for the shared tick_round_for_targets orchestrator (Task 4 / #520)."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.conditions.constants import DurationType
 from world.conditions.factories import ConditionInstanceFactory, ConditionTemplateFactory
@@ -11,7 +11,7 @@ from world.vitals.services import tick_round_for_targets
 
 class TickRoundForTargetsTests(TestCase):
     def test_end_timing_decrements_condition_rounds(self):
-        target = ObjectDB.objects.create(db_key="T1")
+        target = ObjectDBFactory(db_key="T1")
         CharacterSheetFactory(character=target)
         template = ConditionTemplateFactory(
             default_duration_type=DurationType.ROUNDS, default_duration_value=3

--- a/src/world/conditions/tests/test_stage_entry_aftermath.py
+++ b/src/world/conditions/tests/test_stage_entry_aftermath.py
@@ -7,7 +7,7 @@ apply that stage's on_entry_conditions to the same target.
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.events.payloads import ConditionStageChangedPayload
 from world.conditions.factories import (
@@ -24,7 +24,7 @@ from world.conditions.services import (
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/conditions/tests/test_unseen_observer_wiring.py
+++ b/src/world/conditions/tests/test_unseen_observer_wiring.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.conditions.constants import (
     ConditionInteractionOutcome,
     ConditionInteractionTrigger,
@@ -31,7 +32,7 @@ from world.scenes.services import has_unseen_observers
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/covenants/tests/integration/test_court_e2e.py
+++ b/src/world/covenants/tests/integration/test_court_e2e.py
@@ -49,9 +49,9 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper import models as idmapper_models
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.classes.factories import CharacterClassFactory, CharacterClassLevelFactory
@@ -217,7 +217,7 @@ class CourtJourneyEndToEndTests(TestCase):
         # ==============================================================
         # STEP 2 — Mission-gated engagement (both directions).
         # ==============================================================
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="CourtJourneyRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/currency/models.py
+++ b/src/world/currency/models.py
@@ -16,6 +16,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.descriptors import ReverseOneToOneOrNone
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.currency.constants import (
     GRAFT_DEFAULT_PCT,
@@ -232,6 +233,9 @@ class OrgIncomeStream(SharedMemoryModel):
     collected aggregate; the gross/net pair is recorded for declared-vs-
     actual obligations at collection time.
     """
+
+    # Reverse-OneToOne safe accessor (#2386): missing row -> None.
+    domain_holding_or_none = ReverseOneToOneOrNone("domain_holding")
 
     organization = models.ForeignKey(
         ORGANIZATION_MODEL,

--- a/src/world/currency/services.py
+++ b/src/world/currency/services.py
@@ -310,7 +310,7 @@ def accrue_income_stream(stream: OrgIncomeStream) -> int:
     # A domain holding's yield rides its domain's prosperity (#2238): a thriving
     # domain amasses more per cycle, a collapsed one (prosperity 0) nothing.
     # ``domain_holding`` is the reverse OneToOne — absent for non-domain streams.
-    holding = getattr(stream, "domain_holding", None)  # noqa: GETATTR_LITERAL
+    holding = stream.domain_holding_or_none
     if holding is not None:
         gross = int(gross * holding.domain.income_multiplier)
     stream.uncollected_pool = stream.uncollected_pool + gross

--- a/src/world/dreams/tests/test_dream_space.py
+++ b/src/world/dreams/tests/test_dream_space.py
@@ -3,6 +3,7 @@
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.services import create_character_with_sheet
 from world.conditions.models import ConditionTemplate
 from world.conditions.services import apply_condition
@@ -24,19 +25,19 @@ class GetDreamSpaceTests(TestCase):
         ensure_dream_room()
 
     def test_returns_reflection_dream_room_when_exists(self):
-        waking = ObjectDB.objects.create(db_key="Waking Room")
-        dream = ObjectDB.objects.create(db_key="Dream Room")
+        waking = ObjectDBFactory(db_key="Waking Room")
+        dream = ObjectDBFactory(db_key="Dream Room")
         DreamReflection.objects.create(waking_room=waking, dream_room=dream)
         result = get_dream_space(room=waking)
         assert result == dream
 
     def test_falls_back_to_liminal_when_no_reflection(self):
-        room = ObjectDB.objects.create(db_key="No Reflection")
+        room = ObjectDBFactory(db_key="No Reflection")
         result = get_dream_space(room=room)
         assert result == get_dream_room()
 
     def test_falls_back_to_none_when_unseeded(self):
-        room = ObjectDB.objects.create(db_key="Unseeded Room")
+        room = ObjectDBFactory(db_key="Unseeded Room")
         # Delete the liminal room to simulate unseeded state
         from world.vitals.constants import DREAM_ROOM_TAG, DREAM_ROOM_TAG_CATEGORY
 

--- a/src/world/dreams/tests/test_models.py
+++ b/src/world/dreams/tests/test_models.py
@@ -1,8 +1,8 @@
 """Tests for the DreamReflection model."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.dreams.models import DreamReflection
 
 
@@ -10,8 +10,8 @@ class DreamReflectionTests(TestCase):
     """Tests for DreamReflection model creation and lookup."""
 
     def setUp(self):
-        self.waking_room = ObjectDB.objects.create(db_key="Waking Room")
-        self.dream_room = ObjectDB.objects.create(db_key="Dream Room")
+        self.waking_room = ObjectDBFactory(db_key="Waking Room")
+        self.dream_room = ObjectDBFactory(db_key="Dream Room")
 
     def test_create_reflection(self):
         reflection = DreamReflection.objects.create(
@@ -33,7 +33,7 @@ class DreamReflectionTests(TestCase):
         assert result.dream_room == self.dream_room
 
     def test_for_waking_room_returns_none_when_absent(self):
-        other_room = ObjectDB.objects.create(db_key="Other Room")
+        other_room = ObjectDBFactory(db_key="Other Room")
         assert DreamReflection.objects.for_waking_room(other_room) is None
 
     def test_for_waking_room_excludes_inactive(self):
@@ -45,7 +45,7 @@ class DreamReflectionTests(TestCase):
         assert DreamReflection.objects.for_waking_room(self.waking_room) is None
 
     def test_descent_target_optional(self):
-        deep_room = ObjectDB.objects.create(db_key="Deep Dreaming")
+        deep_room = ObjectDBFactory(db_key="Deep Dreaming")
         reflection = DreamReflection.objects.create(
             waking_room=self.waking_room,
             dream_room=self.dream_room,

--- a/src/world/fatigue/tests/test_exhaustion_damage.py
+++ b/src/world/fatigue/tests/test_exhaustion_damage.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from actions.constants import ActionCategory
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.factories import StrainConfigFactory
 from world.conditions.models import DamageType
@@ -221,9 +222,8 @@ class RoundResolutionCollapseTriggerTests(TestCase):
 
     def test_non_character_target_is_skipped(self):
         """A round target with no traits handler (NPC/object) is skipped, not crashed."""
-        from evennia.objects.models import ObjectDB
 
-        bare = ObjectDB.objects.create(db_key="NPC-prop")
+        bare = ObjectDBFactory(db_key="NPC-prop")
         CharacterVitalsFactory(
             character_sheet=CharacterSheetFactory(character=bare),
             health=100,

--- a/src/world/forms/serializers.py
+++ b/src/world/forms/serializers.py
@@ -134,11 +134,7 @@ class AlternateSelfSerializer(serializers.ModelSerializer):
             # (handles AnonymousUser and truthy non-character puppets).
             request = self.context.get("request")
             sheet = puppeted_sheet_for(request.user) if request is not None else None
-            active = (
-                getattr(sheet, "active_alternate_self", None)  # noqa: GETATTR_LITERAL
-                if sheet is not None
-                else None
-            )
+            active = sheet.active_alternate_self_or_none if sheet is not None else None
             self._active_alternate_self_id = (
                 active.alternate_self_id if active is not None else None
             )

--- a/src/world/forms/tests/test_trigger_transformation_flow.py
+++ b/src/world/forms/tests/test_trigger_transformation_flow.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.factories import (
@@ -50,7 +50,7 @@ SELF_FILTER = {"path": "target", "op": "==", "value": "self"}
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/instances/factories.py
+++ b/src/world/instances/factories.py
@@ -1,7 +1,7 @@
-from evennia.objects.models import ObjectDB
 import factory
 import factory.django as factory_django
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.instances.constants import InstanceStatus
 from world.instances.models import InstancedRoom
 
@@ -11,7 +11,7 @@ class InstancedRoomFactory(factory_django.DjangoModelFactory):
         model = InstancedRoom
 
     room = factory.LazyFunction(
-        lambda: ObjectDB.objects.create(
+        lambda: ObjectDBFactory(
             db_key="Instance Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/instances/tests.py
+++ b/src/world/instances/tests.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from evennia_extensions.models import ObjectDisplayData, RoomProfile
 from world.character_sheets.factories import CharacterSheetFactory
 from world.instances.constants import InstanceStatus
@@ -20,11 +21,11 @@ class InstancedRoomModelTests(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.room = ObjectDB.objects.create(
+        cls.room = ObjectDBFactory(
             db_key="Instance Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )
-        cls.return_room = ObjectDB.objects.create(
+        cls.return_room = ObjectDBFactory(
             db_key="Town Square",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -60,15 +61,15 @@ class InstancedRoomValidationTests(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.room = ObjectDB.objects.create(
+        cls.room = ObjectDBFactory(
             db_key="Validation Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )
-        cls.valid_return = ObjectDB.objects.create(
+        cls.valid_return = ObjectDBFactory(
             db_key="Valid Return",
             db_typeclass_path="typeclasses.rooms.Room",
         )
-        cls.non_room_obj = ObjectDB.objects.create(
+        cls.non_room_obj = ObjectDBFactory(
             db_key="A Sword",
             db_typeclass_path="typeclasses.objects.Object",
         )
@@ -100,7 +101,7 @@ class InstancedRoomCascadeTests(TestCase):
 
     def test_cascade_on_room_delete(self):
         """Deleting the room ObjectDB cascades to delete the InstancedRoom."""
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="Temp Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -113,7 +114,7 @@ class InstancedRoomCascadeTests(TestCase):
 
     def test_set_null_on_owner_delete(self):
         """Deleting the CharacterSheet sets owner to null."""
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="Owner Test Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -129,11 +130,11 @@ class InstancedRoomCascadeTests(TestCase):
 
     def test_set_null_on_return_location_delete(self):
         """Deleting the return_location ObjectDB sets it to null."""
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="Return Test Room",
             db_typeclass_path="typeclasses.rooms.Room",
         )
-        return_loc = ObjectDB.objects.create(
+        return_loc = ObjectDBFactory(
             db_key="Return Loc",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -152,7 +153,7 @@ class SpawnInstancedRoomTests(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.return_room = ObjectDB.objects.create(
+        cls.return_room = ObjectDBFactory(
             db_key="Tavern",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -207,7 +208,7 @@ class CompleteInstancedRoomTests(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.return_room = ObjectDB.objects.create(
+        cls.return_room = ObjectDBFactory(
             db_key="Town Square",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -325,8 +326,8 @@ class InstancedRoomReverseLookupTests(TestCase):
 
     def test_owned_instances_reverse_lookup(self):
         """CharacterSheet.owned_instances returns all instances owned by the character."""
-        room1 = ObjectDB.objects.create(db_key="Room A", db_typeclass_path="typeclasses.rooms.Room")
-        room2 = ObjectDB.objects.create(db_key="Room B", db_typeclass_path="typeclasses.rooms.Room")
+        room1 = ObjectDBFactory(db_key="Room A", db_typeclass_path="typeclasses.rooms.Room")
+        room2 = ObjectDBFactory(db_key="Room B", db_typeclass_path="typeclasses.rooms.Room")
         InstancedRoom.objects.create(room=room1, owner=self.sheet)
         InstancedRoom.objects.create(room=room2, owner=self.sheet)
 
@@ -334,9 +335,7 @@ class InstancedRoomReverseLookupTests(TestCase):
 
     def test_instance_data_reverse_lookup(self):
         """ObjectDB.instance_data returns the linked InstancedRoom."""
-        room = ObjectDB.objects.create(
-            db_key="Reverse Room", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        room = ObjectDBFactory(db_key="Reverse Room", db_typeclass_path="typeclasses.rooms.Room")
         instance = InstancedRoom.objects.create(room=room, source_key="test.reverse")
 
         assert room.instance_data == instance

--- a/src/world/items/models.py
+++ b/src/world/items/models.py
@@ -18,6 +18,7 @@ from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from actions.constants import TargetKind
+from core.descriptors import ReverseOneToOneOrNone
 from core.managers import ArxSharedMemoryManager
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.forms.models import ConcealmentLevel, DisguiseKind
@@ -535,6 +536,9 @@ class ItemInstance(SharedMemoryModel):
     References an ItemTemplate for base properties, with per-instance overrides
     for custom names, descriptions, quality, and state.
     """
+
+    # Reverse-OneToOne safe accessor (#2386): missing row -> None.
+    building_permit_details_or_none = ReverseOneToOneOrNone("building_permit_details")
 
     template = models.ForeignKey(
         ItemTemplate,

--- a/src/world/items/services/appearance.py
+++ b/src/world/items/services/appearance.py
@@ -122,9 +122,7 @@ def visible_worn_items_for(
 def _slot_for_row(row: EquippedItem) -> TemplateSlot | None:
     """Return the TemplateSlot for ``row``'s template at the row's region+layer."""
     template = row.item_instance.template
-    slots = getattr(template, "cached_slots", None)  # noqa: GETATTR_LITERAL
-    if slots is None:
-        slots = list(template.slots.all())
+    slots = template.cached_slots
     for slot in slots:
         if slot.body_region == row.body_region and slot.equipment_layer == row.equipment_layer:
             return slot

--- a/src/world/items/services/materialize.py
+++ b/src/world/items/services/materialize.py
@@ -45,7 +45,7 @@ def materialize_item_game_object(
     a defensive guard; ``CharacterSheet.character`` is the PK so a live sheet
     always has one.
     """
-    character = getattr(holder_sheet, "character", None)  # noqa: GETATTR_LITERAL
+    character = holder_sheet.character
     if character is None:
         return None
     game_object = create_object(

--- a/src/world/items/tests/integration/test_mantle_combat_pipeline.py
+++ b/src/world/items/tests/integration/test_mantle_combat_pipeline.py
@@ -54,9 +54,7 @@ class MantleCombatPipelineTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:  # noqa: PLR0915 - end-to-end fixture spans many rows
-        from evennia.objects.models import ObjectDB
-
-        from evennia_extensions.factories import CharacterFactory
+        from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
         from world.areas.constants import AreaLevel
         from world.areas.factories import AreaFactory
         from world.character_sheets.factories import CharacterSheetFactory
@@ -188,7 +186,7 @@ class MantleCombatPipelineTests(TestCase):
             realm=cls.realm,
             dominant_society=cls.society,
         )
-        cls.room_obj = ObjectDB.objects.create(
+        cls.room_obj = ObjectDBFactory(
             db_key="MantleCombatRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/magic/models/gifts.py
+++ b/src/world/magic/models/gifts.py
@@ -135,6 +135,14 @@ class Tradition(NaturalKeyMixin, SharedMemoryModel):
     A tradition may be associated with a society but can also exist independently.
     """
 
+    @cached_property
+    def cached_codex_grants(self) -> list:
+        """Codex grants — the Prefetch/query shared interface (#2386).
+
+        Authored content: negligible staleness on the identity-mapped row.
+        """
+        return list(self.codex_grants.all())
+
     name = models.CharField(
         max_length=200,
         unique=True,

--- a/src/world/magic/models/rituals.py
+++ b/src/world/magic/models/rituals.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.descriptors import ReverseOneToOneOrNone
 from world.magic.constants import ParticipationRule, RitualExecutionKind, TargetKind
 from world.magic.models.ritual_check_config import RitualCheckConfig
 
@@ -58,6 +59,9 @@ class Ritual(SharedMemoryModel):
     (SCENE_ACTION requires a RitualCheckConfig; other kinds may carry one)
     is enforced in clean() only since DB CHECK constraints cannot span tables.
     """
+
+    # Reverse-OneToOne safe accessor (#2386): missing row -> None.
+    check_config_or_none = ReverseOneToOneOrNone("check_config")
 
     name = models.CharField(max_length=120, unique=True)
     description = models.TextField()

--- a/src/world/magic/permissions.py
+++ b/src/world/magic/permissions.py
@@ -39,7 +39,7 @@ class IsRitualAuthorOrStaff(BasePermission):
             return True
         if request.user.is_staff:
             return True
-        author_id = getattr(obj, "author_account_id", None)  # noqa: GETATTR_LITERAL
+        author_id = obj.author_account_id
         if author_id is None:
             return False  # staff-authored ritual — non-staff cannot mutate
         return author_id == request.user.id

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -2557,7 +2557,7 @@ class PendingAudereMajoraOfferSerializer(_PendingOfferCharacterMixin, serializer
 
     def get_intended_path_id(self, obj: object) -> int | None:
         """Return the PathIntent's intended_path_id if it is among eligible paths, else None."""
-        intent = getattr(obj.character_sheet, "path_intent", None)  # noqa: GETATTR_LITERAL
+        intent = obj.character_sheet.path_intent_or_none
         if intent is None:
             return None
         eligible_pks = {p.pk for p in self._eligible_paths_for_obj(obj)}
@@ -2840,7 +2840,7 @@ class RitualSessionListSerializer(serializers.ModelSerializer):
         """Return the presented persona name of the initiator sheet (#981)."""
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        initiator = getattr(obj, "initiator", None)  # noqa: GETATTR_LITERAL
+        initiator = obj.initiator
         if initiator is None:
             return ""
         return active_persona_for_sheet(initiator).name
@@ -2850,11 +2850,9 @@ class RitualSessionListSerializer(serializers.ModelSerializer):
         from world.magic.constants import ParticipantState  # noqa: PLC0415
 
         # Use participants_cached (populated by Prefetch to_attr) when available.
-        cached = obj.participants_cached
-        if cached is not None:
-            participants = cached
-        else:
-            participants = list(getattr(obj, "participants", None).all())  # noqa: GETATTR_LITERAL
+        # participants_cached is a cached_property (never None) — the shared
+        # Prefetch/query interface, #2386.
+        participants = obj.participants_cached
         return {
             "invited": sum(1 for p in participants if p.state == ParticipantState.INVITED),
             "accepted": sum(1 for p in participants if p.state == ParticipantState.ACCEPTED),
@@ -2868,16 +2866,13 @@ class RitualSessionListSerializer(serializers.ModelSerializer):
         if request is None or not request.user.is_authenticated:
             return {"role": "unknown", "state": None}
         user = request.user
-        initiator = getattr(obj, "initiator", None)  # noqa: GETATTR_LITERAL
+        initiator = obj.initiator
         # Check if initiator's sheet belongs to this user.
         my_sheet_ids = set(RosterEntry.objects.for_account(user).character_ids())
         if initiator is not None and initiator.pk in my_sheet_ids:
             return {"role": "initiator", "state": None}
         # Check participant rows. Use participants_cached when prefetched.
-        cached = obj.participants_cached
-        participants_iter = (
-            cached if cached is not None else getattr(obj, "participants", None).all()  # noqa: GETATTR_LITERAL
-        )
+        participants_iter = obj.participants_cached
         for participant in participants_iter:
             if participant.character_sheet_id in my_sheet_ids:
                 return {"role": "participant", "state": participant.state}
@@ -2922,7 +2917,7 @@ class RitualSessionDetailSerializer(serializers.ModelSerializer):
     def get_initiator_name(self, obj: object) -> str:
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        initiator = getattr(obj, "initiator", None)  # noqa: GETATTR_LITERAL
+        initiator = obj.initiator
         if initiator is None:
             return ""
         return active_persona_for_sheet(initiator).name
@@ -2930,19 +2925,11 @@ class RitualSessionDetailSerializer(serializers.ModelSerializer):
     def get_session_references(self, obj: object) -> list[dict[str, object]]:
         """Summarise session-level references (participant=None).
 
-        Uses references_cached (populated by Prefetch to_attr) when available,
-        filtering in Python. Falls back to a DB .filter() query.
+        references_cached is a cached_property (never None) — the shared
+        Prefetch/query interface, #2386 — so we always filter in Python.
         """
         result = []
-        # Prefer prefetched list; fall back to DB query.
-        cached = getattr(obj, "references_cached", None)  # noqa: GETATTR_LITERAL
-        if cached is not None:
-            refs_iter = [r for r in cached if r.participant_id is None]
-        else:
-            refs = getattr(obj, "references", None)  # noqa: GETATTR_LITERAL
-            if refs is None:
-                return result
-            refs_iter = refs.filter(participant__isnull=True)
+        refs_iter = [r for r in obj.references_cached if r.participant_id is None]
         for ref in refs_iter:
             entry: dict[str, object] = {"kind": ref.kind}
             if ref.ref_covenant_id is not None:

--- a/src/world/magic/services/corruption.py
+++ b/src/world/magic/services/corruption.py
@@ -86,6 +86,7 @@ def _resolve_affinity_coefficient(resonance: Resonance, config: CorruptionConfig
 def _resolve_tier_coefficient(tier: int, config: CorruptionConfig) -> int:
     """Return the integer-tenths tier coefficient for a technique tier (1–5)."""
     attr = _TIER_COEF_ATTRS.get(tier, "tier_5_coefficient")
+    # Suppression justified: dynamic tier-coefficient field name; no default, loud.
     return getattr(config, attr)  # noqa: GETATTR_LITERAL
 
 

--- a/src/world/magic/services/crossing.py
+++ b/src/world/magic/services/crossing.py
@@ -99,9 +99,8 @@ def resolve_crossing_offer(
     )
 
     # Invalidate the thread cache so passive read paths pick up the new choice
-    character = thread.owner.character
-    if hasattr(character, "threads"):  # noqa: GETATTR_LITERAL
-        character.threads.invalidate()
+    # (threads is an unconditional cached_property on Character, #2386).
+    thread.owner.character.threads.invalidate()
 
     return CrossingResult(
         option_name=option.name,
@@ -133,8 +132,7 @@ def active_crossing_effects(character: Character) -> list[CrossingEffectInfo]:
         thread = choice.thread
         if thread.target_kind == TargetKind.FACET:
             # Wear-gate: only active if wearing an item with the anchor facet
-            if not hasattr(character, "equipped_items"):  # noqa: GETATTR_LITERAL
-                continue
+            # (equipped_items is an unconditional cached_property on Character).
             matching = character.equipped_items.item_facets_for(thread.target_facet)
             if not matching:
                 continue

--- a/src/world/magic/services/effect_handlers.py
+++ b/src/world/magic/services/effect_handlers.py
@@ -40,8 +40,11 @@ def create_obstacle(*, payload: Any) -> None:
     """
     a = Position.objects.get(pk=payload.position_a_id)
     b = Position.objects.get(pk=payload.position_b_id)
+    # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     blocks_flight = getattr(payload, "blocks_flight", False)  # noqa: GETATTR_LITERAL
+    # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     caster_sheet = getattr(payload, "caster_sheet", None)  # noqa: GETATTR_LITERAL
+    # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     duration_rounds = getattr(payload, "duration_rounds", None)  # noqa: GETATTR_LITERAL
 
     if caster_sheet is not None:
@@ -261,6 +264,7 @@ def summon_ally(*, payload: Any) -> None:
        strength from ``max_health``, quality/properties/capabilities from the
        payload (or defaults), summoned_by=caster sheet.
     """
+    # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     if getattr(payload, "military", False):  # noqa: GETATTR_LITERAL
         _summon_military_unit(payload=payload)
         return
@@ -289,7 +293,9 @@ def summon_ally(*, payload: Any) -> None:
     caster_sheet = participant.character_sheet
 
     threat_pool = ThreatPool.objects.get(pk=payload.threat_pool_id)
+    # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     max_health: int = getattr(payload, "max_health", 30)  # noqa: GETATTR_LITERAL
+    # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     bond_rounds: int | None = getattr(payload, "bond_rounds", None)  # noqa: GETATTR_LITERAL
 
     # Reuse the canonical opponent-creation primitive (anti-reinvention, ADR-0016).
@@ -342,11 +348,15 @@ def _summon_military_unit(*, payload: Any) -> None:
         return  # Caster is not an active battle participant — nothing to summon into.
 
     caster_sheet = participant.character_sheet
+    # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     max_health: int = getattr(payload, "max_health", 30)  # noqa: GETATTR_LITERAL
+    # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     quality: str = getattr(payload, "quality", UnitQuality.TRAINED)  # noqa: GETATTR_LITERAL
+    # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     property_names: list[str] = getattr(payload, "properties", [])  # noqa: GETATTR_LITERAL
     capability_magnitudes: dict[str, int] = getattr(
         payload,
+        # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
         "capabilities",  # noqa: GETATTR_LITERAL
         {},
     )

--- a/src/world/magic/services/fury.py
+++ b/src/world/magic/services/fury.py
@@ -120,7 +120,7 @@ def resolve_fury(*, character, tier, anchor, check_result) -> FuryResolution:
     cfg = _config()
     # Mirrors StrainConfig singleton read in world/fatigue/services.py.
     bonus = realized.intensity_bonus * (100 + cfg.bonus_scale_per_cap_point * cap) // 100
-    grade = getattr(check_result, "success_level", 0)  # noqa: GETATTR_LITERAL
+    grade = check_result.success_level if check_result is not None else 0
     berserk = 0 if grade >= realized.lucid_grade_floor else realized.berserk_severity
     return FuryResolution(realized, realized.control_penalty, bonus, berserk)
 

--- a/src/world/magic/services/ritual_checks.py
+++ b/src/world/magic/services/ritual_checks.py
@@ -51,7 +51,7 @@ def perform_ritual_check(
         raise RitualCheckConfigMissing(msg) from exc
 
     # GETATTR_LITERAL noqa: reverse OneToOne may legitimately be absent.
-    config = getattr(ritual, "check_config", None)  # noqa: GETATTR_LITERAL
+    config = ritual.check_config_or_none
     if config is None or config.check_type is None:
         msg = (
             f"Ritual {ritual_name!r} has no usable RitualCheckConfig. "

--- a/src/world/magic/services/sanctum_cron.py
+++ b/src/world/magic/services/sanctum_cron.py
@@ -72,7 +72,7 @@ def sanctum_resonance_generation_tick() -> dict[str, int]:
     bonus_recipients_accrued = 0
 
     for instance in instances:
-        sanctum = getattr(instance, "sanctum_details", None)  # noqa: GETATTR_LITERAL
+        sanctum = instance.sanctum_details_or_none
         if sanctum is None:
             continue
         try:

--- a/src/world/magic/services/sessions.py
+++ b/src/world/magic/services/sessions.py
@@ -109,6 +109,7 @@ def draft_session(  # noqa: PLR0913
             )
         if ritual.draft_validator_path:
             module_path, _, attr = ritual.draft_validator_path.rpartition(".")
+            # Suppression justified: dynamic importlib resolution from DB config; no default, loud.
             validator = getattr(importlib.import_module(module_path), attr)  # noqa: GETATTR_LITERAL
             validator(session=session)
         return session
@@ -216,7 +217,7 @@ def fire_session(*, session: RitualSession) -> object:
         # Resolve the dispatched service via importlib:
         module_path, _, fn_name = locked.ritual.service_function_path.rpartition(".")
         module = importlib.import_module(module_path)
-        fn = getattr(module, fn_name)  # noqa: GETATTR_LITERAL
+        fn = getattr(module, fn_name)  # noqa: GETATTR_LITERAL — dynamic importlib resolution; loud
         # Call the dispatched service. If it raises, transaction rolls back
         # and the session stays alive for the initiator to retry or cancel.
         result = fn(session=locked)

--- a/src/world/magic/services/techniques.py
+++ b/src/world/magic/services/techniques.py
@@ -552,15 +552,27 @@ def _resolve_check_result(
     check_result: CheckResult | None,
     resolution_result: Any,
 ) -> CheckResult | None:
-    """Return the explicit check_result, else pull it from the resolution result."""
+    """Return the explicit check_result, else pull it from the resolution result.
+
+    Two resolve_fn contracts. The combat leg is STRUCTURAL by ratified spec
+    (2026-04-30-combat-magic-pipeline-integration-design, quoted in
+    ``CombatTechniqueResolution``'s docstring): the extractor accepts any
+    result shape exposing top-level ``check_result`` — so that leg is a
+    deliberate duck probe, not a silent-fail trap (pinned by
+    ``test_extractor_reads_top_level_check_result``). The non-combat leg is
+    our own ``PendingActionResolution`` and dispatches nominally.
+    """
+    from actions.types import PendingActionResolution  # noqa: PLC0415
+
     if check_result is not None:
         return check_result
+    # Suppression justified: structural spec contract (see docstring).
     result = getattr(resolution_result, "check_result", None)  # noqa: GETATTR_LITERAL
     if result is not None:
         return result
-    main = getattr(resolution_result, "main_result", None)  # noqa: GETATTR_LITERAL
-    if main is not None:
-        return getattr(main, "check_result", None)  # noqa: GETATTR_LITERAL
+    if isinstance(resolution_result, PendingActionResolution):
+        main = resolution_result.main_result
+        return main.check_result if main is not None else None
     return None
 
 

--- a/src/world/magic/services/threads.py
+++ b/src/world/magic/services/threads.py
@@ -493,7 +493,7 @@ def _has_weaving_unlock(
             return handler.has_unlock_for_gift(target.gift)  # type: ignore[union-attr]
         case TargetKind.RELATIONSHIP_TRACK | TargetKind.RELATIONSHIP_CAPSTONE:
             # Both RelationshipTrackProgress and RelationshipCapstone expose .track
-            track = target.track  # type: ignore[union-attr]  # noqa: GETATTR_LITERAL
+            track = target.track  # type: ignore[union-attr]
             return handler.has_unlock_for_track(track)
         # Kind-level unlocks: any unlock of that target_kind suffices.
         case TargetKind.FACET | TargetKind.SANCTUM | TargetKind.ORGANIZATION:

--- a/src/world/magic/tests/integration/test_corruption_flow.py
+++ b/src/world/magic/tests/integration/test_corruption_flow.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.conditions.factories import ConditionStageFactory, ConditionTemplateFactory
 from world.conditions.models import ConditionInstance
@@ -52,7 +53,7 @@ _room_counter = 0
 def _create_room() -> ObjectDB:
     global _room_counter  # noqa: PLW0603
     _room_counter += 1
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=f"CorruptionTestRoom_{_room_counter}",
         db_typeclass_path="typeclasses.rooms.Room",
     )
@@ -613,7 +614,7 @@ class FullCastPipelineCorruptionTests(TestCase):
         _resonance, _gift, technique = _make_abyssal_gift_and_technique(
             intensity=2, control=10, anima_cost=2, level=1
         )
-        character = ObjectDB.objects.create(
+        character = ObjectDBFactory(
             db_key="NPCTestChar",
             db_typeclass_path="typeclasses.characters.Character",
         )

--- a/src/world/magic/tests/integration/test_soul_tether_flow.py
+++ b/src/world/magic/tests/integration/test_soul_tether_flow.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase, tag
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.conditions.factories import ConditionStageFactory, ConditionTemplateFactory
 from world.conditions.models import ConditionInstance
@@ -73,7 +74,7 @@ _room_counter = 0
 def _create_room() -> ObjectDB:
     global _room_counter  # noqa: PLW0603
     _room_counter += 1
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=f"TetherIntegRoom_{_room_counter}",
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/magic/tests/services/test_endorsement_privacy.py
+++ b/src/world/magic/tests/services/test_endorsement_privacy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from django.test import TestCase
 from evennia.utils.idmapper import models as idmapper_models
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.exceptions import EndorsementValidationError
 from world.magic.factories import CharacterResonanceFactory, ResonanceFactory
@@ -39,11 +39,8 @@ class WhisperEndorsementTests(TestCase):
 
     def setUp(self):
         idmapper_models.flush_cache()
-        from evennia.objects.models import ObjectDB
 
-        self.room = ObjectDB.objects.create(
-            db_key="TestRoom", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        self.room = ObjectDBFactory(db_key="TestRoom", db_typeclass_path="typeclasses.rooms.Room")
         self.scene = SceneFactory(location=self.room, is_active=True)
 
         self.endorser_char, self.endorser_sheet, self.endorser_account = _char_with_account()
@@ -86,11 +83,8 @@ class VeryPrivateEndorsementTests(TestCase):
 
     def setUp(self):
         idmapper_models.flush_cache()
-        from evennia.objects.models import ObjectDB
 
-        self.room = ObjectDB.objects.create(
-            db_key="TestRoom2", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        self.room = ObjectDBFactory(db_key="TestRoom2", db_typeclass_path="typeclasses.rooms.Room")
         self.scene = SceneFactory(location=self.room, is_active=True)
 
         self.endorser_char, self.endorser_sheet, self.endorser_account = _char_with_account()
@@ -129,11 +123,8 @@ class GetEndorseablePosesTests(TestCase):
 
     def setUp(self):
         idmapper_models.flush_cache()
-        from evennia.objects.models import ObjectDB
 
-        self.room = ObjectDB.objects.create(
-            db_key="TestRoom3", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        self.room = ObjectDBFactory(db_key="TestRoom3", db_typeclass_path="typeclasses.rooms.Room")
         self.scene = SceneFactory(location=self.room, is_active=True)
 
         self.endorser_char, self.endorser_sheet, self.endorser_account = _char_with_account()

--- a/src/world/magic/tests/test_anima_ritual_gaps.py
+++ b/src/world/magic/tests/test_anima_ritual_gaps.py
@@ -145,6 +145,7 @@ class AnimaRecoverySerializerFieldTests(TestCase):
             )
 
         self.assertIsNotNone(result)
+        # Suppression justified: asserts the transient side-channel stash exists.
         payload = getattr(action_request, "_anima_recovery_payload", None)  # noqa: GETATTR_LITERAL
         self.assertIsNotNone(payload)
         # success budget=6, anima goes from 2 to 8

--- a/src/world/magic/tests/test_api.py
+++ b/src/world/magic/tests/test_api.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from evennia_extensions.factories import AccountFactory, CharacterFactory
+from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.items.factories import ItemInstanceFactory
 from world.magic.constants import EffectKind, TargetKind, VitalBonusTarget
@@ -1027,7 +1027,6 @@ class ThreadPullPreviewTests(APITestCase):
         relationship facts about personas the requester cannot perceive
         (mirrors pull_applicability.py's can_perceive gates, ADR-0086).
         """
-        from evennia.objects.models import ObjectDB
 
         rt_thread, threaded_sheet = self._build_relationship_track_pull(
             threaded_sheet_db_key="ThreadedY3"
@@ -1036,10 +1035,10 @@ class ThreadPullPreviewTests(APITestCase):
 
         # Put the requester's and the target's characters in different,
         # unconnected rooms so can_perceive returns False.
-        owner_room = ObjectDB.objects.create(
+        owner_room = ObjectDBFactory(
             db_key="PreviewOwnerRoom", db_typeclass_path="typeclasses.rooms.Room"
         )
-        target_room = ObjectDB.objects.create(
+        target_room = ObjectDBFactory(
             db_key="PreviewTargetRoom", db_typeclass_path="typeclasses.rooms.Room"
         )
         self.sheet.character.location = owner_room

--- a/src/world/magic/tests/test_audere_majora_offer.py
+++ b/src/world/magic/tests/test_audere_majora_offer.py
@@ -3,8 +3,8 @@
 import importlib
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.classes.models import CharacterClassLevel, PathStage
 from world.magic.audere import AUDERE_CONDITION_NAME
 from world.magic.audere_majora import (
@@ -192,7 +192,7 @@ class AudereMajoraOfferServiceTests(TestCase):
         assert Interaction.objects.filter(mode=InteractionMode.EMIT).count() == 0
 
     def test_npc_without_sheet_returns_none(self) -> None:
-        npc = ObjectDB.objects.create(db_key="majora_npc_no_sheet_t3")
+        npc = ObjectDBFactory(db_key="majora_npc_no_sheet_t3")
         assert maybe_create_audere_majora_offer(npc, self.passing_intensity) is None
 
     def test_sheet_without_primary_persona_skips_broadcast(self) -> None:
@@ -226,6 +226,6 @@ class AudereMajoraEligibilityQueryCountTests(TestCase):
         Only 1 query: CharacterSheet.objects.filter(...).first(). No threshold,
         Soulfray, engagement, or path queries fire.
         """
-        npc = ObjectDB.objects.create(db_key="majora_query_count_npc")
+        npc = ObjectDBFactory(db_key="majora_query_count_npc")
         with self.assertNumQueries(1):
             check_audere_majora_eligibility(npc, runtime_intensity=20)

--- a/src/world/magic/tests/test_condition_application.py
+++ b/src/world/magic/tests/test_condition_application.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.test.utils import tag
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.conditions.factories import ConditionTemplateFactory
 from world.conditions.types import AppliedConditionResult, ApplyConditionResult
@@ -248,12 +249,10 @@ class ApplyTechniqueConditionsPostgresTest(TestCase):
     """
 
     def setUp(self) -> None:
-        from evennia.objects.models import ObjectDB
-
         self.sheet = CharacterSheetFactory()
         # Ensure the caster has an ObjectDB location so bulk_apply_conditions
         # can resolve context without errors.
-        room = ObjectDB.objects.create(
+        room = ObjectDBFactory(
             db_key="TestRoom",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/magic/tests/test_pending_stage_advance_offer.py
+++ b/src/world/magic/tests/test_pending_stage_advance_offer.py
@@ -22,6 +22,7 @@ from django.test import TestCase, tag
 from django.utils import timezone
 from rest_framework.test import APITestCase
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.magic.constants import TargetKind
 from world.magic.exceptions import StageAdvanceBonusError
 from world.magic.factories import (
@@ -305,11 +306,9 @@ class SoulTetherStageAdvancePromptWritesPendingRowTests(TestCase):
     """soul_tether_stage_advance_prompt writes a PendingStageAdvanceOffer row (Task 1.7 Step 3)."""
 
     def setUp(self) -> None:
-        from evennia.objects.models import ObjectDB
-
         wire_soul_tether_content()
 
-        self.room = ObjectDB.objects.create(
+        self.room = ObjectDBFactory(
             db_key="Room_SAPromptDB",
             db_typeclass_path="typeclasses.rooms.Room",
         )
@@ -462,11 +461,9 @@ class SoulTetherStageAdvancePromptNoSharedSceneTests(TestCase):
     recorded so the Sineater can respond via the @reply path if they wish."""
 
     def setUp(self) -> None:
-        from evennia.objects.models import ObjectDB
-
         wire_soul_tether_content()
 
-        self.room = ObjectDB.objects.create(
+        self.room = ObjectDBFactory(
             db_key="Room_SAPromptNoScene",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/magic/tests/test_progression_dashboard.py
+++ b/src/world/magic/tests/test_progression_dashboard.py
@@ -165,7 +165,7 @@ class ProgressionDashboardTests(TestCase):
         from world.magic.services.progression_dashboard import build_progression_dashboard
 
         # Verify sheet has no roster_entry
-        assert getattr(self.sheet, "roster_entry", None) is None  # noqa: GETATTR_LITERAL
+        assert self.sheet.roster_entry_or_none is None  # noqa: GETATTR_LITERAL
 
         self._make_nonpublic_milestone(PathStage.POTENTIAL, MagicMilestoneKind.MOTIF)
 

--- a/src/world/magic/tests/test_pull_applicability_court.py
+++ b/src/world/magic/tests/test_pull_applicability_court.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.covenants.constants import CovenantType
 from world.covenants.factories import (
@@ -42,7 +43,7 @@ def _context(target_persona_id: int | None) -> PullActionContext:
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/magic/tests/test_pull_applicability_relationship.py
+++ b/src/world/magic/tests/test_pull_applicability_relationship.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from django.test import TestCase
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.constants import EffectKind, InapplicabilityReason, TargetKind
 from world.magic.factories import ThreadFactory, ThreadPullEffectFactory
@@ -149,8 +150,6 @@ class RelationshipNoStakePrivacyTests(TestCase):
     when the owner can't perceive X."""
 
     def test_no_leak_when_owner_cannot_perceive_hostile_target(self) -> None:
-        from evennia.objects.models import ObjectDB
-
         owner = CharacterSheetFactory()
         threaded_sheet = CharacterSheetFactory()
         thread = _relationship_track_thread(owner=owner, threaded_sheet=threaded_sheet)
@@ -169,12 +168,10 @@ class RelationshipNoStakePrivacyTests(TestCase):
         RelationshipTrackProgressFactory(
             relationship=hostile, track=negative_track, developed_points=5
         )
-        owner_room = ObjectDB.objects.create(
+        owner_room = ObjectDBFactory(
             db_key="OwnerRoom2", db_typeclass_path="typeclasses.rooms.Room"
         )
-        x_room = ObjectDB.objects.create(
-            db_key="XRoom2", db_typeclass_path="typeclasses.rooms.Room"
-        )
+        x_room = ObjectDBFactory(db_key="XRoom2", db_typeclass_path="typeclasses.rooms.Room")
         owner.character.location = owner_room
         x_sheet.character.location = x_room
         context = _context(active_persona_for_sheet(x_sheet).pk)

--- a/src/world/magic/tests/test_pull_modulation_relationship.py
+++ b/src/world/magic/tests/test_pull_modulation_relationship.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from django.test import TestCase
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.constants import EffectKind, TargetKind
 from world.magic.factories import ThreadFactory, ThreadPullEffectFactory
@@ -310,8 +311,6 @@ class RelationshipBondModulationNoResolutionPrivacyGateTests(TestCase):
     future reader doesn't mistake the absence of a gate here for an oversight."""
 
     def test_indirect_trigger_applies_even_when_owner_cannot_perceive_x(self) -> None:
-        from evennia.objects.models import ObjectDB
-
         owner = CharacterSheetFactory()
         threaded_sheet = CharacterSheetFactory()
         thread = _relationship_track_thread(
@@ -342,10 +341,8 @@ class RelationshipBondModulationNoResolutionPrivacyGateTests(TestCase):
         # Put owner's character and X's character in different, unconnected rooms.
         # If resolution were gated on can_perceive, this would leave scaled_value=4;
         # since it isn't, the bonus applies exactly as in the perceivable case.
-        owner_room = ObjectDB.objects.create(
-            db_key="OwnerRoom", db_typeclass_path="typeclasses.rooms.Room"
-        )
-        x_room = ObjectDB.objects.create(db_key="XRoom", db_typeclass_path="typeclasses.rooms.Room")
+        owner_room = ObjectDBFactory(db_key="OwnerRoom", db_typeclass_path="typeclasses.rooms.Room")
+        x_room = ObjectDBFactory(db_key="XRoom", db_typeclass_path="typeclasses.rooms.Room")
         owner.character.location = owner_room
         x_sheet.character.location = x_room
 

--- a/src/world/magic/tests/test_reactive_integration.py
+++ b/src/world/magic/tests/test_reactive_integration.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.events.payloads import (
@@ -44,7 +44,7 @@ SELF_FILTER = {"path": "caster", "op": "==", "value": "self"}
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/magic/tests/test_reactive_scars.py
+++ b/src/world/magic/tests/test_reactive_scars.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.emit import emit_event
@@ -35,7 +35,7 @@ SELF_FILTER = {"path": "target", "op": "==", "value": "self"}
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/magic/tests/test_resonance_environment_service.py
+++ b/src/world/magic/tests/test_resonance_environment_service.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from evennia_extensions.models import RoomProfile
 
 from actions.factories import ConsequencePoolEntryFactory, ConsequencePoolFactory
-from evennia_extensions.factories import RoomProfileFactory
+from evennia_extensions.factories import ObjectDBFactory, RoomProfileFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.constants import EffectType
 from world.checks.factories import CheckTypeFactory, ConsequenceEffectFactory, ConsequenceFactory
@@ -754,7 +754,7 @@ class RefreshResonanceAlignmentTest(ResonanceCacheIsolationMixin, TestCase):
         self.assertEqual(len(self._boon_instances_on(self.sheet.character)), 1)
 
         # Now move character to an ObjectDB room that has no RoomProfile
-        bare_room = ObjectDB.objects.create(
+        bare_room = ObjectDBFactory(
             db_key="BareRoom",
             db_typeclass_path="typeclasses.objects.Object",
         )
@@ -918,10 +918,9 @@ class UseTechniqueResonanceEnvironmentIntegrationTest(ResonanceCacheIsolationMix
         No ConditionInstance should be created. This is the "bare room" guard: the
         orchestrator must handle RoomProfile.DoesNotExist without propagating it.
         """
-        from evennia.objects.models import ObjectDB
 
         # Create a bare room ObjectDB with no RoomProfile attached
-        bare_room = ObjectDB.objects.create(
+        bare_room = ObjectDBFactory(
             db_key="BareRoomT8",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/magic/tests/test_soul_tether_subscribers.py
+++ b/src/world/magic/tests/test_soul_tether_subscribers.py
@@ -32,6 +32,7 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase, tag
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.conditions.factories import (
@@ -75,7 +76,7 @@ from world.relationships.factories import (
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
     """Return a bare ObjectDB room for event dispatch."""
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/magic/tests/test_use_technique.py
+++ b/src/world/magic/tests/test_use_technique.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.factories import FlowDefinitionFactory, FlowStepDefinitionFactory
@@ -41,7 +42,7 @@ SELF_FILTER = {"path": "caster", "op": "==", "value": "self"}
 
 
 def _create_room(key: str = "PowerTestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/magic/tests/test_use_technique_power_terms.py
+++ b/src/world/magic/tests/test_use_technique_power_terms.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.factories import FlowDefinitionFactory, FlowStepDefinitionFactory
@@ -41,7 +42,7 @@ from world.mechanics.factories import CharacterEngagementFactory
 
 
 def _create_room(key: str = "TestRoom") -> ObjectDB:
-    return ObjectDB.objects.create(
+    return ObjectDBFactory(
         db_key=key,
         db_typeclass_path="typeclasses.rooms.Room",
     )

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -2280,7 +2280,7 @@ class RitualSessionViewSet(viewsets.ModelViewSet):
             result_kind = "capstone"
         else:
             result_kind = "unknown"
-        result_id = getattr(result, "pk", None)  # noqa: GETATTR_LITERAL
+        result_id = result.pk if result is not None else None
         return Response(
             {"result_kind": result_kind, "result_id": result_id},
             status=status.HTTP_200_OK,

--- a/src/world/mechanics/services.py
+++ b/src/world/mechanics/services.py
@@ -16,6 +16,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import Prefetch, Q
 
+from typeclasses.characters import Character
 from world.checks.services import chart_has_success_outcomes, preview_check_difficulty
 from world.conditions.services import get_all_capability_values
 from world.distinctions.models import CharacterDistinction
@@ -399,7 +400,7 @@ def passive_facet_bonuses(sheet: object, target: ModifierTarget) -> int:
     char = sheet.character
     # Defensive: raw ObjectDB fixtures (without _typeclass_path) don't have
     # Character typeclass handlers. Skip the walk gracefully.
-    if not hasattr(char, "threads") or not hasattr(char, "equipped_items"):
+    if not isinstance(char, Character):  # threads/equipped_items are Character-only
         return 0
     total = 0
     for thread in char.threads.threads_of_kind(TargetKind.FACET):
@@ -436,7 +437,7 @@ def passive_facet_crossing_bonuses(sheet: object, target: ModifierTarget) -> int
     from world.magic.models.crossing import CrossingChoice  # noqa: PLC0415
 
     char = sheet.character
-    if not hasattr(char, "threads") or not hasattr(char, "equipped_items"):  # noqa: GETATTR_LITERAL
+    if not isinstance(char, Character):  # threads/equipped_items are Character-only
         return 0
     total = 0
     for thread in char.threads.threads_of_kind(TargetKind.FACET):
@@ -480,7 +481,7 @@ def passive_mantle_bonuses(sheet: object, target: ModifierTarget) -> int:
     char = sheet.character
     # Defensive: raw ObjectDB fixtures (without _typeclass_path) don't have
     # Character typeclass handlers. Skip the walk gracefully.
-    if not hasattr(char, "threads"):
+    if not isinstance(char, Character):  # threads/equipped_items are Character-only
         return 0
     total = 0
     for thread in char.threads.threads_of_kind(TargetKind.MANTLE):
@@ -509,7 +510,7 @@ def passive_mantle_crossing_bonuses(sheet: object, target: ModifierTarget) -> in
     from world.magic.models.crossing import CrossingChoice  # noqa: PLC0415
 
     char = sheet.character
-    if not hasattr(char, "threads"):  # noqa: GETATTR_LITERAL
+    if not isinstance(char, Character):  # threads/equipped_items are Character-only
         return 0
     total = 0
     for thread in char.threads.threads_of_kind(TargetKind.MANTLE):

--- a/src/world/mechanics/tests/test_action_generation.py
+++ b/src/world/mechanics/tests/test_action_generation.py
@@ -3,8 +3,8 @@
 from unittest.mock import patch
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.conditions.factories import CapabilityTypeFactory
 from world.mechanics.constants import CapabilitySourceType, DifficultyIndicator
 from world.mechanics.factories import (
@@ -44,8 +44,8 @@ class ActionGenerationTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="ActionChar")
-        cls.location = ObjectDB.objects.create(db_key="ActionRoom")
+        cls.character = ObjectDBFactory(db_key="ActionChar")
+        cls.location = ObjectDBFactory(db_key="ActionRoom")
 
         cls.capability = CapabilityTypeFactory(name="fire_control_ag")
         cls.prop_flammable = PropertyFactory(name="flammable_ag")
@@ -149,8 +149,8 @@ class EffectPropertyFilterTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="EffectChar")
-        cls.location = ObjectDB.objects.create(db_key="EffectRoom")
+        cls.character = ObjectDBFactory(db_key="EffectChar")
+        cls.location = ObjectDBFactory(db_key="EffectRoom")
 
         cls.prop_flammable = PropertyFactory(name="flammable_epf")
         cls.prop_fire = PropertyFactory(name="fire_effect_epf")
@@ -216,8 +216,8 @@ class DifficultyIndicatorForCheckTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="DiffChar")
-        cls.location = ObjectDB.objects.create(db_key="DiffRoom")
+        cls.character = ObjectDBFactory(db_key="DiffChar")
+        cls.location = ObjectDBFactory(db_key="DiffRoom")
 
         cls.capability = CapabilityTypeFactory(name="diff_check_cap")
         cls.prop = PropertyFactory(name="diff_check_prop")

--- a/src/world/mechanics/tests/test_capability_sources.py
+++ b/src/world/mechanics/tests/test_capability_sources.py
@@ -3,8 +3,8 @@
 from decimal import Decimal
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.conditions.factories import CapabilityTypeFactory
 from world.magic.factories import (
@@ -84,7 +84,7 @@ class TraitSourceTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="TraitTestChar")
+        cls.character = ObjectDBFactory(db_key="TraitTestChar")
         cls.capability = CapabilityTypeFactory(name="physical_force")
         cls.trait = Trait.objects.create(
             name="test_strength_src",
@@ -117,7 +117,7 @@ class TraitSourceTests(TestCase):
 
     def test_zero_trait_value_excluded(self) -> None:
         """Trait with value 0 produces no source."""
-        char2 = ObjectDB.objects.create(db_key="NoTraitChar")
+        char2 = ObjectDBFactory(db_key="NoTraitChar")
         CharacterTraitValue.objects.create(
             character=char2,
             trait=self.trait,

--- a/src/world/mechanics/tests/test_challenge_models.py
+++ b/src/world/mechanics/tests/test_challenge_models.py
@@ -3,8 +3,8 @@
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.checks.constants import EffectType
 from world.checks.factories import ConsequenceEffectFactory, ConsequenceFactory
 from world.checks.models import ConsequenceEffect
@@ -225,8 +225,8 @@ class SituationChallengeLinkTests(TestCase):
 class InstanceModelTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.room = ObjectDB.objects.create(db_key="Test Room")
-        cls.character = ObjectDB.objects.create(db_key="Test Character")
+        cls.room = ObjectDBFactory(db_key="Test Room")
+        cls.character = ObjectDBFactory(db_key="Test Character")
         cls.situation_template = SituationTemplateFactory(name="Siege")
         cls.challenge_template = ChallengeTemplateFactory(name="Barricade")
         cls.situation_instance = SituationInstance.objects.create(
@@ -307,7 +307,7 @@ class ChallengeTemplatePropertyTests(TestCase):
 class ObjectPropertyTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.obj = ObjectDB.objects.create(db_key="Iron Door")
+        cls.obj = ObjectDBFactory(db_key="Iron Door")
         cls.prop = PropertyFactory(name="rusty")
         cls.op = ObjectPropertyFactory(object=cls.obj, property=cls.prop)
 

--- a/src/world/mechanics/tests/test_effect_handlers.py
+++ b/src/world/mechanics/tests/test_effect_handlers.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
 from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.captivity.constants import CaptivityStatus
@@ -225,7 +224,7 @@ class CaptureHandlerTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         super().setUpTestData()
-        cls.site = ObjectDB.objects.create(
+        cls.site = ObjectDBFactory(
             db_key="Ambush Site",
             db_typeclass_path="typeclasses.rooms.Room",
         )

--- a/src/world/mechanics/tests/test_pipeline_integration.py
+++ b/src/world/mechanics/tests/test_pipeline_integration.py
@@ -26,6 +26,7 @@ from actions.factories import (
     ConsequencePoolFactory,
 )
 from actions.services import get_effective_consequences, start_action_resolution
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.constants import EffectTarget, EffectType
 from world.checks.factories import (
@@ -120,7 +121,7 @@ class PipelineTestMixin:
         # === 1. Character layer ===
         cls.sheet = CharacterSheetFactory()
         cls.character = cls.sheet.character
-        cls.location = ObjectDB.objects.create(db_key="TestRoom")
+        cls.location = ObjectDBFactory(db_key="TestRoom")
 
         # === 2. Magic identity ===
         cls.flame_resonance = ResonanceFactory(name="Flame")

--- a/src/world/mechanics/tests/test_services.py
+++ b/src/world/mechanics/tests/test_services.py
@@ -2,7 +2,7 @@
 
 from django.test import TestCase, tag
 
-from evennia_extensions.factories import CharacterFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.conditions.factories import DamageTypeFactory
 from world.distinctions.factories import (
@@ -950,13 +950,11 @@ class EquipmentWalkRawObjectDBSafetyTests(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        from evennia.objects.models import ObjectDB
-
         from world.character_sheets.factories import CharacterSheetFactory
         from world.mechanics.factories import ModifierCategoryFactory, ModifierTargetFactory
 
         # Mirror the trait test fixture: raw ObjectDB, no Character typeclass.
-        cls.character = ObjectDB.objects.create(db_key="RawChar")
+        cls.character = ObjectDBFactory(db_key="RawChar")
         cls.sheet = CharacterSheetFactory(character=cls.character)
         cls.target = ModifierTargetFactory(
             category=ModifierCategoryFactory(name="raw_stat"),

--- a/src/world/missions/services/support.py
+++ b/src/world/missions/services/support.py
@@ -332,7 +332,13 @@ def declare_support(
 
     # Emit per-actor STORY + room ambient stir (outside atomic, like group
     # resolution so narrative side-effects don't roll back with a retry).
-    move_label = getattr(move, "name", "") or move.flavor_template or "Support"  # noqa: GETATTR_LITERAL
+    from world.missions.models import MissionAssistPattern  # noqa: PLC0415
+
+    move_label = (
+        (move.name if isinstance(move, MissionAssistPattern) else "")
+        or move.flavor_template
+        or "Support"
+    )
     story_text = move.flavor_template or f"Support declared: {move_label}"
     try:
         sheet = character.sheet_data

--- a/src/world/npc_services/models.py
+++ b/src/world/npc_services/models.py
@@ -21,6 +21,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.descriptors import ReverseOneToOneOrNone
 from core.managers import ArxSharedMemoryManager
 from core.mixins import DiscriminatorMixin
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
@@ -282,6 +283,9 @@ class NPCServiceOffer(SharedMemoryModel):
     Progressive disclosure happens through how staff author predicates, not
     through a separate visibility layer.
     """
+
+    # Reverse-OneToOne safe accessor (#2386): missing row -> None.
+    permit_offer_details_or_none = ReverseOneToOneOrNone("permit_offer_details")
 
     role = models.ForeignKey(
         NPCRole,

--- a/src/world/npc_services/social_disposition.py
+++ b/src/world/npc_services/social_disposition.py
@@ -67,10 +67,16 @@ def apply_social_disposition_delta(actor, target_persona_id, result) -> str | No
     return f"{target_name}'s regard for you warms {disposition_shift_band(delta)}."
 
 
-def _success_level(result) -> int:
-    main = getattr(result, "main_result", None)  # noqa: GETATTR_LITERAL
-    if main is not None and getattr(main, "check_result", None) is not None:  # noqa: GETATTR_LITERAL
-        return main.check_result.success_level or 0
+def _success_level(result: object) -> int:
+    """Success level from a resolution result, 0 when unrolled.
+
+    Only ``PendingActionResolution`` carries ``main_result`` (a ``StepResult``,
+    whose ``check_result`` is non-optional) — type dispatch, not probing (#2386).
+    """
+    from actions.types import PendingActionResolution  # noqa: PLC0415
+
+    if isinstance(result, PendingActionResolution) and result.main_result is not None:
+        return result.main_result.check_result.success_level or 0
     return 0
 
 

--- a/src/world/npc_services/tests/test_guard_detection.py
+++ b/src/world/npc_services/tests/test_guard_detection.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from evennia_extensions.factories import CharacterFactory, RoomProfileFactory
+from evennia_extensions.factories import CharacterFactory, ObjectDBFactory, RoomProfileFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory
 from world.checks.test_helpers import force_check_outcome
@@ -64,10 +64,9 @@ class CheckGuardDetectionTests(TestCase):
 
     def test_no_profile_short_circuits(self):
         """Room with no RoomProfile → no detection."""
-        from evennia.objects.models import ObjectDB
 
         char = CharacterFactory(db_key="wanderer")
-        bare_room = ObjectDB.objects.create(db_key="bare-room")
+        bare_room = ObjectDBFactory(db_key="bare-room")
         check_guard_detection(char, bare_room)
 
     def test_sheetless_character_skipped(self):

--- a/src/world/npc_services/tests/test_servant_fetch.py
+++ b/src/world/npc_services/tests/test_servant_fetch.py
@@ -121,9 +121,8 @@ class FindServantTests(TestCase):
 
     def test_no_profile_returns_none(self):
         """Room with no RoomProfile → None."""
-        from evennia.objects.models import ObjectDB
 
-        bare_room = ObjectDB.objects.create(db_key="bare-room")
+        bare_room = ObjectDBFactory(db_key="bare-room")
         self.assertIsNone(find_servant(bare_room))
 
 

--- a/src/world/progression/tests/test_character_xp.py
+++ b/src/world/progression/tests/test_character_xp.py
@@ -2,9 +2,9 @@
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 import pytest
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.progression.models import CharacterXP, CharacterXPTransaction
 from world.progression.types import ProgressionReason
 
@@ -14,7 +14,7 @@ class CharacterXPModelTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.character = ObjectDB.objects.create(db_key="TestChar")
+        cls.character = ObjectDBFactory(db_key="TestChar")
 
     def test_create_locked_xp(self):
         """Test creating locked (non-transferable) XP record."""
@@ -115,7 +115,7 @@ class CharacterXPTransactionModelTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.character = ObjectDB.objects.create(db_key="TestChar2")
+        cls.character = ObjectDBFactory(db_key="TestChar2")
 
     def test_create_cg_conversion_transaction(self):
         """Test creating a CG conversion transaction."""
@@ -154,7 +154,7 @@ class AwardCGConversionXPTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.character = ObjectDB.objects.create(db_key="ConvertChar")
+        cls.character = ObjectDBFactory(db_key="ConvertChar")
 
     def test_awards_correct_xp(self):
         """Test conversion awards remaining * rate XP."""

--- a/src/world/progression/tests/test_models.py
+++ b/src/world/progression/tests/test_models.py
@@ -5,9 +5,9 @@ Tests for progression models.
 from django.core.exceptions import ValidationError
 from django.test import TestCase, tag
 from evennia.accounts.models import AccountDB
-from evennia.objects.models import ObjectDB
 import pytest
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.models import CharacterSheet
 from world.progression.factories import (
     DevelopmentPointsFactory,
@@ -101,7 +101,7 @@ class DevelopmentPointsModelTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.character = ObjectDB.objects.create(db_key="TestChar")
+        cls.character = ObjectDBFactory(db_key="TestChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
 
     def test_development_points_creation(self):
@@ -163,7 +163,7 @@ class CharacterUnlockModelTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.character = ObjectDB.objects.create(db_key="TestChar")
+        cls.character = ObjectDBFactory(db_key="TestChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
         # Create a class unlock for testing instead
         from world.classes.factories import CharacterClassFactory

--- a/src/world/progression/tests/test_services.py
+++ b/src/world/progression/tests/test_services.py
@@ -4,9 +4,9 @@ Tests for progression services.
 
 from django.test import TestCase, tag
 from evennia.accounts.models import AccountDB
-from evennia.objects.models import ObjectDB
 import pytest
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.models import CharacterSheet
 from world.classes.factories import CharacterClassLevelFactory
 from world.progression.factories import ExperiencePointsDataFactory
@@ -86,10 +86,9 @@ class UnlockServiceTest(TestCase):
             username="testplayer",
             email="test@test.com",
         )
-        cls.character = ObjectDB.objects.create(
-            db_key="TestChar",
-            db_account=cls.account,
-        )
+        cls.character = ObjectDBFactory(db_key="TestChar")
+        cls.character.db_account = cls.account
+        cls.character.save()
 
         # Give character a class level
         cls.class_level = CharacterClassLevelFactory(character=cls.character, level=3)
@@ -210,7 +209,7 @@ class DevelopmentServiceTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.character = ObjectDB.objects.create(db_key="TestChar")
+        cls.character = ObjectDBFactory(db_key="TestChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
 
     def test_award_development_points(self):
@@ -252,7 +251,7 @@ class DevelopmentRateModifierTest(TestCase):
         from world.traits.factories import TraitFactory
         from world.traits.models import TraitCategory, TraitType
 
-        cls.character = ObjectDB.objects.create(db_key="TestChar")
+        cls.character = ObjectDBFactory(db_key="TestChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
 
         cls.physical_trait = TraitFactory(
@@ -344,7 +343,7 @@ class LevelUpRequirementsTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.character = ObjectDB.objects.create(db_key="TestChar")
+        cls.character = ObjectDBFactory(db_key="TestChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
         cls.class_level = CharacterClassLevelFactory(
             character=cls.character,
@@ -404,7 +403,7 @@ class LevelUpRequirementsTest(TestCase):
 
     def test_calculate_level_up_no_class(self):
         """Test level up calculation for character with no class."""
-        character_no_class = ObjectDB.objects.create(db_key="NoClass")
+        character_no_class = ObjectDBFactory(db_key="NoClass")
 
         from world.classes.factories import CharacterClassFactory
 

--- a/src/world/progression/tests/test_skill_development.py
+++ b/src/world/progression/tests/test_skill_development.py
@@ -1,8 +1,8 @@
 """Tests for the skill development system (check-based dp awards and level-ups)."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.models import CharacterSheet
 from world.checks.models import CheckCategory, CheckType, CheckTypeTrait
 from world.classes.factories import CharacterClassFactory
@@ -93,7 +93,7 @@ class DevelopmentPointsAwardTest(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="DevTestChar")
+        cls.character = ObjectDBFactory(db_key="DevTestChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
         cls.trait = TraitFactory(name="swords_dev_test")
 
@@ -171,7 +171,7 @@ class AwardCheckDevelopmentTest(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="CheckDevChar")
+        cls.character = ObjectDBFactory(db_key="CheckDevChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
         cls.trait1 = TraitFactory(name="stealth_check_dev")
         cls.trait2 = TraitFactory(name="agility_check_dev")
@@ -348,7 +348,7 @@ class AwardCheckDevelopmentSkillIndependenceTest(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="SkillIndependenceChar")
+        cls.character = ObjectDBFactory(db_key="SkillIndependenceChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
         cls.skill = SkillFactory()
         cls.category = CheckCategory.objects.create(name="test_skill_independence_category")
@@ -400,7 +400,7 @@ class RustDebtPayoffTest(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="RustDebtChar")
+        cls.character = ObjectDBFactory(db_key="RustDebtChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
         cls.trait = TraitFactory(name="rust_debt_test")
 
@@ -470,7 +470,7 @@ class ApplySkillRustTest(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="RustChar")
+        cls.character = ObjectDBFactory(db_key="RustChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
         cls.trait = TraitFactory(name="rust_apply_test")
 
@@ -536,7 +536,7 @@ class ProcessWeeklySkillDevelopmentTest(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="WeeklyProcessChar")
+        cls.character = ObjectDBFactory(db_key="WeeklyProcessChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
         cls.trait_used = TraitFactory(name="weekly_used_trait")
         cls.trait_unused = TraitFactory(name="weekly_unused_trait")
@@ -761,7 +761,7 @@ class RustPayoffLevelThresholdTest(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.character = ObjectDB.objects.create(db_key="RustPayoffThresholdChar")
+        cls.character = ObjectDBFactory(db_key="RustPayoffThresholdChar")
         cls.sheet, _ = CharacterSheet.objects.get_or_create(character=cls.character)
         cls.trait = TraitFactory(name="rust_threshold_test")
 

--- a/src/world/relationships/views.py
+++ b/src/world/relationships/views.py
@@ -159,6 +159,7 @@ class CharacterRelationshipViewSet(ReadOnlyModelViewSet):
         # drf-spectacular introspects the filterset by calling get_queryset()
         # with an anonymous dummy request; without this guard the user-filter
         # makes introspection fail and the filter params vanish from the schema.
+        # Suppression justified: drf-spectacular swagger_fake_view probe (documented idiom).
         if getattr(self, "swagger_fake_view", False):  # noqa: GETATTR_LITERAL
             return CharacterRelationship.objects.none()
         user = self.request.user

--- a/src/world/room_features/models.py
+++ b/src/world/room_features/models.py
@@ -15,6 +15,7 @@ from django.db.models import Q, UniqueConstraint
 from django.utils import timezone
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.descriptors import ReverseOneToOneOrNone
 from core.mixins import DiscriminatorMixin
 from world.locations.constants import HolderType
 from world.room_features.constants import (
@@ -197,6 +198,12 @@ class RoomFeatureInstance(SharedMemoryModel):
     Dissolution is a soft-delete — the row and all story-significant data are
     preserved. Use ``.active()`` on the queryset to exclude dissolved instances.
     """
+
+    # Reverse-OneToOne safe accessor (#2386): missing row -> None.
+    field_details_or_none = ReverseOneToOneOrNone("field_details")
+
+    # Reverse-OneToOne safe accessor (#2386): missing row -> None.
+    sanctum_details_or_none = ReverseOneToOneOrNone("sanctum_details")
 
     room_profile = models.OneToOneField(
         ROOM_PROFILE_MODEL,

--- a/src/world/roster/models/tenures.py
+++ b/src/world/roster/models/tenures.py
@@ -11,6 +11,7 @@ from django.utils.functional import cached_property
 from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.descriptors import ReverseOneToOneOrNone
 from evennia_extensions.mixins import RelatedCacheClearingMixin
 from world.roster.managers import RosterTenureManager
 
@@ -21,6 +22,12 @@ class RosterTenure(RelatedCacheClearingMixin, SharedMemoryModel):
     Players are identified only as "1st player", "2nd player", etc.
     Links to RosterEntry to keep all roster-related data together.
     """
+
+    # Reverse-OneToOne safe accessor (#2386): missing row -> None.
+    social_consent_preference_or_none = ReverseOneToOneOrNone("social_consent_preference")
+
+    # Reverse-OneToOne safe accessor (#2386): missing row -> None.
+    display_settings_or_none = ReverseOneToOneOrNone("display_settings")
 
     player_data = models.ForeignKey(
         "evennia_extensions.PlayerData",

--- a/src/world/roster/views/settings_views.py
+++ b/src/world/roster/views/settings_views.py
@@ -53,7 +53,7 @@ class VisibilitySettingsView(APIView):
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Return the active character's current ``appear_offline`` value."""
         tenure = self._current_tenure(request)
-        settings_obj = getattr(tenure, "display_settings", None)  # noqa: GETATTR_LITERAL
+        settings_obj = tenure.display_settings_or_none
         appear_offline = bool(settings_obj.appear_offline) if settings_obj is not None else False
         return Response(VisibilitySettingsSerializer({"appear_offline": appear_offline}).data)
 

--- a/src/world/scenes/action_serializers.py
+++ b/src/world/scenes/action_serializers.py
@@ -276,9 +276,10 @@ class CastableTechniqueSerializer(serializers.Serializer):
         if isinstance(obj, Technique):
             return is_technique_hostile(obj)
         # obj may be a CharacterTechnique — fall back to its technique.
-        technique = getattr(obj, "technique", None)  # noqa: GETATTR_LITERAL
-        if isinstance(technique, Technique):
-            return is_technique_hostile(technique)
+        from world.magic.models.techniques import CharacterTechnique  # noqa: PLC0415
+
+        if isinstance(obj, CharacterTechnique):
+            return is_technique_hostile(obj.technique)
         return False
 
     def get_target_spec(self, obj: object) -> dict | None:
@@ -288,15 +289,17 @@ class CastableTechniqueSerializer(serializers.Serializer):
         cardinalities, returns the same shape as actions.serializers.TargetSpecSerializer.
         """
         from actions.player_interface import _target_spec_for_technique_action  # noqa: PLC0415
-        from world.magic.models.techniques import Technique  # noqa: PLC0415
+        from world.magic.models.techniques import (  # noqa: PLC0415
+            CharacterTechnique,
+            Technique,
+        )
 
         if isinstance(obj, Technique):
             technique_id = obj.pk
+        elif isinstance(obj, CharacterTechnique):
+            technique_id = obj.technique_id
         else:
-            technique = getattr(obj, "technique", None)  # noqa: GETATTR_LITERAL
-            if not isinstance(technique, Technique):
-                return None
-            technique_id = technique.pk
+            return None
 
         spec = _target_spec_for_technique_action(technique_id)
         if spec is None:
@@ -639,6 +642,7 @@ class EnhancedSceneActionResultSerializer(serializers.Serializer):
         initiator_account = action_request.initiator_persona.character_sheet.character.db_account
         if initiator_account is None or request.user != initiator_account:
             return None
+        # Suppression justified: transient side-channel stash from the anima resolver.
         payload = getattr(action_request, "_anima_recovery_payload", None)  # noqa: GETATTR_LITERAL
         return AnimaRecoverySerializer(payload).data if payload is not None else None
 

--- a/src/world/scenes/interaction_serializers.py
+++ b/src/world/scenes/interaction_serializers.py
@@ -64,6 +64,8 @@ class InteractionActionLinkSerializer(serializers.ModelSerializer):
         # cached_round_actions is a Prefetch(to_attr=...) attribute set by the
         # interaction_views queryset; getattr with a default keeps serialization
         # safe if this serializer is ever used without that prefetch.
+        # Suppression justified: mutable social prefetch on identity-mapped row; property+setter
+        # pattern (see Interaction.cached_receivers) is the sanctioned conversion.
         round_actions = getattr(action_interaction, "cached_round_actions", [])  # noqa: GETATTR_LITERAL
         for round_action in round_actions:
             opponent = round_action.focused_opponent_target
@@ -370,6 +372,8 @@ class InteractionListSerializer(serializers.ModelSerializer):
         sheet = obj.persona.character_sheet
         if sheet is None:
             return []
+        # Suppression justified: mutable social prefetch on identity-mapped row; property+setter
+        # pattern (see Interaction.cached_receivers) is the sanctioned conversion.
         resonances = getattr(sheet, "cached_resonances", None)  # noqa: GETATTR_LITERAL
         if resonances is None:
             resonances = list(sheet.resonances.select_related("resonance"))
@@ -383,6 +387,8 @@ class InteractionListSerializer(serializers.ModelSerializer):
         ``cached_primary_persona`` (another nested Prefetch).
         """
         out = []
+        # Suppression justified: mutable social prefetch on identity-mapped row; property+setter
+        # pattern (see Interaction.cached_receivers) is the sanctioned conversion.
         for e in getattr(obj, "cached_endorsements", []):  # noqa: GETATTR_LITERAL
             persona = next(iter(e.endorser_sheet.cached_primary_persona), None)
             if persona is None:
@@ -404,6 +410,8 @@ class InteractionListSerializer(serializers.ModelSerializer):
         each cached endorsement's ``endorser_sheet_id``.
         """
         sheet_ids: set[int] = self.context.get("character_sheet_ids", set())
+        # Suppression justified: mutable social prefetch on identity-mapped row; property+setter
+        # pattern (see Interaction.cached_receivers) is the sanctioned conversion.
         for e in getattr(obj, "cached_endorsements", []):  # noqa: GETATTR_LITERAL
             if e.endorser_sheet_id in sheet_ids:
                 return {

--- a/src/world/scenes/presence.py
+++ b/src/world/scenes/presence.py
@@ -131,6 +131,7 @@ def who_listing(viewer_account: object | None = None) -> list[WhoEntry]:
         puppet = session.puppet
         if puppet is None:
             continue
+        # Suppression justified: Evennia ServerSession internal (third-party duck seam).
         last = getattr(session, "cmd_last_visible", None)  # noqa: GETATTR_LITERAL
         idle = now - last if last else 0.0
         if puppet.id not in idle_by_puppet or idle < idle_by_puppet[puppet.id]:

--- a/src/world/scenes/tests/test_round_models.py
+++ b/src/world/scenes/tests/test_round_models.py
@@ -1,7 +1,7 @@
 from django.db import IntegrityError
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.combat.factories import CombatEncounterFactory
 from world.combat.models import CombatEncounter
@@ -25,7 +25,7 @@ class RoundEnumTests(TestCase):
 
 class SceneRoundModelTests(TestCase):
     def setUp(self):
-        self.room = ObjectDB.objects.create(db_key="TestRoom")
+        self.room = ObjectDBFactory(db_key="TestRoom")
 
     def test_create_scene_round_defaults(self):
         rnd = SceneRound.objects.create(room=self.room)

--- a/src/world/scenes/tests/test_scene_check_modifier.py
+++ b/src/world/scenes/tests/test_scene_check_modifier.py
@@ -7,8 +7,8 @@ The SCENE branch is exercised via scene= in collect_check_modifiers().
 """
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.constants import ModifierSourceKind
 from world.checks.factories import CheckTypeFactory
@@ -78,7 +78,7 @@ class SceneContributionCollectionTest(TestCase):
         )
 
     def setUp(self):
-        self.target = ObjectDB.objects.create(db_key="SceneCollectTarget")
+        self.target = ObjectDBFactory(db_key="SceneCollectTarget")
         self.sheet = CharacterSheetFactory(character=self.target)
 
     def test_scene_contribution_present(self):

--- a/src/world/societies/renown.py
+++ b/src/world/societies/renown.py
@@ -329,9 +329,11 @@ def _archetype_dot_product(archetypes: Sequence, society: object) -> int:
     delta = 0
     for principle in PRINCIPLE_FIELD_NAMES:
         archetype_axis_sum = sum(
+            # Suppression justified: dynamic principle-axis field name; no default, loud.
             getattr(arch, f"{principle}_delta")  # noqa: GETATTR_LITERAL
             for arch in archetypes
         )
+        # Suppression justified: dynamic principle-axis field name; no default, loud.
         society_value = getattr(society, principle)  # noqa: GETATTR_LITERAL
         delta += archetype_axis_sum * society_value
     return delta

--- a/src/world/species/services.py
+++ b/src/world/species/services.py
@@ -75,7 +75,7 @@ def _has_sunlight_drawback(sheet) -> bool:
     """Whether the sheet's species (or an ancestor) grants a Sunlight-Exposure drawback."""
     from world.species.factories import SUNLIGHT_EXPOSURE_NAME  # noqa: PLC0415
 
-    if getattr(sheet, "species_id", None) is None:  # noqa: GETATTR_LITERAL
+    if sheet.species_id is None:
         return False
     species_pks = [s.pk for s in _species_and_ancestors(sheet.species)]
     return SpeciesGiftGrant.objects.filter(

--- a/src/world/stories/models.py
+++ b/src/world/stories/models.py
@@ -2362,6 +2362,11 @@ class Stake(SubjectMixin, SharedMemoryModel):
     contracts.
     """
 
+    @cached_property
+    def prefetched_resolutions(self) -> list:
+        """Authored resolutions — the Prefetch/query shared interface (#2386)."""
+        return list(self.resolutions.all())
+
     beat = models.ForeignKey(STORY_BEAT_MODEL, on_delete=models.CASCADE, related_name="stakes")
     template = models.ForeignKey(
         "stories.StakeTemplate",
@@ -2395,6 +2400,11 @@ class StakeResolution(SharedMemoryModel):
     not player-held; PC removal must route through peril (escalates_to_risk +
     consequence pools -> process_damage_consequences).
     """
+
+    @cached_property
+    def prefetched_reward_lines(self) -> list:
+        """Authored reward_lines — the Prefetch/query shared interface (#2386)."""
+        return list(self.reward_lines.all())
 
     stake = models.ForeignKey(STAKE_MODEL, on_delete=models.CASCADE, related_name="resolutions")
     column = models.CharField(max_length=12, choices=StakeResolutionColumn.choices)

--- a/src/world/stories/permissions.py
+++ b/src/world/stories/permissions.py
@@ -15,6 +15,7 @@ from world.stories.models import (
     Beat,
     CustodyClearance,
     Episode,
+    GroupStoryProgress,
     Story,
     StoryNote,
     StoryParticipation,
@@ -1314,7 +1315,7 @@ def _story_log_user_has_access(
 
     # GROUP scope: user is an active member of the GMTable with progress.
     if story.scope == StoryScope.GROUP and progress is not None:
-        gm_table = getattr(progress, "gm_table", None)  # noqa: GETATTR_LITERAL
+        gm_table = progress.gm_table if isinstance(progress, GroupStoryProgress) else None
         if gm_table is not None:
             return (
                 cast(Any, gm_table)

--- a/src/world/stories/serializers.py
+++ b/src/world/stories/serializers.py
@@ -139,6 +139,7 @@ class EraSerializer(serializers.ModelSerializer):
         (``Count("stories_created_in_era")``). Falls back to a direct query only
         when the annotation is absent (e.g. in non-viewset serializer calls).
         """
+        # Suppression justified: queryset annotation probe; absent outside the annotating viewset.
         annotated = getattr(obj, "story_count", None)  # noqa: GETATTR_LITERAL
         if annotated is not None:
             return int(annotated)
@@ -2392,6 +2393,7 @@ class TableBulletinPostSerializer(serializers.ModelSerializer):
 
     def get_replies(self, obj: Any) -> list[Any]:
         """Return cached replies (from Prefetch to_attr) or query the DB."""
+        # Suppression justified: queryset annotation probe; absent outside the annotating viewset.
         reply_list = getattr(obj, "replies_cached", None)  # noqa: GETATTR_LITERAL
         if reply_list is None:
             reply_list = list(obj.replies.select_related("author_persona").all())

--- a/src/world/stories/services/stake_resolution.py
+++ b/src/world/stories/services/stake_resolution.py
@@ -415,9 +415,7 @@ def _branch_for_column(
     the plain default within `column` when no branch matches — preserves
     pre-#1760 single-branch-per-column content unchanged.
     """
-    resolutions = getattr(stake, "prefetched_resolutions", None)  # noqa: GETATTR_LITERAL
-    if resolutions is None:
-        resolutions = list(stake.resolutions.all())
+    resolutions = stake.prefetched_resolutions
     if prefer_lifecycle_state:
         matched = next(
             (r for r in resolutions if r.machine_match_lifecycle_state == prefer_lifecycle_state),
@@ -939,11 +937,9 @@ def _apply_stake_rewards(
 
 
 def _reward_lines_for(resolution: StakeResolution) -> list[StakeRewardLine]:
-    """The branch's reward lines, from the nested prefetch when present."""
-    lines = getattr(resolution, "prefetched_reward_lines", None)  # noqa: GETATTR_LITERAL
-    if lines is None:
-        lines = list(resolution.reward_lines.all())
-    return lines
+    """The branch's reward lines — prefetched_reward_lines is the shared
+    Prefetch/query interface (a cached_property, never None; #2386)."""
+    return resolution.prefetched_reward_lines
 
 
 def _deliver_reward_line(line: StakeRewardLine, participant: Persona, stake: Stake) -> None:

--- a/src/world/tarot/tests/test_character_sheet.py
+++ b/src/world/tarot/tests/test_character_sheet.py
@@ -1,8 +1,8 @@
 """Test tarot fields on CharacterSheet."""
 
 from django.test import TestCase
-from evennia.objects.models import ObjectDB
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.models import CharacterSheet
 from world.tarot.constants import ArcanaType
 from world.tarot.models import TarotCard
@@ -13,7 +13,7 @@ class CharacterSheetTarotTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.character = ObjectDB.objects.create(db_key="TarotTestChar")
+        cls.character = ObjectDBFactory(db_key="TarotTestChar")
         cls.card = TarotCard.objects.create(
             name="The Fool",
             arcana_type=ArcanaType.MAJOR,

--- a/src/world/traits/tests.py
+++ b/src/world/traits/tests.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 import pytest
 
+from evennia_extensions.factories import ObjectDBFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.distinctions.factories import DistinctionCategoryFactory, DistinctionFactory
 from world.distinctions.models import CharacterDistinction, DistinctionEffect
@@ -40,9 +41,7 @@ class TraitModelTests(TestCase):
             },
         )
 
-        from evennia.objects.models import ObjectDB
-
-        self.character = ObjectDB.objects.create(
+        self.character = ObjectDBFactory(
             db_key="testchar",
             db_typeclass_path="typeclasses.characters.Character",
         )
@@ -205,9 +204,8 @@ class TraitHandlerTests(TestCase):
 
     def setUp(self):
         """Set up test data."""
-        from evennia.objects.models import ObjectDB
 
-        self.character = ObjectDB.objects.create(
+        self.character = ObjectDBFactory(
             db_key="testchar",
             db_typeclass_path="typeclasses.characters.Character",
         )
@@ -364,9 +362,8 @@ class StatHandlerTests(TestCase):
 
     def setUp(self):
         """Set up test data for stats."""
-        from evennia.objects.models import ObjectDB
 
-        self.character = ObjectDB.objects.create(
+        self.character = ObjectDBFactory(
             db_key="testchar",
             db_typeclass_path="typeclasses.characters.Character",
         )
@@ -645,9 +642,8 @@ class TraitHandlerStatModifierTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Set up test data including character with sheet and strength trait."""
-        from evennia.objects.models import ObjectDB
 
-        cls.character = ObjectDB.objects.create(db_key="TestChar")
+        cls.character = ObjectDBFactory(db_key="TestChar")
         cls.sheet = CharacterSheetFactory(character=cls.character)
 
         # Create the strength trait as a stat
@@ -799,9 +795,8 @@ class TraitHandlerStatModifierTests(TestCase):
 
     def test_trait_value_no_sheet_returns_base(self):
         """Characters without sheet get unmodified trait values."""
-        from evennia.objects.models import ObjectDB
 
-        character_no_sheet = ObjectDB.objects.create(db_key="NoSheetChar")
+        character_no_sheet = ObjectDBFactory(db_key="NoSheetChar")
         CharacterTraitValueFactory(
             character=character_no_sheet,
             trait=self.strength_trait,
@@ -832,9 +827,8 @@ class GiantsBloodModifierCreationTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Set up test data."""
-        from evennia.objects.models import ObjectDB
 
-        cls.character = ObjectDB.objects.create(db_key="TestChar")
+        cls.character = ObjectDBFactory(db_key="TestChar")
         cls.sheet = CharacterSheetFactory(character=cls.character)
 
         # Create the Giant's Blood distinction with its effects

--- a/tools/lint_noqa_ratchet.py
+++ b/tools/lint_noqa_ratchet.py
@@ -22,6 +22,18 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC = REPO_ROOT / "src"
 BASELINE_FILE = REPO_ROOT / "tools" / "noqa_ratchet_baseline.txt"
 
+# Non-noqa ratcheted patterns: baseline tokens prefixed "pattern:" count regex
+# matches across src/**/*.py instead of noqa suppressions. Same rule: the
+# count may only go down.
+PATTERNS: dict[str, str] = {
+    # Bare ObjectDB rows lack the ObjectParent mixin (no trigger_handler /
+    # character_sheet / positions_cached) and cannot exist in production —
+    # tests must use evennia_extensions.factories.ObjectDBFactory (which goes
+    # through create_object). The grandfathered remainder is the handful of
+    # deliberate production services that build rooms/exits as bare rows.
+    "BARE_OBJECTDB_CREATE": r"ObjectDB\.objects\.create\(",
+}
+
 
 def count_token(token: str) -> int:
     """Count occurrences of ``# noqa: <token>`` under src/ (comments only)."""
@@ -36,6 +48,19 @@ def count_token(token: str) -> int:
     return total
 
 
+def count_pattern(regex: str) -> int:
+    """Count regex matches across src/**/*.py."""
+    pattern = re.compile(regex)
+    total = 0
+    for path in SRC.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        total += len(pattern.findall(text))
+    return total
+
+
 def main() -> int:
     failures: list[str] = []
     for raw in BASELINE_FILE.read_text(encoding="utf-8").splitlines():
@@ -44,7 +69,11 @@ def main() -> int:
             continue
         token, _, allowed_str = line.partition(" ")
         allowed = int(allowed_str)
-        actual = count_token(token)
+        if token.startswith("pattern:"):
+            name = token.removeprefix("pattern:")
+            actual = count_pattern(PATTERNS[name])
+        else:
+            actual = count_token(token)
         if actual > allowed:
             failures.append(
                 f"{token}: {actual} suppressions in src/ exceeds the baseline of {allowed}.\n"

--- a/tools/noqa_ratchet_baseline.txt
+++ b/tools/noqa_ratchet_baseline.txt
@@ -1,5 +1,8 @@
-# Maximum allowed `# noqa: <TOKEN>` suppressions under src/, per token.
-# Enforced by tools/lint_noqa_ratchet.py (pre-commit + CI). May only go DOWN
-# as audit tranches retire grandfathered sites; bumping it up is a deliberate,
+# Maximum allowed counts under src/, per token. Enforced by
+# tools/lint_noqa_ratchet.py (pre-commit + CI). May only go DOWN as audit
+# tranches retire grandfathered sites; bumping a number up is a deliberate,
 # reviewed exception — justify it in the commit message.
-GETATTR_LITERAL 137
+# Plain tokens count '# noqa: <TOKEN>' suppressions; 'pattern:' tokens count
+# the regexes defined in lint_noqa_ratchet.py's PATTERNS map.
+GETATTR_LITERAL 61
+pattern:BARE_OBJECTDB_CREATE 4


### PR DESCRIPTION
Tranche 3 (follows #2386 → #2396 → #2401). Three classifier reports covering the entire remaining `GETATTR_LITERAL` tail, the repo-wide fixture sweep, and the Evennia holder-object hunt — every verdict implemented and test-verified.

## Getattr tail: 125 → 61, every survivor justified

- **27 prunes** — provably-dead defaults, including 12 more `getattr(exc, "user_message", …)` sites (every caught exception type defines it class-level; a shared `UserFacingError` base was evaluated and rejected — no mixed tuples exist anywhere).
- **19 explicit dispatches** — result-shape resolution now type-dispatches (`PendingActionResolution` nominal; the combat leg deliberately kept **structural** per the ratified 2026-04-30 pipeline spec, which `test_extractor_reads_top_level_check_result` pins); three copy-pasted BaseState unwrap helpers consolidated into `flows.object_states.base_state.unwrap_objectdb`; the mechanics thread-walks now guard on `isinstance(char, Character)` (a sheet can legally attach to a plain Object in tests).
- **19 reverse-OneToOne traps → one-line `ReverseOneToOneOrNone` accessors** across 11 models (vehicle, field_details, sanctum_details, check_config, path_intent, active_alternate_self, anima, item_instance, social_consent_preference, display_settings, building_permit_details, permit_offer_details, domain_holding).
- **3 authored-content Prefetch probes → the shared-interface cached_property** (Tradition codex grants, Stake resolutions, StakeResolution reward lines). Everything live-mutating or time-derived (combat conditions with `suppressed_until`, clash/lock sets, the scene feed) is **kept as a probe with context-over-cache justifications** — the #2401 lesson applied: never a cached_property on an identity-mapped parent whose data mutates.
- **48 justification comments added** — every surviving suppression now states its reason (flow-payload seams, thread-locals, dynamic attribute names, Evennia cmdhandler ducks, drf-spectacular idioms).

## Fixture sweep + new ratchet pattern

110 test files converted from bare `ObjectDB.objects.create` (production-impossible objects lacking the ObjectParent mixin) to the typeclassed `ObjectDBFactory`. The ratchet now supports regex patterns: `pattern:BARE_OBJECTDB_CREATE` baseline = 4, grandfathering only the deliberate room/exit-builder production services — a new bare create in any test fails CI.

## Holder hunt

Clean bill: no deepcopy hazards outside the sanctioned test-runner shim, no AttributeHandler duplication. Two dead-defensive sites removed (ndb returns None natively). The documented `.db.locked` cluster left as-is per `commands/CLAUDE.md`.

## Honest ledger

The gauntlet caught one real regression I introduced mid-tranche: the first dispatch draft guessed the wrong carrier type for combat's resolution result, which would have silenced combat mishaps entirely. Fixed against the documented `CombatTechniqueResolution` contract, then relaxed to the spec's structural form when the reactive-integration test pinned the shape contract. Both regression modules re-verified green.

## Tests

9,898-test fast gauntlet + 5,150-test Postgres parity batch (+ focused re-runs after each fix); ~7,000 additional earlier-batch executions during the fixture sweep.

Remaining audit backlog (tranche 4, queued in the plan): the 129 broad `except Exception` handlers — separating sanctioned log-and-continue (#1164 interim) from silent workarounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)