### PR TITLE
Antagonism-consent: finish remaining consumers (register + theft already shipped — #1698/#1141/#1909)

### DIFF
--- a/docs/roadmap/missions.md
+++ b/docs/roadmap/missions.md
@@ -66,6 +66,10 @@ Missions are branching narrative quest chains — the primary way characters int
   in the chain (Legend-Risk Floor, ADR-0107) — each T(n+1) gated on T(n) via the ordinary
   `has_completed_mission` predicate leaf. Journey-level acceptance test:
   `src/integration_tests/pipeline/test_tutorial_chain_e2e.py`.
+  A tutor-offered **"Terms of Engagement"** side-step (gated on T1, parallel to the T2..T7
+  spine — re-gates nothing, #2170) walks the new player to the antagonism-consent tree
+  (web Settings → Privacy / telnet `consent modes`) so the Friends+whitelist default is a
+  chosen, understood starting point (PLACEHOLDER copy).
   Two real pre-existing bugs the tutorial's live-play journey surfaced and fixed in-branch
   (Fold In, Don't File): (1) trigger-giver and board-giver grants
   (`trigger_dispatch._dispatch_from_giver`, `boards.take_from_board`) resolved the acting

--- a/docs/roadmap/ooc-social.md
+++ b/docs/roadmap/ooc-social.md
@@ -159,7 +159,9 @@ Details: `docs/systems/character_creation.md`'s "Email Notifications (#2162)" se
   tutorial chain (`docs/roadmap/missions.md`'s "Tutorial arc / External-Act Beats" entry) walks
   a fresh character through the level-1 loops (room-trigger/examine grants, a crafted-power
   beat, a Notice Board pickup, a covenant vow, a Legend-Risk Floor finale) on both web and
-  telnet, over the ordinary mission engine — no dedicated tutorial UI or engine. Still open:
+  telnet, over the ordinary mission engine — no dedicated tutorial UI or engine. #2170 added
+  the "Terms of Engagement" side-step (tutor-offered, gated on T1): a consent-tree primer so
+  the antagonism Friends+whitelist default is a chosen starting point. Still open:
   the chain's prose is placeholder-quality in-world copy (content polish, explicitly deferred
   inside #1035's scope), no dedicated web-side "you're new here" surfacing beyond the standard
   `JournalPage`/`BeatCard`. The web registration→application funnel polish — ✅ **shipped

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1195,12 +1195,17 @@ so web and telnet converge on the same write path.
 - **ConsentMode (#1698):** `EVERYONE` / `ALL_BUT_BLACKLIST` / `FRIENDS_WHITELIST` (OOC friends via
   `scenes.Friendship`) / `RIVALS` (declared **mutual** rivals via `scenes.Rivalry`, double
   opt-in — #2170; `friend_services.is_rival` + `declare_rival`/`undeclare_rival`, telnet
-  `rival`/`unrival`/`rivals`) / `ALLOWLIST`. Settable at any tree node; `CONSENT_MODE_GUIDANCE`
+  `rival`/`unrival`/`rivals`, web `RivalryViewSet` `/api/scenes/rivals/` + the sheet/card
+  `RivalButton`) / `ALLOWLIST`. Settable at any tree node; `CONSENT_MODE_GUIDANCE`
   + `consent_mode_guidance()` (constants) give the per-mode pros/cons copy the settings page /
-  telnet `consent modes` / `GET /api/consent/categories/modes/` render (PLACEHOLDER, #2170)
+  telnet `consent modes` / `GET /api/consent/categories/modes/` render (PLACEHOLDER, #2170).
+  Onboarding: the "Terms of Engagement" tutorial side-step (tutor-offered, gated on T1;
+  `world/seeds/game_content/tutorial.py`) walks a new player to the consent tree
 - **Consent tree (#2170):** seed builds an **All Antagonism** root (`FRIENDS_WHITELIST`) with
-  `hostile` + `blackmail` parented under it (`world/seeds/consent.py`); `theft` stays its own
-  `ALLOWLIST` root (preserves the #1909 steal gate). `effective_consent_mode(pref, category)`
+  every detriment-capable category — `hostile`, `blackmail`, `manipulative`, `theft` —
+  parented under it (`world/seeds/consent.py`); theft's effective default becomes the root's
+  `FRIENDS_WHITELIST` (its own `ALLOWLIST` survives only as the unseeded `theft_category()`
+  fallback / orphaned-row case). `effective_consent_mode(pref, category)`
   is the shared walk-up (nearest rule wins, else root default) — ADR-0113
 - **Key Methods:** `VisibilityMixin.is_visible_to()`, `_tenure_blocks_actor()` (thin delegator
   to `consent_blocks_targeting`, #1909), `decide_consent_block()` (takes `is_rival`),

--- a/docs/systems/consent.md
+++ b/docs/systems/consent.md
@@ -58,7 +58,11 @@ them; the reverse direction does not.
 actor must have declared the other a rival. Double opt-in by design (unlike one-directional
 friendship): the mode lets a character open an antagonism category to the people they have an
 IC rivalry with, and no one is dragged into that category one-sidedly. Telnet:
-`rival`/`unrival`/`rivals` (`commands/social/rivals.py`).
+`rival`/`unrival`/`rivals` (`commands/social/rivals.py`). Web: `RivalryViewSet`
+(`/api/scenes/rivals/` — list/declare/withdraw, `world/scenes/friend_views.py`; the list
+annotates `is_mutual`), surfaced as the `RivalButton`
+(`frontend/src/friends/components/RivalButton.tsx`) on another character's sheet page and
+card drawer, next to the `FriendButton`.
 
 **ActionTemplate link:** `ActionTemplate.consent_category` (nullable FK → `SocialConsentCategory`,
 `on_delete=SET_NULL`) tags each social template with its category. Uncategorized templates

--- a/frontend/src/friends/__tests__/RivalButton.test.tsx
+++ b/frontend/src/friends/__tests__/RivalButton.test.tsx
@@ -1,0 +1,86 @@
+/** RivalButton (#2170) — declare/withdraw an IC rival, double opt-in. Mocks the hooks. */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RivalButton } from '../components/RivalButton';
+import type { Rivalry } from '../types';
+
+const declareMutate = vi.fn();
+const withdrawMutate = vi.fn();
+
+vi.mock('@/friends/queries', () => ({
+  useRivalsQuery: vi.fn(),
+  useDeclareRivalMutation: vi.fn(() => ({
+    mutate: declareMutate,
+    isPending: false,
+    isError: false,
+  })),
+  useWithdrawRivalMutation: vi.fn(() => ({
+    mutate: withdrawMutate,
+    isPending: false,
+    isError: false,
+  })),
+}));
+
+import { useRivalsQuery } from '@/friends/queries';
+
+const mockQuery = vi.mocked(useRivalsQuery);
+
+function mockRivals(results: Rivalry[]): void {
+  mockQuery.mockReturnValue({
+    data: { count: results.length, next: null, previous: null, results },
+    isLoading: false,
+    isError: false,
+  } as ReturnType<typeof useRivalsQuery>);
+}
+
+function rivalry(overrides: Partial<Rivalry>): Rivalry {
+  return {
+    id: 1,
+    rivaler_tenure: 10,
+    rival_tenure: 20,
+    rivaler_entry: 100,
+    rival_entry: 200,
+    rival_name: 'Bob',
+    is_mutual: false,
+    created_at: '2026-07-01T00:00:00Z',
+    ...overrides,
+  } as Rivalry;
+}
+
+describe('RivalButton', () => {
+  it('renders nothing without an active viewer character', () => {
+    mockRivals([]);
+    const { container } = render(
+      <RivalButton viewerEntryId={null} targetEntryId={200} targetName="Bob" />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('declares a rival on click', () => {
+    mockRivals([]);
+    render(<RivalButton viewerEntryId={100} targetEntryId={200} targetName="Bob" />);
+    fireEvent.click(screen.getByRole('button', { name: /declare rival/i }));
+    expect(declareMutate).toHaveBeenCalledWith({ viewer: 100, rival: 200 });
+  });
+
+  it('shows pending state for a one-way declaration and withdraws on click', () => {
+    mockRivals([rivalry({ id: 7, rivaler_entry: 100, rival_entry: 200 })]);
+    render(<RivalButton viewerEntryId={100} targetEntryId={200} targetName="Bob" />);
+    expect(screen.getByText(/mutual once Bob declares you back/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Withdraw' }));
+    expect(withdrawMutate).toHaveBeenCalledWith(7);
+  });
+
+  it('shows mutual state once both sides declared', () => {
+    mockRivals([rivalry({ rivaler_entry: 100, rival_entry: 200, is_mutual: true })]);
+    render(<RivalButton viewerEntryId={100} targetEntryId={200} targetName="Bob" />);
+    expect(screen.getByText(/you and Bob are mutual rivals/i)).toBeInTheDocument();
+  });
+
+  it('ignores declarations toward other characters', () => {
+    mockRivals([rivalry({ rivaler_entry: 100, rival_entry: 999 })]);
+    render(<RivalButton viewerEntryId={100} targetEntryId={200} targetName="Bob" />);
+    expect(screen.getByRole('button', { name: /declare rival/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/friends/api.ts
+++ b/frontend/src/friends/api.ts
@@ -1,7 +1,7 @@
-/** OOC friends-list REST calls (#1727). */
+/** OOC friends-list (#1727) + rivalry-declaration (#2170) REST calls. */
 import { apiFetch } from '@/evennia_replacements/api';
 
-import type { PaginatedFriendshipList } from './types';
+import type { PaginatedFriendshipList, PaginatedRivalryList, Rivalry } from './types';
 
 /** The requesting player's friendships (across all their characters). */
 export async function listFriends(): Promise<PaginatedFriendshipList> {
@@ -42,5 +42,42 @@ export async function removeFriend(id: number): Promise<void> {
   const res = await apiFetch(`/api/scenes/friends/${id}/`, { method: 'DELETE' });
   if (!res.ok) {
     throw new Error('Failed to remove friend');
+  }
+}
+
+/** The requesting player's rival declarations (across all their characters, #2170). */
+export async function listRivals(): Promise<PaginatedRivalryList> {
+  const res = await apiFetch('/api/scenes/rivals/');
+  if (!res.ok) {
+    throw new Error('Failed to load rivals');
+  }
+  return res.json() as Promise<PaginatedRivalryList>;
+}
+
+export interface DeclareRivalPayload {
+  /** Your declaring character (a RosterEntry pk). */
+  viewer: number;
+  /** The character to declare a rival (a RosterEntry pk). */
+  rival: number;
+}
+
+/** Declare a rival — one side of the #2170 double opt-in; mutual once they declare you back. */
+export async function declareRival(payload: DeclareRivalPayload): Promise<Rivalry> {
+  const res = await apiFetch('/api/scenes/rivals/', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null);
+    throw new Error(detail?.detail ?? 'Failed to declare rival');
+  }
+  return res.json() as Promise<Rivalry>;
+}
+
+/** Withdraw one of your own rival declarations. */
+export async function withdrawRival(id: number): Promise<void> {
+  const res = await apiFetch(`/api/scenes/rivals/${id}/`, { method: 'DELETE' });
+  if (!res.ok) {
+    throw new Error('Failed to withdraw rival declaration');
   }
 }

--- a/frontend/src/friends/components/RivalButton.tsx
+++ b/frontend/src/friends/components/RivalButton.tsx
@@ -1,0 +1,68 @@
+import { useDeclareRivalMutation, useRivalsQuery, useWithdrawRivalMutation } from '../queries';
+
+/** "Declare this character a rival" — shown on another character's sheet/card (#2170).
+ *
+ * Rivalry is **double opt-in**: your declaration is one side's intent, and the rivalry (and the
+ * RIVALS consent mode) only takes effect once they declare you back. A one-way declaration is
+ * just you nursing a grudge. `viewerEntryId` is your active RosterEntry; `targetEntryId` is the
+ * viewed character's RosterEntry.
+ */
+export function RivalButton({
+  viewerEntryId,
+  targetEntryId,
+  targetName,
+}: {
+  viewerEntryId: number | null;
+  targetEntryId: number;
+  targetName: string;
+}) {
+  const { data } = useRivalsQuery();
+  const declare = useDeclareRivalMutation();
+  const withdraw = useWithdrawRivalMutation();
+
+  if (viewerEntryId === null) return null;
+
+  const existing = (data?.results ?? []).find(
+    (row) => row.rivaler_entry === viewerEntryId && row.rival_entry === targetEntryId
+  );
+
+  if (existing) {
+    return (
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-sm italic text-muted-foreground">
+          {existing.is_mutual
+            ? `You and ${targetName} are mutual rivals.`
+            : `Rival declared — mutual once ${targetName} declares you back.`}
+        </span>
+        <button
+          type="button"
+          disabled={withdraw.isPending}
+          className="rounded border px-3 py-1 text-sm hover:bg-accent disabled:opacity-50"
+          onClick={() => withdraw.mutate(existing.id)}
+        >
+          Withdraw
+        </button>
+        {withdraw.isError && (
+          <span className="text-sm text-destructive">{(withdraw.error as Error).message}</span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        disabled={declare.isPending}
+        title="Double opt-in: the rivalry only takes effect once they declare you back."
+        className="rounded border px-3 py-1 text-sm hover:bg-accent disabled:opacity-50"
+        onClick={() => declare.mutate({ viewer: viewerEntryId, rival: targetEntryId })}
+      >
+        ⚔ Declare rival
+      </button>
+      {declare.isError && (
+        <span className="text-sm text-destructive">{(declare.error as Error).message}</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/friends/queries.ts
+++ b/frontend/src/friends/queries.ts
@@ -1,10 +1,18 @@
-/** React Query hooks for the OOC friends list (#1727). */
+/** React Query hooks for the OOC friends list (#1727) and rival declarations (#2170). */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { addFriend, listFriends, removeFriend } from './api';
-import type { AddFriendPayload } from './api';
+import {
+  addFriend,
+  declareRival,
+  listFriends,
+  listRivals,
+  removeFriend,
+  withdrawRival,
+} from './api';
+import type { AddFriendPayload, DeclareRivalPayload } from './api';
 
 export const friendKeys = { list: ['friends'] as const };
+export const rivalKeys = { list: ['rivals'] as const };
 
 export function useFriendsQuery() {
   return useQuery({ queryKey: friendKeys.list, queryFn: listFriends });
@@ -23,5 +31,25 @@ export function useRemoveFriendMutation() {
   return useMutation({
     mutationFn: (id: number) => removeFriend(id),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: friendKeys.list }),
+  });
+}
+
+export function useRivalsQuery() {
+  return useQuery({ queryKey: rivalKeys.list, queryFn: listRivals });
+}
+
+export function useDeclareRivalMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: DeclareRivalPayload) => declareRival(payload),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: rivalKeys.list }),
+  });
+}
+
+export function useWithdrawRivalMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => withdrawRival(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: rivalKeys.list }),
   });
 }

--- a/frontend/src/friends/types.ts
+++ b/frontend/src/friends/types.ts
@@ -1,5 +1,7 @@
-/** OOC friends-list API types (#1727), from the generated OpenAPI schema. */
+/** OOC friends-list (#1727) + rivalry (#2170) API types, from the generated OpenAPI schema. */
 import type { components } from '@/generated/api';
 
 export type Friendship = components['schemas']['Friendship'];
 export type PaginatedFriendshipList = components['schemas']['PaginatedFriendshipList'];
+export type Rivalry = components['schemas']['Rivalry'];
+export type PaginatedRivalryList = components['schemas']['PaginatedRivalryList'];

--- a/frontend/src/game/components/CharacterCardDrawer.test.tsx
+++ b/frontend/src/game/components/CharacterCardDrawer.test.tsx
@@ -22,6 +22,9 @@ vi.mock('@/roster/queries', () => ({
 }));
 vi.mock('@/friends/queries', () => ({
   useAddFriendMutation: vi.fn(),
+  useRivalsQuery: vi.fn(() => ({ data: undefined, isLoading: false, isError: false })),
+  useDeclareRivalMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false })),
+  useWithdrawRivalMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false })),
 }));
 vi.mock('@/relationships/queries', () => ({
   useMyRelationshipToTarget: vi.fn(),

--- a/frontend/src/game/components/CharacterCardDrawer.tsx
+++ b/frontend/src/game/components/CharacterCardDrawer.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { PersonaAvatar } from '@/components/PersonaAvatar';
 import { BackgroundSection, StatsSection, CharacterLink } from '@/components/character';
 import { FriendButton } from '@/friends/components/FriendButton';
+import { RivalButton } from '@/friends/components/RivalButton';
 import { useRosterEntryByNameQuery, useRosterEntryQuery } from '@/roster/queries';
 import { useMyRelationshipToTarget } from '@/relationships/queries';
 import { RelationshipWriteupDialog } from '@/relationships/components/RelationshipWriteupDialog';
@@ -126,6 +127,13 @@ export function CharacterCardDrawer({
             <div className="mt-4 flex flex-wrap items-center gap-3">
               {matchId != null && (
                 <FriendButton
+                  viewerEntryId={viewerEntryId}
+                  targetEntryId={matchId}
+                  targetName={persona.name}
+                />
+              )}
+              {matchId != null && (
+                <RivalButton
                   viewerEntryId={viewerEntryId}
                   targetEntryId={matchId}
                   targetName={persona.name}

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -14978,6 +14978,59 @@ export interface paths {
     patch: operations['risk_calibrations_partial_update'];
     trace?: never;
   };
+  '/api/rivals/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description The requesting player's rival declarations: list, declare, withdraw (#2170).
+     *
+     *     Double opt-in — a declaration here is one side's intent; ``is_mutual`` flips true (and the
+     *     RIVALS consent gate opens) only once the other side declares back. Withdrawing (DELETE)
+     *     removes only your own side.
+     */
+    get: operations['rivals_list'];
+    put?: never;
+    /**
+     * @description The requesting player's rival declarations: list, declare, withdraw (#2170).
+     *
+     *     Double opt-in — a declaration here is one side's intent; ``is_mutual`` flips true (and the
+     *     RIVALS consent gate opens) only once the other side declares back. Withdrawing (DELETE)
+     *     removes only your own side.
+     */
+    post: operations['rivals_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/rivals/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * @description The requesting player's rival declarations: list, declare, withdraw (#2170).
+     *
+     *     Double opt-in — a declaration here is one side's intent; ``is_mutual`` flips true (and the
+     *     RIVALS consent gate opens) only once the other side declares back. Withdrawing (DELETE)
+     *     removes only your own side.
+     */
+    delete: operations['rivals_destroy'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/room-features/defenses/fund-ward/': {
     parameters: {
       query?: never;
@@ -27968,6 +28021,21 @@ export interface components {
       previous?: string | null;
       results: components['schemas']['Ritual'][];
     };
+    PaginatedRivalryList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['Rivalry'][];
+    };
     PaginatedRoomAlarmDetailsList: {
       /** @example 123 */
       count: number;
@@ -31994,6 +32062,46 @@ export interface components {
       state: string;
       /** Format: date-time */
       responded_at: string | null;
+    };
+    /**
+     * @description One of your rival declarations — target name, which character declared, mutual or pending.
+     *
+     *     ``is_mutual`` reports the #2170 double-opt-in state: True only once the other side has
+     *     declared you back (the list queryset annotates it; the create path stamps it explicitly).
+     *     ``rivaler_entry`` / ``rival_entry`` expose the RosterEntry pks web clients speak.
+     */
+    Rivalry: {
+      readonly id: number;
+      /** @description The declarer's tenure (this player's run of the character that named a rival). */
+      readonly rivaler_tenure: number;
+      /** @description The named rival's tenure (a specific player's run of that character). */
+      readonly rival_tenure: number;
+      readonly rivaler_entry: number;
+      readonly rival_entry: number;
+      readonly rival_name: string;
+      readonly is_mutual: boolean;
+      /** Format: date-time */
+      readonly created_at: string;
+    };
+    /**
+     * @description Declare a rival by character (web-friendly): your declaring character + the target.
+     *
+     *     ``viewer`` / ``rival`` are ``RosterEntry`` pks; the view resolves each to its current tenure
+     *     (rivalries are tenure-based, mirroring ``FriendshipCreateSerializer``).
+     */
+    RivalryCreate: {
+      viewer: number;
+      rival: number;
+    };
+    /**
+     * @description Declare a rival by character (web-friendly): your declaring character + the target.
+     *
+     *     ``viewer`` / ``rival`` are ``RosterEntry`` pks; the view resolves each to its current tenure
+     *     (rivalries are tenure-based, mirroring ``FriendshipCreateSerializer``).
+     */
+    RivalryCreateRequest: {
+      viewer: number;
+      rival: number;
     };
     /**
      * @description * `informant` - Informant
@@ -56756,6 +56864,71 @@ export interface operations {
         content: {
           'application/json': components['schemas']['RiskCalibration'];
         };
+      };
+    };
+  };
+  rivals_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedRivalryList'];
+        };
+      };
+    };
+  };
+  rivals_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['RivalryCreateRequest'];
+      };
+    };
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['RivalryCreate'];
+        };
+      };
+    };
+  };
+  rivals_destroy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ReputationTab } from '@/reputation/components/ReputationTab';
 import { VitalsPanel } from '@/vitals/components/VitalsPanel';
 import { FriendButton } from '@/friends/components/FriendButton';
+import { RivalButton } from '@/friends/components/RivalButton';
 import { FriendsTab } from '@/friends/components/FriendsTab';
 import { GossipPanel } from '@/secrets/components/GossipPanel';
 import { SecretsTab } from '@/secrets/components/SecretsTab';
@@ -95,6 +96,14 @@ export function CharacterSheetPage() {
         {/* Friend this character — an OOC trusted-partner designation (#1727), only on others' sheets. */}
         {!isMyCharacter && (
           <FriendButton
+            viewerEntryId={viewerEntryId}
+            targetEntryId={entryId}
+            targetName={entry.character.name}
+          />
+        )}
+        {/* Declare an IC rival — the antagonism-consent counterpart (#2170), double opt-in. */}
+        {!isMyCharacter && (
+          <RivalButton
             viewerEntryId={viewerEntryId}
             targetEntryId={entryId}
             targetName={entry.character.name}

--- a/src/integration_tests/pipeline/test_tutorial_chain_e2e.py
+++ b/src/integration_tests/pipeline/test_tutorial_chain_e2e.py
@@ -161,8 +161,10 @@ class TutorialChainJourneyE2ETests(TestCase):
         # gate blocks same-session progression through T5/T6/T7 (see module
         # docstring). Seed drift on this must fail loudly, not silently
         # reintroduce a need for cooldown fast-forwarding in this test.
+        # 5 offers: the T3/T5/T6/T7 chain steps + the "Terms of Engagement"
+        # consent primer (#2170), a T1-gated side-step off the same tutor.
         tutor_offers = NPCServiceOffer.objects.filter(role=self.tutor_role)
-        self.assertEqual(tutor_offers.count(), 4)
+        self.assertEqual(tutor_offers.count(), 5)
         for offer in tutor_offers:
             self.assertEqual(
                 offer.mission_offer_details.role_cooldown_duration,

--- a/src/schema.json
+++ b/src/schema.json
@@ -24772,6 +24772,80 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/rivals/:
+    get:
+      operationId: rivals_list
+      description: |-
+        The requesting player's rival declarations: list, declare, withdraw (#2170).
+
+        Double opt-in — a declaration here is one side's intent; ``is_mutual`` flips true (and the
+        RIVALS consent gate opens) only once the other side declares back. Withdrawing (DELETE)
+        removes only your own side.
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      tags:
+      - rivals
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRivalryList'
+          description: ''
+    post:
+      operationId: rivals_create
+      description: |-
+        The requesting player's rival declarations: list, declare, withdraw (#2170).
+
+        Double opt-in — a declaration here is one side's intent; ``is_mutual`` flips true (and the
+        RIVALS consent gate opens) only once the other side declares back. Withdrawing (DELETE)
+        removes only your own side.
+      tags:
+      - rivals
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RivalryCreateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RivalryCreate'
+          description: ''
+  /api/rivals/{id}/:
+    delete:
+      operationId: rivals_destroy
+      description: |-
+        The requesting player's rival declarations: list, declare, withdraw (#2170).
+
+        Double opt-in — a declaration here is one side's intent; ``is_mutual`` flips true (and the
+        RIVALS consent gate opens) only once the other side declares back. Withdrawing (DELETE)
+        removes only your own side.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - rivals
+      security:
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/room-features/defenses/fund-ward/:
     post:
       operationId: room_features_defenses_fund_ward_create
@@ -49778,6 +49852,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Ritual'
+    PaginatedRivalryList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Rivalry'
     PaginatedRoomAlarmDetailsList:
       type: object
       required:
@@ -57128,6 +57225,82 @@ components:
       - character_sheet_id
       - responded_at
       - state
+    Rivalry:
+      type: object
+      description: |-
+        One of your rival declarations — target name, which character declared, mutual or pending.
+
+        ``is_mutual`` reports the #2170 double-opt-in state: True only once the other side has
+        declared you back (the list queryset annotates it; the create path stamps it explicitly).
+        ``rivaler_entry`` / ``rival_entry`` expose the RosterEntry pks web clients speak.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        rivaler_tenure:
+          type: integer
+          readOnly: true
+          description: The declarer's tenure (this player's run of the character that
+            named a rival).
+        rival_tenure:
+          type: integer
+          readOnly: true
+          description: The named rival's tenure (a specific player's run of that character).
+        rivaler_entry:
+          type: integer
+          readOnly: true
+        rival_entry:
+          type: integer
+          readOnly: true
+        rival_name:
+          type: string
+          readOnly: true
+        is_mutual:
+          type: boolean
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - id
+      - is_mutual
+      - rival_entry
+      - rival_name
+      - rival_tenure
+      - rivaler_entry
+      - rivaler_tenure
+    RivalryCreate:
+      type: object
+      description: |-
+        Declare a rival by character (web-friendly): your declaring character + the target.
+
+        ``viewer`` / ``rival`` are ``RosterEntry`` pks; the view resolves each to its current tenure
+        (rivalries are tenure-based, mirroring ``FriendshipCreateSerializer``).
+      properties:
+        viewer:
+          type: integer
+        rival:
+          type: integer
+      required:
+      - rival
+      - viewer
+    RivalryCreateRequest:
+      type: object
+      description: |-
+        Declare a rival by character (web-friendly): your declaring character + the target.
+
+        ``viewer`` / ``rival`` are ``RosterEntry`` pks; the view resolves each to its current tenure
+        (rivalries are tenure-based, mirroring ``FriendshipCreateSerializer``).
+      properties:
+        viewer:
+          type: integer
+        rival:
+          type: integer
+      required:
+      - rival
+      - viewer
     RoleContextEnum:
       enum:
       - informant

--- a/src/world/missions/tests/test_tutorial_seed.py
+++ b/src/world/missions/tests/test_tutorial_seed.py
@@ -39,6 +39,7 @@ _T4_NAME = "A Simple Job"
 _T5_NAME = "The Loom"
 _T6_NAME = "Sworn Together"
 _T7_NAME = "The Long Dark"
+_TC_NAME = "Terms of Engagement"
 
 
 def _gate_for(template: MissionTemplate) -> dict:
@@ -141,6 +142,30 @@ class SeedTutorialDevTests(TestCase):
         )
         self.assertIsNotNone(giver.target_id)
         self.assertEqual(self.t2.availability_rule, _gate_for(self.t1))
+
+    # -- Consent primer "Terms of Engagement" (#2170 item 3) ----------------
+
+    def test_consent_primer_gate_offer_and_shape(self) -> None:
+        """The antagonism-consent onboarding side-step: gated on T1, tutor-offered.
+
+        Parallel to the T2..T7 spine — it must never re-gate the chain itself
+        (T2 stays gated on T1, T3 on T2; asserted by their own tests above/below).
+        """
+        primer = MissionTemplate.objects.get(name=_TC_NAME)
+        self.assertEqual(primer.risk_tier, 1)
+        self.assertEqual(primer.availability_rule, _gate_for(self.t1))
+
+        details = MissionOfferDetails.objects.get(mission_template=primer)
+        self.assertEqual(details.offer.kind, OfferKind.MISSION)
+        self.assertEqual(details.role_cooldown_duration, timedelta(0))
+
+        # The epilogue is the surface that points at the real consent tree.
+        self.assertIn("Privacy", primer.epilogue)
+        self.assertIn("consent", primer.epilogue)
+
+        entry = primer.nodes.get(is_entry=True)
+        option = entry.options.get()
+        self.assertEqual(option.option_kind, OptionKind.BRANCH)
 
     # -- T3 First Spark ---------------------------------------------------
 

--- a/src/world/scenes/CLAUDE.md
+++ b/src/world/scenes/CLAUDE.md
@@ -249,7 +249,7 @@ Key service functions for scene round lifecycle:
     `persona profile <name> …` (#1270).
 - **`SceneSummaryRevisionViewSet`**: Summary revision management
 
-### `friend_views.py` (#1727)
+### `friend_views.py` (#1727, #2170)
 - **`FriendshipViewSet`**: the web face of the OOC friends list (`friend_services.py`) —
   list/add/remove. `list` returns the player's friendships (made by any of their characters).
   `create` takes **`viewer`/`friend` as `RosterEntry` pks** (web clients speak character ids, not
@@ -257,6 +257,14 @@ Key service functions for scene round lifecycle:
   calls `add_friend` / `add_friend_all_characters`. Tenure-scoped + alt-private, mirroring the
   Block/Mute control API. Telnet parity is `CmdFriend`/`CmdUnfriend`/`CmdFriends`. React surface:
   `frontend/src/friends/` (`FriendsTab` self-only tab + `FriendButton` on other sheets).
+- **`RivalryViewSet`** (#2170): the web face of rival declarations (`/api/scenes/rivals/`) —
+  list/declare/withdraw, same shape as friendships (`viewer`/`rival` as `RosterEntry` pks,
+  resolved to tenures server-side, calling `declare_rival`). Double opt-in: the list queryset
+  annotates `is_mutual` (an `Exists` on the reciprocal row) and the create response stamps it,
+  so the client can render "mutual rivals" vs "awaiting their declaration"; a DELETE removes
+  only your own side. Telnet parity is `CmdRival`/`CmdUnrival`/`CmdRivals`. React surface:
+  `RivalButton` (`frontend/src/friends/components/`) on another character's sheet page + card
+  drawer, next to the `FriendButton`.
 
 ### `interaction_views.py`
 - **`InteractionViewSet`**: Interaction read + delete + mark_private

--- a/src/world/scenes/friend_serializers.py
+++ b/src/world/scenes/friend_serializers.py
@@ -1,13 +1,15 @@
-"""Serializers for the OOC friends-list API (#1727)."""
+"""Serializers for the OOC friends-list API (#1727) and rivalry declarations (#2170)."""
 
 from __future__ import annotations
 
 from rest_framework import serializers
 
 from world.roster.models import RosterEntry
-from world.scenes.models import Friendship
+from world.scenes.models import Friendship, Rivalry
 
 _NOT_YOUR_CHARACTER = "You can only friend as one of your own characters."
+_NOT_YOUR_CHARACTER_RIVAL = "You can only declare a rival as one of your own characters."
+_SELF_RIVAL = "A character cannot declare themselves a rival."
 
 
 class FriendshipCreateSerializer(serializers.Serializer):
@@ -39,4 +41,60 @@ class FriendshipSerializer(serializers.ModelSerializer):
 
     def get_friend_name(self, obj: Friendship) -> str:
         character = obj.friend_tenure.roster_entry.character_sheet.character
+        return character.db_key if character is not None else "Unknown"
+
+
+class RivalryCreateSerializer(serializers.Serializer):
+    """Declare a rival by character (web-friendly): your declaring character + the target.
+
+    ``viewer`` / ``rival`` are ``RosterEntry`` pks; the view resolves each to its current tenure
+    (rivalries are tenure-based, mirroring ``FriendshipCreateSerializer``).
+    """
+
+    viewer = serializers.PrimaryKeyRelatedField(queryset=RosterEntry.objects.all())
+    rival = serializers.PrimaryKeyRelatedField(queryset=RosterEntry.objects.all())
+
+    def validate_viewer(self, value: RosterEntry) -> RosterEntry:
+        owned = RosterEntry.objects.for_account(self.context["request"].user).filter(pk=value.pk)
+        if not owned.exists():
+            raise serializers.ValidationError(_NOT_YOUR_CHARACTER_RIVAL)
+        return value
+
+    def validate(self, attrs: dict) -> dict:
+        if attrs["viewer"].pk == attrs["rival"].pk:
+            raise serializers.ValidationError(_SELF_RIVAL)
+        return attrs
+
+
+class RivalrySerializer(serializers.ModelSerializer):
+    """One of your rival declarations — target name, which character declared, mutual or pending.
+
+    ``is_mutual`` reports the #2170 double-opt-in state: True only once the other side has
+    declared you back (the list queryset annotates it; the create path stamps it explicitly).
+    ``rivaler_entry`` / ``rival_entry`` expose the RosterEntry pks web clients speak.
+    """
+
+    rival_name = serializers.SerializerMethodField()
+    rivaler_entry = serializers.IntegerField(
+        source="rivaler_tenure.roster_entry_id", read_only=True
+    )
+    rival_entry = serializers.IntegerField(source="rival_tenure.roster_entry_id", read_only=True)
+    is_mutual = serializers.BooleanField(read_only=True)
+
+    class Meta:
+        model = Rivalry
+        fields = [
+            "id",
+            "rivaler_tenure",
+            "rival_tenure",
+            "rivaler_entry",
+            "rival_entry",
+            "rival_name",
+            "is_mutual",
+            "created_at",
+        ]
+        read_only_fields = fields
+
+    def get_rival_name(self, obj: Rivalry) -> str:
+        character = obj.rival_tenure.roster_entry.character_sheet.character
         return character.db_key if character is not None else "Unknown"

--- a/src/world/scenes/friend_views.py
+++ b/src/world/scenes/friend_views.py
@@ -1,12 +1,14 @@
-"""OOC friends-list API (#1727) — the web face of world.scenes.friend_services.
+"""OOC friends-list (#1727) + rivalry-declaration (#2170) API — the web face of
+world.scenes.friend_services.
 
 A player's friendships (those made by any of their characters): list, add (one character or all),
-remove. Tenure-scoped + alt-private, mirroring the Block/Mute control API.
+remove. Rivalries mirror the same shape: list, declare (double opt-in — mutual only once both
+sides declare), withdraw. Tenure-scoped + alt-private, mirroring the Block/Mute control API.
 """
 
 from __future__ import annotations
 
-from django.db.models import QuerySet
+from django.db.models import Exists, OuterRef, QuerySet
 from rest_framework import mixins, serializers, status
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
@@ -15,11 +17,17 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from evennia_extensions.models import PlayerData
-from world.scenes.friend_serializers import FriendshipCreateSerializer, FriendshipSerializer
-from world.scenes.friend_services import add_friend, add_friend_all_characters
-from world.scenes.models import Friendship
+from world.scenes.friend_serializers import (
+    FriendshipCreateSerializer,
+    FriendshipSerializer,
+    RivalryCreateSerializer,
+    RivalrySerializer,
+)
+from world.scenes.friend_services import add_friend, add_friend_all_characters, declare_rival
+from world.scenes.models import Friendship, Rivalry
 
 _NO_ACTIVE_TENURE = "That character has no active tenure to friend."
+_NO_ACTIVE_TENURE_RIVAL = "That character has no active tenure to declare a rival."
 
 
 class FriendsPagination(PageNumberPagination):
@@ -61,3 +69,51 @@ class FriendshipViewSet(
             return Response(status=status.HTTP_201_CREATED)
         friendship = add_friend(friender_tenure=viewer_tenure, friend_tenure=friend_tenure)
         return Response(FriendshipSerializer(friendship).data, status=status.HTTP_201_CREATED)
+
+
+class RivalryViewSet(
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    GenericViewSet,
+):
+    """The requesting player's rival declarations: list, declare, withdraw (#2170).
+
+    Double opt-in — a declaration here is one side's intent; ``is_mutual`` flips true (and the
+    RIVALS consent gate opens) only once the other side declares back. Withdrawing (DELETE)
+    removes only your own side.
+    """
+
+    permission_classes = [IsAuthenticated]
+    pagination_class = FriendsPagination
+    filter_backends: list = []
+
+    def get_queryset(self) -> QuerySet[Rivalry]:
+        reciprocal = Rivalry.objects.filter(
+            rivaler_tenure=OuterRef("rival_tenure"), rival_tenure=OuterRef("rivaler_tenure")
+        )
+        return (
+            Rivalry.objects.filter(rivaler_tenure__player_data__account=self.request.user)
+            .select_related("rival_tenure__roster_entry__character_sheet__character")
+            .annotate(is_mutual=Exists(reciprocal))
+            .order_by("-created_at")
+        )
+
+    def get_serializer_class(self) -> type[serializers.BaseSerializer]:
+        return RivalryCreateSerializer if self.action == "create" else RivalrySerializer
+
+    def create(self, request: Request, *args: object, **kwargs: object) -> Response:
+        serializer = RivalryCreateSerializer(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        # Resolve each character (RosterEntry) to its current tenure — rivalries are tenure-based.
+        viewer_tenure = data["viewer"].current_tenure
+        rival_tenure = data["rival"].current_tenure
+        if viewer_tenure is None or rival_tenure is None:
+            raise serializers.ValidationError(_NO_ACTIVE_TENURE_RIVAL)
+        rivalry = declare_rival(rivaler_tenure=viewer_tenure, rival_tenure=rival_tenure)
+        # The annotated list queryset supplies is_mutual; stamp it explicitly on the create path.
+        rivalry.is_mutual = Rivalry.objects.filter(
+            rivaler_tenure=rival_tenure, rival_tenure=viewer_tenure
+        ).exists()
+        return Response(RivalrySerializer(rivalry).data, status=status.HTTP_201_CREATED)

--- a/src/world/scenes/tests/test_rivalry_api.py
+++ b/src/world/scenes/tests/test_rivalry_api.py
@@ -1,0 +1,92 @@
+"""Rivalry-declaration API (#2170) — the web face of declare/undeclare rival."""
+
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory
+from world.roster.factories import PlayerDataFactory, RosterTenureFactory
+from world.scenes.models import Rivalry
+
+
+class RivalryApiTests(APITestCase):
+    def setUp(self) -> None:
+        self.account = AccountFactory()
+        self.player = PlayerDataFactory(account=self.account)
+        self.my_tenure = RosterTenureFactory(player_data=self.player)
+        self.target_tenure = RosterTenureFactory()
+        self.client.force_authenticate(user=self.account)
+
+    def test_declare_lists_and_withdraw(self) -> None:
+        # Declare.
+        res = self.client.post(
+            reverse("rival-list"),
+            {
+                "viewer": self.my_tenure.roster_entry.pk,
+                "rival": self.target_tenure.roster_entry.pk,
+            },
+            format="json",
+        )
+        self.assertEqual(res.status_code, 201)
+        self.assertFalse(res.data["is_mutual"])
+        rivalry = Rivalry.objects.get(rivaler_tenure=self.my_tenure)
+
+        # List (only mine), with entry pks for client-side matching.
+        rows = self.client.get(reverse("rival-list")).data["results"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["rivaler_entry"], self.my_tenure.roster_entry.pk)
+        self.assertEqual(rows[0]["rival_entry"], self.target_tenure.roster_entry.pk)
+        self.assertFalse(rows[0]["is_mutual"])
+
+        # Withdraw.
+        res = self.client.delete(reverse("rival-detail", args=[rivalry.pk]))
+        self.assertIn(res.status_code, (200, 204))
+        self.assertFalse(Rivalry.objects.exists())
+
+    def test_mutual_once_both_sides_declare(self) -> None:
+        # The target has already declared me — my declaration completes the double opt-in.
+        Rivalry.objects.create(rivaler_tenure=self.target_tenure, rival_tenure=self.my_tenure)
+        res = self.client.post(
+            reverse("rival-list"),
+            {
+                "viewer": self.my_tenure.roster_entry.pk,
+                "rival": self.target_tenure.roster_entry.pk,
+            },
+            format="json",
+        )
+        self.assertEqual(res.status_code, 201)
+        self.assertTrue(res.data["is_mutual"])
+        rows = self.client.get(reverse("rival-list")).data["results"]
+        self.assertTrue(rows[0]["is_mutual"])
+
+    def test_cannot_declare_as_someone_elses_character(self) -> None:
+        other_tenure = RosterTenureFactory()  # not owned by self.account
+        res = self.client.post(
+            reverse("rival-list"),
+            {"viewer": other_tenure.roster_entry.pk, "rival": self.target_tenure.roster_entry.pk},
+            format="json",
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_cannot_declare_self(self) -> None:
+        res = self.client.post(
+            reverse("rival-list"),
+            {"viewer": self.my_tenure.roster_entry.pk, "rival": self.my_tenure.roster_entry.pk},
+            format="json",
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_list_excludes_other_players_rivalries(self) -> None:
+        other_player = PlayerDataFactory(account=AccountFactory())
+        other_rivaler = RosterTenureFactory(player_data=other_player)
+        Rivalry.objects.create(rivaler_tenure=other_rivaler, rival_tenure=self.target_tenure)
+        self.assertEqual(self.client.get(reverse("rival-list")).data["results"], [])
+
+    def test_cannot_delete_another_players_declaration(self) -> None:
+        other_player = PlayerDataFactory(account=AccountFactory())
+        other_rivaler = RosterTenureFactory(player_data=other_player)
+        rivalry = Rivalry.objects.create(
+            rivaler_tenure=other_rivaler, rival_tenure=self.target_tenure
+        )
+        res = self.client.delete(reverse("rival-detail", args=[rivalry.pk]))
+        self.assertEqual(res.status_code, 404)
+        self.assertTrue(Rivalry.objects.filter(pk=rivalry.pk).exists())

--- a/src/world/scenes/urls.py
+++ b/src/world/scenes/urls.py
@@ -2,7 +2,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from world.scenes.action_views import SceneActionRequestViewSet, SceneActionTargetViewSet
-from world.scenes.friend_views import FriendshipViewSet
+from world.scenes.friend_views import FriendshipViewSet, RivalryViewSet
 from world.scenes.interaction_views import (
     InteractionFavoriteViewSet,
     InteractionReactionViewSet,
@@ -63,6 +63,7 @@ router.register(
 router.register(r"blocks", BlockViewSet, basename="block")
 router.register(r"mutes", MuteViewSet, basename="mute")
 router.register(r"friends", FriendshipViewSet, basename="friend")
+router.register(r"rivals", RivalryViewSet, basename="rival")
 
 urlpatterns = [
     path("api/", include(router.urls)),

--- a/src/world/seeds/game_content/tutorial.py
+++ b/src/world/seeds/game_content/tutorial.py
@@ -83,6 +83,7 @@ _T4_NAME = "A Simple Job"
 _T5_NAME = "The Loom"
 _T6_NAME = "Sworn Together"
 _T7_NAME = "The Long Dark"
+_TC_NAME = "Terms of Engagement"
 
 _DETAIL_OBJECT_KEY = "a faint scorch mark on the wall"
 _DETAIL_OBJECT_TYPECLASS = "typeclasses.objects.Object"
@@ -95,10 +96,15 @@ _TUTOR_ROLE_NAME = "Threshold Warden"
 
 @dataclass
 class TutorialSeedResult:
-    """Returned by seed_tutorial_dev(). Templates in chain order, T1 first."""
+    """Returned by seed_tutorial_dev(). Templates in chain order, T1 first.
+
+    ``consent_template`` is the "Terms of Engagement" antagonism-consent primer (#2170) —
+    a tutor-offered side-step gated on T1, parallel to the T2..T7 spine.
+    """
 
     templates: list[MissionTemplate]
     tutor_role: NPCRole
+    consent_template: MissionTemplate
 
 
 def _has_completed(template_id: int) -> dict:
@@ -309,6 +315,63 @@ def _ensure_offer(
             role_cooldown_duration=role_cooldown_duration,
         )
     return offer
+
+
+def _seed_consent_primer(gate_template: MissionTemplate) -> MissionTemplate:
+    """ "Terms of Engagement" — the antagonism-consent onboarding beat (#2170 item 3).
+
+    A tutor-offered side-step gated on T1 (parallel to the T2..T7 spine — it re-gates
+    nothing). Walks the new player to the consent tree so the Friends+whitelist default
+    is a *chosen, understood* starting point, not a silent one: the summary frames it IC,
+    the epilogue points at the real surfaces (web Settings → Privacy; telnet ``consent`` /
+    ``consent modes``, which render the per-mode pros/cons from CONSENT_MODE_GUIDANCE).
+
+    All prose here is PLACEHOLDER (agent-drafted — Apostate to rewrite, #2170).
+    """
+    from world.missions.factories import (  # noqa: PLC0415
+        MissionNodeFactory,
+        MissionOptionFactory,
+        MissionOptionRouteFactory,
+        MissionOptionRouteRewardFactory,
+        MissionTemplateFactory,
+    )
+
+    template = MissionTemplateFactory(
+        name=_TC_NAME,
+        summary=(
+            'The Warden looks you over like a quartermaster sizing a recruit. "This city will '
+            "test you — with knives, with lies, with light fingers. Before it does, decide who "
+            'is allowed to try. Nobody moves against you here without your leave."'
+        ),
+        epilogue=(
+            "Your boundaries are yours to set, and to change. Open Settings → Privacy on the "
+            "web (or type 'consent' in the classic client) to review who may target you with "
+            "hostile play: set the whole Antagonism group at once, or tune a single category. "
+            "'consent modes' explains the trade-offs of each setting — the default lets only "
+            "your OOC friends try anything against you until you say otherwise."
+        ),
+        risk_tier=1,
+        level_band_min=1,
+        level_band_max=5,
+        visibility=MissionVisibility.RESTRICTED,
+        availability_rule=_has_completed(gate_template.pk),
+    )
+    if not template.nodes.exists():
+        entry = MissionNodeFactory(template=template, key="entry", is_entry=True)
+        option = MissionOptionFactory(
+            node=entry,
+            option_kind=OptionKind.BRANCH,
+            source_kind=OptionSource.AUTHORED,
+            authored_ic_framing="Weigh who you'd let raise a hand against you, and set your terms.",
+        )
+        route = MissionOptionRouteFactory(option=option, outcome_tier=None, target_node=None)
+        MissionOptionRouteRewardFactory(
+            route=route,
+            sink=DeedRewardSink.MONEY,
+            amount=25,
+            contract_holder_only=True,
+        )
+    return template
 
 
 def _seed_t3(gate_template: MissionTemplate) -> MissionTemplate:
@@ -599,6 +662,9 @@ def seed_tutorial_dev() -> TutorialSeedResult:
     tutor_role = _ensure_tutor_role()
     _ensure_tutor_functionary(tutor_role, room)
 
+    consent_primer = _seed_consent_primer(t1)
+    _ensure_offer(tutor_role, "A word about boundaries", consent_primer)
+
     t3 = _seed_t3(t2)
     _ensure_offer(tutor_role, "Kindle a first spark", t3)
 
@@ -615,4 +681,8 @@ def seed_tutorial_dev() -> TutorialSeedResult:
     t7 = _seed_t7(t6)
     _ensure_offer(tutor_role, "Answer the long dark's call", t7)
 
-    return TutorialSeedResult(templates=[t1, t2, t3, t4, t5, t6, t7], tutor_role=tutor_role)
+    return TutorialSeedResult(
+        templates=[t1, t2, t3, t4, t5, t6, t7],
+        tutor_role=tutor_role,
+        consent_template=consent_primer,
+    )


### PR DESCRIPTION
Closes #2170

## Summary

Finishes #2170's remaining slices: the declare-rival web path (RivalryViewSet /api/scenes/rivals/ + RivalButton on the character sheet page and card drawer, double opt-in surfaced as mutual-vs-pending state) and the antagonism-consent onboarding step (the tutor-offered 'Terms of Engagement' tutorial side-step, gated on T1, walking a new player to the consent tree — PLACEHOLDER copy for Apostate's rewrite).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2170 (in the issue body)
- Brainstorm/plan: skipped (spec already approved on the issue; implements its ratified remainder)
- Sync-with-main: Rebased cleanly onto origin/main (no conflicts).

<!-- last-addressed-comment: 0 -->