### PR TITLE
403 on progression page for users without a character

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate, useParams } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { GuestOnlyRoute } from './components/GuestOnlyRoute';
 import { ProtectedRoute } from './components/ProtectedRoute';
+import { RequireCharacter } from './components/RequireCharacter';
 import { StaffRoute } from './components/StaffRoute';
 import { Skeleton } from './components/ui/skeleton';
 import { HomePage } from './evennia_replacements/HomePage';
@@ -389,7 +390,9 @@ function App() {
           path="/xp-kudos"
           element={
             <ProtectedRoute>
-              <XpKudosPage />
+              <RequireCharacter>
+                <XpKudosPage />
+              </RequireCharacter>
             </ProtectedRoute>
           }
         />
@@ -919,7 +922,9 @@ function App() {
           element={
             <Suspense fallback={<PageLoadingFallback />}>
               <ProtectedRoute>
-                <ThreadHubPage />
+                <RequireCharacter>
+                  <ThreadHubPage />
+                </RequireCharacter>
               </ProtectedRoute>
             </Suspense>
           }
@@ -929,7 +934,9 @@ function App() {
           element={
             <Suspense fallback={<PageLoadingFallback />}>
               <ProtectedRoute>
-                <WeavingTeachingOffersPage />
+                <RequireCharacter>
+                  <WeavingTeachingOffersPage />
+                </RequireCharacter>
               </ProtectedRoute>
             </Suspense>
           }
@@ -939,7 +946,9 @@ function App() {
           element={
             <Suspense fallback={<PageLoadingFallback />}>
               <ProtectedRoute>
-                <ThreadDetailPage />
+                <RequireCharacter>
+                  <ThreadDetailPage />
+                </RequireCharacter>
               </ProtectedRoute>
             </Suspense>
           }
@@ -949,7 +958,9 @@ function App() {
           element={
             <Suspense fallback={<PageLoadingFallback />}>
               <ProtectedRoute>
-                <SanctumDashboardPage />
+                <RequireCharacter>
+                  <SanctumDashboardPage />
+                </RequireCharacter>
               </ProtectedRoute>
             </Suspense>
           }
@@ -977,7 +988,9 @@ function App() {
           element={
             <Suspense fallback={<PageLoadingFallback />}>
               <ProtectedRoute>
-                <MagicProgressionPage />
+                <RequireCharacter>
+                  <MagicProgressionPage />
+                </RequireCharacter>
               </ProtectedRoute>
             </Suspense>
           }

--- a/frontend/src/components/RequireCharacter.tsx
+++ b/frontend/src/components/RequireCharacter.tsx
@@ -1,0 +1,49 @@
+import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useAccount } from '@/store/hooks';
+
+interface RequireCharacterProps {
+  children: ReactNode;
+}
+
+/**
+ * Route guard that ensures the user has at least one character.
+ *
+ * Shows a friendly "create a character first" card instead of mounting the
+ * page — which would crash on API 403s from character-scoped endpoints
+ * (threads, magic progression, alterations).
+ *
+ * Use inside ProtectedRoute: RequireCharacter assumes the user is already
+ * authenticated.
+ */
+export function RequireCharacter({ children }: RequireCharacterProps) {
+  const account = useAccount();
+  const hasCharacters = (account?.available_characters?.length ?? 0) > 0;
+
+  if (hasCharacters) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>You need a character first</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <p className="text-muted-foreground">
+            This page requires an active character. Browse the roster to find a character to play,
+            or start a new character application.
+          </p>
+          <div className="flex gap-2">
+            <Button asChild>
+              <Link to="/roster">Browse the roster</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/RequireCharacter.test.tsx
+++ b/frontend/src/components/__tests__/RequireCharacter.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Tests for RequireCharacter route guard.
+ *
+ * Verifies that users without a character see a friendly message,
+ * and users with a character see the page content.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { RequireCharacter } from '../RequireCharacter';
+
+function createStore(account: unknown) {
+  return configureStore({
+    reducer: {
+      auth: (_state, action) => {
+        if (action.type === 'INIT') return { account };
+        return { account };
+      },
+    },
+    preloadedState: { auth: { account } },
+  });
+}
+
+function renderWithStore(ui: React.ReactElement, account: unknown) {
+  const store = createStore(account);
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </Provider>
+  );
+}
+
+describe('RequireCharacter', () => {
+  it('renders children when user has characters', () => {
+    const account = {
+      id: 1,
+      username: 'testuser',
+      available_characters: [{ id: 1, name: 'TestChar' }],
+    };
+    renderWithStore(
+      <RequireCharacter>
+        <div>Page content</div>
+      </RequireCharacter>,
+      account
+    );
+    expect(screen.getByText('Page content')).toBeInTheDocument();
+  });
+
+  it('shows friendly message when user has no characters', () => {
+    const account = {
+      id: 1,
+      username: 'testuser',
+      available_characters: [],
+    };
+    renderWithStore(
+      <RequireCharacter>
+        <div>Page content</div>
+      </RequireCharacter>,
+      account
+    );
+    expect(screen.queryByText('Page content')).not.toBeInTheDocument();
+    expect(screen.getByText('You need a character first')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /browse the roster/i })).toBeInTheDocument();
+  });
+
+  it('shows message when account is null', () => {
+    renderWithStore(
+      <RequireCharacter>
+        <div>Page content</div>
+      </RequireCharacter>,
+      null
+    );
+    expect(screen.queryByText('Page content')).not.toBeInTheDocument();
+    expect(screen.getByText('You need a character first')).toBeInTheDocument();
+  });
+
+  it('shows message when available_characters is undefined', () => {
+    const account = { id: 1, username: 'testuser' };
+    renderWithStore(
+      <RequireCharacter>
+        <div>Page content</div>
+      </RequireCharacter>,
+      account
+    );
+    expect(screen.getByText('You need a character first')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/magic/__tests__/PendingAlterationBanner.test.tsx
+++ b/frontend/src/magic/__tests__/PendingAlterationBanner.test.tsx
@@ -96,6 +96,7 @@ function createAuthStore(authenticated: boolean) {
         id: 1,
         username: 'testuser',
         email: 'test@example.com',
+        available_characters: [{ id: 1, name: 'TestChar' }],
       } as Parameters<typeof authSlice.actions.setAccount>[0])
     );
   }

--- a/frontend/src/magic/__tests__/alterationQueries.test.tsx
+++ b/frontend/src/magic/__tests__/alterationQueries.test.tsx
@@ -85,6 +85,7 @@ function createAuthStore(authenticated: boolean) {
         id: 1,
         username: 'testuser',
         email: 'test@example.com',
+        available_characters: [{ id: 1, name: 'TestChar' }],
       } as Parameters<typeof authSlice.actions.setAccount>[0])
     );
   }

--- a/frontend/src/magic/queries.ts
+++ b/frontend/src/magic/queries.ts
@@ -551,10 +551,11 @@ export function useAuthorTechnique() {
  */
 export function usePendingAlterations() {
   const account = useAppSelector((s) => s.auth.account);
+  const hasCharacters = (account?.available_characters?.length ?? 0) > 0;
   return useQuery({
     queryKey: magicKeys.pendingAlterations(),
     queryFn: () => api.getPendingAlterations(),
-    enabled: !!account,
+    enabled: !!account && hasCharacters,
     staleTime: 30_000,
     refetchInterval: 30_000,
   });

--- a/frontend/src/progression/__tests__/XpKudosPage.alterationGate.test.tsx
+++ b/frontend/src/progression/__tests__/XpKudosPage.alterationGate.test.tsx
@@ -119,6 +119,7 @@ function createAuthStore() {
       id: 1,
       username: 'testuser',
       email: 'test@example.com',
+      available_characters: [{ id: 1, name: 'TestChar' }],
     } as Parameters<typeof authSlice.actions.setAccount>[0])
   );
   return store;


### PR DESCRIPTION
Closes #2405

## Summary

Fix 403 errors on /threads, /magic/progression, /xp-kudos, and /sanctums for authenticated users without a character. New RequireCharacter route guard shows a friendly 'create a character first' card instead of mounting pages that crash on character-scoped API 403s. Also gates usePendingAlterations so the site-wide banner doesn't fire 403 requests.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2405 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch is up to date with main, no conflicts.

<!-- last-addressed-comment: 0 -->