### PR TITLE
Error boundary traps users — no way to recover without hard refresh

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,6 +1,10 @@
 import { ReactNode } from 'react';
 import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Home, RefreshCw } from 'lucide-react';
 
 interface Props {
   children: ReactNode;
@@ -14,39 +18,60 @@ function ErrorFallback({
   resetErrorBoundary: () => void;
 }) {
   const isDevelopment = import.meta.env.DEV;
+  const navigate = useNavigate();
+
+  const goHome = () => {
+    resetErrorBoundary();
+    navigate('/');
+  };
+
+  const reloadPage = () => {
+    window.location.reload();
+  };
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <div className="mx-auto max-w-2xl p-6 text-center">
-        <h2 className="text-2xl font-bold text-red-600">Something went wrong</h2>
-        <p className="mt-2 text-muted-foreground">{error.message}</p>
+      <Card className="mx-auto max-w-2xl">
+        <CardHeader>
+          <CardTitle className="text-2xl text-red-600">Something went wrong</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-center">
+          <p className="text-muted-foreground">{error.message}</p>
 
-        {isDevelopment && (
-          <details className="mt-4 text-left">
-            <summary className="cursor-pointer text-sm font-medium">
-              🐛 Debug Info (Development Only)
-            </summary>
-            <pre className="mt-2 overflow-auto rounded bg-gray-100 p-4 text-xs dark:bg-gray-800">
-              <strong>Error:</strong> {error.name}: {error.message}
-              {error.stack && (
-                <>
-                  <br />
-                  <strong>Stack:</strong>
-                  <br />
-                  {error.stack}
-                </>
-              )}
-            </pre>
-          </details>
-        )}
+          {isDevelopment && (
+            <details className="text-left">
+              <summary className="cursor-pointer text-sm font-medium">
+                🐛 Debug Info (Development Only)
+              </summary>
+              <pre className="mt-2 overflow-auto rounded bg-gray-100 p-4 text-xs dark:bg-gray-800">
+                <strong>Error:</strong> {error.name}: {error.message}
+                {error.stack && (
+                  <>
+                    <br />
+                    <strong>Stack:</strong>
+                    <br />
+                    {error.stack}
+                  </>
+                )}
+              </pre>
+            </details>
+          )}
 
-        <button
-          onClick={resetErrorBoundary}
-          className="mt-4 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
-        >
-          Try again
-        </button>
-      </div>
+          <div className="flex justify-center gap-2">
+            <Button onClick={resetErrorBoundary} variant="outline">
+              Try again
+            </Button>
+            <Button onClick={goHome}>
+              <Home className="mr-2 h-4 w-4" />
+              Go Home
+            </Button>
+            <Button onClick={reloadPage} variant="outline">
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Reload
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Tests for ErrorBoundary recovery buttons.
+ *
+ * Verifies that the error fallback renders "Go Home" and "Reload" buttons
+ * in addition to "Try again", so users are never trapped without recovery.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+function ThrowOnRender({ message }: { message: string }) {
+  throw new Error(message);
+}
+
+function renderWithProviders(initialRoute: string = '/') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const navigateMock = vi.fn();
+
+  return {
+    navigateMock,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialRoute]}>
+          <Routes>
+            <Route path="/" element={<div>Home page</div>} />
+            <Route
+              path="/crash"
+              element={
+                <ErrorBoundary>
+                  <ThrowOnRender message="Test error" />
+                </ErrorBoundary>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    ),
+  };
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders home page when no error', () => {
+    renderWithProviders();
+    expect(screen.getByText('Home page')).toBeInTheDocument();
+  });
+
+  it('shows error message and all three recovery buttons', () => {
+    renderWithProviders('/crash');
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('Test error')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument();
+  });
+
+  it('navigates to home when Go Home is clicked', async () => {
+    renderWithProviders('/crash');
+    await userEvent.click(screen.getByRole('button', { name: /go home/i }));
+    // After navigation, the error should be cleared and home should render.
+    // The ThrowOnRender component's error boundary is reset, and navigation
+    // takes us to / which renders "Home page".
+    expect(screen.getByText('Home page')).toBeInTheDocument();
+  });
+
+  it('calls window.location.reload when Reload is clicked', async () => {
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload: reloadSpy },
+      writable: true,
+    });
+
+    renderWithProviders('/crash');
+    await userEvent.click(screen.getByRole('button', { name: /reload/i }));
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -6,13 +6,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ErrorBoundary } from '../ErrorBoundary';
 
-function ThrowOnRender({ message }: { message: string }) {
+function ThrowOnRender({ message }: { message: string }): React.ReactNode {
   throw new Error(message);
 }
 


### PR DESCRIPTION
Closes #2407

## Summary

Add 'Go Home' and 'Reload' recovery buttons to the ErrorBoundary fallback. Previously users were trapped with only a 'Try again' button that re-renders the crashed component — if it re-throws, the only escape was a hard refresh. Also upgrades the fallback to use shadcn Card/Button components.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2407 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch is up to date with main, no conflicts.

<!-- last-addressed-comment: 0 -->