### PR TITLE
Extend content pipeline to load raw fixture JSON from the private lore repo

### DIFF
--- a/justfile
+++ b/justfile
@@ -369,7 +369,9 @@ clean-pyc:
 #   just gen-api-types
 # Build fixtures from the private content checkout, then load them.
 # Requires CONTENT_REPO_PATH in src/.env (the content repo is never named here).
+# If CONTENT_REPO_URL is also set and the checkout doesn't exist, clones it first.
 load-content:
+    bash tools/ensure_content_repo.sh
     uv run python tools/build_content_fixtures.py --load
 
 # Validate content files + report remaining PLACEHOLDER slots; writes nothing.

--- a/src/.env.example
+++ b/src/.env.example
@@ -53,3 +53,12 @@ ALLOW_INTEGRATION_TESTS=false
 INTEGRATION_TEST_USERNAME=integration_test_user
 INTEGRATION_TEST_PASSWORD=IntegrationTestPassword123!
 INTEGRATION_TEST_EMAIL=integration_test@example.com
+
+# Private content repository (optional)
+# Set CONTENT_REPO_PATH to a local checkout of the private lore repo to enable
+# `just load-content` / `just check-content` (builds + upserts authored content).
+# Set CONTENT_REPO_URL to the repo URL so `just load-content` auto-clones it
+# if the checkout doesn't exist yet (requires GH_TOKEN in the environment).
+# Both are per-machine config — the repo is never named in the codebase.
+# CONTENT_REPO_PATH=/home/vscode/ArxII-lore
+# CONTENT_REPO_URL=your-org/your-private-content-repo

--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -155,6 +155,10 @@ class BuildResult:
     # output path -> source file per object, same order as fixtures[output].
     # Lets load_entries name the originating file in a resolution error.
     source_paths: dict[str, list[Path]] = field(default_factory=dict)
+    # Human-readable warnings for objects that were skipped (stale models,
+    # missing NaturalKeyMixin, etc.). Collected during build, surfaced to the
+    # operator by the CLI / admin button.
+    skipped: list[str] = field(default_factory=list)
 
 
 def parse_content_file(path: Path, domain: str) -> ContentEntry:
@@ -366,11 +370,49 @@ DOMAIN_BUILDERS = {
 }
 
 
+def build_fixture_json(content_root: Path, result: BuildResult) -> None:
+    """Scan ``content_root/fixtures/`` for raw Django fixture JSON files.
+
+    Each ``.json`` file is an array of ``{"model": "app.model", "fields": {...}}``
+    objects (optionally with a ``"pk"`` key that is stripped — upsert is by
+    natural key, not pk). Objects are appended into ``result.fixtures`` using
+    the source file path as the key, with corresponding ``source_paths`` for
+    error reporting.
+
+    Fully dynamic: no hardcoded model list. Models are resolved at load time
+    in ``load_entries`` via ``apps.get_model``. Stale labels (renamed/removed
+    models) are skipped there with a warning in ``result.skipped``.
+
+    FK values that are lists (Django's natural-key fixture convention, e.g.
+    ``"resonance": ["resonance", "Insidia"]``) are left as-is in the fields
+    dict — ``_resolve_natural_key_fields`` resolves them at upsert time.
+    """
+    fixtures_dir = content_root / "fixtures"
+    if not fixtures_dir.is_dir():
+        return
+    for path in sorted(fixtures_dir.rglob("*.json")):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            msg = f"{path}: invalid JSON: {exc}"
+            raise ContentError(msg) from exc
+        if not isinstance(raw, list):
+            msg = f"{path}: expected a JSON array of fixture objects."
+            raise ContentError(msg)
+        if not raw:
+            continue
+        key = str(path.relative_to(content_root))
+        result.fixtures[key] = raw
+        result.source_paths[key] = [path] * len(raw)
+
+
 def build_all(content_root: Path) -> BuildResult:
     """Walk known domains under ``content_root``; parse, validate, build.
 
-    Unknown directories are reference canon — ignored by design. Raises
-    ContentError (with every failing file listed) when validation fails.
+    Also scans ``content_root/fixtures/`` for raw Django fixture JSON files
+    (the lore repo's primary content format). Unknown directories are
+    reference canon — ignored by design. Raises ``ContentError`` (with every
+    failing file listed) when validation fails.
     """
     result = BuildResult()
     errors: list[str] = []
@@ -393,6 +435,11 @@ def build_all(content_root: Path) -> BuildResult:
         if objects:
             result.fixtures[config["output"]] = objects
             result.source_paths[config["output"]] = paths
+    # Raw fixture JSON from the lore repo's fixtures/ directory.
+    try:
+        build_fixture_json(content_root, result)
+    except ContentError as exc:
+        errors.append(str(exc))
     if errors:
         msg = "Content validation failed:\n" + "\n".join(errors)
         raise ContentError(msg)
@@ -436,11 +483,63 @@ def _resolve_natural_key_fields(model, fields: dict, source_path: Path | None) -
             )
             raise ContentError(msg)
         related_model = field.related_model
+        from django.core.exceptions import (  # noqa: PLC0415
+            ObjectDoesNotExist as _ObjectDoesNotExist,
+        )
+
         try:
             fields[field_name] = related_model.objects.get_by_natural_key(*value)
         except related_model.DoesNotExist:
             msg = f"{location}: {field_name!r} {related_model.__name__} {value!r} not found."
             raise ContentError(msg) from None
+        except _ObjectDoesNotExist as exc:
+            # A nested FK resolution (inside get_by_natural_key →
+            # _resolve_fk_arg) raises a DIFFERENT model's DoesNotExist —
+            # not related_model.DoesNotExist. Catch the base class to
+            # cover that case too.
+            msg = (
+                f"{location}: {field_name!r} {related_model.__name__} "
+                f"{value!r} not found (nested: {exc})."
+            )
+            raise ContentError(msg) from None
+
+
+def _extract_natural_key(model, fields: dict, source_path: Path | None) -> dict:
+    """Pop the natural-key fields from *fields* and return them as a lookup dict.
+
+    For models with ``NaturalKeyMixin``, pops each field listed in
+    ``NaturalKeyConfig.fields`` from *fields* (so they are NOT passed in
+    ``defaults`` to ``update_or_create`` — passing them would be a no-op on
+    UPDATE but would shadow the lookup on CREATE for auto-gen fields).
+
+    For models WITHOUT ``NaturalKeyMixin``, raises ``ContentError`` naming
+    the model and source file. The loader cannot upsert without a natural key
+    — ``loaddata``'s pk-based INSERT is the only other option, and that path
+    is unsafe for ``SharedMemoryModel`` (see ``load_entries`` docstring).
+    """
+    from core.natural_keys import NaturalKeyMixin  # noqa: PLC0415
+
+    if not issubclass(model, NaturalKeyMixin):
+        location = source_path if source_path is not None else model._meta.label  # noqa: SLF001
+        msg = (
+            f"{location}: model {model.__name__} lacks NaturalKeyMixin — "
+            "cannot upsert by natural key. Add NaturalKeyMixin to the model "
+            "or skip this fixture."
+        )
+        raise ContentError(msg)
+
+    config = model.NaturalKeyConfig
+    lookup: dict = {}
+    for field_name in config.fields:
+        if field_name not in fields:
+            location = source_path if source_path is not None else model._meta.label  # noqa: SLF001
+            msg = (
+                f"{location}: natural-key field {field_name!r} not found in "
+                f"fixture fields for {model.__name__}."
+            )
+            raise ContentError(msg)
+        lookup[field_name] = fields.pop(field_name)
+    return lookup
 
 
 def load_entries(result: BuildResult) -> tuple[int, int]:
@@ -454,10 +553,31 @@ def load_entries(result: BuildResult) -> tuple[int, int]:
     explicitly, which the identity map handles correctly. The emitted
     fixture JSON remains valid for FRESH-database seeding (pure inserts).
 
+    Handles two sources of objects in ``result.fixtures``:
+
+    - **YAML frontmatter entries** (built by the per-domain builders) — use
+      ``name`` as the natural key (every frontmatter domain's model has a
+      DB-unique ``name``).
+    - **Raw fixture JSON** (loaded by ``build_fixture_json``) — resolve the
+      natural key from the model's own ``NaturalKeyConfig.fields`` via
+      ``_extract_natural_key``, so models with composite keys (e.g.
+      ``ConditionStage`` keyed on ``condition`` + ``stage_order``) work too.
+
+    Both paths share the same ``_resolve_natural_key_fields`` pass for FK
+    natural-key-list values.
+
+    Stale model labels (referencing renamed/removed models) are skipped with
+    a warning written to ``result.skipped`` — the load does not fail, but the
+    skip is visible to the operator.
+
     Requires Django to be configured; imports are deferred so the module
     stays import-safe for pure validation.
     """
     from django.apps import apps  # noqa: PLC0415
+    from django.core.exceptions import FieldError  # noqa: PLC0415
+    from django.db import IntegrityError  # noqa: PLC0415
+
+    from core.natural_keys import NaturalKeyConfigError  # noqa: PLC0415
 
     created_count = 0
     updated_count = 0
@@ -465,11 +585,60 @@ def load_entries(result: BuildResult) -> tuple[int, int]:
         paths = result.source_paths.get(output_path, [])
         for obj, source_path in zip(objects, paths, strict=False):
             app_label, model_name = obj["model"].split(".")
-            model = apps.get_model(app_label, model_name)
+            try:
+                model = apps.get_model(app_label, model_name)
+            except LookupError:
+                result.skipped.append(
+                    f"{source_path}: stale model {obj['model']!r} (renamed or removed) — skipped."
+                )
+                continue
             fields = dict(obj["fields"])
-            name = fields.pop("name")
-            _resolve_natural_key_fields(model, fields, source_path)
-            _, created = model.objects.update_or_create(name=name, defaults=fields)
+            # Strip pk if present — upsert is by natural key, not pk.
+            fields.pop("pk", None)
+            try:
+                lookup = _extract_natural_key(model, fields, source_path)
+            except ContentError as exc:
+                result.skipped.append(str(exc))
+                continue
+            # Resolve natural-key-list FK values in both the lookup (the
+            # natural-key fields themselves) and the remaining defaults.
+            try:
+                _resolve_natural_key_fields(model, lookup, source_path)
+                _resolve_natural_key_fields(model, fields, source_path)
+                _, created = model.objects.update_or_create(**lookup, defaults=fields)
+            except (ValueError, TypeError) as exc:
+                # A FK value that is a raw integer (pk-based fixture) rather
+                # than a natural-key list causes a ValueError on assignment.
+                # These fixtures can't be upserted by natural key — skip.
+                result.skipped.append(
+                    f"{source_path}: {model.__name__} could not be loaded "
+                    f"(likely pk-based FK reference): {exc}"
+                )
+                continue
+            except (NaturalKeyConfigError, ContentError, FieldError) as exc:
+                # FK resolution failure or schema drift. ContentError covers
+                # the re-raised DoesNotExist from _resolve_natural_key_fields;
+                # NaturalKeyConfigError covers arity mismatches; FieldError
+                # covers fixture fields that no longer exist on the model.
+                result.skipped.append(f"{source_path}: {model.__name__} could not be loaded: {exc}")
+                continue
+            except model.DoesNotExist as exc:
+                # The model's own DoesNotExist — the natural-key lookup
+                # didn't find an existing row (shouldn't happen for
+                # update_or_create, but catch just in case).
+                result.skipped.append(
+                    f"{source_path}: {model.__name__} could not be loaded (lookup failed): {exc}"
+                )
+                continue
+            except IntegrityError as exc:
+                # DB constraint violation (e.g. a unique constraint on a
+                # non-natural-key field that the fixture data violates).
+                # The record can't be loaded — skip it.
+                result.skipped.append(
+                    f"{source_path}: {model.__name__} could not be loaded "
+                    f"(constraint violation): {exc}"
+                )
+                continue
             if created:
                 created_count += 1
             else:

--- a/src/core_management/tests/test_content_fixtures.py
+++ b/src/core_management/tests/test_content_fixtures.py
@@ -1,5 +1,6 @@
 """Content pipeline (#944): parsing, validation, fixture shape, idempotent load."""
 
+import json
 from pathlib import Path
 import tempfile
 
@@ -381,3 +382,237 @@ class ResolveNaturalKeyFieldsGuardTests(TestCase):
         fields = {"faction_affiliation": ["Builders Guild"]}
         _resolve_natural_key_fields(NPCRole, fields, None)
         assert fields["faction_affiliation"].name == "Builders Guild"
+
+
+class FixtureJsonBuildTests(TestCase):
+    """build_fixture_json: parsing raw Django fixture JSON from fixtures/ dir."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_no_fixtures_dir_is_noop(self) -> None:
+        """build_all with no fixtures/ dir just has frontmatter results."""
+        _write(self.root, "skills/performance.md", GOOD_SKILL)
+        result = build_all(self.root)
+        fixture_keys = [k for k in result.fixtures if k.startswith("fixtures/")]
+        assert fixture_keys == []
+
+    def test_fixture_json_loaded_into_result(self) -> None:
+        """A fixtures/ dir with one JSON file is parsed into result.fixtures."""
+        _write(
+            self.root,
+            "fixtures/magic/effects.json",
+            json.dumps(
+                [
+                    {
+                        "model": "magic.effecttype",
+                        "fields": {
+                            "name": "Test Effect",
+                            "description": "An effect type.",
+                        },
+                    },
+                ]
+            ),
+        )
+        result = build_all(self.root)
+        assert "fixtures/magic/effects.json" in result.fixtures
+        obj = result.fixtures["fixtures/magic/effects.json"][0]
+        assert obj["model"] == "magic.effecttype"
+        assert obj["fields"]["name"] == "Test Effect"
+
+    def test_pk_is_stripped_at_load_time(self) -> None:
+        """Objects with a pk field load fine — pk is stripped in load_entries."""
+        _write(
+            self.root,
+            "fixtures/magic/effects.json",
+            json.dumps(
+                [
+                    {
+                        "model": "magic.effecttype",
+                        "pk": 99,
+                        "fields": {
+                            "name": "Pked Effect",
+                            "description": "Has a pk.",
+                        },
+                    },
+                ]
+            ),
+        )
+        result = build_all(self.root)
+        obj = result.fixtures["fixtures/magic/effects.json"][0]
+        assert "pk" in obj  # pk is in the raw fixture, stripped at load time
+
+    def test_invalid_json_raises_content_error(self) -> None:
+        _write(self.root, "fixtures/bad.json", "{not valid json")
+        with self.assertRaises(ContentError):
+            build_all(self.root)
+
+    def test_non_array_json_raises_content_error(self) -> None:
+        _write(self.root, "fixtures/bad.json", json.dumps({"model": "magic.affinity"}))
+        with self.assertRaises(ContentError):
+            build_all(self.root)
+
+    def test_empty_array_is_skipped(self) -> None:
+        _write(self.root, "fixtures/empty.json", "[]")
+        result = build_all(self.root)
+        assert "fixtures/empty.json" not in result.fixtures
+
+
+class FixtureJsonLoadTests(TestCase):
+    """End-to-end: build fixture JSON → load_entries → upsert by natural key."""
+
+    def setUp(self) -> None:
+        self.content = tempfile.TemporaryDirectory()
+        self.addCleanup(self.content.cleanup)
+        self.root = Path(self.content.name)
+
+    def test_load_creates_then_updates_by_natural_key(self) -> None:
+        """A fixture JSON object with a natural key upserts correctly."""
+        fixture_data = json.dumps(
+            [
+                {
+                    "model": "magic.effecttype",
+                    "fields": {
+                        "name": "Test Effect",
+                        "description": "Original description.",
+                    },
+                },
+            ]
+        )
+        _write(self.root, "fixtures/magic/effects.json", fixture_data)
+        created, updated = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+
+        from world.magic.models import EffectType
+
+        et = EffectType.objects.get(name="Test Effect")
+        assert et.description == "Original description."
+
+        # Re-author the description; reload must UPDATE the same row.
+        updated_data = json.dumps(
+            [
+                {
+                    "model": "magic.effecttype",
+                    "fields": {
+                        "name": "Test Effect",
+                        "description": "Rewritten description.",
+                    },
+                },
+            ]
+        )
+        _write(self.root, "fixtures/magic/effects.json", updated_data)
+        created, updated = load_entries(build_all(self.root))
+        assert (created, updated) == (0, 1)
+        et.refresh_from_db()
+        assert et.description == "Rewritten description."
+
+    def test_pk_stripped_on_load(self) -> None:
+        """Objects with pk fields load fine — pk is ignored, upsert is by natural key."""
+        _write(
+            self.root,
+            "fixtures/magic/effects.json",
+            json.dumps(
+                [
+                    {
+                        "model": "magic.effecttype",
+                        "pk": 42,
+                        "fields": {
+                            "name": "Pked Effect",
+                            "description": "Has a pk.",
+                        },
+                    },
+                ]
+            ),
+        )
+        created, updated = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+
+    def test_stale_model_label_skipped_with_warning(self) -> None:
+        """A fixture referencing a renamed/removed model is skipped, not fatal."""
+        _write(
+            self.root,
+            "fixtures/stale/old_model.json",
+            json.dumps(
+                [
+                    {"model": "magic.threadtype", "fields": {"name": "Friend"}},
+                ]
+            ),
+        )
+        result = build_all(self.root)
+        created, updated = load_entries(result)
+        assert (created, updated) == (0, 0)
+        assert len(result.skipped) == 1
+        assert "magic.threadtype" in result.skipped[0]
+
+    def test_model_without_natural_key_skipped_with_warning(self) -> None:
+        """A model that lacks NaturalKeyMixin is skipped with a clear message."""
+        # RitualSession is a SharedMemoryModel without NaturalKeyMixin.
+        _write(
+            self.root,
+            "fixtures/magic/session.json",
+            json.dumps(
+                [
+                    {"model": "magic.ritualsession", "fields": {"name": "Test"}},
+                ]
+            ),
+        )
+        result = build_all(self.root)
+        load_entries(result)
+        assert any("NaturalKeyMixin" in s for s in result.skipped)
+
+    def test_fk_natural_key_resolved(self) -> None:
+        """FK values as natural-key lists (e.g. ['Name']) resolve correctly."""
+        # ModifierTarget has a 'category' FK to ModifierCategory, which has
+        # NaturalKeyMixin (name). Write a fixture with a natural-key FK ref.
+        _write(
+            self.root,
+            "fixtures/mechanics/targets.json",
+            json.dumps(
+                [
+                    {
+                        "model": "mechanics.modifiertarget",
+                        "fields": {
+                            "category": ["power"],
+                            "name": "Test Target",
+                        },
+                    },
+                ]
+            ),
+        )
+        # Pre-create the ModifierCategory so the FK resolves.
+        from world.mechanics.models import ModifierCategory
+
+        ModifierCategory.objects.get_or_create(name="power")
+        created, updated = load_entries(build_all(self.root))
+        assert created + updated == 1
+
+    def test_combined_frontmatter_and_fixture_json(self) -> None:
+        """Both YAML frontmatter and fixture JSON load in one pass."""
+        _write(self.root, "skills/performance.md", GOOD_SKILL)
+        _write(
+            self.root,
+            "fixtures/magic/effects.json",
+            json.dumps(
+                [
+                    {
+                        "model": "magic.effecttype",
+                        "fields": {
+                            "name": "Combined Test Effect",
+                            "description": "From fixture JSON.",
+                        },
+                    },
+                ]
+            ),
+        )
+        result = build_all(self.root)
+        # Frontmatter entry
+        assert len(result.entries) == 1
+        # Fixture JSON
+        assert "fixtures/magic/effects.json" in result.fixtures
+        # Frontmatter output
+        assert "world/traits/fixtures/content_skills.json" in result.fixtures
+        # Both load
+        created, _updated = load_entries(result)
+        assert created >= 2  # 1 trait + 1 effect type

--- a/src/web/admin/content_load_views.py
+++ b/src/web/admin/content_load_views.py
@@ -92,8 +92,12 @@ def content_load_run(request: HttpRequest) -> HttpResponse:
         )
         return HttpResponseRedirect(reverse("admin_game_setup"))
     placeholders = sum(result.placeholder_counts.values())
+    skip_msg = f", {len(result.skipped)} skipped" if result.skipped else ""
     messages.success(
         request,
-        f"Content load: {created} created, {updated} updated, {placeholders} placeholder entries",
+        f"Content load: {created} created, {updated} updated, "
+        f"{placeholders} placeholder entries{skip_msg}",
     )
+    for skip in result.skipped:
+        messages.warning(request, skip)
     return HttpResponseRedirect(reverse("admin_game_setup"))

--- a/src/world/character_creation/models.py
+++ b/src/world/character_creation/models.py
@@ -440,7 +440,7 @@ class Beginnings(NaturalKeyMixin, SharedMemoryModel):
         return Language.objects.filter(id__in=language_ids)
 
 
-class BeginningTradition(SharedMemoryModel):
+class BeginningTradition(NaturalKeyMixin, SharedMemoryModel):
     """Maps which traditions are available for each beginning during CG.
     CG-only concern -- traditions exist independently post-CG."""
 
@@ -472,6 +472,11 @@ class BeginningTradition(SharedMemoryModel):
         ordering = ["sort_order"]
         verbose_name = "Beginning Tradition"
         verbose_name_plural = "Beginning Traditions"
+
+    class NaturalKeyConfig:
+        fields = ["beginning", "tradition"]
+
+    objects = NaturalKeyManager()
 
     def __str__(self) -> str:
         return f"{self.beginning} -> {self.tradition}"

--- a/src/world/magic/models/cantrips.py
+++ b/src/world/magic/models/cantrips.py
@@ -10,11 +10,12 @@ from django.db import models
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.magic.constants import CantripArchetype
 from world.magic.models.techniques import EffectType, TechniqueStyle
 
 
-class Cantrip(SharedMemoryModel):
+class Cantrip(NaturalKeyMixin, SharedMemoryModel):
     """Staff-curated starter technique template for character creation.
 
     A cantrip is a baby technique — same mechanical system, just preset at low values.
@@ -80,6 +81,11 @@ class Cantrip(SharedMemoryModel):
         ordering = ["sort_order", "name"]
         verbose_name = "Cantrip"
         verbose_name_plural = "Cantrips"
+
+    class NaturalKeyConfig:
+        fields = ["name"]
+
+    objects = NaturalKeyManager()
 
     @cached_property
     def cached_allowed_facets(self) -> list:

--- a/src/world/skills/models.py
+++ b/src/world/skills/models.py
@@ -12,13 +12,14 @@ from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from core.managers import ArxSharedMemoryManager
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.traits.models import Trait, TraitType
 
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
 
-class Skill(SharedMemoryModel):
+class Skill(NaturalKeyMixin, SharedMemoryModel):
     """
     Parent skill definition linked to Trait system.
 
@@ -53,6 +54,11 @@ class Skill(SharedMemoryModel):
     def name(self) -> str:
         """Skill name from linked trait."""
         return self.trait.name
+
+    class NaturalKeyConfig:
+        fields = ["trait"]
+
+    objects = NaturalKeyManager()
 
     @property
     def category(self) -> str:

--- a/src/world/tarot/models.py
+++ b/src/world/tarot/models.py
@@ -12,10 +12,11 @@ from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from core.managers import ArxSharedMemoryManager
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.tarot.constants import SUIT_SINGULAR, ArcanaType, TarotSuit
 
 
-class TarotCard(SharedMemoryModel):
+class TarotCard(NaturalKeyMixin, SharedMemoryModel):
     """
     A single tarot card from the 78-card deck.
 
@@ -65,6 +66,11 @@ class TarotCard(SharedMemoryModel):
             ("arcana_type", "suit", "rank"),
         ]
         ordering: ClassVar[list[str]] = ["arcana_type", "suit", "rank"]
+
+    class NaturalKeyConfig:
+        fields = ["name"]
+
+    objects = NaturalKeyManager()
 
     def __str__(self) -> str:
         return self.name

--- a/src/world/weather/models.py
+++ b/src/world/weather/models.py
@@ -136,7 +136,7 @@ class WeatherType(NaturalKeyMixin, SharedMemoryModel):
         return self.name
 
 
-class WeatherTypeExposure(SharedMemoryModel):
+class WeatherTypeExposure(NaturalKeyMixin, SharedMemoryModel):
     """One exposure axis a weather type imparts to a region while active (#1522).
 
     ``(weather_type, stat_key) -> value``: positive = more discomfort (Stormy → +WET, +WIND;
@@ -164,11 +164,16 @@ class WeatherTypeExposure(SharedMemoryModel):
             ),
         ]
 
+    class NaturalKeyConfig:
+        fields = ["weather_type", "stat_key"]
+
+    objects = NaturalKeyManager()
+
     def __str__(self) -> str:
         return f"{self.weather_type.name}: {self.stat_key} {self.value:+d}"
 
 
-class WeatherEmit(SharedMemoryModel):
+class WeatherEmit(NaturalKeyMixin, SharedMemoryModel):
     """An atmospheric flavour line shown while a weather type holds (#1522).
 
     Seeded (later slice) from the Arx-1 emit corpus. Gated by IC season and time-of-day phase
@@ -201,6 +206,11 @@ class WeatherEmit(SharedMemoryModel):
 
     class Meta:
         ordering = ["weather_type", "id"]
+
+    class NaturalKeyConfig:
+        fields = ["weather_type", "text"]
+
+    objects = NaturalKeyManager()
 
     def __str__(self) -> str:
         return f"{self.weather_type.name} emit #{self.pk}"
@@ -237,7 +247,7 @@ class RegionWeatherState(SharedMemoryModel):
         return f"{self.area.name}: {self.weather_type.name}"
 
 
-class FeastDay(SharedMemoryModel):
+class FeastDay(NaturalKeyMixin, SharedMemoryModel):
     """An annually-recurring IC date that forces a special weather over the world (#1522).
 
     The automation behind "spooky things on feast days" (Eclipse of Mirrors, Moon Madness):
@@ -265,6 +275,11 @@ class FeastDay(SharedMemoryModel):
         constraints = [
             models.UniqueConstraint(fields=["ic_month", "ic_day"], name="unique_feast_day_date"),
         ]
+
+    class NaturalKeyConfig:
+        fields = ["name"]
+
+    objects = NaturalKeyManager()
 
     def __str__(self) -> str:
         return f"{self.name} ({self.ic_month:02d}-{self.ic_day:02d}): {self.weather_type.name}"

--- a/tools/build_content_fixtures.py
+++ b/tools/build_content_fixtures.py
@@ -150,8 +150,16 @@ def _run(args: argparse.Namespace) -> int:
     total = len(result.entries)
     for domain, count in sorted(result.placeholder_counts.items()):
         print(f"PLACEHOLDER remaining in {domain}/: {count}")
+    if result.skipped:
+        print(f"\nSkipped {len(result.skipped)} object(s):")
+        for msg in result.skipped:
+            print(f"  {msg}")
     if args.check:
-        print(f"OK: {total} content files validated; nothing written (--check).")
+        total_objs = sum(len(objs) for objs in result.fixtures.values())
+        print(
+            f"OK: {total} content files + {total_objs} fixture objects "
+            f"validated; nothing written (--check)."
+        )
         return 0
 
     written = write_fixtures(result, SRC_ROOT)
@@ -163,6 +171,8 @@ def _run(args: argparse.Namespace) -> int:
         # Upsert path (NOT loaddata — see load_entries docstring).
         created, updated = _load_content(result)
         print(f"loaded: {created} created, {updated} updated.")
+        if result.skipped:
+            print(f"skipped: {len(result.skipped)} object(s) (see above).")
     return 0
 
 

--- a/tools/ensure_content_repo.sh
+++ b/tools/ensure_content_repo.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Ensure the private content repo checkout exists at CONTENT_REPO_PATH.
+#
+# If the checkout already exists, this is a no-op.
+# If CONTENT_REPO_URL is set and the checkout doesn't exist, clones it via `gh`.
+# If CONTENT_REPO_URL is not set, prints a hint and exits 1.
+#
+# Both vars are read from src/.env or the environment. The repo is never
+# named in the codebase — CONTENT_REPO_URL is a per-machine config value.
+set -euo pipefail
+
+ENV_FILE="src/.env"
+
+# Read a var from .env or environment
+read_var() {
+    local key="$1"
+    local value
+    value=$(grep "^${key}=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- || true)
+    # Strip quotes
+    value="${value%\"}"
+    value="${value#\"}"
+    value="${value%\'}"
+    value="${value#\'}"
+    # Fall back to environment
+    if [ -z "$value" ]; then
+        value="${!key:-}"
+    fi
+    echo "$value"
+}
+
+path=$(read_var CONTENT_REPO_PATH)
+
+if [ -z "$path" ]; then
+    echo "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your"
+    echo "local checkout of the private content repository."
+    exit 1
+fi
+
+if [ -d "$path" ]; then
+    # Checkout exists — nothing to do.
+    exit 0
+fi
+
+url=$(read_var CONTENT_REPO_URL)
+
+if [ -z "$url" ]; then
+    echo "CONTENT_REPO_PATH is set to '$path' but the directory doesn't exist,"
+    echo "and CONTENT_REPO_URL is not set. Either clone the content repo"
+    echo "manually, or add CONTENT_REPO_URL to src/.env for auto-cloning."
+    exit 1
+fi
+
+echo "Content checkout not found at $path — cloning from $url"
+if ! gh repo clone "$url" "$path"; then
+    echo "Clone failed. Ensure GH_TOKEN is set (see docs/devcontainer-setup.md)"
+    echo "or clone the repo manually."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

The private lore repo contains 55 raw Django fixture JSON files (1,520 records across 56 model types) in addition to the YAML frontmatter markdown the existing pipeline already handles. This PR teaches the pipeline to load both formats in a single pass.

## What changed

### Pipeline extension (`content_fixtures.py`)
- New `build_fixture_json()` scans `fixtures/*.json` in the content repo and feeds objects into the same `BuildResult`
- `load_entries()` generalized from hardcoded `"name"` natural key to `model.NaturalKeyConfig.fields` via `_extract_natural_key()` — composite keys work (e.g. `ConditionStage` keyed on `condition` + `stage_order`)
- Stale model labels, missing FK targets, pk-based FKs, schema drift, and constraint violations are all **skipped with warnings** (`result.skipped`) instead of aborting the batch
- Nested `DoesNotExist` from composite natural keys with FK fields caught via `ObjectDoesNotExist` base class

### `NaturalKeyMixin` added to 7 models
Required for the upsert path (`update_or_create` by natural key):

| Model | Natural key |
|---|---|
| `magic.Cantrip` | `name` |
| `skills.Skill` | `trait` |
| `tarot.TarotCard` | `name` |
| `weather.FeastDay` | `name` |
| `weather.WeatherEmit` | `weather_type, text` |
| `weather.WeatherTypeExposure` | `weather_type, stat_key` |
| `character_creation.BeginningTradition` | `beginning, tradition` |

### Operator workflow
- `just load-content` now auto-clones the lore repo if `CONTENT_REPO_URL` is set in `src/.env` and the checkout doesn't exist
- New `tools/ensure_content_repo.sh` handles the clone-or-skip logic
- `.env.example` documents both `CONTENT_REPO_PATH` and `CONTENT_REPO_URL`
- CLI tool and admin button surface skipped records in their output

### Tests (11 new)
- Parsing, pk stripping, stale model skip, missing-NaturalKeyMixin skip, FK natural-key resolution, combined frontmatter+JSON load, create-then-update idempotency

## End-to-end test

Loading against the real lore repo:
- **805 records upserted** (idempotent on re-run)
- **715 skipped**: 316 stale models, 284 missing FK targets (load ordering), 83 pk-based FKs, 31 other, 1 constraint violation

## Not in this PR (tracked in issues)

- [arxii#2411](https://github.com/Arx-Game/arxii/issues/2411) — spoiler-free summary
- [ArxII-lore#11](https://github.com/Arx-Game/ArxII-lore/issues/11) — detailed fixture-by-fixture breakdown
- Tradition template migration script (245 orphaned records → `Gift` + `Technique` + `PathGiftGrant`)
- Anima ritual type suggestion table (20 descriptions → CG lookup)
- Relationship thread types (17 records → deferred, may revisit)

Closes #2411