### PR TITLE
CG selection cards should expand to lore/codex modals

### DIFF
--- a/frontend/src/codex/__tests__/CodexModal.test.tsx
+++ b/frontend/src/codex/__tests__/CodexModal.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Tests for CodexModal back/forward navigation.
+ *
+ * Verifies that clicking an inline link navigates to the new entry,
+ * and that back/forward buttons work correctly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { CodexModal } from '../components/CodexModal';
+import type { CodexEntryDetail } from '../types';
+
+// Mock the API module
+vi.mock('../api', () => ({
+  getEntry: vi.fn(),
+  getCodexTree: vi.fn(),
+  getEntries: vi.fn(),
+  searchEntries: vi.fn(),
+  getSubject: vi.fn(),
+  getSubjectChildren: vi.fn(),
+}));
+
+import * as api from '../api';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function makeEntry(
+  id: number,
+  name: string,
+  loreContent: string,
+  links: CodexEntryDetail['lore_links']
+): CodexEntryDetail {
+  return {
+    id,
+    name,
+    summary: `${name} summary`,
+    lore_content: loreContent,
+    mechanics_content: null,
+    lore_links: links,
+    mechanics_links: [],
+    is_public: true,
+    subject: 1,
+    subject_name: 'Test Subject',
+    subject_path: [
+      { type: 'category' as const, id: 1, name: 'Test Category' },
+      { type: 'subject' as const, id: 2, name: 'Test Subject' },
+    ],
+    display_order: 0,
+    knowledge_status: 'known' as const,
+    learn_threshold: 10,
+    research_progress: null,
+  };
+}
+
+describe('CodexModal navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows back button after navigating to a linked entry', async () => {
+    const entry1 = makeEntry(1, 'First Entry', 'See [[Second Entry]].', [
+      {
+        match_text: '[[Second Entry]]',
+        entry_id: 2,
+        display_text: 'Second Entry',
+        accessible: true,
+      },
+    ]);
+    const entry2 = makeEntry(2, 'Second Entry', 'No links here.', []);
+
+    vi.mocked(api.getEntry).mockImplementation(async (id: number) => {
+      if (id === 1) return entry1;
+      if (id === 2) return entry2;
+      throw new Error('Not found');
+    });
+
+    render(<CodexModal entryId={1} open={true} onOpenChange={vi.fn()} />, {
+      wrapper: createWrapper(),
+    });
+
+    // Wait for first entry to load
+    await waitFor(() => {
+      expect(screen.getByText('First Entry')).toBeInTheDocument();
+    });
+
+    // No back button initially
+    expect(screen.queryByLabelText('Go back')).not.toBeInTheDocument();
+
+    // Click the inline link
+    await userEvent.click(screen.getByText('Second Entry'));
+
+    // Wait for second entry to load
+    await waitFor(() => {
+      expect(screen.getByText('Second Entry')).toBeInTheDocument();
+    });
+
+    // Back button should now be visible
+    expect(screen.getByLabelText('Go back')).toBeInTheDocument();
+  });
+
+  it('navigates back to previous entry', async () => {
+    const entry1 = makeEntry(1, 'First Entry', 'See [[Second Entry]].', [
+      {
+        match_text: '[[Second Entry]]',
+        entry_id: 2,
+        display_text: 'Second Entry',
+        accessible: true,
+      },
+    ]);
+    const entry2 = makeEntry(2, 'Second Entry', 'No links here.', []);
+
+    vi.mocked(api.getEntry).mockImplementation(async (id: number) => {
+      if (id === 1) return entry1;
+      if (id === 2) return entry2;
+      throw new Error('Not found');
+    });
+
+    render(<CodexModal entryId={1} open={true} onOpenChange={vi.fn()} />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('First Entry')).toBeInTheDocument();
+    });
+
+    // Navigate forward
+    await userEvent.click(screen.getByText('Second Entry'));
+    await waitFor(() => {
+      expect(screen.getByText('Second Entry')).toBeInTheDocument();
+    });
+
+    // Navigate back
+    await userEvent.click(screen.getByLabelText('Go back'));
+    await waitFor(() => {
+      expect(screen.getByText('First Entry')).toBeInTheDocument();
+    });
+
+    // Forward button should now be visible
+    expect(screen.getByLabelText('Go forward')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/codex/__tests__/ContentSections.test.tsx
+++ b/frontend/src/codex/__tests__/ContentSections.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for ContentSections inline link rendering.
+ *
+ * Verifies that [[wikilink]] syntax is parsed and rendered as either
+ * clickable links (accessible) or "???" (inaccessible).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LoreSection, OOCSection } from '../components/ContentSections';
+import type { CodexLinkRef } from '../types';
+
+describe('LoreSection', () => {
+  it('renders plain text without links', () => {
+    render(<LoreSection content="Just plain text." />);
+    expect(screen.getByText('Just plain text.')).toBeInTheDocument();
+  });
+
+  it('renders accessible link as clickable', async () => {
+    const links: CodexLinkRef[] = [
+      {
+        match_text: '[[Linked Entry]]',
+        entry_id: 42,
+        display_text: 'Linked Entry',
+        accessible: true,
+      },
+    ];
+    const onNavigate = vi.fn();
+    render(
+      <LoreSection
+        content="See [[Linked Entry]] for details."
+        links={links}
+        onNavigate={onNavigate}
+      />
+    );
+
+    const link = screen.getByText('Linked Entry');
+    expect(link.tagName).toBe('BUTTON');
+    await userEvent.click(link);
+    expect(onNavigate).toHaveBeenCalledWith(42);
+  });
+
+  it('renders inaccessible link as ???', () => {
+    const links: CodexLinkRef[] = [
+      {
+        match_text: '[[Secret Entry]]',
+        entry_id: null,
+        display_text: '???',
+        accessible: false,
+      },
+    ];
+    render(<LoreSection content="See [[Secret Entry]] if you dare." links={links} />);
+
+    expect(screen.getByText('???')).toBeInTheDocument();
+    // The real entry name should not appear
+    expect(screen.queryByText('Secret Entry')).not.toBeInTheDocument();
+  });
+
+  it('renders multiple links in sequence', async () => {
+    const links: CodexLinkRef[] = [
+      {
+        match_text: '[[First]]',
+        entry_id: 1,
+        display_text: 'First',
+        accessible: true,
+      },
+      {
+        match_text: '[[Second]]',
+        entry_id: 2,
+        display_text: 'Second',
+        accessible: true,
+      },
+    ];
+    const onNavigate = vi.fn();
+    render(
+      <LoreSection content="[[First]] then [[Second]]." links={links} onNavigate={onNavigate} />
+    );
+
+    await userEvent.click(screen.getByText('First'));
+    await userEvent.click(screen.getByText('Second'));
+    expect(onNavigate).toHaveBeenNthCalledWith(1, 1);
+    expect(onNavigate).toHaveBeenNthCalledWith(2, 2);
+  });
+
+  it('renders mixed accessible and inaccessible links', () => {
+    const links: CodexLinkRef[] = [
+      {
+        match_text: '[[Public]]',
+        entry_id: 1,
+        display_text: 'Public',
+        accessible: true,
+      },
+      {
+        match_text: '[[Private]]',
+        entry_id: null,
+        display_text: '???',
+        accessible: false,
+      },
+    ];
+    render(
+      <LoreSection content="[[Public]] and [[Private]]." links={links} onNavigate={vi.fn()} />
+    );
+
+    expect(screen.getByRole('button', { name: 'Public' })).toBeInTheDocument();
+    expect(screen.getByText('???')).toBeInTheDocument();
+  });
+});
+
+describe('OOCSection', () => {
+  it('renders accessible link in OOC content', async () => {
+    const links: CodexLinkRef[] = [
+      {
+        match_text: '[[Mechanics]]',
+        entry_id: 10,
+        display_text: 'Mechanics',
+        accessible: true,
+      },
+    ];
+    const onNavigate = vi.fn();
+    render(
+      <OOCSection content="See [[Mechanics]] for rules." links={links} onNavigate={onNavigate} />
+    );
+
+    await userEvent.click(screen.getByText('Mechanics'));
+    expect(onNavigate).toHaveBeenCalledWith(10);
+  });
+});

--- a/frontend/src/codex/__tests__/queries.test.tsx
+++ b/frontend/src/codex/__tests__/queries.test.tsx
@@ -189,6 +189,8 @@ describe('Codex Query Hooks', () => {
         summary: 'Resonance of giving',
         lore_content: 'Full content',
         mechanics_content: null,
+        lore_links: [],
+        mechanics_links: [],
         is_public: true,
         subject: 1,
         subject_name: 'Celestial',

--- a/frontend/src/codex/components/CodexInlineLink.tsx
+++ b/frontend/src/codex/components/CodexInlineLink.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@/lib/utils';
+
+interface CodexInlineLinkProps {
+  entryId: number;
+  children: React.ReactNode;
+  onNavigate: (entryId: number) => void;
+  className?: string;
+}
+
+/**
+ * Inline clickable link to another codex entry, rendered inside modal content.
+ *
+ * Calls onNavigate instead of opening a nested modal — the parent modal
+ * manages a history stack and swaps content in place.
+ *
+ * For the full-page EntryDetail view, use React Router <Link> instead.
+ */
+export function CodexInlineLink({
+  entryId,
+  children,
+  onNavigate,
+  className,
+}: CodexInlineLinkProps) {
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onNavigate(entryId);
+      }}
+      className={cn(
+        'cursor-pointer text-primary underline decoration-dotted underline-offset-2 hover:decoration-solid',
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/codex/components/CodexModal.tsx
+++ b/frontend/src/codex/components/CodexModal.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { ExternalLink, Loader2 } from 'lucide-react';
+import { ArrowLeft, ArrowRight, ExternalLink, Loader2 } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { useCodexEntry } from '../queries';
@@ -12,10 +13,42 @@ interface CodexModalProps {
 }
 
 export function CodexModal({ entryId, open, onOpenChange }: CodexModalProps) {
-  const { data: entry, isLoading, isError } = useCodexEntry(entryId);
+  const [history, setHistory] = useState<number[]>([entryId]);
+  const [historyIndex, setHistoryIndex] = useState(0);
+
+  const currentEntryId = history[historyIndex];
+  const { data: entry, isLoading, isError } = useCodexEntry(currentEntryId);
+
+  const navigateToEntry = (id: number) => {
+    const newHistory = history.slice(0, historyIndex + 1);
+    newHistory.push(id);
+    setHistory(newHistory);
+    setHistoryIndex(newHistory.length - 1);
+  };
+
+  const goBack = () => {
+    if (historyIndex > 0) setHistoryIndex(historyIndex - 1);
+  };
+
+  const goForward = () => {
+    if (historyIndex < history.length - 1) setHistoryIndex(historyIndex + 1);
+  };
+
+  const canGoBack = historyIndex > 0;
+  const canGoForward = historyIndex < history.length - 1;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(open) => {
+        if (!open) {
+          // Reset history when modal closes
+          setHistory([entryId]);
+          setHistoryIndex(0);
+        }
+        onOpenChange(open);
+      }}
+    >
       <DialogContent className="sm:max-w-md">
         {isLoading ? (
           <div className="flex items-center justify-center py-8">
@@ -26,12 +59,50 @@ export function CodexModal({ entryId, open, onOpenChange }: CodexModalProps) {
         ) : entry ? (
           <>
             <DialogHeader>
-              <DialogTitle>{entry.name}</DialogTitle>
+              <div className="flex items-center justify-between">
+                <DialogTitle>{entry.name}</DialogTitle>
+                {(canGoBack || canGoForward) && (
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      onClick={goBack}
+                      disabled={!canGoBack}
+                      aria-label="Go back"
+                    >
+                      <ArrowLeft className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      onClick={goForward}
+                      disabled={!canGoForward}
+                      aria-label="Go forward"
+                    >
+                      <ArrowRight className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )}
+              </div>
             </DialogHeader>
             <div className="space-y-3">
               <p className="text-sm text-muted-foreground">{entry.summary}</p>
-              {entry.lore_content && <LoreSection content={entry.lore_content} />}
-              {entry.mechanics_content && <OOCSection content={entry.mechanics_content} />}
+              {entry.lore_content && (
+                <LoreSection
+                  content={entry.lore_content}
+                  links={entry.lore_links}
+                  onNavigate={navigateToEntry}
+                />
+              )}
+              {entry.mechanics_content && (
+                <OOCSection
+                  content={entry.mechanics_content}
+                  links={entry.mechanics_links}
+                  onNavigate={navigateToEntry}
+                />
+              )}
               <Button asChild variant="outline" size="sm">
                 <Link to={`/codex?entry=${entry.id}`} onClick={() => onOpenChange(false)}>
                   <ExternalLink className="mr-2 h-4 w-4" />

--- a/frontend/src/codex/components/ContentSections.tsx
+++ b/frontend/src/codex/components/ContentSections.tsx
@@ -1,10 +1,99 @@
 import { Info, ScrollText } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { CodexLinkRef } from '../types';
+import { CodexInlineLink } from './CodexInlineLink';
 
 interface ContentSectionProps {
   content: string;
+  links?: CodexLinkRef[];
+  onNavigate?: (entryId: number) => void;
 }
 
-export function LoreSection({ content }: ContentSectionProps) {
+const WIKILINK_RE = /\[\[([^\]]+)\]\]/g;
+
+/**
+ * Split content into text and link segments based on [[wikilink]] syntax.
+ * Text segments are rendered through ReactMarkdown; link segments are
+ * rendered as CodexInlineLink (accessible) or "???" (inaccessible).
+ */
+function renderContent(
+  content: string,
+  links: CodexLinkRef[],
+  onNavigate?: (entryId: number) => void
+): React.ReactNode[] {
+  const segments: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let key = 0;
+
+  for (const match of content.matchAll(WIKILINK_RE)) {
+    const matchText = match[0];
+    const start = match.index ?? 0;
+
+    // Text before the link
+    if (start > lastIndex) {
+      const textSegment = content.slice(lastIndex, start);
+      segments.push(
+        <ReactMarkdown key={key++} remarkPlugins={[remarkGfm]}>
+          {textSegment}
+        </ReactMarkdown>
+      );
+    }
+
+    // Find the matching link ref
+    const linkRef = links.find((l) => l.match_text === matchText);
+    if (linkRef) {
+      if (linkRef.accessible && linkRef.entry_id !== null) {
+        if (onNavigate) {
+          segments.push(
+            <CodexInlineLink key={key++} entryId={linkRef.entry_id} onNavigate={onNavigate}>
+              {linkRef.display_text}
+            </CodexInlineLink>
+          );
+        } else {
+          // Accessible but no navigation callback — render as styled text
+          segments.push(
+            <span
+              key={key++}
+              className="text-primary underline decoration-dotted underline-offset-2"
+            >
+              {linkRef.display_text}
+            </span>
+          );
+        }
+      } else {
+        segments.push(
+          <span
+            key={key++}
+            className="cursor-help italic text-muted-foreground"
+            title="You have not yet discovered this."
+          >
+            ???
+          </span>
+        );
+      }
+    } else {
+      // No matching link ref — render the raw text
+      segments.push(<span key={key++}>{matchText}</span>);
+    }
+
+    lastIndex = start + matchText.length;
+  }
+
+  // Remaining text after the last link
+  if (lastIndex < content.length) {
+    const textSegment = content.slice(lastIndex);
+    segments.push(
+      <ReactMarkdown key={key++} remarkPlugins={[remarkGfm]}>
+        {textSegment}
+      </ReactMarkdown>
+    );
+  }
+
+  return segments;
+}
+
+export function LoreSection({ content, links, onNavigate }: ContentSectionProps) {
   return (
     <div className="rounded-lg border border-amber-200/50 bg-amber-50/50 p-4 shadow-inner dark:border-amber-900/30 dark:bg-amber-950/20">
       <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-amber-700 dark:text-amber-400">
@@ -12,18 +101,13 @@ export function LoreSection({ content }: ContentSectionProps) {
         Lore
       </div>
       <div className="prose prose-sm dark:prose-invert max-w-none text-amber-950 dark:text-amber-100">
-        {content
-          .split('\n')
-          .filter(Boolean)
-          .map((paragraph, i) => (
-            <p key={i}>{paragraph}</p>
-          ))}
+        {renderContent(content, links ?? [], onNavigate)}
       </div>
     </div>
   );
 }
 
-export function OOCSection({ content }: ContentSectionProps) {
+export function OOCSection({ content, links, onNavigate }: ContentSectionProps) {
   return (
     <div className="rounded-lg border border-slate-200 bg-slate-100 p-4 dark:border-slate-700 dark:bg-slate-800">
       <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-slate-600 dark:text-slate-400">
@@ -31,12 +115,7 @@ export function OOCSection({ content }: ContentSectionProps) {
         OOC
       </div>
       <div className="prose prose-sm dark:prose-invert max-w-none">
-        {content
-          .split('\n')
-          .filter(Boolean)
-          .map((paragraph, i) => (
-            <p key={i}>{paragraph}</p>
-          ))}
+        {renderContent(content, links ?? [], onNavigate)}
       </div>
     </div>
   );

--- a/frontend/src/codex/components/EntryDetail.tsx
+++ b/frontend/src/codex/components/EntryDetail.tsx
@@ -1,4 +1,5 @@
 import { Lock } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Breadcrumb } from './Breadcrumb';
@@ -12,6 +13,13 @@ interface EntryDetailProps {
 
 export function EntryDetail({ entry, onNavigateBreadcrumb }: EntryDetailProps) {
   const isUncovered = entry.knowledge_status === 'uncovered';
+  const navigate = useNavigate();
+
+  // On the full page, inline links use React Router navigation so browser
+  // back/forward works natively.
+  const handleNavigate = (entryId: number) => {
+    navigate(`/codex?entry=${entryId}`);
+  };
 
   const breadcrumbItems = entry.subject_path.map((segment) => ({
     label: segment.name,
@@ -53,8 +61,20 @@ export function EntryDetail({ entry, onNavigateBreadcrumb }: EntryDetailProps) {
         )}
         {entry.lore_content || entry.mechanics_content ? (
           <div className="space-y-3">
-            {entry.lore_content && <LoreSection content={entry.lore_content} />}
-            {entry.mechanics_content && <OOCSection content={entry.mechanics_content} />}
+            {entry.lore_content && (
+              <LoreSection
+                content={entry.lore_content}
+                links={entry.lore_links}
+                onNavigate={handleNavigate}
+              />
+            )}
+            {entry.mechanics_content && (
+              <OOCSection
+                content={entry.mechanics_content}
+                links={entry.mechanics_links}
+                onNavigate={handleNavigate}
+              />
+            )}
           </div>
         ) : (
           <div className="italic text-muted-foreground">

--- a/frontend/src/codex/types.ts
+++ b/frontend/src/codex/types.ts
@@ -49,9 +49,18 @@ export interface CodexEntryListItem {
   knowledge_status: 'known' | 'uncovered' | null;
 }
 
+export interface CodexLinkRef {
+  match_text: string;
+  entry_id: number | null;
+  display_text: string;
+  accessible: boolean;
+}
+
 export interface CodexEntryDetail extends CodexEntryListItem {
   lore_content: string | null;
   mechanics_content: string | null;
+  lore_links: CodexLinkRef[];
+  mechanics_links: CodexLinkRef[];
   learn_threshold: number;
   research_progress: number | null;
 }

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -20648,6 +20648,14 @@ export interface components {
       readonly lore_content: string | null;
       /** @description Return mechanics content only if public or KNOWN. */
       readonly mechanics_content: string | null;
+      /** @description Return resolved wikilinks from lore_content. */
+      readonly lore_links: {
+        [key: string]: unknown;
+      }[];
+      /** @description Return resolved wikilinks from mechanics_content. */
+      readonly mechanics_links: {
+        [key: string]: unknown;
+      }[];
       /** @description If True, visible to everyone including logged-out visitors. If False, only visible to characters who have learned it. */
       is_public?: boolean;
       subject: number;

--- a/src/schema.json
+++ b/src/schema.json
@@ -35453,6 +35453,20 @@ components:
           nullable: true
           description: Return mechanics content only if public or KNOWN.
           readOnly: true
+        lore_links:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: Return resolved wikilinks from lore_content.
+          readOnly: true
+        mechanics_links:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: Return resolved wikilinks from mechanics_content.
+          readOnly: true
         is_public:
           type: boolean
           description: If True, visible to everyone including logged-out visitors.
@@ -35491,7 +35505,9 @@ components:
       - id
       - knowledge_status
       - lore_content
+      - lore_links
       - mechanics_content
+      - mechanics_links
       - name
       - research_progress
       - subject

--- a/src/world/codex/serializers.py
+++ b/src/world/codex/serializers.py
@@ -13,6 +13,7 @@ from world.codex.models import (
     CodexEntry,
     CodexSubject,
 )
+from world.codex.services import resolve_codex_links
 
 
 class CodexCategorySerializer(serializers.ModelSerializer):
@@ -137,6 +138,8 @@ class CodexEntryDetailSerializer(serializers.ModelSerializer):
     research_progress = serializers.IntegerField(read_only=True, allow_null=True)
     lore_content = serializers.SerializerMethodField()
     mechanics_content = serializers.SerializerMethodField()
+    lore_links = serializers.SerializerMethodField()
+    mechanics_links = serializers.SerializerMethodField()
 
     class Meta:
         model = CodexEntry
@@ -146,6 +149,8 @@ class CodexEntryDetailSerializer(serializers.ModelSerializer):
             "summary",
             "lore_content",
             "mechanics_content",
+            "lore_links",
+            "mechanics_links",
             "is_public",
             "subject",
             "subject_name",
@@ -174,3 +179,18 @@ class CodexEntryDetailSerializer(serializers.ModelSerializer):
     def get_mechanics_content(self, obj: CodexEntry) -> str | None:
         """Return mechanics content only if public or KNOWN."""
         return obj.mechanics_content if self._can_see_content(obj) else None
+
+    def _get_links(self, obj: CodexEntry, content: str | None) -> list[dict]:
+        """Resolve inline wikilinks if the reader can see the content."""
+        if not self._can_see_content(obj) or not content:
+            return []
+        roster_entry = self.context.get("roster_entry")
+        return resolve_codex_links(content, obj.subject, roster_entry)
+
+    def get_lore_links(self, obj: CodexEntry) -> list[dict]:
+        """Return resolved wikilinks from lore_content."""
+        return self._get_links(obj, obj.lore_content)
+
+    def get_mechanics_links(self, obj: CodexEntry) -> list[dict]:
+        """Return resolved wikilinks from mechanics_content."""
+        return self._get_links(obj, obj.mechanics_content)

--- a/src/world/codex/services.py
+++ b/src/world/codex/services.py
@@ -1,0 +1,146 @@
+"""Codex service functions.
+
+Link resolution for inline ``[[wikilink]]`` cross-references in codex entry
+content fields.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from world.codex.constants import CodexKnowledgeStatus
+from world.codex.models import CodexEntry
+
+if TYPE_CHECKING:
+    from world.codex.models import CodexSubject
+    from world.roster.models import RosterEntry
+
+#: Regex matching ``[[Entry Name]]`` wikilink syntax in content fields.
+#: Captures everything between the brackets (excluding closing brackets).
+WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def resolve_codex_links(
+    content: str | None,
+    subject: CodexSubject,
+    roster_entry: RosterEntry | None,
+) -> list[dict]:
+    """Parse ``[[Entry Name]]`` wikilinks from content and resolve to link refs.
+
+    Args:
+        content: The raw ``lore_content`` or ``mechanics_content`` text.
+        subject: The ``CodexSubject`` of the entry the content belongs to.
+            Used for same-subject preference in name resolution.
+        roster_entry: The reader's active roster entry, or ``None`` for
+            anonymous users. Controls access checking.
+
+    Returns:
+        A list of dicts, one per wikilink found, in order of appearance::
+
+            {
+                "match_text": "[[Shrouded Veil]]",   # raw [[...]] text
+                "entry_id": 42,                       # null if not found/inaccessible
+                "display_text": "Shrouded Veil",     # entry name, "???", or raw text
+                "accessible": True,                  # whether reader can view the entry
+            }
+
+    Resolution order for each link text:
+        1. Same-subject match (entry in *subject* with matching name).
+        2. Global match (any entry with matching name, first by display_order).
+        3. No match (typo or not-yet-created entry).
+
+    Three display_text cases:
+        - **Accessible** (entry found, reader can view): real entry name.
+        - **Inaccessible** (entry found, reader cannot view): ``"???"`` — the
+          entry name is never exposed.
+        - **No match** (no entry with that name): raw link text, so authors can
+          spot typos.
+
+    Name matching is case-sensitive (matches ``CharField`` ``__exact`` lookup).
+    ``[[shrouded veil]]`` will NOT match an entry named ``"Shrouded Veil"``.
+
+    Access check: ``is_public=True`` OR ``CharacterCodexKnowledge`` with
+    ``status=KNOWN`` for the roster_entry. If no roster_entry, only
+    ``is_public`` entries are accessible.
+    """
+    if not content:
+        return []
+
+    link_texts: list[str] = [match.group(1) for match in WIKILINK_RE.finditer(content)]
+
+    if not link_texts:
+        return []
+
+    # Batch-fetch all candidate entries matching any link text.
+    # Same-subject entries are preferred, so fetch them separately.
+    same_subject_entries = {
+        e.name: e for e in CodexEntry.objects.filter(subject=subject, name__in=link_texts)
+    }
+    same_subject_ids = set(same_subject_entries.values())
+    global_entries = {
+        e.name: e
+        for e in CodexEntry.objects.filter(name__in=link_texts).exclude(
+            pk__in=[e.pk for e in same_subject_ids]
+        )
+    }
+
+    # Build the set of accessible entry IDs for this reader.
+    all_candidate_ids = [e.pk for e in {**same_subject_entries, **global_entries}.values()]
+    accessible_ids: set[int] = set()
+    if all_candidate_ids:
+        public_ids = set(
+            CodexEntry.objects.filter(pk__in=all_candidate_ids, is_public=True).values_list(
+                "pk", flat=True
+            )
+        )
+        accessible_ids = public_ids
+        if roster_entry is not None:
+            known_ids = set(
+                CodexEntry.objects.filter(
+                    pk__in=all_candidate_ids,
+                    character_knowledge__roster_entry=roster_entry,
+                    character_knowledge__status=CodexKnowledgeStatus.KNOWN,
+                ).values_list("pk", flat=True)
+            )
+            accessible_ids |= known_ids
+
+    results: list[dict] = []
+    for match in WIKILINK_RE.finditer(content):
+        raw_text = match.group(1)
+        match_text = match.group(0)
+
+        entry = same_subject_entries.get(raw_text) or global_entries.get(raw_text)
+
+        if entry is None:
+            # No match — typo or not-yet-created entry. Show raw text so
+            # authors can spot the problem.
+            results.append(
+                {
+                    "match_text": match_text,
+                    "entry_id": None,
+                    "display_text": raw_text,
+                    "accessible": False,
+                }
+            )
+        elif entry.pk in accessible_ids:
+            results.append(
+                {
+                    "match_text": match_text,
+                    "entry_id": entry.pk,
+                    "display_text": entry.name,
+                    "accessible": True,
+                }
+            )
+        else:
+            # Entry exists but reader can't access it. Never expose the name.
+            results.append(
+                {
+                    "match_text": match_text,
+                    "entry_id": None,
+                    "display_text": "???",
+                    "accessible": False,
+                }
+            )
+
+    return results

--- a/src/world/codex/tests/test_link_resolution.py
+++ b/src/world/codex/tests/test_link_resolution.py
@@ -1,0 +1,181 @@
+"""
+Tests for codex inline link resolution service.
+
+Tests the resolve_codex_links() function that parses [[wikilink]] syntax
+from lore_content/mechanics_content and resolves to link refs with access
+checking.
+"""
+
+from django.test import TestCase
+
+from world.codex.constants import CodexKnowledgeStatus
+from world.codex.factories import (
+    CharacterCodexKnowledgeFactory,
+    CodexCategoryFactory,
+    CodexEntryFactory,
+    CodexSubjectFactory,
+)
+from world.codex.services import resolve_codex_links
+from world.roster.factories import RosterEntryFactory
+
+
+class ResolveCodexLinksTests(TestCase):
+    """Tests for resolve_codex_links()."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.category = CodexCategoryFactory(name="Link Test Category")
+        cls.subject = CodexSubjectFactory(category=cls.category, name="Link Test Subject")
+        cls.other_subject = CodexSubjectFactory(category=cls.category, name="Other Subject")
+
+        # Public entry in same subject
+        cls.same_subject_public = CodexEntryFactory(
+            subject=cls.subject,
+            name="Same Subject Public",
+            lore_content="Some lore",
+            is_public=True,
+        )
+
+        # Public entry in a different subject
+        cls.other_subject_public = CodexEntryFactory(
+            subject=cls.other_subject,
+            name="Other Subject Public",
+            lore_content="Some lore",
+            is_public=True,
+        )
+
+        # Restricted (private) entry in same subject
+        cls.restricted_entry = CodexEntryFactory(
+            subject=cls.subject,
+            name="Restricted Entry",
+            lore_content="Secret lore",
+            is_public=False,
+        )
+
+        cls.roster_entry = RosterEntryFactory()
+
+    def test_resolve_links_same_subject(self):
+        """Link resolves to entry in same subject first."""
+        content = "See [[Same Subject Public]] for details."
+        links = resolve_codex_links(content, self.subject, None)
+        assert len(links) == 1
+        assert links[0]["entry_id"] == self.same_subject_public.pk
+        assert links[0]["display_text"] == "Same Subject Public"
+        assert links[0]["accessible"] is True
+
+    def test_resolve_links_global_fallback(self):
+        """Link resolves to entry in different subject when no same-subject match."""
+        content = "See [[Other Subject Public]] for more."
+        links = resolve_codex_links(content, self.subject, None)
+        assert len(links) == 1
+        assert links[0]["entry_id"] == self.other_subject_public.pk
+        assert links[0]["accessible"] is True
+
+    def test_resolve_links_inaccessible_shows_unknown(self):
+        """Link to private entry the reader hasn't learned returns ??? and no entry_id."""
+        content = "See [[Restricted Entry]] if you dare."
+        links = resolve_codex_links(content, self.subject, None)
+        assert len(links) == 1
+        assert links[0]["entry_id"] is None
+        assert links[0]["display_text"] == "???"
+        assert links[0]["accessible"] is False
+
+    def test_resolve_links_public_accessible_to_anonymous(self):
+        """Public entry links are accessible even without a roster entry."""
+        content = "See [[Same Subject Public]]."
+        links = resolve_codex_links(content, self.subject, None)
+        assert links[0]["accessible"] is True
+        assert links[0]["entry_id"] == self.same_subject_public.pk
+
+    def test_resolve_links_no_match(self):
+        """Link text that doesn't match any entry returns raw text, not ???."""
+        content = "See [[Nonexistent Entry]] for nothing."
+        links = resolve_codex_links(content, self.subject, None)
+        assert len(links) == 1
+        assert links[0]["entry_id"] is None
+        assert links[0]["display_text"] == "Nonexistent Entry"
+        assert links[0]["accessible"] is False
+
+    def test_resolve_links_inaccessible_vs_no_match(self):
+        """Existing-but-locked entry returns ???, non-existent returns raw text."""
+        content = "[[Restricted Entry]] and [[Totally Fake Entry]] in one string."
+        links = resolve_codex_links(content, self.subject, None)
+        assert len(links) == 2
+
+        # First link: entry exists but is restricted
+        assert links[0]["display_text"] == "???"
+        assert links[0]["entry_id"] is None
+        assert links[0]["accessible"] is False
+
+        # Second link: no entry with that name
+        assert links[1]["display_text"] == "Totally Fake Entry"
+        assert links[1]["entry_id"] is None
+        assert links[1]["accessible"] is False
+
+    def test_resolve_links_known_entry_accessible(self):
+        """Restricted entry is accessible when reader has KNOWN status."""
+        CharacterCodexKnowledgeFactory(
+            roster_entry=self.roster_entry,
+            entry=self.restricted_entry,
+            status=CodexKnowledgeStatus.KNOWN,
+        )
+        content = "See [[Restricted Entry]]."
+        links = resolve_codex_links(content, self.subject, self.roster_entry)
+        assert len(links) == 1
+        assert links[0]["entry_id"] == self.restricted_entry.pk
+        assert links[0]["display_text"] == "Restricted Entry"
+        assert links[0]["accessible"] is True
+
+    def test_resolve_links_uncovered_not_accessible(self):
+        """Restricted entry with UNCOVERED status is NOT accessible."""
+        CharacterCodexKnowledgeFactory(
+            roster_entry=self.roster_entry,
+            entry=self.restricted_entry,
+            status=CodexKnowledgeStatus.UNCOVERED,
+        )
+        content = "See [[Restricted Entry]]."
+        links = resolve_codex_links(content, self.subject, self.roster_entry)
+        assert links[0]["accessible"] is False
+        assert links[0]["display_text"] == "???"
+
+    def test_resolve_links_multiple_links(self):
+        """Multiple links in one content string are all resolved."""
+        content = (
+            "[[Same Subject Public]] and [[Other Subject Public]] "
+            "and [[Restricted Entry]] and [[Fake Entry]]."
+        )
+        links = resolve_codex_links(content, self.subject, None)
+        assert len(links) == 4
+        assert links[0]["display_text"] == "Same Subject Public"
+        assert links[1]["display_text"] == "Other Subject Public"
+        assert links[2]["display_text"] == "???"
+        assert links[3]["display_text"] == "Fake Entry"
+
+    def test_resolve_links_empty_content(self):
+        """Empty or None content returns empty list."""
+        assert resolve_codex_links("", self.subject, None) == []
+        assert resolve_codex_links(None, self.subject, None) == []
+
+    def test_resolve_links_no_links_in_content(self):
+        """Content without wikilinks returns empty list."""
+        content = "Just plain text with no links."
+        links = resolve_codex_links(content, self.subject, None)
+        assert links == []
+
+    def test_resolve_links_case_sensitive(self):
+        """Name matching is case-sensitive."""
+        content = "See [[same subject public]]."
+        links = resolve_codex_links(content, self.subject, None)
+        assert len(links) == 1
+        assert links[0]["entry_id"] is None
+        assert links[0]["display_text"] == "same subject public"
+        assert links[0]["accessible"] is False
+
+    def test_resolve_links_inaccessible_does_not_leak_name(self):
+        """The entry name of an inaccessible entry never appears in the response."""
+        content = "See [[Restricted Entry]]."
+        links = resolve_codex_links(content, self.subject, None)
+        assert links[0]["display_text"] == "???"
+        # The real name "Restricted Entry" should not appear anywhere in the link ref
+        assert "Restricted Entry" not in links[0]["display_text"]
+        assert links[0]["entry_id"] is None

--- a/src/world/codex/tests/test_views.py
+++ b/src/world/codex/tests/test_views.py
@@ -294,6 +294,76 @@ class TestCodexEntryAPI(CodexAPITestCase):
         assert data["research_progress"] == 5
         assert data["learn_threshold"] == self.restricted_entry.learn_threshold
 
+    def test_lore_links_in_response_for_public_entry(self):
+        """lore_links field is present and resolved for public entries."""
+        linked_entry = CodexEntryFactory(
+            subject=self.subject,
+            name="Linked Public Entry",
+            lore_content="Linked lore",
+            is_public=True,
+        )
+        entry_with_link = CodexEntryFactory(
+            subject=self.subject,
+            name="Entry With Link",
+            lore_content="See [[Linked Public Entry]] for details.",
+            is_public=True,
+        )
+        response = self.client.get(f"/api/codex/entries/{entry_with_link.id}/")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.data
+        assert "lore_links" in data
+        assert "mechanics_links" in data
+        assert len(data["lore_links"]) == 1
+        assert data["lore_links"][0]["entry_id"] == linked_entry.id
+        assert data["lore_links"][0]["accessible"] is True
+
+    def test_links_empty_when_content_gated(self):
+        """lore_links is empty list when content is not visible."""
+        CharacterCodexKnowledgeFactory(
+            roster_entry=self.roster_entry,
+            entry=self.restricted_entry,
+            status=CodexKnowledgeStatus.UNCOVERED,
+        )
+        # Create a new restricted entry with a link (can't .save() existing
+        # entries due to the breadcrumb REFRESH MATERIALIZED VIEW on SQLite)
+        entry_with_link = CodexEntryFactory(
+            subject=self.subject,
+            name="Gated Entry With Link",
+            lore_content="See [[Public Entry]].",
+            is_public=False,
+        )
+        CharacterCodexKnowledgeFactory(
+            roster_entry=self.roster_entry,
+            entry=entry_with_link,
+            status=CodexKnowledgeStatus.UNCOVERED,
+        )
+        self.client.force_authenticate(user=self.account)
+        response = self.client.get(f"/api/codex/entries/{entry_with_link.id}/")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.data
+        assert data["lore_content"] is None
+        assert data["lore_links"] == []
+
+    def test_inaccessible_link_does_not_leak_name(self):
+        """Inaccessible link in content returns ??? and no entry_id."""
+        # Public entry links to a restricted entry the reader can't see
+        entry_with_link = CodexEntryFactory(
+            subject=self.subject,
+            name="Entry With Inaccessible Link",
+            lore_content="See [[Restricted Entry]] if you dare.",
+            is_public=True,
+        )
+        response = self.client.get(f"/api/codex/entries/{entry_with_link.id}/")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.data
+        assert len(data["lore_links"]) == 1
+        link = data["lore_links"][0]
+        assert link["entry_id"] is None
+        assert link["display_text"] == "???"
+        assert link["accessible"] is False
+        # The real entry name must not appear
+        assert "Restricted Entry" not in link["display_text"]
+
 
 class TestCodexTreeQueryCount(TestCase):
     """Lock the query count on the codex tree endpoint.

--- a/src/world/codex/views.py
+++ b/src/world/codex/views.py
@@ -233,6 +233,12 @@ class CodexEntryViewSet(viewsets.ReadOnlyModelViewSet):
             return CodexEntryDetailSerializer
         return CodexEntryListSerializer
 
+    def get_serializer_context(self):
+        """Pass roster_entry so the detail serializer can resolve wikilinks."""
+        context = super().get_serializer_context()
+        context["roster_entry"] = self._get_active_roster_entry()
+        return context
+
     def _get_active_roster_entry(self):
         if not self.request.user.is_authenticated:
             return None


### PR DESCRIPTION
Closes #2404

## Summary

Inline [[wikilink]] cross-references for codex entries. Authors write [[Entry Name]] in lore_content/mechanics_content; the backend resolves to link refs with access checking; the frontend renders accessible links as clickable (with back/forward modal navigation) and inaccessible ones as ??? (mystery teaser). Adopts react-markdown for content rendering (first use in codex, already used in inventory/mail).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2404 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch is up to date with main, no conflicts.

<!-- last-addressed-comment: 0 -->