### PR TITLE
Silent-fail audit tranche 4: broad-except triage — all 127 handlers classified, BROAD_EXCEPT ratcheted

### DIFF
--- a/src/actions/definitions/alterations.py
+++ b/src/actions/definitions/alterations.py
@@ -10,11 +10,14 @@ returns a user-safe ``ActionResult`` for both surfaces.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from typing import TYPE_CHECKING, Any
 
 from actions.base import Action
 from actions.types import ActionResult, TargetType
 from world.magic.types import AlterationResolutionError
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from evennia.accounts.models import AccountDB
@@ -84,7 +87,8 @@ class ResolveAlterationAction(Action):
             )
         except AlterationResolutionError as exc:
             return None, exc.user_message
-        except Exception:  # noqa: BLE001
+        except Exception:
+            logger.exception("Mage Scar resolution failed")
             return None, "The Mage Scar could not be resolved. Please contact staff."
         return result, ""
 
@@ -157,7 +161,8 @@ class ResolveAlterationAction(Action):
             )
         except AlterationResolutionError as exc:
             return None, exc.user_message
-        except Exception:  # noqa: BLE001
+        except Exception:
+            logger.exception("Mage Scar resolution failed")
             return None, "The Mage Scar could not be resolved. Please contact staff."
         return result, ""
 

--- a/src/actions/definitions/cast.py
+++ b/src/actions/definitions/cast.py
@@ -50,7 +50,7 @@ class CastTechniqueAction(Action):
     category: str = "magic"
     target_type: TargetType = TargetType.SELF
 
-    def execute(  # noqa: PLR0913, C901, PLR0911
+    def execute(  # noqa: PLR0913, PLR0911
         self,
         actor: ObjectDB,
         context: ActionContext | None = None,
@@ -117,6 +117,8 @@ class CastTechniqueAction(Action):
             except Resonance.DoesNotExist:
                 return ActionResult(success=False, message="Resonance not found.")
 
+        from world.magic.exceptions import MagicError  # noqa: PLC0415
+
         try:
             cast = request_technique_cast(
                 scene=scene,
@@ -129,16 +131,12 @@ class CastTechniqueAction(Action):
                 position_params=position_params,
                 preferred_resonance=preferred_resonance,
             )
-        except Exception as exc:
-            # Surface magic-layer exceptions (e.g. MagicError subclasses for
-            # invalid/inert pull declarations) as clean failure results rather
-            # than propagating as crashes.  Re-raise anything that is not a
-            # MagicError so programming errors are still visible.
-            from world.magic.exceptions import MagicError  # noqa: PLC0415
-
-            if not isinstance(exc, MagicError):
-                raise
-            return ActionResult(success=False, message=str(exc))
+        except MagicError as exc:
+            # Surface magic-layer failures (e.g. invalid/inert pull
+            # declarations) as clean failure results; anything else propagates
+            # so programming errors stay visible. user_message, never str(exc)
+            # (exception detail must not reach players).
+            return ActionResult(success=False, message=exc.user_message)
 
         if cast.soulfray_warning is not None and not confirm_soulfray_risk:
             from commands.pending_actions import PendingCast, register_pending  # noqa: PLC0415

--- a/src/actions/definitions/endorsements.py
+++ b/src/actions/definitions/endorsements.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from django.core.exceptions import ObjectDoesNotExist
+
 from actions.base import Action
 from actions.types import ActionContext, ActionResult, TargetType
 
@@ -135,7 +137,7 @@ class SceneEntryEndorseAction(Action):
 
         try:
             persona_name = endorsee_sheet.primary_persona.name
-        except Exception:  # noqa: BLE001
+        except ObjectDoesNotExist:
             persona_name = str(endorsee_sheet)
 
         return ActionResult(
@@ -196,7 +198,7 @@ class StylePresentationEndorseAction(Action):
 
         try:
             persona_name = endorsee_sheet.primary_persona.name
-        except Exception:  # noqa: BLE001
+        except ObjectDoesNotExist:
             persona_name = str(endorsee_sheet)
 
         return ActionResult(

--- a/src/actions/definitions/items.py
+++ b/src/actions/definitions/items.py
@@ -393,7 +393,10 @@ class ActivatePermitAction(Action):
             PermitValidationError,
             activate_permit,
         )
-        from world.scenes.services import persona_for_character  # noqa: PLC0415
+        from world.scenes.services import (  # noqa: PLC0415
+            MissingPrimaryPersonaError,
+            persona_for_character,
+        )
 
         target = kwargs.get("target")
         if target is None:
@@ -415,7 +418,7 @@ class ActivatePermitAction(Action):
 
         try:
             persona = persona_for_character(actor)
-        except Exception:  # noqa: BLE001
+        except MissingPrimaryPersonaError:
             return ActionResult(
                 success=False,
                 message="You don't have a persona to activate this permit with.",

--- a/src/actions/definitions/social.py
+++ b/src/actions/definitions/social.py
@@ -478,10 +478,9 @@ class EntranceAction(_SocialTemplateAction):
                 confirm_soulfray_risk=confirm_soulfray_risk,
                 originated_as_entrance=True,
             )
-        except Exception as exc:
-            if not isinstance(exc, MagicError):
-                raise
-            return _ActionResult(success=False, message=str(exc))
+        except MagicError as exc:
+            # user_message, never str(exc) — exception detail must not reach players.
+            return _ActionResult(success=False, message=exc.user_message)
 
         if cast.soulfray_warning is not None and not confirm_soulfray_risk:
             return self._register_entrance_soulfray_pending(

--- a/src/actions/player_interface.py
+++ b/src/actions/player_interface.py
@@ -59,6 +59,8 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from django.core.exceptions import ObjectDoesNotExist
+
 from actions.constants import ActionBackend, ActionCategory, TargetKind
 from actions.errors import ActionDispatchError
 from actions.registry import get_action
@@ -1353,7 +1355,8 @@ def _tenure_persona_ids(tenure: object) -> set[int]:
     try:
         sheet = tenure.roster_entry.character_sheet  # type: ignore[union-attr]
         return set(sheet.personas.values_list("pk", flat=True))
-    except Exception:  # noqa: BLE001
+    except (AttributeError, ObjectDoesNotExist):
+        # Broken tenure→sheet chain (test/NPC data); read-only helper.
         return set()
 
 

--- a/src/cli/arx.py
+++ b/src/cli/arx.py
@@ -349,7 +349,8 @@ def _find_evennia_processes() -> list[dict]:
         if platform.system() == _WINDOWS:
             return _find_evennia_processes_windows()
         return _find_evennia_processes_unix()
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001 — CLI discovery boundary
+        typer.echo(f"WARNING: process discovery failed: {exc!r}", err=True)
         return []
 
 
@@ -370,7 +371,8 @@ def _kill_process(pid: int) -> bool:
 
         os.kill(pid, signal.SIGKILL)
         return True
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001 — per-process kill isolation
+        typer.echo(f"WARNING: could not kill pid {pid}: {exc!r}", err=True)
         return False
 
 
@@ -406,7 +408,7 @@ def _cleanup_pid_files() -> list[str]:
             try:
                 pid_file.unlink()
                 removed.append(str(pid_file))
-            except Exception:  # noqa: BLE001, S110
+            except OSError:
                 pass
 
     return removed
@@ -548,7 +550,7 @@ def _get_ngrok_status() -> dict | None:
                             "url": tunnel.get("public_url"),
                             "port": port,
                         }
-    except Exception:  # noqa: BLE001, S110
+    except requests.RequestException:
         pass
     return None
 
@@ -567,7 +569,7 @@ def _kill_ngrok() -> None:
             )
         else:
             subprocess.run(["pkill", "-9", "ngrok"], capture_output=True, check=False)
-    except Exception:  # noqa: BLE001, S110
+    except OSError:
         pass
 
 
@@ -733,8 +735,8 @@ def ngrok(  # noqa: C901, PLR0915
                 typer.echo("\nStopping ngrok tunnel...")
                 pyngrok.disconnect(tunnel.public_url)
                 typer.echo("SUCCESS: Stopped ngrok tunnel")
-            except Exception:  # noqa: BLE001
-                typer.echo("WARNING: Error stopping ngrok")
+            except Exception as exc:  # noqa: BLE001 — atexit cleanup boundary
+                typer.echo(f"WARNING: Error stopping ngrok: {exc!r}", err=True)
 
         _restore_env_file(env_file, env_backup)
 

--- a/src/commands/endorse.py
+++ b/src/commands/endorse.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from django.core.exceptions import ObjectDoesNotExist
+
 from commands.command import ArxCommand
 from commands.exceptions import CommandError
 
@@ -75,7 +77,7 @@ class CmdPoses(ArxCommand):
 
         try:
             persona_name = endorsee_sheet.primary_persona.name
-        except Exception:  # noqa: BLE001
+        except ObjectDoesNotExist:
             persona_name = char_name
 
         _PREVIEW_LEN = 80

--- a/src/commands/react.py
+++ b/src/commands/react.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from django.core.exceptions import ValidationError as DjangoValidationError
+
 from commands.command import ArxCommand
 from commands.exceptions import CommandError
 
@@ -232,7 +234,7 @@ class CmdReact(ArxCommand):
         for w in windows:
             try:
                 chips = ", ".join(c.label for c in get_reaction_kind(w.kind).choices_for(w))
-            except Exception:  # noqa: BLE001
+            except DjangoValidationError:
                 chips = "(unknown)"
             pose_preview = (w.interaction.content or "")[:40]
             lines.append(f"  #{w.kind} {pose_preview}...  choices: {chips}")

--- a/src/commands/utils/__init__.py
+++ b/src/commands/utils/__init__.py
@@ -43,6 +43,7 @@ def _has_command_access(command: Any, cmdset_obj: Any, source_name: str) -> bool
             source_name,
             _get_command_key(command),
             e,
+            exc_info=True,
         )
         return False
 
@@ -62,6 +63,7 @@ def _serialize_command(
             source_name,
             _get_command_key(command),
             e,
+            exc_info=True,
         )
 
 

--- a/src/evennia_extensions/admin.py
+++ b/src/evennia_extensions/admin.py
@@ -3,6 +3,7 @@ Django admin configuration for evennia_extensions models.
 """
 
 import contextlib
+import logging
 from typing import ClassVar
 
 from allauth.account.models import EmailAddress, EmailConfirmation
@@ -18,6 +19,8 @@ from evennia_extensions.models import (
     RoomProfile,
     RoomSizeTier,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @admin.register(PlayerData)
@@ -179,6 +182,7 @@ class EmailAddressAdmin(admin.ModelAdmin):
                 sent_count += 1
 
             except Exception as e:
+                logger.exception("Verification email send failed for %s", email_address.email)
                 error_count += 1
                 self.message_user(
                     request,

--- a/src/flows/service_functions/movement.py
+++ b/src/flows/service_functions/movement.py
@@ -1,7 +1,11 @@
 """Movement-related service functions."""
 
+import logging
+
 from commands.exceptions import CommandError
 from flows.object_states.base_state import BaseState
+
+logger = logging.getLogger(__name__)
 
 
 def move_object(
@@ -121,6 +125,8 @@ def traverse_exit(
         try:
             exit.obj.at_traverse(caller.obj, destination.obj)
         except Exception as e:
+            # Without this log a real traverse bug reads as a locked door.
+            logger.exception("at_traverse failed for exit %s", exit.obj.pk)
             if hasattr(exit.obj, "at_failed_traverse"):
                 exit.obj.at_failed_traverse(caller.obj)
             else:

--- a/src/flows/service_functions/serializers/communication.py
+++ b/src/flows/service_functions/serializers/communication.py
@@ -68,15 +68,15 @@ class MessageContentSerializer(serializers.Serializer):
         }
 
     def _render_template(self, template: str, variables: dict[str, str]) -> str:
-        """Render template with variable substitution."""
-        try:
-            # Simple variable substitution - enhance with proper templating
-            result = template
-            for key, value in variables.items():
-                result = result.replace(f"{{{key}}}", str(value))
-            return result
-        except Exception:  # noqa: BLE001
-            return template
+        """Render template with variable substitution.
+
+        No try/except: ``str.replace`` cannot raise for string inputs — the
+        old broad catch only masked bad-variable-type bugs (#2386 tranche 4).
+        """
+        result = template
+        for key, value in variables.items():
+            result = result.replace(f"{{{key}}}", str(value))
+        return result
 
 
 class ChatMessageSerializer(serializers.Serializer):

--- a/src/server/portal/secure_websocket.py
+++ b/src/server/portal/secure_websocket.py
@@ -121,8 +121,9 @@ class SecureWebSocketClient(WebSocketClient):
                         ],
                     )
                     active_sessions = same_csession_count + 1  # +1 for current session
-                except Exception:  # noqa: BLE001
-                    # Fallback: always preserve session to be safe
+                except Exception:  # noqa: BLE001 — session-count boundary
+                    # Fallback: always preserve session to be safe.
+                    logger.log_err("session count failed; preserving webclient session")
                     active_sessions = 2
 
             # Only clear webclient auth if this is the last session AND nonce matches

--- a/src/web/admin/services.py
+++ b/src/web/admin/services.py
@@ -414,7 +414,8 @@ def _analyze_model(
 
     try:
         ma.in_db = model_class.objects.count()
-    except Exception:  # noqa: BLE001
+    except Exception:
+        logger.exception("analyze_fixture: count() failed for %s", model_class.__name__)
         ma.warnings.append("Could not query existing records.")
         return ma
 
@@ -468,7 +469,8 @@ def _classify_record(
     except model_class.DoesNotExist:
         ma.new_count += 1
         return
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
+        logger.exception("analyze_fixture: natural-key lookup failed for %s", nk)
         ma.warnings.append(f"Error looking up {nk}: {exc}")
         ma.new_count += 1
         return
@@ -493,7 +495,10 @@ def _find_local_only_records(
             if obj_nk_str not in seen_nk_strs:
                 ma.local_only_count += 1
                 ma.local_only_records.append(obj_nk_str)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
+        logger.exception(
+            "analyze_fixture: local-only enumeration failed for %s", model_class.__name__
+        )
         ma.warnings.append(f"Could not enumerate local-only records: {exc}")
 
 

--- a/src/web/admin/views.py
+++ b/src/web/admin/views.py
@@ -208,7 +208,8 @@ def import_upload(request):
         try:
             content = uploaded_file.read().decode("utf-8")
             analysis = analyze_fixture(content)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
+            logger.exception("Fixture upload parse failed")
             return render(
                 request,
                 "admin/import_upload.html",

--- a/src/world/agriculture/services/collection.py
+++ b/src/world/agriculture/services/collection.py
@@ -58,10 +58,10 @@ def _pool_difficulty_bonus(field_instance, _character=None) -> int:
     """
     from world.agriculture.services.production import get_food_config  # noqa: PLC0415
 
-    try:
-        pool = field_instance.field_details.uncollected_pool
-    except Exception:  # noqa: BLE001
+    details = field_instance.field_details_or_none
+    if details is None:
         return 0
+    pool = details.uncollected_pool
 
     config = get_food_config()
     threshold = config.pool_difficulty_threshold

--- a/src/world/agriculture/services/domain.py
+++ b/src/world/agriculture/services/domain.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.db import OperationalError, ProgrammingError
+
 if TYPE_CHECKING:
     from world.room_features.models import RoomFeatureInstance
     from world.societies.houses.models import Domain
@@ -22,8 +24,8 @@ def _ancestor_area_ids(area) -> set[int]:
         ancestor_ids = set(
             AreaClosure.objects.filter(descendant_id=area.pk).values_list("ancestor_id", flat=True)
         )
-    except Exception:  # noqa: BLE001
-        # SQLite test fallback: walk the parent chain manually.
+    except (OperationalError, ProgrammingError):
+        # SQLite test fallback (AreaClosure matview missing): walk the parent chain.
         ancestor_ids = set()
         current = area
         while current is not None:
@@ -77,7 +79,7 @@ def max_food_capacity(domain: Domain) -> int:
                 "descendant_id", flat=True
             )
         )
-    except Exception:  # noqa: BLE001
+    except (OperationalError, ProgrammingError):
         # SQLite test fallback: no descendants table — just use the area itself.
         descendant_ids = {domain_area.pk}
     descendant_ids.add(domain_area.pk)

--- a/src/world/character_sheets/serializers.py
+++ b/src/world/character_sheets/serializers.py
@@ -696,9 +696,8 @@ def _build_magic_anima_ritual(sheet: CharacterSheet) -> AnimaRitualSection | Non
         return None
 
     ritual = rituals[0]
-    try:
-        config = ritual.check_config
-    except Exception:  # noqa: BLE001
+    config = ritual.check_config_or_none
+    if config is None:
         return None
 
     return AnimaRitualSection(

--- a/src/world/checks/theater.py
+++ b/src/world/checks/theater.py
@@ -18,7 +18,10 @@ the outcome is the meal.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
@@ -79,6 +82,7 @@ def maybe_emit_resolution_theater(
     payload = build_roulette_payload(title=title, consequences=consequences, selected=selected)
     try:
         character.msg(roulette_result=((), payload))
-    except Exception:  # noqa: BLE001 - theater must never break resolution
+    except Exception:  # noqa: BLE001 — theater must never break resolution
+        logger.debug("roulette payload delivery failed", exc_info=True)
         return False
     return True

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from http import HTTPMethod
+import logging
 from typing import cast
 
 from django.db.models import Prefetch, Q, QuerySet
@@ -83,6 +84,8 @@ from world.items.models import ItemInstance
 from world.scenes.constants import PersonaType, RoundStatus
 from world.scenes.models import Persona, Scene
 from world.stories.pagination import StandardResultsSetPagination
+
+logger = logging.getLogger(__name__)
 
 # Fixed error messages for API responses (never expose raw exception strings).
 _ERR_NOT_PARTICIPANT = "Not a participant in this encounter."
@@ -365,7 +368,10 @@ class CombatEncounterViewSet(ModelViewSet):
                 sheet,
                 covenant_role=covenant_role,
             )
-        except Exception:  # noqa: BLE001
+        except Exception:
+            logger.exception(
+                "add_participant failed for encounter %s sheet %s", encounter.pk, sheet.pk
+            )
             return Response(
                 {"detail": _ERR_ADD_PARTICIPANT},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/src/world/currency/views.py
+++ b/src/world/currency/views.py
@@ -10,6 +10,8 @@ so the UI can show who may spend).
 
 from __future__ import annotations
 
+import logging
+
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import NotFound, PermissionDenied
@@ -33,6 +35,8 @@ from world.currency.services import (
     get_or_create_treasury,
 )
 from world.roster.models import RosterEntry
+
+logger = logging.getLogger(__name__)
 
 _MSG_NO_ORG = "No such organization."
 _MSG_NOT_MEMBER = "You are not a member of that organization."
@@ -192,7 +196,8 @@ def _viewer_persona(request: Request):
         return None
     try:
         return active_persona_for_sheet(sheet)
-    except Exception:  # noqa: BLE001 - fail closed: any resolution fault → deny
+    except Exception:
+        logger.exception("Persona resolution failed for sheet %s; denying", sheet.pk)
         return None
 
 

--- a/src/world/items/services/equip.py
+++ b/src/world/items/services/equip.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 
 from world.items.exceptions import ItemPlacedNotEquippable, SlotConflict, SlotIncompatible
 from world.items.models import EquippedItem, ItemInstance
+
+logger = logging.getLogger(__name__)
 
 
 @transaction.atomic
@@ -100,7 +105,10 @@ def _recompute_body_persona_items_prestige(character_sheet: object) -> None:
 
     try:
         persona = character_sheet.primary_persona
-    except Exception:  # noqa: BLE001 — sheet invariant violated; render no credit.
+    except ObjectDoesNotExist:
+        # Sheet invariant violated (no PRIMARY persona): no prestige credit,
+        # but log it — this is a broken invariant, not an expected state.
+        logger.exception("primary_persona missing for sheet %s", character_sheet.pk)
         return
     if persona is not None:
         recompute_persona_prestige_from_items(persona)

--- a/src/world/magic/exceptions.py
+++ b/src/world/magic/exceptions.py
@@ -5,7 +5,25 @@ from typing import ClassVar
 
 
 class MagicError(Exception):
+    """Base for player-surfaceable magic failures.
+
+    ``user_message`` is what reaches the player. Raise-sites that pass an
+    explicit message are authoring player-facing text (e.g. "Unknown
+    resonance.") and it becomes the user_message; raising with no args keeps
+    the subclass's class-level message. Never surface ``str(exc)`` of other
+    exception types (#2386 tranche 4).
+    """
+
     user_message = "An error occurred."
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+        # Only bare MagicError treats its message as player text (the pull
+        # paths author these). Subclasses raise with INTERNAL detail ("Need
+        # 100 XP … trait_258") and keep their curated class-level
+        # user_message — never leak the internals.
+        if type(self) is MagicError and args and isinstance(args[0], str) and args[0]:
+            self.user_message = args[0]
 
 
 class ResonanceInsufficient(MagicError):

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -1104,9 +1104,8 @@ class RitualSerializer(serializers.ModelSerializer):
 
     def get_check_config(self, obj: Ritual) -> dict | None:
         """Return nested check_config when present, else None."""
-        try:
-            config = obj.check_config
-        except Exception:  # noqa: BLE001
+        config = obj.check_config_or_none
+        if config is None:
             return None
         return RitualCheckConfigSerializer(config).data
 
@@ -1201,9 +1200,8 @@ class RitualPatchSerializer(serializers.ModelSerializer):
         config_data = validated_data.pop("check_config", None)
         ritual = super().update(instance, validated_data)
         if config_data:
-            try:
-                config = instance.check_config
-            except Exception:  # noqa: BLE001
+            config = instance.check_config_or_none
+            if config is None:
                 return ritual
             for field, value in config_data.items():
                 setattr(config, field, value)

--- a/src/world/magic/services/anima_ritual_action.py
+++ b/src/world/magic/services/anima_ritual_action.py
@@ -48,10 +48,8 @@ def _resolve_anima_ritual(
         return  # silently no-op on malformed request
 
     # Ensure the config is loaded (may already be via select_related above).
-    try:
-        _ = ritual.check_config
-    except Exception:  # noqa: BLE001
-        return  # SCENE_ACTION ritual missing config — silently skip
+    if ritual.check_config_or_none is None:
+        return  # SCENE_ACTION ritual missing config — skip
 
     main_result = result.action_resolution.main_result
     if main_result is None or main_result.check_result is None:

--- a/src/world/magic/services/gain.py
+++ b/src/world/magic/services/gain.py
@@ -1094,8 +1094,8 @@ def outfit_trickle_tick() -> int:
         try:
             with transaction.atomic():
                 total_grants += outfit_daily_trickle_for_character(sheet)
-        except Exception:  # noqa: BLE001, S112
-            # TODO: structured log via Evennia logger.
+        except Exception:
+            logger.exception("Outfit resonance trickle failed for sheet %s", sheet.pk)
             continue
 
     return total_grants

--- a/src/world/missions/services/cron.py
+++ b/src/world/missions/services/cron.py
@@ -23,6 +23,8 @@ outcome.
 
 from __future__ import annotations
 
+import logging
+
 from django.db import transaction
 from django.utils import timezone
 
@@ -30,6 +32,8 @@ from world.missions.constants import DeedRewardKind, DeedRewardSink
 from world.missions.models import MissionRewardQueue
 from world.missions.services.rewards import MissionRewardRoutingError
 from world.missions.types import RewardBatchResult
+
+logger = logging.getLogger(__name__)
 
 # Per-sink stub-seal messages. LP references DESIGN §13.3 — the missions
 # design doc section that explains why the LP grant needs a richer payload
@@ -174,7 +178,8 @@ def apply_mission_reward_batch() -> RewardBatchResult:
             _record_failure(row, exc.user_message)
             failed.append(row)
             continue
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
+            logger.exception("Mission reward routing failed for queue row %s", row.pk)
             _record_failure(row, f"{type(exc).__name__}: {exc}")
             failed.append(row)
             continue

--- a/src/world/missions/services/opportunities.py
+++ b/src/world/missions/services/opportunities.py
@@ -16,6 +16,7 @@ at the giver/board (the tab is the map, not the door).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import logging
 from typing import TYPE_CHECKING, cast
 
 from django.db.models import Q
@@ -25,6 +26,8 @@ from world.missions.models import MissionGiver
 from world.missions.services.boards import postings_for_giver
 from world.missions.services.visibility import template_visible_to
 from world.scenes.services import MissingPrimaryPersonaError, persona_for_character
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
@@ -109,7 +112,9 @@ def _nearby_givers(character: ObjectDB, room: ObjectDB | None) -> list[Opportuni
 
     try:
         profile = get_room_profile(room)
-    except Exception:  # noqa: BLE001 — room without a profile: no area
+    except Exception:
+        # so anything caught here is a real fault worth a traceback.
+        logger.exception("get_room_profile failed for room %s", room.pk)
         return []
     if profile.area_id is None:
         return []

--- a/src/world/missions/services/rewards.py
+++ b/src/world/missions/services/rewards.py
@@ -304,10 +304,9 @@ def _route_crime_watch(
 
 def _deliver_immediate_money(line: MissionDeedRewardLine) -> None:
     """Deliver an IMMEDIATE MONEY line, falling back to the stub when sheet-less."""
-    try:
-        sheet = line.recipient.sheet_data
-    except Exception:  # noqa: BLE001 - sheet-less recipient: keep stub fallback
-        sheet = None
+    # character_sheet is the safe accessor: sheet-less recipient → None (stub
+    # fallback); genuine faults propagate instead of misrouting to the stub.
+    sheet = line.recipient.character_sheet
     if sheet is not None:
         deliver_mission_money(recipient_sheet=sheet, amount=line.amount, ref=line.ref)
     else:

--- a/src/world/progression/models/unlocks.py
+++ b/src/world/progression/models/unlocks.py
@@ -10,7 +10,7 @@ This module contains models related to unlocks and requirements:
 
 from typing import ClassVar, cast
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
 from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
@@ -331,7 +331,7 @@ class TraitRequirement(AbstractClassLevelRequirement):
                 f"Need {self.trait.name} {cast(int, self.minimum_value) / RATING_DIVISOR:.1f}, "
                 f"have {trait_value.display_value}",
             )
-        except Exception:  # noqa: BLE001
+        except ObjectDoesNotExist:
             return (
                 False,
                 (
@@ -397,7 +397,7 @@ class ClassLevelRequirement(AbstractClassLevelRequirement):
                 f"Need {self.character_class.name} level {self.minimum_level}, "
                 f"have {class_level.level}",
             )
-        except Exception:  # noqa: BLE001
+        except ObjectDoesNotExist:
             return (
                 False,
                 f"Need {self.character_class.name} level {self.minimum_level}, don't have class",

--- a/src/world/progression/services/spends.py
+++ b/src/world/progression/services/spends.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from evennia.objects.models import ObjectDB
 
@@ -311,7 +312,7 @@ def calculate_level_up_requirements(
             character_class=character_class,
         )
         current_level = current_class_level.level
-    except Exception:  # noqa: BLE001
+    except ObjectDoesNotExist:
         current_level = 0
 
     if target_level <= current_level:

--- a/src/world/projects/services.py
+++ b/src/world/projects/services.py
@@ -140,13 +140,17 @@ def _maybe_grant_project_contribution_resonance(
         )
         return
     try:
-        grant_resonance(
-            contributor_persona.character_sheet,
-            project.resonance,
-            award.resonance_award_amount,
-            source=GainSource.PROJECT_CONTRIBUTION,
-            project=project,
-        )
+        # Savepoint: without it, a DATABASE error inside the grant would mark
+        # the enclosing add_contribution/donate_to_project transaction as
+        # rolled-back even though we swallow the exception here (#2386 t4).
+        with transaction.atomic():
+            grant_resonance(
+                contributor_persona.character_sheet,
+                project.resonance,
+                award.resonance_award_amount,
+                source=GainSource.PROJECT_CONTRIBUTION,
+                project=project,
+            )
     except Exception:
         # A failed bonus forfeits only the bonus, never the contribution it's
         # layered on top of (see docstring above). This runs inside

--- a/src/world/roster/services/gallery_services.py
+++ b/src/world/roster/services/gallery_services.py
@@ -3,6 +3,7 @@ Handles Cloudinary integration for tenure media storage."""
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, cast
 import uuid
 
@@ -16,6 +17,8 @@ from django.core.files.uploadedfile import UploadedFile
 from evennia_extensions.models import Artist, PlayerData, PlayerMedia
 from world.roster.models import RosterTenure, TenureMedia
 from world.roster.services.media_scan import MediaScanService
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from world.roster.models import TenureGallery
@@ -133,7 +136,11 @@ class CloudinaryGalleryService:
             cloudinary.uploader.destroy(media.cloudinary_public_id)
             media.delete()
             return True
-        except Exception:  # noqa: BLE001
+        except Exception:
+            logger.exception(
+                "Cloudinary destroy failed for %s; DB row removed, remote asset orphaned",
+                media.cloudinary_public_id,
+            )
             media.delete()
             return False
 
@@ -178,7 +185,8 @@ class CloudinaryGalleryService:
                     sort_order=index,
                 )
             return True
-        except Exception:  # noqa: BLE001
+        except Exception:
+            logger.exception("Media reorder failed for tenure %s", tenure.pk)
             return False
 
     @classmethod

--- a/src/world/roster/services/mail_notifications.py
+++ b/src/world/roster/services/mail_notifications.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 
-from evennia.utils.logger import log_err
+from evennia.utils.logger import log_trace
 
 from web.webclient.message_types import MailArrivedPayload
 
@@ -46,4 +46,4 @@ def notify_mail_arrived(recipient_tenure: RosterTenure, mail: PlayerMail) -> Non
         )
         account.msg(mail_arrived=((), payload))
     except Exception:  # noqa: BLE001 — best-effort arrival ping; never break mail send (#2160)
-        log_err(f"mail arrival ping failed for mail={mail.pk}")
+        log_trace(f"mail arrival ping failed for mail={mail.pk}")

--- a/src/world/scenes/friend_services.py
+++ b/src/world/scenes/friend_services.py
@@ -115,7 +115,7 @@ def notify_friends_of_status(character: ObjectDB, *, online: bool) -> None:
     count (a friender who re-rostered away no longer watches). Best-effort: a notification failure
     must never break login/logout.
     """
-    from evennia.utils.logger import log_err  # noqa: PLC0415
+    from evennia.utils.logger import log_trace  # noqa: PLC0415
 
     from world.roster.models import RosterTenure  # noqa: PLC0415
 
@@ -141,4 +141,4 @@ def notify_friends_of_status(character: ObjectDB, *, online: bool) -> None:
             seen.add(account.pk)
             account.msg(message)
     except Exception:  # noqa: BLE001 — best-effort watch alert; never break the login hook (#1164)
-        log_err(f"friend watch-alert failed for {character}")
+        log_trace(f"friend watch-alert failed for {character}")

--- a/src/world/scenes/services.py
+++ b/src/world/scenes/services.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+from django.core.exceptions import ObjectDoesNotExist
+
 from world.scenes.constants import SceneAction
 from world.scenes.interaction_services import invalidate_active_scene_cache
 from world.scenes.models import Persona, Scene
@@ -53,7 +55,7 @@ def persona_for_character(character: Character) -> Persona:
         raise MissingPrimaryPersonaError(character)
     try:
         return sheet.primary_persona
-    except Exception as exc:
+    except ObjectDoesNotExist as exc:
         raise MissingPrimaryPersonaError(character) from exc
 
 

--- a/src/world/societies/fame_reactions.py
+++ b/src/world/societies/fame_reactions.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 
 from world.societies.constants import FAME_TIER_ORDER
@@ -44,9 +45,8 @@ def maybe_emit_fame_reaction(character: ObjectDB, room: ObjectDB) -> bool:
     """
     if character is None or room is None:
         return False
-    try:
-        profile = room.room_profile
-    except Exception:  # noqa: BLE001 — non-room containers have no profile
+    profile = room.room_profile_or_none
+    if profile is None:
         return False
 
     persona = _active_persona(character)
@@ -94,7 +94,8 @@ def _active_persona(character: ObjectDB) -> Persona | None:
         return None
     try:
         return active_persona_for_sheet(sheet)
-    except Exception:  # noqa: BLE001 - silent reaction on any resolution fault
+    except ObjectDoesNotExist:
+        # Broken PRIMARY invariant: skip the cosmetic reaction; real faults raise.
         return None
 
 

--- a/src/world/societies/ranking_views.py
+++ b/src/world/societies/ranking_views.py
@@ -10,6 +10,8 @@ board exists, never its names). Raw numbers never leave the server.
 
 from __future__ import annotations
 
+import logging
+
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import NotFound
@@ -24,6 +26,8 @@ from world.societies.ranking_services import (
     get_society_prestige_top_n,
     viewer_is_member_of_society,
 )
+
+logger = logging.getLogger(__name__)
 
 _MSG_NO_DISPLAY = "No ranking display there."
 
@@ -82,7 +86,8 @@ def _viewer_persona(request: Request):
 
     try:
         puppet = request.user.puppet
-    except (AttributeError, Exception):  # noqa: BLE001
+    except AttributeError:
+        # AnonymousUser has no puppet attribute.
         return None
     if puppet is None:
         return None
@@ -91,7 +96,8 @@ def _viewer_persona(request: Request):
         return None
     try:
         return active_persona_for_sheet(sheet)
-    except Exception:  # noqa: BLE001 - fail closed: any resolution fault → deny
+    except Exception:
+        logger.exception("Persona resolution failed for sheet %s; denying", sheet.pk)
         return None
 
 

--- a/src/world/traits/handlers.py
+++ b/src/world/traits/handlers.py
@@ -208,9 +208,8 @@ class TraitHandler:
         from world.mechanics.models import ModifierTarget  # noqa: PLC0415
         from world.mechanics.services import get_modifier_total  # noqa: PLC0415
 
-        try:
-            sheet = self.character.sheet_data
-        except Exception:  # noqa: BLE001
+        sheet = self.character.character_sheet
+        if sheet is None:
             return 0
 
         target = ModifierTarget.get_for_trait(trait)

--- a/tools/lint_noqa_ratchet.py
+++ b/tools/lint_noqa_ratchet.py
@@ -32,7 +32,19 @@ PATTERNS: dict[str, str] = {
     # through create_object). The grandfathered remainder is the handful of
     # deliberate production services that build rooms/exits as bare rows.
     "BARE_OBJECTDB_CREATE": r"ObjectDB\.objects\.create\(",
+    # Broad exception handlers in production code (tranche 4, #1164): every
+    # grandfathered site is a classified boundary (per-item isolation, cron
+    # tick, CLI/request boundary) that logs with exc_info. New ones need the
+    # same classification — or a narrower catch.
+    "BROAD_EXCEPT": r"except Exception\b",
 }
+
+# Pattern tokens whose count should skip test files (tests legitimately use
+# broad catches and bare fixtures the production rule forbids... except where
+# another token explicitly covers tests, like BARE_OBJECTDB_CREATE).
+PATTERNS_EXCLUDE_TESTS = {"BROAD_EXCEPT"}
+
+_TEST_PATH_RE = re.compile(r"(^|/)tests?(/|\.py$)|(^|/)test_[^/]*\.py$")
 
 
 def count_token(token: str) -> int:
@@ -48,11 +60,14 @@ def count_token(token: str) -> int:
     return total
 
 
-def count_pattern(regex: str) -> int:
-    """Count regex matches across src/**/*.py."""
+def count_pattern(regex: str, *, exclude_tests: bool = False) -> int:
+    """Count regex matches across src/**/*.py (optionally skipping test files)."""
     pattern = re.compile(regex)
     total = 0
     for path in SRC.rglob("*.py"):
+        rel = path.relative_to(SRC).as_posix()
+        if exclude_tests and _TEST_PATH_RE.search(rel):
+            continue
         try:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
@@ -71,7 +86,7 @@ def main() -> int:
         allowed = int(allowed_str)
         if token.startswith("pattern:"):
             name = token.removeprefix("pattern:")
-            actual = count_pattern(PATTERNS[name])
+            actual = count_pattern(PATTERNS[name], exclude_tests=name in PATTERNS_EXCLUDE_TESTS)
         else:
             actual = count_token(token)
         if actual > allowed:

--- a/tools/noqa_ratchet_baseline.txt
+++ b/tools/noqa_ratchet_baseline.txt
@@ -6,3 +6,4 @@
 # the regexes defined in lint_noqa_ratchet.py's PATTERNS map.
 GETATTR_LITERAL 61
 pattern:BARE_OBJECTDB_CREATE 4
+pattern:BROAD_EXCEPT 101


### PR DESCRIPTION
The audit's final planned leg (#2386 → #2396 → #2401 → #2409 → this): every production `except Exception` handler classified by three parallel reviewers against the #1164 doctrine — log-and-continue is sanctioned *interim*, but it must log, and breadth must match the boundary.

## The census (127 handlers)

- **73 kept as-is** — legitimate boundaries already logging with tracebacks: per-item cron/tick isolation, best-effort email/notify sends, the `report_error`/`run_safely` family (the #1164 gold standard), CLI/request boundaries, and the admin batch-import's collect-errors-then-rollback design. The roster email flows came out the cleanest code in the entire audit.
- **24 now actually log** — boundaries that were silent or dropped the traceback. Standouts: the outfit resonance trickle was **silently eating player rewards** behind a literal "TODO log"; the Cloudinary gallery delete **orphaned remote assets** with no trace; the fixture dry-run analyzer swallowed tracebacks *and* miscounted lookup errors as "new records"; two fail-closed persona denials couldn't distinguish a broken invariant from a DB outage.
- **28 narrowed to named exceptions** — bodies that only ever handled one specific failure (`ObjectDoesNotExist` family, SQLite-fallback `OperationalError`/`ProgrammingError`, `MissingPrimaryPersonaError`, `DjangoValidationError`); several collapsed onto tranche-3 `*_or_none` descriptors. A real traverse bug no longer reads as a locked door, and server errors in the GM add-participant endpoint no longer masquerade as silent 400s.
- **1 removed** — a catch around `str.replace`, which cannot raise for string inputs.

## The MagicError contract, learned the honest way

Two actions returned raw `str(exc)` in player-facing messages (the forbidden CodeQL pattern). Fixing them surfaced a real design contract the test suite pinned from both directions: **bare `MagicError` messages are authored player text** (the pull-declaration paths), while **subclasses raise with internal diagnostic detail and rely on curated class-level `user_message`**. My first fix was too generic (lost the pull messages), the second too broad (leaked subclass internals — `trait_258` reaching players); the shipped version encodes exactly the split, documented on the base class.

Also: the non-gating project resonance bonus gains its missing savepoint — a DB fault inside the bonus can no longer poison the enclosing contribution transaction that already debited the donor's purse.

## Ratchet

`pattern:BROAD_EXCEPT` added (production files only; tests excluded) at baseline **101**. Every grandfathered site is a classified boundary; a new broad catch fails CI until it's classified or narrowed.

## Tests

7,853-test fast battery (the 22 world.societies failures are the documented pre-existing SQLite matview gap — societies re-verified green on the parity tier) + 5,095-test Postgres parity batch, green after the contract fixes.

With this, the original silent-fail audit plan (#1825 follow-up) is complete: getattr traps, prefetch probes, fixture hygiene, holder workarounds, and exception handling — all triaged, ratcheted, and locked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)